### PR TITLE
doc: fix markdown parsing on doc/api/os.md

### DIFF
--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -389,7 +389,7 @@ operating system response.
 
 Throws a [`SystemError`][] if a user has no `username` or `homedir`.
 
-## `os.version()`
+## `os.version()`
 <!-- YAML
 added: v13.11.0
 -->


### PR DESCRIPTION
Something is wrong on MD parsing

![Screenshot from 2020-04-25 17-33-23](https://user-images.githubusercontent.com/17013303/80292280-200fe200-871b-11ea-8e6d-8163e74b5ab9.png)


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
