### PR TITLE
doc: make openssl maintenance position independent

### DIFF
--- a/doc/guides/maintaining-openssl.md
+++ b/doc/guides/maintaining-openssl.md
@@ -57,7 +57,7 @@ This updates all sources in deps/openssl/openssl by:
 Use `make` to regenerate all platform dependent files in
 `deps/openssl/config/archs/`:
 ```sh
-% cd deps/openssl/config; make
+% make -C deps/openssl/config
 ```
 
 ## 3. Check diffs
@@ -66,8 +66,7 @@ Check diffs if updates are right. Even if no updates in openssl
 sources, `buildinf.h` files will be updated for they have a timestamp
 data in them.
 ```sh
-% cd deps/openssl/config
-% git diff
+% git diff -- deps/openssl
 ```
 
 *Note*: On Windows, OpenSSL Configure generates `makefile` that can be
@@ -95,8 +94,7 @@ The commit message can be (with the openssl version set to the relevant value):
 
  After an OpenSSL source update, all the config files need to be
  regenerated and committed by:
-    $ cd deps/openssl/config
-    $ make
+    $ make -C deps/openssl/config
     $ git add deps/openssl/config/archs
     $ git add deps/openssl/openssl/include/crypto/bn_conf.h
     $ git add deps/openssl/openssl/include/crypto/dso_conf.h


### PR DESCRIPTION
It used to have some `cd` commands that if done literally would
invalidate the subsequent commands. Modify them to be more accurate,
which also simplifies pasting them directly into the console from the
guide while doing an update.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

cc: @hassaanp 

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
