### PR TITLE
tls: move getAllowUnauthorized to internal/options

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -70,7 +70,10 @@ const {
   ERR_TLS_INVALID_STATE
 } = codes;
 const { onpskexchange: kOnPskExchange } = internalBinding('symbols');
-const { getOptionValue } = require('internal/options');
+const {
+  getOptionValue,
+  getAllowUnauthorized,
+} = require('internal/options');
 const {
   validateString,
   validateBuffer,
@@ -1533,22 +1536,12 @@ function onConnectEnd() {
   }
 }
 
-let warnOnAllowUnauthorized = true;
-
 // Arguments: [port,] [host,] [options,] [cb]
 exports.connect = function connect(...args) {
   args = normalizeConnectArgs(args);
   let options = args[0];
   const cb = args[1];
-  const allowUnauthorized = process.env.NODE_TLS_REJECT_UNAUTHORIZED === '0';
-
-  if (allowUnauthorized && warnOnAllowUnauthorized) {
-    warnOnAllowUnauthorized = false;
-    process.emitWarning('Setting the NODE_TLS_REJECT_UNAUTHORIZED ' +
-                        'environment variable to \'0\' makes TLS connections ' +
-                        'and HTTPS requests insecure by disabling ' +
-                        'certificate verification.');
-  }
+  const allowUnauthorized = getAllowUnauthorized();
 
   options = {
     rejectUnauthorized: !allowUnauthorized,

--- a/lib/internal/options.js
+++ b/lib/internal/options.js
@@ -3,6 +3,8 @@
 const { getOptions } = internalBinding('options');
 const { options, aliases } = getOptions();
 
+let warnOnAllowUnauthorized = true;
+
 function getOptionValue(option) {
   const result = options.get(option);
   if (!result) {
@@ -11,8 +13,23 @@ function getOptionValue(option) {
   return result.value;
 }
 
+function getAllowUnauthorized() {
+  const allowUnauthorized = process.env.NODE_TLS_REJECT_UNAUTHORIZED === '0';
+
+  if (allowUnauthorized && warnOnAllowUnauthorized) {
+    warnOnAllowUnauthorized = false;
+    process.emitWarning(
+      'Setting the NODE_TLS_REJECT_UNAUTHORIZED ' +
+      'environment variable to \'0\' makes TLS connections ' +
+      'and HTTPS requests insecure by disabling ' +
+      'certificate verification.');
+  }
+  return allowUnauthorized;
+}
+
 module.exports = {
   options,
   aliases,
-  getOptionValue
+  getOptionValue,
+  getAllowUnauthorized,
 };


### PR DESCRIPTION
Make it so that the allow unauthorized warning can be easily reused
by the QUIC impl once that lands.

Extracted from the QUIC PR: https://github.com/nodejs/node/pull/32379

Signed-off-by: James M Snell <jasnell@gmail.com>

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
