### PR TITLE
deps: V8: cherry-pick e1eac1b16c96

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -35,7 +35,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.12',
+    'v8_embedder_string': '-node.13',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/test/cctest/parsing/test-scanner-streams.cc
+++ b/deps/v8/test/cctest/parsing/test-scanner-streams.cc
@@ -331,8 +331,8 @@ TEST(Utf8AdvanceUntilOverChunkBoundaries) {
   for (size_t i = 1; i < len; i++) {
     // Copy source string into buffer, splitting it at i.
     // Then add three chunks, 0..i-1, i..strlen-1, empty.
-    strncpy(buffer, unicode_utf8, i);
-    strncpy(buffer + i + 1, unicode_utf8 + i, len - i);
+    memcpy(buffer, unicode_utf8, i);
+    memcpy(buffer + i + 1, unicode_utf8 + i, len - i);
     buffer[i] = '\0';
     buffer[len + 1] = '\n';
     buffer[len + 2] = '\0';
@@ -360,8 +360,8 @@ TEST(Utf8ChunkBoundaries) {
   for (size_t i = 1; i < len; i++) {
     // Copy source string into buffer, splitting it at i.
     // Then add three chunks, 0..i-1, i..strlen-1, empty.
-    strncpy(buffer, unicode_utf8, i);
-    strncpy(buffer + i + 1, unicode_utf8 + i, len - i);
+    memcpy(buffer, unicode_utf8, i);
+    memcpy(buffer + i + 1, unicode_utf8 + i, len - i);
     buffer[i] = '\0';
     buffer[len + 1] = '\0';
     buffer[len + 2] = '\0';


### PR DESCRIPTION
Original commit message:

    Fix compilation error with devtoolset-8

    We are compiling V8 using devtoolset-8 and it is generating a new
    compilation error related to String Truncation:

    error: ‘char* strncpy(char*, const char*, size_t)’ output truncated copying between 1 and 15 bytes from a string of length 15 [-Werror=stringop-truncation]
              strncpy(buffer, unicode_utf8, i);

    Which basically means the null terminating character was not added to
    the end of the buffer:
    https://developers.redhat.com/blog/2018/05/24/detecting-string-truncation-with-gcc-8/

    This CL will changes 2 uses of "strncpy" to "memcpy" as strings
    are being copied partially and `\n` being added at a later stage.

    Change-Id: I3656afb00463d70ddb8700a487a1978b793e1d09
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2155038
    Reviewed-by: Andreas Haas <ahaas@chromium.org>
    Reviewed-by: Toon Verwaest <verwaest@chromium.org>
    Commit-Queue: Milad Farazmand <miladfar@ca.ibm.com>
    Cr-Commit-Position: refs/heads/master@{#67277}

Refs: https://github.com/v8/v8/commit/e1eac1b16c966879102c2310d7649637227eaa02

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
