### PR TITLE
events: support useCapture boolean

### DIFF
--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -396,6 +396,9 @@ function validateListener(listener) {
 }
 
 function validateEventListenerOptions(options) {
+  if (typeof options === 'boolean') {
+    options = { capture: options };
+  }
   if (options == null || typeof options !== 'object')
     throw new ERR_INVALID_ARG_TYPE('options', 'object', options);
   const {

--- a/test/parallel/test-eventtarget.js
+++ b/test/parallel/test-eventtarget.js
@@ -113,10 +113,11 @@ ok(EventTarget);
   ok(!eventTarget.dispatchEvent(event));
 }
 {
-  // adding event listeners with a boolean useCapture
+  // Adding event listeners with a boolean useCapture
   const eventTarget = new EventTarget();
   const event = new Event('foo');
-  eventTarget.addEventListener('foo', common.mustCall((event) => strictEqual(event.type, 'foo')), false);
+  const fn = common.mustCall((event) => strictEqual(event.type, 'foo'));
+  eventTarget.addEventListener('foo', fn, false);
   eventTarget.dispatchEvent(event);
 }
 {

--- a/test/parallel/test-eventtarget.js
+++ b/test/parallel/test-eventtarget.js
@@ -112,7 +112,13 @@ ok(EventTarget);
   eventTarget.addEventListener('foo', (event) => event.preventDefault());
   ok(!eventTarget.dispatchEvent(event));
 }
-
+{
+  // adding event listeners with a boolean useCapture
+  const eventTarget = new EventTarget();
+  const event = new Event('foo');
+  eventTarget.addEventListener('foo', common.mustCall((event) => strictEqual(event.type, 'foo')), false);
+  eventTarget.dispatchEvent(event);
+}
 {
   const eventTarget = new NodeEventTarget();
   strictEqual(eventTarget.listenerCount('foo'), 0);


### PR DESCRIPTION
Support "options" as a boolean in EventTarget. 

I ran into this due to working on porting the WPT over and I didn't want to make this change as part of a bigger PR.

(Before this PR the behavior was to throw)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
