### PR TITLE
perf_hooks: fix error message for invalid entryTypes

### DIFF
--- a/lib/perf_hooks.js
+++ b/lib/perf_hooks.js
@@ -341,11 +341,12 @@ class PerformanceObserver extends AsyncResource {
     if (typeof options !== 'object' || options === null) {
       throw new ERR_INVALID_ARG_TYPE('options', 'Object', options);
     }
-    if (!ArrayIsArray(options.entryTypes)) {
-      throw new ERR_INVALID_OPT_VALUE('entryTypes', options);
+    const { entryTypes } = options;
+    if (!ArrayIsArray(entryTypes)) {
+      throw new ERR_INVALID_OPT_VALUE('entryTypes', entryTypes);
     }
-    const entryTypes = options.entryTypes.filter(filterTypes).map(mapTypes);
-    if (entryTypes.length === 0) {
+    const filteredEntryTypes = entryTypes.filter(filterTypes).map(mapTypes);
+    if (filteredEntryTypes.length === 0) {
       throw new ERR_VALID_PERFORMANCE_ENTRY_TYPE();
     }
     this.disconnect();
@@ -353,7 +354,7 @@ class PerformanceObserver extends AsyncResource {
     this[kBuffer][kEntries] = [];
     L.init(this[kBuffer][kEntries]);
     this[kBuffering] = Boolean(options.buffered);
-    for (const entryType of entryTypes) {
+    for (const entryType of filteredEntryTypes) {
       const list = getObserversList(entryType);
       if (this[kTypes][entryType]) continue;
       const item = { obs: this };

--- a/test/parallel/test-performanceobserver.js
+++ b/test/parallel/test-performanceobserver.js
@@ -58,7 +58,7 @@ assert.strictEqual(counts[NODE_PERFORMANCE_ENTRY_TYPE_FUNCTION], 0);
                   {
                     code: 'ERR_INVALID_OPT_VALUE',
                     name: 'TypeError',
-                    message: 'The value "[object Object]" is invalid ' +
+                    message: `The value "${i}" is invalid ` +
                                    'for option "entryTypes"'
                   });
   });


### PR DESCRIPTION
Will now print a more meaningful value instead of always "[object Object]".
