### PR TITLE
[v14.x] stream: runtime deprecate Transform._transformState

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2695,6 +2695,18 @@ The `repl` module exports a `_builtinLibs` property that contains an array with
 native modules. It was incomplete so far and instead it's better to rely upon
 `require('module').builtinModules`.
 
+<a id="DEP0XXX"></a>
+### DEP0XXX: `Transform._transformState`
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/33126
+    description: Runtime deprecation.
+-->
+Type: Runtime
+`Transform._transformState` will be removed in future versions where it is
+no longer required due to simplification of the implementation.
+
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`--throw-deprecation`]: cli.html#cli_throw_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size

--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -64,7 +64,9 @@
 'use strict';
 
 const {
+  ObjectDefineProperty,
   ObjectSetPrototypeOf,
+  Symbol
 } = primordials;
 
 module.exports = Transform;
@@ -75,12 +77,15 @@ const {
   ERR_TRANSFORM_WITH_LENGTH_0
 } = require('internal/errors').codes;
 const Duplex = require('_stream_duplex');
+const internalUtil = require('internal/util');
+
 ObjectSetPrototypeOf(Transform.prototype, Duplex.prototype);
 ObjectSetPrototypeOf(Transform, Duplex);
 
+const kTransformState = Symbol('kTransformState');
 
 function afterTransform(er, data) {
-  const ts = this._transformState;
+  const ts = this[kTransformState];
   ts.transforming = false;
 
   const cb = ts.writecb;
@@ -111,7 +116,7 @@ function Transform(options) {
 
   Duplex.call(this, options);
 
-  this._transformState = {
+  this[kTransformState] = {
     afterTransform: afterTransform.bind(this),
     needTransform: false,
     transforming: false,
@@ -147,8 +152,17 @@ function prefinish() {
   }
 }
 
+ObjectDefineProperty(Transform.prototype, '_transformState', {
+  get: internalUtil.deprecate(function() {
+    return this[kTransformState];
+  }, 'Transform.prototype._transformState is deprecated', 'DEP0XXX'),
+  set: internalUtil.deprecate(function(val) {
+    this[kTransformState] = val;
+  }, 'Transform.prototype._transformState is deprecated', 'DEP0XXX')
+});
+
 Transform.prototype.push = function(chunk, encoding) {
-  this._transformState.needTransform = false;
+  this[kTransformState].needTransform = false;
   return Duplex.prototype.push.call(this, chunk, encoding);
 };
 
@@ -167,7 +181,7 @@ Transform.prototype._transform = function(chunk, encoding, cb) {
 };
 
 Transform.prototype._write = function(chunk, encoding, cb) {
-  const ts = this._transformState;
+  const ts = this[kTransformState];
   ts.writecb = cb;
   ts.writechunk = chunk;
   ts.writeencoding = encoding;
@@ -184,7 +198,7 @@ Transform.prototype._write = function(chunk, encoding, cb) {
 // _transform does all the work.
 // That we got here means that the readable side wants more data.
 Transform.prototype._read = function(n) {
-  const ts = this._transformState;
+  const ts = this[kTransformState];
 
   if (ts.writechunk !== null && !ts.transforming) {
     ts.transforming = true;
@@ -215,7 +229,7 @@ function done(stream, er, data) {
   if (stream._writableState.length)
     throw new ERR_TRANSFORM_WITH_LENGTH_0();
 
-  if (stream._transformState.transforming)
+  if (stream[kTransformState].transforming)
     throw new ERR_TRANSFORM_ALREADY_TRANSFORMING();
   return stream.push(null);
 }


### PR DESCRIPTION
stream: runtime deprecate Transform._transformState
    
Transform._transformState is removed in future version as part of a refactoring.
    
Refs: https://github.com/nodejs/node/pull/32763
Refs: https://github.com/nodejs/node/pull/33105#issuecomment-620657114

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
