### PR TITLE
cli: add --heapsnapshot-near-heap-limit option

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -341,9 +341,8 @@ added: REPLACEME
 > Stability: 1 - Experimental
 
 Writes a V8 heap snapshot to disk when the V8 heap usage is approaching the
-heap limit. `count` should be either -1 (in which case no snapshots would be
-written), or a positive integer (in which case Node.js will write no more than
-`max_count` snapshots to disk).
+heap limit. `count` should be a non-negative integer (in which case
+Node.js will write no more than `max_count` snapshots to disk).
 
 When generating snapshots, garbage collection may be triggered and bring
 the heap usage down, therefore multiple snapshots may be written to disk

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -333,6 +333,53 @@ reference. Code may break under this flag.
 `--require` runs prior to freezing intrinsics in order to allow polyfills to
 be added.
 
+### `--heapsnapshot-near-heap-limit=max_count`
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+Writes a V8 heap snapshot to disk when the V8 heap usage is approaching the
+heap limit. `count` should be either -1 (in which case no snapshots would be
+written), or a positive integer (in which case Node.js will write no more than
+`max_count` snapshots to disk).
+
+When generating snapshots, garbage collection may be triggered and bring
+the heap usage down, therefore multiple snapshots may be written to disk
+before the Node.js instance finally runs out of memory. These heap snapshots
+can be compared to determine what objects are being allocated during the
+time consecutive snapshots are taken. It's not guaranteed that Node.js will
+write exactly `max_count` snapshots to disk, but it will try
+its best to generate at least one and up to `max_count` snapshots before the
+Node.js instance runs out of memory.
+
+Generating V8 snapshots takes time and memory (both memory managed by the
+V8 heap and native memory outside the V8 heap). The bigger the heap is,
+the more resources it needs. Node.js will adjust the V8 heap to accommondate
+the additional V8 heap memory overhead, and try its best to avoid using up
+all the memory avialable to the process. When the process uses
+more memory than the system deems appropriate, the process may be terminated
+abruptly by the system, depending on the system configuration.
+
+```console
+$ node --max-old-space-size=100 --heapsnapshot-near-heap-limit=3 index.js
+Wrote snapshot to Heap.20200430.100036.49580.0.001.heapsnapshot
+Wrote snapshot to Heap.20200430.100037.49580.0.002.heapsnapshot
+Wrote snapshot to Heap.20200430.100038.49580.0.003.heapsnapshot
+
+<--- Last few GCs --->
+
+[49580:0x110000000]     4826 ms: Mark-sweep 130.6 (147.8) -> 130.5 (147.8) MB, 27.4 / 0.0 ms  (average mu = 0.126, current mu = 0.034) allocation failure scavenge might not succeed
+[49580:0x110000000]     4845 ms: Mark-sweep 130.6 (147.8) -> 130.6 (147.8) MB, 18.8 / 0.0 ms  (average mu = 0.088, current mu = 0.031) allocation failure scavenge might not succeed
+
+
+<--- JS stacktrace --->
+
+FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
+....
+```
+
 ### `--heapsnapshot-signal=signal`
 <!-- YAML
 added: v12.0.0
@@ -1276,6 +1323,7 @@ Node.js options that are allowed are:
 * `--force-context-aware`
 * `--force-fips`
 * `--frozen-intrinsics`
+* `--heapsnapshot-near-heap-limit`
 * `--heapsnapshot-signal`
 * `--http-parser`
 * `--icu-data-dir`

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -351,7 +351,7 @@ can be compared to determine what objects are being allocated during the
 time consecutive snapshots are taken. It's not guaranteed that Node.js will
 write exactly `max_count` snapshots to disk, but it will try
 its best to generate at least one and up to `max_count` snapshots before the
-Node.js instance runs out of memory.
+Node.js instance runs out of memory when `max_count` is greater than `0`.
 
 Generating V8 snapshots takes time and memory (both memory managed by the
 V8 heap and native memory outside the V8 heap). The bigger the heap is,

--- a/doc/node.1
+++ b/doc/node.1
@@ -182,6 +182,10 @@ Same requirements as
 .It Fl -frozen-intrinsics
 Enable experimental frozen intrinsics support.
 .
