### PR TITLE
fs: fix memory corruption issues around fs.Dir

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -855,6 +855,15 @@ An unknown Diffie-Hellman group name was given. See
 
 The [`fs.Dir`][] was previously closed.
 
+<a id="ERR_DIR_CONCURRENT_OPERATION"></a>
+### `ERR_DIR_CONCURRENT_OPERATION`
+<!-- YAML
+added: REPLACEME
+-->
+
+A synchronous read or close call was attempted on an [`fs.Dir`][] which has
+ongoing asynchronous operations.
+
 <a id="ERR_DNS_SET_SERVERS_FAILED"></a>
 ### `ERR_DNS_SET_SERVERS_FAILED`
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -788,6 +788,9 @@ E('ERR_CRYPTO_SIGN_KEY_REQUIRED', 'No key provided to sign', Error);
 E('ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH',
   'Input buffers must have the same byte length', RangeError);
 E('ERR_DIR_CLOSED', 'Directory handle was closed', Error);
+E('ERR_DIR_CONCURRENT_OPERATION',
+  'Cannot do synchronous work on directory handle with concurrent ' +
+  'asynchronous operations', Error);
 E('ERR_DNS_SET_SERVERS_FAILED', 'c-ares failed to set servers: "%s" [%s]',
   Error);
 E('ERR_DOMAIN_CALLBACK_NOT_AVAILABLE',

--- a/lib/internal/fs/dir.js
+++ b/lib/internal/fs/dir.js
@@ -12,6 +12,7 @@ const dirBinding = internalBinding('fs_dir');
 const {
   codes: {
     ERR_DIR_CLOSED,
+    ERR_DIR_CONCURRENT_OPERATION,
     ERR_INVALID_CALLBACK,
     ERR_MISSING_ARGS
   }
@@ -37,6 +38,7 @@ const kDirOptions = Symbol('kDirOptions');
 const kDirReadImpl = Symbol('kDirReadImpl');
 const kDirReadPromisified = Symbol('kDirReadPromisified');
 const kDirClosePromisified = Symbol('kDirClosePromisified');
+const kDirOperationQueue = Symbol('kDirOperationQueue');
 
 class Dir {
   constructor(handle, path, options) {
@@ -45,6 +47,10 @@ class Dir {
     this[kDirBufferedEntries] = [];
     this[kDirPath] = path;
     this[kDirClosed] = false;
+
+    // Either `null` or an Array of pending operations (= functions to be called
+    // once the current operation is done).
+    this[kDirOperationQueue] = null;
 
     this[kDirOptions] = {
       bufferSize: 32,
@@ -79,6 +85,13 @@ class Dir {
       throw new ERR_INVALID_CALLBACK(callback);
     }
 
+    if (this[kDirOperationQueue] !== null) {
+      this[kDirOperationQueue].push(() => {
+        this[kDirReadImpl](maybeSync, callback);
+      });
+      return;
+    }
+
     if (this[kDirBufferedEntries].length > 0) {
       const [ name, type ] = this[kDirBufferedEntries].splice(0, 2);
       if (maybeSync)
@@ -90,6 +103,12 @@ class Dir {
 
     const req = new FSReqCallback();
     req.oncomplete = (err, result) => {
+      process.nextTick(() => {
+        const queue = this[kDirOperationQueue];
+        this[kDirOperationQueue] = null;
+        for (const op of queue) op();
+      });
+
       if (err || result === null) {
         return callback(err, result);
       }
@@ -98,6 +117,7 @@ class Dir {
       getDirent(this[kDirPath], result[0], result[1], callback);
     };
 
+    this[kDirOperationQueue] = [];
     this[kDirHandle].read(
       this[kDirOptions].encoding,
       this[kDirOptions].bufferSize,
@@ -108,6 +128,10 @@ class Dir {
   readSync() {
     if (this[kDirClosed] === true) {
       throw new ERR_DIR_CLOSED();
+    }
+
+    if (this[kDirOperationQueue] !== null) {
+      throw new ERR_DIR_CONCURRENT_OPERATION();
     }
 
     if (this[kDirBufferedEntries].length > 0) {
@@ -143,6 +167,13 @@ class Dir {
       throw new ERR_INVALID_CALLBACK(callback);
     }
 
+    if (this[kDirOperationQueue] !== null) {
+      this[kDirOperationQueue].push(() => {
+        this.close(callback);
+      });
+      return;
+    }
+
     this[kDirClosed] = true;
     const req = new FSReqCallback();
     req.oncomplete = callback;
@@ -152,6 +183,10 @@ class Dir {
   closeSync() {
     if (this[kDirClosed] === true) {
       throw new ERR_DIR_CLOSED();
+    }
+
+    if (this[kDirOperationQueue] !== null) {
+      throw new ERR_DIR_CONCURRENT_OPERATION();
     }
 
     this[kDirClosed] = true;

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -184,6 +184,7 @@ class FSReqAfterScope final {
  public:
   FSReqAfterScope(FSReqBase* wrap, uv_fs_t* req);
   ~FSReqAfterScope();
+  void Clear();
 
   bool Proceed();
 
@@ -195,7 +196,7 @@ class FSReqAfterScope final {
   FSReqAfterScope& operator=(const FSReqAfterScope&&) = delete;
 
  private:
-  FSReqBase* wrap_ = nullptr;
+  BaseObjectPtr<FSReqBase> wrap_;
   uv_fs_t* req_ = nullptr;
   v8::HandleScope handle_scope_;
   v8::Context::Scope context_scope_;


### PR DESCRIPTION
##### fs: clean up Dir.read() uv_fs_t data before calling into JS

A call into JS can schedule another operation on the same `uv_dir_t`.
In particular, when the handle is closed from the callback for a
directory read operation, there previously was a race condition window:

1. A `dir.read()` operation is submitted to libuv
2. The read operation is finished by libuv, calling `AfterDirRead()`
3. We call into JS
4. JS calls dir.close()
5. libuv posts the close request to a thread in the pool
6. The close request runs, destroying the directory handle
7. `AfterDirRead()` is being exited.

Exiting the `FSReqAfterScope` in step 7 attempts to destroy the original
uv_fs_t` from step 1, which now points to an `uv_dir_t` that has
already been destroyed in step 5.

By forcing the `FSReqAfterScope` to clean up before we call into JS,
we can be sure that no other operations on the same `uv_dir_t` are
submitted concurrently.

This addresses issues observed when running with ASAN/valgrind.

##### fs: forbid concurrent operations on Dir handle

libuv does not expect concurrent operations on `uv_dir_t` instances,
and will gladly create memory leaks, corrupt data, or crash the
process.

This patch forbids that, and:

- Makes sure that concurrent async operations are run sequentially
- Throws an exception if sync operations are attempted during an
  async operation

The assumption here is that a thrown exception is preferable to
a potential hard crash.

This fully fixes flakiness from `parallel/test-fs-opendir` when
run under ASAN.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
