### PR TITLE
n-api: simplify uv_idle wrangling

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -250,8 +250,8 @@ class ThreadSafeFunction : public node::AsyncResource {
       if (max_queue_size > 0) {
         cond = std::make_unique<node::ConditionVariable>();
       }
-      if ((max_queue_size == 0 || cond) &&
-          uv_idle_init(loop, &idle) == 0) {
+      if (max_queue_size == 0 || cond) {
+        CHECK_EQ(0, uv_idle_init(loop, &idle));
         return napi_ok;
       }
 
@@ -291,7 +291,6 @@ class ThreadSafeFunction : public node::AsyncResource {
   void DispatchOne() {
     void* data = nullptr;
     bool popped_value = false;
-    bool idle_stop_failed = false;
 
     {
       node::Mutex::ScopedLock lock(this->mutex);
@@ -317,43 +316,24 @@ class ThreadSafeFunction : public node::AsyncResource {
             }
             CloseHandlesAndMaybeDelete();
           } else {
-            if (uv_idle_stop(&idle) != 0) {
-              idle_stop_failed = true;
-            }
+            CHECK_EQ(0, uv_idle_stop(&idle));
           }
         }
       }
     }
 
-    if (popped_value || idle_stop_failed) {
+    if (popped_value) {
       v8::HandleScope scope(env->isolate);
       CallbackScope cb_scope(this);
-
-      if (idle_stop_failed) {
-        CHECK(napi_throw_error(env,
-                               "ERR_NAPI_TSFN_STOP_IDLE_LOOP",
-                               "Failed to stop the idle loop") == napi_ok);
-      } else {
-        napi_value js_callback = nullptr;
-        if (!ref.IsEmpty()) {
-          v8::Local<v8::Function> js_cb =
-            v8::Local<v8::Function>::New(env->isolate, ref);
-          js_callback = v8impl::JsValueFromV8LocalValue(js_cb);
-        }
-        env->CallIntoModuleThrow([&](napi_env env) {
-          call_js_cb(env, js_callback, context, data);
-        });
+      napi_value js_callback = nullptr;
+      if (!ref.IsEmpty()) {
+        v8::Local<v8::Function> js_cb =
+          v8::Local<v8::Function>::New(env->isolate, ref);
+        js_callback = v8impl::JsValueFromV8LocalValue(js_cb);
       }
-    }
-  }
-
-  void MaybeStartIdle() {
-    if (uv_idle_start(&idle, IdleCb) != 0) {
-      v8::HandleScope scope(env->isolate);
-      CallbackScope cb_scope(this);
-      CHECK(napi_throw_error(env,
-                             "ERR_NAPI_TSFN_START_IDLE_LOOP",
-                             "Failed to start the idle loop") == napi_ok);
+      env->CallIntoModuleThrow([&](napi_env env) {
+        call_js_cb(env, js_callback, context, data);
+      });
     }
   }
 
@@ -435,7 +415,7 @@ class ThreadSafeFunction : public node::AsyncResource {
   static void AsyncCb(uv_async_t* async) {
     ThreadSafeFunction* ts_fn =
         node::ContainerOf(&ThreadSafeFunction::async, async);
-    ts_fn->MaybeStartIdle();
+    CHECK_EQ(0, uv_idle_start(&ts_fn->idle, IdleCb));
   }
 
   static void Cleanup(void* data) {


### PR DESCRIPTION
uv_idle_init(), uv_idle_start() and uv_idle_stop() always succeed.
Remove the superfluous error handling.

Refs: https://github.com/libuv/libuv/pull/2803