### PR TITLE
stream: finished should complete with read-only Duplex

### DIFF
--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -77,7 +77,8 @@ function eos(stream, opts, callback) {
     state.autoDestroy &&
     state.emitClose &&
     state.closed === false &&
-    (!!stream.readable === readable && !!stream.writable === writable)
+    isReadable(stream) === readable &&
+    isWritable(stream) === writable
   );
 
   let writableFinished = stream.writableFinished ||

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -77,7 +77,7 @@ function eos(stream, opts, callback) {
     state.autoDestroy &&
     state.emitClose &&
     state.closed === false &&
-    (stream.readable === readable && stream.writable === writable)
+    (!!stream.readable === readable && !!stream.writable === writable)
   );
 
   let writableFinished = stream.writableFinished ||

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -76,7 +76,8 @@ function eos(stream, opts, callback) {
     state &&
     state.autoDestroy &&
     state.emitClose &&
-    state.closed === false
+    state.closed === false &&
+    (stream.readable === readable && stream.writable === writable)
   );
 
   let writableFinished = stream.writableFinished ||

--- a/test/parallel/test-stream-finished.js
+++ b/test/parallel/test-stream-finished.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const common = require('../common');
-const { Writable, Readable, Transform, finished } = require('stream');
+const { Writable, Readable, Transform, finished, Duplex } = require('stream');
 const assert = require('assert');
 const EE = require('events');
 const fs = require('fs');
@@ -351,4 +351,20 @@ testClosed((opts) => new Writable({ write() {}, ...opts }));
   r.push('asd');
   r.push(null);
   r.destroy();
+}
+
+{
+  const d = new Duplex({
+    final(cb) { }, // Never close writable side for test purpose
+    read() {
+      this.push(null);
+    }
+  });
+
+  d.on('end', common.mustCall());
+
+  finished(d, { readable: true, writable: false }, common.mustCall());
+
+  d.end();
+  d.resume();
 }

--- a/test/parallel/test-stream-finished.js
+++ b/test/parallel/test-stream-finished.js
@@ -368,3 +368,19 @@ testClosed((opts) => new Writable({ write() {}, ...opts }));
   d.end();
   d.resume();
 }
+
+{
+  const d = new Duplex({
+    final(cb) { }, // Never close writable side for test purpose
+    read() {
+      this.push(null);
+    }
+  });
+
+  d.on('end', common.mustCall());
+
+  d.end();
+  finished(d, { readable: true, writable: false }, common.mustCall());
+
+  d.resume();
+}


### PR DESCRIPTION
If passed a Duplex where readable or writable has been
explicitly disabled then don't assume 'close' will be
emitted.

Fixes: https://github.com/nodejs/node/issues/32965

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
