### PR TITLE
meta: add issue template for API reference docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/3-api-ref-docs-problem.md
+++ b/.github/ISSUE_TEMPLATE/3-api-ref-docs-problem.md
@@ -34,34 +34,16 @@ Subsystem: if known, please specify affected core module name
 
 ## Location
 
-_Section of the site where the content exists (or should)_
+_Section of the site where the content exists_
 
 Affected URL(s):
 - https://nodejs.org/api/✍️
 
-## Reproduction procedure
+## Problem description
 
-_Steps to reproduce the problem_
+_Concise explanation of what you found to be problematic_
 
-✍️
-
-## Expected behavior/code
-
-_What your expectation was_
-
-✍️
-
-## Actual behavior/code
-
-_What you found to be problematic_
-
-✍️
-
-## Additional information
-
-_Anything else (e.g., screenshots, etc.) that may help solve the problem_
-
-<!-- Enter “n/a” if enough detail exists elsewhere in this template. -->
+<!-- If applicable, include any screenshots that may help solve the problem. -->
 
 ✍️
 

--- a/.github/ISSUE_TEMPLATE/3-api-ref-docs-problem.md
+++ b/.github/ISSUE_TEMPLATE/3-api-ref-docs-problem.md
@@ -1,0 +1,74 @@
+---
+name: "\U0001F4D7 Open an issue regarding the nodejs.org API reference docs"
+about: Let us know about any problematic API reference documents
+title: "doc: "
+labels: doc
+---
+
+# 📗 API Reference Docs Problem
+
+<!--
+Thank you for wanting to make nodejs.org better!
+
+This template is for issues with the Node.js API reference docs.
+
+If you found a problem with nodejs.org beyond the API reference docs, please
+file an issue in our website repo at “https://github.com/nodejs/nodejs.org”.
+
+For the issue title, enter a one-line summary after “doc: ”. If unsure about
+something, please do the best you can.
+
+The “✍️” signifies a request for input.
+
+Version: output of “node -v”
+Platform: output of “uname -a” (UNIX), or version and 32 or 64-bit (Windows)
+Subsystem: if known, please specify affected core module name
+-->
+
+- **Version**: ✍️
+- **Platform**: ✍️
+- **Subsystem**: ✍️
+
+## Problem type
+
+<!-- ✍️ Use “[x]” to mark a selection. -->
+
+- [ ] Missing
+- [ ] Needed
+- [ ] Confusing
+- [ ] Didn't work
+- [ ] Other (<!-- ? Please specify if chosen. -->)
+
+## Location
+
+_Section of the site where the content lives (or should)._
+
+Affected URL(s):
+
+- https://nodejs.org/api/✍️
+
+## Reproduction procedure
+
+_Steps to reproduce the problem_
+
+✍️
+
+## Expected behavior/code
+
+_What you were expecting._
+
+✍️
+
+## Additional information
+
+_Any other information that would be helpful to solve this._
+
+<!-- ? Enter “n/a” if enough details exist elsewhere in this template. -->
+
+✍️
+
+---
+
+<!-- ? Use “[x]” to check the box below if interested in contributing. -->
+
+- [ ] I would like to work on this issue and submit a pull request.

--- a/.github/ISSUE_TEMPLATE/3-api-ref-docs-problem.md
+++ b/.github/ISSUE_TEMPLATE/3-api-ref-docs-problem.md
@@ -1,5 +1,5 @@
 ---
-name: "\U0001F4D7 Open an issue regarding the nodejs.org API reference docs"
+name: "\U0001F4D7 Open an issue regarding the Node.js API reference docs"
 about: Let us know about any problematic API reference documents
 title: "doc: "
 labels: doc
@@ -7,19 +7,22 @@ labels: doc
 
 # 📗 API Reference Docs Problem
 
-<!--
+<!------------------------------------------------------------------------------
 Thank you for wanting to make nodejs.org better!
 
 This template is for issues with the Node.js API reference docs.
 
+For more general support, please open an issue in
+our help repo at “https://github.com/nodejs/help”.
+
+For the issue title, enter a one-line summary after “doc: ”.
+The “✍️” signifies a request for input. If unsure, do the best you can.
+
 If you found a problem with nodejs.org beyond the API reference docs, please
-file an issue in our website repo at “https://github.com/nodejs/nodejs.org”.
+open an issue in our website repo at “https://github.com/nodejs/nodejs.org”.
+------------------------------------------------------------------------------->
 
-For the issue title, enter a one-line summary after “doc: ”. If unsure about
-something, please do the best you can.
-
-The “✍️” signifies a request for input.
-
+<!--
 Version: output of “node -v”
 Platform: output of “uname -a” (UNIX), or version and 32 or 64-bit (Windows)
 Subsystem: if known, please specify affected core module name
@@ -29,22 +32,11 @@ Subsystem: if known, please specify affected core module name
 - **Platform**: ✍️
 - **Subsystem**: ✍️
 
-## Problem type
-
-<!-- ✍️ Use “[x]” to mark a selection. -->
-
-- [ ] Missing
-- [ ] Needed
-- [ ] Confusing
-- [ ] Didn't work
-- [ ] Other (<!-- ? Please specify if chosen. -->)
-
 ## Location
 
-_Section of the site where the content lives (or should)._
+_Section of the site where the content exists (or should)_
 
 Affected URL(s):
-
 - https://nodejs.org/api/✍️
 
 ## Reproduction procedure
@@ -55,20 +47,26 @@ _Steps to reproduce the problem_
 
 ## Expected behavior/code
 
-_What you were expecting._
+_What your expectation was_
+
+✍️
+
+## Actual behavior/code
+
+_What you found to be problematic_
 
 ✍️
 
 ## Additional information
 
-_Any other information that would be helpful to solve this._
+_Anything else (e.g., screenshots, etc.) that may help solve the problem_
 
-<!-- ? Enter “n/a” if enough details exist elsewhere in this template. -->
+<!-- Enter “n/a” if enough detail exists elsewhere in this template. -->
 
 ✍️
 
 ---
 
-<!-- ? Use “[x]” to check the box below if interested in contributing. -->
+<!-- Use “[x]” to check the box below if interested in contributing. -->
 
 - [ ] I would like to work on this issue and submit a pull request.


### PR DESCRIPTION
Prior to this commit, there was no GitHub issue template guiding
users to open issues about gaps in the API reference docs.

Refs: https://github.com/nodejs/node/pull/31123
Closes: https://github.com/nodejs/nodejs.org/issues/2866

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
