### PR TITLE
n-api: ensure scope present for finalization

### DIFF
--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -267,6 +267,7 @@ class RefBase : protected Finalizer, RefTracker {
  protected:
   inline void Finalize(bool is_env_teardown = false) override {
     if (_finalize_callback != nullptr) {
+      v8::HandleScope handle_scope(_env->isolate);
       _env->CallIntoModule([&](napi_env env) {
         _finalize_callback(
             env,

--- a/test/node-api/test_worker_terminate_finalization/binding.gyp
+++ b/test/node-api/test_worker_terminate_finalization/binding.gyp
@@ -1,0 +1,8 @@
+{
+  "targets": [
+    {
+      "target_name": "test_worker_terminate_finalization",
+      "sources": [ "test_worker_terminate_finalization.c" ]
+    }
+  ]
+}

--- a/test/node-api/test_worker_terminate_finalization/test.js
+++ b/test/node-api/test_worker_terminate_finalization/test.js
@@ -1,0 +1,18 @@
+'use strict';
+const common = require('../../common');
+const { Worker, isMainThread } = require('worker_threads');
+
+if (isMainThread) {
+  const worker = new Worker(__filename);
+  worker.on('error', common.mustNotCall());
+} else {
+  const { Test } =
+    require(`./build/${common.buildType}/test_worker_terminate_finalization`);
+
+  // Spin up thread and call add-on create the right sequence
+  // of rerences to hit the case reported in
+  // https://github.com/nodejs/node-addon-api/issues/722
+  // will crash if run under debug and its not possible to
+  // create object in the specific finalizer
+  Test(new Object());
+}

--- a/test/node-api/test_worker_terminate_finalization/test_worker_terminate_finalization.c
+++ b/test/node-api/test_worker_terminate_finalization/test_worker_terminate_finalization.c
@@ -1,0 +1,41 @@
+#include <stdio.h>
+#include <node_api.h>
+#include <assert.h>
+#include <malloc.h>
+#include "../../js-native-api/common.h"
+
+int wrappedNativeData;
+napi_ref ref;
+void WrapFinalizer(napi_env env, void* data, void* hint) {
+  uint32_t count;
+  NAPI_CALL_RETURN_VOID(env, napi_reference_unref(env, ref, &count));
+}
+
+napi_value Test(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value argv[1];
+  napi_value result;
+  napi_ref ref;
+  napi_ref wrapResult;
+
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, argv, NULL, NULL));
+  NAPI_CALL(env, napi_create_external_buffer(env, 4, (void*) malloc(4), NULL, NULL, &result));
+  NAPI_CALL(env, napi_create_reference(env, result, 1, &ref));
+  NAPI_CALL(env, napi_wrap(env, argv[0], (void*) &wrappedNativeData, WrapFinalizer, NULL, &wrapResult));
+  return NULL;
+}
+
+napi_value Init(napi_env env, napi_value exports) {
+  napi_property_descriptor properties[] = {
+    DECLARE_NAPI_PROPERTY("Test", Test)
+  };
+
+  NAPI_CALL(env, napi_define_properties(
+      env, exports, sizeof(properties) / sizeof(*properties), properties));
+
+  return exports;
+}
+
+// Do not start using NAPI_MODULE_INIT() here, so that we can test
+// compatibility of Workers with NAPI_MODULE().
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)


### PR DESCRIPTION
Spent some time looking at https://github.com/nodejs/node-addon-api/pull/729 which was related to a crash during finalization when using node-addon-api ObjectWrap.

I think it should be fixed in core as opposed to node-addon-api as it should be possible to hit the same problem using N-API directly instead of node-addon-api.

It seems to be more subtle than the scope never being in place. The added is the simplest test that causes the problem to recreate when run under debug and without the change adding the scope.

Refs: https://github.com/nodejs/node-addon-api/issues/722

Ensure a scope is on stack during finalization
as finalization functions can create JS Objects

Signed-off-by: Michael Dawson <michael_dawson@ca.ibm.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
