### PR TITLE
doc: explicitly doc package.exports is breaking

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -191,6 +191,12 @@ also be used within `"exports"` to define different package entry points per
 environment, including whether the package is referenced via `require` or via
 `import`.
 
+***Warning***: Introducing the exports field prevents consumers of a package
+for using any entry points that is not defined, including the `package.json`.
+This is a Semver-Major change. To make the introduction of `"exports"`
+Semver-Minor either ensure that every previously supported entry point is
+exported or include a export of the root of the package `"./"; "./"`.
+
 If both `"exports"` and `"main"` are defined, the `"exports"` field takes
 precedence over `"main"`.
 


### PR DESCRIPTION
If package authors don't explicitly include all previously supported
entry points introducing package.exports will be a Semver-Major change.

Add a warning about this behavior and offer two potential solutions
for module authors.

Refs: https://github.com/then/is-promise/issues/20