### PR TITLE
inspector: throw error when activating an already active inspector

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1210,6 +1210,13 @@ time.
 The `--input-type` flag was used to attempt to execute a file. This flag can
 only be used with input via `--eval`, `--print` or `STDIN`.
 
+<a id="ERR_INSPECTOR_ALREADY_ACTIVATED"></a>
+### `ERR_INSPECTOR_ALREADY_ACTIVATED`
+
+While using the `inspector` module, an attempt was made to activate the
+inspector when it already started to listen on a port. Use `inspector.close()`
+before activating it on a different address.
+
 <a id="ERR_INSPECTOR_ALREADY_CONNECTED"></a>
 ### `ERR_INSPECTOR_ALREADY_CONNECTED`
 

--- a/lib/inspector.js
+++ b/lib/inspector.js
@@ -8,6 +8,7 @@ const {
 } = primordials;
 
 const {
+  ERR_INSPECTOR_ALREADY_ACTIVATED,
   ERR_INSPECTOR_ALREADY_CONNECTED,
   ERR_INSPECTOR_CLOSED,
   ERR_INSPECTOR_COMMAND,
@@ -33,6 +34,7 @@ const {
   MainThreadConnection,
   open,
   url,
+  isEnabled,
   waitForDebugger
 } = internalBinding('inspector');
 
@@ -131,6 +133,9 @@ class Session extends EventEmitter {
 }
 
 function inspectorOpen(port, host, wait) {
+  if (isEnabled()) {
+    throw new ERR_INSPECTOR_ALREADY_ACTIVATED();
+  }
   open(port, host);
   if (wait)
     waitForDebugger();

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -920,6 +920,10 @@ E('ERR_INCOMPATIBLE_OPTION_PAIR',
   'Option "%s" cannot be used in combination with option "%s"', TypeError);
 E('ERR_INPUT_TYPE_NOT_ALLOWED', '--input-type can only be used with string ' +
   'input via --eval, --print, or STDIN', Error);
+E('ERR_INSPECTOR_ALREADY_ACTIVATED',
+  'Inspector is already activated. Close it with inspector.close() ' +
+  'before activating it again.',
+  Error);
 E('ERR_INSPECTOR_ALREADY_CONNECTED', '%s is already connected', Error);
 E('ERR_INSPECTOR_CLOSED', 'Session was closed', Error);
 E('ERR_INSPECTOR_COMMAND', 'Inspector error %d: %s', Error);

--- a/test/sequential/test-inspector-already-activated-cli.js
+++ b/test/sequential/test-inspector-already-activated-cli.js
@@ -1,0 +1,18 @@
+// Flags: --inspect=0
+'use strict';
+
+const common = require('../common');
+common.skipIfInspectorDisabled();
+
+const assert = require('assert');
+const inspector = require('inspector');
+const wsUrl = inspector.url();
+assert(wsUrl.startsWith('ws://'));
+assert.throws(() => {
+  inspector.open(0, undefined, false);
+}, {
+  code: 'ERR_INSPECTOR_ALREADY_ACTIVATED'
+})
+assert.strictEqual(inspector.url(), wsUrl);
+inspector.close();
+assert.strictEqual(inspector.url(), undefined);

--- a/test/sequential/test-inspector-already-activated-cli.js
+++ b/test/sequential/test-inspector-already-activated-cli.js
@@ -3,6 +3,7 @@
 
 const common = require('../common');
 common.skipIfInspectorDisabled();
+common.skipIfWorker();
 
 const assert = require('assert');
 const inspector = require('inspector');
@@ -12,7 +13,7 @@ assert.throws(() => {
   inspector.open(0, undefined, false);
 }, {
   code: 'ERR_INSPECTOR_ALREADY_ACTIVATED'
-})
+});
 assert.strictEqual(inspector.url(), wsUrl);
 inspector.close();
 assert.strictEqual(inspector.url(), undefined);


### PR DESCRIPTION
When the user tries to activate the inspector that is already active
on a different port and host, we previously just silently reset
the port and host stored in the Environment without actually doing
anything for that to be effective. After this patch, we throw
an error telling the user to close the active inspector before invoking
`inspector.open()` again.

Fixes: https://github.com/nodejs/node/issues/33012

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
