### PR TITLE
worker: add stack size resource limit option

### DIFF
--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -172,6 +172,7 @@ added: v13.2.0
   * `maxYoungGenerationSizeMb` {number}
   * `maxOldGenerationSizeMb` {number}
   * `codeRangeSizeMb` {number}
+  * `stackSizeMb` {number}
 
 Provides the set of JS engine resource constraints inside this Worker thread.
 If the `resourceLimits` option was passed to the [`Worker`][] constructor,
@@ -574,6 +575,8 @@ changes:
       recently created objects.
     * `codeRangeSizeMb` {number} The size of a pre-allocated memory range
       used for generated code.
+    * `stackSizeMb` {number} The default maximum stack size for the thread.
+      Small values may lead to unusable Worker instances. **Default:** `4`.
 
 ### Event: `'error'`
 <!-- YAML
@@ -667,6 +670,7 @@ added: v13.2.0
   * `maxYoungGenerationSizeMb` {number}
   * `maxOldGenerationSizeMb` {number}
   * `codeRangeSizeMb` {number}
+  * `stackSizeMb` {number}
 
 Provides the set of JS engine resource constraints for this Worker thread.
 If the `resourceLimits` option was passed to the [`Worker`][] constructor,

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -54,6 +54,7 @@ const {
   kMaxYoungGenerationSizeMb,
   kMaxOldGenerationSizeMb,
   kCodeRangeSizeMb,
+  kStackSizeMb,
   kTotalResourceLimitCount
 } = internalBinding('worker');
 
@@ -379,6 +380,8 @@ function parseResourceLimits(obj) {
     ret[kMaxYoungGenerationSizeMb] = obj.maxYoungGenerationSizeMb;
   if (typeof obj.codeRangeSizeMb === 'number')
     ret[kCodeRangeSizeMb] = obj.codeRangeSizeMb;
+  if (typeof obj.stackSizeMb === 'number')
+    ret[kStackSizeMb] = obj.stackSizeMb;
   return ret;
 }
 
@@ -386,7 +389,8 @@ function makeResourceLimits(float64arr) {
   return {
     maxYoungGenerationSizeMb: float64arr[kMaxYoungGenerationSizeMb],
     maxOldGenerationSizeMb: float64arr[kMaxOldGenerationSizeMb],
-    codeRangeSizeMb: float64arr[kCodeRangeSizeMb]
+    codeRangeSizeMb: float64arr[kCodeRangeSizeMb],
+    stackSizeMb: float64arr[kStackSizeMb]
   };
 }
 

--- a/src/node_worker.h
+++ b/src/node_worker.h
@@ -16,6 +16,7 @@ enum ResourceLimits {
   kMaxYoungGenerationSizeMb,
   kMaxOldGenerationSizeMb,
   kCodeRangeSizeMb,
+  kStackSizeMb,
   kTotalResourceLimitCount
 };
 
