### PR TITLE
src: separate owning and non-owning AliasedBuffers

### DIFF
--- a/src/aliased_buffer.h
+++ b/src/aliased_buffer.h
@@ -9,6 +9,18 @@
 
 namespace node {
 
+template <class NativeT,
+          class V8T,
+          // SFINAE NativeT to be scalar
+          typename Trait = std::enable_if_t<std::is_scalar<NativeT>::value>>
+class OwningAliasedBufferBase;
+
+template <class NativeT,
+          class V8T,
+          // SFINAE NativeT to be scalar
+          typename Trait = std::enable_if_t<std::is_scalar<NativeT>::value>>
+class AliasedBufferViewBase;
+
 /**
  * Do not use this class directly when creating instances of it - use the
  * Aliased*Array defined at the end of this file instead.
@@ -26,83 +38,9 @@ namespace node {
  * The encapsulation herein provides a placeholder where such writes can be
  * observed. Any notification APIs will be left as a future exercise.
  */
-template <class NativeT,
-          class V8T,
-          // SFINAE NativeT to be scalar
-          typename = std::enable_if_t<std::is_scalar<NativeT>::value>>
+template <class NativeT, class V8T>
 class AliasedBufferBase {
  public:
-  AliasedBufferBase(v8::Isolate* isolate, const size_t count)
-      : isolate_(isolate), count_(count), byte_offset_(0) {
-    CHECK_GT(count, 0);
-    const v8::HandleScope handle_scope(isolate_);
-    const size_t size_in_bytes =
-        MultiplyWithOverflowCheck(sizeof(NativeT), count);
-
-    // allocate v8 ArrayBuffer
-    v8::Local<v8::ArrayBuffer> ab = v8::ArrayBuffer::New(
-        isolate_, size_in_bytes);
-    buffer_ = static_cast<NativeT*>(ab->GetBackingStore()->Data());
-
-    // allocate v8 TypedArray
-    v8::Local<V8T> js_array = V8T::New(ab, byte_offset_, count);
-    js_array_ = v8::Global<V8T>(isolate, js_array);
-  }
-
-  /**
-   * Create an AliasedBufferBase over a sub-region of another aliased buffer.
-   * The two will share a v8::ArrayBuffer instance &
-   * a native buffer, but will each read/write to different sections of the
-   * native buffer.
-   *
-   *  Note that byte_offset must by aligned by sizeof(NativeT).
-   */
-  // TODO(refack): refactor into a non-owning `AliasedBufferBaseView`
-  AliasedBufferBase(
-      v8::Isolate* isolate,
-      const size_t byte_offset,
-      const size_t count,
-      const AliasedBufferBase<uint8_t, v8::Uint8Array>& backing_buffer)
-      : isolate_(isolate), count_(count), byte_offset_(byte_offset) {
-    const v8::HandleScope handle_scope(isolate_);
-
-    v8::Local<v8::ArrayBuffer> ab = backing_buffer.GetArrayBuffer();
-
-    // validate that the byte_offset is aligned with sizeof(NativeT)
-    CHECK_EQ(byte_offset & (sizeof(NativeT) - 1), 0);
-    // validate this fits inside the backing buffer
-    CHECK_LE(MultiplyWithOverflowCheck(sizeof(NativeT), count),
-             ab->ByteLength() - byte_offset);
-
-    buffer_ = reinterpret_cast<NativeT*>(
-        const_cast<uint8_t*>(backing_buffer.GetNativeBuffer() + byte_offset));
-
-    v8::Local<V8T> js_array = V8T::New(ab, byte_offset, count);
-    js_array_ = v8::Global<V8T>(isolate, js_array);
-  }
-
-  AliasedBufferBase(const AliasedBufferBase& that)
-      : isolate_(that.isolate_),
-        count_(that.count_),
-        byte_offset_(that.byte_offset_),
-        buffer_(that.buffer_) {
-    js_array_ = v8::Global<V8T>(that.isolate_, that.GetJSArray());
-  }
-
-  AliasedBufferBase& operator=(AliasedBufferBase&& that) noexcept {
-    this->~AliasedBufferBase();
-    isolate_ = that.isolate_;
-    count_ = that.count_;
-    byte_offset_ = that.byte_offset_;
-    buffer_ = that.buffer_;
-
-    js_array_.Reset(isolate_, that.js_array_.Get(isolate_));
-
-    that.buffer_ = nullptr;
-    that.js_array_.Reset();
-    return *this;
-  }
-
   /**
    * Helper class that is returned from operator[] to support assignment into
    * a specified location.
@@ -212,50 +150,133 @@ class AliasedBufferBase {
     return count_;
   }
 
-  // Should only be used to extend the array.
-  // Should only be used on an owning array, not one created as a sub array of
-  // an owning `AliasedBufferBase`.
-  void reserve(size_t new_capacity) {
-    DCHECK_GE(new_capacity, count_);
-    DCHECK_EQ(byte_offset_, 0);
-    const v8::HandleScope handle_scope(isolate_);
-
-    const size_t old_size_in_bytes = sizeof(NativeT) * count_;
-    const size_t new_size_in_bytes = MultiplyWithOverflowCheck(sizeof(NativeT),
-                                                              new_capacity);
-
-    // allocate v8 new ArrayBuffer
-    v8::Local<v8::ArrayBuffer> ab = v8::ArrayBuffer::New(
-        isolate_, new_size_in_bytes);
-
-    // allocate new native buffer
-    NativeT* new_buffer = static_cast<NativeT*>(ab->GetBackingStore()->Data());
-    // copy old content
-    memcpy(new_buffer, buffer_, old_size_in_bytes);
-
-    // allocate v8 TypedArray
-    v8::Local<V8T> js_array = V8T::New(ab, byte_offset_, new_capacity);
-
-    // move over old v8 TypedArray
-    js_array_ = std::move(v8::Global<V8T>(isolate_, js_array));
-
-    buffer_ = new_buffer;
-    count_ = new_capacity;
-  }
+  friend class OwningAliasedBufferBase<NativeT, V8T>;
+  friend class AliasedBufferViewBase<NativeT, V8T>;
 
  private:
+  AliasedBufferBase(v8::Isolate* isolate, const size_t count)
+      : isolate_(isolate), count_(count) {}
+
   v8::Isolate* isolate_;
   size_t count_;
-  size_t byte_offset_;
   NativeT* buffer_;
   v8::Global<V8T> js_array_;
 };
 
-typedef AliasedBufferBase<int32_t, v8::Int32Array> AliasedInt32Array;
-typedef AliasedBufferBase<uint8_t, v8::Uint8Array> AliasedUint8Array;
-typedef AliasedBufferBase<uint32_t, v8::Uint32Array> AliasedUint32Array;
-typedef AliasedBufferBase<double, v8::Float64Array> AliasedFloat64Array;
-typedef AliasedBufferBase<uint64_t, v8::BigUint64Array> AliasedBigUint64Array;
+template <class NativeT, class V8T, typename Trait>
+class OwningAliasedBufferBase : public AliasedBufferBase<NativeT, V8T> {
+  typedef AliasedBufferBase<NativeT, V8T> BaseType;
+
+ public:
+  OwningAliasedBufferBase(v8::Isolate* isolate, const size_t count)
+      : BaseType(isolate, count) {
+    CHECK_GT(count, 0);
+    const v8::HandleScope handle_scope(isolate);
+    const size_t size_in_bytes =
+        MultiplyWithOverflowCheck(sizeof(NativeT), count);
+
+    // allocate v8 ArrayBuffer
+    v8::Local<v8::ArrayBuffer> ab =
+        v8::ArrayBuffer::New(isolate, size_in_bytes);
+    BaseType::buffer_ = static_cast<NativeT*>(ab->GetBackingStore()->Data());
+
+    // allocate v8 TypedArray
+    v8::Local<V8T> js_array = V8T::New(ab, 0, count);
+    BaseType::js_array_ = v8::Global<V8T>(isolate, js_array);
+  }
+
+  // Should only be used to extend the array.
+  void reserve(size_t new_capacity) {
+    size_t count = BaseType::count_;
+    v8::Isolate* isolate = BaseType::isolate_;
+    DCHECK_GE(new_capacity, count);
+    const v8::HandleScope handle_scope(isolate);
+
+    const size_t old_size_in_bytes = sizeof(NativeT) * count;
+    const size_t new_size_in_bytes = MultiplyWithOverflowCheck(sizeof(NativeT),
+                                                              new_capacity);
+
+    // allocate v8 new ArrayBuffer
+    v8::Local<v8::ArrayBuffer> ab =
+        v8::ArrayBuffer::New(isolate, new_size_in_bytes);
+
+    // allocate new native buffer
+    NativeT* new_buffer = static_cast<NativeT*>(ab->GetBackingStore()->Data());
+    // copy old content
+    memcpy(new_buffer, BaseType::buffer_, old_size_in_bytes);
+
+    // allocate v8 TypedArray
+    v8::Local<V8T> js_array = V8T::New(ab, 0, new_capacity);
+
+    // move over old v8 TypedArray
+    BaseType::js_array_ = std::move(v8::Global<V8T>(isolate, js_array));
+
+    BaseType::buffer_ = new_buffer;
+    BaseType::count_ = new_capacity;
+  }
+  OwningAliasedBufferBase(const OwningAliasedBufferBase&) = delete;
+  OwningAliasedBufferBase& operator=(const OwningAliasedBufferBase&) = delete;
+  OwningAliasedBufferBase(OwningAliasedBufferBase&&) = delete;
+  OwningAliasedBufferBase& operator=(OwningAliasedBufferBase&&) = delete;
+};
+
+/**
+ * Create an AliasedBufferViewBase over a sub-region of another
+ * AliasedBufferBase. The two will share a v8::ArrayBuffer instance &
+ * a native buffer, but will each read/write to different sections of the
+ * native buffer.
+ *
+ *  Note that byte_offset must by aligned by sizeof(NativeT).
+ */
+template <class NativeT, class V8T, typename Trait>
+class AliasedBufferViewBase : public AliasedBufferBase<NativeT, V8T> {
+  typedef AliasedBufferBase<NativeT, V8T> BaseType;
+
+ public:
+  AliasedBufferViewBase(
+      v8::Isolate* isolate,
+      const size_t byte_offset,
+      const size_t count,
+      const AliasedBufferBase<uint8_t, v8::Uint8Array>& backing_buffer)
+      : BaseType(isolate, count), byte_offset_(byte_offset) {
+    const v8::HandleScope handle_scope(isolate);
+
+    v8::Local<v8::ArrayBuffer> ab = backing_buffer.GetArrayBuffer();
+
+    // validate that the byte_offset is aligned with sizeof(NativeT)
+    CHECK_EQ(byte_offset & (sizeof(NativeT) - 1), 0);
+    // validate this fits inside the backing buffer
+    CHECK_LE(MultiplyWithOverflowCheck(sizeof(NativeT), count),
+             ab->ByteLength() - byte_offset);
+
+    BaseType::buffer_ = reinterpret_cast<NativeT*>(
+        const_cast<uint8_t*>(backing_buffer.GetNativeBuffer() + byte_offset));
+
+    v8::Local<V8T> js_array = V8T::New(ab, byte_offset, count);
+    BaseType::js_array_ = v8::Global<V8T>(isolate, js_array);
+  }
+
+  AliasedBufferViewBase(const AliasedBufferViewBase&) = delete;
+  AliasedBufferViewBase& operator=(const AliasedBufferViewBase&) = delete;
+  AliasedBufferViewBase(AliasedBufferViewBase&&) = delete;
+  AliasedBufferViewBase& operator=(AliasedBufferViewBase&&) = delete;
+
+ private:
+  size_t byte_offset_;
+};
+
+#define ALIASED_BUFFER_TYPES(V)                                                \
+  V(uint8_t, Uint8Array)                                                       \
+  V(int32_t, Int32Array)                                                       \
+  V(uint32_t, Uint32Array)                                                     \
+  V(double, Float64Array)                                                      \
+  V(uint64_t, BigUint64Array)
+
+#define V(NativeT, V8T)                                                        \
+  typedef OwningAliasedBufferBase<NativeT, v8::V8T> OwningAliased##V8T;        \
+  typedef AliasedBufferViewBase<NativeT, v8::V8T> Aliased##V8T##View;
+ALIASED_BUFFER_TYPES(V)
+#undef V
 }  // namespace node
 
 #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -100,15 +100,15 @@ inline AsyncHooks::AsyncHooks()
   // context during bootstrap (code that runs before entering uv_run()).
   async_id_fields_[AsyncHooks::kAsyncIdCounter] = 1;
 }
