### PR TITLE
events: deal with Symbol() passed to event constructor

### DIFF
--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -50,7 +50,7 @@ class Event {
     this.#cancelable = !!cancelable;
     this.#bubbles = !!bubbles;
     this.#composed = !!composed;
-    this.#type = '' + type;
+    this.#type = `${type}`;
     // isTrusted is special (LegacyUnforgeable)
     Object.defineProperty(this, 'isTrusted', {
       get() { return false; },

--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -50,7 +50,7 @@ class Event {
     this.#cancelable = !!cancelable;
     this.#bubbles = !!bubbles;
     this.#composed = !!composed;
-    this.#type = String(type);
+    this.#type = '' + type;
     // isTrusted is special (LegacyUnforgeable)
     Object.defineProperty(this, 'isTrusted', {
       get() { return false; },

--- a/test/parallel/test-eventtarget.js
+++ b/test/parallel/test-eventtarget.js
@@ -49,6 +49,7 @@ ok(EventTarget);
 
   ev.preventDefault();
   strictEqual(ev.defaultPrevented, true);
+  throws(() => new Event(Symbol()), TypeError);
 }
 {
   const ev = new Event('foo');


### PR DESCRIPTION
Align behavior of `Event` constructor when a symbol is passed with what the DOM does.

Old behavior:
 - `new Event(Symbol())` creates an event with type "Symbol()"
New behavior:
 - `new Event(Symbol())` throws an error (like browsers do).

cc @jasnell 
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)