### PR TITLE
buffer,n-api: release external buffers from BackingStore callback

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -727,9 +727,9 @@ void Environment::SetUnrefImmediate(Fn&& cb) {
 }
 
 template <typename Fn>
-void Environment::SetImmediateThreadsafe(Fn&& cb) {
+void Environment::SetImmediateThreadsafe(Fn&& cb, bool refed) {
   auto callback =
-      native_immediates_threadsafe_.CreateCallback(std::move(cb), false);
+      native_immediates_threadsafe_.CreateCallback(std::move(cb), refed);
   {
     Mutex::ScopedLock lock(native_immediates_threadsafe_mutex_);
     native_immediates_threadsafe_.Push(std::move(callback));

--- a/src/env.cc
+++ b/src/env.cc
@@ -743,19 +743,10 @@ void Environment::RunAndClearNativeImmediates(bool only_refed) {
   // exceptions, so we do not need to handle that.
   RunAndClearInterrupts();
 
-  // It is safe to check .size() first, because there is a causal relationship
-  // between pushes to the threadsafe and this function being called.
-  // For the common case, it's worth checking the size first before establishing
-  // a mutex lock.
-  if (native_immediates_threadsafe_.size() > 0) {
-    Mutex::ScopedLock lock(native_immediates_threadsafe_mutex_);
-    native_immediates_.ConcatMove(std::move(native_immediates_threadsafe_));
-  }
-
-  auto drain_list = [&]() {
+  auto drain_list = [&](NativeImmediateQueue* queue) {
     TryCatchScope try_catch(this);
     DebugSealHandleScope seal_handle_scope(isolate());
-    while (auto head = native_immediates_.Shift()) {
+    while (auto head = queue->Shift()) {
       if (head->is_refed())
         ref_count++;
 
@@ -773,12 +764,26 @@ void Environment::RunAndClearNativeImmediates(bool only_refed) {
     }
     return false;
   };
-  while (drain_list()) {}
+  while (drain_list(&native_immediates_)) {}
 
   immediate_info()->ref_count_dec(ref_count);
 
   if (immediate_info()->ref_count() == 0)
     ToggleImmediateRef(false);
+
+  // It is safe to check .size() first, because there is a causal relationship
+  // between pushes to the threadsafe immediate list and this function being
+  // called. For the common case, it's worth checking the size first before
+  // establishing a mutex lock.
+  // This is intentionally placed after the `ref_count` handling, because when
+  // refed threadsafe immediates are created, they are not counted towards the
+  // count in immediate_info() either.
+  NativeImmediateQueue threadsafe_immediates;
+  if (native_immediates_threadsafe_.size() > 0) {
+    Mutex::ScopedLock lock(native_immediates_threadsafe_mutex_);
+    threadsafe_immediates.ConcatMove(std::move(native_immediates_threadsafe_));
+  }
+  while (drain_list(&threadsafe_immediates)) {}
 }
 
 void Environment::RequestInterruptFromV8() {

--- a/src/env.h
+++ b/src/env.h
@@ -1168,7 +1168,7 @@ class Environment : public MemoryRetainer {
   inline void SetUnrefImmediate(Fn&& cb);
   template <typename Fn>
   // This behaves like SetImmediate() but can be called from any thread.
-  inline void SetImmediateThreadsafe(Fn&& cb);
+  inline void SetImmediateThreadsafe(Fn&& cb, bool refed = true);
   // This behaves like V8's Isolate::RequestInterrupt(), but also accounts for
   // the event loop (i.e. combines the V8 function with SetImmediate()).
   // The passed callback may not throw exceptions.

--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -371,39 +371,6 @@ class Reference : public RefBase {
   v8impl::Persistent<v8::Value> _persistent;
 };
 
-class ArrayBufferReference final : public Reference {
- public:
-  // Same signatures for ctor and New() as Reference, except this only works
-  // with ArrayBuffers:
-  template <typename... Args>
-  explicit ArrayBufferReference(napi_env env,
-                                v8::Local<v8::ArrayBuffer> value,
-                                Args&&... args)
-    : Reference(env, value, std::forward<Args>(args)...) {}
-
-  template <typename... Args>
-  static ArrayBufferReference* New(napi_env env,
-                                   v8::Local<v8::ArrayBuffer> value,
-                                   Args&&... args) {
-    return new ArrayBufferReference(env, value, std::forward<Args>(args)...);
-  }
-
- private:
-  inline void Finalize(bool is_env_teardown) override {
-    if (is_env_teardown) {
-      v8::HandleScope handle_scope(_env->isolate);
-      v8::Local<v8::Value> obj = Get();
-      CHECK(!obj.IsEmpty());
-      CHECK(obj->IsArrayBuffer());
-      v8::Local<v8::ArrayBuffer> ab = obj.As<v8::ArrayBuffer>();
-      if (ab->IsDetachable())
-        ab->Detach();
-    }
-
-    Reference::Finalize(is_env_teardown);
-  }
-};
-
 enum UnwrapAction {
   KeepWrap,
   RemoveWrap
@@ -2710,37 +2677,27 @@ napi_status napi_create_external_arraybuffer(napi_env env,
                                              napi_finalize finalize_cb,
                                              void* finalize_hint,
                                              napi_value* result) {
-  NAPI_PREAMBLE(env);
-  CHECK_ARG(env, result);
-
-  v8::Isolate* isolate = env->isolate;
-  // The buffer will be freed with v8impl::ArrayBufferReference::New()
-  // below, hence this BackingStore does not need to free the buffer.
-  std::unique_ptr<v8::BackingStore> backing =
-      v8::ArrayBuffer::NewBackingStore(external_data,
-                                       byte_length,
-                                       [](void*, size_t, void*){},
-                                       nullptr);
-  v8::Local<v8::ArrayBuffer> buffer =
-      v8::ArrayBuffer::New(isolate, std::move(backing));
-  v8::Maybe<bool> marked = env->mark_arraybuffer_as_untransferable(buffer);
-  CHECK_MAYBE_NOTHING(env, marked, napi_generic_failure);
-
-  if (finalize_cb != nullptr) {
-    // Create a self-deleting weak reference that invokes the finalizer
-    // callback and detaches the ArrayBuffer if it still exists on Environment
-    // teardown.
-    v8impl::ArrayBufferReference::New(env,
-        buffer,
-        0,
-        true,
-        finalize_cb,
-        external_data,
-        finalize_hint);
-  }
-
-  *result = v8impl::JsValueFromV8LocalValue(buffer);
-  return GET_RETURN_STATUS(env);
+  // The API contract here is that the cleanup function runs on the JS thread,
+  // and is able to use napi_env. Implementing that properly is hard, so use the
+  // `Buffer` variant for easier implementation.
+  napi_value buffer;
+  napi_status status;
+  status = napi_create_external_buffer(
+      env,
+      byte_length,
+      external_data,
+      finalize_cb,
+      finalize_hint,
+      &buffer);
+  if (status != napi_ok) return status;
+  return napi_get_typedarray_info(
+      env,
+      buffer,
+      nullptr,
+      nullptr,
+      nullptr,
+      result,
+      nullptr);
 }
 
 napi_status napi_get_arraybuffer_info(napi_env env,

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -754,7 +754,7 @@ void Worker::TakeHeapSnapshot(const FunctionCallbackInfo<Value>& args) {
               env, std::move(snapshot));
           Local<Value> args[] = { stream->object() };
           taker->MakeCallback(env->ondone_string(), arraysize(args), args);
-        });
+        }, /* refed */ false);
   });
   args.GetReturnValue().Set(scheduled ? taker->object() : Local<Object>());
 }

--- a/test/addons/null-buffer-neuter/binding.cc
+++ b/test/addons/null-buffer-neuter/binding.cc
@@ -11,6 +11,10 @@ static void FreeCallback(char* data, void* hint) {
   alive--;
 }
 
+void IsAlive(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  args.GetReturnValue().Set(alive);
+}
+
 void Run(const v8::FunctionCallbackInfo<v8::Value>& args) {
   v8::Isolate* isolate = args.GetIsolate();
   alive++;
@@ -27,15 +31,11 @@ void Run(const v8::FunctionCallbackInfo<v8::Value>& args) {
     char* data = node::Buffer::Data(buf);
     assert(data == nullptr);
   }
-
-  isolate->RequestGarbageCollectionForTesting(
-      v8::Isolate::kFullGarbageCollection);
-
-  assert(alive == 0);
 }
 
 void init(v8::Local<v8::Object> exports) {
   NODE_SET_METHOD(exports, "run", Run);
+  NODE_SET_METHOD(exports, "isAlive", IsAlive);
 }
 
 NODE_MODULE(NODE_GYP_MODULE_NAME, init)

--- a/test/addons/null-buffer-neuter/test.js
+++ b/test/addons/null-buffer-neuter/test.js
@@ -1,7 +1,11 @@
 'use strict';
 // Flags: --expose-gc
-
 const common = require('../../common');
+const assert = require('assert');
 const binding = require(`./build/${common.buildType}/binding`);
 
 binding.run();
+global.gc();
+setImmediate(() => {
+  assert.strictEqual(binding.isAlive(), 0);
+});

--- a/test/node-api/test_buffer/test.js
+++ b/test/node-api/test_buffer/test.js
@@ -4,7 +4,7 @@
 const common = require('../../common');
 const binding = require(`./build/${common.buildType}/test_buffer`);
 const assert = require('assert');
-const setImmediatePromise = require('util').promisify(setImmediate);
+const tick = require('util').promisify(require('../../common/tick'));
 
 (async function() {
   assert.strictEqual(binding.newBuffer().toString(), binding.theText);
@@ -12,7 +12,7 @@ const setImmediatePromise = require('util').promisify(setImmediate);
   console.log('gc1');
   global.gc();
   assert.strictEqual(binding.getDeleterCallCount(), 0);
-  await setImmediatePromise();
+  await tick(10);
   assert.strictEqual(binding.getDeleterCallCount(), 1);
   assert.strictEqual(binding.copyBuffer().toString(), binding.theText);
 
@@ -22,7 +22,7 @@ const setImmediatePromise = require('util').promisify(setImmediate);
   buffer = null;
   global.gc();
   assert.strictEqual(binding.getDeleterCallCount(), 1);
-  await setImmediatePromise();
+  await tick(10);
   console.log('gc2');
   assert.strictEqual(binding.getDeleterCallCount(), 2);
 })().then(common.mustCall());

--- a/test/node-api/test_buffer/test.js
+++ b/test/node-api/test_buffer/test.js
@@ -1,5 +1,5 @@
 'use strict';
-// Flags: --expose-gc
+// Flags: --expose-gc --no-concurrent-array-buffer-freeing --no-concurrent-array-buffer-sweeping
 
 const common = require('../../common');
 const binding = require(`./build/${common.buildType}/test_buffer`);


### PR DESCRIPTION
(The first commit is #33320, split out due to different backportability, hence the `blocked` label.)

Release `Buffer` and `ArrayBuffer` instances that were created through
our addon APIs and have finalizers attached to them only after V8 has
called the deleter callback passed to the `BackingStore`, instead of
relying on our own GC callback(s).

This fixes the following race condition:

1. Addon code allocates pointer P via `malloc`.
2. P is passed into `napi_create_external_buffer` with a finalization
   callback which calls `free(P)`. P is inserted into V8’s global array
   buffer table for tracking.
3. The finalization callback is executed on GC. P is freed and returned
   to the allocator. P is not yet removed from V8’s global array
   buffer table. (!)
4. Addon code attempts to allocate memory once again. The allocator
   returns P, as it is now available.
5. P is passed into `napi_create_external_buffer`. P still has not been
   removed from the v8 global array buffer table.
6. The world ends with `Check failed: result.second`.

Since our API contract is to call the finalizer on the JS thread on
which the `ArrayBuffer` was created, but V8 may call the `BackingStore`
deleter callback on another thread, fixing this requires posting
a task back to the JS thread.

Refs: https://github.com/nodejs/node/issues/32463#issuecomment-625877175
Fixes: https://github.com/nodejs/node/issues/32463

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
