### PR TITLE
cli: add `--trace-atomics-wait` flag

### DIFF
--- a/benchmark/worker/atomics-wait.js
+++ b/benchmark/worker/atomics-wait.js
@@ -1,4 +1,5 @@
 'use strict';
+/* global SharedArrayBuffer */
 
 const common = require('../common.js');
 const bench = common.createBenchmark(main, {

--- a/benchmark/worker/atomics-wait.js
+++ b/benchmark/worker/atomics-wait.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const common = require('../common.js');
+const bench = common.createBenchmark(main, {
+  n: [1e7]
+});
+
+function main({ n }) {
+  const i32arr = new Int32Array(new SharedArrayBuffer(4));
+  bench.start();
+  for (let i = 0; i < n; i++)
+    Atomics.wait(i32arr, 0, 1);  // Will return immediately.
+  bench.end(n);
+}

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -821,7 +821,7 @@ for TLSv1.2, which is not as secure as TLSv1.3.
 added: REPLACEME
 -->
 
-Print short summaries of calls to `Atomics.wait()` to stderr.
+Print short summaries of calls to [`Atomics.wait()`][] to stderr.
 The output could look like this:
 
 ```text
@@ -834,6 +834,14 @@ The output could look like this:
 [Thread 0] Atomics.wait(0x55d134fe4290 + 4, 0, inf) was woken up by another thread
 [Thread 1] Atomics.wait(0x55d134fe4290 + 4, -1, inf) was woken up by another thread
 ```
+
+The fields here correspond to:
+
+- The thread id as given by [`worker_threads.threadId`][]
+- The base address of the `SharedArrayBuffer` in question, as well as the
+  byte offset corresponding to the index passed to `Atomics.wait()`
+- The expected value that was passed to `Atomics.wait()`
+- The timeout passed to `Atomics.wait`
 
 ### `--trace-deprecation`
 <!-- YAML
@@ -1494,12 +1502,14 @@ $ node --max-old-space-size=1536 index.js
 ```
 
 [`--openssl-config`]: #cli_openssl_config_file
+[`Atomics.wait()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/wait
 [`Buffer`]: buffer.html#buffer_class_buffer
 [`SlowBuffer`]: buffer.html#buffer_class_slowbuffer
 [`process.setUncaughtExceptionCaptureCallback()`]: process.html#process_process_setuncaughtexceptioncapturecallback_fn
 [`tls.DEFAULT_MAX_VERSION`]: tls.html#tls_tls_default_max_version
 [`tls.DEFAULT_MIN_VERSION`]: tls.html#tls_tls_default_min_version
 [`unhandledRejection`]: process.html#process_event_unhandledrejection
+[`worker_threads.threadId`]: worker_threads.html##worker_threads_worker_threadid
 [Chrome DevTools Protocol]: https://chromedevtools.github.io/devtools-protocol/
 [REPL]: repl.html
 [ScriptCoverage]: https://chromedevtools.github.io/devtools-protocol/tot/Profiler#type-ScriptCoverage

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -816,6 +816,25 @@ added: v12.0.0
 Set default [`tls.DEFAULT_MIN_VERSION`][] to 'TLSv1.3'. Use to disable support
 for TLSv1.2, which is not as secure as TLSv1.3.
 
+### `--trace-atomics-wait`
+<!-- YAML
+added: REPLACEME
+-->
+
+Print short summaries of calls to `Atomics.wait()` to stderr.
+The output could look like this:
+
+```text
+[Thread 0] Atomics.wait(0x55d134fe4290 + 0, 1, inf) started
+[Thread 0] Atomics.wait(0x55d134fe4290 + 0, 1, inf) did not wait because the values mismatched
+[Thread 0] Atomics.wait(0x55d134fe4290 + 0, 0, 10) started
+[Thread 0] Atomics.wait(0x55d134fe4290 + 0, 0, 10) timed out
+[Thread 0] Atomics.wait(0x55d134fe4290 + 4, 0, inf) started
+[Thread 1] Atomics.wait(0x55d134fe4290 + 4, -1, inf) started
+[Thread 0] Atomics.wait(0x55d134fe4290 + 4, 0, inf) was woken up by another thread
+[Thread 1] Atomics.wait(0x55d134fe4290 + 4, -1, inf) was woken up by another thread
+```
+
 ### `--trace-deprecation`
 <!-- YAML
 added: v0.8.0
@@ -1205,6 +1224,7 @@ Node.js options that are allowed are:
 * `--tls-min-v1.1`
 * `--tls-min-v1.2`
 * `--tls-min-v1.3`
+* `--trace-atomics-wait`
 * `--trace-deprecation`
 * `--trace-event-categories`
 * `--trace-event-file-pattern`

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -825,14 +825,14 @@ Print short summaries of calls to [`Atomics.wait()`][] to stderr.
 The output could look like this:
 
 ```text
-[Thread 0] Atomics.wait(0x55d134fe4290 + 0, 1, inf) started
-[Thread 0] Atomics.wait(0x55d134fe4290 + 0, 1, inf) did not wait because the values mismatched
-[Thread 0] Atomics.wait(0x55d134fe4290 + 0, 0, 10) started
-[Thread 0] Atomics.wait(0x55d134fe4290 + 0, 0, 10) timed out
-[Thread 0] Atomics.wait(0x55d134fe4290 + 4, 0, inf) started
-[Thread 1] Atomics.wait(0x55d134fe4290 + 4, -1, inf) started
-[Thread 0] Atomics.wait(0x55d134fe4290 + 4, 0, inf) was woken up by another thread
-[Thread 1] Atomics.wait(0x55d134fe4290 + 4, -1, inf) was woken up by another thread
+(node:15701) [Thread 0] Atomics.wait(<address> + 0, 1, inf) started
+(node:15701) [Thread 0] Atomics.wait(<address> + 0, 1, inf) did not wait because the values mismatched
+(node:15701) [Thread 0] Atomics.wait(<address> + 0, 0, 10) started
+(node:15701) [Thread 0] Atomics.wait(<address> + 0, 0, 10) timed out
+(node:15701) [Thread 0] Atomics.wait(<address> + 4, 0, inf) started
+(node:15701) [Thread 1] Atomics.wait(<address> + 4, -1, inf) started
+(node:15701) [Thread 0] Atomics.wait(<address> + 4, 0, inf) was woken up by another thread
+(node:15701) [Thread 1] Atomics.wait(<address> + 4, -1, inf) was woken up by another thread
 ```
 
 The fields here correspond to:

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -837,11 +837,11 @@ The output could look like this:
 
 The fields here correspond to:
 
-- The thread id as given by [`worker_threads.threadId`][]
-- The base address of the `SharedArrayBuffer` in question, as well as the
+* The thread id as given by [`worker_threads.threadId`][]
+* The base address of the `SharedArrayBuffer` in question, as well as the
   byte offset corresponding to the index passed to `Atomics.wait()`
-- The expected value that was passed to `Atomics.wait()`
-- The timeout passed to `Atomics.wait`
+* The expected value that was passed to `Atomics.wait()`
+* The timeout passed to `Atomics.wait`
 
 ### `--trace-deprecation`
 <!-- YAML

--- a/doc/node.1
+++ b/doc/node.1
@@ -363,6 +363,10 @@ but the option is supported for compatibility with older Node.js versions.
 Set default minVersion to 'TLSv1.3'. Use to disable support for TLSv1.2 in
 favour of TLSv1.3, which is more secure.
 .
+.It Fl -trace-atomics-wait
+Print short summaries of calls to
+.Sy Atomics.wait() .
+.
 .It Fl -trace-deprecation
 Print stack traces for deprecations.
 .

--- a/src/node.cc
+++ b/src/node.cc
@@ -256,7 +256,9 @@ static void AtomicsWaitCallback(Isolate::AtomicsWaitEvent event,
   }
 
   fprintf(stderr,
-          "[Thread %" PRIu64 "] Atomics.wait(%p + %zx, %" PRId64 ", %.f) %s\n",
+          "(node:%d) [Thread %" PRIu64 "] Atomics.wait(%p + %zx, %" PRId64
+              ", %.f) %s\n",
+          static_cast<int>(uv_os_getpid()),
           env->thread_id(),
           array_buffer->GetBackingStore()->Data(),
           offset_in_bytes,

--- a/src/node.cc
+++ b/src/node.cc
@@ -229,11 +229,54 @@ int Environment::InitializeInspector(
 }
 #endif  // HAVE_INSPECTOR && NODE_USE_V8_PLATFORM
 
+#define ATOMIC_WAIT_EVENTS(V)                                               \
+  V(kStartWait,           "started")                                        \
+  V(kWokenUp,             "was woken up by another thread")                 \
+  V(kTimedOut,            "timed out")                                      \
+  V(kTerminatedExecution, "was stopped by terminated execution")            \
+  V(kAPIStopped,          "was stopped through the embedder API")           \
+  V(kNotEqual,            "did not wait because the values mismatched")     \
+
+static void AtomicsWaitCallback(Isolate::AtomicsWaitEvent event,
+                                Local<v8::SharedArrayBuffer> array_buffer,
+                                size_t offset_in_bytes, int64_t value,
+                                double timeout_in_ms,
+                                Isolate::AtomicsWaitWakeHandle* stop_handle,
+                                void* data) {
+  Environment* env = static_cast<Environment*>(data);
+
+  const char* message;
+  switch (event) {
+#define V(key, msg)                         \
+    case Isolate::AtomicsWaitEvent::key:    \
+      message = msg;                        \
+      break;
+    ATOMIC_WAIT_EVENTS(V)
+#undef V
+  }
+
+  fprintf(stderr,
+          "[Thread %" PRIu64 "] Atomics.wait(%p + %zx, %" PRId64 ", %.f) %s\n",
+          env->thread_id(),
+          array_buffer->GetBackingStore()->Data(),
+          offset_in_bytes,
+          value,
+          timeout_in_ms,
+          message);
+}
+
 void Environment::InitializeDiagnostics() {
   isolate_->GetHeapProfiler()->AddBuildEmbedderGraphCallback(
       Environment::BuildEmbedderGraph, this);
   if (options_->trace_uncaught)
     isolate_->SetCaptureStackTraceForUncaughtExceptions(true);
+  if (options_->trace_atomics_wait) {
+    isolate_->SetAtomicsWaitCallback(AtomicsWaitCallback, this);
+    AddCleanupHook([](void* data) {
+      Environment* env = static_cast<Environment*>(data);
+      env->isolate()->SetAtomicsWaitCallback(nullptr, nullptr);
+    }, this);
+  }
 
 #if defined HAVE_DTRACE || defined HAVE_ETW
   InitDTrace(this);

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -435,6 +435,10 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "throw an exception on deprecations",
             &EnvironmentOptions::throw_deprecation,
             kAllowedInEnvironment);
+  AddOption("--trace-atomics-wait",
+            "trace Atomics.wait() operations",
+            &EnvironmentOptions::trace_atomics_wait,
+            kAllowedInEnvironment);
   AddOption("--trace-deprecation",
             "show stack traces on deprecations",
             &EnvironmentOptions::trace_deprecation,

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -140,6 +140,7 @@ class EnvironmentOptions : public Options {
   std::string redirect_warnings;
   bool test_udp_no_try_send = false;
   bool throw_deprecation = false;
+  bool trace_atomics_wait = false;
   bool trace_deprecation = false;
   bool trace_exit = false;
   bool trace_sync_io = false;

--- a/test/parallel/test-trace-atomics-wait.js
+++ b/test/parallel/test-trace-atomics-wait.js
@@ -34,6 +34,7 @@ assert.strictEqual(proc.status, 0);
 const SABAddress = proc.stderr.match(/Atomics\.wait\((?<SAB>.+) \+/).groups.SAB;
 const actualTimeline = proc.stderr
   .replace(new RegExp(SABAddress, 'g'), '<address>')
+  .replace(new RegExp(`\\(node:${proc.pid}\\) `, 'g'), '')
   .replace(/infinity/g, 'inf')
   .replace(/\r/g, '')
   .trim();

--- a/test/parallel/test-trace-atomics-wait.js
+++ b/test/parallel/test-trace-atomics-wait.js
@@ -35,7 +35,7 @@ const SABAddress = proc.stderr.match(/Atomics\.wait\((?<SAB>.+) \+/).groups.SAB;
 const actualTimeline = proc.stderr
   .replace(new RegExp(SABAddress, 'g'), '<address>')
   .replace(new RegExp(`\\(node:${proc.pid}\\) `, 'g'), '')
-  .replace(/infinity/g, 'inf')
+  .replace(/\binf(inity)?\b/gi, 'inf')
   .replace(/\r/g, '')
   .trim();
 console.log('+++ normalized stdout +++');

--- a/test/parallel/test-trace-atomics-wait.js
+++ b/test/parallel/test-trace-atomics-wait.js
@@ -1,0 +1,74 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const child_process = require('child_process');
+const { Worker } = require('worker_threads');
+
+if (process.argv[2] === 'child') {
+  const i32arr = new Int32Array(new SharedArrayBuffer(8));
+  assert.strictEqual(Atomics.wait(i32arr, 0, 1), 'not-equal');
+  assert.strictEqual(Atomics.wait(i32arr, 0, 0, 10), 'timed-out');
+
+  new Worker(`
+  const i32arr = require('worker_threads').workerData;
+  Atomics.store(i32arr, 1, -1);
+  Atomics.notify(i32arr, 1);
+  Atomics.wait(i32arr, 1, -1);
+  `, { eval: true, workerData: i32arr });
+
+  Atomics.wait(i32arr, 1, 0);
+  assert.strictEqual(Atomics.load(i32arr, 1), -1);
+  Atomics.store(i32arr, 1, 0);
+  Atomics.notify(i32arr, 1);
+  return;
+}
+
+const proc = child_process.spawnSync(
+  process.execPath,
+  [ '--trace-atomics-wait', __filename, 'child' ],
+  { encoding: 'utf8', stdio: [ 'inherit', 'inherit', 'pipe' ] });
+
+if (proc.status !== 0) console.log(proc);
+assert.strictEqual(proc.status, 0);
+
+const expectedLines = [
+  { threadId: 0, offset: 0, value: 1, timeout: 'inf',
+    message: 'started' },
+  { threadId: 0, offset: 0, value: 1, timeout: 'inf',
+    message: 'did not wait because the values mismatched' },
+  { threadId: 0, offset: 0, value: 0, timeout: '10',
+    message: 'started' },
+  { threadId: 0, offset: 0, value: 0, timeout: '10',
+    message: 'timed out' },
+  { threadId: 0, offset: 4, value: 0, timeout: 'inf',
+    message: 'started' },
+  { threadId: 1, offset: 4, value: -1, timeout: 'inf',
+    message: 'started' },
+  { threadId: 0, offset: 4, value: 0, timeout: 'inf',
+    message: 'was woken up by another thread' },
+  { threadId: 1, offset: 4, value: -1, timeout: 'inf',
+    message: 'was woken up by another thread' }
+];
+
+let SABAddress;
+const re = /^\[Thread (?<threadId>\d+)\] Atomics\.wait\((?<SAB>(?:0x)?[0-9a-f]+) \+ (?<offset>\d+), (?<value>-?\d+), (?<timeout>inf|infinity|[0-9.]+)\) (?<message>.+)$/;
+for (const line of proc.stderr.split('\n').map((line) => line.trim())) {
+  if (!line) continue;
+  console.log('Matching', { line });
+  const actual = line.match(re).groups;
+  const expected = expectedLines.shift();
+
+  if (SABAddress === undefined)
+    SABAddress = actual.SAB;
+  else
+    assert.strictEqual(actual.SAB, SABAddress);
+
+  assert.strictEqual(+actual.threadId, expected.threadId);
+  assert.strictEqual(+actual.offset, expected.offset);
+  assert.strictEqual(+actual.value, expected.value);
+  assert.strictEqual(actual.message, expected.message);
+  if (expected.timeout === 'inf')
+    assert.match(actual.timeout, /inf(inity)?/);
+  else
+    assert.strictEqual(actual.timeout, expected.timeout);
+}


### PR DESCRIPTION
Adds a flag that helps with debugging deadlocks due to incorrectly
implemented `Atomics.wait()` calls.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
