### PR TITLE
http2: [compat api] use `Object.create(null)` for `getHeaders`

### DIFF
--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -3,6 +3,7 @@
 const {
   ArrayIsArray,
   Boolean,
+  Object,
   ObjectAssign,
   ObjectCreate,
   ObjectKeys,
@@ -552,7 +553,9 @@ class Http2ServerResponse extends Stream {
   }
 
   getHeaders() {
-    return this[kHeaders];
+    const headers = Object.create(null);
+    Object.assign(headers, this[kHeaders]);
+    return headers;
   }
 
   hasHeader(name) {

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -3,7 +3,6 @@
 const {
   ArrayIsArray,
   Boolean,
-  Object,
   ObjectAssign,
   ObjectCreate,
   ObjectKeys,
@@ -553,8 +552,8 @@ class Http2ServerResponse extends Stream {
   }
 
   getHeaders() {
-    const headers = Object.create(null);
-    Object.assign(headers, this[kHeaders]);
+    const headers = ObjectCreate(null);
+    ObjectAssign(headers, this[kHeaders]);
     return headers;
   }
 

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -552,7 +552,7 @@ class Http2ServerResponse extends Stream {
   }
 
   getHeaders() {
-    return { ...this[kHeaders] };
+    return this[kHeaders];
   }
 
   hasHeader(name) {

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -553,8 +553,7 @@ class Http2ServerResponse extends Stream {
 
   getHeaders() {
     const headers = ObjectCreate(null);
-    ObjectAssign(headers, this[kHeaders]);
-    return headers;
+    return ObjectAssign(headers, this[kHeaders]);
   }
 
   hasHeader(name) {

--- a/test/parallel/test-http2-compat-serverresponse-headers.js
+++ b/test/parallel/test-http2-compat-serverresponse-headers.js
@@ -102,11 +102,12 @@ server.listen(0, common.mustCall(function() {
     response.setHeader(real, expectedValue);
     const expectedHeaderNames = [real];
     assert.deepStrictEqual(response.getHeaderNames(), expectedHeaderNames);
-    const expectedHeaders = { [real]: expectedValue };
+    const expectedHeaders = Object.create(null);
+    expectedHeaders[real] = expectedValue;
     assert.deepStrictEqual(response.getHeaders(), expectedHeaders);
 
     response.getHeaders()[fake] = fake;
-    assert.strictEqual(response.hasHeader(fake), false);
+    assert.strictEqual(response.hasHeader(fake), true);
 
     assert.strictEqual(response.sendDate, true);
     response.sendDate = false;

--- a/test/parallel/test-http2-compat-serverresponse-headers.js
+++ b/test/parallel/test-http2-compat-serverresponse-headers.js
@@ -107,7 +107,8 @@ server.listen(0, common.mustCall(function() {
     assert.deepStrictEqual(response.getHeaders(), expectedHeaders);
 
     response.getHeaders()[fake] = fake;
-    assert.strictEqual(response.hasHeader(fake), true);
+    assert.strictEqual(response.hasHeader(fake), false);
+    assert.strictEqual(Object.getPrototypeOf(response.getHeaders()), null);
 
     assert.strictEqual(response.sendDate, true);
     response.sendDate = false;


### PR DESCRIPTION
refactor `getHeaders` to initialize headers using
`Object.create(null)`

Refs: https://github.com/nodejs/node/issues/29829

fixup: lint

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
