### PR TITLE
wasi: avoid hard crash if start() is never called

### DIFF
--- a/src/node_wasi.cc
+++ b/src/node_wasi.cc
@@ -1791,11 +1791,11 @@ uvwasi_errno_t WASI::backingStore(char** store, size_t* byte_length) {
   Local<Object> memory = PersistentToLocal::Strong(this->memory_);
   Local<Value> prop;
 
-  if (!memory->Get(env->context(), env->buffer_string()).ToLocal(&prop))
+  if (this->memory_.IsEmpty() ||
+      !memory->Get(env->context(), env->buffer_string()).ToLocal(&prop) ||
+      !prop->IsArrayBuffer()) {
     return UVWASI_EINVAL;
-
-  if (!prop->IsArrayBuffer())
-    return UVWASI_EINVAL;
+  }
 
   Local<ArrayBuffer> ab = prop.As<ArrayBuffer>();
   std::shared_ptr<BackingStore> backing_store = ab->GetBackingStore();

--- a/test/wasi/test-no-start-call.js
+++ b/test/wasi/test-no-start-call.js
@@ -1,0 +1,35 @@
+'use strict';
+const common = require('../common');
+
+if (process.argv[2] === 'child') {
+  (async () => {
+    const fs = require('fs');
+    const path = require('path');
+    const { WASI } = require('wasi');
+    const wasmDir = path.join(__dirname, 'wasm');
+    const modulePath = path.join(wasmDir, 'main_args.wasm');
+    const buffer = fs.readFileSync(modulePath);
+    const wasi = new WASI();
+    const importObject = { wasi_snapshot_preview1: wasi.wasiImport };
+    const { instance } = await WebAssembly.instantiate(buffer, importObject);
+
+    // Verify that calling the _start() export instead of start() does not
+    // crash. The application will fail with a non-zero exit code.
+    instance.exports._start();
+  })().then(common.mustCall());
+} else {
+  const assert = require('assert');
+  const { spawnSync } = require('child_process');
+  const child = spawnSync(process.execPath, [
+    '--experimental-wasi-unstable-preview1',
+    '--experimental-wasm-bigint',
+    '--no-warnings',
+    __filename,
+    'child'
+  ]);
+
+  assert.strictEqual(child.stdout.toString(), '');
+  assert.strictEqual(child.stderr.toString(), '');
+  assert.strictEqual(child.signal, null);
+  assert.notStrictEqual(child.status, 0);
+}


### PR DESCRIPTION
Prior to this commit, calling the WebAssembly instance's `_start()`
export directly would hard crash the process because the memory
was never configured. This commit adds an additional check that
the memory is usable. With this commit, calling `_start()` directly
will still lead to WASI exiting with a non-zero exit code, but
Node does not crash.

Fixes: https://github.com/nodejs/node/issues/33175

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)