### PR TITLE
docs: normalize C++ code block info strings

### DIFF
--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -157,11 +157,11 @@ The context-aware addon can be structured to avoid global static data by
 performing the following steps:
 * Define a class which will hold per-addon-instance data and which has a static
 member of the form
-    ```C++
-    static void DeleteInstance(void* data) {
-      // Cast `data` to an instance of the class and delete it.
-    }
-    ```
+  ```cpp
+  static void DeleteInstance(void* data) {
+    // Cast `data` to an instance of the class and delete it.
+  }
+  ```
 * Heap-allocate an instance of this class in the addon initializer. This can be
 accomplished using the `new` keyword.
 * Call `node::AddEnvironmentCleanupHook()`, passing it the above-created
@@ -245,7 +245,7 @@ In order to support [`Worker`][] threads, addons need to clean up any resources
 they may have allocated when such a thread exists. This can be achieved through
 the usage of the `AddEnvironmentCleanupHook()` function:
 
-```c++
+```cpp
 void AddEnvironmentCleanupHook(v8::Isolate* isolate,
                                void (*fun)(void* arg),
                                void* arg);

--- a/doc/api/embedding.md
+++ b/doc/api/embedding.md
@@ -33,7 +33,7 @@ Node.js requires some per-process state management in order to run:
 The following example shows how these can be set up. Some class names are from
 the `node` and `v8` C++ namespaces, respectively.
 
