### PR TITLE
cluster: removed unused addressType argument from constructor

### DIFF
--- a/lib/internal/cluster/master.js
+++ b/lib/internal/cluster/master.js
@@ -297,12 +297,7 @@ function queryServer(worker, message) {
       constructor = SharedHandle;
     }
 
-    handle = new constructor(key,
-                             address,
-                             message.port,
-                             message.addressType,
-                             message.fd,
-                             message.flags);
+    handle = new constructor(key, address, message);
     handles.set(key, handle);
   }
 

--- a/lib/internal/cluster/round_robin_handle.js
+++ b/lib/internal/cluster/round_robin_handle.js
@@ -13,7 +13,7 @@ const { constants } = internalBinding('tcp_wrap');
 
 module.exports = RoundRobinHandle;
 
-function RoundRobinHandle(key, address, port, addressType, fd, flags) {
+function RoundRobinHandle(key, address, { port, fd, flags }) {
   this.key = key;
   this.all = new Map();
   this.free = new Map();

--- a/lib/internal/cluster/shared_handle.js
+++ b/lib/internal/cluster/shared_handle.js
@@ -6,7 +6,7 @@ const net = require('net');
 
 module.exports = SharedHandle;
 
-function SharedHandle(key, address, port, addressType, fd, flags) {
+function SharedHandle(key, address, { port, addressType, fd, flags }) {
   this.key = key;
   this.workers = new Map();
   this.handle = null;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

When intializing the constructor for cluster master we are heavily using
a generic structure, but the effect of passing arguments that are
related to shared_handle is that there is a stale argument passed to
round robin handler (`addressType`).

We can avoid such scenarios as all the remaining entities are being
destructured from the message object.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->