### PR TITLE
http: destroy timeout socket by Agent

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -2274,6 +2274,11 @@ removed: v10.0.0
 Used when an invalid character is found in an HTTP response status message
 (reason phrase).
 
+<a id="ERR_HTTP_SOCKET_TIMEOUT"></a>
+### ERR_HTTP_SOCKET_TIMEOUT
+
+A socket timed out, it's triggered by HTTP.
+
 <a id="ERR_INDEX_OUT_OF_RANGE"></a>
 ### `ERR_INDEX_OUT_OF_RANGE`
 <!-- YAML

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -929,6 +929,11 @@ An invalid HTTP header value was specified.
 
 Status code was outside the regular status code range (100-999).
 
+<a id="ERR_HTTP_SOCKET_TIMEOUT"></a>
+### `ERR_HTTP_SOCKET_TIMEOUT`
+
+The request timed out due to inactivity.
+
 <a id="ERR_HTTP_TRAILER_INVALID"></a>
 ### `ERR_HTTP_TRAILER_INVALID`
 

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -861,7 +861,7 @@ Once a socket is assigned to this request and is connected
 [`socket.setTimeout()`][] will be called.
 
 If no `'timeout'` listener is registered the request will error
-with `ERR_HTTP_SOCKET_TIMEOUT`.
+with `ERR_HTTP_SOCKET_TIMEOUT` and the underlying socket will be destroyed.
 
 ### `request.socket`
 <!-- YAML

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -860,6 +860,9 @@ changes:
 Once a socket is assigned to this request and is connected
 [`socket.setTimeout()`][] will be called.
 
+If no `'timeout'` listener is registered the request will error
+with `ERR_HTTP_SOCKET_TIMEOUT`.
+
 ### `request.socket`
 <!-- YAML
 added: v0.3.0

--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -34,6 +34,7 @@ const debug = require('internal/util/debuglog').debuglog('http');
 const { async_id_symbol } = require('internal/async_hooks').symbols;
 const {
   codes: {
+    ERR_HTTP_SOCKET_TIMEOUT,
     ERR_INVALID_ARG_TYPE,
   },
 } = require('internal/errors');
