### PR TITLE
test: fix out-of-bound reads from invalid sizeof usage

### DIFF
--- a/test/addons/worker-buffer-callback/binding.cc
+++ b/test/addons/worker-buffer-callback/binding.cc
@@ -30,7 +30,7 @@ void Initialize(Local<Object> exports,
                node::Buffer::New(
                    isolate,
                    data,
-                   sizeof(data),
+                   sizeof(char),
                    [](char* data, void* hint) {
                      delete data;
                      free_call_count++;

--- a/test/node-api/test_worker_buffer_callback/test_worker_buffer_callback.c
+++ b/test/node-api/test_worker_buffer_callback/test_worker_buffer_callback.c
@@ -35,7 +35,7 @@ NAPI_MODULE_INIT() {
   NAPI_CALL(env, napi_create_external_arraybuffer(
       env,
       data,
-      sizeof(data),
+      sizeof(char),
       finalize_cb,
       NULL,
       &buffer));


### PR DESCRIPTION
`sizeof(data)` does not return the correct result here, as it measures
the size of the `data` variable, not what it points to.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
