### PR TITLE
doc: add comment about highWaterMark limit

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -93,6 +93,11 @@ A key goal of the `stream` API, particularly the [`stream.pipe()`][] method,
 is to limit the buffering of data to acceptable levels such that sources and
 destinations of differing speeds will not overwhelm the available memory.
 
+The `highWaterMark` option is a threshold, not a limit: it dictates the amount
+of data that a stream buffers before it stops asking for more data. It does not
+enforce a strict memory limitation in general. Specific stream implementations
+may choose to enforce stricter limits but doing so is optional.
+
 Because [`Duplex`][] and [`Transform`][] streams are both `Readable` and
 `Writable`, each maintains *two* separate internal buffers used for reading and
 writing, allowing each side to operate independently of the other while


### PR DESCRIPTION
Add a comment regarding memory limits and setting `highWaterMark`

See https://github.com/nodejs/node/pull/33387#issuecomment-629377778 and https://github.com/nodejs/node/pull/33387#issuecomment-629533171 @nodejs/streams 

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
