### PR TITLE
win,fs: use namespaced path in absolute symlinks

### DIFF
--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -302,6 +302,10 @@ function preprocessSymlinkDestination(path, type, linkPath) {
     path = pathModule.resolve(linkPath, '..', path);
     return pathModule.toNamespacedPath(path);
   }
+  if (pathModule.isAbsolute(path)) {
+    // If the path is absolute, use the \\?\-prefix to enable long filenames
+    return pathModule.toNamespacedPath(path);
+  }
   // Windows symlinks don't tolerate forward slashes.
   return ('' + path).replace(/\//g, '\\');
 }

--- a/test/parallel/test-fs-symlink-longpath.js
+++ b/test/parallel/test-fs-symlink-longpath.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+const tmpDir = tmpdir.path;
+const longPath = path.join(...[tmpDir].concat(Array(30).fill('1234567890')));
+fs.mkdirSync(longPath, { recursive: true });
+
+// Test if we can have symlinks to files and folders with long filenames
+const targetDirtectory = path.join(longPath, 'target-directory');
+fs.mkdirSync(targetDirtectory);
+const pathDirectory = path.join(tmpDir, 'new-directory');
+fs.symlink(targetDirtectory, pathDirectory, 'dir', common.mustCall((err) => {
+  assert.ifError(err);
+  assert(fs.existsSync(pathDirectory));
+}));
+
+const targetFile = path.join(longPath, 'target-file');
+fs.writeFileSync(targetFile, 'data');
+const pathFile = path.join(tmpDir, 'new-file');
+fs.symlink(targetFile, pathFile, common.mustCall((err) => {
+  assert.ifError(err);
+  assert(fs.existsSync(pathFile));
+}));


### PR DESCRIPTION
Use the namespaced (with the `\\?\` prefix) paths for symlink targets when the path is absolute. This allows creation of symlinks to files with long filenames.

Fixes: https://github.com/nodejs/node/issues/27795

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
