### PR TITLE
src: add default: case to silence compiler warning

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -243,7 +243,7 @@ static void AtomicsWaitCallback(Isolate::AtomicsWaitEvent event,
                                 void* data) {
   Environment* env = static_cast<Environment*>(data);
 
-  const char* message;
+  const char* message = "(unknown event)";
   switch (event) {
 #define V(key, msg)                         \
     case Isolate::AtomicsWaitEvent::key:    \


### PR DESCRIPTION
This fails compilation on at least one platform because there is no
`default:` case, despite all currently possible enum values being
listed.

Fix that by adding a default message that won’t be used unless V8
introduces new enum values.

Refs: https://github.com/nodejs/node/commit/c7eeef568ce5a3714b89689160ec85c017527364#commitcomment-39228519

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
