### PR TITLE
Revert "vm: add importModuleDynamically option to compileFunction"

### DIFF
--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -88,7 +88,7 @@ changes:
     This option is part of the experimental modules API, and should not be
     considered stable.
     * `specifier` {string} specifier passed to `import()`
-    * `script` {vm.Script}
+    * `module` {vm.Module}
     * Returns: {Module Namespace Object|vm.Module} Returning a `vm.Module` is
       recommended in order to take advantage of error tracking, and to avoid
       issues with namespaces that contain `then` function exports.
@@ -811,6 +811,9 @@ changes:
     - v13.14.0
     pr-url: https://github.com/nodejs/node/pull/32985
     description: The `importModuleDynamically` option is now supported.
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/33364
+    description: Removal of `importModuleDynamically` due to compatibility issues
 -->
 
 * `code` {string} The body of the function to compile.
@@ -833,16 +836,6 @@ changes:
   * `contextExtensions` {Object[]} An array containing a collection of context
     extensions (objects wrapping the current scope) to be applied while
     compiling. **Default:** `[]`.
-  * `importModuleDynamically` {Function} Called during evaluation of this module
-    when `import()` is called. If this option is not specified, calls to
-    `import()` will reject with [`ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING`][].
-    This option is part of the experimental modules API, and should not be
-    considered stable.
-    * `specifier` {string} specifier passed to `import()`
-    * `function` {Function}
-    * Returns: {Module Namespace Object|vm.Module} Returning a `vm.Module` is
-      recommended in order to take advantage of error tracking, and to avoid
-      issues with namespaces that contain `then` function exports.
 * Returns: {Function}
 
 Compiles the given code into the provided context (if no context is

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -77,6 +77,7 @@ const preserveSymlinksMain = getOptionValue('--preserve-symlinks-main');
 const manifest = getOptionValue('--experimental-policy') ?
   require('internal/process/policy').manifest :
   null;
+const { compileFunction } = internalBinding('contextify');
 
 // Whether any user-provided CJS modules had been loaded (executed).
 // Used for internal assertions.
@@ -1102,25 +1103,40 @@ function wrapSafe(filename, content, cjsModuleInstance) {
       },
     });
   }
+  let compiled;
   try {
-    return vm.compileFunction(content, [
-      'exports',
-      'require',
-      'module',
-      '__filename',
-      '__dirname',
-    ], {
+    compiled = compileFunction(
+      content,
       filename,
-      importModuleDynamically(specifier) {
-        const loader = asyncESM.ESMLoader;
-        return loader.import(specifier, normalizeReferrerURL(filename));
-      },
-    });
+      0,
+      0,
+      undefined,
+      false,
+      undefined,
+      [],
+      [
+        'exports',
+        'require',
+        'module',
+        '__filename',
+        '__dirname',
+      ]
+    );
   } catch (err) {
     if (process.mainModule === cjsModuleInstance)
       enrichCJSError(err);
     throw err;
   }
+
+  const { callbackMap } = internalBinding('module_wrap');
+  callbackMap.set(compiled.cacheKey, {
+    importModuleDynamically: async (specifier) => {
+      const loader = asyncESM.ESMLoader;
+      return loader.import(specifier, normalizeReferrerURL(filename));
+    }
+  });
+
+  return compiled.function;
 }
 
 // Run the file contents in the correct scope or sandbox. Expose

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -313,7 +313,6 @@ function compileFunction(code, params, options = {}) {
     produceCachedData = false,
     parsingContext = undefined,
     contextExtensions = [],
-    importModuleDynamically,
   } = options;
 
   validateString(filename, 'options.filename');
@@ -359,22 +358,6 @@ function compileFunction(code, params, options = {}) {
 
   if (result.cachedData) {
     result.function.cachedData = result.cachedData;
-  }
-
-  if (importModuleDynamically !== undefined) {
-    if (typeof importModuleDynamically !== 'function') {
-      throw new ERR_INVALID_ARG_TYPE('options.importModuleDynamically',
-                                     'function',
-                                     importModuleDynamically);
-    }
-    const { importModuleDynamicallyWrap } =
-      require('internal/vm/module');
-    const { callbackMap } = internalBinding('module_wrap');
-    const wrapped = importModuleDynamicallyWrap(importModuleDynamically);
-    const func = result.function;
-    callbackMap.set(result.cacheKey, {
-      importModuleDynamically: (s, _k) => wrapped(s, func),
-    });
   }
 
   return result.function;

--- a/test/parallel/test-vm-module-basic.js
+++ b/test/parallel/test-vm-module-basic.js
@@ -8,8 +8,7 @@ const {
   Module,
   SourceTextModule,
   SyntheticModule,
-  createContext,
-  compileFunction,
+  createContext
 } = require('vm');
 const util = require('util');
 
@@ -156,21 +155,5 @@ const util = require('util');
     message: 'The "options" argument must be of type object.' +
       ' Received null',
     name: 'TypeError'
-  });
-}
-
-// Test compileFunction importModuleDynamically
-{
-  const module = new SyntheticModule([], () => {});
-  module.link(() => {});
-  const f = compileFunction('return import("x")', [], {
-    importModuleDynamically(specifier, referrer) {
-      assert.strictEqual(specifier, 'x');
-      assert.strictEqual(referrer, f);
-      return module;
-    },
-  });
-  f().then((ns) => {
-    assert.strictEqual(ns, module.namespace);
   });
 }

--- a/tools/doc/type-parser.js
+++ b/tools/doc/type-parser.js
@@ -154,7 +154,6 @@ const customTypesMap = {
   'URLSearchParams': 'url.html#url_class_urlsearchparams',
 
   'vm.Module': 'vm.html#vm_class_vm_module',
-  'vm.Script': 'vm.html#vm_class_vm_script',
   'vm.SourceTextModule': 'vm.html#vm_class_vm_sourcetextmodule',
 
   'MessagePort': 'worker_threads.html#worker_threads_class_messageport',


### PR DESCRIPTION
This reverts commit 74c393dd93cc0e461e3796fbcc09545fcacdecaf.

Fixes: https://github.com/nodejs/node/issues/33166
See: https://github.com/nodejs/node/pull/32985
See: https://github.com/nodejs/node/issues/31860

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
