### PR TITLE
stream: pipeline should only destroy un-finished streams.

### DIFF
--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -25,43 +25,18 @@ let EE;
 let PassThrough;
 let createReadableStreamAsyncIterator;
 
-function isIncoming(stream) {
-  return (
-    stream.socket &&
-    typeof stream.complete === 'boolean' &&
-    ArrayIsArray(stream.rawTrailers) &&
-    ArrayIsArray(stream.rawHeaders)
-  );
-}
+function destroyer(stream, reading, writing, callback) {
+  callback = once(callback);
 
-function isOutgoing(stream) {
-  return (
-    stream.socket &&
-    typeof stream.setHeader === 'function'
-  );
-}
-
-function destroyer(stream, reading, writing, final, callback) {
-  const _destroy = once((err) => {
-    if (!err && (isIncoming(stream) || isOutgoing(stream))) {
-      // http/1 request objects have a coupling to their response and should
-      // not be prematurely destroyed. Assume they will handle their own
-      // lifecycle.
-      return callback();
-    }
-
-    if (!err && reading && !writing && stream.writable) {
-      return callback();
-    }
-
-    if (err || !final || !stream.readable) {
-      destroyImpl.destroyer(stream, err);
-    }
-    callback(err);
+  let finished = false;
+  stream.on('close', () => {
+    finished = true;
   });
 
   if (eos === undefined) eos = require('internal/streams/end-of-stream');
   eos(stream, { readable: reading, writable: writing }, (err) => {
+    finished = !err;
+
     const rState = stream._readableState;
     if (
       err &&
@@ -78,14 +53,19 @@ function destroyer(stream, reading, writing, final, callback) {
       // eos will only fail with premature close on the reading side for
       // duplex streams.
       stream
-        .once('end', _destroy)
-        .once('error', _destroy);
+        .once('end', callback)
+        .once('error', callback);
     } else {
-      _destroy(err);
+      callback(err);
     }
   });
 
-  return (err) => _destroy(err || new ERR_STREAM_DESTROYED('pipe'));
+  return once((err) => {
+    if (!finished) {
+      destroyImpl.destroyer(stream, err);
+    }
+    callback(err || new ERR_STREAM_DESTROYED('pipe'));
+  });
 }
 
 function popCallback(streams) {
@@ -204,7 +184,7 @@ function pipeline(...streams) {
 
     if (isStream(stream)) {
       finishCount++;
-      destroys.push(destroyer(stream, reading, writing, !reading, finish));
+      destroys.push(destroyer(stream, reading, writing, finish));
     }
 
     if (i === 0) {
@@ -262,7 +242,7 @@ function pipeline(...streams) {
         ret = pt;
 
         finishCount++;
-        destroys.push(destroyer(ret, false, true, true, finish));
+        destroys.push(destroyer(ret, false, true, finish));
       }
     } else if (isStream(stream)) {
       if (isReadable(ret)) {

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -60,11 +60,12 @@ function destroyer(stream, reading, writing, callback) {
     }
   });
 
-  return once((err) => {
+  return (err) => {
     if (finished) return;
+    finished = true;
     destroyImpl.destroyer(stream, err);
     callback(err || new ERR_STREAM_DESTROYED('pipe'));
-  });
+  };
 }
 
 function popCallback(streams) {

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -61,9 +61,8 @@ function destroyer(stream, reading, writing, callback) {
   });
 
   return once((err) => {
-    if (!finished) {
-      destroyImpl.destroyer(stream, err);
-    }
+    if (finished) return;
+    destroyImpl.destroyer(stream, err);
     callback(err || new ERR_STREAM_DESTROYED('pipe'));
   });
 }

--- a/test/parallel/test-stream-pipeline.js
+++ b/test/parallel/test-stream-pipeline.js
@@ -916,7 +916,7 @@ const { promisify } = require('util');
   const src = new PassThrough({ autoDestroy: false });
   const dst = new PassThrough({ autoDestroy: false });
   pipeline(src, dst, common.mustCall(() => {
-    assert.strictEqual(src.destroyed, true);
+    assert.strictEqual(src.destroyed, false);
     assert.strictEqual(dst.destroyed, false);
   }));
   src.end();

--- a/test/parallel/test-stream-pipeline.js
+++ b/test/parallel/test-stream-pipeline.js
@@ -13,6 +13,7 @@ const {
 const assert = require('assert');
 const http = require('http');
 const { promisify } = require('util');
+const net = require('net');
 
 {
   let finished = false;
@@ -1117,4 +1118,96 @@ const { promisify } = require('util');
   pipeline(src, dst, common.mustCall((err) => {
     assert.strictEqual(closed, true);
   }));
+}
+
+{
+  const server = net.createServer(common.mustCall((socket) => {
+    // echo server
+    pipeline(socket, socket, common.mustCall());
+    // 13 force destroys the socket before it has a chance to emit finish
+    socket.on('finish', common.mustCall(() => {
+      server.close();
+    }));
+  })).listen(0, common.mustCall(() => {
+    const socket = net.connect(server.address().port);
+    socket.end();
+  }));
+}
+
+{
+  const d = new Duplex({
+    autoDestroy: false,
+    write: common.mustCall((data, enc, cb) => {
+      d.push(data);
+      cb();
+    }),
+    read: common.mustCall(() => {
+      d.push(null);
+    }),
+    final: common.mustCall((cb) => {
+      setTimeout(() => {
+        assert.strictEqual(d.destroyed, false);
+        cb();
+      }, 1000);
+    }),
+    destroy: common.mustNotCall()
+  });
+
+  const sink = new Writable({
+    write: common.mustCall((data, enc, cb) => {
+      cb();
+    })
+  });
+
+  pipeline(d, sink, common.mustCall());
+
+  d.write('test');
+  d.end();
+}
+
+{
+  const server = net.createServer(common.mustCall((socket) => {
+    // echo server
+    pipeline(socket, socket, common.mustCall());
+    socket.on('finish', common.mustCall(() => {
+      server.close();
+    }));
+  })).listen(0, common.mustCall(() => {
+    const socket = net.connect(server.address().port);
+    socket.end();
+  }));
+}
+
+{
+  const d = new Duplex({
+    autoDestroy: false,
+    write: common.mustCall((data, enc, cb) => {
+      d.push(data);
+      cb();
+    }),
+    read: common.mustCall(() => {
+      d.push(null);
+    }),
+    final: common.mustCall((cb) => {
+      setTimeout(() => {
+        assert.strictEqual(d.destroyed, false);
+        cb();
+      }, 1000);
+    }),
+    // `destroy()` won't be invoked by pipeline since
+    // the writable side has not completed when
+    // the pipeline has completed.
+    destroy: common.mustNotCall()
+  });
+
+  const sink = new Writable({
+    write: common.mustCall((data, enc, cb) => {
+      cb();
+    })
+  });
+
+  pipeline(d, sink, common.mustCall());
+
+  d.write('test');
+  d.end();
 }


### PR DESCRIPTION
This PR logically reverts https://github.com/nodejs/node/pull/31940 which
has caused lots of unnecessary breakage in the ecosystem.

This PR also aligns better with the actual documented behavior:

`stream.pipeline()` will call `stream.destroy(err)` on all streams except:
  * `Readable` streams which have emitted `'end'` or `'close'`.
  * `Writable` streams which have emitted `'finish'` or `'close'`.

The behavior introduced in https://github.com/nodejs/node/pull/31940
was much more aggressive in terms of destroying streams. This was
good for avoiding potential resources leaks however breaks some
common assumputions in legacy streams.

Furthermore, it makes the code simpler and removes some hacks.

Fixes: https://github.com/nodejs/node/issues/32954
Fixes: https://github.com/nodejs/node/issues/32955

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
