### PR TITLE
events: Start porting WPT tests

### DIFF
--- a/test/parallel/test-eventtarget-whatwg-once.js
+++ b/test/parallel/test-eventtarget-whatwg-once.js
@@ -1,0 +1,91 @@
+// Flags: --expose-internals --no-warnings
+'use strict';
+
+const common = require('../common');
+
+const {
+  Event,
+  EventTarget,
+} = require('internal/event_target');
+
+const {
+  strictEqual,
+} = require('assert');
+
+// Manually ported from: wpt@dom/events/AddEventListenerOptions-once.html
+{
+  const document = new EventTarget();
+  let invoked_once = false;
+  let invoked_normal = false;
+  function handler_once() {
+    invoked_once = true;
+  }
+
+  function handler_normal() {
+    invoked_normal = true;
+  }
+
+  document.addEventListener('test', handler_once, { once: true });
+  document.addEventListener('test', handler_normal);
+  document.dispatchEvent(new Event('test'));
+  strictEqual(invoked_once, true, 'Once handler should be invoked');
+  strictEqual(invoked_normal, true, 'Normal handler should be invoked');
+
+  invoked_once = false;
+  invoked_normal = false;
+  document.dispatchEvent(new Event('test'));
+  strictEqual(invoked_once, false, 'Once handler shouldn\'t be invoked again');
+  strictEqual(invoked_normal, true, 'Normal handler should be invoked again');
+  document.removeEventListener('test', handler_normal);
+}
+
+
+{
+  // Manually ported from AddEventListenerOptions-once.html
+  const document = new EventTarget();
+  let invoked_count = 0;
+  function handler() {
+    invoked_count++;
+  }
+  document.addEventListener('test', handler, { once: true });
+  document.addEventListener('test', handler);
+  document.dispatchEvent(new Event('test'));
+  strictEqual(invoked_count, 1, 'The handler should only be added once');
+
+  invoked_count = 0;
+  document.dispatchEvent(new Event('test'));
+  strictEqual(invoked_count, 0, 'The handler was added as a once listener');
+
+  invoked_count = 0;
+  document.addEventListener('test', handler, { once: true });
+  document.removeEventListener('test', handler);
+  document.dispatchEvent(new Event('test'));
+  strictEqual(invoked_count, 0, 'The handler should have been removed');
+}
+
+{
+  // TODO(benjamingr) fix EventTarget recursion
+  common.skip('EventTarget recursion is currently broken');
+  const document = new EventTarget();
+  let invoked_count = 0;
+  function handler() {
+    invoked_count++;
+    if (invoked_count === 1)
+      document.dispatchEvent(new Event('test'));
+  }
+  document.addEventListener('test', handler, { once: true });
+  document.dispatchEvent(new Event('test'));
+  strictEqual(invoked_count, 1, 'Once handler should only be invoked once');
+
+  invoked_count = 0;
+  function handler2() {
+    invoked_count++;
+    if (invoked_count === 1)
+      document.addEventListener('test', handler2, { once: true });
+    if (invoked_count <= 2)
+      document.dispatchEvent(new Event('test'));
+  }
+  document.addEventListener('test', handler2, { once: true });
+  document.dispatchEvent(new Event('test'));
+  strictEqual(invoked_count, 2, 'Once handler should only be invoked once');
+}


### PR DESCRIPTION
I tried porting the WPT tests through `git node wpt` - it worked pretty well initially but there were several big issues:

 - All the meaningful tests are HTML files.
 - Even the JS files contained a lot of DOM logic. 
 - The WHATWG tests don't test `EventTarget` directly - rather they test `document` and `window` as event targets.

I started down the path of implementing a `document`, `window`, `appendChild` and then decided it would probably be easier to just manually port these tests after changing them to terms Node understands.

Ideally, we could contribute these back to WPT as less-tried-to-document tests for EventTarget.

For example where the test does `document.addEventListener` I do `let document = new EventEmitter()` first. 

When I tried porting https://github.com/web-platform-tests/wpt/blob/master/dom/events/AddEventListenerOptions-once.html#L36-L57 it threw `ERR_EVENT_RECURSION` indicating that that behavior is probably not spec compliant. @jasnell any objections to changing it to align with the spec and allow dispatching an event while in an event handler for the same handler?

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
