### PR TITLE
stream: don't emit finish after close

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -153,6 +153,10 @@ function ReadableState(options, stream, isDuplex) {
   // Indicates whether the stream has finished destroying.
   this.closed = false;
 
+  // True if close has been emitted or would have been emitted
+  // depending on emitClose.
+  this.closeEmitted = false;
+
   // Crypto is kind of old and crusty.  Historically, its default string
   // encoding is 'binary' so we have to make this configurable.
   // Everything else in the universe uses 'utf8', though.

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -153,10 +153,6 @@ function ReadableState(options, stream, isDuplex) {
   // Indicates whether the stream has finished destroying.
   this.closed = false;
 
-  // True if close has been emitted or would have been emitted
-  // depending on emitClose.
-  this.closeEmitted = false;
-
   // Crypto is kind of old and crusty.  Historically, its default string
   // encoding is 'binary' so we have to make this configurable.
   // Everything else in the universe uses 'utf8', though.

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -661,8 +661,6 @@ function finish(stream, state) {
   if (state.errorEmitted || state.closeEmitted)
     return;
 
-  // TODO(ronag): This could occur after 'close' is emitted.
-
   state.finished = true;
   stream.emit('finish');
 

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -175,6 +175,10 @@ function WritableState(options, stream, isDuplex) {
 
   // Indicates whether the stream has finished destroying.
   this.closed = false;
+
+  // True if close has been emitted or would have been emitted
+  // depending on emitClose.
+  this.closeEmitted = false;
 }
 
 function resetBuffer(state) {
@@ -653,7 +657,8 @@ function finishMaybe(stream, state, sync) {
 
 function finish(stream, state) {
   state.pendingcb--;
-  if (state.errorEmitted)
+  // TODO (ronag): Unify with needFinish.
+  if (state.errorEmitted || state.closeEmitted)
     return;
 
   // TODO(ronag): This could occur after 'close' is emitted.

--- a/lib/internal/streams/destroy.js
+++ b/lib/internal/streams/destroy.js
@@ -73,6 +73,13 @@ function emitCloseNT(self) {
   const r = self._readableState;
   const w = self._writableState;
 
+  if (w) {
+    w.closeEmitted = true;
+  }
+  if (r) {
+    r.closeEmitted = true;
+  }
+
   if ((w && w.emitClose) || (r && r.emitClose)) {
     self.emit('close');
   }
@@ -101,25 +108,27 @@ function undestroy() {
   const w = this._writableState;
 
   if (r) {
-    r.closed = false;
     r.destroyed = false;
+    r.closed = false;
+    r.closeEmitted = false;
     r.errored = false;
+    r.errorEmitted = false;
     r.reading = false;
     r.ended = false;
     r.endEmitted = false;
-    r.errorEmitted = false;
   }
 
   if (w) {
-    w.closed = false;
     w.destroyed = false;
+    w.closed = false;
+    w.closeEmitted = false;
     w.errored = false;
+    w.errorEmitted = false;
     w.ended = false;
     w.ending = false;
     w.finalCalled = false;
     w.prefinished = false;
     w.finished = false;
-    w.errorEmitted = false;
   }
 }
 

--- a/lib/internal/streams/destroy.js
+++ b/lib/internal/streams/destroy.js
@@ -76,9 +76,6 @@ function emitCloseNT(self) {
   if (w) {
     w.closeEmitted = true;
   }
-  if (r) {
-    r.closeEmitted = true;
-  }
 
   if ((w && w.emitClose) || (r && r.emitClose)) {
     self.emit('close');
@@ -108,14 +105,13 @@ function undestroy() {
   const w = this._writableState;
 
   if (r) {
-    r.destroyed = false;
     r.closed = false;
-    r.closeEmitted = false;
+    r.destroyed = false;
     r.errored = false;
-    r.errorEmitted = false;
     r.reading = false;
     r.ended = false;
     r.endEmitted = false;
+    r.errorEmitted = false;
   }
 
   if (w) {

--- a/test/parallel/test-stream-writable-finish-destroyed.js
+++ b/test/parallel/test-stream-writable-finish-destroyed.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const common = require('../common');
+const { Writable } = require('stream');
+
+{
+  const w = new Writable({
+    write(chunk, encoding, cb) {
+      w.on('close', () => {
+        cb();
+      });
+    }
+  });
+
+  w.end('asd');
+  w.destroy();
+  w.on('finish', common.mustNotCall());
+}
+
+{
+  const w = new Writable({
+    write(chunk, encoding, cb) {
+      w.on('close', () => {
+        cb();
+        w.end();
+      });
+    }
+  });
+
+  w.write('asd');
+  w.destroy();
+  w.on('finish', common.mustNotCall());
+}

--- a/test/parallel/test-stream-writable-finish-destroyed.js
+++ b/test/parallel/test-stream-writable-finish-destroyed.js
@@ -5,11 +5,11 @@ const { Writable } = require('stream');
 
 {
   const w = new Writable({
-    write(chunk, encoding, cb) {
-      w.on('close', () => {
+    write: common.mustCall((chunk, encoding, cb) => {
+      w.on('close', common.mustCall(() => {
         cb();
-      });
-    }
+      }));
+    })
   });
 
   w.end('asd');
@@ -19,12 +19,12 @@ const { Writable } = require('stream');
 
 {
   const w = new Writable({
-    write(chunk, encoding, cb) {
-      w.on('close', () => {
+    write: common.mustCall((chunk, encoding, cb) => {
+      w.on('close', common.mustCall(() => {
         cb();
         w.end();
-      });
-    }
+      }));
+    })
   });
 
   w.on('finish', common.mustNotCall());

--- a/test/parallel/test-stream-writable-finish-destroyed.js
+++ b/test/parallel/test-stream-writable-finish-destroyed.js
@@ -27,7 +27,7 @@ const { Writable } = require('stream');
     }
   });
 
+  w.on('finish', common.mustNotCall());
   w.write('asd');
   w.destroy();
-  w.on('finish', common.mustNotCall());
 }

--- a/test/parallel/test-stream-writable-finish-destroyed.js
+++ b/test/parallel/test-stream-writable-finish-destroyed.js
@@ -12,9 +12,9 @@ const { Writable } = require('stream');
     })
   });
 
+  w.on('finish', common.mustNotCall());
   w.end('asd');
   w.destroy();
-  w.on('finish', common.mustNotCall());
 }
 
 {


### PR DESCRIPTION
Writable stream could emit 'finish' after 'close'.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
