### PR TITLE
fs: add .ref() and .unref() methods to the StatWatcher and FSWatcher

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -596,9 +596,44 @@ called previously.
 <!-- YAML
 added: REPLACEME
 -->
+
 When called, the active `FSWatcher` object will not require the Node.js
 event loop to remain active. If there is no other activity keeping the
 event loop running, the process may exit before the `FSWatcher` object's
+callback is invoked. Calling `watcher.unref()` multiple times will have
+no effect.
+
+## Class: `fs.StatWatcher`
+<!-- YAML
+added: REPLACEME
+-->
+
+* Extends {EventEmitter}
+
+A successful call to `fs.watchFile()` method will return a new `fs.StatWatcher`
+object.
+
+### `watcher.ref()`
+<!-- YAML
+added: REPLACEME
+-->
+
+When called, requests that the Node.js event loop *not* exit so long as the
+`StatWatcher` is active. Calling `watcher.ref()` multiple times will have
+no effect.
+
+By default, all `StatWatcher` objects are "ref'ed", making it normally
+unnecessary to call `watcher.ref()` unless `watcher.unref()` had been
+called previously.
+
+### `watcher.unref()`
+<!-- YAML
+added: REPLACEME
+-->
+
+When called, the active `StatWatcher` object will not require the Node.js
+event loop to remain active. If there is no other activity keeping the
+event loop running, the process may exit before the `StatWatcher` object's
 callback is invoked. Calling `watcher.unref()` multiple times will have
 no effect.
 
@@ -3981,6 +4016,7 @@ changes:
 * `listener` {Function}
   * `current` {fs.Stats}
   * `previous` {fs.Stats}
+* Returns: {fs.StatWatcher}
 
 Watch for changes on `filename`. The callback `listener` will be called each
 time the file is accessed.

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -579,6 +579,29 @@ added: v0.5.8
 Stop watching for changes on the given `fs.FSWatcher`. Once stopped, the
 `fs.FSWatcher` object is no longer usable.
 
+### `watcher.ref()`
+<!-- YAML
+added: REPLACEME
+-->
+
+When called, requests that the Node.js event loop *not* exit so long as the
+`FSWatcher` is active. Calling `watcher.ref()` multiple times will have
+no effect.
+
+By default, all `FSWatcher` objects are "ref'ed", making it normally
+unnecessary to call `watcher.ref()` unless `watcher.unref()` had been
+called previously.
+
+### `watcher.unref()`
+<!-- YAML
+added: REPLACEME
+-->
+When called, the active `FSWatcher` object will not require the Node.js
+event loop to remain active. If there is no other activity keeping the
+event loop running, the process may exit before the `FSWatcher` object's
+callback is invoked. Calling `watcher.unref()` multiple times will have
+no effect.
+
 ## Class: `fs.ReadStream`
 <!-- YAML
 added: v0.1.93

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -584,6 +584,8 @@ Stop watching for changes on the given `fs.FSWatcher`. Once stopped, the
 added: REPLACEME
 -->
 
+* Returns: {fs.FSWatcher}
+
 When called, requests that the Node.js event loop *not* exit so long as the
 `FSWatcher` is active. Calling `watcher.ref()` multiple times will have
 no effect.
@@ -596,6 +598,8 @@ called previously.
 <!-- YAML
 added: REPLACEME
 -->
+
+* Returns: {fs.FSWatcher}
 
 When called, the active `FSWatcher` object will not require the Node.js
 event loop to remain active. If there is no other activity keeping the
@@ -618,6 +622,8 @@ object.
 added: REPLACEME
 -->
 
+* Returns: {fs.StatWatcher}
+
 When called, requests that the Node.js event loop *not* exit so long as the
 `StatWatcher` is active. Calling `watcher.ref()` multiple times will have
 no effect.
@@ -630,6 +636,8 @@ called previously.
 <!-- YAML
 added: REPLACEME
 -->
+
+* Returns: {fs.StatWatcher}
 
 When called, the active `StatWatcher` object will not require the Node.js
 event loop to remain active. If there is no other activity keeping the

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1489,6 +1489,9 @@ function watchFile(filename, options, listener) {
     stat[watchers.kFSStatWatcherStart](filename,
                                        options.persistent, options.interval);
     statWatchers.set(filename, stat);
+  } else {
+    stat[watchers.KFSStatWatcherRefCount]++;
+    stat[watchers.KFSStatWatcherMaxRefCount]++;
   }
 
   stat.addListener('change', listener);

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1490,8 +1490,7 @@ function watchFile(filename, options, listener) {
                                        options.persistent, options.interval);
     statWatchers.set(filename, stat);
   } else {
-    stat[watchers.KFSStatWatcherRefCount]++;
-    stat[watchers.KFSStatWatcherMaxRefCount]++;
+    stat[watchers.kFSStatWatcherAddOrCleanRef]('add');
   }
 
   stat.addListener('change', listener);
