### PR TITLE
doc: update readline key-bindings and TODO comments

### DIFF
--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -750,7 +750,7 @@ const { createInterface } = require('readline');
   <tr>
     <td><code>ctrl</code> + <code>shift</code> + <code>delete</code></td>
     <td>Delete line right</td>
-    <td>Doesn't work on Linux and Mac</td>
+    <td>Doesn't work on Mac</td>
   </tr>
   <tr>
     <td><code>ctrl</code> + <code>c</code></td>
@@ -824,7 +824,7 @@ const { createInterface } = require('readline');
     + <code>backspace</code></td>
     <td>Delete backwards to a word boundary</td>
     <td><code>ctrl</code> + <code>backspace</code> Doesn't
-    work as expected on Windows</td>
+    work on Linux, Mac and Windows</td>
   </tr>
   <tr>
     <td><code>ctrl</code> + <code>delete</code></td>

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -855,6 +855,8 @@ Interface.prototype._ttyWrite = function(s, key) {
   if (key.ctrl && key.shift) {
     /* Control and shift pressed */
     switch (key.name) {
+      // TODO(BridgeAR): The transmitted escape sequence is `\b` and that is
+      // identical to <ctrl>-h. It should have a unique escape sequence.
       case 'backspace':
         this._deleteLineLeft();
         break;
@@ -952,8 +954,10 @@ Interface.prototype._ttyWrite = function(s, key) {
         }
         break;
 
-      // TODO(BridgeAR): This seems broken?
       case 'w': // Delete backwards to a word boundary
+      // TODO(BridgeAR): The transmitted escape sequence is `\b` and that is
+      // identical to <ctrl>-h. It should have a unique escape sequence.
+      // Falls through
       case 'backspace':
         this._deleteWordLeft();
         break;

--- a/test/parallel/test-assert-deep.js
+++ b/test/parallel/test-assert-deep.js
@@ -957,8 +957,6 @@ assertDeepAndStrictEqual(obj1, obj2);
 
 // Check proxies.
 {
-  // TODO(BridgeAR): Check if it would not be better to detect proxies instead
-  // of just using the proxy value.
   const arrProxy = new Proxy([1, 2], {});
   assert.deepStrictEqual(arrProxy, [1, 2]);
   const tmp = util.inspect.defaultOptions;


### PR DESCRIPTION
#### doc: fix readline key binding documentation

The documentation for two key bindings was not correct.

#### lib: update TODO comments

This removes one TODO comment and adds another that indicates that
readline is currently not able to trigger specific escape sequences.

@nodejs/streams @nodejs/libuv does anyone know why the stream emits `\b` in case `<ctrl><backspace>` or `<ctrl><shift><backspace>` is used? I would expect it to be a different escape code and I tried to find documentation about it but I failed.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
