### PR TITLE
repl: simplify internal repl

### DIFF
--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -555,6 +555,10 @@ A list of the names of all Node.js modules, e.g., `'http'`.
 <!-- YAML
 added: v0.1.91
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/33461
+    description: The `NODE_REPL_MODE` environment variable now accounts for
+                 all repl instances.
   - version:
      - v13.4.0
      - v12.17.0

--- a/lib/internal/main/repl.js
+++ b/lib/internal/main/repl.js
@@ -35,21 +35,7 @@ if (process.env.NODE_REPL_EXTERNAL_MODULE) {
   console.log(`Welcome to Node.js ${process.version}.\n` +
     'Type ".help" for more information.');
 
-  const cliRepl = require('internal/repl');
-  cliRepl.createInternalRepl(process.env, (err, repl) => {
-    if (err) {
-      throw err;
-    }
-    repl.on('exit', () => {
-      if (repl._flushing) {
-        repl.pause();
-        return repl.once('flushHistory', () => {
-          process.exit();
-        });
-      }
-      process.exit();
-    });
-  });
+  require('internal/repl').createInternalRepl();
 
   // If user passed '-e' or '--eval' along with `-i` or `--interactive`,
   // evaluate the code in the current context.

--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -3,44 +3,21 @@
 const {
   Number,
   NumberIsNaN,
-  ObjectCreate,
 } = primordials;
 
 const REPL = require('repl');
 const { kStandaloneREPL } = require('internal/repl/utils');
 
-module.exports = ObjectCreate(REPL);
-module.exports.createInternalRepl = createRepl;
-
-function createRepl(env, opts, cb) {
-  if (typeof opts === 'function') {
-    cb = opts;
-    opts = null;
-  }
+function createInternalRepl(opts = {}, callback = () => {}) {
   opts = {
     [kStandaloneREPL]: true,
-    ignoreUndefined: false,
     useGlobal: true,
     breakEvalOnSigint: true,
-    ...opts
+    ...opts,
+    terminal: parseInt(process.env.NODE_NO_READLINE) ? false : opts.terminal,
   };
 
-  if (parseInt(env.NODE_NO_READLINE)) {
-    opts.terminal = false;
-  }
-
-  if (env.NODE_REPL_MODE) {
-    opts.replMode = {
-      'strict': REPL.REPL_MODE_STRICT,
-      'sloppy': REPL.REPL_MODE_SLOPPY
-    }[env.NODE_REPL_MODE.toLowerCase().trim()];
-  }
-
-  if (opts.replMode === undefined) {
-    opts.replMode = REPL.REPL_MODE_SLOPPY;
-  }
-
-  const historySize = Number(env.NODE_REPL_HISTORY_SIZE);
+  const historySize = Number(process.env.NODE_REPL_HISTORY_SIZE);
   if (!NumberIsNaN(historySize) && historySize > 0) {
     opts.historySize = historySize;
   } else {
@@ -48,6 +25,13 @@ function createRepl(env, opts, cb) {
   }
 
   const repl = REPL.start(opts);
-  const term = 'terminal' in opts ? opts.terminal : process.stdout.isTTY;
-  repl.setupHistory(term ? env.NODE_REPL_HISTORY : '', cb);
+  const historyPath = repl.terminal ? process.env.NODE_REPL_HISTORY : '';
+  repl.setupHistory(historyPath, (err, repl) => {
+    if (err) {
+      throw err;
+    }
+    callback(repl);
+  });
 }
+
+module.exports = { createInternalRepl };

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -113,6 +113,7 @@ const {
   setupPreview,
   setupReverseSearch,
 } = require('internal/repl/utils');
+const { hasColors } = require('internal/tty');
 const {
   getOwnNonIndexProperties,
   propertyFilter: {
@@ -211,8 +212,8 @@ function REPLServer(prompt,
     // If possible, check if stdout supports colors or not.
     if (options.output.hasColors) {
       options.useColors = options.output.hasColors();
-    } else if (process.env.NODE_DISABLE_COLORS === undefined) {
-      options.useColors = true;
+    } else {
+      options.useColors = hasColors();
     }
   }
 
@@ -257,7 +258,6 @@ function REPLServer(prompt,
   this._domain = options.domain || domain.create();
   this.useGlobal = !!useGlobal;
   this.ignoreUndefined = !!ignoreUndefined;
-  this.replMode = replMode || module.exports.REPL_MODE_SLOPPY;
   this.underscoreAssigned = false;
   this.last = undefined;
   this.underscoreErrAssigned = false;
@@ -266,6 +266,11 @@ function REPLServer(prompt,
   this.editorMode = false;
   // Context id for use with the inspector protocol.
   this[kContextId] = undefined;
+
+  this.replMode = replMode ||
+    (/^\s*strict\s*$/i.test(process.env.NODE_REPL_MODE) ?
+      module.exports.REPL_MODE_STRICT :
+      module.exports.REPL_MODE_SLOPPY);
 
   if (this.breakEvalOnSigint && eval_) {
     // Allowing this would not reflect user expectations.

--- a/test/parallel/test-repl-colors.js
+++ b/test/parallel/test-repl-colors.js
@@ -20,6 +20,7 @@ inout._write = function(s, _, cb) {
 
 const repl = new REPLServer({ input: inout, output: inout, useColors: true });
 inout.isTTY = true;
+inout.hasColors = () => true;
 const repl2 = new REPLServer({ input: inout, output: inout });
 
 process.on('exit', function() {

--- a/test/parallel/test-repl-history-navigation.js
+++ b/test/parallel/test-repl-history-navigation.js
@@ -521,6 +521,8 @@ function cleanupTmpFile() {
   return true;
 }
 
+const originalEnv = process.env;
+
 function runTest() {
   const opts = tests.shift();
   if (!opts) return; // All done
@@ -535,7 +537,9 @@ function runTest() {
   const lastChunks = [];
   let i = 0;
 
-  REPL.createInternalRepl(opts.env, {
+  process.env = { ...originalEnv, ...opts.env };
+
+  REPL.createInternalRepl({
     input: new ActionStream(),
     output: new stream.Writable({
       write(chunk, _, next) {
@@ -570,12 +574,7 @@ function runTest() {
     useColors: false,
     preview: opts.preview,
     terminal: true
-  }, function(err, repl) {
-    if (err) {
-      console.error(`Failed test # ${numtests - tests.length}`);
-      throw err;
-    }
-
+  }, function(repl) {
     repl.once('close', () => {
       if (opts.clean)
         cleanupTmpFile();

--- a/test/parallel/test-repl-history-perm.js
+++ b/test/parallel/test-repl-history-perm.js
@@ -35,9 +35,7 @@ const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 const replHistoryPath = path.join(tmpdir.path, '.node_repl_history');
 
-const checkResults = common.mustCall(function(err, r) {
-  assert.ifError(err);
-
+const checkResults = common.mustCall((repl) => {
   const stat = fs.statSync(replHistoryPath);
   const fileMode = stat.mode & 0o777;
   assert.strictEqual(
@@ -45,12 +43,13 @@ const checkResults = common.mustCall(function(err, r) {
     `REPL history file should be mode 0600 but was 0${fileMode.toString(8)}`);
 
   // Close the REPL
-  r.input.emit('keypress', '', { ctrl: true, name: 'd' });
-  r.input.end();
+  repl.input.emit('keypress', '', { ctrl: true, name: 'd' });
+  repl.input.end();
 });
 
+process.env.NODE_REPL_HISTORY = replHistoryPath;
+
 repl.createInternalRepl(
-  { NODE_REPL_HISTORY: replHistoryPath },
   {
     terminal: true,
     input: stream,

--- a/test/parallel/test-repl-options.js
+++ b/test/parallel/test-repl-options.js
@@ -42,6 +42,7 @@ common.expectWarning({
 
 // Create a dummy stream that does nothing
 const stream = new ArrayStream();
+stream.hasColors = () => true;
 
 // 1, mostly defaults
 const r1 = repl.start({

--- a/test/parallel/test-repl-reverse-search.js
+++ b/test/parallel/test-repl-reverse-search.js
@@ -282,6 +282,9 @@ function cleanupTmpFile() {
   return true;
 }
 
+
+const originalEnv = { ...process.env };
+
 function runTest() {
   const opts = tests.shift();
   if (!opts) return; // All done
@@ -297,7 +300,9 @@ function runTest() {
   const lastChunks = [];
   let i = 0;
 
-  REPL.createInternalRepl(opts.env, {
+  process.env = { ...originalEnv, ...opts.env };
+
+  REPL.createInternalRepl({
     input: new ActionStream(),
     output: new stream.Writable({
       write(chunk, _, next) {
@@ -330,12 +335,7 @@ function runTest() {
     prompt,
     useColors: opts.useColors || false,
     terminal: true
-  }, function(err, repl) {
-    if (err) {
-      console.error(`Failed test # ${numtests - tests.length}`);
-      throw err;
-    }
-
+  }, function(repl) {
     repl.once('close', () => {
       if (opts.clean)
         cleanupTmpFile();

--- a/test/parallel/test-repl-use-global.js
+++ b/test/parallel/test-repl-use-global.js
@@ -14,23 +14,19 @@ const globalTestCases = [
   [undefined, 'undefined']
 ];
 
-const globalTest = (useGlobal, cb, output) => (err, repl) => {
-  if (err)
-    return cb(err);
-
+const globalTest = (cb, output) => (repl) => {
   let str = '';
   output.on('data', (data) => (str += data));
   global.lunch = 'tacos';
   repl.write('global.lunch;\n');
   repl.close();
   delete global.lunch;
-  cb(null, str.trim());
+  cb(str.trim());
 };
 
 // Test how the global object behaves in each state for useGlobal
 for (const [option, expected] of globalTestCases) {
-  runRepl(option, globalTest, common.mustCall((err, output) => {
-    assert.ifError(err);
+  runRepl(option, globalTest, common.mustCall((output) => {
     assert.strictEqual(output, expected);
   }));
 }
@@ -43,10 +39,7 @@ for (const [option, expected] of globalTestCases) {
 // suite is aware of it, causing a failure to be flagged.
 //
 const processTestCases = [false, undefined];
-const processTest = (useGlobal, cb, output) => (err, repl) => {
-  if (err)
-    return cb(err);
-
+const processTest = (cb, output) => (repl) => {
   let str = '';
   output.on('data', (data) => (str += data));
 
@@ -54,12 +47,11 @@ const processTest = (useGlobal, cb, output) => (err, repl) => {
   repl.write('let process;\n');
   repl.write('21 * 2;\n');
   repl.close();
-  cb(null, str.trim());
+  cb(str.trim());
 };
 
 for (const option of processTestCases) {
-  runRepl(option, processTest, common.mustCall((err, output) => {
-    assert.ifError(err);
+  runRepl(option, processTest, common.mustCall((output) => {
     assert.strictEqual(output, 'undefined\n42');
   }));
 }
@@ -76,8 +68,5 @@ function runRepl(useGlobal, testFunc, cb) {
     prompt: ''
   };
 
-  repl.createInternalRepl(
-    process.env,
-    opts,
-    testFunc(useGlobal, cb, opts.output));
+  repl.createInternalRepl(opts, testFunc(cb, opts.output));
 }


### PR DESCRIPTION
##### repl: always check for NODE_REPL_MODE environment variable

This makes sure all REPL instances check for the NODE_REPL_MODE
environment variable in case the `replMode` is not passed through
as option.

At the same time this simplifies the internal REPL code significantly
and color detection is improved.

<s>##### doc: document the `--use-strict` flag for the REPL

Add information that this flag is going to evaluate all code in strict
mode. Also use the regular `default` description as it's used in other
options.</s>

@nodejs/repl @nodejs/documentation PTAL

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
