### PR TITLE
repl: improve static import error message in repl

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -58,6 +58,7 @@ const {
   PromiseRace,
   RegExp,
   Set,
+  StringPrototypeIncludes,
   Symbol,
   WeakSet,
 } = primordials;
@@ -570,6 +571,14 @@ function REPLServer(prompt,
             e.stack = e.stack
               .replace(/^repl:\d+\r?\n/, '')
               .replace(/^\s+at\s.*\n?/gm, '');
+            const importErrorStr = 'Cannot use import statement outside a ' +
+              'module';
+            if (StringPrototypeIncludes(e.message, importErrorStr)) {
+              e.message = 'Cannot use import statement inside the Node.js ' +
+                'repl, alternatively use dynamic import';
+              e.stack = e.stack.replace(/SyntaxError:.*\n/,
+                                        `SyntaxError: ${e.message}\n`);
+            }
           } else if (self.replMode === module.exports.REPL_MODE_STRICT) {
             e.stack = e.stack.replace(/(\s+at\s+repl:)(\d+)/,
                                       (_, pre, line) => pre + (line - 1));

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -805,6 +805,16 @@ const tcpTests = [
   {
     send: `require(${JSON.stringify(moduleFilename)}).number`,
     expect: '42'
+  },
+  {
+    send: 'import comeOn from \'fhqwhgads\'',
+    expect: [
+      kSource,
+      kArrow,
+      '',
+      'Uncaught:',
+      /^SyntaxError: .* dynamic import/
+    ]
   }
 ];
 


### PR DESCRIPTION
Currently the error is rather ambiguous and does not inform folks that
static import is not supported in the repl. This overrides the default
error message with one that is more informative.

Closes: https://github.com/nodejs/node/issues/33576