### PR TITLE
[v14.x] deps: V8: ABI compatibility with master

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -35,7 +35,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.12',
+    'v8_embedder_string': '-node.13',
 
     ##### V8 defaults for Node.js #####
 

--- a/common.gypi
+++ b/common.gypi
@@ -35,7 +35,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.13',
+    'v8_embedder_string': '-node.14',
 
     ##### V8 defaults for Node.js #####
 

--- a/common.gypi
+++ b/common.gypi
@@ -35,7 +35,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.18',
+    'v8_embedder_string': '-node.19',
 
     ##### V8 defaults for Node.js #####
 

--- a/common.gypi
+++ b/common.gypi
@@ -35,7 +35,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.21',
+    'v8_embedder_string': '-node.22',
 
     ##### V8 defaults for Node.js #####
 

--- a/common.gypi
+++ b/common.gypi
@@ -35,7 +35,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.22',
+    'v8_embedder_string': '-node.23',
 
     ##### V8 defaults for Node.js #####
 

--- a/common.gypi
+++ b/common.gypi
@@ -35,7 +35,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.16',
+    'v8_embedder_string': '-node.17',
 
     ##### V8 defaults for Node.js #####
 

--- a/common.gypi
+++ b/common.gypi
@@ -35,7 +35,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.20',
+    'v8_embedder_string': '-node.21',
 
     ##### V8 defaults for Node.js #####
 

--- a/common.gypi
+++ b/common.gypi
@@ -35,7 +35,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.24',
+    'v8_embedder_string': '-node.25',
 
     ##### V8 defaults for Node.js #####
 

--- a/common.gypi
+++ b/common.gypi
@@ -35,7 +35,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.17',
+    'v8_embedder_string': '-node.18',
 
     ##### V8 defaults for Node.js #####
 

--- a/common.gypi
+++ b/common.gypi
@@ -35,7 +35,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.14',
+    'v8_embedder_string': '-node.15',
 
     ##### V8 defaults for Node.js #####
 

--- a/common.gypi
+++ b/common.gypi
@@ -35,7 +35,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.26',
+    'v8_embedder_string': '-node.27',
 
     ##### V8 defaults for Node.js #####
 

--- a/common.gypi
+++ b/common.gypi
@@ -35,7 +35,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.27',
+    'v8_embedder_string': '-node.28',
 
     ##### V8 defaults for Node.js #####
 

--- a/common.gypi
+++ b/common.gypi
@@ -35,7 +35,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.29',
+    'v8_embedder_string': '-node.30',
 
     ##### V8 defaults for Node.js #####
 

--- a/common.gypi
+++ b/common.gypi
@@ -35,7 +35,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.15',
+    'v8_embedder_string': '-node.16',
 
     ##### V8 defaults for Node.js #####
 

--- a/common.gypi
+++ b/common.gypi
@@ -35,7 +35,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.19',
+    'v8_embedder_string': '-node.20',
 
     ##### V8 defaults for Node.js #####
 

--- a/common.gypi
+++ b/common.gypi
@@ -35,7 +35,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.28',
+    'v8_embedder_string': '-node.29',
 
     ##### V8 defaults for Node.js #####
 

--- a/common.gypi
+++ b/common.gypi
@@ -35,7 +35,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.25',
+    'v8_embedder_string': '-node.26',
 
     ##### V8 defaults for Node.js #####
 