+.It Fl -heapsnapshot-near-heap-limit Ns = Ns Ar max_count
+Generate heap snapshot when the V8 heap usage is approaching the heap limit.
+No more than the specified number of snapshots will be generated.
+.
 .It Fl -heapsnapshot-signal Ns = Ns Ar signal
 Generate heap snapshot on specified signal.
 .

--- a/src/debug_utils.h
+++ b/src/debug_utils.h
@@ -41,6 +41,7 @@ void FWrite(FILE* file, const std::string& str);
 // from a provider type to a debug category.
 #define DEBUG_CATEGORY_NAMES(V)                                                \
   NODE_ASYNC_PROVIDER_TYPES(V)                                                 \
+  V(DIAGNOSTICS)                                                               \
   V(HUGEPAGES)                                                                 \
   V(INSPECTOR_SERVER)                                                          \
   V(INSPECTOR_PROFILER)                                                        \

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -614,6 +614,22 @@ inline const std::string& Environment::exec_path() const {
   return exec_path_;
 }
 
+inline std::string Environment::GetCwd() {
+  char cwd[PATH_MAX_BYTES];
+  size_t size = PATH_MAX_BYTES;
+  const int err = uv_cwd(cwd, &size);
+
+  if (err == 0) {
+    CHECK_GT(size, 0);
+    return cwd;
+  }
+
+  // This can fail if the cwd is deleted. In that case, fall back to
+  // exec_path.
+  const std::string& exec_path = exec_path_;
+  return exec_path.substr(0, exec_path.find_last_of(kPathSeparator));
+}
+
 #if HAVE_INSPECTOR
 inline void Environment::set_coverage_directory(const char* dir) {
   coverage_directory_ = std::string(dir);

--- a/src/env.h
+++ b/src/env.h
@@ -595,6 +595,7 @@ class IsolateData : public MemoryRetainer {
 #undef VP
   inline v8::Local<v8::String> async_wrap_provider(int index) const;
 
+  size_t max_young_gen_size = 1;
   std::unordered_map<const char*, v8::Eternal<v8::String>> static_str_map;
 
   inline v8::Isolate* isolate() const;
@@ -959,6 +960,9 @@ class Environment : public MemoryRetainer {
   void VerifyNoStrongBaseObjects();
   // Should be called before InitializeInspector()
   void InitializeDiagnostics();
+
+  std::string GetCwd();
+
 #if HAVE_INSPECTOR
   // If the environment is created for a worker, pass parent_handle and
   // the ownership if transferred into the Environment.
@@ -1317,6 +1321,9 @@ class Environment : public MemoryRetainer {
   inline void RemoveCleanupHook(void (*fn)(void*), void* arg);
   void RunCleanup();
 
+  static size_t NearHeapLimitCallback(void* data,
+                                      size_t current_heap_limit,
+                                      size_t initial_heap_limit);
   static void BuildEmbedderGraph(v8::Isolate* isolate,
                                  v8::EmbedderGraph* graph,
                                  void* data);
@@ -1434,6 +1441,9 @@ class Environment : public MemoryRetainer {
   std::vector<std::string> exec_argv_;
   std::vector<std::string> argv_;
   std::string exec_path_;
+
+  bool is_processing_heap_limit_callback_ = false;
+  int64_t heap_limit_snapshot_taken_ = 0;
 
   uint32_t module_id_counter_ = 0;
   uint32_t script_id_counter_ = 0;

--- a/src/heap_utils.cc
+++ b/src/heap_utils.cc
@@ -313,7 +313,9 @@ inline void TakeSnapshot(Isolate* isolate, v8::OutputStream* out) {
   snapshot->Serialize(out, HeapSnapshot::kJSON);
 }
 
-inline bool WriteSnapshot(Isolate* isolate, const char* filename) {
+}  // namespace
+
+bool WriteSnapshot(Isolate* isolate, const char* filename) {
   FILE* fp = fopen(filename, "w");
   if (fp == nullptr)
     return false;
@@ -322,8 +324,6 @@ inline bool WriteSnapshot(Isolate* isolate, const char* filename) {
   fclose(fp);
   return true;
 }
-
-}  // namespace
 
 void DeleteHeapSnapshot(const HeapSnapshot* snapshot) {
   const_cast<HeapSnapshot*>(snapshot)->Delete();

--- a/src/inspector_profiler.cc
+++ b/src/inspector_profiler.cc
@@ -394,22 +394,6 @@ static void EndStartedProfilers(Environment* env) {
   }
 }
 
-std::string GetCwd(Environment* env) {
-  char cwd[PATH_MAX_BYTES];
-  size_t size = PATH_MAX_BYTES;
-  const int err = uv_cwd(cwd, &size);
-
-  if (err == 0) {
-    CHECK_GT(size, 0);
-    return cwd;
-  }
-
-  // This can fail if the cwd is deleted. In that case, fall back to
-  // exec_path.
-  const std::string& exec_path = env->exec_path();
-  return exec_path.substr(0, exec_path.find_last_of(kPathSeparator));
-}
-
 void StartProfilers(Environment* env) {
   AtExit(env, [](void* env) {
     EndStartedProfilers(static_cast<Environment*>(env));
@@ -427,7 +411,7 @@ void StartProfilers(Environment* env) {
   if (env->options()->cpu_prof) {
     const std::string& dir = env->options()->cpu_prof_dir;
     env->set_cpu_prof_interval(env->options()->cpu_prof_interval);
-    env->set_cpu_prof_dir(dir.empty() ? GetCwd(env) : dir);
+    env->set_cpu_prof_dir(dir.empty() ? env->GetCwd() : dir);
     if (env->options()->cpu_prof_name.empty()) {
       DiagnosticFilename filename(env, "CPU", "cpuprofile");
       env->set_cpu_prof_name(*filename);
@@ -442,7 +426,7 @@ void StartProfilers(Environment* env) {
   if (env->options()->heap_prof) {
     const std::string& dir = env->options()->heap_prof_dir;
     env->set_heap_prof_interval(env->options()->heap_prof_interval);
-    env->set_heap_prof_dir(dir.empty() ? GetCwd(env) : dir);
+    env->set_heap_prof_dir(dir.empty() ? env->GetCwd() : dir);
     if (env->options()->heap_prof_name.empty()) {
       DiagnosticFilename filename(env, "Heap", "heapprofile");
       env->set_heap_prof_name(*filename);

--- a/src/node.cc
+++ b/src/node.cc
@@ -275,6 +275,10 @@ static void AtomicsWaitCallback(Isolate::AtomicsWaitEvent event,
 void Environment::InitializeDiagnostics() {
   isolate_->GetHeapProfiler()->AddBuildEmbedderGraphCallback(
       Environment::BuildEmbedderGraph, this);
+  if (options_->heap_snapshot_near_heap_limit > 0) {
+    isolate_->AddNearHeapLimitCallback(Environment::NearHeapLimitCallback,
+                                       this);
+  }
   if (options_->trace_uncaught)
     isolate_->SetCaptureStackTraceForUncaughtExceptions(true);
   if (options_->trace_atomics_wait) {

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -363,6 +363,10 @@ class DiagnosticFilename {
   std::string filename_;
 };
 
+namespace heap {
+bool WriteSnapshot(v8::Isolate* isolate, const char* filename);
+}
+
 class TraceEventScope {
  public:
   TraceEventScope(const char* category,

--- a/src/node_main_instance.cc
+++ b/src/node_main_instance.cc
@@ -108,6 +108,8 @@ NodeMainInstance::NodeMainInstance(
     // complete.
     SetIsolateErrorHandlers(isolate_, s);
   }
+  isolate_data_->max_young_gen_size =
+      params->constraints.max_young_generation_size_in_bytes();
 }
 
 void NodeMainInstance::Dispose() {

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -118,10 +118,8 @@ void EnvironmentOptions::CheckOptions(std::vector<std::string>* errors) {
                       "used, not both");
   }
 
-  if (heap_snapshot_near_heap_limit < 1 &&
-      heap_snapshot_near_heap_limit != -1) {
-    errors->push_back(
-        "--heap-snapshot-near-heap-limit must be either postive or -1");
+  if (heap_snapshot_near_heap_limit < 0) {
+    errors->push_back("--heap-snapshot-near-heap-limit must not be negative");
   }
 
 #if HAVE_INSPECTOR

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -118,6 +118,12 @@ void EnvironmentOptions::CheckOptions(std::vector<std::string>* errors) {
                       "used, not both");
   }
 
+  if (heap_snapshot_near_heap_limit < 1 &&
+      heap_snapshot_near_heap_limit != -1) {
+    errors->push_back(
+        "--heap-snapshot-near-heap-limit must be either postive or -1");
+  }
+
 #if HAVE_INSPECTOR
   if (!cpu_prof) {
     if (!cpu_prof_name.empty()) {
@@ -340,6 +346,12 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
   AddOption("--heapsnapshot-signal",
             "Generate heap snapshot on specified signal",
             &EnvironmentOptions::heap_snapshot_signal,
+            kAllowedInEnvironment);
+  AddOption("--heapsnapshot-near-heap-limit",
+            "Generate heap snapshots whenever V8 is approaching "
+            "the heap limit. No more than the specified number of "
+            "heap snapshots will be generated.",
+            &EnvironmentOptions::heap_snapshot_near_heap_limit,
             kAllowedInEnvironment);
   AddOption("--http-parser", "", NoOp{}, kAllowedInEnvironment);
   AddOption("--insecure-http-parser",

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -115,7 +115,7 @@ class EnvironmentOptions : public Options {
   bool experimental_vm_modules = false;
   bool expose_internals = false;
   bool frozen_intrinsics = false;
-  int64_t heap_snapshot_near_heap_limit = -1;
+  int64_t heap_snapshot_near_heap_limit = 0;
   std::string heap_snapshot_signal;
   uint64_t max_http_header_size = 16 * 1024;
   bool no_deprecation = false;

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -115,6 +115,7 @@ class EnvironmentOptions : public Options {
   bool experimental_vm_modules = false;
   bool expose_internals = false;
   bool frozen_intrinsics = false;
+  int64_t heap_snapshot_near_heap_limit = -1;
   std::string heap_snapshot_signal;
   uint64_t max_http_header_size = 16 * 1024;
   bool no_deprecation = false;

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -159,6 +159,9 @@ class WorkerThreadData {
     Isolate::Initialize(isolate, params);
     SetIsolateUpForNode(isolate);
 
+    // Be sure it's called before Environment::InitializeDiagnostics()
+    // so that this callback stays when the callback of
+    // --heapsnapshot-near-heap-limit gets is popped.
     isolate->AddNearHeapLimitCallback(Worker::NearHeapLimit, w);
 
     {
@@ -177,6 +180,8 @@ class WorkerThreadData {
       if (w_->per_isolate_opts_)
         isolate_data_->set_options(std::move(w_->per_isolate_opts_));
       isolate_data_->set_worker_context(w_);
+      isolate_data_->max_young_gen_size =
+          params.constraints.max_young_generation_size_in_bytes();
     }
 
     Mutex::ScopedLock lock(w_->mutex_);

--- a/test/fixtures/workload/bounded.js
+++ b/test/fixtures/workload/bounded.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const total = parseInt(process.env.TEST_ALLOCATION) || 5000;
+const chunk = parseInt(process.env.TEST_CHUNK) || 1000;
+const cleanInterval = parseInt(process.env.TEST_CLEAN_INTERVAL) || 100;
+let count = 0;
+let arr = [];
+function runAllocation() {
+  count++;
+  if (count < total) {
+    if (count % cleanInterval === 0) {
+      arr.splice(0, arr.length);
+      setImmediate(runAllocation);
+    } else {
+      const str = JSON.stringify(process.config).slice(0, chunk);
+      arr.push(str);
+      setImmediate(runAllocation);
+    }
+  }
+}
+
+setImmediate(runAllocation);

--- a/test/fixtures/workload/grow-worker.js
+++ b/test/fixtures/workload/grow-worker.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const { Worker } = require('worker_threads');
+const path = require('path');
+const max_snapshots = parseInt(process.env.TEST_SNAPSHOTS) || 1;
+new Worker(path.join(__dirname, 'grow.js'), {
+  execArgv: [
+    `--heapsnapshot-near-heap-limit=${max_snapshots}`,
+  ],
+  resourceLimits: {
+    maxOldGenerationSizeMb:
+      parseInt(process.env.TEST_OLD_SPACE_SIZE) || 20
+  }
+});

--- a/test/fixtures/workload/grow.js
+++ b/test/fixtures/workload/grow.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const chunk = parseInt(process.env.TEST_CHUNK) || 1000;
+
+let arr = [];
+function runAllocation() {
+  const str = JSON.stringify(process.config).slice(0, chunk);
+  arr.push(str);
+  setImmediate(runAllocation);
+}
+
+setImmediate(runAllocation);

--- a/test/parallel/test-heapsnapshot-near-heap-limit-bounded.js
+++ b/test/parallel/test-heapsnapshot-near-heap-limit-bounded.js
@@ -1,0 +1,36 @@
+'use strict';
+
+require('../common');
+const tmpdir = require('../common/tmpdir');
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+const fixtures = require('../common/fixtures');
+const fs = require('fs');
+const env = {
+  ...process.env,
+  TEST_ALLOCATION: 50000,
+  TEST_CHUNK: 1000,
+  TEST_CLEAN_INTERVAL: 500,
+  NODE_DEBUG_NATIVE: 'diagnostics'
+};
+
+{
+  console.log('\nTesting limit = 1');
+  tmpdir.refresh();
+  const child = spawnSync(process.execPath, [
+    '--trace-gc',
+    '--heapsnapshot-near-heap-limit=1',
+    '--max-old-space-size=50',
+    fixtures.path('workload', 'bounded.js')
+  ], {
+    cwd: tmpdir.path,
+    env,
+  });
+  console.log(child.stdout.toString());
+  console.log(child.stderr.toString());
+  assert.strictEqual(child.signal, null);
+  assert.strictEqual(child.status, 0);
+  const list = fs.readdirSync(tmpdir.path)
+    .filter((file) => file.endsWith('.heapsnapshot'));
+  assert.strictEqual(list.length, 0);
+}

--- a/test/parallel/test-heapsnapshot-near-heap-limit.js
+++ b/test/parallel/test-heapsnapshot-near-heap-limit.js
@@ -1,0 +1,106 @@
+'use strict';
+
+const common = require('../common');
+const tmpdir = require('../common/tmpdir');
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+const fixtures = require('../common/fixtures');
+const fs = require('fs');
+const env = {
+  ...process.env,
+  NODE_DEBUG_NATIVE: 'diagnostics'
+};
+
+{
+  tmpdir.refresh();
+  const child = spawnSync(process.execPath, [
+    '--heapsnapshot-near-heap-limit=-15',
+    '--max-old-space-size=50',
+    fixtures.path('workload', 'grow.js')
+  ], {
+    cwd: tmpdir.path,
+    env,
+  });
+  assert.strictEqual(child.status, 9);
+}
+
+{
+  tmpdir.refresh();
+  const child = spawnSync(process.execPath, [
+    '--heapsnapshot-near-heap-limit=0',
+    '--max-old-space-size=50',
+    fixtures.path('workload', 'grow.js')
+  ], {
+    cwd: tmpdir.path,
+    env,
+  });
+  assert.strictEqual(child.status, 9);
+}
+
+{
+  console.log('\nTesting limit = 1');
+  tmpdir.refresh();
+  const child = spawnSync(process.execPath, [
+    '--trace-gc',
+    '--heapsnapshot-near-heap-limit=1',
+    '--max-old-space-size=50',
+    fixtures.path('workload', 'grow.js')
+  ], {
+    cwd: tmpdir.path,
+    env,
+  });
+  console.log(child.stdout.toString());
+  console.log(child.stderr.toString());
+  assert(common.nodeProcessAborted(child.status, child.signal),
+         'process should have aborted, but did not');
+  const list = fs.readdirSync(tmpdir.path)
+    .filter((file) => file.endsWith('.heapsnapshot'));
+  assert.strictEqual(list.length, 1);
+}
+
+{
+  console.log('\nTesting limit = 3');
+  tmpdir.refresh();
+  const child = spawnSync(process.execPath, [
+    '--trace-gc',
+    '--heapsnapshot-near-heap-limit=3',
+    '--max-old-space-size=50',
+    fixtures.path('workload', 'grow.js')
+  ], {
+    cwd: tmpdir.path,
+    env,
+  });
+  console.log(child.stdout.toString());
+  console.log(child.stderr.toString());
+  assert(common.nodeProcessAborted(child.status, child.signal),
+         'process should have aborted, but did not');
+  const list = fs.readdirSync(tmpdir.path)
+    .filter((file) => file.endsWith('.heapsnapshot'));
+  assert(list.length > 0 && list.length <= 3);
+}
+
+
+{
+  console.log('\nTesting worker');
+  tmpdir.refresh();
+  const child = spawnSync(process.execPath, [
+    fixtures.path('workload', 'grow-worker.js')
+  ], {
+    cwd: tmpdir.path,
+    env: {
+      TEST_SNAPSHOTS: 1,
+      TEST_OLD_SPACE_SIZE: 50,
+      ...env
+    }
+  });
+  console.log(child.stdout.toString());
+  const stderr = child.stderr.toString();
+  console.log(stderr);
+  // There should be one snapshot taken and then after the
+  // snapshot heap limit callback is popped, the OOM callback
+  // becomes effective.
+  assert(stderr.includes('ERR_WORKER_OUT_OF_MEMORY'));
+  const list = fs.readdirSync(tmpdir.path)
+    .filter((file) => file.endsWith('.heapsnapshot'));
+  assert.strictEqual(list.length, 1);
+}

--- a/test/parallel/test-heapsnapshot-near-heap-limit.js
+++ b/test/parallel/test-heapsnapshot-near-heap-limit.js
@@ -25,8 +25,10 @@ const env = {
 }
 
 {
+  console.log('\nTesting limit = 0');
   tmpdir.refresh();
   const child = spawnSync(process.execPath, [
+    '--trace-gc',
     '--heapsnapshot-near-heap-limit=0',
     '--max-old-space-size=50',
     fixtures.path('workload', 'grow.js')
@@ -34,7 +36,13 @@ const env = {
     cwd: tmpdir.path,
     env,
   });
-  assert.strictEqual(child.status, 9);
+  console.log(child.stdout.toString());
+  console.log(child.stderr.toString());
+  assert(common.nodeProcessAborted(child.status, child.signal),
+         'process should have aborted, but did not');
+  const list = fs.readdirSync(tmpdir.path)
+    .filter((file) => file.endsWith('.heapsnapshot'));
+  assert.strictEqual(list.length, 0);
 }
 
 {

--- a/test/pummel/test-heapsnapshot-near-heap-limit-big.js
+++ b/test/pummel/test-heapsnapshot-near-heap-limit-big.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const common = require('../common');
+const tmpdir = require('../common/tmpdir');
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+const fixtures = require('../common/fixtures');
+const fs = require('fs');
+const env = {
+  ...process.env,
+  NODE_DEBUG_NATIVE: 'diagnostics'
+};
+
+if (!common.enoughTestMem)
+  common.skip('Insufficient memory for snapshot test');
+
+{
+  console.log('\nTesting limit = 3');
+  tmpdir.refresh();
+  const child = spawnSync(process.execPath, [
+    '--heapsnapshot-near-heap-limit=3',
+    '--max-old-space-size=512',
+    fixtures.path('workload', 'grow.js')
+  ], {
+    cwd: tmpdir.path,
+    env: {
+      ...env,
+      TEST_CHUNK: 2000,
+    }
+  });
+  const stderr = child.stderr.toString();
+  console.log(stderr);
+  assert(common.nodeProcessAborted(child.status, child.signal),
+         'process should have aborted, but did not');
+  const list = fs.readdirSync(tmpdir.path)
+    .filter((file) => file.endsWith('.heapsnapshot'));
+  if (list.length === 0) {
+    assert(stderr.includes(
+      'Not generating snapshots because it\'s too risky'));
+  } else {
+    assert(list.length > 0 && list.length <= 5);
+  }
+}

--- a/test/pummel/test-heapsnapshot-near-heap-limit-big.js
+++ b/test/pummel/test-heapsnapshot-near-heap-limit-big.js
@@ -38,6 +38,6 @@ if (!common.enoughTestMem)
     assert(stderr.includes(
       'Not generating snapshots because it\'s too risky'));
   } else {
-    assert(list.length > 0 && list.length <= 5);
+    assert(list.length > 0 && list.length <= 3);
   }
 }


### PR DESCRIPTION
This patch adds a --heapsnapshot-near-heap-limit CLI option
that takes heap snapshots when the V8 heap is approaching
the heap size limit. It will try to write the snapshots
to disk before the program crashes due to OOM.

This currently takes a number specifying the maximum number
of heap snapshots Node.js will write - doing heap snapshots
triggers GC eagerly and could keep the process in limbo for longer
than it should in a heap with unbounded growth, and it may consume
a lot of CPU and I/O resources to serialize these snapshots while the
process is irresponsive, so users may want to limit the number of
heap snapshots taken. The heap limit could be approached multiple
times due to the GC trigger by taking heap snapshots, thus multiple
heap snapshots may be taken before the program crashes.

Refs: https://github.com/nodejs/node/issues/27552

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
