### PR TITLE
test: improve http-client coverage

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -186,9 +186,11 @@ function ClientRequest(input, options, cb) {
   const defaultPort = options.defaultPort ||
                     (this.agent && this.agent.defaultPort);
 
-  const port = options.port = options.port || defaultPort || 80;
-  const host = options.host = validateHost(options.hostname, 'hostname') ||
-                            validateHost(options.host, 'host') || 'localhost';
+  const optsWithoutSignal = { __proto__: null, ...options };
+
+  const port = optsWithoutSignal.port = options.port || defaultPort || 80;
+  const host = optsWithoutSignal.host = validateHost(options.hostname, 'hostname') ||
+                                        validateHost(options.host, 'host') || 'localhost';
 
   const setHost = (options.setHost === undefined || Boolean(options.setHost));
 
@@ -200,6 +202,7 @@ function ClientRequest(input, options, cb) {
   const signal = options.signal;
   if (signal) {
     addAbortSignal(signal, this);
+    delete optsWithoutSignal.signal;
   }
   let method = options.method;
   const methodIsString = (typeof method === 'string');
@@ -325,12 +328,6 @@ function ClientRequest(input, options, cb) {
   }
 
   this[kUniqueHeaders] = parseUniqueHeadersOption(options.uniqueHeaders);
-
-  let optsWithoutSignal = options;
-  if (optsWithoutSignal.signal) {
-    optsWithoutSignal = ObjectAssign({}, options);
-    delete optsWithoutSignal.signal;
-  }
 
   // initiate connection
   if (this.agent) {

--- a/test/parallel/test-http-client-input-function.js
+++ b/test/parallel/test-http-client-input-function.js
@@ -8,9 +8,9 @@ const assert = require('assert');
   const server = http.createServer(common.mustCall((req, res) => {
     res.writeHead(200);
     res.end('hello world');
-  })).listen(80, '127.0.0.1');
+  })).listen(8080, '127.0.0.1');
 
