### PR TITLE
WIP: stream: mutable highWaterMark and objectMode

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -568,6 +568,24 @@ added: v12.3.0
 
 Getter for the property `objectMode` of a given `Writable` stream.
 
+##### `writable.updateWritableHighwaterMark(highwaterMark)`
+<!-- YAML
+added: v9.3.0
+-->
+
+* `highwaterMark` {number} new highwaterMark
+
+Update the value of `highWaterMark` of a given `Writable` stream.
+
+##### `writable.updateWritableObjectMode(objectMode)`
+<!-- YAML
+added: v12.3.0
+-->
+
+* `objectMode` {boolean} new objectMode
+
+Update the value of `objectMode` of a given `Writable` stream.
+
 ##### `writable.write(chunk[, encoding][, callback])`
 <!-- YAML
 added: v0.9.4
@@ -1210,6 +1228,24 @@ added: v12.3.0
 * {boolean}
 
 Getter for the property `objectMode` of a given `Readable` stream.
+
+##### `readable.updateReadableHighWaterMark(highwaterMark)`
+<!-- YAML
+added: v9.3.0
+-->
+
+* `highwaterMark` {number} new highwaterMark
+
+Update the value of `highWaterMark` of a given `Readable` stream.
+
+##### `readable.updateReadableObjectMode(objectMode)`
+<!-- YAML
+added: v12.3.0
+-->
+
+* `objectMode` {boolean} new objectMode
+
+Update the value of `objectMode` of a given `Readable` stream.
 
 ##### `readable.resume()`
 <!-- YAML

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -480,12 +480,16 @@ Readable.prototype.read = function(n) {
     debug('length less than watermark', doRead);
   }
 
-  let objectModeUpdateRequest = state.updateObjectMode !== null;
+  const objectModeUpdateRequest = state.updateObjectMode !== null;
 
   // However, if we've ended, then there's no point, if we're already
   // reading, then it's unnecessary, and if we're destroyed or errored,
   // then it's not allowed.
