### PR TITLE
module: hide internal stack when emitCircularRequireWarning

### DIFF
--- a/lib/internal/process/warning.js
+++ b/lib/internal/process/warning.js
@@ -58,6 +58,17 @@ function doEmitWarning(warning) {
   return () => process.emit('warning', warning);
 }
 
+function hideInternalStacks(stacks) {
+  const newStack = [];
+  for (const stack of stacks.split('\n')) {
+    if (/\(internal\/.+\)$/.test(stack)) {
+      continue;
+    }
+    newStack.push(stack);
+  }
+  return newStack.join('\n');
+}
+
 let traceWarningHelperShown = false;
 function onWarning(warning) {
   if (!(warning instanceof Error)) return;
@@ -69,7 +80,8 @@ function onWarning(warning) {
   if (warning.code)
     msg += `[${warning.code}] `;
   if (trace && warning.stack) {
-    msg += `${warning.stack}`;
+    // hide internal stack
+    msg += hideInternalStacks(`${warning.stack}`);
   } else {
     const toString =
       typeof warning.toString === 'function' ?

--- a/lib/internal/process/warning.js
+++ b/lib/internal/process/warning.js
@@ -80,8 +80,7 @@ function onWarning(warning) {
   if (warning.code)
     msg += `[${warning.code}] `;
   if (trace && warning.stack) {
-    // hide internal stack
-    msg += hideInternalStacks(`${warning.stack}`);
+    msg += `${warning.stack}`;
   } else {
     const toString =
       typeof warning.toString === 'function' ?
@@ -91,12 +90,16 @@ function onWarning(warning) {
   if (typeof warning.detail === 'string') {
     msg += `\n${warning.detail}`;
   }
-  if (!trace && !traceWarningHelperShown) {
-    const flag = isDeprecation ? '--trace-deprecation' : '--trace-warnings';
-    const argv0 = require('path').basename(process.argv0 || 'node', '.exe');
-    msg += `\n(Use \`${argv0} ${flag} ...\` to show where the warning ` +
-           'was created)';
-    traceWarningHelperShown = true;
+  if (!traceWarningHelperShown) {
+    if (!trace) {
+      const flag = isDeprecation ? '--trace-deprecation' : '--trace-warnings';
+      const argv0 = require('path').basename(process.argv0 || 'node', '.exe');
+      msg += `\n(Use \`${argv0} ${flag} ...\` to show where the warning ` +
+          'was created)';
+      traceWarningHelperShown = true;
+    } else {
+      msg = hideInternalStacks(msg);
+    }
   }
   const warningFile = lazyOption();
   if (warningFile) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Fixes: https://github.com/nodejs/node/issues/32987
Refs: https://github.com/nodejs/node/pull/29935

previously:

```js
> node --trace-warnings a
(node:19168) Warning: Accessing non-existent property 'foo' of module exports inside circular dependency
    at emitCircularRequireWarning (internal/modules/cjs/loader.js:814:11)
    at Object.get (internal/modules/cjs/loader.js:825:5)
    at Object.<anonymous> (C:\Users\Himself65\Desktop\github\test\cycle\c.js:4:10)
    at Module._compile (internal/modules/cjs/loader.js:1185:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1205:10)
    at Module.load (internal/modules/cjs/loader.js:1034:32)
    at Function.Module._load (internal/modules/cjs/loader.js:923:14)
    at Module.require (internal/modules/cjs/loader.js:1074:19)
    at require (internal/modules/cjs/helpers.js:72:18)
    at Object.<anonymous> (C:\Users\Himself65\Desktop\github\test\cycle\b.js:1:1)
```

now

```js
node\Release\node.exe --trace-warnings C:\Users\Himself65\Desktop\github\test\cycle\a.js
(node:18824) Warning: Accessing non-existent property 'foo' of module exports inside circular dependency
    at Object.<anonymous> (C:\Users\Himself65\Desktop\github\test\cycle\c.js:4:10)
    at Object.<anonymous> (C:\Users\Himself65\Desktop\github\test\cycle\b.js:1:1)
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
