### PR TITLE
stream: refactor the objectMode assignment logic

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -93,13 +93,16 @@ function ReadableState(options, stream, isDuplex) {
   if (typeof isDuplex !== 'boolean')
     isDuplex = stream instanceof Stream.Duplex;
 
-  // Object stream flag. Used to make read(n) ignore n and to
-  // make all the buffer merging and length checks go away
-  this.objectMode = !!(options && options.objectMode);
+  if (options) {
+    // Object stream flag. Used to make read(n) ignore n and to
+    // make all the buffer merging and length checks go away
+    this.objectMode = !!options.objectMode;
 
-  if (isDuplex)
-    this.objectMode = this.objectMode ||
-      !!(options && options.readableObjectMode);
+    if (isDuplex && !this.objectMode)
+      this.objectMode = !!options.readableObjectMode;
+  } else {
+    this.objectMode = false;
+  }
 
   // The point at which it stops calling _read() to fill the buffer
   // Note: 0 is a valid value, means "don't call _read preemptively ever"


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

~7% improvement.  reduce repetitive judgments when `options` is undefined.

``` 
 streams/creation.js kind='duplex' n=50000000                    0.85 %      ±3.68% ±4.90% ±6.37%
 streams/creation.js kind='readable' n=50000000         ***      6.89 %      ±3.93% ±5.25% ±6.85%
 streams/creation.js kind='transform' n=50000000                 0.17 %      ±4.49% ±5.99% ±7.82%
 streams/creation.js kind='writable' n=50000000                 -1.35 %      ±3.37% ±4.48% ±5.84%
```

/cc @ronag 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
