### PR TITLE
stream: consistent punctuation

### DIFF
--- a/lib/_stream_duplex.js
+++ b/lib/_stream_duplex.js
@@ -83,7 +83,7 @@ ObjectDefineProperties(Duplex.prototype, {
     },
     set(value) {
       // Backward compatibility, the user is explicitly
-      // managing destroyed
+      // managing destroyed.
       if (this._readableState && this._writableState) {
         this._readableState.destroyed = value;
         this._writableState.destroyed = value;

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -94,7 +94,7 @@ function ReadableState(options, stream, isDuplex) {
     isDuplex = stream instanceof Stream.Duplex;
 
   // Object stream flag. Used to make read(n) ignore n and to
-  // make all the buffer merging and length checks go away
+  // make all the buffer merging and length checks go away.
   this.objectMode = !!(options && options.objectMode);
 
   if (isDuplex)
@@ -109,7 +109,7 @@ function ReadableState(options, stream, isDuplex) {
 
   // A linked list is used to store data chunks instead of an array because the
   // linked list can remove elements from the beginning faster than
-  // array.shift()
+  // array.shift().
   this.buffer = new BufferList();
   this.length = 0;
   this.pipes = [];
@@ -132,16 +132,16 @@ function ReadableState(options, stream, isDuplex) {
   this.resumeScheduled = false;
   this[kPaused] = null;
 
-  // True if the error was already emitted and should not be thrown again
+  // True if the error was already emitted and should not be thrown again.
   this.errorEmitted = false;
 
   // Should close be emitted on destroy. Defaults to true.
   this.emitClose = !options || options.emitClose !== false;
 
-  // Should .destroy() be called after 'end' (and potentially 'finish')
+  // Should .destroy() be called after 'end' (and potentially 'finish').
   this.autoDestroy = !options || options.autoDestroy !== false;
 
-  // Has it been destroyed
+  // Has it been destroyed.
   this.destroyed = false;
 
   // Indicates whether the stream has errored. When true no further
@@ -159,11 +159,11 @@ function ReadableState(options, stream, isDuplex) {
   this.defaultEncoding = (options && options.defaultEncoding) || 'utf8';
 
   // Ref the piped dest which we need a drain event on it
-  // type: null | Writable | Set<Writable>
+  // type: null | Writable | Set<Writable>.
   this.awaitDrainWriters = null;
   this.multiAwaitDrain = false;
 
-  // If true, a maybeReadMore has been scheduled
+  // If true, a maybeReadMore has been scheduled.
   this.readingMore = false;
 
   this.decoder = null;
@@ -182,7 +182,7 @@ function Readable(options) {
     return new Readable(options);
 
   // Checking for a Stream.Duplex instance is faster here instead of inside
-  // the ReadableState constructor, at least with V8 6.5
+  // the ReadableState constructor, at least with V8 6.5.
   const isDuplex = this instanceof Stream.Duplex;
 
   this._readableState = new ReadableState(options, this, isDuplex);
@@ -216,7 +216,7 @@ Readable.prototype.push = function(chunk, encoding) {
   return readableAddChunk(this, chunk, encoding, false);
 };
 
-// Unshift should *always* be something directly out of read()
+// Unshift should *always* be something directly out of read().
 Readable.prototype.unshift = function(chunk, encoding) {
   return readableAddChunk(this, chunk, encoding, true);
 };
@@ -231,7 +231,7 @@ function readableAddChunk(stream, chunk, encoding, addToFront) {
       encoding = encoding || state.defaultEncoding;
       if (addToFront && state.encoding && state.encoding !== encoding) {
         // When unshifting, if state.encoding is set, we have to save
-        // the string in the BufferList with the state encoding
+        // the string in the BufferList with the state encoding.
         chunk = Buffer.from(chunk, encoding).toString(state.encoding);
       } else if (encoding !== state.encoding) {
         chunk = Buffer.from(chunk, encoding);
@@ -322,7 +322,7 @@ Readable.prototype.setEncoding = function(enc) {
     StringDecoder = require('string_decoder').StringDecoder;
   const decoder = new StringDecoder(enc);
   this._readableState.decoder = decoder;
-  // If setEncoding(null), decoder.encoding equals utf8
+  // If setEncoding(null), decoder.encoding equals utf8.
   this._readableState.encoding = this._readableState.decoder.encoding;
 
   const buffer = this._readableState.buffer;
@@ -338,7 +338,7 @@ Readable.prototype.setEncoding = function(enc) {
   return this;
 };
 
-// Don't raise the hwm > 1GB
+// Don't raise the hwm > 1GB.
 const MAX_HWM = 0x40000000;
 function computeNewHighWaterMark(n) {
   if (n >= MAX_HWM) {
@@ -346,7 +346,7 @@ function computeNewHighWaterMark(n) {
     n = MAX_HWM;
   } else {
     // Get the next highest power of 2 to prevent increasing hwm excessively in
-    // tiny amounts
+    // tiny amounts.
     n--;
     n |= n >>> 1;
     n |= n >>> 2;
@@ -366,7 +366,7 @@ function howMuchToRead(n, state) {
   if (state.objectMode)
     return 1;
   if (NumberIsNaN(n)) {
-    // Only flow one buffer at a time
+    // Only flow one buffer at a time.
     if (state.flowing && state.length)
       return state.buffer.first().length;
     else
@@ -449,7 +449,7 @@ Readable.prototype.read = function(n) {
   let doRead = state.needReadable;
   debug('need readable', doRead);
 
-  // If we currently have less than the highWaterMark, then also read some
+  // If we currently have less than the highWaterMark, then also read some.
   if (state.length === 0 || state.length - n < state.highWaterMark) {
     doRead = true;
     debug('length less than watermark', doRead);
@@ -527,7 +527,7 @@ function onEofChunk(stream, state) {
   if (state.sync) {
     // If we are sync, wait until next tick to emit the data.
     // Otherwise we risk emitting data in the flow()
-    // the readable code triggers during a read() call
+    // the readable code triggers during a read() call.
     emitReadable(stream);
   } else {
     // Emit 'readable' now to make sure it gets picked up.
@@ -561,7 +561,7 @@ function emitReadable_(stream) {
     state.emittedReadable = false;
   }
 
-  // The stream needs another readable event if
+  // The stream needs another readable event if:
   // 1. It is not flowing, as the flow mechanism will take
   //    care of it.
   // 2. It is not ended.
@@ -680,7 +680,7 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
   let cleanedUp = false;
   function cleanup() {
     debug('cleanup');
-    // Cleanup event handlers once the pipe is broken
+    // Cleanup event handlers once the pipe is broken.
     dest.removeListener('close', onclose);
     dest.removeListener('finish', onfinish);
     if (ondrain) {
@@ -774,7 +774,7 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
     src.unpipe(dest);
   }
 
-  // Tell the dest that it's being piped to
+  // Tell the dest that it's being piped to.
   dest.emit('pipe', src);
 
   // Start the flow if it hasn't been started already.
@@ -844,7 +844,7 @@ Readable.prototype.unpipe = function(dest) {
 };
 
 // Set up data events if they are asked for
-// Ensure readable listeners eventually get something
+// Ensure readable listeners eventually get something.
 Readable.prototype.on = function(ev, fn) {
   const res = Stream.prototype.on.call(this, ev, fn);
   const state = this._readableState;
@@ -854,7 +854,7 @@ Readable.prototype.on = function(ev, fn) {
     // a few lines down. This is needed to support once('readable').
     state.readableListening = this.listenerCount('readable') > 0;
 
-    // Try start flowing on next tick if stream isn't explicitly paused
+    // Try start flowing on next tick if stream isn't explicitly paused.
     if (state.flowing !== false)
       this.resume();
   } else if (ev === 'readable') {
@@ -917,7 +917,7 @@ function updateReadableListening(self) {
     // the upcoming resume will not flow.
     state.flowing = true;
 
-    // Crude way to check if we should resume
+    // Crude way to check if we should resume.
   } else if (self.listenerCount('data') > 0) {
     self.resume();
   } else if (!state.readableListening) {
@@ -938,7 +938,7 @@ Readable.prototype.resume = function() {
     debug('resume');
     // We flow only if there is no one listening
     // for readable, but we still have to call
-    // resume()
+    // resume().
     state.flowing = !state.readableListening;
     resume(this, state);
   }
@@ -1006,7 +1006,7 @@ Readable.prototype.wrap = function(stream) {
     if (state.decoder)
       chunk = state.decoder.write(chunk);
 
-    // Don't skip over falsy values in objectMode
+    // Don't skip over falsy values in objectMode.
     if (state.objectMode && (chunk === null || chunk === undefined))
       return;
     else if (!state.objectMode && (!chunk || !chunk.length))
@@ -1058,7 +1058,7 @@ Readable.prototype[SymbolAsyncIterator] = function() {
 
 // Making it explicit these properties are not enumerable
 // because otherwise some prototype manipulation in
-// userland will fail
+// userland will fail.
 ObjectDefineProperties(Readable.prototype, {
   readable: {
     get() {
@@ -1135,13 +1135,13 @@ ObjectDefineProperties(Readable.prototype, {
     },
     set(value) {
       // We ignore the value if the stream
-      // has not been initialized yet
+      // has not been initialized yet.
       if (!this._readableState) {
         return;
       }
 
       // Backward compatibility, the user is explicitly
-      // managing destroyed
+      // managing destroyed.
       this._readableState.destroyed = value;
     }
   },
@@ -1178,7 +1178,7 @@ Readable._fromList = fromList;
 // This function is designed to be inlinable, so please take care when making
 // changes to the function body.
 function fromList(n, state) {
-  // nothing buffered
+  // nothing buffered.
   if (state.length === 0)
     return null;
 
@@ -1186,7 +1186,7 @@ function fromList(n, state) {
   if (state.objectMode)
     ret = state.buffer.shift();
   else if (!n || n >= state.length) {
-    // Read it all, truncate the list
+    // Read it all, truncate the list.
     if (state.decoder)
       ret = state.buffer.join('');
     else if (state.buffer.length === 1)
@@ -1195,7 +1195,7 @@ function fromList(n, state) {
       ret = state.buffer.concat(state.length);
     state.buffer.clear();
   } else {
-    // read part of list
+    // read part of list.
     ret = state.buffer.consume(n, state.decoder);
   }
 
@@ -1224,7 +1224,7 @@ function endReadableNT(state, stream) {
       process.nextTick(endWritableNT, state, stream);
     } else if (state.autoDestroy) {
       // In case of duplex streams we need a way to detect
-      // if the writable side is ready for autoDestroy as well
+      // if the writable side is ready for autoDestroy as well.
       const wState = stream._writableState;
       const autoDestroy = !wState || (
         wState.autoDestroy &&

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -83,21 +83,21 @@ function WritableState(options, stream, isDuplex) {
 
   // The point at which write() starts returning false
   // Note: 0 is a valid value, means that we always return false if
-  // the entire buffer is not flushed immediately on write()
+  // the entire buffer is not flushed immediately on write().
   this.highWaterMark = options ?
     getHighWaterMark(this, options, 'writableHighWaterMark', isDuplex) :
     getDefaultHighWaterMark(false);
 
-  // if _final has been called
+  // if _final has been called.
   this.finalCalled = false;
 
   // drain event flag.
   this.needDrain = false;
   // At the start of calling end()
   this.ending = false;
-  // When end() has been called, and returned
+  // When end() has been called, and returned.
   this.ended = false;
-  // When 'finish' is emitted
+  // When 'finish' is emitted.
   this.finished = false;
 
   // Has it been destroyed
@@ -122,7 +122,7 @@ function WritableState(options, stream, isDuplex) {
   // A flag to see when we're in the middle of a write.
   this.writing = false;
 
-  // When true all writes will be buffered until .uncork() call
+  // When true all writes will be buffered until .uncork() call.
   this.corked = 0;
 
   // A flag to be able to tell if the onwrite cb is called immediately,
@@ -136,10 +136,10 @@ function WritableState(options, stream, isDuplex) {
   // end up in an overlapped onwrite situation.
   this.bufferProcessing = false;
 
-  // The callback that's passed to _write(chunk,cb)
+  // The callback that's passed to _write(chunk, cb).
   this.onwrite = onwrite.bind(undefined, stream);
 
-  // The callback that the user supplies to write(chunk,encoding,cb)
+  // The callback that the user supplies to write(chunk, encoding, cb).
   this.writecb = null;
 
   // The amount that is being written when _write is called.
@@ -152,20 +152,20 @@ function WritableState(options, stream, isDuplex) {
   resetBuffer(this);
 
   // Number of pending user-supplied write callbacks
-  // this must be 0 before 'finish' can be emitted
+  // this must be 0 before 'finish' can be emitted.
   this.pendingcb = 0;
 
   // Emit prefinish if the only thing we're waiting for is _write cbs
-  // This is relevant for synchronous Transform streams
+  // This is relevant for synchronous Transform streams.
   this.prefinished = false;
 
-  // True if the error was already emitted and should not be thrown again
+  // True if the error was already emitted and should not be thrown again.
   this.errorEmitted = false;
 
   // Should close be emitted on destroy. Defaults to true.
   this.emitClose = !options || options.emitClose !== false;
 
-  // Should .destroy() be called after 'finish' (and potentially 'end')
+  // Should .destroy() be called after 'finish' (and potentially 'end').
   this.autoDestroy = !options || options.autoDestroy !== false;
 
   // Indicates whether the stream has errored. When true all write() calls
@@ -225,7 +225,7 @@ function Writable(options) {
   // `_writableState` that would lead to infinite recursion.
 
   // Checking for a Stream.Duplex instance is faster here instead of inside
-  // the WritableState constructor, at least with V8 6.5
+  // the WritableState constructor, at least with V8 6.5.
   const isDuplex = (this instanceof Stream.Duplex);
 
   if (!isDuplex && !realHasInstance.call(Writable, this))
@@ -487,7 +487,7 @@ function errorBuffer(state, err) {
   resetBuffer(state);
 }
 
-// If there's something in the buffer waiting, then process it
+// If there's something in the buffer waiting, then process it.
 function clearBuffer(stream, state) {
   if (state.corked || state.bufferProcessing) {
     return;
@@ -564,7 +564,7 @@ Writable.prototype.end = function(chunk, encoding, cb) {
   if (chunk !== null && chunk !== undefined)
     this.write(chunk, encoding);
 
-  // .end() fully uncorks
+  // .end() fully uncorks.
   if (state.corked) {
     state.corked = 1;
     this.uncork();
@@ -662,7 +662,7 @@ function finish(stream, state) {
 
   if (state.autoDestroy) {
     // In case of duplex streams we need a way to detect
-    // if the readable side is ready for autoDestroy as well
+    // if the readable side is ready for autoDestroy as well.
     const rState = stream._readableState;
     const autoDestroy = !rState || (
       rState.autoDestroy &&
@@ -703,7 +703,7 @@ ObjectDefineProperties(Writable.prototype, {
       return this._writableState ? this._writableState.destroyed : false;
     },
     set(value) {
-      // Backward compatibility, the user is explicitly managing destroyed
+      // Backward compatibility, the user is explicitly managing destroyed.
       if (this._writableState) {
         this._writableState.destroyed = value;
       }


### PR DESCRIPTION
Cleanup comments to use consistent punctuation.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
