### PR TITLE
Move AsyncLocalStorage into its own core module

### DIFF
--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -872,218 +872,43 @@ for (let i = 0; i < 10; i++) {
 added: v13.10.0
 -->
 
-This class is used to create asynchronous state within callbacks and promise
-chains. It allows storing data throughout the lifetime of a web request
-or any other asynchronous duration. It is similar to thread-local storage
-in other languages.
+This is an alias to the `async_local_storage` module kept here for backward
+compatibility. `require('async_local_storage')` is the preferred way to use
+this class.
 
-The following example uses `AsyncLocalStorage` to build a simple logger
-that assigns IDs to incoming HTTP requests and includes them in messages
-logged within each request.
+The class methods are listed here to keep track of their introduction version.
 
-```js
-const http = require('http');
-const { AsyncLocalStorage } = require('async_hooks');
-
-const asyncLocalStorage = new AsyncLocalStorage();
-
-function logWithId(msg) {
-  const id = asyncLocalStorage.getStore();
-  console.log(`${id !== undefined ? id : '-'}:`, msg);
-}
-
-let idSeq = 0;
-http.createServer((req, res) => {
-  asyncLocalStorage.run(idSeq++, () => {
-    logWithId('start');
-    // Imagine any chain of async operations here
-    setImmediate(() => {
-      logWithId('finish');
-      res.end();
-    });
-  });
-}).listen(8080);
-
-http.get('http://localhost:8080');
-http.get('http://localhost:8080');
-// Prints:
-//   0: start
-//   1: start
-//   0: finish
-//   1: finish
-```
-
-When having multiple instances of `AsyncLocalStorage`, they are independent
-from each other. It is safe to instantiate this class multiple times.
+Please refer to the [documentation of the Async Local Storage module][].
 
 ### `new AsyncLocalStorage()`
 <!-- YAML
 added: v13.10.0
 -->
 
-Creates a new instance of `AsyncLocalStorage`. Store is only provided within a
-`run` method call.
-
 ### `asyncLocalStorage.disable()`
 <!-- YAML
 added: v13.10.0
 -->
-
-This method disables the instance of `AsyncLocalStorage`. All subsequent calls
-to `asyncLocalStorage.getStore()` will return `undefined` until
-`asyncLocalStorage.run()` is called again.
-
-When calling `asyncLocalStorage.disable()`, all current contexts linked to the
-instance will be exited.
-
-Calling `asyncLocalStorage.disable()` is required before the
-`asyncLocalStorage` can be garbage collected. This does not apply to stores
-provided by the `asyncLocalStorage`, as those objects are garbage collected
-along with the corresponding async resources.
-
-This method is to be used when the `asyncLocalStorage` is not in use anymore
-in the current process.
 
 ### `asyncLocalStorage.getStore()`
 <!-- YAML
 added: v13.10.0
 -->
 
-* Returns: {any}
-
-This method returns the current store.
-If this method is called outside of an asynchronous context initialized by
-calling `asyncLocalStorage.run`, it will return `undefined`.
-
 ### `asyncLocalStorage.enterWith(store)`
 <!-- YAML
 added: v13.11.0
 -->
-
-* `store` {any}
-
-Calling `asyncLocalStorage.enterWith(store)` will transition into the context
-for the remainder of the current synchronous execution and will persist
-through any following asynchronous calls.
-
-Example:
-
-```js
-const store = { id: 1 };
-asyncLocalStorage.enterWith(store);
-asyncLocalStorage.getStore(); // Returns the store object
-someAsyncOperation(() => {
-  asyncLocalStorage.getStore(); // Returns the same object
-});
-```
-
-This transition will continue for the _entire_ synchronous execution.
-This means that if, for example, the context is entered within an event
-handler subsequent event handlers will also run within that context unless
-specifically bound to another context with an `AsyncResource`.
-
-```js
-const store = { id: 1 };
-
-emitter.on('my-event', () => {
-  asyncLocalStorage.enterWith(store);
-});
-emitter.on('my-event', () => {
-  asyncLocalStorage.getStore(); // Returns the same object
-});
-
-asyncLocalStorage.getStore(); // Returns undefined
-emitter.emit('my-event');
-asyncLocalStorage.getStore(); // Returns the same object
-```
 
 ### `asyncLocalStorage.run(store, callback[, ...args])`
 <!-- YAML
 added: v13.10.0
 -->
 
-* `store` {any}
-* `callback` {Function}
-* `...args` {any}
-
-This methods runs a function synchronously within a context and return its
-return value. The store is not accessible outside of the callback function or
-the asynchronous operations created within the callback.
-
-Optionally, arguments can be passed to the function. They will be passed to
-the callback function.
-
-If the callback function throws an error, it will be thrown by `run` too.
-The stacktrace will not be impacted by this call and the context will
-be exited.
-
-Example:
-
-```js
-const store = { id: 2 };
-try {
-  asyncLocalStorage.run(store, () => {
-    asyncLocalStorage.getStore(); // Returns the store object
-    throw new Error();
-  });
-} catch (e) {
-  asyncLocalStorage.getStore(); // Returns undefined
-  // The error will be caught here
-}
-```
-
 ### `asyncLocalStorage.exit(callback[, ...args])`
 <!-- YAML
 added: v13.10.0
 -->
-
-* `callback` {Function}
-* `...args` {any}
-
-This methods runs a function synchronously outside of a context and return its
-return value. The store is not accessible within the callback function or
-the asynchronous operations created within the callback.
-
-Optionally, arguments can be passed to the function. They will be passed to
-the callback function.
-
-If the callback function throws an error, it will be thrown by `exit` too.
-The stacktrace will not be impacted by this call and
-the context will be re-entered.
-
-Example:
-
-```js
-// Within a call to run
-try {
-  asyncLocalStorage.getStore(); // Returns the store object or value
-  asyncLocalStorage.exit(() => {
-    asyncLocalStorage.getStore(); // Returns undefined
-    throw new Error();
-  });
-} catch (e) {
-  asyncLocalStorage.getStore(); // Returns the same object or value
-  // The error will be caught here
-}
-```
-
-### Usage with `async/await`
-
-If, within an async function, only one `await` call is to run within a context,
-the following pattern should be used:
-
-```js
-async function fn() {
-  await asyncLocalStorage.run(new Map(), () => {
-    asyncLocalStorage.getStore().set('key', value);
-    return foo(); // The return value of foo will be awaited
-  });
-}
-```
-
-In this example, the store is only available in the callback function and the
-functions called by `foo`. Outside of `run`, calling `getStore` will return
-`undefined`.
 
 [`after` callback]: #async_hooks_after_asyncid
 [`before` callback]: #async_hooks_before_asyncid
@@ -1094,3 +919,4 @@ functions called by `foo`. Outside of `run`, calling `getStore` will return
 [PromiseHooks]: https://docs.google.com/document/d/1rda3yKGHimKIhg5YeoAmCOtyURgsbTH_qaYR79FELlk/edit
 [`Worker`]: worker_threads.html#worker_threads_class_worker
 [promise execution tracking]: #async_hooks_promise_execution_tracking
+[documentation of the Async Local Storage module]: async_local_storage.md

--- a/doc/api/async_local_storage.md
+++ b/doc/api/async_local_storage.md
@@ -1,0 +1,222 @@
+# Async Hooks
+<!--introduced_in: REPLACEME-->
+
+> Stability: 1 - Experimental
+
+## Class: `AsyncLocalStorage`
+<!-- YAML
+added: v13.10.0
+-->
+
+This class is used to create asynchronous state within callbacks and promise
+chains. It allows storing data throughout the lifetime of a web request
+or any other asynchronous duration. It is similar to thread-local storage
+in other languages.
+
+The following example uses `AsyncLocalStorage` to build a simple logger
+that assigns IDs to incoming HTTP requests and includes them in messages
+logged within each request.
+
+```js
+const http = require('http');
+const AsyncLocalStorage = require('async_local_storage');
+
+const asyncLocalStorage = new AsyncLocalStorage();
+
+function logWithId(msg) {
+  const id = asyncLocalStorage.getStore();
+  console.log(`${id !== undefined ? id : '-'}:`, msg);
+}
+
+let idSeq = 0;
+http.createServer((req, res) => {
+  asyncLocalStorage.run(idSeq++, () => {
+    logWithId('start');
+    // Imagine any chain of async operations here
+    setImmediate(() => {
+      logWithId('finish');
+      res.end();
+    });
+  });
+}).listen(8080);
+
+http.get('http://localhost:8080');
+http.get('http://localhost:8080');
+// Prints:
+//   0: start
+//   1: start
+//   0: finish
+//   1: finish
+```
+
+When having multiple instances of `AsyncLocalStorage`, they are independent
+from each other. It is safe to instantiate this class multiple times.
+
+### `new AsyncLocalStorage()`
+<!-- YAML
+added: v13.10.0
+-->
+
+Creates a new instance of `AsyncLocalStorage`. Store is only provided within a
+`run` method call.
+
+### `asyncLocalStorage.disable()`
+<!-- YAML
+added: v13.10.0
+-->
+
+This method disables the instance of `AsyncLocalStorage`. All subsequent calls
+to `asyncLocalStorage.getStore()` will return `undefined` until
+`asyncLocalStorage.run()` is called again.
+
+When calling `asyncLocalStorage.disable()`, all current contexts linked to the
+instance will be exited.
+
+Calling `asyncLocalStorage.disable()` is required before the
+`asyncLocalStorage` can be garbage collected. This does not apply to stores
+provided by the `asyncLocalStorage`, as those objects are garbage collected
+along with the corresponding async resources.
+
+This method is to be used when the `asyncLocalStorage` is not in use anymore
+in the current process.
+
+### `asyncLocalStorage.getStore()`
+<!-- YAML
+added: v13.10.0
+-->
+
+* Returns: {any}
+
+This method returns the current store.
+If this method is called outside of an asynchronous context initialized by
+calling `asyncLocalStorage.run`, it will return `undefined`.
+
+### `asyncLocalStorage.enterWith(store)`
+<!-- YAML
+added: v13.11.0
+-->
+
+* `store` {any}
+
+Calling `asyncLocalStorage.enterWith(store)` will transition into the context
+for the remainder of the current synchronous execution and will persist
+through any following asynchronous calls.
+
+Example:
+
+```js
+const store = { id: 1 };
+asyncLocalStorage.enterWith(store);
+asyncLocalStorage.getStore(); // Returns the store object
+someAsyncOperation(() => {
+  asyncLocalStorage.getStore(); // Returns the same object
+});
+```
+
+This transition will continue for the _entire_ synchronous execution.
+This means that if, for example, the context is entered within an event
+handler subsequent event handlers will also run within that context unless
+specifically bound to another context with an `AsyncResource`.
+
+```js
+const store = { id: 1 };
+
+emitter.on('my-event', () => {
+  asyncLocalStorage.enterWith(store);
+});
+emitter.on('my-event', () => {
+  asyncLocalStorage.getStore(); // Returns the same object
+});
+
+asyncLocalStorage.getStore(); // Returns undefined
+emitter.emit('my-event');
+asyncLocalStorage.getStore(); // Returns the same object
+```
+
+### `asyncLocalStorage.run(store, callback[, ...args])`
+<!-- YAML
+added: v13.10.0
+-->
+
+* `store` {any}
+* `callback` {Function}
+* `...args` {any}
+
+This methods runs a function synchronously within a context and return its
+return value. The store is not accessible outside of the callback function or
+the asynchronous operations created within the callback.
+
+Optionally, arguments can be passed to the function. They will be passed to
+the callback function.
+
+If the callback function throws an error, it will be thrown by `run` too.
+The stacktrace will not be impacted by this call and the context will
+be exited.
+
+Example:
+
+```js
+const store = { id: 2 };
+try {
+  asyncLocalStorage.run(store, () => {
+    asyncLocalStorage.getStore(); // Returns the store object
+    throw new Error();
+  });
+} catch (e) {
+  asyncLocalStorage.getStore(); // Returns undefined
+  // The error will be caught here
+}
+```
+
+### `asyncLocalStorage.exit(callback[, ...args])`
+<!-- YAML
+added: v13.10.0
+-->
+
+* `callback` {Function}
+* `...args` {any}
+
+This methods runs a function synchronously outside of a context and return its
+return value. The store is not accessible within the callback function or
+the asynchronous operations created within the callback.
+
+Optionally, arguments can be passed to the function. They will be passed to
+the callback function.
+
+If the callback function throws an error, it will be thrown by `exit` too.
+The stacktrace will not be impacted by this call and
+the context will be re-entered.
+
+Example:
+
+```js
+// Within a call to run
+try {
+  asyncLocalStorage.getStore(); // Returns the store object or value
+  asyncLocalStorage.exit(() => {
+    asyncLocalStorage.getStore(); // Returns undefined
+    throw new Error();
+  });
+} catch (e) {
+  asyncLocalStorage.getStore(); // Returns the same object or value
+  // The error will be caught here
+}
+```
+
+### Usage with `async/await`
+
+If, within an async function, only one `await` call is to run within a context,
+the following pattern should be used:
+
+```js
+async function fn() {
+  await asyncLocalStorage.run(new Map(), () => {
+    asyncLocalStorage.getStore().set('key', value);
+    return foo(); // The return value of foo will be awaited
+  });
+}
+```
+
+In this example, the store is only available in the callback function and the
+functions called by `foo`. Outside of `run`, calling `getStore` will return
+`undefined`.

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -2,6 +2,7 @@
 
 const {
   NumberIsSafeInteger,
+  Object,
   ReflectApply,
   Symbol,
 } = primordials;
@@ -210,85 +211,10 @@ class AsyncResource {
   }
 }
 
