### PR TITLE
wasi: update start() to better match spec

### DIFF
--- a/doc/api/wasi.md
+++ b/doc/api/wasi.md
@@ -76,13 +76,14 @@ added:
 
 * `instance` {WebAssembly.Instance}
 
-Attempt to begin execution of `instance` by invoking its `_start()` export.
-If `instance` does not contain a `_start()` export, then `start()` attempts to
-invoke the `_initialize()` export. If neither of those exports is present on
-`instance`, then `start()` does nothing.
+Attempt to begin execution of `instance` as a WASI command by invoking its
+`_start()` export. If `instance` does not contain a `_start()` export, or if
+`instance` contains an `_initialize()` export, then an exception is thrown.
 
 `start()` requires that `instance` exports a [`WebAssembly.Memory`][] named
 `memory`. If `instance` does not have a `memory` export an exception is thrown.
+
+If `start()` is called more than once, an exception is thrown.
 
 ### `wasi.wasiImport`
 <!-- YAML

--- a/doc/api/wasi.md
+++ b/doc/api/wasi.md
@@ -78,8 +78,8 @@ added:
 
 Attempt to begin execution of `instance` by invoking its `_start()` export.
 If `instance` does not contain a `_start()` export, then `start()` attempts to
-invoke the `__wasi_unstable_reactor_start()` export. If neither of those exports
-is present on `instance`, then `start()` does nothing.
+invoke the `_initialize()` export. If neither of those exports is present on
+`instance`, then `start()` does nothing.
 
 `start()` requires that `instance` exports a [`WebAssembly.Memory`][] named
 `memory`. If `instance` does not have a `memory` export an exception is thrown.

--- a/lib/wasi.js
+++ b/lib/wasi.js
@@ -97,8 +97,8 @@ class WASI {
     try {
       if (exports._start)
         exports._start();
-      else if (exports.__wasi_unstable_reactor_start)
-        exports.__wasi_unstable_reactor_start();
+      else if (exports._initialize)
+        exports._initialize();
     } catch (err) {
       if (err !== kExitCode) {
         throw err;

--- a/lib/wasi.js
+++ b/lib/wasi.js
@@ -80,7 +80,17 @@ class WASI {
 
     validateObject(exports, 'instance.exports');
 
-    const { memory } = exports;
+    const { _initialize, _start, memory } = exports;
+
+    if (typeof _start !== 'function') {
+      throw new ERR_INVALID_ARG_TYPE(
+        'instance.exports._start', 'function', _start);
+    }
+
+    if (_initialize !== undefined) {
+      throw new ERR_INVALID_ARG_TYPE(
+        'instance.exports._initialize', 'undefined', _initialize);
+    }
 
     if (!(memory instanceof WebAssembly.Memory)) {
       throw new ERR_INVALID_ARG_TYPE(
@@ -95,10 +105,7 @@ class WASI {
     this[kSetMemory](memory);
 
     try {
-      if (exports._start)
-        exports._start();
-      else if (exports._initialize)
-        exports._initialize();
+      exports._start();
     } catch (err) {
       if (err !== kExitCode) {
         throw err;

--- a/test/wasi/test-wasi-start-validation.js
+++ b/test/wasi/test-wasi-start-validation.js
@@ -83,7 +83,7 @@ const bufferSource = fixtures.readSync('simple.wasm');
     get() {
       return {
         memory: new WebAssembly.Memory({ initial: 1 }),
-        __wasi_unstable_reactor_start: common.mustCall()
+        _initialize: common.mustCall()
       };
     }
   });


### PR DESCRIPTION
This PR contains two changes:

First commit:

    wasi: rename __wasi_unstable_reactor_start()
    
    Upstream WASI has renamed __wasi_unstable_reactor_start() to
    _initialize(). This commit updates Node's WASI implementation to
    reflect that change.

Second commit:

    wasi: update start() behavior to match spec
    
    _start() and _initialize() shouldn't be called from the same
    function, as they have different behavior. Furthermore, Node
    should throw if both are provided. This commit updates the
    implementation, docs, and tests accordingly.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)