### PR TITLE
doc: clarify folders when using esm modules

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -798,6 +798,19 @@ indexes (e.g. `'./startup/index.js'`) must also be fully specified.
 This behavior matches how `import` behaves in browser environments, assuming a
 typically configured server.
 
+### No folder imports
+
+Folders cannot be imported using ES modules.
+
+Previously it was possible to `require` a folder if it contained either an
+`index.js` file or a `package.json` file. This is no longer supported. Instead
+the desired entry file can be referenced directly.
+
+```js
+import './folder-with-index-file/index.js';
+import './folder-with-package-json-file/main.js';
+```
+
 ### No `NODE_PATH`
 
 `NODE_PATH` is not part of resolving `import` specifiers. Please use symlinks


### PR DESCRIPTION
Clarify behaviour of ES modules when importing folders vs common js.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
