### PR TITLE
src: crypto_common edits

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -2486,7 +2486,7 @@ void SSLWrap<Base>::CertCbDone(const FunctionCallbackInfo<Value>& args) {
     // Store the SNI context for later use.
     w->sni_context_ = BaseObjectPtr<SecureContext>(sc);
 
-    if (UseSNIContext(w->ssl_, sc) && !w->SetCACerts(sc)) {
+    if (UseSNIContext(w->ssl_, w->sni_context_) && !w->SetCACerts(sc)) {
       // Not clear why sometimes we throw error, and sometimes we call
       // onerror(). Both cause .destroy(), but onerror does a bit more.
       unsigned long err = ERR_get_error();  // NOLINT(runtime/int)

--- a/src/node_crypto_common.cc
+++ b/src/node_crypto_common.cc
@@ -34,6 +34,7 @@ using v8::NewStringType;
 using v8::Null;
 using v8::Object;
 using v8::String;
+using v8::Undefined;
 using v8::Value;
 
 namespace crypto {
@@ -330,11 +331,15 @@ const char* X509ErrorCode(long err) {  // NOLINT(runtime/int)
 }
 
 MaybeLocal<Value> GetValidationErrorReason(Environment* env, int err) {
+  if (err == 0)
+    return Undefined(env->isolate());
   const char* reason = X509_verify_cert_error_string(err);
   return OneByteString(env->isolate(), reason);
 }
 
 MaybeLocal<Value> GetValidationErrorCode(Environment* env, int err) {
+  if (err == 0)
+    return Undefined(env->isolate());
   return OneByteString(env->isolate(), X509ErrorCode(err));
 }
 

--- a/src/node_crypto_common.cc
+++ b/src/node_crypto_common.cc
@@ -1,3 +1,4 @@
+#include "base_object-inl.h"
 #include "env-inl.h"
 #include "node_buffer.h"
 #include "node_crypto.h"
@@ -223,7 +224,7 @@ long VerifyPeerCertificate(  // NOLINT(runtime/int)
   return err;
 }
 
-int UseSNIContext(const SSLPointer& ssl, SecureContext* context) {
+int UseSNIContext(const SSLPointer& ssl, BaseObjectPtr<SecureContext> context) {
   SSL_CTX* ctx = context->ctx_.get();
   X509* x509 = SSL_CTX_get0_certificate(ctx);
   EVP_PKEY* pkey = SSL_CTX_get0_privatekey(ctx);

--- a/src/node_crypto_common.h
+++ b/src/node_crypto_common.h
@@ -71,7 +71,7 @@ long VerifyPeerCertificate(  // NOLINT(runtime/int)
     const SSLPointer& ssl,
     long def = X509_V_ERR_UNSPECIFIED);  // NOLINT(runtime/int)
 
-int UseSNIContext(const SSLPointer& ssl, SecureContext* context);
+int UseSNIContext(const SSLPointer& ssl, BaseObjectPtr<SecureContext> context);
 
 const char* GetClientHelloALPN(const SSLPointer& ssl);
 


### PR DESCRIPTION
Extracted from the [QUIC PR](https://github.com/nodejs/node/pull/32379):

Commit 1: Updates UseSNIContext to use BaseObjectPtr
Commit 2: Returns Undefined when validation err == 0. This is currently only used by the QUIC implementation but the change itself is not QUIC specific.

/cc @addaleax @sam-github 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
