### PR TITLE
Add %J console format specifier

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -236,6 +236,7 @@ corresponding argument. Supported specifiers are:
 * `%f`: `parseFloat(value)` is used for all values expect `Symbol`.
 * `%j`: JSON. Replaced with the string `'[Circular]'` if the argument contains
   circular references.
+* `%J`: Indented version of %j.
 * `%o`: `Object`. A string representation of an object with generic JavaScript
   object formatting. Similar to `util.inspect()` with options
   `{ showHidden: true, showProxy: true }`. This will show the full object

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -1770,14 +1770,14 @@ function hasBuiltInToString(value) {
 
 const firstErrorLine = (error) => error.message.split('\n')[0];
 let CIRCULAR_ERROR_MESSAGE;
-function tryStringify(arg) {
+function tryStringify(arg, indentation = 0) {
   try {
-    return JSONStringify(arg);
+    return JSONStringify(arg, null, indentation);
   } catch (err) {
     // Populate the circular error message lazily
     if (!CIRCULAR_ERROR_MESSAGE) {
       try {
-        const a = {}; a.a = a; JSONStringify(a);
+        const a = {}; a.a = a; JSONStringify(a, null, indentation);
       } catch (err) {
         CIRCULAR_ERROR_MESSAGE = firstErrorLine(err);
       }
@@ -1841,6 +1841,9 @@ function formatWithOptionsInternal(inspectOptions, ...args) {
               break;
             case 106: // 'j'
               tempStr = tryStringify(args[++a]);
+              break;
+            case 74: // 'J'
+              tempStr = tryStringify(args[++a], 2);
               break;
             case 100: // 'd'
               const tempNum = args[++a];

--- a/test/parallel/test-util-format.js
+++ b/test/parallel/test-util-format.js
@@ -44,6 +44,7 @@ assert.strictEqual(util.format(symbol), 'Symbol(foo)');
 assert.strictEqual(util.format('foo', symbol), 'foo Symbol(foo)');
 assert.strictEqual(util.format('%s', symbol), 'Symbol(foo)');
 assert.strictEqual(util.format('%j', symbol), 'undefined');
+assert.strictEqual(util.format('%J', symbol), 'undefined');
 
 // Number format specifier
 assert.strictEqual(util.format('%d'), '%d');
@@ -236,6 +237,16 @@ assert.strictEqual(util.format('%j', 42), '42');
 assert.strictEqual(util.format('%j', '42'), '"42"');
 assert.strictEqual(util.format('%j %j', 42, 43), '42 43');
 assert.strictEqual(util.format('%j %j', 42), '42 %j');
+
+// Indented JSON format specifier
+assert.strictEqual(util.format('%J'), '%J');
+assert.strictEqual(util.format('%J', 42), '42');
+assert.strictEqual(util.format('%J', '42'), '"42"');
+assert.strictEqual(util.format('%J %J', 42, 43), '42 43');
+assert.strictEqual(util.format('%J %J', 42), '42 %J');
+assert.strictEqual(
+  util.format('%J', { foo: { bar: 42 } })
+  , '{\n  "foo": {\n    "bar": 42\n  }\n}');
 
 // Object format specifier
 const obj = {

--- a/test/pummel/test-child-process-spawn-loop.js
+++ b/test/pummel/test-child-process-spawn-loop.js
@@ -30,7 +30,7 @@ const N = 40;
 let finished = false;
 
 function doSpawn(i) {
-  const child = spawn('python', ['-c', `print ${SIZE} * "C"`]);
+  const child = spawn('python', ['-c', `print(${SIZE} * "C")`]);
   let count = 0;
 
   child.stdout.setEncoding('ascii');


### PR DESCRIPTION
This pull request adds %J format specifier for printing indented JSON.

I believe there may be some appetite for achieving this without cumbersome `console.log(JSON.stringify(a, null, 2))`. Some representative github code searches:

* `"console.log(" "JSON.stringify("` 3.5mil JS results
* `"console.log(" "%j"` 1.1mil JS results
* `"console.dir("` 300k JS results

Actually, now that I look at previous github issues this exact idea was mentioned in https://github.com/nodejs/node/pull/14558. The controversial `%o` format specifier does seem to be getting a lot of use, as far as I can tell with github code search. Thoughts?

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