-  if (state.ended || state.reading || state.destroyed || state.errored || objectModeUpdateRequest) {
+  if (state.ended ||
+      state.reading ||
+      state.destroyed ||
+      state.errored ||
+    objectModeUpdateRequest) {
     doRead = false;
     debug('reading or ended or objectMode update', doRead);
   } else if (doRead) {
@@ -959,13 +963,13 @@ function nReadingNextTick(self) {
 
 Readable.prototype.updateReadableHighwaterMark = function(newHighwaterMark) {
   this._readableState.updateHighwaterMark = newHighwaterMark;
-}
+};
 
 Readable.prototype.updateReadableObjectMode = function(objectMode) {
   objectMode = !!objectMode;
   if (objectMode !== this._readableState.objectMode)
     this._readableState.updateObjectMode = objectMode;
-}
+};
 
 // pause() and resume() are remnants of the legacy readable stream API
 // If the user uses them, then switch into old mode.

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -167,7 +167,15 @@ function ReadableState(options, stream, isDuplex) {
   this.awaitDrainWriters = null;
   this.multiAwaitDrain = false;
 
+<<<<<<< HEAD
   // If true, a maybeReadMore has been scheduled.
+=======
+  // Flags to update highwatermark and objectMode
+  this.updateHighwaterMark = null;
+  this.updateObjectMode = null;
+
+  // If true, a maybeReadMore has been scheduled
+>>>>>>> feat: methods to update HWM and ObjectMode for streams
   this.readingMore = false;
 
   this.decoder = null;
@@ -396,6 +404,17 @@ Readable.prototype.read = function(n) {
   const state = this._readableState;
   const nOrig = n;
 
+  // If they called updateHighwaterMark since last read
+  if (state.updateHighwaterMark !== null) {
+    state.highWaterMark = state.updateHighwaterMark;
+    state.updateHighwaterMark = null;
+  }
+
+  if (state.updateObjectMode !== null && state.length === 0) {
+    state.objectMode = state.updateObjectMode;
+    state.updateObjectMode = null;
+  }
+
   // If we're asking for more than the current hwm, then raise the hwm.
   if (n > state.highWaterMark)
     state.highWaterMark = computeNewHighWaterMark(n);
@@ -461,12 +480,14 @@ Readable.prototype.read = function(n) {
     debug('length less than watermark', doRead);
   }
 
+  let objectModeUpdateRequest = state.updateObjectMode !== null;
+
   // However, if we've ended, then there's no point, if we're already
   // reading, then it's unnecessary, and if we're destroyed or errored,
   // then it's not allowed.
-  if (state.ended || state.reading || state.destroyed || state.errored) {
+  if (state.ended || state.reading || state.destroyed || state.errored || objectModeUpdateRequest) {
     doRead = false;
-    debug('reading or ended', doRead);
+    debug('reading or ended or objectMode update', doRead);
   } else if (doRead) {
     debug('do read');
     state.reading = true;
@@ -934,6 +955,16 @@ function updateReadableListening(self) {
 function nReadingNextTick(self) {
   debug('readable nexttick read 0');
   self.read(0);
+}
+
+Readable.prototype.updateReadableHighwaterMark = function(newHighwaterMark) {
+  this._readableState.updateHighwaterMark = newHighwaterMark;
+}
+
+Readable.prototype.updateReadableObjectMode = function(objectMode) {
+  objectMode = !!objectMode;
+  if (objectMode !== this._readableState.objectMode)
+    this._readableState.updateObjectMode = objectMode;
 }
 
 // pause() and resume() are remnants of the legacy readable stream API

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -350,7 +350,7 @@ Writable.prototype.setDefaultEncoding = function setDefaultEncoding(encoding) {
 // If we return false, then we need a drain event, so set that flag.
 function writeOrBuffer(stream, state, chunk, encoding, cb) {
   let needObjectModeUpdate = state.updateObjectMode !== null;
-  if (needObjectModeUpdate && state.length === 0){
+  if (needObjectModeUpdate && state.length === 0) {
     state.objectMode = state.updateObjectMode;
     state.updateObjectMode = null;
     needObjectModeUpdate = false;
@@ -572,13 +572,13 @@ Writable.prototype._writev = null;
 
 Writable.prototype.updateWritableHighwaterMark = function(newHighwaterMark) {
   this._writableState.updateHighwaterMark = newHighwaterMark;
-}
+};
 
 Writable.prototype.updateWritableObjectMode = function(objectMode) {
   objectMode = !!objectMode;
   if (objectMode !== this._writableState.objectMode)
     this._writableState.updateObjectMode = objectMode;
-}
+};
 
 Writable.prototype.end = function(chunk, encoding, cb) {
   const state = this._writableState;

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -181,11 +181,15 @@ function WritableState(options, stream, isDuplex) {
   this.closeEmitted = false;
 }
 
-function resetBuffer(state) {
-  state.buffered = [];
-  state.bufferedIndex = 0;
-  state.allBuffers = true;
-  state.allNoop = true;
+  // Flags to update highwatermark and objectMode
+  this.updateHighwaterMark = null;
+  this.updateObjectMode = null;
+
+  // Allocate the first CorkedRequest, there is always
+  // one allocated and free to use, and we maintain at most two
+  const corkReq = { next: null, entry: null, finish: undefined };
+  corkReq.finish = onCorkedFinish.bind(undefined, corkReq, this);
+  this.corkedRequestsFree = corkReq;
 }
 
 WritableState.prototype.getBuffer = function getBuffer() {
@@ -261,6 +265,12 @@ Writable.prototype.pipe = function() {
 
 Writable.prototype.write = function(chunk, encoding, cb) {
   const state = this._writableState;
+
+  // If they called updateHighwaterMark since last read
+  if (state.updateHighwaterMark !== null) {
+    state.highWaterMark = state.updateHighwaterMark;
+    state.updateHighwaterMark = null;
+  }
 
   if (typeof encoding === 'function') {
     cb = encoding;
@@ -338,7 +348,14 @@ Writable.prototype.setDefaultEncoding = function setDefaultEncoding(encoding) {
 // If we're already writing something, then just put this
 // in the queue, and wait our turn.  Otherwise, call _write
 // If we return false, then we need a drain event, so set that flag.
-function writeOrBuffer(stream, state, chunk, encoding, callback) {
+function writeOrBuffer(stream, state, chunk, encoding, cb) {
+  let needObjectModeUpdate = state.updateObjectMode !== null;
+  if (needObjectModeUpdate && state.length === 0){
+    state.objectMode = state.updateObjectMode;
+    state.updateObjectMode = null;
+    needObjectModeUpdate = false;
+  }
+
   const len = state.objectMode ? 1 : chunk.length;
 
   state.length += len;
@@ -368,7 +385,7 @@ function writeOrBuffer(stream, state, chunk, encoding, callback) {
 
   // Return false if errored or destroyed in order to break
   // any synchronous while(stream.write(data)) loops.
-  return ret && !state.errored && !state.destroyed;
+  return ret && !needObjectModeUpdate && !state.errored && !state.destroyed;
 }
 
 function doWrite(stream, state, writev, len, chunk, encoding, cb) {
@@ -552,6 +569,16 @@ Writable.prototype._write = function(chunk, encoding, cb) {
 };
 
 Writable.prototype._writev = null;
+
+Writable.prototype.updateWritableHighwaterMark = function(newHighwaterMark) {
+  this._writableState.updateHighwaterMark = newHighwaterMark;
+}
+
+Writable.prototype.updateWritableObjectMode = function(objectMode) {
+  objectMode = !!objectMode;
+  if (objectMode !== this._writableState.objectMode)
+    this._writableState.updateObjectMode = objectMode;
+}
 
 Writable.prototype.end = function(chunk, encoding, cb) {
   const state = this._writableState;

--- a/test/parallel/test-stream-readable-hwm-mutable.js
+++ b/test/parallel/test-stream-readable-hwm-mutable.js
@@ -21,16 +21,16 @@ const rs = new stream.Readable({
 
     // Both highwatermark and objectmode should update
     // before it makes next _read request.
-    assert(highWaterMark === currHighWaterMark);
-    assert(objectMode === currObjectMode);
+    assert.strictEqual(highWaterMark, currHighWaterMark);
+    assert.strictEqual(objectMode, currObjectMode);
 
     this.push(Buffer.alloc(1024));
 
     if (pushes === 30) {
-        this.updateReadableHighwaterMark(2048);
-        this.updateReadableObjectMode(false);
-        currHighWaterMark = 2048;
-        currObjectMode = false;
+      this.updateReadableHighwaterMark(2048);
+      this.updateReadableObjectMode(false);
+      currHighWaterMark = 2048;
+      currObjectMode = false;
     }
 
   }, 101)

--- a/test/parallel/test-stream-readable-hwm-mutable.js
+++ b/test/parallel/test-stream-readable-hwm-mutable.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const stream = require('stream');
+
+let currHighWaterMark = 20;
+let currObjectMode = true;
+let pushes = 0;
+const rs = new stream.Readable({
+  highWaterMark: currHighWaterMark,
+  objectMode: currObjectMode,
+  read: common.mustCall(function() {
+    if (pushes++ === 100) {
+      this.push(null);
+      return;
+    }
+
+    const highWaterMark = this._readableState.highWaterMark;
+    const objectMode = this._readableState.objectMode;
+
+    // Both highwatermark and objectmode should update
+    // before it makes next _read request.
+    assert(highWaterMark === currHighWaterMark);
+    assert(objectMode === currObjectMode);
+
+    this.push(Buffer.alloc(1024));
+
+    if (pushes === 30) {
+        this.updateReadableHighwaterMark(2048);
+        this.updateReadableObjectMode(false);
+        currHighWaterMark = 2048;
+        currObjectMode = false;
+    }
+
+  }, 101)
+});
+
+const ws = stream.Writable({
+  write: common.mustCall(function(data, enc, cb) {
+    setImmediate(cb);
+  }, 100)
+});
+
+rs.pipe(ws);

--- a/test/parallel/test-stream-writable-hwm-mutable.js
+++ b/test/parallel/test-stream-writable-hwm-mutable.js
@@ -29,8 +29,8 @@ const ws = stream.Writable({
 
     // Should update highwatermark and objectmode
     // after emptying current buffer
-    assert(highWaterMark === currHighWaterMark);
-    assert(objectMode === currObjectMode);
+    assert.strictEqual(highWaterMark, currHighWaterMark);
+    assert.strictEqual(objectMode, currObjectMode);
 
     if (read++ === 30) {
       this.updateWritableHighwaterMark(2048);

--- a/test/parallel/test-stream-writable-hwm-mutable.js
+++ b/test/parallel/test-stream-writable-hwm-mutable.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const stream = require('stream');
+
+let pushes = 0;
+const rs = new stream.Readable({
+  read: common.mustCall(function() {
+    if (pushes++ === 100) {
+      this.push(null);
+      return;
+    }
+
+    this.push(Buffer.alloc(1024));
+  }, 101)
+});
+
+let currHighWaterMark = 0;
+let currObjectMode = true;
+let read = 0;
+const ws = stream.Writable({
+  highWaterMark: currHighWaterMark,
+  objectMode: currObjectMode,
+  write: common.mustCall(function(data, enc, cb) {
+
+    const highWaterMark = this._writableState.highWaterMark;
+    const objectMode = this._writableState.objectMode;
+
+    // Should update highwatermark and objectmode
+    // after emptying current buffer
+    assert(highWaterMark === currHighWaterMark);
+    assert(objectMode === currObjectMode);
+
+    if (read++ === 30) {
+      this.updateWritableHighwaterMark(2048);
+      this.updateWritableObjectMode(false);
+      currHighWaterMark = 2048;
+      currObjectMode = false;
+    }
+
+    setImmediate(cb);
+
+  }, 100)
+});
+
+rs.pipe(ws);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
added methods to update highWaterMark and objectMode values of Readable and Writable streams.
Refs: https://github.com/nodejs/node/issues/32731
Can also be used for following: https://github.com/nodejs/node/issues/30107
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
