### PR TITLE
module: fix check for package.json at volume root

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -41,6 +41,7 @@ const {
   SafeMap,
   String,
   StringPrototypeIndexOf,
+  StringPrototypeLastIndexOf,
   StringPrototypeMatch,
   StringPrototypeSlice,
   StringPrototypeStartsWith,
@@ -286,12 +287,13 @@ function readPackageScope(checkPath) {
   const rootSeparatorIndex = checkPath.indexOf(path.sep);
   let separatorIndex;
   while (
-    (separatorIndex = checkPath.lastIndexOf(path.sep)) > rootSeparatorIndex
+    (separatorIndex = StringPrototypeLastIndexOf(checkPath, path.sep)) >=
+     rootSeparatorIndex
   ) {
     checkPath = checkPath.slice(0, separatorIndex);
     if (checkPath.endsWith(path.sep + 'node_modules'))
       return false;
-    const pjson = readPackage(checkPath);
+    const pjson = readPackage(checkPath + path.sep);
     if (pjson) return {
       path: checkPath,
       data: pjson


### PR DESCRIPTION
Fixes https://github.com/nodejs/node/issues/33438. A `package.json` at the volume root containing `"type": "module"` now behaves as documented. Thanks to @vitalets for pinpointing exactly where the problem was.

No idea how to write a test for this, but I tested it manually and this fixes the issue.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

cc @nodejs/modules-active-members 

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