-  const req = new http.ClientRequest(common.mustCall((response) => {
+  const req = new http.ClientRequest('http://127.0.0.1:8080', common.mustCall((response) => {
     let body = '';
     response.setEncoding('utf8');
     response.on('data', (chunk) => {

--- a/test/parallel/test-http-client-input-function.js
+++ b/test/parallel/test-http-client-input-function.js
@@ -8,20 +8,22 @@ const assert = require('assert');
   const server = http.createServer(common.mustCall((req, res) => {
     res.writeHead(200);
     res.end('hello world');
-  })).listen(8080, '127.0.0.1');
+  })).listen(0, '127.0.0.1');
 
-  const req = new http.ClientRequest('http://127.0.0.1:8080', common.mustCall((response) => {
-    let body = '';
-    response.setEncoding('utf8');
-    response.on('data', (chunk) => {
-      body += chunk;
-    });
+  server.on('listening', common.mustCall(() => {
+    const req = new http.ClientRequest(server.address(), common.mustCall((response) => {
+      let body = '';
+      response.setEncoding('utf8');
+      response.on('data', (chunk) => {
+        body += chunk;
+      });
 
-    response.on('end', common.mustCall(() => {
-      assert.strictEqual(body, 'hello world');
-      server.close();
+      response.on('end', common.mustCall(() => {
+        assert.strictEqual(body, 'hello world');
+        server.close();
+      }));
     }));
-  }));
 
-  req.end();
+    req.end();
+  }));
 }

--- a/test/parallel/test-http-client-input-function.js
+++ b/test/parallel/test-http-client-input-function.js
@@ -1,14 +1,28 @@
 'use strict';
 
 const common = require('../common');
+const http = require('http');
 const assert = require('assert');
 const ClientRequest = require('http').ClientRequest;
 
 {
-  const req = new ClientRequest(() => {});
-  req.on('error', common.mustCall((err) => {
-    assert.strictEqual(err.code, 'ECONNREFUSED');
+  const server = http.createServer(common.mustCall((req, res) => {
+    res.writeHead(200);
+    res.end('hello world');
+  })).listen(80, '127.0.0.1');
+
+  const req = new ClientRequest(common.mustCall((response) => {
+    let body = '';
+    response.setEncoding('utf8');
+    response.on('data', (chunk) => {
+      body += chunk;
+    });
+
+    response.on('end', common.mustCall(() => {
+      assert.strictEqual(body, 'hello world');
+      server.close();
+    }));
   }));
-  assert.strictEqual(req.path, '/');
-  assert.strictEqual(req.method, 'GET');
+
+  req.end();
 }

--- a/test/parallel/test-http-client-input-function.js
+++ b/test/parallel/test-http-client-input-function.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const ClientRequest = require('http').ClientRequest;
+
+{
+  const req = new ClientRequest(() => {});
+  req.on('error', common.mustCall((err) => {
+    assert.strictEqual(err.code, 'ECONNREFUSED');
+  }))
+  assert.strictEqual(req.path, '/');
+  assert.strictEqual(req.method, 'GET');
+}

--- a/test/parallel/test-http-client-input-function.js
+++ b/test/parallel/test-http-client-input-function.js
@@ -3,7 +3,6 @@
 const common = require('../common');
 const http = require('http');
 const assert = require('assert');
-const ClientRequest = require('http').ClientRequest;
 
 {
   const server = http.createServer(common.mustCall((req, res) => {
@@ -11,7 +10,7 @@ const ClientRequest = require('http').ClientRequest;
     res.end('hello world');
   })).listen(80, '127.0.0.1');
 
-  const req = new ClientRequest(common.mustCall((response) => {
+  const req = new http.ClientRequest(common.mustCall((response) => {
     let body = '';
     response.setEncoding('utf8');
     response.on('data', (chunk) => {

--- a/test/parallel/test-http-client-input-function.js
+++ b/test/parallel/test-http-client-input-function.js
@@ -8,7 +8,7 @@ const ClientRequest = require('http').ClientRequest;
   const req = new ClientRequest(() => {});
   req.on('error', common.mustCall((err) => {
     assert.strictEqual(err.code, 'ECONNREFUSED');
-  }))
+  }));
   assert.strictEqual(req.path, '/');
   assert.strictEqual(req.method, 'GET');
 }

--- a/test/parallel/test-http-client-insecure-http-parser-error.js
+++ b/test/parallel/test-http-client-insecure-http-parser-error.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const ClientRequest = require('http').ClientRequest;
+
+{
+  assert.throws(() => {
+    new ClientRequest({insecureHTTPParser: 'wrongValue'});
+  }, {
+    code: /ERR_INVALID_ARG_TYPE/
+  }, 'http request should throw when passing not-boolean value as insecureHTTPParser');
+}

--- a/test/parallel/test-http-client-insecure-http-parser-error.js
+++ b/test/parallel/test-http-client-insecure-http-parser-error.js
@@ -8,6 +8,7 @@ const ClientRequest = require('http').ClientRequest;
   assert.throws(() => {
     new ClientRequest({ insecureHTTPParser: 'wrongValue' });
   }, {
-    code: /ERR_INVALID_ARG_TYPE/
+    code: 'ERR_INVALID_ARG_TYPE',
+    message: /insecureHTTPParser/
   }, 'http request should throw when passing invalid insecureHTTPParser');
 }

--- a/test/parallel/test-http-client-insecure-http-parser-error.js
+++ b/test/parallel/test-http-client-insecure-http-parser-error.js
@@ -1,13 +1,13 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const ClientRequest = require('http').ClientRequest;
 
 {
   assert.throws(() => {
-    new ClientRequest({insecureHTTPParser: 'wrongValue'});
+    new ClientRequest({ insecureHTTPParser: 'wrongValue' });
   }, {
     code: /ERR_INVALID_ARG_TYPE/
-  }, 'http request should throw when passing not-boolean value as insecureHTTPParser');
+  }, 'http request should throw when passing invalid insecureHTTPParser');
 }


### PR DESCRIPTION
Based on https://coverage.nodejs.org/coverage-d12d5ef3ef8e5d9f/lib/_http_client.js.html, I try to improve coverage to line 120 (http-client-input-function), 194-197 (http-client-insecure-http-parser-error)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
