### PR TITLE
src: use MaybeLocal.ToLocal instead of IsEmpty

### DIFF
--- a/src/node_native_module.cc
+++ b/src/node_native_module.cc
@@ -292,14 +292,14 @@ MaybeLocal<Function> NativeModuleLoader::LookupAndCompile(
 
   // This could fail when there are early errors in the native modules,
   // e.g. the syntax errors
-  if (maybe_fun.IsEmpty()) {
+  Local<Function> fun;
+  if (!maybe_fun.ToLocal(&fun)) {
     // In the case of early errors, v8 is already capable of
     // decorating the stack for us - note that we use CompileFunctionInContext
     // so there is no need to worry about wrappers.
     return MaybeLocal<Function>();
   }
 
-  Local<Function> fun = maybe_fun.ToLocalChecked();
   // XXX(joyeecheung): this bookkeeping is not exactly accurate because
   // it only starts after the Environment is created, so the per_context.js
   // will never be in any of these two sets, but the two sets are only for


### PR DESCRIPTION
This commit suggest using `MaybeLocal.ToLocal` and passing in the
`Local<Function> fun`.

The motivation for doing this is that the following
`MaybeLocal.ToLocalChecked` call can then be avoided.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
