### PR TITLE
process: Change default --unhandled-rejections=throw

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1007,15 +1007,11 @@ added:
  - v10.17.0
 -->
 
-By default all unhandled rejections trigger a warning plus a deprecation warning
-for the very first unhandled rejection in case no [`unhandledRejection`][] hook
-is used.
-
 Using this flag allows to change what should happen when an unhandled rejection
 occurs. One of the following modes can be chosen:
 
 * `throw`: Emit [`unhandledRejection`][]. If this hook is not set, raise the
-  unhandled rejection as an uncaught exception.
+  unhandled rejection as an uncaught exception. This is the default.
 * `strict`: Raise the unhandled rejection as an uncaught exception.
 * `warn`: Always trigger a warning, no matter if the [`unhandledRejection`][]
   hook is set or not but do not print the deprecation warning.

--- a/lib/internal/process/promises.js
+++ b/lib/internal/process/promises.js
@@ -57,11 +57,6 @@ const kThrowUnhandledRejections = 3;
 
 const kWarnWithErrorCodeUnhandledRejections = 4;
 
-// --unhandled-rejections is unset:
-// Emit 'unhandledRejection', if it's unhandled, emit
-// 'UnhandledPromiseRejectionWarning', then emit deprecation warning.
-const kDefaultUnhandledRejections = 5;
-
 let unhandledRejectionsMode;
 
 function setHasRejectionToWarn(value) {
@@ -86,7 +81,7 @@ function getUnhandledRejectionsMode() {
     case 'warn-with-error-code':
       return kWarnWithErrorCodeUnhandledRejections;
     default:
-      return kDefaultUnhandledRejections;
+      return kThrowUnhandledRejections;
   }
 }
 
@@ -175,15 +170,6 @@ function emitUnhandledRejectionWarning(uid, reason) {
   process.emitWarning(warning);
 }
 
-let deprecationWarned = false;
-function emitDeprecationWarning() {
-  process.emitWarning(
-    'Unhandled promise rejections are deprecated. In the future, ' +
-    'promise rejections that are not handled will terminate the ' +
-    'Node.js process with a non-zero exit code.',
-    'DeprecationWarning', 'DEP0018');
-}
-
 // If this method returns true, we've executed user code or triggered
 // a warning to be emitted which requires the microtask and next tick
 // queues to be drained again.
@@ -238,17 +224,6 @@ function processPromiseRejections() {
         if (!handled) {
           emitUnhandledRejectionWarning(uid, reason);
           process.exitCode = 1;
-        }
-        break;
-      }
-      case kDefaultUnhandledRejections: {
-        const handled = process.emit('unhandledRejection', reason, promise);
-        if (!handled) {
-          emitUnhandledRejectionWarning(uid, reason);
-          if (!deprecationWarned) {
-            emitDeprecationWarning();
-            deprecationWarned = true;
-          }
         }
         break;
       }

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -599,11 +599,8 @@ function getBufferSources(buf) {
   return [...getArrayBufferViews(buf), new Uint8Array(buf).buffer];
 }
 
-// Crash the process on unhandled rejections.
-const crashOnUnhandledRejection = (err) => { throw err; };
-process.on('unhandledRejection', crashOnUnhandledRejection);
 function disableCrashOnUnhandledRejection() {
-  process.removeListener('unhandledRejection', crashOnUnhandledRejection);
+  process.on('unhandledRejection', () => {});
 }
 
 function getTTYfd() {

--- a/test/es-module/test-esm-cjs-load-error-note.mjs
+++ b/test/es-module/test-esm-cjs-load-error-note.mjs
@@ -63,8 +63,7 @@ pImport2.stderr.on('data', (data) => {
   pImport2Stderr += data;
 });
 pImport2.on('close', mustCall((code) => {
-  // As this exits normally we expect 0
-  assert.strictEqual(code, 0);
+  assert.strictEqual(code, expectedCode);
   assert.ok(!pImport2Stderr.includes(expectedNote),
             `${expectedNote} must not be included in ${pImport2Stderr}`);
 }));
@@ -94,7 +93,7 @@ pImport4.on('close', mustCall((code) => {
             `${expectedNote} not found in ${pImport4Stderr}`);
 }));
 
-// Must exit with zero and show note
+// Must exit non-zero and show note
 const pImport5 = spawn(process.execPath, [Import5]);
 let pImport5Stderr = '';
 pImport5.stderr.setEncoding('utf8');
