### PR TITLE
docs: normalize plaintext code blocks

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -285,7 +285,7 @@ console.error(err.message);
 The `error.stack` property is a string describing the point in the code at which
 the `Error` was instantiated.
 
-```txt
+```text
 Error: Things keep happening!
    at /home/gbusey/file.js:525:2
    at Frobnicator.refrobulate (/home/gbusey/business-logic.js:424:21)

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -285,7 +285,7 @@ console.error(err.message);
 The `error.stack` property is a string describing the point in the code at which
 the `Error` was instantiated.
 
-```text
+```console
 Error: Things keep happening!
    at /home/gbusey/file.js:525:2
    at Frobnicator.refrobulate (/home/gbusey/business-logic.js:424:21)

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -3467,7 +3467,7 @@ is recommended.
 
 For example, given the following directory structure:
 
-```fundamental
+```text
 - txtDir
 -- file.txt
 - app.js

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1974,7 +1974,7 @@ added: v0.1.90
 Request URL string. This contains only the URL that is
 present in the actual HTTP request. If the request is:
 
-```txt
+```text
 GET /status?name=ryan HTTP/1.1\r\n
 Accept: text/plain\r\n
 \r\n

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1974,7 +1974,7 @@ added: v0.1.90
 Request URL string. This contains only the URL that is
 present in the actual HTTP request. If the request is:
 
-```text
+```http
 GET /status?name=ryan HTTP/1.1\r\n
 Accept: text/plain\r\n
 \r\n

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -2983,7 +2983,7 @@ added: v8.4.0
 Request URL string. This contains only the URL that is
 present in the actual HTTP request. If the request is:
 
-```text
+```http
 GET /status?name=ryan HTTP/1.1\r\n
 Accept: text/plain\r\n
 \r\n

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -2983,7 +2983,7 @@ added: v8.4.0
 Request URL string. This contains only the URL that is
 present in the actual HTTP request. If the request is:
 
-```txt
+```text
 GET /status?name=ryan HTTP/1.1\r\n
 Accept: text/plain\r\n
 \r\n
@@ -2999,7 +2999,7 @@ Then `request.url` will be:
 To parse the url into its parts `require('url').parse(request.url)`
 can be used:
 
