### PR TITLE
[v10.x] deps: fix V8 compiler error with clang++-11

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -33,7 +33,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.56',
+    'v8_embedder_string': '-node.57',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,

--- a/deps/v8/src/torque/ast-generator.cc
+++ b/deps/v8/src/torque/ast-generator.cc
@@ -120,7 +120,7 @@ Statement* AstGenerator::GetOptionalHelperBody(
 
 antlrcpp::Any AstGenerator::visitParameterList(
     TorqueParser::ParameterListContext* context) {
-  ParameterList result{{}, {}, context->VARARGS(), {}};
+  ParameterList result{{}, {}, context->VARARGS() != nullptr, {}};
   if (context->VARARGS()) {
     result.arguments_variable = context->IDENTIFIER()->getSymbol()->getText();
   }
@@ -141,7 +141,7 @@ antlrcpp::Any AstGenerator::visitTypeList(
 
 antlrcpp::Any AstGenerator::visitTypeListMaybeVarArgs(
     TorqueParser::TypeListMaybeVarArgsContext* context) {
-  ParameterList result{{}, {}, context->VARARGS(), {}};
+  ParameterList result{{}, {}, context->VARARGS() != nullptr, {}};
   result.types.reserve(context->type().size());
   for (auto* type : context->type()) {
     result.types.push_back(GetType(type));


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/33040

		  error: type 'antlr4::tree::TerminalNode *' cannot be narrowed to 'bool'
			  in initializer list [-Wc++11-narrowing]
			ParameterList result{{}, {}, context->VARARGS(), {}};

Occurs twice:
		../../deps/v8/src/torque/ast-generator.cc:123:32:
		../../deps/v8/src/torque/ast-generator.cc:144:32:

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
