### PR TITLE
errors: fully inspect uncaught exceptions on exit

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -16,6 +16,7 @@ const {
   JSONStringify,
   Map,
   MathAbs,
+  MathMax,
   NumberIsInteger,
   ObjectDefineProperty,
   ObjectKeys,
@@ -700,7 +701,11 @@ const fatalExceptionStackEnhancers = {
                    require('internal/tty').hasColors()) ||
                    defaultColors);
     try {
-      return inspect(error, { colors });
+      return inspect(error, {
+        colors,
+        customInspect: false,
+        depth: MathMax(inspect.defaultOptions.depth, 5)
+      });
     } catch {
       return originalStack;
     }

--- a/test/message/assert_throws_stack.out
+++ b/test/message/assert_throws_stack.out
@@ -29,6 +29,6 @@ AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
       at *
       at *
       at *,
-  expected: [Object],
+  expected: { bar: true },
   operator: 'throws'
 }


### PR DESCRIPTION
This makes sure errors are fully inspected during exit. That is
important to provide as many debugging information to the user as
possible.

Signed-off-by: Ruben Bridgewater <ruben@bridgewater.de>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