-inline AliasedUint32Array& AsyncHooks::fields() {
+inline OwningAliasedUint32Array& AsyncHooks::fields() {
   return fields_;
 }
 
-inline AliasedFloat64Array& AsyncHooks::async_id_fields() {
+inline OwningAliasedFloat64Array& AsyncHooks::async_id_fields() {
   return async_id_fields_;
 }
 
-inline AliasedFloat64Array& AsyncHooks::async_ids_stack() {
+inline OwningAliasedFloat64Array& AsyncHooks::async_ids_stack() {
   return async_ids_stack_;
 }
 
@@ -241,7 +241,7 @@ inline void Environment::PopAsyncCallbackScope() {
 inline ImmediateInfo::ImmediateInfo(v8::Isolate* isolate)
     : fields_(isolate, kFieldsCount) {}
 
-inline AliasedUint32Array& ImmediateInfo::fields() {
+inline OwningAliasedUint32Array& ImmediateInfo::fields() {
   return fields_;
 }
 
@@ -268,7 +268,7 @@ inline void ImmediateInfo::ref_count_dec(uint32_t decrement) {
 inline TickInfo::TickInfo(v8::Isolate* isolate)
     : fields_(isolate, kFieldsCount) {}
 
-inline AliasedUint8Array& TickInfo::fields() {
+inline OwningAliasedUint8Array& TickInfo::fields() {
   return fields_;
 }
 
@@ -507,11 +507,12 @@ inline void Environment::set_abort_on_uncaught_exception(bool value) {
   options_->abort_on_uncaught_exception = value;
 }
 
-inline AliasedUint32Array& Environment::should_abort_on_uncaught_toggle() {
+inline OwningAliasedUint32Array&
+Environment::should_abort_on_uncaught_toggle() {
   return should_abort_on_uncaught_toggle_;
 }
 
-inline AliasedInt32Array& Environment::stream_base_state() {
+inline OwningAliasedInt32Array& Environment::stream_base_state() {
   return stream_base_state_;
 }
 

--- a/src/env.h
+++ b/src/env.h
@@ -647,9 +647,9 @@ class AsyncHooks : public MemoryRetainer {
     kUidFieldsCount,
   };
 
-  inline AliasedUint32Array& fields();
-  inline AliasedFloat64Array& async_id_fields();
-  inline AliasedFloat64Array& async_ids_stack();
+  inline OwningAliasedUint32Array& fields();
+  inline OwningAliasedFloat64Array& async_id_fields();
+  inline OwningAliasedFloat64Array& async_ids_stack();
   inline v8::Local<v8::Array> execution_async_resources();
 
   inline v8::Local<v8::String> provider_string(int idx);
@@ -694,12 +694,12 @@ class AsyncHooks : public MemoryRetainer {
   friend class Environment;  // So we can call the constructor.
   inline AsyncHooks();
   // Stores the ids of the current execution context stack.
-  AliasedFloat64Array async_ids_stack_;
+  OwningAliasedFloat64Array async_ids_stack_;
   // Attached to a Uint32Array that tracks the number of active hooks for
   // each type.
-  AliasedUint32Array fields_;
+  OwningAliasedUint32Array fields_;
   // Attached to a Float64Array that tracks the state of async resources.
-  AliasedFloat64Array async_id_fields_;
+  OwningAliasedFloat64Array async_id_fields_;
 
   void grow_async_ids_stack();
 
@@ -708,7 +708,7 @@ class AsyncHooks : public MemoryRetainer {
 
 class ImmediateInfo : public MemoryRetainer {
  public:
-  inline AliasedUint32Array& fields();
+  inline OwningAliasedUint32Array& fields();
   inline uint32_t count() const;
   inline uint32_t ref_count() const;
   inline bool has_outstanding() const;
@@ -731,12 +731,12 @@ class ImmediateInfo : public MemoryRetainer {
 
   enum Fields { kCount, kRefCount, kHasOutstanding, kFieldsCount };
 
-  AliasedUint32Array fields_;
+  OwningAliasedUint32Array fields_;
 };
 
 class TickInfo : public MemoryRetainer {
  public:
-  inline AliasedUint8Array& fields();
+  inline OwningAliasedUint8Array& fields();
   inline bool has_tick_scheduled() const;
   inline bool has_rejection_to_warn() const;
 
@@ -756,7 +756,7 @@ class TickInfo : public MemoryRetainer {
 
   enum Fields { kHasTickScheduled = 0, kHasRejectionToWarn, kFieldsCount };
 
-  AliasedUint8Array fields_;
+  OwningAliasedUint8Array fields_;
 };
 
 class TrackingTraceStateObserver :
@@ -977,9 +977,9 @@ class Environment : public MemoryRetainer {
   // This is a pseudo-boolean that keeps track of whether an uncaught exception
   // should abort the process or not if --abort-on-uncaught-exception was
   // passed to Node. If the flag was not passed, it is ignored.
-  inline AliasedUint32Array& should_abort_on_uncaught_toggle();
+  inline OwningAliasedUint32Array& should_abort_on_uncaught_toggle();
 
-  inline AliasedInt32Array& stream_base_state();
+  inline OwningAliasedInt32Array& stream_base_state();
 
   // The necessary API for async_hooks.
   inline double new_async_id();
@@ -1315,12 +1315,12 @@ class Environment : public MemoryRetainer {
   uint32_t script_id_counter_ = 0;
   uint32_t function_id_counter_ = 0;
 
-  AliasedUint32Array should_abort_on_uncaught_toggle_;
+  OwningAliasedUint32Array should_abort_on_uncaught_toggle_;
   int should_not_abort_scope_counter_ = 0;
 
   std::unique_ptr<TrackingTraceStateObserver> trace_state_observer_;
 
-  AliasedInt32Array stream_base_state_;
+  OwningAliasedInt32Array stream_base_state_;
 
   std::unique_ptr<performance::PerformanceState> performance_state_;
   std::unordered_map<std::string, uint64_t> performance_marks_;

--- a/src/node_file-inl.h
+++ b/src/node_file-inl.h
@@ -231,9 +231,11 @@ FSReqBase* GetReqWrap(const v8::FunctionCallbackInfo<v8::Value>& args,
   Environment* env = binding_data->env();
   if (value->StrictEquals(env->fs_use_promises_symbol())) {
     if (use_bigint) {
-      return FSReqPromise<AliasedBigUint64Array>::New(binding_data, use_bigint);
+      return FSReqPromise<OwningAliasedBigUint64Array>::New(binding_data,
+                                                            use_bigint);
     } else {
-      return FSReqPromise<AliasedFloat64Array>::New(binding_data, use_bigint);
+      return FSReqPromise<OwningAliasedFloat64Array>::New(binding_data,
+                                                          use_bigint);
     }
   }
   return nullptr;

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -20,8 +20,8 @@ class BindingData : public BaseObject {
       stats_field_array(env->isolate(), kFsStatsBufferLength),
       stats_field_bigint_array(env->isolate(), kFsStatsBufferLength) {}
 
-  AliasedFloat64Array stats_field_array;
-  AliasedBigUint64Array stats_field_bigint_array;
+  OwningAliasedFloat64Array stats_field_array;
+  OwningAliasedBigUint64Array stats_field_bigint_array;
 
   std::vector<BaseObjectPtr<FileHandleReadWrap>>
       file_handle_read_wrap_freelist;

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -49,7 +49,7 @@ namespace {
 const char zero_bytes_256[256] = {};
 
 bool HasHttp2Observer(Environment* env) {
-  AliasedUint32Array& observers = env->performance_state()->observers;
+  AliasedUint32ArrayView& observers = env->performance_state()->observers;
   return observers[performance::NODE_PERFORMANCE_ENTRY_TYPE_HTTP2] != 0;
 }
 
@@ -122,7 +122,7 @@ Http2Options::Http2Options(Http2State* http2_state, SessionType type) {
     nghttp2_option_set_builtin_recv_extension_type(option, NGHTTP2_ORIGIN);
   }
 
-  AliasedUint32Array& buffer = http2_state->options_buffer;
+  AliasedUint32ArrayView& buffer = http2_state->options_buffer;
   uint32_t flags = buffer[IDX_OPTIONS_FLAGS];
 
   if (flags & (1 << IDX_OPTIONS_MAX_DEFLATE_DYNAMIC_TABLE_SIZE)) {
@@ -208,7 +208,7 @@ Http2Options::Http2Options(Http2State* http2_state, SessionType type) {
 size_t Http2Settings::Init(
     Http2State* http2_state,
     nghttp2_settings_entry* entries) {
-  AliasedUint32Array& buffer = http2_state->settings_buffer;
+  AliasedUint32ArrayView& buffer = http2_state->settings_buffer;
   uint32_t flags = buffer[IDX_SETTINGS_COUNT];
 
   size_t count = 0;
@@ -277,7 +277,7 @@ Local<Value> Http2Settings::Pack(
 // Updates the shared TypedArray with the current remote or local settings for
 // the session.
 void Http2Settings::Update(Http2Session* session, get_setting fn) {
-  AliasedUint32Array& buffer = session->http2_state()->settings_buffer;
+  AliasedUint32ArrayView& buffer = session->http2_state()->settings_buffer;
 
 #define V(name)                                                                \
   buffer[IDX_SETTINGS_ ## name] =                                              \
@@ -288,7 +288,7 @@ void Http2Settings::Update(Http2Session* session, get_setting fn) {
 
 // Initializes the shared TypedArray with the default settings values.
 void Http2Settings::RefreshDefaults(Http2State* http2_state) {
-  AliasedUint32Array& buffer = http2_state->settings_buffer;
+  AliasedUint32ArrayView& buffer = http2_state->settings_buffer;
   uint32_t flags = 0;
 
 #define V(name)                                                            \
@@ -546,7 +546,7 @@ void Http2Stream::EmitStatistics() {
     if (!HasHttp2Observer(env))
       return;
     HandleScope handle_scope(env->isolate());
-    AliasedFloat64Array& buffer = entry->http2_state()->stream_stats_buffer;
+    AliasedFloat64ArrayView& buffer = entry->http2_state()->stream_stats_buffer;
     buffer[IDX_STREAM_STATS_ID] = entry->id();
     if (entry->first_byte() != 0) {
       buffer[IDX_STREAM_STATS_TIMETOFIRSTBYTE] =
@@ -584,7 +584,8 @@ void Http2Session::EmitStatistics() {
     if (!HasHttp2Observer(env))
       return;
     HandleScope handle_scope(env->isolate());
-    AliasedFloat64Array& buffer = entry->http2_state()->session_stats_buffer;
+    AliasedFloat64ArrayView& buffer =
+        entry->http2_state()->session_stats_buffer;
     buffer[IDX_SESSION_STATS_TYPE] = entry->type();
     buffer[IDX_SESSION_STATS_PINGRTT] = entry->ping_rtt() / 1e6;
     buffer[IDX_SESSION_STATS_FRAMESRECEIVED] = entry->frame_count();
@@ -2396,7 +2397,8 @@ void Http2Session::RefreshState(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
   Debug(session, "refreshing state");
 
-  AliasedFloat64Array& buffer = session->http2_state()->session_state_buffer;
+  AliasedFloat64ArrayView& buffer =
+      session->http2_state()->session_state_buffer;
 
   nghttp2_session* s = session->session();
 
@@ -2658,7 +2660,7 @@ void Http2Stream::RefreshState(const FunctionCallbackInfo<Value>& args) {
   Debug(stream, "refreshing state");
 
   CHECK_NOT_NULL(stream->session());
-  AliasedFloat64Array& buffer =
+  AliasedFloat64ArrayView& buffer =
       stream->session()->http2_state()->stream_state_buffer;
 
   nghttp2_stream* str = stream->stream();

--- a/src/node_http2_state.h
+++ b/src/node_http2_state.h
@@ -119,13 +119,13 @@ class Http2State : public BaseObject {
         root_buffer) {
   }
 
-  AliasedUint8Array root_buffer;
-  AliasedFloat64Array session_state_buffer;
-  AliasedFloat64Array stream_state_buffer;
-  AliasedFloat64Array stream_stats_buffer;
-  AliasedFloat64Array session_stats_buffer;
-  AliasedUint32Array options_buffer;
-  AliasedUint32Array settings_buffer;
+  OwningAliasedUint8Array root_buffer;
+  AliasedFloat64ArrayView session_state_buffer;
+  AliasedFloat64ArrayView stream_state_buffer;
+  AliasedFloat64ArrayView stream_stats_buffer;
+  AliasedFloat64ArrayView session_stats_buffer;
+  AliasedUint32ArrayView options_buffer;
+  AliasedUint32ArrayView settings_buffer;
 
   void MemoryInfo(MemoryTracker* tracker) const override;
   SET_SELF_SIZE(Http2State)

--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -116,7 +116,7 @@ void PerformanceEntry::Notify(Environment* env,
                               PerformanceEntryType type,
                               Local<Value> object) {
   Context::Scope scope(env->context());
-  AliasedUint32Array& observers = env->performance_state()->observers;
+  AliasedUint32ArrayView& observers = env->performance_state()->observers;
   if (type != NODE_PERFORMANCE_ENTRY_TYPE_INVALID &&
       observers[type]) {
     node::MakeCallback(env->isolate(),
@@ -173,7 +173,7 @@ void Measure(const FunctionCallbackInfo<Value>& args) {
   Utf8Value name(env->isolate(), args[0]);
   Utf8Value startMark(env->isolate(), args[1]);
 
-  AliasedFloat64Array& milestones = env->performance_state()->milestones;
+  AliasedFloat64ArrayView& milestones = env->performance_state()->milestones;
 
   uint64_t startTimestamp = timeOrigin;
   uint64_t start = GetPerformanceMark(env, *startMark);
@@ -239,7 +239,7 @@ void PerformanceGCCallback(Environment* env,
   HandleScope scope(env->isolate());
   Local<Context> context = env->context();
 
-  AliasedUint32Array& observers = env->performance_state()->observers;
+  AliasedUint32ArrayView& observers = env->performance_state()->observers;
   if (observers[NODE_PERFORMANCE_ENTRY_TYPE_GC]) {
     Local<Object> obj;
     if (!entry->ToObject().ToLocal(&obj)) return;
@@ -361,7 +361,7 @@ void TimerFunctionCall(const FunctionCallbackInfo<Value>& args) {
     return;
   args.GetReturnValue().Set(ret.ToLocalChecked());
 
-  AliasedUint32Array& observers = env->performance_state()->observers;
+  AliasedUint32ArrayView& observers = env->performance_state()->observers;
   if (!observers[NODE_PERFORMANCE_ENTRY_TYPE_FUNCTION])
     return;
 
@@ -392,7 +392,7 @@ void Notify(const FunctionCallbackInfo<Value>& args) {
   Utf8Value type(env->isolate(), args[0]);
   Local<Value> entry = args[1];
   PerformanceEntryType entry_type = ToPerformanceEntryTypeEnum(*type);
-  AliasedUint32Array& observers = env->performance_state()->observers;
+  AliasedUint32ArrayView& observers = env->performance_state()->observers;
   if (entry_type != NODE_PERFORMANCE_ENTRY_TYPE_INVALID &&
       observers[entry_type]) {
     USE(env->performance_entry_callback()->

--- a/src/node_perf_common.h
+++ b/src/node_perf_common.h
@@ -72,9 +72,9 @@ class PerformanceState {
       milestones[i] = -1.;
   }
 
-  AliasedUint8Array root;
-  AliasedFloat64Array milestones;
-  AliasedUint32Array observers;
+  OwningAliasedUint8Array root;
+  AliasedFloat64ArrayView milestones;
+  AliasedUint32ArrayView observers;
 
   uint64_t performance_last_gc_start_mark = 0;
 

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -96,9 +96,9 @@ class BindingData : public BaseObject {
         heap_code_statistics_buffer(env->isolate(),
                                     kHeapCodeStatisticsPropertiesCount) {}
 
-  AliasedFloat64Array heap_statistics_buffer;
-  AliasedFloat64Array heap_space_statistics_buffer;
-  AliasedFloat64Array heap_code_statistics_buffer;
+  OwningAliasedFloat64Array heap_statistics_buffer;
+  OwningAliasedFloat64Array heap_space_statistics_buffer;
+  OwningAliasedFloat64Array heap_code_statistics_buffer;
 
   void MemoryInfo(MemoryTracker* tracker) const override {
     tracker->TrackField("heap_statistics_buffer", heap_statistics_buffer);
@@ -124,7 +124,7 @@ void UpdateHeapStatisticsBuffer(const FunctionCallbackInfo<Value>& args) {
   BindingData* data = Unwrap<BindingData>(args.Data());
   HeapStatistics s;
   args.GetIsolate()->GetHeapStatistics(&s);
-  AliasedFloat64Array& buffer = data->heap_statistics_buffer;
+  OwningAliasedFloat64Array& buffer = data->heap_statistics_buffer;
 #define V(index, name, _) buffer[index] = static_cast<double>(s.name());
   HEAP_STATISTICS_PROPERTIES(V)
 #undef V
@@ -139,7 +139,7 @@ void UpdateHeapSpaceStatisticsBuffer(const FunctionCallbackInfo<Value>& args) {
   size_t space_index = static_cast<size_t>(args[0].As<v8::Uint32>()->Value());
   isolate->GetHeapSpaceStatistics(&s, space_index);
 
-  AliasedFloat64Array& buffer = data->heap_space_statistics_buffer;
+  OwningAliasedFloat64Array& buffer = data->heap_space_statistics_buffer;
 
 #define V(index, name, _) buffer[index] = static_cast<double>(s.name());
   HEAP_SPACE_STATISTICS_PROPERTIES(V)
@@ -150,7 +150,7 @@ void UpdateHeapCodeStatisticsBuffer(const FunctionCallbackInfo<Value>& args) {
   BindingData* data = Unwrap<BindingData>(args.Data());
   HeapCodeStatistics s;
   args.GetIsolate()->GetHeapCodeAndMetadataStatistics(&s);
-  AliasedFloat64Array& buffer = data->heap_code_statistics_buffer;
+  OwningAliasedFloat64Array& buffer = data->heap_code_statistics_buffer;
 
 #define V(index, name, _) buffer[index] = static_cast<double>(s.name());
   HEAP_CODE_STATISTICS_PROPERTIES(V)

--- a/test/abort/test_abort-aliased-buffer-overflow/binding.cc
+++ b/test/abort/test_abort-aliased-buffer-overflow/binding.cc
@@ -10,7 +10,7 @@ void AllocateAndResizeBuffer(
     v8::Isolate* isolate = args.GetIsolate();
     int64_t length = args[0].As<v8::BigInt>()->Int64Value();
 
-     node::AliasedBigUint64Array array{isolate, 0};
+    node::OwningAliasedBigUint64Array array{isolate, 0};
 
     array.reserve(length);
     assert(false);


### PR DESCRIPTION
Move the reserve() method into an owning variant of AliasedBuffer,
and split the two constructors to different classes to make the
contract explicit instead of relying on run time CHECKs.
Also deletes unused assignment operator and copy/move
constructors to make sure they don't get copied by accident.

This addresses a TODO in aliased_buffer.h

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
