### PR TITLE
buffer,n-api: fix double ArrayBuffer::Detach() during cleanup

### DIFF
--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -392,10 +392,12 @@ class ArrayBufferReference final : public Reference {
   inline void Finalize(bool is_env_teardown) override {
     if (is_env_teardown) {
       v8::HandleScope handle_scope(_env->isolate);
-      v8::Local<v8::Value> ab = Get();
-      CHECK(!ab.IsEmpty());
-      CHECK(ab->IsArrayBuffer());
-      ab.As<v8::ArrayBuffer>()->Detach();
+      v8::Local<v8::Value> obj = Get();
+      CHECK(!obj.IsEmpty());
+      CHECK(obj->IsArrayBuffer());
+      v8::Local<v8::ArrayBuffer> ab = obj.As<v8::ArrayBuffer>();
+      if (ab->IsDetachable())
+        ab->Detach();
     }
 
     Reference::Finalize(is_env_teardown);

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -152,7 +152,8 @@ void CallbackInfo::CleanupHook(void* data) {
     HandleScope handle_scope(self->env_->isolate());
     Local<ArrayBuffer> ab = self->persistent_.Get(self->env_->isolate());
     CHECK(!ab.IsEmpty());
-    ab->Detach();
+    if (ab->IsDetachable())
+      ab->Detach();
   }
 
   self->WeakCallback(self->env_->isolate());


### PR DESCRIPTION
These calls could fail if the `ArrayBuffer` had already been explicitly
detached at some point in the past.

The necessary test changes already came with 4f523c2c1a1c and could
be ported back to v12.x with a backport of this PR.

Fixes: https://github.com/nodejs/node/issues/33022
Refs: https://github.com/nodejs/node/pull/30551

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
