### PR TITLE
build: fix inability to detect correct python command in configure

### DIFF
--- a/configure
+++ b/configure
@@ -5,11 +5,11 @@
 # as is the fact that the ] goes on a new line.
 _=[ 'exec' '/bin/sh' '-c' '''
 test ${FORCE_PYTHON2} && exec python2 "$0" "$@"  # workaround for gclient
-which python3.8 >/dev/null && exec python3.8 "$0" "$@"
-which python3.7 >/dev/null && exec python3.7 "$0" "$@"
-which python3.6 >/dev/null && exec python3.6 "$0" "$@"
-which python3.5 >/dev/null && exec python3.5 "$0" "$@"
-which python2.7 >/dev/null && exec python2.7 "$0" "$@"
+command -v python3.8 >/dev/null && exec python3.8 "$0" "$@"
+command -v python3.7 >/dev/null && exec python3.7 "$0" "$@"
+command -v python3.6 >/dev/null && exec python3.6 "$0" "$@"
+command -v python3.5 >/dev/null && exec python3.5 "$0" "$@"
+command -v python2.7 >/dev/null && exec python2.7 "$0" "$@"
 exec python "$0" "$@"
 ''' "$0" "$@"
 ]


### PR DESCRIPTION
The "which" utility is not guaranteed to be installed, and if it is, its behavior is not portable.

Conversely, the "command -v" shell builtin is required to exist in all POSIX 2008 compliant shells, and is thus guaranteed to work everywhere.

Examples of open-source shells likely to be installed as /bin/sh on Linux, which implement the 12-year-old standard: ash, bash, busybox, dash, ksh, mksh and zsh.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)