### PR TITLE
src,win: Replacement of unsupported versions of Windows runtime exit.

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -117,8 +117,6 @@
 #include <string>
 #include <vector>
 
-// =========== windows headers ============
-
 #ifdef _WIN32
 #include <windows.h>
 #include <VersionHelpers.h>

--- a/src/node.cc
+++ b/src/node.cc
@@ -117,6 +117,14 @@
 #include <string>
 #include <vector>
 
+// =========== windows headers ============
+
+#ifdef _WIN32
+#include <windows.h>
+#include <VersionHelpers.h>
+#include <WinError.h>
+#endif
+
 namespace node {
 
 using native_module::NativeModuleEnv;
@@ -742,6 +750,21 @@ int ProcessGlobalArgs(std::vector<std::string>* args,
                 "--abort_on_uncaught_exception") != v8_args.end()) {
     env_opts->abort_on_uncaught_exception = true;
   }
+  
+#ifdef _WIN32
+  // Displace warning while using unsupported version of Windows.
+  // Hide with --no-warnings options.
+  if (!per_process::cli_options->per_isolate->per_env->no_warnings) {
+    if (!IsWindows8Point1OrGreater() &&
+        !(IsWindowsServer() && IsWindows8OrGreater())) {
+      fprintf(stderr, "Node.js is only supported on Windows 8.1, "
+                      "Windows Server 2012 R2, or higher. "
+                      "Node.js will not accept bug reports "
+                      "or patches while using unsupported "
+                      "versions of Windows.\n\n");
+    }
+  }
+#endif
 
   // TODO(bnoordhuis) Intercept --prof arguments and start the CPU profiler
   // manually?  That would give us a little more control over its runtime

--- a/src/node.cc
+++ b/src/node.cc
@@ -750,7 +750,7 @@ int ProcessGlobalArgs(std::vector<std::string>* args,
                 "--abort_on_uncaught_exception") != v8_args.end()) {
     env_opts->abort_on_uncaught_exception = true;
   }
-  
+
 #ifdef _WIN32
   // Displace warning while using unsupported version of Windows.
   // Hide with --no-warnings options.

--- a/src/node.cc
+++ b/src/node.cc
@@ -750,7 +750,7 @@ int ProcessGlobalArgs(std::vector<std::string>* args,
   }
 
 #ifdef _WIN32
