### PR TITLE
http: added scheduling option to http agent

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -110,6 +110,11 @@ http.get({
 ### `new Agent([options])`
 <!-- YAML
 added: v0.3.4
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/33278
+    description: Add `scheduling` option to specify the free socket
+                 scheduling strategy.
 -->
 
 * `options` {Object} Set of configurable options to set on the agent.
@@ -132,6 +137,18 @@ added: v0.3.4
   * `maxFreeSockets` {number} Maximum number of sockets to leave open
     in a free state. Only relevant if `keepAlive` is set to `true`.
     **Default:** `256`.
+  * `scheduling` {string} Scheduling strategy to apply when picking
+    the next free socket to use. It can be `'fifo'` or `'lifo'`.
+    The main difference between the two scheduling strategies is that `'lifo'`
+    selects the most recently used socket, while `'fifo'` selects
+    the least recently used socket.
+    In case of a low rate of request per second, the `'lifo'` scheduling
+    will lower the risk of picking a socket that might have been closed
+    by the server due to inactivity.
+    In case of a high rate of request per second,
+    the `'fifo'` scheduling will maximize the number of open sockets,
+    while the `'lifo'` scheduling will keep it as low as possible.
+    **Default:** `'fifo'`.
   * `timeout` {number} Socket timeout in milliseconds.
     This will set the timeout when the socket is created.
 

--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -35,6 +35,7 @@ const { async_id_symbol } = require('internal/async_hooks').symbols;
 const {
   codes: {
     ERR_INVALID_ARG_TYPE,
+    ERR_INVALID_OPT_VALUE,
   },
 } = require('internal/errors');
 const { once } = require('internal/util');
@@ -86,6 +87,11 @@ function Agent(options) {
   this.keepAlive = this.options.keepAlive || false;
   this.maxSockets = this.options.maxSockets || Agent.defaultMaxSockets;
   this.maxFreeSockets = this.options.maxFreeSockets || 256;
+  this.scheduling = this.options.scheduling || 'fifo';
+
+  if (this.scheduling !== 'fifo' && this.scheduling !== 'lifo') {
+    throw new ERR_INVALID_OPT_VALUE('scheduling', this.scheduling);
+  }
 
   this.on('free', (socket, options) => {
     const name = this.getName(options);
@@ -219,7 +225,9 @@ Agent.prototype.addRequest = function addRequest(req, options, port/* legacy */,
     while (freeSockets.length && freeSockets[0].destroyed) {
       freeSockets.shift();
     }
-    socket = freeSockets.shift();
+    socket = this.scheduling === 'fifo' ?
+      freeSockets.shift() :
+      freeSockets.pop();
     if (!freeSockets.length)
       delete this.freeSockets[name];
   }

--- a/test/parallel/test-http-agent-scheduling.js
+++ b/test/parallel/test-http-agent-scheduling.js
@@ -1,0 +1,148 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+function createServer(count) {
+  return http.createServer(common.mustCallAtLeast((req, res) => {
+    // Return the remote port number used for this connection.
+    res.end(req.socket.remotePort.toString(10));
+  }), count);
+}
+
+function makeRequest(url, agent, callback) {
+  http
+    .request(url, { agent }, (res) => {
+      let data = '';
+      res.setEncoding('ascii');
+      res.on('data', (c) => {
+        data += c;
+      });
+      res.on('end', () => {
+        process.nextTick(callback, data);
+      });
+    })
+    .end();
+}
+
+function bulkRequest(url, agent, done) {
+  const ports = [];
+  let count = agent.maxSockets;
+
+  for (let i = 0; i < agent.maxSockets; i++) {
+    makeRequest(url, agent, callback);
+  }
+
+  function callback(port) {
+    count -= 1;
+    ports.push(port);
+    if (count === 0) {
+      done(ports);
+    }
+  }
+}
+
+function defaultTest() {
+  const server = createServer(8);
+  server.listen(0, onListen);
+
+  function onListen() {
+    const url = `http://localhost:${server.address().port}`;
+    const agent = new http.Agent({
+      keepAlive: true,
+      maxSockets: 5
+    });
+
+    bulkRequest(url, agent, (ports) => {
+      makeRequest(url, agent, (port) => {
+        assert.strictEqual(ports[0], port);
+        makeRequest(url, agent, (port) => {
+          assert.strictEqual(ports[1], port);
+          makeRequest(url, agent, (port) => {
+            assert.strictEqual(ports[2], port);
+            server.close();
+            agent.destroy();
+          });
+        });
+      });
+    });
+  }
+}
+
+function fifoTest() {
+  const server = createServer(8);
+  server.listen(0, onListen);
+
+  function onListen() {
+    const url = `http://localhost:${server.address().port}`;
+    const agent = new http.Agent({
+      keepAlive: true,
+      maxSockets: 5,
+      scheduling: 'fifo'
+    });
+
+    bulkRequest(url, agent, (ports) => {
+      makeRequest(url, agent, (port) => {
+        assert.strictEqual(ports[0], port);
+        makeRequest(url, agent, (port) => {
+          assert.strictEqual(ports[1], port);
+          makeRequest(url, agent, (port) => {
+            assert.strictEqual(ports[2], port);
+            server.close();
+            agent.destroy();
+          });
+        });
+      });
+    });
+  }
+}
+
+function lifoTest() {
+  const server = createServer(8);
+  server.listen(0, onListen);
+
+  function onListen() {
+    const url = `http://localhost:${server.address().port}`;
+    const agent = new http.Agent({
+      keepAlive: true,
+      maxSockets: 5,
+      scheduling: 'lifo'
+    });
+
+    bulkRequest(url, agent, (ports) => {
+      makeRequest(url, agent, (port) => {
+        assert.strictEqual(ports[ports.length - 1], port);
+        makeRequest(url, agent, (port) => {
+          assert.strictEqual(ports[ports.length - 1], port);
+          makeRequest(url, agent, (port) => {
+            assert.strictEqual(ports[ports.length - 1], port);
+            server.close();
+            agent.destroy();
+          });
+        });
+      });
+    });
+  }
+}
+
+function badSchedulingOptionTest() {
+  try {
+    new http.Agent({
+      keepAlive: true,
+      maxSockets: 5,
+      scheduling: 'filo'
+    });
+  } catch (err) {
+    assert.strictEqual(err.code, 'ERR_INVALID_OPT_VALUE');
+    assert.strictEqual(
+      err.message,
+      'The value "filo" is invalid for option "scheduling"'
+    );
+  }
+}
+
+defaultTest();
+fifoTest();
+lifoTest();
+badSchedulingOptionTest();


### PR DESCRIPTION
Hello everyone!

This pr introduces a new configuration option in the HTTP agent, named `scheduling`.
By default, the agent iterates over the free sockets in a FIFO fashion, the newly added `scheduling` option allows using a LIFO instead.
If nothing is configured, the behavior will be the same as before, so this change should not be considered as breaking.

### Why this is useful?

I've encountered a case where the application was sending requests at a high rate (around 200 req/sec), with low response time. Every now and then, the response time increased massively for a few seconds and the agent started opening as many sockets as it could, later, the response time was low again, and only a few sockets were used at a given time.
The issue is that the agent will not close the `freeSockets`, because since the default scheduling sequence is FIFO, every socket will be reused before it reaches its timeout.
This situation was happening in a system with multiple instances of Node, and the receiver of the request was overwhelmed by the high number of open and never closed sockets.

By switching to a LIFO scheduling, I saw that the spikes were handled as expected, but as soon as the response time was low again, the `freeSockets` start decreasing, and only the minimum amount of sockets was used.

Given that both scheduling strategies have pros and cons, I've decided to expose them as an option, so the user can have more control based on their needs.

### How does it work?

The user only need to configure the `scheduling` option, only `fifo` and `lifo` are accepted.
```js
const agent = new http.Agent({
  keepAlive: true,
  maxSockets: 256,
  maxFreeSockets: 256,
  timeout: 30000,
  scheduling: 'lifo'
})
```

I didn't update the documentation yet, I'll do that once we settle on the feature and the implementation :)
If possible, I would love to see this change landing both in Node.js v12 and v14.

Related: https://github.com/nodejs/node/pull/31526
cc @mcollina @ronag 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
