### PR TITLE
esm: unflag import.meta.resolve

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -165,15 +165,6 @@ Enable experimental Source Map V3 support for stack traces.
 Currently, overriding `Error.prepareStackTrace` is ignored when the
 `--enable-source-maps` flag is set.
 
-### `--experimental-import-meta-resolve`
-<!-- YAML
-added:
-  - v13.9.0
-  - v12.16.2
--->
-
-Enable experimental `import.meta.resolve()` support.
-
 ### `--experimental-json-modules`
 <!-- YAML
 added: v12.9.0
@@ -1180,7 +1171,6 @@ Node.js options that are allowed are:
 * `--disable-proto`
 * `--enable-fips`
 * `--enable-source-maps`
-* `--experimental-import-meta-resolve`
 * `--experimental-json-modules`
 * `--experimental-loader`
 * `--experimental-modules`

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -894,8 +894,7 @@ const __dirname = dirname(__filename);
 ### No `require.resolve`
 
 Former use cases relying on `require.resolve` to determine the resolved path
-of a module can be supported via `import.meta.resolve`, which is experimental
-and supported via the `--experimental-import-meta-resolve` flag:
+of a module can be supported via `import.meta.resolve`:
 
 ```js
 (async () => {

--- a/doc/node.1
+++ b/doc/node.1
@@ -121,9 +121,6 @@ Requires Node.js to be built with
 .It Fl -enable-source-maps
 Enable experimental Source Map V3 support for stack traces.
 .
-.It Fl -experimental-import-meta-resolve
-Enable experimental ES modules support for import.meta.resolve().
-.
 .It Fl -experimental-json-modules
 Enable experimental JSON interop support for the ES Module loader.
 .

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -30,9 +30,6 @@ const { ERR_UNKNOWN_BUILTIN_MODULE } = require('internal/errors').codes;
 const { maybeCacheSourceMap } = require('internal/source_map/source_map_cache');
 const moduleWrap = internalBinding('module_wrap');
 const { ModuleWrap } = moduleWrap;
-const { getOptionValue } = require('internal/options');
-const experimentalImportMetaResolve =
-    getOptionValue('--experimental-import-meta-resolve');
 
 const debug = debuglog('esm');
 
@@ -71,8 +68,7 @@ function createImportMetaResolve(defaultParentUrl) {
 
 function initializeImportMeta(meta, { url }) {
   // Alphabetical
-  if (experimentalImportMetaResolve)
-    meta.resolve = createImportMetaResolve(url);
+  meta.resolve = createImportMetaResolve(url);
   meta.url = url;
 }
 

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -292,10 +292,6 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "experimental ES Module support for webassembly modules",
             &EnvironmentOptions::experimental_wasm_modules,
             kAllowedInEnvironment);
-  AddOption("--experimental-import-meta-resolve",
-            "experimental ES Module import.meta.resolve() support",
-            &EnvironmentOptions::experimental_import_meta_resolve,
-            kAllowedInEnvironment);
   AddOption("--experimental-policy",
             "use the specified file as a "
             "security policy",

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -106,7 +106,6 @@ class EnvironmentOptions : public Options {
   std::string experimental_specifier_resolution;
   std::string es_module_specifier_resolution;
   bool experimental_wasm_modules = false;
-  bool experimental_import_meta_resolve = false;
   std::string module_type;
   std::string experimental_policy;
   std::string experimental_policy_integrity;

--- a/test/es-module/test-esm-import-meta-resolve.mjs
+++ b/test/es-module/test-esm-import-meta-resolve.mjs
@@ -1,4 +1,3 @@
-// Flags: --experimental-import-meta-resolve
 import '../common/index.mjs';
 import assert from 'assert';
 

--- a/test/es-module/test-esm-import-meta.mjs
+++ b/test/es-module/test-esm-import-meta.mjs
@@ -3,7 +3,7 @@ import assert from 'assert';
 
 assert.strictEqual(Object.getPrototypeOf(import.meta), null);
 
-const keys = ['url'];
+const keys = ['resolve', 'url'];
 assert.deepStrictEqual(Reflect.ownKeys(import.meta), keys);
 
 const descriptors = Object.getOwnPropertyDescriptors(import.meta);

--- a/test/es-module/test-esm-nowarn-exports.mjs
+++ b/test/es-module/test-esm-nowarn-exports.mjs
@@ -4,7 +4,6 @@ import { strictEqual, ok } from 'assert';
 import { spawn } from 'child_process';
 
 const child = spawn(process.execPath, [
-  '--experimental-import-meta-resolve',
   path('/es-modules/import-resolve-exports.mjs')
 ]);
 


### PR DESCRIPTION
Now that TLA has landed, the workflows around this are really quite nice.

For example, to load the package.json file from an external package one can write:

```js
import { promises as fs } from 'fs';
const pkgUrl = await import.meta.resolve('pkg/');
const pjson = await fs.readFile(new URL('package.json', pkgUrl));
```

Note: this is in no way meant to be a full solution to the other issue discussion, where @ljharb has suggested some directions forward.

Other examples were included in the original PR - https://github.com/nodejs/node/pull/31032.

I do think unflagging is important as this is a critical feature for ESM to ensure it has the `require.resolve` use cases supported.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
