### PR TITLE
doc: normalize Markdown code block info strings

### DIFF
--- a/doc/guides/releases.md
+++ b/doc/guides/releases.md
@@ -283,7 +283,7 @@ in the release branch (e.g. a release for Node.js v4 would be added to the
 
 The new entry should take the following form:
 
-```md
+```markdown
 <a id="x.y.x"></a>
 ## YYYY-MM-DD, Version x.y.z (Release Type), @releaser
 

--- a/tools/doc/README.md
+++ b/tools/doc/README.md
@@ -4,7 +4,7 @@ Here's how the node docs work.
 
 Each type of heading has a description block.
 
-```md
+```markdown
 # module
 
 <!--introduced_in=v0.10.0-->


### PR DESCRIPTION
Prior to this commit, Markdown fenced code blocks in Markdown
files had inconsistent info strings. This has been corrected to
standardize on the one shown in the CommonMark spec.

Refs: https://github.com/commonmark/commonmark-spec/blob/1103710025f340702edcb070be41f9982b6544d5/spec.txt#L131

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
