### PR TITLE
module: disable ./ restriction for exports RHS

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -1629,8 +1629,8 @@ The resolver can throw the following errors:
 **PACKAGE_EXPORTS_TARGET_RESOLVE**(_packageURL_, _target_, _subpath_, _env_)
 
 > 1. If _target_ is a String, then
->    1. If _target_ does not start with _"./"_ or contains any _"node_modules"_
->       segments including _"node_modules"_ percent-encoding, throw an
+>    1. If _target_ is an empty string or contains any _"node_modules"_ segments
+>       including _"node_modules"_ percent-encoding, throw an
 >       _Invalid Package Target_ error.
 >    1. Let _resolvedTarget_ be the URL resolution of the concatenation of
 >       _packageURL_ and _target_.

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -20,7 +20,6 @@ const {
   ObjectDefineProperty,
   ObjectKeys,
   StringPrototypeSlice,
-  StringPrototypeStartsWith,
   Symbol,
   SymbolFor,
   WeakMap,
@@ -1105,27 +1104,18 @@ E('ERR_INVALID_PACKAGE_CONFIG', (path, message, hasMessage = true) => {
 }, Error);
 E('ERR_INVALID_PACKAGE_TARGET',
   (pkgPath, key, subpath, target, base = undefined) => {
-    const relError = typeof target === 'string' &&
-      target.length && !StringPrototypeStartsWith(target, './');
     if (key === null) {
       if (subpath !== '') {
         return `Invalid "exports" target ${JSONStringify(target)} defined ` +
         `for '${subpath}' in the package config ${pkgPath} imported from ` +
-        `${base}.${relError ? '; targets must start with "./"' : ''}`;
+        base;
       } else {
         return `Invalid "exports" main target ${target} defined in the ` +
-          `package config ${pkgPath} imported from ${base}${relError ?
-            '; targets must start with "./"' : ''}`;
+          `package config ${pkgPath} imported from ${base}`;
       }
     } else if (key === '.') {
       return `Invalid "exports" main target ${JSONStringify(target)} defined ` +
-      `in the package config ${pkgPath}${sep}package.json${relError ?
-        '; targets must start with "./"' : ''}`;
-    } else if (relError) {
-      return `Invalid "exports" target ${JSONStringify(target)} defined for '${
-        StringPrototypeSlice(key, 0, -subpath.length || key.length)}' in the ` +
-        `package config ${pkgPath}${sep}package.json; ` +
-        'targets must start with "./"';
+      `in the package config ${pkgPath}${sep}package.json`;
     } else {
       return `Invalid "exports" target ${JSONStringify(target)} defined for '${
         StringPrototypeSlice(key, 0, -subpath.length || key.length)}' in the ` +

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -525,19 +525,17 @@ function isArrayIndex(p) {
 
 function resolveExportsTarget(baseUrl, target, subpath, mappingKey) {
   if (typeof target === 'string') {
-    let resolvedTarget, resolvedTargetPath;
     const pkgPathPath = baseUrl.pathname;
-    if (StringPrototypeStartsWith(target, './')) {
-      resolvedTarget = new URL(target, baseUrl);
-      resolvedTargetPath = resolvedTarget.pathname;
-      if (!StringPrototypeStartsWith(resolvedTargetPath, pkgPathPath) ||
-          StringPrototypeIndexOf(resolvedTargetPath, '/node_modules/',
-                                 pkgPathPath.length - 1) !== -1)
-        resolvedTarget = undefined;
-    }
-    if (subpath.length > 0 && target[target.length - 1] !== '/')
-      resolvedTarget = undefined;
-    if (resolvedTarget === undefined)
+    if (target === '')
+      throw new ERR_INVALID_PACKAGE_TARGET(StringPrototypeSlice(baseUrl.pathname
+        , 0, -1), mappingKey, subpath, target);
+    const resolvedTarget =
+        new URL(target.startsWith('./') ? target : './' + target, baseUrl);
+    const resolvedTargetPath = resolvedTarget.pathname;
+    if (!StringPrototypeStartsWith(resolvedTargetPath, pkgPathPath) ||
+        StringPrototypeIndexOf(resolvedTargetPath, '/node_modules/',
+                               pkgPathPath.length - 1) !== -1 ||
+        (subpath.length > 0 && target[target.length - 1] !== '/'))
       throw new ERR_INVALID_PACKAGE_TARGET(StringPrototypeSlice(baseUrl.pathname
         , 0, -1), mappingKey, subpath, target);
     const resolved = new URL(subpath, resolvedTarget);

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -301,12 +301,13 @@ function throwExportsInvalid(
 
 function resolveExportsTargetString(
   target, subpath, match, packageJSONUrl, base) {
-  if (target[0] !== '.' || target[1] !== '/' ||
+  if (target === '' ||
       (subpath !== '' && target[target.length - 1] !== '/')) {
     throwExportsInvalid(match, target, packageJSONUrl, base);
   }
 
-  const resolved = new URL(target, packageJSONUrl);
+  const resolved =
+      new URL(target.startsWith('./') ? target : './' + target, packageJSONUrl);
   const resolvedPath = resolved.pathname;
   const packagePath = new URL('.', packageJSONUrl).pathname;
 

--- a/test/es-module/test-esm-exports.mjs
+++ b/test/es-module/test-esm-exports.mjs
@@ -81,10 +81,8 @@ import fromInside from '../fixtures/node_modules/pkgexports/lib/hole.js';
     ['pkgexports/belowfile', './belowfile'],
     // Invalid targets
     ['pkgexports/invalid2', './invalid2'],
+    // Empty string is invalid
     ['pkgexports/invalid3', './invalid3'],
-    ['pkgexports/invalid5', 'invalid5'],
-    // Missing / invalid fallbacks
-    ['pkgexports/nofallback2', './nofallback2'],
     // Reaching into nested node_modules
     ['pkgexports/nodemodules', './nodemodules'],
     // Self resolve invalid
@@ -135,7 +133,10 @@ import fromInside from '../fixtures/node_modules/pkgexports/lib/hole.js';
 
   const notFoundExports = new Map([
     // Non-existing file
+    ['pkgexports/invalid5', 'pkgexports/invalid5'],
     ['pkgexports/sub/not-a-file.js', 'pkgexports/sub/not-a-file.js'],
+    // Fallback builtin
+    ['pkgexports/nofallback2', 'pkgexports/nofallback2'],
     // No extension lookups
     ['pkgexports/no-ext', 'pkgexports/no-ext'],
   ]);

--- a/test/fixtures/node_modules/pkgexports/package.json
+++ b/test/fixtures/node_modules/pkgexports/package.json
@@ -15,8 +15,8 @@
     "./invalid3": "",
     "./invalid4": {},
     "./invalid5": "invalid5.js",
-    "./fallbackdir/": [[], null, {}, "builtin:x/", "./fallbackfile", "./"],
-    "./fallbackfile": [[], null, {}, "builtin:x", "./asdf.js"],
+    "./fallbackdir/": [[], null, {}, "../builtin:x/", "./fallbackfile", "./"],
+    "./fallbackfile": [[], null, {}, "../builtin:x", "./asdf.js"],
     "./nofallback1": [],
     "./nofallback2": [null, {}, "builtin:x"],
     "./nodemodules": "./node_modules/internalpkg/x.js",
@@ -35,7 +35,7 @@
         "nomatch": "./nothing.js"
       }
     }],
-    "./no-ext": "./asdf",
+    "./no-ext": "asdf",
     "./resolve-self": {
       "require": "./resolve-self.js",
       "import": "./resolve-self.mjs"
@@ -44,6 +44,6 @@
       "require": "./resolve-self-invalid.js",
       "import": "./resolve-self-invalid.mjs"
     },
-    "./subpath/": "./subpath/"
+    "./subpath/": "subpath/"
   }
 }


### PR DESCRIPTION
This PR remove the restriction in `"exports"` that RHS string targets must begin with a `"./"`. In doing so this more closely matches existing entry point definition systems like the `"main"` in that `"./index.js"` and `"index.js"` are equivalent.

There were a few reasons this restriction was originally made:

* Alignment with import maps - they specifically require this `"./"` for target mappings. Bare specifiers on the RHS are reserved for import maps composition use cases.
* Alignment with the browser field - the `"browser"` field permits both package and relative specifiers on the right hand side, using `"./"` as the distinction.
* To allow external package maps in future as opposed to only local - requiring `"./"` reserves a future design space for mapping into other packages using exports.
* To allow URL and builtin mappings - it was also considered that it might be possible to map into a specifier like `"node:fs"` in a fallback, which would provide a conditional polyfill path for builtin modules like import maps originally proposed.
* To allow other syntax variants in future - restricting to `"./"` means we retain the full unicode space open for any new forwards compatibility with future features. We can invent that a specifier must start with say `#` to mean something completely and utterly different when it is resolved or interpreted.

Having started from the widest design space, we are at a position now to decide if we want to restrict it in the name of usability given this isn't necessarily intuitive to users.

Personally I'm still somewhat 50/50 on this, probably leaning towards having it land. Modules are only as good as their adoption and all and I'm not sure there is really yet a killer future feature that is restricted by landing this, that couldn't still be implemented another way since we do still retain space for new syntax under the LHS mapping keys.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
