### PR TITLE
tools,doc: fix version picker in docs to show all available versions

### DIFF
--- a/tools/doc/generate.js
+++ b/tools/doc/generate.js
@@ -101,7 +101,8 @@ async function main() {
   const basename = path.basename(filename, '.md');
   const htmlTarget = path.join(outputDir, `${basename}.html`);
   const jsonTarget = path.join(outputDir, `${basename}.json`);
-  const versionPickerTarget = path.join(outputDir, `.${basename}.versions.js`);
+  const versionPickerTarget =
+    path.join(outputDir, '..', `.${basename}.versions.js`);
 
   return Promise.allSettled([
     fs.writeFile(htmlTarget, myHtml),

--- a/tools/doc/generate.js
+++ b/tools/doc/generate.js
@@ -92,14 +92,20 @@ async function main() {
     .use(htmlStringify)
     .process(input);
 
-  const myHtml = await html.toHTML({ input, content, filename, nodeVersion,
-                                     versions });
+  const myHtml = await html.toHTML(
+    { input, content, filename, nodeVersion, versions }
+  );
+  const myVersionPicker = await html.versionPicker(
+    { input, content, filename, nodeVersion, versions }
+  );
   const basename = path.basename(filename, '.md');
   const htmlTarget = path.join(outputDir, `${basename}.html`);
   const jsonTarget = path.join(outputDir, `${basename}.json`);
+  const versionPickerTarget = path.join(outputDir, `.${basename}.versions.js`);
 
   return Promise.allSettled([
     fs.writeFile(htmlTarget, myHtml),
+    fs.writeFile(versionPickerTarget, myVersionPicker),
     fs.writeFile(jsonTarget, JSON.stringify(content.json, null, 2)),
   ]);
 }

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -100,7 +100,7 @@ function toHTML({ input,
     return `document.write('${htmlPayload}')`;
   }
 
-  const versionsJS = `.${filename}.versions.js`;
+  const versionsJS = `../.${filename}.versions.js`;
   return HTML.replace('__ALTDOCS__', `<script src="${versionsJS}"></script>`);
 }
 


### PR DESCRIPTION
Quickly slapped-together proof-of-concept but I want feedback on the general idea/approach, so here's a draft PR.

Current situation is that we hard code the version picker into the docs at build time. This results in a confusing user experience described (partially--there are other oddities not described in there, I think) in https://github.com/nodejs/node/issues/32077.

This change moves the version picker into a separate JS file that is one directory above the docs so all versions of the docs can share. Since older versions (say, version 10.x) are smart enough to detect newer relevant releases (say, version 14.x) at build time, these JS files will always be up to date.

TODO:

- [ ] Confirm that these one-directory-up files will be moved to the web server on release. If not, then we need to add that to the release job/process.
- [ ] Replace `document.write()` and render-blocking `<script>` tag with a non-blocking approach

@codebytere @richardlau @rvagg @nschonni @XhmikosR @alexandrtovmach

To test locally: `make doc-only` and then open `out/doc/api/index.html` in a web browser. (The resulting HTML files will work offline. No need to spin up a web server. Or at least that's my experience on macOS.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
