### PR TITLE
stream: fix sync write perf regression

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -421,27 +421,24 @@ function onwrite(stream, er) {
       onwriteError(stream, state, er, cb);
     }
   } else {
-    if (!state.destroyed) {
+    if (state.buffered.length > state.bufferedIndex) {
       clearBuffer(stream, state);
     }
-    if (state.needDrain || cb !== nop || state.ending || state.destroyed) {
-      if (sync) {
-        // It is a common case that the callback passed to .write() is always
-        // the same. In that case, we do not schedule a new nextTick(), but
-        // rather just increase a counter, to improve performance and avoid
-        // memory allocations.
-        if (state.afterWriteTickInfo !== null &&
-            state.afterWriteTickInfo.cb === cb) {
-          state.afterWriteTickInfo.count++;
-        } else {
-          state.afterWriteTickInfo = { count: 1, cb, stream, state };
-          process.nextTick(afterWriteTick, state.afterWriteTickInfo);
-        }
+
+    if (sync) {
+      // It is a common case that the callback passed to .write() is always
+      // the same. In that case, we do not schedule a new nextTick(), but
+      // rather just increase a counter, to improve performance and avoid
+      // memory allocations.
+      if (state.afterWriteTickInfo !== null &&
+          state.afterWriteTickInfo.cb === cb) {
+        state.afterWriteTickInfo.count++;
       } else {
-        afterWrite(stream, state, 1, cb);
+        state.afterWriteTickInfo = { count: 1, cb, stream, state };
+        process.nextTick(afterWriteTick, state.afterWriteTickInfo);
       }
     } else {
-      state.pendingcb--;
+      afterWrite(stream, state, 1, cb);
     }
   }
 }
@@ -489,7 +486,7 @@ function errorBuffer(state, err) {
 
 // If there's something in the buffer waiting, then process it
 function clearBuffer(stream, state) {
-  if (state.corked || state.bufferProcessing) {
+  if (state.corked || state.bufferProcessing || state.destroyed) {
     return;
   }
 


### PR DESCRIPTION
While https://github.com/nodejs/node/pull/31046 did make async writes faster it at the same time made sync writes slower.

This PR corrects this while maintaining performance improvements.

```js
 streams/writable-manywrites.js callback='no' writev='no' sync='no' n=2000000                    2.55 %       ±3.61% ±4.81%  ±6.26%
 streams/writable-manywrites.js callback='no' writev='no' sync='yes' n=2000000          ***      7.46 %       ±3.52% ±4.69%  ±6.10%
 streams/writable-manywrites.js callback='no' writev='yes' sync='no' n=2000000                   4.13 %       ±4.74% ±6.34%  ±8.32%
 streams/writable-manywrites.js callback='no' writev='yes' sync='yes' n=2000000                  3.91 %       ±4.16% ±5.53%  ±7.20%
 streams/writable-manywrites.js callback='yes' writev='no' sync='no' n=2000000            *      3.91 %       ±3.09% ±4.11%  ±5.36%
 streams/writable-manywrites.js callback='yes' writev='no' sync='yes' n=2000000         ***     24.84 %       ±3.67% ±4.89%  ±6.36%
 streams/writable-manywrites.js callback='yes' writev='yes' sync='no' n=2000000                  2.69 %       ±6.09% ±8.13% ±10.64%
 streams/writable-manywrites.js callback='yes' writev='yes' sync='yes' n=2000000        ***     12.66 %       ±3.47% ±4.62%  ±6.01%
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
