### PR TITLE
doc: set module version 83 to node 14

### DIFF
--- a/doc/abi_version_registry.json
+++ b/doc/abi_version_registry.json
@@ -1,6 +1,6 @@
 {
   "NODE_MODULE_VERSION": [
-    { "modules": 83, "runtime": "node", "variant": "v8_8.1", "versions": "14.0.0-pre" },
+    { "modules": 83, "runtime": "node",     "variant": "v8_8.1",               "versions": "14.0.0" },
     { "modules": 82, "runtime": "electron", "variant": "electron",             "versions": "10" },
     { "modules": 81, "runtime": "node",     "variant": "v8_7.9",               "versions": "14.0.0-pre" },
     { "modules": 80, "runtime": "electron", "variant": "electron",             "versions": "9" },


### PR DESCRIPTION
Clearly state the modules version 83 is official node 14, similar as
it is done for other major node versions.
