### PR TITLE
stream: don't emit end after close

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -153,6 +153,10 @@ function ReadableState(options, stream, isDuplex) {
   // Indicates whether the stream has finished destroying.
   this.closed = false;
 
+  // True if close has been emitted or would have been emitted
+  // depending on emitClose.
+  this.closeEmitted = false;
+
   // Crypto is kind of old and crusty.  Historically, its default string
   // encoding is 'binary' so we have to make this configurable.
   // Everything else in the universe uses 'utf8', though.
@@ -1216,7 +1220,8 @@ function endReadableNT(state, stream) {
   debug('endReadableNT', state.endEmitted, state.length);
 
   // Check that we didn't get one last unshift.
-  if (!state.errorEmitted && !state.endEmitted && state.length === 0) {
+  if (!state.errorEmitted && !state.closeEmitted &&
+      !state.endEmitted && state.length === 0) {
     state.endEmitted = true;
     stream.emit('end');
 

--- a/lib/internal/streams/destroy.js
+++ b/lib/internal/streams/destroy.js
@@ -76,6 +76,9 @@ function emitCloseNT(self) {
   if (w) {
     w.closeEmitted = true;
   }
+  if (r) {
+    r.closeEmitted = true;
+  }
 
   if ((w && w.emitClose) || (r && r.emitClose)) {
     self.emit('close');
@@ -106,12 +109,13 @@ function undestroy() {
 
   if (r) {
     r.closed = false;
+    r.closeEmitted = false;
     r.destroyed = false;
     r.errored = false;
+    r.errorEmitted = false;
     r.reading = false;
     r.ended = false;
     r.endEmitted = false;
-    r.errorEmitted = false;
   }
 
   if (w) {

--- a/test/parallel/test-stream-duplex-destroy.js
+++ b/test/parallel/test-stream-duplex-destroy.js
@@ -124,7 +124,7 @@ const assert = require('assert');
 
   duplex.removeListener('end', fail);
   duplex.removeListener('finish', fail);
-  duplex.on('end', common.mustCall());
+  duplex.on('end', common.mustNotCall());
   duplex.on('finish', common.mustCall());
   assert.strictEqual(duplex.destroyed, true);
 }

--- a/test/parallel/test-stream-readable-destroy.js
+++ b/test/parallel/test-stream-readable-destroy.js
@@ -113,7 +113,7 @@ const assert = require('assert');
   read.destroy();
 
   read.removeListener('end', fail);
-  read.on('end', common.mustCall());
+  read.on('end', common.mustNotCall());
   assert.strictEqual(read.destroyed, true);
 }
 

--- a/test/parallel/test-stream-readable-end-destroyed.js
+++ b/test/parallel/test-stream-readable-end-destroyed.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const common = require('../common');
+const { Readable } = require('stream');
+
+{
+  // Don't emit 'end' after 'close'.
+
+  const r = new Readable();
+
+  r.on('end', common.mustNotCall());
+  r.resume();
+  r.destroy();
+  r.on('close', common.mustCall(() => {
+    r.push(null);
+  }));
+}


### PR DESCRIPTION
Readable stream could emit 'end' after 'close'.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
