### PR TITLE
src: fix empty-named env var assertion failure

### DIFF
--- a/src/node_env_var.cc
+++ b/src/node_env_var.cc
@@ -227,7 +227,7 @@ void MapKVStore::Set(Isolate* isolate, Local<String> key, Local<String> value) {
   Mutex::ScopedLock lock(mutex_);
   Utf8Value key_str(isolate, key);
   Utf8Value value_str(isolate, value);
-  if (*key_str != nullptr && *value_str != nullptr) {
+  if (*key_str != nullptr && key_str.length() > 0 && *value_str != nullptr) {
     map_[std::string(*key_str, key_str.length())] =
         std::string(*value_str, value_str.length());
   }

--- a/src/node_env_var.cc
+++ b/src/node_env_var.cc
@@ -121,7 +121,7 @@ void RealEnvStore::Set(Isolate* isolate,
   node::Utf8Value val(isolate, value);
 
 #ifdef _WIN32
-  if (key[0] == L'=') return;
+  if (key.length() > 0 && key[0] == L'=') return;
 #endif
   uv_os_setenv(*key, *val);
   DateTimeConfigurationChangeNotification(isolate, key);

--- a/src/node_env_var.cc
+++ b/src/node_env_var.cc
@@ -121,7 +121,7 @@ void RealEnvStore::Set(Isolate* isolate,
   node::Utf8Value val(isolate, value);
 
 #ifdef _WIN32
-  if (key.length() > 0 && key[0] == L'=') return;
+  if (key[0] == L'=') return;
 #endif
   uv_os_setenv(*key, *val);
   DateTimeConfigurationChangeNotification(isolate, key);

--- a/src/node_env_var.cc
+++ b/src/node_env_var.cc
@@ -121,7 +121,7 @@ void RealEnvStore::Set(Isolate* isolate,
   node::Utf8Value val(isolate, value);
 
 #ifdef _WIN32
-  if (key[0] == L'=') return;
+  if (key[0] == '=') return;
 #endif
   uv_os_setenv(*key, *val);
   DateTimeConfigurationChangeNotification(isolate, key);
@@ -139,7 +139,7 @@ int32_t RealEnvStore::Query(const char* key) const {
   }
 
 #ifdef _WIN32
-  if (key[0] == L'=') {
+  if (key[0] == '=') {
     return static_cast<int32_t>(v8::ReadOnly) |
            static_cast<int32_t>(v8::DontDelete) |
            static_cast<int32_t>(v8::DontEnum);

--- a/src/node_env_var.cc
+++ b/src/node_env_var.cc
@@ -121,7 +121,7 @@ void RealEnvStore::Set(Isolate* isolate,
   node::Utf8Value val(isolate, value);
 
 #ifdef _WIN32
-  if (key[0] == '=') return;
+  if (key.length() > 0 && key[0] == '=') return;
 #endif
   uv_os_setenv(*key, *val);
   DateTimeConfigurationChangeNotification(isolate, key);

--- a/src/util.h
+++ b/src/util.h
@@ -351,12 +351,12 @@ class MaybeStackBuffer {
   }
 
   T& operator[](size_t index) {
-    CHECK_LT(index, length() + 1);
+    CHECK_LT(index, length());
     return buf_[index];
   }
 
   const T& operator[](size_t index) const {
-    CHECK_LT(index, length() + 1);
+    CHECK_LT(index, length());
     return buf_[index];
   }
 

--- a/src/util.h
+++ b/src/util.h
@@ -351,12 +351,12 @@ class MaybeStackBuffer {
   }
 
   T& operator[](size_t index) {
-    CHECK_LT(index, length());
+    CHECK_LT(index, length() + 1);
     return buf_[index];
   }
 
   const T& operator[](size_t index) const {
-    CHECK_LT(index, length());
+    CHECK_LT(index, length() + 1);
     return buf_[index];
   }
 

--- a/test/parallel/test-process-env.js
+++ b/test/parallel/test-process-env.js
@@ -106,3 +106,11 @@ if (common.isWindows) {
   const keys = Object.keys(process.env);
   assert.ok(keys.length > 0);
 }
+
+// Setting environment variables on Windows with empty names should not cause
+// an assertion failure.
+// https://github.com/nodejs/node/issues/32920
+{
+  process.env[''] = '';
+  assert.strictEqual(process.env[''], undefined);
+}


### PR DESCRIPTION
Setting an environment variable with an empty name on Windows resulted in an assertion failure, because it was checked for an '=' sign at the beginning without verifying the length was greater than 0.

Fixes: https://github.com/nodejs/node/issues/32920
Refs: https://github.com/nodejs/node/pull/27310

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

