### PR TITLE
http2: wait for secureConnect before initializing

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -464,6 +464,7 @@ function TLSSocket(socket, opts) {
   this._securePending = false;
   this._newSessionPending = false;
   this._controlReleased = false;
+  this.secureConnecting = true;
   this._SNICallback = null;
   this.servername = null;
   this.alpnProtocol = null;
@@ -1026,6 +1027,7 @@ function onServerSocketSecure() {
 
   if (!this.destroyed && this._releaseControl()) {
     debug('server emit secureConnection');
+    this.secureConnecting = false;
     this._tlsOptions.server.emit('secureConnection', this);
   }
 }

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1152,7 +1152,7 @@ class Http2Session extends EventEmitter {
       socket.disableRenegotiation();
 
     const setupFn = setupHandle.bind(this, socket, type, options);
-    if (socket.connecting) {
+    if (socket.connecting || socket.secureConnecting) {
       const connectEvent =
         socket instanceof tls.TLSSocket ? 'secureConnect' : 'connect';
       socket.once(connectEvent, () => {

--- a/test/internet/test-http2-issue-32922.js
+++ b/test/internet/test-http2-issue-32922.js
@@ -1,0 +1,80 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const http2 = require('http2');
+const net = require('net');
+
+const {
+  HTTP2_HEADER_PATH,
+} = http2.constants;
+
+// Create a normal session, as a control case
+function normalSession(cb) {
+  http2.connect('https://google.com', (clientSession) => {
+    let error = null;
+    const req = clientSession.request({ [HTTP2_HEADER_PATH]: '/' });
+    req.on('error', (err) => {
+      error = err;
+    });
+    req.on('response', (_headers) => {
+      req.on('data', (_chunk) => { });
+      req.on('end', () => {
+        clientSession.close();
+        return cb(error);
+      });
+    });
+  });
+}
+normalSession(common.mustCall(function(err) {
+  assert.ifError(err);
+}));
+
+// Create a session using a socket that has not yet finished connecting
+function socketNotFinished(done) {
+  const socket2 = net.connect(443, 'google.com');
+  http2.connect('https://google.com', { socket2 }, (clientSession) => {
+    let error = null;
+    const req = clientSession.request({ [HTTP2_HEADER_PATH]: '/' });
+    req.on('error', (err) => {
+      error = err;
+    });
+    req.on('response', (_headers) => {
+      req.on('data', (_chunk) => { });
+      req.on('end', () => {
+        clientSession.close();
+        socket2.destroy();
+        return done(error);
+      });
+    });
+  });
+}
+socketNotFinished(common.mustCall(function(err) {
+  assert.ifError(err);
+}));
+
+// Create a session using a socket that has finished connecting
+function socketFinished(done) {
+  const socket = net.connect(443, 'google.com', () => {
+    http2.connect('https://google.com', { socket }, (clientSession) => {
+      let error = null;
+      const req = clientSession.request({ [HTTP2_HEADER_PATH]: '/' });
+      req.on('error', (err) => {
+        error = err;
+      });
+      req.on('response', (_headers) => {
+        req.on('data', (_chunk) => { });
+        req.on('end', () => {
+          clientSession.close();
+          return done(error);
+        });
+      });
+    });
+  });
+}
+socketFinished(common.mustCall(function(err) {
+  assert.ifError(err);
+}));


### PR DESCRIPTION
As @murgatroid99 points out in #32922, a connection may have its `connecting` property set to `true`, while TLS is still connecting. This results in `setupFn()` being fired before the connection is actually ready.

This PR introduces the property `secureConnecting` on `TLSSocket`, which will not be set to `true` until the `secureConnection` event is emitted.

Fixes: #32922

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
