### PR TITLE
src: fix null deref in AllocatedBuffer::clear

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -1013,7 +1013,10 @@ inline AllocatedBuffer::~AllocatedBuffer() {
 
 inline void AllocatedBuffer::clear() {
   uv_buf_t buf = release();
-  env_->Free(buf.base, buf.len);
+  if (buf.base != nullptr) {
+    CHECK_NOT_NULL(env_);
+    env_->Free(buf.base, buf.len);
+  }
 }
 
 // It's a bit awkward to define this Buffer::New() overload here, but it


### PR DESCRIPTION
An empty buffer can have a null environment.  Previously, we were
getting away with with this, but -fsanitize=null in clang caught it.

Cherry-pick of https://github.com/nodejs/node/pull/32892 to
v12.x branch.

Ref: https://github.com/nodejs/node/pull/32892

##### Checklist

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines]