### PR TITLE
Allow passing KeyObjects via postMessage

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1214,6 +1214,10 @@ This can be called many times with new data as it is streamed.
 <!-- YAML
 added: v11.6.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/33360
+    description: Instances of this class can now be passed to worker threads
+                 using `postMessage`.
   - version: v11.13.0
     pr-url: https://github.com/nodejs/node/pull/26438
     description: This class is now exported.
@@ -1228,6 +1232,10 @@ keyword.
 
 Most applications should consider using the new `KeyObject` API instead of
 passing keys as strings or `Buffer`s due to improved security features.
+
+`KeyObject` instances can be passed to other threads via [`postMessage()`][].
+The receiver obtains a cloned `KeyObject`, and the `KeyObject` does not need to
+be listed in the `transferList` argument.
 
 ### `keyObject.asymmetricKeyType`
 <!-- YAML
@@ -3518,6 +3526,7 @@ the `crypto`, `tls`, and `https` modules and are generally specific to OpenSSL.
 [`hmac.digest()`]: #crypto_hmac_digest_encoding
 [`hmac.update()`]: #crypto_hmac_update_data_inputencoding
 [`keyObject.export()`]: #crypto_keyobject_export_options
+[`postMessage()`]: worker_threads.html#worker_threads_port_postmessage_value_transferlist
 [`sign.sign()`]: #crypto_sign_sign_privatekey_outputencoding
 [`sign.update()`]: #crypto_sign_update_data_inputencoding
 [`stream.Writable` options]: stream.html#stream_new_stream_writable_options

--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -329,6 +329,9 @@ are part of the channel.
 added: v10.5.0
 changes:
   - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/33360
+    description: Added `KeyObject` to the list of cloneable types.
+  - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/33772
     description: Added `FileHandle` to the list of transferable types.
 -->
@@ -348,8 +351,8 @@ In particular, the significant differences to `JSON` are:
 * `value` may contain typed arrays, both using `ArrayBuffer`s
    and `SharedArrayBuffer`s.
 * `value` may contain [`WebAssembly.Module`][] instances.
