### PR TITLE
src: separate out NgLibMemoryManagerBase

### DIFF
--- a/src/node_mem.h
+++ b/src/node_mem.h
@@ -13,8 +13,12 @@ namespace mem {
 // use different struct names. To allow for code re-use,
 // the NgLibMemoryManager template class can be used for both.
 
+struct NgLibMemoryManagerBase {
+ virtual void StopTrackingMemory(void* ptr) = 0;
+};
+
 template <typename Class, typename AllocatorStructName>
-class NgLibMemoryManager {
+class NgLibMemoryManager : public NgLibMemoryManagerBase {
  public:
   // Class needs to provide these methods:
   // void CheckAllocatedSize(size_t previous_size) const;
@@ -24,7 +28,7 @@ class NgLibMemoryManager {
 
   AllocatorStructName MakeAllocator();
 
-  void StopTrackingMemory(void* ptr);
+  void StopTrackingMemory(void* ptr) override;
 
  private:
   static void* ReallocImpl(void* ptr, size_t size, void* user_data);

--- a/src/node_mem.h
+++ b/src/node_mem.h
@@ -14,7 +14,7 @@ namespace mem {
 // the NgLibMemoryManager template class can be used for both.
 
 struct NgLibMemoryManagerBase {
- virtual void StopTrackingMemory(void* ptr) = 0;
+  virtual void StopTrackingMemory(void* ptr) = 0;
 };
 
 template <typename Class, typename AllocatorStructName>


### PR DESCRIPTION
Extracted from the [QUIC PR](https://github.com/nodejs/node/pull/32379)

So far, this is only used by the QUIC PR directly but the change itself
is independent of QUIC, even if not used directly by anything else yet.
Separated out [per request](https://github.com/nodejs/node/pull/32379/files?file-filters%5B%5D=.bat&file-filters%5B%5D=.gyp&file-filters%5B%5D=.gypi&file-filters%5B%5D=.h&file-filters%5B%5D=.md&file-filters%5B%5D=.py&file-filters%5B%5D=.sh&file-filters%5B%5D=No+extension&file-filters%5B%5D=dotfile#r409086650).

/cc @addaleax @sam-github 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
