### PR TITLE
doc: clarify about the Node.js-only extensions in perf_hooks

### DIFF
--- a/doc/api/perf_hooks.md
+++ b/doc/api/perf_hooks.md
@@ -1,13 +1,18 @@
-# Performance Timing API
+# Performance Measurement APIs
 
 <!--introduced_in=v8.5.0-->
 
 > Stability: 2 - Stable
 
-The Performance Timing API provides an implementation of the
-[W3C Performance Timeline][] specification. The purpose of the API
-is to support collection of high resolution performance metrics.
-This is the same Performance API as implemented in modern Web browsers.
+This module provides an implementation of a subset of the W3C
+[Web Performance APIs][] as well as additional APIs for
+Node.js-specific performance measurements.
+
+Currently, Node.js supports the following [Web Performance APIs][]:
+
+* [High Resolution Time][]
+* [Performance Timeline][]
+* [User Timing][]
 
 ```js
 const { PerformanceObserver, performance } = require('perf_hooks');
@@ -28,10 +33,13 @@ doSomeLongRunningProcess(() => {
 });
 ```
 
-## Class: `Performance`
+## `perf_hooks.performance`
 <!-- YAML
 added: v8.5.0
 -->
+
+An object that can be used to collect performance metrics from the current
+Node.js instance. It's similar to [`window.performance`][] in browsers.
 
 ### `performance.clearMarks([name])`
 <!-- YAML
@@ -95,6 +103,9 @@ added: v8.5.0
 
 * {PerformanceNodeTiming}
 
+> Note: This property is an extension by Node.js. It's not available in Web
+> browsers.
+
 An instance of the `PerformanceNodeTiming` class that provides performance
 metrics for specific Node.js operational milestones.
 
@@ -124,6 +135,9 @@ added: v8.5.0
 -->
 
 * `fn` {Function}
+
+> Note: This property is an extension by Node.js. It's not available in Web
+> browsers.
 
 Wraps a function within a new function that measures the running time of the
 wrapped function. A `PerformanceObserver` must be subscribed to the `'function'`
@@ -192,8 +206,15 @@ added: v8.5.0
 
 * {string}
 
-The type of the performance entry. Currently it may be one of: `'node'`,
-`'mark'`, `'measure'`, `'gc'`, `'function'`, `'http2'` or `'http'`.
+The type of the performance entry. Currently it may be one of:
+
+* `'node'` (Node.js only)
+* `'mark'` (available on the Web)
+* `'measure'` (available on the Web)
+* `'gc'` (Node.js only)
+* `'function'` (Node.js only)
+* `'http2'` (Node.js only)
+* `'http'` (Node.js only)
 
 ### `performanceEntry.kind`
 <!-- YAML
@@ -201,6 +222,9 @@ added: v8.5.0
 -->
 
 * {number}
+
+> Note: This property is an extension by Node.js. It is not available in Web
+> browsers.
 
 When `performanceEntry.entryType` is equal to `'gc'`, the `performance.kind`
 property identifies the type of garbage collection operation that occurred.
@@ -217,6 +241,9 @@ added: v13.9.0
 -->
 
 * {number}
+
+> Note: This property is an extension by Node.js. It is not available in Web
+> browsers.
 
 When `performanceEntry.entryType` is equal to `'gc'`, the `performance.flags`
 property contains additional information about garbage collection operation.
@@ -235,7 +262,11 @@ The value may be one of:
 added: v8.5.0
 -->
 
-Provides timing details for Node.js itself.
+> Note: This class is an extension by Node.js. It's not available in Web
+> browsers.
+
+Provides timing details for Node.js itself. The constructor of this class
+is not directly exposed to users.
 
 ### `performanceNodeTiming.bootstrapComplete`
 <!-- YAML
@@ -300,7 +331,7 @@ added: v8.5.0
 The high resolution millisecond timestamp at which the V8 platform was
 initialized.
 
-## Class: `PerformanceObserver`
+## Class: `perf_hooks.PerformanceObserver`
 
 ### `new PerformanceObserver(callback)`
 <!-- YAML
@@ -402,6 +433,7 @@ added: v8.5.0
 
 The `PerformanceObserverEntryList` class is used to provide access to the
 `PerformanceEntry` instances passed to a `PerformanceObserver`.
+The constructor of this class is not directly exposed to users.
 
 ### `performanceObserverEntryList.getEntries()`
 <!-- YAML
@@ -449,6 +481,9 @@ added: v11.10.0
     than zero. **Default:** `10`.
 * Returns: {Histogram}
 
+> Note: This property is an extension by Node.js. It's not available in Web
+> browsers.
+
 Creates a `Histogram` object that samples and reports the event loop delay
 over time. The delays will be reported in nanoseconds.
 
@@ -477,7 +512,11 @@ console.log(h.percentile(99));
 <!-- YAML
 added: v11.10.0
 -->
-Tracks the event loop delay at a given sampling rate.
+Tracks the event loop delay at a given sampling rate. The constructor of
+this class not directly exposed to users.
+
+> Note: This class is an extension by Node.js. It's not available in Web
+> browsers.
 
 #### `histogram.disable()`
 <!-- YAML
@@ -651,5 +690,9 @@ require('some-module');
 
 [`'exit'`]: process.html#process_event_exit
 [`timeOrigin`]: https://w3c.github.io/hr-time/#dom-performance-timeorigin
+[`window.performance`]: https://developer.mozilla.org/en-US/docs/Web/API/Window/performance
 [Async Hooks]: async_hooks.html
