### PR TITLE
wasi: simplify WASI memory management

### DIFF
--- a/src/node_wasi.cc
+++ b/src/node_wasi.cc
@@ -661,27 +661,24 @@ void WASI::FdPread(const FunctionCallbackInfo<Value>& args) {
                          iovs_ptr,
                          iovs_len * UVWASI_SERDES_SIZE_iovec_t);
   CHECK_BOUNDS_OR_RETURN(args, mem_size, nread_ptr, UVWASI_SERDES_SIZE_size_t);
-  uvwasi_iovec_t* iovs = UncheckedCalloc<uvwasi_iovec_t>(iovs_len);
+  std::vector<uvwasi_iovec_t> iovs(iovs_len);
   uvwasi_errno_t err;
 
-  if (iovs == nullptr) {
-    args.GetReturnValue().Set(UVWASI_ENOMEM);
-    return;
-  }
-
-  err = uvwasi_serdes_readv_iovec_t(memory, mem_size, iovs_ptr, iovs, iovs_len);
+  err = uvwasi_serdes_readv_iovec_t(memory,
+                                    mem_size,
+                                    iovs_ptr,
+                                    iovs.data(),
+                                    iovs_len);
   if (err != UVWASI_ESUCCESS) {
-    free(iovs);
     args.GetReturnValue().Set(err);
     return;
   }
 
   uvwasi_size_t nread;
-  err = uvwasi_fd_pread(&wasi->uvw_, fd, iovs, iovs_len, offset, &nread);
+  err = uvwasi_fd_pread(&wasi->uvw_, fd, iovs.data(), iovs_len, offset, &nread);
   if (err == UVWASI_ESUCCESS)
     uvwasi_serdes_write_size_t(memory, nread_ptr, nread);
 
-  free(iovs);
   args.GetReturnValue().Set(err);
 }
 
@@ -764,31 +761,29 @@ void WASI::FdPwrite(const FunctionCallbackInfo<Value>& args) {
                          mem_size,
                          nwritten_ptr,
                          UVWASI_SERDES_SIZE_size_t);
-  uvwasi_ciovec_t* iovs = UncheckedCalloc<uvwasi_ciovec_t>(iovs_len);
+  std::vector<uvwasi_ciovec_t> iovs(iovs_len);
   uvwasi_errno_t err;
-
-  if (iovs == nullptr) {
-    args.GetReturnValue().Set(UVWASI_ENOMEM);
-    return;
-  }
 
   err = uvwasi_serdes_readv_ciovec_t(memory,
                                      mem_size,
                                      iovs_ptr,
-                                     iovs,
+                                     iovs.data(),
                                      iovs_len);
   if (err != UVWASI_ESUCCESS) {
-    free(iovs);
     args.GetReturnValue().Set(err);
     return;
   }
 
   uvwasi_size_t nwritten;
-  err = uvwasi_fd_pwrite(&wasi->uvw_, fd, iovs, iovs_len, offset, &nwritten);
+  err = uvwasi_fd_pwrite(&wasi->uvw_,
+                         fd,
+                         iovs.data(),
+                         iovs_len,
+                         offset,
+                         &nwritten);
   if (err == UVWASI_ESUCCESS)
     uvwasi_serdes_write_size_t(memory, nwritten_ptr, nwritten);
 
-  free(iovs);
   args.GetReturnValue().Set(err);
 }
 
@@ -814,27 +809,24 @@ void WASI::FdRead(const FunctionCallbackInfo<Value>& args) {
                          iovs_ptr,
                          iovs_len * UVWASI_SERDES_SIZE_iovec_t);
   CHECK_BOUNDS_OR_RETURN(args, mem_size, nread_ptr, UVWASI_SERDES_SIZE_size_t);
-  uvwasi_iovec_t* iovs = UncheckedCalloc<uvwasi_iovec_t>(iovs_len);
+  std::vector<uvwasi_iovec_t> iovs(iovs_len);
   uvwasi_errno_t err;
 
