### PR TITLE
build: enable `--error-on-warn` for POSIX workflows

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -18,6 +18,6 @@ jobs:
       - name: Environment Information
         run: npx envinfo
       - name: Build
-        run: make build-ci -j2 V=1
+        run: make build-ci -j2 V=1 CONFIG_FLAGS="--error-on-warn"
       - name: Test
         run: make run-ci -j2 V=1 TEST_CI_ARGS="-p dots"

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -18,6 +18,6 @@ jobs:
       - name: Environment Information
         run: npx envinfo
       - name: Build
-        run: make build-ci -j8 V=1
+        run: make build-ci -j8 V=1 CONFIG_FLAGS="--error-on-warn"
       - name: Test
         run: make run-ci -j8 V=1 TEST_CI_ARGS="-p dots"

--- a/node.gyp
+++ b/node.gyp
@@ -378,6 +378,9 @@
       'conditions': [
         [ 'error_on_warn=="true"', {
           'cflags': ['-Werror'],
+          'xcode_settings': {
+            'WARNING_CFLAGS': [ '-Werror' ],
+          },
         }],
         [ 'node_intermediate_lib_type=="static_library" and '
             'node_shared=="true" and OS=="aix"', {
@@ -757,6 +760,9 @@
       'conditions': [
         [ 'error_on_warn=="true"', {
           'cflags': ['-Werror'],
+          'xcode_settings': {
+            'WARNING_CFLAGS': [ '-Werror' ],
+          },
         }],
         [ 'node_builtin_modules_path!=""', {
           'defines': [ 'NODE_BUILTIN_MODULES_PATH="<(node_builtin_modules_path)"' ]


### PR DESCRIPTION
Treat warnings as errors for non-deps code on Linux and macOS workflows.

Refs: https://github.com/nodejs/node/pull/32685

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
