### PR TITLE
lib,test: improve validateNumber and validators coverage

### DIFF
--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -2,9 +2,11 @@
 
 const {
   ArrayIsArray,
+  NumberPOSITIVE_INFINITY,
   NumberIsInteger,
   NumberMAX_SAFE_INTEGER,
   NumberMIN_SAFE_INTEGER,
+  NumberNEGATIVE_INFINITY,
 } = primordials;
 
 const {
@@ -121,9 +123,13 @@ function validateString(value, name) {
     throw new ERR_INVALID_ARG_TYPE(name, 'string', value);
 }
 
-function validateNumber(value, name) {
+function validateNumber(value, name,
+                        min = NumberNEGATIVE_INFINITY,
+                        max = NumberPOSITIVE_INFINITY) {
   if (typeof value !== 'number')
     throw new ERR_INVALID_ARG_TYPE(name, 'number', value);
+  if (value < min || value > max)
+    throw new ERR_OUT_OF_RANGE(name, `>= ${min} && <= ${max}`, value);
 }
 
 function validateBoolean(value, name) {

--- a/test/parallel/test-validators.js
+++ b/test/parallel/test-validators.js
@@ -13,12 +13,7 @@ const {
   validateObject,
   validateString,
 } = require('internal/validators');
-const {
-  MAX_SAFE_INTEGER,
-  MIN_SAFE_INTEGER,
-  NEGATIVE_INFINITY,
-  POSITIVE_INFINITY,
-} = Number;
+const { MAX_SAFE_INTEGER, MIN_SAFE_INTEGER } = Number;
 const outOfRangeError = {
   code: 'ERR_OUT_OF_RANGE',
   name: 'RangeError',

--- a/test/parallel/test-validators.js
+++ b/test/parallel/test-validators.js
@@ -3,13 +3,22 @@
 
 require('../common');
 const assert = require('assert');
+const { Buffer } = require('buffer');
 const {
   validateArray,
   validateBoolean,
+  validateBuffer,
   validateInteger,
+  validateNumber,
   validateObject,
+  validateString,
 } = require('internal/validators');
-const { MAX_SAFE_INTEGER, MIN_SAFE_INTEGER } = Number;
+const {
+  MAX_SAFE_INTEGER,
+  MIN_SAFE_INTEGER,
+  NEGATIVE_INFINITY,
+  POSITIVE_INFINITY,
+} = Number;
 const outOfRangeError = {
   code: 'ERR_OUT_OF_RANGE',
   name: 'RangeError',
@@ -84,4 +93,36 @@ const invalidArgValueError = {
     });
 
   validateObject(null, 'foo', { nullable: true });
+}
+
+{
+  // validateString tests
+  validateString('hi', 'foo');
+
+  [1, false, [], {}, NaN, 1n, null, undefined].forEach((i) => {
+    assert.throws(() => validateString(i, 'foo'), invalidArgTypeError);
+  });
+}
+
+{
+  // validateBuffer tests
+  validateBuffer(Buffer.from('hi'), 'foo');
+  validateBuffer(Buffer.alloc(10), 'foo');
+  validateBuffer(new Uint8Array(10), 'foo');
+  validateBuffer(new DataView((new Uint8Array(10)).buffer));
+
+  [1, false, '', {}, [], 1n, null, undefined].forEach((i) => {
+    assert.throws(() => validateBuffer(i, 'foo'), invalidArgTypeError);
+  });
+}
+
+{
+  // validateNumber tests
+
+  ['', false, [], {}, 1n, null, undefined].forEach((i) => {
+    assert.throws(() => validateNumber(i, 'foo'), invalidArgTypeError);
+  });
+
+  assert.throws(() => validateNumber(1, 'foo', 2), outOfRangeError);
+  assert.throws(() => validateNumber(3, 'foo', 0, 2), outOfRangeError);
 }


### PR DESCRIPTION
Adds a min/max predicate to validateNumber (which will be used
by the QUIC impl, extracted from that PR) ... and improves test
coverage in test-validators.js

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
