### PR TITLE
tools: add docserve target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -813,6 +813,11 @@ out/doc/api/all.json: $(apidocs_json) tools/doc/alljson.js
 docopen: $(apidocs_html)
 	@$(PYTHON) -mwebbrowser file://$(PWD)/out/doc/api/all.html
 
+.PHONY: docserve
+docserve: $(apidocs_html)
+	@$(PYTHON) -mwebbrowser http://localhost:8000/all.html
+	@$(PYTHON) -m http.server -d $(PWD)/out/doc/api
+
 .PHONY: docclean
 docclean:
 	$(RM) -r out/doc


### PR DESCRIPTION
Spaws a webserver serving the docs. Helpful to circumvent the OS
permission limitations or to access the docs form a different device on
the local network.

I'm using macOS, and my browser doesn't have permission (nor need to have IMO) access to my local files.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
