### PR TITLE
tools: update broken types in type parser

### DIFF
--- a/tools/doc/type-parser.js
+++ b/tools/doc/type-parser.js
@@ -15,10 +15,10 @@ const jsPrimitives = {
 
 const jsGlobalObjectsUrl = `${jsDocPrefix}Reference/Global_Objects/`;
 const jsGlobalTypes = [
-  'Array', 'ArrayBuffer', 'ArrayBufferView', 'DataView', 'Date', 'Error',
+  'Array', 'ArrayBuffer', 'DataView', 'Date', 'Error',
   'EvalError', 'Function', 'Map', 'Object', 'Promise', 'RangeError',
   'ReferenceError', 'RegExp', 'Set', 'SharedArrayBuffer', 'SyntaxError',
-  'TypeError', 'TypedArray', 'URIError', 'Uint8Array', 'WebAssembly.Instance',
+  'TypeError', 'TypedArray', 'URIError', 'Uint8Array',
 ];
 
 const customTypesMap = {
@@ -26,11 +26,16 @@ const customTypesMap = {
 
   'this': `${jsDocPrefix}Reference/Operators/this`,
 
+  'ArrayBufferView':
+    'https://developer.mozilla.org/en-US/docs/Web/API/ArrayBufferView',
+
   'AsyncIterator': 'https://tc39.github.io/ecma262/#sec-asynciterator-interface',
 
   'AsyncIterable': 'https://tc39.github.io/ecma262/#sec-asynciterable-interface',
 
   'bigint': `${jsDocPrefix}Reference/Global_Objects/BigInt`,
+  'WebAssembly.Instance':
+    `${jsDocPrefix}Reference/Global_Objects/WebAssembly/Instance`,
 
   'Iterable':
     `${jsDocPrefix}Reference/Iteration_protocols#The_iterable_protocol`,


### PR DESCRIPTION
The links for the `ArrayBufferView` and `WebAssembly.Instance` types appear to be broken. This commit updates them to point to the correct MDN locations.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)