### PR TITLE
fs: Refactor the import of internalUtil

### DIFF
--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -15,7 +15,7 @@ const {
   ERR_OUT_OF_RANGE,
   ERR_STREAM_DESTROYED
 } = require('internal/errors').codes;
-const internalUtil = require('internal/util');
+const { deprecate } = require('internal/util');
 const { validateNumber } = require('internal/validators');
 const fs = require('fs');
 const { Buffer } = require('buffer');
@@ -142,7 +142,7 @@ function ReadStream(path, options) {
 ObjectSetPrototypeOf(ReadStream.prototype, Readable.prototype);
 ObjectSetPrototypeOf(ReadStream, Readable);
 
-const openReadFs = internalUtil.deprecate(function() {
+const openReadFs = deprecate(function() {
   _openReadFs(this);
 }, 'ReadStream.prototype.open() is deprecated', 'DEP0135');
 ReadStream.prototype.open = openReadFs;
@@ -370,7 +370,7 @@ WriteStream.prototype._final = function(callback) {
   callback();
 };
 
-const openWriteFs = internalUtil.deprecate(function() {
+const openWriteFs = deprecate(function() {
   _openWriteFs(this);
 }, 'WriteStream.prototype.open() is deprecated', 'DEP0135');
 WriteStream.prototype.open = openWriteFs;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Deconstructing the `.deprecate()` that introduces `internal/util`.

/cc @BridgeAR 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
