### PR TITLE
wasi: prevent syscalls before start

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -2099,6 +2099,11 @@ meaning of the error depends on the specific function.
 
 The WASI instance has already started.
 
+<a id="ERR_WASI_NOT_STARTED"></a>
+### `ERR_WASI_NOT_STARTED`
+
+The WASI instance has not been started.
+
 <a id="ERR_WORKER_INIT_FAILED"></a>
 ### `ERR_WORKER_INIT_FAILED`
 

--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -54,6 +54,7 @@ void OnFatalError(const char* location, const char* message);
   V(ERR_TRANSFERRING_EXTERNALIZED_SHAREDARRAYBUFFER, TypeError)                \
   V(ERR_TLS_PSK_SET_IDENTIY_HINT_FAILED, Error)                                \
   V(ERR_VM_MODULE_CACHED_DATA_REJECTED, Error)                                 \
+  V(ERR_WASI_NOT_STARTED, Error)                                               \
   V(ERR_WORKER_INIT_FAILED, Error)                                             \
   V(ERR_PROTO_ACCESS, Error)
 
@@ -104,6 +105,7 @@ void OnFatalError(const char* location, const char* message);
   V(ERR_TRANSFERRING_EXTERNALIZED_SHAREDARRAYBUFFER,                           \
     "Cannot serialize externalized SharedArrayBuffer")                         \
   V(ERR_TLS_PSK_SET_IDENTIY_HINT_FAILED, "Failed to set PSK identity hint")    \
+  V(ERR_WASI_NOT_STARTED, "wasi.start has not been called")                    \
   V(ERR_WORKER_INIT_FAILED, "Worker initialization failure")                   \
   V(ERR_PROTO_ACCESS,                                                          \
     "Accessing Object.prototype.__proto__ has been "                           \

--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -105,7 +105,7 @@ void OnFatalError(const char* location, const char* message);
   V(ERR_TRANSFERRING_EXTERNALIZED_SHAREDARRAYBUFFER,                           \
     "Cannot serialize externalized SharedArrayBuffer")                         \
   V(ERR_TLS_PSK_SET_IDENTIY_HINT_FAILED, "Failed to set PSK identity hint")    \
-  V(ERR_WASI_NOT_STARTED, "wasi.start has not been called")                    \
+  V(ERR_WASI_NOT_STARTED, "wasi.start() has not been called")                  \
   V(ERR_WORKER_INIT_FAILED, "Worker initialization failure")                   \
   V(ERR_PROTO_ACCESS,                                                          \
     "Accessing Object.prototype.__proto__ has been "                           \

--- a/test/wasi/test-wasi-not-started.js
+++ b/test/wasi/test-wasi-not-started.js
@@ -1,0 +1,40 @@
+'use strict';
+require('../common');
+
+if (process.argv[2] === 'wasi-child') {
+  const assert = require('assert');
+  const fs = require('fs');
+  const path = require('path');
+
+  const { WASI } = require('wasi');
+  const wasi = new WASI({
+    args: ['foo', '-bar', '--baz=value']
+  });
+  const importObject = { wasi_snapshot_preview1: wasi.wasiImport };
+
+  const modulePath = path.join(__dirname, 'wasm', 'main_args.wasm');
+  const buffer = fs.readFileSync(modulePath);
+
+  assert.rejects(async () => {
+    const { instance } = await WebAssembly.instantiate(buffer, importObject);
+    instance.exports._start();
+  }, {
+    name: 'Error',
+    code: 'ERR_WASI_NOT_STARTED',
+    message: 'wasi.start has not been called'
+  });
+} else {
+  const assert = require('assert');
+  const cp = require('child_process');
+
+  const child = cp.spawnSync(process.execPath, [
+    '--experimental-wasi-unstable-preview1',
+    '--experimental-wasm-bigint',
+    __filename,
+    'wasi-child'
+  ], {
+    env: { ...process.env, NODE_DEBUG_NATIVE: 'wasi' }
+  });
+  assert.strictEqual(child.signal, null);
+  assert.strictEqual(child.status, 0);
+}

--- a/test/wasi/test-wasi-not-started.js
+++ b/test/wasi/test-wasi-not-started.js
@@ -21,7 +21,7 @@ if (process.argv[2] === 'wasi-child') {
   }, {
     name: 'Error',
     code: 'ERR_WASI_NOT_STARTED',
-    message: 'wasi.start has not been called'
+    message: 'wasi.start() has not been called'
   });
 } else {
   const assert = require('assert');


### PR DESCRIPTION
Calling `instance.exports._start()` crashes the process with a segmentation fault. This prevents syscalls before `start()` has been called.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
