### PR TITLE
doc,tools: change bigint type to camelcase

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1349,7 +1349,7 @@ added:
 
 * `offset` {integer} Number of bytes to skip before starting to read. Must
   satisfy: `0 <= offset <= buf.length - 8`. **Default:** `0`.
-* Returns: {bigint}
+* Returns: {BigInt}
 
 Reads a signed 64-bit integer from `buf` at the specified `offset` with
 the specified [endianness][] (`readBigInt64BE()` reads as big endian,
@@ -1367,7 +1367,7 @@ added:
 
 * `offset` {integer} Number of bytes to skip before starting to read. Must
   satisfy: `0 <= offset <= buf.length - 8`. **Default:** `0`.
-* Returns: {bigint}
+* Returns: {BigInt}
 
 Reads an unsigned 64-bit integer from `buf` at the specified `offset` with
 the specified [endianness][] (`readBigUInt64BE()` reads as big endian,
@@ -2037,7 +2037,7 @@ added:
  - v10.20.0
 -->
 
-* `value` {bigint} Number to be written to `buf`.
+* `value` {BigInt} Number to be written to `buf`.
 * `offset` {integer} Number of bytes to skip before starting to write. Must
   satisfy: `0 <= offset <= buf.length - 8`. **Default:** `0`.
 * Returns: {integer} `offset` plus the number of bytes written.
@@ -2065,7 +2065,7 @@ added:
  - v10.20.0
 -->
 
-* `value` {bigint} Number to be written to `buf`.
+* `value` {BigInt} Number to be written to `buf`.
 * `offset` {integer} Number of bytes to skip before starting to write. Must
   satisfy: `0 <= offset <= buf.length - 8`. **Default:** `0`.
 * Returns: {integer} `offset` plus the number of bytes written.

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -661,7 +661,7 @@ A `fs.Stats` object provides information about a file.
 Objects returned from [`fs.stat()`][], [`fs.lstat()`][] and [`fs.fstat()`][] and
 their synchronous counterparts are of this type.
 If `bigint` in the `options` passed to those methods is true, the numeric values
-will be `bigint` instead of `number`, and the object will contain additional
+will be `BigInt` instead of `number`, and the object will contain additional
 nanosecond-precision properties suffixed with `Ns`.
 
 ```console
@@ -782,61 +782,61 @@ This method is only valid when using [`fs.lstat()`][].
 
 ### `stats.dev`
 
-* {number|bigint}
+* {number|BigInt}
 
 The numeric identifier of the device containing the file.
 
 ### `stats.ino`
 
-* {number|bigint}
+* {number|BigInt}
 
 The file system specific "Inode" number for the file.
 
 ### `stats.mode`
 
-* {number|bigint}
+* {number|BigInt}
 
 A bit-field describing the file type and mode.
 
 ### `stats.nlink`
 
-* {number|bigint}
+* {number|BigInt}
 
 The number of hard-links that exist for the file.
 
 ### `stats.uid`
 
-* {number|bigint}
+* {number|BigInt}
 
 The numeric user identifier of the user that owns the file (POSIX).
 
 ### `stats.gid`
 
-* {number|bigint}
+* {number|BigInt}
 
 The numeric group identifier of the group that owns the file (POSIX).
 
 ### `stats.rdev`
 
-* {number|bigint}
+* {number|BigInt}
 
 A numeric device identifier if the file is considered "special".
 
 ### `stats.size`
 
-* {number|bigint}
+* {number|BigInt}
 
 The size of the file in bytes.
 
 ### `stats.blksize`
 
-* {number|bigint}
+* {number|BigInt}
 
 The file system block size for i/o operations.
 
 ### `stats.blocks`
 
-* {number|bigint}
+* {number|BigInt}
 
 The number of blocks allocated for this file.
 
@@ -845,7 +845,7 @@ The number of blocks allocated for this file.
 added: v8.1.0
 -->
 
-* {number|bigint}
+* {number|BigInt}
 
 The timestamp indicating the last time this file was accessed expressed in
 milliseconds since the POSIX Epoch.
@@ -855,7 +855,7 @@ milliseconds since the POSIX Epoch.
 added: v8.1.0
 -->
 
-* {number|bigint}
+* {number|BigInt}
 
 The timestamp indicating the last time this file was modified expressed in
 milliseconds since the POSIX Epoch.
@@ -865,7 +865,7 @@ milliseconds since the POSIX Epoch.
 added: v8.1.0
 -->
 
-* {number|bigint}
+* {number|BigInt}
 
 The timestamp indicating the last time the file status was changed expressed
 in milliseconds since the POSIX Epoch.
@@ -875,7 +875,7 @@ in milliseconds since the POSIX Epoch.
 added: v8.1.0
 -->
 
-* {number|bigint}
+* {number|BigInt}
 
 The timestamp indicating the creation time of this file expressed in
 milliseconds since the POSIX Epoch.
@@ -885,7 +885,7 @@ milliseconds since the POSIX Epoch.
 added: v12.10.0
 -->
 
-* {bigint}
+* {BigInt}
 
 Only present when `bigint: true` is passed into the method that generates
 the object.
@@ -897,7 +897,7 @@ nanoseconds since the POSIX Epoch.
 added: v12.10.0
 -->
 
-* {bigint}
+* {BigInt}
 
 Only present when `bigint: true` is passed into the method that generates
 the object.
@@ -909,7 +909,7 @@ nanoseconds since the POSIX Epoch.
 added: v12.10.0
 -->
 
-* {bigint}
+* {BigInt}
 
 Only present when `bigint: true` is passed into the method that generates
 the object.
@@ -921,7 +921,7 @@ in nanoseconds since the POSIX Epoch.
 added: v12.10.0
 -->
 
-* {bigint}
+* {BigInt}
 
 Only present when `bigint: true` is passed into the method that generates
 the object.
@@ -969,11 +969,11 @@ The timestamp indicating the creation time of this file.
 The `atimeMs`, `mtimeMs`, `ctimeMs`, `birthtimeMs` properties are
 numeric values that hold the corresponding times in milliseconds. Their
 precision is platform specific. When `bigint: true` is passed into the
-method that generates the object, the properties will be [bigints][],
+method that generates the object, the properties will be {BigInt}s,
 otherwise they will be [numbers][MDN-Number].
 
 The `atimeNs`, `mtimeNs`, `ctimeNs`, `birthtimeNs` properties are
-[bigints][] that hold the corresponding times in nanoseconds. They are
+{BigInt}s that hold the corresponding times in nanoseconds. They are
 only present when `bigint: true` is passed into the method that generates
 the object. Their precision is platform specific.
 
@@ -2067,13 +2067,13 @@ changes:
   - version: v10.5.0
     pr-url: https://github.com/nodejs/node/pull/20220
     description: Accepts an additional `options` object to specify whether
-                 the numeric values returned should be bigint.
+                 the numeric values returned should be BigInt.
 -->
 
 * `fd` {integer}
 * `options` {Object}
   * `bigint` {boolean} Whether the numeric values in the returned
-    [`fs.Stats`][] object should be `bigint`. **Default:** `false`.
+    [`fs.Stats`][] object should be `BigInt`. **Default:** `false`.
 * `callback` {Function}
   * `err` {Error}
   * `stats` {fs.Stats}
@@ -2089,13 +2089,13 @@ changes:
   - version: v10.5.0
     pr-url: https://github.com/nodejs/node/pull/20220
     description: Accepts an additional `options` object to specify whether
-                 the numeric values returned should be bigint.
+                 the numeric values returned should be BigInt.
 -->
 
 * `fd` {integer}
 * `options` {Object}
   * `bigint` {boolean} Whether the numeric values in the returned
-    [`fs.Stats`][] object should be `bigint`. **Default:** `false`.
+    [`fs.Stats`][] object should be `BigInt`. **Default:** `false`.
 * Returns: {fs.Stats}
 
 Synchronous fstat(2).
@@ -2388,13 +2388,13 @@ changes:
   - version: v10.5.0
     pr-url: https://github.com/nodejs/node/pull/20220
     description: Accepts an additional `options` object to specify whether
-                 the numeric values returned should be bigint.
+                 the numeric values returned should be BigInt.
 -->
 
 * `path` {string|Buffer|URL}
 * `options` {Object}
   * `bigint` {boolean} Whether the numeric values in the returned
-    [`fs.Stats`][] object should be `bigint`. **Default:** `false`.
+    [`fs.Stats`][] object should be `BigInt`. **Default:** `false`.
 * `callback` {Function}
   * `err` {Error}
   * `stats` {fs.Stats}
@@ -2415,13 +2415,13 @@ changes:
   - version: v10.5.0
     pr-url: https://github.com/nodejs/node/pull/20220
     description: Accepts an additional `options` object to specify whether
-                 the numeric values returned should be bigint.
+                 the numeric values returned should be BigInt.
 -->
 
 * `path` {string|Buffer|URL}
 * `options` {Object}
   * `bigint` {boolean} Whether the numeric values in the returned
-    [`fs.Stats`][] object should be `bigint`. **Default:** `false`.
+    [`fs.Stats`][] object should be `BigInt`. **Default:** `false`.
 * Returns: {fs.Stats}
 
 Synchronous lstat(2).
@@ -3452,13 +3452,13 @@ changes:
   - version: v10.5.0
     pr-url: https://github.com/nodejs/node/pull/20220
     description: Accepts an additional `options` object to specify whether
-                 the numeric values returned should be bigint.
+                 the numeric values returned should be BigInt.
 -->
 
 * `path` {string|Buffer|URL}
 * `options` {Object}
   * `bigint` {boolean} Whether the numeric values in the returned
-    [`fs.Stats`][] object should be `bigint`. **Default:** `false`.
+    [`fs.Stats`][] object should be `BigInt`. **Default:** `false`.
 * `callback` {Function}
   * `err` {Error}
   * `stats` {fs.Stats}
@@ -3557,13 +3557,13 @@ changes:
   - version: v10.5.0
     pr-url: https://github.com/nodejs/node/pull/20220
     description: Accepts an additional `options` object to specify whether
-                 the numeric values returned should be bigint.
+                 the numeric values returned should be BigInt.
 -->
 
 * `path` {string|Buffer|URL}
 * `options` {Object}
   * `bigint` {boolean} Whether the numeric values in the returned
-    [`fs.Stats`][] object should be `bigint`. **Default:** `false`.
+    [`fs.Stats`][] object should be `BigInt`. **Default:** `false`.
 * Returns: {fs.Stats}
 
 Synchronous stat(2).
@@ -3943,7 +3943,7 @@ added: v0.1.31
 changes:
   - version: v10.5.0
     pr-url: https://github.com/nodejs/node/pull/20220
-    description: The `bigint` option is now supported.
+    description: The `BigInt` option is now supported.
   - version: v7.6.0
     pr-url: https://github.com/nodejs/node/pull/10739
     description: The `filename` parameter can be a WHATWG `URL` object using
@@ -4544,12 +4544,12 @@ changes:
   - version: v10.5.0
     pr-url: https://github.com/nodejs/node/pull/20220
     description: Accepts an additional `options` object to specify whether
-                 the numeric values returned should be bigint.
+                 the numeric values returned should be BigInt.
 -->
 
 * `options` {Object}
   * `bigint` {boolean} Whether the numeric values in the returned
-    [`fs.Stats`][] object should be `bigint`. **Default:** `false`.
+    [`fs.Stats`][] object should be `BigInt`. **Default:** `false`.
 * Returns: {Promise}
 
 Retrieves the [`fs.Stats`][] for the file.
@@ -4959,13 +4959,13 @@ changes:
   - version: v10.5.0
     pr-url: https://github.com/nodejs/node/pull/20220
     description: Accepts an additional `options` object to specify whether
-                 the numeric values returned should be bigint.
+                 the numeric values returned should be BigInt.
 -->
 
 * `path` {string|Buffer|URL}
 * `options` {Object}
   * `bigint` {boolean} Whether the numeric values in the returned
-    [`fs.Stats`][] object should be `bigint`. **Default:** `false`.
+    [`fs.Stats`][] object should be `BigInt`. **Default:** `false`.
 * Returns: {Promise}
 
 Asynchronous lstat(2). The `Promise` is resolved with the [`fs.Stats`][] object
@@ -5258,13 +5258,13 @@ changes:
   - version: v10.5.0
     pr-url: https://github.com/nodejs/node/pull/20220
     description: Accepts an additional `options` object to specify whether
-                 the numeric values returned should be bigint.
+                 the numeric values returned should be BigInt.
 -->
 
 * `path` {string|Buffer|URL}
 * `options` {Object}
   * `bigint` {boolean} Whether the numeric values in the returned
-    [`fs.Stats`][] object should be `bigint`. **Default:** `false`.
+    [`fs.Stats`][] object should be `BigInt`. **Default:** `false`.
 * Returns: {Promise}
 
 The `Promise` is resolved with the [`fs.Stats`][] object for the given `path`.
@@ -5778,7 +5778,6 @@ the file contents.
 [MSDN-Rel-Path]: https://docs.microsoft.com/en-us/windows/desktop/FileIO/naming-a-file#fully-qualified-vs-relative-paths
 [MSDN-Using-Streams]: https://docs.microsoft.com/en-us/windows/desktop/FileIO/using-streams
 [Naming Files, Paths, and Namespaces]: https://docs.microsoft.com/en-us/windows/desktop/FileIO/naming-a-file
-[bigints]: https://tc39.github.io/proposal-bigint
 [chcp]: https://ss64.com/nt/chcp.html
 [inode]: https://en.wikipedia.org/wiki/Inode
 [support of file system `flags`]: #fs_file_system_flags

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1374,7 +1374,7 @@ added: v0.7.6
 * Returns: {integer[]}
 
 This is the legacy version of [`process.hrtime.bigint()`][]
-before `bigint` was introduced in JavaScript.
+before `BigInt` was introduced in JavaScript.
 
 The `process.hrtime()` method returns the current high-resolution real time
 in a `[seconds, nanoseconds]` tuple `Array`, where `nanoseconds` is the
@@ -1409,14 +1409,14 @@ setTimeout(() => {
 added: v10.7.0
 -->
 
-* Returns: {bigint}
+* Returns: {BigInt}
 
-The `bigint` version of the [`process.hrtime()`][] method returning the
-current high-resolution real time in nanoseconds as a `bigint`.
+The `BigInt` version of the [`process.hrtime()`][] method returning the
+current high-resolution real time in nanoseconds as a `BigInt`.
 
 Unlike [`process.hrtime()`][], it does not support an additional `time`
 argument since the difference can just be computed directly
-by subtraction of the two `bigint`s.
+by subtraction of the two `BigInt`s.
 
 ```js
 const start = process.hrtime.bigint();

--- a/tools/doc/type-parser.js
+++ b/tools/doc/type-parser.js
@@ -33,7 +33,7 @@ const customTypesMap = {
 
   'AsyncIterable': 'https://tc39.github.io/ecma262/#sec-asynciterable-interface',
 
-  'bigint': `${jsDocPrefix}Reference/Global_Objects/BigInt`,
+  'BigInt': `${jsDocPrefix}Reference/Global_Objects/BigInt`,
   'WebAssembly.Instance':
     `${jsDocPrefix}Reference/Global_Objects/WebAssembly/Instance`,
 


### PR DESCRIPTION
This motivation for this change came from a pr on the quic branch where
the type BigInt was used instead of the lowercase version which caused
the doc target to fail.

It was a little surprising that this type was lower case and I wanted to
create this commit to see if this could be changed or not (I don't know
the original reason so there might be a good reason for it to be lower
case).


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
