### PR TITLE
[v12.x] deps: V8: cherry-pick 548f6c81d424

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -34,7 +34,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.37',
+    'v8_embedder_string': '-node.38',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/json/json-parser.cc
+++ b/deps/v8/src/json/json-parser.cc
@@ -828,7 +828,7 @@ MaybeHandle<Object> JsonParser<Char>::ParseJsonValue() {
             Map maybe_feedback = JSObject::cast(*element_stack.back()).map();
             // Don't consume feedback from objects with a map that's detached
             // from the transition tree.
-            if (!maybe_feedback.GetBackPointer().IsUndefined(isolate_)) {
+            if (!maybe_feedback.IsDetached(isolate_)) {
               feedback = handle(maybe_feedback, isolate_);
             }
           }

--- a/deps/v8/src/objects/map-inl.h
+++ b/deps/v8/src/objects/map-inl.h
@@ -119,6 +119,12 @@ bool Map::CanHaveFastTransitionableElementsKind() const {
   return CanHaveFastTransitionableElementsKind(instance_type());
 }
 
+bool Map::IsDetached(Isolate* isolate) const {
+  if (is_prototype_map()) return true;
+  return instance_type() == JS_OBJECT_TYPE && NumberOfOwnDescriptors() > 0 &&
+         GetBackPointer().IsUndefined(isolate);
+}
+
 // static
 void Map::GeneralizeIfCanHaveTransitionableFastElementsKind(
     Isolate* isolate, InstanceType instance_type,
@@ -697,7 +703,10 @@ void Map::AppendDescriptor(Isolate* isolate, Descriptor* desc) {
 
 DEF_GETTER(Map, GetBackPointer, HeapObject) {
   Object object = constructor_or_backpointer(isolate);
-  if (object.IsMap(isolate)) {
+  // This is the equivalent of IsMap() but avoids reading the instance type so
+  // it can be used concurrently without acquire load.
+  if (object.IsHeapObject() && HeapObject::cast(object).map(isolate) ==
+                                   GetReadOnlyRoots(isolate).meta_map()) {
     return Map::cast(object);
   }
   // Can't use ReadOnlyRoots(isolate) as this isolate could be produced by

--- a/deps/v8/src/objects/map.h
+++ b/deps/v8/src/objects/map.h
@@ -428,6 +428,11 @@ class Map : public HeapObject {
   inline bool has_sealed_elements() const;
   inline bool has_frozen_elements() const;
 
+  // Weakly checks whether a map is detached from all transition trees. If this
+  // returns true, the map is guaranteed to be detached. If it returns false,
+  // there is no guarantee it is attached.
+  inline bool IsDetached(Isolate* isolate) const;
+
   // Returns true if the current map doesn't have DICTIONARY_ELEMENTS but if a
   // map with DICTIONARY_ELEMENTS was found in the prototype chain.
   bool DictionaryElementsInPrototypeChainOnly(Isolate* isolate);


### PR DESCRIPTION
- `git cherry-pick 78eb420fed154b7729283a3d63c99fa9989ffbea`
- Original PR: https://github.com/nodejs/node/pull/33484
- Fix for https://github.com/nodejs/node/issues/32049

---

Original commit message:

    [runtime] Don't track transitions for certainly detached maps

    Previously such maps were marked as prototype, but that has bad
    performance / memory characteristics if objects are used as
    dictionaries.

    Bug: b:148346655, v8:10339
    Change-Id: I287c5664c8b7799a084669aaaffe3affcf73e95f
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2179322
    Reviewed-by: Igor Sheludko <ishell@chromium.org>
    Commit-Queue: Toon Verwaest <verwaest@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#67537}

Refs: https://github.com/v8/v8/commit/548f6c81d4246736a7feafd7995fdf6f24ed1149

PR-URL: https://github.com/nodejs/node/pull/33484
Reviewed-By: Anna Henningsen <anna@addaleax.net>
Reviewed-By: Matheus Marchini <mat@mmarchini.me>
Reviewed-By: Matteo Collina <matteo.collina@gmail.com>
Reviewed-By: Colin Ihrig <cjihrig@gmail.com>
Reviewed-By: James M Snell <jasnell@gmail.com>
Reviewed-By: Ruben Bridgewater <ruben@bridgewater.de>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
