### PR TITLE
deps: backport v8 commits useful for snapshot integration

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.16',
+    'v8_embedder_string': '-node.17',
 
     ##### V8 defaults for Node.js #####
 

--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.15',
+    'v8_embedder_string': '-node.16',
 
     ##### V8 defaults for Node.js #####
 

--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.14',
+    'v8_embedder_string': '-node.15',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -9788,6 +9788,11 @@ class V8_EXPORT V8 {
 
 /**
  * Helper class to create a snapshot data blob.
+ *
+ * The Isolate used by a SnapshotCreator is owned by it, and will be entered
+ * and exited by the constructor and destructor, respectively; The destructor
+ * will also destroy the Isolate. Experimental language features, including
+ * those available by default, are not available while creating a snapshot.
  */
 class V8_EXPORT SnapshotCreator {
  public:
@@ -9816,6 +9821,10 @@ class V8_EXPORT SnapshotCreator {
   SnapshotCreator(const intptr_t* external_references = nullptr,
                   StartupData* existing_blob = nullptr);
 
+  /**
+   * Destroy the snapshot creator, and exit and dispose of the Isolate
+   * associated with it.
+   */
   ~SnapshotCreator();
 
   /**

--- a/deps/v8/src/heap/factory.cc
+++ b/deps/v8/src/heap/factory.cc
@@ -2761,8 +2761,12 @@ Handle<JSGlobalProxy> Factory::NewUninitializedJSGlobalProxy(int size) {
   map->set_is_access_check_needed(true);
   map->set_may_have_interesting_symbols(true);
   LOG(isolate(), MapDetails(*map));
-  return Handle<JSGlobalProxy>::cast(
+  Handle<JSGlobalProxy> proxy = Handle<JSGlobalProxy>::cast(
       NewJSObjectFromMap(map, AllocationType::kYoung));
+  // Create identity hash early in case there is any JS collection containing
+  // a global proxy key and needs to be rehashed after deserialization.
+  proxy->GetOrCreateIdentityHash(isolate());
+  return proxy;
 }
 
 void Factory::ReinitializeJSGlobalProxy(Handle<JSGlobalProxy> object,

--- a/deps/v8/src/objects/heap-object.h
+++ b/deps/v8/src/objects/heap-object.h
@@ -191,7 +191,7 @@ class HeapObject : public Object {
   bool CanBeRehashed() const;
 
   // Rehash the object based on the layout inferred from its map.
-  void RehashBasedOnMap(ReadOnlyRoots root);
+  void RehashBasedOnMap(Isolate* isolate);
 
   // Layout description.
 #define HEAP_OBJECT_FIELDS(V) \

--- a/deps/v8/src/objects/js-collection.h
+++ b/deps/v8/src/objects/js-collection.h
@@ -30,6 +30,7 @@ class JSSet : public TorqueGeneratedJSSet<JSSet, JSCollection> {
  public:
   static void Initialize(Handle<JSSet> set, Isolate* isolate);
   static void Clear(Isolate* isolate, Handle<JSSet> set);
+  void Rehash(Isolate* isolate);
 
   // Dispatched behavior.
   DECL_PRINTER(JSSet)
@@ -56,6 +57,7 @@ class JSMap : public TorqueGeneratedJSMap<JSMap, JSCollection> {
  public:
   static void Initialize(Handle<JSMap> map, Isolate* isolate);
   static void Clear(Isolate* isolate, Handle<JSMap> map);
+  void Rehash(Isolate* isolate);
 
   // Dispatched behavior.
   DECL_PRINTER(JSMap)

--- a/deps/v8/src/objects/ordered-hash-table.cc
+++ b/deps/v8/src/objects/ordered-hash-table.cc
@@ -196,6 +196,13 @@ HeapObject OrderedHashMap::GetEmpty(ReadOnlyRoots ro_roots) {
 
 template <class Derived, int entrysize>
 MaybeHandle<Derived> OrderedHashTable<Derived, entrysize>::Rehash(
+    Isolate* isolate, Handle<Derived> table) {
+  return OrderedHashTable<Derived, entrysize>::Rehash(isolate, table,
+                                                      table->Capacity());
+}
+
+template <class Derived, int entrysize>
+MaybeHandle<Derived> OrderedHashTable<Derived, entrysize>::Rehash(
     Isolate* isolate, Handle<Derived> table, int new_capacity) {
   DCHECK(!table->IsObsolete());
 
@@ -248,6 +255,20 @@ MaybeHandle<OrderedHashSet> OrderedHashSet::Rehash(Isolate* isolate,
                                                    int new_capacity) {
   return OrderedHashTable<OrderedHashSet, 1>::Rehash(isolate, table,
                                                      new_capacity);
+}
+
+MaybeHandle<OrderedHashSet> OrderedHashSet::Rehash(
+    Isolate* isolate, Handle<OrderedHashSet> table) {
+  return OrderedHashTable<
+      OrderedHashSet, OrderedHashSet::kEntrySizeWithoutChain>::Rehash(isolate,
+                                                                      table);
+}
+
+MaybeHandle<OrderedHashMap> OrderedHashMap::Rehash(
+    Isolate* isolate, Handle<OrderedHashMap> table) {
+  return OrderedHashTable<
+      OrderedHashMap, OrderedHashMap::kEntrySizeWithoutChain>::Rehash(isolate,
+                                                                      table);
 }
 
 MaybeHandle<OrderedHashMap> OrderedHashMap::Rehash(Isolate* isolate,

--- a/deps/v8/src/objects/ordered-hash-table.h
+++ b/deps/v8/src/objects/ordered-hash-table.h
@@ -138,6 +138,7 @@ class OrderedHashTable : public FixedArray {
 
   // The extra +1 is for linking the bucket chains together.
   static const int kEntrySize = entrysize + 1;
+  static const int kEntrySizeWithoutChain = entrysize;
   static const int kChainOffset = entrysize;
 
   static const int kNotFound = -1;
@@ -200,6 +201,8 @@ class OrderedHashTable : public FixedArray {
   static MaybeHandle<Derived> Allocate(
       Isolate* isolate, int capacity,
       AllocationType allocation = AllocationType::kYoung);
+
+  static MaybeHandle<Derived> Rehash(Isolate* isolate, Handle<Derived> table);
   static MaybeHandle<Derived> Rehash(Isolate* isolate, Handle<Derived> table,
                                      int new_capacity);
 
@@ -244,6 +247,8 @@ class V8_EXPORT_PRIVATE OrderedHashSet
   static MaybeHandle<OrderedHashSet> Rehash(Isolate* isolate,
                                             Handle<OrderedHashSet> table,
                                             int new_capacity);
+  static MaybeHandle<OrderedHashSet> Rehash(Isolate* isolate,
+                                            Handle<OrderedHashSet> table);
   static MaybeHandle<OrderedHashSet> Allocate(
       Isolate* isolate, int capacity,
       AllocationType allocation = AllocationType::kYoung);
@@ -273,6 +278,8 @@ class V8_EXPORT_PRIVATE OrderedHashMap
   static MaybeHandle<OrderedHashMap> Rehash(Isolate* isolate,
                                             Handle<OrderedHashMap> table,
                                             int new_capacity);
+  static MaybeHandle<OrderedHashMap> Rehash(Isolate* isolate,
+                                            Handle<OrderedHashMap> table);
   Object ValueAt(int entry);
 
   // This takes and returns raw Address values containing tagged Object

--- a/deps/v8/src/snapshot/deserializer.cc
+++ b/deps/v8/src/snapshot/deserializer.cc
@@ -70,7 +70,7 @@ void Deserializer::Initialize(Isolate* isolate) {
 void Deserializer::Rehash() {
   DCHECK(can_rehash() || deserializing_user_code());
   for (HeapObject item : to_rehash_) {
-    item.RehashBasedOnMap(ReadOnlyRoots(isolate_));
+    item.RehashBasedOnMap(isolate_);
   }
 }
 
@@ -129,6 +129,14 @@ void Deserializer::DeserializeDeferredObjects() {
         PostProcessNewObject(object, space);
       }
     }
+  }
+
+  // When the deserialization of maps are deferred, they will be created
+  // as filler maps, and we postpone the post processing until the maps
+  // are also deserialized.
+  for (const auto& pair : fillers_to_post_process_) {
+    DCHECK(!pair.first.IsFiller());
+    PostProcessNewObject(pair.first, pair.second);
   }
 }
 
@@ -201,7 +209,11 @@ HeapObject Deserializer::PostProcessNewObject(HeapObject obj,
   DisallowHeapAllocation no_gc;
 
   if ((FLAG_rehash_snapshot && can_rehash_) || deserializing_user_code()) {
-    if (obj.IsString()) {
+    if (obj.IsFiller()) {
+      DCHECK_EQ(fillers_to_post_process_.find(obj),
+                fillers_to_post_process_.end());
+      fillers_to_post_process_.insert({obj, space});
+    } else if (obj.IsString()) {
       // Uninitialize hash field as we need to recompute the hash.
       String string = String::cast(obj);
       string.set_hash_field(String::kEmptyHashField);

--- a/deps/v8/src/snapshot/deserializer.h
+++ b/deps/v8/src/snapshot/deserializer.h
@@ -194,6 +194,11 @@ class V8_EXPORT_PRIVATE Deserializer : public SerializerDeserializer {
   // TODO(6593): generalize rehashing, and remove this flag.
   bool can_rehash_;
   std::vector<HeapObject> to_rehash_;
+  // Store the objects whose maps are deferred and thus initialized as filler
+  // maps during deserialization, so that they can be processed later when the
+  // maps become available.
+  std::unordered_map<HeapObject, SnapshotSpace, Object::Hasher>
+      fillers_to_post_process_;
 
 #ifdef DEBUG
   uint32_t num_api_references_;

--- a/deps/v8/src/snapshot/deserializer.h
+++ b/deps/v8/src/snapshot/deserializer.h
@@ -107,6 +107,7 @@ class V8_EXPORT_PRIVATE Deserializer : public SerializerDeserializer {
   }
 
   std::shared_ptr<BackingStore> backing_store(size_t i) {
+    DCHECK_LT(i, backing_stores_.size());
     return backing_stores_[i];
   }
 

--- a/deps/v8/src/snapshot/object-deserializer.cc
+++ b/deps/v8/src/snapshot/object-deserializer.cc
@@ -48,9 +48,9 @@ MaybeHandle<HeapObject> ObjectDeserializer::Deserialize(Isolate* isolate) {
     LinkAllocationSites();
     LogNewMapEvents();
     result = handle(HeapObject::cast(root), isolate);
-    Rehash();
     allocator()->RegisterDeserializedObjectsForBlackAllocation();
   }
+  Rehash();
   CommitPostProcessedObjects();
   return scope.CloseAndEscape(result);
 }

--- a/deps/v8/src/snapshot/partial-deserializer.cc
+++ b/deps/v8/src/snapshot/partial-deserializer.cc
@@ -57,12 +57,12 @@ MaybeHandle<Object> PartialDeserializer::Deserialize(
     // new code, which also has to be flushed from instruction cache.
     CHECK_EQ(start_address, code_space->top());
 
-    if (FLAG_rehash_snapshot && can_rehash()) Rehash();
     LogNewMapEvents();
 
     result = handle(root, isolate);
   }
 
+  if (FLAG_rehash_snapshot && can_rehash()) Rehash();
   SetupOffHeapArrayBufferBackingStores();
 
   return result;

--- a/deps/v8/src/snapshot/serializer-common.cc
+++ b/deps/v8/src/snapshot/serializer-common.cc
@@ -76,7 +76,8 @@ ExternalReferenceEncoder::Value ExternalReferenceEncoder::Encode(
   if (maybe_index.IsNothing()) {
     void* addr = reinterpret_cast<void*>(address);
     v8::base::OS::PrintError("Unknown external reference %p.\n", addr);
-    v8::base::OS::PrintError("%s", ExternalReferenceTable::ResolveSymbol(addr));
+    v8::base::OS::PrintError("%s\n",
+                             ExternalReferenceTable::ResolveSymbol(addr));
     v8::base::OS::Abort();
   }
   Value result(maybe_index.FromJust());

--- a/deps/v8/src/snapshot/serializer-common.cc
+++ b/deps/v8/src/snapshot/serializer-common.cc
@@ -125,7 +125,14 @@ void SerializerDeserializer::Iterate(Isolate* isolate, RootVisitor* visitor) {
 }
 
 bool SerializerDeserializer::CanBeDeferred(HeapObject o) {
-  return !o.IsString() && !o.IsScript() && !o.IsJSTypedArray();
+  // ArrayBuffer instances are serialized by first re-assigning a index
+  // to the backing store field, then serializing the object, and then
+  // storing the actual backing store address again (and the same for the
+  // ArrayBufferExtension). If serialization of the object itself is deferred,
+  // the real backing store address is written into the snapshot, which cannot
+  // be processed when deserializing.
+  return !o.IsString() && !o.IsScript() && !o.IsJSTypedArray() &&
+         !o.IsJSArrayBuffer();
 }
 
 void SerializerDeserializer::RestoreExternalReferenceRedirectors(

--- a/deps/v8/src/snapshot/startup-serializer.cc
+++ b/deps/v8/src/snapshot/startup-serializer.cc
@@ -193,6 +193,7 @@ void SerializedHandleChecker::VisitRootPointers(Root root,
     PrintF("%s handle not serialized: ",
            root == Root::kGlobalHandles ? "global" : "eternal");
     (*p).Print();
+    PrintF("\n");
     ok_ = false;
   }
 }

--- a/deps/v8/test/cctest/test-serialize.cc
+++ b/deps/v8/test/cctest/test-serialize.cc
@@ -3778,7 +3778,7 @@ UNINITIALIZED_TEST(SnapshotCreatorIncludeGlobalProxy) {
   FreeCurrentEmbeddedBlob();
 }
 
-UNINITIALIZED_TEST(ReinitializeHashSeedNotRehashable) {
+UNINITIALIZED_TEST(ReinitializeHashSeedJSCollectionRehashable) {
   DisableAlwaysOpt();
   i::FLAG_rehash_snapshot = true;
   i::FLAG_hash_seed = 42;
@@ -3796,13 +3796,18 @@ UNINITIALIZED_TEST(ReinitializeHashSeedNotRehashable) {
       CompileRun(
           "var m = new Map();"
           "m.set('a', 1);"
-          "m.set('b', 2);");
+          "m.set('b', 2);"
+          "var s = new Set();"
+          "s.add(1);"
+          "s.add(globalThis);");
       ExpectInt32("m.get('b')", 2);
+      ExpectTrue("s.has(1)");
+      ExpectTrue("s.has(globalThis)");
       creator.SetDefaultContext(context);
     }
     blob =
         creator.CreateBlob(v8::SnapshotCreator::FunctionCodeHandling::kClear);
-    CHECK(!blob.CanBeRehashed());
+    CHECK(blob.CanBeRehashed());
   }
 
   ReadOnlyHeap::ClearSharedHeapForTest();
@@ -3812,8 +3817,8 @@ UNINITIALIZED_TEST(ReinitializeHashSeedNotRehashable) {
   create_params.snapshot_blob = &blob;
   v8::Isolate* isolate = v8::Isolate::New(create_params);
   {
-    // Check that no rehashing has been performed.
-    CHECK_EQ(static_cast<uint64_t>(42),
+    // Check that rehashing has been performed.
+    CHECK_EQ(static_cast<uint64_t>(1337),
              HashSeed(reinterpret_cast<i::Isolate*>(isolate)));
     v8::Isolate::Scope isolate_scope(isolate);
     v8::HandleScope handle_scope(isolate);
@@ -3821,6 +3826,8 @@ UNINITIALIZED_TEST(ReinitializeHashSeedNotRehashable) {
     CHECK(!context.IsEmpty());
     v8::Context::Scope context_scope(context);
     ExpectInt32("m.get('b')", 2);
+    ExpectTrue("s.has(1)");
+    ExpectTrue("s.has(globalThis)");
   }
   isolate->Dispose();
   delete[] blob.data;


### PR DESCRIPTION
The first and last commits are fairly new and contain conflicts with our current version of V8, they may need to be reapplied the next time we update V8

#### deps: V8: backport ea0719b8ed08

Original commit message:

    [snapshot] Do not defer ArrayBuffers during snapshotting

    ArrayBuffer instances are serialized by first re-assigning a index
    to the backing store field, then serializing the object, and then
    storing the actual backing store address again (and the same for the
    ArrayBufferExtension). If serialization of the object itself is deferred,
    the real backing store address is written into the snapshot, which cannot be
    processed when deserializing, leading to a crash.

    This fixes this by not deferring ArrayBuffer serialization and adding a DCHECK
    for the crash that previously occurred.

    Change-Id: Id9bea8268061bd0770cde7bfeb6695248978f994
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2144123
    Commit-Queue: Jakob Gruber <jgruber@chromium.org>
    Reviewed-by: Dan Elphick <delphick@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#67114}

Refs: https://github.com/v8/v8/commit/ea0719b8ed087d1f511e78595dcb596faa7638d0

#### deps: V8: backport bb9f0c2b2fe9

Original commit message:

    [snapshot] Improve snapshot docs and error printing

    - Minor improvements to the documentation for snapshotting.
    - Add newlines to printed errors where necessary.

    Change-Id: I822e7e850adb67eae73b51c23cf34e40ba3106f0
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2144954
    Reviewed-by: Toon Verwaest <verwaest@chromium.org>
    Commit-Queue: Toon Verwaest <verwaest@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#67111}

Refs: https://github.com/v8/v8/commit/bb9f0c2b2fe920a717794f3279758846f59f7840

#### deps: V8: backport 22014de00115

Original commit message:

    Reland "[snapshot] rehash JSMap and JSSet during deserialization"

    This is a reland of 8374feed55a5b3010f2e9593560a2d84f9f6725f.

    Fixed rehashing of global proxy keys by creating its identity hash
    early, before the deserialization of the context snapshot.

    Original change's description:
    > [snapshot] rehash JSMap and JSSet during deserialization
    >
    > To rehash JSMap and JSSet, we simply replace the backing store
    > with a new one created with the new hash.
    >
    > Bug: v8:9187
    > Change-Id: I90c25b18b33b7bc2b6ffe1b89fe17aa5f978b517
    > Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2143983
    > Commit-Queue: Joyee Cheung <joyee@igalia.com>
    > Reviewed-by: Jakob Gruber <jgruber@chromium.org>
    > Reviewed-by: Camillo Bruni <cbruni@chromium.org>
    > Cr-Commit-Position: refs/heads/master@{#67663}

    Bug: v8:9187, v8:10523
    Change-Id: I7a0319b1d10ff07644de902fec43e7c2b1dd8da9
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2212085
    Reviewed-by: Leszek Swirski <leszeks@chromium.org>
    Reviewed-by: Camillo Bruni <cbruni@chromium.org>
    Reviewed-by: Jakob Gruber <jgruber@chromium.org>
    Commit-Queue: Joyee Cheung <joyee@igalia.com>
    Cr-Commit-Position: refs/heads/master@{#67999}

Refs: https://github.com/v8/v8/commit/22014de00115dae09ae3d4a6c3a9f178d5495ef2

Refs: https://github.com/nodejs/node/issues/17058

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
