### PR TITLE
src: add default value to error parameter in Encode

### DIFF
--- a/src/api/encoding.cc
+++ b/src/api/encoding.cc
@@ -103,15 +103,11 @@ Local<Value> Encode(Isolate* isolate,
                     size_t len,
                     enum encoding encoding) {
   CHECK_NE(encoding, UCS2);
-  Local<Value> error;
-  return StringBytes::Encode(isolate, buf, len, encoding, &error)
-      .ToLocalChecked();
+  return StringBytes::Encode(isolate, buf, len, encoding).ToLocalChecked();
 }
 
 Local<Value> Encode(Isolate* isolate, const uint16_t* buf, size_t len) {
-  Local<Value> error;
-  return StringBytes::Encode(isolate, buf, len, &error)
-      .ToLocalChecked();
+  return StringBytes::Encode(isolate, buf, len).ToLocalChecked();
 }
 
 // Returns -1 if the handle was not valid for decoding

--- a/src/fs_event_wrap.cc
+++ b/src/fs_event_wrap.cc
@@ -209,18 +209,15 @@ void FSEventWrap::OnEvent(uv_fs_event_t* handle, const char* filename,
   };
 
   if (filename != nullptr) {
-    Local<Value> error;
     MaybeLocal<Value> fn = StringBytes::Encode(env->isolate(),
                                                filename,
-                                               wrap->encoding_,
-                                               &error);
+                                               wrap->encoding_);
     if (fn.IsEmpty()) {
       argv[0] = Integer::New(env->isolate(), UV_EINVAL);
       argv[2] = StringBytes::Encode(env->isolate(),
                                     filename,
                                     strlen(filename),
-                                    BUFFER,
-                                    &error).ToLocalChecked();
+                                    BUFFER).ToLocalChecked();
     } else {
       argv[2] = fn.ToLocalChecked();
     }

--- a/src/string_bytes.h
+++ b/src/string_bytes.h
@@ -87,24 +87,24 @@ class StringBytes {
 
   // Take the bytes in the src, and turn it into a Buffer or String.
   static v8::MaybeLocal<v8::Value> Encode(v8::Isolate* isolate,
-                                          const char* buf,
-                                          size_t buflen,
-                                          enum encoding encoding,
-                                          v8::Local<v8::Value>* error);
+      const char* buf,
+      size_t buflen,
+      enum encoding encoding,
+      v8::Local<v8::Value>* error = nullptr);
 
   // Warning: This reverses endianness on BE platforms, even though the
   // signature using uint16_t implies that it should not.
   // However, the brokenness is already public API and can't therefore
   // be changed easily.
   static v8::MaybeLocal<v8::Value> Encode(v8::Isolate* isolate,
-                                          const uint16_t* buf,
-                                          size_t buflen,
-                                          v8::Local<v8::Value>* error);
+      const uint16_t* buf,
+      size_t buflen,
+      v8::Local<v8::Value>* error = nullptr);
 
   static v8::MaybeLocal<v8::Value> Encode(v8::Isolate* isolate,
-                                          const char* buf,
-                                          enum encoding encoding,
-                                          v8::Local<v8::Value>* error);
+      const char* buf,
+      enum encoding encoding,
+      v8::Local<v8::Value>* error = nullptr);
 
   static size_t hex_encode(const char* src,
                            size_t slen,


### PR DESCRIPTION
This commit adds a default value for the error parameter in
`StringBytes::Encode`.

The motivation for this is that there are usages where the error is not
used and a pointer to an empty `Local<Value>` is created and passed in
which can now be avoided.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
