### PR TITLE
stream: Duplex forward writableObjectMode

### DIFF
--- a/lib/_stream_duplex.js
+++ b/lib/_stream_duplex.js
@@ -75,6 +75,8 @@ ObjectDefineProperties(Duplex.prototype, {
     ObjectGetOwnPropertyDescriptor(Writable.prototype, 'writable'),
   writableHighWaterMark:
     ObjectGetOwnPropertyDescriptor(Writable.prototype, 'writableHighWaterMark'),
+  writableObjectMode:
+    ObjectGetOwnPropertyDescriptor(Writable.prototype, 'writableObjectMode'),
   writableBuffer:
     ObjectGetOwnPropertyDescriptor(Writable.prototype, 'writableBuffer'),
   writableLength:

--- a/test/parallel/test-stream-duplex-props.js
+++ b/test/parallel/test-stream-duplex-props.js
@@ -1,0 +1,29 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const { Duplex } = require('stream');
+
+{
+  const d = new Duplex({ 
+    objectMode: true,
+    highWaterMark: 100
+  });
+
+  assert.strictEqual(d.writableObjectMode, true);
+  assert.strictEqual(d.writableHighWaterMark, 100);
+}
+
+{
+  const d = new Duplex({
+    readableObjectMode: false,
+    readableHighWaterMark: 10,
+    writableObjectMode: true,
+    writableHighWaterMark: 100
+  });
+
+  assert.strictEqual(d.writableObjectMode, true);
+  assert.strictEqual(d.writableHighWaterMark, 100);
+  assert.strictEqual(d.readableObjectMode, false);
+  assert.strictEqual(d.readableHighWaterMark, 10);
+}

--- a/test/parallel/test-stream-duplex-props.js
+++ b/test/parallel/test-stream-duplex-props.js
@@ -5,13 +5,15 @@ const assert = require('assert');
 const { Duplex } = require('stream');
 
 {
-  const d = new Duplex({ 
+  const d = new Duplex({
     objectMode: true,
     highWaterMark: 100
   });
 
   assert.strictEqual(d.writableObjectMode, true);
   assert.strictEqual(d.writableHighWaterMark, 100);
+  assert.strictEqual(d.readableObjectMode, true);
+  assert.strictEqual(d.readableHighWaterMark, 100);
 }
 
 {


### PR DESCRIPTION
Duplex did not properly forward writableObjectMode.

Fixes: https://github.com/nodejs/node/issues/33388

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