-[W3C Performance Timeline]: https://w3c.github.io/performance-timeline/
+[High Resolution Time]: https://www.w3.org/TR/hr-time-2
+[Performance Timeline]: https://w3c.github.io/performance-timeline/
+[Web Performance APIs]: https://w3c.github.io/perf-timing-primer/
+[User Timing]: https://www.w3.org/TR/user-timing/

--- a/doc/api/perf_hooks.md
+++ b/doc/api/perf_hooks.md
@@ -8,7 +8,7 @@ This module provides an implementation of a subset of the W3C
 [Web Performance APIs][] as well as additional APIs for
 Node.js-specific performance measurements.
 
-Currently, Node.js supports the following [Web Performance APIs][]:
+Node.js supports the following [Web Performance APIs][]:
 
 * [High Resolution Time][]
 * [Performance Timeline][]
@@ -39,7 +39,7 @@ added: v8.5.0
 -->
 
 An object that can be used to collect performance metrics from the current
-Node.js instance. It's similar to [`window.performance`][] in browsers.
+Node.js instance. It is similar to [`window.performance`][] in browsers.
 
 ### `performance.clearMarks([name])`
 <!-- YAML
@@ -103,8 +103,7 @@ added: v8.5.0
 
 * {PerformanceNodeTiming}
 
-> Note: This property is an extension by Node.js. It's not available in Web
-> browsers.
+_This property is an extension by Node.js. It is not available in Web browsers._
 
 An instance of the `PerformanceNodeTiming` class that provides performance
 metrics for specific Node.js operational milestones.
@@ -136,8 +135,7 @@ added: v8.5.0
 
 * `fn` {Function}
 
-> Note: This property is an extension by Node.js. It's not available in Web
-> browsers.
+_This property is an extension by Node.js. It is not available in Web browsers._
 
 Wraps a function within a new function that measures the running time of the
 wrapped function. A `PerformanceObserver` must be subscribed to the `'function'`
@@ -206,7 +204,7 @@ added: v8.5.0
 
 * {string}
 
-The type of the performance entry. Currently it may be one of:
+The type of the performance entry. It may be one of:
 
 * `'node'` (Node.js only)
 * `'mark'` (available on the Web)
@@ -223,8 +221,7 @@ added: v8.5.0
 
 * {number}
 
-> Note: This property is an extension by Node.js. It is not available in Web
-> browsers.
+_This property is an extension by Node.js. It is not available in Web browsers._
 
 When `performanceEntry.entryType` is equal to `'gc'`, the `performance.kind`
 property identifies the type of garbage collection operation that occurred.
@@ -242,8 +239,7 @@ added: v13.9.0
 
 * {number}
 
-> Note: This property is an extension by Node.js. It is not available in Web
-> browsers.
+_This property is an extension by Node.js. It is not available in Web browsers._
 
 When `performanceEntry.entryType` is equal to `'gc'`, the `performance.flags`
 property contains additional information about garbage collection operation.
@@ -262,11 +258,10 @@ The value may be one of:
 added: v8.5.0
 -->
 
-> Note: This class is an extension by Node.js. It's not available in Web
-> browsers.
+_This property is an extension by Node.js. It is not available in Web browsers._
 
 Provides timing details for Node.js itself. The constructor of this class
-is not directly exposed to users.
+is not exposed to users.
 
 ### `performanceNodeTiming.bootstrapComplete`
 <!-- YAML
@@ -433,7 +428,7 @@ added: v8.5.0
 
 The `PerformanceObserverEntryList` class is used to provide access to the
 `PerformanceEntry` instances passed to a `PerformanceObserver`.
-The constructor of this class is not directly exposed to users.
+The constructor of this class is not exposed to users.
 
 ### `performanceObserverEntryList.getEntries()`
 <!-- YAML
@@ -481,8 +476,7 @@ added: v11.10.0
     than zero. **Default:** `10`.
 * Returns: {Histogram}
 
-> Note: This property is an extension by Node.js. It's not available in Web
-> browsers.
+_This property is an extension by Node.js. It is not available in Web browsers._
 
 Creates a `Histogram` object that samples and reports the event loop delay
 over time. The delays will be reported in nanoseconds.
@@ -513,10 +507,9 @@ console.log(h.percentile(99));
 added: v11.10.0
 -->
 Tracks the event loop delay at a given sampling rate. The constructor of
-this class not directly exposed to users.
+this class not exposed to users.
 
-> Note: This class is an extension by Node.js. It's not available in Web
-> browsers.
+_This property is an extension by Node.js. It is not available in Web browsers._
 
 #### `histogram.disable()`
 <!-- YAML

--- a/tools/doc/type-parser.js
+++ b/tools/doc/type-parser.js
@@ -125,7 +125,7 @@ const customTypesMap = {
   'PerformanceNodeTiming':
     'perf_hooks.html#perf_hooks_class_performancenodetiming_extends_performanceentry', // eslint-disable-line max-len
   'PerformanceObserver':
-    'perf_hooks.html#perf_hooks_class_performanceobserver',
+    'perf_hooks.html#perf_hooks_class_perf_hooks_performanceobserver',
   'PerformanceObserverEntryList':
     'perf_hooks.html#perf_hooks_class_performanceobserverentrylist',
 


### PR DESCRIPTION
- Add clarifications for Node.js-only extensions
- Explain the Web Performance APIs implemented in Node.js and
  clarify that perf_hooks also include other non-Web APIs.
- Prefix exposed interfaces with `perf_hooks.` to distinguish
  them from internal classes.

Refs: https://github.com/nodejs/node/issues/28635

cc @jasnell 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
