### PR TITLE
events: set target property to null

### DIFF
--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -60,6 +60,7 @@ class Event {
       enumerable: true,
       configurable: false
     });
+    this[kTarget] = null;
   }
 
   [customInspectSymbol](depth, options) {
@@ -241,7 +242,7 @@ class EventTarget {
     }
 
     if (this.#emitting.has(event.type) ||
-        event[kTarget] !== undefined) {
+        event[kTarget] !== null) {
       throw new ERR_EVENT_RECURSION(event.type);
     }
 

--- a/test/parallel/test-eventtarget.js
+++ b/test/parallel/test-eventtarget.js
@@ -370,6 +370,7 @@ ok(EventTarget);
 {
   const target = new EventTarget();
   const event = new Event('foo');
+  strictEqual(event.target, null);
   target.addEventListener('foo', common.mustCall((event) => {
     strictEqual(event.target, target);
     strictEqual(event.currentTarget, target);


### PR DESCRIPTION
Another small fix to set the `target` property of the event to `null` and not undefined (to align behaviors)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