@@ -339,8 +340,13 @@ function installListeners(agent, s, options) {
   function onTimeout() {
     debug('CLIENT socket onTimeout');
 
+    if (s.listenerCount('timeout') === 1) {
+      // No req timeout handler, agent must destroy the socket.
+      s.destroy(new ERR_HTTP_SOCKET_TIMEOUT());
+      return;
+    }
+
     // Destroy if in free list.
-    // TODO(ronag): Always destroy, even if not in free list.
     const sockets = agent.freeSockets;
     for (const name of ObjectKeys(sockets)) {
       if (sockets[name].includes(s)) {

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -915,6 +915,7 @@ E('ERR_HTTP_HEADERS_SENT',
 E('ERR_HTTP_INVALID_HEADER_VALUE',
   'Invalid value "%s" for header "%s"', TypeError);
 E('ERR_HTTP_INVALID_STATUS_CODE', 'Invalid status code: %s', RangeError);
+E('ERR_HTTP_SOCKET_TIMEOUT', 'Socket timeout', Error);
 E('ERR_HTTP_TRAILER_INVALID',
   'Trailers are invalid with this transfer encoding', Error);
 E('ERR_INCOMPATIBLE_OPTION_PAIR',

--- a/test/parallel/test-gc-http-client-timeout.js
+++ b/test/parallel/test-gc-http-client-timeout.js
@@ -5,6 +5,7 @@
 
 const common = require('../common');
 const onGC = require('../common/ongc');
+const assert = require('assert');
 
 function serverHandler(req, res) {
   setTimeout(function() {
@@ -37,6 +38,11 @@ function getall() {
 
   req.setTimeout(10, function() {
     console.log('timeout (expected)');
+  });
+  req.on('error', (err) => {
+    // only allow Socket timeout error
+    assert.strictEqual(err.code, 'ERR_SOCKET_TIMEOUT');
+    assert.strictEqual(err.message, 'Socket timeout');
   });
 
   count++;

--- a/test/parallel/test-gc-http-client-timeout.js
+++ b/test/parallel/test-gc-http-client-timeout.js
@@ -39,7 +39,7 @@ function getall() {
     console.log('timeout (expected)');
   });
   req.on('error', common.expectsError({
-    // Only allow Socket timeout error
+    // Only allow Socket timeout error.
     code: 'ERR_HTTP_SOCKET_TIMEOUT',
     message: 'Socket timeout'
   }));

--- a/test/parallel/test-gc-http-client-timeout.js
+++ b/test/parallel/test-gc-http-client-timeout.js
@@ -39,11 +39,11 @@ function getall() {
   req.setTimeout(10, function() {
     console.log('timeout (expected)');
   });
-  req.on('error', (err) => {
-    // only allow Socket timeout error
-    assert.strictEqual(err.code, 'ERR_SOCKET_TIMEOUT');
-    assert.strictEqual(err.message, 'Socket timeout');
-  });
+  req.on('error', common.expectsError({
+    // Only allow Socket timeout error
+    code: 'ERR_SOCKET_TIMEOUT',
+    message: 'Socket timeout'
+  }));
 
   count++;
   onGC(req, { ongc });

--- a/test/parallel/test-gc-http-client-timeout.js
+++ b/test/parallel/test-gc-http-client-timeout.js
@@ -40,7 +40,7 @@ function getall() {
   });
   req.on('error', common.expectsError({
     // Only allow Socket timeout error
-    code: 'ERR_SOCKET_TIMEOUT',
+    code: 'ERR_HTTP_SOCKET_TIMEOUT',
     message: 'Socket timeout'
   }));
 

--- a/test/parallel/test-gc-http-client-timeout.js
+++ b/test/parallel/test-gc-http-client-timeout.js
@@ -5,7 +5,6 @@
 
 const common = require('../common');
 const onGC = require('../common/ongc');
-const assert = require('assert');
 
 function serverHandler(req, res) {
   setTimeout(function() {

--- a/test/parallel/test-http-agent-timeout.js
+++ b/test/parallel/test-http-agent-timeout.js
@@ -132,3 +132,43 @@ const http = require('http');
       }));
   }));
 }
+
+{
+  // Ensure custom keepSocketAlive timeout is respected
+
+  const CUSTOM_TIMEOUT = 60;
+  const AGENT_TIMEOUT = 50;
+
+  class CustomAgent extends http.Agent {
+    keepSocketAlive(socket) {
+      if (!super.keepSocketAlive(socket)) {
+        return false;
+      }
+
+      socket.setTimeout(CUSTOM_TIMEOUT);
+      return true;
+    }
+  }
+
+  const agent = new CustomAgent({ keepAlive: true, timeout: AGENT_TIMEOUT });
+
+  const server = http.createServer((req, res) => {
+    res.end();
+  });
+
+  server.listen(0, common.mustCall(() => {
+    http.get({ port: server.address().port, agent })
+      .on('response', common.mustCall((res) => {
+        const socket = res.socket;
+        assert(socket);
+        res.resume();
+        socket.on('free', common.mustCall(() => {
+          socket.on('timeout', common.mustCall(() => {
+            assert.strictEqual(socket.timeout, CUSTOM_TIMEOUT);
+            agent.destroy();
+            server.close();
+          }));
+        }));
+      }));
+  }));
+}

--- a/test/sequential/test-http-custom-timeout-handler.js
+++ b/test/sequential/test-http-custom-timeout-handler.js
@@ -1,0 +1,26 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+const server = http.createServer(common.mustCall((req, res) => {
+  server.close();
+  // do nothing, wait client socket timeout and close
+}));
+
+server.listen(0, common.mustCall(() => {
+  const agent = new http.Agent({ timeout: 100 });
+  const req = http.get({
+    path: '/',
+    port: server.address().port,
+    timeout: 50,
+    agent
+  }, common.mustNotCall())
+  .on('error', common.mustCall((err) => {
+    assert.strictEqual(err.message, 'socket hang up');
+    assert.strictEqual(err.code, 'ECONNRESET');
+  }));
+  req.on('timeout', common.mustCall(() => {
+    req.abort();
+  }));
+}));

--- a/test/sequential/test-http-custom-timeout-handler.js
+++ b/test/sequential/test-http-custom-timeout-handler.js
@@ -5,7 +5,8 @@ const http = require('http');
 
 const server = http.createServer(common.mustCall((req, res) => {
   server.close();
-  // do nothing, wait client socket timeout and close
+  // Do nothing, just wait for the client socket timeout and close the
+  // connection.
 }));
 
 server.listen(0, common.mustCall(() => {
@@ -16,9 +17,9 @@ server.listen(0, common.mustCall(() => {
     timeout: 50,
     agent
   }, common.mustNotCall())
-  .on('error', common.mustCall((err) => {
-    assert.strictEqual(err.message, 'socket hang up');
-    assert.strictEqual(err.code, 'ECONNRESET');
+  .on('error', common.expectsError({
+    message: 'socket hang up',
+    code: 'ECONNRESET'
   }));
   req.on('timeout', common.mustCall(() => {
     req.abort();

--- a/test/sequential/test-http-custom-timeout-handler.js
+++ b/test/sequential/test-http-custom-timeout-handler.js
@@ -1,6 +1,5 @@
 'use strict';
 const common = require('../common');
-const assert = require('assert');
 const http = require('http');
 
 const server = http.createServer(common.mustCall((req, res) => {

--- a/test/sequential/test-http-default-timeout-handler.js
+++ b/test/sequential/test-http-default-timeout-handler.js
@@ -1,0 +1,29 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+const server = http.createServer(common.mustCall((req, res) => {
+  server.close();
+  // do nothing, wait client socket timeout and close
+}));
+
+server.listen(0, common.mustCall(() => {
+  let req;
+  const timer = setTimeout(() => {
+    req.abort();
+    assert.fail('should not timeout here');
+  }, 100);
+
+  const agent = new http.Agent({ timeout: 50 });
+  req = http.get({
+    path: '/',
+    port: server.address().port,
+    agent
+  }, common.mustNotCall())
+  .on('error', common.mustCall((err) => {
+    clearTimeout(timer);
+    assert.strictEqual(err.message, 'Socket timeout');
+    assert.strictEqual(err.code, 'ERR_HTTP_SOCKET_TIMEOUT');
+  }));
+}));

--- a/test/sequential/test-http-default-timeout-handler.js
+++ b/test/sequential/test-http-default-timeout-handler.js
@@ -14,7 +14,7 @@ server.listen(0, common.mustCall(() => {
   const timer = setTimeout(() => {
     req.abort();
     assert.fail('should not timeout here');
-  }, 100);
+  }, 1000);
 
   const agent = new http.Agent({ timeout: 50 });
   req = http.get({

--- a/test/sequential/test-http-default-timeout-handler.js
+++ b/test/sequential/test-http-default-timeout-handler.js
@@ -5,7 +5,8 @@ const http = require('http');
 
 const server = http.createServer(common.mustCall((req, res) => {
   server.close();
-  // do nothing, wait client socket timeout and close
+  // Do nothing, just wait for the client socket timeout and close the
+  // connection.
 }));
 
 server.listen(0, common.mustCall(() => {

--- a/test/sequential/test-http-default-timeout-handler.js
+++ b/test/sequential/test-http-default-timeout-handler.js
@@ -10,20 +10,13 @@ const server = http.createServer(common.mustCall((req, res) => {
 }));
 
 server.listen(0, common.mustCall(() => {
-  let req;
-  const timer = setTimeout(() => {
-    req.abort();
-    assert.fail('should not timeout here');
-  }, 1000);
-
   const agent = new http.Agent({ timeout: 50 });
-  req = http.get({
+  http.get({
     path: '/',
     port: server.address().port,
     agent
   }, common.mustNotCall())
   .on('error', common.mustCall((err) => {
-    clearTimeout(timer);
     assert.strictEqual(err.message, 'Socket timeout');
     assert.strictEqual(err.code, 'ERR_HTTP_SOCKET_TIMEOUT');
   }));

--- a/test/sequential/test-http-request-on-free-socket-timeout.js
+++ b/test/sequential/test-http-request-on-free-socket-timeout.js
@@ -1,0 +1,52 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+const server = http.createServer(common.mustCallAtLeast((req, res) => {
+  const content = 'Hello Agent';
+  res.writeHead(200, {
+    'Content-Length': content.length.toString(),
+  });
+  res.write(content);
+  res.end();
+}, 2));
+
+server.listen(0, common.mustCall(() => {
+  const agent = new http.Agent({ timeout: 100, keepAlive: true });
+  const req = http.get({
+    path: '/',
+    port: server.address().port,
+    agent
+  }, common.mustCall((res) => {
+    assert.strictEqual(res.statusCode, 200);
+    res.resume();
+    res.on('end', common.mustCall());
+  }));
+
+  const timer = setTimeout(() => {
+    assert.fail('should not timeout here');
+    req.abort();
+  }, 1000);
+
+  req.on('socket', common.mustCall((socket) => {
+    // wait free socket become free and timeout
+    socket.on('timeout', common.mustCall(() => {
+      // free socket should be destroyed
+      assert.strictEqual(socket.writable, false);
+      // send new request will be fails
+      clearTimeout(timer);
+      const newReq = http.get({
+        path: '/',
+        port: server.address().port,
+        agent
+      }, common.mustCall((res) => {
+        // agent must create a new socket to handle request
+        assert.notStrictEqual(newReq.socket, socket);
+        assert.strictEqual(res.statusCode, 200);
+        res.resume();
+        res.on('end', common.mustCall(() => server.close()));
+      }));
+    }));
+  }));
+}));

--- a/test/sequential/test-http-request-on-free-socket-timeout.js
+++ b/test/sequential/test-http-request-on-free-socket-timeout.js
@@ -30,11 +30,10 @@ server.listen(0, common.mustCall(() => {
   }, 1000);
 
   req.on('socket', common.mustCall((socket) => {
-    // wait free socket become free and timeout
     socket.on('timeout', common.mustCall(() => {
       // free socket should be destroyed
       assert.strictEqual(socket.writable, false);
-      // send new request will be fails
+      // Sending new requests will fail
       clearTimeout(timer);
       const newReq = http.get({
         path: '/',

--- a/test/sequential/test-http-request-on-free-socket-timeout.js
+++ b/test/sequential/test-http-request-on-free-socket-timeout.js
@@ -33,7 +33,6 @@ server.listen(0, common.mustCall(() => {
     socket.on('timeout', common.mustCall(() => {
       // Free socket should be destroyed
       assert.strictEqual(socket.writable, false);
-      // Sending new requests will fail
       clearTimeout(timer);
       const newReq = http.get({
         path: '/',

--- a/test/sequential/test-http-request-on-free-socket-timeout.js
+++ b/test/sequential/test-http-request-on-free-socket-timeout.js
@@ -31,7 +31,7 @@ server.listen(0, common.mustCall(() => {
 
   req.on('socket', common.mustCall((socket) => {
     socket.on('timeout', common.mustCall(() => {
-      // free socket should be destroyed
+      // Free socket should be destroyed
       assert.strictEqual(socket.writable, false);
       // Sending new requests will fail
       clearTimeout(timer);
@@ -40,7 +40,7 @@ server.listen(0, common.mustCall(() => {
         port: server.address().port,
         agent
       }, common.mustCall((res) => {
-        // agent must create a new socket to handle request
+        // Agent must create a new socket to handle request
         assert.notStrictEqual(newReq.socket, socket);
         assert.strictEqual(res.statusCode, 200);
         res.resume();


### PR DESCRIPTION
Agent must destroy timeout socket when there is no any timeout
handler. Avoid socket hang on forever when the server don't send
any response back.

This is a try at landing https://github.com/nodejs/node/pull/23752 which has become stale.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
