### PR TITLE
src: retrieve binding data from the context

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -400,15 +400,21 @@ NODE_MODULE_CONTEXT_AWARE_INTERNAL(cares_wrap, Initialize)
 
 Some internal bindings, such as the HTTP parser, maintain internal state that
 only affects that particular binding. In that case, one common way to store
-that state is through the use of `Environment::BindingScope`, which gives all
-new functions created within it access to an object for storing such state.
+that state is through the use of `Environment::AddBindingData`, which gives
+binding functions access to an object for storing such state.
 That object is always a [`BaseObject`][].
+
+Its class needs to have a static `binding_data_name` field that based on a
+constant string, in order to disambiguate it from other classes of this type,
+and which could e.g. match the binding’s name.
 
 ```c++
 // In the HTTP parser source code file:
 class BindingData : public BaseObject {
  public:
   BindingData(Environment* env, Local<Object> obj) : BaseObject(env, obj) {}
+
+  static constexpr FastStringKey binding_data_name { "http_parser" };
 
   std::vector<char> parser_buffer;
   bool parser_buffer_in_use = false;
@@ -422,18 +428,17 @@ static void New(const FunctionCallbackInfo<Value>& args) {
   new Parser(binding_data, args.This());
 }
 
-// ... because the initialization function told the Environment to use this
-// BindingData class for all functions created by it:
+// ... because the initialization function told the Environment to store the
+// BindingData object:
 void InitializeHttpParser(Local<Object> target,
                           Local<Value> unused,
                           Local<Context> context,
                           void* priv) {
   Environment* env = Environment::GetCurrent(context);
-  Environment::BindingScope<BindingData> binding_scope(context, target);
-  if (!binding_scope) return;
-  BindingData* binding_data = binding_scope.data;
+  BindingData* const binding_data =
+      env->AddBindingData<BindingData>(context, target);
+  if (binding_data == nullptr) return;
 
-  // Created within the Environment::BindingScope
   Local<FunctionTemplate> t = env->NewFunctionTemplate(Parser::New);
   ...
 }

--- a/src/README.md
+++ b/src/README.md
@@ -402,13 +402,13 @@ Some internal bindings, such as the HTTP parser, maintain internal state that
 only affects that particular binding. In that case, one common way to store
 that state is through the use of `Environment::BindingScope`, which gives all
 new functions created within it access to an object for storing such state.
-That object is always a `BindingDataBase`.
+That object is always a [`BaseObject`][].
 
 ```c++
 // In the HTTP parser source code file:
