### PR TITLE
[v12.x] deps: V8: backport fb26d0bb1835

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -34,7 +34,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.38',
+    'v8_embedder_string': '-node.39',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/heap/factory.h
+++ b/deps/v8/src/heap/factory.h
@@ -524,6 +524,9 @@ class V8_EXPORT_PRIVATE Factory {
 
   Handle<JSObject> NewFunctionPrototype(Handle<JSFunction> function);
 
+  Handle<WeakArrayList> NewWeakArrayList(
+      int capacity, AllocationType allocation = AllocationType::kYoung);
+
   Handle<WeakCell> NewWeakCell();
 
   // Returns a deep copy of the JavaScript object.
@@ -547,6 +550,10 @@ class V8_EXPORT_PRIVATE Factory {
 
   Handle<WeakArrayList> CopyWeakArrayListAndGrow(
       Handle<WeakArrayList> array, int grow_by,
+      AllocationType allocation = AllocationType::kYoung);
+
+  Handle<WeakArrayList> CompactWeakArrayList(
+      Handle<WeakArrayList> array, int new_capacity,
       AllocationType allocation = AllocationType::kYoung);
 
   Handle<PropertyArray> CopyPropertyArrayAndGrow(
@@ -1111,6 +1118,10 @@ class V8_EXPORT_PRIVATE Factory {
   // Initializes JSObject body starting at given offset.
   void InitializeJSObjectBody(Handle<JSObject> obj, Handle<Map> map,
                               int start_offset);
+
+ private:
+  Handle<WeakArrayList> NewUninitializedWeakArrayList(
+      int capacity, AllocationType allocation = AllocationType::kYoung);
 };
 
 // Utility class to simplify argument handling around JSFunction creation.

--- a/deps/v8/src/objects/fixed-array.h
+++ b/deps/v8/src/objects/fixed-array.h
@@ -339,6 +339,17 @@ class WeakArrayList : public HeapObject {
       Isolate* isolate, Handle<WeakArrayList> array,
       const MaybeObjectHandle& value);
 
+  // Appends an element to the array and possibly compacts and shrinks live weak
+  // references to the start of the collection. Only use this method when
+  // indices to elements can change.
+  static Handle<WeakArrayList> Append(
+      Isolate* isolate, Handle<WeakArrayList> array,
+      const MaybeObjectHandle& value,
+      AllocationType allocation = AllocationType::kYoung);
+
+  // Compact weak references to the beginning of the array.
+  V8_EXPORT_PRIVATE void Compact(Isolate* isolate);
+
   inline MaybeObject Get(int index) const;
   inline MaybeObject Get(Isolate* isolate, int index) const;
 
@@ -350,6 +361,10 @@ class WeakArrayList : public HeapObject {
 
   static constexpr int SizeForCapacity(int capacity) {
     return kHeaderSize + capacity * kTaggedSize;
+  }
+
+  static constexpr int CapacityForLength(int length) {
+    return length + Max(length / 2, 2);
   }
 
   // Gives access to raw memory which stores the array's data.
@@ -382,6 +397,9 @@ class WeakArrayList : public HeapObject {
 
   // Returns the number of non-cleaned weak references in the array.
   int CountLiveWeakReferences() const;
+
+  // Returns the number of non-cleaned elements in the array.
+  int CountLiveElements() const;
 
   // Returns whether an entry was found and removed. Will move the elements
   // around in the array - this method can only be used in cases where the user

--- a/deps/v8/test/unittests/BUILD.gn
+++ b/deps/v8/test/unittests/BUILD.gn
@@ -190,6 +190,7 @@ v8_source_set("unittests_sources") {
     "numbers/conversions-unittest.cc",
     "objects/object-unittest.cc",
     "objects/value-serializer-unittest.cc",
+    "objects/weakarraylist-unittest.cc",
     "parser/ast-value-unittest.cc",
     "parser/preparser-unittest.cc",
     "profiler/strings-storage-unittest.cc",

--- a/deps/v8/test/unittests/objects/weakarraylist-unittest.cc
+++ b/deps/v8/test/unittests/objects/weakarraylist-unittest.cc
@@ -1,0 +1,59 @@
+// Copyright 2019 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "src/heap/factory.h"
+#include "test/unittests/test-utils.h"
+
+namespace v8 {
+namespace internal {
+
+using WeakArrayListTest = TestWithIsolate;
+
+TEST_F(WeakArrayListTest, Compact) {
+  Handle<WeakArrayList> list = isolate()->factory()->NewWeakArrayList(10);
+  EXPECT_EQ(list->length(), 0);
+  EXPECT_EQ(list->capacity(), 10);
+
+  MaybeObject some_object =
+      MaybeObject::FromObject(*isolate()->factory()->empty_fixed_array());
+  MaybeObject weak_ref = MaybeObject::MakeWeak(some_object);
+  MaybeObject smi = MaybeObject::FromSmi(Smi::FromInt(0));
+  MaybeObject cleared_ref = HeapObjectReference::ClearedValue(isolate());
+  list->Set(0, weak_ref);
+  list->Set(1, smi);
+  list->Set(2, cleared_ref);
+  list->Set(3, cleared_ref);
+  list->set_length(5);
+
+  list->Compact(isolate());
+  EXPECT_EQ(list->length(), 3);
+  EXPECT_EQ(list->capacity(), 10);
+}
+
+TEST_F(WeakArrayListTest, OutOfPlaceCompact) {
+  Handle<WeakArrayList> list = isolate()->factory()->NewWeakArrayList(20);
+  EXPECT_EQ(list->length(), 0);
+  EXPECT_EQ(list->capacity(), 20);
+
+  MaybeObject some_object =
+      MaybeObject::FromObject(*isolate()->factory()->empty_fixed_array());
+  MaybeObject weak_ref = MaybeObject::MakeWeak(some_object);
+  MaybeObject smi = MaybeObject::FromSmi(Smi::FromInt(0));
+  MaybeObject cleared_ref = HeapObjectReference::ClearedValue(isolate());
+  list->Set(0, weak_ref);
+  list->Set(1, smi);
+  list->Set(2, cleared_ref);
+  list->Set(3, smi);
+  list->Set(4, cleared_ref);
+  list->set_length(6);
+
+  Handle<WeakArrayList> compacted =
+      isolate()->factory()->CompactWeakArrayList(list, 4);
+  EXPECT_EQ(list->length(), 6);
+  EXPECT_EQ(compacted->length(), 4);
+  EXPECT_EQ(compacted->capacity(), 4);
+}
+
+}  // namespace internal
+}  // namespace v8


### PR DESCRIPTION
Original commit message:

    [objects] Compact and shrink script_list

    So far creating scripts always grew the script_list without ever
    reusing cleared slots or shrinking. While this is probably not a
    problem with script_list in practice, this is still a memory leak.

    Fix this leak by using WeakArrayList::Append instead of AddToEnd.
    Append adds to the end of the array, but potentially compacts and
    shrinks the list as well. Other WeakArrayLists can use this method as
    well, as long as they are not using indices into this array.

    Bug: v8:10031
    Change-Id: If743c4cc3f8d67ab735522f0ded038b2fb43e437
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/1967385
    Commit-Queue: Dominik Inführ <dinfuehr@chromium.org>
    Reviewed-by: Ulan Degenbaev <ulan@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#65640}

Refs: https://github.com/v8/v8/commit/fb26d0bb1835dd18d175128fcb18590bee4ec218

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
