### PR TITLE
modules: runtime deprecate module.parent

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2612,6 +2612,9 @@ no longer required due to simplification of the implementation.
 ### DEP0144: `module.parent`
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/33534
+    description: Runtime deprecation.
   - version:
     - v14.6.0
     - v12.19.0
@@ -2619,7 +2622,7 @@ changes:
     description: Documentation-only deprecation.
 -->
 
-Type: Documentation-only (supports [`--pending-deprecation`][])
+Type: Runtime (supports [`--pending-deprecation`][])
 
 A CommonJS module can access the first module that required it using
 `module.parent`. This feature is deprecated because it does not work
@@ -2642,6 +2645,9 @@ When looking for the CommonJS modules that have required the current one,
 const moduleParents = Object.values(require.cache)
   .filter((m) => m.children.includes(module));
 ```
+
+Without `--pending-deprecation`, runtime warnings occur only when this property
+is accessed from a module that have a nullish value for their `module.parent`.
 
 ### DEP0145: `socket.bufferSize`
 <!-- YAML

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -917,10 +917,10 @@ deprecated:
 > Stability: 0 - Deprecated: Please use [`require.main`][] and
 > [`module.children`][] instead.
 
-* {module | null | undefined}
+* {module | null | UnknownModule}
 
 The module that first required this one, or `null` if the current module is the
-entry point of the current process, or `undefined` if the module was loaded by
+entry point of the current process, or `UnknownModule` if the module was loaded by
 something that is not a CommonJS module (E.G.: REPL or `import`).
 
 ### `module.path`

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -917,10 +917,10 @@ deprecated:
 > Stability: 0 - Deprecated: Please use [`require.main`][] and
 > [`module.children`][] instead.
 
-* {module | null | UnknownModule}
+* {module | null | undefined}
 
 The module that first required this one, or `null` if the current module is the
-entry point of the current process, or `UnknownModule` if the module was loaded by
+entry point of the current process, or `undefined` if the module was loaded by
 something that is not a CommonJS module (E.G.: REPL or `import`).
 
 ### `module.path`

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -252,11 +252,6 @@ function getModuleParent() {
     );
     getModuleParent.warned = true;
   }
-  if (parent === undefined) {
-    const parent = new (class UnknownModule {})();
-    moduleParentCache.set(this, parent);
-    return parent;
-  }
   return parent;
 }
 

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -241,7 +241,23 @@ ObjectDefineProperty(Module.prototype, 'isPreloading', isPreloadingDesc);
 ObjectDefineProperty(NativeModule.prototype, 'isPreloading', isPreloadingDesc);
 
 function getModuleParent() {
-  return moduleParentCache.get(this);
+  const parent = moduleParentCache.get(this);
+  if (!process.noDeprecation && !getModuleParent.warned &&
+      (parent == null || pendingDeprecation)) {
+    process.emitWarning(
+      'module.parent is deprecated due to accuracy issues. Please use ' +
+        'require.main to find program entry point instead.',
+      'DeprecationWarning',
+      'DEP0144'
+    );
+    getModuleParent.warned = true;
+  }
+  if (parent === undefined) {
+    const parent = new (class UnknownModule {})();
+    moduleParentCache.set(this, parent);
+    return parent;
+  }
+  return parent;
 }
 
 function setModuleParent(value) {
@@ -249,18 +265,13 @@ function setModuleParent(value) {
 }
 
 ObjectDefineProperty(Module.prototype, 'parent', {
-  get: pendingDeprecation ? deprecate(
-    getModuleParent,
-    'module.parent is deprecated due to accuracy issues. Please use ' +
-      'require.main to find program entry point instead.',
-    'DEP0144'
-  ) : getModuleParent,
-  set: pendingDeprecation ? deprecate(
+  get: getModuleParent,
+  set: deprecate(
     setModuleParent,
     'module.parent is deprecated due to accuracy issues. Please use ' +
       'require.main to find program entry point instead.',
     'DEP0144'
-  ) : setModuleParent,
+  ),
 });
 
 let debug = require('internal/util/debuglog').debuglog('module', (fn) => {

--- a/test/fixtures/cjs-module-parent.js
+++ b/test/fixtures/cjs-module-parent.js
@@ -1,0 +1,5 @@
+'use strict';
+const assert = require('assert');
+
+// Accessing module.parent should not be falsy.
+assert.ok(module.parent)

--- a/test/fixtures/cjs-module-parent.js
+++ b/test/fixtures/cjs-module-parent.js
@@ -1,5 +1,5 @@
 'use strict';
-const assert = require('assert');
 
-// Accessing module.parent should not be falsy.
-assert.ok(module.parent)
+if(!module.parent) {
+    setImmediate(() => {});
+}

--- a/test/parallel/test-module-parent-deprecation-no-warning-for-cjs-users.js
+++ b/test/parallel/test-module-parent-deprecation-no-warning-for-cjs-users.js
@@ -1,0 +1,7 @@
+'use strict';
+
+require('../common');
+const fixtures = require('../common/fixtures');
+
+// Accessing module.parent from a child module should not raise a warning.
+require(fixtures.path('cjs-module-parent.js'));

--- a/test/parallel/test-module-parent-deprecation-warning-for-esm-users.mjs
+++ b/test/parallel/test-module-parent-deprecation-warning-for-esm-users.mjs
@@ -1,0 +1,7 @@
+import { mustCall } from '../common/index.mjs';
+import fixtures from '../common/fixtures.js';
+
+// Accessing module.parent from a child module should raise a deprecation
+// warning when imported from ESM.
+import(fixtures.path('cjs-module-parent.js'))
+    .then(mustCall());

--- a/test/parallel/test-module-parent-deprecation.js
+++ b/test/parallel/test-module-parent-deprecation.js
@@ -1,6 +1,5 @@
-// Flags: --pending-deprecation
-
 'use strict';
+
 const common = require('../common');
 const assert = require('assert');
 

--- a/test/parallel/test-module-parent-pending-deprecation.js
+++ b/test/parallel/test-module-parent-pending-deprecation.js
@@ -1,0 +1,15 @@
+// Flags: --pending-deprecation
+
+'use strict';
+
+const common = require('../common');
+const fixtures = require('../common/fixtures');
+
+common.expectWarning(
+  'DeprecationWarning',
+  'module.parent is deprecated due to accuracy issues. Please use ' +
+      'require.main to find program entry point instead.',
+  'DEP0144'
+);
+
+require(fixtures.path('cjs-module-parent.js'));

--- a/test/parallel/test-module-parent-setter-deprecation.js
+++ b/test/parallel/test-module-parent-setter-deprecation.js
@@ -1,5 +1,3 @@
-// Flags: --pending-deprecation
-
 'use strict';
 const common = require('../common');
 


### PR DESCRIPTION
TL;DR: runtime warning when this `module.parent` is accessed from a module that have a nullish value for their `module.parent` (when a ESM imports it or when the module is run as the entry point of the process).

Currently, `module.parent` provides a way for CJS users to get which CJS modules required the current module first. This feature – not very useful by itself – is also used to make assumption about the program entry point. It is not rare to find packages that wrap their test code inside a `if(!module.parent)` condition, assuming that a falsy value means the module is run from CLI. The issue with this pattern is that the assumption doesn't work as soon as the module interacts with ESM or REPL.

With ESM being unflagged in current and LTS release lines, I predict this could become a real pain point for users trying to use ESM in Node.js.

###### Current issue

The issue I'd like to address is when a dependency is using the `if(!module.parent)` pattern to run its tests, and the test code gets executed for ESM users without their knowledge; those tests that may have side effects and make the end user code fail without obvious reason.

###### Action taken in this PR

- ~set `module.parent` to a truthy value instead of `undefined` (in this PR, I'm using a dummy class `UnknownModule`).~ that was moved to https://github.com/nodejs/node/pull/37702.
- add a runtime warning when `module.parent` is nullish, so it warns:
  * library authors not to use this pattern.
  * end user facing the bug that it may impact their code.

###### Objections and alternative solutions

- Because the `UnknownModule` object created is effectively just an empty object, it doesn't have any property of the module object users may expect.
  If this is not acceptable, we can keep the current behaviour (`module.parent` is `undefined` if the module was loaded by something that is not a CommonJS module).
- Some packages may use the `if(!module.parent)` pattern in their CLI exposed file. That would lead to end users seeing a warning they have no control over. I don't think there would be a lot of packages affected by this, but that's a possibility.
  If this is not acceptable, we can check if the file is inside a `node_modules` folder (similarly to what we do for `Buffer` constructor), or stick to the doc only deprecation for the time being.

Refs: #32217

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
