### PR TITLE
lib: update executionAsyncId/triggerAsyncId comment

### DIFF
--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -41,11 +41,11 @@ const {
   execution_async_resources,
   owner_symbol
 } = async_wrap;
-// Store the pair executionAsyncId and triggerAsyncId in a std::stack on
-// Environment::AsyncHooks::async_ids_stack_ tracks the resource responsible for
-// the current execution stack. This is unwound as each resource exits. In the
-// case of a fatal exception this stack is emptied after calling each hook's
-// after() callback.
+// Store the pair executionAsyncId and triggerAsyncId in a AliasedFloat64Array
+// in Environment::AsyncHooks::async_ids_stack_ which tracks the resource
+// responsible for the current execution stack. This is unwound as each resource
+// exits. In the case of a fatal exception this stack is emptied after calling
+// each hook's after() callback.
 const {
   pushAsyncContext: pushAsyncContext_,
   popAsyncContext: popAsyncContext_


### PR DESCRIPTION
This commit updates the comment referring to the
executionAsyncId/triggerAsyncId pair being stored in a std::stack.

It looks like this was changed from std::stack to AliasedFloat64Array in
Commit 83e5215a4e8438a43b9f0002b7a43e2fd2dd37a4 ("async_hooks: use typed array stack as fast path").


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