--- a/common.gypi
+++ b/common.gypi
@@ -35,7 +35,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.23',
+    'v8_embedder_string': '-node.24',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/BUILD.gn
+++ b/deps/v8/BUILD.gn
@@ -2298,6 +2298,8 @@ v8_source_set("v8_base_without_compiler") {
     "src/heap/factory-inl.h",
     "src/heap/factory.cc",
     "src/heap/factory.h",
+    "src/heap/finalization-group-cleanup-task.cc",
+    "src/heap/finalization-group-cleanup-task.h",
     "src/heap/gc-idle-time-handler.cc",
     "src/heap/gc-idle-time-handler.h",
     "src/heap/gc-tracer.cc",

--- a/deps/v8/include/v8-inspector.h
+++ b/deps/v8/include/v8-inspector.h
@@ -145,7 +145,10 @@ class V8_EXPORT V8InspectorSession {
   virtual void breakProgram(StringView breakReason,
                             StringView breakDetails) = 0;
   virtual void setSkipAllPauses(bool) = 0;
-  virtual void resume() = 0;
+
+  // NOTE: setTerminateOnResume is not implemented on the base version of
+  // Node.js v14.0.0 / V8 8.1.
+  virtual void resume(bool setTerminateOnResume = false) = 0;
   virtual void stepOver() = 0;
   virtual std::vector<std::unique_ptr<protocol::Debugger::API::SearchMatch>>
   searchInTextByLines(StringView text, StringView query, bool caseSensitive,

--- a/deps/v8/include/v8-inspector.h
+++ b/deps/v8/include/v8-inspector.h
@@ -65,15 +65,15 @@ class V8_EXPORT StringView {
 class V8_EXPORT StringBuffer {
  public:
   virtual ~StringBuffer() = default;
-  virtual const StringView& string() = 0;
+  virtual StringView string() const = 0;
   // This method copies contents.
-  static std::unique_ptr<StringBuffer> create(const StringView&);
+  static std::unique_ptr<StringBuffer> create(StringView);
 };
 
 class V8_EXPORT V8ContextInfo {
  public:
   V8ContextInfo(v8::Local<v8::Context> context, int contextGroupId,
-                const StringView& humanReadableName)
+                StringView humanReadableName)
       : context(context),
         contextGroupId(contextGroupId),
         humanReadableName(humanReadableName),
@@ -132,37 +132,36 @@ class V8_EXPORT V8InspectorSession {
   virtual void addInspectedObject(std::unique_ptr<Inspectable>) = 0;
 
   // Dispatching protocol messages.
-  static bool canDispatchMethod(const StringView& method);
-  virtual void dispatchProtocolMessage(const StringView& message) = 0;
+  static bool canDispatchMethod(StringView method);
+  virtual void dispatchProtocolMessage(StringView message) = 0;
   virtual std::vector<uint8_t> state() = 0;
   virtual std::vector<std::unique_ptr<protocol::Schema::API::Domain>>
   supportedDomains() = 0;
 
   // Debugger actions.
-  virtual void schedulePauseOnNextStatement(const StringView& breakReason,
-                                            const StringView& breakDetails) = 0;
+  virtual void schedulePauseOnNextStatement(StringView breakReason,
+                                            StringView breakDetails) = 0;
   virtual void cancelPauseOnNextStatement() = 0;
-  virtual void breakProgram(const StringView& breakReason,
-                            const StringView& breakDetails) = 0;
+  virtual void breakProgram(StringView breakReason,
+                            StringView breakDetails) = 0;
   virtual void setSkipAllPauses(bool) = 0;
   virtual void resume() = 0;
   virtual void stepOver() = 0;
   virtual std::vector<std::unique_ptr<protocol::Debugger::API::SearchMatch>>
-  searchInTextByLines(const StringView& text, const StringView& query,
-                      bool caseSensitive, bool isRegex) = 0;
+  searchInTextByLines(StringView text, StringView query, bool caseSensitive,
+                      bool isRegex) = 0;
 
   // Remote objects.
   virtual std::unique_ptr<protocol::Runtime::API::RemoteObject> wrapObject(
-      v8::Local<v8::Context>, v8::Local<v8::Value>, const StringView& groupName,
+      v8::Local<v8::Context>, v8::Local<v8::Value>, StringView groupName,
       bool generatePreview) = 0;
 
   virtual bool unwrapObject(std::unique_ptr<StringBuffer>* error,
-                            const StringView& objectId, v8::Local<v8::Value>*,
+                            StringView objectId, v8::Local<v8::Value>*,
                             v8::Local<v8::Context>*,
                             std::unique_ptr<StringBuffer>* objectGroup) = 0;
-  virtual void releaseObjectGroup(const StringView&) = 0;
-  virtual void triggerPreciseCoverageDeltaUpdate(
-      const StringView& occassion) = 0;
+  virtual void releaseObjectGroup(StringView) = 0;
+  virtual void triggerPreciseCoverageDeltaUpdate(StringView occassion) = 0;
 };
 
 class V8_EXPORT V8InspectorClient {
@@ -240,7 +239,7 @@ struct V8_EXPORT V8StackTraceId {
   V8StackTraceId(uintptr_t id, const std::pair<int64_t, int64_t> debugger_id);
   V8StackTraceId(uintptr_t id, const std::pair<int64_t, int64_t> debugger_id,
                  bool should_pause);
-  explicit V8StackTraceId(const StringView&);
+  explicit V8StackTraceId(StringView);
   V8StackTraceId& operator=(const V8StackTraceId&) = default;
   V8StackTraceId& operator=(V8StackTraceId&&) noexcept = default;
   ~V8StackTraceId() = default;
@@ -265,26 +264,26 @@ class V8_EXPORT V8Inspector {
   virtual void idleFinished() = 0;
 
   // Async stack traces instrumentation.
-  virtual void asyncTaskScheduled(const StringView& taskName, void* task,
+  virtual void asyncTaskScheduled(StringView taskName, void* task,
                                   bool recurring) = 0;
   virtual void asyncTaskCanceled(void* task) = 0;
   virtual void asyncTaskStarted(void* task) = 0;
   virtual void asyncTaskFinished(void* task) = 0;
   virtual void allAsyncTasksCanceled() = 0;
 
-  virtual V8StackTraceId storeCurrentStackTrace(
-      const StringView& description) = 0;
+  virtual V8StackTraceId storeCurrentStackTrace(StringView description) = 0;
   virtual void externalAsyncTaskStarted(const V8StackTraceId& parent) = 0;
   virtual void externalAsyncTaskFinished(const V8StackTraceId& parent) = 0;
 
   // Exceptions instrumentation.
-  virtual unsigned exceptionThrown(
-      v8::Local<v8::Context>, const StringView& message,
-      v8::Local<v8::Value> exception, const StringView& detailedMessage,
-      const StringView& url, unsigned lineNumber, unsigned columnNumber,
-      std::unique_ptr<V8StackTrace>, int scriptId) = 0;
+  virtual unsigned exceptionThrown(v8::Local<v8::Context>, StringView message,
+                                   v8::Local<v8::Value> exception,
+                                   StringView detailedMessage, StringView url,
+                                   unsigned lineNumber, unsigned columnNumber,
+                                   std::unique_ptr<V8StackTrace>,
+                                   int scriptId) = 0;
   virtual void exceptionRevoked(v8::Local<v8::Context>, unsigned exceptionId,
-                                const StringView& message) = 0;
+                                StringView message) = 0;
 
   // Connection.
   class V8_EXPORT Channel {
@@ -295,8 +294,9 @@ class V8_EXPORT V8Inspector {
     virtual void sendNotification(std::unique_ptr<StringBuffer> message) = 0;
     virtual void flushProtocolNotifications() = 0;
   };
-  virtual std::unique_ptr<V8InspectorSession> connect(
-      int contextGroupId, Channel*, const StringView& state) = 0;
+  virtual std::unique_ptr<V8InspectorSession> connect(int contextGroupId,
+                                                      Channel*,
+                                                      StringView state) = 0;
 
   // API methods.
   virtual std::unique_ptr<V8StackTrace> createStackTrace(

--- a/deps/v8/include/v8-internal.h
+++ b/deps/v8/include/v8-internal.h
@@ -160,10 +160,10 @@ class Internals {
       kNumIsolateDataSlots * kApiSystemPointerSize;
   static const int kExternalMemoryLimitOffset =
       kExternalMemoryOffset + kApiInt64Size;
-  static const int kExternalMemoryAtLastMarkCompactOffset =
+  static const int kExternalMemoryLowSinceMarkCompactOffset =
       kExternalMemoryLimitOffset + kApiInt64Size;
   static const int kIsolateFastCCallCallerFpOffset =
-      kExternalMemoryAtLastMarkCompactOffset + kApiInt64Size;
+      kExternalMemoryLowSinceMarkCompactOffset + kApiInt64Size;
   static const int kIsolateFastCCallCallerPcOffset =
       kIsolateFastCCallCallerFpOffset + kApiSystemPointerSize;
   static const int kIsolateStackGuardOffset =

--- a/deps/v8/include/v8-internal.h
+++ b/deps/v8/include/v8-internal.h
@@ -106,6 +106,10 @@ const int kApiTaggedSize = kApiInt32Size;
 const int kApiTaggedSize = kApiSystemPointerSize;
 #endif
 
+constexpr bool PointerCompressionIsEnabled() {
+  return kApiTaggedSize != kApiSystemPointerSize;
+}
+
 #ifdef V8_31BIT_SMIS_ON_64BIT_ARCH
 using PlatformSmiTagging = SmiTagging<kApiInt32Size>;
 #else

--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -5926,13 +5926,14 @@ class V8_EXPORT External : public Value {
   static void CheckCast(v8::Value* obj);
 };
 
-#define V8_INTRINSICS_LIST(F)                    \
-  F(ArrayProto_entries, array_entries_iterator)  \
-  F(ArrayProto_forEach, array_for_each_iterator) \
-  F(ArrayProto_keys, array_keys_iterator)        \
-  F(ArrayProto_values, array_values_iterator)    \
-  F(ErrorPrototype, initial_error_prototype)     \
-  F(IteratorPrototype, initial_iterator_prototype)
+#define V8_INTRINSICS_LIST(F)                      \
+  F(ArrayProto_entries, array_entries_iterator)    \
+  F(ArrayProto_forEach, array_for_each_iterator)   \
+  F(ArrayProto_keys, array_keys_iterator)          \
+  F(ArrayProto_values, array_values_iterator)      \
+  F(ErrorPrototype, initial_error_prototype)       \
+  F(IteratorPrototype, initial_iterator_prototype) \
+  F(ObjProto_valueOf, object_value_of_function)
 
 enum Intrinsic {
 #define V8_DECL_INTRINSIC(name, iname) k##name,

--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -2786,9 +2786,6 @@ class V8_EXPORT Value : public Data {
    */
   bool IsWasmModuleObject() const;
 
-  V8_DEPRECATED("Use IsWasmModuleObject")
-  bool IsWebAssemblyCompiledModule() const;
-
   /**
    * Returns true if the value is a Module Namespace Object.
    */

--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -2181,6 +2181,7 @@ enum StateTag {
   COMPILER,
   OTHER,
   EXTERNAL,
+  ATOMICS_WAIT,
   IDLE
 };
 

--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -5885,6 +5885,9 @@ class V8_EXPORT FinalizationGroup : public Object {
    * occurred. Otherwise the result is |true| if the cleanup callback
    * was called successfully. The result is never |false|.
    */
+  V8_DEPRECATED(
+      "FinalizationGroup cleanup is automatic if "
+      "HostCleanupFinalizationGroupCallback is not set")
   static V8_WARN_UNUSED_RESULT Maybe<bool> Cleanup(
       Local<FinalizationGroup> finalization_group);
 };
@@ -8444,6 +8447,9 @@ class V8_EXPORT Isolate {
    * are ready to be cleaned up and require FinalizationGroup::Cleanup()
    * to be called in a future task.
    */
+  V8_DEPRECATED(
+      "FinalizationGroup cleanup is automatic if "
+      "HostCleanupFinalizationGroupCallback is not set")
   void SetHostCleanupFinalizationGroupCallback(
       HostCleanupFinalizationGroupCallback callback);
 
@@ -9056,10 +9062,10 @@ class V8_EXPORT Isolate {
   void LowMemoryNotification();
 
   /**
-   * Optional notification that a context has been disposed. V8 uses
-   * these notifications to guide the GC heuristic. Returns the number
-   * of context disposals - including this one - since the last time
-   * V8 had a chance to clean up.
+   * Optional notification that a context has been disposed. V8 uses these
+   * notifications to guide the GC heuristic and cancel FinalizationGroup
+   * cleanup tasks. Returns the number of context disposals - including this one
+   * - since the last time V8 had a chance to clean up.
    *
    * The optional parameter |dependant_context| specifies whether the disposed
    * context was depending on state from other contexts or not.

--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -6382,11 +6382,6 @@ class V8_EXPORT FunctionTemplate : public Template {
       ConstructorBehavior behavior = ConstructorBehavior::kAllow,
       SideEffectType side_effect_type = SideEffectType::kHasSideEffect);
 
-  /** Get a template included in the snapshot by index. */
-  V8_DEPRECATED("Use v8::Isolate::GetDataFromSnapshotOnce instead")
-  static MaybeLocal<FunctionTemplate> FromSnapshot(Isolate* isolate,
-                                                   size_t index);
-
   /**
    * Creates a function template backed/cached by a private property.
    */
@@ -6673,11 +6668,6 @@ class V8_EXPORT ObjectTemplate : public Template {
   static Local<ObjectTemplate> New(
       Isolate* isolate,
       Local<FunctionTemplate> constructor = Local<FunctionTemplate>());
-
-  /** Get a template included in the snapshot by index. */
-  V8_DEPRECATED("Use v8::Isolate::GetDataFromSnapshotOnce instead")
-  static MaybeLocal<ObjectTemplate> FromSnapshot(Isolate* isolate,
-                                                 size_t index);
 
   /** Creates a new instance of this template.*/
   V8_WARN_UNUSED_RESULT MaybeLocal<Object> NewInstance(Local<Context> context);
@@ -9765,13 +9755,6 @@ class V8_EXPORT SnapshotCreator {
   size_t AddContext(Local<Context> context,
                     SerializeInternalFieldsCallback callback =
                         SerializeInternalFieldsCallback());
-
-  /**
-   * Add a template to be included in the snapshot blob.
-   * \returns the index of the template in the snapshot blob.
-   */
-  V8_DEPRECATED("use AddData instead")
-  size_t AddTemplate(Local<Template> template_obj);
 
   /**
    * Attach arbitrary V8::Data to the context snapshot, which can be retrieved

--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -8380,6 +8380,13 @@ class V8_EXPORT Isolate {
     kRegExpReplaceCalledOnSlowRegExp = 80,
     kDisplayNames = 81,
     kSharedArrayBufferConstructed = 82,
+    kArrayPrototypeHasElements = 83,
+    kObjectPrototypeHasElements = 84,
+    kNumberFormatStyleUnit = 85,
+    kDateTimeFormatRange = 86,
+    kDateTimeFormatDateTimeStyle = 87,
+    kBreakIteratorTypeWord = 88,
+    kBreakIteratorTypeLine = 89,
 
     // If you add new values here, you'll also need to update Chromium's:
     // web_feature.mojom, use_counter_callback.cc, and enums.xml. V8 changes to

--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -9530,7 +9530,12 @@ class V8_EXPORT V8 {
    * Initializes V8. This function needs to be called before the first Isolate
    * is created. It always returns true.
    */
-  static bool Initialize();
+  V8_INLINE static bool Initialize() {
+    const int kBuildConfiguration =
+        (internal::PointerCompressionIsEnabled() ? kPointerCompression : 0) |
+        (internal::SmiValuesAre31Bits() ? k31BitSmis : 0);
+    return Initialize(kBuildConfiguration);
+  }
 
   /**
    * Allows the host application to provide a callback which can be used
@@ -9663,6 +9668,17 @@ class V8_EXPORT V8 {
 
  private:
   V8();
+
+  enum BuildConfigurationFeatures {
+    kPointerCompression = 1 << 0,
+    k31BitSmis = 1 << 1,
+  };
+
+  /**
+   * Checks that the embedder build configuration is compatible with
+   * the V8 binary and if so initializes V8.
+   */
+  static bool Initialize(int build_config);
 
   static internal::Address* GlobalizeReference(internal::Isolate* isolate,
                                                internal::Address* handle);

--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -9180,7 +9180,7 @@ class V8_EXPORT Isolate {
    * Returns the UnwindState necessary for use with the Unwinder API.
    */
   // TODO(petermarshall): Remove this API.
-  V8_DEPRECATE_SOON("Use entry_stubs + code_pages version.")
+  V8_DEPRECATED("Use entry_stubs + code_pages version.")
   UnwindState GetUnwindState();
 
   /**
@@ -10534,7 +10534,7 @@ class V8_EXPORT Unwinder {
    * \return True on success.
    */
   // TODO(petermarshall): Remove this API
-  V8_DEPRECATE_SOON("Use entry_stubs + code_pages version.")
+  V8_DEPRECATED("Use entry_stubs + code_pages version.")
   static bool TryUnwindV8Frames(const UnwindState& unwind_state,
                                 RegisterState* register_state,
                                 const void* stack_base);
@@ -10562,7 +10562,7 @@ class V8_EXPORT Unwinder {
    * (but not necessarily) be successful.
    */
   // TODO(petermarshall): Remove this API
-  V8_DEPRECATE_SOON("Use code_pages version.")
+  V8_DEPRECATED("Use code_pages version.")
   static bool PCIsInV8(const UnwindState& unwind_state, void* pc);
 
   /**

--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -2447,14 +2447,6 @@ class V8_EXPORT ValueDeserializer {
   void SetSupportsLegacyWireFormat(bool supports_legacy_wire_format);
 
   /**
-   * Expect inline wasm in the data stream (rather than in-memory transfer)
-   */
-  V8_DEPRECATED(
-      "Wasm module serialization is only supported via explicit methods, e.g. "
-      "CompiledWasmModule::Serialize()")
-  void SetExpectInlineWasm(bool allow_inline_wasm) {}
-
-  /**
    * Reads the underlying wire format version. Likely mostly to be useful to
    * legacy code reading old wire format versions. Must be called after
    * ReadHeader.

--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -6279,6 +6279,7 @@ typedef bool (*AccessCheckCallback)(Local<Context> accessing_context,
                                     Local<Object> accessed_object,
                                     Local<Value> data);
 
+class CFunction;
 /**
  * A FunctionTemplate is used to create functions at runtime. There
  * can only be one function created from a FunctionTemplate in a
@@ -6387,7 +6388,8 @@ class V8_EXPORT FunctionTemplate : public Template {
       Local<Value> data = Local<Value>(),
       Local<Signature> signature = Local<Signature>(), int length = 0,
       ConstructorBehavior behavior = ConstructorBehavior::kAllow,
-      SideEffectType side_effect_type = SideEffectType::kHasSideEffect);
+      SideEffectType side_effect_type = SideEffectType::kHasSideEffect,
+      const CFunction* not_available_in_node_v14_yet = nullptr);
 
   /**
    * Creates a function template backed/cached by a private property.
@@ -6418,7 +6420,8 @@ class V8_EXPORT FunctionTemplate : public Template {
    */
   void SetCallHandler(
       FunctionCallback callback, Local<Value> data = Local<Value>(),
-      SideEffectType side_effect_type = SideEffectType::kHasSideEffect);
+      SideEffectType side_effect_type = SideEffectType::kHasSideEffect,
+      const CFunction* not_available_in_node_v14_yet = nullptr);
 
   /** Set the predefined length property for the FunctionTemplate. */
   void SetLength(int length);
@@ -8110,7 +8113,10 @@ class V8_EXPORT Isolate {
           array_buffer_allocator_shared(),
           external_references(nullptr),
           allow_atomics_wait(true),
-          only_terminate_in_safe_scope(false) {}
+          only_terminate_in_safe_scope(false),
+          embedder_wrapper_type_index(-1),
+          embedder_wrapper_object_index(-1) {}
+
 
     /**
      * Allows the host application to provide the address of a function that is
@@ -8174,6 +8180,10 @@ class V8_EXPORT Isolate {
      * Termination is postponed when there is no active SafeForTerminationScope.
      */
     bool only_terminate_in_safe_scope;
+
+    // Not available in Node v14 yet.
+    int embedder_wrapper_type_index;
+    int embedder_wrapper_object_index;
   };
 
 

--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -1128,17 +1128,11 @@ class TracedReference : public TracedReferenceBase<T> {
 
   /**
    * Copy assignment operator initializing TracedGlobal from an existing one.
-   *
-   * Note: Prohibited when |other| has a finalization callback set through
-   * |SetFinalizationCallback|.
    */
   V8_INLINE TracedReference& operator=(const TracedReference& rhs);
 
   /**
    * Copy assignment operator initializing TracedGlobal from an existing one.
-   *
-   * Note: Prohibited when |other| has a finalization callback set through
-   * |SetFinalizationCallback|.
    */
   template <class S>
   V8_INLINE TracedReference& operator=(const TracedReference<S>& rhs);
@@ -1155,20 +1149,6 @@ class TracedReference : public TracedReferenceBase<T> {
     return reinterpret_cast<TracedReference<S>&>(
         const_cast<TracedReference<T>&>(*this));
   }
-
-  /**
-   * Adds a finalization callback to the handle. The type of this callback is
-   * similar to WeakCallbackType::kInternalFields, i.e., it will pass the
-   * parameter and the first two internal fields of the object.
-   *
-   * The callback is then supposed to reset the handle in the callback. No
-   * further V8 API may be called in this callback. In case additional work
-   * involving V8 needs to be done, a second callback can be scheduled using
-   * WeakCallbackInfo<void>::SetSecondPassCallback.
-   */
-  V8_DEPRECATED("Use TracedGlobal<> if callbacks are required.")
-  V8_INLINE void SetFinalizationCallback(
-      void* parameter, WeakCallbackInfo<void>::Callback callback);
 };
 
  /**
@@ -10948,13 +10928,6 @@ uint16_t TracedReferenceBase<T>::WrapperClassId() const {
 
 template <class T>
 void TracedGlobal<T>::SetFinalizationCallback(
-    void* parameter, typename WeakCallbackInfo<void>::Callback callback) {
-  V8::SetFinalizationCallbackTraced(
-      reinterpret_cast<internal::Address*>(this->val_), parameter, callback);
-}
-
-template <class T>
-void TracedReference<T>::SetFinalizationCallback(
     void* parameter, typename WeakCallbackInfo<void>::Callback callback) {
   V8::SetFinalizationCallbackTraced(
       reinterpret_cast<internal::Address*>(this->val_), parameter, callback);

--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -7545,6 +7545,8 @@ class V8_EXPORT HeapStatistics {
   size_t total_heap_size_executable() { return total_heap_size_executable_; }
   size_t total_physical_size() { return total_physical_size_; }
   size_t total_available_size() { return total_available_size_; }
+  size_t total_global_handles_size() { return total_global_handles_size_; }
+  size_t used_global_handles_size() { return used_global_handles_size_; }
   size_t used_heap_size() { return used_heap_size_; }
   size_t heap_size_limit() { return heap_size_limit_; }
   size_t malloced_memory() { return malloced_memory_; }
@@ -7572,6 +7574,8 @@ class V8_EXPORT HeapStatistics {
   bool does_zap_garbage_;
   size_t number_of_native_contexts_;
   size_t number_of_detached_contexts_;
+  size_t total_global_handles_size_;
+  size_t used_global_handles_size_;
 
   friend class V8;
   friend class Isolate;

--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -4757,27 +4757,9 @@ class V8_EXPORT WasmModuleObject : public Object {
    */
   CompiledWasmModule GetCompiledModule();
 
-  /**
-   * If possible, deserialize the module, otherwise compile it from the provided
-   * uncompiled bytes.
-   */
-  V8_DEPRECATED(
-      "Use WasmStreaming for deserialization from cache or the "
-      "CompiledWasmModule to transfer between isolates")
-  static MaybeLocal<WasmModuleObject> DeserializeOrCompile(
-      Isolate* isolate, MemorySpan<const uint8_t> serialized_module,
-      MemorySpan<const uint8_t> wire_bytes);
-
   V8_INLINE static WasmModuleObject* Cast(Value* obj);
 
  private:
-  static MaybeLocal<WasmModuleObject> Deserialize(
-      Isolate* isolate, MemorySpan<const uint8_t> serialized_module,
-      MemorySpan<const uint8_t> wire_bytes);
-  static MaybeLocal<WasmModuleObject> Compile(Isolate* isolate,
-                                              const uint8_t* start,
-                                              size_t length);
-
   static void CheckCast(Value* obj);
 };
 

--- a/deps/v8/src/api/api.cc
+++ b/deps/v8/src/api/api.cc
@@ -5652,7 +5652,25 @@ void v8::V8::InitializePlatform(Platform* platform) {
 
 void v8::V8::ShutdownPlatform() { i::V8::ShutdownPlatform(); }
 
-bool v8::V8::Initialize() {
+bool v8::V8::Initialize(const int build_config) {
+  const bool kEmbedderPointerCompression =
+      (build_config & kPointerCompression) != 0;
+  if (kEmbedderPointerCompression != COMPRESS_POINTERS_BOOL) {
+    FATAL(
+        "Embedder-vs-V8 build configuration mismatch. On embedder side "
+        "pointer compression is %s while on V8 side it's %s.",
+        kEmbedderPointerCompression ? "ENABLED" : "DISABLED",
+        COMPRESS_POINTERS_BOOL ? "ENABLED" : "DISABLED");
+  }
+
+  const int kEmbedderSmiValueSize = (build_config & k31BitSmis) ? 31 : 32;
+  if (kEmbedderSmiValueSize != internal::kSmiValueSize) {
+    FATAL(
+        "Embedder-vs-V8 build configuration mismatch. On embedder side "
+        "Smi value size is %d while on V8 side it's %d.",
+        kEmbedderSmiValueSize, internal::kSmiValueSize);
+  }
+
   i::V8::Initialize();
   return true;
 }

--- a/deps/v8/src/api/api.cc
+++ b/deps/v8/src/api/api.cc
@@ -1499,7 +1499,7 @@ static Local<FunctionTemplate> FunctionTemplateNew(
 Local<FunctionTemplate> FunctionTemplate::New(
     Isolate* isolate, FunctionCallback callback, v8::Local<Value> data,
     v8::Local<Signature> signature, int length, ConstructorBehavior behavior,
-    SideEffectType side_effect_type) {
+    SideEffectType side_effect_type, const CFunction*) {
   i::Isolate* i_isolate = reinterpret_cast<i::Isolate*>(isolate);
   // Changes to the environment cannot be captured in the snapshot. Expect no
   // function templates when the isolate is created for serialization.
@@ -1540,7 +1540,8 @@ Local<AccessorSignature> AccessorSignature::New(
 
 void FunctionTemplate::SetCallHandler(FunctionCallback callback,
                                       v8::Local<Value> data,
-                                      SideEffectType side_effect_type) {
+                                      SideEffectType side_effect_type,
+                                      const CFunction*) {
   auto info = Utils::OpenHandle(this);
   EnsureNotInstantiated(info, "v8::FunctionTemplate::SetCallHandler");
   i::Isolate* isolate = info->GetIsolate();

--- a/deps/v8/src/api/api.cc
+++ b/deps/v8/src/api/api.cc
@@ -3438,7 +3438,6 @@ VALUE_IS_SPECIFIC_TYPE(Set, JSSet)
 VALUE_IS_SPECIFIC_TYPE(WasmModuleObject, WasmModuleObject)
 VALUE_IS_SPECIFIC_TYPE(WeakMap, JSWeakMap)
 VALUE_IS_SPECIFIC_TYPE(WeakSet, JSWeakSet)
-VALUE_IS_SPECIFIC_TYPE(WebAssemblyCompiledModule, WasmModuleObject)
 
 #undef VALUE_IS_SPECIFIC_TYPE
 

--- a/deps/v8/src/api/api.cc
+++ b/deps/v8/src/api/api.cc
@@ -631,10 +631,6 @@ size_t SnapshotCreator::AddContext(Local<Context> context,
   return index;
 }
 
-size_t SnapshotCreator::AddTemplate(Local<Template> template_obj) {
-  return AddData(template_obj);
-}
-
 size_t SnapshotCreator::AddData(i::Address object) {
   DCHECK_NE(object, i::kNullAddress);
   SnapshotCreatorData* data = SnapshotCreatorData::cast(data_);
@@ -1490,21 +1486,6 @@ Local<FunctionTemplate> FunctionTemplate::New(
   return templ;
 }
 
-MaybeLocal<FunctionTemplate> FunctionTemplate::FromSnapshot(Isolate* isolate,
-                                                            size_t index) {
-  i::Isolate* i_isolate = reinterpret_cast<i::Isolate*>(isolate);
-  i::FixedArray serialized_objects = i_isolate->heap()->serialized_objects();
-  int int_index = static_cast<int>(index);
-  if (int_index < serialized_objects.length()) {
-    i::Object info = serialized_objects.get(int_index);
-    if (info.IsFunctionTemplateInfo()) {
-      return Utils::ToLocal(i::Handle<i::FunctionTemplateInfo>(
-          i::FunctionTemplateInfo::cast(info), i_isolate));
-    }
-  }
-  return Local<FunctionTemplate>();
-}
-
 Local<FunctionTemplate> FunctionTemplate::NewWithCache(
     Isolate* isolate, FunctionCallback callback, Local<Private> cache_property,
     Local<Value> data, Local<Signature> signature, int length,
@@ -1685,21 +1666,6 @@ static Local<ObjectTemplate> ObjectTemplateNew(
 Local<ObjectTemplate> ObjectTemplate::New(
     i::Isolate* isolate, v8::Local<FunctionTemplate> constructor) {
   return ObjectTemplateNew(isolate, constructor, false);
-}
-
-MaybeLocal<ObjectTemplate> ObjectTemplate::FromSnapshot(Isolate* isolate,
-                                                        size_t index) {
-  i::Isolate* i_isolate = reinterpret_cast<i::Isolate*>(isolate);
-  i::FixedArray serialized_objects = i_isolate->heap()->serialized_objects();
-  int int_index = static_cast<int>(index);
-  if (int_index < serialized_objects.length()) {
-    i::Object info = serialized_objects.get(int_index);
-    if (info.IsObjectTemplateInfo()) {
-      return Utils::ToLocal(i::Handle<i::ObjectTemplateInfo>(
-          i::ObjectTemplateInfo::cast(info), i_isolate));
-    }
-  }
-  return Local<ObjectTemplate>();
 }
 
 // Ensure that the object template has a constructor.  If no

--- a/deps/v8/src/api/api.cc
+++ b/deps/v8/src/api/api.cc
@@ -5753,7 +5753,9 @@ HeapStatistics::HeapStatistics()
       peak_malloced_memory_(0),
       does_zap_garbage_(false),
       number_of_native_contexts_(0),
-      number_of_detached_contexts_(0) {}
+      number_of_detached_contexts_(0),
+      total_global_handles_size_(0),
+      used_global_handles_size_(0) {}
 
 HeapSpaceStatistics::HeapSpaceStatistics()
     : space_name_(nullptr),

--- a/deps/v8/src/api/api.h
+++ b/deps/v8/src/api/api.h
@@ -26,6 +26,7 @@ namespace v8 {
 
 namespace internal {
 class JSArrayBufferView;
+class JSFinalizationGroup;
 }  // namespace internal
 
 namespace debug {
@@ -560,6 +561,10 @@ void InvokeAccessorGetterCallback(
 
 void InvokeFunctionCallback(const v8::FunctionCallbackInfo<v8::Value>& info,
                             v8::FunctionCallback callback);
+
+void InvokeFinalizationGroupCleanupFromTask(
+    Handle<Context> context, Handle<JSFinalizationGroup> finalization_group,
+    Handle<Object> callback);
 
 }  // namespace internal
 }  // namespace v8

--- a/deps/v8/src/builtins/builtins-weak-refs.cc
+++ b/deps/v8/src/builtins/builtins-weak-refs.cc
@@ -148,9 +148,8 @@ BUILTIN(FinalizationGroupCleanupSome) {
     callback = callback_obj;
   }
 
-  // Don't do set_scheduled_for_cleanup(false); we still have the microtask
-  // scheduled and don't want to schedule another one in case the user never
-  // executes microtasks.
+  // Don't do set_scheduled_for_cleanup(false); we still have the task
+  // scheduled.
   if (JSFinalizationGroup::Cleanup(isolate, finalization_group, callback)
           .IsNothing()) {
     DCHECK(isolate->has_pending_exception());

--- a/deps/v8/src/d8/d8.cc
+++ b/deps/v8/src/d8/d8.cc
@@ -1066,7 +1066,7 @@ bool Shell::ExecuteModule(Isolate* isolate, const char* file_name) {
     // able to just busy loop waiting for execution to finish.
     Local<Promise> result_promise(Local<Promise>::Cast(result));
     while (result_promise->State() == Promise::kPending) {
-      isolate->RunMicrotasks();
+      isolate->PerformMicrotaskCheckpoint();
     }
 
     if (result_promise->State() == Promise::kRejected) {
@@ -3297,7 +3297,6 @@ bool ProcessMessages(
     while (v8::platform::PumpMessageLoop(g_default_platform, isolate,
                                          behavior())) {
       MicrotasksScope::PerformCheckpoint(isolate);
-      isolate->ClearKeptObjects();
     }
     if (g_default_platform->IdleTasksEnabled(isolate)) {
       v8::platform::RunIdleTasks(g_default_platform, isolate,

--- a/deps/v8/src/d8/d8.h
+++ b/deps/v8/src/d8/d8.h
@@ -226,8 +226,6 @@ class PerIsolateData {
     PerIsolateData* data_;
   };
 
-  inline void HostCleanupFinalizationGroup(Local<FinalizationGroup> fg);
-  inline MaybeLocal<FinalizationGroup> GetCleanupFinalizationGroup();
   inline void SetTimeout(Local<Function> callback, Local<Context> context);
   inline MaybeLocal<Function> GetTimeoutCallback();
   inline MaybeLocal<Context> GetTimeoutContext();
@@ -245,7 +243,6 @@ class PerIsolateData {
   Global<Value> realm_shared_;
   std::queue<Global<Function>> set_timeout_callbacks_;
   std::queue<Global<Context>> set_timeout_contexts_;
-  std::queue<Global<FinalizationGroup>> cleanup_finalization_groups_;
   AsyncHooks* async_hooks_wrapper_;
 
   int RealmIndexOrThrow(const v8::FunctionCallbackInfo<v8::Value>& args,
@@ -423,8 +420,6 @@ class Shell : public i::AllStatic {
   static void SetUMask(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void MakeDirectory(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void RemoveDirectory(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void HostCleanupFinalizationGroup(Local<Context> context,
-                                           Local<FinalizationGroup> fg);
   static MaybeLocal<Promise> HostImportModuleDynamically(
       Local<Context> context, Local<ScriptOrModule> referrer,
       Local<String> specifier);

--- a/deps/v8/src/execution/futex-emulation.cc
+++ b/deps/v8/src/execution/futex-emulation.cc
@@ -9,6 +9,7 @@
 #include "src/base/macros.h"
 #include "src/base/platform/time.h"
 #include "src/execution/isolate.h"
+#include "src/execution/vm-state-inl.h"
 #include "src/handles/handles-inl.h"
 #include "src/numbers/conversions.h"
 #include "src/objects/bigint.h"
@@ -132,6 +133,7 @@ template <typename T>
 Object FutexEmulation::Wait(Isolate* isolate,
                             Handle<JSArrayBuffer> array_buffer, size_t addr,
                             T value, double rel_timeout_ms) {
+  VMState<ATOMICS_WAIT> state(isolate);
   DCHECK_LT(addr, array_buffer->byte_length());
 
   bool use_timeout = rel_timeout_ms != V8_INFINITY;

--- a/deps/v8/src/execution/isolate-data.h
+++ b/deps/v8/src/execution/isolate-data.h
@@ -117,7 +117,7 @@ class IsolateData final {
   V(kEmbedderDataOffset, Internals::kNumIsolateDataSlots* kSystemPointerSize) \
   V(kExternalMemoryOffset, kInt64Size)                                        \
   V(kExternalMemoryLlimitOffset, kInt64Size)                                  \
-  V(kExternalMemoryAtLastMarkCompactOffset, kInt64Size)                       \
+  V(kExternalMemoryLowSinceMarkCompactOffset, kInt64Size)                     \
   V(kFastCCallCallerFPOffset, kSystemPointerSize)                             \
   V(kFastCCallCallerPCOffset, kSystemPointerSize)                             \
   V(kStackGuardOffset, StackGuard::kSizeInBytes)                              \
@@ -151,7 +151,7 @@ class IsolateData final {
   int64_t external_memory_limit_ = kExternalAllocationSoftLimit;
 
   // Caches the amount of external memory registered at the last MC.
-  int64_t external_memory_at_last_mark_compact_ = 0;
+  int64_t external_memory_low_since_mark_compact_ = 0;
 
   // Stores the state of the caller for TurboAssembler::CallCFunction so that
   // the sampling CPU profiler can iterate the stack during such calls. These
@@ -220,8 +220,9 @@ void IsolateData::AssertPredictableLayout() {
                 kExternalMemoryOffset);
   STATIC_ASSERT(offsetof(IsolateData, external_memory_limit_) ==
                 kExternalMemoryLlimitOffset);
-  STATIC_ASSERT(offsetof(IsolateData, external_memory_at_last_mark_compact_) ==
-                kExternalMemoryAtLastMarkCompactOffset);
+  STATIC_ASSERT(
+      offsetof(IsolateData, external_memory_low_since_mark_compact_) ==
+      kExternalMemoryLowSinceMarkCompactOffset);
   STATIC_ASSERT(offsetof(IsolateData, fast_c_call_caller_fp_) ==
                 kFastCCallCallerFPOffset);
   STATIC_ASSERT(offsetof(IsolateData, fast_c_call_caller_pc_) ==

--- a/deps/v8/src/execution/isolate.cc
+++ b/deps/v8/src/execution/isolate.cc
@@ -2900,10 +2900,10 @@ void Isolate::CheckIsolateLayout() {
   CHECK_EQ(static_cast<int>(
                OFFSET_OF(Isolate, isolate_data_.external_memory_limit_)),
            Internals::kExternalMemoryLimitOffset);
-  CHECK_EQ(Internals::kExternalMemoryAtLastMarkCompactOffset % 8, 0);
+  CHECK_EQ(Internals::kExternalMemoryLowSinceMarkCompactOffset % 8, 0);
   CHECK_EQ(static_cast<int>(OFFSET_OF(
-               Isolate, isolate_data_.external_memory_at_last_mark_compact_)),
-           Internals::kExternalMemoryAtLastMarkCompactOffset);
+               Isolate, isolate_data_.external_memory_low_since_mark_compact_)),
+           Internals::kExternalMemoryLowSinceMarkCompactOffset);
 }
 
 void Isolate::ClearSerializerData() {

--- a/deps/v8/src/execution/isolate.h
+++ b/deps/v8/src/execution/isolate.h
@@ -1391,6 +1391,10 @@ class Isolate final : private HiddenFactory {
   void ClearKeptObjects();
   void SetHostCleanupFinalizationGroupCallback(
       HostCleanupFinalizationGroupCallback callback);
+  HostCleanupFinalizationGroupCallback
+  host_cleanup_finalization_group_callback() const {
+    return host_cleanup_finalization_group_callback_;
+  }
   void RunHostCleanupFinalizationGroupCallback(Handle<JSFinalizationGroup> fg);
 
   void SetHostImportModuleDynamicallyCallback(

--- a/deps/v8/src/execution/microtask-queue.cc
+++ b/deps/v8/src/execution/microtask-queue.cc
@@ -115,6 +115,7 @@ void MicrotaskQueue::PerformCheckpoint(v8::Isolate* v8_isolate) {
       !HasMicrotasksSuppressions()) {
     Isolate* isolate = reinterpret_cast<Isolate*>(v8_isolate);
     RunMicrotasks(isolate);
+    isolate->ClearKeptObjects();
   }
 }
 

--- a/deps/v8/src/execution/vm-state-inl.h
+++ b/deps/v8/src/execution/vm-state-inl.h
@@ -14,11 +14,9 @@
 namespace v8 {
 namespace internal {
 
-//
-// VMState class implementation.  A simple stack of VM states held by the
-// logger and partially threaded through the call stack.  States are pushed by
-// VMState construction and popped by destruction.
-//
+// VMState class implementation. A simple stack of VM states held by the logger
+// and partially threaded through the call stack. States are pushed by VMState
+// construction and popped by destruction.
 inline const char* StateToString(StateTag state) {
   switch (state) {
     case JS:
@@ -35,6 +33,8 @@ inline const char* StateToString(StateTag state) {
       return "OTHER";
     case EXTERNAL:
       return "EXTERNAL";
+    case ATOMICS_WAIT:
+      return "ATOMICS_WAIT";
     case IDLE:
       return "IDLE";
   }

--- a/deps/v8/src/execution/vm-state.h
+++ b/deps/v8/src/execution/vm-state.h
@@ -11,11 +11,10 @@
 namespace v8 {
 namespace internal {
 
-// Logging and profiling.  A StateTag represents a possible state of
-// the VM. The logger maintains a stack of these. Creating a VMState
-// object enters a state by pushing on the stack, and destroying a
-// VMState object leaves a state by popping the current state from the
-// stack.
+// Logging and profiling. A StateTag represents a possible state of the VM. The
+// logger maintains a stack of these. Creating a VMState object enters a state
+// by pushing on the stack, and destroying a VMState object leaves a state by
+// popping the current state from the stack.
 template <StateTag Tag>
 class VMState {
  public:

--- a/deps/v8/src/heap/finalization-group-cleanup-task.cc
+++ b/deps/v8/src/heap/finalization-group-cleanup-task.cc
@@ -1,0 +1,74 @@
+// Copyright 2020 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "src/heap/finalization-group-cleanup-task.h"
+
+#include "src/execution/frames.h"
+#include "src/execution/interrupts-scope.h"
+#include "src/execution/stack-guard.h"
+#include "src/execution/v8threads.h"
+#include "src/heap/heap-inl.h"
+#include "src/objects/js-weak-refs-inl.h"
+#include "src/tracing/trace-event.h"
+
+namespace v8 {
+namespace internal {
+
+FinalizationGroupCleanupTask::FinalizationGroupCleanupTask(Heap* heap)
+    : heap_(heap) {}
+
+void FinalizationGroupCleanupTask::SlowAssertNoActiveJavaScript() {
+#ifdef ENABLE_SLOW_DCHECKS
+  class NoActiveJavaScript : public ThreadVisitor {
+   public:
+    void VisitThread(Isolate* isolate, ThreadLocalTop* top) override {
+      for (StackFrameIterator it(isolate, top); !it.done(); it.Advance()) {
+        DCHECK(!it.frame()->is_java_script());
+      }
+    }
+  };
+  NoActiveJavaScript no_active_js_visitor;
+  Isolate* isolate = heap_->isolate();
+  no_active_js_visitor.VisitThread(isolate, isolate->thread_local_top());
+  isolate->thread_manager()->IterateArchivedThreads(&no_active_js_visitor);
+#endif  // ENABLE_SLOW_DCHECKS
+}
+
+void FinalizationGroupCleanupTask::Run() {
+  Isolate* isolate = heap_->isolate();
+  DCHECK(!isolate->host_cleanup_finalization_group_callback());
+  SlowAssertNoActiveJavaScript();
+
+  TRACE_EVENT_CALL_STATS_SCOPED(isolate, "v8",
+                                "V8.FinalizationGroupCleanupTask");
+
+  HandleScope handle_scope(isolate);
+  Handle<JSFinalizationGroup> finalization_group;
+  // There could be no dirty FinalizationGroups. When a context is disposed by
+  // the embedder, its FinalizationGroups are removed from the dirty list.
+  if (!heap_->TakeOneDirtyJSFinalizationGroup().ToHandle(&finalization_group)) {
+    return;
+  }
+  finalization_group->set_scheduled_for_cleanup(false);
+
+  // Since FinalizationGroup cleanup callbacks are scheduled by V8, enter the
+  // FinalizationGroup's context.
+  Handle<Context> context(Context::cast(finalization_group->native_context()),
+                          isolate);
+  Handle<Object> callback(finalization_group->cleanup(), isolate);
+  v8::Context::Scope context_scope(v8::Utils::ToLocal(context));
+  v8::TryCatch catcher(reinterpret_cast<v8::Isolate*>(isolate));
+  catcher.SetVerbose(true);
+
+  // Exceptions are reported via the message handler. This is ensured by the
+  // verbose TryCatch.
+  InvokeFinalizationGroupCleanupFromTask(context, finalization_group, callback);
+
+  // Repost if there are remaining dirty FinalizationGroups.
+  heap_->set_is_finalization_group_cleanup_task_posted(false);
+  heap_->PostFinalizationGroupCleanupTaskIfNeeded();
+}
+
+}  // namespace internal
+}  // namespace v8

--- a/deps/v8/src/heap/finalization-group-cleanup-task.h
+++ b/deps/v8/src/heap/finalization-group-cleanup-task.h
@@ -1,0 +1,36 @@
+// Copyright 2020 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef V8_HEAP_FINALIZATION_GROUP_CLEANUP_TASK_H_
+#define V8_HEAP_FINALIZATION_GROUP_CLEANUP_TASK_H_
+
+#include "include/v8-platform.h"
+#include "src/objects/js-weak-refs.h"
+
+namespace v8 {
+namespace internal {
+
+// The GC schedules a cleanup task when the dirty FinalizationGroup list is
+// non-empty. The task processes a single FinalizationGroup and posts another
+// cleanup task if there are remaining dirty FinalizationGroups on the list.
+class FinalizationGroupCleanupTask : public Task {
+ public:
+  explicit FinalizationGroupCleanupTask(Heap* heap);
+  ~FinalizationGroupCleanupTask() override = default;
+
+  void Run() override;
+
+ private:
+  FinalizationGroupCleanupTask(const FinalizationGroupCleanupTask&) = delete;
+  void operator=(const FinalizationGroupCleanupTask&) = delete;
+
+  void SlowAssertNoActiveJavaScript();
+
+  Heap* heap_;
+};
+
+}  // namespace internal
+}  // namespace v8
+
+#endif  // V8_HEAP_FINALIZATION_GROUP_CLEANUP_TASK_H_

--- a/deps/v8/src/heap/heap-inl.h
+++ b/deps/v8/src/heap/heap-inl.h
@@ -65,7 +65,14 @@ int64_t Heap::external_memory() {
 }
 
 void Heap::update_external_memory(int64_t delta) {
-  isolate()->isolate_data()->external_memory_ += delta;
+  const int64_t amount = isolate()->isolate_data()->external_memory_ + delta;
+  isolate()->isolate_data()->external_memory_ = amount;
+  if (amount <
+      isolate()->isolate_data()->external_memory_low_since_mark_compact_) {
+    isolate()->isolate_data()->external_memory_low_since_mark_compact_ = amount;
+    isolate()->isolate_data()->external_memory_limit_ =
+        amount + kExternalAllocationSoftLimit;
+  }
 }
 
 void Heap::update_external_memory_concurrently_freed(uintptr_t freed) {
@@ -73,8 +80,8 @@ void Heap::update_external_memory_concurrently_freed(uintptr_t freed) {
 }
 
 void Heap::account_external_memory_concurrently_freed() {
-  isolate()->isolate_data()->external_memory_ -=
-      external_memory_concurrently_freed_;
+  update_external_memory(
+      -static_cast<int64_t>(external_memory_concurrently_freed_));
   external_memory_concurrently_freed_ = 0;
 }
 

--- a/deps/v8/src/heap/heap-inl.h
+++ b/deps/v8/src/heap/heap-inl.h
@@ -615,6 +615,10 @@ void Heap::DecrementExternalBackingStoreBytes(ExternalBackingStoreType type,
   base::CheckedDecrement(&backing_store_bytes_, amount);
 }
 
+bool Heap::HasDirtyJSFinalizationGroups() {
+  return !dirty_js_finalization_groups().IsUndefined(isolate());
+}
+
 AlwaysAllocateScope::AlwaysAllocateScope(Heap* heap) : heap_(heap) {
   heap_->always_allocate_scope_count_++;
 }

--- a/deps/v8/src/heap/heap.cc
+++ b/deps/v8/src/heap/heap.cc
@@ -1452,7 +1452,7 @@ void Heap::ReportExternalMemoryPressure() {
           kGCCallbackFlagSynchronousPhantomCallbackProcessing |
           kGCCallbackFlagCollectAllExternalMemory);
   if (isolate()->isolate_data()->external_memory_ >
-      (isolate()->isolate_data()->external_memory_at_last_mark_compact_ +
+      (isolate()->isolate_data()->external_memory_low_since_mark_compact_ +
        external_memory_hard_limit())) {
     CollectAllGarbage(
         kReduceMemoryFootprintMask,
@@ -2143,7 +2143,7 @@ void Heap::RecomputeLimits(GarbageCollector collector) {
 
   if (collector == MARK_COMPACTOR) {
     // Register the amount of external allocated memory.
-    isolate()->isolate_data()->external_memory_at_last_mark_compact_ =
+    isolate()->isolate_data()->external_memory_low_since_mark_compact_ =
         isolate()->isolate_data()->external_memory_;
     isolate()->isolate_data()->external_memory_limit_ =
         isolate()->isolate_data()->external_memory_ +
@@ -4743,12 +4743,12 @@ size_t Heap::GlobalSizeOfObjects() {
 uint64_t Heap::PromotedExternalMemorySize() {
   IsolateData* isolate_data = isolate()->isolate_data();
   if (isolate_data->external_memory_ <=
-      isolate_data->external_memory_at_last_mark_compact_) {
+      isolate_data->external_memory_low_since_mark_compact_) {
     return 0;
   }
   return static_cast<uint64_t>(
       isolate_data->external_memory_ -
-      isolate_data->external_memory_at_last_mark_compact_);
+      isolate_data->external_memory_low_since_mark_compact_);
 }
 
 bool Heap::AllocationLimitOvershotByLargeMargin() {
@@ -4871,7 +4871,7 @@ Heap::IncrementalMarkingLimit Heap::IncrementalMarkingLimitReached() {
     double gained_since_last_gc =
         PromotedSinceLastGC() +
         (isolate()->isolate_data()->external_memory_ -
-         isolate()->isolate_data()->external_memory_at_last_mark_compact_);
+         isolate()->isolate_data()->external_memory_low_since_mark_compact_);
     double size_before_gc =
         OldGenerationObjectsAndPromotedExternalMemorySize() -
         gained_since_last_gc;

--- a/deps/v8/src/heap/mark-compact.cc
+++ b/deps/v8/src/heap/mark-compact.cc
@@ -2534,6 +2534,9 @@ void MarkCompactCollector::ClearJSWeakRefs() {
       RecordSlot(weak_cell, slot, HeapObject::cast(*slot));
     }
   }
+  if (!isolate()->host_cleanup_finalization_group_callback()) {
+    heap()->PostFinalizationGroupCleanupTaskIfNeeded();
+  }
 }
 
 void MarkCompactCollector::AbortWeakObjects() {

--- a/deps/v8/src/init/bootstrapper.cc
+++ b/deps/v8/src/init/bootstrapper.cc
@@ -1551,9 +1551,10 @@ void Genesis::InitializeGlobal(Handle<JSGlobalObject> global_object,
         isolate_, isolate_->initial_object_prototype(), "toString",
         Builtins::kObjectPrototypeToString, 0, true);
     native_context()->set_object_to_string(*object_to_string);
-    SimpleInstallFunction(isolate_, isolate_->initial_object_prototype(),
-                          "valueOf", Builtins::kObjectPrototypeValueOf, 0,
-                          true);
+    Handle<JSFunction> object_value_of = SimpleInstallFunction(
+        isolate_, isolate_->initial_object_prototype(), "valueOf",
+        Builtins::kObjectPrototypeValueOf, 0, true);
+    native_context()->set_object_value_of_function(*object_value_of);
 
     SimpleInstallGetterSetter(
         isolate_, isolate_->initial_object_prototype(), factory->proto_string(),

--- a/deps/v8/src/inspector/string-util.cc
+++ b/deps/v8/src/inspector/string-util.cc
@@ -129,41 +129,38 @@ namespace {
 // default-constructed StringView instance.
 class EmptyStringBuffer : public StringBuffer {
  public:
-  const StringView& string() override { return string_; }
-
- private:
-  StringView string_;
+  StringView string() const override { return StringView(); }
 };
 
 // Contains LATIN1 text data or CBOR encoded binary data in a vector.
 class StringBuffer8 : public StringBuffer {
  public:
-  explicit StringBuffer8(std::vector<uint8_t> data)
-      : data_(std::move(data)), string_(data_.data(), data_.size()) {}
+  explicit StringBuffer8(std::vector<uint8_t> data) : data_(std::move(data)) {}
 
-  const StringView& string() override { return string_; }
+  StringView string() const override {
+    return StringView(data_.data(), data_.size());
+  }
 
  private:
   std::vector<uint8_t> data_;
-  StringView string_;
 };
 
 // Contains a 16 bit string (String16).
 class StringBuffer16 : public StringBuffer {
  public:
-  explicit StringBuffer16(String16 data)
-      : data_(std::move(data)), string_(data_.characters16(), data_.length()) {}
+  explicit StringBuffer16(String16 data) : data_(std::move(data)) {}
 
-  const StringView& string() override { return string_; }
+  StringView string() const override {
+    return StringView(data_.characters16(), data_.length());
+  }
 
  private:
   String16 data_;
-  StringView string_;
 };
 }  // namespace
 
 // static
-std::unique_ptr<StringBuffer> StringBuffer::create(const StringView& string) {
+std::unique_ptr<StringBuffer> StringBuffer::create(StringView string) {
   if (string.length() == 0) return std::make_unique<EmptyStringBuffer>();
   if (string.is8Bit()) {
     return std::make_unique<StringBuffer8>(std::vector<uint8_t>(

--- a/deps/v8/src/inspector/v8-inspector-impl.cc
+++ b/deps/v8/src/inspector/v8-inspector-impl.cc
@@ -155,8 +155,7 @@ std::unique_ptr<V8StackTrace> V8InspectorImpl::createStackTrace(
 }
 
 std::unique_ptr<V8InspectorSession> V8InspectorImpl::connect(
-    int contextGroupId, V8Inspector::Channel* channel,
-    const StringView& state) {
+    int contextGroupId, V8Inspector::Channel* channel, StringView state) {
   int sessionId = ++m_lastSessionId;
   std::unique_ptr<V8InspectorSessionImpl> session =
       V8InspectorSessionImpl::create(this, contextGroupId, sessionId, channel,
@@ -256,9 +255,9 @@ void V8InspectorImpl::idleStarted() { m_isolate->SetIdle(true); }
 void V8InspectorImpl::idleFinished() { m_isolate->SetIdle(false); }
 
 unsigned V8InspectorImpl::exceptionThrown(
-    v8::Local<v8::Context> context, const StringView& message,
-    v8::Local<v8::Value> exception, const StringView& detailedMessage,
-    const StringView& url, unsigned lineNumber, unsigned columnNumber,
+    v8::Local<v8::Context> context, StringView message,
+    v8::Local<v8::Value> exception, StringView detailedMessage, StringView url,
+    unsigned lineNumber, unsigned columnNumber,
     std::unique_ptr<V8StackTrace> stackTrace, int scriptId) {
   int groupId = contextGroupId(context);
   if (!groupId || m_muteExceptionsMap[groupId]) return 0;
@@ -277,7 +276,7 @@ unsigned V8InspectorImpl::exceptionThrown(
 
 void V8InspectorImpl::exceptionRevoked(v8::Local<v8::Context> context,
                                        unsigned exceptionId,
-                                       const StringView& message) {
+                                       StringView message) {
   int groupId = contextGroupId(context);
   if (!groupId) return;
 
@@ -292,8 +291,7 @@ std::unique_ptr<V8StackTrace> V8InspectorImpl::captureStackTrace(
   return m_debugger->captureStackTrace(fullStack);
 }
 
-V8StackTraceId V8InspectorImpl::storeCurrentStackTrace(
-    const StringView& description) {
+V8StackTraceId V8InspectorImpl::storeCurrentStackTrace(StringView description) {
   return m_debugger->storeCurrentStackTrace(description);
 }
 
@@ -305,7 +303,7 @@ void V8InspectorImpl::externalAsyncTaskFinished(const V8StackTraceId& parent) {
   m_debugger->externalAsyncTaskFinished(parent);
 }
 
-void V8InspectorImpl::asyncTaskScheduled(const StringView& taskName, void* task,
+void V8InspectorImpl::asyncTaskScheduled(StringView taskName, void* task,
                                          bool recurring) {
   if (!task) return;
   m_debugger->asyncTaskScheduled(taskName, task, recurring);

--- a/deps/v8/src/inspector/v8-inspector-impl.h
+++ b/deps/v8/src/inspector/v8-inspector-impl.h
@@ -77,7 +77,7 @@ class V8InspectorImpl : public V8Inspector {
   // V8Inspector implementation.
   std::unique_ptr<V8InspectorSession> connect(int contextGroupId,
                                               V8Inspector::Channel*,
-                                              const StringView& state) override;
+                                              StringView state) override;
   void contextCreated(const V8ContextInfo&) override;
   void contextDestroyed(v8::Local<v8::Context>) override;
   v8::MaybeLocal<v8::Context> contextById(int contextId) override;
@@ -85,25 +85,25 @@ class V8InspectorImpl : public V8Inspector {
   void resetContextGroup(int contextGroupId) override;
   void idleStarted() override;
   void idleFinished() override;
-  unsigned exceptionThrown(v8::Local<v8::Context>, const StringView& message,
+  unsigned exceptionThrown(v8::Local<v8::Context>, StringView message,
                            v8::Local<v8::Value> exception,
-                           const StringView& detailedMessage,
-                           const StringView& url, unsigned lineNumber,
-                           unsigned columnNumber, std::unique_ptr<V8StackTrace>,
+                           StringView detailedMessage, StringView url,
+                           unsigned lineNumber, unsigned columnNumber,
+                           std::unique_ptr<V8StackTrace>,
                            int scriptId) override;
   void exceptionRevoked(v8::Local<v8::Context>, unsigned exceptionId,
-                        const StringView& message) override;
+                        StringView message) override;
   std::unique_ptr<V8StackTrace> createStackTrace(
       v8::Local<v8::StackTrace>) override;
   std::unique_ptr<V8StackTrace> captureStackTrace(bool fullStack) override;
-  void asyncTaskScheduled(const StringView& taskName, void* task,
+  void asyncTaskScheduled(StringView taskName, void* task,
                           bool recurring) override;
   void asyncTaskCanceled(void* task) override;
   void asyncTaskStarted(void* task) override;
   void asyncTaskFinished(void* task) override;
   void allAsyncTasksCanceled() override;
 
-  V8StackTraceId storeCurrentStackTrace(const StringView& description) override;
+  V8StackTraceId storeCurrentStackTrace(StringView description) override;
   void externalAsyncTaskStarted(const V8StackTraceId& parent) override;
   void externalAsyncTaskFinished(const V8StackTraceId& parent) override;
 

--- a/deps/v8/src/inspector/v8-inspector-session-impl.cc
+++ b/deps/v8/src/inspector/v8-inspector-session-impl.cc
@@ -448,7 +448,9 @@ void V8InspectorSessionImpl::setSkipAllPauses(bool skip) {
   m_debuggerAgent->setSkipAllPauses(skip);
 }
 
-void V8InspectorSessionImpl::resume() { m_debuggerAgent->resume(); }
+void V8InspectorSessionImpl::resume(bool terminateOnResume) {
+  m_debuggerAgent->resume();
+}
 
 void V8InspectorSessionImpl::stepOver() { m_debuggerAgent->stepOver(); }
 

--- a/deps/v8/src/inspector/v8-inspector-session-impl.cc
+++ b/deps/v8/src/inspector/v8-inspector-session-impl.cc
@@ -32,12 +32,12 @@ using v8_crdtp::cbor::CheckCBORMessage;
 using v8_crdtp::json::ConvertCBORToJSON;
 using v8_crdtp::json::ConvertJSONToCBOR;
 
-bool IsCBORMessage(const StringView& msg) {
+bool IsCBORMessage(StringView msg) {
   return msg.is8Bit() && msg.length() >= 2 && msg.characters8()[0] == 0xd8 &&
          msg.characters8()[1] == 0x5a;
 }
 
-Status ConvertToCBOR(const StringView& state, std::vector<uint8_t>* cbor) {
+Status ConvertToCBOR(StringView state, std::vector<uint8_t>* cbor) {
   return state.is8Bit()
              ? ConvertJSONToCBOR(
                    span<uint8_t>(state.characters8(), state.length()), cbor)
@@ -45,7 +45,7 @@ Status ConvertToCBOR(const StringView& state, std::vector<uint8_t>* cbor) {
                    span<uint16_t>(state.characters16(), state.length()), cbor);
 }
 
-std::unique_ptr<protocol::DictionaryValue> ParseState(const StringView& state) {
+std::unique_ptr<protocol::DictionaryValue> ParseState(StringView state) {
   std::vector<uint8_t> converted;
   span<uint8_t> cbor;
   if (IsCBORMessage(state))
@@ -62,7 +62,7 @@ std::unique_ptr<protocol::DictionaryValue> ParseState(const StringView& state) {
 }  // namespace
 
 // static
-bool V8InspectorSession::canDispatchMethod(const StringView& method) {
+bool V8InspectorSession::canDispatchMethod(StringView method) {
   return stringViewStartsWith(method,
                               protocol::Runtime::Metainfo::commandPrefix) ||
          stringViewStartsWith(method,
@@ -84,7 +84,7 @@ int V8ContextInfo::executionContextId(v8::Local<v8::Context> context) {
 
 std::unique_ptr<V8InspectorSessionImpl> V8InspectorSessionImpl::create(
     V8InspectorImpl* inspector, int contextGroupId, int sessionId,
-    V8Inspector::Channel* channel, const StringView& state) {
+    V8Inspector::Channel* channel, StringView state) {
   return std::unique_ptr<V8InspectorSessionImpl>(new V8InspectorSessionImpl(
       inspector, contextGroupId, sessionId, channel, state));
 }
@@ -93,7 +93,7 @@ V8InspectorSessionImpl::V8InspectorSessionImpl(V8InspectorImpl* inspector,
                                                int contextGroupId,
                                                int sessionId,
                                                V8Inspector::Channel* channel,
-                                               const StringView& savedState)
+                                               StringView savedState)
     : m_contextGroupId(contextGroupId),
       m_sessionId(sessionId),
       m_inspector(inspector),
@@ -239,7 +239,7 @@ Response V8InspectorSessionImpl::findInjectedScript(
   return findInjectedScript(objectId->contextId(), injectedScript);
 }
 
-void V8InspectorSessionImpl::releaseObjectGroup(const StringView& objectGroup) {
+void V8InspectorSessionImpl::releaseObjectGroup(StringView objectGroup) {
   releaseObjectGroup(toString16(objectGroup));
 }
 
@@ -253,7 +253,7 @@ void V8InspectorSessionImpl::releaseObjectGroup(const String16& objectGroup) {
 }
 
 bool V8InspectorSessionImpl::unwrapObject(
-    std::unique_ptr<StringBuffer>* error, const StringView& objectId,
+    std::unique_ptr<StringBuffer>* error, StringView objectId,
     v8::Local<v8::Value>* object, v8::Local<v8::Context>* context,
     std::unique_ptr<StringBuffer>* objectGroup) {
   String16 objectGroupString;
@@ -288,8 +288,7 @@ Response V8InspectorSessionImpl::unwrapObject(const String16& objectId,
 std::unique_ptr<protocol::Runtime::API::RemoteObject>
 V8InspectorSessionImpl::wrapObject(v8::Local<v8::Context> context,
                                    v8::Local<v8::Value> value,
-                                   const StringView& groupName,
-                                   bool generatePreview) {
+                                   StringView groupName, bool generatePreview) {
   return wrapObject(context, value, toString16(groupName), generatePreview);
 }
 
@@ -336,8 +335,7 @@ void V8InspectorSessionImpl::reportAllContexts(V8RuntimeAgentImpl* agent) {
                               });
 }
 
-void V8InspectorSessionImpl::dispatchProtocolMessage(
-    const StringView& message) {
+void V8InspectorSessionImpl::dispatchProtocolMessage(StringView message) {
   using v8_crdtp::span;
   using v8_crdtp::SpanFrom;
   span<uint8_t> cbor;
@@ -425,7 +423,9 @@ V8InspectorSession::Inspectable* V8InspectorSessionImpl::inspectedObject(
 }
 
 void V8InspectorSessionImpl::schedulePauseOnNextStatement(
-    const StringView& breakReason, const StringView& breakDetails) {
+    StringView breakReason, StringView breakDetails) {
+  std::vector<uint8_t> cbor;
+  ConvertToCBOR(breakDetails, &cbor);
   m_debuggerAgent->schedulePauseOnNextStatement(
       toString16(breakReason),
       protocol::DictionaryValue::cast(
@@ -436,8 +436,8 @@ void V8InspectorSessionImpl::cancelPauseOnNextStatement() {
   m_debuggerAgent->cancelPauseOnNextStatement();
 }
 
-void V8InspectorSessionImpl::breakProgram(const StringView& breakReason,
-                                          const StringView& breakDetails) {
+void V8InspectorSessionImpl::breakProgram(StringView breakReason,
+                                          StringView breakDetails) {
   m_debuggerAgent->breakProgram(
       toString16(breakReason),
       protocol::DictionaryValue::cast(
@@ -453,8 +453,7 @@ void V8InspectorSessionImpl::resume() { m_debuggerAgent->resume(); }
 void V8InspectorSessionImpl::stepOver() { m_debuggerAgent->stepOver(); }
 
 std::vector<std::unique_ptr<protocol::Debugger::API::SearchMatch>>
-V8InspectorSessionImpl::searchInTextByLines(const StringView& text,
-                                            const StringView& query,
+V8InspectorSessionImpl::searchInTextByLines(StringView text, StringView query,
                                             bool caseSensitive, bool isRegex) {
   // TODO(dgozman): search may operate on StringView and avoid copying |text|.
   std::vector<std::unique_ptr<protocol::Debugger::SearchMatch>> matches =
@@ -467,7 +466,7 @@ V8InspectorSessionImpl::searchInTextByLines(const StringView& text,
 }
 
 void V8InspectorSessionImpl::triggerPreciseCoverageDeltaUpdate(
-    const StringView& occassion) {
+    StringView occassion) {
   m_profilerAgent->triggerPreciseCoverageDeltaUpdate(toString16(occassion));
 }
 

--- a/deps/v8/src/inspector/v8-inspector-session-impl.h
+++ b/deps/v8/src/inspector/v8-inspector-session-impl.h
@@ -77,7 +77,7 @@ class V8InspectorSessionImpl : public V8InspectorSession,
   void cancelPauseOnNextStatement() override;
   void breakProgram(StringView breakReason, StringView breakDetails) override;
   void setSkipAllPauses(bool) override;
-  void resume() override;
+  void resume(bool terminateOnResume = false) override;
   void stepOver() override;
   std::vector<std::unique_ptr<protocol::Debugger::API::SearchMatch>>
   searchInTextByLines(StringView text, StringView query, bool caseSensitive,

--- a/deps/v8/src/inspector/v8-inspector-session-impl.h
+++ b/deps/v8/src/inspector/v8-inspector-session-impl.h
@@ -32,9 +32,11 @@ using protocol::Response;
 class V8InspectorSessionImpl : public V8InspectorSession,
                                public protocol::FrontendChannel {
  public:
-  static std::unique_ptr<V8InspectorSessionImpl> create(
-      V8InspectorImpl*, int contextGroupId, int sessionId,
-      V8Inspector::Channel*, const StringView& state);
+  static std::unique_ptr<V8InspectorSessionImpl> create(V8InspectorImpl*,
+                                                        int contextGroupId,
+                                                        int sessionId,
+                                                        V8Inspector::Channel*,
+                                                        StringView state);
   ~V8InspectorSessionImpl() override;
 
   V8InspectorImpl* inspector() const { return m_inspector; }
@@ -64,39 +66,38 @@ class V8InspectorSessionImpl : public V8InspectorSession,
   void releaseObjectGroup(const String16& objectGroup);
 
   // V8InspectorSession implementation.
-  void dispatchProtocolMessage(const StringView& message) override;
+  void dispatchProtocolMessage(StringView message) override;
   std::vector<uint8_t> state() override;
   std::vector<std::unique_ptr<protocol::Schema::API::Domain>> supportedDomains()
       override;
   void addInspectedObject(
       std::unique_ptr<V8InspectorSession::Inspectable>) override;
-  void schedulePauseOnNextStatement(const StringView& breakReason,
-                                    const StringView& breakDetails) override;
+  void schedulePauseOnNextStatement(StringView breakReason,
+                                    StringView breakDetails) override;
   void cancelPauseOnNextStatement() override;
-  void breakProgram(const StringView& breakReason,
-                    const StringView& breakDetails) override;
+  void breakProgram(StringView breakReason, StringView breakDetails) override;
   void setSkipAllPauses(bool) override;
   void resume() override;
   void stepOver() override;
   std::vector<std::unique_ptr<protocol::Debugger::API::SearchMatch>>
-  searchInTextByLines(const StringView& text, const StringView& query,
-                      bool caseSensitive, bool isRegex) override;
-  void releaseObjectGroup(const StringView& objectGroup) override;
-  bool unwrapObject(std::unique_ptr<StringBuffer>*, const StringView& objectId,
+  searchInTextByLines(StringView text, StringView query, bool caseSensitive,
+                      bool isRegex) override;
+  void releaseObjectGroup(StringView objectGroup) override;
+  bool unwrapObject(std::unique_ptr<StringBuffer>*, StringView objectId,
                     v8::Local<v8::Value>*, v8::Local<v8::Context>*,
                     std::unique_ptr<StringBuffer>* objectGroup) override;
   std::unique_ptr<protocol::Runtime::API::RemoteObject> wrapObject(
-      v8::Local<v8::Context>, v8::Local<v8::Value>, const StringView& groupName,
+      v8::Local<v8::Context>, v8::Local<v8::Value>, StringView groupName,
       bool generatePreview) override;
 
   V8InspectorSession::Inspectable* inspectedObject(unsigned num);
   static const unsigned kInspectedObjectBufferSize = 5;
 
-  void triggerPreciseCoverageDeltaUpdate(const StringView& occassion) override;
+  void triggerPreciseCoverageDeltaUpdate(StringView occassion) override;
 
  private:
   V8InspectorSessionImpl(V8InspectorImpl*, int contextGroupId, int sessionId,
-                         V8Inspector::Channel*, const StringView& state);
+                         V8Inspector::Channel*, StringView state);
   protocol::DictionaryValue* agentState(const String16& name);
 
   // protocol::FrontendChannel implementation.

--- a/deps/v8/src/inspector/v8-stack-trace-impl.cc
+++ b/deps/v8/src/inspector/v8-stack-trace-impl.cc
@@ -124,7 +124,7 @@ V8StackTraceId::V8StackTraceId(uintptr_t id,
                                bool should_pause)
     : id(id), debugger_id(debugger_id), should_pause(should_pause) {}
 
-V8StackTraceId::V8StackTraceId(const StringView& json)
+V8StackTraceId::V8StackTraceId(StringView json)
     : id(0), debugger_id(V8DebuggerId().pair()) {
   auto dict =
       protocol::DictionaryValue::cast(protocol::StringUtil::parseJSON(json));

--- a/deps/v8/src/logging/counters.h
+++ b/deps/v8/src/logging/counters.h
@@ -735,6 +735,7 @@ class RuntimeCallTimer final {
   V(ArrayBuffer_Detach)                                    \
   V(ArrayBuffer_New)                                       \
   V(ArrayBuffer_NewBackingStore)                           \
+  V(ArrayBuffer_BackingStore_Reallocate)                   \
   V(Array_CloneElementAt)                                  \
   V(Array_New)                                             \
   V(BigInt64Array_New)                                     \

--- a/deps/v8/src/logging/counters.h
+++ b/deps/v8/src/logging/counters.h
@@ -988,6 +988,7 @@ class RuntimeCallTimer final {
   V(DeoptimizeCode)                            \
   V(DeserializeContext)                        \
   V(DeserializeIsolate)                        \
+  V(FinalizationGroupCleanupFromTask)          \
   V(FunctionCallback)                          \
   V(FunctionLengthGetter)                      \
   V(FunctionPrototypeGetter)                   \

--- a/deps/v8/src/objects/backing-store.h
+++ b/deps/v8/src/objects/backing-store.h
@@ -87,6 +87,9 @@ class V8_EXPORT_PRIVATE BackingStore : public BackingStoreBase {
   bool GrowWasmMemoryInPlace(Isolate* isolate, size_t delta_pages,
                              size_t max_pages);
 
+  // Wrapper around ArrayBuffer::Allocator::Reallocate.
+  bool Reallocate(Isolate* isolate, size_t new_byte_length);
+
   // Allocate a new, larger, backing store for this Wasm memory and copy the
   // contents of this backing store into it.
   std::unique_ptr<BackingStore> CopyWasmMemory(Isolate* isolate,

--- a/deps/v8/src/objects/contexts.h
+++ b/deps/v8/src/objects/contexts.h
@@ -348,6 +348,7 @@ enum ContextLookupFlags {
   V(MAP_SET_INDEX, JSFunction, map_set)                                        \
   V(FUNCTION_HAS_INSTANCE_INDEX, JSFunction, function_has_instance)            \
   V(OBJECT_TO_STRING, JSFunction, object_to_string)                            \
+  V(OBJECT_VALUE_OF_FUNCTION_INDEX, JSFunction, object_value_of_function)      \
   V(PROMISE_ALL_INDEX, JSFunction, promise_all)                                \
   V(PROMISE_CATCH_INDEX, JSFunction, promise_catch)                            \
   V(PROMISE_FUNCTION_INDEX, JSFunction, promise_function)                      \

--- a/deps/v8/src/objects/js-weak-refs.h
+++ b/deps/v8/src/objects/js-weak-refs.h
@@ -6,7 +6,6 @@
 #define V8_OBJECTS_JS_WEAK_REFS_H_
 
 #include "src/objects/js-objects.h"
-#include "src/objects/microtask.h"
 
 // Has to be the last include (doesn't have include guards):
 #include "src/objects/object-macros.h"

--- a/deps/v8/src/profiler/profile-generator.cc
+++ b/deps/v8/src/profiler/profile-generator.cc
@@ -1014,6 +1014,7 @@ CodeEntry* ProfileGenerator::EntryForVMState(StateTag tag) {
     case PARSER:
     case COMPILER:
     case BYTECODE_COMPILER:
+    case ATOMICS_WAIT:
     // DOM events handlers are reported as OTHER / EXTERNAL entries.
     // To avoid confusing people, let's put all these entries into
     // one bucket.

--- a/deps/v8/src/profiler/sampling-heap-profiler.cc
+++ b/deps/v8/src/profiler/sampling-heap-profiler.cc
@@ -178,6 +178,9 @@ SamplingHeapProfiler::AllocationNode* SamplingHeapProfiler::AddStack() {
       case IDLE:
         name = "(IDLE)";
         break;
+      // Treat atomics wait as a normal JS event; we don't care about the
+      // difference for allocations.
+      case ATOMICS_WAIT:
       case JS:
         name = "(JS)";
         break;

--- a/deps/v8/test/cctest/test-api-array-buffer.cc
+++ b/deps/v8/test/cctest/test-api-array-buffer.cc
@@ -761,3 +761,74 @@ TEST(BackingStore_HoldAllocatorAlive_AfterIsolateShutdown) {
   backing_store.reset();
   CHECK(allocator_weak.expired());
 }
+
+TEST(BackingStore_ReallocateExpand) {
+  LocalContext env;
+  v8::Isolate* isolate = env->GetIsolate();
+  std::unique_ptr<v8::BackingStore> backing_store =
+      v8::ArrayBuffer::NewBackingStore(isolate, 10);
+  {
+    uint8_t* data = reinterpret_cast<uint8_t*>(
+        reinterpret_cast<uintptr_t>(backing_store->Data()));
+    for (uint8_t i = 0; i < 10; i++) {
+      data[i] = i;
+    }
+  }
+  std::unique_ptr<v8::BackingStore> new_backing_store =
+      v8::BackingStore::Reallocate(isolate, std::move(backing_store), 20);
+  CHECK_EQ(new_backing_store->ByteLength(), 20);
+  CHECK(!new_backing_store->IsShared());
+  {
+    uint8_t* data = reinterpret_cast<uint8_t*>(
+        reinterpret_cast<uintptr_t>(new_backing_store->Data()));
+    for (uint8_t i = 0; i < 10; i++) {
+      CHECK_EQ(data[i], i);
+    }
+    for (uint8_t i = 10; i < 20; i++) {
+      CHECK_EQ(data[i], 0);
+    }
+  }
+}
+
+TEST(BackingStore_ReallocateShrink) {
+  LocalContext env;
+  v8::Isolate* isolate = env->GetIsolate();
+  std::unique_ptr<v8::BackingStore> backing_store =
+      v8::ArrayBuffer::NewBackingStore(isolate, 20);
+  {
+    uint8_t* data = reinterpret_cast<uint8_t*>(backing_store->Data());
+    for (uint8_t i = 0; i < 20; i++) {
+      data[i] = i;
+    }
+  }
+  std::unique_ptr<v8::BackingStore> new_backing_store =
+      v8::BackingStore::Reallocate(isolate, std::move(backing_store), 10);
+  CHECK_EQ(new_backing_store->ByteLength(), 10);
+  CHECK(!new_backing_store->IsShared());
+  {
+    uint8_t* data = reinterpret_cast<uint8_t*>(new_backing_store->Data());
+    for (uint8_t i = 0; i < 10; i++) {
+      CHECK_EQ(data[i], i);
+    }
+  }
+}
+
+TEST(BackingStore_ReallocateNotShared) {
+  LocalContext env;
+  v8::Isolate* isolate = env->GetIsolate();
+  std::unique_ptr<v8::BackingStore> backing_store =
+      v8::ArrayBuffer::NewBackingStore(isolate, 20);
+  std::unique_ptr<v8::BackingStore> new_backing_store =
+      v8::BackingStore::Reallocate(isolate, std::move(backing_store), 10);
+  CHECK(!new_backing_store->IsShared());
+}
+
+TEST(BackingStore_ReallocateShared) {
+  LocalContext env;
+  v8::Isolate* isolate = env->GetIsolate();
+  std::unique_ptr<v8::BackingStore> backing_store =
+      v8::SharedArrayBuffer::NewBackingStore(isolate, 20);
+  std::unique_ptr<v8::BackingStore> new_backing_store =
+      v8::BackingStore::Reallocate(isolate, std::move(backing_store), 10);
+  CHECK(new_backing_store->IsShared());
+}

--- a/deps/v8/test/cctest/test-api.cc
+++ b/deps/v8/test/cctest/test-api.cc
@@ -19911,7 +19911,7 @@ TEST(RunMicrotasksIgnoresThrownExceptionsFromApi) {
     CHECK(!isolate->IsExecutionTerminating());
     isolate->EnqueueMicrotask(ThrowExceptionMicrotask);
     isolate->EnqueueMicrotask(IncrementCounterMicrotask);
-    isolate->RunMicrotasks();
+    isolate->PerformMicrotaskCheckpoint();
     CHECK_EQ(1, microtask_callback_count);
     CHECK(!try_catch.HasCaught());
   }
@@ -19953,7 +19953,7 @@ TEST(SetAutorunMicrotasks) {
   CHECK_EQ(0, CompileRun("ext2Calls")->Int32Value(env.local()).FromJust());
   CHECK_EQ(1u, microtasks_completed_callback_count);
 
-  env->GetIsolate()->RunMicrotasks();
+  env->GetIsolate()->PerformMicrotaskCheckpoint();
   CHECK_EQ(2, CompileRun("ext1Calls")->Int32Value(env.local()).FromJust());
   CHECK_EQ(1, CompileRun("ext2Calls")->Int32Value(env.local()).FromJust());
   CHECK_EQ(2u, microtasks_completed_callback_count);
@@ -19965,7 +19965,7 @@ TEST(SetAutorunMicrotasks) {
   CHECK_EQ(1, CompileRun("ext2Calls")->Int32Value(env.local()).FromJust());
   CHECK_EQ(2u, microtasks_completed_callback_count);
 
-  env->GetIsolate()->RunMicrotasks();
+  env->GetIsolate()->PerformMicrotaskCheckpoint();
   CHECK_EQ(2, CompileRun("ext1Calls")->Int32Value(env.local()).FromJust());
   CHECK_EQ(2, CompileRun("ext2Calls")->Int32Value(env.local()).FromJust());
   CHECK_EQ(3u, microtasks_completed_callback_count);
@@ -20015,7 +20015,7 @@ TEST(RunMicrotasksWithoutEnteringContext) {
     isolate->EnqueueMicrotask(
         Function::New(context, MicrotaskOne).ToLocalChecked());
   }
-  isolate->RunMicrotasks();
+  isolate->PerformMicrotaskCheckpoint();
   {
     Context::Scope context_scope(context);
     CHECK_EQ(1, CompileRun("ext1Calls")->Int32Value(context).FromJust());
@@ -20039,7 +20039,7 @@ static void Regress808911_CurrentContextWrapper(
   CHECK(isolate->GetCurrentContext() !=
         isolate->GetEnteredOrMicrotaskContext());
   isolate->EnqueueMicrotask(Regress808911_MicrotaskCallback, isolate);
-  isolate->RunMicrotasks();
+  isolate->PerformMicrotaskCheckpoint();
 }
 
 THREADED_TEST(Regress808911) {
@@ -22507,7 +22507,7 @@ TEST(PromiseThen) {
                   .ToLocalChecked()
                   ->Int32Value(context.local())
                   .FromJust());
-  isolate->RunMicrotasks();
+  isolate->PerformMicrotaskCheckpoint();
   CHECK_EQ(1, global->Get(context.local(), v8_str("x1"))
                   .ToLocalChecked()
                   ->Int32Value(context.local())
@@ -22533,7 +22533,7 @@ TEST(PromiseThen) {
                   .ToLocalChecked()
                   ->Int32Value(context.local())
                   .FromJust());
-  isolate->RunMicrotasks();
+  isolate->PerformMicrotaskCheckpoint();
   CHECK_EQ(0, global->Get(context.local(), v8_str("x1"))
                   .ToLocalChecked()
                   ->Int32Value(context.local())
@@ -22553,7 +22553,7 @@ TEST(PromiseThen) {
                   .ToLocalChecked()
                   ->Int32Value(context.local())
                   .FromJust());
-  isolate->RunMicrotasks();
+  isolate->PerformMicrotaskCheckpoint();
   CHECK_EQ(3, global->Get(context.local(), v8_str("x1"))
                   .ToLocalChecked()
                   ->Int32Value(context.local())
@@ -22602,7 +22602,7 @@ TEST(PromiseThen2) {
                   .ToLocalChecked()
                   ->Int32Value(context.local())
                   .FromJust());
-  isolate->RunMicrotasks();
+  isolate->PerformMicrotaskCheckpoint();
   CHECK_EQ(1, global->Get(context.local(), v8_str("x1"))
                   .ToLocalChecked()
                   ->Int32Value(context.local())
@@ -22613,7 +22613,7 @@ TEST(PromiseThen2) {
                   .FromJust());
 
   Local<v8::Promise> b = a->Then(context.local(), f3, f2).ToLocalChecked();
-  isolate->RunMicrotasks();
+  isolate->PerformMicrotaskCheckpoint();
   CHECK_EQ(1, global->Get(context.local(), v8_str("x1"))
                   .ToLocalChecked()
                   ->Int32Value(context.local())
@@ -22624,7 +22624,7 @@ TEST(PromiseThen2) {
                   .FromJust());
 
   Local<v8::Promise> c = b->Then(context.local(), f1, f2).ToLocalChecked();
-  isolate->RunMicrotasks();
+  isolate->PerformMicrotaskCheckpoint();
   CHECK_EQ(1, global->Get(context.local(), v8_str("x1"))
                   .ToLocalChecked()
                   ->Int32Value(context.local())
@@ -22635,7 +22635,7 @@ TEST(PromiseThen2) {
                     .FromJust());
 
   v8::Local<v8::Promise> d = c->Then(context.local(), f1, f2).ToLocalChecked();
-  isolate->RunMicrotasks();
+  isolate->PerformMicrotaskCheckpoint();
   CHECK_EQ(103, global->Get(context.local(), v8_str("x1"))
                     .ToLocalChecked()
                     ->Int32Value(context.local())
@@ -22646,7 +22646,7 @@ TEST(PromiseThen2) {
                     .FromJust());
 
   v8::Local<v8::Promise> e = d->Then(context.local(), f3, f2).ToLocalChecked();
-  isolate->RunMicrotasks();
+  isolate->PerformMicrotaskCheckpoint();
   CHECK_EQ(103, global->Get(context.local(), v8_str("x1"))
                     .ToLocalChecked()
                     ->Int32Value(context.local())
@@ -22657,7 +22657,7 @@ TEST(PromiseThen2) {
                     .FromJust());
 
   v8::Local<v8::Promise> f = e->Then(context.local(), f1, f3).ToLocalChecked();
-  isolate->RunMicrotasks();
+  isolate->PerformMicrotaskCheckpoint();
   CHECK_EQ(103, global->Get(context.local(), v8_str("x1"))
                     .ToLocalChecked()
                     ->Int32Value(context.local())
@@ -22668,7 +22668,7 @@ TEST(PromiseThen2) {
                     .FromJust());
 
   f->Then(context.local(), f1, f2).ToLocalChecked();
-  isolate->RunMicrotasks();
+  isolate->PerformMicrotaskCheckpoint();
   CHECK_EQ(103, global->Get(context.local(), v8_str("x1"))
                     .ToLocalChecked()
                     ->Int32Value(context.local())
@@ -25735,7 +25735,7 @@ TEST(DynamicImport) {
   i::MaybeHandle<i::JSPromise> maybe_promise =
       i_isolate->RunHostImportModuleDynamicallyCallback(referrer, specifier);
   i::Handle<i::JSPromise> promise = maybe_promise.ToHandleChecked();
-  isolate->RunMicrotasks();
+  isolate->PerformMicrotaskCheckpoint();
   CHECK(result->Equals(i::String::cast(promise->result())));
 }
 
@@ -26435,7 +26435,7 @@ TEST(MicrotaskContextShouldBeNativeContext) {
       "  await 42;"
       "})().then(callback);}");
 
-  isolate->RunMicrotasks();
+  isolate->PerformMicrotaskCheckpoint();
 }
 
 TEST(PreviewSetKeysIteratorEntriesWithDeleted) {

--- a/deps/v8/test/cctest/test-api.cc
+++ b/deps/v8/test/cctest/test-api.cc
@@ -25979,6 +25979,8 @@ void AtomicsWaitCallbackForTesting(
   CHECK_EQ(timeout_in_ms, info->expected_timeout);
   CHECK_EQ(value, info->expected_value);
   CHECK_EQ(offset_in_bytes, info->expected_offset);
+  CHECK_EQ(v8::StateTag::ATOMICS_WAIT,
+           reinterpret_cast<i::Isolate*>(info->isolate)->current_vm_state());
 
   auto ThrowSomething = [&]() {
     info->isolate->ThrowException(v8::Integer::New(info->isolate, 42));

--- a/deps/v8/test/cctest/test-modules.cc
+++ b/deps/v8/test/cctest/test-modules.cc
@@ -830,7 +830,7 @@ TEST(ModuleEvaluationTopLevelAwaitDynamicImport) {
     CHECK_EQ(promise->State(), v8::Promise::kPending);
     CHECK(!try_catch.HasCaught());
 
-    isolate->RunMicrotasks();
+    isolate->PerformMicrotaskCheckpoint();
     CHECK_EQ(promise->State(), v8::Promise::kFulfilled);
   }
   i::FLAG_harmony_top_level_await = previous_top_level_await_flag_value;
@@ -874,7 +874,7 @@ TEST(ModuleEvaluationTopLevelAwaitDynamicImportError) {
     CHECK_EQ(promise->State(), v8::Promise::kPending);
     CHECK(!try_catch.HasCaught());
 
-    isolate->RunMicrotasks();
+    isolate->PerformMicrotaskCheckpoint();
     CHECK_EQ(Module::kErrored, module->GetStatus());
     CHECK_EQ(promise->State(), v8::Promise::kRejected);
     CHECK(promise->Result()->StrictEquals(v8_str("boom")));

--- a/deps/v8/test/cctest/test-thread-termination.cc
+++ b/deps/v8/test/cctest/test-thread-termination.cc
@@ -492,10 +492,11 @@ TEST(TerminateFromOtherThreadWhileMicrotaskRunning) {
   isolate->EnqueueMicrotask(
       v8::Function::New(isolate->GetCurrentContext(), MicrotaskShouldNotRun)
           .ToLocalChecked());
-  isolate->RunMicrotasks();
+  isolate->PerformMicrotaskCheckpoint();
 
   isolate->CancelTerminateExecution();
-  isolate->RunMicrotasks();  // should not run MicrotaskShouldNotRun
+  // Should not run MicrotaskShouldNotRun.
+  isolate->PerformMicrotaskCheckpoint();
 
   thread.Join();
   delete semaphore;
@@ -913,7 +914,7 @@ TEST(TerminateInMicrotask) {
       CHECK(context2 == isolate->GetCurrentContext());
       CHECK(context2 == isolate->GetEnteredOrMicrotaskContext());
       CHECK(!isolate->IsExecutionTerminating());
-      isolate->RunMicrotasks();
+      isolate->PerformMicrotaskCheckpoint();
       CHECK(context2 == isolate->GetCurrentContext());
       CHECK(context2 == isolate->GetEnteredOrMicrotaskContext());
       CHECK(try_catch.HasCaught());
@@ -948,7 +949,7 @@ TEST(TerminateInApiMicrotask) {
     CHECK(!isolate->IsExecutionTerminating());
     isolate->EnqueueMicrotask(TerminationMicrotask);
     isolate->EnqueueMicrotask(UnreachableMicrotask);
-    isolate->RunMicrotasks();
+    isolate->PerformMicrotaskCheckpoint();
     CHECK(try_catch.HasCaught());
     CHECK(try_catch.HasTerminated());
     CHECK(isolate->IsExecutionTerminating());

--- a/deps/v8/test/fuzzer/wasm-async.cc
+++ b/deps/v8/test/fuzzer/wasm-async.cc
@@ -78,7 +78,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   // Wait for the promise to resolve.
   while (!done) {
     support->PumpMessageLoop(platform::MessageLoopBehavior::kWaitForWork);
-    isolate->RunMicrotasks();
+    isolate->PerformMicrotaskCheckpoint();
   }
   return 0;
 }

--- a/deps/v8/test/fuzzer/wasm.cc
+++ b/deps/v8/test/fuzzer/wasm.cc
@@ -69,6 +69,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
 
   // Pump the message loop and run micro tasks, e.g. GC finalization tasks.
   support->PumpMessageLoop(v8::platform::MessageLoopBehavior::kDoNotWait);
-  isolate->RunMicrotasks();
+  isolate->PerformMicrotaskCheckpoint();
   return 0;
 }

--- a/deps/v8/test/inspector/isolate-data.cc
+++ b/deps/v8/test/inspector/isolate-data.cc
@@ -461,13 +461,14 @@ namespace {
 class StringBufferImpl : public v8_inspector::StringBuffer {
  public:
   StringBufferImpl(v8::Isolate* isolate, v8::Local<v8::String> string)
-      : data_(ToVector(isolate, string)),
-        view_(data_.begin(), data_.length()) {}
-  const v8_inspector::StringView& string() override { return view_; }
+      : data_(ToVector(isolate, string)) {}
+
+  v8_inspector::StringView string() const override {
+    return v8_inspector::StringView(data_.begin(), data_.length());
+  }
 
  private:
   v8::internal::Vector<uint16_t> data_;
-  v8_inspector::StringView view_;
 };
 }  // anonymous namespace
 

--- a/deps/v8/test/message/weakref-finalizationgroup-error.js
+++ b/deps/v8/test/message/weakref-finalizationgroup-error.js
@@ -1,0 +1,26 @@
+// Copyright 2020 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-weak-refs --expose-gc --noincremental-marking
+// Flags: --no-stress-opt
+
+// Since cleanup tasks are top-level tasks, errors thrown from them don't stop
+// future cleanup tasks from running.
+
+function callback(iter) {
+  [...iter];
+  throw new Error('callback');
+};
+
+const fg1 = new FinalizationGroup(callback);
+const fg2 = new FinalizationGroup(callback);
+
+(function() {
+let x = {};
+fg1.register(x, {});
+fg2.register(x, {});
+x = null;
+})();
+
+gc();

--- a/deps/v8/test/message/weakref-finalizationgroup-error.out
+++ b/deps/v8/test/message/weakref-finalizationgroup-error.out
@@ -1,0 +1,12 @@
+*%(basename)s:{NUMBER}: Error: callback
+  throw new Error('callback');
+  ^
+Error: callback
+    at callback (*%(basename)s:{NUMBER}:{NUMBER})
+
+*%(basename)s:{NUMBER}: Error: callback
+  throw new Error('callback');
+  ^
+Error: callback
+    at callback (*%(basename)s:{NUMBER}:{NUMBER})
+

--- a/deps/v8/test/mjsunit/harmony/weakrefs/cleanup-on-detached-realm.js
+++ b/deps/v8/test/mjsunit/harmony/weakrefs/cleanup-on-detached-realm.js
@@ -9,15 +9,28 @@ let r = Realm.create();
 let FG = Realm.eval(r, "FinalizationGroup");
 Realm.detachGlobal(r);
 
+let fg_not_run = new FG(() => {
+  assertUnreachable();
+});
+(() => {
+  fg_not_run.register({});
+})();
+
+gc();
+
+// Disposing the realm cancels the already scheduled fg_not_run's finalizer.
+Realm.dispose(r);
+
 let fg = new FG(()=> {
   cleanedUp = true;
 });
 
+// FGs that are alive after disposal can still schedule tasks.
 (() => {
   let object = {};
   fg.register(object, {});
 
-  // object goes out of scope.
+  // object becomes unreachable.
 })();
 
 gc();

--- a/deps/v8/test/mjsunit/harmony/weakrefs/reentrant-task-abort-from-cleanup.js
+++ b/deps/v8/test/mjsunit/harmony/weakrefs/reentrant-task-abort-from-cleanup.js
@@ -1,0 +1,25 @@
+// Copyright 2020 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-weak-refs --expose-gc --noincremental-marking
+
+let call_count = 0;
+let reentrant_gc =
+    function(iter) {
+  [...iter];
+  gc();
+  call_count++;
+}
+
+let fg = new FinalizationGroup(reentrant_gc);
+
+(function() {
+fg.register({}, 42);
+})();
+
+gc();
+
+setTimeout(function() {
+  assertEquals(1, call_count);
+}, 0);

--- a/test/addons/addon.status
+++ b/test/addons/addon.status
@@ -9,6 +9,7 @@ prefix addons
 [$arch==arm]
 # https://github.com/nodejs/node/issues/30786
 openssl-binding/test: PASS,FLAKY
+zlib-binding/test: PASS,FLAKY
 
 [$system==ibmi]
 openssl-binding/test: SKIP


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/32831#issuecomment-613249664

@targos @mmarchini @BethGriggs @nodejs/v8 

Contains a number of cherry-picks, and some superficial changes to the API, to ensure ABI compatibility of v14.x with the current V8 master branch.

There are two larger changes here, one that affects how microtasks are run and one that affects how `FinalizationGroup`s are handled. The cherry-picks for those applied cleanly, and I don’t see any reason not to backport them. However, I think that once master picks them up, we will want to clean up our code a bit as a follow-up. If that makes somebody uncomfortable, I would suggest also cherry-picking those changes to master for parity.

Also, `make test-v8` and V8 CI still don’t work, but I’ve manually applied these patches here on the V8 tag that our code is based on and successfully ran the tests locally on my V8 clone.