### PR TITLE
process: use v8 fast api calls for hrtime

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.17',
+    'v8_embedder_string': '-node.18',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -8184,7 +8184,9 @@ class V8_EXPORT Isolate {
           array_buffer_allocator_shared(),
           external_references(nullptr),
           allow_atomics_wait(true),
-          only_terminate_in_safe_scope(false) {}
+          only_terminate_in_safe_scope(false),
+          embedder_wrapper_type_index(-1),
+          embedder_wrapper_object_index(-1) {}
 
     /**
      * Allows the host application to provide the address of a function that is
@@ -8248,6 +8250,14 @@ class V8_EXPORT Isolate {
      * Termination is postponed when there is no active SafeForTerminationScope.
      */
     bool only_terminate_in_safe_scope;
+
+    /**
+     * The following parameters describe the offsets for addressing type info
+     * for wrapped API objects and are used by the fast C API
+     * (for details see v8-fast-api-calls.h).
+     */
+    int embedder_wrapper_type_index;
+    int embedder_wrapper_object_index;
   };
 
 

--- a/deps/v8/src/api/api.cc
+++ b/deps/v8/src/api/api.cc
@@ -1582,8 +1582,9 @@ void FunctionTemplate::SetCallHandler(FunctionCallback callback,
     data = v8::Undefined(reinterpret_cast<v8::Isolate*>(isolate));
   }
   obj->set_data(*Utils::OpenHandle(*data));
-  if (c_function != nullptr) {
-    DCHECK_NOT_NULL(c_function->GetAddress());
+  // Blink passes CFunction's constructed with the default constructor
+  // for non-fast calls, so we should check the address too.
+  if (c_function != nullptr && c_function->GetAddress()) {
     i::FunctionTemplateInfo::SetCFunction(
         isolate, info,
         i::handle(*FromCData(isolate, c_function->GetAddress()), isolate));
@@ -8333,6 +8334,10 @@ void Isolate::Initialize(Isolate* isolate,
   }
   i_isolate->set_only_terminate_in_safe_scope(
       params.only_terminate_in_safe_scope);
+  i_isolate->set_embedder_wrapper_type_index(
+      params.embedder_wrapper_type_index);
+  i_isolate->set_embedder_wrapper_object_index(
+      params.embedder_wrapper_object_index);
 
   if (!i::V8::GetCurrentPlatform()
            ->GetForegroundTaskRunner(isolate)

--- a/deps/v8/test/cctest/test-api.cc
+++ b/deps/v8/test/cctest/test-api.cc
@@ -27064,6 +27064,8 @@ void SetupTest(v8::Local<v8::Value> initial_value, LocalContext* env,
   v8::Isolate* isolate = CcTest::isolate();
 
   v8::CFunction c_func = v8::CFunction::Make(ApiNumberChecker<T>::CheckArgFast);
+  CHECK_EQ(c_func.ArgumentInfo(0).GetType(),
+           v8::CTypeInfo::Type::kUnwrappedApiObject);
 
   Local<v8::FunctionTemplate> checker_templ = v8::FunctionTemplate::New(
       isolate, ApiNumberChecker<T>::CheckArgSlow, v8::Local<v8::Value>(),

--- a/lib/internal/process/per_thread.js
+++ b/lib/internal/process/per_thread.js
@@ -41,7 +41,6 @@ function assert(x, msg) {
 function wrapProcessMethods(binding) {
   const {
     hrtime: _hrtime,
-    hrtimeBigInt: _hrtimeBigInt,
     cpuUsage: _cpuUsage,
     memoryUsage: _memoryUsage,
     resourceUsage: _resourceUsage
@@ -113,10 +112,10 @@ function wrapProcessMethods(binding) {
   // The 3 entries filled in by the original process.hrtime contains
   // the upper/lower 32 bits of the second part of the value,
   // and the remaining nanoseconds of the value.
-  const hrValues = new Uint32Array(3);
+  const hrValues = new Uint32Array(_hrtime.buffer);
 
   function hrtime(time) {
-    _hrtime(hrValues);
+    _hrtime.hrtime();
 
     if (time !== undefined) {
       if (!ArrayIsArray(time)) {
@@ -140,9 +139,9 @@ function wrapProcessMethods(binding) {
 
   // Use a BigUint64Array in the closure because this is actually a bit
   // faster than simply returning a BigInt from C++ in V8 7.1.
-  const hrBigintValues = new BigUint64Array(1);
+  const hrBigintValues = new BigUint64Array(_hrtime.buffer, 0, 1);
   function hrtimeBigInt() {
-    _hrtimeBigInt(hrBigintValues);
+    _hrtime.hrtimeBigInt();
     return hrBigintValues[0];
   }
 

--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -209,6 +209,8 @@ void SetIsolateCreateParamsForNode(Isolate::CreateParams* params) {
     // heap based on the actual physical memory.
     params->constraints.ConfigureDefaults(total_memory, 0);
   }
+  params->embedder_wrapper_object_index = BaseObject::InternalFields::kSlot;
+  params->embedder_wrapper_type_index = std::numeric_limits<int>::max();
 }
 
 void SetIsolateErrorHandlers(v8::Isolate* isolate, const IsolateSettings& s) {


### PR DESCRIPTION
This is all still very up in the air and experimental and unknown.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

```
[00:01:18|% 100| 1/1 files | 200/200 runs | 3/3 configs]: Done
                                                  confidence improvement accuracy (*)   (**)  (***)
 process/bench-hrtime.js type='bigint' n=1000000        ***    240.17 %       ±2.08% ±2.75% ±3.54%
 process/bench-hrtime.js type='diff' n=1000000          ***    220.36 %       ±3.06% ±4.04% ±5.21%
 process/bench-hrtime.js type='raw' n=1000000           ***    246.85 %       ±2.09% ±2.76% ±3.56%
```