### PR TITLE
n-api: fix false assumption on napi_async_context structures

### DIFF
--- a/test/node-api/test_callback_scope/test.js
+++ b/test/node-api/test_callback_scope/test.js
@@ -4,14 +4,14 @@ const common = require('../../common');
 const assert = require('assert');
 const { runInCallbackScope } = require(`./build/${common.buildType}/binding`);
 
-assert.strictEqual(runInCallbackScope({}, 0, 0, () => 42), 42);
+assert.strictEqual(runInCallbackScope({}, 'test-resource', () => 42), 42);
 
 {
   process.once('uncaughtException', common.mustCall((err) => {
     assert.strictEqual(err.message, 'foo');
   }));
 
-  runInCallbackScope({}, 0, 0, () => {
+  runInCallbackScope({}, 'test-resource', () => {
     throw new Error('foo');
   });
 }


### PR DESCRIPTION
napi_async_context should be an opaque type and not be used as same as
node::async_context.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