-* `value` may not contain native (C++-backed) objects other than `MessagePort`s
-  and [`FileHandle`][]s.
+* `value` may not contain native (C++-backed) objects other than `MessagePort`s,
+  [`FileHandle`][]s, and [`KeyObject`][]s.
 
 ```js
 const { MessageChannel } = require('worker_threads');
@@ -849,6 +852,7 @@ active handle in the event system. If the worker is already `unref()`ed calling
 [`EventEmitter`]: events.html
 [`EventTarget`]: https://developer.mozilla.org/en-US/docs/Web/API/EventTarget
 [`FileHandle`]: fs.html#fs_class_filehandle
+[`KeyObject`]: crypto.html#crypto_class_keyobject
 [`MessagePort`]: #worker_threads_class_messageport
 [`SharedArrayBuffer`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer
 [`Uint8Array`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array

--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -43,6 +43,13 @@ for (const m of [[kKeyEncodingPKCS1, 'pkcs1'], [kKeyEncodingPKCS8, 'pkcs8'],
                  [kKeyEncodingSPKI, 'spki'], [kKeyEncodingSEC1, 'sec1']])
   encodingNames[m[0]] = m[1];
 
+function checkKeyTypeAndHandle(type, handle) {
+  if (type !== 'secret' && type !== 'public' && type !== 'private')
+    throw new ERR_INVALID_ARG_VALUE('type', type);
+  if (typeof handle !== 'object' || !(handle instanceof KeyObjectHandle))
+    throw new ERR_INVALID_ARG_TYPE('handle', 'object', handle);
+}
+
 // Creating the KeyObject class is a little complicated due to inheritance
 // and that fact that KeyObjects should be transferrable between threads,
 // which requires the KeyObject base class to be implemented in C++.
@@ -57,11 +64,7 @@ const [
   // Publicly visible KeyObject class.
   class KeyObject extends NativeKeyObject {
     constructor(type, handle) {
-      super();
-      if (type !== 'secret' && type !== 'public' && type !== 'private')
-        throw new ERR_INVALID_ARG_VALUE('type', type);
-      if (typeof handle !== 'object')
-        throw new ERR_INVALID_ARG_TYPE('handle', 'object', handle);
+      super(checkKeyTypeAndHandle(type, handle) || handle);
 
       this[kKeyType] = type;
 

--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -331,23 +331,23 @@ function createSecretKey(key) {
   key = prepareSecretKey(key, true);
   if (key.byteLength === 0)
     throw new ERR_OUT_OF_RANGE('key.byteLength', '> 0', key.byteLength);
-  const handle = new KeyObjectHandle(kKeyTypeSecret);
-  handle.init(key);
+  const handle = new KeyObjectHandle();
+  handle.init(kKeyTypeSecret, key);
   return new SecretKeyObject(handle);
 }
 
 function createPublicKey(key) {
   const { format, type, data } = prepareAsymmetricKey(key, kCreatePublic);
-  const handle = new KeyObjectHandle(kKeyTypePublic);
-  handle.init(data, format, type);
+  const handle = new KeyObjectHandle();
+  handle.init(kKeyTypePublic, data, format, type);
   return new PublicKeyObject(handle);
 }
 
 function createPrivateKey(key) {
   const { format, type, data, passphrase } =
     prepareAsymmetricKey(key, kCreatePrivate);
-  const handle = new KeyObjectHandle(kKeyTypePrivate);
-  handle.init(data, format, type, passphrase);
+  const handle = new KeyObjectHandle();
+  handle.init(kKeyTypePrivate, data, format, type, passphrase);
   return new PrivateKeyObject(handle);
 }
 

--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -7,6 +7,7 @@ const {
 
 const {
   KeyObjectHandle,
+  createNativeKeyObjectClass,
   kKeyTypeSecret,
   kKeyTypePublic,
   kKeyTypePrivate,
@@ -42,80 +43,96 @@ for (const m of [[kKeyEncodingPKCS1, 'pkcs1'], [kKeyEncodingPKCS8, 'pkcs8'],
                  [kKeyEncodingSPKI, 'spki'], [kKeyEncodingSEC1, 'sec1']])
   encodingNames[m[0]] = m[1];
 
-class KeyObject {
-  constructor(type, handle) {
-    if (type !== 'secret' && type !== 'public' && type !== 'private')
-      throw new ERR_INVALID_ARG_VALUE('type', type);
-    if (typeof handle !== 'object')
-      throw new ERR_INVALID_ARG_TYPE('handle', 'object', handle);
+// Creating the KeyObject class is a little complicated due to inheritance
+// and that fact that KeyObjects should be transferrable between threads,
+// which requires the KeyObject base class to be implemented in C++.
+// The creation requires a callback to make sure that the NativeKeyObject
+// base class cannot exist without the other KeyObject implementations.
+const [
+  KeyObject,
+  SecretKeyObject,
+  PublicKeyObject,
+  PrivateKeyObject
+] = createNativeKeyObjectClass((NativeKeyObject) => {
+  // Publicly visible KeyObject class.
+  class KeyObject extends NativeKeyObject {
+    constructor(type, handle) {
+      super();
+      if (type !== 'secret' && type !== 'public' && type !== 'private')
+        throw new ERR_INVALID_ARG_VALUE('type', type);
+      if (typeof handle !== 'object')
+        throw new ERR_INVALID_ARG_TYPE('handle', 'object', handle);
 
-    this[kKeyType] = type;
+      this[kKeyType] = type;
 
-    ObjectDefineProperty(this, kHandle, {
-      value: handle,
-      enumerable: false,
-      configurable: false,
-      writable: false
-    });
+      ObjectDefineProperty(this, kHandle, {
+        value: handle,
+        enumerable: false,
+        configurable: false,
+        writable: false
+      });
+    }
+
+    get type() {
+      return this[kKeyType];
+    }
   }
 
-  get type() {
-    return this[kKeyType];
-  }
-}
+  class SecretKeyObject extends KeyObject {
+    constructor(handle) {
+      super('secret', handle);
+    }
 
-class SecretKeyObject extends KeyObject {
-  constructor(handle) {
-    super('secret', handle);
-  }
+    get symmetricKeySize() {
+      return this[kHandle].getSymmetricKeySize();
+    }
 
-  get symmetricKeySize() {
-    return this[kHandle].getSymmetricKeySize();
-  }
-
-  export() {
-    return this[kHandle].export();
-  }
-}
-
-const kAsymmetricKeyType = Symbol('kAsymmetricKeyType');
-
-class AsymmetricKeyObject extends KeyObject {
-  get asymmetricKeyType() {
-    return this[kAsymmetricKeyType] ||
-           (this[kAsymmetricKeyType] = this[kHandle].getAsymmetricKeyType());
-  }
-}
-
-class PublicKeyObject extends AsymmetricKeyObject {
-  constructor(handle) {
-    super('public', handle);
+    export() {
+      return this[kHandle].export();
+    }
   }
 
-  export(encoding) {
-    const {
-      format,
-      type
-    } = parsePublicKeyEncoding(encoding, this.asymmetricKeyType);
-    return this[kHandle].export(format, type);
-  }
-}
+  const kAsymmetricKeyType = Symbol('kAsymmetricKeyType');
 
-class PrivateKeyObject extends AsymmetricKeyObject {
-  constructor(handle) {
-    super('private', handle);
+  class AsymmetricKeyObject extends KeyObject {
+    get asymmetricKeyType() {
+      return this[kAsymmetricKeyType] ||
+             (this[kAsymmetricKeyType] = this[kHandle].getAsymmetricKeyType());
+    }
   }
 
-  export(encoding) {
-    const {
-      format,
-      type,
-      cipher,
-      passphrase
-    } = parsePrivateKeyEncoding(encoding, this.asymmetricKeyType);
-    return this[kHandle].export(format, type, cipher, passphrase);
+  class PublicKeyObject extends AsymmetricKeyObject {
+    constructor(handle) {
+      super('public', handle);
+    }
+
+    export(encoding) {
+      const {
+        format,
+        type
+      } = parsePublicKeyEncoding(encoding, this.asymmetricKeyType);
+      return this[kHandle].export(format, type);
+    }
   }
-}
+
+  class PrivateKeyObject extends AsymmetricKeyObject {
+    constructor(handle) {
+      super('private', handle);
+    }
+
+    export(encoding) {
+      const {
+        format,
+        type,
+        cipher,
+        passphrase
+      } = parsePrivateKeyEncoding(encoding, this.asymmetricKeyType);
+      return this[kHandle].export(format, type, cipher, passphrase);
+    }
+  }
+
+  return [KeyObject, SecretKeyObject, PublicKeyObject, PrivateKeyObject];
+});
 
 function parseKeyFormat(formatStr, defaultFormat, optionName) {
   if (formatStr === undefined && defaultFormat !== undefined)

--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -6,7 +6,7 @@ const {
 } = primordials;
 
 const {
-  KeyObject: KeyObjectHandle,
+  KeyObjectHandle,
   kKeyTypeSecret,
   kKeyTypePublic,
   kKeyTypePrivate,

--- a/src/env.h
+++ b/src/env.h
@@ -487,6 +487,9 @@ constexpr size_t kFsStatsBufferLength =
   V(buffer_prototype_object, v8::Object)                                       \
   V(crypto_key_object_constructor, v8::Function)                               \
   V(crypto_key_object_handle_constructor, v8::Function)                        \
+  V(crypto_key_object_private_constructor, v8::Function)                       \
+  V(crypto_key_object_public_constructor, v8::Function)                        \
+  V(crypto_key_object_secret_constructor, v8::Function)                        \
   V(domexception_function, v8::Function)                                       \
   V(enhance_fatal_stack_after_inspector, v8::Function)                         \
   V(enhance_fatal_stack_before_inspector, v8::Function)                        \

--- a/src/env.h
+++ b/src/env.h
@@ -486,6 +486,7 @@ constexpr size_t kFsStatsBufferLength =
   V(async_hooks_promise_resolve_function, v8::Function)                        \
   V(buffer_prototype_object, v8::Object)                                       \
   V(crypto_key_object_constructor, v8::Function)                               \
+  V(crypto_key_object_handle_constructor, v8::Function)                        \
   V(domexception_function, v8::Function)                                       \
   V(enhance_fatal_stack_after_inspector, v8::Function)                         \
   V(enhance_fatal_stack_before_inspector, v8::Function)                        \

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3244,27 +3244,24 @@ EVP_PKEY* ManagedEVPPKey::get() const {
   return pkey_.get();
 }
 
-KeyObjectData* KeyObjectData::CreateSecret(v8::Local<v8::ArrayBufferView> abv) {
+std::shared_ptr<KeyObjectData> KeyObjectData::CreateSecret(
+    Local<ArrayBufferView> abv) {
   size_t key_len = abv->ByteLength();
   char* mem = MallocOpenSSL<char>(key_len);
   abv->CopyContents(mem, key_len);
-  KeyObjectData* data = new KeyObjectData();
-  data->key_type_ = kKeyTypeSecret;
-  data->symmetric_key_ = std::unique_ptr<char, std::function<void(char*)>>(mem,
+  return std::shared_ptr<KeyObjectData>(new KeyObjectData(
+      std::unique_ptr<char, std::function<void(char*)>>(mem,
           [key_len](char* p) {
             OPENSSL_clear_free(p, key_len);
-          });
-  data->symmetric_key_len_ = key_len;
-  return data;
+          }),
+      key_len));
 }
 
-KeyObjectData* KeyObjectData::CreateAsymmetric(KeyType key_type,
-                                               const ManagedEVPPKey& pkey) {
+std::shared_ptr<KeyObjectData> KeyObjectData::CreateAsymmetric(
+    KeyType key_type,
+    const ManagedEVPPKey& pkey) {
   CHECK(pkey);
-  KeyObjectData* data = new KeyObjectData();
-  data->key_type_ = key_type;
-  data->asymmetric_key_ = pkey;
-  return data;
+  return std::shared_ptr<KeyObjectData>(new KeyObjectData(key_type, pkey));
 }
 
 KeyType KeyObjectData::GetKeyType() const {
@@ -3308,26 +3305,24 @@ Local<Function> KeyObjectHandle::Initialize(Environment* env,
   return function;
 }
 
-MaybeLocal<Object> KeyObjectHandle::Create(Environment* env,
-                                           KeyType key_type,
-                                           const ManagedEVPPKey& pkey) {
-  CHECK_NE(key_type, kKeyTypeSecret);
-  Local<Value> type = Integer::New(env->isolate(), key_type);
+MaybeLocal<Object> KeyObjectHandle::Create(
+    Environment* env,
+    std::shared_ptr<KeyObjectData> data) {
   Local<Object> obj;
   if (!env->crypto_key_object_handle_constructor()
-           ->NewInstance(env->context(), 1, &type)
+           ->NewInstance(env->context(), 0, nullptr)
            .ToLocal(&obj)) {
     return MaybeLocal<Object>();
   }
 
   KeyObjectHandle* key = Unwrap<KeyObjectHandle>(obj);
   CHECK_NOT_NULL(key);
-  key->data_.reset(KeyObjectData::CreateAsymmetric(key_type, pkey));
+  key->data_ = data;
   return obj;
 }
 
-const KeyObjectData* KeyObjectHandle::Data() {
-  return data_.get();
+const std::shared_ptr<KeyObjectData>& KeyObjectHandle::Data() {
+  return data_;
 }
 
 void KeyObjectHandle::New(const FunctionCallbackInfo<Value>& args) {
@@ -3357,8 +3352,7 @@ void KeyObjectHandle::Init(const FunctionCallbackInfo<Value>& args) {
   case kKeyTypeSecret:
     CHECK_EQ(args.Length(), 2);
     CHECK(args[1]->IsArrayBufferView());
-    key->data_.reset(
-        KeyObjectData::CreateSecret(args[1].As<ArrayBufferView>()));
+    key->data_ = KeyObjectData::CreateSecret(args[1].As<ArrayBufferView>());
     break;
   case kKeyTypePublic:
     CHECK_EQ(args.Length(), 4);
@@ -3367,7 +3361,7 @@ void KeyObjectHandle::Init(const FunctionCallbackInfo<Value>& args) {
     pkey = GetPublicOrPrivateKeyFromJs(args, &offset);
     if (!pkey)
       return;
-    key->data_.reset(KeyObjectData::CreateAsymmetric(type, pkey));
+    key->data_ = KeyObjectData::CreateAsymmetric(type, pkey);
     break;
   case kKeyTypePrivate:
     CHECK_EQ(args.Length(), 5);
@@ -3376,7 +3370,7 @@ void KeyObjectHandle::Init(const FunctionCallbackInfo<Value>& args) {
     pkey = GetPrivateKeyFromJs(args, &offset, false);
     if (!pkey)
       return;
-    key->data_.reset(KeyObjectData::CreateAsymmetric(type, pkey));
+    key->data_ = KeyObjectData::CreateAsymmetric(type, pkey);
     break;
   default:
     CHECK(false);
@@ -3472,7 +3466,50 @@ MaybeLocal<Value> KeyObjectHandle::ExportPrivateKey(
 }
 
 void NativeKeyObject::New(const FunctionCallbackInfo<Value>& args) {
-  CHECK_EQ(args.Length(), 0);
+  Environment* env = Environment::GetCurrent(args);
+  CHECK_EQ(args.Length(), 1);
+  CHECK(args[0]->IsObject());
+  KeyObjectHandle* handle = Unwrap<KeyObjectHandle>(args[0].As<Object>());
+  new NativeKeyObject(env, args.This(), handle->Data());
+}
+
+BaseObjectPtr<BaseObject> NativeKeyObject::KeyObjectTransferData::Deserialize(
+        Environment* env,
+        Local<Context> context,
+        std::unique_ptr<worker::TransferData> self) {
+  if (context != env->context()) {
+    THROW_ERR_MESSAGE_TARGET_CONTEXT_UNAVAILABLE(env);
+    return {};
+  }
+
+  Local<Value> handle = KeyObjectHandle::Create(env, data_).ToLocalChecked();
+  Local<Function> key_ctor;
+  switch (data_->GetKeyType()) {
+    case kKeyTypeSecret:
+      key_ctor = env->crypto_key_object_secret_constructor();
+      break;
+    case kKeyTypePublic:
+      key_ctor = env->crypto_key_object_public_constructor();
+      break;
+    case kKeyTypePrivate:
+      key_ctor = env->crypto_key_object_private_constructor();
+      break;
+    default:
+      CHECK(false);
+  }
+
+  Local<Value> key =
+      key_ctor->NewInstance(context, 1, &handle).ToLocalChecked();
+  return BaseObjectPtr<BaseObject>(Unwrap<KeyObjectHandle>(key.As<Object>()));
+}
+
+BaseObject::TransferMode NativeKeyObject::GetTransferMode() const {
+  return BaseObject::TransferMode::kCloneable;
+}
+
+std::unique_ptr<worker::TransferData> NativeKeyObject::CloneForMessaging()
+    const {
+  return std::make_unique<KeyObjectTransferData>(handle_data_);
 }
 
 static void CreateNativeKeyObjectClass(
@@ -3486,13 +3523,24 @@ static void CreateNativeKeyObjectClass(
   Local<FunctionTemplate> t = env->NewFunctionTemplate(NativeKeyObject::New);
   t->InstanceTemplate()->SetInternalFieldCount(
       KeyObjectHandle::kInternalFieldCount);
+  t->Inherit(BaseObject::GetConstructorTemplate(env));
 
   Local<Value> ctor = t->GetFunction(env->context()).ToLocalChecked();
 
   Local<Value> recv = Undefined(env->isolate());
-  Local<Value> ret =
-      callback.As<Function>()->Call(env->context(), recv, 1, &ctor)
-      .ToLocalChecked();
+  Local<Value> ret_v;
+  if (callback.As<Function>()->Call(
+          env->context(), recv, 1, &ctor).ToLocal(&ret)) {
+    return;
+  }
+  Local<Array> ret = ret_v.As<Array>();
+  Local<Value> ctor;
+  if (!ret->Get(env->context(), 1).ToLocal(&ctor)) return;
+  env->set_crypto_key_object_secret_constructor(ctor.As<Function>());
+  if (!ret->Get(env->context(), 2).ToLocal(&ctor)) return;
+  env->set_crypto_key_object_public_constructor(ctor.As<Function>());
+  if (!ret->Get(env->context(), 3).ToLocal(&ctor)) return;
+  env->set_crypto_key_object_private_constructor(ctor.As<Function>());
   args.GetReturnValue().Set(ret);
 }
 
@@ -6308,8 +6356,9 @@ class GenerateKeyPairJob : public CryptoJob {
     if (public_key_encoding_.output_key_object_) {
       // Note that this has the downside of containing sensitive data of the
       // private key.
-      if (!KeyObjectHandle::Create(env(), kKeyTypePublic, pkey_)
-               .ToLocal(pubkey))
+      std::shared_ptr<KeyObjectData> data =
+          KeyObjectData::CreateAsymmetric(kKeyTypePublic, pkey_);
+      if (!KeyObjectHandle::Create(env(), data).ToLocal(pubkey))
         return false;
     } else {
       if (!WritePublicKey(env(), pkey_.get(), public_key_encoding_)
@@ -6319,8 +6368,9 @@ class GenerateKeyPairJob : public CryptoJob {
 
     // Now do the same for the private key.
     if (private_key_encoding_.output_key_object_) {
-      if (!KeyObjectHandle::Create(env(), kKeyTypePrivate, pkey_)
-              .ToLocal(privkey))
+      std::shared_ptr<KeyObjectData> data =
+          KeyObjectData::CreateAsymmetric(kKeyTypePrivate, pkey_);
+      if (!KeyObjectHandle::Create(env(), data).ToLocal(privkey))
         return false;
     } else {
       if (!WritePrivateKey(env(), pkey_.get(), private_key_encoding_)

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3529,12 +3529,11 @@ static void CreateNativeKeyObjectClass(
 
   Local<Value> recv = Undefined(env->isolate());
   Local<Value> ret_v;
-  if (callback.As<Function>()->Call(
-          env->context(), recv, 1, &ctor).ToLocal(&ret)) {
+  if (!callback.As<Function>()->Call(
+          env->context(), recv, 1, &ctor).ToLocal(&ret_v)) {
     return;
   }
   Local<Array> ret = ret_v.As<Array>();
-  Local<Value> ctor;
   if (!ret->Get(env->context(), 1).ToLocal(&ctor)) return;
   env->set_crypto_key_object_secret_constructor(ctor.As<Function>());
   if (!ret->Get(env->context(), 2).ToLocal(&ctor)) return;

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -463,6 +463,15 @@ class KeyObjectHandle : public BaseObject {
   ManagedEVPPKey asymmetric_key_;
 };
 
+class NativeKeyObject : public BaseObject {
+ public:
+  static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
+
+  SET_NO_MEMORY_INFO()
+  SET_MEMORY_INFO_NAME(NativeKeyObject)
+  SET_SELF_SIZE(NativeKeyObject)
+};
+
 class CipherBase : public BaseObject {
  public:
   static void Initialize(Environment* env, v8::Local<v8::Object> target);

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -343,7 +343,7 @@ class ByteSource {
   static ByteSource NullTerminatedCopy(Environment* env,
                                        v8::Local<v8::Value> value);
 
-  static ByteSource FromSymmetricKeyObject(v8::Local<v8::Value> handle);
+  static ByteSource FromSymmetricKeyObjectHandle(v8::Local<v8::Value> handle);
 
   ByteSource(const ByteSource&) = delete;
   ByteSource& operator=(const ByteSource&) = delete;
@@ -408,7 +408,7 @@ class ManagedEVPPKey {
   EVPKeyPointer pkey_;
 };
 
-class KeyObject : public BaseObject {
+class KeyObjectHandle : public BaseObject {
  public:
   static v8::Local<v8::Function> Initialize(Environment* env,
                                             v8::Local<v8::Object> target);
@@ -419,8 +419,8 @@ class KeyObject : public BaseObject {
 
   // TODO(tniessen): track the memory used by OpenSSL types
   SET_NO_MEMORY_INFO()
-  SET_MEMORY_INFO_NAME(KeyObject)
-  SET_SELF_SIZE(KeyObject)
+  SET_MEMORY_INFO_NAME(KeyObjectHandle)
+  SET_SELF_SIZE(KeyObjectHandle)
 
   KeyType GetKeyType() const;
 
@@ -452,7 +452,9 @@ class KeyObject : public BaseObject {
   v8::MaybeLocal<v8::Value> ExportPrivateKey(
       const PrivateKeyEncodingConfig& config) const;
 
-  KeyObject(Environment* env, v8::Local<v8::Object> wrap, KeyType key_type);
+  KeyObjectHandle(Environment* env,
+                  v8::Local<v8::Object> wrap,
+                  KeyType key_type);
 
  private:
   const KeyType key_type_;

--- a/test/parallel/test-crypto-key-objects-messageport.js
+++ b/test/parallel/test-crypto-key-objects-messageport.js
@@ -1,0 +1,85 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const { createSecretKey, generateKeyPairSync, randomBytes } = require('crypto');
+const { createContext } = require('vm');
+const {
+  MessageChannel,
+  Worker,
+  isMainThread,
+  moveMessagePortToContext,
+  parentPort
+} = require('worker_threads');
+
+function keyToString(key) {
+  let ret;
+  if (key.type === 'secret') {
+    ret = key.export().toString('hex');
+  } else {
+    ret = key.export({ type: 'pkcs1', format: 'pem' });
+  }
+  return ret;
+}
+
+// Worker threads simply reply with their representation of the received key.
+if (!isMainThread) {
+  return parentPort.once('message', ({ key }) => {
+    parentPort.postMessage(keyToString(key));
+  });
+}
+
+// The main thread generates keys and passes them to worker threads.
+const secretKey = createSecretKey(randomBytes(32));
+const { publicKey, privateKey } = generateKeyPairSync('rsa', {
+  modulusLength: 1024
+});
+
+// Get immutable representations of all keys.
+const keys = [secretKey, publicKey, privateKey]
+             .map((key) => [key, keyToString(key)]);
+
+for (const [key, repr] of keys) {
+  {
+    // Test 1: No context change.
+    const { port1, port2 } = new MessageChannel();
+
+    port1.postMessage({ key });
+    assert.strictEqual(keyToString(key), repr);
+
+    port2.once('message', common.mustCall(({ key }) => {
+      assert.strictEqual(keyToString(key), repr);
+    }));
+  }
+
+  {
+    // Test 2: Across threads.
+    const worker = new Worker(__filename);
+    worker.once('message', common.mustCall((receivedRepresentation) => {
+      assert.strictEqual(receivedRepresentation, repr);
+    }));
+    worker.on('disconnect', () => console.log('disconnect'));
+    worker.postMessage({ key });
+  }
+
+  {
+    // Test 3: Across contexts (should not work).
+    const { port1, port2 } = new MessageChannel();
+    const context = createContext();
+    const port2moved = moveMessagePortToContext(port2, context);
+    assert(!(port2moved instanceof Object));
+
+    // TODO(addaleax): Switch this to a 'messageerror' event once MessagePort
+    // implements EventTarget fully and in a cross-context manner.
+    port2moved.emit = common.mustCall((name, err) => {
+      assert.strictEqual(name, 'messageerror');
+      assert.strictEqual(err.code, 'ERR_MESSAGE_TARGET_CONTEXT_UNAVAILABLE');
+    });
+
+    port2moved.start();
+    port1.postMessage({ key });
+    port1.close();
+  }
+}

--- a/test/parallel/test-crypto-key-objects-messageport.js
+++ b/test/parallel/test-crypto-key-objects-messageport.js
@@ -9,7 +9,6 @@ const { createContext } = require('vm');
 const {
   MessageChannel,
   Worker,
-  isMainThread,
   moveMessagePortToContext,
   parentPort
 } = require('worker_threads');
@@ -25,11 +24,14 @@ function keyToString(key) {
 }
 
 // Worker threads simply reply with their representation of the received key.
-if (!isMainThread) {
+if (process.env.HAS_STARTED_WORKER) {
   return parentPort.once('message', ({ key }) => {
     parentPort.postMessage(keyToString(key));
   });
 }
+
+// Don't use isMainThread to allow running this test inside a worker.
+process.env.HAS_STARTED_WORKER = 1;
 
 // The main thread generates keys and passes them to worker threads.
 const secretKey = createSecretKey(randomBytes(32));


### PR DESCRIPTION
This patch allows to pass `KeyObject` instances between threads/contexts, and is based on some great work by @addaleax.

While the public API has not changed, the internal structure has become a little complicated. In order to be cloneable, the `KeyObject` class must be implemented in C++. However, `KeyObject` relies on its JavaScript class hierarchy. To get around this problem, a new base class `NativeKeyObject` is added, from which all `KeyObject` classes inherit:

```
             +---------------------+
             |     BaseObject      |
             +---------------------+
                        |
                        |
                        |
             +---------------------+
             |   NativeKeyObject   |
             +---------------------+
                        |
                        |
                        |
             +---------------------+
             |      KeyObject      |
             +---------------------+
               /                 \
              /                   \
             /                     \
            /                       \
+---------------------+    +---------------------+
|   SecretKeyObject   |    | AsymmetricKeyObject |
+---------------------+    +---------------------+
                             /                 \
                            /                   \
                           /                     \
                          /                       \
              +---------------------+   +---------------------+
              |   PublicKeyObject   |   |   PrivateKeyObject  |
              +---------------------+   +---------------------+
```

`NativeKeyObject` has no properties and doesn't change the behavior of `KeyObject`. It only exists to be cloneable.

Each `KeyObject` `k` has an associated `KeyObjectHandle`, which is stored in `k[kHandle]`. The public `KeyObject` API uses the internal `KeyObjectHandle` API to perform most operations, however, a `KeyObjectHandle` is a `BaseObject` and cannot be shared between threads directly. Instead, each `KeyObjectHandle` references a `KeyObjectData` object, which contains the actual key. This object can be shared between threads:

```
+-----------------+
| NativeKeyObject |
+-----------------+
        ^
     extends
        |
+-----------------+    +-----------------+    +---------------+
| KeyObject  (JS) | -> | KeyObjectHandle | -> | KeyObjectData |
+-----------------+    +-----------------+    +---------------+
```

When a key is passed via a `MessagePort`, the receiver creates a new `KeyObjectHandle` and the correct `KeyObject` (one of `SecretKeyObject`, `PublicKeyObject`, `PrivateKeyObject`). However, it does not create a new `KeyObjectData` object: All threads always refer to the same `KeyObjectData` for the same key:

```
+-------------------+
| NativeKeyObject 1 | ------------------------------------------+
+-------------------+                                           |
        ^                                                       |
     extends                                                    |
        |                                                       |
