### PR TITLE
lib: make the builtInObjects set deterministic during bootstrap

### DIFF
--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -3,6 +3,7 @@
 const {
   Map,
   ObjectDefineProperty,
+  ObjectGetOwnPropertyNames,
   SafeWeakMap,
 } = primordials;
 
@@ -177,6 +178,13 @@ function setupDebugEnv() {
   require('internal/util/debuglog').initializeDebugEnv(process.env.NODE_DEBUG);
   if (getOptionValue('--expose-internals')) {
     require('internal/bootstrap/loaders').NativeModule.exposeInternals();
+  }
+
+  const { builtInObjects } = require('internal/util/inspect');
+  // The content of this list depends on e.g. v8 flags, as well as
+  // what gets added by Node.js to the global object.
+  for (const key of ObjectGetOwnPropertyNames(globalThis)) {
+    builtInObjects.add(key);
   }
 }
 

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -181,7 +181,7 @@ function setupDebugEnv() {
   }
 
   const { builtInObjects } = require('internal/util/inspect');
-  // The content of this list depends on e.g. v8 flags, as well as
+  // The content of this list depends on e.g. V8 flags, as well as
   // what gets added by Node.js to the global object.
   for (const key of ObjectGetOwnPropertyNames(globalThis)) {
     builtInObjects.add(key);

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -130,9 +130,58 @@ const typedArraySizeGetter = uncurryThis(
 
 let hexSlice;
 
-const builtInObjects = new Set(
-  ObjectGetOwnPropertyNames(global).filter((e) => /^[A-Z][a-zA-Z0-9]+$/.test(e))
-);
+// Make this list explicit instead of filtering over globalThis so that
+// this list is deterministic during the bootstrap regardless of:
+// a) Wether this file is required when the context is going to be
+//    serialized, or what the V8 flags are. V8 does not add
+//    SharedArrayBuffer, Atomics, WebAssembly, and other flaggable
+//    globals e.g. harmony ones to a context that will be serialized.
+// b) Wether this file is required before or after bootstrap
+//    (Node.js adds things like Buffer, URL, etc.)
+const builtInObjects = new Set([
+  'Object',
+  'Function',
+  'Array',
+  'Number',
+  'Infinity',
+  'NaN',
+  'Boolean',
+  'String',
+  'Symbol',
+  'Date',
+  'Promise',
+  'RegExp',
+  'Error',
+  'EvalError',
+  'RangeError',
+  'ReferenceError',
+  'SyntaxError',
+  'TypeError',
+  'URIError',
+  'JSON',
+  'Math',
+  'Intl',
+  'ArrayBuffer',
+  'Uint8Array',
+  'Int8Array',
+  'Uint16Array',
+  'Int16Array',
+  'Uint32Array',
+  'Int32Array',
+  'Float32Array',
+  'Float64Array',
+  'Uint8ClampedArray',
+  'BigUint64Array',
+  'BigInt64Array',
+  'DataView',
+  'Map',
+  'BigInt',
+  'Set',
+  'WeakMap',
+  'WeakSet',
+  'Proxy',
+  'Reflect'
+]);
 
 // https://tc39.es/ecma262/#sec-IsHTMLDDA-internal-slot
 const isUndetectableObject = (v) => typeof v === 'undefined' && v !== undefined;
@@ -2033,5 +2082,6 @@ module.exports = {
   formatWithOptions,
   getStringWidth,
   inspectDefaultOptions,
-  stripVTControlCharacters
+  stripVTControlCharacters,
+  builtInObjects,
 };

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -132,11 +132,11 @@ let hexSlice;
 
 // Make this list explicit instead of filtering over globalThis so that
 // this list is deterministic during the bootstrap regardless of:
-// a) Wether this file is required when the context is going to be
+// a) Whether this file is required when the context is going to be
 //    serialized, or what the V8 flags are. V8 does not add
 //    SharedArrayBuffer, Atomics, WebAssembly, and other flaggable
 //    globals e.g. harmony ones to a context that will be serialized.
-// b) Wether this file is required before or after bootstrap
+// b) Whether this file is required before or after bootstrap
 //    (Node.js adds things like Buffer, URL, etc.)
 const builtInObjects = new Set([
   'Object',


### PR DESCRIPTION
Make this list explicit instead of filtering over globalThis so that
this list is deterministic during the bootstrap regardless of:
a) Wether this file is required when the context is going to be
   serialized, or what the V8 flags are. V8 does not add
   SharedArrayBuffer, Atomics, WebAssembly, and other flaggable
   globals e.g. harmony ones to a context that will be serialized.
b) Wether this file is required before or after bootstrap
   (Node.js adds things like Buffer, URL, etc.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
