### PR TITLE
v8: use AliasedBuffers for passing heap statistics around

### DIFF
--- a/lib/v8.js
+++ b/lib/v8.js
@@ -95,7 +95,6 @@ const {
 
   // Properties for heap spaces statistics buffer extraction.
   kHeapSpaces,
-  kHeapSpaceStatisticsPropertiesCount,
   kSpaceSizeIndex,
   kSpaceUsedSizeIndex,
   kSpaceAvailableSizeIndex,

--- a/lib/v8.js
+++ b/lib/v8.js
@@ -73,12 +73,12 @@ class Deserializer extends _Deserializer { }
 const {
   cachedDataVersionTag,
   setFlagsFromString: _setFlagsFromString,
-  heapStatisticsArrayBuffer,
-  heapSpaceStatisticsArrayBuffer,
-  heapCodeStatisticsArrayBuffer,
-  updateHeapStatisticsArrayBuffer,
-  updateHeapSpaceStatisticsArrayBuffer,
-  updateHeapCodeStatisticsArrayBuffer,
+  heapStatisticsBuffer,
+  heapSpaceStatisticsBuffer,
+  heapCodeStatisticsBuffer,
+  updateHeapStatisticsBuffer,
+  updateHeapSpaceStatisticsBuffer,
+  updateHeapCodeStatisticsBuffer,
 
   // Properties for heap statistics buffer extraction.
   kTotalHeapSizeIndex,
@@ -109,15 +109,6 @@ const {
 
 const kNumberOfHeapSpaces = kHeapSpaces.length;
 
-const heapStatisticsBuffer =
-    new Float64Array(heapStatisticsArrayBuffer);
-
-const heapSpaceStatisticsBuffer =
-    new Float64Array(heapSpaceStatisticsArrayBuffer);
-
-const heapCodeStatisticsBuffer =
-    new Float64Array(heapCodeStatisticsArrayBuffer);
-
 function setFlagsFromString(flags) {
   validateString(flags, 'flags');
   _setFlagsFromString(flags);
@@ -126,7 +117,7 @@ function setFlagsFromString(flags) {
 function getHeapStatistics() {
   const buffer = heapStatisticsBuffer;
 
-  updateHeapStatisticsArrayBuffer();
+  updateHeapStatisticsBuffer();
 
   return {
     'total_heap_size': buffer[kTotalHeapSizeIndex],
@@ -146,16 +137,15 @@ function getHeapStatistics() {
 function getHeapSpaceStatistics() {
   const heapSpaceStatistics = new Array(kNumberOfHeapSpaces);
   const buffer = heapSpaceStatisticsBuffer;
-  updateHeapSpaceStatisticsArrayBuffer();
 
   for (let i = 0; i < kNumberOfHeapSpaces; i++) {
-    const propertyOffset = i * kHeapSpaceStatisticsPropertiesCount;
+    updateHeapSpaceStatisticsBuffer(i);
     heapSpaceStatistics[i] = {
       space_name: kHeapSpaces[i],
-      space_size: buffer[propertyOffset + kSpaceSizeIndex],
-      space_used_size: buffer[propertyOffset + kSpaceUsedSizeIndex],
-      space_available_size: buffer[propertyOffset + kSpaceAvailableSizeIndex],
-      physical_space_size: buffer[propertyOffset + kPhysicalSpaceSizeIndex]
+      space_size: buffer[kSpaceSizeIndex],
+      space_used_size: buffer[kSpaceUsedSizeIndex],
+      space_available_size: buffer[kSpaceAvailableSizeIndex],
+      physical_space_size: buffer[kPhysicalSpaceSizeIndex]
     };
   }
 
@@ -165,7 +155,7 @@ function getHeapSpaceStatistics() {
 function getHeapCodeStatistics() {
   const buffer = heapCodeStatisticsBuffer;
 
-  updateHeapCodeStatisticsArrayBuffer();
+  updateHeapCodeStatisticsBuffer();
   return {
     'code_and_metadata_size': buffer[kCodeAndMetadataSizeIndex],
     'bytecode_and_metadata_size': buffer[kBytecodeAndMetadataSizeIndex],

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -30,7 +30,6 @@ namespace node {
 
 using v8::Array;
 using v8::ArrayBuffer;
-using v8::BackingStore;
 using v8::Context;
 using v8::FunctionCallbackInfo;
 using v8::HeapCodeStatistics;
@@ -78,13 +77,29 @@ static constexpr size_t kHeapSpaceStatisticsPropertiesCount =
     HEAP_SPACE_STATISTICS_PROPERTIES(V);
 #undef V
 
+#define HEAP_CODE_STATISTICS_PROPERTIES(V)                                     \
+  V(0, code_and_metadata_size, kCodeAndMetadataSizeIndex)                      \
+  V(1, bytecode_and_metadata_size, kBytecodeAndMetadataSizeIndex)              \
+  V(2, external_script_source_size, kExternalScriptSourceSizeIndex)
+
+#define V(a, b, c) +1
+static const size_t kHeapCodeStatisticsPropertiesCount =
+    HEAP_CODE_STATISTICS_PROPERTIES(V);
+#undef V
+
 class BindingData : public BaseObject {
  public:
-  BindingData(Environment* env, Local<Object> obj) : BaseObject(env, obj) {}
+  BindingData(Environment* env, Local<Object> obj)
+      : BaseObject(env, obj),
+        heap_statistics_buffer(env->isolate(), kHeapStatisticsPropertiesCount),
+        heap_space_statistics_buffer(env->isolate(),
+                                     kHeapSpaceStatisticsPropertiesCount),
+        heap_code_statistics_buffer(env->isolate(),
+                                    kHeapCodeStatisticsPropertiesCount) {}
 
-  std::shared_ptr<BackingStore> heap_statistics_buffer;
-  std::shared_ptr<BackingStore> heap_space_statistics_buffer;
-  std::shared_ptr<BackingStore> heap_code_statistics_buffer;
+  AliasedFloat64Array heap_statistics_buffer;
+  AliasedFloat64Array heap_space_statistics_buffer;
+  AliasedFloat64Array heap_code_statistics_buffer;
 
   void MemoryInfo(MemoryTracker* tracker) const override {
     tracker->TrackField("heap_statistics_buffer", heap_statistics_buffer);
@@ -97,15 +112,6 @@ class BindingData : public BaseObject {
   SET_MEMORY_INFO_NAME(BindingData)
 };
 
-#define HEAP_CODE_STATISTICS_PROPERTIES(V)                                    \
-  V(0, code_and_metadata_size, kCodeAndMetadataSizeIndex)                    \
-  V(1, bytecode_and_metadata_size, kBytecodeAndMetadataSizeIndex)             \
-  V(2, external_script_source_size, kExternalScriptSourceSizeIndex)
-
-#define V(a, b, c) +1
-static const size_t kHeapCodeStatisticsPropertiesCount =
-    HEAP_CODE_STATISTICS_PROPERTIES(V);
-#undef V
 
 void CachedDataVersionTag(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
@@ -115,13 +121,11 @@ void CachedDataVersionTag(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(result);
 }
 
-
-void UpdateHeapStatisticsArrayBuffer(const FunctionCallbackInfo<Value>& args) {
+void UpdateHeapStatisticsBuffer(const FunctionCallbackInfo<Value>& args) {
   BindingData* data = Unwrap<BindingData>(args.Data());
   HeapStatistics s;
   args.GetIsolate()->GetHeapStatistics(&s);
-  double* const buffer =
-      static_cast<double*>(data->heap_statistics_buffer->Data());
+  AliasedFloat64Array& buffer = data->heap_statistics_buffer;
 #define V(index, name, _) buffer[index] = static_cast<double>(s.name());
   HEAP_STATISTICS_PROPERTIES(V)
 #undef V
@@ -132,29 +136,23 @@ void UpdateHeapSpaceStatisticsBuffer(const FunctionCallbackInfo<Value>& args) {
   BindingData* data = Unwrap<BindingData>(args.Data());
   HeapSpaceStatistics s;
   Isolate* const isolate = args.GetIsolate();
-  size_t number_of_heap_spaces = isolate->NumberOfHeapSpaces();
+  CHECK(args[0]->IsUint32());
+  size_t space_index = static_cast<size_t>(args[0].As<v8::Uint32>()->Value());
+  isolate->GetHeapSpaceStatistics(&s, space_index);
 
-  double* const buffer =
-      static_cast<double*>(data->heap_space_statistics_buffer->Data());
+  AliasedFloat64Array& buffer = data->heap_space_statistics_buffer;
 
-  for (size_t i = 0; i < number_of_heap_spaces; i++) {
-    isolate->GetHeapSpaceStatistics(&s, i);
-    size_t const property_offset = i * kHeapSpaceStatisticsPropertiesCount;
-#define V(index, name, _)                                            \
-      buffer[property_offset + index] = static_cast<double>(s.name());
-    HEAP_SPACE_STATISTICS_PROPERTIES(V)
+#define V(index, name, _) buffer[index] = static_cast<double>(s.name());
+  HEAP_SPACE_STATISTICS_PROPERTIES(V)
 #undef V
-  }
 }
 
-
-void UpdateHeapCodeStatisticsArrayBuffer(
-    const FunctionCallbackInfo<Value>& args) {
+void UpdateHeapCodeStatisticsBuffer(const FunctionCallbackInfo<Value>& args) {
   BindingData* data = Unwrap<BindingData>(args.Data());
   HeapCodeStatistics s;
   args.GetIsolate()->GetHeapCodeAndMetadataStatistics(&s);
-  double* const buffer =
-      static_cast<double*>(data->heap_code_statistics_buffer->Data());
+  AliasedFloat64Array& buffer = data->heap_code_statistics_buffer;
+
 #define V(index, name, _) buffer[index] = static_cast<double>(s.name());
   HEAP_CODE_STATISTICS_PROPERTIES(V)
 #undef V
@@ -181,20 +179,14 @@ void Initialize(Local<Object> target,
                              CachedDataVersionTag);
 
   // Export symbols used by v8.getHeapStatistics()
-  env->SetMethod(target,
-                 "updateHeapStatisticsArrayBuffer",
-                 UpdateHeapStatisticsArrayBuffer);
+  env->SetMethod(
+      target, "updateHeapStatisticsBuffer", UpdateHeapStatisticsBuffer);
 
-  const size_t heap_statistics_buffer_byte_length =
-      sizeof(double) * kHeapStatisticsPropertiesCount;
-
-  Local<ArrayBuffer> heap_statistics_ab =
-      ArrayBuffer::New(env->isolate(), heap_statistics_buffer_byte_length);
-  binding_data->heap_statistics_buffer = heap_statistics_ab->GetBackingStore();
-  target->Set(env->context(),
-              FIXED_ONE_BYTE_STRING(env->isolate(),
-                                    "heapStatisticsArrayBuffer"),
-              heap_statistics_ab).Check();
+  target
+      ->Set(env->context(),
+            FIXED_ONE_BYTE_STRING(env->isolate(), "heapStatisticsBuffer"),
+            binding_data->heap_statistics_buffer.GetJSArray())
+      .Check();
 
 #define V(i, _, name)                                                         \
   target->Set(env->context(),                                                 \
@@ -205,22 +197,14 @@ void Initialize(Local<Object> target,
 #undef V
 
   // Export symbols used by v8.getHeapCodeStatistics()
-  env->SetMethod(target,
-                 "updateHeapCodeStatisticsArrayBuffer",
-                 UpdateHeapCodeStatisticsArrayBuffer);
+  env->SetMethod(
+      target, "updateHeapCodeStatisticsBuffer", UpdateHeapCodeStatisticsBuffer);
 
-  const size_t heap_code_statistics_buffer_byte_length =
-      sizeof(double) * kHeapCodeStatisticsPropertiesCount;
-
-  Local<ArrayBuffer> heap_code_statistics_ab =
-      ArrayBuffer::New(env->isolate(),
-                       heap_code_statistics_buffer_byte_length);
-  binding_data->heap_code_statistics_buffer =
-      heap_code_statistics_ab->GetBackingStore();
-  target->Set(env->context(),
-              FIXED_ONE_BYTE_STRING(env->isolate(),
-                                    "heapCodeStatisticsArrayBuffer"),
-              heap_code_statistics_ab).Check();
+  target
+      ->Set(env->context(),
+            FIXED_ONE_BYTE_STRING(env->isolate(), "heapCodeStatisticsBuffer"),
+            binding_data->heap_code_statistics_buffer.GetJSArray())
+      .Check();
 
 #define V(i, _, name)                                                         \
   target->Set(env->context(),                                                 \
@@ -258,24 +242,15 @@ void Initialize(Local<Object> target,
                          number_of_heap_spaces)).Check();
 
   env->SetMethod(target,
-                 "updateHeapSpaceStatisticsArrayBuffer",
+                 "updateHeapSpaceStatisticsBuffer",
                  UpdateHeapSpaceStatisticsBuffer);
 
-  const size_t heap_space_statistics_buffer_byte_length =
-      sizeof(double) *
-      kHeapSpaceStatisticsPropertiesCount *
-      number_of_heap_spaces;
-
-  Local<ArrayBuffer> heap_space_statistics_ab =
-      ArrayBuffer::New(env->isolate(),
-                       heap_space_statistics_buffer_byte_length);
-  binding_data->heap_space_statistics_buffer =
-      heap_space_statistics_ab->GetBackingStore();
-
-  target->Set(env->context(),
-              FIXED_ONE_BYTE_STRING(env->isolate(),
-                                    "heapSpaceStatisticsArrayBuffer"),
-              heap_space_statistics_ab).Check();
+  target
+      ->Set(env->context(),
+            FIXED_ONE_BYTE_STRING(env->isolate(),
+                                  "heapSpaceStatisticsBuffer"),
+            binding_data->heap_space_statistics_buffer.GetJSArray())
+      .Check();
 
 #define V(i, _, name)                                                         \
   target->Set(env->context(),                                                 \

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -29,7 +29,6 @@
 namespace node {
 
 using v8::Array;
-using v8::ArrayBuffer;
 using v8::Context;
 using v8::FunctionCallbackInfo;
 using v8::HeapCodeStatistics;
@@ -213,14 +212,6 @@ void Initialize(Local<Object> target,
 
   HEAP_CODE_STATISTICS_PROPERTIES(V)
 #undef V
-
-  // Export symbols used by v8.getHeapSpaceStatistics()
-  target->Set(env->context(),
-              FIXED_ONE_BYTE_STRING(env->isolate(),
-                                    "kHeapSpaceStatisticsPropertiesCount"),
-              Uint32::NewFromUnsigned(env->isolate(),
-                                      kHeapSpaceStatisticsPropertiesCount))
-              .Check();
 
   size_t number_of_heap_spaces = env->isolate()->NumberOfHeapSpaces();
 


### PR DESCRIPTION
Instead of holding shared pointers to ArrayBuffers, simplify
the code by using AliasedBuffers directly which allows the
binding to own the buffers.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
