### PR TITLE
test: mark two WASI tests flaky on windows

### DIFF
--- a/test/wasi/wasi.status
+++ b/test/wasi/wasi.status
@@ -5,3 +5,11 @@ prefix wasi
 # sample-test                        : PASS,FLAKY
 
 [true] # This section applies to all platforms
+
+[$system==win32]
+# These tests have become flaky on Windows in the CI. The failures do not appear
+# to be consistent, or even in the same parts of the tests. They do seem to be
+# related to trying to open or stat files though.
+# https://github.com/nodejs/node/pull/33376#issuecomment-628049988
+test-wasi: PASS,FLAKY
+test-wasi-symlinks: PASS,FLAKY


### PR DESCRIPTION
These tests have become flaky on Windows in the CI. The failures do not appear to be consistent, or even in the same parts of the tests. They do seem to be related to trying to open or stat files though.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
