### PR TITLE
doc: add note about clientError writable handling

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1041,6 +1041,21 @@ ensure the response is a properly formatted HTTP response message.
   correctly;
 * `rawPacket`: the raw packet of current request.
 
+In some cases the client has already received the response and/or the socket
+has already been destroyed, like in case of `ECONNRESET` errors. Before
+trying to send data to the socket, it is better to check that it is still
+writable.
+
+```js
+server.on('clientError', (err, socket) => {
+  if (err.code === 'ECONNRESET' || !this.writable) {
+    return;
+  }
+
+  socket.end('HTTP/1.1 400 Bad Request\r\n\r\n');
+});
+```
+
 ### Event: `'close'`
 <!-- YAML
 added: v0.1.4

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1048,7 +1048,7 @@ writable.
 
 ```js
 server.on('clientError', (err, socket) => {
-  if (err.code === 'ECONNRESET' || !this.writable) {
+  if (err.code === 'ECONNRESET' || !socket.writable) {
     return;
   }
 

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1041,7 +1041,7 @@ ensure the response is a properly formatted HTTP response message.
   correctly;
 * `rawPacket`: the raw packet of current request.
 
-In some cases the client has already received the response and/or the socket
+In some cases, the client has already received the response and/or the socket
 has already been destroyed, like in case of `ECONNRESET` errors. Before
 trying to send data to the socket, it is better to check that it is still
 writable.


### PR DESCRIPTION
Fixes #33302.

This PR add a little note about checking writable state of socket in `clientError` before attempt to send data.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)