### PR TITLE
support util.promisify for fs.readv

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -3209,6 +3209,9 @@ from the current position.
 The callback will be given three arguments: `err`, `bytesRead`, and
 `buffers`. `bytesRead` is how many bytes were read from the file.
 
+If this method is invoked as its [`util.promisify()`][]ed version, it returns
+a `Promise` for an `Object` with `bytesRead` and `buffers` properties.
+
 ## `fs.readvSync(fd, buffers[, position])`
 <!-- YAML
 added:

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -597,6 +597,9 @@ function readv(fd, buffers, position, callback) {
   return binding.readBuffers(fd, buffers, position, req);
 }
 
+ObjectDefineProperty(readv, internalUtil.customPromisifyArgs,
+                     { value: ['bytesRead', 'buffers'], enumerable: false });
+
 function readvSync(fd, buffers, position) {
   validateInt32(fd, 'fd', 0);
   validateBufferArray(buffers);

--- a/test/parallel/test-fs-readv-promisify.js
+++ b/test/parallel/test-fs-readv-promisify.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const common = require('../common');
+const fixtures = require('../common/fixtures');
+const fs = require('fs');
+const readv = require('util').promisify(fs.readv);
+const assert = require('assert');
+const filepath = fixtures.path('x.txt');
+const fd = fs.openSync(filepath, 'r');
+
+const expected = [Buffer.from('xyz\n')];
+
+readv(fd, expected)
+  .then(function({ bytesRead, buffers }) {
+    assert.deepStrictEqual(bytesRead, expected[0].length);
+    assert.deepStrictEqual(buffers, expected);
+  })
+  .then(common.mustCall());


### PR DESCRIPTION

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

This PR adds support for `util.promisify` of the `fs.readv` function.

Currently, you can only use this as a promise if you are accessing it via a `FileHandler`.  

Other functions in the `fs` module have similar functionality,  and it would be good to make the non-sync functions consistent.  I'll probably also try to add this same thing on the other functions if this is approved
