### PR TITLE
dns: Add dns/promises alias

### DIFF
--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -611,7 +611,7 @@ earlier ones time out or result in some other error.
 
 The `dns.promises` API provides an alternative set of asynchronous DNS methods
 that return `Promise` objects rather than using callbacks. The API is accessible
-via `require('dns').promises`.
+via `require('dns').promises` or `require('dns/promises')`.
 
 ### Class: `dnsPromises.Resolver`
 <!-- YAML

--- a/lib/dns/promises.js
+++ b/lib/dns/promises.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('internal/dns/promises');

--- a/lib/dns/promises.js
+++ b/lib/dns/promises.js
@@ -1,3 +1,5 @@
 'use strict';
 
-module.exports = require('internal/dns/promises');
+const dnsPromises = require('internal/dns/promises');
+dnsPromises.setServers = require('dns').setServers;
+module.exports = dnsPromises;

--- a/node.gyp
+++ b/node.gyp
@@ -48,6 +48,7 @@
       'lib/cluster.js',
       'lib/dgram.js',
       'lib/dns.js',
+      'lib/dns/promises.js',
       'lib/domain.js',
       'lib/events.js',
       'lib/fs.js',

--- a/test/es-module/test-esm-dns-promises.mjs
+++ b/test/es-module/test-esm-dns-promises.mjs
@@ -1,0 +1,14 @@
+// Flags: --expose-internals
+import '../common/index.mjs';
+import assert from 'assert';
+import { lookupService } from 'dns/promises';
+
+const invalidAddress = 'fasdfdsaf';
+
+assert.throws(() => {
+  lookupService(invalidAddress, 0);
+}, {
+  code: 'ERR_INVALID_OPT_VALUE',
+  name: 'TypeError',
+  message: `The value "${invalidAddress}" is invalid for option "address"`
+});

--- a/test/parallel/test-dns-promises-exists.js
+++ b/test/parallel/test-dns-promises-exists.js
@@ -1,0 +1,6 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+
+assert.strictEqual(require('dns/promises'), require('dns').promises);

--- a/test/parallel/test-dns-setservers-type-check.js
+++ b/test/parallel/test-dns-setservers-type-check.js
@@ -85,3 +85,38 @@ const promiseResolver = new dns.promises.Resolver();
     );
   });
 }
+
+// This test for 'dns/promises'
+{
+  const {
+    setServers,
+    resolve
+  } = require('dns/promises');
+
+  // This should not throw any error.
+  (async () => {
+    const localhost = await resolve('localhost');
+    setServers(localhost);
+  })();
+
+  [
+    [null],
+    [undefined],
+    [Number(addresses.DNS4_SERVER)],
+    [
+      {
+        address: addresses.DNS4_SERVER
+      }
+    ]
+  ].forEach((val) => {
+    const errObj = {
+      code: 'ERR_INVALID_ARG_TYPE',
+      name: 'TypeError',
+      message: 'The "servers[0]" argument must be of type string.' +
+              common.invalidArgTypeHelper(val[0])
+    };
+    assert.throws(() => {
+      setServers(val);
+    }, errObj);
+  });
+}

--- a/test/parallel/test-dns-setservers-type-check.js
+++ b/test/parallel/test-dns-setservers-type-check.js
@@ -89,14 +89,12 @@ const promiseResolver = new dns.promises.Resolver();
 // This test for 'dns/promises'
 {
   const {
-    setServers,
-    resolve
+    setServers
   } = require('dns/promises');
 
   // This should not throw any error.
   (async () => {
-    const localhost = await resolve('localhost');
-    setServers(localhost);
+    setServers([ '127.0.0.1' ]);
   })();
 
   [


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

This adds `dns/promises` alias to `dns.promises`. `fs/promises` has already been added. (#31553)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
