### PR TITLE
doc: fix esm extension example with type module

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -16,6 +16,7 @@ code for reuse. Modules are defined using a variety of [`import`][] and
 First, to enable modules in Node.js for `.js` extensions, ensure there is a
 `package.json` file in the root of the project with `"type": "module"` set:
 
+<!-- eslint-skip -->
 ```js
 // package.json
 {

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -13,6 +13,19 @@ ECMAScript modules are [the official standard format][] to package JavaScript
 code for reuse. Modules are defined using a variety of [`import`][] and
 [`export`][] statements.
 
+First, to enable modules in Node.js for `.js` extensions, ensure there is a
+`package.json` file in the root of the project with `"type": "module"` set:
+
+```js
+// package.json
+{
+  "name": "app",
+  "type": "module"
+}
+```
+
+> An alternative to setting `"type": "module" is to use the `.mjs` extension.
+
 The following example of an ES module exports a function:
 
 ```js


### PR DESCRIPTION
As an alternative to https://github.com/nodejs/node/pull/33408, fixing up the docs issue with the `"type": "module"` instructions, while still noting `.mjs`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
