### PR TITLE
fs: readdir fails when libuv returns UV_DIRENT_UNKNOWN and the first arg is Buffer 

### DIFF
--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -177,7 +177,7 @@ const bufferSep = Buffer.from(pathModule.sep);
 
 function join(path, name) {
   if ((typeof path === 'string' || isUint8Array(path)) &&
-    name === undefined) {
+      name === undefined) {
     return path;
   }
 

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -173,6 +173,31 @@ function copyObject(source) {
   return target;
 }
 
+const bufferSep = Buffer.from(pathModule.sep);
+
+function join(path, name) {
+  if ((typeof path === 'string' || isUint8Array(path)) &&
+    name === undefined) {
+    return path;
+  }
+
+  if (typeof path === 'string' && isUint8Array(name)) {
+    const pathBuffer = Buffer.from(pathModule.join(path, pathModule.sep));
+    return Buffer.concat([pathBuffer, name]);
+  }
+
+  if (typeof path === 'string' && typeof name === 'string') {
+    return pathModule.join(path, name);
+  }
+
+  if (isUint8Array(path) && isUint8Array(name)) {
+    return Buffer.concat([path, bufferSep, name]);
+  }
+
+  throw new ERR_INVALID_ARG_TYPE(
+    'path', ['string', 'Buffer'], path);
+}
+
 function getDirents(path, [names, types], callback) {
   let i;
   if (typeof callback === 'function') {
@@ -185,7 +210,14 @@ function getDirents(path, [names, types], callback) {
         const name = names[i];
         const idx = i;
         toFinish++;
-        lazyLoadFs().lstat(pathModule.join(path, name), (err, stats) => {
+        let filepath;
+        try {
+          filepath = join(path, name);
+        } catch (err) {
+          callback(err);
+          return;
+        }
+        lazyLoadFs().lstat(filepath, (err, stats) => {
           if (err) {
             callback(err);
             return;
@@ -214,7 +246,14 @@ function getDirents(path, [names, types], callback) {
 function getDirent(path, name, type, callback) {
   if (typeof callback === 'function') {
     if (type === UV_DIRENT_UNKNOWN) {
-      lazyLoadFs().lstat(pathModule.join(path, name), (err, stats) => {
+      let filepath;
+      try {
+        filepath = join(path, name);
+      } catch (err) {
+        callback(err);
+        return;
+      }
+      lazyLoadFs().lstat(filepath, (err, stats) => {
         if (err) {
           callback(err);
           return;
@@ -225,7 +264,7 @@ function getDirent(path, name, type, callback) {
       callback(null, new Dirent(name, type));
     }
   } else if (type === UV_DIRENT_UNKNOWN) {
-    const stats = lazyLoadFs().lstatSync(pathModule.join(path, name));
+    const stats = lazyLoadFs().lstatSync(join(path, name));
     return new DirentFromStats(name, stats);
   } else {
     return new Dirent(name, type);

--- a/test/parallel/test-fs-readdir-buffer.js
+++ b/test/parallel/test-fs-readdir-buffer.js
@@ -2,8 +2,8 @@
 const fs = require('fs');
 
 const common = require('../common');
-if (common.isWindows) {
-    common.skip('windows doesnt support /dev');
+if (!common.isOSX) {
+    common.skip('this tests works only on MacOS');
 }
 
 const assert = require('assert');

--- a/test/parallel/test-fs-readdir-buffer.js
+++ b/test/parallel/test-fs-readdir-buffer.js
@@ -1,0 +1,17 @@
+'use strict';
+const fs = require('fs');
+
+const common = require('../common');
+if (common.isWindows) {
+    common.skip('windows doesnt support /dev');
+}
+
+const assert = require('assert');
+
+fs.readdir(
+    Buffer.from("/dev"),
+    {withFileTypes: true, encoding: "buffer"},
+    common.mustCall((e,d) => {
+        assert.strictEqual(e, null);
+    })
+);

--- a/test/parallel/test-fs-readdir-buffer.js
+++ b/test/parallel/test-fs-readdir-buffer.js
@@ -1,17 +1,17 @@
 'use strict';
+const common = require('../common');
 const fs = require('fs');
 
-const common = require('../common');
 if (!common.isOSX) {
-    common.skip('this tests works only on MacOS');
+  common.skip('this tests works only on MacOS');
 }
 
 const assert = require('assert');
 
 fs.readdir(
-    Buffer.from("/dev"),
-    {withFileTypes: true, encoding: "buffer"},
-    common.mustCall((e,d) => {
-        assert.strictEqual(e, null);
-    })
+  Buffer.from('/dev'),
+  { withFileTypes: true, encoding: 'buffer' },
+  common.mustCall((e, d) => {
+    assert.strictEqual(e, null);
+  })
 );

--- a/test/parallel/test-fs-utils-get-dirents.js
+++ b/test/parallel/test-fs-utils-get-dirents.js
@@ -1,11 +1,11 @@
 // Flags: --expose-internals
 'use strict';
 
-const { getDirent, getDirents } = require('internal/fs/utils');
+const common = require('../common');
+const { getDirents, getDirent } = require('internal/fs/utils');
 const assert = require('assert');
 const { internalBinding } = require('internal/test/binding');
 const { UV_DIRENT_UNKNOWN } = internalBinding('constants').fs;
-const common = require('../common');
 const fs = require('fs');
 const path = require('path');
 
@@ -13,29 +13,111 @@ const tmpdir = require('../common/tmpdir');
 const filename = 'foo';
 
 {
-    // setup
-    tmpdir.refresh();
-    fs.writeFileSync(path.join(tmpdir.path, filename), '')
+  // setup
+  tmpdir.refresh();
+  fs.writeFileSync(path.join(tmpdir.path, filename), '');
 }
+// getDirents
 {
-    // string + string
-    getDirents(
-        tmpdir.path,
-        [[filename], [UV_DIRENT_UNKNOWN]],
-        common.mustCall((err, names) => {
-            assert.strictEqual(err, null);
-            assert.strictEqual(names.length, 1);
-        },
+  // string + string
+  getDirents(
+    tmpdir.path,
+    [[filename], [UV_DIRENT_UNKNOWN]],
+    common.mustCall((err, names) => {
+      assert.strictEqual(err, null);
+      assert.strictEqual(names.length, 1);
+    },
     ));
 }
 {
-    // Buffer + string
-    getDirents(
-        Buffer.from(tmpdir.path),
-        [[filename], [UV_DIRENT_UNKNOWN]],
-        common.mustCall((err, names) => {
-            assert.strictEqual(err, null);
-            assert.strictEqual(names.length, 1);
-        },
+  // string + Buffer
+  getDirents(
+    tmpdir.path,
+    [[Buffer.from(filename)], [UV_DIRENT_UNKNOWN]],
+    common.mustCall((err, names) => {
+      assert.strictEqual(err, null);
+      assert.strictEqual(names.length, 1);
+    },
+    ));
+}
+{
+  // Buffer + Buffer
+  getDirents(
+    Buffer.from(tmpdir.path),
+    [[Buffer.from(filename)], [UV_DIRENT_UNKNOWN]],
+    common.mustCall((err, names) => {
+      assert.strictEqual(err, null);
+      assert.strictEqual(names.length, 1);
+    },
+    ));
+}
+{
+  // wrong combination
+  getDirents(
+    42,
+    [[Buffer.from(filename)], [UV_DIRENT_UNKNOWN]],
+    common.mustCall((err) => {
+      assert.strictEqual(
+        err.message,
+        [
+          'The "path" argument must be of type string or an ' +
+          'instance of Buffer. Received type number (42)'
+        ].join(''));
+    },
+    ));
+}
+// getDirent
+{
+  // string + string
+  getDirent(
+    tmpdir.path,
+    filename,
+    UV_DIRENT_UNKNOWN,
+    common.mustCall((err, dirent) => {
+      assert.strictEqual(err, null);
+      assert.strictEqual(dirent.name, filename);
+    },
+    ));
+}
+{
+  // string + Buffer
+  const filenameBuffer = Buffer.from(filename);
+  getDirent(
+    tmpdir.path,
+    filenameBuffer,
+    UV_DIRENT_UNKNOWN,
+    common.mustCall((err, dirent) => {
+      assert.strictEqual(err, null);
+      assert.strictEqual(dirent.name, filenameBuffer);
+    },
+    ));
+}
+{
+  // Buffer + Buffer
+  const filenameBuffer = Buffer.from(filename);
+  getDirent(
+    Buffer.from(tmpdir.path),
+    filenameBuffer,
+    UV_DIRENT_UNKNOWN,
+    common.mustCall((err, dirent) => {
+      assert.strictEqual(err, null);
+      assert.strictEqual(dirent.name, filenameBuffer);
+    },
+    ));
+}
+{
+  // wrong combination
+  getDirent(
+    42,
+    Buffer.from(filename),
+    UV_DIRENT_UNKNOWN,
+    common.mustCall((err) => {
+      assert.strictEqual(
+        err.message,
+        [
+          'The "path" argument must be of type string or an ' +
+          'instance of Buffer. Received type number (42)'
+        ].join(''));
+    },
     ));
 }

--- a/test/parallel/test-fs-utils-get-dirents.js
+++ b/test/parallel/test-fs-utils-get-dirents.js
@@ -1,0 +1,41 @@
+// Flags: --expose-internals
+'use strict';
+
+const { getDirent, getDirents } = require('internal/fs/utils');
+const assert = require('assert');
+const { internalBinding } = require('internal/test/binding');
+const { UV_DIRENT_UNKNOWN } = internalBinding('constants').fs;
+const common = require('../common');
+const fs = require('fs');
+const path = require('path');
+
+const tmpdir = require('../common/tmpdir');
+const filename = 'foo';
+
+{
+    // setup
+    tmpdir.refresh();
+    fs.writeFileSync(path.join(tmpdir.path, filename), '')
+}
+{
+    // string + string
+    getDirents(
+        tmpdir.path,
+        [[filename], [UV_DIRENT_UNKNOWN]],
+        common.mustCall((err, names) => {
+            assert.strictEqual(err, null);
+            assert.strictEqual(names.length, 1);
+        },
+    ));
+}
+{
+    // Buffer + string
+    getDirents(
+        Buffer.from(tmpdir.path),
+        [[filename], [UV_DIRENT_UNKNOWN]],
+        common.mustCall((err, names) => {
+            assert.strictEqual(err, null);
+            assert.strictEqual(names.length, 1);
+        },
+    ));
+}


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/33348

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
