### PR TITLE
module: no type module resolver changes

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -1601,13 +1601,6 @@ The resolver can throw the following errors:
 >       1. Return **PACKAGE_EXPORTS_TARGET_RESOLVE**(_packageURL_,
 >          _mainExport_, _""_).
 >    1. Throw a _Package Path Not Exported_ error.
-> 1. If _pjson.main_ is a String, then
->    1. Let _resolvedMain_ be the URL resolution of _packageURL_, "/", and
->       _pjson.main_.
->    1. If the file at _resolvedMain_ exists, then
->       1. Return _resolvedMain_.
-> 1. If _pjson.type_ is equal to _"module"_, then
->    1. Throw a _Module Not Found_ error.
 > 1. Let _legacyMainURL_ be the result applying the legacy
 >    **LOAD_AS_DIRECTORY** CommonJS resolver to _packageURL_, throwing a
 >    _Module Not Found_ error for no resolution.

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -439,11 +439,6 @@ function packageMainResolve(packageJSONUrl, packageConfig, base, conditions) {
 
       throw new ERR_PACKAGE_PATH_NOT_EXPORTED(packageJSONUrl, '.');
     }
-    if (packageConfig.main !== undefined) {
-      const resolved = new URL(packageConfig.main, packageJSONUrl);
-      const path = fileURLToPath(resolved);
-      if (tryStatSync(path).isFile()) return resolved;
-    }
     if (getOptionValue('--experimental-specifier-resolution') === 'node') {
       if (packageConfig.main !== undefined) {
         return finalizeResolution(
@@ -453,9 +448,7 @@ function packageMainResolve(packageJSONUrl, packageConfig, base, conditions) {
           new URL('index', packageJSONUrl), base);
       }
     }
-    if (packageConfig.type !== 'module') {
-      return legacyMainResolve(packageJSONUrl, packageConfig);
-    }
+    return legacyMainResolve(packageJSONUrl, packageConfig);
   }
 
   throw new ERR_MODULE_NOT_FOUND(

--- a/test/es-module/test-esm-type-main.mjs
+++ b/test/es-module/test-esm-type-main.mjs
@@ -1,0 +1,9 @@
+import { mustNotCall } from '../common/index.mjs';
+import assert from 'assert';
+import { importFixture } from '../fixtures/pkgexports.mjs';
+
+(async () => {
+  const m = await importFixture('type-main');
+  assert.strictEqual(m.default, 'asdf');
+})()
+.catch(mustNotCall);

--- a/test/fixtures/node_modules/type-main/index.js
+++ b/test/fixtures/node_modules/type-main/index.js
@@ -1,0 +1,1 @@
+export default 'asdf';

--- a/test/fixtures/node_modules/type-main/package.json
+++ b/test/fixtures/node_modules/type-main/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "index",
+  "type": "module"
+}


### PR DESCRIPTION
Previously a special case was implemented where `"main"` requires an explicit file extension when using `"type": "module"` in the ESM loader.

This was done before `"exports"` was a first-class main resolution mechanism.

With this change, `"type": "module"` will never affect resolution itself, only interpretation of the module format.

This change is backwards compatible, although care should be taken to backport it so that it doesn't result in surprising behaviour in older versions of Node.js if we miss eg 12 backports.

@nodejs/modules-active-members 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
