### PR TITLE
doc: normalize JavaScript code block info strings

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -4260,7 +4260,7 @@ recommended.
 When `file` is a file descriptor, the behavior is almost identical to directly
 calling `fs.write()` like:
 
-```javascript
+```js
 fs.write(fd, Buffer.from(data, options.encoding), callback);
 ```
 

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -896,7 +896,7 @@ The `'readable'` event is emitted when there is data available to be read from
 the stream. In some cases, attaching a listener for the `'readable'` event will
 cause some amount of data to be read into an internal buffer.
 
-```javascript
+```js
 const readable = getReadableStreamSomehow();
 readable.on('readable', function() {
   // There is some data to read now.

--- a/doc/guides/writing-tests.md
+++ b/doc/guides/writing-tests.md
@@ -29,7 +29,7 @@ For example, look for `test-streams` when writing a test for `lib/streams.js`.
 
 Let's analyze this basic test from the Node.js test suite:
 
-```javascript
+```js
 'use strict';                                                          // 1
 const common = require('../common');                                   // 2
 const fixtures = require('../common/fixtures');                        // 3
@@ -57,7 +57,7 @@ server.listen(0, () => {                                               // 14
 
 ### **Lines 1-3**
 
-```javascript
+```js
 'use strict';
 const common = require('../common');
 const fixtures = require('../common/fixtures');
@@ -78,13 +78,13 @@ the test leaks variables into the global space. In situations where a test uses
 no functions or other properties exported by `common`, include it without
 assigning it to an identifier:
 
-```javascript
+```js
 require('../common');
 ```
 
 ### **Lines 5-6**
 
-```javascript
+```js
 // This test ensures that the http-parser can handle UTF-8 characters
 // in the http header.
 ```
@@ -94,7 +94,7 @@ designed to test.
 
 ### **Lines 8-9**
 
-```javascript
+```js
 const assert = require('assert');
 const http = require('http');
 ```
@@ -136,7 +136,7 @@ In the event a test needs a timer, consider using the
 `common.platformTimeout()` method. It allows setting specific timeouts
 depending on the platform:
 
-```javascript
+```js
 const timer = setTimeout(fail, common.platformTimeout(4000));
 ```
 
@@ -155,7 +155,7 @@ One interesting case is `common.mustCall`. The use of `common.mustCall` may
 avoid the use of extra variables and the corresponding assertions. Let's
 explain this with a real test from the test suite.
 
-```javascript
+```js
 'use strict';
 require('../common');
 const assert = require('assert');
@@ -189,7 +189,7 @@ const server = http.createServer((req, res) => {
 
 This test could be greatly simplified by using `common.mustCall` like this:
 
-```javascript
+```js
 'use strict';
 const common = require('../common');
 const http = require('http');
@@ -216,7 +216,7 @@ provides a simple countdown mechanism for tests that require a particular
 action to be taken after a given number of completed tasks (for instance,
 shutting down an HTTP server after a specific number of requests).
 
-```javascript
+```js
 const Countdown = require('../common/countdown');
 
 const countdown = new Countdown(2, () => {
@@ -237,7 +237,7 @@ hence, the test fail - in the case of an `unhandledRejection` event. It is
 possible to disable it with `common.disableCrashOnUnhandledRejection()` if
 needed.
 
-```javascript
+```js
 const common = require('../common');
 const assert = require('assert');
 const fs = require('fs').promises;
@@ -257,7 +257,7 @@ test followed by the flags. For example, to allow a test to require some of the
 `internal/*` modules, add the `--expose-internals` flag.
 A test that would require `internal/freelist` could start like this:
 
-```javascript
+```js
 'use strict';
 
 // Flags: --expose-internals


### PR DESCRIPTION
Prior to this commit, JavaScript fenced code blocks in Markdown files
had inconsistent info strings. This has been corrected to standardize
on the one with the highest frequency in the doc/api/ dir.

Stats:
>  'js' => 1091,
>  'javascript' => 2,

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
