### PR TITLE
doc: normalize C code block info strings

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -109,7 +109,7 @@ versions:
 Thus, for an addon to remain ABI-compatible across Node.js major versions, it
 must make use exclusively of N-API by restricting itself to using
 
-```C
+```c
 #include <node_api.h>
 ```
 
@@ -206,7 +206,7 @@ available to the module user when the native module is installed.
 In order to use the N-API functions, include the file [`node_api.h`][] which is
 located in the src directory in the node development tree:
 
-```C
+```c
 #include <node_api.h>
 ```
 
@@ -214,7 +214,7 @@ This will opt into the default `NAPI_VERSION` for the given release of Node.js.
 In order to ensure compatibility with specific versions of N-API, the version
 can be specified explicitly when including the header:
 
-```C
+```c
 #define NAPI_VERSION 3
 #include <node_api.h>
 ```
@@ -225,7 +225,7 @@ the specified (and earlier) versions.
 Some of the N-API surface is considered experimental and requires explicit
 opt-in to access those APIs:
 
-```C
+```c
 #define NAPI_EXPERIMENTAL
 #include <node_api.h>
 ```
@@ -272,7 +272,7 @@ N-API or any implementation of N-API outside of Node.js.
 to the addon and which instantiates the addon by calling into `addon.c` when the
 addon is loaded into a Node.js environment.
 
-```C
+```c
 // addon.h
 #ifndef _ADDON_H_
 #define _ADDON_H_
@@ -281,7 +281,7 @@ napi_value create_addon(napi_env env);
 #endif  // _ADDON_H_
 ```
 
-```C
+```c
 // addon.c
 #include "addon.h"
 
@@ -330,7 +330,7 @@ napi_value create_addon(napi_env env) {
 }
 ```
 
-```C
+```c
 // addon_node.c
 #include <node_api.h>
 #include "addon.h"
@@ -380,7 +380,7 @@ added:
 napiVersion: 6
 -->
 