-const storageList = [];
-const storageHook = createHook({
-  init(asyncId, type, triggerAsyncId, resource) {
-    const currentResource = executionAsyncResource();
-    // Value of currentResource is always a non null object
-    for (let i = 0; i < storageList.length; ++i) {
-      storageList[i]._propagate(resource, currentResource);
-    }
-  }
-});
-
-class AsyncLocalStorage {
-  constructor() {
-    this.kResourceStore = Symbol('kResourceStore');
-    this.enabled = false;
-  }
-
-  disable() {
-    if (this.enabled) {
-      this.enabled = false;
-      // If this.enabled, the instance must be in storageList
-      storageList.splice(storageList.indexOf(this), 1);
-      if (storageList.length === 0) {
-        storageHook.disable();
-      }
-    }
-  }
-
-  // Propagate the context from a parent resource to a child one
-  _propagate(resource, triggerResource) {
-    const store = triggerResource[this.kResourceStore];
-    if (this.enabled) {
-      resource[this.kResourceStore] = store;
-    }
-  }
-
-  enterWith(store) {
-    if (!this.enabled) {
-      this.enabled = true;
-      storageList.push(this);
-      storageHook.enable();
-    }
-    const resource = executionAsyncResource();
-    resource[this.kResourceStore] = store;
-  }
-
-  run(store, callback, ...args) {
-    const resource = new AsyncResource('AsyncLocalStorage');
-    return resource.runInAsyncScope(() => {
-      this.enterWith(store);
-      return callback(...args);
-    });
-  }
-
-  exit(callback, ...args) {
-    if (!this.enabled) {
-      return callback(...args);
-    }
-    this.enabled = false;
-    try {
-      return callback(...args);
-    } finally {
-      this.enabled = true;
-    }
-  }
-
-  getStore() {
-    const resource = executionAsyncResource();
-    if (this.enabled) {
-      return resource[this.kResourceStore];
-    }
-  }
-}
-
 // Placing all exports down here because the exported classes won't export
 // otherwise.
 module.exports = {
   // Public API
-  AsyncLocalStorage,
   createHook,
   executionAsyncId,
   triggerAsyncId,
@@ -296,3 +222,11 @@ module.exports = {
   // Embedder API
   AsyncResource,
 };
+
+// Because of a circular dependency, we need to load AsyncLocalStorage lazily
+Object.defineProperty(module.exports, 'AsyncLocalStorage', {
+  enumerable: true,
+  get() {
+    return require('async_local_storage');
+  }
+});

--- a/lib/async_local_storage.js
+++ b/lib/async_local_storage.js
@@ -1,0 +1,83 @@
+'use strict';
+const { Symbol } = primordials;
+const {
+  createHook,
+  executionAsyncResource,
+  AsyncResource
+} = require('async_hooks');
+
+const storageList = [];
+const storageHook = createHook({
+  init(asyncId, type, triggerAsyncId, resource) {
+    const currentResource = executionAsyncResource();
+    // Value of currentResource is always a non null object
+    for (let i = 0; i < storageList.length; ++i) {
+      storageList[i]._propagate(resource, currentResource);
+    }
+  }
+});
+
+class AsyncLocalStorage {
+  constructor() {
+    this.kResourceStore = Symbol('kResourceStore');
+    this.enabled = false;
+  }
+
+  disable() {
+    if (this.enabled) {
+      this.enabled = false;
+      // If this.enabled, the instance must be in storageList
+      storageList.splice(storageList.indexOf(this), 1);
+      if (storageList.length === 0) {
+        storageHook.disable();
+      }
+    }
+  }
+
+  // Propagate the context from a parent resource to a child one
+  _propagate(resource, triggerResource) {
+    const store = triggerResource[this.kResourceStore];
+    if (this.enabled) {
+      resource[this.kResourceStore] = store;
+    }
+  }
+
+  enterWith(store) {
+    if (!this.enabled) {
+      this.enabled = true;
+      storageList.push(this);
+      storageHook.enable();
+    }
+    const resource = executionAsyncResource();
+    resource[this.kResourceStore] = store;
+  }
+
+  run(store, callback, ...args) {
+    const resource = new AsyncResource('AsyncLocalStorage');
+    return resource.runInAsyncScope(() => {
+      this.enterWith(store);
+      return callback(...args);
+    });
+  }
+
+  exit(callback, ...args) {
+    if (!this.enabled) {
+      return callback(...args);
+    }
+    this.enabled = false;
+    try {
+      return callback(...args);
+    } finally {
+      this.enabled = true;
+    }
+  }
+
+  getStore() {
+    const resource = executionAsyncResource();
+    if (this.enabled) {
+      return resource[this.kResourceStore];
+    }
+  }
+}
+
+module.exports = AsyncLocalStorage;

--- a/lib/internal/modules/cjs/helpers.js
+++ b/lib/internal/modules/cjs/helpers.js
@@ -112,6 +112,7 @@ function stripBOM(content) {
 const builtinLibs = [
   'assert',
   'async_hooks',
+  'async_local_storage',
   'buffer',
   'child_process',
   'cluster',

--- a/node.gyp
+++ b/node.gyp
@@ -39,6 +39,7 @@
       'lib/internal/per_context/domexception.js',
       'lib/internal/per_context/messageport.js',
       'lib/async_hooks.js',
+      'lib/async_local_storage.js',
       'lib/assert.js',
       'lib/buffer.js',
       'lib/child_process.js',

--- a/test/async-hooks/test-async-local-storage-require-order-1.js
+++ b/test/async-hooks/test-async-local-storage-require-order-1.js
@@ -1,0 +1,8 @@
+'use strict';
+// There might be circular dependency issues between these modules
+require('../common');
+const assert = require('assert');
+const AsyncLocalStorage = require('async_local_storage');
+const AsyncHooks = require('async_hooks');
+
+assert.strictEqual(AsyncHooks.AsyncLocalStorage, AsyncLocalStorage);

--- a/test/async-hooks/test-async-local-storage-require-order-2.js
+++ b/test/async-hooks/test-async-local-storage-require-order-2.js
@@ -1,0 +1,8 @@
+'use strict';
+// There might be circular dependency issues between these modules
+require('../common');
+const assert = require('assert');
+const AsyncHooks = require('async_hooks');
+const AsyncLocalStorage = require('async_local_storage');
+
+assert.strictEqual(AsyncHooks.AsyncLocalStorage, AsyncLocalStorage);


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

This introduces the `async_local_storage` core module by moving the `AsyncLocalStorage` class away from `async_hook`.

The goal here is to move the high level API to its own module so it can be eventually considered as
stable while Async Hooks are still experimental. I belive that doing so will eventually give more space to iterate over Async Hooks without breaking the ecosystem (too much).

This is technically a breaking change and for now, there is a backward compatible way to import the `AsyncLocalStorage` class from `async_hooks`.

In a perfect world, we could hope to have this released in v15 and stable in v16.

I am not sure the documentation state is ideal, I tried to make this change while keeping the history of the API.

cc @Qard @Flarna @puzpuzpuz @mcollina 
