### PR TITLE
http: fixes memory retention issue with FreeList and HTTPParser

### DIFF
--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -161,12 +161,10 @@ const parsers = new FreeList('parsers', 1000, function parsersCb() {
 
   cleanParser(parser);
 
-  parser.onIncoming = null;
   parser[kOnHeaders] = parserOnHeaders;
   parser[kOnHeadersComplete] = parserOnHeadersComplete;
   parser[kOnBody] = parserOnBody;
   parser[kOnMessageComplete] = parserOnMessageComplete;
-  parser[kOnTimeout] = null;
 
   return parser;
 });
@@ -232,7 +230,9 @@ function cleanParser(parser) {
   parser.outgoing = null;
   parser.maxHeaderPairs = MAX_HEADER_PAIRS;
   parser[kOnExecute] = null;
+  parser[kOnTimeout] = null;
   parser._consumed = false;
+  parser.onIncoming = null;
 }
 
 function prepareError(err, parser, rawPacket) {

--- a/test/parallel/test-http-parser-memory-retention.js
+++ b/test/parallel/test-http-parser-memory-retention.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+const { HTTPParser } = require('_http_common');
+
+// Test that the `HTTPParser` instance is cleaned up before being returned to
+// the pool to avoid memory retention issues.
+
+const kOnTimeout = HTTPParser.kOnTimeout | 0;
+const server = http.createServer();
+
+server.on('request', common.mustCall((request, response) => {
+  const parser = request.socket.parser;
+
+  assert.strictEqual(typeof parser[kOnTimeout], 'function');
+
+  request.socket.on('close', common.mustCall(() => {
+    assert.strictEqual(parser[kOnTimeout], null);
+  }));
+
+  response.end();
+  server.close();
+}));
+
+server.listen(common.mustCall(() => {
+  const request = http.get({ port: server.address().port });
+  let parser;
+
+  request.on('socket', common.mustCall(() => {
+    parser = request.parser;
+    assert.strictEqual(typeof parser.onIncoming, 'function');
+  }));
+
+  request.on('response', common.mustCall((response) => {
+    response.resume();
+    response.on('end', common.mustCall(() => {
+      assert.strictEqual(parser.onIncoming, null);
+    }));
+  }));
+}));


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/29394
Refs: https://github.com/nodejs/node/pull/33167#issuecomment-622102450

The issue here is that because the HTTPParser is pooled it has the possibility to act as a retainer of a lot of data. In summary we have to reset `parser.onIncoming` and `parser[kOnTimeout]` to `null` to prevent these from retaining memory while the HTTPParser is sitting in the FreeList unused.

I'd like this to eventually be cherry picked into the Node 14 release.

See the reference for details.

---

@ronag Here's your [PR](https://github.com/nodejs/node/pull/33167#issuecomment-622114411).