-  // Displace warning while using unsupported version of Windows.
+  // Display a warning while using an unsupported version of Windows.
   // Hide with --no-warnings options.
   if (!per_process::cli_options->per_isolate->per_env->no_warnings) {
     if (!IsWindows8Point1OrGreater() &&

--- a/src/node_main.cc
+++ b/src/node_main.cc
@@ -32,9 +32,9 @@ int wmain(int argc, wchar_t* wargv[]) {
   if (!IsWindows8Point1OrGreater() &&
       !(IsWindowsServer() && IsWindows8OrGreater())) {
     fprintf(stderr, "This application is only supported on Windows 8.1, "
-                    "Windows Server 2012 R2, or higher. Node.js will not"
-                    "accept bug reports or patches while using unsupported"
-                    "versions of Windows.");
+                    "Windows Server 2012 R2, or higher. Node.js will not "
+                    "accept bug reports or patches while using unsupported "
+                    "versions of Windows.\n\n\n");
   }
 
   // Convert argv to UTF8

--- a/src/node_main.cc
+++ b/src/node_main.cc
@@ -28,7 +28,8 @@
 #include <WinError.h>
 
 int wmain(int argc, wchar_t* wargv[]) {
-  // Display deprecation banner without exiting application for unsupported versions.
+  // Display deprecation banner without exiting
+  // the application for unsupported versions of Windows.
   if (!IsWindows8Point1OrGreater() &&
       !(IsWindowsServer() && IsWindows8OrGreater())) {
     fprintf(stderr, "This application is only supported on Windows 8.1, "

--- a/src/node_main.cc
+++ b/src/node_main.cc
@@ -24,20 +24,9 @@
 
 #ifdef _WIN32
 #include <windows.h>
-#include <VersionHelpers.h>
 #include <WinError.h>
 
 int wmain(int argc, wchar_t* wargv[]) {
-  // Display deprecation banner without exiting
-  // the application for unsupported versions of Windows.
-  if (!IsWindows8Point1OrGreater() &&
-      !(IsWindowsServer() && IsWindows8OrGreater())) {
-    fprintf(stderr, "This application is only supported on Windows 8.1, "
-                    "Windows Server 2012 R2, or higher. Node.js will not "
-                    "accept bug reports or patches while using unsupported "
-                    "versions of Windows.\n\n\n");
-  }
-
   // Convert argv to UTF8
   char** argv = new char*[argc + 1];
   for (int i = 0; i < argc; i++) {

--- a/src/node_main.cc
+++ b/src/node_main.cc
@@ -28,13 +28,13 @@
 #include <WinError.h>
 
 int wmain(int argc, wchar_t* wargv[]) {
-  // Windows Server 2012 (not R2) is supported until 10/10/2023, so we allow it
-  // to run in the experimental support tier.
+  // Display deprecation banner without exiting application for unsupported versions.
   if (!IsWindows8Point1OrGreater() &&
       !(IsWindowsServer() && IsWindows8OrGreater())) {
     fprintf(stderr, "This application is only supported on Windows 8.1, "
-                    "Windows Server 2012 R2, or higher.");
-    exit(ERROR_EXE_MACHINE_TYPE_MISMATCH);
+                    "Windows Server 2012 R2, or higher. Node.js will not"
+                    "accept bug reports or patches while using unsupported"
+                    "versions of Windows.");
   }
 
   // Convert argv to UTF8

--- a/tools/msvs/msi/product.wxs
+++ b/tools/msvs/msi/product.wxs
@@ -23,8 +23,8 @@
              Compressed="yes"
              InstallScope="perMachine"/>
 
-    <Condition Message="This application is only supported on Windows 8.1, Windows Server 2012 R2, or higher.">
-      <![CDATA[Installed OR (VersionNT >= 603) OR (VersionNT >= 602 AND MsiNTProductType <> 1)]]>
+    <Condition Message="This application is only supported on Windows 7, Windows Server 2008 R2, or higher.">
+      <![CDATA[Installed OR (VersionNT >= 601)]]>
     </Condition>
 
     <Media Id="1" Cabinet="media1.cab" EmbedCab="yes"/>

--- a/tools/msvs/msi/product.wxs
+++ b/tools/msvs/msi/product.wxs
@@ -23,7 +23,7 @@
              Compressed="yes"
              InstallScope="perMachine"/>
 
-    <Condition Message="This application is only supported on Windows 7, Windows Server 2008 R2, or higher.">
+    <Condition Message="This application will only install on Windows 7, Windows Server 2008 R2, or higher but is only supported on Windows 8.1, Windows Server 2012 R2, or higher.">
       <![CDATA[Installed OR (VersionNT >= 601)]]>
     </Condition>
 

--- a/tools/msvs/msi/product.wxs
+++ b/tools/msvs/msi/product.wxs
@@ -23,7 +23,7 @@
              Compressed="yes"
              InstallScope="perMachine"/>
 
-    <Condition Message="This application will only install on Windows 7, Windows Server 2008 R2, or higher but is only supported on Windows 8.1, Windows Server 2012 R2, or higher.">
+    <Condition Message="This application will install on Windows 7, Windows Server 2008 R2, or higher, but is only supported on Windows 8.1, Windows Server 2012 R2, or higher.">
       <![CDATA[Installed OR (VersionNT >= 601)]]>
     </Condition>
 


### PR DESCRIPTION
Replaces Windows 7 EOL runtime program termination (https://github.com/nodejs/node/pull/31954) to an unsupported Windows operating system notice at runtime to notify minimal support for using an unsupported version of Windows.

Tests do not pass due to stderr output, and I am unsure of how to handle this further myself due to my limited knowledge of C++. Node.js did compile and act as expected when supplied `-e` or an input file.

Discussed originally in https://github.com/nodejs/node/issues/33034.
Fixes #33034 

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)