### PR TITLE
repl: add builtinModules

### DIFF
--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -540,6 +540,15 @@ by default. However, this is not the case when creating a REPL
 programmatically. Use this method to initialize a history log file when working
 with REPL instances programmatically.
 
+## `repl.builtinModules`
+<!-- YAML
+added: REPLACEME
+-->
+
+* {string[]}
+
+A list of the names of all Node.js modules, e.g., `'http'`.
+
 ## `repl.start([options])`
 <!-- YAML
 added: v0.1.91

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -86,7 +86,7 @@ const {
 const { Console } = require('console');
 const CJSModule = require('internal/modules/cjs/loader').Module;
 let _builtinLibs = [...CJSModule.builtinModules]
-  .filter((e) => !e.startsWith('_'));
+  .filter((e) => !e.startsWith('_') && !e.includes('/'));
 const domain = require('domain');
 const debug = require('internal/util/debuglog').debuglog('repl');
 const {
@@ -1609,6 +1609,13 @@ module.exports = {
   REPL_MODE_STRICT,
   Recoverable
 };
+
+ObjectDefineProperty(module.exports, 'builtinModules', {
+  get: () => _builtinLibs,
+  set: (val) => _builtinLibs = val,
+  enumerable: true,
+  configurable: true
+});
 
 ObjectDefineProperty(module.exports, '_builtinLibs', {
   get: pendingDeprecation ? deprecate(

--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -224,9 +224,18 @@ putIn.run(['.clear']);
 testMe.complete('require(\'', common.mustCall(function(error, data) {
   assert.strictEqual(error, null);
   builtinModules.forEach((lib) => {
-    if (!lib.startsWith('_'))
-      assert(data[0].includes(lib), `${lib} not found`);
+    assert(
+      data[0].includes(lib) || lib.startsWith('_') || lib.includes('/'),
+      `${lib} not found`
+    );
   });
+  const newModule = 'foobar';
+  assert(!builtinModules.includes(newModule));
+  repl.builtinModules.push(newModule);
+  testMe.complete('require(\'', common.mustCall((_, [modules]) => {
+    assert.strictEqual(data[0].length + 1, modules.length);
+    assert(modules.includes(newModule));
+  }));
 }));
 
 testMe.complete("require\t( 'n", common.mustCall(function(error, data) {


### PR DESCRIPTION
This adds an alias to `_builtinLibs` that is documented and should
as such also be accessed publicly. It does not contain any
underscored modules.

Signed-off-by: Ruben Bridgewater <ruben@bridgewater.de>

<s>TODO: Add a test

https://github.com/nodejs/node/pull/33282 should land first. It updates
the list to contain all modules. That is currently not the case.</s>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
