### PR TITLE
cli: add alias for report-directory to make it consistent

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -639,7 +639,7 @@ Write reports in a compact format, single-line JSON, more easily consumable
 by log processing systems than the default multi-line format designed for
 human consumption.
 
-### `--report-directory=directory`
+### --report-directory=directory`, `report-dir=directory`
 <!-- YAML
 added: v11.8.0
 changes:
@@ -1245,6 +1245,7 @@ Node.js options that are allowed are:
 * `--prof-process`
 * `--redirect-warnings`
 * `--report-compact`
+* `--report-dir`
 * `--report-directory`
 * `--report-filename`
 * `--report-on-fatalerror`

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -639,7 +639,7 @@ Write reports in a compact format, single-line JSON, more easily consumable
 by log processing systems than the default multi-line format designed for
 human consumption.
 
-### --report-directory=directory`, `report-dir=directory`
+### --report-dir=directory`, `report-directory=directory`
 <!-- YAML
 added: v11.8.0
 changes:
@@ -1245,8 +1245,7 @@ Node.js options that are allowed are:
 * `--prof-process`
 * `--redirect-warnings`
 * `--report-compact`
-* `--report-dir`
-* `--report-directory`
+* `--report-dir`, `--report-directory`
 * `--report-filename`
 * `--report-on-fatalerror`
 * `--report-on-signal`

--- a/doc/node.1
+++ b/doc/node.1
@@ -291,7 +291,7 @@ Write
 .Sy diagnostic reports
 in a compact format, single-line JSON.
 .
-.It Fl -report-directory
+.It Fl -report-directory Fl -report-dir
 Location at which the
 .Sy diagnostic report
 will be generated.

--- a/doc/node.1
+++ b/doc/node.1
@@ -291,7 +291,7 @@ Write
 .Sy diagnostic reports
 in a compact format, single-line JSON.
 .
-.It Fl -report-directory Fl -report-dir
+.It Fl -report-dir Fl -report-directory
 Location at which the
 .Sy diagnostic report
 will be generated.

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -667,9 +667,10 @@ PerProcessOptionsParser::PerProcessOptionsParser(
             kAllowedInEnvironment);
   AddOption("--report-directory",
             "define custom report pathname."
-            " (default: current working directory of Node.js process)",
+            " (default: current working directory)",
             &PerProcessOptions::report_directory,
             kAllowedInEnvironment);
+  AddAlias("--report-dir", "--report-directory");
   AddOption("--report-filename",
             "define custom report file name."
             " (default: YYYYMMDD.HHMMSS.PID.SEQUENCE#.txt)",

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -665,12 +665,12 @@ PerProcessOptionsParser::PerProcessOptionsParser(
             "output compact single-line JSON",
             &PerProcessOptions::report_compact,
             kAllowedInEnvironment);
-  AddOption("--report-directory",
+  AddOption("--report-dir",
             "define custom report pathname."
             " (default: current working directory)",
             &PerProcessOptions::report_directory,
             kAllowedInEnvironment);
-  AddAlias("--report-dir", "--report-directory");
+  AddAlias("--report-directory", "--report-dir");
   AddOption("--report-filename",
             "define custom report file name."
             " (default: YYYYMMDD.HHMMSS.PID.SEQUENCE#.txt)",


### PR DESCRIPTION
Currently every other cli option uses "dir" to reference a directory
so add an alias to allow for conistency.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
