### PR TITLE
doc:  add warning for socket.connect reuse

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2668,6 +2668,22 @@ Type: Documentation-only
 
 Use [`request.destroy()`][] instead of [`request.abort()`][].
 
+<a id="DEP0XXX"></a>
+### DEP0XXX: Use `net.connect()` instead of re-using sockets through
+`socket.connect()`
+<!-- YAML
+changes:
+  - version:
+    - REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/33204
+    description: Documentation-only deprecation.
+-->
+
+Type: Documentation-only
+
+Use [`net.connect()`][] instead of re-using sockets through
+[`socket.connect()`][].
+
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`--throw-deprecation`]: cli.html#cli_throw_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
@@ -2722,6 +2738,7 @@ Use [`request.destroy()`][] instead of [`request.abort()`][].
 [`https.get()`]: https.html#https_https_get_options_callback
 [`https.request()`]: https.html#https_https_request_options_callback
 [`module.createRequire()`]: modules.html#modules_module_createrequire_filename
+[`net.connect()`]: net.html#net_net_connect
 [`os.networkInterfaces()`]: os.html#os_os_networkinterfaces
 [`os.tmpdir()`]: os.html#os_os_tmpdir
 [`process.env`]: process.html#process_process_env
@@ -2742,6 +2759,7 @@ Use [`request.destroy()`][] instead of [`request.abort()`][].
 [`script.createCachedData()`]: vm.html#vm_script_createcacheddata
 [`setInterval()`]: timers.html#timers_setinterval_callback_delay_args
 [`setTimeout()`]: timers.html#timers_settimeout_callback_delay_args
+[`socket.connect()`]: net.html#net_socket_connect
 [`timeout.ref()`]: timers.html#timers_timeout_ref
 [`timeout.refresh()`]: timers.html#timers_timeout_refresh
 [`timeout.unref()`]: timers.html#timers_timeout_unref

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2668,22 +2668,6 @@ Type: Documentation-only
 
 Use [`request.destroy()`][] instead of [`request.abort()`][].
 
-<a id="DEP0XXX"></a>
-### DEP0XXX: Use `net.connect()` instead of re-using sockets through
-`socket.connect()`
-<!-- YAML
-changes:
-  - version:
-    - REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/33204
-    description: Documentation-only deprecation.
--->
-
-Type: Documentation-only
-
-Use [`net.connect()`][] instead of re-using sockets through
-[`socket.connect()`][].
-
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`--throw-deprecation`]: cli.html#cli_throw_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
@@ -2738,7 +2722,6 @@ Use [`net.connect()`][] instead of re-using sockets through
 [`https.get()`]: https.html#https_https_get_options_callback
 [`https.request()`]: https.html#https_https_request_options_callback
 [`module.createRequire()`]: modules.html#modules_module_createrequire_filename
-[`net.connect()`]: net.html#net_net_connect
 [`os.networkInterfaces()`]: os.html#os_os_networkinterfaces
 [`os.tmpdir()`]: os.html#os_os_tmpdir
 [`process.env`]: process.html#process_process_env
@@ -2759,7 +2742,6 @@ Use [`net.connect()`][] instead of re-using sockets through
 [`script.createCachedData()`]: vm.html#vm_script_createcacheddata
 [`setInterval()`]: timers.html#timers_setinterval_callback_delay_args
 [`setTimeout()`]: timers.html#timers_settimeout_callback_delay_args
-[`socket.connect()`]: net.html#net_socket_connect
 [`timeout.ref()`]: timers.html#timers_timeout_ref
 [`timeout.refresh()`]: timers.html#timers_timeout_refresh
 [`timeout.unref()`]: timers.html#timers_timeout_unref

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -581,6 +581,11 @@ added: v0.5.3
 The amount of bytes sent.
 
 ### `socket.connect()`
+<!-- YAML
+deprecated: REPLACEME
+-->
+
+> Stability: 0 - Deprecated: Use [`net.connect()`][] instead.
 
 Initiate a connection on a given socket.
 

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -600,9 +600,9 @@ the error passed to the [`'error'`][] listener.
 The last parameter `connectListener`, if supplied, will be added as a listener
 for the [`'connect'`][] event **once**.
 
-This function should not be used for reconnecting a socket. Calling
-[`socket.connect()`][] a second time leads to undefined behavior.
-[`net.connect()`][] implicitly calls [`socket.connect()`][].
+This function should only be used for reconnecting a socket after
+`'close'` has been emitted or otherwise it may lead to undefined
+behavior.
 
 #### `socket.connect(options[, connectListener])`
 <!-- YAML

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -600,6 +600,10 @@ the error passed to the [`'error'`][] listener.
 The last parameter `connectListener`, if supplied, will be added as a listener
 for the [`'connect'`][] event **once**.
 
+This function should not be used for reconnecting a socket. Calling
+[`socket.connect()`][] a second time leads to undefined behavior.
+[`net.connect()`][] implicitly calls [`socket.connect()`][].
+
 #### `socket.connect(options[, connectListener])`
 <!-- YAML
 added: v0.1.90

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -581,11 +581,6 @@ added: v0.5.3
 The amount of bytes sent.
 
 ### `socket.connect()`
-<!-- YAML
-deprecated: REPLACEME
--->
-
-> Stability: 0 - Deprecated: Use [`net.connect()`][] instead.
 
 Initiate a connection on a given socket.
 


### PR DESCRIPTION
`socket.connect` is subtly broken due to timing and _undestroy issues. Discourage usage and ask users to instead create a new socket instance.

Note, this is a problem when calling `connect` a second time.

I believe since it's a bit tricky to resolve, it might be appropriate to deprecate this use case since there is a viable alternative in simply creating a new socket.

Refs: https://github.com/nodejs/node/issues/25969

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
