### PR TITLE
build: add --v8-lite-mode flag

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -646,6 +646,14 @@ parser.add_option('--v8-with-dchecks',
     default=False,
     help='compile V8 with debug checks and runtime debugging features enabled')
 
+parser.add_option('--v8-lite-mode',
+    action='store_true',
+    dest='v8_lite_mode',
+    default=False,
+    help='compile V8 in lite mode for constrained environments (lowers V8 '+
+         'memory footprint, but also implies no just-in-time compilation ' +
+         'support, thus much slower execution)')
+
 parser.add_option('--node-builtin-modules-path',
     action='store',
     dest='node_builtin_modules_path',
@@ -1246,6 +1254,7 @@ def configure_library(lib, output, pkgname=None):
 
 
 def configure_v8(o):
+  o['variables']['v8_enable_lite_mode'] = 1 if options.v8_lite_mode else 0
   o['variables']['v8_enable_gdbjit'] = 1 if options.gdb else 0
   o['variables']['v8_no_strict_aliasing'] = 1  # Work around compiler bugs.
   o['variables']['v8_optimized_debug'] = 0 if options.v8_non_optimized_debug else 1


### PR DESCRIPTION
This small change just exposes the V8 compilation option for Lite Mode (see https://v8.dev/blog/v8-lite) which also implies jitless (see https://v8.dev/blog/jitless) when set.

It should be useful in some niche scenarios like compiling for memory constrained platforms or those that don't allow for just in time compilation (like iOS).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
The tests do not pass when compiling with this flag activated due to V8 not supporting webassebly in lite mode. The normal build is unaffected and the tests pass.
- [ ] tests and/or benchmarks are included
No additional tests or benchmarks added. The V8 team has an extensive overview of the lite mode.
- [ ] documentation is changed or added
I'm not sure if the flag needs to be added to documentation. It's pretty niche and other similar flags don't seem to be documented as far as I can tell.
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
