### PR TITLE
crypto: fix wrong error message

### DIFF
--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -268,10 +268,10 @@ function prepareAsymmetricKey(key, ctx) {
     // Either PEM or DER using PKCS#1 or SPKI.
     if (!isStringOrBuffer(data)) {
       throw new ERR_INVALID_ARG_TYPE(
-        'key',
+        'key.key property',
         ['string', 'Buffer', 'TypedArray', 'DataView',
          ...(ctx !== kCreatePrivate ? ['KeyObject'] : [])],
-        key);
+        data);
     }
 
     const isPublic =

--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -268,7 +268,7 @@ function prepareAsymmetricKey(key, ctx) {
     // Either PEM or DER using PKCS#1 or SPKI.
     if (!isStringOrBuffer(data)) {
       throw new ERR_INVALID_ARG_TYPE(
-        'key.key property',
+        'key.key',
         ['string', 'Buffer', 'TypedArray', 'DataView',
          ...(ctx !== kCreatePrivate ? ['KeyObject'] : [])],
         data);

--- a/test/parallel/test-crypto-sign-verify.js
+++ b/test/parallel/test-crypto-sign-verify.js
@@ -390,7 +390,7 @@ assert.throws(
     verify.update(new clazz());
   });
 
-  [{}, [], 1, Infinity].forEach((input) => {
+  [1, {}, [], Infinity].forEach((input) => {
     let prop = '"key" argument';
     let value = input;
     if (typeof input === 'object') {

--- a/test/parallel/test-crypto-sign-verify.js
+++ b/test/parallel/test-crypto-sign-verify.js
@@ -390,13 +390,19 @@ assert.throws(
     verify.update(new clazz());
   });
 
-  [1, {}, [], Infinity].forEach((input) => {
+  [{}, [], 1, Infinity].forEach((input) => {
+    let prop = '"key" argument';
+    let value = input;
+    if (typeof input === 'object') {
+      prop = '"key.key" property';
+      value = undefined;
+    }
     const errObj = {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "key.key property" argument must be of type string or an instance of ' +
-               'Buffer, TypedArray, DataView, or KeyObject.' +
-               common.invalidArgTypeHelper(input)
+      message: `The ${prop} must be of type string or ` +
+               'an instance of Buffer, TypedArray, DataView, or KeyObject.' +
+               common.invalidArgTypeHelper(value)
     };
 
     assert.throws(() => sign.sign(input), errObj);
@@ -478,25 +484,33 @@ assert.throws(
 [1, {}, [], true, Infinity].forEach((input) => {
   const data = Buffer.alloc(1);
   const sig = Buffer.alloc(1);
-  const received = common.invalidArgTypeHelper(input);
   const errObj = {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
     message: 'The "data" argument must be an instance of Buffer, ' +
-             `TypedArray, or DataView.${received}`
+             'TypedArray, or DataView.' +
+             common.invalidArgTypeHelper(input)
   };
 
   assert.throws(() => crypto.sign(null, input, 'asdf'), errObj);
   assert.throws(() => crypto.verify(null, input, 'asdf', sig), errObj);
 
-  errObj.message = 'The "key" argument must be of type string or an instance ' +
-                   `of Buffer, TypedArray, DataView, or KeyObject.${received}`;
+  let prop = '"key" argument';
+  let value = input;
+  if (typeof input === 'object') {
+    prop = '"key.key" property';
+    value = undefined;
+  }
+  errObj.message = `The ${prop} must be of type string or ` +
+              'an instance of Buffer, TypedArray, DataView, or KeyObject.' +
+              common.invalidArgTypeHelper(value);
 
   assert.throws(() => crypto.sign(null, data, input), errObj);
   assert.throws(() => crypto.verify(null, data, input, sig), errObj);
 
   errObj.message = 'The "signature" argument must be an instance of ' +
-                   `Buffer, TypedArray, or DataView.${received}`;
+                   'Buffer, TypedArray, or DataView.' +
+                   common.invalidArgTypeHelper(input);
   assert.throws(() => crypto.verify(null, data, 'test', input), errObj);
 });
 

--- a/test/parallel/test-crypto-sign-verify.js
+++ b/test/parallel/test-crypto-sign-verify.js
@@ -394,7 +394,7 @@ assert.throws(
     const errObj = {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "key" argument must be of type string or an instance of ' +
+      message: 'The "key.key property" argument must be of type string or an instance of ' +
                'Buffer, TypedArray, DataView, or KeyObject.' +
                common.invalidArgTypeHelper(input)
     };


### PR DESCRIPTION
When calling `crypto.sign()`, if the `key` parameter object is
missing the `key` property, the error message is wrong.

Before the fix:
TypeError [ERR_INVALID_ARG_TYPE]: The "key" argument must be of
type string or an instance of Buffer, TypedArray, DataView, or
KeyObject. Received an instance of Object

Expected:
TypeError [ERR_INVALID_ARG_TYPE]: The "key.key" property
must be of type string or an instance of Buffer, TypedArray,
DataView, or KeyObject. Received undefined

Fixes: https://github.com/nodejs/node/issues/33480
This seems like a copy&paste bug. Somebody copied from the end of
the function, where this is correct, to here, where it's wrong.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)