### PR TITLE
events: add tests, better toString

### DIFF
--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -282,6 +282,7 @@ class EventTarget {
 
     return `${name} ${inspect({}, opts)}`;
   }
+  get [Symbol.toStringTag]() { return 'EventTarget'; }
 }
 
 Object.defineProperties(EventTarget.prototype, {

--- a/test/parallel/test-eventtarget.js
+++ b/test/parallel/test-eventtarget.js
@@ -75,7 +75,14 @@ ok(EventTarget);
   eventTarget.removeEventListener('foo', ev1);
   eventTarget.dispatchEvent(new Event('foo'));
 }
-
+{
+  // event subclassing
+  const SubEvent = class extends Event {};
+  const ev = new SubEvent('foo');
+  const eventTarget = new EventTarget();
+  eventTarget.addEventListener('foo', common.mustCall((event) => strictEqual(event, ev)), { once: true });
+  eventTarget.dispatchEvent(ev);
+}
 {
   const eventTarget = new NodeEventTarget();
   strictEqual(eventTarget.listenerCount('foo'), 0);
@@ -383,4 +390,11 @@ ok(EventTarget);
   target.dispatchEvent(new Event('foo'));
   target.removeEventListener('foo', a, { capture: false });
   target.dispatchEvent(new Event('foo'));
+}
+
+{
+  const target = new EventTarget();
+  strictEqual(target.toString(), "[object EventTarget]");
+  const event = new Event();
+  strictEqual(event.toString(), "[object Event]");
 }

--- a/test/parallel/test-eventtarget.js
+++ b/test/parallel/test-eventtarget.js
@@ -80,7 +80,8 @@ ok(EventTarget);
   const SubEvent = class extends Event {};
   const ev = new SubEvent('foo');
   const eventTarget = new EventTarget();
-  eventTarget.addEventListener('foo', common.mustCall((event) => strictEqual(event, ev)), { once: true });
+  const fn = common.mustCall((event) => strictEqual(event, ev));
+  eventTarget.addEventListener('foo', fn, { once: true });
   eventTarget.dispatchEvent(ev);
 }
 {
@@ -394,7 +395,7 @@ ok(EventTarget);
 
 {
   const target = new EventTarget();
-  strictEqual(target.toString(), "[object EventTarget]");
+  strictEqual(target.toString(), '[object EventTarget]');
   const event = new Event();
-  strictEqual(event.toString(), "[object Event]");
+  strictEqual(event.toString(), '[object Event]');
 }


### PR DESCRIPTION
Support `toStringTag` on EventTarget so that our implmentation logs `[object EventTarget]`, add tests to that and a test for subclassing `Event`s.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
