### PR TITLE
src: fix invalid windowBits=8 gzip segfault

### DIFF
--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -614,7 +614,7 @@ function Zlib(opts, mode) {
       windowBits = 0;
     } else {
       // `{ windowBits: 8 }` is valid for deflate but nog gzip.
-      const min = Z_MIN_WINDOWBITS + (mode === GZIP);
+      const min = Z_MIN_WINDOWBITS + (mode === GZIP ? 1 : 0);
       windowBits = checkRangesOrGetDefault(
         opts.windowBits, 'options.windowBits',
         min, Z_MAX_WINDOWBITS, Z_DEFAULT_WINDOWBITS);

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -613,7 +613,7 @@ function Zlib(opts, mode) {
          mode === UNZIP)) {
       windowBits = 0;
     } else {
-      // `{ windowBits: 8 }` is valid for deflate but nog gzip.
+      // `{ windowBits: 8 }` is valid for deflate but not gzip.
       const min = Z_MIN_WINDOWBITS + (mode === GZIP ? 1 : 0);
       windowBits = checkRangesOrGetDefault(
         opts.windowBits, 'options.windowBits',

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -613,9 +613,11 @@ function Zlib(opts, mode) {
          mode === UNZIP)) {
       windowBits = 0;
     } else {
+      // `{ windowBits: 8 }` is valid for deflate but nog gzip.
+      const min = Z_MIN_WINDOWBITS + (mode === GZIP);
       windowBits = checkRangesOrGetDefault(
         opts.windowBits, 'options.windowBits',
-        Z_MIN_WINDOWBITS, Z_MAX_WINDOWBITS, Z_DEFAULT_WINDOWBITS);
+        min, Z_MAX_WINDOWBITS, Z_DEFAULT_WINDOWBITS);
     }
 
     level = checkRangesOrGetDefault(

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -111,7 +111,12 @@ enum node_zlib_mode {
 
 struct CompressionError {
   CompressionError(const char* message, const char* code, int err)
-    : message(message), code(code), err(err) {}
+      : message(message)
+      , code(code)
+      , err(err) {
+    CHECK_NOT_NULL(message);
+  }
+
   CompressionError() = default;
 
   const char* message = nullptr;
@@ -997,7 +1002,7 @@ CompressionError ZlibContext::Init(
   if (err_ != Z_OK) {
     dictionary_.clear();
     mode_ = NONE;
-    return ErrorForMessage(nullptr);
+    return ErrorForMessage("zlib error");
   }
 
   return SetDictionary();

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -111,9 +111,9 @@ enum node_zlib_mode {
 
 struct CompressionError {
   CompressionError(const char* message, const char* code, int err)
-      : message(message)
-      , code(code)
-      , err(err) {
+      : message(message),
+        code(code),
+        err(err) {
     CHECK_NOT_NULL(message);
   }
 

--- a/test/parallel/test-zlib-failed-init.js
+++ b/test/parallel/test-zlib-failed-init.js
@@ -21,7 +21,7 @@ assert.throws(
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
     message: 'The value of "options.windowBits" is out of range. It must ' +
-             'be >= 8 and <= 15. Received 0'
+             'be >= 9 and <= 15. Received 0'
   }
 );
 

--- a/test/parallel/test-zlib-zero-windowBits.js
+++ b/test/parallel/test-zlib-zero-windowBits.js
@@ -28,6 +28,6 @@ const zlib = require('zlib');
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
     message: 'The value of "options.windowBits" is out of range. ' +
-             'It must be >= 8 and <= 15. Received 0'
+             'It must be >= 9 and <= 15. Received 0'
   });
 }

--- a/test/parallel/test-zlib.js
+++ b/test/parallel/test-zlib.js
@@ -27,6 +27,13 @@ const stream = require('stream');
 const fs = require('fs');
 const fixtures = require('../common/fixtures');
 
+// Should not segfault.
+assert.throws(() => zlib.gzipSync(Buffer.alloc(0), { windowBits: 8 }), {
+  code: 'ERR_ZLIB_INITIALIZATION_FAILED',
+  name: 'Error',
+  message: 'Initialization failed',
+});
+
 let zlibPairs = [
   [zlib.Deflate, zlib.Inflate],
   [zlib.Gzip, zlib.Gunzip],

--- a/test/parallel/test-zlib.js
+++ b/test/parallel/test-zlib.js
@@ -29,9 +29,10 @@ const fixtures = require('../common/fixtures');
 
 // Should not segfault.
 assert.throws(() => zlib.gzipSync(Buffer.alloc(0), { windowBits: 8 }), {
-  code: 'ERR_ZLIB_INITIALIZATION_FAILED',
-  name: 'Error',
-  message: 'Initialization failed',
+  code: 'ERR_OUT_OF_RANGE',
+  name: 'RangeError',
+  message: 'The value of "options.windowBits" is out of range. ' +
+           'It must be >= 9 and <= 15. Received 8',
 });
 
 let zlibPairs = [


### PR DESCRIPTION
`{ windowBits: 8 }` is legal for deflate streams but not gzip streams.
Fix a nullptr dereference when formatting the error message.

Bug introduced in commit c34eae5 ("zlib: refactor zlib internals")
from September 2018.

<hr>

zlib: reject windowBits=8 when mode=GZIP

It's also handled in C++ land now, per the previous commit, but
intercepting it in JS land makes for prettier error messages.