@@ -102,7 +101,7 @@ pImport5.stderr.on('data', (data) => {
   pImport5Stderr += data;
 });
 pImport5.on('close', mustCall((code) => {
-  assert.strictEqual(code, 0);
+  assert.strictEqual(code, expectedCode);
   assert.ok(!pImport5Stderr.includes(expectedNote),
             `${expectedNote} must not be included in ${pImport5Stderr}`);
 }));

--- a/test/message/promise_unhandled_warn_with_error.js
+++ b/test/message/promise_unhandled_warn_with_error.js
@@ -1,10 +1,8 @@
 // Flags: --unhandled-rejections=warn-with-error-code
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
-
-common.disableCrashOnUnhandledRejection();
 
 Promise.reject(new Error('alas'));
 process.on('exit', assert.strictEqual.bind(null, 1));

--- a/test/message/unhandled_promise_trace_warnings.js
+++ b/test/message/unhandled_promise_trace_warnings.js
@@ -1,6 +1,5 @@
-// Flags: --trace-warnings
+// Flags: --trace-warnings --unhandled-rejections=warn
 'use strict';
-const common = require('../common');
-common.disableCrashOnUnhandledRejection();
+require('../common');
 const p = Promise.reject(new Error('This was rejected'));
 setImmediate(() => p.catch(() => {}));

--- a/test/message/unhandled_promise_trace_warnings.out
+++ b/test/message/unhandled_promise_trace_warnings.out
@@ -17,10 +17,6 @@
     at *
     at *
     at *
-(node:*) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
-    at *
-    at *
-    at *
 (node:*) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 1)
     at handledRejection (internal/process/promises.js:*)
     at promiseRejectHandler (internal/process/promises.js:*)

--- a/test/parallel/test-promise-unhandled-default.js
+++ b/test/parallel/test-promise-unhandled-default.js
@@ -1,4 +1,3 @@
-// Flags: --unhandled-rejections=throw
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-promise-unhandled-warn-no-hook.js
+++ b/test/parallel/test-promise-unhandled-warn-no-hook.js
@@ -3,10 +3,7 @@
 
 const common = require('../common');
 
