### PR TITLE
util: add debugtest utility

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -136,6 +136,42 @@ let debuglog = util.debuglog('internals', (debug) => {
 });
 ```
 
+### `debuglog().enabled`
+<!-- YAML
+added: REPLACEME
+-->
+
+* {boolean}
+
+The `util.debuglog().enabled` getter is used to create a test that can be used
+in conditionals based on the existence of the `NODE_DEBUG` environment variable.
+If the `section` name appears within the value of that environment variable,
+then the returned value will be `true`. If not, then the returned value will be
+`false`.
+
+```js
+const util = require('util');
+const enabled = util.debuglog('foo').enabled;
+if (enabled) {
+  console.log('hello from foo [%d]', 123);
+}
+```
+
+If this program is run with `NODE_DEBUG=foo` in the environment, then it will
+output something like:
+
+```console
+hello from foo [123]
+```
+
+## `util.debug(section)`
+<!-- YAML
+added: REPLACEME
+-->
+
+Alias for `util.debuglog`. Usage allows for readability of that doesn't imply
+logging when only using `util.debuglog().enabled`.
+
 ## `util.deprecate(fn, msg[, code])`
 <!-- YAML
 added: v0.8.0

--- a/lib/internal/util/debuglog.js
+++ b/lib/internal/util/debuglog.js
@@ -1,20 +1,26 @@
 'use strict';
 
 const {
+  FunctionPrototypeBind,
+  ObjectCreate,
+  ObjectDefineProperty,
   RegExp,
+  RegExpPrototypeTest,
+  StringPrototypeToUpperCase
 } = primordials;
 
 const { inspect, format, formatWithOptions } = require('internal/util/inspect');
 
 // `debugs` is deliberately initialized to undefined so any call to
 // debuglog() before initializeDebugEnv() is called will throw.
-let debugs;
+let debugImpls;
 
 let debugEnvRegex = /^$/;
+let testEnabled;
 
 // `debugEnv` is initial value of process.env.NODE_DEBUG
 function initializeDebugEnv(debugEnv) {
-  debugs = {};
+  debugImpls = ObjectCreate(null);
   if (debugEnv) {
     debugEnv = debugEnv.replace(/[|\\{}()[\]^$+?.]/g, '\\$&')
       .replace(/\*/g, '.*')
@@ -22,6 +28,7 @@ function initializeDebugEnv(debugEnv) {
       .toUpperCase();
     debugEnvRegex = new RegExp(`^${debugEnv}$`, 'i');
   }
+  testEnabled = FunctionPrototypeBind(RegExpPrototypeTest, null, debugEnvRegex);
 }
 
 // Emits warning when user sets
@@ -37,23 +44,22 @@ function emitWarningIfNeeded(set) {
 
 function noop() {}
 
-function debuglogImpl(set) {
-  set = set.toUpperCase();
-  if (debugs[set] === undefined) {
-    if (debugEnvRegex.test(set)) {
+function debuglogImpl(enabled, set) {
+  if (debugImpls[set] === undefined) {
+    if (enabled) {
       const pid = process.pid;
       emitWarningIfNeeded(set);
-      debugs[set] = function debug(...args) {
+      debugImpls[set] = function debug(...args) {
         const colors = process.stderr.hasColors && process.stderr.hasColors();
         const msg = formatWithOptions({ colors }, ...args);
         const coloredPID = inspect(pid, { colors });
         process.stderr.write(format('%s %s: %s\n', set, coloredPID, msg));
       };
     } else {
-      debugs[set] = noop;
+      debugImpls[set] = noop;
     }
   }
-  return debugs[set];
+  return debugImpls[set];
 }
 
 // debuglogImpl depends on process.pid and process.env.NODE_DEBUG,
@@ -61,17 +67,34 @@ function debuglogImpl(set) {
 // that may be loaded before these run time states are allowed to
 // be accessed.
 function debuglog(set, cb) {
+  function init() {
+    set = StringPrototypeToUpperCase(set);
+    enabled = testEnabled(set);
+  }
   let debug = (...args) => {
+    init();
     // Only invokes debuglogImpl() when the debug function is
     // called for the first time.
-    debug = debuglogImpl(set);
+    debug = debuglogImpl(enabled, set);
     if (typeof cb === 'function')
       cb(debug);
     debug(...args);
   };
-  return (...args) => {
-    debug(...args);
+  let enabled;
+  let test = () => {
+    init();
+    test = () => enabled;
+    return enabled;
   };
+  const logger = (...args) => debug(...args);
+  ObjectDefineProperty(logger, 'enabled', {
+    get() {
+      return test();
+    },
+    configurable: true,
+    enumerable: true
+  });
+  return logger;
 }
 
 module.exports = {

--- a/lib/util.js
+++ b/lib/util.js
@@ -239,6 +239,7 @@ module.exports = {
   _exceptionWithHostPort: exceptionWithHostPort,
   _extend,
   callbackify,
+  debug: debuglog,
   debuglog,
   deprecate,
   format,

--- a/test/sequential/test-util-debug.js
+++ b/test/sequential/test-util-debug.js
@@ -57,7 +57,7 @@ function parent() {
 
 function test(environ, shouldWrite, section, forceColors = false) {
   let expectErr = '';
-  const expectOut = 'ok\n';
+  const expectOut = shouldWrite ? 'enabled\n' : 'disabled\n';
 
   const spawn = require('child_process').spawn;
   const child = spawn(process.execPath, [__filename, 'child', section], {
@@ -123,5 +123,5 @@ function child(section) {
   }));
   debug('this', { is: 'a' }, /debugging/);
   debug('num=%d str=%s obj=%j', 1, 'a', { foo: 'bar' });
-  console.log('ok');
+  console.log(debug.enabled ? 'enabled' : 'disabled');
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Currently we have a `debuglog` utility to allow logging when debugging. This PR introduces a corollary `debugtest` utility to see if something is being debugged rather than logging. This would allow people using `debuglog` style conditional debugging to avoid doing unnecessary work such as creating strings etc. For example:

```mjs
const debug = debuglog('foo');
debug(`${obj}`);
```

Would always stringify the object, even if `foo` is not being debugged. Additionally, it would allow branching to add additional debugging logic that may be undesirable when not debugging. For example:

```mjs
const debug = debugtest('foo');
class Foo {
  #bar;
  // ...
  get _bar() {
    if (debug) return this.#bar;
  }
  set _bar(v) {
    if (debug) return this.#bar = v;
  }
}
```