### PR TITLE
worker: fix crash when .unref() is called during exit

### DIFF
--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -660,7 +660,7 @@ void Worker::StopThread(const FunctionCallbackInfo<Value>& args) {
 void Worker::Ref(const FunctionCallbackInfo<Value>& args) {
   Worker* w;
   ASSIGN_OR_RETURN_UNWRAP(&w, args.This());
-  if (!w->has_ref_) {
+  if (!w->has_ref_ && !w->thread_joined_) {
     w->has_ref_ = true;
     w->env()->add_refs(1);
   }
@@ -669,7 +669,7 @@ void Worker::Ref(const FunctionCallbackInfo<Value>& args) {
 void Worker::Unref(const FunctionCallbackInfo<Value>& args) {
   Worker* w;
   ASSIGN_OR_RETURN_UNWRAP(&w, args.This());
-  if (w->has_ref_) {
+  if (w->has_ref_ && !w->thread_joined_) {
     w->has_ref_ = false;
     w->env()->add_refs(-1);
   }

--- a/test/parallel/test-worker-unref-from-message-during-exit.js
+++ b/test/parallel/test-worker-unref-from-message-during-exit.js
@@ -2,6 +2,9 @@
 const common = require('../common');
 const { Worker } = require('worker_threads');
 
+// This used to crash because the `.unref()` was unexpected while the Worker
+// was exiting.
+
 const w = new Worker(`
 require('worker_threads').parentPort.postMessage({});
 `, { eval: true });

--- a/test/parallel/test-worker-unref-from-message-during-exit.js
+++ b/test/parallel/test-worker-unref-from-message-during-exit.js
@@ -1,0 +1,13 @@
+'use strict';
+const common = require('../common');
+const { Worker } = require('worker_threads');
+
+const w = new Worker(`
+require('worker_threads').parentPort.postMessage({});
+`, { eval: true });
+w.on('message', common.mustCall(() => {
+  w.unref();
+}));
+
+// Wait a bit so that the 'message' event is emitted while the Worker exits.
+Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 100);


### PR DESCRIPTION
To be more precise, fix a crash when `worker.unref()` is called
from a message on the Worker that is not emitted before the Worker
thread has stopped.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
