### PR TITLE
events: fix event-target enumerable keys

### DIFF
--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -51,6 +51,13 @@ class Event {
     this.#bubbles = !!bubbles;
     this.#composed = !!composed;
     this.#type = String(type);
+    // isTrusted is special (LegacyUnforgeable)
+    Object.defineProperty(this, 'isTrusted', {
+      get() { return false; },
+      set(ignoredValue) { return false; },
+      enumerable: true,
+      configurable: false
+    });
   }
 
   [customInspectSymbol](depth, options) {
@@ -99,7 +106,6 @@ class Event {
   get returnValue() { return !this.defaultPrevented; }
   get bubbles() { return this.#bubbles; }
   get composed() { return this.#composed; }
-  get isTrusted() { return false; }
   get eventPhase() {
     return this[kTarget] ? 2 : 0;  // Equivalent to AT_TARGET or NONE
   }

--- a/test/parallel/test-eventtarget.js
+++ b/test/parallel/test-eventtarget.js
@@ -50,7 +50,10 @@ ok(EventTarget);
   ev.preventDefault();
   strictEqual(ev.defaultPrevented, true);
 }
-
+{
+  const ev = new Event('foo');
+  deepStrictEqual(Object.keys(ev), ['isTrusted']);
+}
 {
   const eventTarget = new EventTarget();
 


### PR DESCRIPTION
Another quick one as I look for deltas before adding the WPTs.

TIL about https://heycam.github.io/webidl/#LegacyUnforgeable 

Also I asked about this behavior on #whatwg to make sure I got it right (Edge behaves differently from Chrome and Firefox here)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

