### PR TITLE
stream: inline unbuffered _write

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -364,7 +364,12 @@ function writeOrBuffer(stream, state, chunk, encoding, cb) {
     }
     state.bufferedRequestCount += 1;
   } else {
-    doWrite(stream, state, false, len, chunk, encoding, cb);
+    state.writelen = len;
+    state.writecb = cb;
+    state.writing = true;
+    state.sync = true;
+    stream._write(chunk, encoding, state.onwrite);
+    state.sync = false;
   }
 
   // Return false if errored or destroyed in order to break


### PR DESCRIPTION
A ~15% improvement for the sync case

```
 streams/writable-manywrites.js callback='no' writev='no' sync='no' n=2000000                    1.68 %       ±5.45% ±7.25%  ±9.45%
 streams/writable-manywrites.js callback='no' writev='no' sync='yes' n=2000000          ***     15.98 %       ±3.86% ±5.14%  ±6.69%
 streams/writable-manywrites.js callback='no' writev='yes' sync='no' n=2000000                   0.28 %       ±5.36% ±7.14%  ±9.30%
 streams/writable-manywrites.js callback='no' writev='yes' sync='yes' n=2000000                  0.89 %       ±4.58% ±6.09%  ±7.92%
 streams/writable-manywrites.js callback='yes' writev='no' sync='no' n=2000000                  -1.19 %       ±4.94% ±6.58%  ±8.56%
 streams/writable-manywrites.js callback='yes' writev='no' sync='yes' n=2000000         ***     19.24 %       ±4.17% ±5.55%  ±7.23%
 streams/writable-manywrites.js callback='yes' writev='yes' sync='no' n=2000000                 -1.97 %       ±5.91% ±7.87% ±10.24%
 streams/writable-manywrites.js callback='yes' writev='yes' sync='yes' n=2000000                -0.03 %       ±4.68% ±6.22%  ±8.10%
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
