### PR TITLE
async_hooks,worker: fix process.exit() crashes in async fn with async_hook enabled

### DIFF
--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -260,6 +260,11 @@ void Worker::Run() {
 
     DeleteFnPtr<Environment, FreeEnvironment> env_;
     auto cleanup_env = OnScopeLeave([&]() {
+      // TODO(addaleax): This call is harmless but should not be necessary.
+      // Figure out why V8 is raising a DCHECK() here without it
+      // (in test/parallel/test-async-hooks-worker-asyncfn-terminate-4.js).
+      isolate_->CancelTerminateExecution();
+
       if (!env_) return;
       env_->set_can_call_into_js(false);
 

--- a/test/parallel/test-async-hooks-worker-asyncfn-terminate-1.js
+++ b/test/parallel/test-async-hooks-worker-asyncfn-terminate-1.js
@@ -1,0 +1,15 @@
+'use strict';
+const common = require('../common');
+const { Worker } = require('worker_threads');
+
+const w = new Worker(`
+const { createHook } = require('async_hooks');
+
+setImmediate(async () => {
+  createHook({ init() {} }).enable();
+  await 0;
+  process.exit();
+});
+`, { eval: true });
+
+w.on('exit', common.mustCall());

--- a/test/parallel/test-async-hooks-worker-asyncfn-terminate-2.js
+++ b/test/parallel/test-async-hooks-worker-asyncfn-terminate-2.js
@@ -1,0 +1,21 @@
+'use strict';
+const common = require('../common');
+const { Worker } = require('worker_threads');
+
+// Like test-async-hooks-worker-promise.js but with the `await` and `createHook`
+// lines switched, because that resulted in different assertion failures
+// (one a Node.js assertion and one a V8 DCHECK) and it seems prudent to
+// cover both of those failures.
+
+const w = new Worker(`
+const { createHook } = require('async_hooks');
+
+setImmediate(async () => {
+  await 0;
+  createHook({ init() {} }).enable();
+  process.exit();
+});
+`, { eval: true });
+
+w.postMessage({});
+w.on('exit', common.mustCall());

--- a/test/parallel/test-async-hooks-worker-asyncfn-terminate-3.js
+++ b/test/parallel/test-async-hooks-worker-asyncfn-terminate-3.js
@@ -2,7 +2,7 @@
 const common = require('../common');
 const { Worker } = require('worker_threads');
 
-// Like test-async-hooks-worker-promise.js but with an additrional statement
+// Like test-async-hooks-worker-promise.js but with an additional statement
 // after the `process.exit()` call, that shouldn’t really make a difference
 // but apparently does.
 

--- a/test/parallel/test-async-hooks-worker-asyncfn-terminate-3.js
+++ b/test/parallel/test-async-hooks-worker-asyncfn-terminate-3.js
@@ -1,0 +1,20 @@
+'use strict';
+const common = require('../common');
+const { Worker } = require('worker_threads');
+
+// Like test-async-hooks-worker-promise.js but with an additrional statement
+// after the `process.exit()` call, that shouldn’t really make a difference
+// but apparently does.
+
+const w = new Worker(`
+const { createHook } = require('async_hooks');
+
+setImmediate(async () => {
+  createHook({ init() {} }).enable();
+  await 0;
+  process.exit();
+  process._rawDebug('THIS SHOULD NEVER BE REACHED');
+});
+`, { eval: true });
+
+w.on('exit', common.mustCall());

--- a/test/parallel/test-async-hooks-worker-asyncfn-terminate-4.js
+++ b/test/parallel/test-async-hooks-worker-asyncfn-terminate-4.js
@@ -1,0 +1,24 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { Worker } = require('worker_threads');
+
+// Like test-async-hooks-worker-promise.js but doing a trivial counter increase
+// after process.exit(). This should not make a difference, but apparently it
+// does. This is *also* different from test-async-hooks-worker-promise-3.js,
+// in that the statement is an ArrayBuffer access rather than a full method,
+// which *also* makes a difference even though it shouldn’t.
+
+const workerData = new Int32Array(new SharedArrayBuffer(4));
+const w = new Worker(`
+const { createHook } = require('async_hooks');
+
+setImmediate(async () => {
+  createHook({ init() {} }).enable();
+  await 0;
+  process.exit();
+  workerData[0]++;
+});
+`, { eval: true, workerData });
+
+w.on('exit', common.mustCall(() => assert.strictEqual(workerData[0], 0)));


### PR DESCRIPTION
##### worker: call CancelTerminateExecution() before exiting Locker

As the comment indicates, this fixes a DCHECK failure, although I don’t
quite understand why it is happening in the first place.

##### async_hooks: clear async_id_stack for terminations in more places

Termination exceptions are similar to uncaught exceptions in that they
should clear the async id stack, because no ongoing async callbacks
will be brought to completion when execution terminates.

Previously, there was a check that made sure that that happened when
the termination occurred during the callback itself, but no such check
was in place for the case that the termination occurred during
microtasks started by them. This commit adds such a check, both for
microtasks and the `nextTick` queue. The latter addition doesn’t fix
a crash, but still makes sense conceptually.

The condition here is also flipped from applying only on Worker threads
to also applying on the main thread, and setting the `failed_` flag
rather than reading it. The former makes sense because the public C++
`Stop(env)` API can have the same effect as worker thread termination,
but on the main thread rather than a Worker thread.

##### test: regression tests for async_hooks + Promise + Worker interaction

Add regression tests for the case in which an async_hook is enabled
inside a Worker thread and `process.exit()` is called during the
async part of an async function.

This commit includes multiple tests that seem like they should all
crash in a similar way, but interestingly don’t. In particular, it’s
surprising that the presence of a statement after `process.exit()`
in a function has an effect on the kind of crash that’s being
exhibited (V8 DCHECK vs. assertion in our own code) and the
circumstances under which it crashes (e.g. the -1 and -2 tests
can be “fixed” by reverting 13c5a1629cd025b, although they
should have the same behavior as the -3 and -4 tests).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
