### PR TITLE
repl: support optional chaining during autocompletion

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1066,7 +1066,7 @@ REPLServer.prototype.turnOffEditorMode = deprecate(
 const requireRE = /\brequire\s*\(\s*['"`](([\w@./-]+\/)?(?:[\w@./-]*))(?![^'"`])$/;
 const fsAutoCompleteRE = /fs(?:\.promises)?\.\s*[a-z][a-zA-Z]+\(\s*["'](.*)/;
 const simpleExpressionRE =
-    /(?:[a-zA-Z_$](?:\w|\$)*\.)*[a-zA-Z_$](?:\w|\$)*\.?$/;
+    /(?:[a-zA-Z_$](?:\w|\$)*\??\.)*[a-zA-Z_$](?:\w|\$)*\??\.?$/;
 
 function isIdentifier(str) {
   if (str === '') {
@@ -1138,7 +1138,7 @@ function complete(line, callback) {
   line = line.trimLeft();
 
   // REPL commands (e.g. ".break").
-  let filter;
+  let filter = '';
   if (/^\s*\.(\w*)$/.test(line)) {
     completionGroups.push(ObjectKeys(this.commands));
     completeOn = line.match(/^\s*\.(\w*)$/)[1];
@@ -1253,10 +1253,8 @@ function complete(line, callback) {
     let expr;
     completeOn = (match ? match[0] : '');
     if (line.length === 0) {
-      filter = '';
       expr = '';
     } else if (line[line.length - 1] === '.') {
-      filter = '';
       expr = match[0].slice(0, match[0].length - 1);
     } else {
       const bits = match[0].split('.');
@@ -1283,6 +1281,12 @@ function complete(line, callback) {
       if (filter !== '') addCommonWords(completionGroups);
       completionGroupsLoaded();
       return;
+    }
+
+    let chaining = '.';
+    if (expr[expr.length - 1] === '?') {
+      expr = expr.slice(0, -1);
+      chaining = '?.';
     }
 
     const evalExpr = `try { ${expr} } catch {}`;
@@ -1316,12 +1320,12 @@ function complete(line, callback) {
       }
 
       if (memberGroups.length) {
-        for (let i = 0; i < memberGroups.length; i++) {
-          completionGroups.push(
-            memberGroups[i].map((member) => `${expr}.${member}`));
+        expr += chaining;
+        for (const group of memberGroups) {
+          completionGroups.push(group.map((member) => `${expr}${member}`));
         }
         if (filter) {
-          filter = `${expr}.${filter}`;
+          filter = `${expr}${filter}`;
         }
       }
 

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1111,12 +1111,10 @@ REPLServer.prototype.complete = function() {
   this.completer.apply(this, arguments);
 };
 
-function gracefulOperation(fn, args, alternative) {
+function gracefulReaddir(...args) {
   try {
-    return fn(...args);
-  } catch {
-    return alternative;
-  }
+    return fs.readdirSync(...args);
+  } catch {}
 }
 
 // Provide a list of completions for the given leading text. This is
@@ -1145,8 +1143,6 @@ function complete(line, callback) {
     if (completeOn.length) {
       filter = completeOn;
     }
-
-    completionGroupsLoaded();
   } else if (requireRE.test(line)) {
     // require('...<Tab>')
     const extensions = ObjectKeys(this.context.require.extensions);
@@ -1173,11 +1169,7 @@ function complete(line, callback) {
 
     for (let dir of paths) {
       dir = path.resolve(dir, subdir);
-      const dirents = gracefulOperation(
-        fs.readdirSync,
-        [dir, { withFileTypes: true }],
-        []
-      );
+      const dirents = gracefulReaddir(dir, { withFileTypes: true }) || [];
       for (const dirent of dirents) {
         if (versionedFileNamesRe.test(dirent.name) || dirent.name === '.npm') {
           // Exclude versioned names that 'npm' installs.
@@ -1193,7 +1185,7 @@ function complete(line, callback) {
         }
         group.push(`${subdir}${dirent.name}/`);
         const absolute = path.resolve(dir, dirent.name);
-        const subfiles = gracefulOperation(fs.readdirSync, [absolute], []);
+        const subfiles = gracefulReaddir(absolute) || [];
         for (const subfile of subfiles) {
           if (indexes.includes(subfile)) {
             group.push(`${subdir}${dirent.name}`);
@@ -1209,31 +1201,22 @@ function complete(line, callback) {
     if (!subdir) {
       completionGroups.push(_builtinLibs);
     }
-
-    completionGroupsLoaded();
   } else if (fsAutoCompleteRE.test(line)) {
-    filter = '';
+    let baseName = '';
     let filePath = line.match(fsAutoCompleteRE)[1];
-    let fileList;
+    let fileList = gracefulReaddir(filePath, { withFileTypes: true });
 
-    try {
-      fileList = fs.readdirSync(filePath, { withFileTypes: true });
-      completionGroups.push(fileList.map((dirent) => dirent.name));
-      completeOn = '';
-    } catch {
-      try {
-        const baseName = path.basename(filePath);
-        filePath = path.dirname(filePath);
-        fileList = fs.readdirSync(filePath, { withFileTypes: true });
-        const filteredValue = fileList.filter((d) =>
-          d.name.startsWith(baseName))
-          .map((d) => d.name);
-        completionGroups.push(filteredValue);
-        completeOn = baseName;
-      } catch {}
+    if (!fileList) {
+      baseName = path.basename(filePath);
+      filePath = path.dirname(filePath);
+      fileList = gracefulReaddir(filePath, { withFileTypes: true }) || [];
     }
 
-    completionGroupsLoaded();
+    const filteredValue = fileList
+      .filter((dirent) => dirent.name.startsWith(baseName))
+      .map((d) => d.name);
+    completionGroups.push(filteredValue);
+    completeOn = baseName;
   // Handle variable member lookup.
   // We support simple chained expressions like the following (no function
   // calls, etc.). That is for simplicity and also because we *eval* that
@@ -1291,32 +1274,26 @@ function complete(line, callback) {
 
     const evalExpr = `try { ${expr} } catch {}`;
     this.eval(evalExpr, this.context, 'repl', (e, obj) => {
-      if (obj != null) {
-        if (typeof obj === 'object' || typeof obj === 'function') {
-          try {
-            memberGroups.push(filteredOwnPropertyNames(obj));
-          } catch {
-            // Probably a Proxy object without `getOwnPropertyNames` trap.
-            // We simply ignore it here, as we don't want to break the
-            // autocompletion. Fixes the bug
-            // https://github.com/nodejs/node/issues/2119
-          }
+      try {
+        let p;
+        if ((typeof obj === 'object' && obj !== null) ||
+            typeof obj === 'function') {
+          memberGroups.push(filteredOwnPropertyNames(obj));
+          p = ObjectGetPrototypeOf(obj);
+        } else {
+          p = obj.constructor ? obj.constructor.prototype : null;
         }
-        // Works for non-objects
-        try {
-          let p;
-          if (typeof obj === 'object' || typeof obj === 'function') {
-            p = ObjectGetPrototypeOf(obj);
-          } else {
-            p = obj.constructor ? obj.constructor.prototype : null;
-          }
-          // Circular refs possible? Let's guard against that.
-          let sentinel = 5;
-          while (p !== null && sentinel-- !== 0) {
-            memberGroups.push(filteredOwnPropertyNames(p));
-            p = ObjectGetPrototypeOf(p);
-          }
-        } catch {}
+        // Circular refs possible? Let's guard against that.
+        let sentinel = 5;
+        while (p !== null && sentinel-- !== 0) {
+          memberGroups.push(filteredOwnPropertyNames(p));
+          p = ObjectGetPrototypeOf(p);
+        }
+      } catch {
+        // Maybe a Proxy object without `getOwnPropertyNames` trap.
+        // We simply ignore it here, as we don't want to break the
+        // autocompletion. Fixes the bug
+        // https://github.com/nodejs/node/issues/2119
       }
 
       if (memberGroups.length) {
@@ -1331,9 +1308,10 @@ function complete(line, callback) {
 
       completionGroupsLoaded();
     });
-  } else {
-    completionGroupsLoaded();
+    return;
   }
+
+  return completionGroupsLoaded();
 
   // Will be called when all completionGroups are in place
   // Useful for async autocompletion
@@ -1341,11 +1319,10 @@ function complete(line, callback) {
     // Filter, sort (within each group), uniq and merge the completion groups.
     if (completionGroups.length && filter) {
       const newCompletionGroups = [];
-      for (let i = 0; i < completionGroups.length; i++) {
-        group = completionGroups[i]
-          .filter((elem) => elem.indexOf(filter) === 0);
-        if (group.length) {
-          newCompletionGroups.push(group);
+      for (const group of completionGroups) {
+        const filteredGroup = group.filter((e) => e.indexOf(filter) === 0);
+        if (filteredGroup.length) {
+          newCompletionGroups.push(filteredGroup);
         }
       }
       completionGroups = newCompletionGroups;

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1117,6 +1117,24 @@ function gracefulReaddir(...args) {
   } catch {}
 }
 
+function completeFSFunctions(line) {
+  let baseName = '';
+  let filePath = line.match(fsAutoCompleteRE)[1];
+  let fileList = gracefulReaddir(filePath, { withFileTypes: true });
+
+  if (!fileList) {
+    baseName = path.basename(filePath);
+    filePath = path.dirname(filePath);
+    fileList = gracefulReaddir(filePath, { withFileTypes: true }) || [];
+  }
+
+  const completions = fileList
+    .filter((dirent) => dirent.name.startsWith(baseName))
+    .map((d) => d.name);
+
+  return [[completions], baseName];
+}
+
 // Provide a list of completions for the given leading text. This is
 // given to the readline interface for handling tab completion.
 //
@@ -1202,21 +1220,7 @@ function complete(line, callback) {
       completionGroups.push(_builtinLibs);
     }
   } else if (fsAutoCompleteRE.test(line)) {
-    let baseName = '';
-    let filePath = line.match(fsAutoCompleteRE)[1];
-    let fileList = gracefulReaddir(filePath, { withFileTypes: true });
-
-    if (!fileList) {
-      baseName = path.basename(filePath);
-      filePath = path.dirname(filePath);
-      fileList = gracefulReaddir(filePath, { withFileTypes: true }) || [];
-    }
-
-    const filteredValue = fileList
-      .filter((dirent) => dirent.name.startsWith(baseName))
-      .map((d) => d.name);
-    completionGroups.push(filteredValue);
-    completeOn = baseName;
+    [completionGroups, completeOn] = completeFSFunctions(line);
   // Handle variable member lookup.
   // We support simple chained expressions like the following (no function
   // calls, etc.). That is for simplicity and also because we *eval* that
@@ -1228,25 +1232,22 @@ function complete(line, callback) {
   //   foo<|>         # all scope vars with filter 'foo'
   //   foo.<|>        # completions for 'foo' with filter ''
   } else if (line.length === 0 || /\w|\.|\$/.test(line[line.length - 1])) {
-    const match = simpleExpressionRE.exec(line);
+    const [match] = simpleExpressionRE.exec(line) || [''];
     if (line.length !== 0 && !match) {
       completionGroupsLoaded();
       return;
     }
-    let expr;
-    completeOn = (match ? match[0] : '');
-    if (line.length === 0) {
-      expr = '';
-    } else if (line[line.length - 1] === '.') {
-      expr = match[0].slice(0, match[0].length - 1);
-    } else {
-      const bits = match[0].split('.');
+    let expr = '';
+    completeOn = match;
+    if (line.endsWith('.')) {
+      expr = match.slice(0, -1);
+    } else if (line.length !== 0) {
+      const bits = match.split('.');
       filter = bits.pop();
       expr = bits.join('.');
     }
 
     // Resolve expr and get its completions.
-    const memberGroups = [];
     if (!expr) {
       // Get global vars synchronously
       completionGroups.push(getGlobalLexicalScopeNames(this[kContextId]));
@@ -1267,11 +1268,12 @@ function complete(line, callback) {
     }
 
     let chaining = '.';
-    if (expr[expr.length - 1] === '?') {
+    if (expr.endsWith('?')) {
       expr = expr.slice(0, -1);
       chaining = '?.';
     }
 
+    const memberGroups = [];
     const evalExpr = `try { ${expr} } catch {}`;
     this.eval(evalExpr, this.context, 'repl', (e, obj) => {
       try {
@@ -1320,7 +1322,7 @@ function complete(line, callback) {
     if (completionGroups.length && filter) {
       const newCompletionGroups = [];
       for (const group of completionGroups) {
-        const filteredGroup = group.filter((e) => e.indexOf(filter) === 0);
+        const filteredGroup = group.filter((str) => str.startsWith(filter));
         if (filteredGroup.length) {
           newCompletionGroups.push(filteredGroup);
         }

--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -68,6 +68,19 @@ testMe.complete('console.lo', common.mustCall(function(error, data) {
   assert.deepStrictEqual(data, [['console.log'], 'console.lo']);
 }));
 
+testMe.complete('console?.lo', common.mustCall((error, data) => {
+  assert.deepStrictEqual(data, [['console?.log'], 'console?.lo']);
+}));
+
+testMe.complete('console?.zzz', common.mustCall((error, data) => {
+  assert.deepStrictEqual(data, [[], 'console?.zzz']);
+}));
+
+testMe.complete('console?.', common.mustCall((error, data) => {
+  assert(data[0].includes('console?.log'));
+  assert.strictEqual(data[1], 'console?.');
+}));
+
 // Tab Complete will return globally scoped variables
 putIn.run(['};']);
 testMe.complete('inner.o', common.mustCall(function(error, data) {


### PR DESCRIPTION
##### repl: support optional chaining during autocompletion

This makes sure the autocompletion is able to handle optional
chaining notations.

##### repl: simplify repl autocompletion

This refactors the repl autocompletion code for simplicity and
readability.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
