### PR TITLE
inspector: only write coverage in fully bootstrapped Environments

### DIFF
--- a/src/inspector_profiler.cc
+++ b/src/inspector_profiler.cc
@@ -209,6 +209,16 @@ void V8CoverageConnection::WriteProfile(Local<String> message) {
   HandleScope handle_scope(isolate);
   Context::Scope context_scope(context);
 
+  // This is only set up during pre-execution (when the environment variables
+  // becomes available in the JS land). If it's empty, we don't have coverage
+  // directory path (which is resolved in JS land at the moment) either, so
+  // the best we could to is to just discard the profile and do nothing.
+  // This should only happen in half-baked Environments created using the
+  // embedder API.
+  if (env_->source_map_cache_getter().IsEmpty()) {
+    return;
+  }
+
   // Get message.result from the response.
   Local<Object> result;
   if (!ParseProfile(env_, message, type()).ToLocal(&result)) {


### PR DESCRIPTION
The NODE_V8_COVERAGE folder and the source map computation are setup
during pre-execution since they rely on environment variables as well
as JS states. Therefore, we need to give up serialization of JS coverage
profiles for Environments that have not go through pre-execution. Currently
this is only possible for Environments created using the embedder API
CreateEnvironment().

As a result we won't have JS coverage data for most cctests, but if that
proves to be necessary we could just run lib/internal/main/environment.js
for these Environments created for cctests.

Fixes: https://github.com/nodejs/node/issues/32912
Refs: https://github.com/nodejs/node/commit/65e18a8e9f912dfa04a804124b6a19514bb45165
Refs: https://github.com/nodejs/node/commit/5bf43729a403b992cc90b5cdbbaaf505769d1107
Refs: https://github.com/nodejs/node/commit/8aa7ef7840ef5f7161f3195e51a3fa6783290160

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
