### PR TITLE
test: uv_tty_init now returns EINVAL on IBM i

### DIFF
--- a/test/parallel/test-ttywrap-invalid-fd.js
+++ b/test/parallel/test-ttywrap-invalid-fd.js
@@ -21,14 +21,13 @@ assert.throws(
 
 {
   const info = {
-    code: common.isWindows || common.isIBMi ? 'EBADF' : 'EINVAL',
-    message: common.isWindows ||
-      common.isIBMi ? 'bad file descriptor' : 'invalid argument',
-    errno: common.isWindows || common.isIBMi ? UV_EBADF : UV_EINVAL,
+    code: common.isWindows ? 'EBADF' : 'EINVAL',
+    message: common.isWindows ? 'bad file descriptor' : 'invalid argument',
+    errno: common.isWindows ? UV_EBADF : UV_EINVAL,
     syscall: 'uv_tty_init'
   };
 
-  const suffix = common.isWindows || common.isIBMi ?
+  const suffix = common.isWindows ?
     'EBADF (bad file descriptor)' : 'EINVAL (invalid argument)';
   const message = `TTY initialization failed: uv_tty_init returned ${suffix}`;
 


### PR DESCRIPTION
Since the PR https://github.com/libuv/libuv/pull/2753 has been landed, we need to revert the code change in PR https://github.com/nodejs/node/pull/32338.

Based on the comment -- https://github.com/libuv/libuv/pull/2753#issuecomment-604234761
