### PR TITLE
stream: don't wait for close on legacy streams

### DIFF
--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -72,7 +72,7 @@ function eos(stream, opts, callback) {
   // TODO (ronag): Improve soft detection to include core modules and
   // common ecosystem modules that do properly emit 'close' but fail
   // this generic check.
-  const willEmitClose = (
+  let willEmitClose = (
     state &&
     state.autoDestroy &&
     state.emitClose &&
@@ -85,6 +85,11 @@ function eos(stream, opts, callback) {
     (wState && wState.finished);
   const onfinish = () => {
     writableFinished = true;
+    // Stream should not be destroyed here. If it is that
+    // means that user space is doing something differently and
+    // we cannot trust willEmitClose.
+    if (stream.destroyed) willEmitClose = false;
+
     if (willEmitClose && (!stream.readable || readable)) return;
     if (!readable || readableEnded) callback.call(stream);
   };
@@ -93,6 +98,11 @@ function eos(stream, opts, callback) {
     (rState && rState.endEmitted);
   const onend = () => {
     readableEnded = true;
+    // Stream should not be destroyed here. If it is that
+    // means that user space is doing something differently and
+    // we cannot trust willEmitClose.
+    if (stream.destroyed) willEmitClose = false;
+
     if (willEmitClose && (!stream.writable || writable)) return;
     if (!writable || writableFinished) callback.call(stream);
   };

--- a/test/parallel/test-stream-finished.js
+++ b/test/parallel/test-stream-finished.js
@@ -384,3 +384,15 @@ testClosed((opts) => new Writable({ write() {}, ...opts }));
 
   d.resume();
 }
+
+{
+  // Test for compat for e.g. fd-slicer which implements
+  // non standard destroy behavior which might not emit
+  // 'close'.
+  const r = new Readable();
+  finished(r, common.mustCall());
+  r.resume();
+  r.push('asd');
+  r.destroyed = true;
+  r.push(null);
+}


### PR DESCRIPTION
Try to detect non standard streams and don't wait for
'close' on these. In particular if we detected
that destroyed is true before we expect it to be then
fallback to compat behavior.

Fixes: https://github.com/nodejs/node/issues/33050

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
