### PR TITLE
async_hooks: improve resource stack performance

### DIFF
--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -6,6 +6,7 @@ const {
   ObjectPrototypeHasOwnProperty,
   ObjectDefineProperty,
   Promise,
+  SafeMap,
   Symbol,
 } = primordials;
 
@@ -38,7 +39,6 @@ const async_wrap = internalBinding('async_wrap');
 const {
   async_hook_fields,
   async_id_fields,
-  execution_async_resources
 } = async_wrap;
 // Store the pair executionAsyncId and triggerAsyncId in a AliasedFloat64Array
 // in Environment::AsyncHooks::async_ids_stack_ which tracks the resource
@@ -47,7 +47,9 @@ const {
 // each hook's after() callback.
 const {
   pushAsyncContext: pushAsyncContext_,
-  popAsyncContext: popAsyncContext_
+  popAsyncContext: popAsyncContext_,
+  clearAsyncIdStack,
+  executionAsyncResource: executionAsyncResource_,
 } = async_wrap;
 // For performance reasons, only track Promises when a hook is enabled.
 const { enablePromiseHook, disablePromiseHook } = async_wrap;
@@ -84,9 +86,11 @@ const { resource_symbol, owner_symbol } = internalBinding('symbols');
 // Each constant tracks how many callbacks there are for any given step of
 // async execution. These are tracked so if the user didn't include callbacks
 // for a given step, that step can bail out early.
-const { kInit, kBefore, kAfter, kDestroy, kTotals, kPromiseResolve,
-        kCheck, kExecutionAsyncId, kAsyncIdCounter, kTriggerAsyncId,
-        kDefaultTriggerAsyncId, kStackLength } = async_wrap.constants;
+const {
+  kInit, kBefore, kAfter, kDestroy, kTotals, kPromiseResolve,
+  kCheck, kExecutionAsyncId, kAsyncIdCounter, kTriggerAsyncId,
+  kDefaultTriggerAsyncId, kCachedResourceIsValid, kStackLength
+} = async_wrap.constants;
 
 const { async_id_symbol,
         trigger_async_id_symbol } = internalBinding('symbols');
@@ -104,12 +108,24 @@ const emitPromiseResolveNative =
     emitHookFactory(promise_resolve_symbol, 'emitPromiseResolveNative');
 
 const topLevelResource = {};
+// Contains a [stack height] -> [resource] map for things pushed onto the
+// async resource stack from JS.
+const jsResourceStack = new SafeMap();
+// Contains either a single key (null) or nothing. If the key is present,
+// this points to the current async resource.
+const cachedResourceHolder = new SafeMap();
 
 function executionAsyncResource() {
   const index = async_hook_fields[kStackLength] - 1;
   if (index === -1) return topLevelResource;
-  const resource = execution_async_resources[index];
-  return lookupPublicResource(resource);
+
+  if (async_hook_fields[kCachedResourceIsValid])
+    return cachedResourceHolder.get(null);
+  const resource = jsResourceStack.get(index) ?? executionAsyncResource_();
+  const publicResource = lookupPublicResource(resource);
+  async_hook_fields[kCachedResourceIsValid] = 1;
+  cachedResourceHolder.set(null, publicResource);
+  return publicResource;
 }
 
 // Used to fatally abort the process if a callback throws.
@@ -450,16 +466,6 @@ function emitDestroyScript(asyncId) {
 }
 
 
-// Keep in sync with Environment::AsyncHooks::clear_async_id_stack
-// in src/env-inl.h.
-function clearAsyncIdStack() {
-  async_id_fields[kExecutionAsyncId] = 0;
-  async_id_fields[kTriggerAsyncId] = 0;
-  async_hook_fields[kStackLength] = 0;
-  execution_async_resources.splice(0, execution_async_resources.length);
-}
-
-
 function hasAsyncIdStack() {
   return hasHooks(kStackLength);
 }
@@ -472,15 +478,22 @@ function pushAsyncContext(asyncId, triggerAsyncId, resource) {
     return pushAsyncContext_(asyncId, triggerAsyncId, resource);
   async_wrap.async_ids_stack[offset * 2] = async_id_fields[kExecutionAsyncId];
   async_wrap.async_ids_stack[offset * 2 + 1] = async_id_fields[kTriggerAsyncId];
-  execution_async_resources[offset] = resource;
   async_hook_fields[kStackLength]++;
   async_id_fields[kExecutionAsyncId] = asyncId;
   async_id_fields[kTriggerAsyncId] = triggerAsyncId;
+  jsResourceStack.set(offset, resource);
+  if (async_hook_fields[kCachedResourceIsValid])
+    cachedResourceHolder.clear();
+  async_hook_fields[kCachedResourceIsValid] = 0;
 }
 
 
 // This is the equivalent of the native pop_async_ids() call.
 function popAsyncContext(asyncId) {
+  async_hook_fields[kCachedResourceIsValid] = 0;
+  if (async_hook_fields[kCachedResourceIsValid])
+    cachedResourceHolder.clear();
+
   const stackLength = async_hook_fields[kStackLength];
   if (stackLength === 0) return false;
 
@@ -490,9 +503,17 @@ function popAsyncContext(asyncId) {
   }
 
   const offset = stackLength - 1;
+
+  if (!jsResourceStack.has(offset)) {
+    // For some reason this popAsyncContext() call removes a resource for a
+    // corresponding push() call from C++, so let the C++ code handle this
+    // pop operation since it's on the native the resource stack.
+    return popAsyncContext_(asyncId);
+  }
+
   async_id_fields[kExecutionAsyncId] = async_wrap.async_ids_stack[2 * offset];
   async_id_fields[kTriggerAsyncId] = async_wrap.async_ids_stack[2 * offset + 1];
-  execution_async_resources.pop();
+  jsResourceStack.delete(offset);
   async_hook_fields[kStackLength] = offset;
   return offset > 0;
 }
@@ -547,5 +568,7 @@ module.exports = {
     after: emitAfterNative,
     destroy: emitDestroyNative,
     promise_resolve: emitPromiseResolveNative
-  }
+  },
+  jsResourceStack,
+  cachedResourceHolder
 };

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -105,8 +105,11 @@ if (credentials.implementsPosixCredentials) {
 // process. They use the same functions as the JS embedder API. These callbacks
 // are setup immediately to prevent async_wrap.setupHooks() from being hijacked
 // and the cost of doing so is negligible.
-const { nativeHooks } = require('internal/async_hooks');
-internalBinding('async_wrap').setupHooks(nativeHooks);
+const {
+  nativeHooks, jsResourceStack, cachedResourceHolder
+} = require('internal/async_hooks');
+internalBinding('async_wrap').setupHooks(
+  nativeHooks, jsResourceStack, cachedResourceHolder);
 
 const {
   setupTaskQueue,

--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -39,6 +39,7 @@ using v8::HandleScope;
 using v8::Integer;
 using v8::Isolate;
 using v8::Local;
+using v8::Map;
 using v8::Maybe;
 using v8::MaybeLocal;
 using v8::Name;
@@ -415,6 +416,11 @@ static void SetupHooks(const FunctionCallbackInfo<Value>& args) {
   SET_HOOK_FN(destroy);
   SET_HOOK_FN(promise_resolve);
 #undef SET_HOOK_FN
+
+  CHECK(args[1]->IsMap());
+  CHECK(args[2]->IsMap());
+  env->async_hooks()->set_js_execution_async_resources(args[1].As<Map>());
+  env->async_hooks()->set_cached_resource_holder(args[2].As<Map>());
 }
 
 static void EnablePromiseHook(const FunctionCallbackInfo<Value>& args) {
@@ -566,6 +572,16 @@ Local<FunctionTemplate> AsyncWrap::GetConstructorTemplate(Environment* env) {
   return tmpl;
 }
 
+static void ExecutionAsyncResource(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  args.GetReturnValue().Set(env->async_hooks()->execution_async_resource());
+}
+
+static void ClearAsyncIdStack(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  env->async_hooks()->clear_async_id_stack();
+}
+
 void AsyncWrap::Initialize(Local<Object> target,
                            Local<Value> unused,
                            Local<Context> context,
@@ -581,6 +597,8 @@ void AsyncWrap::Initialize(Local<Object> target,
   env->SetMethod(target, "enablePromiseHook", EnablePromiseHook);
   env->SetMethod(target, "disablePromiseHook", DisablePromiseHook);
   env->SetMethod(target, "registerDestroyHook", RegisterDestroyHook);
+  env->SetMethod(target, "executionAsyncResource", ExecutionAsyncResource);
+  env->SetMethod(target, "clearAsyncIdStack", ClearAsyncIdStack);
 
   PropertyAttribute ReadOnlyDontDelete =
       static_cast<PropertyAttribute>(ReadOnly | DontDelete);
@@ -613,10 +631,6 @@ void AsyncWrap::Initialize(Local<Object> target,
                          "async_id_fields",
                          env->async_hooks()->async_id_fields().GetJSArray());
 
-  FORCE_SET_TARGET_FIELD(target,
-                         "execution_async_resources",
-                         env->async_hooks()->execution_async_resources());
-
   target->Set(context,
               env->async_ids_stack_string(),
               env->async_hooks()->async_ids_stack().GetJSArray()).Check();
@@ -637,6 +651,7 @@ void AsyncWrap::Initialize(Local<Object> target,
   SET_HOOKS_CONSTANT(kTriggerAsyncId);
   SET_HOOKS_CONSTANT(kAsyncIdCounter);
   SET_HOOKS_CONSTANT(kDefaultTriggerAsyncId);
+  SET_HOOKS_CONSTANT(kCachedResourceIsValid);
   SET_HOOKS_CONSTANT(kStackLength);
 #undef SET_HOOKS_CONSTANT
   FORCE_SET_TARGET_FIELD(target, "constants", constants);

--- a/src/env.h
+++ b/src/env.h
@@ -639,6 +639,7 @@ class AsyncHooks : public MemoryRetainer {
     kTotals,
     kCheck,
     kStackLength,
+    kCachedResourceIsValid,
     kFieldsCount,
   };
 
@@ -653,7 +654,7 @@ class AsyncHooks : public MemoryRetainer {
   inline AliasedUint32Array& fields();
   inline AliasedFloat64Array& async_id_fields();
   inline AliasedFloat64Array& async_ids_stack();
-  inline v8::Local<v8::Array> execution_async_resources();
+  inline v8::Local<v8::Value> execution_async_resource();
 
   inline v8::Local<v8::String> provider_string(int idx);
 
@@ -664,6 +665,8 @@ class AsyncHooks : public MemoryRetainer {
       v8::Local<v8::Value> execution_async_resource_);
   inline bool pop_async_context(double async_id);
   inline void clear_async_id_stack();  // Used in fatal exceptions.
+  inline void set_js_execution_async_resources(v8::Local<v8::Map> value);
+  inline void set_cached_resource_holder(v8::Local<v8::Map> value);
 
   AsyncHooks(const AsyncHooks&) = delete;
   AsyncHooks& operator=(const AsyncHooks&) = delete;
@@ -706,7 +709,9 @@ class AsyncHooks : public MemoryRetainer {
 
   void grow_async_ids_stack();
 
-  v8::Global<v8::Array> execution_async_resources_;
+  std::vector<v8::Global<v8::Value>> native_execution_async_resources_;
+  v8::Global<v8::Map> js_execution_async_resources_;
+  v8::Global<v8::Map> cached_resource_holder_;
 };
 
 class ImmediateInfo : public MemoryRetainer {


### PR DESCRIPTION
Removes some of the performance overhead that came with
`executionAsyncResource()` by storing async resources that
are managed by JS and those managed by C++ separately, and
instead caching the result of `executionAsyncResource()` with
low overhead to avoid multiple calls into C++.

This particularly improves performance when async hooks are not
being used.

    $ ./node benchmark/compare.js --new ./node --old ./node-master --runs 30 --filter messageport worker | Rscript benchmark/compare.R
    [00:04:41|% 100| 1/1 files | 60/60 runs | 2/2 configs]: Done
                                                       confidence improvement accuracy (*)    (**)   (***)
     worker/messageport.js n=1000000 payload='object'          *      8.85 %       ±7.40%  ±9.85% ±12.83%
     worker/messageport.js n=1000000 payload='string'        ***     18.56 %       ±8.37% ±11.13% ±14.49%

(I’ll also try to run the `async_hooks` benchmarks, but they are failing locally for me on master – hence only the ones for MessagePorts as another measure.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
