### PR TITLE
test: improve WPT runner to summarize status and update WPT

### DIFF
--- a/test/common/wpt.js
+++ b/test/common/wpt.js
@@ -42,6 +42,18 @@ class ResourceLoader {
     this.path = path;
   }
 
+  toRealFilePath(from, url) {
+    // We need to patch this to load the WebIDL parser
+    url = url.replace(
+      '/resources/WebIDLParser.js',
+      '/resources/webidl2/lib/webidl2.js'
+    );
+    const base = path.dirname(from);
+    return url.startsWith('/') ?
+      fixtures.path('wpt', url) :
+      fixtures.path('wpt', base, url);
+  }
+
   /**
    * Load a resource in test/fixtures/wpt specified with a URL
    * @param {string} from the path of the file loading this resource,
@@ -51,15 +63,7 @@ class ResourceLoader {
    *                            pseudo-Response object.
    */
   read(from, url, asFetch = true) {
-    // We need to patch this to load the WebIDL parser
-    url = url.replace(
-      '/resources/WebIDLParser.js',
-      '/resources/webidl2/lib/webidl2.js'
-    );
-    const base = path.dirname(from);
-    const file = url.startsWith('/') ?
-      fixtures.path('wpt', url) :
-      fixtures.path('wpt', base, url);
+    const file = this.toRealFilePath(from, url);
     if (asFetch) {
       return fsPromises.readFile(file)
         .then((data) => {
@@ -135,7 +139,8 @@ class StatusRuleSet {
   }
 }
 
-class WPTTest {
+// A specification of WPT test
+class WPTTestSpec {
   /**
    * @param {string} mod name of the WPT module, e.g.
    *                     'html/webappapis/microtask-queuing'
@@ -227,8 +232,8 @@ class StatusLoader {
     this.path = path;
     this.loaded = false;
     this.rules = new StatusRuleSet();
-    /** @type {WPTTest[]} */
-    this.tests = [];
+    /** @type {WPTTestSpec[]} */
+    this.specs = [];
   }
 
   /**
@@ -265,15 +270,19 @@ class StatusLoader {
     for (const file of list) {
       const relativePath = path.relative(subDir, file);
       const match = this.rules.match(relativePath);
-      this.tests.push(new WPTTest(this.path, relativePath, match));
+      this.specs.push(new WPTTestSpec(this.path, relativePath, match));
     }
     this.loaded = true;
   }
 }
 
-const PASSED = 1;
-const FAILED = 2;
-const SKIPPED = 3;
+const kPass = 'pass';
+const kFail = 'fail';
+const kSkip = 'skip';
+const kTimeout = 'timeout';
+const kIncomplete = 'incomplete';
+const kUncaught = 'uncaught';
+const NODE_UNCAUGHT = 100;
 
 class WPTRunner {
   constructor(path) {
@@ -286,12 +295,13 @@ class WPTRunner {
 
     this.status = new StatusLoader(path);
     this.status.load();
-    this.tests = new Map(
-      this.status.tests.map((item) => [item.filename, item])
+    this.specMap = new Map(
+      this.status.specs.map((item) => [item.filename, item])
     );
 
-    this.results = new Map();
+    this.results = {};
     this.inProgress = new Set();
+    this.unexpectedFailures = [];
   }
 
   /**
@@ -328,39 +338,97 @@ class WPTRunner {
     // only `subset.any.js` will be run by the runner.
     if (process.argv[2]) {
       const filename = process.argv[2];
-      if (!this.tests.has(filename)) {
+      if (!this.specMap.has(filename)) {
         throw new Error(`${filename} not found!`);
       }
-      queue.push(this.tests.get(filename));
+      queue.push(this.specMap.get(filename));
     } else {
       queue = this.buildQueue();
     }
 
-    this.inProgress = new Set(queue.map((item) => item.filename));
+    this.inProgress = new Set(queue.map((spec) => spec.filename));
 
-    for (const test of queue) {
-      const filename = test.filename;
-      const content = test.getContent();
-      const meta = test.title = this.getMeta(content);
+    for (const spec of queue) {
+      const testFileName = spec.filename;
+      const content = spec.getContent();
+      const meta = spec.title = this.getMeta(content);
 
-      const absolutePath = test.getAbsolutePath();
-      const context = this.generateContext(test);
-      const relativePath = test.getRelativePath();
-      const code = this.mergeScripts(relativePath, meta, content);
-      try {
-        vm.runInContext(code, context, {
-          filename: absolutePath
-        });
-      } catch (err) {
-        this.fail(filename, {
-          name: '',
-          message: err.message,
-          stack: inspect(err)
-        }, 'UNCAUGHT');
-        this.inProgress.delete(filename);
+      const absolutePath = spec.getAbsolutePath();
+      const context = this.generateContext(spec);
+      const relativePath = spec.getRelativePath();
+      const scriptsToRun = [];
+      // Scripts specified with the `// META: script=` header
+      if (meta.script) {
+        for (const script of meta.script) {
+          scriptsToRun.push({
+            filename: this.resource.toRealFilePath(relativePath, script),
+            code: this.resource.read(relativePath, script, false)
+          });
+        }
+      }
+      // The actual test
+      scriptsToRun.push({
+        code: content,
+        filename: absolutePath
+      });
+
+      for (const { code, filename } of scriptsToRun) {
+        try {
+          vm.runInContext(code, context, { filename });
+        } catch (err) {
+          this.fail(
+            testFileName,
+            {
+              status: NODE_UNCAUGHT,
+              name: 'evaluation in WPTRunner.runJsTests()',
+              message: err.message,
+              stack: inspect(err)
+            },
+            kUncaught
+          );
+          this.inProgress.delete(filename);
+          break;
+        }
       }
     }
-    this.tryFinish();
+
+    process.on('exit', () => {
+      const total = this.specMap.size;
+      if (this.inProgress.size > 0) {
+        for (const filename of this.inProgress) {
+          this.fail(filename, { name: 'Unknown' }, kIncomplete);
+        }
+      }
+      inspect.defaultOptions.depth = Infinity;
+      console.log(this.results);
+
+      const failures = [];
+      let expectedFailures = 0;
+      let skipped = 0;
+      for (const key of Object.keys(this.results)) {
+        const item = this.results[key];
+        if (item.fail && item.fail.unexpected) {
+          failures.push(key);
+        }
+        if (item.fail && item.fail.expected) {
+          expectedFailures++;
+        }
+        if (item.skip) {
+          skipped++;
+        }
+      }
+      const ran = total - skipped;
+      const passed = ran - expectedFailures - failures.length;
+      console.log(`Ran ${ran}/${total} tests, ${skipped} skipped,`,
+                  `${passed} passed, ${expectedFailures} expected failures,`,
+                  `${failures.length} unexpected failures`);
+      if (failures.length > 0) {
+        const file = path.join('test', 'wpt', 'status', `${this.path}.json`);
+        throw new Error(
+          `Found ${failures.length} unexpected failures. ` +
+          `Consider updating ${file} for these files:\n${failures.join('\n')}`);
+      }
+    });
   }
 
   mock(testfile) {
@@ -410,115 +478,124 @@ class WPTRunner {
     sandbox.self = sandbox;
     // TODO(joyeecheung): we are not a window - work with the upstream to
     // add a new scope for us.
-
     return context;
   }
 
-  resultCallback(filename, test) {
-    switch (test.status) {
+  getTestTitle(filename) {
+    const spec = this.specMap.get(filename);
+    const title = spec.meta && spec.meta.title;
+    return title ? `${filename} : ${title}` : filename;
+  }
+
+  // Map WPT test status to strings
+  getTestStatus(status) {
+    switch (status) {
       case 1:
-        this.fail(filename, test, 'FAILURE');
-        break;
+        return kFail;
       case 2:
-        this.fail(filename, test, 'TIMEOUT');
-        break;
+        return kTimeout;
       case 3:
-        this.fail(filename, test, 'INCOMPLETE');
-        break;
+        return kIncomplete;
+      case NODE_UNCAUGHT:
+        return kUncaught;
       default:
-        this.succeed(filename, test);
+        return kPass;
     }
   }
 
+  /**
+   * Report the status of each specific test case (there could be multiple
+   * in one test file).
+   *
+   * @param {string} filename
+   * @param {Test} test  The Test object returned by WPT harness
+   */
+  resultCallback(filename, test) {
+    const status = this.getTestStatus(test.status);
+    const title = this.getTestTitle(filename);
+    console.log(`---- ${title} ----`);
+    if (status !== kPass) {
+      this.fail(filename, test, status);
+    } else {
+      this.succeed(filename, test, status);
+    }
+  }
+
+  /**
+   * Report the status of each WPT test (one per file)
+   *
+   * @param {string} filename
+   * @param {Test[]} test  The Test objects returned by WPT harness
+   */
   completionCallback(filename, tests, harnessStatus) {
+    // Treat it like a test case failure
     if (harnessStatus.status === 2) {
-      assert.fail(`test harness timed out in ${filename}`);
+      const title = this.getTestTitle(filename);
+      console.log(`---- ${title} ----`);
+      this.resultCallback(filename, { status: 2, name: 'Unknown' });
     }
     this.inProgress.delete(filename);
-    this.tryFinish();
   }
 
-  tryFinish() {
-    if (this.inProgress.size > 0) {
-      return;
+  addTestResult(filename, item) {
+    let result = this.results[filename];
+    if (!result) {
+      result = this.results[filename] = {};
     }
-
-    this.reportResults();
-  }
-
-  reportResults() {
-    const unexpectedFailures = [];
-    for (const [filename, items] of this.results) {
-      const test = this.tests.get(filename);
-      let title = test.meta && test.meta.title;
-      title = title ? `${filename} : ${title}` : filename;
-      console.log(`---- ${title} ----`);
-      for (const item of items) {
-        switch (item.type) {
-          case FAILED: {
-            if (test.failReasons.length) {
-              console.log(`[EXPECTED_FAILURE] ${item.test.name}`);
-              console.log(test.failReasons.join('; '));
-            } else {
-              console.log(`[UNEXPECTED_FAILURE] ${item.test.name}`);
-              unexpectedFailures.push([title, filename, item]);
-            }
-            break;
-          }
-          case PASSED: {
-            console.log(`[PASSED] ${item.test.name}`);
-            break;
-          }
-          case SKIPPED: {
-            console.log(`[SKIPPED] ${item.reason}`);
-            break;
-          }
-        }
-      }
-    }
-
-    if (unexpectedFailures.length > 0) {
-      for (const [title, filename, item] of unexpectedFailures) {
-        console.log(`---- ${title} ----`);
-        console.log(`[${item.reason}] ${item.test.name}`);
-        console.log(item.test.message);
-        console.log(item.test.stack);
-        const command = `${process.execPath} ${process.execArgv}` +
-                        ` ${require.main.filename} ${filename}`;
-        console.log(`Command: ${command}\n`);
-      }
-      assert.fail(`${unexpectedFailures.length} unexpected failures found`);
-    }
-  }
-
-  addResult(filename, item) {
-    const result = this.results.get(filename);
-    if (result) {
-      result.push(item);
+    if (item.status === kSkip) {
+      // { filename: { skip: 'reason' } }
+      result[kSkip] = item.reason;
     } else {
-      this.results.set(filename, [item]);
+      // { filename: { fail: { expected: [ ... ],
+      //                      unexpected: [ ... ] } }}
+      if (!result[item.status]) {
+        result[item.status] = {};
+      }
+      const key = item.expected ? 'expected' : 'unexpected';
+      if (!result[item.status][key]) {
+        result[item.status][key] = [];
+      }
+      if (result[item.status][key].indexOf(item.reason) === -1) {
+        result[item.status][key].push(item.reason);
+      }
     }
   }
 
-  succeed(filename, test) {
-    this.addResult(filename, {
-      type: PASSED,
-      test
-    });
+  succeed(filename, test, status) {
+    console.log(`[${status.toUpperCase()}] ${test.name}`);
   }
 
-  fail(filename, test, reason) {
-    this.addResult(filename, {
-      type: FAILED,
-      test,
-      reason
+  fail(filename, test, status) {
+    const spec = this.specMap.get(filename);
+    const expected = !!(spec.failReasons.length);
+    if (expected) {
+      console.log(`[EXPECTED_FAILURE][${status.toUpperCase()}] ${test.name}`);
+      console.log(spec.failReasons.join('; '));
+    } else {
+      console.log(`[UNEXPECTED_FAILURE][${status.toUpperCase()}] ${test.name}`);
+    }
+    if (status === kFail || status === kUncaught) {
+      console.log(test.message);
+      console.log(test.stack);
+    }
+    const command = `${process.execPath} ${process.execArgv}` +
+                    ` ${require.main.filename} ${filename}`;
+    console.log(`Command: ${command}\n`);
+    this.addTestResult(filename, {
+      expected,
+      status: kFail,
+      reason: test.message || status
     });
   }
 
   skip(filename, reasons) {
-    this.addResult(filename, {
-      type: SKIPPED,
-      reason: reasons.join('; ')
+    const title = this.getTestTitle(filename);
+    console.log(`---- ${title} ----`);
+    const joinedReasons = reasons.join('; ');
+    console.log(`[SKIPPED] ${joinedReasons}`);
+    this.addTestResult(filename, {
+      status: kSkip,
+      reason: joinedReasons
     });
   }
 
@@ -546,36 +623,22 @@ class WPTRunner {
     }
   }
 
-  mergeScripts(base, meta, content) {
-    if (!meta.script) {
-      return content;
-    }
-
-    // only one script
-    let result = '';
-    for (const script of meta.script) {
-      result += this.resource.read(base, script, false);
-    }
-
-    return result + content;
-  }
-
   buildQueue() {
     const queue = [];
-    for (const test of this.tests.values()) {
-      const filename = test.filename;
-      if (test.skipReasons.length > 0) {
-        this.skip(filename, test.skipReasons);
+    for (const spec of this.specMap.values()) {
+      const filename = spec.filename;
+      if (spec.skipReasons.length > 0) {
+        this.skip(filename, spec.skipReasons);
         continue;
       }
 
-      const lackingIntl = intlRequirements.isLacking(test.requires);
+      const lackingIntl = intlRequirements.isLacking(spec.requires);
       if (lackingIntl) {
         this.skip(filename, [ `requires ${lackingIntl}` ]);
         continue;
       }
 
-      queue.push(test);
+      queue.push(spec);
     }
     return queue;
   }

--- a/test/fixtures/wpt/README.md
+++ b/test/fixtures/wpt/README.md
@@ -14,7 +14,7 @@ Last update:
 - encoding: https://github.com/web-platform-tests/wpt/tree/5059d2c777/encoding
 - url: https://github.com/web-platform-tests/wpt/tree/418f7fabeb/url
 - resources: https://github.com/web-platform-tests/wpt/tree/e1fddfbf80/resources
-- interfaces: https://github.com/web-platform-tests/wpt/tree/712c9f275e/interfaces
+- interfaces: https://github.com/web-platform-tests/wpt/tree/8ada332aea/interfaces
 - html/webappapis/microtask-queuing: https://github.com/web-platform-tests/wpt/tree/0c3bed38df/html/webappapis/microtask-queuing
 - html/webappapis/timers: https://github.com/web-platform-tests/wpt/tree/ddfe9c089b/html/webappapis/timers
 - hr-time: https://github.com/web-platform-tests/wpt/tree/a5d1774ecf/hr-time

--- a/test/fixtures/wpt/interfaces/console.idl
+++ b/test/fixtures/wpt/interfaces/console.idl
@@ -12,10 +12,10 @@ namespace console { // but see namespace object requirements below
   void error(any... data);
   void info(any... data);
   void log(any... data);
-  void table(any tabularData, optional sequence<DOMString> properties);
+  void table(optional any tabularData, optional sequence<DOMString> properties);
   void trace(any... data);
   void warn(any... data);
-  void dir(any item, optional object? options);
+  void dir(optional any item, optional object? options);
   void dirxml(any... data);
 
   // Counting

--- a/test/fixtures/wpt/interfaces/dom.idl
+++ b/test/fixtures/wpt/interfaces/dom.idl
@@ -1,0 +1,622 @@
+// GENERATED CONTENT - DO NOT EDIT
+// Content was automatically extracted by Reffy into reffy-reports
+// (https://github.com/tidoust/reffy-reports)
+// Source: DOM Standard (https://dom.spec.whatwg.org/)
+
+[Exposed=(Window,Worker,AudioWorklet)]
+interface Event {
+  constructor(DOMString type, optional EventInit eventInitDict = {});
+
+  readonly attribute DOMString type;
+  readonly attribute EventTarget? target;
+  readonly attribute EventTarget? srcElement; // historical
+  readonly attribute EventTarget? currentTarget;
+  sequence<EventTarget> composedPath();
+
+  const unsigned short NONE = 0;
+  const unsigned short CAPTURING_PHASE = 1;
+  const unsigned short AT_TARGET = 2;
+  const unsigned short BUBBLING_PHASE = 3;
+  readonly attribute unsigned short eventPhase;
+
+  void stopPropagation();
+           attribute boolean cancelBubble; // historical alias of .stopPropagation
+  void stopImmediatePropagation();
+
+  readonly attribute boolean bubbles;
+  readonly attribute boolean cancelable;
+           attribute boolean returnValue;  // historical
+  void preventDefault();
+  readonly attribute boolean defaultPrevented;
+  readonly attribute boolean composed;
+
+  [LegacyUnforgeable] readonly attribute boolean isTrusted;
+  readonly attribute DOMHighResTimeStamp timeStamp;
+
+  void initEvent(DOMString type, optional boolean bubbles = false, optional boolean cancelable = false); // historical
+};
+
+dictionary EventInit {
+  boolean bubbles = false;
+  boolean cancelable = false;
+  boolean composed = false;
+};
+
+partial interface Window {
+  [Replaceable] readonly attribute any event; // historical
+};
+
+[Exposed=(Window,Worker)]
+interface CustomEvent : Event {
+  constructor(DOMString type, optional CustomEventInit eventInitDict = {});
+
+  readonly attribute any detail;
+
+  void initCustomEvent(DOMString type, optional boolean bubbles = false, optional boolean cancelable = false, optional any detail = null); // historical
+};
+
+dictionary CustomEventInit : EventInit {
+  any detail = null;
+};
+
+[Exposed=(Window,Worker,AudioWorklet)]
+interface EventTarget {
+  constructor();
+
+  void addEventListener(DOMString type, EventListener? callback, optional (AddEventListenerOptions or boolean) options = {});
+  void removeEventListener(DOMString type, EventListener? callback, optional (EventListenerOptions or boolean) options = {});
+  boolean dispatchEvent(Event event);
+};
+
+callback interface EventListener {
+  void handleEvent(Event event);
+};
+
+dictionary EventListenerOptions {
+  boolean capture = false;
+};
+
+dictionary AddEventListenerOptions : EventListenerOptions {
+  boolean passive = false;
+  boolean once = false;
+};
+
+[Exposed=(Window,Worker)]
+interface AbortController {
+  constructor();
+
+  [SameObject] readonly attribute AbortSignal signal;
+
+  void abort();
+};
+
+[Exposed=(Window,Worker)]
+interface AbortSignal : EventTarget {
+  readonly attribute boolean aborted;
+
+  attribute EventHandler onabort;
+};
+interface mixin NonElementParentNode {
+  Element? getElementById(DOMString elementId);
+};
+Document includes NonElementParentNode;
+DocumentFragment includes NonElementParentNode;
+
+interface mixin DocumentOrShadowRoot {
+};
+Document includes DocumentOrShadowRoot;
+ShadowRoot includes DocumentOrShadowRoot;
+
+interface mixin ParentNode {
+  [SameObject] readonly attribute HTMLCollection children;
+  readonly attribute Element? firstElementChild;
+  readonly attribute Element? lastElementChild;
+  readonly attribute unsigned long childElementCount;
+
+  [CEReactions, Unscopable] void prepend((Node or DOMString)... nodes);
+  [CEReactions, Unscopable] void append((Node or DOMString)... nodes);
+  [CEReactions, Unscopable] void replaceChildren((Node or DOMString)... nodes);
+
+  Element? querySelector(DOMString selectors);
+  [NewObject] NodeList querySelectorAll(DOMString selectors);
+};
+Document includes ParentNode;
+DocumentFragment includes ParentNode;
+Element includes ParentNode;
+
+interface mixin NonDocumentTypeChildNode {
+  readonly attribute Element? previousElementSibling;
+  readonly attribute Element? nextElementSibling;
+};
+Element includes NonDocumentTypeChildNode;
+CharacterData includes NonDocumentTypeChildNode;
+
+interface mixin ChildNode {
+  [CEReactions, Unscopable] void before((Node or DOMString)... nodes);
+  [CEReactions, Unscopable] void after((Node or DOMString)... nodes);
+  [CEReactions, Unscopable] void replaceWith((Node or DOMString)... nodes);
+  [CEReactions, Unscopable] void remove();
+};
+DocumentType includes ChildNode;
+Element includes ChildNode;
+CharacterData includes ChildNode;
+
+interface mixin Slottable {
+  readonly attribute HTMLSlotElement? assignedSlot;
+};
+Element includes Slottable;
+Text includes Slottable;
+
+[Exposed=Window]
+interface NodeList {
+  getter Node? item(unsigned long index);
+  readonly attribute unsigned long length;
+  iterable<Node>;
+};
+
+[Exposed=Window, LegacyUnenumerableNamedProperties]
+interface HTMLCollection {
+  readonly attribute unsigned long length;
+  getter Element? item(unsigned long index);
+  getter Element? namedItem(DOMString name);
+};
+
+[Exposed=Window]
+interface MutationObserver {
+  constructor(MutationCallback callback);
+
+  void observe(Node target, optional MutationObserverInit options = {});
+  void disconnect();
+  sequence<MutationRecord> takeRecords();
+};
+
+callback MutationCallback = void (sequence<MutationRecord> mutations, MutationObserver observer);
+
+dictionary MutationObserverInit {
+  boolean childList = false;
+  boolean attributes;
+  boolean characterData;
+  boolean subtree = false;
+  boolean attributeOldValue;
+  boolean characterDataOldValue;
+  sequence<DOMString> attributeFilter;
+};
+
+[Exposed=Window]
+interface MutationRecord {
+  readonly attribute DOMString type;
+  [SameObject] readonly attribute Node target;
+  [SameObject] readonly attribute NodeList addedNodes;
+  [SameObject] readonly attribute NodeList removedNodes;
+  readonly attribute Node? previousSibling;
+  readonly attribute Node? nextSibling;
+  readonly attribute DOMString? attributeName;
+  readonly attribute DOMString? attributeNamespace;
+  readonly attribute DOMString? oldValue;
+};
+
+[Exposed=Window]
+interface Node : EventTarget {
+  const unsigned short ELEMENT_NODE = 1;
+  const unsigned short ATTRIBUTE_NODE = 2;
+  const unsigned short TEXT_NODE = 3;
+  const unsigned short CDATA_SECTION_NODE = 4;
+  const unsigned short ENTITY_REFERENCE_NODE = 5; // historical
+  const unsigned short ENTITY_NODE = 6; // historical
+  const unsigned short PROCESSING_INSTRUCTION_NODE = 7;
+  const unsigned short COMMENT_NODE = 8;
+  const unsigned short DOCUMENT_NODE = 9;
+  const unsigned short DOCUMENT_TYPE_NODE = 10;
+  const unsigned short DOCUMENT_FRAGMENT_NODE = 11;
+  const unsigned short NOTATION_NODE = 12; // historical
+  readonly attribute unsigned short nodeType;
+  readonly attribute DOMString nodeName;
+
+  readonly attribute USVString baseURI;
+
+  readonly attribute boolean isConnected;
+  readonly attribute Document? ownerDocument;
+  Node getRootNode(optional GetRootNodeOptions options = {});
+  readonly attribute Node? parentNode;
+  readonly attribute Element? parentElement;
+  boolean hasChildNodes();
+  [SameObject] readonly attribute NodeList childNodes;
+  readonly attribute Node? firstChild;
+  readonly attribute Node? lastChild;
+  readonly attribute Node? previousSibling;
+  readonly attribute Node? nextSibling;
+
+  [CEReactions] attribute DOMString? nodeValue;
+  [CEReactions] attribute DOMString? textContent;
+  [CEReactions] void normalize();
+
+  [CEReactions, NewObject] Node cloneNode(optional boolean deep = false);
+  boolean isEqualNode(Node? otherNode);
+  boolean isSameNode(Node? otherNode); // historical alias of ===
+
+  const unsigned short DOCUMENT_POSITION_DISCONNECTED = 0x01;
+  const unsigned short DOCUMENT_POSITION_PRECEDING = 0x02;
+  const unsigned short DOCUMENT_POSITION_FOLLOWING = 0x04;
+  const unsigned short DOCUMENT_POSITION_CONTAINS = 0x08;
+  const unsigned short DOCUMENT_POSITION_CONTAINED_BY = 0x10;
+  const unsigned short DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC = 0x20;
+  unsigned short compareDocumentPosition(Node other);
+  boolean contains(Node? other);
+
+  DOMString? lookupPrefix(DOMString? namespace);
+  DOMString? lookupNamespaceURI(DOMString? prefix);
+  boolean isDefaultNamespace(DOMString? namespace);
+
+  [CEReactions] Node insertBefore(Node node, Node? child);
+  [CEReactions] Node appendChild(Node node);
+  [CEReactions] Node replaceChild(Node node, Node child);
+  [CEReactions] Node removeChild(Node child);
+};
+
+dictionary GetRootNodeOptions {
+  boolean composed = false;
+};
+
+[Exposed=Window]
+interface Document : Node {
+  constructor();
+
+  [SameObject] readonly attribute DOMImplementation implementation;
+  readonly attribute USVString URL;
+  readonly attribute USVString documentURI;
+  readonly attribute DOMString compatMode;
+  readonly attribute DOMString characterSet;
+  readonly attribute DOMString charset; // historical alias of .characterSet
+  readonly attribute DOMString inputEncoding; // historical alias of .characterSet
+  readonly attribute DOMString contentType;
+
+  readonly attribute DocumentType? doctype;
+  readonly attribute Element? documentElement;
+  HTMLCollection getElementsByTagName(DOMString qualifiedName);
+  HTMLCollection getElementsByTagNameNS(DOMString? namespace, DOMString localName);
+  HTMLCollection getElementsByClassName(DOMString classNames);
+
+  [CEReactions, NewObject] Element createElement(DOMString localName, optional (DOMString or ElementCreationOptions) options = {});
+  [CEReactions, NewObject] Element createElementNS(DOMString? namespace, DOMString qualifiedName, optional (DOMString or ElementCreationOptions) options = {});
+  [NewObject] DocumentFragment createDocumentFragment();
+  [NewObject] Text createTextNode(DOMString data);
+  [NewObject] CDATASection createCDATASection(DOMString data);
+  [NewObject] Comment createComment(DOMString data);
+  [NewObject] ProcessingInstruction createProcessingInstruction(DOMString target, DOMString data);
+
+  [CEReactions, NewObject] Node importNode(Node node, optional boolean deep = false);
+  [CEReactions] Node adoptNode(Node node);
+
+  [NewObject] Attr createAttribute(DOMString localName);
+  [NewObject] Attr createAttributeNS(DOMString? namespace, DOMString qualifiedName);
+
+  [NewObject] Event createEvent(DOMString interface); // historical
+
+  [NewObject] Range createRange();
+
+  // NodeFilter.SHOW_ALL = 0xFFFFFFFF
+  [NewObject] NodeIterator createNodeIterator(Node root, optional unsigned long whatToShow = 0xFFFFFFFF, optional NodeFilter? filter = null);
+  [NewObject] TreeWalker createTreeWalker(Node root, optional unsigned long whatToShow = 0xFFFFFFFF, optional NodeFilter? filter = null);
+};
+
+[Exposed=Window]
+interface XMLDocument : Document {};
+
+dictionary ElementCreationOptions {
+  DOMString is;
+};
+
+[Exposed=Window]
+interface DOMImplementation {
+  [NewObject] DocumentType createDocumentType(DOMString qualifiedName, DOMString publicId, DOMString systemId);
+  [NewObject] XMLDocument createDocument(DOMString? namespace, [LegacyNullToEmptyString] DOMString qualifiedName, optional DocumentType? doctype = null);
+  [NewObject] Document createHTMLDocument(optional DOMString title);
+
+  boolean hasFeature(); // useless; always returns true
+};
+
+[Exposed=Window]
+interface DocumentType : Node {
+  readonly attribute DOMString name;
+  readonly attribute DOMString publicId;
+  readonly attribute DOMString systemId;
+};
+
+[Exposed=Window]
+interface DocumentFragment : Node {
+  constructor();
+};
+
+[Exposed=Window]
+interface ShadowRoot : DocumentFragment {
+  readonly attribute ShadowRootMode mode;
+  readonly attribute Element host;
+  attribute EventHandler onslotchange;
+};
+
+enum ShadowRootMode { "open", "closed" };
+
+[Exposed=Window]
+interface Element : Node {
+  readonly attribute DOMString? namespaceURI;
+  readonly attribute DOMString? prefix;
+  readonly attribute DOMString localName;
+  readonly attribute DOMString tagName;
+
+  [CEReactions] attribute DOMString id;
+  [CEReactions] attribute DOMString className;
+  [SameObject, PutForwards=value] readonly attribute DOMTokenList classList;
+  [CEReactions, Unscopable] attribute DOMString slot;
+
+  boolean hasAttributes();
+  [SameObject] readonly attribute NamedNodeMap attributes;
+  sequence<DOMString> getAttributeNames();
+  DOMString? getAttribute(DOMString qualifiedName);
+  DOMString? getAttributeNS(DOMString? namespace, DOMString localName);
+  [CEReactions] void setAttribute(DOMString qualifiedName, DOMString value);
+  [CEReactions] void setAttributeNS(DOMString? namespace, DOMString qualifiedName, DOMString value);
+  [CEReactions] void removeAttribute(DOMString qualifiedName);
+  [CEReactions] void removeAttributeNS(DOMString? namespace, DOMString localName);
+  [CEReactions] boolean toggleAttribute(DOMString qualifiedName, optional boolean force);
+  boolean hasAttribute(DOMString qualifiedName);
+  boolean hasAttributeNS(DOMString? namespace, DOMString localName);
+
+  Attr? getAttributeNode(DOMString qualifiedName);
+  Attr? getAttributeNodeNS(DOMString? namespace, DOMString localName);
+  [CEReactions] Attr? setAttributeNode(Attr attr);
+  [CEReactions] Attr? setAttributeNodeNS(Attr attr);
+  [CEReactions] Attr removeAttributeNode(Attr attr);
+
+  ShadowRoot attachShadow(ShadowRootInit init);
+  readonly attribute ShadowRoot? shadowRoot;
+
+  Element? closest(DOMString selectors);
+  boolean matches(DOMString selectors);
+  boolean webkitMatchesSelector(DOMString selectors); // historical alias of .matches
+
+  HTMLCollection getElementsByTagName(DOMString qualifiedName);
+  HTMLCollection getElementsByTagNameNS(DOMString? namespace, DOMString localName);
+  HTMLCollection getElementsByClassName(DOMString classNames);
+
+  [CEReactions] Element? insertAdjacentElement(DOMString where, Element element); // historical
+  void insertAdjacentText(DOMString where, DOMString data); // historical
+};
+
+dictionary ShadowRootInit {
+  required ShadowRootMode mode;
+  boolean delegatesFocus = false;
+};
+
+[Exposed=Window,
+ LegacyUnenumerableNamedProperties]
+interface NamedNodeMap {
+  readonly attribute unsigned long length;
+  getter Attr? item(unsigned long index);
+  getter Attr? getNamedItem(DOMString qualifiedName);
+  Attr? getNamedItemNS(DOMString? namespace, DOMString localName);
+  [CEReactions] Attr? setNamedItem(Attr attr);
+  [CEReactions] Attr? setNamedItemNS(Attr attr);
+  [CEReactions] Attr removeNamedItem(DOMString qualifiedName);
+  [CEReactions] Attr removeNamedItemNS(DOMString? namespace, DOMString localName);
+};
+
+[Exposed=Window]
+interface Attr : Node {
+  readonly attribute DOMString? namespaceURI;
+  readonly attribute DOMString? prefix;
+  readonly attribute DOMString localName;
+  readonly attribute DOMString name;
+  [CEReactions] attribute DOMString value;
+
+  readonly attribute Element? ownerElement;
+
+  readonly attribute boolean specified; // useless; always returns true
+};
+[Exposed=Window]
+interface CharacterData : Node {
+  attribute [LegacyNullToEmptyString] DOMString data;
+  readonly attribute unsigned long length;
+  DOMString substringData(unsigned long offset, unsigned long count);
+  void appendData(DOMString data);
+  void insertData(unsigned long offset, DOMString data);
+  void deleteData(unsigned long offset, unsigned long count);
+  void replaceData(unsigned long offset, unsigned long count, DOMString data);
+};
+
+[Exposed=Window]
+interface Text : CharacterData {
+  constructor(optional DOMString data = "");
+
+  [NewObject] Text splitText(unsigned long offset);
+  readonly attribute DOMString wholeText;
+};
+
+[Exposed=Window]
+interface CDATASection : Text {
+};
+[Exposed=Window]
+interface ProcessingInstruction : CharacterData {
+  readonly attribute DOMString target;
+};
+[Exposed=Window]
+interface Comment : CharacterData {
+  constructor(optional DOMString data = "");
+};
+
+[Exposed=Window]
+interface AbstractRange {
+  readonly attribute Node startContainer;
+  readonly attribute unsigned long startOffset;
+  readonly attribute Node endContainer;
+  readonly attribute unsigned long endOffset;
+  readonly attribute boolean collapsed;
+};
+
+dictionary StaticRangeInit {
+  required Node startContainer;
+  required unsigned long startOffset;
+  required Node endContainer;
+  required unsigned long endOffset;
+};
+
+[Exposed=Window]
+interface StaticRange : AbstractRange {
+  constructor(StaticRangeInit init);
+};
+
+[Exposed=Window]
+interface Range : AbstractRange {
+  constructor();
+
+  readonly attribute Node commonAncestorContainer;
+
+  void setStart(Node node, unsigned long offset);
+  void setEnd(Node node, unsigned long offset);
+  void setStartBefore(Node node);
+  void setStartAfter(Node node);
+  void setEndBefore(Node node);
+  void setEndAfter(Node node);
+  void collapse(optional boolean toStart = false);
+  void selectNode(Node node);
+  void selectNodeContents(Node node);
+
+  const unsigned short START_TO_START = 0;
+  const unsigned short START_TO_END = 1;
+  const unsigned short END_TO_END = 2;
+  const unsigned short END_TO_START = 3;
+  short compareBoundaryPoints(unsigned short how, Range sourceRange);
+
+  [CEReactions] void deleteContents();
+  [CEReactions, NewObject] DocumentFragment extractContents();
+  [CEReactions, NewObject] DocumentFragment cloneContents();
+  [CEReactions] void insertNode(Node node);
+  [CEReactions] void surroundContents(Node newParent);
+
+  [NewObject] Range cloneRange();
+  void detach();
+
+  boolean isPointInRange(Node node, unsigned long offset);
+  short comparePoint(Node node, unsigned long offset);
+
+  boolean intersectsNode(Node node);
+
+  stringifier;
+};
+
+[Exposed=Window]
+interface NodeIterator {
+  [SameObject] readonly attribute Node root;
+  readonly attribute Node referenceNode;
+  readonly attribute boolean pointerBeforeReferenceNode;
+  readonly attribute unsigned long whatToShow;
+  readonly attribute NodeFilter? filter;
+
+  Node? nextNode();
+  Node? previousNode();
+
+  void detach();
+};
+
+[Exposed=Window]
+interface TreeWalker {
+  [SameObject] readonly attribute Node root;
+  readonly attribute unsigned long whatToShow;
+  readonly attribute NodeFilter? filter;
+           attribute Node currentNode;
+
+  Node? parentNode();
+  Node? firstChild();
+  Node? lastChild();
+  Node? previousSibling();
+  Node? nextSibling();
+  Node? previousNode();
+  Node? nextNode();
+};
+[Exposed=Window]
+callback interface NodeFilter {
+  // Constants for acceptNode()
+  const unsigned short FILTER_ACCEPT = 1;
+  const unsigned short FILTER_REJECT = 2;
+  const unsigned short FILTER_SKIP = 3;
+
+  // Constants for whatToShow
+  const unsigned long SHOW_ALL = 0xFFFFFFFF;
+  const unsigned long SHOW_ELEMENT = 0x1;
+  const unsigned long SHOW_ATTRIBUTE = 0x2;
+  const unsigned long SHOW_TEXT = 0x4;
+  const unsigned long SHOW_CDATA_SECTION = 0x8;
+  const unsigned long SHOW_ENTITY_REFERENCE = 0x10; // historical
+  const unsigned long SHOW_ENTITY = 0x20; // historical
+  const unsigned long SHOW_PROCESSING_INSTRUCTION = 0x40;
+  const unsigned long SHOW_COMMENT = 0x80;
+  const unsigned long SHOW_DOCUMENT = 0x100;
+  const unsigned long SHOW_DOCUMENT_TYPE = 0x200;
+  const unsigned long SHOW_DOCUMENT_FRAGMENT = 0x400;
+  const unsigned long SHOW_NOTATION = 0x800; // historical
+
+  unsigned short acceptNode(Node node);
+};
+
+[Exposed=Window]
+interface DOMTokenList {
+  readonly attribute unsigned long length;
+  getter DOMString? item(unsigned long index);
+  boolean contains(DOMString token);
+  [CEReactions] void add(DOMString... tokens);
+  [CEReactions] void remove(DOMString... tokens);
+  [CEReactions] boolean toggle(DOMString token, optional boolean force);
+  [CEReactions] boolean replace(DOMString token, DOMString newToken);
+  boolean supports(DOMString token);
+  [CEReactions] stringifier attribute DOMString value;
+  iterable<DOMString>;
+};
+
+[Exposed=Window]
+interface XPathResult {
+  const unsigned short ANY_TYPE = 0;
+  const unsigned short NUMBER_TYPE = 1;
+  const unsigned short STRING_TYPE = 2;
+  const unsigned short BOOLEAN_TYPE = 3;
+  const unsigned short UNORDERED_NODE_ITERATOR_TYPE = 4;
+  const unsigned short ORDERED_NODE_ITERATOR_TYPE = 5;
+  const unsigned short UNORDERED_NODE_SNAPSHOT_TYPE = 6;
+  const unsigned short ORDERED_NODE_SNAPSHOT_TYPE = 7;
+  const unsigned short ANY_UNORDERED_NODE_TYPE = 8;
+  const unsigned short FIRST_ORDERED_NODE_TYPE = 9;
+
+  readonly attribute unsigned short resultType;
+  readonly attribute unrestricted double numberValue;
+  readonly attribute DOMString stringValue;
+  readonly attribute boolean booleanValue;
+  readonly attribute Node? singleNodeValue;
+  readonly attribute boolean invalidIteratorState;
+  readonly attribute unsigned long snapshotLength;
+
+  Node? iterateNext();
+  Node? snapshotItem(unsigned long index);
+};
+
+[Exposed=Window]
+interface XPathExpression {
+  // XPathResult.ANY_TYPE = 0
+  XPathResult evaluate(Node contextNode, optional unsigned short type = 0, optional XPathResult? result = null);
+};
+
+callback interface XPathNSResolver {
+  DOMString? lookupNamespaceURI(DOMString? prefix);
+};
+
+interface mixin XPathEvaluatorBase {
+  [NewObject] XPathExpression createExpression(DOMString expression, optional XPathNSResolver? resolver = null);
+  XPathNSResolver createNSResolver(Node nodeResolver);
+  // XPathResult.ANY_TYPE = 0
+  XPathResult evaluate(DOMString expression, Node contextNode, optional XPathNSResolver? resolver = null, optional unsigned short type = 0, optional XPathResult? result = null);
+};
+Document includes XPathEvaluatorBase;
+
+[Exposed=Window]
+interface XPathEvaluator {
+  constructor();
+};
+
+XPathEvaluator includes XPathEvaluatorBase;

--- a/test/fixtures/wpt/interfaces/encoding.idl
+++ b/test/fixtures/wpt/interfaces/encoding.idl
@@ -18,10 +18,11 @@ dictionary TextDecodeOptions {
   boolean stream = false;
 };
 
-[Constructor(optional DOMString label = "utf-8", optional TextDecoderOptions options),
- Exposed=(Window,Worker)]
+[Exposed=(Window,Worker)]
 interface TextDecoder {
-  USVString decode(optional BufferSource input, optional TextDecodeOptions options);
+  constructor(optional DOMString label = "utf-8", optional TextDecoderOptions options = {});
+
+  USVString decode(optional [AllowShared] BufferSource input, optional TextDecodeOptions options = {});
 };
 TextDecoder includes TextDecoderCommon;
 
@@ -29,10 +30,17 @@ interface mixin TextEncoderCommon {
   readonly attribute DOMString encoding;
 };
 
-[Constructor,
- Exposed=(Window,Worker)]
+dictionary TextEncoderEncodeIntoResult {
+  unsigned long long read;
+  unsigned long long written;
+};
+
+[Exposed=(Window,Worker)]
 interface TextEncoder {
+  constructor();
+
   [NewObject] Uint8Array encode(optional USVString input = "");
+  TextEncoderEncodeIntoResult encodeInto(USVString source, [AllowShared] Uint8Array destination);
 };
 TextEncoder includes TextEncoderCommon;
 
@@ -41,16 +49,16 @@ interface mixin GenericTransformStream {
   readonly attribute WritableStream writable;
 };
 
-[Constructor(optional DOMString label = "utf-8", optional TextDecoderOptions options),
- Exposed=(Window,Worker)]
+[Exposed=(Window,Worker)]
 interface TextDecoderStream {
+  constructor(optional DOMString label = "utf-8", optional TextDecoderOptions options = {});
 };
 TextDecoderStream includes TextDecoderCommon;
 TextDecoderStream includes GenericTransformStream;
 
-[Constructor,
- Exposed=(Window,Worker)]
+[Exposed=(Window,Worker)]
 interface TextEncoderStream {
+  constructor();
 };
 TextEncoderStream includes TextEncoderCommon;
 TextEncoderStream includes GenericTransformStream;

--- a/test/fixtures/wpt/interfaces/hr-time.idl
+++ b/test/fixtures/wpt/interfaces/hr-time.idl
@@ -1,0 +1,17 @@
+// GENERATED CONTENT - DO NOT EDIT
+// Content was automatically extracted by Reffy into reffy-reports
+// (https://github.com/tidoust/reffy-reports)
+// Source: High Resolution Time (https://w3c.github.io/hr-time/)
+
+typedef double DOMHighResTimeStamp;
+
+[Exposed=(Window,Worker)]
+interface Performance : EventTarget {
+    DOMHighResTimeStamp now();
+    readonly attribute DOMHighResTimeStamp timeOrigin;
+    [Default] object toJSON();
+};
+
+partial interface mixin WindowOrWorkerGlobalScope {
+  [Replaceable] readonly attribute Performance performance;
+};

--- a/test/fixtures/wpt/interfaces/html.idl
+++ b/test/fixtures/wpt/interfaces/html.idl
@@ -1,0 +1,2615 @@
+// GENERATED CONTENT - DO NOT EDIT
+// Content was automatically extracted by Reffy into reffy-reports
+// (https://github.com/tidoust/reffy-reports)
+// Source: HTML Standard (https://html.spec.whatwg.org/multipage/)
+
+[Exposed=Window,
+ LegacyUnenumerableNamedProperties]
+interface HTMLAllCollection {
+  readonly attribute unsigned long length;
+  getter Element (unsigned long index);
+  getter (HTMLCollection or Element)? namedItem(DOMString name);
+  (HTMLCollection or Element)? item(optional DOMString nameOrIndex);
+
+  // Note: HTMLAllCollection objects have a custom [[Call]] internal method and an [[IsHTMLDDA]] internal slot.
+};
+
+[Exposed=Window]
+interface HTMLFormControlsCollection : HTMLCollection {
+  // inherits length and item()
+  getter (RadioNodeList or Element)? namedItem(DOMString name); // shadows inherited namedItem()
+};
+
+[Exposed=Window]
+interface RadioNodeList : NodeList {
+  attribute DOMString value;
+};
+
+[Exposed=Window]
+interface HTMLOptionsCollection : HTMLCollection {
+  // inherits item(), namedItem()
+  [CEReactions] attribute unsigned long length; // shadows inherited length
+  [CEReactions] setter void (unsigned long index, HTMLOptionElement? option);
+  [CEReactions] void add((HTMLOptionElement or HTMLOptGroupElement) element, optional (HTMLElement or long)? before = null);
+  [CEReactions] void remove(long index);
+  attribute long selectedIndex;
+};
+
+[Exposed=(Window,Worker)]
+interface DOMStringList {
+  readonly attribute unsigned long length;
+  getter DOMString? item(unsigned long index);
+  boolean contains(DOMString string);
+};
+
+enum DocumentReadyState { "loading", "interactive", "complete" };
+typedef (HTMLScriptElement or SVGScriptElement) HTMLOrSVGScriptElement;
+
+[LegacyOverrideBuiltIns]
+partial interface Document {
+  // resource metadata management
+  [PutForwards=href, LegacyUnforgeable] readonly attribute Location? location;
+  attribute USVString domain;
+  readonly attribute USVString referrer;
+  attribute USVString cookie;
+  readonly attribute DOMString lastModified;
+  readonly attribute DocumentReadyState readyState;
+
+  // DOM tree accessors
+  getter object (DOMString name);
+  [CEReactions] attribute DOMString title;
+  [CEReactions] attribute DOMString dir;
+  [CEReactions] attribute HTMLElement? body;
+  readonly attribute HTMLHeadElement? head;
+  [SameObject] readonly attribute HTMLCollection images;
+  [SameObject] readonly attribute HTMLCollection embeds;
+  [SameObject] readonly attribute HTMLCollection plugins;
+  [SameObject] readonly attribute HTMLCollection links;
+  [SameObject] readonly attribute HTMLCollection forms;
+  [SameObject] readonly attribute HTMLCollection scripts;
+  NodeList getElementsByName(DOMString elementName);
+  readonly attribute HTMLOrSVGScriptElement? currentScript; // classic scripts in a document tree only
+
+  // dynamic markup insertion
+  [CEReactions] Document open(optional DOMString unused1, optional DOMString unused2); // both arguments are ignored
+  WindowProxy? open(USVString url, DOMString name, DOMString features);
+  [CEReactions] void close();
+  [CEReactions] void write(DOMString... text);
+  [CEReactions] void writeln(DOMString... text);
+
+  // user interaction
+  readonly attribute WindowProxy? defaultView;
+  boolean hasFocus();
+  [CEReactions] attribute DOMString designMode;
+  [CEReactions] boolean execCommand(DOMString commandId, optional boolean showUI = false, optional DOMString value = "");
+  boolean queryCommandEnabled(DOMString commandId);
+  boolean queryCommandIndeterm(DOMString commandId);
+  boolean queryCommandState(DOMString commandId);
+  boolean queryCommandSupported(DOMString commandId);
+  DOMString queryCommandValue(DOMString commandId);
+
+  // special event handler IDL attributes that only apply to Document objects
+  [LegacyLenientThis] attribute EventHandler onreadystatechange;
+
+  // also has obsolete members
+};
+Document includes GlobalEventHandlers;
+Document includes DocumentAndElementEventHandlers;
+
+partial interface mixin DocumentOrShadowRoot {
+  readonly attribute Element? activeElement;
+};
+
+[Exposed=Window]
+interface HTMLElement : Element {
+  [HTMLConstructor] constructor();
+
+  // metadata attributes
+  [CEReactions] attribute DOMString title;
+  [CEReactions] attribute DOMString lang;
+  [CEReactions] attribute boolean translate;
+  [CEReactions] attribute DOMString dir;
+
+  // user interaction
+  [CEReactions] attribute boolean hidden;
+  void click();
+  [CEReactions] attribute DOMString accessKey;
+  readonly attribute DOMString accessKeyLabel;
+  [CEReactions] attribute boolean draggable;
+  [CEReactions] attribute boolean spellcheck;
+  [CEReactions] attribute DOMString autocapitalize;
+
+  [CEReactions] attribute [LegacyNullToEmptyString] DOMString innerText;
+
+  ElementInternals attachInternals();
+};
+
+HTMLElement includes GlobalEventHandlers;
+HTMLElement includes DocumentAndElementEventHandlers;
+HTMLElement includes ElementContentEditable;
+HTMLElement includes HTMLOrSVGElement;
+
+[Exposed=Window]
+interface HTMLUnknownElement : HTMLElement {
+  // Note: intentionally no [HTMLConstructor]
+};
+
+interface mixin HTMLOrSVGElement {
+  [SameObject] readonly attribute DOMStringMap dataset;
+  attribute DOMString nonce; // intentionally no [CEReactions]
+
+  [CEReactions] attribute boolean autofocus;
+  [CEReactions] attribute long tabIndex;
+  void focus(optional FocusOptions options = {});
+  void blur();
+};
+
+[Exposed=Window,
+ LegacyOverrideBuiltIns]
+interface DOMStringMap {
+  getter DOMString (DOMString name);
+  [CEReactions] setter void (DOMString name, DOMString value);
+  [CEReactions] deleter void (DOMString name);
+};
+
+[Exposed=Window]
+interface HTMLHtmlElement : HTMLElement {
+  [HTMLConstructor] constructor();
+};
+
+[Exposed=Window]
+interface HTMLHeadElement : HTMLElement {
+  [HTMLConstructor] constructor();
+};
+
+[Exposed=Window]
+interface HTMLTitleElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [CEReactions] attribute DOMString text;
+};
+
+[Exposed=Window]
+interface HTMLBaseElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [CEReactions] attribute USVString href;
+  [CEReactions] attribute DOMString target;
+};
+
+[Exposed=Window]
+interface HTMLLinkElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [CEReactions] attribute USVString href;
+  [CEReactions] attribute DOMString? crossOrigin;
+  [CEReactions] attribute DOMString rel;
+  [CEReactions] attribute DOMString as; // (default "")
+  [SameObject, PutForwards=value] readonly attribute DOMTokenList relList;
+  [CEReactions] attribute DOMString media;
+  [CEReactions] attribute DOMString integrity;
+  [CEReactions] attribute DOMString hreflang;
+  [CEReactions] attribute DOMString type;
+  [SameObject, PutForwards=value] readonly attribute DOMTokenList sizes;
+  [CEReactions] attribute USVString imageSrcset;
+  [CEReactions] attribute DOMString imageSizes;
+  [CEReactions] attribute DOMString referrerPolicy;
+};
+HTMLLinkElement includes LinkStyle;
+
+[Exposed=Window]
+interface HTMLMetaElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [CEReactions] attribute DOMString name;
+  [CEReactions] attribute DOMString httpEquiv;
+  [CEReactions] attribute DOMString content;
+};
+
+[Exposed=Window]
+interface HTMLStyleElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [CEReactions] attribute DOMString media;
+};
+HTMLStyleElement includes LinkStyle;
+
+[Exposed=Window]
+interface HTMLBodyElement : HTMLElement {
+  [HTMLConstructor] constructor();
+};
+
+HTMLBodyElement includes WindowEventHandlers;
+
+[Exposed=Window]
+interface HTMLHeadingElement : HTMLElement {
+  [HTMLConstructor] constructor();
+};
+
+[Exposed=Window]
+interface HTMLParagraphElement : HTMLElement {
+  [HTMLConstructor] constructor();
+};
+
+[Exposed=Window]
+interface HTMLHRElement : HTMLElement {
+  [HTMLConstructor] constructor();
+};
+
+[Exposed=Window]
+interface HTMLPreElement : HTMLElement {
+  [HTMLConstructor] constructor();
+};
+
+[Exposed=Window]
+interface HTMLQuoteElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [CEReactions] attribute USVString cite;
+};
+
+[Exposed=Window]
+interface HTMLOListElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [CEReactions] attribute boolean reversed;
+  [CEReactions] attribute long start;
+  [CEReactions] attribute DOMString type;
+};
+
+[Exposed=Window]
+interface HTMLUListElement : HTMLElement {
+  [HTMLConstructor] constructor();
+};
+
+[Exposed=Window]
+interface HTMLMenuElement : HTMLElement {
+  [HTMLConstructor] constructor();
+};
+
+[Exposed=Window]
+interface HTMLLIElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [CEReactions] attribute long value;
+};
+
+[Exposed=Window]
+interface HTMLDListElement : HTMLElement {
+  [HTMLConstructor] constructor();
+};
+
+[Exposed=Window]
+interface HTMLDivElement : HTMLElement {
+  [HTMLConstructor] constructor();
+};
+
+[Exposed=Window]
+interface HTMLAnchorElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [CEReactions] attribute DOMString target;
+  [CEReactions] attribute DOMString download;
+  [CEReactions] attribute USVString ping;
+  [CEReactions] attribute DOMString rel;
+  [SameObject, PutForwards=value] readonly attribute DOMTokenList relList;
+  [CEReactions] attribute DOMString hreflang;
+  [CEReactions] attribute DOMString type;
+
+  [CEReactions] attribute DOMString text;
+
+  [CEReactions] attribute DOMString referrerPolicy;
+};
+HTMLAnchorElement includes HTMLHyperlinkElementUtils;
+
+[Exposed=Window]
+interface HTMLDataElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [CEReactions] attribute DOMString value;
+};
+
+[Exposed=Window]
+interface HTMLTimeElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [CEReactions] attribute DOMString dateTime;
+};
+
+[Exposed=Window]
+interface HTMLSpanElement : HTMLElement {
+  [HTMLConstructor] constructor();
+};
+
+[Exposed=Window]
+interface HTMLBRElement : HTMLElement {
+  [HTMLConstructor] constructor();
+};
+
+interface mixin HTMLHyperlinkElementUtils {
+  [CEReactions] stringifier attribute USVString href;
+  readonly attribute USVString origin;
+  [CEReactions] attribute USVString protocol;
+  [CEReactions] attribute USVString username;
+  [CEReactions] attribute USVString password;
+  [CEReactions] attribute USVString host;
+  [CEReactions] attribute USVString hostname;
+  [CEReactions] attribute USVString port;
+  [CEReactions] attribute USVString pathname;
+  [CEReactions] attribute USVString search;
+  [CEReactions] attribute USVString hash;
+};
+
+[Exposed=Window]
+interface HTMLModElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [CEReactions] attribute USVString cite;
+  [CEReactions] attribute DOMString dateTime;
+};
+
+[Exposed=Window]
+interface HTMLPictureElement : HTMLElement {
+  [HTMLConstructor] constructor();
+};
+
+[Exposed=Window]
+interface HTMLSourceElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [CEReactions] attribute USVString src;
+  [CEReactions] attribute DOMString type;
+  [CEReactions] attribute USVString srcset;
+  [CEReactions] attribute DOMString sizes;
+  [CEReactions] attribute DOMString media;
+};
+
+[Exposed=Window,
+ LegacyFactoryFunction=Image(optional unsigned long width, optional unsigned long height)]
+interface HTMLImageElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [CEReactions] attribute DOMString alt;
+  [CEReactions] attribute USVString src;
+  [CEReactions] attribute USVString srcset;
+  [CEReactions] attribute DOMString sizes;
+  [CEReactions] attribute DOMString? crossOrigin;
+  [CEReactions] attribute DOMString useMap;
+  [CEReactions] attribute boolean isMap;
+  [CEReactions] attribute unsigned long width;
+  [CEReactions] attribute unsigned long height;
+  readonly attribute unsigned long naturalWidth;
+  readonly attribute unsigned long naturalHeight;
+  readonly attribute boolean complete;
+  readonly attribute USVString currentSrc;
+  [CEReactions] attribute DOMString referrerPolicy;
+  [CEReactions] attribute DOMString decoding;
+  [CEReactions] attribute DOMString loading;
+
+  Promise<void> decode();
+};
+
+[Exposed=Window]
+interface HTMLIFrameElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [CEReactions] attribute USVString src;
+  [CEReactions] attribute DOMString srcdoc;
+  [CEReactions] attribute DOMString name;
+  [SameObject, PutForwards=value] readonly attribute DOMTokenList sandbox;
+  [CEReactions] attribute DOMString allow;
+  [CEReactions] attribute boolean allowFullscreen;
+  [CEReactions] attribute boolean allowPaymentRequest;
+  [CEReactions] attribute DOMString width;
+  [CEReactions] attribute DOMString height;
+  [CEReactions] attribute DOMString referrerPolicy;
+  readonly attribute Document? contentDocument;
+  readonly attribute WindowProxy? contentWindow;
+  Document? getSVGDocument();
+};
+
+[Exposed=Window]
+interface HTMLEmbedElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [CEReactions] attribute USVString src;
+  [CEReactions] attribute DOMString type;
+  [CEReactions] attribute DOMString width;
+  [CEReactions] attribute DOMString height;
+  Document? getSVGDocument();
+};
+
+[Exposed=Window]
+interface HTMLObjectElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [CEReactions] attribute USVString data;
+  [CEReactions] attribute DOMString type;
+  [CEReactions] attribute DOMString name;
+  [CEReactions] attribute DOMString useMap;
+  readonly attribute HTMLFormElement? form;
+  [CEReactions] attribute DOMString width;
+  [CEReactions] attribute DOMString height;
+  readonly attribute Document? contentDocument;
+  readonly attribute WindowProxy? contentWindow;
+  Document? getSVGDocument();
+
+  readonly attribute boolean willValidate;
+  readonly attribute ValidityState validity;
+  readonly attribute DOMString validationMessage;
+  boolean checkValidity();
+  boolean reportValidity();
+  void setCustomValidity(DOMString error);
+};
+
+[Exposed=Window]
+interface HTMLParamElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [CEReactions] attribute DOMString name;
+  [CEReactions] attribute DOMString value;
+};
+
+[Exposed=Window]
+interface HTMLVideoElement : HTMLMediaElement {
+  [HTMLConstructor] constructor();
+
+  [CEReactions] attribute unsigned long width;
+  [CEReactions] attribute unsigned long height;
+  readonly attribute unsigned long videoWidth;
+  readonly attribute unsigned long videoHeight;
+  [CEReactions] attribute USVString poster;
+  [CEReactions] attribute boolean playsInline;
+};
+
+[Exposed=Window,
+ LegacyFactoryFunction=Audio(optional DOMString src)]
+interface HTMLAudioElement : HTMLMediaElement {
+  [HTMLConstructor] constructor();
+};
+
+[Exposed=Window]
+interface HTMLTrackElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [CEReactions] attribute DOMString kind;
+  [CEReactions] attribute USVString src;
+  [CEReactions] attribute DOMString srclang;
+  [CEReactions] attribute DOMString label;
+  [CEReactions] attribute boolean default;
+
+  const unsigned short NONE = 0;
+  const unsigned short LOADING = 1;
+  const unsigned short LOADED = 2;
+  const unsigned short ERROR = 3;
+  readonly attribute unsigned short readyState;
+
+  readonly attribute TextTrack track;
+};
+
+enum CanPlayTypeResult { "" /* empty string */, "maybe", "probably" };
+typedef (MediaStream or MediaSource or Blob) MediaProvider;
+
+[Exposed=Window]
+interface HTMLMediaElement : HTMLElement {
+
+  // error state
+  readonly attribute MediaError? error;
+
+  // network state
+  [CEReactions] attribute USVString src;
+  attribute MediaProvider? srcObject;
+  readonly attribute USVString currentSrc;
+  [CEReactions] attribute DOMString? crossOrigin;
+  const unsigned short NETWORK_EMPTY = 0;
+  const unsigned short NETWORK_IDLE = 1;
+  const unsigned short NETWORK_LOADING = 2;
+  const unsigned short NETWORK_NO_SOURCE = 3;
+  readonly attribute unsigned short networkState;
+  [CEReactions] attribute DOMString preload;
+  readonly attribute TimeRanges buffered;
+  void load();
+  CanPlayTypeResult canPlayType(DOMString type);
+
+  // ready state
+  const unsigned short HAVE_NOTHING = 0;
+  const unsigned short HAVE_METADATA = 1;
+  const unsigned short HAVE_CURRENT_DATA = 2;
+  const unsigned short HAVE_FUTURE_DATA = 3;
+  const unsigned short HAVE_ENOUGH_DATA = 4;
+  readonly attribute unsigned short readyState;
+  readonly attribute boolean seeking;
+
+  // playback state
+  attribute double currentTime;
+  void fastSeek(double time);
+  readonly attribute unrestricted double duration;
+  object getStartDate();
+  readonly attribute boolean paused;
+  attribute double defaultPlaybackRate;
+  attribute double playbackRate;
+  readonly attribute TimeRanges played;
+  readonly attribute TimeRanges seekable;
+  readonly attribute boolean ended;
+  [CEReactions] attribute boolean autoplay;
+  [CEReactions] attribute boolean loop;
+  Promise<void> play();
+  void pause();
+
+  // controls
+  [CEReactions] attribute boolean controls;
+  attribute double volume;
+  attribute boolean muted;
+  [CEReactions] attribute boolean defaultMuted;
+
+  // tracks
+  [SameObject] readonly attribute AudioTrackList audioTracks;
+  [SameObject] readonly attribute VideoTrackList videoTracks;
+  [SameObject] readonly attribute TextTrackList textTracks;
+  TextTrack addTextTrack(TextTrackKind kind, optional DOMString label = "", optional DOMString language = "");
+};
+
+[Exposed=Window]
+interface MediaError {
+  const unsigned short MEDIA_ERR_ABORTED = 1;
+  const unsigned short MEDIA_ERR_NETWORK = 2;
+  const unsigned short MEDIA_ERR_DECODE = 3;
+  const unsigned short MEDIA_ERR_SRC_NOT_SUPPORTED = 4;
+
+  readonly attribute unsigned short code;
+  readonly attribute DOMString message;
+};
+
+[Exposed=Window]
+interface AudioTrackList : EventTarget {
+  readonly attribute unsigned long length;
+  getter AudioTrack (unsigned long index);
+  AudioTrack? getTrackById(DOMString id);
+
+  attribute EventHandler onchange;
+  attribute EventHandler onaddtrack;
+  attribute EventHandler onremovetrack;
+};
+
+[Exposed=Window]
+interface AudioTrack {
+  readonly attribute DOMString id;
+  readonly attribute DOMString kind;
+  readonly attribute DOMString label;
+  readonly attribute DOMString language;
+  attribute boolean enabled;
+};
+
+[Exposed=Window]
+interface VideoTrackList : EventTarget {
+  readonly attribute unsigned long length;
+  getter VideoTrack (unsigned long index);
+  VideoTrack? getTrackById(DOMString id);
+  readonly attribute long selectedIndex;
+
+  attribute EventHandler onchange;
+  attribute EventHandler onaddtrack;
+  attribute EventHandler onremovetrack;
+};
+
+[Exposed=Window]
+interface VideoTrack {
+  readonly attribute DOMString id;
+  readonly attribute DOMString kind;
+  readonly attribute DOMString label;
+  readonly attribute DOMString language;
+  attribute boolean selected;
+};
+
+[Exposed=Window]
+interface TextTrackList : EventTarget {
+  readonly attribute unsigned long length;
+  getter TextTrack (unsigned long index);
+  TextTrack? getTrackById(DOMString id);
+
+  attribute EventHandler onchange;
+  attribute EventHandler onaddtrack;
+  attribute EventHandler onremovetrack;
+};
+
+enum TextTrackMode { "disabled",  "hidden",  "showing" };
+enum TextTrackKind { "subtitles",  "captions",  "descriptions",  "chapters",  "metadata" };
+
+[Exposed=Window]
+interface TextTrack : EventTarget {
+  readonly attribute TextTrackKind kind;
+  readonly attribute DOMString label;
+  readonly attribute DOMString language;
+
+  readonly attribute DOMString id;
+  readonly attribute DOMString inBandMetadataTrackDispatchType;
+
+  attribute TextTrackMode mode;
+
+  readonly attribute TextTrackCueList? cues;
+  readonly attribute TextTrackCueList? activeCues;
+
+  void addCue(TextTrackCue cue);
+  void removeCue(TextTrackCue cue);
+
+  attribute EventHandler oncuechange;
+};
+
+[Exposed=Window]
+interface TextTrackCueList {
+  readonly attribute unsigned long length;
+  getter TextTrackCue (unsigned long index);
+  TextTrackCue? getCueById(DOMString id);
+};
+
+[Exposed=Window]
+interface TextTrackCue : EventTarget {
+  readonly attribute TextTrack? track;
+
+  attribute DOMString id;
+  attribute double startTime;
+  attribute double endTime;
+  attribute boolean pauseOnExit;
+
+  attribute EventHandler onenter;
+  attribute EventHandler onexit;
+};
+
+[Exposed=Window]
+interface TimeRanges {
+  readonly attribute unsigned long length;
+  double start(unsigned long index);
+  double end(unsigned long index);
+};
+
+[Exposed=Window,
+ Constructor(DOMString type, optional TrackEventInit eventInitDict = {})]
+interface TrackEvent : Event {
+  readonly attribute (VideoTrack or AudioTrack or TextTrack)? track;
+};
+
+dictionary TrackEventInit : EventInit {
+  (VideoTrack or AudioTrack or TextTrack)? track = null;
+};
+
+[Exposed=Window]
+interface HTMLMapElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [CEReactions] attribute DOMString name;
+  [SameObject] readonly attribute HTMLCollection areas;
+};
+
+[Exposed=Window]
+interface HTMLAreaElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [CEReactions] attribute DOMString alt;
+  [CEReactions] attribute DOMString coords;
+  [CEReactions] attribute DOMString shape;
+  [CEReactions] attribute DOMString target;
+  [CEReactions] attribute DOMString download;
+  [CEReactions] attribute USVString ping;
+  [CEReactions] attribute DOMString rel;
+  [SameObject, PutForwards=value] readonly attribute DOMTokenList relList;
+  [CEReactions] attribute DOMString referrerPolicy;
+};
+HTMLAreaElement includes HTMLHyperlinkElementUtils;
+
+[Exposed=Window]
+interface HTMLTableElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [CEReactions] attribute HTMLTableCaptionElement? caption;
+  HTMLTableCaptionElement createCaption();
+  [CEReactions] void deleteCaption();
+
+  [CEReactions] attribute HTMLTableSectionElement? tHead;
+  HTMLTableSectionElement createTHead();
+  [CEReactions] void deleteTHead();
+
+  [CEReactions] attribute HTMLTableSectionElement? tFoot;
+  HTMLTableSectionElement createTFoot();
+  [CEReactions] void deleteTFoot();
+
+  [SameObject] readonly attribute HTMLCollection tBodies;
+  HTMLTableSectionElement createTBody();
+
+  [SameObject] readonly attribute HTMLCollection rows;
+  HTMLTableRowElement insertRow(optional long index = -1);
+  [CEReactions] void deleteRow(long index);
+};
+
+[Exposed=Window]
+interface HTMLTableCaptionElement : HTMLElement {
+  [HTMLConstructor] constructor();
+};
+
+[Exposed=Window]
+interface HTMLTableColElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [CEReactions] attribute unsigned long span;
+};
+
+[Exposed=Window]
+interface HTMLTableSectionElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [SameObject] readonly attribute HTMLCollection rows;
+  HTMLTableRowElement insertRow(optional long index = -1);
+  [CEReactions] void deleteRow(long index);
+};
+
+[Exposed=Window]
+interface HTMLTableRowElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  readonly attribute long rowIndex;
+  readonly attribute long sectionRowIndex;
+  [SameObject] readonly attribute HTMLCollection cells;
+  HTMLTableCellElement insertCell(optional long index = -1);
+  [CEReactions] void deleteCell(long index);
+};
+
+[Exposed=Window]
+interface HTMLTableCellElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [CEReactions] attribute unsigned long colSpan;
+  [CEReactions] attribute unsigned long rowSpan;
+  [CEReactions] attribute DOMString headers;
+  readonly attribute long cellIndex;
+
+  [CEReactions] attribute DOMString scope; // only conforming for th elements
+  [CEReactions] attribute DOMString abbr;  // only conforming for th elements
+};
+
+[Exposed=Window,
+ LegacyOverrideBuiltIns,
+ LegacyUnenumerableNamedProperties]
+interface HTMLFormElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [CEReactions] attribute DOMString acceptCharset;
+  [CEReactions] attribute USVString action;
+  [CEReactions] attribute DOMString autocomplete;
+  [CEReactions] attribute DOMString enctype;
+  [CEReactions] attribute DOMString encoding;
+  [CEReactions] attribute DOMString method;
+  [CEReactions] attribute DOMString name;
+  [CEReactions] attribute boolean noValidate;
+  [CEReactions] attribute DOMString target;
+  [CEReactions] attribute DOMString rel;
+  [SameObject, PutForwards=value] readonly attribute DOMTokenList relList;
+
+  [SameObject] readonly attribute HTMLFormControlsCollection elements;
+  readonly attribute unsigned long length;
+  getter Element (unsigned long index);
+  getter (RadioNodeList or Element) (DOMString name);
+
+  void submit();
+  void requestSubmit(optional HTMLElement? submitter = null);
+  [CEReactions] void reset();
+  boolean checkValidity();
+  boolean reportValidity();
+};
+
+[Exposed=Window]
+interface HTMLLabelElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  readonly attribute HTMLFormElement? form;
+  [CEReactions] attribute DOMString htmlFor;
+  readonly attribute HTMLElement? control;
+};
+
+[Exposed=Window]
+interface HTMLInputElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [CEReactions] attribute DOMString accept;
+  [CEReactions] attribute DOMString alt;
+  [CEReactions] attribute DOMString autocomplete;
+  [CEReactions] attribute boolean defaultChecked;
+  attribute boolean checked;
+  [CEReactions] attribute DOMString dirName;
+  [CEReactions] attribute boolean disabled;
+  readonly attribute HTMLFormElement? form;
+  attribute FileList? files;
+  [CEReactions] attribute USVString formAction;
+  [CEReactions] attribute DOMString formEnctype;
+  [CEReactions] attribute DOMString formMethod;
+  [CEReactions] attribute boolean formNoValidate;
+  [CEReactions] attribute DOMString formTarget;
+  [CEReactions] attribute unsigned long height;
+  attribute boolean indeterminate;
+  readonly attribute HTMLElement? list;
+  [CEReactions] attribute DOMString max;
+  [CEReactions] attribute long maxLength;
+  [CEReactions] attribute DOMString min;
+  [CEReactions] attribute long minLength;
+  [CEReactions] attribute boolean multiple;
+  [CEReactions] attribute DOMString name;
+  [CEReactions] attribute DOMString pattern;
+  [CEReactions] attribute DOMString placeholder;
+  [CEReactions] attribute boolean readOnly;
+  [CEReactions] attribute boolean required;
+  [CEReactions] attribute unsigned long size;
+  [CEReactions] attribute USVString src;
+  [CEReactions] attribute DOMString step;
+  [CEReactions] attribute DOMString type;
+  [CEReactions] attribute DOMString defaultValue;
+  [CEReactions] attribute [LegacyNullToEmptyString] DOMString value;
+  attribute object? valueAsDate;
+  attribute unrestricted double valueAsNumber;
+  [CEReactions] attribute unsigned long width;
+
+  void stepUp(optional long n = 1);
+  void stepDown(optional long n = 1);
+
+  readonly attribute boolean willValidate;
+  readonly attribute ValidityState validity;
+  readonly attribute DOMString validationMessage;
+  boolean checkValidity();
+  boolean reportValidity();
+  void setCustomValidity(DOMString error);
+
+  readonly attribute NodeList? labels;
+
+  void select();
+  attribute unsigned long? selectionStart;
+  attribute unsigned long? selectionEnd;
+  attribute DOMString? selectionDirection;
+  void setRangeText(DOMString replacement);
+  void setRangeText(DOMString replacement, unsigned long start, unsigned long end, optional SelectionMode selectionMode = "preserve");
+  void setSelectionRange(unsigned long start, unsigned long end, optional DOMString direction);
+};
+
+[Exposed=Window]
+interface HTMLButtonElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [CEReactions] attribute boolean disabled;
+  readonly attribute HTMLFormElement? form;
+  [CEReactions] attribute USVString formAction;
+  [CEReactions] attribute DOMString formEnctype;
+  [CEReactions] attribute DOMString formMethod;
+  [CEReactions] attribute boolean formNoValidate;
+  [CEReactions] attribute DOMString formTarget;
+  [CEReactions] attribute DOMString name;
+  [CEReactions] attribute DOMString type;
+  [CEReactions] attribute DOMString value;
+
+  readonly attribute boolean willValidate;
+  readonly attribute ValidityState validity;
+  readonly attribute DOMString validationMessage;
+  boolean checkValidity();
+  boolean reportValidity();
+  void setCustomValidity(DOMString error);
+
+  readonly attribute NodeList labels;
+};
+
+[Exposed=Window]
+interface HTMLSelectElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [CEReactions] attribute DOMString autocomplete;
+  [CEReactions] attribute boolean disabled;
+  readonly attribute HTMLFormElement? form;
+  [CEReactions] attribute boolean multiple;
+  [CEReactions] attribute DOMString name;
+  [CEReactions] attribute boolean required;
+  [CEReactions] attribute unsigned long size;
+
+  readonly attribute DOMString type;
+
+  [SameObject] readonly attribute HTMLOptionsCollection options;
+  [CEReactions] attribute unsigned long length;
+  getter Element? item(unsigned long index);
+  HTMLOptionElement? namedItem(DOMString name);
+  [CEReactions] void add((HTMLOptionElement or HTMLOptGroupElement) element, optional (HTMLElement or long)? before = null);
+  [CEReactions] void remove(); // ChildNode overload
+  [CEReactions] void remove(long index);
+  [CEReactions] setter void (unsigned long index, HTMLOptionElement? option);
+
+  [SameObject] readonly attribute HTMLCollection selectedOptions;
+  attribute long selectedIndex;
+  attribute DOMString value;
+
+  readonly attribute boolean willValidate;
+  readonly attribute ValidityState validity;
+  readonly attribute DOMString validationMessage;
+  boolean checkValidity();
+  boolean reportValidity();
+  void setCustomValidity(DOMString error);
+
+  readonly attribute NodeList labels;
+};
+
+[Exposed=Window]
+interface HTMLDataListElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [SameObject] readonly attribute HTMLCollection options;
+};
+
+[Exposed=Window]
+interface HTMLOptGroupElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [CEReactions] attribute boolean disabled;
+  [CEReactions] attribute DOMString label;
+};
+
+[Exposed=Window,
+ LegacyFactoryFunction=Option(optional DOMString text = "", optional DOMString value, optional boolean defaultSelected = false, optional boolean selected = false)]
+interface HTMLOptionElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [CEReactions] attribute boolean disabled;
+  readonly attribute HTMLFormElement? form;
+  [CEReactions] attribute DOMString label;
+  [CEReactions] attribute boolean defaultSelected;
+  attribute boolean selected;
+  [CEReactions] attribute DOMString value;
+
+  [CEReactions] attribute DOMString text;
+  readonly attribute long index;
+};
+
+[Exposed=Window]
+interface HTMLTextAreaElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [CEReactions] attribute DOMString autocomplete;
+  [CEReactions] attribute unsigned long cols;
+  [CEReactions] attribute DOMString dirName;
+  [CEReactions] attribute boolean disabled;
+  readonly attribute HTMLFormElement? form;
+  [CEReactions] attribute long maxLength;
+  [CEReactions] attribute long minLength;
+  [CEReactions] attribute DOMString name;
+  [CEReactions] attribute DOMString placeholder;
+  [CEReactions] attribute boolean readOnly;
+  [CEReactions] attribute boolean required;
+  [CEReactions] attribute unsigned long rows;
+  [CEReactions] attribute DOMString wrap;
+
+  readonly attribute DOMString type;
+  [CEReactions] attribute DOMString defaultValue;
+  attribute [LegacyNullToEmptyString] DOMString value;
+  readonly attribute unsigned long textLength;
+
+  readonly attribute boolean willValidate;
+  readonly attribute ValidityState validity;
+  readonly attribute DOMString validationMessage;
+  boolean checkValidity();
+  boolean reportValidity();
+  void setCustomValidity(DOMString error);
+
+  readonly attribute NodeList labels;
+
+  void select();
+  attribute unsigned long selectionStart;
+  attribute unsigned long selectionEnd;
+  attribute DOMString selectionDirection;
+  void setRangeText(DOMString replacement);
+  void setRangeText(DOMString replacement, unsigned long start, unsigned long end, optional SelectionMode selectionMode = "preserve");
+  void setSelectionRange(unsigned long start, unsigned long end, optional DOMString direction);
+};
+
+[Exposed=Window]
+interface HTMLOutputElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [SameObject, PutForwards=value] readonly attribute DOMTokenList htmlFor;
+  readonly attribute HTMLFormElement? form;
+  [CEReactions] attribute DOMString name;
+
+  readonly attribute DOMString type;
+  [CEReactions] attribute DOMString defaultValue;
+  [CEReactions] attribute DOMString value;
+
+  readonly attribute boolean willValidate;
+  readonly attribute ValidityState validity;
+  readonly attribute DOMString validationMessage;
+  boolean checkValidity();
+  boolean reportValidity();
+  void setCustomValidity(DOMString error);
+
+  readonly attribute NodeList labels;
+};
+
+[Exposed=Window]
+interface HTMLProgressElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [CEReactions] attribute double value;
+  [CEReactions] attribute double max;
+  readonly attribute double position;
+  readonly attribute NodeList labels;
+};
+
+[Exposed=Window]
+interface HTMLMeterElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [CEReactions] attribute double value;
+  [CEReactions] attribute double min;
+  [CEReactions] attribute double max;
+  [CEReactions] attribute double low;
+  [CEReactions] attribute double high;
+  [CEReactions] attribute double optimum;
+  readonly attribute NodeList labels;
+};
+
+[Exposed=Window]
+interface HTMLFieldSetElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [CEReactions] attribute boolean disabled;
+  readonly attribute HTMLFormElement? form;
+  [CEReactions] attribute DOMString name;
+
+  readonly attribute DOMString type;
+
+  [SameObject] readonly attribute HTMLCollection elements;
+
+  readonly attribute boolean willValidate;
+  [SameObject] readonly attribute ValidityState validity;
+  readonly attribute DOMString validationMessage;
+  boolean checkValidity();
+  boolean reportValidity();
+  void setCustomValidity(DOMString error);
+};
+
+[Exposed=Window]
+interface HTMLLegendElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  readonly attribute HTMLFormElement? form;
+};
+
+enum SelectionMode {
+  "select",
+  "start",
+  "end",
+  "preserve" // default
+};
+
+[Exposed=Window]
+interface ValidityState {
+  readonly attribute boolean valueMissing;
+  readonly attribute boolean typeMismatch;
+  readonly attribute boolean patternMismatch;
+  readonly attribute boolean tooLong;
+  readonly attribute boolean tooShort;
+  readonly attribute boolean rangeUnderflow;
+  readonly attribute boolean rangeOverflow;
+  readonly attribute boolean stepMismatch;
+  readonly attribute boolean badInput;
+  readonly attribute boolean customError;
+  readonly attribute boolean valid;
+};
+
+[Exposed=Window]
+interface SubmitEvent : Event {
+  constructor(DOMString type, optional SubmitEventInit eventInitDict = {});
+
+  readonly attribute HTMLElement? submitter;
+};
+
+dictionary SubmitEventInit : EventInit {
+  HTMLElement? submitter = null;
+};
+
+[Exposed=Window]
+interface FormDataEvent : Event {
+  constructor(DOMString type, FormDataEventInit eventInitDict);
+
+  readonly attribute FormData formData;
+};
+
+dictionary FormDataEventInit : EventInit {
+  required FormData formData;
+};
+
+[Exposed=Window]
+interface HTMLDetailsElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [CEReactions] attribute boolean open;
+};
+
+[Exposed=Window]
+interface HTMLDialogElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [CEReactions] attribute boolean open;
+  attribute DOMString returnValue;
+  [CEReactions] void show();
+  [CEReactions] void showModal();
+  [CEReactions] void close(optional DOMString returnValue);
+};
+
+[Exposed=Window]
+interface HTMLScriptElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [CEReactions] attribute USVString src;
+  [CEReactions] attribute DOMString type;
+  [CEReactions] attribute boolean noModule;
+  [CEReactions] attribute boolean async;
+  [CEReactions] attribute boolean defer;
+  [CEReactions] attribute DOMString? crossOrigin;
+  [CEReactions] attribute DOMString text;
+  [CEReactions] attribute DOMString integrity;
+  [CEReactions] attribute DOMString referrerPolicy;
+
+};
+
+[Exposed=Window]
+interface HTMLTemplateElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  readonly attribute DocumentFragment content;
+};
+
+[Exposed=Window]
+interface HTMLSlotElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [CEReactions] attribute DOMString name;
+  sequence<Node> assignedNodes(optional AssignedNodesOptions options = {});
+  sequence<Element> assignedElements(optional AssignedNodesOptions options = {});
+};
+
+dictionary AssignedNodesOptions {
+  boolean flatten = false;
+};
+
+typedef (CanvasRenderingContext2D or ImageBitmapRenderingContext or WebGLRenderingContext or WebGL2RenderingContext) RenderingContext;
+
+[Exposed=Window]
+interface HTMLCanvasElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [CEReactions] attribute unsigned long width;
+  [CEReactions] attribute unsigned long height;
+
+  RenderingContext? getContext(DOMString contextId, optional any options = null);
+
+  USVString toDataURL(optional DOMString type = "image/png", optional any quality);
+  void toBlob(BlobCallback _callback, optional DOMString type = "image/png", optional any quality);
+  OffscreenCanvas transferControlToOffscreen();
+};
+
+callback BlobCallback = void (Blob? blob);
+
+typedef (HTMLImageElement or
+         SVGImageElement) HTMLOrSVGImageElement;
+
+typedef (HTMLOrSVGImageElement or
+         HTMLVideoElement or
+         HTMLCanvasElement or
+         ImageBitmap or
+         OffscreenCanvas) CanvasImageSource;
+
+enum CanvasFillRule { "nonzero", "evenodd" };
+
+dictionary CanvasRenderingContext2DSettings {
+  boolean alpha = true;
+  boolean desynchronized = false;
+};
+
+enum ImageSmoothingQuality { "low", "medium", "high" };
+
+[Exposed=Window]
+interface CanvasRenderingContext2D {
+  // back-reference to the canvas
+  readonly attribute HTMLCanvasElement canvas;
+
+  CanvasRenderingContext2DSettings getContextAttributes();
+};
+CanvasRenderingContext2D includes CanvasState;
+CanvasRenderingContext2D includes CanvasTransform;
+CanvasRenderingContext2D includes CanvasCompositing;
+CanvasRenderingContext2D includes CanvasImageSmoothing;
+CanvasRenderingContext2D includes CanvasFillStrokeStyles;
+CanvasRenderingContext2D includes CanvasShadowStyles;
+CanvasRenderingContext2D includes CanvasFilters;
+CanvasRenderingContext2D includes CanvasRect;
+CanvasRenderingContext2D includes CanvasDrawPath;
+CanvasRenderingContext2D includes CanvasUserInterface;
+CanvasRenderingContext2D includes CanvasText;
+CanvasRenderingContext2D includes CanvasDrawImage;
+CanvasRenderingContext2D includes CanvasImageData;
+CanvasRenderingContext2D includes CanvasPathDrawingStyles;
+CanvasRenderingContext2D includes CanvasTextDrawingStyles;
+CanvasRenderingContext2D includes CanvasPath;
+
+interface mixin CanvasState {
+  // state
+  void save(); // push state on state stack
+  void restore(); // pop state stack and restore state
+};
+
+interface mixin CanvasTransform {
+  // transformations (default transform is the identity matrix)
+  void scale(unrestricted double x, unrestricted double y);
+  void rotate(unrestricted double angle);
+  void translate(unrestricted double x, unrestricted double y);
+  void transform(unrestricted double a, unrestricted double b, unrestricted double c, unrestricted double d, unrestricted double e, unrestricted double f);
+
+  [NewObject] DOMMatrix getTransform();
+  void setTransform(unrestricted double a, unrestricted double b, unrestricted double c, unrestricted double d, unrestricted double e, unrestricted double f);
+  void setTransform(optional DOMMatrix2DInit transform = {});
+  void resetTransform();
+
+};
+
+interface mixin CanvasCompositing {
+  // compositing
+  attribute unrestricted double globalAlpha; // (default 1.0)
+  attribute DOMString globalCompositeOperation; // (default source-over)
+};
+
+interface mixin CanvasImageSmoothing {
+  // image smoothing
+  attribute boolean imageSmoothingEnabled; // (default true)
+  attribute ImageSmoothingQuality imageSmoothingQuality; // (default low)
+
+};
+
+interface mixin CanvasFillStrokeStyles {
+  // colors and styles (see also the CanvasPathDrawingStyles and CanvasTextDrawingStyles interfaces)
+  attribute (DOMString or CanvasGradient or CanvasPattern) strokeStyle; // (default black)
+  attribute (DOMString or CanvasGradient or CanvasPattern) fillStyle; // (default black)
+  CanvasGradient createLinearGradient(double x0, double y0, double x1, double y1);
+  CanvasGradient createRadialGradient(double x0, double y0, double r0, double x1, double y1, double r1);
+  CanvasPattern? createPattern(CanvasImageSource image, [LegacyNullToEmptyString] DOMString repetition);
+
+};
+
+interface mixin CanvasShadowStyles {
+  // shadows
+  attribute unrestricted double shadowOffsetX; // (default 0)
+  attribute unrestricted double shadowOffsetY; // (default 0)
+  attribute unrestricted double shadowBlur; // (default 0)
+  attribute DOMString shadowColor; // (default transparent black)
+};
+
+interface mixin CanvasFilters {
+  // filters
+  attribute DOMString filter; // (default "none")
+};
+
+interface mixin CanvasRect {
+  // rects
+  void clearRect(unrestricted double x, unrestricted double y, unrestricted double w, unrestricted double h);
+  void fillRect(unrestricted double x, unrestricted double y, unrestricted double w, unrestricted double h);
+  void strokeRect(unrestricted double x, unrestricted double y, unrestricted double w, unrestricted double h);
+};
+
+interface mixin CanvasDrawPath {
+  // path API (see also CanvasPath)
+  void beginPath();
+  void fill(optional CanvasFillRule fillRule = "nonzero");
+  void fill(Path2D path, optional CanvasFillRule fillRule = "nonzero");
+  void stroke();
+  void stroke(Path2D path);
+  void clip(optional CanvasFillRule fillRule = "nonzero");
+  void clip(Path2D path, optional CanvasFillRule fillRule = "nonzero");
+  boolean isPointInPath(unrestricted double x, unrestricted double y, optional CanvasFillRule fillRule = "nonzero");
+  boolean isPointInPath(Path2D path, unrestricted double x, unrestricted double y, optional CanvasFillRule fillRule = "nonzero");
+  boolean isPointInStroke(unrestricted double x, unrestricted double y);
+  boolean isPointInStroke(Path2D path, unrestricted double x, unrestricted double y);
+};
+
+interface mixin CanvasUserInterface {
+  void drawFocusIfNeeded(Element element);
+  void drawFocusIfNeeded(Path2D path, Element element);
+  void scrollPathIntoView();
+  void scrollPathIntoView(Path2D path);
+};
+
+interface mixin CanvasText {
+  // text (see also the CanvasPathDrawingStyles and CanvasTextDrawingStyles interfaces)
+  void fillText(DOMString text, unrestricted double x, unrestricted double y, optional unrestricted double maxWidth);
+  void strokeText(DOMString text, unrestricted double x, unrestricted double y, optional unrestricted double maxWidth);
+  TextMetrics measureText(DOMString text);
+};
+
+interface mixin CanvasDrawImage {
+  // drawing images
+  void drawImage(CanvasImageSource image, unrestricted double dx, unrestricted double dy);
+  void drawImage(CanvasImageSource image, unrestricted double dx, unrestricted double dy, unrestricted double dw, unrestricted double dh);
+  void drawImage(CanvasImageSource image, unrestricted double sx, unrestricted double sy, unrestricted double sw, unrestricted double sh, unrestricted double dx, unrestricted double dy, unrestricted double dw, unrestricted double dh);
+};
+
+interface mixin CanvasImageData {
+  // pixel manipulation
+  ImageData createImageData(long sw, long sh);
+  ImageData createImageData(ImageData imagedata);
+  ImageData getImageData(long sx, long sy, long sw, long sh);
+  void putImageData(ImageData imagedata, long dx, long dy);
+  void putImageData(ImageData imagedata, long dx, long dy, long dirtyX, long dirtyY, long dirtyWidth, long dirtyHeight);
+};
+
+enum CanvasLineCap { "butt", "round", "square" };
+enum CanvasLineJoin { "round", "bevel", "miter" };
+enum CanvasTextAlign { "start", "end", "left", "right", "center" };
+enum CanvasTextBaseline { "top", "hanging", "middle", "alphabetic", "ideographic", "bottom" };
+enum CanvasDirection { "ltr", "rtl", "inherit" };
+
+interface mixin CanvasPathDrawingStyles {
+  // line caps/joins
+  attribute unrestricted double lineWidth; // (default 1)
+  attribute CanvasLineCap lineCap; // (default "butt")
+  attribute CanvasLineJoin lineJoin; // (default "miter")
+  attribute unrestricted double miterLimit; // (default 10)
+
+  // dashed lines
+  void setLineDash(sequence<unrestricted double> segments); // default empty
+  sequence<unrestricted double> getLineDash();
+  attribute unrestricted double lineDashOffset;
+};
+
+interface mixin CanvasTextDrawingStyles {
+  // text
+  attribute DOMString font; // (default 10px sans-serif)
+  attribute CanvasTextAlign textAlign; // (default: "start")
+  attribute CanvasTextBaseline textBaseline; // (default: "alphabetic")
+  attribute CanvasDirection direction; // (default: "inherit")
+};
+
+interface mixin CanvasPath {
+  // shared path API methods
+  void closePath();
+  void moveTo(unrestricted double x, unrestricted double y);
+  void lineTo(unrestricted double x, unrestricted double y);
+  void quadraticCurveTo(unrestricted double cpx, unrestricted double cpy, unrestricted double x, unrestricted double y);
+  void bezierCurveTo(unrestricted double cp1x, unrestricted double cp1y, unrestricted double cp2x, unrestricted double cp2y, unrestricted double x, unrestricted double y);
+  void arcTo(unrestricted double x1, unrestricted double y1, unrestricted double x2, unrestricted double y2, unrestricted double radius);
+  void rect(unrestricted double x, unrestricted double y, unrestricted double w, unrestricted double h);
+  void arc(unrestricted double x, unrestricted double y, unrestricted double radius, unrestricted double startAngle, unrestricted double endAngle, optional boolean anticlockwise = false);
+  void ellipse(unrestricted double x, unrestricted double y, unrestricted double radiusX, unrestricted double radiusY, unrestricted double rotation, unrestricted double startAngle, unrestricted double endAngle, optional boolean anticlockwise = false);
+};
+
+[Exposed=(Window,Worker)]
+interface CanvasGradient {
+  // opaque object
+  void addColorStop(double offset, DOMString color);
+};
+
+[Exposed=(Window,Worker)]
+interface CanvasPattern {
+  // opaque object
+  void setTransform(optional DOMMatrix2DInit transform = {});
+};
+
+[Exposed=(Window,Worker)]
+interface TextMetrics {
+  // x-direction
+  readonly attribute double width; // advance width
+  readonly attribute double actualBoundingBoxLeft;
+  readonly attribute double actualBoundingBoxRight;
+
+  // y-direction
+  readonly attribute double fontBoundingBoxAscent;
+  readonly attribute double fontBoundingBoxDescent;
+  readonly attribute double actualBoundingBoxAscent;
+  readonly attribute double actualBoundingBoxDescent;
+  readonly attribute double emHeightAscent;
+  readonly attribute double emHeightDescent;
+  readonly attribute double hangingBaseline;
+  readonly attribute double alphabeticBaseline;
+  readonly attribute double ideographicBaseline;
+};
+
+[Exposed=(Window,Worker),
+ Serializable]
+interface ImageData {
+  constructor(unsigned long sw, unsigned long sh);
+  constructor(Uint8ClampedArray data, unsigned long sw, optional unsigned long sh);
+
+  readonly attribute unsigned long width;
+  readonly attribute unsigned long height;
+  readonly attribute Uint8ClampedArray data;
+};
+
+[Exposed=(Window,Worker)]
+interface Path2D {
+  constructor(optional (Path2D or DOMString) path);
+
+  void addPath(Path2D path, optional DOMMatrix2DInit transform = {});
+};
+Path2D includes CanvasPath;
+
+[Exposed=(Window,Worker)]
+interface ImageBitmapRenderingContext {
+  readonly attribute (HTMLCanvasElement or OffscreenCanvas) canvas;
+  void transferFromImageBitmap(ImageBitmap? bitmap);
+};
+
+dictionary ImageBitmapRenderingContextSettings {
+  boolean alpha = true;
+};
+
+typedef (OffscreenCanvasRenderingContext2D or ImageBitmapRenderingContext or WebGLRenderingContext or WebGL2RenderingContext) OffscreenRenderingContext;
+
+dictionary ImageEncodeOptions {
+  DOMString type = "image/png";
+  unrestricted double quality;
+};
+
+enum OffscreenRenderingContextId { "2d", "bitmaprenderer", "webgl", "webgl2" };
+
+[Exposed=(Window,Worker), Transferable]
+interface OffscreenCanvas : EventTarget {
+  constructor([EnforceRange] unsigned long long width, [EnforceRange] unsigned long long height);
+
+  attribute [EnforceRange] unsigned long long width;
+  attribute [EnforceRange] unsigned long long height;
+
+  OffscreenRenderingContext? getContext(OffscreenRenderingContextId contextId, optional any options = null);
+  ImageBitmap transferToImageBitmap();
+  Promise<Blob> convertToBlob(optional ImageEncodeOptions options = {});
+};
+
+[Exposed=(Window,Worker)]
+interface OffscreenCanvasRenderingContext2D {
+  void commit();
+  readonly attribute OffscreenCanvas canvas;
+};
+
+OffscreenCanvasRenderingContext2D includes CanvasState;
+OffscreenCanvasRenderingContext2D includes CanvasTransform;
+OffscreenCanvasRenderingContext2D includes CanvasCompositing;
+OffscreenCanvasRenderingContext2D includes CanvasImageSmoothing;
+OffscreenCanvasRenderingContext2D includes CanvasFillStrokeStyles;
+OffscreenCanvasRenderingContext2D includes CanvasShadowStyles;
+OffscreenCanvasRenderingContext2D includes CanvasFilters;
+OffscreenCanvasRenderingContext2D includes CanvasRect;
+OffscreenCanvasRenderingContext2D includes CanvasDrawPath;
+OffscreenCanvasRenderingContext2D includes CanvasText;
+OffscreenCanvasRenderingContext2D includes CanvasDrawImage;
+OffscreenCanvasRenderingContext2D includes CanvasImageData;
+OffscreenCanvasRenderingContext2D includes CanvasPathDrawingStyles;
+OffscreenCanvasRenderingContext2D includes CanvasTextDrawingStyles;
+OffscreenCanvasRenderingContext2D includes CanvasPath;
+
+[Exposed=Window]
+interface CustomElementRegistry {
+  [CEReactions] void define(DOMString name, CustomElementConstructor constructor, optional ElementDefinitionOptions options = {});
+  any get(DOMString name);
+  Promise<void> whenDefined(DOMString name);
+  [CEReactions] void upgrade(Node root);
+};
+
+callback CustomElementConstructor = HTMLElement ();
+
+dictionary ElementDefinitionOptions {
+  DOMString extends;
+};
+
+[Exposed=Window]
+interface ElementInternals {
+  // Form-associated custom elements
+
+  void setFormValue((File or USVString or FormData)? value,
+                    optional (File or USVString or FormData)? state);
+
+  readonly attribute HTMLFormElement? form;
+
+  void setValidity(optional ValidityStateFlags flags = {},
+                   optional DOMString message,
+                   optional HTMLElement anchor);
+  readonly attribute boolean willValidate;
+  readonly attribute ValidityState validity;
+  readonly attribute DOMString validationMessage;
+  boolean checkValidity();
+  boolean reportValidity();
+
+  readonly attribute NodeList labels;
+};
+
+dictionary ValidityStateFlags {
+  boolean valueMissing = false;
+  boolean typeMismatch = false;
+  boolean patternMismatch = false;
+  boolean tooLong = false;
+  boolean tooShort = false;
+  boolean rangeUnderflow = false;
+  boolean rangeOverflow = false;
+  boolean stepMismatch = false;
+  boolean badInput = false;
+  boolean customError = false;
+};
+
+dictionary FocusOptions {
+  boolean preventScroll = false;
+};
+
+interface mixin ElementContentEditable {
+  [CEReactions] attribute DOMString contentEditable;
+  [CEReactions] attribute DOMString enterKeyHint;
+  readonly attribute boolean isContentEditable;
+  [CEReactions] attribute DOMString inputMode;
+};
+
+[Exposed=Window,
+ Constructor]
+interface DataTransfer {
+  attribute DOMString dropEffect;
+  attribute DOMString effectAllowed;
+
+  [SameObject] readonly attribute DataTransferItemList items;
+
+  void setDragImage(Element image, long x, long y);
+
+  /* old interface */
+  readonly attribute FrozenArray<DOMString> types;
+  DOMString getData(DOMString format);
+  void setData(DOMString format, DOMString data);
+  void clearData(optional DOMString format);
+  [SameObject] readonly attribute FileList files;
+};
+
+[Exposed=Window]
+interface DataTransferItemList {
+  readonly attribute unsigned long length;
+  getter DataTransferItem (unsigned long index);
+  DataTransferItem? add(DOMString data, DOMString type);
+  DataTransferItem? add(File data);
+  void remove(unsigned long index);
+  void clear();
+};
+
+[Exposed=Window]
+interface DataTransferItem {
+  readonly attribute DOMString kind;
+  readonly attribute DOMString type;
+  void getAsString(FunctionStringCallback? _callback);
+  File? getAsFile();
+};
+
+callback FunctionStringCallback = void (DOMString data);
+
+[Exposed=Window,
+ Constructor(DOMString type, optional DragEventInit eventInitDict = {})]
+interface DragEvent : MouseEvent {
+  readonly attribute DataTransfer? dataTransfer;
+};
+
+dictionary DragEventInit : MouseEventInit {
+  DataTransfer? dataTransfer = null;
+};
+
+[Global=Window,
+ Exposed=Window,
+ LegacyUnenumerableNamedProperties]
+interface Window : EventTarget {
+  // the current browsing context
+  [LegacyUnforgeable] readonly attribute WindowProxy window;
+  [Replaceable] readonly attribute WindowProxy self;
+  [LegacyUnforgeable] readonly attribute Document document;
+  attribute DOMString name;
+  [PutForwards=href, LegacyUnforgeable] readonly attribute Location location;
+  readonly attribute History history;
+  readonly attribute CustomElementRegistry customElements;
+  [Replaceable] readonly attribute BarProp locationbar;
+  [Replaceable] readonly attribute BarProp menubar;
+  [Replaceable] readonly attribute BarProp personalbar;
+  [Replaceable] readonly attribute BarProp scrollbars;
+  [Replaceable] readonly attribute BarProp statusbar;
+  [Replaceable] readonly attribute BarProp toolbar;
+  attribute DOMString status;
+  void close();
+  readonly attribute boolean closed;
+  void stop();
+  void focus();
+  void blur();
+
+  // other browsing contexts
+  [Replaceable] readonly attribute WindowProxy frames;
+  [Replaceable] readonly attribute unsigned long length;
+  [LegacyUnforgeable] readonly attribute WindowProxy? top;
+  attribute any opener;
+  [Replaceable] readonly attribute WindowProxy? parent;
+  readonly attribute Element? frameElement;
+  WindowProxy? open(optional USVString url = "", optional DOMString target = "_blank", optional [LegacyNullToEmptyString] DOMString features = "");
+  getter object (DOMString name);
+  // Since this is the global object, the IDL named getter adds a NamedPropertiesObject exotic
+  // object on the prototype chain. Indeed, this does not make the global object an exotic object.
+  // Indexed access is taken care of by the WindowProxy exotic object.
+
+  // the user agent
+  readonly attribute Navigator navigator;
+  [SecureContext] readonly attribute ApplicationCache applicationCache;
+
+  // user prompts
+  void alert();
+  void alert(DOMString message);
+  boolean confirm(optional DOMString message = "");
+  DOMString? prompt(optional DOMString message = "", optional DOMString default = "");
+  void print();
+
+  void postMessage(any message, USVString targetOrigin, optional sequence<object> transfer = []);
+  void postMessage(any message, optional WindowPostMessageOptions options = {});
+};
+Window includes GlobalEventHandlers;
+Window includes WindowEventHandlers;
+
+dictionary WindowPostMessageOptions : PostMessageOptions {
+  USVString targetOrigin = "/";
+};
+
+[Exposed=Window]
+interface BarProp {
+  readonly attribute boolean visible;
+};
+
+enum ScrollRestoration { "auto", "manual" };
+
+[Exposed=Window]
+interface History {
+  readonly attribute unsigned long length;
+  attribute ScrollRestoration scrollRestoration;
+  readonly attribute any state;
+  void go(optional long delta = 0);
+  void back();
+  void forward();
+  void pushState(any data, DOMString title, optional USVString? url = null);
+  void replaceState(any data, DOMString title, optional USVString? url = null);
+};
+
+[Exposed=Window]
+interface Location { // but see also additional creation steps and overridden internal methods
+  [LegacyUnforgeable] stringifier attribute USVString href;
+  [LegacyUnforgeable] readonly attribute USVString origin;
+  [LegacyUnforgeable] attribute USVString protocol;
+  [LegacyUnforgeable] attribute USVString host;
+  [LegacyUnforgeable] attribute USVString hostname;
+  [LegacyUnforgeable] attribute USVString port;
+  [LegacyUnforgeable] attribute USVString pathname;
+  [LegacyUnforgeable] attribute USVString search;
+  [LegacyUnforgeable] attribute USVString hash;
+
+  [LegacyUnforgeable] void assign(USVString url);
+  [LegacyUnforgeable] void replace(USVString url);
+  [LegacyUnforgeable] void reload();
+
+  [LegacyUnforgeable, SameObject] readonly attribute DOMStringList ancestorOrigins;
+};
+
+[Exposed=Window,
+ Constructor(DOMString type, optional PopStateEventInit eventInitDict = {})]
+interface PopStateEvent : Event {
+  readonly attribute any state;
+};
+
+dictionary PopStateEventInit : EventInit {
+  any state = null;
+};
+
+[Exposed=Window,
+ Constructor(DOMString type, optional HashChangeEventInit eventInitDict = {})]
+interface HashChangeEvent : Event {
+  readonly attribute USVString oldURL;
+  readonly attribute USVString newURL;
+};
+
+dictionary HashChangeEventInit : EventInit {
+  USVString oldURL = "";
+  USVString newURL = "";
+};
+
+[Exposed=Window,
+ Constructor(DOMString type, optional PageTransitionEventInit eventInitDict = {})]
+interface PageTransitionEvent : Event {
+  readonly attribute boolean persisted;
+};
+
+dictionary PageTransitionEventInit : EventInit {
+  boolean persisted = false;
+};
+
+[Exposed=Window]
+interface BeforeUnloadEvent : Event {
+  attribute DOMString returnValue;
+};
+
+[SecureContext,
+ Exposed=Window]
+interface ApplicationCache : EventTarget {
+
+  // update status
+  const unsigned short UNCACHED = 0;
+  const unsigned short IDLE = 1;
+  const unsigned short CHECKING = 2;
+  const unsigned short DOWNLOADING = 3;
+  const unsigned short UPDATEREADY = 4;
+  const unsigned short OBSOLETE = 5;
+  readonly attribute unsigned short status;
+
+  // updates
+  void update();
+  void abort();
+  void swapCache();
+
+  // events
+  attribute EventHandler onchecking;
+  attribute EventHandler onerror;
+  attribute EventHandler onnoupdate;
+  attribute EventHandler ondownloading;
+  attribute EventHandler onprogress;
+  attribute EventHandler onupdateready;
+  attribute EventHandler oncached;
+  attribute EventHandler onobsolete;
+};
+
+interface mixin NavigatorOnLine {
+  readonly attribute boolean onLine;
+};
+
+[Exposed=(Window,Worker)]
+interface ErrorEvent : Event {
+  constructor(DOMString type, optional ErrorEventInit eventInitDict = {});
+
+  readonly attribute DOMString message;
+  readonly attribute USVString filename;
+  readonly attribute unsigned long lineno;
+  readonly attribute unsigned long colno;
+  readonly attribute any error;
+};
+
+dictionary ErrorEventInit : EventInit {
+  DOMString message = "";
+  USVString filename = "";
+  unsigned long lineno = 0;
+  unsigned long colno = 0;
+  any error = null;
+};
+
+[Exposed=(Window,Worker)]
+interface PromiseRejectionEvent : Event {
+  constructor(DOMString type, PromiseRejectionEventInit eventInitDict);
+
+  readonly attribute Promise<any> promise;
+  readonly attribute any reason;
+};
+
+dictionary PromiseRejectionEventInit : EventInit {
+  required Promise<any> promise;
+  any reason;
+};
+
+[LegacyTreatNonObjectAsNull]
+callback EventHandlerNonNull = any (Event event);
+typedef EventHandlerNonNull? EventHandler;
+
+[LegacyTreatNonObjectAsNull]
+callback OnErrorEventHandlerNonNull = any ((Event or DOMString) event, optional DOMString source, optional unsigned long lineno, optional unsigned long colno, optional any error);
+typedef OnErrorEventHandlerNonNull? OnErrorEventHandler;
+
+[LegacyTreatNonObjectAsNull]
+callback OnBeforeUnloadEventHandlerNonNull = DOMString? (Event event);
+typedef OnBeforeUnloadEventHandlerNonNull? OnBeforeUnloadEventHandler;
+
+interface mixin GlobalEventHandlers {
+  attribute EventHandler onabort;
+  attribute EventHandler onauxclick;
+  attribute EventHandler onblur;
+  attribute EventHandler oncancel;
+  attribute EventHandler oncanplay;
+  attribute EventHandler oncanplaythrough;
+  attribute EventHandler onchange;
+  attribute EventHandler onclick;
+  attribute EventHandler onclose;
+  attribute EventHandler oncontextmenu;
+  attribute EventHandler oncuechange;
+  attribute EventHandler ondblclick;
+  attribute EventHandler ondrag;
+  attribute EventHandler ondragend;
+  attribute EventHandler ondragenter;
+  attribute EventHandler ondragexit;
+  attribute EventHandler ondragleave;
+  attribute EventHandler ondragover;
+  attribute EventHandler ondragstart;
+  attribute EventHandler ondrop;
+  attribute EventHandler ondurationchange;
+  attribute EventHandler onemptied;
+  attribute EventHandler onended;
+  attribute OnErrorEventHandler onerror;
+  attribute EventHandler onfocus;
+  attribute EventHandler onformdata;
+  attribute EventHandler oninput;
+  attribute EventHandler oninvalid;
+  attribute EventHandler onkeydown;
+  attribute EventHandler onkeypress;
+  attribute EventHandler onkeyup;
+  attribute EventHandler onload;
+  attribute EventHandler onloadeddata;
+  attribute EventHandler onloadedmetadata;
+  attribute EventHandler onloadstart;
+  attribute EventHandler onmousedown;
+  [LegacyLenientThis] attribute EventHandler onmouseenter;
+  [LegacyLenientThis] attribute EventHandler onmouseleave;
+  attribute EventHandler onmousemove;
+  attribute EventHandler onmouseout;
+  attribute EventHandler onmouseover;
+  attribute EventHandler onmouseup;
+  attribute EventHandler onpause;
+  attribute EventHandler onplay;
+  attribute EventHandler onplaying;
+  attribute EventHandler onprogress;
+  attribute EventHandler onratechange;
+  attribute EventHandler onreset;
+  attribute EventHandler onresize;
+  attribute EventHandler onscroll;
+  attribute EventHandler onsecuritypolicyviolation;
+  attribute EventHandler onseeked;
+  attribute EventHandler onseeking;
+  attribute EventHandler onselect;
+  attribute EventHandler onslotchange;
+  attribute EventHandler onstalled;
+  attribute EventHandler onsubmit;
+  attribute EventHandler onsuspend;
+  attribute EventHandler ontimeupdate;
+  attribute EventHandler ontoggle;
+  attribute EventHandler onvolumechange;
+  attribute EventHandler onwaiting;
+  attribute EventHandler onwebkitanimationend;
+  attribute EventHandler onwebkitanimationiteration;
+  attribute EventHandler onwebkitanimationstart;
+  attribute EventHandler onwebkittransitionend;
+  attribute EventHandler onwheel;
+};
+
+interface mixin WindowEventHandlers {
+  attribute EventHandler onafterprint;
+  attribute EventHandler onbeforeprint;
+  attribute OnBeforeUnloadEventHandler onbeforeunload;
+  attribute EventHandler onhashchange;
+  attribute EventHandler onlanguagechange;
+  attribute EventHandler onmessage;
+  attribute EventHandler onmessageerror;
+  attribute EventHandler onoffline;
+  attribute EventHandler ononline;
+  attribute EventHandler onpagehide;
+  attribute EventHandler onpageshow;
+  attribute EventHandler onpopstate;
+  attribute EventHandler onrejectionhandled;
+  attribute EventHandler onstorage;
+  attribute EventHandler onunhandledrejection;
+  attribute EventHandler onunload;
+};
+
+interface mixin DocumentAndElementEventHandlers {
+  attribute EventHandler oncopy;
+  attribute EventHandler oncut;
+  attribute EventHandler onpaste;
+};
+
+typedef (DOMString or Function) TimerHandler;
+
+interface mixin WindowOrWorkerGlobalScope {
+  [Replaceable] readonly attribute USVString origin;
+
+  // base64 utility methods
+  DOMString btoa(DOMString data);
+  ByteString atob(DOMString data);
+
+  // timers
+  long setTimeout(TimerHandler handler, optional long timeout = 0, any... arguments);
+  void clearTimeout(optional long handle = 0);
+  long setInterval(TimerHandler handler, optional long timeout = 0, any... arguments);
+  void clearInterval(optional long handle = 0);
+
+  // microtask queuing
+  void queueMicrotask(VoidFunction callback);
+
+  // ImageBitmap
+  Promise<ImageBitmap> createImageBitmap(ImageBitmapSource image, optional ImageBitmapOptions options = {});
+  Promise<ImageBitmap> createImageBitmap(ImageBitmapSource image, long sx, long sy, long sw, long sh, optional ImageBitmapOptions options = {});
+};
+Window includes WindowOrWorkerGlobalScope;
+WorkerGlobalScope includes WindowOrWorkerGlobalScope;
+
+[Exposed=Window]
+interface DOMParser {
+  constructor();
+
+  [NewObject] Document parseFromString(DOMString string, DOMParserSupportedType type);
+};
+
+enum DOMParserSupportedType {
+  "text/html",
+  "text/xml",
+  "application/xml",
+  "application/xhtml+xml",
+  "image/svg+xml"
+};
+
+[Exposed=Window]
+interface Navigator {
+  // objects implementing this interface also implement the interfaces given below
+};
+Navigator includes NavigatorID;
+Navigator includes NavigatorLanguage;
+Navigator includes NavigatorOnLine;
+Navigator includes NavigatorContentUtils;
+Navigator includes NavigatorCookies;
+Navigator includes NavigatorPlugins;
+Navigator includes NavigatorConcurrentHardware;
+
+interface mixin NavigatorID {
+  readonly attribute DOMString appCodeName; // constant "Mozilla"
+  readonly attribute DOMString appName; // constant "Netscape"
+  readonly attribute DOMString appVersion;
+  readonly attribute DOMString platform;
+  readonly attribute DOMString product; // constant "Gecko"
+  [Exposed=Window] readonly attribute DOMString productSub;
+  readonly attribute DOMString userAgent;
+  [Exposed=Window] readonly attribute DOMString vendor;
+  [Exposed=Window] readonly attribute DOMString vendorSub; // constant ""
+};
+
+partial interface mixin NavigatorID {
+  [Exposed=Window] boolean taintEnabled(); // constant false
+  [Exposed=Window] readonly attribute DOMString oscpu;
+};
+
+interface mixin NavigatorLanguage {
+  readonly attribute DOMString language;
+  readonly attribute FrozenArray<DOMString> languages;
+};
+
+interface mixin NavigatorContentUtils {
+  [SecureContext] void registerProtocolHandler(DOMString scheme, USVString url);
+  [SecureContext] void unregisterProtocolHandler(DOMString scheme, USVString url);
+};
+
+interface mixin NavigatorCookies {
+  readonly attribute boolean cookieEnabled;
+};
+
+interface mixin NavigatorPlugins {
+  [SameObject] readonly attribute PluginArray plugins;
+  [SameObject] readonly attribute MimeTypeArray mimeTypes;
+  boolean javaEnabled();
+};
+
+[Exposed=Window,
+ LegacyUnenumerableNamedProperties]
+interface PluginArray {
+  void refresh(optional boolean reload = false);
+  readonly attribute unsigned long length;
+  getter Plugin? item(unsigned long index);
+  getter Plugin? namedItem(DOMString name);
+};
+
+[Exposed=Window,
+ LegacyUnenumerableNamedProperties]
+interface MimeTypeArray {
+  readonly attribute unsigned long length;
+  getter MimeType? item(unsigned long index);
+  getter MimeType? namedItem(DOMString name);
+};
+
+[Exposed=Window,
+ LegacyUnenumerableNamedProperties]
+interface Plugin {
+  readonly attribute DOMString name;
+  readonly attribute DOMString description;
+  readonly attribute DOMString filename;
+  readonly attribute unsigned long length;
+  getter MimeType? item(unsigned long index);
+  getter MimeType? namedItem(DOMString name);
+};
+
+[Exposed=Window]
+interface MimeType {
+  readonly attribute DOMString type;
+  readonly attribute DOMString description;
+  readonly attribute DOMString suffixes; // comma-separated
+  readonly attribute Plugin enabledPlugin;
+};
+
+[Exposed=(Window,Worker), Serializable, Transferable]
+interface ImageBitmap {
+  readonly attribute unsigned long width;
+  readonly attribute unsigned long height;
+  void close();
+};
+
+typedef (CanvasImageSource or
+         Blob or
+         ImageData) ImageBitmapSource;
+
+enum ImageOrientation { "none", "flipY" };
+enum PremultiplyAlpha { "none", "premultiply", "default" };
+enum ColorSpaceConversion { "none", "default" };
+enum ResizeQuality { "pixelated", "low", "medium", "high" };
+
+dictionary ImageBitmapOptions {
+  ImageOrientation imageOrientation = "none";
+  PremultiplyAlpha premultiplyAlpha = "default";
+  ColorSpaceConversion colorSpaceConversion = "default";
+  [EnforceRange] unsigned long resizeWidth;
+  [EnforceRange] unsigned long resizeHeight;
+  ResizeQuality resizeQuality = "low";
+};
+
+callback FrameRequestCallback = void (DOMHighResTimeStamp time);
+
+interface mixin AnimationFrameProvider {
+  unsigned long requestAnimationFrame(FrameRequestCallback callback);
+  void cancelAnimationFrame(unsigned long handle);
+};
+Window includes AnimationFrameProvider;
+DedicatedWorkerGlobalScope includes AnimationFrameProvider;
+
+[Exposed=(Window,Worker,AudioWorklet)]
+interface MessageEvent : Event {
+  constructor(DOMString type, optional MessageEventInit eventInitDict = {});
+
+  readonly attribute any data;
+  readonly attribute USVString origin;
+  readonly attribute DOMString lastEventId;
+  readonly attribute MessageEventSource? source;
+  readonly attribute FrozenArray<MessagePort> ports;
+
+  void initMessageEvent(DOMString type, optional boolean bubbles = false, optional boolean cancelable = false, optional any data = null, optional USVString origin = "", optional DOMString lastEventId = "", optional MessageEventSource? source = null, optional sequence<MessagePort> ports = []);
+};
+
+dictionary MessageEventInit : EventInit {
+  any data = null;
+  USVString origin = "";
+  DOMString lastEventId = "";
+  MessageEventSource? source = null;
+  sequence<MessagePort> ports = [];
+};
+
+typedef (WindowProxy or MessagePort or ServiceWorker) MessageEventSource;
+
+[Exposed=(Window,Worker)]
+interface EventSource : EventTarget {
+  constructor(USVString url, optional EventSourceInit eventSourceInitDict = {});
+
+  readonly attribute USVString url;
+  readonly attribute boolean withCredentials;
+
+  // ready state
+  const unsigned short CONNECTING = 0;
+  const unsigned short OPEN = 1;
+  const unsigned short CLOSED = 2;
+  readonly attribute unsigned short readyState;
+
+  // networking
+  attribute EventHandler onopen;
+  attribute EventHandler onmessage;
+  attribute EventHandler onerror;
+  void close();
+};
+
+dictionary EventSourceInit {
+  boolean withCredentials = false;
+};
+
+enum BinaryType { "blob", "arraybuffer" };
+[Exposed=(Window,Worker)]
+interface WebSocket : EventTarget {
+  constructor(USVString url, optional (DOMString or sequence<DOMString>) protocols = []);
+
+  readonly attribute USVString url;
+
+  // ready state
+  const unsigned short CONNECTING = 0;
+  const unsigned short OPEN = 1;
+  const unsigned short CLOSING = 2;
+  const unsigned short CLOSED = 3;
+  readonly attribute unsigned short readyState;
+  readonly attribute unsigned long long bufferedAmount;
+
+  // networking
+  attribute EventHandler onopen;
+  attribute EventHandler onerror;
+  attribute EventHandler onclose;
+  readonly attribute DOMString extensions;
+  readonly attribute DOMString protocol;
+  void close(optional [Clamp] unsigned short code, optional USVString reason);
+
+  // messaging
+  attribute EventHandler onmessage;
+  attribute BinaryType binaryType;
+  void send(USVString data);
+  void send(Blob data);
+  void send(ArrayBuffer data);
+  void send(ArrayBufferView data);
+};
+
+[Exposed=(Window,Worker)]
+interface CloseEvent : Event {
+  constructor(DOMString type, optional CloseEventInit eventInitDict = {});
+
+  readonly attribute boolean wasClean;
+  readonly attribute unsigned short code;
+  readonly attribute USVString reason;
+};
+
+dictionary CloseEventInit : EventInit {
+  boolean wasClean = false;
+  unsigned short code = 0;
+  USVString reason = "";
+};
+
+[Constructor, Exposed=(Window,Worker)]
+interface MessageChannel {
+  readonly attribute MessagePort port1;
+  readonly attribute MessagePort port2;
+};
+
+[Exposed=(Window,Worker,AudioWorklet), Transferable]
+interface MessagePort : EventTarget {
+  void postMessage(any message, sequence<object> transfer);
+  void postMessage(any message, optional PostMessageOptions options = {});
+  void start();
+  void close();
+
+  // event handlers
+  attribute EventHandler onmessage;
+  attribute EventHandler onmessageerror;
+};
+
+dictionary PostMessageOptions {
+  sequence<object> transfer = [];
+};
+
+[Exposed=(Window,Worker)]
+interface BroadcastChannel : EventTarget {
+  constructor(DOMString name);
+
+  readonly attribute DOMString name;
+  void postMessage(any message);
+  void close();
+  attribute EventHandler onmessage;
+  attribute EventHandler onmessageerror;
+};
+
+[Exposed=Worker]
+interface WorkerGlobalScope : EventTarget {
+  readonly attribute WorkerGlobalScope self;
+  readonly attribute WorkerLocation location;
+  readonly attribute WorkerNavigator navigator;
+  void importScripts(USVString... urls);
+
+  attribute OnErrorEventHandler onerror;
+  attribute EventHandler onlanguagechange;
+  attribute EventHandler onoffline;
+  attribute EventHandler ononline;
+  attribute EventHandler onrejectionhandled;
+  attribute EventHandler onunhandledrejection;
+};
+
+[Global=(Worker,DedicatedWorker),Exposed=DedicatedWorker]
+interface DedicatedWorkerGlobalScope : WorkerGlobalScope {
+  [Replaceable] readonly attribute DOMString name;
+
+  void postMessage(any message, sequence<object> transfer);
+  void postMessage(any message, optional PostMessageOptions options = {});
+
+  void close();
+
+  attribute EventHandler onmessage;
+  attribute EventHandler onmessageerror;
+};
+
+[Global=(Worker,SharedWorker),Exposed=SharedWorker]
+interface SharedWorkerGlobalScope : WorkerGlobalScope {
+  [Replaceable] readonly attribute DOMString name;
+
+  void close();
+
+  attribute EventHandler onconnect;
+};
+
+interface mixin AbstractWorker {
+  attribute EventHandler onerror;
+};
+
+[Exposed=(Window,Worker)]
+interface Worker : EventTarget {
+  constructor(USVString scriptURL, optional WorkerOptions options = {});
+
+  void terminate();
+
+  void postMessage(any message, sequence<object> transfer);
+  void postMessage(any message, optional PostMessageOptions options = {});
+  attribute EventHandler onmessage;
+  attribute EventHandler onmessageerror;
+};
+
+dictionary WorkerOptions {
+  WorkerType type = "classic";
+  RequestCredentials credentials = "same-origin"; // credentials is only used if type is "module"
+  DOMString name = "";
+};
+
+enum WorkerType { "classic", "module" };
+
+Worker includes AbstractWorker;
+
+[Exposed=(Window,Worker)]
+interface SharedWorker : EventTarget {
+  constructor(USVString scriptURL, optional (DOMString or WorkerOptions) options = {});
+
+  readonly attribute MessagePort port;
+};
+SharedWorker includes AbstractWorker;
+
+interface mixin NavigatorConcurrentHardware {
+  readonly attribute unsigned long long hardwareConcurrency;
+};
+
+[Exposed=Worker]
+interface WorkerNavigator {};
+WorkerNavigator includes NavigatorID;
+WorkerNavigator includes NavigatorLanguage;
+WorkerNavigator includes NavigatorOnLine;
+WorkerNavigator includes NavigatorConcurrentHardware;
+
+[Exposed=Worker]
+interface WorkerLocation {
+  stringifier readonly attribute USVString href;
+  readonly attribute USVString origin;
+  readonly attribute USVString protocol;
+  readonly attribute USVString host;
+  readonly attribute USVString hostname;
+  readonly attribute USVString port;
+  readonly attribute USVString pathname;
+  readonly attribute USVString search;
+  readonly attribute USVString hash;
+};
+
+[Exposed=Window]
+interface Storage {
+  readonly attribute unsigned long length;
+  DOMString? key(unsigned long index);
+  getter DOMString? getItem(DOMString key);
+  setter void setItem(DOMString key, DOMString value);
+  deleter void removeItem(DOMString key);
+  void clear();
+};
+
+interface mixin WindowSessionStorage {
+  readonly attribute Storage sessionStorage;
+};
+Window includes WindowSessionStorage;
+
+interface mixin WindowLocalStorage {
+  readonly attribute Storage localStorage;
+};
+Window includes WindowLocalStorage;
+
+[Exposed=Window,
+ Constructor(DOMString type, optional StorageEventInit eventInitDict = {})]
+interface StorageEvent : Event {
+  readonly attribute DOMString? key;
+  readonly attribute DOMString? oldValue;
+  readonly attribute DOMString? newValue;
+  readonly attribute USVString url;
+  readonly attribute Storage? storageArea;
+
+  void initStorageEvent(DOMString type, optional boolean bubbles = false, optional boolean cancelable = false, optional DOMString? key = null, optional DOMString? oldValue = null, optional DOMString? newValue = null, optional USVString url = "", optional Storage? storageArea = null);
+};
+
+dictionary StorageEventInit : EventInit {
+  DOMString? key = null;
+  DOMString? oldValue = null;
+  DOMString? newValue = null;
+  USVString url = "";
+  Storage? storageArea = null;
+};
+
+[Exposed=Window]
+interface HTMLMarqueeElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [CEReactions] attribute DOMString behavior;
+  [CEReactions] attribute DOMString bgColor;
+  [CEReactions] attribute DOMString direction;
+  [CEReactions] attribute DOMString height;
+  [CEReactions] attribute unsigned long hspace;
+  [CEReactions] attribute long loop;
+  [CEReactions] attribute unsigned long scrollAmount;
+  [CEReactions] attribute unsigned long scrollDelay;
+  [CEReactions] attribute boolean trueSpeed;
+  [CEReactions] attribute unsigned long vspace;
+  [CEReactions] attribute DOMString width;
+
+  attribute EventHandler onbounce;
+  attribute EventHandler onfinish;
+  attribute EventHandler onstart;
+
+  void start();
+  void stop();
+};
+
+[Exposed=Window]
+interface HTMLFrameSetElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [CEReactions] attribute DOMString cols;
+  [CEReactions] attribute DOMString rows;
+};
+HTMLFrameSetElement includes WindowEventHandlers;
+
+[Exposed=Window]
+interface HTMLFrameElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [CEReactions] attribute DOMString name;
+  [CEReactions] attribute DOMString scrolling;
+  [CEReactions] attribute USVString src;
+  [CEReactions] attribute DOMString frameBorder;
+  [CEReactions] attribute USVString longDesc;
+  [CEReactions] attribute boolean noResize;
+  readonly attribute Document? contentDocument;
+  readonly attribute WindowProxy? contentWindow;
+
+  [CEReactions] attribute [LegacyNullToEmptyString] DOMString marginHeight;
+  [CEReactions] attribute [LegacyNullToEmptyString] DOMString marginWidth;
+};
+
+partial interface HTMLAnchorElement {
+  [CEReactions] attribute DOMString coords;
+  [CEReactions] attribute DOMString charset;
+  [CEReactions] attribute DOMString name;
+  [CEReactions] attribute DOMString rev;
+  [CEReactions] attribute DOMString shape;
+};
+
+partial interface HTMLAreaElement {
+  [CEReactions] attribute boolean noHref;
+};
+
+partial interface HTMLBodyElement {
+  [CEReactions] attribute [LegacyNullToEmptyString] DOMString text;
+  [CEReactions] attribute [LegacyNullToEmptyString] DOMString link;
+  [CEReactions] attribute [LegacyNullToEmptyString] DOMString vLink;
+  [CEReactions] attribute [LegacyNullToEmptyString] DOMString aLink;
+  [CEReactions] attribute [LegacyNullToEmptyString] DOMString bgColor;
+  [CEReactions] attribute DOMString background;
+};
+
+partial interface HTMLBRElement {
+  [CEReactions] attribute DOMString clear;
+};
+
+partial interface HTMLTableCaptionElement {
+  [CEReactions] attribute DOMString align;
+};
+
+partial interface HTMLTableColElement {
+  [CEReactions] attribute DOMString align;
+  [CEReactions] attribute DOMString ch;
+  [CEReactions] attribute DOMString chOff;
+  [CEReactions] attribute DOMString vAlign;
+  [CEReactions] attribute DOMString width;
+};
+
+[Exposed=Window]
+interface HTMLDirectoryElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [CEReactions] attribute boolean compact;
+};
+
+partial interface HTMLDivElement {
+  [CEReactions] attribute DOMString align;
+};
+
+partial interface HTMLDListElement {
+  [CEReactions] attribute boolean compact;
+};
+
+partial interface HTMLEmbedElement {
+  [CEReactions] attribute DOMString align;
+  [CEReactions] attribute DOMString name;
+};
+
+[Exposed=Window]
+interface HTMLFontElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  [CEReactions] attribute [LegacyNullToEmptyString] DOMString color;
+  [CEReactions] attribute DOMString face;
+  [CEReactions] attribute DOMString size;
+};
+
+partial interface HTMLHeadingElement {
+  [CEReactions] attribute DOMString align;
+};
+
+partial interface HTMLHRElement {
+  [CEReactions] attribute DOMString align;
+  [CEReactions] attribute DOMString color;
+  [CEReactions] attribute boolean noShade;
+  [CEReactions] attribute DOMString size;
+  [CEReactions] attribute DOMString width;
+};
+
+partial interface HTMLHtmlElement {
+  [CEReactions] attribute DOMString version;
+};
+
+partial interface HTMLIFrameElement {
+  [CEReactions] attribute DOMString align;
+  [CEReactions] attribute DOMString scrolling;
+  [CEReactions] attribute DOMString frameBorder;
+  [CEReactions] attribute USVString longDesc;
+
+  [CEReactions] attribute [LegacyNullToEmptyString] DOMString marginHeight;
+  [CEReactions] attribute [LegacyNullToEmptyString] DOMString marginWidth;
+};
+
+partial interface HTMLImageElement {
+  [CEReactions] attribute DOMString name;
+  [CEReactions] attribute USVString lowsrc;
+  [CEReactions] attribute DOMString align;
+  [CEReactions] attribute unsigned long hspace;
+  [CEReactions] attribute unsigned long vspace;
+  [CEReactions] attribute USVString longDesc;
+
+  [CEReactions] attribute [LegacyNullToEmptyString] DOMString border;
+};
+
+partial interface HTMLInputElement {
+  [CEReactions] attribute DOMString align;
+  [CEReactions] attribute DOMString useMap;
+};
+
+partial interface HTMLLegendElement {
+  [CEReactions] attribute DOMString align;
+};
+
+partial interface HTMLLIElement {
+  [CEReactions] attribute DOMString type;
+};
+
+partial interface HTMLLinkElement {
+  [CEReactions] attribute DOMString charset;
+  [CEReactions] attribute DOMString rev;
+  [CEReactions] attribute DOMString target;
+};
+
+partial interface HTMLMenuElement {
+  [CEReactions] attribute boolean compact;
+};
+
+partial interface HTMLMetaElement {
+  [CEReactions] attribute DOMString scheme;
+};
+
+partial interface HTMLObjectElement {
+  [CEReactions] attribute DOMString align;
+  [CEReactions] attribute DOMString archive;
+  [CEReactions] attribute DOMString code;
+  [CEReactions] attribute boolean declare;
+  [CEReactions] attribute unsigned long hspace;
+  [CEReactions] attribute DOMString standby;
+  [CEReactions] attribute unsigned long vspace;
+  [CEReactions] attribute DOMString codeBase;
+  [CEReactions] attribute DOMString codeType;
+
+  [CEReactions] attribute [LegacyNullToEmptyString] DOMString border;
+};
+
+partial interface HTMLOListElement {
+  [CEReactions] attribute boolean compact;
+};
+
+partial interface HTMLParagraphElement {
+  [CEReactions] attribute DOMString align;
+};
+
+partial interface HTMLParamElement {
+  [CEReactions] attribute DOMString type;
+  [CEReactions] attribute DOMString valueType;
+};
+
+partial interface HTMLPreElement {
+  [CEReactions] attribute long width;
+};
+
+partial interface HTMLStyleElement {
+  [CEReactions] attribute DOMString type;
+};
+
+partial interface HTMLScriptElement {
+  [CEReactions] attribute DOMString charset;
+  [CEReactions] attribute DOMString event;
+  [CEReactions] attribute DOMString htmlFor;
+};
+
+partial interface HTMLTableElement {
+  [CEReactions] attribute DOMString align;
+  [CEReactions] attribute DOMString border;
+  [CEReactions] attribute DOMString frame;
+  [CEReactions] attribute DOMString rules;
+  [CEReactions] attribute DOMString summary;
+  [CEReactions] attribute DOMString width;
+
+  [CEReactions] attribute [LegacyNullToEmptyString] DOMString bgColor;
+  [CEReactions] attribute [LegacyNullToEmptyString] DOMString cellPadding;
+  [CEReactions] attribute [LegacyNullToEmptyString] DOMString cellSpacing;
+};
+
+partial interface HTMLTableSectionElement {
+  [CEReactions] attribute DOMString align;
+  [CEReactions] attribute DOMString ch;
+  [CEReactions] attribute DOMString chOff;
+  [CEReactions] attribute DOMString vAlign;
+};
+
+partial interface HTMLTableCellElement {
+  [CEReactions] attribute DOMString align;
+  [CEReactions] attribute DOMString axis;
+  [CEReactions] attribute DOMString height;
+  [CEReactions] attribute DOMString width;
+
+  [CEReactions] attribute DOMString ch;
+  [CEReactions] attribute DOMString chOff;
+  [CEReactions] attribute boolean noWrap;
+  [CEReactions] attribute DOMString vAlign;
+
+  [CEReactions] attribute [LegacyNullToEmptyString] DOMString bgColor;
+};
+
+partial interface HTMLTableRowElement {
+  [CEReactions] attribute DOMString align;
+  [CEReactions] attribute DOMString ch;
+  [CEReactions] attribute DOMString chOff;
+  [CEReactions] attribute DOMString vAlign;
+
+  [CEReactions] attribute [LegacyNullToEmptyString] DOMString bgColor;
+};
+
+partial interface HTMLUListElement {
+  [CEReactions] attribute boolean compact;
+  [CEReactions] attribute DOMString type;
+};
+
+partial interface Document {
+  [CEReactions] attribute [LegacyNullToEmptyString] DOMString fgColor;
+  [CEReactions] attribute [LegacyNullToEmptyString] DOMString linkColor;
+  [CEReactions] attribute [LegacyNullToEmptyString] DOMString vlinkColor;
+  [CEReactions] attribute [LegacyNullToEmptyString] DOMString alinkColor;
+  [CEReactions] attribute [LegacyNullToEmptyString] DOMString bgColor;
+
+  [SameObject] readonly attribute HTMLCollection anchors;
+  [SameObject] readonly attribute HTMLCollection applets;
+
+  void clear();
+  void captureEvents();
+  void releaseEvents();
+
+  [SameObject] readonly attribute HTMLAllCollection all;
+};
+
+partial interface Window {
+  void captureEvents();
+  void releaseEvents();
+
+  [Replaceable, SameObject] readonly attribute External external;
+};
+
+[Exposed=Window]
+interface External {
+  void AddSearchProvider();
+  void IsSearchProviderInstalled();
+};

