### PR TITLE
doc: improve worker pool example

### DIFF
--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -817,10 +817,10 @@ class WorkerPool extends EventEmitter {
       // current one.
       this.workers.splice(this.workers.indexOf(worker), 1);
       this.addNewWorker();
-      this.emit(kWorkerFreedEvent);
     });
     this.workers.push(worker);
     this.freeWorkers.push(worker);
+    this.emit(kWorkerFreedEvent);
   }
 
   runTask(task, callback) {

--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -817,6 +817,7 @@ class WorkerPool extends EventEmitter {
       // current one.
       this.workers.splice(this.workers.indexOf(worker), 1);
       this.addNewWorker();
+      this.emit(kWorkerFreedEvent);
     });
     this.workers.push(worker);
     this.freeWorkers.push(worker);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

In the worker pool example, the `kWorkerFreedEvent` should be emitted in case of error as well. After adding new worker in the error handler, the pending tasks should be notified of an available worker.

For instance, assume that we create a worker pool with two workers. Then we call `runTask` thrice such that the first two tasks are still running when it's called for the third time. As a result, the third task will be enqueued and wait for a `kWorkerFreedEvent`. Now suppose that both of the first two tasks throw an error. In response, our error handler replaces the two existing workers with new ones. But if  `kWorkerFreedEvent` is not emitted after replacing the workers, the third task which was enqueued will never (assuming no more tasks are added after that) know of an available worker and hence will never run.

