### PR TITLE
docs, errors, http, tests: fixed socket.setEncoding fatal error

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -934,6 +934,11 @@ An invalid HTTP header value was specified.
 
 Status code was outside the regular status code range (100-999).
 
+<a id="ERR_HTTP_SOCKET_ENCODING"></a>
+### `ERR_HTTP_SOCKET_ENCODING`
+
+Changing the socket encoding is not allowed per [RFC 7230 Section 3][].
+
 <a id="ERR_HTTP_TRAILER_INVALID"></a>
 ### `ERR_HTTP_TRAILER_INVALID`
 
@@ -2590,6 +2595,7 @@ such as `process.stdout.on('data')`.
 [exports]: esm.html#esm_package_entry_points
 [file descriptors]: https://en.wikipedia.org/wiki/File_descriptor
 [policy]: policy.html
+[RFC 7230 Section 3]: https://tools.ietf.org/html/rfc7230#section-3
 [stream-based]: stream.html
 [syscall]: http://man7.org/linux/man-pages/man2/syscalls.2.html
 [Subresource Integrity specification]: https://www.w3.org/TR/SRI/#the-integrity-attribute

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -63,6 +63,7 @@ const {
 const {
   ERR_HTTP_HEADERS_SENT,
   ERR_HTTP_INVALID_STATUS_CODE,
+  ERR_HTTP_SOCKET_ENCODING,
   ERR_INVALID_ARG_TYPE,
   ERR_INVALID_CHAR
 } = codes;
@@ -476,6 +477,7 @@ function connectionListenerInternal(server, socket) {
   socket.on = generateSocketListenerWrapper('on');
   socket.addListener = generateSocketListenerWrapper('addListener');
   socket.prependListener = generateSocketListenerWrapper('prependListener');
+  socket.setEncoding = socketSetEncoding;
 
   // We only consume the socket if it has never been consumed before.
   if (socket._handle && socket._handle.isStreamBase &&
@@ -491,6 +493,10 @@ function connectionListenerInternal(server, socket) {
     onParserTimeout.bind(undefined, server, socket);
 
   socket._paused = false;
+}
+
+function socketSetEncoding() {
+  throw new ERR_HTTP_SOCKET_ENCODING();
 }
 
 function updateOutgoingData(socket, state, delta) {

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -916,6 +916,8 @@ E('ERR_HTTP_HEADERS_SENT',
 E('ERR_HTTP_INVALID_HEADER_VALUE',
   'Invalid value "%s" for header "%s"', TypeError);
 E('ERR_HTTP_INVALID_STATUS_CODE', 'Invalid status code: %s', RangeError);
+E('ERR_HTTP_SOCKET_ENCODING',
+  'Changing the socket encoding is not allowed per RFC7230 Section 3.', Error);
 E('ERR_HTTP_TRAILER_INVALID',
   'Trailers are invalid with this transfer encoding', Error);
 E('ERR_INCOMPATIBLE_OPTION_PAIR',

--- a/test/parallel/test-http-socket-encoding-error.js
+++ b/test/parallel/test-http-socket-encoding-error.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+const server = http.createServer().listen(0, connectToServer);
+
+server.on('connection', common.mustCall((socket) => {
+  assert.throws(
+    () => {
+      socket.setEncoding('');
+    },
+    {
+      code: 'ERR_HTTP_SOCKET_ENCODING',
+      name: 'Error',
+      message: 'Changing the socket encoding is not ' +
+        'allowed per RFC7230 Section 3.'
+    }
+  );
+
+  socket.end();
+}));
+
+function connectToServer() {
+  const client = new http.Agent().createConnection(this.address().port, () => {
+    client.end();
+  }).on('end', () => server.close());
+}


### PR DESCRIPTION
applied updates from previous pull-requests to disallow
socket.setEncoding before a http connection is parsed.
wrapped socket.setEncoding to throw an error.
previously resulted in a fatal error

Fixes: nodejs#18118
Ref: nodejs#18178
Ref: nodejs#19344

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
