### PR TITLE
doc: fix LTS replaceme tags

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -11,7 +11,9 @@ invariants.
 <!-- YAML
 added: v9.9.0
 changes:
-  - version: v13.9.0
+  - version:
+      - v13.9.0
+      - v12.16.2
     description: Changed "strict mode" to "strict assertion mode" and "legacy
                  mode" to "legacy assertion mode" to avoid confusion with the
                  more usual meaining of "strict mode".
@@ -564,7 +566,9 @@ parameter is an instance of an [`Error`][] then it will be thrown instead of the
 
 ## `assert.doesNotMatch(string, regexp[, message])`
 <!-- YAML
-added: v13.6.0
+added:
+  - v13.6.0
+  - v12.16.0
 -->
 
 * `string` {string}
@@ -911,7 +915,9 @@ let err;
 
 ## `assert.match(string, regexp[, message])`
 <!-- YAML
-added: v13.6.0
+added:
+  - v13.6.0
+  - v12.16.0
 -->
 
 * `string` {string}

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1341,7 +1341,9 @@ The `buf.parent` property is a deprecated alias for `buf.buffer`.
 ### `buf.readBigInt64BE([offset])`
 ### `buf.readBigInt64LE([offset])`
 <!-- YAML
-added: v12.0.0
+added:
+ - v12.0.0
+ - v10.20.0
 -->
 
 * `offset` {integer} Number of bytes to skip before starting to read. Must
@@ -1357,7 +1359,9 @@ Integers read from a `Buffer` are interpreted as two's complement signed values.
 ### `buf.readBigUInt64BE([offset])`
 ### `buf.readBigUInt64LE([offset])`
 <!-- YAML
-added: v12.0.0
+added:
+ - v12.0.0
+ - v10.20.0
 -->
 
 * `offset` {integer} Number of bytes to skip before starting to read. Must
@@ -2027,7 +2031,9 @@ console.log(`${length} bytes: ${buffer.toString('utf8', 8, 10)}`);
 ### `buf.writeBigInt64BE(value[, offset])`
 ### `buf.writeBigInt64LE(value[, offset])`
 <!-- YAML
-added: v12.0.0
+added:
+ - v12.0.0
+ - v10.20.0
 -->
 
 * `value` {bigint} Number to be written to `buf`.
@@ -2053,7 +2059,9 @@ console.log(buf);
 ### `buf.writeBigUInt64BE(value[, offset])`
 ### `buf.writeBigUInt64LE(value[, offset])`
 <!-- YAML
-added: v12.0.0
+added:
+ - v12.0.0
+ - v10.20.0
 -->
 
 * `value` {bigint} Number to be written to `buf`.

--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -329,7 +329,9 @@ arbitrary command execution.**
 <!-- YAML
 added: v0.5.0
 changes:
-  - version: v13.2.0
+  - version:
+      - v13.2.0
+      - v12.16.0
     pr-url: https://github.com/nodejs/node/pull/30162
     description: The `serialization` option is supported now.
   - version: v8.0.0
@@ -400,7 +402,9 @@ The `shell` option available in [`child_process.spawn()`][] is not supported by
 <!-- YAML
 added: v0.1.90
 changes:
-  - version: v13.2.0
+  - version:
+      - v13.2.0
+      - v12.16.0
     pr-url: https://github.com/nodejs/node/pull/30162
     description: The `serialization` option is supported now.
   - version: v8.8.0
@@ -1556,7 +1560,9 @@ unavailable.
 
 ## Advanced Serialization
 <!-- YAML
-added: v13.2.0
+added:
+ - v13.2.0
+ - v12.16.0
 -->
 
 Child processes support a serialization mechanism for IPC that is based on the

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -167,7 +167,9 @@ Currently, overriding `Error.prepareStackTrace` is ignored when the
 
 ### `--experimental-import-meta-resolve`
 <!-- YAML
-added: v13.9.0
+added:
+  - v13.9.0
+  - v12.16.2
 -->
 
 Enable experimental `import.meta.resolve()` support.
@@ -210,7 +212,9 @@ Enable experimental top-level `await` keyword support in REPL.
 
 ### `--experimental-specifier-resolution=mode`
 <!-- YAML
-added: v13.4.0
+added:
+ - v13.4.0
+ - v12.16.0
 -->
 
 Sets the resolution algorithm for resolving ES module specifiers. Valid options
@@ -231,7 +235,9 @@ Enable experimental ES Module support in the `vm` module.
 
 ### `--experimental-wasi-unstable-preview1`
 <!-- YAML
-added: v13.3.0
+added:
+  - v13.3.0
+  - v12.16.0
 changes:
   - version: v13.6.0
     pr-url: https://github.com/nodejs/node/pull/30980
@@ -417,7 +423,10 @@ endpoint on `http://host:port/json/list`.
 
 ### `--insecure-http-parser`
 <!-- YAML
-added: v13.4.0
+added:
+ - v13.4.0
+ - v12.15.0
+ - v10.19.0
 -->
 
 Use an insecure HTTP parser that accepts invalid HTTP headers. This may allow
@@ -439,7 +448,9 @@ disappear in a non-semver-major release.
 
 ### `--max-http-header-size=size`
 <!-- YAML
