### PR TITLE
test: skip test_threadsafe_function for debug build

### DIFF
--- a/test/node-api/test_threadsafe_function/test.js
+++ b/test/node-api/test_threadsafe_function/test.js
@@ -1,6 +1,9 @@
 'use strict';
 
 const common = require('../../common');
+if (process.config.variables.is_debug) {
+  common.skip('v8::Isolate::GetCurrent() will abort in debug mode');
+}
 const assert = require('assert');
 const binding = require(`./build/${common.buildType}/binding`);
 const { fork } = require('child_process');


### PR DESCRIPTION
This comit suggests skipping this test when the build type is `Debug`. The
reason for this is that it currently aborts with the following message:
```console
 1: 0xe5ba88 node::DumpBacktrace(_IO_FILE*) [out/Debug/node]
 2: 0xfc4e2d  [out/Debug/node]
 3: 0xfc4e4d  [out/Debug/node]
 4: 0x288c9e8 V8_Fatal(char const*, int, char const*, ...)
    [out/Debug/node]
 5: 0x288ca13  [out/Debug/node]
 6: 0x115ef49 v8::internal::Isolate::Current() [out/Debug/node]
 7: 0xec6e1c  [out/Debug/node]
 8: 0xec9c26 napi_call_threadsafe_function [out/Debug/node]
 9: 0x7f3a39de3474
    [test/node-api/test_threadsafe_function/build/Debug/binding.node]
10: 0x7f3a39a5a4e2  [/lib64/libpthread.so.0]
11: 0x7f3a399896d3 clone [/lib64/libc.so.6]
Illegal instruction (core dumped)
```
This is generated from `ThreadSafeFunction::Push` and the call to
`v8::Isolate::GetCurrent()` which has a debug mode check (DCHECK) which is
causing this to abort if the current thread's Isolate is a null. As far
as I know there is nothing like v8::internal::Isolate::TryGetCurrent()
exposed with could be used which is the reason for suggesting this test
just be skipped.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
