### PR TITLE
test: add tests for options.fs in fs streams

### DIFF
--- a/test/parallel/test-fs-stream-fs-options.js
+++ b/test/parallel/test-fs-stream-fs-options.js
@@ -1,0 +1,73 @@
+'use strict';
+
+require('../common');
+const fixtures = require('../common/fixtures');
+const path = require('path');
+const fs = require('fs');
+const assert = require('assert');
+
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+
+const streamOpts = ['open', 'close'];
+const writeStreamOptions = [...streamOpts, 'write'];
+const readStreamOptions = [...streamOpts, 'read'];
+const originalFs = { fs };
+
+{
+  const file = path.join(tmpdir.path, 'write-end-test0.txt');
+
+  writeStreamOptions.forEach((fn) => {
+    const overrideFs = Object.assign({}, originalFs.fs, { [fn]: null });
+    if (fn === 'write') overrideFs.writev = null;
+
+    const opts = {
+      fs: overrideFs
+    };
+    assert.throws(
+      () => fs.createWriteStream(file, opts), {
+        code: 'ERR_INVALID_ARG_TYPE',
+        name: 'TypeError',
+        message: `The "options.fs.${fn}" property must be of type function. ` +
+        'Received null'
+      },
+      `createWriteStream options.fs.${fn} should throw if isn't a function`
+    );
+  });
+}
+
+{
+  const file = path.join(tmpdir.path, 'write-end-test0.txt');
+  const overrideFs = Object.assign({}, originalFs.fs, { writev: 'not a fn' });
+  const opts = {
+    fs: overrideFs
+  };
+  assert.throws(
+    () => fs.createWriteStream(file, opts), {
+      code: 'ERR_INVALID_ARG_TYPE',
+      name: 'TypeError',
+      message: 'The "options.fs.writev" property must be of type function. ' +
+        'Received type string (\'not a fn\')'
+    },
+    'createWriteStream options.fs.writev should throw if isn\'t a function'
+  );
+}
+
+{
+  const file = fixtures.path('x.txt');
+  readStreamOptions.forEach((fn) => {
+    const overrideFs = Object.assign({}, originalFs.fs, { [fn]: null });
+    const opts = {
+      fs: overrideFs
+    };
+    assert.throws(
+      () => fs.createReadStream(file, opts), {
+        code: 'ERR_INVALID_ARG_TYPE',
+        name: 'TypeError',
+        message: `The "options.fs.${fn}" property must be of type function. ` +
+        'Received null'
+      },
+      `createReadStream options.fs.${fn} should throw if isn't a function`
+    );
+  });
+}


### PR DESCRIPTION
This add tests for the new `options.fs` override methods in the `fs` Stream operations

##### Checklist
- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)