### PR TITLE
util,readline: NFC-normalize strings before getStringWidth

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -1922,6 +1922,13 @@ function formatWithOptionsInternal(inspectOptions, ...args) {
   return str;
 }
 
+function prepareStringForGetStringWidth(str, removeControlChars) {
+  str = str.normalize('NFC');
+  if (removeControlChars)
+    str = stripVTControlCharacters(str);
+  return str;
+}
+
 if (internalBinding('config').hasIntl) {
   const icu = internalBinding('icu');
   // icu.getStringWidth(string, ambiguousAsFullWidth, expandEmojiSequence)
@@ -1931,8 +1938,8 @@ if (internalBinding('config').hasIntl) {
   // the receiving end supports.
   getStringWidth = function getStringWidth(str, removeControlChars = true) {
     let width = 0;
-    if (removeControlChars)
-      str = stripVTControlCharacters(str);
+
+    str = prepareStringForGetStringWidth(str, removeControlChars);
     for (let i = 0; i < str.length; i++) {
       // Try to avoid calling into C++ by first handling the ASCII portion of
       // the string. If it is fully ASCII, we skip the C++ part.
@@ -1952,9 +1959,7 @@ if (internalBinding('config').hasIntl) {
   getStringWidth = function getStringWidth(str, removeControlChars = true) {
     let width = 0;
 
-    if (removeControlChars)
-      str = stripVTControlCharacters(str);
-
+    str = prepareStringForGetStringWidth(str, removeControlChars);
     for (const char of str) {
       const code = char.codePointAt(0);
       if (isFullWidthCodePoint(code)) {

--- a/test/parallel/test-icu-stringwidth.js
+++ b/test/parallel/test-icu-stringwidth.js
@@ -87,3 +87,12 @@ for (let i = 0; i < 256; i++) {
     assert.strictEqual(getStringWidth(char), 1);
   }
 }
+
+{
+  const a = '한글'.normalize('NFD'); // 한글
+  const b = '한글'.normalize('NFC'); // 한글
+  assert.strictEqual(a.length, 6);
+  assert.strictEqual(b.length, 2);
+  assert.strictEqual(getStringWidth(a), 4);
+  assert.strictEqual(getStringWidth(b), 4);
+}


### PR DESCRIPTION
The assumption here is that decomposed characters render like their
composed character equivalents, and that working with the former
comes with a risk of over-estimating string widths given that
we compute them on a per-code-point basis. The regression test
added here (한글 vs 한글) is an example of that happening.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
