### PR TITLE
doc: doc and test URLSearchParams discrepancy

### DIFF
--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -477,7 +477,7 @@ can be used to mutate the URL instance; to replace the entirety of query
 parameters of the URL, use the [`url.search`][] setter. See
 [`URLSearchParams`][] documentation for details.
 
-Care must be taken when using `.searchParams` to modify the `URL` because,
+Use care when using `.searchParams` to modify the `URL` because,
 per the WHATWG specification, the `URLSearchParams` object uses
 different rules to determine which characters to percent-encode. For
 instance, the `URL` object will not percent encode the ASCII tilde (`~`)

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -479,7 +479,7 @@ parameters of the URL, use the [`url.search`][] setter. See
 
 Care must be taken when using `.searchParams` to modify the `URL` because,
 per the WHATWG specification, the `URLSearchParams` object uses slightly
-different rules to determine which characters should be percent-encoded. For
+different rules to determine which characters to percent-encode. For
 instance, the `URL` object will not percent encode the ASCII tilde (`~`)
 character, while `URLSearchParams` will always encode it:
 

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -478,7 +478,7 @@ parameters of the URL, use the [`url.search`][] setter. See
 [`URLSearchParams`][] documentation for details.
 
 Care must be taken when using `.searchParams` to modify the `URL` because,
-per the WHATWG specification, the `URLSearchParams` object uses slightly
+per the WHATWG specification, the `URLSearchParams` object uses
 different rules to determine which characters to percent-encode. For
 instance, the `URL` object will not percent encode the ASCII tilde (`~`)
 character, while `URLSearchParams` will always encode it:

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -472,9 +472,27 @@ and [`url.format()`][] methods would produce.
 * {URLSearchParams}
 
 Gets the [`URLSearchParams`][] object representing the query parameters of the
-URL. This property is read-only; to replace the entirety of query parameters of
-the URL, use the [`url.search`][] setter. See [`URLSearchParams`][]
-documentation for details.
+URL. This property is read-only but the `URLSearchParams` object it provides
+can be used to mutate the URL instance; to replace the entirety of query
+parameters of the URL, use the [`url.search`][] setter. See
+[`URLSearchParams`][] documentation for details.
+
+Care must be taken when using `.searchParams` to modify the `URL` because,
+per the WHATWG specification, the `URLSearchParams` object uses slightly
+different rules to determine which characters should be percent-encoded. For
+instance, the `URL` object will not percent encode the ASCII tilde (`~`)
+character, while `URLSearchParams` will always encode it:
+
+```js
+const myUrl = new URL('https://example.org/abc?foo=~bar');
+
+console.log(myUrl.search);  // prints ?foo=~bar
+
+// Modify the URL via searchParams...
+myUrl.searchParams.sort();
+
+console.log(myUrl.search);  // prints ?foo=%7Ebar
+```
 
 #### `url.username`
 

--- a/test/parallel/test-whatwg-url-custom-searchparams-stringifier.js
+++ b/test/parallel/test-whatwg-url-custom-searchparams-stringifier.js
@@ -16,3 +16,12 @@ const URLSearchParams = require('url').URLSearchParams;
     message: 'Value of "this" must be of type URLSearchParams'
   });
 }
+
+// The URLSearchParams stringifier mutates the base URL using
+// different percent-encoding rules than the URL itself.
+{
+  const myUrl = new URL('https://example.org?foo=~bar');
+  assert.strictEqual(myUrl.search, '?foo=~bar');
+  myUrl.searchParams.sort();
+  assert.strictEqual(myUrl.search, '?foo=%7Ebar');
+}


### PR DESCRIPTION
The WHATWG URL spec is not going to change this behavior so
let's document it

Fixes: https://github.com/nodejs/node/issues/33037

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
