### PR TITLE
lib: update validators with allowUndefined option

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -184,10 +184,11 @@ function ClientRequest(input, options, cb) {
     method = this.method = 'GET';
   }
 
-  const maxHeaderSize = options.maxHeaderSize;
-  if (maxHeaderSize !== undefined)
-    validateInteger(maxHeaderSize, 'maxHeaderSize', 0);
-  this.maxHeaderSize = maxHeaderSize;
+  validateInteger(
+    options.maxHeaderSize,
+    'maxHeaderSize',
+    { min: 0, allowUndefined: true });
+  this.maxHeaderSize = options.maxHeaderSize;
 
   const insecureHTTPParser = options.insecureHTTPParser;
   if (insecureHTTPParser !== undefined &&

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -330,10 +330,11 @@ function Server(options, requestListener) {
   this[kIncomingMessage] = options.IncomingMessage || IncomingMessage;
   this[kServerResponse] = options.ServerResponse || ServerResponse;
 
-  const maxHeaderSize = options.maxHeaderSize;
-  if (maxHeaderSize !== undefined)
-    validateInteger(maxHeaderSize, 'maxHeaderSize', 0);
-  this.maxHeaderSize = maxHeaderSize;
+  validateInteger(
+    options.maxHeaderSize,
+    'maxHeaderSize',
+    { min: 0, allowUndefined: true });
+  this.maxHeaderSize = options.maxHeaderSize;
 
   const insecureHTTPParser = options.insecureHTTPParser;
   if (insecureHTTPParser !== undefined &&

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -861,8 +861,7 @@ TLSSocket.prototype.renegotiate = function(options, callback) {
 TLSSocket.prototype.exportKeyingMaterial = function(length, label, context) {
   validateUint32(length, 'length', true);
   validateString(label, 'label');
-  if (context !== undefined)
-    validateBuffer(context, 'context');
+  validateBuffer(context, 'context', { allowUndefined: true });
 
   if (!this._secureEstablished)
     throw new ERR_TLS_INVALID_STATE();

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1227,8 +1227,8 @@ function chmodSync(path, mode) {
 function lchown(path, uid, gid, callback) {
   callback = makeCallback(callback);
   path = getValidatedPath(path);
-  validateInteger(uid, 'uid', -1, kMaxUserId);
-  validateInteger(gid, 'gid', -1, kMaxUserId);
+  validateInteger(uid, 'uid', { min: -1, max: kMaxUserId });
+  validateInteger(gid, 'gid', { min: -1, max: kMaxUserId });
   const req = new FSReqCallback();
   req.oncomplete = callback;
   binding.lchown(pathModule.toNamespacedPath(path), uid, gid, req);
@@ -1236,8 +1236,8 @@ function lchown(path, uid, gid, callback) {
 
 function lchownSync(path, uid, gid) {
   path = getValidatedPath(path);
-  validateInteger(uid, 'uid', -1, kMaxUserId);
-  validateInteger(gid, 'gid', -1, kMaxUserId);
+  validateInteger(uid, 'uid', { min: -1, max: kMaxUserId });
+  validateInteger(gid, 'gid', { min: -1, max: kMaxUserId });
   const ctx = { path };
   binding.lchown(pathModule.toNamespacedPath(path), uid, gid, undefined, ctx);
   handleErrorFromBinding(ctx);
@@ -1245,8 +1245,8 @@ function lchownSync(path, uid, gid) {
 
 function fchown(fd, uid, gid, callback) {
   validateInt32(fd, 'fd', 0);
-  validateInteger(uid, 'uid', -1, kMaxUserId);
-  validateInteger(gid, 'gid', -1, kMaxUserId);
+  validateInteger(uid, 'uid', { min: -1, max: kMaxUserId });
+  validateInteger(gid, 'gid', { min: -1, max: kMaxUserId });
 
   const req = new FSReqCallback();
   req.oncomplete = makeCallback(callback);
@@ -1255,8 +1255,8 @@ function fchown(fd, uid, gid, callback) {
 
 function fchownSync(fd, uid, gid) {
   validateInt32(fd, 'fd', 0);
-  validateInteger(uid, 'uid', -1, kMaxUserId);
-  validateInteger(gid, 'gid', -1, kMaxUserId);
+  validateInteger(uid, 'uid', { min: -1, max: kMaxUserId });
+  validateInteger(gid, 'gid', { min: -1, max: kMaxUserId });
 
   const ctx = {};
   binding.fchown(fd, uid, gid, undefined, ctx);
@@ -1266,8 +1266,8 @@ function fchownSync(fd, uid, gid) {
 function chown(path, uid, gid, callback) {
   callback = makeCallback(callback);
   path = getValidatedPath(path);
-  validateInteger(uid, 'uid', -1, kMaxUserId);
-  validateInteger(gid, 'gid', -1, kMaxUserId);
+  validateInteger(uid, 'uid', { min: -1, max: kMaxUserId });
+  validateInteger(gid, 'gid', { min: -1, max: kMaxUserId });
 
   const req = new FSReqCallback();
   req.oncomplete = callback;
@@ -1276,8 +1276,8 @@ function chown(path, uid, gid, callback) {
 
 function chownSync(path, uid, gid) {
   path = getValidatedPath(path);
-  validateInteger(uid, 'uid', -1, kMaxUserId);
-  validateInteger(gid, 'gid', -1, kMaxUserId);
+  validateInteger(uid, 'uid', { min: -1, max: kMaxUserId });
+  validateInteger(gid, 'gid', { min: -1, max: kMaxUserId });
   const ctx = { path };
   binding.chown(pathModule.toNamespacedPath(path), uid, gid, undefined, ctx);
   handleErrorFromBinding(ctx);

--- a/lib/internal/crypto/scrypt.js
+++ b/lib/internal/crypto/scrypt.js
@@ -108,7 +108,7 @@ function check(password, salt, keylen, options) {
     }
     if (options.maxmem !== undefined) {
       maxmem = options.maxmem;
-      validateInteger(maxmem, 'maxmem', 0);
+      validateInteger(maxmem, 'maxmem', { min: 0 });
     }
     if (N === 0) N = defaults.N;
     if (r === 0) r = defaults.r;

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -2,9 +2,11 @@
 
 const {
   ArrayIsArray,
+  NumberINFINITY,
   NumberIsInteger,
   NumberMAX_SAFE_INTEGER,
   NumberMIN_SAFE_INTEGER,
+  NumberNEGATIVE_INFINITY,
 } = primordials;
 
 const {
@@ -71,7 +73,12 @@ function parseFileMode(value, name, def) {
 }
 
 const validateInteger = hideStackFrames(
-  (value, name, min = NumberMIN_SAFE_INTEGER, max = NumberMAX_SAFE_INTEGER) => {
+  (value, name,
+   { min = NumberMIN_SAFE_INTEGER,
+     max = NumberMAX_SAFE_INTEGER,
+     allowUndefined = false } = {}) => {
+    if (allowUndefined && value === undefined)
+      return;
     if (typeof value !== 'number')
       throw new ERR_INVALID_ARG_TYPE(name, 'number', value);
     if (!NumberIsInteger(value))
@@ -116,23 +123,35 @@ const validateUint32 = hideStackFrames((value, name, positive) => {
   }
 });
 
-function validateString(value, name) {
+function validateString(value, name, { allowUndefined = false } = {}) {
+  if (allowUndefined && value === undefined)
+    return;
   if (typeof value !== 'string')
     throw new ERR_INVALID_ARG_TYPE(name, 'string', value);
 }
 
-function validateNumber(value, name) {
+function validateNumber(
+  value,
+  name,
+  { min = NumberNEGATIVE_INFINITY,
+    max = NumberINFINITY } = {}) {
   if (typeof value !== 'number')
     throw new ERR_INVALID_ARG_TYPE(name, 'number', value);
+  if (value < min || value > max)
+    throw new ERR_OUT_OF_RANGE(name, `>= ${min} && <= ${max}`, value);
 }
 
-function validateBoolean(value, name) {
+function validateBoolean(value, name, { allowUndefined = false } = {}) {
+  if (allowUndefined && value === undefined)
+    return;
   if (typeof value !== 'boolean')
     throw new ERR_INVALID_ARG_TYPE(name, 'boolean', value);
 }
 
 const validateObject = hideStackFrames(
-  (value, name, { nullable = false } = {}) => {
+  (value, name, { nullable = false, allowUndefined = false } = {}) => {
+    if (allowUndefined && value === undefined)
+      return;
     if ((!nullable && value === null) ||
         ArrayIsArray(value) ||
         typeof value !== 'object') {
@@ -164,7 +183,10 @@ function validateSignalName(signal, name = 'signal') {
   }
 }
 
-const validateBuffer = hideStackFrames((buffer, name = 'buffer') => {
+const validateBuffer = hideStackFrames((
+  buffer, name = 'buffer', { allowUndefined = false } = {}) => {
+  if (allowUndefined && buffer === undefined)
+    return;
   if (!isArrayBufferView(buffer)) {
     throw new ERR_INVALID_ARG_TYPE(name,
                                    ['Buffer', 'TypedArray', 'DataView'],

--- a/lib/path.js
+++ b/lib/path.js
@@ -666,8 +666,7 @@ const win32 = {
   },
 
   basename(path, ext) {
-    if (ext !== undefined)
-      validateString(ext, 'ext');
+    validateString(ext, 'ext', { allowUndefined: true });
     validateString(path, 'path');
     let start = 0;
     let end = -1;
@@ -1151,8 +1150,7 @@ const posix = {
   },
 
   basename(path, ext) {
-    if (ext !== undefined)
-      validateString(ext, 'ext');
+    validateString(ext, 'ext', { allowUndefined: true });
     validateString(path, 'path');
 
     let start = 0;

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -189,18 +189,26 @@ function getContextOptions(options) {
     origin: options.contextOrigin,
     codeGeneration: undefined,
   };
-  if (contextOptions.name !== undefined)
-    validateString(contextOptions.name, 'options.contextName');
-  if (contextOptions.origin !== undefined)
-    validateString(contextOptions.origin, 'options.contextOrigin');
+  validateString(
+    contextOptions.name,
+    'options.contextName',
+    { allowUndefined: true });
+  validateString(
+    contextOptions.origin,
+    'options.contextOrigin',
+    { allowUndefined: true });
   if (options.contextCodeGeneration !== undefined) {
     validateObject(options.contextCodeGeneration,
                    'options.contextCodeGeneration');
     const { strings, wasm } = options.contextCodeGeneration;
-    if (strings !== undefined)
-      validateBoolean(strings, 'options.contextCodeGeneration.strings');
-    if (wasm !== undefined)
-      validateBoolean(wasm, 'options.contextCodeGeneration.wasm');
+    validateBoolean(
+      strings,
+      'options.contextCodeGeneration.strings',
+      { allowUndefined: true });
+    validateBoolean(
+      wasm,
+      'options.contextCodeGeneration.wasm',
+      { allowUndefined: true });
     contextOptions.codeGeneration = { strings, wasm };
   }
   return contextOptions;
@@ -228,10 +236,11 @@ function createContext(contextObject = {}, options = {}) {
   } = options;
 
   validateString(name, 'options.name');
-  if (origin !== undefined)
-    validateString(origin, 'options.origin');
-  if (codeGeneration !== undefined)
-    validateObject(codeGeneration, 'options.codeGeneration');
+  validateString(origin, 'options.origin', { allowUndefined: true });
+  validateObject(
+    codeGeneration,
+    'options.codeGeneration',
+    { allowUndefined: true });
 
   let strings = true;
   let wasm = true;
@@ -318,8 +327,7 @@ function compileFunction(code, params, options = {}) {
   validateString(filename, 'options.filename');
   validateUint32(columnOffset, 'options.columnOffset');
   validateUint32(lineOffset, 'options.lineOffset');
-  if (cachedData !== undefined)
-    validateBuffer(cachedData, 'options.cachedData');
+  validateBuffer(cachedData, 'options.cachedData', { allowUndefined: true });
   validateBoolean(produceCachedData, 'options.produceCachedData');
   if (parsingContext !== undefined) {
     if (

--- a/test/parallel/test-validators.js
+++ b/test/parallel/test-validators.js
@@ -70,7 +70,9 @@ const invalidArgValueError = {
   validateString(undefined, 'foo', { allowUndefined: true });
 
   [1, NaN, null, undefined, {}, []].forEach((i) => {
-    assert.throws(() => validateString(i, 'foo'));
+    assert.throws(() => validateString(i, 'foo'), {
+      code: 'ERR_INVALID_ARG_TYPE'
+    });
   });
 }
 

--- a/test/parallel/test-validators.js
+++ b/test/parallel/test-validators.js
@@ -7,6 +7,8 @@ const {
   validateArray,
   validateBoolean,
   validateInteger,
+  validateNumber,
+  validateString,
   validateObject,
 } = require('internal/validators');
 const { MAX_SAFE_INTEGER, MIN_SAFE_INTEGER } = Number;
@@ -37,8 +39,39 @@ const invalidArgValueError = {
   }, outOfRangeError);
 
   // validateInteger() works with unsafe integers.
-  validateInteger(MAX_SAFE_INTEGER + 1, 'foo', 0, MAX_SAFE_INTEGER + 1);
-  validateInteger(MIN_SAFE_INTEGER - 1, 'foo', MIN_SAFE_INTEGER - 1);
+  validateInteger(
+    MAX_SAFE_INTEGER + 1,
+    'foo',
+    { min: 0, max: MAX_SAFE_INTEGER + 1 });
+  validateInteger(
+    MIN_SAFE_INTEGER - 1,
+    'foo',
+    { min: MIN_SAFE_INTEGER - 1 });
+  validateInteger(undefined, 'foo', { allowUndefined: true });
+}
+
+{
+  // validateNumber tests
+  validateNumber(1, 'foo');
+  validateNumber(1.1, 'foo');
+  validateNumber(1, 'foo', { min: 0 });
+  validateNumber(2, 'foo', { max: 2 });
+
+  ['test', true, {}, [], null].forEach((i) => {
+    assert.throws(() => validateNumber(i, 'foo'), invalidArgTypeError);
+  });
+  assert.throws(() => validateNumber(1, 'foo', { min: 2 }), outOfRangeError);
+  assert.throws(() => validateNumber(2, 'foo', { max: 1 }), outOfRangeError);
+}
+
+{
+  // validateString tests
+  validateString('test', 'foo');
+  validateString(undefined, 'foo', { allowUndefined: true });
+
+  [1, NaN, null, undefined, {}, []].forEach((i) => {
+    assert.throws(() => validateString(i, 'foo'));
+  });
 }
 
 {
@@ -63,6 +96,7 @@ const invalidArgValueError = {
   // validateBoolean tests.
   validateBoolean(true, 'foo');
   validateBoolean(false, 'foo');
+  validateBoolean(undefined, 'foo', { allowUndefined: true });
 
   [undefined, null, 0, 0.0, 42, '', 'string', {}, []].forEach((val) => {
     assert.throws(() => {
@@ -75,6 +109,7 @@ const invalidArgValueError = {
   // validateObject tests.
   validateObject({}, 'foo');
   validateObject({ a: 42, b: 'foo' }, 'foo');
+  validateObject(undefined, 'foo', { allowUndefined: true });
 
   [undefined, null, true, false, 0, 0.0, 42, '', 'string', []]
     .forEach((val) => {


### PR DESCRIPTION
Extracted from the [QUIC PR](https://github.com/nodejs/node/pull/32379). Add allowUndefined as an option for multiple validators.

Signed-off-by: James M Snell <jasnell@gmail.com>

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