--- a/test/fixtures/wpt/interfaces/url.idl
+++ b/test/fixtures/wpt/interfaces/url.idl
@@ -3,10 +3,11 @@
 // (https://github.com/tidoust/reffy-reports)
 // Source: URL Standard (https://url.spec.whatwg.org/)
 
-[Constructor(USVString url, optional USVString base),
- Exposed=(Window,Worker),
+[Exposed=(Window,Worker),
  LegacyWindowAlias=webkitURL]
 interface URL {
+  constructor(USVString url, optional USVString base);
+
   stringifier attribute USVString href;
   readonly attribute USVString origin;
            attribute USVString protocol;
@@ -23,9 +24,10 @@ interface URL {
   USVString toJSON();
 };
 
-[Constructor(optional (sequence<sequence<USVString>> or record<USVString, USVString> or USVString) init = ""),
- Exposed=(Window,Worker)]
+[Exposed=(Window,Worker)]
 interface URLSearchParams {
+  constructor(optional (sequence<sequence<USVString>> or record<USVString, USVString> or USVString) init = "");
+
   void append(USVString name, USVString value);
   void delete(USVString name);
   USVString? get(USVString name);

--- a/test/fixtures/wpt/resources/SVGAnimationTestCase-testharness.js
+++ b/test/fixtures/wpt/resources/SVGAnimationTestCase-testharness.js
@@ -1,0 +1,102 @@
+// NOTE(edvardt):
+// This file is a slimmed down wrapper for the old SVGAnimationTestCase.js,
+// it has some convenience functions and should not be used for new tests.
+// New tests should not build on this API as it's just meant to keep things
+// working.
+
+// Helper functions
+const xlinkNS = "http://www.w3.org/1999/xlink"
+
+function expectFillColor(element, red, green, blue, message) {
+    let color = window.getComputedStyle(element, null).fill;
+    var re = new RegExp("rgba?\\(([^, ]*), ([^, ]*), ([^, ]*)(?:, )?([^, ]*)\\)");
+    rgb = re.exec(color);
+
+    assert_approx_equals(Number(rgb[1]), red, 2.0, message);
+    assert_approx_equals(Number(rgb[2]), green, 2.0, message);
+    assert_approx_equals(Number(rgb[3]), blue, 2.0, message);
+}
+
+function expectColor(element, red, green, blue, property) {
+    if (typeof property != "string")
+      color = getComputedStyle(element).getPropertyValue("color");
+    else
+      color = getComputedStyle(element).getPropertyValue(property);
+    var re = new RegExp("rgba?\\(([^, ]*), ([^, ]*), ([^, ]*)(?:, )?([^, ]*)\\)");
+    rgb = re.exec(color);
+    assert_approx_equals(Number(rgb[1]), red, 2.0);
+    assert_approx_equals(Number(rgb[2]), green, 2.0);
+    assert_approx_equals(Number(rgb[3]), blue, 2.0);
+}
+
+function createSVGElement(type) {
+  return document.createElementNS("http://www.w3.org/2000/svg", type);
+}
+
+// Inspired by Layoutests/animations/animation-test-helpers.js
+function moveAnimationTimelineAndSample(index) {
+    var animationId = expectedResults[index][0];
+    var time = expectedResults[index][1];
+    var sampleCallback = expectedResults[index][2];
+    var animation = rootSVGElement.ownerDocument.getElementById(animationId);
+
+    // If we want to sample the animation end, add a small delta, to reliable point past the end of the animation.
+    newTime = time;
+
+    // The sample time is relative to the start time of the animation, take that into account.
+    rootSVGElement.setCurrentTime(newTime);
+
+    // NOTE(edvardt):
+    // This is a dumb hack, some of the old tests sampled before the animation start, this
+    // isn't technically part of the animation tests and is "impossible" to translate since
+    // tests start automatically. Thus I solved it by skipping it.
+    if (time != 0.0)
+        sampleCallback();
+}
+
+var currentTest = 0;
+var expectedResults;
+
+function sampleAnimation(t) {
+    if (currentTest == expectedResults.length) {
+        t.done();
+        return;
+    }
+
+    moveAnimationTimelineAndSample(currentTest);
+    ++currentTest;
+
+    step_timeout(t.step_func(function () { sampleAnimation(t); }), 0);
+}
+
+function runAnimationTest(t, expected) {
+    if (!expected)
+        throw("Expected results are missing!");
+    if (currentTest > 0)
+        throw("Not allowed to call runAnimationTest() twice");
+
+    expectedResults = expected;
+    testCount = expectedResults.length;
+    currentTest = 0;
+
+    step_timeout(t.step_func(function () { sampleAnimation(this); }), 50);
+}
+
+function smil_async_test(func) {
+  async_test(t => {
+    window.onload = t.step_func(function () {
+      // Pause animations, we'll drive them manually.
+      // This also ensures that the timeline is paused before
+      // it starts. This should make the instance time of the below
+      // 'click' (for instance) 0, and hence minimize rounding
+      // errors for the addition in moveAnimationTimelineAndSample.
+      rootSVGElement.pauseAnimations();
+
+      // If eg. an animation is running with begin="0s", and
+      // we want to sample the first time, before the animation
+      // starts, then we can't delay the testing by using an
+      // onclick event, as the animation would be past start time.
+      func(t);
+    });
+  });
+}

--- a/test/fixtures/wpt/resources/webidl2/lib/README.md
+++ b/test/fixtures/wpt/resources/webidl2/lib/README.md
@@ -1,0 +1,4 @@
+This directory contains a built version of the [webidl2.js library](https://github.com/w3c/webidl2.js).
+It is built by running `npm run build-debug` at the root of that repository.
+
+The `webidl2.js.headers` file is a local addition to ensure the script is interpreted as UTF-8.

--- a/test/fixtures/wpt/versions.json
+++ b/test/fixtures/wpt/versions.json
@@ -16,7 +16,7 @@
     "path": "resources"
   },
   "interfaces": {
-    "commit": "712c9f275e83997884749dbcaa503f12c0ff5bba",
+    "commit": "8ada332aeac03764f73ec7ff66f682c5c0b454b4",
     "path": "interfaces"
   },
   "html/webappapis/microtask-queuing": {

--- a/test/wpt/status/hr-time.json
+++ b/test/wpt/status/hr-time.json
@@ -1,1 +1,8 @@
-{}
+{
+  "window-worker-timeOrigin.window.js": {
+    "fail": "Blob is not defined"
+  },
+  "idlharness.any.js": {
+    "skip": "TODO: update IDL parser"
+  }
+}


### PR DESCRIPTION
#### test: update WPT interfaces and hr-time

This commit updates the interfaces to
https://github.com/web-platform-tests/wpt/tree/8ada332aea/interfaces
and updates the hr-time test status:

- `window-worker-timeOrigin.window.js` should be skipped because we
  don't implement `Blob`
- `idlharness.any.js` should be skipped since the IDL parser needs
  to be updated, but the parser update would also result in
  an update of the test harness which in turn requires updates of
  other tests. We need to fix the URL implementation first,
  and then update the harness and all the tests.

#### test: refactor WPTRunner

- Print test results as soon as they are available, instead of
  until after all the tests are complete. This helps us printing
  tests whose completion callback is not called because of
  failures.
- Run the scripts specified by `// META: script=` one by one
  instead of concatenating them first for better error stack
  traces.
- Print a status summary when the test process is about to exit.
  This can be used as reference for updating the status file.

For example the stderr output of
`out/Release/node test/wpt/test-console.js` would be:

```
{
  'idlharness.any.js': {
    fail: {
      expected: [
        'assert_equals: operation has wrong .length expected 1 but got 0'
      ]
    }
  }
}
Ran 4/4 tests, 0 skipped, 3 passed, 1 expected failures, 0 unexpected failures
```



##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
