### PR TITLE
[v12.x] Revert "doc: fix default server timeout description for https"

### DIFF
--- a/doc/api/https.md
+++ b/doc/api/https.md
@@ -123,13 +123,9 @@ See [`http.Server#setTimeout()`][].
 ### `server.timeout`
 <!-- YAML
 added: v0.11.2
-changes:
-  - version: v13.0.0
-    pr-url: https://github.com/nodejs/node/pull/27558
-    description: The default timeout changed from 120s to 0 (no timeout).
 -->
 
-* {number} **Default:** 0 (no timeout)
+* {number} **Default:** `120000` (2 minutes)
 
 See [`http.Server#timeout`][].
 


### PR DESCRIPTION
This reverts commit 86686ccbabf0573f7e6cc2be60f6fb7e98ef44ab.

The change landed on v12.x by mistake.