### PR TITLE
[v10.x] n-api: backport ArrayBuffer detaching APIs

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -2953,6 +2953,8 @@ of the ECMAScript Language Specification.
 added: REPLACEME
 -->
 
+> Stability: 1 - Experimental
+
 ```C
 napi_status napi_detach_arraybuffer(napi_env env,
                                     napi_value arraybuffer)

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -2972,6 +2972,31 @@ that is, created with [`napi_create_external_arraybuffer`][].
 This API represents the invocation of the `ArrayBuffer` detach operation as
 defined in [Section 24.1.1.3][] of the ECMAScript Language Specification.
 
+### napi_is_detached_arraybuffer
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+```C
+napi_status napi_is_detached_arraybuffer(napi_env env,
+                                         napi_value arraybuffer,
+                                         bool* result)
+```
+
+* `[in] env`: The environment that the API is invoked under.
+* `[in] arraybuffer`: The JavaScript `ArrayBuffer` to be checked.
+* `[out] result`: Whether the `arraybuffer` is detached.
+
+Returns `napi_ok` if the API succeeded.
+
+The `ArrayBuffer` is considered detached if its internal data is `null`.
+
+This API represents the invocation of the `ArrayBuffer` `IsDetachedBuffer`
+operation as defined in [Section 24.1.1.2][] of the ECMAScript Language
+Specification.
+
 ## Working with JavaScript Properties
 
 N-API exposes a set of APIs to get and set properties on JavaScript
@@ -4924,6 +4949,7 @@ This API may only be called from the main thread.
 [Section 8.7]: https://tc39.es/ecma262/#sec-agents
 [Section 9.1.6]: https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-defineownproperty-p-desc
 [Working with JavaScript Functions]: #n_api_working_with_javascript_functions
+[Section 24.1.1.2]: https://tc39.es/ecma262/#sec-isdetachedbuffer
 [Working with JavaScript Properties]: #n_api_working_with_javascript_properties
 [Working with JavaScript Values - Abstract Operations]: #n_api_working_with_javascript_values_abstract_operations
 [Working with JavaScript Values]: #n_api_working_with_javascript_values

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -265,6 +265,8 @@ typedef enum {
   napi_closing,
   napi_bigint_expected,
   napi_date_expected,
+  napi_arraybuffer_expected,
+  napi_detachable_arraybuffer_expected,
 } napi_status;
 ```
 If additional information is required upon an API returning a failed status,