-  if (iovs == nullptr) {
-    args.GetReturnValue().Set(UVWASI_ENOMEM);
-    return;
-  }
-
-  err = uvwasi_serdes_readv_iovec_t(memory, mem_size, iovs_ptr, iovs, iovs_len);
+  err = uvwasi_serdes_readv_iovec_t(memory,
+                                    mem_size,
+                                    iovs_ptr,
+                                    iovs.data(),
+                                    iovs_len);
   if (err != UVWASI_ESUCCESS) {
-    free(iovs);
     args.GetReturnValue().Set(err);
     return;
   }
 
   uvwasi_size_t nread;
-  err = uvwasi_fd_read(&wasi->uvw_, fd, iovs, iovs_len, &nread);
+  err = uvwasi_fd_read(&wasi->uvw_, fd, iovs.data(), iovs_len, &nread);
   if (err == UVWASI_ESUCCESS)
     uvwasi_serdes_write_size_t(memory, nread_ptr, nread);
 
-  free(iovs);
   args.GetReturnValue().Set(err);
 }
 
@@ -996,31 +988,24 @@ void WASI::FdWrite(const FunctionCallbackInfo<Value>& args) {
                          mem_size,
                          nwritten_ptr,
                          UVWASI_SERDES_SIZE_size_t);
-  uvwasi_ciovec_t* iovs = UncheckedCalloc<uvwasi_ciovec_t>(iovs_len);
+  std::vector<uvwasi_ciovec_t> iovs(iovs_len);
   uvwasi_errno_t err;
-
-  if (iovs == nullptr) {
-    args.GetReturnValue().Set(UVWASI_ENOMEM);
-    return;
-  }
 
   err = uvwasi_serdes_readv_ciovec_t(memory,
                                      mem_size,
                                      iovs_ptr,
-                                     iovs,
+                                     iovs.data(),
                                      iovs_len);
   if (err != UVWASI_ESUCCESS) {
-    free(iovs);
     args.GetReturnValue().Set(err);
     return;
   }
 
   uvwasi_size_t nwritten;
-  err = uvwasi_fd_write(&wasi->uvw_, fd, iovs, iovs_len, &nwritten);
+  err = uvwasi_fd_write(&wasi->uvw_, fd, iovs.data(), iovs_len, &nwritten);
   if (err == UVWASI_ESUCCESS)
     uvwasi_serdes_write_size_t(memory, nwritten_ptr, nwritten);
 
-  free(iovs);
   args.GetReturnValue().Set(err);
 }
 
@@ -1435,21 +1420,8 @@ void WASI::PollOneoff(const FunctionCallbackInfo<Value>& args) {
                          mem_size,
                          nevents_ptr,
                          UVWASI_SERDES_SIZE_size_t);