-```c++
+```cpp
 int main(int argc, char** argv) {
   std::vector<std::string> args(argv, argv + argc);
   std::vector<std::string> exec_args;
@@ -93,7 +93,7 @@ The `node::NewIsolate()` helper function creates a `v8::Isolate`,
 sets it up with some Node.js-specific hooks (e.g. the Node.js error handler),
 and registers it with the platform automatically.
 
-```c++
+```cpp
 int RunNodeInstance(MultiIsolatePlatform* platform,
                     const std::vector<std::string>& args,
                     const std::vector<std::string>& exec_args) {

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -45,12 +45,12 @@ following `node-addon-api` code. The first section shows the
 `node-addon-api` code and the second section shows what actually gets
 used in the addon.
 
-```C++
+```cpp
 Object obj = Object::New(env);
 obj["foo"] = String::New(env, "bar");
 ```
 
-```C++
+```cpp
 napi_status status;
 napi_value object, string;
 status = napi_create_object(env, &object);
@@ -87,7 +87,7 @@ versions:
 
 * the Node.js C++ APIs available via any of
 
-    ```C++
+    ```cpp
     #include <node.h>
     #include <node_buffer.h>
     #include <node_version.h>
@@ -96,13 +96,13 @@ versions:
 
 * the libuv APIs which are also included with Node.js and available via
 
-    ```C++
+    ```cpp
     #include <uv.h>
     ```
 
 * the V8 API available via
 
-    ```C++
+    ```cpp
     #include <v8.h>
     ```
 

--- a/doc/guides/cpp-style-guide.md
+++ b/doc/guides/cpp-style-guide.md
@@ -67,7 +67,7 @@ Comments should also start with uppercase and finish with a dot.
 
 Examples:
 
-```c++
+```cpp
 // A single-line comment.
 
 // Multi-line comments
@@ -82,14 +82,14 @@ comments.
 
 ### 2 spaces of indentation for blocks or bodies of conditionals
 
-```c++
+```cpp
 if (foo)
   bar();
 ```
 
 or
 
-```c++
+```cpp
 if (foo) {
   bar();
   baz();
@@ -102,7 +102,7 @@ Braces are optional if the statement body only has one line.
 
 ### 4 spaces of indentation for statement continuations
 
-```c++
+```cpp
 VeryLongTypeName very_long_result = SomeValueWithAVeryLongName +
     SomeOtherValueWithAVeryLongName;
 ```
@@ -111,7 +111,7 @@ Operators are before the line break in these cases.
 
 ### Align function arguments vertically
 
-```c++
+```cpp
 void FunctionWithAVeryLongName(int parameter_with_a_very_long_name,
                                double other_parameter_with_a_very_long_name,
                                ...);
@@ -119,7 +119,7 @@ void FunctionWithAVeryLongName(int parameter_with_a_very_long_name,
 
 If that doesn’t work, break after the `(` and use 4 spaces of indentation:
 
-```c++
+```cpp
 void FunctionWithAReallyReallyReallyLongNameSeriouslyStopIt(
     int okay_there_is_no_space_left_in_the_previous_line,
     ...);
@@ -129,7 +129,7 @@ void FunctionWithAReallyReallyReallyLongNameSeriouslyStopIt(
 
 Long initialization lists are formatted like this:
 
-```c++
+```cpp
 HandleWrap::HandleWrap(Environment* env,
                        Local<Object> object,
                        uv_handle_t* handle,
@@ -144,7 +144,7 @@ HandleWrap::HandleWrap(Environment* env,
 Exceptions are simple getters/setters, which are named `property_name()` and
 `set_property_name()`, respectively.
 
-```c++
+```cpp
 class FooBar {
  public:
   void DoSomething();
@@ -157,7 +157,7 @@ class FooBar {
 
 ### `snake_case` for local variables and parameters
 
-```c++
+```cpp
 int FunctionThatDoesSomething(const char* important_string) {
   const char* pointer_into_string = important_string;
 }
@@ -165,7 +165,7 @@ int FunctionThatDoesSomething(const char* important_string) {
 
 ### `snake_case_` for private class fields
 
-```c++
+```cpp
 class Foo {
  private:
   int counter_ = 0;
@@ -176,7 +176,7 @@ class Foo {
 
 For plain C-like structs snake_case can be used.
 
-```c++
+```cpp
 struct foo_bar {
   int name;
 }
@@ -184,7 +184,7 @@ struct foo_bar {
 
 ### Space after `template`
 
-```c++
+```cpp
 template <typename T>
 class FancyContainer {
  ...
@@ -232,7 +232,7 @@ Using non-const references often obscures which values are changed by an
 assignment. Consider using a pointer instead, which requires more explicit
 syntax to indicate that modifications take place.
 
-```c++
+```cpp
 class ExampleClass {
  public:
   explicit ExampleClass(OtherClass* other_ptr) : pointer_to_other_(other_ptr) {}
@@ -269,7 +269,7 @@ When working with typed arrays that involve direct data modification
 from C++, use an `AliasedBuffer` when possible. The API abstraction and
 the usage scope of `AliasedBuffer` are documented in [aliased_buffer.h][].
 
-```c++
+```cpp
 // Create an AliasedBuffer.
 AliasedBuffer<uint32_t, v8::Uint32Array> data;
 ...

--- a/doc/guides/investigating_native_memory_leak.md
+++ b/doc/guides/investigating_native_memory_leak.md
@@ -103,7 +103,7 @@ example leak based on the "Hello world" addon from
 In this example, a loop which allocates ~1MB of memory and never frees it
 has been added:
 
-```C++
+```cpp
 void* malloc_holder = nullptr;
 napi_value Method(napi_env env, napi_callback_info info) {
   napi_status status;

--- a/doc/guides/node-postmortem-support.md
+++ b/doc/guides/node-postmortem-support.md
@@ -35,7 +35,7 @@ For example, if we want to add a constant with the offset for
 `sizeof(req_)` depends on the type of T, which means the class definition should
 be like this:
 
-```c++
+```cpp
 template <typename T>
 class ReqWrap : public AsyncWrap {
  private:
@@ -49,7 +49,7 @@ class ReqWrap : public AsyncWrap {
 
 instead of:
 
-```c++
+```cpp
 template <typename T>
 class ReqWrap : public AsyncWrap {
  private:

--- a/doc/guides/writing-tests.md
+++ b/doc/guides/writing-tests.md
@@ -356,7 +356,7 @@ The unit test should be placed in `test/cctest` and be named with the prefix
 `test` followed by the name of unit being tested. For example, the code below
 would be placed in `test/cctest/test_env.cc`:
 
-```c++
+```cpp
 #include "gtest/gtest.h"
 #include "node_test_fixture.h"
 #include "env.h"

--- a/src/README.md
+++ b/src/README.md
@@ -137,7 +137,7 @@ function getFoo(obj) {
 }
 ```
 
-```c++
+```cpp
 v8::Local<v8::Value> GetFoo(v8::Local<v8::Context> context,
                             v8::Local<v8::Object> obj) {
   v8::Isolate* isolate = context->GetIsolate();
@@ -168,7 +168,7 @@ See [exception handling][] for more information about the usage of `.To()`,
 If it is known that a `Local<Value>` refers to a more specific type, it can
 be cast to that type using `.As<...>()`:
 
-```c++
+```cpp
 v8::Local<v8::Value> some_value;
 // CHECK() is a Node.js utilitity that works similar to assert().
 CHECK(some_value->IsUint8Array());
@@ -201,7 +201,7 @@ alive even if no other objects refer to them. Weak global handles do not do
 that, and instead optionally call a callback when the object they refer to
 is garbage-collected.
 
-```c++
+```cpp
 v8::Global<v8::Object> reference;
 
 void StoreReference(v8::Isolate* isolate, v8::Local<v8::Object> obj) {
@@ -329,7 +329,7 @@ The platform can be accessed through `isolate_data->platform()` given an
 C++ functions exposed to JS follow a specific signature. The following example
 is from `node_util.cc`:
 
-```c++
+```cpp
 void ArrayBufferViewHasBuffer(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[0]->IsArrayBufferView());
   args.GetReturnValue().Set(args[0].As<ArrayBufferView>()->HasBuffer());
@@ -351,7 +351,7 @@ floating-point number or a `Local<Value>` to set the return value.
 Node.js provides various helpers for building JS classes in C++ and/or attaching
 C++ functions to the exports of a built-in module:
 
-```c++
+```cpp
 void Initialize(Local<Object> target,
                 Local<Value> unused,
                 Local<Context> context,
@@ -409,7 +409,7 @@ constant string, in order to disambiguate it from other classes of this type,
 and which could e.g. match the binding’s name (in the example above, that would
 be `cares_wrap`).
 
-```c++
+```cpp
 // In the HTTP parser source code file:
 class BindingData : public BaseObject {
  public:
@@ -523,7 +523,7 @@ to perform further calls to APIs that return `Maybe`s.
 A typical pattern for dealing with APIs that return `Maybe` and `MaybeLocal` is
 using `.ToLocal()` and `.To()` and returning early in case there is an error:
 
-```c++
+```cpp
 // This could also return a v8::MaybeLocal<v8::Number>, for example.
 v8::Maybe<double> SumNumbers(v8::Local<v8::Context> context,
                              v8::Local<v8::Array> array_of_integers) {
@@ -692,7 +692,7 @@ A helper for this is the `ASSIGN_OR_RETURN_UNWRAP` macro that returns from the
 current function if unwrapping fails (typically that means that the `BaseObject`
 has been deleted earlier).
 
-```c++
+```cpp
 void Http2Session::Request(const FunctionCallbackInfo<Value>& args) {
   Http2Session* session;
   ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
@@ -780,7 +780,7 @@ queues once it returns.
 Before calling `MakeCallback()`, it is typically necessary to enter both a
 `HandleScope` and a `Context::Scope`.
 
-```c++
+```cpp
 void StatWatcher::Callback(uv_fs_poll_t* handle,
                            int status,
                            const uv_stat_t* prev,
@@ -872,7 +872,7 @@ The `Utf8Value`, `TwoByteValue` (i.e. UTF-16 value) and `BufferValue`
 inherit from this class and allow accessing the characters in a JavaScript
 string this way.
 
-```c++
+```cpp
 static void Chdir(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   // ...


### PR DESCRIPTION
Prior to this commit, C++ fenced code blocks in Markdown files had
inconsistent info strings. This has been corrected to standarize on
the one with the highest frequency in the doc/api/ dir.

Stats:
>   'cpp' => 19,
>   'C++' => 6,
>    'c++' => 3,

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
