### PR TITLE
n-api: remove `napi_env::CallIntoModuleThrow`

### DIFF
--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -267,7 +267,7 @@ class RefBase : protected Finalizer, RefTracker {
  protected:
   inline void Finalize(bool is_env_teardown = false) override {
     if (_finalize_callback != nullptr) {
-      _env->CallIntoModuleThrow([&](napi_env env) {
+      _env->CallIntoModule([&](napi_env env) {
         _finalize_callback(
             env,
             _finalize_data,
@@ -475,7 +475,7 @@ class CallbackWrapperBase : public CallbackWrapper {
     napi_callback cb = _bundle->*FunctionField;
 
     napi_value result;
-    env->CallIntoModuleThrow([&](napi_env env) {
+    env->CallIntoModule([&](napi_env env) {
       result = cb(env, cbinfo_wrapper);
     });
 

--- a/src/js_native_api_v8.h
+++ b/src/js_native_api_v8.h
@@ -82,8 +82,15 @@ struct napi_env__ {
     return v8::Just(true);
   }
 
-  template <typename T, typename U>
-  void CallIntoModule(T&& call, U&& handle_exception) {
+  static inline void
+  HandleThrow(napi_env env, v8::Local<v8::Value> value) {
+    env->isolate->ThrowException(value);
+  }
+  using ThrowHandler = std::function<void(napi_env, v8::Local<v8::Value>)>;
+
+  template <typename T>
+  inline void CallIntoModule(T&& call,
+                             ThrowHandler handle_exception = HandleThrow) {
     int open_handle_scopes_before = open_handle_scopes;
     int open_callback_scopes_before = open_callback_scopes;
     napi_clear_last_error(this);
@@ -94,13 +101,6 @@ struct napi_env__ {
       handle_exception(this, last_exception.Get(this->isolate));
       last_exception.Reset();
     }
-  }
-
-  template <typename T>
-  void CallIntoModuleThrow(T&& call) {
-    CallIntoModule(call, [&](napi_env env, v8::Local<v8::Value> value) {
-      env->isolate->ThrowException(value);
-    });
   }
 
   v8impl::Persistent<v8::Value> last_exception;

--- a/src/js_native_api_v8.h
+++ b/src/js_native_api_v8.h
@@ -86,11 +86,10 @@ struct napi_env__ {
   HandleThrow(napi_env env, v8::Local<v8::Value> value) {
     env->isolate->ThrowException(value);
   }
-  using ThrowHandler = std::function<void(napi_env, v8::Local<v8::Value>)>;
+  typedef void (*ThrowHandler)(napi_env, v8::Local<v8::Value>);
 
-  template <typename T>
-  inline void CallIntoModule(T&& call,
-                             ThrowHandler handle_exception = HandleThrow) {
+  template <typename T, typename U = ThrowHandler>
+  inline void CallIntoModule(T&& call, U&& handle_exception = HandleThrow) {
     int open_handle_scopes_before = open_handle_scopes;
     int open_callback_scopes_before = open_callback_scopes;
     napi_clear_last_error(this);

--- a/src/js_native_api_v8.h
+++ b/src/js_native_api_v8.h
@@ -86,9 +86,8 @@ struct napi_env__ {
   HandleThrow(napi_env env, v8::Local<v8::Value> value) {
     env->isolate->ThrowException(value);
   }
-  typedef void (*ThrowHandler)(napi_env, v8::Local<v8::Value>);
 
-  template <typename T, typename U = ThrowHandler>
+  template <typename T, typename U = decltype(HandleThrow)>
   inline void CallIntoModule(T&& call, U&& handle_exception = HandleThrow) {
     int open_handle_scopes_before = open_handle_scopes;
     int open_callback_scopes_before = open_callback_scopes;

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -57,7 +57,7 @@ class BufferFinalizer : private Finalizer {
       v8::HandleScope handle_scope(finalizer->_env->isolate);
       v8::Context::Scope context_scope(finalizer->_env->context());
 
-      finalizer->_env->CallIntoModuleThrow([&](napi_env env) {
+      finalizer->_env->CallIntoModule([&](napi_env env) {
         finalizer->_finalize_callback(
             env,
             finalizer->_finalize_data,
@@ -308,7 +308,7 @@ class ThreadSafeFunction : public node::AsyncResource {
           v8::Local<v8::Function>::New(env->isolate, ref);
         js_callback = v8impl::JsValueFromV8LocalValue(js_cb);
       }
-      env->CallIntoModuleThrow([&](napi_env env) {
+      env->CallIntoModule([&](napi_env env) {
         call_js_cb(env, js_callback, context, data);
       });
     }
@@ -318,7 +318,7 @@ class ThreadSafeFunction : public node::AsyncResource {
     v8::HandleScope scope(env->isolate);
     if (finalize_cb) {
       CallbackScope cb_scope(this);
-      env->CallIntoModuleThrow([&](napi_env env) {
+      env->CallIntoModule([&](napi_env env) {
         finalize_cb(env, finalize_data, context);
       });
     }
@@ -455,7 +455,7 @@ void napi_module_register_by_symbol(v8::Local<v8::Object> exports,
   napi_env env = v8impl::NewEnv(context);
 
   napi_value _exports;
-  env->CallIntoModuleThrow([&](napi_env env) {
+  env->CallIntoModule([&](napi_env env) {
     _exports = init(env, v8impl::JsValueFromV8LocalValue(exports));
   });
 


### PR DESCRIPTION
Give `napi_env::CallIntoModule` the thrower used by
`CallIntoModuleThrow` as its default second argument. That way we do
not need two different methods on `napi_env` for calling into the
addon.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
Re: https://github.com/nodejs/node/pull/33508