@@ -1506,9 +1505,13 @@ function unwatchFile(filename, listener) {
   if (stat === undefined) return;
 
   if (typeof listener === 'function') {
+    const beforeListenerCount = stat.listenerCount('change');
     stat.removeListener('change', listener);
+    if (stat.listenerCount('change') < beforeListenerCount)
+      stat[watchers.kFSStatWatcherAddOrCleanRef]('clean');
   } else {
     stat.removeAllListeners('change');
+    stat[watchers.kFSStatWatcherAddOrCleanRef]('cleanAll');
   }
 
   if (stat.listenerCount('change') === 0) {

--- a/lib/internal/fs/watchers.js
+++ b/lib/internal/fs/watchers.js
@@ -33,6 +33,7 @@ const kFSWatchStart = Symbol('kFSWatchStart');
 const kFSStatWatcherStart = Symbol('kFSStatWatcherStart');
 const KFSStatWatcherRefCount = Symbol('KFSStatWatcherRefCount');
 const KFSStatWatcherMaxRefCount = Symbol('KFSStatWatcherMaxRefCount');
+const kFSStatWatcherAddOrCleanRef = Symbol('kFSStatWatcherAddOrCleanRef');
 
 function emitStop(self) {
   self.emit('stop');
@@ -121,19 +122,39 @@ StatWatcher.prototype.stop = function() {
   this._handle = null;
 };
 
+// Clean up or add ref counters.
+StatWatcher.prototype[kFSStatWatcherAddOrCleanRef] = function(operate) {
+  if (operate === 'add') {
+    // Add a Ref
+    this[KFSStatWatcherRefCount]++;
+    this[KFSStatWatcherMaxRefCount]++;
+  } else if (operate === 'clean') {
+    // Clean up a single
+    this[KFSStatWatcherMaxRefCount]--;
+    this.unref();
+  } else if (operate === 'cleanAll') {
+    // Clean up all
+    this[KFSStatWatcherMaxRefCount] = 0;
+    this[KFSStatWatcherRefCount] = 0;
+    this._handle && this._handle.unref();
+  }
+};
+
 StatWatcher.prototype.ref = function() {
   // Avoid refCount calling ref multiple times causing unref to have no effect.
   if (this[KFSStatWatcherRefCount] === this[KFSStatWatcherMaxRefCount])
-    return;
+    return this;
   if (this._handle && this[KFSStatWatcherRefCount]++ === 0)
     this._handle.ref();
+  return this;
 };
 
 StatWatcher.prototype.unref = function() {
   // Avoid refCount calling unref multiple times causing ref to have no effect.
-  if (this[KFSStatWatcherRefCount] === 0) return;
+  if (this[KFSStatWatcherRefCount] === 0) return this;
   if (this._handle && --this[KFSStatWatcherRefCount] === 0)
     this._handle.unref();
+  return this;
 };
 
 
@@ -229,10 +250,12 @@ FSWatcher.prototype.close = function() {
 
 FSWatcher.prototype.ref = function() {
   if (this._handle) this._handle.ref();
+  return this;
 };
 
 FSWatcher.prototype.unref = function() {
   if (this._handle) this._handle.unref();
+  return this;
 };
 
 function emitCloseNT(self) {
@@ -251,6 +274,5 @@ module.exports = {
   StatWatcher,
   kFSWatchStart,
   kFSStatWatcherStart,
-  KFSStatWatcherRefCount,
-  KFSStatWatcherMaxRefCount,
+  kFSStatWatcherAddOrCleanRef,
 };

--- a/lib/internal/fs/watchers.js
+++ b/lib/internal/fs/watchers.js
@@ -31,6 +31,8 @@ const kUseBigint = Symbol('kUseBigint');
 
 const kFSWatchStart = Symbol('kFSWatchStart');
 const kFSStatWatcherStart = Symbol('kFSStatWatcherStart');
+const KFSStatWatcherRefCount = Symbol('KFSStatWatcherRefCount');
+const KFSStatWatcherMaxRefCount = Symbol('KFSStatWatcherMaxRefCount');
 
 function emitStop(self) {
   self.emit('stop');
@@ -42,6 +44,8 @@ function StatWatcher(bigint) {
   this._handle = null;
   this[kOldStatus] = -1;
   this[kUseBigint] = bigint;
+  this[KFSStatWatcherRefCount] = 1;
+  this[KFSStatWatcherMaxRefCount] = 1;
 }
 ObjectSetPrototypeOf(StatWatcher.prototype, EventEmitter.prototype);
 ObjectSetPrototypeOf(StatWatcher, EventEmitter);
@@ -75,7 +79,7 @@ StatWatcher.prototype[kFSStatWatcherStart] = function(filename,
   this._handle[owner_symbol] = this;
   this._handle.onchange = onchange;
   if (!persistent)
-    this._handle.unref();
+    this.unref();
 
   // uv_fs_poll is a little more powerful than ev_stat but we curb it for
   // the sake of backwards compatibility.
@@ -115,6 +119,21 @@ StatWatcher.prototype.stop = function() {
                              this);
   this._handle.close();
   this._handle = null;
+};
+
+StatWatcher.prototype.ref = function() {
+  // Avoid refCount calling ref multiple times causing unref to have no effect.
+  if (this[KFSStatWatcherRefCount] === this[KFSStatWatcherMaxRefCount])
+    return;
+  if (this._handle && this[KFSStatWatcherRefCount]++ === 0)
+    this._handle.ref();
+};
+
+StatWatcher.prototype.unref = function() {
+  // Avoid refCount calling unref multiple times causing ref to have no effect.
+  if (this[KFSStatWatcherRefCount] === 0) return;
+  if (this._handle && --this[KFSStatWatcherRefCount] === 0)
+    this._handle.unref();
 };
 
 
@@ -208,6 +227,14 @@ FSWatcher.prototype.close = function() {
   process.nextTick(emitCloseNT, this);
 };
 
+FSWatcher.prototype.ref = function() {
+  if (this._handle) this._handle.ref();
+};
+
+FSWatcher.prototype.unref = function() {
+  if (this._handle) this._handle.unref();
+};
+
 function emitCloseNT(self) {
   self.emit('close');
 }
@@ -223,5 +250,7 @@ module.exports = {
   FSWatcher,
   StatWatcher,
   kFSWatchStart,
-  kFSStatWatcherStart
+  kFSStatWatcherStart,
+  KFSStatWatcherRefCount,
+  KFSStatWatcherMaxRefCount,
 };

--- a/src/fs_event_wrap.cc
+++ b/src/fs_event_wrap.cc
@@ -101,9 +101,8 @@ void FSEventWrap::Initialize(Local<Object> target,
       FSEventWrap::kInternalFieldCount);
   t->SetClassName(fsevent_string);
 
-  t->Inherit(AsyncWrap::GetConstructorTemplate(env));
+  t->Inherit(HandleWrap::GetConstructorTemplate(env));
   env->SetProtoMethod(t, "start", Start);
-  env->SetProtoMethod(t, "close", Close);
 
   Local<FunctionTemplate> get_initialized_templ =
       FunctionTemplate::New(env->isolate(),

--- a/test/parallel/test-fs-watch-ref-unref.js
+++ b/test/parallel/test-fs-watch-ref-unref.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const common = require('../common');
+
+if (common.isIBMi)
+  common.skip('IBMi does not support `fs.watch()`');
+
+const fs = require('fs');
+const assert = require('assert');
+
+let refCount = 0;
+
+const watcher = fs.watch(__filename, common.mustNotCall());
+
+function unref() {
+  watcher.unref();
+  refCount--;
+  assert.strictEqual(refCount, -1);
+}
+
+function ref() {
+  watcher.ref();
+  refCount++;
+  assert.strictEqual(refCount, 0);
+}
+
+unref();
+
+setTimeout(
+  common.mustCall(() => {
+    ref();
+    unref();
+  }),
+  common.platformTimeout(100)
+);

--- a/test/parallel/test-fs-watch-ref-unref.js
+++ b/test/parallel/test-fs-watch-ref-unref.js
@@ -6,30 +6,15 @@ if (common.isIBMi)
   common.skip('IBMi does not support `fs.watch()`');
 
 const fs = require('fs');
-const assert = require('assert');
-
-let refCount = 0;
 
 const watcher = fs.watch(__filename, common.mustNotCall());
 
-function unref() {
-  watcher.unref();
-  refCount--;
-  assert.strictEqual(refCount, -1);
-}
-
-function ref() {
-  watcher.ref();
-  refCount++;
-  assert.strictEqual(refCount, 0);
-}
-
-unref();
+watcher.unref();
 
 setTimeout(
   common.mustCall(() => {
-    ref();
-    unref();
+    watcher.ref();
+    watcher.unref();
   }),
   common.platformTimeout(100)
 );

--- a/test/parallel/test-fs-watchfile-ref-unref.js
+++ b/test/parallel/test-fs-watchfile-ref-unref.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const common = require('../common');
+
+const fs = require('fs');
+const assert = require('assert');
+
+let refCount = 0;
+
+const watcher = fs.watchFile(__filename, common.mustNotCall());
+
+function unref() {
+  watcher.unref();
+  refCount--;
+  assert.strictEqual(refCount, -1);
+}
+
+function ref() {
+  watcher.ref();
+  refCount++;
+  assert.strictEqual(refCount, 0);
+}
+
+unref();
+
+setTimeout(
+  common.mustCall(() => {
+    ref();
+    unref();
+    watcher.unref();
+    watcher.ref();
+    watcher.ref();
+    watcher.unref();
+  }),
+  common.platformTimeout(100)
+);

--- a/tools/doc/type-parser.js
+++ b/tools/doc/type-parser.js
@@ -84,6 +84,7 @@ const customTypesMap = {
   'fs.FSWatcher': 'fs.html#fs_class_fs_fswatcher',
   'fs.ReadStream': 'fs.html#fs_class_fs_readstream',
   'fs.Stats': 'fs.html#fs_class_fs_stats',
+  'fs.StatWatcher': 'fs.html#fs_class_fs_statwatcher',
   'fs.WriteStream': 'fs.html#fs_class_fs_writestream',
 
   'http.Agent': 'http.html#http_class_http_agent',


### PR DESCRIPTION

add `.ref()` and `.unref()` methods to the `StatWatcher` and `FSWatcher` classes. 

Fixes: #33096 

/cc @addaleax 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
