### PR TITLE
errors: skip fatal error highlighting on windows

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -674,15 +674,31 @@ const fatalExceptionStackEnhancers = {
   },
   afterInspector(error) {
     const originalStack = error.stack;
+    let useColors = true;
+    // Some consoles do not convert ANSI escape sequences to colors,
+    // rather display them directly to the stdout. On those consoles,
+    // libuv emulates colors by intercepting stdout stream and calling
+    // corresponding Windows API functions for setting console colors.
+    // However, fatal error are handled differently and we cannot easily
+    // highlight them. On Windows, detecting whether a console supports
+    // ANSI escape sequences is not reliable.
+    if (process.platform === 'win32') {
+      const info = internalBinding('os').getOSInformation();
+      const ver = info[2].split('.').map((a) => +a);
+      if (ver[0] !== 10 || ver[2] < 14393) {
+        useColors = false;
+      }
+    }
     const {
       inspect,
       inspectDefaultOptions: {
         colors: defaultColors
       }
     } = lazyInternalUtilInspect();
-    const colors = (internalBinding('util').guessHandleType(2) === 'TTY' &&
+    const colors = useColors &&
+                   ((internalBinding('util').guessHandleType(2) === 'TTY' &&
                    require('internal/tty').hasColors()) ||
-                   defaultColors;
+                   defaultColors);
     try {
       return inspect(error, { colors });
     } catch {


### PR DESCRIPTION
Some consoles do not convert ANSI escape sequences to colors,
rather display them directly to the stdout. On those consoles,
libuv emulates colors by intercepting stdout stream and calling
corresponding Windows API functions for setting console colors.
However, fatal error are handled differently and we cannot easily
highlight them.

Fixes https://github.com/nodejs/node/issues/29387

---

According to [this](https://api.dart.dev/stable/1.24.3/dart-io/Stdout/supportsAnsiEscapes.html), Windows fully supports ANSI escapes starting from v.1607 ("Anniversery Update", OS build 14393), so we could add additional check:

```js
if (process.platform === 'win32') {
  const ver = os.release().split('.').map(a => +a);
  if (ver[0] !== 10 || ver[2] < 14393) {
    return originalStack;
  }
}
```

but given that https://github.com/nodejs/node/issues/29387#issuecomment-620716360 uses build 17763, seems like that this test is not reliable.

---

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)