### PR TITLE
http2: Reuse ._onTimeout() to Http2Session and Http2Stream classes

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1460,27 +1460,7 @@ class Http2Session extends EventEmitter {
   }
 
   _onTimeout() {
-    // If the session is destroyed, this should never actually be invoked,
-    // but just in case...
-    if (this.destroyed)
-      return;
-    // This checks whether a write is currently in progress and also whether
-    // that write is actually sending data across the write. The kHandle
-    // stored `chunksSentSinceLastWrite` is only updated when a timeout event
-    // happens, meaning that if a write is ongoing it should never equal the
-    // newly fetched, updated value.
-    if (this[kState].writeQueueSize > 0) {
-      const handle = this[kHandle];
-      const chunksSentSinceLastWrite = handle !== undefined ?
-        handle.chunksSentSinceLastWrite : null;
-      if (chunksSentSinceLastWrite !== null &&
-          chunksSentSinceLastWrite !== handle.updateChunksSent()) {
-        this[kUpdateTimer]();
-        return;
-      }
-    }
-
-    this.emit('timeout');
+    onTimeout.call(this);
   }
 
   ref() {
@@ -1909,25 +1889,7 @@ class Http2Stream extends Duplex {
   }
 
   _onTimeout() {
-    if (this.destroyed)
-      return;
-    // This checks whether a write is currently in progress and also whether
-    // that write is actually sending data across the write. The kHandle
-    // stored `chunksSentSinceLastWrite` is only updated when a timeout event
-    // happens, meaning that if a write is ongoing it should never equal the
-    // newly fetched, updated value.
-    if (this[kState].writeQueueSize > 0) {
-      const handle = this[kSession][kHandle];
-      const chunksSentSinceLastWrite = handle !== undefined ?
-        handle.chunksSentSinceLastWrite : null;
-      if (chunksSentSinceLastWrite !== null &&
-          chunksSentSinceLastWrite !== handle.updateChunksSent()) {
-        this[kUpdateTimer]();
-        return;
-      }
-    }
-
-    this.emit('timeout');
+    onTimeout.call(this, kSession);
   }
 
   // True if the HEADERS frame has been sent
@@ -2212,6 +2174,30 @@ class Http2Stream extends Duplex {
       }
     }
   }
+}
+
+function onTimeout(kSession) {
+  // If the session is destroyed, this should never actually be invoked,
+  // but just in case...
+  if (this.destroyed)
+    return;
+  // This checks whether a write is currently in progress and also whether
+  // that write is actually sending data across the write. The kHandle
+  // stored `chunksSentSinceLastWrite` is only updated when a timeout event
+  // happens, meaning that if a write is ongoing it should never equal the
+  // newly fetched, updated value.
+  if (this[kState].writeQueueSize > 0) {
+    const handle = kSession ? this[kSession][kHandle] : this[kHandle];
+    const chunksSentSinceLastWrite = handle !== undefined ?
+      handle.chunksSentSinceLastWrite : null;
+    if (chunksSentSinceLastWrite !== null &&
+      chunksSentSinceLastWrite !== handle.updateChunksSent()) {
+      this[kUpdateTimer]();
+      return;
+    }
+  }
+
+  this.emit('timeout');
 }
 
 function callStreamClose(stream) {

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1460,7 +1460,7 @@ class Http2Session extends EventEmitter {
   }
 
   _onTimeout() {
-    onTimeout.call(this);
+    callTimeout(this);
   }
 
   ref() {
@@ -1889,7 +1889,7 @@ class Http2Stream extends Duplex {
   }
 
   _onTimeout() {
-    onTimeout.call(this, kSession);
+    callTimeout(this, kSession);
   }
 
   // True if the HEADERS frame has been sent
@@ -2176,28 +2176,28 @@ class Http2Stream extends Duplex {
   }
 }
 
-function onTimeout(kSession) {
+function callTimeout(self, kSession) {
   // If the session is destroyed, this should never actually be invoked,
   // but just in case...
-  if (this.destroyed)
+  if (self.destroyed)
     return;
   // This checks whether a write is currently in progress and also whether
   // that write is actually sending data across the write. The kHandle
   // stored `chunksSentSinceLastWrite` is only updated when a timeout event
   // happens, meaning that if a write is ongoing it should never equal the
   // newly fetched, updated value.
-  if (this[kState].writeQueueSize > 0) {
-    const handle = kSession ? this[kSession][kHandle] : this[kHandle];
+  if (self[kState].writeQueueSize > 0) {
+    const handle = kSession ? self[kSession][kHandle] : self[kHandle];
     const chunksSentSinceLastWrite = handle !== undefined ?
       handle.chunksSentSinceLastWrite : null;
     if (chunksSentSinceLastWrite !== null &&
       chunksSentSinceLastWrite !== handle.updateChunksSent()) {
-      this[kUpdateTimer]();
+      self[kUpdateTimer]();
       return;
     }
   }
 
-  this.emit('timeout');
+  self.emit('timeout');
 }
 
 function callStreamClose(stream) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
