### PR TITLE
src: use MaybeLocal.ToLocal instead of IsEmpty worker

### DIFF
--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -487,9 +487,9 @@ void Worker::New(const FunctionCallbackInfo<Value>& args) {
 #ifndef NODE_WITHOUT_NODE_OPTIONS
     MaybeLocal<String> maybe_node_opts =
         env_vars->Get(isolate, OneByteString(isolate, "NODE_OPTIONS"));
-    if (!maybe_node_opts.IsEmpty()) {
-      std::string node_options(
-          *String::Utf8Value(isolate, maybe_node_opts.ToLocalChecked()));
+    Local<String> node_opts;
+    if (maybe_node_opts.ToLocal(&node_opts)) {
+      std::string node_options(*String::Utf8Value(isolate, node_opts));
       std::vector<std::string> errors{};
       std::vector<std::string> env_argv =
           ParseNodeOptionsEnvVar(node_options, &errors);
@@ -529,14 +529,11 @@ void Worker::New(const FunctionCallbackInfo<Value>& args) {
       if (!array->Get(env->context(), i).ToLocal(&arg)) {
         return;
       }
-      MaybeLocal<String> arg_v8_string =
-          arg->ToString(env->context());
-      if (arg_v8_string.IsEmpty()) {
+      Local<String> arg_v8;
+      if (!arg->ToString(env->context()).ToLocal(&arg_v8)) {
         return;
       }
-      Utf8Value arg_utf8_value(
-          args.GetIsolate(),
-          arg_v8_string.FromMaybe(Local<String>()));
+      Utf8Value arg_utf8_value(args.GetIsolate(), arg_v8);
       std::string arg_string(arg_utf8_value.out(), arg_utf8_value.length());
       exec_argv.push_back(arg_string);
     }


### PR DESCRIPTION
This commit suggest using `MaybeLocal.ToLocal` and passing in the
`Local<String>` node_opts. It also introduces a variable, arg_v8, of type
`Local<String>` to enable the use of ToLocal.

The motivation for doing this is that the following
`MaybeLocal::ToLocalChecked` and `MaybeLocal::FromMaybe` calls can then be
avoided.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
