### PR TITLE
buffer: improve copy() performance

### DIFF
--- a/benchmark/buffers/buffer-copy.js
+++ b/benchmark/buffers/buffer-copy.js
@@ -4,18 +4,16 @@ const common = require('../common.js');
 const bench = common.createBenchmark(main, {
   bytes: [0, 8, 128, 32 * 1024],
   partial: ['true', 'false'],
-  oob: ['true', 'false'],
   n: [6e6]
 });
 
-function main({ n, bytes, partial, oob }) {
+function main({ n, bytes, partial }) {
   const source = Buffer.allocUnsafe(bytes);
-  const target = Buffer.allocUnsafe(bytes * 2);
+  const target = Buffer.allocUnsafe(bytes);
   const sourceStart = (partial === 'true' ? Math.floor(bytes / 2) : 0);
-  const sourceEnd = (oob === 'true' ? source.length + 1 : source.length);
   bench.start();
   for (let i = 0; i < n; i++) {
-    source.copy(target, 0, sourceStart, sourceEnd);
+    source.copy(target, 0, sourceStart);
   }
   bench.end(n);
 }

--- a/benchmark/buffers/buffer-copy.js
+++ b/benchmark/buffers/buffer-copy.js
@@ -4,16 +4,18 @@ const common = require('../common.js');
 const bench = common.createBenchmark(main, {
   bytes: [0, 8, 128, 32 * 1024],
   partial: ['true', 'false'],
+  oob: ['true', 'false'],
   n: [6e6]
 });
 
-function main({ n, bytes, partial }) {
+function main({ n, bytes, partial, oob }) {
   const source = Buffer.allocUnsafe(bytes);
-  const target = Buffer.allocUnsafe(bytes);
+  const target = Buffer.allocUnsafe(bytes * 2);
   const sourceStart = (partial === 'true' ? Math.floor(bytes / 2) : 0);
+  const sourceEnd = (oob === 'true' ? source.length + 1 : source.length);
   bench.start();
   for (let i = 0; i < n; i++) {
-    source.copy(target, 0, sourceStart);
+    source.copy(target, 0, sourceStart, sourceEnd);
   }
   bench.end(n);
 }

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -257,7 +257,7 @@ function _copyActual(source, target, targetStart, sourceStart, sourceEnd) {
   if (nb > sourceLen)
     nb = sourceLen;
 
-  if (sourceStart !== 0 || sourceEnd !== source.length)
+  if (sourceStart !== 0 || sourceEnd < source.length)
     source = new Uint8Array(source.buffer, source.byteOffset + sourceStart, nb);
 
   target.set(source, targetStart);


### PR DESCRIPTION
There is no need to create a slice when `sourceEnd` is out of bounds.

Results of included benchmark:

```
                                                                           confidence improvement accuracy (*)     (**)    (***)
 buffers\\buffer-copy.js n=6000000 oob='false' partial='false' bytes=0                     3.30 %      ±4.96%  ±6.62%  ±8.65%
 buffers\\buffer-copy.js n=6000000 oob='false' partial='false' bytes=128                  -0.66 %      ±3.54%  ±4.71%  ±6.13%
 buffers\\buffer-copy.js n=6000000 oob='false' partial='false' bytes=32768                -3.02 %      ±8.44% ±11.30% ±14.83%
 buffers\\buffer-copy.js n=6000000 oob='false' partial='false' bytes=8                     2.80 %      ±5.54%  ±7.37%  ±9.61%
 buffers\\buffer-copy.js n=6000000 oob='false' partial='true' bytes=0                      2.29 %      ±4.58%  ±6.10%  ±7.98%
 buffers\\buffer-copy.js n=6000000 oob='false' partial='true' bytes=128                    1.90 %      ±3.39%  ±4.52%  ±5.88%
 buffers\\buffer-copy.js n=6000000 oob='false' partial='true' bytes=32768                  0.23 %      ±7.59% ±10.10% ±13.16%
 buffers\\buffer-copy.js n=6000000 oob='false' partial='true' bytes=8                      2.75 %      ±4.06%  ±5.42%  ±7.07%
 buffers\\buffer-copy.js n=6000000 oob='true' partial='false' bytes=0                      2.68 %      ±4.89%  ±6.52%  ±8.50%
 buffers\\buffer-copy.js n=6000000 oob='true' partial='false' bytes=128           ***    135.43 %      ±7.70% ±10.31% ±13.57%
 buffers\\buffer-copy.js n=6000000 oob='true' partial='false' bytes=32768           *      5.98 %      ±4.85%  ±6.46%  ±8.40%
 buffers\\buffer-copy.js n=6000000 oob='true' partial='false' bytes=8             ***    142.55 %     ±10.22% ±13.71% ±18.06%
 buffers\\buffer-copy.js n=6000000 oob='true' partial='true' bytes=0                       4.42 %      ±4.67%  ±6.26%  ±8.23%
 buffers\\buffer-copy.js n=6000000 oob='true' partial='true' bytes=128                     0.66 %      ±2.75%  ±3.66%  ±4.77%
 buffers\\buffer-copy.js n=6000000 oob='true' partial='true' bytes=32768                  -1.10 %      ±7.26%  ±9.67% ±12.59%
 buffers\\buffer-copy.js n=6000000 oob='true' partial='true' bytes=8                       2.74 %      ±3.92%  ±5.23%  ±6.82%
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
