### PR TITLE
stream: fix stream.finished on Duplex

### DIFF
--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -147,10 +147,17 @@ function eos(stream, opts, callback) {
   if (opts.error !== false) stream.on('error', onerror);
   stream.on('close', onclose);
 
-  const closed = (wState && wState.closed) || (rState && rState.closed) ||
-    (wState && wState.errorEmitted) || (rState && rState.errorEmitted) ||
-    (wState && wState.finished) || (rState && rState.endEmitted) ||
-    (rState && stream.req && stream.aborted);
+  const closed = (
+    (wState && wState.closed) ||
+    (rState && rState.closed) ||
+    (wState && wState.errorEmitted) ||
+    (rState && rState.errorEmitted) ||
+    (rState && stream.req && stream.aborted) ||
+    (
+      (!writable || (wState && wState.finished)) &&
+      (!readable || (rState && rState.endEmitted))
+    )
+  );
 
   if (closed) {
     // TODO(ronag): Re-throw error if errorEmitted?
@@ -158,6 +165,7 @@ function eos(stream, opts, callback) {
     // before being closed? i.e. if closed but not errored, ended or finished.
     // TODO(ronag): Throw some kind of error? Does it make sense
     // to call finished() on a "finished" stream?
+    // TODO(ronag): willEmitClose?
     process.nextTick(() => {
       callback();
     });

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -166,7 +166,9 @@ function eos(stream, opts, callback) {
     // TODO(ronag): Throw some kind of error? Does it make sense
     // to call finished() on a "finished" stream?
     // TODO(ronag): willEmitClose?
-    process.nextTick(callback);
+    process.nextTick(() => {
+      callback();
+    });
   }
 
   return function() {

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -166,9 +166,7 @@ function eos(stream, opts, callback) {
     // TODO(ronag): Throw some kind of error? Does it make sense
     // to call finished() on a "finished" stream?
     // TODO(ronag): willEmitClose?
-    process.nextTick(() => {
-      callback();
-    });
+    process.nextTick(callback);
   }
 
   return function() {

--- a/test/parallel/test-stream-finished.js
+++ b/test/parallel/test-stream-finished.js
@@ -468,3 +468,11 @@ testClosed((opts) => new Writable({ write() {}, ...opts }));
   p.end();
   finished(p, common.mustNotCall());
 }
+
+{
+  const p = new PassThrough();
+  p.end();
+  p.on('finish', common.mustCall(() => {
+    finished(p, common.mustNotCall());
+  }));
+}

--- a/test/parallel/test-stream-finished.js
+++ b/test/parallel/test-stream-finished.js
@@ -448,10 +448,10 @@ testClosed((opts) => new Writable({ write() {}, ...opts }));
   }
 
   const instance = new HelloWorld(response);
+  instance.setEncoding('utf8');
   instance.end();
 
   (async () => {
-    instance.setEncoding('utf8');
 
     let res = '';
     for await (const data of instance) {

--- a/test/parallel/test-stream-finished.js
+++ b/test/parallel/test-stream-finished.js
@@ -451,8 +451,6 @@ testClosed((opts) => new Writable({ write() {}, ...opts }));
   instance.end();
 
   (async () => {
-    await new Promise((resolve) => setTimeout(resolve, 100));
-
     instance.setEncoding('utf8');
 
     let res = '';
@@ -461,7 +459,7 @@ testClosed((opts) => new Writable({ write() {}, ...opts }));
     }
 
     assert.strictEqual(res, 'chunk 1chunk 2chunk 3');
-  })();
+  })().then(common.mustCall());
 }
 
 {

--- a/test/parallel/test-stream-finished.js
+++ b/test/parallel/test-stream-finished.js
@@ -451,15 +451,17 @@ testClosed((opts) => new Writable({ write() {}, ...opts }));
   instance.setEncoding('utf8');
   instance.end();
 
-  instance.on('finish', common.mustCall(async () => {
-    assert.strictEqual(instance.writableFinished, true);
+  instance.on('finish', common.mustCall(() => {
+    (async () => {
+      assert.strictEqual(instance.writableFinished, true);
 
-    let res = '';
-    for await (const data of instance) {
-      res += data;
-    }
+      let res = '';
+      for await (const data of instance) {
+        res += data;
+      }
 
-    assert.strictEqual(res, 'chunk 1chunk 2chunk 3');
+      assert.strictEqual(res, 'chunk 1chunk 2chunk 3');
+    })().then(common.mustCall());
   }));
 }
 

--- a/test/parallel/test-stream-finished.js
+++ b/test/parallel/test-stream-finished.js
@@ -408,10 +408,10 @@ testClosed((opts) => new Writable({ write() {}, ...opts }));
   // Regression https://github.com/nodejs/node/issues/33130
 
   const response = new PassThrough();
-  setTimeout(() => response.write('chunk 1'), 500);
-  setTimeout(() => response.write('chunk 2'), 1000);
-  setTimeout(() => response.write('chunk 3'), 1500);
-  setTimeout(() => response.end(), 2000);
+  response.write('chunk 1');
+  response.write('chunk 2');
+  response.write('chunk 3');
+  response.end();
 
   class HelloWorld extends Duplex {
     constructor(response) {
@@ -453,9 +453,11 @@ testClosed((opts) => new Writable({ write() {}, ...opts }));
   (async () => {
     await new Promise((resolve) => setTimeout(resolve, 100));
 
+    instance.setEncoding('utf8');
+
     let res = '';
     for await (const data of instance) {
-      res += data.toString();
+      res += data;
     }
 
     assert.strictEqual(res, 'chunk 1chunk 2chunk 3');

--- a/test/parallel/test-stream-finished.js
+++ b/test/parallel/test-stream-finished.js
@@ -408,10 +408,6 @@ testClosed((opts) => new Writable({ write() {}, ...opts }));
   // Regression https://github.com/nodejs/node/issues/33130
 
   const response = new PassThrough();
-  response.write('chunk 1');
-  response.write('chunk 2');
-  response.write('chunk 3');
-  response.end();
 
   class HelloWorld extends Duplex {
     constructor(response) {
@@ -452,6 +448,12 @@ testClosed((opts) => new Writable({ write() {}, ...opts }));
   instance.end();
 
   instance.on('finish', common.mustCall(() => {
+    setImmediate(common.mustCall(() => {
+      response.write('chunk 1');
+      response.write('chunk 2');
+      response.write('chunk 3');
+      response.end();
+    }));
     (async () => {
       assert.strictEqual(instance.writableFinished, true);
 

--- a/test/parallel/test-stream-finished.js
+++ b/test/parallel/test-stream-finished.js
@@ -451,7 +451,8 @@ testClosed((opts) => new Writable({ write() {}, ...opts }));
   instance.setEncoding('utf8');
   instance.end();
 
-  (async () => {
+  instance.on('finish', common.mustCall(async () => {
+    assert.strictEqual(instance.writableFinished, true);
 
     let res = '';
     for await (const data of instance) {
@@ -459,7 +460,7 @@ testClosed((opts) => new Writable({ write() {}, ...opts }));
     }
 
     assert.strictEqual(res, 'chunk 1chunk 2chunk 3');
-  })().then(common.mustCall());
+  }));
 }
 
 {


### PR DESCRIPTION
finished would incorrectly believe that a Duplex is already
closed if either the readable or writable side has completed.

Fixes: https://github.com/nodejs/node/issues/33130

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