-added: v11.6.0
+added:
+ - v11.6.0
+ - v10.15.0
 changes:
   - version: v13.13.0
     pr-url: https://github.com/nodejs/node/pull/32520
@@ -737,7 +748,9 @@ with crypto support (default).
 
 ### `--tls-keylog=file`
 <!-- YAML
-added: v13.2.0
+added:
+ - v13.2.0
+ - v12.16.0
 -->
 
 Log TLS key material to a file. The key material is in NSS `SSLKEYLOGFILE`
@@ -746,7 +759,9 @@ traffic.
 
 ### `--tls-max-v1.2`
 <!-- YAML
-added: v12.0.0
+added:
+ - v12.0.0
+ - v10.20.0
 -->
 
 Set [`tls.DEFAULT_MAX_VERSION`][] to 'TLSv1.2'. Use to disable support for
@@ -762,7 +777,9 @@ for TLSv1.3.
 
 ### `--tls-min-v1.0`
 <!-- YAML
-added: v12.0.0
+added:
+ - v12.0.0
+ - v10.20.0
 -->
 
 Set default [`tls.DEFAULT_MIN_VERSION`][] to 'TLSv1'. Use for compatibility with
@@ -770,7 +787,9 @@ old TLS clients or servers.
 
 ### `--tls-min-v1.1`
 <!-- YAML
-added: v12.0.0
+added:
+ - v12.0.0
+ - v10.20.0
 -->
 
 Set default [`tls.DEFAULT_MIN_VERSION`][] to 'TLSv1.1'. Use for compatibility
@@ -778,7 +797,9 @@ with old TLS clients or servers.
 
 ### `--tls-min-v1.2`
 <!-- YAML
-added: v12.2.0
+added:
+ - v12.2.0
+ - v10.20.0
 -->
 
 Set default [`tls.DEFAULT_MIN_VERSION`][] to 'TLSv1.2'. This is the default for
@@ -825,7 +846,9 @@ Enables the collection of trace event tracing information.
 
 ### `--trace-exit`
 <!-- YAML
-added: v13.5.0
+added:
+ - v13.5.0
+ - v12.16.0
 -->
 
 Prints a stack trace whenever an environment is exited proactively,
@@ -882,7 +905,9 @@ Track heap object allocations for heap snapshots.
 
 ### `--unhandled-rejections=mode`
 <!-- YAML
-added: v12.0.0
+added:
+ - v12.0.0
+ - v10.17.0
 -->
 
 By default all unhandled rejections trigger a warning plus a deprecation warning
@@ -1273,7 +1298,9 @@ to an empty string (`''` or `' '`) disables persistent REPL history.
 
 ### `NODE_REPL_EXTERNAL_MODULE=file`
 <!-- YAML
-added: v13.0.0
+added:
+ - v13.0.0
+ - v12.16.0
 -->
 
 Path to a Node.js module which will be loaded in place of the built-in REPL.

--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -724,7 +724,9 @@ values are `'rr'` and `'none'`.
 <!-- YAML
 added: v0.7.1
 changes:
-  - version: v13.2.0
+  - version:
+     - v13.2.0
+     - v12.16.0
     pr-url: https://github.com/nodejs/node/pull/30162
     description: The `serialization` option is supported now.
   - version: v9.5.0

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1674,7 +1674,9 @@ changes:
   - version: v11.6.0
     pr-url: https://github.com/nodejs/node/pull/24234
     description: The `key` argument can now be a `KeyObject`.
-  - version: v11.2.0
+  - version:
+     - v11.2.0
+     - v10.17.0
     pr-url: https://github.com/nodejs/node/pull/24081
     description: The cipher `chacha20-poly1305` is now supported.
   - version: v10.10.0
@@ -1768,7 +1770,9 @@ changes:
   - version: v11.6.0
     pr-url: https://github.com/nodejs/node/pull/24234
     description: The `key` argument can now be a `KeyObject`.
-  - version: v11.2.0
+  - version:
+     - v11.2.0
+     - v10.17.0
     pr-url: https://github.com/nodejs/node/pull/24081
     description: The cipher `chacha20-poly1305` is now supported.
   - version: v10.10.0
@@ -2781,7 +2785,9 @@ request.
 <!-- YAML
 added: v10.5.0
 changes:
-  - version: v12.8.0
+  - version:
+     - v12.8.0
+     - v10.17.0
     pr-url: https://github.com/nodejs/node/pull/28799
     description: The `maxmem` value can now be any safe integer.
   - version: v10.9.0