-common.disableCrashOnUnhandledRejection();
-
-// Verify that ignoring unhandled rejection works fine and that no warning is
-// logged.
+// Verify that --unhandled-rejections=warn works fine
 
 new Promise(() => {
   throw new Error('One');

--- a/test/parallel/test-promises-unhandled-proxy-rejections.js
+++ b/test/parallel/test-promises-unhandled-proxy-rejections.js
@@ -3,21 +3,6 @@ const common = require('../common');
 
 common.disableCrashOnUnhandledRejection();
 
-const expectedDeprecationWarning = ['Unhandled promise rejections are ' +
-                                   'deprecated. In the future, promise ' +
-                                   'rejections that are not handled will ' +
-                                   'terminate the Node.js process with a ' +
-                                   'non-zero exit code.', 'DEP0018'];
-const expectedPromiseWarning = ['Unhandled promise rejection. ' +
-  'This error originated either by throwing ' +
-  'inside of an async function without a catch ' +
-  'block, or by rejecting a promise which was ' +
-  'not handled with .catch(). To terminate the ' +
-  'node process on unhandled promise rejection, ' +
-  'use the CLI flag `--unhandled-rejections=strict` (see ' +
-  'https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). ' +
-  '(rejection id: 1)'];
-
 function throwErr() {
   throw new Error('Error from proxy');
 }
@@ -38,10 +23,7 @@ const thorny = new Proxy({}, {
   construct: throwErr
 });
 
-common.expectWarning({
-  DeprecationWarning: expectedDeprecationWarning,
-  UnhandledPromiseRejectionWarning: expectedPromiseWarning,
-});
+process.on('warning', common.mustNotCall());
 
 // Ensure this doesn't crash
 Promise.reject(thorny);

--- a/test/parallel/test-promises-unhandled-rejections.js
+++ b/test/parallel/test-promises-unhandled-rejections.js
@@ -668,6 +668,7 @@ asyncTest('Throwing an error inside a rejectionHandled handler goes to' +
           ' unhandledException, and does not cause .catch() to throw an ' +
           'exception', function(done) {
   clean();
+  common.disableCrashOnUnhandledRejection();
   const e = new Error();
   const e2 = new Error();
   const tearDownException = setupException(function(err) {
@@ -702,19 +703,17 @@ asyncTest('Rejected promise inside unhandledRejection allows nextTick loop' +
 });
 
 asyncTest(
-  'Unhandled promise rejection emits a warning immediately',
+  'Promise rejection triggers unhandledRejection immediately',
   function(done) {
     clean();
     Promise.reject(0);
-    const { emitWarning } = process;
-    process.emitWarning = common.mustCall((...args) => {
+    process.on('unhandledRejection', common.mustCall((err) => {
       if (timer) {
         clearTimeout(timer);
         timer = null;
         done();
       }
-      emitWarning(...args);
-    }, 2);
+    }));
 
     let timer = setTimeout(common.mustNotCall(), 10000);
   },

--- a/test/parallel/test-promises-unhandled-symbol-rejections.js
+++ b/test/parallel/test-promises-unhandled-symbol-rejections.js
@@ -1,14 +1,10 @@
+// Flags: --unhandled-rejections=warn
 'use strict';
 const common = require('../common');
 
 common.disableCrashOnUnhandledRejection();
 
 const expectedValueWarning = ['Symbol()'];
-const expectedDeprecationWarning = ['Unhandled promise rejections are ' +
-                                   'deprecated. In the future, promise ' +
-                                   'rejections that are not handled will ' +
-                                   'terminate the Node.js process with a ' +
-                                   'non-zero exit code.', 'DEP0018'];
 const expectedPromiseWarning = ['Unhandled promise rejection. ' +
   'This error originated either by throwing ' +
   'inside of an async function without a catch ' +
@@ -20,7 +16,6 @@ const expectedPromiseWarning = ['Unhandled promise rejection. ' +
   '(rejection id: 1)'];
 
 common.expectWarning({
-  DeprecationWarning: expectedDeprecationWarning,
   UnhandledPromiseRejectionWarning: [
     expectedValueWarning,
     expectedPromiseWarning

--- a/test/parallel/test-promises-warning-on-unhandled-rejection.js
+++ b/test/parallel/test-promises-warning-on-unhandled-rejection.js
@@ -1,4 +1,4 @@
-// Flags: --no-warnings
+// Flags: --no-warnings --unhandled-rejections=warn
 'use strict';
 
 // Test that warnings are emitted when a Promise experiences an uncaught
@@ -6,8 +6,6 @@
 
 const common = require('../common');
 const assert = require('assert');
-
-common.disableCrashOnUnhandledRejection();
 
 let b = 0;
 
@@ -27,14 +25,10 @@ process.on('warning', common.mustCall((warning) => {
       );
       break;
     case 2:
-      // One time deprecation warning, first unhandled rejection
-      assert.strictEqual(warning.name, 'DeprecationWarning');
-      break;
-    case 3:
       // Number rejection error displayed. Note it's been stringified
       assert.strictEqual(warning.message, '42');
       break;
-    case 4:
+    case 3:
       // Unhandled rejection warning (won't be handled next tick)
       assert.strictEqual(warning.name, 'UnhandledPromiseRejectionWarning');
       assert(
@@ -43,13 +37,13 @@ process.on('warning', common.mustCall((warning) => {
         `but did not. Had "${warning.message}" instead.`
       );
       break;
-    case 5:
+    case 4:
       // Rejection handled asynchronously.
       assert.strictEqual(warning.name, 'PromiseRejectionHandledWarning');
       assert(/Promise rejection was handled asynchronously/
         .test(warning.message));
   }
-}, 6));
+}, 5));
 
 const p = Promise.reject('This was rejected'); // Reject with a string
 setImmediate(common.mustCall(() => p.catch(() => { })));

--- a/test/sequential/test-inspector-async-call-stack-abort.js
+++ b/test/sequential/test-inspector-async-call-stack-abort.js
@@ -9,7 +9,6 @@ const { strictEqual } = require('assert');
 const eyecatcher = 'nou, houdoe he?';
 
 if (process.argv[2] === 'child') {
-  common.disableCrashOnUnhandledRejection();
   const { Session } = require('inspector');
   const { promisify } = require('util');
   const { internalBinding } = require('internal/test/binding');
@@ -31,7 +30,7 @@ if (process.argv[2] === 'child') {
   const options = { encoding: 'utf8' };
   const proc = spawnSync(
     process.execPath, ['--expose-internals', __filename, 'child'], options);
-  strictEqual(proc.status, 0);
+  strictEqual(proc.status, 1);
   strictEqual(proc.signal, null);
   strictEqual(proc.stderr.includes(eyecatcher), true);
 }


### PR DESCRIPTION
This is a semver-major change that resolves DEP0018.

All users that have set an unhandledRejection hook or set a non-default
value for the --unhandled-rejections flag will see no change in behavior
after this change.

Fixes: #20392
Refs: https://nodejs.org/dist/latest/docs/api/deprecations.html#deprecations_dep0018_unhandled_promise_rejections

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