+-------------------+    +-------------------+                  |
| KeyObject 1  (JS) | -> | KeyObjectHandle 1 | --------------+  |
+-------------------+    +-------------------+               |  |
                                                             |  |
                                                             |  |
                                                             |  |
                                                             |  |
                                                             |  |
+-------------------+                                        |  |
| NativeKeyObject 2 | ------------------------------------+  |  |
+-------------------+                                     |  |  |
        ^                                                 |  |  |
     extends                                              |  |  |
        |                                                 |  |  |
+-------------------+    +-------------------+            |  |  |
| KeyObject 2  (JS) | -> | KeyObjectHandle 2 | --------+  |  |  |
+-------------------+    +-------------------+         |  |  |  |
                                                       |  |  |  |
                                                       |  |  |  |
                                                       |  |  |  |
                                                       |  |  |  |
                                                       |  |  |  |
+-------------------+                                  |  |  |  |
| NativeKeyObject 3 | ------------------------------+  |  |  |  |
+-------------------+                               |  |  |  |  |
        ^                                           |  |  |  |  |
     extends                                        |  |  |  |  |
        |                                           v  v  v  v  v
+-------------------+    +-------------------+    +---------------+
| KeyObject 3  (JS) | -> | KeyObjectHandle 3 | -> | KeyObjectData |
+-------------------+    +-------------------+    +---------------+
```

Since almost all operations go through the `KeyObjectHandle`, it makes sense for the `KeyObjectHandle` to contain a pointer to the `KeyObjectData`. However, the `NativeKeyObject` class implements `CloneForMessaging` and therefore also needs access to the same `KeyObjectData`. In theory, we could go through `this[kHandle]->Data()`, but it is easier to also maintain a pointer from the `NativeKeyObject` to the same `KeyObjectData`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

cc @addaleax @panva @nodejs/crypto @nodejs/security-wg