-class BindingData : public BindingDataBase {
+class BindingData : public BaseObject {
  public:
-  BindingData(Environment* env, Local<Object> obj) : BindingDataBase(env, obj) {}
+  BindingData(Environment* env, Local<Object> obj) : BaseObject(env, obj) {}
 
   std::vector<char> parser_buffer;
   bool parser_buffer_in_use = false;
@@ -418,7 +418,7 @@ class BindingData : public BindingDataBase {
 
 // Available for binding functions, e.g. the HTTP Parser constructor:
 static void New(const FunctionCallbackInfo<Value>& args) {
-  BindingData* binding_data = BindingDataBase::Unwrap<BindingData>(args);
+  BindingData* binding_data = Environment::GetBindingData<BindingData>(args);
   new Parser(binding_data, args.This());
 }
 
@@ -429,7 +429,7 @@ void InitializeHttpParser(Local<Object> target,
                           Local<Context> context,
                           void* priv) {
   Environment* env = Environment::GetCurrent(context);
-  Environment::BindingScope<BindingData> binding_scope(env, context, target);
+  Environment::BindingScope<BindingData> binding_scope(context, target);
   if (!binding_scope) return;
   BindingData* binding_data = binding_scope.data;
 

--- a/src/README.md
+++ b/src/README.md
@@ -406,7 +406,8 @@ That object is always a [`BaseObject`][].
 
 Its class needs to have a static `binding_data_name` field that based on a
 constant string, in order to disambiguate it from other classes of this type,
-and which could e.g. match the binding’s name.
+and which could e.g. match the binding’s name (in the example above, that would
+be `cares_wrap`).
 
 ```c++
 // In the HTTP parser source code file:

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -369,6 +369,7 @@ inline T* Environment::AddBindingData(
   DCHECK_NOT_NULL(list);
   auto result = list->emplace(T::binding_data_name, item);
   CHECK(result.second);
+  DCHECK_EQ(GetBindingData<T>(context), item.get());
   return item.get();
 }
 

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -344,12 +344,12 @@ inline T* Environment::GetBindingData(
 
 template <typename T>
 inline T* Environment::GetBindingData(v8::Local<v8::Context> context) {
-  BindingDataStore* list = static_cast<BindingDataStore*>(
+  BindingDataStore* map = static_cast<BindingDataStore*>(
       context->GetAlignedPointerFromEmbedderData(
           ContextEmbedderIndex::kBindingListIndex));
-  DCHECK_NOT_NULL(list);
-  auto it = list->find(T::binding_data_name);
-  DCHECK_NE(it, list->end());
+  DCHECK_NOT_NULL(map);
+  auto it = map->find(T::binding_data_name);
+  if (UNLIKELY(it == map->end())) return nullptr;
   T* result = static_cast<T*>(it->second.get());
   DCHECK_NOT_NULL(result);
   DCHECK_EQ(result->env(), GetCurrent(context));
@@ -363,11 +363,11 @@ inline T* Environment::AddBindingData(
   DCHECK_EQ(GetCurrent(context), this);
   // This won't compile if T is not a BaseObject subclass.
   BaseObjectPtr<T> item = MakeDetachedBaseObject<T>(this, target);
-  BindingDataStore* list = static_cast<BindingDataStore*>(
+  BindingDataStore* map = static_cast<BindingDataStore*>(
       context->GetAlignedPointerFromEmbedderData(
           ContextEmbedderIndex::kBindingListIndex));
-  DCHECK_NOT_NULL(list);
-  auto result = list->emplace(T::binding_data_name, item);
+  DCHECK_NOT_NULL(map);
+  auto result = map->emplace(T::binding_data_name, item);
   CHECK(result.second);
   DCHECK_EQ(GetBindingData<T>(context), item.get());
   return item.get();

--- a/src/env.cc
+++ b/src/env.cc
@@ -261,16 +261,6 @@ void TrackingTraceStateObserver::UpdateTraceCategoryState() {
   USE(cb->Call(env_->context(), Undefined(isolate), arraysize(args), args));
 }
 
-class NoBindingData : public BaseObject {
- public:
-  NoBindingData(Environment* env, Local<Object> obj)
-      : BaseObject(env, obj) {}
-
-  SET_NO_MEMORY_INFO()
-  SET_MEMORY_INFO_NAME(NoBindingData)
-  SET_SELF_SIZE(NoBindingData)
-};
-
 void Environment::CreateProperties() {
   HandleScope handle_scope(isolate_);
   Local<Context> ctx = context();
@@ -282,11 +272,6 @@ void Environment::CreateProperties() {
         BaseObject::kInternalFieldCount);
 
     set_binding_data_ctor_template(templ);
-    Local<Function> ctor = templ->GetFunction(ctx).ToLocalChecked();
-    Local<Object> obj = ctor->NewInstance(ctx).ToLocalChecked();
-    uint32_t index = NewBindingData<NoBindingData>(ctx, obj).second;
-    default_callback_data_ = index;
-    current_callback_data_ = index;
   }
 
   // Store primordials setup by the per-context script in the environment.

--- a/src/fs_event_wrap.cc
+++ b/src/fs_event_wrap.cc
@@ -108,7 +108,7 @@ void FSEventWrap::Initialize(Local<Object> target,
   Local<FunctionTemplate> get_initialized_templ =
       FunctionTemplate::New(env->isolate(),
                             GetInitialized,
-                            env->current_callback_data(),
+                            Local<Value>(),
                             Signature::New(env->isolate(), t));
 
   t->PrototypeTemplate()->SetAccessorProperty(

--- a/src/node.cc
+++ b/src/node.cc
@@ -331,8 +331,7 @@ MaybeLocal<Value> Environment::BootstrapNode() {
 
   Local<String> env_string = FIXED_ONE_BYTE_STRING(isolate_, "env");
   Local<Object> env_var_proxy;
-  if (!CreateEnvVarProxy(context(), isolate_, Local<Value>())
-           .ToLocal(&env_var_proxy) ||
+  if (!CreateEnvVarProxy(context(), isolate_).ToLocal(&env_var_proxy) ||
       process_object()->Set(context(), env_string, env_var_proxy).IsNothing()) {
     return MaybeLocal<Value>();
   }

--- a/src/node.cc
+++ b/src/node.cc
@@ -331,7 +331,7 @@ MaybeLocal<Value> Environment::BootstrapNode() {
 
   Local<String> env_string = FIXED_ONE_BYTE_STRING(isolate_, "env");
   Local<Object> env_var_proxy;
-  if (!CreateEnvVarProxy(context(), isolate_, current_callback_data())
+  if (!CreateEnvVarProxy(context(), isolate_, Local<Value>())
            .ToLocal(&env_var_proxy) ||
       process_object()->Set(context(), env_string, env_var_proxy).IsNothing()) {
     return MaybeLocal<Value>();

--- a/src/node_binding.cc
+++ b/src/node_binding.cc
@@ -230,6 +230,7 @@ namespace node {
 
 using v8::Context;
 using v8::Exception;
+using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::Local;
 using v8::NewStringType;
@@ -556,8 +557,11 @@ inline struct node_module* FindModule(struct node_module* list,
 static Local<Object> InitModule(Environment* env,
                                 node_module* mod,
                                 Local<String> module) {
-  Local<Object> exports = Object::New(env->isolate());
   // Internal bindings don't have a "module" object, only exports.
+  Local<Function> ctor = env->binding_data_ctor_template()
+                             ->GetFunction(env->context())
+                             .ToLocalChecked();
+  Local<Object> exports = ctor->NewInstance(env->context()).ToLocalChecked();
   CHECK_NULL(mod->nm_register_func);
   CHECK_NOT_NULL(mod->nm_context_register_func);
   Local<Value> unused = Undefined(env->isolate());

--- a/src/node_context_data.h
+++ b/src/node_context_data.h
@@ -25,11 +25,16 @@ namespace node {
 #define NODE_CONTEXT_TAG 35
 #endif
 
+#ifndef NODE_BINDING_LIST
+#define NODE_BINDING_LIST_INDEX 36
+#endif
+
 enum ContextEmbedderIndex {
   kEnvironment = NODE_CONTEXT_EMBEDDER_DATA_INDEX,
   kSandboxObject = NODE_CONTEXT_SANDBOX_OBJECT_INDEX,
   kAllowWasmCodeGeneration = NODE_CONTEXT_ALLOW_WASM_CODE_GENERATION_INDEX,
   kContextTag = NODE_CONTEXT_TAG,
+  KBindingListIndex = NODE_BINDING_LIST_INDEX
 };
 
 }  // namespace node

--- a/src/node_context_data.h
+++ b/src/node_context_data.h
@@ -34,7 +34,7 @@ enum ContextEmbedderIndex {
   kSandboxObject = NODE_CONTEXT_SANDBOX_OBJECT_INDEX,
   kAllowWasmCodeGeneration = NODE_CONTEXT_ALLOW_WASM_CODE_GENERATION_INDEX,
   kContextTag = NODE_CONTEXT_TAG,
-  KBindingListIndex = NODE_BINDING_LIST_INDEX
+  kBindingListIndex = NODE_BINDING_LIST_INDEX
 };
 
 }  // namespace node

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -505,7 +505,7 @@ void SecureContext::Initialize(Environment* env, Local<Object> target) {
   Local<FunctionTemplate> ctx_getter_templ =
       FunctionTemplate::New(env->isolate(),
                             CtxGetter,
-                            env->current_callback_data(),
+                            Local<Value>(),
                             Signature::New(env->isolate(), t));
 
 
@@ -5103,7 +5103,7 @@ void DiffieHellman::Initialize(Environment* env, Local<Object> target) {
     Local<FunctionTemplate> verify_error_getter_templ =
         FunctionTemplate::New(env->isolate(),
                               DiffieHellman::VerifyErrorGetter,
-                              env->current_callback_data(),
+                              Local<Value>(),
                               Signature::New(env->isolate(), t),
                               /* length */ 0,
                               ConstructorBehavior::kThrow,

--- a/src/node_env_var.cc
+++ b/src/node_env_var.cc
@@ -379,7 +379,7 @@ static void EnvEnumerator(const PropertyCallbackInfo<Array>& info) {
 
 MaybeLocal<Object> CreateEnvVarProxy(Local<Context> context,
                                      Isolate* isolate,
-                                     Local<Object> data) {
+                                     Local<Value> data) {
   EscapableHandleScope scope(isolate);
   Local<ObjectTemplate> env_proxy_template = ObjectTemplate::New(isolate);
   env_proxy_template->SetHandler(NamedPropertyHandlerConfiguration(

--- a/src/node_env_var.cc
+++ b/src/node_env_var.cc
@@ -377,13 +377,11 @@ static void EnvEnumerator(const PropertyCallbackInfo<Array>& info) {
       env->env_vars()->Enumerate(env->isolate()));
 }
 
-MaybeLocal<Object> CreateEnvVarProxy(Local<Context> context,
-                                     Isolate* isolate,
-                                     Local<Value> data) {
+MaybeLocal<Object> CreateEnvVarProxy(Local<Context> context, Isolate* isolate) {
   EscapableHandleScope scope(isolate);
   Local<ObjectTemplate> env_proxy_template = ObjectTemplate::New(isolate);
   env_proxy_template->SetHandler(NamedPropertyHandlerConfiguration(
-      EnvGetter, EnvSetter, EnvQuery, EnvDeleter, EnvEnumerator, data,
+      EnvGetter, EnvSetter, EnvQuery, EnvDeleter, EnvEnumerator, Local<Value>(),
       PropertyHandlerFlags::kHasNoSideEffect));
   return scope.EscapeMaybe(env_proxy_template->NewInstance(context));
 }

--- a/src/node_file-inl.h
+++ b/src/node_file-inl.h
@@ -227,7 +227,7 @@ FSReqBase* GetReqWrap(const v8::FunctionCallbackInfo<v8::Value>& args,
     return Unwrap<FSReqBase>(value.As<v8::Object>());
   }
 
-  BindingData* binding_data = BindingDataBase::Unwrap<BindingData>(args);
+  BindingData* binding_data = Environment::GetBindingData<BindingData>(args);
   Environment* env = binding_data->env();
   if (value->StrictEquals(env->fs_use_promises_symbol())) {
     if (use_bigint) {

--- a/src/node_file-inl.h
+++ b/src/node_file-inl.h
@@ -227,7 +227,7 @@ FSReqBase* GetReqWrap(const v8::FunctionCallbackInfo<v8::Value>& args,
     return Unwrap<FSReqBase>(value.As<v8::Object>());
   }
 
-  BindingData* binding_data = Unwrap<BindingData>(args.Data());
+  BindingData* binding_data = BindingDataBase::Unwrap<BindingData>(args);
   Environment* env = binding_data->env();
   if (value->StrictEquals(env->fs_use_promises_symbol())) {
     if (use_bigint) {

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -158,7 +158,7 @@ FileHandle* FileHandle::New(BindingData* binding_data,
 }
 
 void FileHandle::New(const FunctionCallbackInfo<Value>& args) {
-  BindingData* binding_data = Unwrap<BindingData>(args.Data());
+  BindingData* binding_data = BindingDataBase::Unwrap<BindingData>(args);
   Environment* env = binding_data->env();
   CHECK(args.IsConstructCall());
   CHECK(args[0]->IsInt32());
@@ -543,7 +543,7 @@ void FSReqCallback::SetReturnValue(const FunctionCallbackInfo<Value>& args) {
 
 void NewFSReqCallback(const FunctionCallbackInfo<Value>& args) {
   CHECK(args.IsConstructCall());
-  BindingData* binding_data = Unwrap<BindingData>(args.Data());
+  BindingData* binding_data = BindingDataBase::Unwrap<BindingData>(args);
   new FSReqCallback(binding_data, args.This(), args[0]->IsTrue());
 }
 
@@ -948,7 +948,7 @@ static void InternalModuleStat(const FunctionCallbackInfo<Value>& args) {
 }
 
 static void Stat(const FunctionCallbackInfo<Value>& args) {
-  BindingData* binding_data = Unwrap<BindingData>(args.Data());
+  BindingData* binding_data = BindingDataBase::Unwrap<BindingData>(args);
   Environment* env = binding_data->env();
 
   const int argc = args.Length();
@@ -979,7 +979,7 @@ static void Stat(const FunctionCallbackInfo<Value>& args) {
 }
 
 static void LStat(const FunctionCallbackInfo<Value>& args) {
-  BindingData* binding_data = Unwrap<BindingData>(args.Data());
+  BindingData* binding_data = BindingDataBase::Unwrap<BindingData>(args);
   Environment* env = binding_data->env();
 
   const int argc = args.Length();
@@ -1011,7 +1011,7 @@ static void LStat(const FunctionCallbackInfo<Value>& args) {
 }
 
 static void FStat(const FunctionCallbackInfo<Value>& args) {
-  BindingData* binding_data = Unwrap<BindingData>(args.Data());
+  BindingData* binding_data = BindingDataBase::Unwrap<BindingData>(args);
   Environment* env = binding_data->env();
 
   const int argc = args.Length();
@@ -1674,7 +1674,7 @@ static void Open(const FunctionCallbackInfo<Value>& args) {
 }
 
 static void OpenFileHandle(const FunctionCallbackInfo<Value>& args) {
-  BindingData* binding_data = Unwrap<BindingData>(args.Data());
+  BindingData* binding_data = BindingDataBase::Unwrap<BindingData>(args);
   Environment* env = binding_data->env();
   Isolate* isolate = env->isolate();
 
@@ -2309,7 +2309,7 @@ void Initialize(Local<Object> target,
                 void* priv) {
   Environment* env = Environment::GetCurrent(context);
   Isolate* isolate = env->isolate();
-  Environment::BindingScope<BindingData> binding_scope(env);
+  Environment::BindingScope<BindingData> binding_scope(env, context, target);
   if (!binding_scope) return;
   BindingData* binding_data = binding_scope.data;
 

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -158,7 +158,7 @@ FileHandle* FileHandle::New(BindingData* binding_data,
 }
 
 void FileHandle::New(const FunctionCallbackInfo<Value>& args) {
-  BindingData* binding_data = BindingDataBase::Unwrap<BindingData>(args);
+  BindingData* binding_data = Environment::GetBindingData<BindingData>(args);
   Environment* env = binding_data->env();
   CHECK(args.IsConstructCall());
   CHECK(args[0]->IsInt32());
@@ -543,7 +543,7 @@ void FSReqCallback::SetReturnValue(const FunctionCallbackInfo<Value>& args) {
 
 void NewFSReqCallback(const FunctionCallbackInfo<Value>& args) {
   CHECK(args.IsConstructCall());
-  BindingData* binding_data = BindingDataBase::Unwrap<BindingData>(args);
+  BindingData* binding_data = Environment::GetBindingData<BindingData>(args);
   new FSReqCallback(binding_data, args.This(), args[0]->IsTrue());
 }
 
@@ -948,7 +948,7 @@ static void InternalModuleStat(const FunctionCallbackInfo<Value>& args) {
 }
 
 static void Stat(const FunctionCallbackInfo<Value>& args) {
-  BindingData* binding_data = BindingDataBase::Unwrap<BindingData>(args);
+  BindingData* binding_data = Environment::GetBindingData<BindingData>(args);
   Environment* env = binding_data->env();
 
   const int argc = args.Length();
@@ -979,7 +979,7 @@ static void Stat(const FunctionCallbackInfo<Value>& args) {
 }
 
 static void LStat(const FunctionCallbackInfo<Value>& args) {
-  BindingData* binding_data = BindingDataBase::Unwrap<BindingData>(args);
+  BindingData* binding_data = Environment::GetBindingData<BindingData>(args);
   Environment* env = binding_data->env();
 
   const int argc = args.Length();
@@ -1011,7 +1011,7 @@ static void LStat(const FunctionCallbackInfo<Value>& args) {
 }
 
 static void FStat(const FunctionCallbackInfo<Value>& args) {
-  BindingData* binding_data = BindingDataBase::Unwrap<BindingData>(args);
+  BindingData* binding_data = Environment::GetBindingData<BindingData>(args);
   Environment* env = binding_data->env();
 
   const int argc = args.Length();
@@ -1674,7 +1674,7 @@ static void Open(const FunctionCallbackInfo<Value>& args) {
 }
 
 static void OpenFileHandle(const FunctionCallbackInfo<Value>& args) {
-  BindingData* binding_data = BindingDataBase::Unwrap<BindingData>(args);
+  BindingData* binding_data = Environment::GetBindingData<BindingData>(args);
   Environment* env = binding_data->env();
   Isolate* isolate = env->isolate();
 
@@ -2309,7 +2309,7 @@ void Initialize(Local<Object> target,
                 void* priv) {
   Environment* env = Environment::GetCurrent(context);
   Isolate* isolate = env->isolate();
-  Environment::BindingScope<BindingData> binding_scope(env, context, target);
+  Environment::BindingScope<BindingData> binding_scope(context, target);
   if (!binding_scope) return;
   BindingData* binding_data = binding_scope.data;
 

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -2303,15 +2303,18 @@ void BindingData::MemoryInfo(MemoryTracker* tracker) const {
                       file_handle_read_wrap_freelist);
 }
 
+// TODO(addaleax): Remove once we're on C++17.
+constexpr FastStringKey BindingData::binding_data_name;
+
 void Initialize(Local<Object> target,
                 Local<Value> unused,
                 Local<Context> context,
                 void* priv) {
   Environment* env = Environment::GetCurrent(context);
   Isolate* isolate = env->isolate();
-  Environment::BindingScope<BindingData> binding_scope(context, target);
-  if (!binding_scope) return;
-  BindingData* binding_data = binding_scope.data;
+  BindingData* const binding_data =
+      env->AddBindingData<BindingData>(context, target);
+  if (binding_data == nullptr) return;
 
   env->SetMethod(target, "access", Access);
   env->SetMethod(target, "close", Close);

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -13,10 +13,10 @@ namespace fs {
 
 class FileHandleReadWrap;
 
-class BindingData : public BindingDataBase {
+class BindingData : public BaseObject {
  public:
   explicit BindingData(Environment* env, v8::Local<v8::Object> wrap)
-      : BindingDataBase(env, wrap),
+      : BaseObject(env, wrap),
         stats_field_array(env->isolate(), kFsStatsBufferLength),
         stats_field_bigint_array(env->isolate(), kFsStatsBufferLength) {}
 

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -13,12 +13,12 @@ namespace fs {
 
 class FileHandleReadWrap;
 
-class BindingData : public BaseObject {
+class BindingData : public BindingDataBase {
  public:
   explicit BindingData(Environment* env, v8::Local<v8::Object> wrap)
-    : BaseObject(env, wrap),
-      stats_field_array(env->isolate(), kFsStatsBufferLength),
-      stats_field_bigint_array(env->isolate(), kFsStatsBufferLength) {}
+      : BindingDataBase(env, wrap),
+        stats_field_array(env->isolate(), kFsStatsBufferLength),
+        stats_field_bigint_array(env->isolate(), kFsStatsBufferLength) {}
 
   AliasedFloat64Array stats_field_array;
   AliasedBigUint64Array stats_field_bigint_array;

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -26,6 +26,8 @@ class BindingData : public BaseObject {
   std::vector<BaseObjectPtr<FileHandleReadWrap>>
       file_handle_read_wrap_freelist;
 
+  static constexpr FastStringKey binding_data_name { "fs" };
+
   void MemoryInfo(MemoryTracker* tracker) const override;
   SET_SELF_SIZE(BindingData)
   SET_MEMORY_INFO_NAME(BindingData)

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -2351,7 +2351,7 @@ void HttpErrorString(const FunctionCallbackInfo<Value>& args) {
 // would be suitable, for instance, for creating the Base64
 // output for an HTTP2-Settings header field.
 void PackSettings(const FunctionCallbackInfo<Value>& args) {
-  Http2State* state = Unwrap<Http2State>(args.Data());
+  Http2State* state = BindingDataBase::Unwrap<Http2State>(args);
   args.GetReturnValue().Set(Http2Settings::Pack(state));
 }
 
@@ -2359,7 +2359,7 @@ void PackSettings(const FunctionCallbackInfo<Value>& args) {
 // default SETTINGS. RefreshDefaultSettings updates that TypedArray with the
 // default values.
 void RefreshDefaultSettings(const FunctionCallbackInfo<Value>& args) {
-  Http2State* state = Unwrap<Http2State>(args.Data());
+  Http2State* state = BindingDataBase::Unwrap<Http2State>(args);
   Http2Settings::RefreshDefaults(state);
 }
 
@@ -2423,7 +2423,7 @@ void Http2Session::RefreshState(const FunctionCallbackInfo<Value>& args) {
 
 // Constructor for new Http2Session instances.
 void Http2Session::New(const FunctionCallbackInfo<Value>& args) {
-  Http2State* state = Unwrap<Http2State>(args.Data());
+  Http2State* state = BindingDataBase::Unwrap<Http2State>(args);
   Environment* env = state->env();
   CHECK(args.IsConstructCall());
   SessionType type =
@@ -2950,7 +2950,7 @@ void Initialize(Local<Object> target,
   Isolate* isolate = env->isolate();
   HandleScope handle_scope(isolate);
 
-  Environment::BindingScope<Http2State> binding_scope(env);
+  Environment::BindingScope<Http2State> binding_scope(env, context, target);
   if (!binding_scope) return;
   Http2State* state = binding_scope.data;
 

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -2941,6 +2941,9 @@ void Http2State::MemoryInfo(MemoryTracker* tracker) const {
   tracker->TrackField("root_buffer", root_buffer);
 }
 
+// TODO(addaleax): Remove once we're on C++17.
+constexpr FastStringKey Http2State::binding_data_name;
+
 // Set up the process.binding('http2') binding.
 void Initialize(Local<Object> target,
                 Local<Value> unused,
@@ -2950,9 +2953,8 @@ void Initialize(Local<Object> target,
   Isolate* isolate = env->isolate();
   HandleScope handle_scope(isolate);
 
-  Environment::BindingScope<Http2State> binding_scope(context, target);
-  if (!binding_scope) return;
-  Http2State* state = binding_scope.data;
+  Http2State* const state = env->AddBindingData<Http2State>(context, target);
+  if (state == nullptr) return;
 
 #define SET_STATE_TYPEDARRAY(name, field)             \
   target->Set(context,                                \

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -2351,7 +2351,7 @@ void HttpErrorString(const FunctionCallbackInfo<Value>& args) {
 // would be suitable, for instance, for creating the Base64
 // output for an HTTP2-Settings header field.
 void PackSettings(const FunctionCallbackInfo<Value>& args) {
-  Http2State* state = BindingDataBase::Unwrap<Http2State>(args);
+  Http2State* state = Environment::GetBindingData<Http2State>(args);
   args.GetReturnValue().Set(Http2Settings::Pack(state));
 }
 
@@ -2359,7 +2359,7 @@ void PackSettings(const FunctionCallbackInfo<Value>& args) {
 // default SETTINGS. RefreshDefaultSettings updates that TypedArray with the
 // default values.
 void RefreshDefaultSettings(const FunctionCallbackInfo<Value>& args) {
-  Http2State* state = BindingDataBase::Unwrap<Http2State>(args);
+  Http2State* state = Environment::GetBindingData<Http2State>(args);
   Http2Settings::RefreshDefaults(state);
 }
 
@@ -2423,7 +2423,7 @@ void Http2Session::RefreshState(const FunctionCallbackInfo<Value>& args) {
 
 // Constructor for new Http2Session instances.
 void Http2Session::New(const FunctionCallbackInfo<Value>& args) {
-  Http2State* state = BindingDataBase::Unwrap<Http2State>(args);
+  Http2State* state = Environment::GetBindingData<Http2State>(args);
   Environment* env = state->env();
   CHECK(args.IsConstructCall());
   SessionType type =
@@ -2950,7 +2950,7 @@ void Initialize(Local<Object> target,
   Isolate* isolate = env->isolate();
   HandleScope handle_scope(isolate);
 
-  Environment::BindingScope<Http2State> binding_scope(env, context, target);
+  Environment::BindingScope<Http2State> binding_scope(context, target);
   if (!binding_scope) return;
   Http2State* state = binding_scope.data;
 

--- a/src/node_http2_state.h
+++ b/src/node_http2_state.h
@@ -80,44 +80,39 @@ namespace http2 {
     IDX_SESSION_STATS_COUNT
   };
 
-class Http2State : public BaseObject {
+class Http2State : public BindingDataBase {
  public:
   Http2State(Environment* env, v8::Local<v8::Object> obj)
-    : BaseObject(env, obj),
-      root_buffer(
-        env->isolate(),
-        sizeof(http2_state_internal)),
-      session_state_buffer(
-        env->isolate(),
-        offsetof(http2_state_internal, session_state_buffer),
-        IDX_SESSION_STATE_COUNT,
-        root_buffer),
-      stream_state_buffer(
-        env->isolate(),
-        offsetof(http2_state_internal, stream_state_buffer),
-        IDX_STREAM_STATE_COUNT,
-        root_buffer),
-      stream_stats_buffer(
-        env->isolate(),
-        offsetof(http2_state_internal, stream_stats_buffer),
-        IDX_STREAM_STATS_COUNT,
-        root_buffer),
-      session_stats_buffer(
-        env->isolate(),
-        offsetof(http2_state_internal, session_stats_buffer),
-        IDX_SESSION_STATS_COUNT,
-        root_buffer),
-      options_buffer(
-        env->isolate(),
-        offsetof(http2_state_internal, options_buffer),
-        IDX_OPTIONS_FLAGS + 1,
-        root_buffer),
-      settings_buffer(
-        env->isolate(),
-        offsetof(http2_state_internal, settings_buffer),
-        IDX_SETTINGS_COUNT + 1,
-        root_buffer) {
-  }
+      : BindingDataBase(env, obj),
+        root_buffer(env->isolate(), sizeof(http2_state_internal)),
+        session_state_buffer(
+            env->isolate(),
+            offsetof(http2_state_internal, session_state_buffer),
+            IDX_SESSION_STATE_COUNT,
+            root_buffer),
+        stream_state_buffer(
+            env->isolate(),
+            offsetof(http2_state_internal, stream_state_buffer),
+            IDX_STREAM_STATE_COUNT,
+            root_buffer),
+        stream_stats_buffer(
+            env->isolate(),
+            offsetof(http2_state_internal, stream_stats_buffer),
+            IDX_STREAM_STATS_COUNT,
+            root_buffer),
+        session_stats_buffer(
+            env->isolate(),
+            offsetof(http2_state_internal, session_stats_buffer),
+            IDX_SESSION_STATS_COUNT,
+            root_buffer),
+        options_buffer(env->isolate(),
+                        offsetof(http2_state_internal, options_buffer),
+                        IDX_OPTIONS_FLAGS + 1,
+                        root_buffer),
+        settings_buffer(env->isolate(),
+                        offsetof(http2_state_internal, settings_buffer),
+                        IDX_SETTINGS_COUNT + 1,
+                        root_buffer) {}
 
   AliasedUint8Array root_buffer;
   AliasedFloat64Array session_state_buffer;

--- a/src/node_http2_state.h
+++ b/src/node_http2_state.h
@@ -126,6 +126,8 @@ class Http2State : public BaseObject {
   SET_SELF_SIZE(Http2State)
   SET_MEMORY_INFO_NAME(Http2State)
 
+  static constexpr FastStringKey binding_data_name { "http2" };
+
  private:
   struct http2_state_internal {
     // doubles first so that they are always sizeof(double)-aligned

--- a/src/node_http2_state.h
+++ b/src/node_http2_state.h
@@ -80,10 +80,10 @@ namespace http2 {
     IDX_SESSION_STATS_COUNT
   };
 
-class Http2State : public BindingDataBase {
+class Http2State : public BaseObject {
  public:
   Http2State(Environment* env, v8::Local<v8::Object> obj)
-      : BindingDataBase(env, obj),
+      : BaseObject(env, obj),
         root_buffer(env->isolate(), sizeof(http2_state_internal)),
         session_state_buffer(
             env->isolate(),

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -82,9 +82,10 @@ inline bool IsOWS(char c) {
   return c == ' ' || c == '\t';
 }
 
-class BindingData : public BaseObject {
+class BindingData : public BindingDataBase {
  public:
-  BindingData(Environment* env, Local<Object> obj) : BaseObject(env, obj) {}
+  BindingData(Environment* env, Local<Object> obj)
+      : BindingDataBase(env, obj) {}
 
   std::vector<char> parser_buffer;
   bool parser_buffer_in_use = false;
@@ -444,7 +445,7 @@ class Parser : public AsyncWrap, public StreamListener {
   }
 
   static void New(const FunctionCallbackInfo<Value>& args) {
-    BindingData* binding_data = Unwrap<BindingData>(args.Data());
+    BindingData* binding_data = BindingDataBase::Unwrap<BindingData>(args);
     new Parser(binding_data, args.This());
   }
 
@@ -920,7 +921,7 @@ void InitializeHttpParser(Local<Object> target,
                           Local<Context> context,
                           void* priv) {
   Environment* env = Environment::GetCurrent(context);
-  Environment::BindingScope<BindingData> binding_scope(env);
+  Environment::BindingScope<BindingData> binding_scope(env, context, target);
   if (!binding_scope) return;
 
   Local<FunctionTemplate> t = env->NewFunctionTemplate(Parser::New);

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -82,10 +82,10 @@ inline bool IsOWS(char c) {
   return c == ' ' || c == '\t';
 }
 
-class BindingData : public BindingDataBase {
+class BindingData : public BaseObject {
  public:
   BindingData(Environment* env, Local<Object> obj)
-      : BindingDataBase(env, obj) {}
+      : BaseObject(env, obj) {}
 
   std::vector<char> parser_buffer;
   bool parser_buffer_in_use = false;
@@ -445,7 +445,7 @@ class Parser : public AsyncWrap, public StreamListener {
   }
 
   static void New(const FunctionCallbackInfo<Value>& args) {
-    BindingData* binding_data = BindingDataBase::Unwrap<BindingData>(args);
+    BindingData* binding_data = Environment::GetBindingData<BindingData>(args);
     new Parser(binding_data, args.This());
   }
 
@@ -921,7 +921,7 @@ void InitializeHttpParser(Local<Object> target,
                           Local<Context> context,
                           void* priv) {
   Environment* env = Environment::GetCurrent(context);
-  Environment::BindingScope<BindingData> binding_scope(env, context, target);
+  Environment::BindingScope<BindingData> binding_scope(context, target);
   if (!binding_scope) return;
 
   Local<FunctionTemplate> t = env->NewFunctionTemplate(Parser::New);

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -87,6 +87,8 @@ class BindingData : public BaseObject {
   BindingData(Environment* env, Local<Object> obj)
       : BaseObject(env, obj) {}
 
+  static constexpr FastStringKey binding_data_name { "http_parser" };
+
   std::vector<char> parser_buffer;
   bool parser_buffer_in_use = false;
 
@@ -96,6 +98,9 @@ class BindingData : public BaseObject {
   SET_SELF_SIZE(BindingData)
   SET_MEMORY_INFO_NAME(BindingData)
 };
+
+// TODO(addaleax): Remove once we're on C++17.
+constexpr FastStringKey BindingData::binding_data_name;
 
 // helper class for the Parser
 struct StringPtr {
@@ -921,8 +926,9 @@ void InitializeHttpParser(Local<Object> target,
                           Local<Context> context,
                           void* priv) {
   Environment* env = Environment::GetCurrent(context);
-  Environment::BindingScope<BindingData> binding_scope(context, target);
-  if (!binding_scope) return;
+  BindingData* const binding_data =
+      env->AddBindingData<BindingData>(context, target);
+  if (binding_data == nullptr) return;
 
   Local<FunctionTemplate> t = env->NewFunctionTemplate(Parser::New);
   t->InstanceTemplate()->SetInternalFieldCount(Parser::kInternalFieldCount);

--- a/src/node_native_module_env.cc
+++ b/src/node_native_module_env.cc
@@ -190,7 +190,7 @@ void NativeModuleEnv::Initialize(Local<Object> target,
                     FIXED_ONE_BYTE_STRING(env->isolate(), "moduleCategories"),
                     GetModuleCategories,
                     nullptr,
-                    env->as_callback_data(),
+                    Local<Value>(),
                     DEFAULT,
                     None,
                     SideEffectType::kHasNoSideEffect)

--- a/src/node_native_module_env.cc
+++ b/src/node_native_module_env.cc
@@ -190,7 +190,7 @@ void NativeModuleEnv::Initialize(Local<Object> target,
                     FIXED_ONE_BYTE_STRING(env->isolate(), "moduleCategories"),
                     GetModuleCategories,
                     nullptr,
-                    env->as_callback_data(),
+                    env->default_callback_data(),
                     DEFAULT,
                     None,
                     SideEffectType::kHasNoSideEffect)

--- a/src/node_native_module_env.cc
+++ b/src/node_native_module_env.cc
@@ -190,7 +190,7 @@ void NativeModuleEnv::Initialize(Local<Object> target,
                     FIXED_ONE_BYTE_STRING(env->isolate(), "moduleCategories"),
                     GetModuleCategories,
                     nullptr,
-                    env->default_callback_data(),
+                    env->as_callback_data(),
                     DEFAULT,
                     None,
                     SideEffectType::kHasNoSideEffect)

--- a/src/node_process.h
+++ b/src/node_process.h
@@ -9,7 +9,7 @@ namespace node {
 
 v8::MaybeLocal<v8::Object> CreateEnvVarProxy(v8::Local<v8::Context> context,
                                              v8::Isolate* isolate,
-                                             v8::Local<v8::Object> data);
+                                             v8::Local<v8::Value> data);
 
 // Most of the time, it's best to use `console.error` to write
 // to the process.stderr stream.  However, in some cases, such as

--- a/src/node_process.h
+++ b/src/node_process.h
@@ -8,8 +8,7 @@
 namespace node {
 
 v8::MaybeLocal<v8::Object> CreateEnvVarProxy(v8::Local<v8::Context> context,
-                                             v8::Isolate* isolate,
-                                             v8::Local<v8::Value> data);
+                                             v8::Isolate* isolate);
 
 // Most of the time, it's best to use `console.error` to write
 // to the process.stderr stream.  However, in some cases, such as

--- a/src/node_process_object.cc
+++ b/src/node_process_object.cc
@@ -147,7 +147,7 @@ void PatchProcessObject(const FunctionCallbackInfo<Value>& args) {
                 FIXED_ONE_BYTE_STRING(isolate, "title"),
                 ProcessTitleGetter,
                 env->owns_process_state() ? ProcessTitleSetter : nullptr,
-                env->current_callback_data(),
+                Local<Value>(),
                 DEFAULT,
                 None,
                 SideEffectType::kHasNoSideEffect)
@@ -198,7 +198,7 @@ void PatchProcessObject(const FunctionCallbackInfo<Value>& args) {
                           FIXED_ONE_BYTE_STRING(isolate, "debugPort"),
                           DebugPortGetter,
                           env->owns_process_state() ? DebugPortSetter : nullptr,
-                          env->current_callback_data())
+                          Local<Value>())
             .FromJust());
 }
 

--- a/src/node_stat_watcher.cc
+++ b/src/node_stat_watcher.cc
@@ -95,7 +95,8 @@ void StatWatcher::Callback(uv_fs_poll_t* handle,
 
 void StatWatcher::New(const FunctionCallbackInfo<Value>& args) {
   CHECK(args.IsConstructCall());
-  fs::BindingData* binding_data = Unwrap<fs::BindingData>(args.Data());
+  fs::BindingData* binding_data =
+      BindingDataBase::Unwrap<fs::BindingData>(args);
   new StatWatcher(binding_data, args.This(), args[0]->IsTrue());
 }
 

--- a/src/node_stat_watcher.cc
+++ b/src/node_stat_watcher.cc
@@ -96,7 +96,7 @@ void StatWatcher::Callback(uv_fs_poll_t* handle,
 void StatWatcher::New(const FunctionCallbackInfo<Value>& args) {
   CHECK(args.IsConstructCall());
   fs::BindingData* binding_data =
-      BindingDataBase::Unwrap<fs::BindingData>(args);
+      Environment::GetBindingData<fs::BindingData>(args);
   new StatWatcher(binding_data, args.This(), args[0]->IsTrue());
 }
 

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -86,10 +86,10 @@ static const size_t kHeapCodeStatisticsPropertiesCount =
     HEAP_CODE_STATISTICS_PROPERTIES(V);
 #undef V
 
-class BindingData : public BindingDataBase {
+class BindingData : public BaseObject {
  public:
   BindingData(Environment* env, Local<Object> obj)
-      : BindingDataBase(env, obj),
+      : BaseObject(env, obj),
         heap_statistics_buffer(env->isolate(), kHeapStatisticsPropertiesCount),
         heap_space_statistics_buffer(env->isolate(),
                                      kHeapSpaceStatisticsPropertiesCount),
@@ -121,7 +121,7 @@ void CachedDataVersionTag(const FunctionCallbackInfo<Value>& args) {
 }
 
 void UpdateHeapStatisticsBuffer(const FunctionCallbackInfo<Value>& args) {
-  BindingData* data = BindingDataBase::Unwrap<BindingData>(args);
+  BindingData* data = Environment::GetBindingData<BindingData>(args);
   HeapStatistics s;
   args.GetIsolate()->GetHeapStatistics(&s);
   AliasedFloat64Array& buffer = data->heap_statistics_buffer;
@@ -132,7 +132,7 @@ void UpdateHeapStatisticsBuffer(const FunctionCallbackInfo<Value>& args) {
 
 
 void UpdateHeapSpaceStatisticsBuffer(const FunctionCallbackInfo<Value>& args) {
-  BindingData* data = BindingDataBase::Unwrap<BindingData>(args);
+  BindingData* data = Environment::GetBindingData<BindingData>(args);
   HeapSpaceStatistics s;
   Isolate* const isolate = args.GetIsolate();
   CHECK(args[0]->IsUint32());
@@ -147,7 +147,7 @@ void UpdateHeapSpaceStatisticsBuffer(const FunctionCallbackInfo<Value>& args) {
 }
 
 void UpdateHeapCodeStatisticsBuffer(const FunctionCallbackInfo<Value>& args) {
-  BindingData* data = BindingDataBase::Unwrap<BindingData>(args);
+  BindingData* data = Environment::GetBindingData<BindingData>(args);
   HeapCodeStatistics s;
   args.GetIsolate()->GetHeapCodeAndMetadataStatistics(&s);
   AliasedFloat64Array& buffer = data->heap_code_statistics_buffer;
@@ -170,7 +170,7 @@ void Initialize(Local<Object> target,
                 Local<Context> context,
                 void* priv) {
   Environment* env = Environment::GetCurrent(context);
-  Environment::BindingScope<BindingData> binding_scope(env, context, target);
+  Environment::BindingScope<BindingData> binding_scope(context, target);
   if (!binding_scope) return;
   BindingData* binding_data = binding_scope.data;
 

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -96,6 +96,8 @@ class BindingData : public BaseObject {
         heap_code_statistics_buffer(env->isolate(),
                                     kHeapCodeStatisticsPropertiesCount) {}
 
+  static constexpr FastStringKey binding_data_name { "v8" };
+
   AliasedFloat64Array heap_statistics_buffer;
   AliasedFloat64Array heap_space_statistics_buffer;
   AliasedFloat64Array heap_code_statistics_buffer;
@@ -111,6 +113,8 @@ class BindingData : public BaseObject {
   SET_MEMORY_INFO_NAME(BindingData)
 };
 
+// TODO(addaleax): Remove once we're on C++17.
+constexpr FastStringKey BindingData::binding_data_name;
 
 void CachedDataVersionTag(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
@@ -170,9 +174,9 @@ void Initialize(Local<Object> target,
                 Local<Context> context,
                 void* priv) {
   Environment* env = Environment::GetCurrent(context);
-  Environment::BindingScope<BindingData> binding_scope(context, target);
-  if (!binding_scope) return;
-  BindingData* binding_data = binding_scope.data;
+  BindingData* const binding_data =
+      env->AddBindingData<BindingData>(context, target);
+  if (binding_data == nullptr) return;
 
   env->SetMethodNoSideEffect(target, "cachedDataVersionTag",
                              CachedDataVersionTag);

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -86,10 +86,10 @@ static const size_t kHeapCodeStatisticsPropertiesCount =
     HEAP_CODE_STATISTICS_PROPERTIES(V);
 #undef V
 
-class BindingData : public BaseObject {
+class BindingData : public BindingDataBase {
  public:
   BindingData(Environment* env, Local<Object> obj)
-      : BaseObject(env, obj),
+      : BindingDataBase(env, obj),
         heap_statistics_buffer(env->isolate(), kHeapStatisticsPropertiesCount),
         heap_space_statistics_buffer(env->isolate(),
                                      kHeapSpaceStatisticsPropertiesCount),
@@ -121,7 +121,7 @@ void CachedDataVersionTag(const FunctionCallbackInfo<Value>& args) {
 }
 
 void UpdateHeapStatisticsBuffer(const FunctionCallbackInfo<Value>& args) {
-  BindingData* data = Unwrap<BindingData>(args.Data());
+  BindingData* data = BindingDataBase::Unwrap<BindingData>(args);
   HeapStatistics s;
   args.GetIsolate()->GetHeapStatistics(&s);
   AliasedFloat64Array& buffer = data->heap_statistics_buffer;
@@ -132,7 +132,7 @@ void UpdateHeapStatisticsBuffer(const FunctionCallbackInfo<Value>& args) {
 
 
 void UpdateHeapSpaceStatisticsBuffer(const FunctionCallbackInfo<Value>& args) {
-  BindingData* data = Unwrap<BindingData>(args.Data());
+  BindingData* data = BindingDataBase::Unwrap<BindingData>(args);
   HeapSpaceStatistics s;
   Isolate* const isolate = args.GetIsolate();
   CHECK(args[0]->IsUint32());
@@ -147,7 +147,7 @@ void UpdateHeapSpaceStatisticsBuffer(const FunctionCallbackInfo<Value>& args) {
 }
 
 void UpdateHeapCodeStatisticsBuffer(const FunctionCallbackInfo<Value>& args) {
-  BindingData* data = Unwrap<BindingData>(args.Data());
+  BindingData* data = BindingDataBase::Unwrap<BindingData>(args);
   HeapCodeStatistics s;
   args.GetIsolate()->GetHeapCodeAndMetadataStatistics(&s);
   AliasedFloat64Array& buffer = data->heap_code_statistics_buffer;
@@ -170,7 +170,7 @@ void Initialize(Local<Object> target,
                 Local<Context> context,
                 void* priv) {
   Environment* env = Environment::GetCurrent(context);
-  Environment::BindingScope<BindingData> binding_scope(env);
+  Environment::BindingScope<BindingData> binding_scope(env, context, target);
   if (!binding_scope) return;
   BindingData* binding_data = binding_scope.data;
 

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -142,7 +142,7 @@ Local<FunctionTemplate> LibuvStreamWrap::GetConstructorTemplate(
     Local<FunctionTemplate> get_write_queue_size =
         FunctionTemplate::New(env->isolate(),
                               GetWriteQueueSize,
-                              env->current_callback_data(),
+                              Local<Value>(),
                               Signature::New(env->isolate(), tmpl));
     tmpl->PrototypeTemplate()->SetAccessorProperty(
         env->write_queue_size_string(),

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -1276,7 +1276,7 @@ void TLSWrap::Initialize(Local<Object> target,
   Local<FunctionTemplate> get_write_queue_size =
       FunctionTemplate::New(env->isolate(),
                             GetWriteQueueSize,
-                            env->current_callback_data(),
+                            Local<Value>(),
                             Signature::New(env->isolate(), t));
   t->PrototypeTemplate()->SetAccessorProperty(
       env->write_queue_size_string(),

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -145,7 +145,7 @@ void UDPWrap::Initialize(Local<Object> target,
   Local<FunctionTemplate> get_fd_templ =
       FunctionTemplate::New(env->isolate(),
                             UDPWrap::GetFD,
-                            env->current_callback_data(),
+                            Local<Value>(),
                             signature);
 
   t->PrototypeTemplate()->SetAccessorProperty(env->fd_string(),

--- a/src/util-inl.h
+++ b/src/util-inl.h
@@ -533,6 +533,37 @@ inline bool IsSafeJsInt(v8::Local<v8::Value> v) {
   return false;
 }
 
+constexpr size_t FastStringKey::HashImpl(const char* str) {
+  // Low-quality hash (djb2), but just fine for current use cases.
+  size_t h = 5381;
+  do {
+    h = h * 33 + *str;  // NOLINT(readability/pointer_notation)
+  } while (*(str++) != '\0');
+  return h;
+}
+
+constexpr size_t FastStringKey::Hash::operator()(
+    const FastStringKey& key) const {
+  return key.cached_hash_;
+}
+
+constexpr bool FastStringKey::operator==(const FastStringKey& other) const {
+  const char* p1 = name_;
+  const char* p2 = other.name_;
+  if (p1 == p2) return true;
+  do {
+    if (*p1 != *p2) return false;
+  } while (*(p1++) != '\0');
+  return true;
+}
+
+constexpr FastStringKey::FastStringKey(const char* name)
+  : name_(name), cached_hash_(HashImpl(name)) {}
+
+constexpr const char* FastStringKey::c_str() const {
+  return name_;
+}
+
 }  // namespace node
 
 #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS

--- a/src/util-inl.h
+++ b/src/util-inl.h
@@ -552,8 +552,8 @@ constexpr bool FastStringKey::operator==(const FastStringKey& other) const {
   const char* p2 = other.name_;
   if (p1 == p2) return true;
   do {
-    if (*p1 != *p2) return false;
-  } while (*(p1++) != '\0');
+    if (*(p1++) != *(p2++)) return false;
+  } while (*p1 != '\0');
   return true;
 }
 

--- a/src/util.h
+++ b/src/util.h
@@ -764,6 +764,27 @@ class PersistentToLocal {
   }
 };
 
+// Can be used as a key for std::unordered_map when lookup performance is more
+// important than size and the keys are statically used to avoid redundant hash
+// computations.
+class FastStringKey {
+ public:
+  constexpr explicit FastStringKey(const char* name);
+
+  struct Hash {
+    constexpr size_t operator()(const FastStringKey& key) const;
+  };
+  constexpr bool operator==(const FastStringKey& other) const;
+
+  constexpr const char* c_str() const;
+
+ private:
+  static constexpr size_t HashImpl(const char* str);
+
+  const char* name_;
+  size_t cached_hash_;
+};
+
 }  // namespace node
 
 #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS


### PR DESCRIPTION
This is mostly taken from the common subset of #32761 and #32984, with a few modifications on top of it (notably, `BindingData` does not make sense as a class any longer and can be replaced by `BaseObject` directly).

---

Instead of passing them through the data bound to function
templates, store references to them in a list embedded inside
the context, and store the integer index
(which is context-independent) in the function template data.
This makes the function templates more context-independent,
and makes it possible to embed binding data in non-main contexts.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