@@ -2946,6 +2948,30 @@ defined in
 [Section 7.2.14](https://tc39.github.io/ecma262/#sec-strict-equality-comparison)
 of the ECMAScript Language Specification.
 
+### napi_detach_arraybuffer
+<!-- YAML
+added: REPLACEME
+-->
+
+```C
+napi_status napi_detach_arraybuffer(napi_env env,
+                                    napi_value arraybuffer)
+```
+
+* `[in] env`: The environment that the API is invoked under.
+* `[in] arraybuffer`: The JavaScript `ArrayBuffer` to be detached.
+
+Returns `napi_ok` if the API succeeded. If a non-detachable `ArrayBuffer` is
+passed in it returns `napi_detachable_arraybuffer_expected`.
+
+Generally, an `ArrayBuffer` is non-detachable if it has been detached before.
+The engine may impose additional conditions on whether an `ArrayBuffer` is
+detachable. For example, V8 requires that the `ArrayBuffer` be external,
+that is, created with [`napi_create_external_arraybuffer`][].
+
+This API represents the invocation of the `ArrayBuffer` detach operation as
+defined in [Section 24.1.1.3][] of the ECMAScript Language Specification.
+
 ## Working with JavaScript Properties
 
 N-API exposes a set of APIs to get and set properties on JavaScript
@@ -4889,6 +4915,7 @@ This API may only be called from the main thread.
 [Section 22.1]: https://tc39.github.io/ecma262/#sec-array-objects
 [Section 22.2]: https://tc39.github.io/ecma262/#sec-typedarray-objects
 [Section 24.1]: https://tc39.github.io/ecma262/#sec-arraybuffer-objects
+[Section 24.1.1.3]: https://tc39.es/ecma262/#sec-detacharraybuffer
 [Section 24.3]: https://tc39.github.io/ecma262/#sec-dataview-objects
 [Section 25.4]: https://tc39.github.io/ecma262/#sec-promise-objects
 [Section 6.1.4]: https://tc39.github.io/ecma262/#sec-ecmascript-language-types-string-type

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -1386,6 +1386,8 @@ const char* error_messages[] = {nullptr,
                                 "Thread-safe function handle is closing",
                                 "A bigint was expected",
                                 "A date was expected",
+                                "An arraybuffer was expected",
+                                "A detachable arraybuffer was expected",
 };
 
 static inline napi_status napi_clear_last_error(napi_env env) {
@@ -1416,7 +1418,7 @@ napi_status napi_get_last_error_info(napi_env env,
   // message in the `napi_status` enum each time a new error message is added.
   // We don't have a napi_status_last as this would result in an ABI
   // change each time a message was added.
-  const int last_status = napi_date_expected;
+  const int last_status = napi_detachable_arraybuffer_expected;
 
   static_assert(
       node::arraysize(error_messages) == last_status + 1,
@@ -4379,6 +4381,25 @@ napi_status napi_get_instance_data(napi_env env,
   CHECK_ARG(env, data);
 
   *data = env->instance_data.data;
+
+  return napi_clear_last_error(env);
+}
+
+napi_status napi_detach_arraybuffer(napi_env env, napi_value arraybuffer) {
+  CHECK_ENV(env);
+  CHECK_ARG(env, arraybuffer);
+
+  v8::Local<v8::Value> value = v8impl::V8LocalValueFromJsValue(arraybuffer);
+  RETURN_STATUS_IF_FALSE(
+      env, value->IsArrayBuffer(), napi_arraybuffer_expected);
+
+  v8::Local<v8::ArrayBuffer> it = value.As<v8::ArrayBuffer>();
+  RETURN_STATUS_IF_FALSE(
+      env, it->IsExternal(), napi_detachable_arraybuffer_expected);
+  RETURN_STATUS_IF_FALSE(
+      env, it->IsNeuterable(), napi_detachable_arraybuffer_expected);
+
+  it->Neuter();
 
   return napi_clear_last_error(env);
 }

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -4403,3 +4403,18 @@ napi_status napi_detach_arraybuffer(napi_env env, napi_value arraybuffer) {
 
   return napi_clear_last_error(env);
 }
+
+napi_status napi_is_detached_arraybuffer(napi_env env,
+                                         napi_value arraybuffer,
+                                         bool* result) {
+  CHECK_ENV(env);
+  CHECK_ARG(env, arraybuffer);
+  CHECK_ARG(env, result);
+
+  v8::Local<v8::Value> value = v8impl::V8LocalValueFromJsValue(arraybuffer);
+
+  *result = value->IsArrayBuffer() &&
+            value.As<v8::ArrayBuffer>()->GetContents().Data() == nullptr;
+
+  return napi_clear_last_error(env);
+}

--- a/src/node_api.h
+++ b/src/node_api.h
@@ -752,6 +752,11 @@ napi_get_all_property_names(napi_env env,
 NAPI_EXTERN napi_status
 napi_detach_arraybuffer(napi_env env,
                         napi_value arraybuffer);
+
+NAPI_EXTERN napi_status
+napi_is_detached_arraybuffer(napi_env env,
+                             napi_value value,
+                             bool* result);
 #endif  // NAPI_EXPERIMENTAL
 
 EXTERN_C_END

--- a/src/node_api.h
+++ b/src/node_api.h
@@ -747,6 +747,13 @@ napi_get_all_property_names(napi_env env,
 
 #endif  // NAPI_VERSION >= 6
 
+#ifdef NAPI_EXPERIMENTAL
+// ArrayBuffer detaching
+NAPI_EXTERN napi_status
+napi_detach_arraybuffer(napi_env env,
+                        napi_value arraybuffer);
+#endif  // NAPI_EXPERIMENTAL
+
 EXTERN_C_END
 
 #endif  // SRC_NODE_API_H_

--- a/src/node_api_types.h
+++ b/src/node_api_types.h
@@ -83,6 +83,8 @@ typedef enum {
   napi_closing,
   napi_bigint_expected,
   napi_date_expected,
+  napi_arraybuffer_expected,
+  napi_detachable_arraybuffer_expected,
 } napi_status;
 // Note: when adding a new enum value to `napi_status`, please also update
 // `const int last_status` in `napi_get_last_error_info()' definition,

--- a/test/addons-napi/test_typedarray/test.js
+++ b/test/addons-napi/test_typedarray/test.js
@@ -74,3 +74,21 @@ nonByteArrayTypes.forEach((currentType) => {
     console.log(`start of offset ${currentType}`);
   }, RangeError);
 });
+
+// Test detaching
+arrayTypes.forEach((currentType) => {
+  const buffer = Reflect.construct(currentType, [8]);
+  assert.throws(
+    () => test_typedarray.Detach(buffer),
+    /A detachable arraybuffer was expected/);
+});
+{
+  const buffer = test_typedarray.External();
+  assert.ok(externalResult instanceof Int8Array);
+  assert.strictEqual(externalResult.length, 3);
+  assert.strictEqual(externalResult.byteLength, 3);
+  test_typedarray.Detach(buffer);
+  assert.ok(externalResult instanceof Int8Array);
+  assert.strictEqual(buffer.length, 0);
+  assert.strictEqual(buffer.byteLength, 0);
+}

--- a/test/addons-napi/test_typedarray/test.js
+++ b/test/addons-napi/test_typedarray/test.js
@@ -87,8 +87,21 @@ arrayTypes.forEach((currentType) => {
   assert.ok(externalResult instanceof Int8Array);
   assert.strictEqual(externalResult.length, 3);
   assert.strictEqual(externalResult.byteLength, 3);
+  assert.ok(!test_typedarray.IsDetached(buffer.buffer));
   test_typedarray.Detach(buffer);
+  assert.ok(test_typedarray.IsDetached(buffer.buffer));
   assert.ok(externalResult instanceof Int8Array);
   assert.strictEqual(buffer.length, 0);
   assert.strictEqual(buffer.byteLength, 0);
+}
+
+{
+  const buffer = new ArrayBuffer(128);
+  assert.ok(!test_typedarray.IsDetached(buffer));
+}
+
+{
+  const buffer = test_typedarray.NullArrayBuffer();
+  assert.ok(buffer instanceof ArrayBuffer);
+  assert.ok(test_typedarray.IsDetached(buffer));
 }

--- a/test/addons-napi/test_typedarray/test_typedarray.c
+++ b/test/addons-napi/test_typedarray/test_typedarray.c
@@ -1,3 +1,4 @@
+#define NAPI_EXPERIMENTAL
 #include <node_api.h>
 #include <string.h>
 #include "../common.h"
@@ -165,11 +166,29 @@ static napi_value CreateTypedArray(napi_env env, napi_callback_info info) {
   return output_array;
 }
 
+static napi_value Detach(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args[1];
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NAPI_ASSERT(env, argc == 1, "Wrong number of arguments.");
+
+  bool is_typedarray;
+  NAPI_CALL(env, napi_is_typedarray(env, args[0], &is_typedarray));
+  NAPI_ASSERT(env, is_typedarray, "Wrong type of arguments. Expects a typedarray as first argument.");
+
+  napi_value arraybuffer;
+  NAPI_CALL(env, napi_get_typedarray_info(env, args[0], NULL, NULL, NULL, &arraybuffer, NULL));
+  NAPI_CALL(env, napi_detach_arraybuffer(env, arraybuffer));
+
+  return NULL;
+}
+
 static napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
     DECLARE_NAPI_PROPERTY("Multiply", Multiply),
     DECLARE_NAPI_PROPERTY("External", External),
     DECLARE_NAPI_PROPERTY("CreateTypedArray", CreateTypedArray),
+    DECLARE_NAPI_PROPERTY("Detach", Detach),
   };
 
   NAPI_CALL(env, napi_define_properties(

--- a/test/addons-napi/test_typedarray/test_typedarray.c
+++ b/test/addons-napi/test_typedarray/test_typedarray.c
@@ -97,6 +97,15 @@ static napi_value External(napi_env env, napi_callback_info info) {
   return output_array;
 }
 
+
+static napi_value NullArrayBuffer(napi_env env, napi_callback_info info) {
+  static void* data = NULL;
+  napi_value arraybuffer;
+  NAPI_CALL(env,
+      napi_create_external_arraybuffer(env, data, 0, NULL, NULL, &arraybuffer));
+  return arraybuffer;
+}
+
 static napi_value CreateTypedArray(napi_env env, napi_callback_info info) {
   size_t argc = 4;
   napi_value args[4];
@@ -183,12 +192,35 @@ static napi_value Detach(napi_env env, napi_callback_info info) {
   return NULL;
 }
 
+static napi_value IsDetached(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args[1];
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NAPI_ASSERT(env, argc == 1, "Wrong number of arguments.");
+
+  napi_value array_buffer = args[0];
+  bool is_arraybuffer;
+  NAPI_CALL(env, napi_is_arraybuffer(env, array_buffer, &is_arraybuffer));
+  NAPI_ASSERT(env, is_arraybuffer,
+      "Wrong type of arguments. Expects an array buffer as first argument.");
+
+  bool is_detached;
+  NAPI_CALL(env, napi_is_detached_arraybuffer(env, array_buffer, &is_detached));
+
+  napi_value result;
+  NAPI_CALL(env, napi_get_boolean(env, is_detached, &result));
+
+  return result;
+}
+
 static napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
     DECLARE_NAPI_PROPERTY("Multiply", Multiply),
     DECLARE_NAPI_PROPERTY("External", External),
+    DECLARE_NAPI_PROPERTY("NullArrayBuffer", NullArrayBuffer),
     DECLARE_NAPI_PROPERTY("CreateTypedArray", CreateTypedArray),
     DECLARE_NAPI_PROPERTY("Detach", Detach),
+    DECLARE_NAPI_PROPERTY("IsDetached", IsDetached),
   };
 
   NAPI_CALL(env, napi_define_properties(


### PR DESCRIPTION
This PR backports ArrayBuffer detaching related N-API to v10.x, commits: 
##### n-api: add `napi_detach_arraybuffer`
As ArrayBuffer#detach is an ecma spec operation
([Section 24.1.1.3](https://tc39.es/ecma262/#sec-detacharraybuffer)),
it might be good to have it in N-API.

Fixes #29674

PR-URL: #29768
Reviewed-By: Anna Henningsen <anna@addaleax.net>
Reviewed-By: David Carlier <devnexen@gmail.com>
Reviewed-By: Colin Ihrig <cjihrig@gmail.com>
Reviewed-By: James M Snell <jasnell@gmail.com>
Reviewed-By: Gabriel Schulhof <gabriel.schulhof@intel.com>

##### n-api: implement napi_is_detached_arraybuffer
This implements ArrayBuffer#IsDetachedBuffer operation as per ECMAScript
specification Section 24.1.1.2 https://tc39.es/ecma262/#sec-isdetachedbuffer

Closes: https://github.com/nodejs/node/issues/29955

PR-URL: https://github.com/nodejs/node/pull/30613
Fixes: https://github.com/nodejs/node/issues/29955
Reviewed-By: Anna Henningsen <anna@addaleax.net>
Reviewed-By: Gus Caplan <me@gus.host>
Reviewed-By: David Carlier <devnexen@gmail.com>
Reviewed-By: Chengzhong Wu <legendecas@gmail.com>
Reviewed-By: Michael Dawson <michael_dawson@ca.ibm.com>

##### doc,n-api: mark napi_detach_arraybuffer as experimental
As its actual release stage.

PR-URL: https://github.com/nodejs/node/pull/30703
Reviewed-By: Denys Otrishko <shishugi@gmail.com>
Reviewed-By: Luigi Pinca <luigipinca@gmail.com>
Reviewed-By: Michael Dawson <michael_dawson@ca.ibm.com>
Reviewed-By: Tobias Nießen <tniessen@tnie.de>