### PR TITLE
v8: patch for thenables in PromiseHook API

### DIFF
--- a/deps/v8/src/builtins/builtins-microtask-queue-gen.cc
+++ b/deps/v8/src/builtins/builtins-microtask-queue-gen.cc
@@ -198,11 +198,20 @@ void MicrotaskQueueBuiltinsAssembler::RunSingleMicrotask(
     const TNode<Object> thenable = LoadObjectField(
         microtask, PromiseResolveThenableJobTask::kThenableOffset);
 
+    // Run the promise before/debug hook if enabled.
+    RunPromiseHook(Runtime::kPromiseHookBefore, microtask_context,
+                   CAST(promise_to_resolve));
+
     {
       ScopedExceptionHandler handler(this, &if_exception, &var_exception);
       CallBuiltin(Builtins::kPromiseResolveThenableJob, native_context,
                   promise_to_resolve, thenable, then);
     }
+
+    // Run the promise after/debug hook if enabled.
+    RunPromiseHook(Runtime::kPromiseHookAfter, microtask_context,
+                   CAST(promise_to_resolve));
+
     RewindEnteredContext(saved_entered_context_count);
     SetCurrentContext(current_context);
     Goto(&done);


### PR DESCRIPTION
Thenables produce an additional promise which is not currently emitting before/after hooks from the PromiseHook API in V8. This change makes that additional promise also emit the proper events.

I spent some time digging into V8 trying to figure out a fix for the thenables issue which I previously attempted a higher-level fix for in #33189 and got some resistance. With this change, `async_hooks` and therefore `AsyncLocalStorage` will now be able to correctly propagate context _into_ the `then(...)` method call of a thenable.

I'm submitting this as a PR here to seek help in getting this change into V8 and for us to have the option to land it as a patch, if we want. I haven't written tests for it, though I've tested it manually, as I'm not yet sure how we want to approach landing this.

cc @nodejs/v8 @nodejs/diagnostics @nodejs/async_hooks 