### PR TITLE
stream: some simplification

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -185,6 +185,15 @@ function WritableState(options, stream, isDuplex) {
   this.corkedRequestsFree = corkReq;
 }
 
+ObjectDefineProperties(WritableState.prototype, {
+  // Backwards compat.
+  writing: {
+    get() {
+      return !!this.writecb;
+    }
+  }
+});
+
 WritableState.prototype.getBuffer = function getBuffer() {
   let current = this.bufferedRequest;
   const out = [];

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -185,15 +185,6 @@ function WritableState(options, stream, isDuplex) {
   this.corkedRequestsFree = corkReq;
 }
 
-ObjectDefineProperties(WritableState.prototype, {
-  // Backwards compat.
-  writing: {
-    get() {
-      return !!this.writecb;
-    }
-  }
-});
-
 WritableState.prototype.getBuffer = function getBuffer() {
   let current = this.bufferedRequest;
   const out = [];

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -120,9 +120,6 @@ function WritableState(options, stream, isDuplex) {
   // socket or file.
   this.length = 0;
 
-  // A flag to see when we're in the middle of a write.
-  this.writing = false;
-
   // When true all writes will be buffered until .uncork() call
   this.corked = 0;
 
@@ -187,6 +184,14 @@ function WritableState(options, stream, isDuplex) {
   corkReq.finish = onCorkedFinish.bind(undefined, corkReq, this);
   this.corkedRequestsFree = corkReq;
 }
+
+ObjectDefineProperties(WritableState.prototype, {
+  writing: {
+    get() {
+      return !!this.writecb;
+    }
+  }
+});
 
 WritableState.prototype.getBuffer = function getBuffer() {
   let current = this.bufferedRequest;
@@ -318,7 +323,7 @@ Writable.prototype.uncork = function() {
   if (state.corked) {
     state.corked--;
 
-    if (!state.writing &&
+    if (!state.writecb &&
         !state.corked &&
         !state.bufferProcessing &&
         state.bufferedRequest)
@@ -349,7 +354,7 @@ function writeOrBuffer(stream, state, chunk, encoding, cb) {
   if (!ret)
     state.needDrain = true;
 
-  if (state.writing || state.corked || state.errored) {
+  if (state.writecb || state.corked || state.errored) {
     const last = state.lastBufferedRequest;
     state.lastBufferedRequest = {
       chunk,
@@ -375,7 +380,6 @@ function writeOrBuffer(stream, state, chunk, encoding, cb) {
 function doWrite(stream, state, writev, len, chunk, encoding, cb) {
   state.writelen = len;
   state.writecb = cb;
-  state.writing = true;
   state.sync = true;
   if (state.destroyed)
     state.onwrite(new ERR_STREAM_DESTROYED('write'));
@@ -409,7 +413,6 @@ function onwrite(stream, er) {
     return;
   }
 
-  state.writing = false;
   state.writecb = null;
   state.length -= state.writelen;
   state.writelen = 0;
@@ -484,7 +487,7 @@ function afterWrite(stream, state, count, cb) {
 
 // If there's something in the buffer waiting, then invoke callbacks.
 function errorBuffer(state, err) {
-  if (state.writing || !state.bufferedRequest) {
+  if (state.writecb || !state.bufferedRequest) {
     return;
   }
 
@@ -551,7 +554,7 @@ function clearBuffer(stream, state) {
       // it means that we need to wait until it does.
       // also, that means that the chunk and cb are currently
       // being processed, so move the buffer counter past them.
-      if (state.writing) {
+      if (state.writecb) {
         break;
       }
     }
@@ -621,7 +624,7 @@ function needFinish(state) {
           !state.errored &&
           state.bufferedRequest === null &&
           !state.finished &&
-          !state.writing);
+          !state.writecb);
 }
 
 function callFinal(stream, state) {

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -186,6 +186,7 @@ function WritableState(options, stream, isDuplex) {
 }
 
 ObjectDefineProperties(WritableState.prototype, {
+  // Backwards compat.
   writing: {
     get() {
       return !!this.writecb;
@@ -323,11 +324,7 @@ Writable.prototype.uncork = function() {
   if (state.corked) {
     state.corked--;
 
-    if (!state.writecb &&
-        !state.corked &&
-        !state.bufferProcessing &&
-        state.bufferedRequest)
-      clearBuffer(this, state);
+    clearBuffer(this, state);
   }
 };
 
@@ -432,13 +429,7 @@ function onwrite(stream, er) {
       onwriteError(stream, state, er, cb);
     }
   } else {
-    // Check if we're actually ready to finish, but don't emit yet
-    const finished = needFinish(state) || stream.destroyed;
-
-    if (!finished &&
-        !state.corked &&
-        !state.bufferProcessing &&
-        state.bufferedRequest) {
+    if (state.bufferedRequest) {
       clearBuffer(stream, state);
     }
 
@@ -503,6 +494,13 @@ function errorBuffer(state, err) {
 
 // If there's something in the buffer waiting, then process it
 function clearBuffer(stream, state) {
+  if (state.writecb ||
+      state.corked ||
+      state.bufferProcessing ||
+      !state.bufferedRequest) {
+    return;
+  }
+
   state.bufferProcessing = true;
   let entry = state.bufferedRequest;
 


### PR DESCRIPTION
~7% improvement

NOTE: Contains 2 commits to reduce the number of PRs.

```js
 streams/writable-manywrites.js callback='no' writev='no' sync='no' n=2000000                    6.27 %       ±6.47%  ±8.63% ±11.26%
 streams/writable-manywrites.js callback='no' writev='no' sync='yes' n=2000000            *      8.43 %       ±6.68%  ±8.90% ±11.59%
 streams/writable-manywrites.js callback='no' writev='yes' sync='no' n=2000000                   7.77 %       ±7.88% ±10.49% ±13.69%
 streams/writable-manywrites.js callback='no' writev='yes' sync='yes' n=2000000           *      6.79 %       ±5.75%  ±7.65%  ±9.96%
 streams/writable-manywrites.js callback='yes' writev='no' sync='no' n=2000000          ***     11.31 %       ±6.08%  ±8.11% ±10.60%
 streams/writable-manywrites.js callback='yes' writev='no' sync='yes' n=2000000          **      7.76 %       ±5.46%  ±7.27%  ±9.46%
 streams/writable-manywrites.js callback='yes' writev='yes' sync='no' n=2000000                  6.12 %       ±7.40%  ±9.85% ±12.82%
 streams/writable-manywrites.js callback='yes' writev='yes' sync='yes' n=2000000         **      8.11 %       ±4.90%  ±6.52%  ±8.48%
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