@@ -95,7 +96,7 @@ class Worker : public AsyncWrap {
   void UpdateResourceConstraints(v8::ResourceConstraints* constraints);
 
   // Full size of the thread's stack.
-  static constexpr size_t kStackSize = 4 * 1024 * 1024;
+  size_t stack_size_ = 4 * 1024 * 1024;
   // Stack buffer size that is not available to the JS engine.
   static constexpr size_t kStackBufferSize = 192 * 1024;
 

--- a/src/node_worker.h
+++ b/src/node_worker.h
@@ -34,8 +34,11 @@ class Worker : public AsyncWrap {
   void Run();
 
   // Forcibly exit the thread with a specified exit code. This may be called
-  // from any thread.
-  void Exit(int code);
+  // from any thread. `error_code` and `error_message` can be used to create
+  // a custom `'error'` event before emitting `'exit'`.
+  void Exit(int code,
+            const char* error_code = nullptr,
+            const char* error_message = nullptr);
 
   // Wait for the worker thread to stop (in a blocking manner).
   void JoinThread();

--- a/test/parallel/test-worker-resource-limits.js
+++ b/test/parallel/test-worker-resource-limits.js
@@ -12,6 +12,7 @@ const testResourceLimits = {
   maxOldGenerationSizeMb: 16,
   maxYoungGenerationSizeMb: 4,
   codeRangeSizeMb: 16,
+  stackSizeMb: 1,
 };
 
 // Do not use isMainThread so that this test itself can be run inside a Worker.

--- a/test/parallel/test-worker-stack-overflow-stack-size.js
+++ b/test/parallel/test-worker-stack-overflow-stack-size.js
@@ -8,7 +8,7 @@ const { Worker } = require('worker_threads');
 // Verify that Workers don't care about --stack-size, as they have their own
 // fixed and known stack sizes.
 
-async function runWorker() {
+async function runWorker(options = {}) {
   const empiricalStackDepth = new Uint32Array(new SharedArrayBuffer(4));
   const worker = new Worker(`
   const { workerData: { empiricalStackDepth } } = require('worker_threads');
@@ -18,26 +18,45 @@ async function runWorker() {
   }
   f();`, {
     eval: true,
-    workerData: { empiricalStackDepth }
+    workerData: { empiricalStackDepth },
+    ...options
   });
 
   const [ error ] = await once(worker, 'error');
 
-  common.expectsError({
-    constructor: RangeError,
-    message: 'Maximum call stack size exceeded'
-  })(error);
+  if (!options.skipErrorCheck) {
+    common.expectsError({
+      constructor: RangeError,
+      message: 'Maximum call stack size exceeded'
+    })(error);
+  }
 
   return empiricalStackDepth[0];
 }
 
 (async function() {
-  v8.setFlagsFromString('--stack-size=500');
-  const w1stack = await runWorker();
-  v8.setFlagsFromString('--stack-size=1000');
-  const w2stack = await runWorker();
-  // Make sure the two stack sizes are within 10 % of each other, i.e. not
-  // affected by the different `--stack-size` settings.
-  assert(Math.max(w1stack, w2stack) / Math.min(w1stack, w2stack) < 1.1,
-         `w1stack = ${w1stack}, w2stack ${w2stack} are too far apart`);
+  {
+    v8.setFlagsFromString('--stack-size=500');
+    const w1stack = await runWorker();
+    v8.setFlagsFromString('--stack-size=1000');
+    const w2stack = await runWorker();
+    // Make sure the two stack sizes are within 10 % of each other, i.e. not
+    // affected by the different `--stack-size` settings.
+    assert(Math.max(w1stack, w2stack) / Math.min(w1stack, w2stack) < 1.1,
+           `w1stack = ${w1stack}, w2stack = ${w2stack} are too far apart`);
+  }
+
+  {
+    const w1stack = await runWorker({ resourceLimits: { stackSizeMb: 0.5 } });
+    const w2stack = await runWorker({ resourceLimits: { stackSizeMb: 1.0 } });
+    // Make sure the two stack sizes are at least 40 % apart from each other,
+    // i.e. affected by the different `stackSizeMb` settings.
+    assert(w2stack > w1stack * 1.4,
+           `w1stack = ${w1stack}, w2stack = ${w2stack} are too close`);
+  }
+
+  // Test that various low stack sizes result in an 'error' event.
+  for (const stackSizeMb of [ 0.001, 0.01, 0.1, 0.2, 0.3, 0.5 ]) {
+    await runWorker({ resourceLimits: { stackSizeMb }, skipErrorCheck: true });
+  }
 })().then(common.mustCall());


### PR DESCRIPTION
worker: add stack size resource limit option

Add `stackSizeMb` to the `resourceLimit` option group.

Refs: https://github.com/nodejs/node/pull/31593#issuecomment-619633820

(Blocked on the first commit, which is https://github.com/nodejs/node/pull/33084)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
