### PR TITLE
http: free parser on keepalive

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -409,7 +409,6 @@ function socketCloseListener() {
 
   // NOTE: It's important to get parser here, because it could be freed by
   // the `socketOnData`.
-  const parser = socket.parser;
   const res = req.res;
   if (res) {
     // Socket closed before we emitted 'end' below.
@@ -443,10 +442,7 @@ function socketCloseListener() {
   if (req.outputData)
     req.outputData.length = 0;
 
-  if (parser) {
-    parser.finish();
-    freeParser(parser, req, socket);
-  }
+  freeSocket(req, socket);
 }
 
 function socketErrorListener(err) {
@@ -461,11 +457,7 @@ function socketErrorListener(err) {
     req.emit('error', err);
   }
 
-  const parser = socket.parser;
-  if (parser) {
-    parser.finish();
-    freeParser(parser, req, socket);
-  }
+  freeSocket(req, socket);
 
   // Ensure that no further data will come out of the socket
   socket.removeListener('data', socketOnData);
@@ -476,7 +468,6 @@ function socketErrorListener(err) {
 function socketOnEnd() {
   const socket = this;
   const req = this._httpMessage;
-  const parser = this.parser;
 
   if (!req.res && !req.socket._hadError) {
     // If we don't have a response then we know that the socket
@@ -484,10 +475,7 @@ function socketOnEnd() {
     req.socket._hadError = true;
     req.emit('error', connResetException('socket hang up'));
   }
-  if (parser) {
-    parser.finish();
-    freeParser(parser, req, socket);
-  }
+  freeSocket(req, this);
   socket.destroy();
 }
 
@@ -519,8 +507,7 @@ function socketOnData(d) {
     if (req.timeoutCb)
       socket.removeListener('timeout', req.timeoutCb);
 
-    parser.finish();
-    freeParser(parser, req, socket);
+    freeSocket(req, this);
 
     const bodyHead = d.slice(bytesParsed, d.length);
 
@@ -712,7 +699,16 @@ function emitFreeNT(req) {
   }
 
   if (req.socket) {
+    freeSocket(req, req.socket);
     req.socket.emit('free');
+  }
+}
+
+function freeSocket(req, socket) {
+  const parser = socket.parser;
+  if (parser) {
+    parser.finish();
+    freeParser(parser, req, socket);
   }
 }
 


### PR DESCRIPTION
Free parser when putting socket back in the agent keep alive free list.
    
Fixes: https://github.com/nodejs/node/issues/29394

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
