### PR TITLE
win: allow skipping the supported platform check

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1341,8 +1341,9 @@ Overriding this value to an empty string (`''`) will use the built-in REPL.
 added: REPLACEME
 -->
 
-Skips the check for a supported platform that happens during Node.js startup.
-Using this might lead to issues during execution.
+If `value` equals `'1'`, the check for a supported platform is skipped during
+Node.js startup. Node.js might not execute correctly. Any issues encountered
+on unsupported platforms will not be fixed.
 
 ### `NODE_TLS_REJECT_UNAUTHORIZED=value`
 

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1336,6 +1336,14 @@ added:
 Path to a Node.js module which will be loaded in place of the built-in REPL.
 Overriding this value to an empty string (`''`) will use the built-in REPL.
 
+### `NODE_SKIP_PLATFORM_CHECK=value`
+<!-- YAML
+added: REPLACEME
+-->
+
+Skips the check for a supported platform that happens during Node.js startup.
+Using this might lead to issues during execution.
+
 ### `NODE_TLS_REJECT_UNAUTHORIZED=value`
 
 If `value` equals `'0'`, certificate validation is disabled for TLS connections.

--- a/doc/node.1
+++ b/doc/node.1
@@ -565,6 +565,13 @@ The default path is
 which is overridden by this variable.
 Setting the value to an empty string ("" or " ") will disable persistent REPL history.
 .
+.It Ev NODE_SKIP_PLATFORM_CHECK
+When set to
+.Ar 1 ,
+the check for a supported platform is skipped during Node.js startup.
+Node.js might not execute correctly.
+Any issues encountered on unsupported platforms will not be fixed.
+.
 .It Ev NODE_TLS_REJECT_UNAUTHORIZED
 When set to
 .Ar 0 ,

--- a/src/node_main.cc
+++ b/src/node_main.cc
@@ -40,8 +40,8 @@ int wmain(int argc, wchar_t* wargv[]) {
       (GetEnvironmentVariableA(SKIP_CHECK_VAR, buf, sizeof(buf)) !=
        SKIP_CHECK_SIZE ||
        strncmp(buf, SKIP_CHECK_VALUE, SKIP_CHECK_SIZE + 1) != 0)) {
-    fprintf(stderr, "This application is only supported on Windows 8.1, "
-                    "Windows Server 2012 R2, or\nhigher.\n"
+    fprintf(stderr, "Node.js is only supported on Windows 8.1, Windows "
+                    "Server 2012 R2, or higher.\n"
                     "Setting the " SKIP_CHECK_VAR " environment variable "
                     "to 1 skips this\ncheck, but Node.js might not execute "
                     "correctly. Any issues encountered on\nunsupported "

--- a/src/node_main.cc
+++ b/src/node_main.cc
@@ -28,18 +28,24 @@
 #include <WinError.h>
 
 #define SKIP_CHECK_VAR "NODE_SKIP_PLATFORM_CHECK"
+#define SKIP_CHECK_SIZE 1
+#define SKIP_CHECK_VALUE "1"
 
 int wmain(int argc, wchar_t* wargv[]) {
   // Windows Server 2012 (not R2) is supported until 10/10/2023, so we allow it
   // to run in the experimental support tier.
+  char buf[SKIP_CHECK_SIZE + 1];
   if (!IsWindows8Point1OrGreater() &&
       !(IsWindowsServer() && IsWindows8OrGreater()) &&
-      GetEnvironmentVariableA(SKIP_CHECK_VAR, nullptr, 0) == 0) {
+      (GetEnvironmentVariableA(SKIP_CHECK_VAR, buf, sizeof(buf)) !=
+       SKIP_CHECK_SIZE ||
+       strncmp(buf, SKIP_CHECK_VALUE, SKIP_CHECK_SIZE + 1) != 0)) {
     fprintf(stderr, "This application is only supported on Windows 8.1, "
-                    "Windows Server 2012 R2, or higher.\n"
-                    "If the environment varaible " SKIP_CHECK_VAR
-                    " is defined this check is skipped, but Node.js might "
-                    "not execute correctly.");
+                    "Windows Server 2012 R2, or\nhigher.\n"
+                    "Setting the " SKIP_CHECK_VAR " environment variable "
+                    "to 1 skips this\ncheck, but Node.js might not execute "
+                    "correctly. Any issues encountered on\nunsupported "
+                    "platforms will not be fixed.");
     exit(ERROR_EXE_MACHINE_TYPE_MISMATCH);
   }
 

--- a/src/node_main.cc
+++ b/src/node_main.cc
@@ -27,13 +27,19 @@
 #include <VersionHelpers.h>
 #include <WinError.h>
 
+#define SKIP_CHECK_VAR "NODE_SKIP_PLATFORM_CHECK"
+
 int wmain(int argc, wchar_t* wargv[]) {
   // Windows Server 2012 (not R2) is supported until 10/10/2023, so we allow it
   // to run in the experimental support tier.
   if (!IsWindows8Point1OrGreater() &&
-      !(IsWindowsServer() && IsWindows8OrGreater())) {
+      !(IsWindowsServer() && IsWindows8OrGreater()) &&
+      GetEnvironmentVariableA(SKIP_CHECK_VAR, nullptr, 0) == 0) {
     fprintf(stderr, "This application is only supported on Windows 8.1, "
-                    "Windows Server 2012 R2, or higher.");
+                    "Windows Server 2012 R2, or higher.\n"
+                    "If the environment varaible " SKIP_CHECK_VAR
+                    " is defined this check is skipped, but Node.js might "
+                    "not execute correctly.");
     exit(ERROR_EXE_MACHINE_TYPE_MISMATCH);
   }
 


### PR DESCRIPTION
This is an alternative to https://github.com/nodejs/node/pull/33108, which allows skipping the supported platform check by setting an environment variable. This works when Node is executed as a subprocess, such as when running npm/node-gyp, unless the variable is explicitly filtered out.

The MSI is still blocked on Windows 7, the exe or packaged version should be used to run on that system.

I don't think we should land this on LTS branches right away, but no strong opinion. LTS versions might run without issues until their EOL, so I'm inclined to not land this there for now.

cc @nodejs/platform-windows 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
