### PR TITLE
src: fix compiler warnings in node_http2.cc

### DIFF
--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -991,7 +991,6 @@ int Http2Session::OnStreamClose(nghttp2_session* handle,
   MaybeLocal<Value> answer =
     stream->MakeCallback(env->http2session_on_stream_close_function(),
                           1, &arg);
-  Local<Value> def = v8::False(env->isolate());
   if (answer.IsEmpty() || answer.ToLocalChecked()->IsFalse()) {
     // Skip to destroy
     stream->Destroy();
@@ -2752,7 +2751,6 @@ void Http2Session::Origin(const FunctionCallbackInfo<Value>& args) {
 
 // Submits a PING frame to be sent to the connected peer.
 void Http2Session::Ping(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
   Http2Session* session;
   ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
 
@@ -2771,7 +2769,6 @@ void Http2Session::Ping(const FunctionCallbackInfo<Value>& args) {
 
 // Submits a SETTINGS frame for the Http2Session
 void Http2Session::Settings(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
   Http2Session* session;
   ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
   CHECK(args[0]->IsFunction());


### PR DESCRIPTION
Currently, the following compiler warnings are generated:
```console
../src/node_http2.cc: In static member function
‘static int node::http2::Http2Session::OnStreamClose(nghttp2_session*,
    int32_t, uint32_t, void*)’:
../src/node_http2.cc:994:16: warning:
variable ‘def’ set but not used [-Wunused-but-set-variable]
  994 |   Local<Value> def = v8::False(env->isolate());
      |                ^~~
../src/node_http2.cc: In static member function
‘static void node::http2::Http2Session::Ping(
    const v8::FunctionCallbackInfo<v8::Value>&)’:
../src/node_http2.cc:2755:16: warning:
unused variable ‘env’ [-Wunused-variable]
 2755 |   Environment* env = Environment::GetCurrent(args);
      |                ^~~
../src/node_http2.cc: In static member function
‘static void node::http2::Http2Session::Settings(
const v8::FunctionCallbackInfo<v8::Value>&)’:
../src/node_http2.cc:2774:16: warning:
unused variable ‘env’ [-Wunused-variable]
 2774 |   Environment* env = Environment::GetCurrent(args);
      |                ^~~
```
This commit removes these unused variables.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
