### PR TITLE
doc: clarify when not to run CI on docs

### DIFF
--- a/doc/guides/collaborator-guide.md
+++ b/doc/guides/collaborator-guide.md
@@ -177,9 +177,10 @@ All pull requests must pass continuous integration tests. Code changes must pass
 on [project CI server](https://ci.nodejs.org/). Pull requests that only change
 documentation and comments can use GitHub Actions results.
 
-Do not land any pull requests without passing (green or yellow) CI runs (except
-for documentation-only changes, with green GitHub actions is enough). If there
-are CI failures unrelated to the change in the pull request, try "Resume
+Do not land any pull requests without a passing (green or yellow) CI run.
+For documentation-only changes, GitHub Actions CI is sufficient.
+For all other code changes, Jenkins CI must pass as well. If there are
+Jenkins CI failures unrelated to the change in the pull request, try "Resume
 Build". It is in the left navigation of the relevant `node-test-pull-request`
 job. It will preserve all the green results from the current job but re-run
 everything else. Start a fresh CI if more than seven days have elapsed since

--- a/doc/guides/collaborator-guide.md
+++ b/doc/guides/collaborator-guide.md
@@ -177,8 +177,9 @@ All pull requests must pass continuous integration tests. Code changes must pass
 on [project CI server](https://ci.nodejs.org/). Pull requests that only change
 documentation and comments can use GitHub Actions results.
 
-Do not land any pull requests without passing (green or yellow) CI runs. If
-there are CI failures unrelated to the change in the pull request, try "Resume
+Do not land any pull requests without passing (green or yellow) CI runs (except
+for documentation-only changes, with green GitHub actions is enough). If there
+are CI failures unrelated to the change in the pull request, try "Resume
 Build". It is in the left navigation of the relevant `node-test-pull-request`
 job. It will preserve all the green results from the current job but re-run
 everything else. Start a fresh CI if more than seven days have elapsed since


### PR DESCRIPTION
Collaborators won't need to run CI on documentation-only changes.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
