### PR TITLE
stream: write should throw on unknown encoding

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -264,6 +264,8 @@ Writable.prototype.write = function(chunk, encoding, cb) {
   } else {
     if (!encoding)
       encoding = state.defaultEncoding;
+    else if (encoding !== 'buffer' && !Buffer.isEncoding(encoding))
+      throw new ERR_UNKNOWN_ENCODING(encoding);
     if (typeof cb !== 'function')
       cb = nop;
   }

--- a/test/parallel/test-stream-writable-write-error.js
+++ b/test/parallel/test-stream-writable-write-error.js
@@ -4,17 +4,17 @@ const assert = require('assert');
 
 const { Writable } = require('stream');
 
-function expectError(w, arg, code, sync) {
+function expectError(w, args, code, sync) {
   if (sync) {
     if (code) {
-      assert.throws(() => w.write(arg), { code });
+      assert.throws(() => w.write(...args), { code });
     } else {
-      w.write(arg);
+      w.write(...args);
     }
   } else {
     let errorCalled = false;
     let ticked = false;
-    w.write(arg, common.mustCall((err) => {
+    w.write(...args, common.mustCall((err) => {
       assert.strictEqual(ticked, true);
       assert.strictEqual(errorCalled, false);
       assert.strictEqual(err.code, code);
@@ -34,7 +34,7 @@ function test(autoDestroy) {
       _write() {}
     });
     w.end();
-    expectError(w, 'asd', 'ERR_STREAM_WRITE_AFTER_END');
+    expectError(w, ['asd'], 'ERR_STREAM_WRITE_AFTER_END');
   }
 
   {
@@ -50,7 +50,7 @@ function test(autoDestroy) {
       autoDestroy,
       _write() {}
     });
-    expectError(w, null, 'ERR_STREAM_NULL_VALUES', true);
+    expectError(w, [null], 'ERR_STREAM_NULL_VALUES', true);
   }
 
   {
@@ -58,7 +58,15 @@ function test(autoDestroy) {
       autoDestroy,
       _write() {}
     });
-    expectError(w, {}, 'ERR_INVALID_ARG_TYPE', true);
+    expectError(w, [{}], 'ERR_INVALID_ARG_TYPE', true);
+  }
+
+  {
+    const w = new Writable({
+      autoDestroy,
+      _write() {}
+    });
+    expectError(w, ['asd', 'noencoding'], 'ERR_UNKNOWN_ENCODING', true);
   }
 }
 

--- a/test/parallel/test-stream-writable-write-error.js
+++ b/test/parallel/test-stream-writable-write-error.js
@@ -63,6 +63,7 @@ function test(autoDestroy) {
 
   {
     const w = new Writable({
+      decodeStrings: false,
       autoDestroy,
       _write() {}
     });


### PR DESCRIPTION
Validate encoding passed to write(chunk, encoding, cb) and throw if it is invalid.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
