### PR TITLE
src: retrieve .text coordinates for large pages

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -252,11 +252,6 @@
     'node_mksnapshot_exec': '<(PRODUCT_DIR)/<(EXECUTABLE_PREFIX)node_mksnapshot<(EXECUTABLE_SUFFIX)',
     'mkcodecache_exec': '<(PRODUCT_DIR)/<(EXECUTABLE_PREFIX)mkcodecache<(EXECUTABLE_SUFFIX)',
     'conditions': [
-      ['GENERATOR == "ninja"', {
-        'node_text_start_object_path': 'src/large_pages/node_text_start.node_text_start.o'
-      }, {
-        'node_text_start_object_path': 'node_text_start/src/large_pages/node_text_start.o'
-      }],
       [ 'node_shared=="true"', {
         'node_target_type%': 'shared_library',
         'conditions': [
@@ -320,19 +315,6 @@
   },
 
   'targets': [
-    {
-      'target_name': 'node_text_start',
-      'type': 'none',
-      'conditions': [
-        [ 'OS in "linux freebsd" and '
-          'target_arch=="x64"', {
-          'type': 'static_library',
-          'sources': [
-            'src/large_pages/node_text_start.S'
-          ]
-        }],
-      ]
-    },
     {
       'target_name': '<(node_core_target_name)',
       'type': 'executable',
@@ -512,13 +494,6 @@
           'sources': [
             'src/node_snapshot_stub.cc'
           ],
-        }],
-        [ 'OS in "linux freebsd" and '
-          'target_arch=="x64"', {
-          'dependencies': [ 'node_text_start' ],
-          'ldflags+': [
-            '<(obj_dir)/<(node_text_start_object_path)'
-          ]
         }],
       ],
     }, # node_core_target_name

--- a/src/large_pages/node_large_page.cc
+++ b/src/large_pages/node_large_page.cc
@@ -184,9 +184,9 @@ class MappedFilePointer: public MemoryMapPointer {
                           size_t offset = 0) {
     Debug("Hugepages info: attempting to open %s\n", fname);
 
-    do
+    do {
       fd_ = open(fname, O_RDONLY);
-    while (fd_ == -1 && errno == EINTR);
+    } while (fd_ == -1 && errno == EINTR);
     if (fd_ == -1) goto fail;
 
     struct stat file_info;

--- a/src/large_pages/node_text_start.S
+++ b/src/large_pages/node_text_start.S
@@ -1,5 +1,0 @@
-.text
-.align 0x2000
-.global __node_text_start
-.hidden __node_text_start
-__node_text_start:


### PR DESCRIPTION
After locating the in-memory base address of the Node.js executable
using `dl_iterate_phdr(3)` we open the on-disk executable file and
extract the address and size of the `.text` section. We then add the
in-memory base address to the offset to locate the `.text` section in
memory.

This approach removes the need for a symbol to tell us where the
`.text` section is located, and, unlike the previous approach,
guarantees that we will always have the entire `.text` section
available for re-mapping.

Signed-off-by: @gabrielschulhof
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
