### PR TITLE
n-api: add uint32 test for -1

### DIFF
--- a/test/js-native-api/test_number/test.js
+++ b/test/js-native-api/test_number/test.js
@@ -48,6 +48,7 @@ testUint32(4294967295);
 testUint32(4294967296, 0);
 testUint32(4294967297, 1);
 testUint32(17 * 4294967296 + 1, 1);
+testUint32(-1, 0xffffffff);
 
 // Validate documented behavior when value is retrieved as 32-bit integer with
 // `napi_get_value_int32`


### PR DESCRIPTION
Adds a test to ensure that napi_get_value_uint32 returns 0xffffffff for
-1.

Re: https://github.com/nodejs/node/issues/33117
Signed-off-by: @gabrielschulhof

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
