### PR TITLE
src: turn AllocatedBuffer into thin wrapper around v8::BackingStore

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -867,117 +867,91 @@ inline IsolateData* Environment::isolate_data() const {
   return isolate_data_;
 }
 
-inline char* Environment::AllocateUnchecked(size_t size) {
-  return static_cast<char*>(
-      isolate_data()->allocator()->AllocateUninitialized(size));
+AllocatedBuffer Environment::AllocateManaged(size_t size) {
+  NoArrayBufferZeroFillScope no_zero_fill_scope(isolate_data());
+  std::unique_ptr<v8::BackingStore> bs =
+      v8::ArrayBuffer::NewBackingStore(isolate(), size);
+  return AllocatedBuffer(this, std::move(bs));
 }
 
-inline char* Environment::Allocate(size_t size) {
-  char* ret = AllocateUnchecked(size);
-  CHECK_NE(ret, nullptr);
-  return ret;
+std::unordered_map<char*, std::unique_ptr<v8::BackingStore>>*
+    Environment::released_allocated_buffers() {
+  return &released_allocated_buffers_;
 }
 
-inline void Environment::Free(char* data, size_t size) {
-  if (data != nullptr)
-    isolate_data()->allocator()->Free(data, size);
+AllocatedBuffer::AllocatedBuffer(
+    Environment* env, std::unique_ptr<v8::BackingStore> bs)
+    : env_(env), backing_store_(std::move(bs)) {}
+
+AllocatedBuffer::AllocatedBuffer(
+    Environment* env, uv_buf_t buffer)
+    : env_(env) {
+  if (buffer.base == nullptr) return;
+
+  auto map = env->released_allocated_buffers();
+  auto it = map->find(buffer.base);
+  CHECK_NE(it, map->end());
+  backing_store_ = std::move(it->second);
+  map->erase(it);
 }
 
-inline AllocatedBuffer Environment::AllocateManaged(size_t size, bool checked) {
-  char* data = checked ? Allocate(size) : AllocateUnchecked(size);
-  if (data == nullptr) size = 0;
-  return AllocatedBuffer(this, uv_buf_init(data, size));
-}
-
-inline AllocatedBuffer::AllocatedBuffer(Environment* env, uv_buf_t buf)
-    : env_(env), buffer_(buf) {}
-
-inline void AllocatedBuffer::Resize(size_t len) {
-  // The `len` check is to make sure we don't end up with `nullptr` as our base.
-  char* new_data = env_->Reallocate(buffer_.base, buffer_.len,
-                                    len > 0 ? len : 1);
-  CHECK_NOT_NULL(new_data);
-  buffer_ = uv_buf_init(new_data, len);
+void AllocatedBuffer::Resize(size_t len) {
+  if (len == 0) {
+    backing_store_ = v8::ArrayBuffer::NewBackingStore(env_->isolate(), 0);
+    return;
+  }
+  NoArrayBufferZeroFillScope no_zero_fill_scope(env_->isolate_data());
+  backing_store_ = v8::BackingStore::Reallocate(
+      env_->isolate(), std::move(backing_store_), len);
 }
 
 inline uv_buf_t AllocatedBuffer::release() {
-  uv_buf_t ret = buffer_;
-  buffer_ = uv_buf_init(nullptr, 0);
+  if (data() == nullptr) return uv_buf_init(nullptr, 0);
+
+  CHECK_NOT_NULL(env_);
+  uv_buf_t ret = uv_buf_init(data(), size());
+  env_->released_allocated_buffers()->emplace(
+      ret.base, std::move(backing_store_));
   return ret;
 }
 
-inline char* AllocatedBuffer::data() {
-  return buffer_.base;
+char* AllocatedBuffer::data() {
+  if (!backing_store_) return nullptr;
+  return static_cast<char*>(backing_store_->Data());
 }
 
-inline const char* AllocatedBuffer::data() const {
-  return buffer_.base;
+const char* AllocatedBuffer::data() const {
+  if (!backing_store_) return nullptr;
+  return static_cast<char*>(backing_store_->Data());
 }
 
-inline size_t AllocatedBuffer::size() const {
-  return buffer_.len;
+size_t AllocatedBuffer::size() const {
+  if (!backing_store_) return 0;
+  return backing_store_->ByteLength();
 }
 
-inline AllocatedBuffer::AllocatedBuffer(Environment* env)
-    : env_(env), buffer_(uv_buf_init(nullptr, 0)) {}
-
-inline AllocatedBuffer::AllocatedBuffer(AllocatedBuffer&& other)
-    : AllocatedBuffer() {
-  *this = std::move(other);
-}
-
-inline AllocatedBuffer& AllocatedBuffer::operator=(AllocatedBuffer&& other) {
-  clear();
-  env_ = other.env_;
-  buffer_ = other.release();
-  return *this;
-}
-
-inline AllocatedBuffer::~AllocatedBuffer() {
-  clear();
-}
-
-inline void AllocatedBuffer::clear() {
-  uv_buf_t buf = release();
-  if (buf.base != nullptr) {
-    CHECK_NOT_NULL(env_);
-    env_->Free(buf.base, buf.len);
-  }
+void AllocatedBuffer::clear() {
+  backing_store_.reset();
 }
 
 // It's a bit awkward to define this Buffer::New() overload here, but it
 // avoids a circular dependency with node_internals.h.
 namespace Buffer {
-v8::MaybeLocal<v8::Object> New(Environment* env,
-                               char* data,
-                               size_t length,
-                               bool uses_malloc);
+v8::MaybeLocal<v8::Uint8Array> New(Environment* env,
+                                   v8::Local<v8::ArrayBuffer> ab,
+                                   size_t byte_offset,
+                                   size_t length);
 }
 
 inline v8::MaybeLocal<v8::Object> AllocatedBuffer::ToBuffer() {
-  CHECK_NOT_NULL(env_);
-  v8::MaybeLocal<v8::Object> obj = Buffer::New(env_, data(), size(), false);
-  if (!obj.IsEmpty()) release();
-  return obj;
+  v8::Local<v8::ArrayBuffer> ab = ToArrayBuffer();
+  return Buffer::New(env_, ab, 0, ab->ByteLength())
+      .FromMaybe(v8::Local<v8::Uint8Array>());
 }
 
 inline v8::Local<v8::ArrayBuffer> AllocatedBuffer::ToArrayBuffer() {
   CHECK_NOT_NULL(env_);
-  uv_buf_t buf = release();
-  auto callback = [](void* data, size_t length, void* deleter_data){
-    CHECK_NOT_NULL(deleter_data);
-
-    static_cast<v8::ArrayBuffer::Allocator*>(deleter_data)
-        ->Free(data, length);
-  };
-  std::unique_ptr<v8::BackingStore> backing =
-      v8::ArrayBuffer::NewBackingStore(buf.base,
-                                       buf.len,
-                                       callback,
-                                       env_->isolate()
-                                          ->GetArrayBufferAllocator());
-  return v8::ArrayBuffer::New(env_->isolate(),
-                              std::move(backing));
+  return v8::ArrayBuffer::New(env_->isolate(), std::move(backing_store_));
 }
 
 inline void Environment::ThrowError(const char* errmsg) {

--- a/src/env.cc
+++ b/src/env.cc
@@ -1133,27 +1133,18 @@ void Environment::MemoryInfo(MemoryTracker* tracker) const {
   // node, we shift its sizeof() size out of the Environment node.
 }
 
-char* Environment::Reallocate(char* data, size_t old_size, size_t size) {
-  if (old_size == size) return data;
-  // If we know that the allocator is our ArrayBufferAllocator, we can let
-  // if reallocate directly.
-  if (isolate_data()->uses_node_allocator()) {
-    return static_cast<char*>(
-        isolate_data()->node_allocator()->Reallocate(data, old_size, size));
-  }
-  // Generic allocators do not provide a reallocation method; we need to
-  // allocate a new chunk of memory and copy the data over.
-  char* new_data = AllocateUnchecked(size);
-  if (new_data == nullptr) return nullptr;
-  memcpy(new_data, data, std::min(size, old_size));
-  if (size > old_size)
-    memset(new_data + old_size, 0, size - old_size);
-  Free(data, old_size);
-  return new_data;
-}
-
 void Environment::RunWeakRefCleanup() {
   isolate()->ClearKeptObjects();
+}
+
+NoArrayBufferZeroFillScope::NoArrayBufferZeroFillScope(
+    IsolateData* isolate_data)
+  : node_allocator_(isolate_data->node_allocator()) {
+  if (node_allocator_ != nullptr) node_allocator_->zero_fill_field()[0] = 0;
+}
+
+NoArrayBufferZeroFillScope::~NoArrayBufferZeroFillScope() {
+  if (node_allocator_ != nullptr) node_allocator_->zero_fill_field()[0] = 1;
 }
 
 // Not really any better place than env.cc at this moment.

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -327,16 +327,7 @@ MaybeLocal<Object> New(Environment* env, size_t length) {
     return Local<Object>();
   }
 
-  AllocatedBuffer ret(env);
-  if (length > 0) {
-    ret = env->AllocateManaged(length, false);
-    if (ret.data() == nullptr) {
-      THROW_ERR_MEMORY_ALLOCATION_FAILED(env);
-      return Local<Object>();
-    }
-  }
-
-  return scope.EscapeMaybe(ret.ToBuffer());
+  return scope.EscapeMaybe(env->AllocateManaged(length).ToBuffer());
 }
 
 
@@ -363,14 +354,8 @@ MaybeLocal<Object> Copy(Environment* env, const char* data, size_t length) {
     return Local<Object>();
   }
 
-  AllocatedBuffer ret(env);
+  AllocatedBuffer ret = env->AllocateManaged(length);
   if (length > 0) {
-    CHECK_NOT_NULL(data);
-    ret = env->AllocateManaged(length, false);
-    if (ret.data() == nullptr) {
-      THROW_ERR_MEMORY_ALLOCATION_FAILED(env);
-      return Local<Object>();
-    }
     memcpy(ret.data(), data, length);
   }
 
@@ -445,53 +430,23 @@ MaybeLocal<Object> New(Isolate* isolate, char* data, size_t length) {
     return MaybeLocal<Object>();
   }
   Local<Object> obj;
-  if (Buffer::New(env, data, length, true).ToLocal(&obj))
+  if (Buffer::New(env, data, length).ToLocal(&obj))
     return handle_scope.Escape(obj);
   return Local<Object>();
 }
 
-// Warning: If this call comes through the public node_buffer.h API,
-// the contract for this function is that `data` is allocated with malloc()
+// The contract for this function is that `data` is allocated with malloc()
 // and not necessarily isolate's ArrayBuffer::Allocator.
 MaybeLocal<Object> New(Environment* env,
                        char* data,
-                       size_t length,
-                       bool uses_malloc) {
+                       size_t length) {
   if (length > 0) {
     CHECK_NOT_NULL(data);
     CHECK(length <= kMaxLength);
   }
 
-  if (uses_malloc) {
-    if (!env->isolate_data()->uses_node_allocator()) {
-      // We don't know for sure that the allocator is malloc()-based, so we need
-      // to fall back to the FreeCallback variant.
-      auto free_callback = [](char* data, void* hint) { free(data); };
-      return New(env, data, length, free_callback, nullptr);
-    } else {
-      // This is malloc()-based, so we can acquire it into our own
-      // ArrayBufferAllocator.
-      CHECK_NOT_NULL(env->isolate_data()->node_allocator());
-      env->isolate_data()->node_allocator()->RegisterPointer(data, length);
-    }
-  }
-
-  auto callback = [](void* data, size_t length, void* deleter_data){
-    CHECK_NOT_NULL(deleter_data);
-
-    static_cast<v8::ArrayBuffer::Allocator*>(deleter_data)
-        ->Free(data, length);
-  };
-  std::unique_ptr<v8::BackingStore> backing =
-      v8::ArrayBuffer::NewBackingStore(data,
-                                       length,
-                                       callback,
-                                       env->isolate()
-                                          ->GetArrayBufferAllocator());
-  Local<ArrayBuffer> ab = ArrayBuffer::New(env->isolate(),
-                                           std::move(backing));
-
-  return Buffer::New(env, ab, 0, length).FromMaybe(Local<Object>());
+  auto free_callback = [](char* data, void* hint) { free(data); };
+  return New(env, data, length, free_callback, nullptr);
 }
 
 namespace {

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -4023,7 +4023,7 @@ bool CipherBase::Final(AllocatedBuffer* out) {
   bool ok;
   if (kind_ == kDecipher && mode == EVP_CIPH_CCM_MODE) {
     ok = !pending_auth_failed_;
-    *out = AllocatedBuffer(env());  // Empty buffer.
+    *out = env()->AllocateManaged(0);  // Empty buffer.
   } else {
     int out_len = out->size();
     ok = EVP_CipherFinal_ex(ctx_.get(),

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -156,12 +156,10 @@ v8::MaybeLocal<v8::Object> New(Environment* env,
                                size_t length,
                                void (*callback)(char* data, void* hint),
                                void* hint);
-// Takes ownership of |data|.  Must allocate |data| with the current Isolate's
-// ArrayBuffer::Allocator().
+// Takes ownership of |data|.  |data| must be allocated with malloc().
 v8::MaybeLocal<v8::Object> New(Environment* env,
                                char* data,
-                               size_t length,
-                               bool uses_malloc);
+                               size_t length);
 // Creates a Buffer instance over an existing ArrayBuffer.
 v8::MaybeLocal<v8::Uint8Array> New(Environment* env,
                                    v8::Local<v8::ArrayBuffer> ab,
@@ -183,7 +181,7 @@ static v8::MaybeLocal<v8::Object> New(Environment* env,
   const size_t len_in_bytes = buf->length() * sizeof(buf->out()[0]);
 
   if (buf->IsAllocated())
-    ret = New(env, src, len_in_bytes, true);
+    ret = New(env, src, len_in_bytes);
   else if (!buf->IsInvalidated())
     ret = Copy(env, src, len_in_bytes);
 

--- a/src/node_serdes.cc
+++ b/src/node_serdes.cc
@@ -206,8 +206,7 @@ void SerializerContext::ReleaseBuffer(const FunctionCallbackInfo<Value>& args) {
   std::pair<uint8_t*, size_t> ret = ctx->serializer_.Release();
   auto buf = Buffer::New(ctx->env(),
                          reinterpret_cast<char*>(ret.first),
-                         ret.second,
-                         true /* uses_malloc */);
+                         ret.second);
 
   if (!buf.IsEmpty()) {
     args.GetReturnValue().Set(buf.ToLocalChecked());


### PR DESCRIPTION
With V8 8.3, the two APIs basically have feature parity, so
`AllocatedBuffer` can be turned into a wrapper around
`v8::BackingStore`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
