### PR TITLE
doc: update napi_async_init documentation

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -4674,6 +4674,11 @@ napi_status napi_async_init(napi_env env,
 * `[in] env`: The environment that the API is invoked under.
 * `[in] async_resource`: Object associated with the async work
   that will be passed to possible `async_hooks` [`init` hooks][].
+  In order to retain ABI compatibility with previous versions,
+  passing `NULL` for `async_resource` will not result in an error, however,
+  this will result incorrect operation of async hooks for the
+  napi_async_context created. Potential issues include
+  loss of async context when using the AsyncLocalStorage API.
 * `[in] async_resource_name`: Identifier for the kind of resource
   that is being provided for diagnostic information exposed by the
   `async_hooks` API.

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -4684,7 +4684,7 @@ Returns `napi_ok` if the API succeeded.
 In order to retain ABI compatibility with previous versions,
 passing `NULL` for `async_resource` will not result in an error, however,
 this will result incorrect operation of async hooks for the
-napi_async_context created. Potential issues include include
+napi_async_context created. Potential issues include
 loss of async context when using the AsyncLocalStorage API.
 
 ### napi_async_destroy

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -4672,7 +4672,7 @@ napi_status napi_async_init(napi_env env,
 ```
 
 * `[in] env`: The environment that the API is invoked under.
-* `[in] async_resource`: An optional object associated with the async work
+* `[in] async_resource`: Object associated with the async work
   that will be passed to possible `async_hooks` [`init` hooks][].
 * `[in] async_resource_name`: Identifier for the kind of resource
   that is being provided for diagnostic information exposed by the
@@ -4680,6 +4680,12 @@ napi_status napi_async_init(napi_env env,
 * `[out] result`: The initialized async context.
 
 Returns `napi_ok` if the API succeeded.
+
+In order to retain ABI compatibility with previous versions,
+passing `NULL` for `async_resource` will not result in an error, however,
+this will result incorrect operation of async hooks for the
+napi_async_context created. Potential issues include include
+loss of async context when using the AsyncLocalStorage API.
 
 ### napi_async_destroy
 <!-- YAML

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -4686,12 +4686,6 @@ napi_status napi_async_init(napi_env env,
 
 Returns `napi_ok` if the API succeeded.
 
-In order to retain ABI compatibility with previous versions,
-passing `NULL` for `async_resource` will not result in an error, however,
-this will result incorrect operation of async hooks for the
-napi_async_context created. Potential issues include
-loss of async context when using the AsyncLocalStorage API.
-
 ### napi_async_destroy
 <!-- YAML
 added: v8.6.0


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/33153

Change documentation to make async_resource required
as opposed to optional in napi-async_init.

Changes over time mean this parameter is required for
proper operation of async hooks (which are still experimental).
This changes the documentation to document what
callers should do. We are doing this only in the doc
in order to avoid a breaking change in N-API. We could
create a new version of the method for which the
parametrer is enforced as mandatory but we should only
do that once async hooks is no longer experimental. In
that case we could deprecate (but not remove this version
of the method).

Signed-off-by: Michael Dawson <michael_dawson@ca.ibm.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