@@ -2839,7 +2845,9 @@ crypto.scrypt('secret', 'salt', 64, { N: 1024 }, (err, derivedKey) => {
 <!-- YAML
 added: v10.5.0
 changes:
-  - version: v12.8.0
+  - version:
+     - v12.8.0
+     - v10.17.0
     pr-url: https://github.com/nodejs/node/pull/28799
     description: The `maxmem` value can now be any safe integer.
   - version: v10.9.0

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2569,7 +2569,9 @@ and [`fs.createReadStream()`][]) or by passing a file descriptor in options.
 ### DEP0136: `http` `finished`
 <!-- YAML
 changes:
-  - version: v13.4.0
+  - version:
+     - v13.4.0
+     - v12.16.0
     pr-url: https://github.com/nodejs/node/pull/28679
     description: Documentation-only deprecation.
 -->

--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -128,7 +128,9 @@ if (cluster.isMaster) {
 
 ### `socket.addSourceSpecificMembership(sourceAddress, groupAddress[, multicastInterface])`
 <!-- YAML
-added: v13.1.0
+added:
+ - v13.1.0
+ - v12.16.0
 -->
 * `sourceAddress` {string}
 * `groupAddress` {string}
@@ -317,7 +319,9 @@ drop membership on all valid interfaces.
 
 ### `socket.dropSourceSpecificMembership(sourceAddress, groupAddress[, multicastInterface])`
 <!-- YAML
-added: v13.1.0
+added:
+ - v13.1.0
+ - v12.16.0
 -->
 
 * `sourceAddress` {string}

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -2151,7 +2151,9 @@ Creation of a [`zlib`][] object failed due to incorrect configuration.
 ### `HPE_HEADER_OVERFLOW`
 <!-- YAML
 changes:
-  - version: v11.4.0
+  - version:
+     - v11.4.0
+     - v10.15.0
     pr-url: https://github.com/nodejs/node/commit/186035243fad247e3955f
     description: Max header size in `http_parser` was set to 8KB.
 -->

--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -224,7 +224,9 @@ recommendation is to **not use `async` functions as `'error'` event handlers**.
 <!-- YAML
 added: v0.1.26
 changes:
-  - version: v13.4.0
+  - version:
+     - v13.4.0
+     - v12.16.0
     pr-url: https://github.com/nodejs/node/pull/27867
     description: Added captureRejections option.
 -->
@@ -362,7 +364,9 @@ Its `name` property is set to `'MaxListenersExceededWarning'`.
 
 ### `EventEmitter.errorMonitor`
 <!-- YAML
-added: v13.6.0
+added:
+ - v13.6.0
+ - v12.16.0
 -->
 
 This symbol shall be used to install a listener for only monitoring `'error'`
@@ -783,7 +787,9 @@ emitter.emit('log');
 
 ### `emitter[Symbol.for('nodejs.rejection')](err, eventName[, ...args])`
 <!-- YAML
-added: v13.4.0
+added:
+ - v13.4.0
+ - v12.16.0
 -->
 
 > Stability: 1 - captureRejections is experimental.
@@ -819,7 +825,9 @@ class MyClass extends EventEmitter {
 
 ## `events.once(emitter, name)`
 <!-- YAML
-added: v11.13.0
+added:
+ - v11.13.0
+ - v10.16.0
 -->
 
 * `emitter` {EventEmitter}
@@ -865,7 +873,9 @@ run();
 
 ## `events.captureRejections`
 <!-- YAML
-added: v13.4.0
+added:
+ - v13.4.0
+ - v12.16.0
 -->
 
 > Stability: 1 - captureRejections is experimental.
@@ -876,7 +886,9 @@ Change the default `captureRejections` option on all new `EventEmitter` objects.
 
 ## `events.captureRejectionSymbol`
 <!-- YAML
-added: v13.4.0
+added:
+ - v13.4.0
+ - v12.16.0
 -->
 
 > Stability: 1 - captureRejections is experimental.
@@ -887,7 +899,9 @@ See how to write a custom [rejection handler][rejection].
 
 ## `events.on(emitter, eventName)`
 <!-- YAML
-added: v13.6.0
+added:
+ - v13.6.0
+ - v12.16.0
 -->
 
 * `emitter` {EventEmitter}

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -637,7 +637,9 @@ argument to `fs.createReadStream()`. If `path` is passed as a string, then
 
 ### `readStream.pending`
 <!-- YAML
-added: v11.2.0
+added:
+ - v11.2.0
+ - v10.16.0
 -->
 
 * {boolean}
@@ -2653,7 +2655,9 @@ Functions based on `fs.open()` exhibit this behavior as well:
 <!-- YAML
 added: v12.12.0
 changes:
-  - version: v13.1.0
+  - version:
+     - v13.1.0
+     - v12.16.0
     pr-url: https://github.com/nodejs/node/pull/30114
     description: The `bufferSize` option was introduced.
 -->
@@ -2680,7 +2684,9 @@ directory and subsequent read operations.
 <!-- YAML
 added: v12.12.0
 changes:
-  - version: v13.1.0
+  - version:
+     - v13.1.0
+     - v12.16.0
     pr-url: https://github.com/nodejs/node/pull/30114
     description: The `bufferSize` option was introduced.
 -->
@@ -3332,7 +3338,9 @@ Synchronous rename(2). Returns `undefined`.
 <!-- YAML
 added: v0.0.2
 changes:
-  - version: v13.3.0
+  - version:
+     - v13.3.0
+     - v12.16.0
     pr-url: https://github.com/nodejs/node/pull/30644
     description: The `maxBusyTries` option is renamed to `maxRetries`, and its
                  default is 0. The `emfileWait` option has been removed, and
@@ -3385,7 +3393,9 @@ Windows and an `ENOTDIR` error on POSIX.
 <!-- YAML
 added: v0.1.21
 changes:
-  - version: v13.3.0
+  - version:
+     - v13.3.0
+     - v12.16.0
     pr-url: https://github.com/nodejs/node/pull/30644
     description: The `maxBusyTries` option is renamed to `maxRetries`, and its
                  default is 0. The `emfileWait` option has been removed, and
@@ -5042,7 +5052,9 @@ a colon, Node.js will open a file system stream, as described by
 <!-- YAML
 added: v12.12.0
 changes:
-  - version: v13.1.0
+  - version:
+     - v13.1.0
+     - v12.16.0
     pr-url: https://github.com/nodejs/node/pull/30114
     description: The `bufferSize` option was introduced.
 -->
@@ -5200,7 +5212,9 @@ upon success.
 <!-- YAML
 added: v10.0.0
 changes:
-  - version: v13.3.0
+  - version:
+     - v13.3.0
+     - v12.16.0
     pr-url: https://github.com/nodejs/node/pull/30644
     description: The `maxBusyTries` option is renamed to `maxRetries`, and its
                  default is 0. The `emfileWait` option has been removed, and

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -652,7 +652,9 @@ See [`writable.destroyed`][] for further details.
 ### `request.finished`
 <!-- YAML
 added: v0.0.1
-deprecated: v13.4.0
+deprecated:
+ - v13.4.0
+ - v12.16.0
 -->
 
 > Stability: 0 - Deprecated. Use [`request.writableEnded`][].
@@ -729,9 +731,10 @@ request.removeHeader('Content-Type');
 ```
 
 ### `request.reusedSocket`
-
 <!-- YAML
-added: v13.0.0
+added:
+ - v13.0.0
+ - v12.16.0
 -->
 
 * {boolean} Whether the request is send through a reused socket.
@@ -1133,7 +1136,9 @@ Stops the server from accepting new connections. See [`net.Server.close()`][].
 
 ### `server.headersTimeout`
 <!-- YAML
-added: v11.3.0
+added:
+ - v11.3.0
+ - v10.14.0
 -->
 
 * {number} **Default:** `60000`
@@ -1305,7 +1310,9 @@ See [`response.socket`][].
 
 ### `response.cork()`
 <!-- YAML
-added: v13.2.0
+added:
+ - v13.2.0
+ - v12.16.0
 -->
 
 See [`writable.cork()`][].
@@ -1337,7 +1344,9 @@ is finished.
 ### `response.finished`
 <!-- YAML
 added: v0.0.2
-deprecated: v13.4.0
+deprecated:
+ - v13.4.0
+ - v12.16.0
 -->
 
 > Stability: 0 - Deprecated. Use [`response.writableEnded`][].
@@ -1604,7 +1613,9 @@ status message which was sent out.
 
 ### `response.uncork()`
 <!-- YAML
-added: v13.2.0
+added:
+ - v13.2.0
+ - v12.16.0
 -->
 
 See [`writable.uncork()`][].
@@ -1680,7 +1691,9 @@ the request body should be sent. See the [`'checkContinue'`][] event on
 <!-- YAML
 added: v0.1.30
 changes:
-  - version: v11.10.0
+  - version:
+     - v11.10.0
+     - v10.17.0
     pr-url: https://github.com/nodejs/node/pull/25974
     description: Return `this` from `writeHead()` to allow chaining with
                  `end()`.
@@ -1759,7 +1772,9 @@ the request body should be sent.
 <!-- YAML
 added: v0.1.17
 changes:
-  - version: v13.1.0
+  - version:
+     - v13.1.0
+     - v12.16.0
     pr-url: https://github.com/nodejs/node/pull/30135
     description: The `readableHighWaterMark` value mirrors that of the socket.
 -->
@@ -2058,7 +2073,10 @@ Found'`.
 <!-- YAML
 added: v0.1.13
 changes:
-  - version: v13.8.0
+  - version:
+     - v13.8.0
+     - v12.15.0
+     - v10.19.0
     pr-url: https://github.com/nodejs/node/pull/31448
     description: The `insecureHTTPParser` option is supported now.
   - version: v13.3.0
@@ -2173,7 +2191,9 @@ requests.
 
 ## `http.maxHeaderSize`
 <!-- YAML
-added: v11.6.0
+added:
+ - v11.6.0
+ - v10.15.0
 -->
 
 * {number}
@@ -2189,7 +2209,10 @@ This can be overridden for servers and client requests by passing the
 <!-- YAML
 added: v0.3.6
 changes:
-  - version: v13.8.0
+  - version:
+     - v13.8.0
+     - v12.15.0
+     - v10.19.0
     pr-url: https://github.com/nodejs/node/pull/31448
     description: The `insecureHTTPParser` option is supported now.
   - version: v13.3.0

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1035,7 +1035,9 @@ the `'aborted'` event will have been emitted.
 
 #### `http2stream.bufferSize`
 <!-- YAML
-added: v11.2.0
+added:
+ - v11.2.0
+ - v10.16.0
 -->
 
 * {number}
@@ -1988,10 +1990,14 @@ value only affects new connections to the server, not any existing connections.
 <!-- YAML
 added: v8.4.0
 changes:
-  - version: v13.3.0
+  - version:
+     - v13.3.0
+     - v12.16.0
     pr-url: https://github.com/nodejs/node/pull/30534
     description: Added `maxSessionRejectedStreams` option with a default of 100.
-  - version: v13.3.0
+  - version:
+     - v13.3.0
+     - v12.16.0
     pr-url: https://github.com/nodejs/node/pull/30534
     description: Added `maxSessionInvalidFrames` option with a default of 1000.
   - version: v13.0.0
@@ -2115,10 +2121,14 @@ server.listen(80);
 <!-- YAML
 added: v8.4.0
 changes:
-  - version: v13.3.0
+  - version:
+     - v13.3.0
+     - v12.16.0
     pr-url: https://github.com/nodejs/node/pull/30534
     description: Added `maxSessionRejectedStreams` option with a default of 100.
-  - version: v13.3.0
+  - version:
+     - v13.3.0
+     - v12.16.0
     pr-url: https://github.com/nodejs/node/pull/30534
     description: Added `maxSessionInvalidFrames` option with a default of 1000.
   - version: v13.0.0
@@ -3121,7 +3131,9 @@ is finished.
 #### `response.finished`
 <!-- YAML
 added: v8.4.0
-deprecated: v13.4.0
+deprecated:
+ - v13.4.0
+ - v12.16.0
 -->
 
 > Stability: 0 - Deprecated. Use [`response.writableEnded`][].
@@ -3429,7 +3441,9 @@ should be sent. See the [`'checkContinue'`][] event on `Http2Server` and
 <!-- YAML
 added: v8.4.0
 changes:
-  - version: v11.10.0
+  - version:
+     - v11.10.0
+     - v10.17.0
     pr-url: https://github.com/nodejs/node/pull/25974
     description: Return `this` from `writeHead()` to allow chaining with
                  `end()`.

--- a/doc/api/https.md
+++ b/doc/api/https.md
@@ -47,7 +47,9 @@ changes:
 
 #### Event: `'keylog'`
 <!-- YAML
-added: v13.2.0
+added:
+ - v13.2.0
+ - v12.16.0
 -->
 
 * `line` {Buffer} Line of ASCII text, in NSS `SSLKEYLOGFILE` format.

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -374,7 +374,9 @@ tied to the life cycle of the Agent.
 
 ### napi_set_instance_data
 <!-- YAML
-added: v12.8.0
+added:
+ - v12.8.0
+ - v10.20.0
 napiVersion: 6
 -->
 
@@ -402,7 +404,9 @@ by the previous call, it will not be called.
 
 ### napi_get_instance_data
 <!-- YAML
-added: v12.8.0
+added:
+ - v12.8.0
+ - v10.20.0
 napiVersion: 6
 -->
 
@@ -1665,7 +1669,9 @@ the `napi_value` in question is of the JavaScript type expected by the API.
 ### Enum types
 #### napi_key_collection_mode
 <!-- YAML
-added: v13.7.0
+added:
+ - v13.7.0
+ - v10.20.0
 napiVersion: 6
 -->
 
@@ -1686,7 +1692,9 @@ of the objects's prototype chain as well.
 
 #### napi_key_filter
 <!-- YAML
-added: v13.7.0
+added:
+ - v13.7.0
+ - v10.20.0
 napiVersion: 6
 -->
 
@@ -1705,7 +1713,9 @@ Property filter bits. They can be or'ed to build a composite filter.
 
 #### napi_key_conversion
 <!-- YAML
-added: v13.7.0
+added:
+ - v13.7.0
+ - v10.20.0
 napiVersion: 6
 -->
 
@@ -1902,7 +1912,9 @@ structure, in most cases using a `TypedArray` will suffice.
 
 #### napi_create_date
 <!-- YAML
-added: v11.11.0
+added:
+ - v11.11.0
+ - v10.17.0
 napiVersion: 5
 -->
 
@@ -2583,7 +2595,9 @@ This API returns various properties of a `DataView`.
 
 #### napi_get_date_value
 <!-- YAML
-added: v11.11.0
+added:
+ - v11.11.0
+ - v10.17.0
 napiVersion: 5
 -->
 
@@ -3201,7 +3215,9 @@ This API checks if the `Object` passed in is a buffer.
 
 ### napi_is_date
 <!-- YAML
-added: v11.11.0
+added:
+ - v11.11.0
+ - v10.17.0
 napiVersion: 5
 -->
 
@@ -3297,7 +3313,9 @@ defined in [Section 7.2.14][] of the ECMAScript Language Specification.
 
 ### napi_detach_arraybuffer
 <!-- YAML
-added: v13.0.0
+added:
+ - v13.0.0
+ - v12.16.0
 -->
 
 > Stability: 1 - Experimental
@@ -3323,7 +3341,9 @@ defined in [Section 24.1.1.3][] of the ECMAScript Language Specification.
 
 ### napi_is_detached_arraybuffer
 <!-- YAML
-added: v13.3.0
+added:
+ - v13.3.0
+ - v12.16.0
 -->
 
 > Stability: 1 - Experimental
@@ -3592,7 +3612,9 @@ included.
 
 #### napi_get_all_property_names
 <!-- YAML
-added: v13.7.0
+added:
+ - v13.7.0
+ - v10.20.0
 napiVersion: 6
 -->
 
@@ -5181,7 +5203,9 @@ prevent the event loop from exiting. The APIs `napi_ref_threadsafe_function` and
 added: v10.6.0
 napiVersion: 4
 changes:
-  - version: v12.6.0
+  - version:
+     - v12.6.0
+     - v10.17.0
     pr-url: https://github.com/nodejs/node/pull/27791
     description: Made `func` parameter optional with custom `call_js_cb`.
 -->

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -787,7 +787,9 @@ Useful to throttle back an upload.
 
 ### `socket.pending`
 <!-- YAML
-added: v11.2.0
+added:
+ - v11.2.0
+ - v10.16.0
 -->
 
 * {boolean}

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -224,7 +224,9 @@ most convenient for scripts).
 <!-- YAML
 added: v0.1.18
 changes:
-  - version: v12.0.0
+  - version:
+     - v12.0.0
+     - v10.17.0
     pr-url: https://github.com/nodejs/node/pull/26599
     description: Added the `origin` argument.
 -->

--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -315,9 +315,13 @@ The `rl.write()` method will write the data to the `readline` `Interface`'s
 
 ### `rl[Symbol.asyncIterator]()`
 <!-- YAML
-added: v11.4.0
+added:
+ - v11.4.0
+ - v10.16.0
 changes:
-  - version: v11.14.0
+  - version:
+     - v11.14.0
+     - v10.17.0
     pr-url: https://github.com/nodejs/node/pull/26989
     description: Symbol.asyncIterator support is no longer experimental.
 -->
@@ -401,7 +405,9 @@ as well as the column where the terminal caret will be rendered.
 
 ### `rl.getCursorPos()`
 <!-- YAML
-added: v13.5.0
+added:
+ - v13.5.0
+ - v12.16.0
 -->
 
 * Returns: {Object}

--- a/doc/api/report.md
+++ b/doc/api/report.md
@@ -580,7 +580,9 @@ Specific API documentation can be found under
 ## Interaction with Workers
 <!-- YAML
 changes:
-  - version: v13.9.0
+  - version:
+      - v13.9.0
+      - v12.16.2
     pr-url: https://github.com/nodejs/node/pull/31386
     description: Workers are now included in the report.
 -->

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -519,7 +519,9 @@ does not indicate whether the data has been flushed, for this use
 
 ##### `writable.writableCorked`
 <!-- YAML
-added: v13.2.0
+added:
+ - v13.2.0
+ - v12.16.0
 -->
 
 * {integer}
@@ -1809,17 +1811,19 @@ method.
 #### Constructor: `new stream.Writable([options])`
 <!-- YAML
 changes:
+  - version: v14.0.0
+    pr-url: https://github.com/nodejs/node/pull/30623
+    description: Change `autoDestroy` option default to `true`.
+  - version:
+     - v11.2.0
+     - v10.16.0
+    pr-url: https://github.com/nodejs/node/pull/22795
+    description: Add `autoDestroy` option to automatically `destroy()` the
+                 stream when it emits `'finish'` or errors.
   - version: v10.0.0
     pr-url: https://github.com/nodejs/node/pull/18438
     description: Add `emitClose` option to specify if `'close'` is emitted on
                  destroy.
-  - version: v11.2.0
-    pr-url: https://github.com/nodejs/node/pull/22795
-    description: Add `autoDestroy` option to automatically `destroy()` the
-                 stream when it emits `'finish'` or errors.
-  - version: v14.0.0
-    pr-url: https://github.com/nodejs/node/pull/30623
-    description: Change `autoDestroy` option default to `true`.
 -->
 
 * `options` {Object}
@@ -2093,7 +2097,9 @@ constructor and implement the `readable._read()` method.
 #### `new stream.Readable([options])`
 <!-- YAML
 changes:
-  - version: v11.2.0
+  - version:
+     - v11.2.0
+     - v10.16.0
     pr-url: https://github.com/nodejs/node/pull/22795
     description: Add `autoDestroy` option to automatically `destroy()` the
                  stream when it emits `'end'` or errors.

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -372,7 +372,9 @@ Accepts encrypted connections using TLS or SSL.
 
 ### Event: `'keylog'`
 <!-- YAML
-added: v12.3.0
+added:
+ - v12.3.0
+ - v10.20.0
 -->
 
 * `line` {Buffer} Line of ASCII text, in NSS `SSLKEYLOGFILE` format.
@@ -692,7 +694,9 @@ Construct a new `tls.TLSSocket` object from an existing TCP socket.
 
 ### Event: `'keylog'`
 <!-- YAML
-added: v12.3.0
+added:
+ - v12.3.0
+ - v10.20.0
 -->
 
 * `line` {Buffer} Line of ASCII text, in NSS `SSLKEYLOGFILE` format.
@@ -857,13 +861,15 @@ socket has been destroyed, `null` will be returned.
 <!-- YAML
 added: v0.11.4
 changes:
+  - version:
+     - v13.4.0
+     - v12.16.0
+    pr-url: https://github.com/nodejs/node/pull/30637
+    description: Return the IETF cipher name as `standardName`.
   - version: v12.0.0
     pr-url: https://github.com/nodejs/node/pull/26625
     description: Return the minimum cipher version, instead of a fixed string
       (`'TLSv1/SSLv3'`).
-  - version: v13.4.0
-    pr-url: https://github.com/nodejs/node/pull/30637
-    description: Return the IETF cipher name as `standardName`.
 -->
 
 * Returns: {Object}
@@ -1277,7 +1283,9 @@ changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/32786
     description: The `highWaterMark` option is accepted now.
-  - version: v13.6.0
+  - version:
+     - v13.6.0
+     - v12.16.0
     pr-url: https://github.com/nodejs/node/pull/23188
     description: The `pskCallback` option is now supported.
   - version: v12.9.0
@@ -1289,7 +1297,9 @@ changes:
   - version: v12.2.0
     pr-url: https://github.com/nodejs/node/pull/27497
     description: The `enableTrace` option is now supported.
-  - version: v11.8.0
+  - version:
+     - v11.8.0
+     - v10.16.0
     pr-url: https://github.com/nodejs/node/pull/25517
     description: The `timeout` option is supported now.
   - version: v8.0.0
@@ -1475,7 +1485,9 @@ changes:
   - version: v11.5.0
     pr-url: https://github.com/nodejs/node/pull/24733
     description: The `ca:` option now supports `BEGIN TRUSTED CERTIFICATE`.
-  - version: v11.4.0
+  - version:
+     - v11.4.0
+     - v10.16.0
     pr-url: https://github.com/nodejs/node/pull/24405
     description: The `minVersion` and `maxVersion` can be used to restrict
                  the allowed TLS protocol versions.

--- a/doc/api/tty.md
+++ b/doc/api/tty.md
@@ -216,7 +216,9 @@ of columns and rows in the corresponding [TTY](tty.html).
 
 ### `writeStream.hasColors([count][, env])`
 <!-- YAML
-added: v11.13.0
+added:
+ - v11.13.0
+ - v10.16.0
 -->
 
 * `count` {integer} The number of colors that are requested (minimum 2).

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -401,7 +401,9 @@ changes:
   - version: v13.13.0
     pr-url: https://github.com/nodejs/node/pull/32392
     description: The `maxStringLength` option is supported now.
-  - version: v13.5.0
+  - version:
+     - v13.5.0
+     - v12.16.0
     pr-url: https://github.com/nodejs/node/pull/30768
     description: User defined prototype properties are inspected in case
                  `showHidden` is `true`.
@@ -1002,7 +1004,9 @@ throw an error.
 <!-- YAML
 added: v8.0.0
 changes:
-  - version: v13.12.0
+  - version:
+      - v13.12.0
+      - v12.16.2
     pr-url: https://github.com/nodejs/node/pull/31672
     description: This is now defined as a shared symbol.
 -->

--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -347,7 +347,9 @@ vm.measureMemory({ mode: 'detailed' }, context)
 
 ## Class: `vm.Module`
 <!-- YAML
-added: v13.0.0
+added:
+ - v13.0.0
+ - v12.16.0
 -->
 
 > Stability: 1 - Experimental
@@ -696,7 +698,9 @@ const module2 = new vm.SourceTextModule('const a = 1;', { cachedData });
 
 ## Class: `vm.SyntheticModule`
 <!-- YAML
-added: v13.0.0
+added:
+ - v13.0.0
+ - v12.16.0
 -->
 
 > Stability: 1 - Experimental
@@ -725,7 +729,9 @@ const module = new vm.SyntheticModule(['default'], function() {
 
 ### Constructor: `new vm.SyntheticModule(exportNames, evaluateCallback[, options])`
 <!-- YAML
-added: v13.0.0
+added:
+ - v13.0.0
+ - v12.16.0
 -->
 
 * `exportNames` {string[]} Array of names that will be exported from the module.
@@ -745,7 +751,9 @@ the module to access information outside the specified `context`. Use
 
 ### `syntheticModule.setExport(name, value)`
 <!-- YAML
-added: v13.0.0
+added:
+ - v13.0.0
+ - v12.16.0
 -->
 
 * `name` {string} Name of the export to set.

--- a/doc/api/wasi.md
+++ b/doc/api/wasi.md
@@ -1,6 +1,6 @@
 # WebAssembly System Interface (WASI)
 
-<!--introduced_in=v13.3.0-->
+<!--introduced_in=v12.16.0-->
 
 > Stability: 1 - Experimental
 
@@ -34,7 +34,9 @@ CLI arguments are needed for the previous example to run.
 
 ## Class: `WASI`
 <!-- YAML
-added: v13.3.0
+added:
+ - v13.3.0
+ - v12.16.0
 -->
 
 The `WASI` class provides the WASI system call API and additional convenience
@@ -45,7 +47,9 @@ sandbox directory structure configured explicitly.
 
 ### `new WASI([options])`
 <!-- YAML
-added: v13.3.0
+added:
+ - v13.3.0
+ - v12.16.0
 -->
 
 * `options` {Object}
@@ -65,7 +69,9 @@ added: v13.3.0
 
 ### `wasi.start(instance)`
 <!-- YAML
-added: v13.3.0
+added:
+ - v13.3.0
+ - v12.16.0
 -->
 
 * `instance` {WebAssembly.Instance}
@@ -80,7 +86,9 @@ is present on `instance`, then `start()` does nothing.
 
 ### `wasi.wasiImport`
 <!-- YAML
-added: v13.3.0
+added:
+ - v13.3.0
+ - v12.16.0
 -->
 
 * {Object}

--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -165,7 +165,9 @@ When this function is used, no `'message'` event will be emitted and the
 
 ## `worker.resourceLimits`
 <!-- YAML
-added: v13.2.0
+added:
+ - v13.2.0
+ - v12.16.0
 -->
 
 * {Object}
@@ -520,10 +522,14 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/31664
     description: The `filename` parameter can be a WHATWG `URL` object using
                  `file:` protocol.
-  - version: v13.2.0
+  - version:
+     - v13.2.0
+     - v12.16.0
     pr-url: https://github.com/nodejs/node/pull/26628
     description: The `resourceLimits` option was introduced.
-  - version: v13.4.0
+  - version:
+     - v13.4.0
+     - v12.16.0
     pr-url: https://github.com/nodejs/node/pull/30559
     description: The `argv` option was introduced.
 -->
@@ -664,7 +670,9 @@ no effect.
 
 ### `worker.resourceLimits`
 <!-- YAML
-added: v13.2.0
+added:
+ - v13.2.0
+ - v12.16.0
 -->
 
 * {Object}

--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -411,7 +411,9 @@ Compression strategy.
 
 ### Brotli constants
 <!-- YAML
-added: v11.7.0
+added:
+ - v11.7.0
+ - v10.16.0
 -->
 
 There are several options and other constants available for Brotli-based
@@ -545,14 +547,18 @@ const stream = zlib.createBrotliCompress({
 
 ## Class: `zlib.BrotliCompress`
 <!-- YAML
-added: v11.7.0
+added:
+ - v11.7.0
+ - v10.16.0
 -->
 
 Compress data using the Brotli algorithm.
 
 ## Class: `zlib.BrotliDecompress`
 <!-- YAML
-added: v11.7.0
+added:
+ - v11.7.0
+ - v10.16.0
 -->
 
 Decompress data using the Brotli algorithm.
@@ -633,7 +639,9 @@ the header.
 <!-- YAML
 added: v0.5.8
 changes:
-  - version: v11.7.0
+  - version:
+     - v11.7.0
+     - v10.16.0
     pr-url: https://github.com/nodejs/node/pull/24939
     description: This class was renamed from `Zlib` to `ZlibBase`.
 -->
@@ -727,7 +735,9 @@ Provides an object enumerating Zlib-related constants.
 
 ## `zlib.createBrotliCompress([options])`
 <!-- YAML
-added: v11.7.0
+added:
+ - v11.7.0
+ - v10.16.0
 -->
 
 * `options` {brotli options}
@@ -736,7 +746,9 @@ Creates and returns a new [`BrotliCompress`][] object.
 
 ## `zlib.createBrotliDecompress([options])`
 <!-- YAML
-added: v11.7.0
+added:
+ - v11.7.0
+ - v10.16.0
 -->
 
 * `options` {brotli options}
@@ -828,7 +840,9 @@ without a callback.
 
 ### `zlib.brotliCompress(buffer[, options], callback)`
 <!-- YAML
-added: v11.7.0
+added:
+ - v11.7.0
+ - v10.16.0
 -->
 
 * `buffer` {Buffer|TypedArray|DataView|ArrayBuffer|string}
@@ -837,7 +851,9 @@ added: v11.7.0
 
 ### `zlib.brotliCompressSync(buffer[, options])`
 <!-- YAML
-added: v11.7.0
+added:
+ - v11.7.0
+ - v10.16.0
 -->
 
 * `buffer` {Buffer|TypedArray|DataView|ArrayBuffer|string}
@@ -847,7 +863,9 @@ Compress a chunk of data with [`BrotliCompress`][].
 
 ### `zlib.brotliDecompress(buffer[, options], callback)`
 <!-- YAML
-added: v11.7.0
+added:
+ - v11.7.0
+ - v10.16.0
 -->
 
 * `buffer` {Buffer|TypedArray|DataView|ArrayBuffer|string}
@@ -856,7 +874,9 @@ added: v11.7.0
 
 ### `zlib.brotliDecompressSync(buffer[, options])`
 <!-- YAML
-added: v11.7.0
+added:
+ - v11.7.0
+ - v10.16.0
 -->
 
 * `buffer` {Buffer|TypedArray|DataView|ArrayBuffer|string}


### PR DESCRIPTION
When cherry-picking release commits for LTS releases into master,
the `REPLACEME` metadata can be taken over as well, to give users
a more accurate view of what is being released on which release line.

This addresses this problem for all previous LTS releases for which
this has not been done.

@nodejs/releasers 

Fixes: https://github.com/nodejs/node/issues/33001

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
