### PR TITLE
http: use `autoDestroy: true` in incoming message

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -742,7 +742,6 @@ function emitFreeNT(req) {
   if (req.socket) {
     req.socket.emit('free');
   }
-
 }
 
 function tickOnSocket(req, socket) {

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -430,25 +430,13 @@ function socketCloseListener() {
   req.destroyed = true;
   if (res) {
     // Socket closed before we emitted 'end' below.
-    // TOOD(ronag): res.destroy(err)
     if (!res.complete) {
-      res.aborted = true;
-      res.emit('aborted');
-      if (res.listenerCount('error') > 0) {
-        res.emit('error', connResetException('aborted'));
-      }
+      res.destroy(connResetException('aborted'));
     }
     req._closed = true;
     req.emit('close');
     if (!res.aborted && res.readable) {
-      res.on('end', function() {
-        this.destroyed = true;
-        this.emit('close');
-      });
       res.push(null);
-    } else {
-      res.destroyed = true;
-      res.emit('close');
     }
   } else {
     if (!req.socket._hadError) {
@@ -697,7 +685,6 @@ function responseKeepAlive(req) {
 
   req.destroyed = true;
   if (req.res) {
-    req.res.destroyed = true;
     // Detach socket from IncomingMessage to avoid destroying the freed
     // socket in IncomingMessage.destroy().
     req.res.socket = null;
@@ -752,13 +739,10 @@ function requestOnPrefinish() {
 function emitFreeNT(req) {
   req._closed = true;
   req.emit('close');
-  if (req.res) {
-    req.res.emit('close');
-  }
-
   if (req.socket) {
     req.socket.emit('free');
   }
+
 }
 
 function tickOnSocket(req, socket) {

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -359,7 +359,11 @@ IncomingMessage.prototype._dump = function _dump() {
 };
 
 function onError(instance, cb, error) {
-  instance.listenerCount('error') > 0 ? cb(error) : cb();
+  if (instance.listenerCount('error') > 0) {
+    cb(error);
+  } else {
+    cb();
+  }
 }
 
 module.exports = {

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -54,7 +54,7 @@ function IncomingMessage(socket) {
     };
   }
 
-  Stream.Readable.call(this, { autoDestroy: false, ...streamOptions });
+  Stream.Readable.call(this, streamOptions);
 
   this._readableState.readingMore = true;
 
@@ -160,18 +160,19 @@ IncomingMessage.prototype._read = function _read(n) {
     readStart(this.socket);
 };
 
-
 // It's possible that the socket will be destroyed, and removed from
 // any messages, before ever calling this.  In that case, just skip
 // it, since something else is destroying this connection anyway.
-IncomingMessage.prototype.destroy = function destroy(error) {
-  // TODO(ronag): Implement in terms of _destroy
-  this.destroyed = true;
-  if (this.socket)
-    this.socket.destroy(error);
-  return this;
+IncomingMessage.prototype._destroy = function _destroy(err, cb) {
+  if (!this.readableEnded || !this.complete) {
+    this.aborted = true;
+    this.emit('aborted');
+  }
+  if (this.socket && !this.readableEnded) {
+    this.socket.destroy(err);
+  }
+  this.listenerCount('error') > 0 ? cb(err) : cb();
 };
-
 
 IncomingMessage.prototype._addHeaderLines = _addHeaderLines;
 function _addHeaderLines(headers, n) {

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -171,6 +171,9 @@ IncomingMessage.prototype._destroy = function _destroy(err, cb) {
 
   // If aborted and the underlying socket not already destroyed,
   // destroy it.
+  // We have to check if the socket is already destroyed because finished
+  // does not call the callback when this methdod is invoked from `_http_client`
+  // in `test/parallel/test-http-client-spurious-aborted.js`
   if (this.socket && !this.socket.destroyed && this.aborted) {
     this.socket.destroy(err);
     const cleanup = finished(this.socket, (e) => {
@@ -359,6 +362,9 @@ IncomingMessage.prototype._dump = function _dump() {
 };
 
 function onError(instance, cb, error) {
+  // This is to keep backward compatible behavior.
+  // An error is emitted only if there are listeners attached to
+  // the event.
   if (instance.listenerCount('error') > 0) {
     cb(error);
   } else {

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -361,14 +361,13 @@ IncomingMessage.prototype._dump = function _dump() {
   }
 };
 
-function onError(instance, error, cb) {
+function onError(self, error, cb) {
   // This is to keep backward compatible behavior.
-  // An error is emitted only if there are listeners attached to
-  // the event.
-  if (instance.listenerCount('error') > 0) {
-    cb(error);
-  } else {
+  // An error is emitted only if there are listeners attached to the event.
+  if (self.listenerCount('error') === 0) {
     cb();
+  } else {
+    cb(error);
   }
 }
 

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -27,7 +27,7 @@ const {
   Symbol
 } = primordials;
 
-const Stream = require('stream');
+const { Readable, finished } = require('stream');
 
 const kHeaders = Symbol('kHeaders');
 const kHeadersCount = Symbol('kHeadersCount');
@@ -54,7 +54,7 @@ function IncomingMessage(socket) {
     };
   }
 
-  Stream.Readable.call(this, streamOptions);
+  Readable.call(this, streamOptions);
 
   this._readableState.readingMore = true;
 
@@ -89,8 +89,8 @@ function IncomingMessage(socket) {
   // read by the user, so there's no point continuing to handle it.
   this._dumped = false;
 }
-ObjectSetPrototypeOf(IncomingMessage.prototype, Stream.Readable.prototype);
-ObjectSetPrototypeOf(IncomingMessage, Stream.Readable);
+ObjectSetPrototypeOf(IncomingMessage.prototype, Readable.prototype);
+ObjectSetPrototypeOf(IncomingMessage, Readable);
 
 ObjectDefineProperty(IncomingMessage.prototype, 'connection', {
   get: function() {
@@ -168,10 +168,18 @@ IncomingMessage.prototype._destroy = function _destroy(err, cb) {
     this.aborted = true;
     this.emit('aborted');
   }
-  if (this.socket && !this.readableEnded) {
+
+  // If aborted and the underlying socket not already destroyed,
+  // destroy it.
+  if (this.socket && !this.socket.destroyed && this.aborted) {
     this.socket.destroy(err);
+    const cleanup = finished(this.socket, (e) => {
+      cleanup();
+      onError(this, cb, e || err);
+    });
+  } else {
+    onError(this, cb, err);
   }
-  this.listenerCount('error') > 0 ? cb(err) : cb();
 };
 
 IncomingMessage.prototype._addHeaderLines = _addHeaderLines;
@@ -349,6 +357,10 @@ IncomingMessage.prototype._dump = function _dump() {
     this.resume();
   }
 };
+
+function onError(instance, cb, error) {
+  instance.listenerCount('error') > 0 ? cb(error) : cb();
+}
 
 module.exports = {
   IncomingMessage,

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -169,7 +169,7 @@ IncomingMessage.prototype._destroy = function _destroy(err, cb) {
     this.emit('aborted');
   }
 
-  // If aborted and the underlying socket not already destroyed,
+  // If aborted and the underlying socket is not already destroyed,
   // destroy it.
   // We have to check if the socket is already destroyed because finished
   // does not call the callback when this methdod is invoked from `_http_client`
@@ -178,10 +178,10 @@ IncomingMessage.prototype._destroy = function _destroy(err, cb) {
     this.socket.destroy(err);
     const cleanup = finished(this.socket, (e) => {
       cleanup();
-      onError(this, cb, e || err);
+      onError(this, e || err, cb);
     });
   } else {
-    onError(this, cb, err);
+    onError(this, err, cb);
   }
 };
 
@@ -361,7 +361,7 @@ IncomingMessage.prototype._dump = function _dump() {
   }
 };
 
-function onError(instance, cb, error) {
+function onError(instance, error, cb) {
   // This is to keep backward compatible behavior.
   // An error is emitted only if there are listeners attached to
   // the event.

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -575,14 +575,7 @@ function socketOnClose(socket, state) {
 function abortIncoming(incoming) {
   while (incoming.length) {
     const req = incoming.shift();
-    // TODO(ronag): req.destroy(err)
-    req.aborted = true;
-    req.destroyed = true;
-    req.emit('aborted');
-    if (req.listenerCount('error') > 0) {
-      req.emit('error', connResetException('aborted'));
-    }
-    req.emit('close');
+    req.destroy(connResetException('aborted'));
   }
   // Abort socket._httpMessage ?
 }
@@ -741,14 +734,9 @@ function clearIncoming(req) {
   if (parser && parser.incoming === req) {
     if (req.readableEnded) {
       parser.incoming = null;
-      req.destroyed = true;
-      req.emit('close');
     } else {
       req.on('end', clearIncoming);
     }
-  } else {
-    req.destroyed = true;
-    req.emit('close');
   }
 }
 

--- a/test/parallel/test-http-client-incomingmessage-destroy.js
+++ b/test/parallel/test-http-client-incomingmessage-destroy.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const common = require('../common');
+const { createServer, get } = require('http');
+const assert = require('assert');
+
+const server = createServer(common.mustCall((req, res) => {
+  res.writeHead(200);
+  res.write('Part of res.');
+}));
+
+function onUncaught(error) {
+  assert.strictEqual(error.message, 'Destroy test');
+  server.close();
+}
+
+process.on('uncaughtException', common.mustCall(onUncaught));
+
+server.listen(0, () => {
+  get({
+    port: server.address().port
+  }, common.mustCall((res) => {
+    res.destroy(new Error('Destroy test'));
+  }));
+});

--- a/test/parallel/test-http-server-incomingmessage-destroy.js
+++ b/test/parallel/test-http-server-incomingmessage-destroy.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const common = require('../common');
+const { createServer, get } = require('http');
+const assert = require('assert');
+
+const server = createServer(common.mustCall((req, res) => {
+  req.destroy(new Error('Destroy test'));
+}));
+
+function onUncaught(error) {}
+
+process.on('uncaughtException', common.mustNotCall(onUncaught));
+
+server.listen(0, common.mustCall(() => {
+  get({
+    port: server.address().port
+  }, (res) => {
+    res.resume();
+  }).on('error', (error) => {
+    assert.strictEqual(error.message, 'socket hang up');
+    assert.strictEqual(error.code, 'ECONNRESET');
+    server.close();
+  });
+}));


### PR DESCRIPTION
Enable the default `autoDestroy: true` option in IncomingMessage.

Refactor `_http_client` and `_http_server` to remove any manual destroying/closing of IncomingMessage.
Refactor IncomingMessage `destroy` method to use the standard implementation of the stream module and move the abort logic 
 inside of it.


Ref:

#30625

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)


<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->