### PR TITLE
tools: remove unused code in doc generation tool

### DIFF
--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -313,23 +313,11 @@ function versionSort(a, b) {
 
 function buildToc({ filename, apilinks }) {
   return (tree, file) => {
-    const startIncludeRefRE = /^\s*<!-- \[start-include:(.+)\] -->\s*$/;
-    const endIncludeRefRE = /^\s*<!-- \[end-include:.+\] -->\s*$/;
-    const realFilenames = [filename];
     const idCounters = Object.create(null);
     let toc = '';
     let depth = 0;
 
     visit(tree, null, (node) => {
-      // Keep track of the current filename for comment wrappers of inclusions.
-      if (node.type === 'html') {
-        const [, includedFileName] = node.value.match(startIncludeRefRE) || [];
-        if (includedFileName !== undefined)
-          realFilenames.unshift(includedFileName);
-        else if (endIncludeRefRE.test(node.value))
-          realFilenames.shift();
-      }
-
       if (node.type !== 'heading') return;
 
       if (node.depth - depth > 1) {
@@ -339,7 +327,7 @@ function buildToc({ filename, apilinks }) {
       }
 
       depth = node.depth;
-      const realFilename = path.basename(realFilenames[0], '.md');
+      const realFilename = path.basename(filename, '.md');
       const headingText = file.contents.slice(
         node.children[0].position.start.offset,
         node.position.end.offset).trim();


### PR DESCRIPTION
tools/doc/html.js includes code that looks for comments with
`start-include` and `end-include` for file inclusion. This seems to be
legacy code that is no longer used. The code only appears in the
table-of-contents generation function. The strings `start-include` and
`end-include` appear nowhere else in our tools and nowhere at all in our
docs.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
