### PR TITLE
http2: avoid `Object.create(null)` for `Http2ServerRequest.headers`

### DIFF
--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -288,7 +288,7 @@ class Http2ServerRequest extends Readable {
       didRead: false,
     };
     // headers in HTTP/1 are not initialized using Object.create(null)
-    // which, although preferable, simply breaks too much code.
+    // which, although preferable, would simply break too much code.
     // Ergo, header initialization using Object.create(null) in HTTP/2
     // is intentional.
     this[kHeaders] = headers;

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -287,7 +287,7 @@ class Http2ServerRequest extends Readable {
       closed: false,
       didRead: false,
     };
-    // headers in HTTP/1 are not initialized using Object.create(null) which,
+    // Headers in HTTP/1 are not initialized using Object.create(null) which,
     // although preferable, would simply break too much code. Ergo header
     // initialization using Object.create(null) in HTTP/2 is intentional.
     this[kHeaders] = headers;

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -287,10 +287,9 @@ class Http2ServerRequest extends Readable {
       closed: false,
       didRead: false,
     };
-    // headers in HTTP/1 are not initialized using Object.create(null)
-    // which, although preferable, would simply break too much code.
-    // Ergo, header initialization using Object.create(null) in HTTP/2
-    // is intentional.
+    // headers in HTTP/1 are not initialized using Object.create(null) which,
+    // although preferable, would simply break too much code. Ergo header
+    // initialization using Object.create(null) in HTTP/2 is intentional.
     this[kHeaders] = headers;
     this[kRawHeaders] = rawHeaders;
     this[kTrailers] = {};

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -287,6 +287,10 @@ class Http2ServerRequest extends Readable {
       closed: false,
       didRead: false,
     };
+    // headers in HTTP/1 are not initialized using Object.create(null)
+    // which, although preferable, simply breaks too much code.
+    // Ergo, header initialization using Object.create(null) in HTTP/2
+    // is intentional.
     this[kHeaders] = headers;
     this[kRawHeaders] = rawHeaders;
     this[kTrailers] = {};


### PR DESCRIPTION
Currently http2.Http2ServerRequest.headers returns headers which is initialized by Object.create(null) which is a different behaviour than what is seen in http.

Refs: https://github.com/nodejs/node/issues/29829
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
