### PR TITLE
worker: perform initial port.unref() before preload modules

### DIFF
--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -92,6 +92,7 @@ if (process.env.NODE_CHANNEL_FD) {
 
 port.on('message', (message) => {
   if (message.type === LOAD_SCRIPT) {
+    port.unref();
     const {
       argv,
       cwdCounter,
@@ -145,7 +146,6 @@ port.on('message', (message) => {
 
     debug(`[${threadId}] starts worker script ${filename} ` +
           `(eval = ${eval}) at cwd = ${process.cwd()}`);
-    port.unref();
     port.postMessage({ type: UP_AND_RUNNING });
     if (doEval) {
       const { evalScript } = require('internal/process/execution');

--- a/test/parallel/test-worker-stdio-from-preload-module.js
+++ b/test/parallel/test-worker-stdio-from-preload-module.js
@@ -1,0 +1,20 @@
+'use strict';
+const common = require('../common');
+const fixtures = require('../common/fixtures');
+const { Worker } = require('worker_threads');
+const assert = require('assert');
+
+// Regression test for https://github.com/nodejs/node/issues/31777:
+// stdio operations coming from preload modules should count towards the
+// ref count of the internal communication port on the Worker side.
+
+for (let i = 0; i < 10; i++) {
+  const w = new Worker('console.log("B");', {
+    execArgv: ['--require', fixtures.path('printA.js')],
+    eval: true,
+    stdout: true
+  });
+  w.on('exit', common.mustCall(() => {
+    assert.strictEqual(w.stdout.read().toString(), 'A\nB\n');
+  }));
+}


### PR DESCRIPTION
The refcount of the internal communication port is relevant for
stdio, but the `port.unref()` call effectively resets any `.ref()`
calls happening during stdio operations happening before it.

Therefore, do the `.unref()` call before loading preload modules,
which may cause stdio operations.

Fixes: https://github.com/nodejs/node/issues/31777

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
