### PR TITLE
meta: add flaky test issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/4-report-a-flaky-test.md
+++ b/.github/ISSUE_TEMPLATE/4-report-a-flaky-test.md
@@ -1,0 +1,30 @@
+---
+name: Report a flaky test
+about: Report a flaky test in our CI
+labels: "CI / flaky test"
+
+---
+
+<!--
+Thank you for reporting a flaky test.
+
+Flaky tests are tests that fail occaisonally in Node.js CI, but not consistently enough to block PRs from landing, 
+or that are failing in CI jobs or test modes that are not run for every PR. 
+
+Please fill in as much of the template below as you're able.
+
+Test: The test that is flaky - e.g. `test-fs-stat-bigint`
+Platform: The platform the test is flaky on - e.g. `macos` or `linux`
+Console Output: A pasted console output from a failed CI job showing the whole failure of the test
+Build Links: Links to builds affected by the flaky test
+
+If any investigation has been done, please include any information found, such as how consistently the test fails, whether the failure could be reproduced locally, when the test started failing, or anything else you think is relevant.
+-->
+
+* **Test**:
+* **Platform**:
+* **Console Output:**
+```
+REPLACE ME
+```
+* **Build Links**:


### PR DESCRIPTION
Add a flaky test issue template to ensure that enough information is provided for investigation

I think this will be useful especially for newer people interested in helping out the build WG as it requires no access to report flaky tests, and is often an approach we ask people to take to help familarise themselves with our CI/test suite.

##### Checklist

- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
