### PR TITLE
modules: partial doc removal of --experimental-modules

### DIFF
--- a/doc/node.1
+++ b/doc/node.1
@@ -132,9 +132,6 @@ Specify the
 .Ar module
 to use as a custom module loader.
 .
-.It Fl -experimental-modules
-Enable experimental latest experimental modules features.
-.
 .It Fl -experimental-policy
 Use the specified file as a security policy.
 .

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -285,7 +285,7 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             kAllowedInEnvironment);
   AddAlias("--loader", "--experimental-loader");
   AddOption("--experimental-modules",
-            "experimental modules features",
+            "",
             &EnvironmentOptions::experimental_modules,
             kAllowedInEnvironment);
   AddOption("--experimental-wasm-modules",


### PR DESCRIPTION
This removes `--experimental-modules` from showing up in `node -h`
and also removes the documentation from the man pages.

It will still work as a no-op, and is still included in cli.md

Refs: https://github.com/nodejs/modules/issues/502
