### PR TITLE
doc: normalize shell session code block info strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,7 +572,7 @@ Primary GPG keys for Node.js Releasers (some Releasers sign with subkeys):
 
 To import the full set of trusted release keys:
 
-```shell
+```bash
 gpg --keyserver pool.sks-keyservers.net --recv-keys 4ED778F539E3634C779C87C6D7062848A1AB005C
 gpg --keyserver pool.sks-keyservers.net --recv-keys 94AE36675C464D64BAFA68DD7434390BDBE9B9C5
 gpg --keyserver pool.sks-keyservers.net --recv-keys 71DCFD284A79C3B38668286BC97EC7A07EDE3FC1

--- a/doc/api/intl.md
+++ b/doc/api/intl.md
@@ -115,13 +115,13 @@ through either:
 
 * The [`NODE_ICU_DATA`][] environment variable:
 
-  ```shell
+  ```bash
   env NODE_ICU_DATA=/some/directory node
   ```
 
 * The [`--icu-data-dir`][] CLI parameter:
 
-  ```shell
+  ```bash
   node --icu-data-dir=/some/directory
   ```
 

--- a/doc/guides/backporting-to-release-lines.md
+++ b/doc/guides/backporting-to-release-lines.md
@@ -35,7 +35,7 @@ replace that with the staging branch for the targeted release line.
 2. Make sure that the local staging branch is up to date with the remote.
 3. Create a new branch off of the staging branch, as shown below.
 
-    ```shell
+    ```bash
     # Assuming your fork of Node.js is checked out in $NODE_DIR,
     # the origin remote points to your fork, and the upstream remote points
     # to git://github.com/nodejs/node
@@ -55,7 +55,7 @@ replace that with the staging branch for the targeted release line.
    will likely fail due to conflicts. In that case, you will see something
    like this:
 
-    ```shell
+    ```console
     # Say the $SHA is 773cdc31ef
     $ git cherry-pick $SHA # Use your commit hash
     error: could not apply 773cdc3... <commit title>

--- a/doc/guides/maintaining-V8.md
+++ b/doc/guides/maintaining-V8.md
@@ -328,7 +328,7 @@ that Node.js may be floating (or else cause a merge conflict).
 
 The rough outline of the process is:
 
-```shell
+```bash
 # Assuming your fork of Node.js is checked out in $NODE_DIR
 # and you want to update the Node.js master branch.
 # Find the current (OLD) version in
@@ -367,7 +367,7 @@ above. A better strategy is to
 
 To audit for floating patches:
 
-```shell
+```bash
 git log --oneline deps/v8
 ```
 
@@ -375,7 +375,7 @@ To replace the copy of V8 in Node.js, use the [`git-node`][] tool. For example,
 if you want to replace the copy of V8 in Node.js with the branch-head for V8 5.1
 branch:
 
-```shell
+```bash
 cd $NODE_DIR
 git node v8 major --branch=5.1-lkgr
 ```

--- a/doc/guides/maintaining-icu.md
+++ b/doc/guides/maintaining-icu.md
@@ -21,7 +21,7 @@ ICU consumes and includes:
 
 The current versions of these items can be viewed for node with `node -p process.versions`:
 
-```shell
+```console
 $ node -p process.versions
 
 {
@@ -101,7 +101,7 @@ should be sufficient).
 * Configure Node.js with the specific [ICU version](http://icu-project.org/download)
   you want to upgrade to, for example:
 
-```shell
+```bash
 ./configure \
     --with-intl=full-icu \
     --with-icu-source=http://download.icu-project.org/files/icu4c/58.1/icu4c-58_1-src.tgz
@@ -118,7 +118,7 @@ make
 
 * Verify the Node.js build works:
 
-```shell
+```bash
 make test-ci
 ```
 
@@ -137,13 +137,13 @@ new Intl.DateTimeFormat('es', { month: 'long' }).format(new Date(9E8));
 > :warning: Do not modify any source code in `deps/icu-small` !
 > See section below about floating patches to ICU.
 
-```shell
+```bash
 python tools/icu/shrink-icu-src.py
 ```
 
 * Now, do a clean rebuild of Node.js to test:
 
-```shell
+```bash
 make -k distclean
 ./configure
 make
@@ -168,7 +168,7 @@ so make this a separate commit from the smaller changes.
 
 * Now, rebuild the Node.js license.
 
-```shell
+```bash
 # clean up - remove deps/icu
 make clean
 tools/license-builder.sh
@@ -178,7 +178,7 @@ tools/license-builder.sh
 It should match the ICU URL used in the first step.  When this is done, the
 following should build with small ICU.
 
-```shell
+```bash
 # clean up
 rm -rf out deps/icu deps/icu4c*
 ./configure --with-intl=small-icu --download=all
@@ -210,7 +210,7 @@ version.
 For example, to patch `source/tools/toolutil/pkg_genc.cpp` for
 ICU version 63:
 
-```shell
+```bash
 # go to your Node.js source directory
 cd <node>
 
@@ -233,7 +233,7 @@ make clean && ./configure && make
 
 You should see a message such as:
 
-```shell
+```console
 INFO: Using floating patch "tools/icu/patches/63/source/tools/toolutil/pkg_genc.cpp" from "tools/icu"
 ```
 

--- a/doc/guides/maintaining-root-certs.md
+++ b/doc/guides/maintaining-root-certs.md
@@ -30,7 +30,7 @@ the nodejs/node repository.
 
     Update the tag in the commands below, and run:
 
-    ```shell
+    ```bash
     cd tools/
     ./mk-ca-bundle.pl -v 2>_before
     curl -O https://hg.mozilla.org/projects/nss/raw-file/NSS_3_41_RTM/lib/ckfw/builtins/certdata.txt
@@ -57,7 +57,7 @@ the nodejs/node repository.
 
     Run the command below:
 
-    ```shell
+    ```bash
     ./mk-ca-bundle.pl -v 2>_after
     ```
 
@@ -65,7 +65,7 @@ the nodejs/node repository.
 
     Determine what changes were made by diffing the before and after files:
 
-    ```shell
+    ```console
     % diff _before _after
     11d10
     < Parsing: Visa eCommerce Root

--- a/doc/guides/maintaining-zlib.md
+++ b/doc/guides/maintaining-zlib.md
@@ -6,7 +6,7 @@ performance improvements not currently available in standard zlib.
 ## Updating zlib
 
 Update zlib:
-```shell
+```bash
 git clone https://chromium.googlesource.com/chromium/src/third_party/zlib
 cp deps/zlib/zlib.gyp deps/zlib/win32/zlib.def deps
 rm -rf deps/zlib zlib/.git


### PR DESCRIPTION
Prior to this commit, shell fenced code blocks in Markdown files had
inconsistent info strings. This has been corrected to standarize on
the one with the highest frequency in the doc/api/ dir.

Stats:
> 'console' => 54,
> 'shell' => 2,

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
