### PR TITLE
module: do not warn when accessing `__esModule` of unfinished exports

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -825,13 +825,16 @@ function emitCircularRequireWarning(prop) {
 // warns when non-existend properties are accessed.
 const CircularRequirePrototypeWarningProxy = new Proxy({}, {
   get(target, prop) {
-    if (prop in target) return target[prop];
+    // Allow __esModule access in any case because it is used in the output
+    // of transpiled code to determine whether something comes from an
+    // ES module, and is not used as a regular key of `module.exports`.
+    if (prop in target || prop === '__esModule') return target[prop];
     emitCircularRequireWarning(prop);
     return undefined;
   },
 
   getOwnPropertyDescriptor(target, prop) {
-    if (ObjectPrototypeHasOwnProperty(target, prop))
+    if (ObjectPrototypeHasOwnProperty(target, prop) || prop === '__esModule')
       return ObjectGetOwnPropertyDescriptor(target, prop);
     emitCircularRequireWarning(prop);
     return undefined;

--- a/test/fixtures/cycles/warning-esm-half-transpiled-a.js
+++ b/test/fixtures/cycles/warning-esm-half-transpiled-a.js
@@ -1,0 +1,1 @@
+require('./warning-esm-half-transpiled-b.js');

--- a/test/fixtures/cycles/warning-esm-half-transpiled-b.js
+++ b/test/fixtures/cycles/warning-esm-half-transpiled-b.js
@@ -1,0 +1,2 @@
+const a = require('./warning-esm-half-transpiled-a.js');
+a.__esModule;

--- a/test/parallel/test-module-circular-dependency-warning.js
+++ b/test/parallel/test-module-circular-dependency-warning.js
@@ -31,3 +31,10 @@ assert.strictEqual(Object.getPrototypeOf(classExport).name, 'Parent');
 const esmTranspiledExport =
   require(fixtures.path('cycles', 'warning-esm-transpiled-a.js'));
 assert.strictEqual(esmTranspiledExport.__esModule, true);
+
+// If module.exports.__esModule is being accessed but is not present, e.g.
+// because only the one of the files is a transpiled ES module, no warning
+// should be emitted.
+const halfTranspiledExport =
+  require(fixtures.path('cycles', 'warning-esm-half-transpiled-a.js'));
+assert.strictEqual(halfTranspiledExport.__esModule, undefined);


### PR DESCRIPTION
Since this property access is performed by generated code, and not
used for accessing the actual exports of a module (and because
transpilers generally define it as the first key of `module.exports`
when it *is* present), it should be okay to allow it.

Refs: https://github.com/nodejs/node/pull/29935
Fixes: https://github.com/nodejs/node/issues/33046

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
