### PR TITLE
test: ensure finish is emitted before destroy

### DIFF
--- a/test/parallel/test-net-allow-half-open.js
+++ b/test/parallel/test-net-allow-half-open.js
@@ -4,22 +4,44 @@ const common = require('../common');
 const assert = require('assert');
 const net = require('net');
 
-const server = net.createServer(common.mustCall((socket) => {
-  socket.end(Buffer.alloc(1024));
-})).listen(0, common.mustCall(() => {
-  const socket = net.connect(server.address().port);
-  assert.strictEqual(socket.allowHalfOpen, false);
-  socket.resume();
-  socket.on('end', common.mustCall(() => {
-    process.nextTick(() => {
-      // Ensure socket is not destroyed straight away
-      // without proper shutdown.
+{
+  const server = net.createServer(common.mustCall((socket) => {
+    socket.end(Buffer.alloc(1024));
+  })).listen(0, common.mustCall(() => {
+    const socket = net.connect(server.address().port);
+    assert.strictEqual(socket.allowHalfOpen, false);
+    socket.resume();
+    socket.on('end', common.mustCall(() => {
+      process.nextTick(() => {
+        // Ensure socket is not destroyed straight away
+        // without proper shutdown.
+        assert(!socket.destroyed);
+        server.close();
+      });
+    }));
+    socket.on('finish', common.mustCall(() => {
       assert(!socket.destroyed);
+    }));
+    socket.on('close', common.mustCall());
+  }));
+}
+
+{
+  const server = net.createServer(common.mustCall((socket) => {
+    socket.end(Buffer.alloc(1024));
+  })).listen(0, common.mustCall(() => {
+    const socket = net.connect(server.address().port);
+    assert.strictEqual(socket.allowHalfOpen, false);
+    socket.resume();
+    socket.on('end', common.mustCall(() => {
+      assert(!socket.destroyed);
+    }));
+    socket.end('asd');
+    socket.on('finish', common.mustCall(() => {
+      assert(!socket.destroyed);
+    }));
+    socket.on('close', common.mustCall(() => {
       server.close();
-    });
+    }));
   }));
-  socket.on('finish', common.mustCall(() => {
-    assert(!socket.destroyed);
-  }));
-  socket.on('close', common.mustCall());
-}));
+}


### PR DESCRIPTION
Adds a test to ensure that 'finish' is emitted
before the socket is destroyed by allow half-open
enforcer.

Refs: https://github.com/nodejs/node/commit/3c07b1793cfe12a7cebc3a0e3e3c3fd2b60a3560#commitcomment-38810268

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
