### PR TITLE
tls: fix --tls-keylog option

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -701,7 +701,7 @@ added:
 
 * `line` {Buffer} Line of ASCII text, in NSS `SSLKEYLOGFILE` format.
 
-The `keylog` event is emitted on a client `tls.TLSSocket` when key material
+The `keylog` event is emitted on a `tls.TLSSocket` when key material
 is generated or received by the socket. This keying material can be stored
 for debugging, as it allows captured TLS traffic to be decrypted. It may
 be emitted multiple times, before or after the handshake completes.

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -372,16 +372,9 @@ function onPskClientCallback(hint, maxPskLen, maxIdentityLen) {
   return { psk: ret.psk, identity: ret.identity };
 }
 
-function onkeylogclient(line) {
-  debug('client onkeylog');
-  this[owner_symbol].emit('keylog', line);
-}
-
 function onkeylog(line) {
-  debug('server onkeylog');
-  const owner = this[owner_symbol];
-  if (owner.server)
-    owner.server.emit('keylog', line, owner);
+  debug('onkeylog');
+  this[owner_symbol].emit('keylog', line);
 }
 
 function onocspresponse(resp) {
@@ -663,13 +656,26 @@ TLSSocket.prototype._init = function(socket, wrap) {
   if (requestCert || rejectUnauthorized)
     ssl.setVerifyMode(requestCert, rejectUnauthorized);
 
+  // Only call .onkeylog if there is a keylog listener.
+  ssl.onkeylog = onkeylog;
+  this.on('newListener', keylogNewListener);
+
+  function keylogNewListener(event) {
+    if (event !== 'keylog')
+      return;
+
+    ssl.enableKeylogCallback();
+
+    // Remove this listener since it's no longer needed.
+    this.removeListener('newListener', keylogNewListener);
+  }
+
   if (options.isServer) {
     ssl.onhandshakestart = onhandshakestart;
     ssl.onhandshakedone = onhandshakedone;
     ssl.onclienthello = loadSession;
     ssl.oncertcb = loadSNI;
     ssl.onnewsession = onnewsession;
-    ssl.onkeylog = onkeylog;
     ssl.lastHandshakeTime = 0;
     ssl.handshakes = 0;
 
@@ -679,8 +685,6 @@ TLSSocket.prototype._init = function(socket, wrap) {
         // Also starts the client hello parser as a side effect.
         ssl.enableSessionCallbacks();
       }
-      if (this.server.listenerCount('keylog') > 0)
-        ssl.enableKeylogCallback();
       if (this.server.listenerCount('OCSPRequest') > 0)
         ssl.enableCertCb();
     }
@@ -709,21 +713,6 @@ TLSSocket.prototype._init = function(socket, wrap) {
       // Remove this listener since it's no longer needed.
       this.removeListener('newListener', newListener);
     }
-
-    ssl.onkeylog = onkeylogclient;
-
-    // Only call .onkeylog if there is a keylog listener.
-    this.on('newListener', keylogNewListener);
-
-    function keylogNewListener(event) {
-      if (event !== 'keylog')
-        return;
-
-      ssl.enableKeylogCallback();
-
-      // Remove this listener since it's no longer needed.
-      this.removeListener('newListener', keylogNewListener);
-    }
   }
 
   if (tlsKeylog) {
@@ -731,17 +720,16 @@ TLSSocket.prototype._init = function(socket, wrap) {
       warnOnTlsKeylog = false;
       process.emitWarning('Using --tls-keylog makes TLS connections insecure ' +
         'by writing secret key material to file ' + tlsKeylog);
-      ssl.enableKeylogCallback();
-      this.on('keylog', (line) => {
-        appendFile(tlsKeylog, line, { mode: 0o600 }, (err) => {
-          if (err && warnOnTlsKeylogError) {
-            warnOnTlsKeylogError = false;
-            process.emitWarning('Failed to write TLS keylog (this warning ' +
-              'will not be repeated): ' + err);
-          }
-        });
-      });
     }
+    this.on('keylog', (line) => {
+      appendFile(tlsKeylog, line, { mode: 0o600 }, (err) => {
+        if (err && warnOnTlsKeylogError) {
+          warnOnTlsKeylogError = false;
+          process.emitWarning('Failed to write TLS keylog (this warning ' +
+            'will not be repeated): ' + err);
+        }
+      });
+    });
   }
 
   ssl.onerror = onerror;
@@ -1044,6 +1032,10 @@ function onSocketTLSError(err) {
   }
 }
 
+function onSocketKeylog(line) {
+  this._tlsOptions.server.emit('keylog', line, this);
+}
+
 function onSocketClose(err) {
   // Closed because of error - no need to emit it twice
   if (err)
@@ -1075,6 +1067,9 @@ function tlsConnectionListener(rawSocket) {
   });
 
   socket.on('secure', onServerSocketSecure);
+
+  if (this.listenerCount('keylog') > 0)
+    socket.on('keylog', onSocketKeylog);
 
   socket[kErrorEmitted] = false;
   socket.on('close', onSocketClose);


### PR DESCRIPTION
There's a typo that causes only the first socket to be logged (i.e. when the warning is emitted).

In addition, server sockets aren't logged because `keylog` events are not emitted on tls.Server, not the socket. This behaviour is counterintuitive and has caused more bugs in the past, so make all sockets (server or client) emit `keylog`. tls.Server will just re-emit these events.

Refs: https://github.com/nodejs/node/pull/30055

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)