### PR TITLE
src: use BaseObjectPtr in StreamReq::Dispose

### DIFF
--- a/src/stream_base-inl.h
+++ b/src/stream_base-inl.h
@@ -4,6 +4,7 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "async_wrap-inl.h"
+#include "base_object-inl.h"
 #include "node.h"
 #include "stream_base.h"
 #include "v8.h"
@@ -31,9 +32,10 @@ StreamReq* StreamReq::FromObject(v8::Local<v8::Object> req_wrap_obj) {
 }
 
 void StreamReq::Dispose() {
-  std::unique_ptr<StreamReq> ptr(this);
+  BaseObjectPtr<AsyncWrap> destroy_me{GetAsyncWrap()};
   object()->SetAlignedPointerInInternalField(
       StreamReq::kStreamReqField, nullptr);
+  destroy_me->Detach();
 }
 
 v8::Local<v8::Object> StreamReq::object() {


### PR DESCRIPTION
Allow the AsyncWrap to be properly detached.

Extracted from the [QUIC PR](https://github.com/nodejs/node/pull/32379).

Refs: https://github.com/nodejs/node/pull/32379/files?file-filters%5B%5D=.bat&file-filters%5B%5D=.gyp&file-filters%5B%5D=.gypi&file-filters%5B%5D=.h&file-filters%5B%5D=.md&file-filters%5B%5D=.py&file-filters%5B%5D=.sh&file-filters%5B%5D=No+extension&file-filters%5B%5D=dotfile#r409084763

/cc @addaleax @sam-github 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