-```C
+```c
 napi_status napi_set_instance_data(napi_env env,
                                    void* data,
                                    napi_finalize finalize_cb,
@@ -410,7 +410,7 @@ added:
 napiVersion: 6
 -->
 
-```C
+```c
 napi_status napi_get_instance_data(napi_env env,
                                    void** data);
 ```
@@ -439,7 +439,7 @@ napiVersion: 1
 Integral status code indicating the success or failure of a N-API call.
 Currently, the following status codes are supported.
 
-```C
+```c
 typedef enum {
   napi_ok,
   napi_invalid_arg,
@@ -475,7 +475,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 typedef struct {
   const char* error_message;
   void* engine_reserved;
@@ -533,7 +533,7 @@ the thread-safe function is to be closed immediately (`napi_tsfn_abort`) or
 merely released (`napi_tsfn_release`) and thus available for subsequent use via
 `napi_acquire_threadsafe_function()` and `napi_call_threadsafe_function()`.
 
-```C
+```c
 typedef enum {
   napi_tsfn_release,
   napi_tsfn_abort
@@ -550,7 +550,7 @@ A value to be given to `napi_call_threadsafe_function()` to indicate whether
 the call should block whenever the queue associated with the thread-safe
 function is full.
 
-```C
+```c
 typedef enum {
   napi_tsfn_nonblocking,
   napi_tsfn_blocking
@@ -615,7 +615,7 @@ Function pointer type for user-provided native functions which are to be
 exposed to JavaScript via N-API. Callback functions should satisfy the
 following signature:
 
-```C
+```c
 typedef napi_value (*napi_callback)(napi_env, napi_callback_info);
 ```
 
@@ -631,7 +631,7 @@ must provide a function satisfying the following signature which would get
 called upon the object's collection. Currently, `napi_finalize` can be used for
 finding out when objects that have external data are collected.
 
-```C
+```c
 typedef void (*napi_finalize)(napi_env env,
                               void* finalize_data,
                               void* finalize_hint);
@@ -645,7 +645,7 @@ napiVersion: 1
 Function pointer used with functions that support asynchronous
 operations. Callback functions must satisfy the following signature:
 
-```C
+```c
 typedef void (*napi_async_execute_callback)(napi_env env, void* data);
 ```
 
@@ -664,7 +664,7 @@ napiVersion: 1
 Function pointer used with functions that support asynchronous
 operations. Callback functions must satisfy the following signature:
 
-```C
+```c
 typedef void (*napi_async_complete_callback)(napi_env env,
                                              napi_status status,
                                              void* data);
@@ -692,7 +692,7 @@ via `napi_make_callback`.
 
 Callback functions must satisfy the following signature:
 
-```C
+```c
 typedef void (*napi_threadsafe_function_call_js)(napi_env env,
                                                  napi_value js_callback,
                                                  void* context,
@@ -751,7 +751,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 typedef struct napi_extended_error_info {
   const char* error_message;
   void* engine_reserved;
@@ -778,7 +778,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status
 napi_get_last_error_info(napi_env env,
                          const napi_extended_error_info** result);
@@ -888,7 +888,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 NAPI_EXTERN napi_status napi_throw(napi_env env, napi_value error);
 ```
 
@@ -905,7 +905,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 NAPI_EXTERN napi_status napi_throw_error(napi_env env,
                                          const char* code,
                                          const char* msg);
@@ -925,7 +925,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 NAPI_EXTERN napi_status napi_throw_type_error(napi_env env,
                                               const char* code,
                                               const char* msg);
@@ -945,7 +945,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 NAPI_EXTERN napi_status napi_throw_range_error(napi_env env,
                                                const char* code,
                                                const char* msg);
@@ -965,7 +965,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 NAPI_EXTERN napi_status napi_is_error(napi_env env,
                                       napi_value value,
                                       bool* result);
@@ -986,7 +986,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 NAPI_EXTERN napi_status napi_create_error(napi_env env,
                                           napi_value code,
                                           napi_value msg,
@@ -1010,7 +1010,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 NAPI_EXTERN napi_status napi_create_type_error(napi_env env,
                                                napi_value code,
                                                napi_value msg,
@@ -1034,7 +1034,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 NAPI_EXTERN napi_status napi_create_range_error(napi_env env,
                                                 napi_value code,
                                                 napi_value msg,
@@ -1058,7 +1058,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_get_and_clear_last_exception(napi_env env,
                                               napi_value* result);
 ```
@@ -1076,7 +1076,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_is_exception_pending(napi_env env, bool* result);
 ```
 
@@ -1093,7 +1093,7 @@ added: v9.10.0
 napiVersion: 3
 -->
 
-```C
+```c
 napi_status napi_fatal_exception(napi_env env, napi_value err);
 ```
 
@@ -1114,7 +1114,7 @@ added: v8.2.0
 napiVersion: 1
 -->
 
-```C
+```c
 NAPI_NO_RETURN void napi_fatal_error(const char* location,
                                                  size_t location_len,
                                                  const char* message,
@@ -1156,7 +1156,7 @@ It is often necessary to make the lifespan of handles shorter than
 the lifespan of a native method. For example, consider a native method
 that has a loop which iterates through the elements in a large array:
 
-```C
+```c
 for (int i = 0; i < 1000000; i++) {
   napi_value result;
   napi_status status = napi_get_element(env, object, i, &result);
@@ -1188,7 +1188,7 @@ Taking the earlier example, adding calls to [`napi_open_handle_scope`][] and
 [`napi_close_handle_scope`][] would ensure that at most a single handle
 is valid throughout the execution of the loop:
 
-```C
+```c
 for (int i = 0; i < 1000000; i++) {
   napi_handle_scope scope;
   napi_status status = napi_open_handle_scope(env, &scope);
@@ -1228,7 +1228,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 NAPI_EXTERN napi_status napi_open_handle_scope(napi_env env,
                                                napi_handle_scope* result);
 ```
@@ -1246,7 +1246,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 NAPI_EXTERN napi_status napi_close_handle_scope(napi_env env,
                                                 napi_handle_scope scope);
 ```
@@ -1267,7 +1267,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 NAPI_EXTERN napi_status
     napi_open_escapable_handle_scope(napi_env env,
                                      napi_handle_scope* result);
@@ -1287,7 +1287,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 NAPI_EXTERN napi_status
     napi_close_escapable_handle_scope(napi_env env,
                                       napi_handle_scope scope);
@@ -1309,7 +1309,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_escape_handle(napi_env env,
                                napi_escapable_handle_scope scope,
                                napi_value escapee,
@@ -1376,7 +1376,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 NAPI_EXTERN napi_status napi_create_reference(napi_env env,
                                               napi_value value,
                                               uint32_t initial_refcount,
@@ -1400,7 +1400,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 NAPI_EXTERN napi_status napi_delete_reference(napi_env env, napi_ref ref);
 ```
 
@@ -1419,7 +1419,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 NAPI_EXTERN napi_status napi_reference_ref(napi_env env,
                                            napi_ref ref,
                                            uint32_t* result);
@@ -1440,7 +1440,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 NAPI_EXTERN napi_status napi_reference_unref(napi_env env,
                                              napi_ref ref,
                                              uint32_t* result);
@@ -1461,7 +1461,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 NAPI_EXTERN napi_status napi_get_reference_value(napi_env env,
                                                  napi_ref ref,
                                                  napi_value* result);
@@ -1497,7 +1497,7 @@ added: v10.2.0
 napiVersion: 3
 -->
 
-```C
+```c
 NODE_EXTERN napi_status napi_add_env_cleanup_hook(napi_env env,
                                                   void (*fun)(void* arg),
                                                   void* arg);
@@ -1524,7 +1524,7 @@ added: v10.2.0
 napiVersion: 3
 -->
 
-```C
+```c
 NAPI_EXTERN napi_status napi_remove_env_cleanup_hook(napi_env env,
                                                      void (*fun)(void* arg),
                                                      void* arg);
@@ -1542,14 +1542,14 @@ N-API modules are registered in a manner similar to other modules
 except that instead of using the `NODE_MODULE` macro the following
 is used:
 
-```C
+```c
 NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)
 ```
 
 The next difference is the signature for the `Init` method. For a N-API
 module it is as follows:
 
-```C
+```c
 napi_value Init(napi_env env, napi_value exports);
 ```
 
@@ -1562,7 +1562,7 @@ specify anything as the `exports` property of the module.
 To add the method `hello` as a function so that it can be called as a method
 provided by the addon:
 
-```C
+```c
 napi_value Init(napi_env env, napi_value exports) {
   napi_status status;
   napi_property_descriptor desc =
@@ -1575,7 +1575,7 @@ napi_value Init(napi_env env, napi_value exports) {
 
 To set a function to be returned by the `require()` for the addon:
 
-```C
+```c
 napi_value Init(napi_env env, napi_value exports) {
   napi_value method;
   napi_status status;
@@ -1588,7 +1588,7 @@ napi_value Init(napi_env env, napi_value exports) {
 To define a class so that new instances can be created (often used with
 [Object Wrap][]):
 
-```C
+```c
 // NOTE: partial example, not all referenced code is included
 napi_value Init(napi_env env, napi_value exports) {
   napi_status status;
@@ -1616,7 +1616,7 @@ napi_value Init(napi_env env, napi_value exports) {
 If the module will be loaded multiple times during the lifetime of the Node.js
 process, use the `NAPI_MODULE_INIT` macro to initialize the module:
 
-```C
+```c
 NAPI_MODULE_INIT() {
   napi_value answer;
   napi_status result;
@@ -1675,7 +1675,7 @@ added:
 napiVersion: 6
 -->
 
-```C
+```c
 typedef enum {
   napi_key_include_prototypes,
   napi_key_own_only
@@ -1698,7 +1698,7 @@ added:
 napiVersion: 6
 -->
 
-```C
+```c
 typedef enum {
   napi_key_all_properties = 0,
   napi_key_writable = 1,
@@ -1719,7 +1719,7 @@ added:
 napiVersion: 6
 -->
 
-```C
+```c
 typedef enum {
   napi_key_keep_numbers,
   napi_key_numbers_to_strings
@@ -1732,7 +1732,7 @@ indices.
 
 #### napi_valuetype
 
-```C
+```c
 typedef enum {
   // ES6 types (corresponds to typeof)
   napi_undefined,
@@ -1758,7 +1758,7 @@ object such that no properties can be set on it, and no prototype.
 
 #### napi_typedarray_type
 
-```C
+```c
 typedef enum {
   napi_int8_array,
   napi_uint8_array,
@@ -1785,7 +1785,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_create_array(napi_env env, napi_value* result)
 ```
 
@@ -1804,7 +1804,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_create_array_with_length(napi_env env,
                                           size_t length,
                                           napi_value* result)
@@ -1833,7 +1833,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_create_arraybuffer(napi_env env,
                                     size_t byte_length,
                                     void** data,
@@ -1866,7 +1866,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_create_buffer(napi_env env,
                                size_t size,
                                void** data,
@@ -1889,7 +1889,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_create_buffer_copy(napi_env env,
                                     size_t length,
                                     const void* data,
@@ -1918,7 +1918,7 @@ added:
 napiVersion: 5
 -->
 
-```C
+```c
 napi_status napi_create_date(napi_env env,
                              double time,
                              napi_value* result);
@@ -1944,7 +1944,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_create_external(napi_env env,
                                  void* data,
                                  napi_finalize finalize_cb,
@@ -1984,7 +1984,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status
 napi_create_external_arraybuffer(napi_env env,
                                  void* external_data,
@@ -2028,7 +2028,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_create_external_buffer(napi_env env,
                                         size_t length,
                                         void* data,
@@ -2069,7 +2069,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_create_object(napi_env env, napi_value* result)
 ```
 
@@ -2090,7 +2090,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_create_symbol(napi_env env,
                                napi_value description,
                                napi_value* result)
@@ -2114,7 +2114,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_create_typedarray(napi_env env,
                                    napi_typedarray_type type,
                                    size_t length,
@@ -2151,7 +2151,7 @@ added: v8.3.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_create_dataview(napi_env env,
                                  size_t byte_length,
                                  napi_value arraybuffer,
@@ -2186,7 +2186,7 @@ added: v8.4.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_create_int32(napi_env env, int32_t value, napi_value* result)
 ```
 
@@ -2208,7 +2208,7 @@ added: v8.4.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_create_uint32(napi_env env, uint32_t value, napi_value* result)
 ```
 
@@ -2230,7 +2230,7 @@ added: v8.4.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_create_int64(napi_env env, int64_t value, napi_value* result)
 ```
 
@@ -2255,7 +2255,7 @@ added: v8.4.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_create_double(napi_env env, double value, napi_value* result)
 ```
 
@@ -2277,7 +2277,7 @@ added: v10.7.0
 napiVersion: 6
 -->
 
-```C
+```c
 napi_status napi_create_bigint_int64(napi_env env,
                                      int64_t value,
                                      napi_value* result);
@@ -2297,7 +2297,7 @@ added: v10.7.0
 napiVersion: 6
 -->
 
-```C
+```c
 napi_status napi_create_bigint_uint64(napi_env env,
                                       uint64_t value,
                                       napi_value* result);
@@ -2317,7 +2317,7 @@ added: v10.7.0
 napiVersion: 6
 -->
 
-```C
+```c
 napi_status napi_create_bigint_words(napi_env env,
                                      int sign_bit,
                                      size_t word_count,
@@ -2346,7 +2346,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_create_string_latin1(napi_env env,
                                       const char* str,
                                       size_t length,
@@ -2373,7 +2373,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_create_string_utf16(napi_env env,
                                      const char16_t* str,
                                      size_t length,
@@ -2400,7 +2400,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_create_string_utf8(napi_env env,
                                     const char* str,
                                     size_t length,
@@ -2428,7 +2428,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_get_array_length(napi_env env,
                                   napi_value value,
                                   uint32_t* result)
@@ -2452,7 +2452,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_get_arraybuffer_info(napi_env env,
                                       napi_value arraybuffer,
                                       void** data,
@@ -2484,7 +2484,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_get_buffer_info(napi_env env,
                                  napi_value value,
                                  void** data,
@@ -2511,7 +2511,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_get_prototype(napi_env env,
                                napi_value object,
                                napi_value* result)
@@ -2531,7 +2531,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_get_typedarray_info(napi_env env,
                                      napi_value typedarray,
                                      napi_typedarray_type* type,
@@ -2570,7 +2570,7 @@ added: v8.3.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_get_dataview_info(napi_env env,
                                    napi_value dataview,
                                    size_t* byte_length,
@@ -2601,7 +2601,7 @@ added:
 napiVersion: 5
 -->
 
-```C
+```c
 napi_status napi_get_date_value(napi_env env,
                                 napi_value value,
                                 double* result)
@@ -2627,7 +2627,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_get_value_bool(napi_env env, napi_value value, bool* result)
 ```
 
@@ -2648,7 +2648,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_get_value_double(napi_env env,
                                   napi_value value,
                                   double* result)
@@ -2671,7 +2671,7 @@ added: v10.7.0
 napiVersion: 6
 -->
 
-```C
+```c
 napi_status napi_get_value_bigint_int64(napi_env env,
                                         napi_value value,
                                         int64_t* result,
@@ -2697,7 +2697,7 @@ added: v10.7.0
 napiVersion: 6
 -->
 
-```C
+```c
 napi_status napi_get_value_bigint_uint64(napi_env env,
                                         napi_value value,
                                         uint64_t* result,
@@ -2723,7 +2723,7 @@ added: v10.7.0
 napiVersion: 6
 -->
 
-```C
+```c
 napi_status napi_get_value_bigint_words(napi_env env,
                                         napi_value value,
                                         int* sign_bit,
@@ -2752,7 +2752,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_get_value_external(napi_env env,
                                     napi_value value,
                                     void** result)
@@ -2774,7 +2774,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_get_value_int32(napi_env env,
                                  napi_value value,
                                  int32_t* result)
@@ -2804,7 +2804,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_get_value_int64(napi_env env,
                                  napi_value value,
                                  int64_t* result)
@@ -2833,7 +2833,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_get_value_string_latin1(napi_env env,
                                          napi_value value,
                                          char* buf,
@@ -2862,7 +2862,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_get_value_string_utf8(napi_env env,
                                        napi_value value,
                                        char* buf,
@@ -2890,7 +2890,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_get_value_string_utf16(napi_env env,
                                         napi_value value,
                                         char16_t* buf,
@@ -2918,7 +2918,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_get_value_uint32(napi_env env,
                                   napi_value value,
                                   uint32_t* result)
@@ -2942,7 +2942,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_get_boolean(napi_env env, bool value, napi_value* result)
 ```
 
@@ -2962,7 +2962,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_get_global(napi_env env, napi_value* result)
 ```
 
@@ -2979,7 +2979,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_get_null(napi_env env, napi_value* result)
 ```
 
@@ -2996,7 +2996,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_get_undefined(napi_env env, napi_value* result)
 ```
 
@@ -3026,7 +3026,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_coerce_to_bool(napi_env env,
                                 napi_value value,
                                 napi_value* result)
@@ -3048,7 +3048,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_coerce_to_number(napi_env env,
                                   napi_value value,
                                   napi_value* result)
@@ -3070,7 +3070,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_coerce_to_object(napi_env env,
                                   napi_value value,
                                   napi_value* result)
@@ -3092,7 +3092,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_coerce_to_string(napi_env env,
                                   napi_value value,
                                   napi_value* result)
@@ -3114,7 +3114,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_typeof(napi_env env, napi_value value, napi_valuetype* result)
 ```
 
@@ -3138,7 +3138,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_instanceof(napi_env env,
                             napi_value object,
                             napi_value constructor,
@@ -3163,7 +3163,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_is_array(napi_env env, napi_value value, bool* result)
 ```
 
@@ -3182,7 +3182,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_is_arraybuffer(napi_env env, napi_value value, bool* result)
 ```
 
@@ -3200,7 +3200,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_is_buffer(napi_env env, napi_value value, bool* result)
 ```
 
@@ -3221,7 +3221,7 @@ added:
 napiVersion: 5
 -->
 
-```C
+```c
 napi_status napi_is_date(napi_env env, napi_value value, bool* result)
 ```
 
@@ -3240,7 +3240,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_is_error(napi_env env, napi_value value, bool* result)
 ```
 
@@ -3258,7 +3258,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_is_typedarray(napi_env env, napi_value value, bool* result)
 ```
 
@@ -3276,7 +3276,7 @@ added: v8.3.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_is_dataview(napi_env env, napi_value value, bool* result)
 ```
 
@@ -3294,7 +3294,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_strict_equals(napi_env env,
                                napi_value lhs,
                                napi_value rhs,
@@ -3320,7 +3320,7 @@ added:
 
 > Stability: 1 - Experimental
 
-```C
+```c
 napi_status napi_detach_arraybuffer(napi_env env,
                                     napi_value arraybuffer)
 ```
@@ -3348,7 +3348,7 @@ added:
 
 > Stability: 1 - Experimental
 
-```C
+```c
 napi_status napi_is_detached_arraybuffer(napi_env env,
                                          napi_value arraybuffer,
                                          bool* result)
@@ -3399,7 +3399,7 @@ obj.myProp = 123;
 
 The equivalent can be done using N-API values with the following snippet:
 
-```C
+```c
 napi_status status = napi_generic_failure;
 
 // const obj = {}
@@ -3426,7 +3426,7 @@ arr[123] = 'hello';
 
 The equivalent can be done using N-API values with the following snippet:
 
-```C
+```c
 napi_status status = napi_generic_failure;
 
 // const arr = [];
@@ -3453,7 +3453,7 @@ const value = arr[123];
 
 The following is the approximate equivalent of the N-API counterpart:
 
-```C
+```c
 napi_status status = napi_generic_failure;
 
 // const arr = []
@@ -3479,7 +3479,7 @@ Object.defineProperties(obj, {
 
 The following is the approximate equivalent of the N-API counterpart:
 
-```C
+```c
 napi_status status = napi_status_generic_failure;
 
 // const obj = {};
@@ -3509,7 +3509,7 @@ if (status != napi_ok) return status;
 ### Structures
 #### napi_property_attributes
 
-```C
+```c
 typedef enum {
   napi_default = 0,
   napi_writable = 1 << 0,
@@ -3540,7 +3540,7 @@ They can be one or more of the following bitflags:
 
 #### napi_property_descriptor
 
-```C
+```c
 typedef struct {
   // One of utf8name or name should be NULL.
   const char* utf8name;
@@ -3591,7 +3591,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_get_property_names(napi_env env,
                                     napi_value object,
                                     napi_value* result);
@@ -3618,7 +3618,7 @@ added:
 napiVersion: 6
 -->
 
-```C
+```c
 napi_get_all_property_names(napi_env env,
                             napi_value object,
                             napi_key_collection_mode key_mode,
@@ -3648,7 +3648,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_set_property(napi_env env,
                               napi_value object,
                               napi_value key,
@@ -3670,7 +3670,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_get_property(napi_env env,
                               napi_value object,
                               napi_value key,
@@ -3692,7 +3692,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_has_property(napi_env env,
                               napi_value object,
                               napi_value key,
@@ -3714,7 +3714,7 @@ added: v8.2.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_delete_property(napi_env env,
                                  napi_value object,
                                  napi_value key,
@@ -3737,7 +3737,7 @@ added: v8.2.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_has_own_property(napi_env env,
                                   napi_value object,
                                   napi_value key,
@@ -3761,7 +3761,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_set_named_property(napi_env env,
                                     napi_value object,
                                     const char* utf8Name,
@@ -3784,7 +3784,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_get_named_property(napi_env env,
                                     napi_value object,
                                     const char* utf8Name,
@@ -3807,7 +3807,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_has_named_property(napi_env env,
                                     napi_value object,
                                     const char* utf8Name,
@@ -3830,7 +3830,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_set_element(napi_env env,
                              napi_value object,
                              uint32_t index,
@@ -3852,7 +3852,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_get_element(napi_env env,
                              napi_value object,
                              uint32_t index,
@@ -3874,7 +3874,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_has_element(napi_env env,
                              napi_value object,
                              uint32_t index,
@@ -3897,7 +3897,7 @@ added: v8.2.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_delete_element(napi_env env,
                                 napi_value object,
                                 uint32_t index,
@@ -3920,7 +3920,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_define_properties(napi_env env,
                                    napi_value object,
                                    size_t property_count,
@@ -3971,7 +3971,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 NAPI_EXTERN napi_status napi_call_function(napi_env env,
                                            napi_value recv,
                                            napi_value func,
@@ -4007,7 +4007,7 @@ function AddTwo(num) {
 Then, the above function can be invoked from a native add-on using the
 following code:
 
-```C
+```c
 // Get the function named "AddTwo" on the global object
 napi_value global, add_two, arg;
 napi_status status = napi_get_global(env, &global);
@@ -4040,7 +4040,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_create_function(napi_env env,
                                  const char* utf8name,
                                  size_t length,
@@ -4075,7 +4075,7 @@ In order to expose a function as part of the
 add-on's module exports, set the newly created function on the exports
 object. A sample module might look as follows:
 
-```C
+```c
 napi_value SayHello(napi_env env, napi_callback_info info) {
   printf("Hello\n");
   return NULL;
@@ -4121,7 +4121,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_get_cb_info(napi_env env,
                              napi_callback_info cbinfo,
                              size_t* argc,
@@ -4153,7 +4153,7 @@ added: v8.6.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_get_new_target(napi_env env,
                                 napi_callback_info cbinfo,
                                 napi_value* result)
@@ -4174,7 +4174,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_new_instance(napi_env env,
                               napi_value cons,
                               size_t argc,
@@ -4206,7 +4206,7 @@ const value = new MyObject(arg);
 
 The following can be approximated in N-API using the following snippet:
 
-```C
+```c
 // Get the constructor function MyObject
 napi_value global, constructor, arg, value;
 napi_status status = napi_get_global(env, &global);
@@ -4249,7 +4249,7 @@ called on a class prototype and a function called on an instance of a class.
 A common pattern used to address this problem is to save a persistent
 reference to the class constructor for later `instanceof` checks.
 
-```C
+```c
 napi_value MyClass_constructor = NULL;
 status = napi_get_reference_value(env, MyClass::es_constructor, &MyClass_constructor);
 assert(napi_ok == status);
@@ -4271,7 +4271,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_define_class(napi_env env,
                               const char* utf8name,
                               size_t length,
@@ -4336,7 +4336,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_wrap(napi_env env,
                       napi_value js_object,
                       void* native_object,
@@ -4393,7 +4393,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_unwrap(napi_env env,
                         napi_value js_object,
                         void** result);
@@ -4420,7 +4420,7 @@ added: v8.5.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_remove_wrap(napi_env env,
                              napi_value js_object,
                              void** result);
@@ -4444,7 +4444,7 @@ added: v8.0.0
 napiVersion: 5
 -->
 
-```C
+```c
 napi_status napi_add_finalizer(napi_env env,
                                napi_value js_object,
                                void* native_object,
@@ -4509,7 +4509,7 @@ it will likely execute JavaScript.
 
 These functions implement the following interfaces:
 
-```C
+```c
 typedef void (*napi_async_execute_callback)(napi_env env,
                                             void* data);
 typedef void (*napi_async_complete_callback)(napi_env env,
@@ -4524,7 +4524,7 @@ addon-provided `void*` data that was passed into the
 Once created the async worker can be queued
 for execution using the [`napi_queue_async_work`][] function:
 
-```C
+```c
 napi_status napi_queue_async_work(napi_env env,
                                   napi_async_work work);
 ```
@@ -4547,7 +4547,7 @@ changes:
     description: Added `async_resource` and `async_resource_name` parameters.
 -->
 
-```C
+```c
 napi_status napi_create_async_work(napi_env env,
                                    napi_value async_resource,
                                    napi_value async_resource_name,
@@ -4592,7 +4592,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_delete_async_work(napi_env env,
                                    napi_async_work work);
 ```
@@ -4612,7 +4612,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_queue_async_work(napi_env env,
                                   napi_async_work work);
 ```
@@ -4632,7 +4632,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_cancel_async_work(napi_env env,
                                    napi_async_work work);
 ```
@@ -4664,7 +4664,7 @@ added: v8.6.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_async_init(napi_env env,
                             napi_value async_resource,
                             napi_value async_resource_name,
@@ -4692,7 +4692,7 @@ added: v8.6.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_async_destroy(napi_env env,
                                napi_async_context async_context);
 ```
@@ -4713,7 +4713,7 @@ changes:
     description: Added `async_context` parameter.
 -->
 
-```C
+```c
 NAPI_EXTERN napi_status napi_make_callback(napi_env env,
                                            napi_async_context async_context,
                                            napi_value recv,
@@ -4757,7 +4757,7 @@ added: v9.6.0
 napiVersion: 3
 -->
 
-```C
+```c
 NAPI_EXTERN napi_status napi_open_callback_scope(napi_env env,
                                                  napi_value resource_object,
                                                  napi_async_context context,
@@ -4784,7 +4784,7 @@ added: v9.6.0
 napiVersion: 3
 -->
 
-```C
+```c
 NAPI_EXTERN napi_status napi_close_callback_scope(napi_env env,
                                                   napi_callback_scope scope)
 ```
@@ -4802,7 +4802,7 @@ added: v8.4.0
 napiVersion: 1
 -->
 
-```C
+```c
 typedef struct {
   uint32_t major;
   uint32_t minor;
@@ -4831,7 +4831,7 @@ added: v8.0.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_get_version(napi_env env,
                              uint32_t* result);
 ```
@@ -4863,7 +4863,7 @@ added: v8.5.0
 napiVersion: 1
 -->
 
-```C
+```c
 NAPI_EXTERN napi_status napi_adjust_external_memory(napi_env env,
                                                     int64_t change_in_bytes,
                                                     int64_t* result);
@@ -4944,7 +4944,7 @@ added: v8.5.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_create_promise(napi_env env,
                                 napi_deferred* deferred,
                                 napi_value* promise);
@@ -4966,7 +4966,7 @@ added: v8.5.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_resolve_deferred(napi_env env,
                                   napi_deferred deferred,
                                   napi_value resolution);
@@ -4991,7 +4991,7 @@ added: v8.5.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_reject_deferred(napi_env env,
                                  napi_deferred deferred,
                                  napi_value rejection);
@@ -5016,7 +5016,7 @@ added: v8.5.0
 napiVersion: 1
 -->
 
-```C
+```c
 napi_status napi_is_promise(napi_env env,
                             napi_value value,
                             bool* is_promise);
@@ -5038,7 +5038,7 @@ added: v8.5.0
 napiVersion: 1
 -->
 
-```C
+```c
 NAPI_EXTERN napi_status napi_run_script(napi_env env,
                                         napi_value script,
                                         napi_value* result);
@@ -5074,7 +5074,7 @@ added:
 napiVersion: 2
 -->
 
-```C
+```c
 NAPI_EXTERN napi_status napi_get_uv_event_loop(napi_env env,
                                                struct uv_loop_s** loop);
 ```
@@ -5215,7 +5215,7 @@ changes:
     description: Made `func` parameter optional with custom `call_js_cb`.
 -->
 
-```C
+```c
 NAPI_EXTERN napi_status
 napi_create_threadsafe_function(napi_env env,
                                 napi_value func,
@@ -5259,7 +5259,7 @@ added: v10.6.0
 napiVersion: 4
 -->
 
-```C
+```c
 NAPI_EXTERN napi_status
 napi_get_threadsafe_function_context(napi_threadsafe_function func,
                                      void** result);
@@ -5283,7 +5283,7 @@ changes:
       the main thread or a worker thread and the queue is full.
 -->
 
-```C
+```c
 NAPI_EXTERN napi_status
 napi_call_threadsafe_function(napi_threadsafe_function func,
                               void* data,
@@ -5315,7 +5315,7 @@ added: v10.6.0
 napiVersion: 4
 -->
 
-```C
+```c
 NAPI_EXTERN napi_status
 napi_acquire_threadsafe_function(napi_threadsafe_function func);
 ```
@@ -5337,7 +5337,7 @@ added: v10.6.0
 napiVersion: 4
 -->
 
-```C
+```c
 NAPI_EXTERN napi_status
 napi_release_threadsafe_function(napi_threadsafe_function func,
                                  napi_threadsafe_function_release_mode mode);
@@ -5366,7 +5366,7 @@ added: v10.6.0
 napiVersion: 4
 -->
 
-```C
+```c
 NAPI_EXTERN napi_status
 napi_ref_threadsafe_function(napi_env env, napi_threadsafe_function func);
 ```
@@ -5387,7 +5387,7 @@ added: v10.6.0
 napiVersion: 4
 -->
 
-```C
+```c
 NAPI_EXTERN napi_status
 napi_unref_threadsafe_function(napi_env env, napi_threadsafe_function func);
 ```


### PR DESCRIPTION
Prior to this commit, C fenced code blocks in Markdown files had
inconsistent info strings. This has been corrected to standardize on
the lowercase variant, which matches the others, is the typical file
extension for C files, and is the CSS class used by highlight.js
despite representing a minority of appearances in the doc/api/ dir.

Stats:
>  'C' => 181,
>  'c' => 3,

Refs: highlightjs/highlight.js#2577

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
