### PR TITLE
worker: fix race condition in node_messaging.cc

### DIFF
--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -464,8 +464,7 @@ void MessagePortData::Disentangle() {
 }
 
 MessagePort::~MessagePort() {
-  if (data_)
-    data_->owner_ = nullptr;
+  if (data_) Detach();
 }
 
 MessagePort::MessagePort(Environment* env,
@@ -662,10 +661,9 @@ void MessagePort::OnMessage() {
 void MessagePort::OnClose() {
   Debug(this, "MessagePort::OnClose()");
   if (data_) {
-    data_->owner_ = nullptr;
-    data_->Disentangle();
+    // Detach() returns move(data_).
+    Detach()->Disentangle();
   }
-  data_.reset();
 }
 
 std::unique_ptr<MessagePortData> MessagePort::Detach() {


### PR DESCRIPTION
`AddToIncomingQueue()` relies on `owner_` only being modified with
`mutex_` being locked, but in these two places, that didn’t happen.

Modify them to use `Detach()` instead, which has the same effect
as setting `owner_ = nullptr` here, but does it with proper locking.

This race condition probably only shows up in practice when Node.js
is compiled in debug mode, because the compiler eliminates the
duplicate load in `AddToIncomingQueue()` when compiling with
optimizations enabled.

(The other side of the race condition happens here:

https://github.com/nodejs/node/blob/48b159562d1dfcf005d3f91b0bfdf10206ce2557/src/node_messaging.cc#L430-L433

)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
