### PR TITLE
esm: fix annotations on getSource hook doc snippet

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -1252,19 +1252,17 @@ potentially avoid reading files from disk.
 ```js
 /**
  * @param {string} url
- * @param {object} context
- * @param {string} context.format
- * @param {function} defaultGetSource
- * @returns {object} response
- * @returns {string|buffer} response.source
+ * @param {{ format: string }} context
+ * @param {Function} defaultGetSource
+ * @returns {Promise<{ source: (SharedArrayBuffer | string | Uint8Array) }>}
  */
 export async function getSource(url, context, defaultGetSource) {
   const { format } = context;
-  if (someCondition) {
+  if (Math.random() > 0.5) { // Some condition.
     // For some or all URLs, do some custom logic for retrieving the source.
     // Always return an object of the form {source: <string|buffer>}.
     return {
-      source: '...'
+      source: '...',
     };
   }
   // Defer to Node.js for all other URLs.


### PR DESCRIPTION
Prior to this commit, the type annotations on this hook were invalid.
This has been corrected and is ensured to be compatible with both the
TypeScript and Closure type systems.

```ruby
Notes:
    https://www.typescriptlang.org/play?useJavaScript=true#code/PQKhCgAIUgBAHAhgJ0QW0gbwM4BdkCWAdgOYC+kArsgDZQwIrpaaQBmA9smorgFyQ8hUpDIUAxhyK4ApgA9c9OElQZMAMUpFxuAlIoATGW0SUauAOIzcAZQ7VxMpbGTXqRbFgAKyDmgLYMgA8rNj2yI4CABQ2ABYoMgYAgsioAJ4AQpRsbDLIkAA+gvjEJIWQAKrEuAAcKekAlKIAfGT0wODy8Fy4kIjYadrsWjp6RJAk1nYOMlHUNAA0kJLS8rhLRiZmllPhjk2YUMtSeFjsXDy9FAC8x6sKANxHBGyQUQCyvLEAdKhEBn4ok1mpAAAzfACsByOkEgwGAkHUXEEfhkkGRiBoNEqACUADLYDYcFFoNHiSh4PyQGgcEgEcTnfKuEoyABupUguFiaLCM2+MLhCKSNAA7og0p5me4+uMOAAjABWMh06NeXLRnG4WF5ERkAiCQlKBTl2VyyFa-NhsKlyHGhytVp1kUgAHJvu6XQsBWQnrC2rD4ZAACLGPKc4kAOQ4Rm+Cs8mr6WPR6vyFXx2EtkBt402pnMVlse1m8yWK1kCg2xjzO0LMwaTzIQA
    https://closure-compiler.appspot.com/home#code%3D%252F%252F%2520%253D%253DClosureCompiler%253D%253D%250A%252F%252F%2520%2540compilation_level%2520ADVANCED_OPTIMIZATIONS%250A%252F%252F%2520%2540warning_level%2520VERBOSE%250A%252F%252F%2520%2540jscomp_error%2520strictCheckTypes%250A%252F%252F%2520%2540language_out%2520ECMASCRIPT_NEXT%250A%252F%252F%2520%2540checks_only%250A%252F%252F%2520%253D%253D%252FClosureCompiler%253D%253D%250A%250A%252F**%250A%2520*%2520%2540param%2520%257Bstring%257D%2520url%250A%2520*%2520%2540param%2520%257B%257B%2520format%253A%2520string%2520%257D%257D%2520context%250A%2520*%2520%2540param%2520%257BFunction%257D%2520defaultGetSource%250A%2520*%2520%2540returns%2520%257BPromise%253C%257B%2520source%253A%2520(SharedArrayBuffer%2520%257C%2520string%2520%257C%2520Uint8Array)%2520%257D%253E%257D%250A%2520*%252F%250Aexport%2520async%2520function%2520getSource(url%252C%2520context%252C%2520defaultGetSource)%2520%257B%250A%2520%2520const%2520%257B%2520format%2520%257D%2520%253D%2520context%253B%250A%2520%2520if%2520(Math.random()%2520%253E%25200.5)%2520%257B%250A%2520%2520%2520%2520%252F%252F%2520For%2520some%2520or%2520all%2520URLs%252C%2520do%2520some%2520custom%2520logic%2520for%2520retrieving%2520the%2520source.%250A%2520%2520%2520%2520%252F%252F%2520Always%2520return%2520an%2520object%2520of%2520the%2520form%2520%257Bsource%253A%2520%253Cstring%257Cbuffer%253E%257D.%250A%2520%2520%2520%2520return%2520%257B%250A%2520%2520%2520%2520%2520%2520source%253A%2520'...'%252C%250A%2520%2520%2520%2520%257D%253B%250A%2520%2520%257D%250A%2520%2520%252F%252F%2520Defer%2520to%2520Node.js%2520for%2520all%2520other%2520URLs.%250A%2520%2520return%2520defaultGetSource(url%252C%2520context%252C%2520defaultGetSource)%253B%250A%257D
```
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] tests and/or benchmarks are included (out of band)
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
