### PR TITLE
src: remove unused misc variable

### DIFF
--- a/src/node_main_instance.cc
+++ b/src/node_main_instance.cc
@@ -39,8 +39,7 @@ NodeMainInstance::NodeMainInstance(Isolate* isolate,
   isolate_data_ =
       std::make_unique<IsolateData>(isolate_, event_loop, platform, nullptr);
 
-  IsolateSettings misc;
-  SetIsolateMiscHandlers(isolate_, misc);
+  SetIsolateMiscHandlers(isolate_, {});
 }
 
 std::unique_ptr<NodeMainInstance> NodeMainInstance::Create(

--- a/src/node_main_instance.cc
+++ b/src/node_main_instance.cc
@@ -190,8 +190,7 @@ NodeMainInstance::CreateMainEnvironment(int* exit_code) {
     context =
         Context::FromSnapshot(isolate_, kNodeContextIndex).ToLocalChecked();
     InitializeContextRuntime(context);
-    IsolateSettings s;
-    SetIsolateErrorHandlers(isolate_, s);
+    SetIsolateErrorHandlers(isolate_, {});
   } else {
     context = NewContext(isolate_);
   }


### PR DESCRIPTION
This commit removes the unused `misc` variable from one of the
`NodeMainInstance` constructors.

Another option could be to add a default argument to
`SetIsolateMiscHandlers` but I'd like to hear what others think about that
first.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