-  uvwasi_subscription_t* in =
-      UncheckedCalloc<uvwasi_subscription_t>(nsubscriptions);
-
-  if (in == nullptr) {
-    args.GetReturnValue().Set(UVWASI_ENOMEM);
-    return;
-  }
-
-  uvwasi_event_t* out = UncheckedCalloc<uvwasi_event_t>(nsubscriptions);
-
-  if (out == nullptr) {
-    free(in);
-    args.GetReturnValue().Set(UVWASI_ENOMEM);
-    return;
-  }
+  std::vector<uvwasi_subscription_t> in(nsubscriptions);
+  std::vector<uvwasi_event_t> out(nsubscriptions);
 
   for (uint32_t i = 0; i < nsubscriptions; ++i) {
     uvwasi_serdes_read_subscription_t(memory, in_ptr, &in[i]);
@@ -1458,8 +1430,8 @@ void WASI::PollOneoff(const FunctionCallbackInfo<Value>& args) {
 
   uvwasi_size_t nevents;
   uvwasi_errno_t err = uvwasi_poll_oneoff(&wasi->uvw_,
-                                          in,
-                                          out,
+                                          in.data(),
+                                          out.data(),
                                           nsubscriptions,
                                           &nevents);
   if (err == UVWASI_ESUCCESS) {
@@ -1471,8 +1443,6 @@ void WASI::PollOneoff(const FunctionCallbackInfo<Value>& args) {
     }
   }
 
-  free(in);
-  free(out);
   args.GetReturnValue().Set(err);
 }
 
@@ -1563,20 +1533,13 @@ void WASI::SockRecv(const FunctionCallbackInfo<Value>& args) {
                          ri_data_len * UVWASI_SERDES_SIZE_iovec_t);
   CHECK_BOUNDS_OR_RETURN(args, mem_size, ro_datalen_ptr, 4);
   CHECK_BOUNDS_OR_RETURN(args, mem_size, ro_flags_ptr, 4);
-  uvwasi_iovec_t* ri_data = UncheckedCalloc<uvwasi_iovec_t>(ri_data_len);
-
-  if (ri_data == nullptr) {
-    args.GetReturnValue().Set(UVWASI_ENOMEM);
-    return;
-  }
-
+  std::vector<uvwasi_iovec_t> ri_data(ri_data_len);
   uvwasi_errno_t err = uvwasi_serdes_readv_iovec_t(memory,
                                                    mem_size,
                                                    ri_data_ptr,
-                                                   ri_data,
+                                                   ri_data.data(),
                                                    ri_data_len);
   if (err != UVWASI_ESUCCESS) {
-    free(ri_data);
     args.GetReturnValue().Set(err);
     return;
   }
@@ -1585,7 +1548,7 @@ void WASI::SockRecv(const FunctionCallbackInfo<Value>& args) {
   uvwasi_roflags_t ro_flags;
   err = uvwasi_sock_recv(&wasi->uvw_,
                          sock,
-                         ri_data,
+                         ri_data.data(),
                          ri_data_len,
                          ri_flags,
                          &ro_datalen,
@@ -1595,7 +1558,6 @@ void WASI::SockRecv(const FunctionCallbackInfo<Value>& args) {
     uvwasi_serdes_write_roflags_t(memory, ro_flags_ptr, ro_flags);
   }
 
-  free(ri_data);
   args.GetReturnValue().Set(err);
 }
 
@@ -1632,20 +1594,13 @@ void WASI::SockSend(const FunctionCallbackInfo<Value>& args) {
                          mem_size,
                          so_datalen_ptr,
                          UVWASI_SERDES_SIZE_size_t);
-  uvwasi_ciovec_t* si_data = UncheckedCalloc<uvwasi_ciovec_t>(si_data_len);
-
-  if (si_data == nullptr) {
-    args.GetReturnValue().Set(UVWASI_ENOMEM);
-    return;
-  }
-
+  std::vector<uvwasi_ciovec_t> si_data(si_data_len);
   uvwasi_errno_t err = uvwasi_serdes_readv_ciovec_t(memory,
                                                     mem_size,
                                                     si_data_ptr,
-                                                    si_data,
+                                                    si_data.data(),
                                                     si_data_len);
   if (err != UVWASI_ESUCCESS) {
-    free(si_data);
     args.GetReturnValue().Set(err);
     return;
   }
@@ -1653,14 +1608,13 @@ void WASI::SockSend(const FunctionCallbackInfo<Value>& args) {
   uvwasi_size_t so_datalen;
   err = uvwasi_sock_send(&wasi->uvw_,
                          sock,
-                         si_data,
+                         si_data.data(),
                          si_data_len,
                          si_flags,
                          &so_datalen);
   if (err == UVWASI_ESUCCESS)
     uvwasi_serdes_write_size_t(memory, so_datalen_ptr, so_datalen);
 
-  free(si_data);
   args.GetReturnValue().Set(err);
 }
 


### PR DESCRIPTION
This commit migrates the WASI C++ code from `UncheckedCalloc()` to `std::vector`s. Should help with code coverage as well.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)