-```txt
+```text
 $ node
 > require('url').parse('/status?name=ryan')
 Url {

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -2999,7 +2999,7 @@ Then `request.url` will be:
 To parse the url into its parts `require('url').parse(request.url)`
 can be used:
 
-```text
+```console
 $ node
 > require('url').parse('/status?name=ryan')
 Url {

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -409,7 +409,7 @@ example, then `require('./some-library')` would attempt to load:
 If these attempts fail, then Node.js will report the entire module as missing
 with the default error:
 
-```text
+```console
 Error: Cannot find module 'some-library'
 ```
 

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -149,7 +149,7 @@ the `require.resolve()` function.
 Putting together all of the above, here is the high-level algorithm
 in pseudocode of what `require()` does:
 
-```txt
+```text
 require(X) from module at path Y
 1. If X is a core module,
    a. return the core module
@@ -409,7 +409,7 @@ example, then `require('./some-library')` would attempt to load:
 If these attempts fail, then Node.js will report the entire module as missing
 with the default error:
 
-```txt
+```text
 Error: Cannot find module 'some-library'
 ```
 

--- a/doc/api/report.md
+++ b/doc/api/report.md
@@ -503,7 +503,7 @@ containing `libuv` handle information and an OS platform information section
 showing CPU and memory usage and system limits. An example report can be
 triggered using the Node.js REPL:
 
-```raw
+```text
 $ node
 > process.report.writeReport();
 Writing Node.js report to file: report.20181126.091102.8480.0.001.json

--- a/doc/api/report.md
+++ b/doc/api/report.md
@@ -503,7 +503,7 @@ containing `libuv` handle information and an OS platform information section
 showing CPU and memory usage and system limits. An example report can be
 triggered using the Node.js REPL:
 
-```text
+```console
 $ node
 > process.report.writeReport();
 Writing Node.js report to file: report.20181126.091102.8480.0.001.json

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -272,7 +272,7 @@ Reused, TLSv1.2, Cipher is ECDHE-RSA-AES128-GCM-SHA256
 Node.js is built with a default suite of enabled and disabled TLS ciphers.
 Currently, the default cipher suite is:
 
-```txt
+```text
 TLS_AES_256_GCM_SHA384:
 TLS_CHACHA20_POLY1305_SHA256:
 TLS_AES_128_GCM_SHA256:

--- a/doc/api/tracing.md
+++ b/doc/api/tracing.md
@@ -36,7 +36,7 @@ The available categories are:
 
 By default the `node`, `node.async_hooks`, and `v8` categories are enabled.
 
-```txt
+```text
 node --trace-event-categories v8,node,node.async_hooks server.js
 ```
 
@@ -45,7 +45,7 @@ flag to enable trace events. This requirement has been removed. However, the
 `--trace-events-enabled` flag *may* still be used and will enable the
 `node`, `node.async_hooks`, and `v8` trace event categories by default.
 
-```txt
+```text
 node --trace-events-enabled
 
 // is equivalent to
@@ -74,7 +74,7 @@ The logging file is by default called `node_trace.${rotation}.log`, where
 be specified with `--trace-event-file-pattern` that accepts a template
 string that supports `${rotation}` and `${pid}`:
 
-```txt
+```text
 node --trace-event-categories v8 --trace-event-file-pattern '${pid}-${rotation}.log' server.js
 ```
 

--- a/doc/api/tracing.md
+++ b/doc/api/tracing.md
@@ -48,7 +48,7 @@ flag to enable trace events. This requirement has been removed. However, the
 ```bash
 node --trace-events-enabled
 
-// is equivalent to
+# is equivalent to
 
 node --trace-event-categories v8,node,node.async_hooks
 ```

--- a/doc/api/tracing.md
+++ b/doc/api/tracing.md
@@ -36,7 +36,7 @@ The available categories are:
 
 By default the `node`, `node.async_hooks`, and `v8` categories are enabled.
 
-```text
+```bash
 node --trace-event-categories v8,node,node.async_hooks server.js
 ```
 

--- a/doc/api/tracing.md
+++ b/doc/api/tracing.md
@@ -74,7 +74,7 @@ The logging file is by default called `node_trace.${rotation}.log`, where
 be specified with `--trace-event-file-pattern` that accepts a template
 string that supports `${rotation}` and `${pid}`:
 
-```text
+```bash
 node --trace-event-categories v8 --trace-event-file-pattern '${pid}-${rotation}.log' server.js
 ```
 

--- a/doc/api/tracing.md
+++ b/doc/api/tracing.md
@@ -45,7 +45,7 @@ flag to enable trace events. This requirement has been removed. However, the
 `--trace-events-enabled` flag *may* still be used and will enable the
 `node`, `node.async_hooks`, and `v8` trace event categories by default.
 
-```text
+```bash
 node --trace-events-enabled
 
 // is equivalent to

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -29,7 +29,7 @@ properties of a WHATWG `URL` object.
 WHATWG URL's `origin` property includes `protocol` and `host`, but not
 `username` or `password`.
 
-```txt
+```text
 ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                              href                                              │
 ├──────────┬──┬─────────────────────┬────────────────────────┬───────────────────────────┬───────┤
@@ -1263,7 +1263,7 @@ located within the structure of the URL.
 Within the Legacy API, spaces (`' '`) and the following characters will be
 automatically escaped in the properties of URL objects:
 
-```txt
+```text
 < > " ` \r \n \t { } | \ ^ '
 ```
 

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -93,7 +93,7 @@ debuglog('hello from foo [%d]', 123);
 If this program is run with `NODE_DEBUG=foo` in the environment, then
 it will output something like:
 
-```text
+```console
 FOO 3245: hello from foo [123]
 ```
 

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -42,7 +42,7 @@ callbackFunction((err, ret) => {
 
 Will print:
 
-```txt
+```text
 hello world
 ```
 
@@ -93,7 +93,7 @@ debuglog('hello from foo [%d]', 123);
 If this program is run with `NODE_DEBUG=foo` in the environment, then
 it will output something like:
 
-```txt
+```text
 FOO 3245: hello from foo [123]
 ```
 
@@ -112,7 +112,7 @@ debuglog('hi there, it\'s foo-bar [%d]', 2333);
 if it is run with `NODE_DEBUG=foo*` in the environment, then it will output
 something like:
 
-```txt
+```text
 FOO-BAR 3257: hi there, it's foo-bar [2333]
 ```
 

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -112,7 +112,7 @@ debuglog('hi there, it\'s foo-bar [%d]', 2333);
 if it is run with `NODE_DEBUG=foo*` in the environment, then it will output
 something like:
 
-```text
+```console
 FOO-BAR 3257: hi there, it's foo-bar [2333]
 ```
 

--- a/doc/guides/building-node-with-ninja.md
+++ b/doc/guides/building-node-with-ninja.md
@@ -15,7 +15,7 @@ the project's root.
 When running `make`, you will see output similar to the following
 if the build has succeeded:
 
-```text
+```console
 ninja: Entering directory `out/Release`
 [4/4] LINK node, POSTBUILDS
 ```

--- a/doc/guides/building-node-with-ninja.md
+++ b/doc/guides/building-node-with-ninja.md
@@ -15,7 +15,7 @@ the project's root.
 When running `make`, you will see output similar to the following
 if the build has succeeded:
 
-```txt
+```text
 ninja: Entering directory `out/Release`
 [4/4] LINK node, POSTBUILDS
 ```

--- a/doc/guides/contributing/pull-requests.md
+++ b/doc/guides/contributing/pull-requests.md
@@ -178,7 +178,7 @@ situation would trigger the breaking change and what is the exact change.
 
 Sample complete commit message:
 
-```txt
+```text
 subsystem: explain the commit in one line
 
 The body of the commit message should be one or more paragraphs, explaining

--- a/doc/guides/releases.md
+++ b/doc/guides/releases.md
@@ -342,7 +342,7 @@ The `CHANGELOG.md`, `doc/changelogs/CHANGELOG_Vx.md`, `src/node_version.h`, and
 `REPLACEME` changes should be the final commit that will be tagged for the
 release. When committing these to git, use the following message format:
 
-```txt
+```text
 YYYY-MM-DD, Version x.y.z (Release Type)
 
 Notable changes:
@@ -355,7 +355,7 @@ For security releases, begin the commit message with the phrase
 [distribution indexer](https://github.com/nodejs/nodejs-dist-indexer) to
 identify it as such:
 
-```txt
+```text
 YYYY-MM-DD, Version x.y.z (Release Type)
 
 This is a security release.
@@ -491,7 +491,7 @@ $ git secure-tag <vx.y.z> <commit-sha> -sm "YYYY-MM-DD Node.js vx.y.z (<release-
 `release-type` is either "Current" or "LTS". For LTS releases, you should also
  include the release codename, for example:
 
-```txt
+```text
 2019-10-22 Node.js v10.17.0 'Dubnium' (LTS) Release
 ```
 
@@ -507,7 +507,7 @@ On release proposal branch, edit `src/node_version.h` again and:
 
 Commit this change with the following commit message format:
 
-```txt
+```text
 Working on vx.y.z # where 'z' is the incremented patch number
 
 PR-URL: <full URL to your release proposal PR>


### PR DESCRIPTION
The PR normalizes `txt`, `fundamental`, and `raw` fenced code blocks in markdown files to use `text` as the [info string](https://github.github.com/gfm/#info-string) (i.e. language).

Resolves https://github.com/nodejs/node/issues/32938

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

cc @nodejs/documentation 
