### PR TITLE
http: don't throw on `Uint8Array`s for `http.ServerResponse#write`

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -63,7 +63,7 @@ const {
   hideStackFrames
 } = require('internal/errors');
 const { validateString } = require('internal/validators');
-const{ isUint8Array } = require('internal/util/types');
+const { isUint8Array } = require('internal/util/types');
 
 const HIGH_WATER_MARK = getDefaultHighWaterMark();
 const { CRLF, debug } = common;

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -63,6 +63,7 @@ const {
   hideStackFrames
 } = require('internal/errors');
 const { validateString } = require('internal/validators');
+const{ isUint8Array } = require('internal/util/types');
 
 const HIGH_WATER_MARK = getDefaultHighWaterMark();
 const { CRLF, debug } = common;
@@ -672,7 +673,7 @@ function write_(msg, chunk, encoding, callback, fromEnd) {
     throw new ERR_STREAM_NULL_VALUES();
   } else if (typeof chunk === 'string') {
     len = Buffer.byteLength(chunk, encoding);
-  } else if (chunk instanceof Buffer) {
+  } else if (isUint8Array(chunk)) {
     len = chunk.length;
   } else {
     throw new ERR_INVALID_ARG_TYPE(

--- a/test/parallel/test-http-outgoing-write-types.js
+++ b/test/parallel/test-http-outgoing-write-types.js
@@ -1,0 +1,24 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+const httpServer = http.createServer(common.mustCall(function(req, res) {
+  httpServer.close();
+  assert.throws(() => {
+    res.write(['Throws.']);
+  }, {
+    code: 'ERR_INVALID_ARG_TYPE'
+  });
+  // should not throw
+  res.write('1a2b3c');
+  // should not throw
+  res.write(new Uint8Array(1024));
+  // should not throw
+  res.write(Buffer.from('1'.repeat(1024)));
+  res.end();
+}));
+
+httpServer.listen(0, common.mustCall(function() {
+  http.get({ port: this.address().port });
+}));


### PR DESCRIPTION
Same as https://github.com/nodejs/node/pull/33146/ but for `write`

Refs: https://github.com/nodejs/node/issues/29829
Fixes: https://github.com/nodejs/node/issues/33379
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
