### PR TITLE
stream: removes unused params

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -619,7 +619,7 @@ Writable.prototype.end = function(chunk, encoding, cb) {
     if (err || state.finished)
       process.nextTick(cb, err);
     else
-      onFinished(this, state, cb);
+      onFinished(this, cb);
   }
 
   return this;
@@ -715,7 +715,7 @@ function onCorkedFinish(corkReq, state, err) {
 }
 
 // TODO(ronag): Avoid using events to implement internal logic.
-function onFinished(stream, state, cb) {
+function onFinished(stream, cb) {
   function onerror(err) {
     stream.removeListener('finish', onfinish);
     stream.removeListener('error', onerror);


### PR DESCRIPTION
This PR removes the `state` param in the `onFinished` function
since it's never used within it.


- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

