### PR TITLE
http2: add maxHeaderSize option to http2

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -2495,6 +2495,7 @@ properties.
 * `maxHeaderListSize` {number} Specifies the maximum size (uncompressed octets)
   of header list that will be accepted. The minimum allowed value is 0. The
   maximum allowed value is 2<sup>32</sup>-1. **Default:** `65535`.
+* `maxHeaderSize` {number} Alias for `maxHeaderListSize`.
 * `enableConnectProtocol`{boolean} Specifies `true` if the "Extended Connect
   Protocol" defined by [RFC 8441][] is to be enabled. This setting is only
   meaningful if sent by the server. Once the `enableConnectProtocol` setting

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -906,6 +906,9 @@ const validateSettings = hideStackFrames((settings) => {
   assertWithinRange('maxHeaderListSize',
                     settings.maxHeaderListSize,
                     0, kMaxInt);
+  assertWithinRange('maxHeaderSize',
+                    settings.maxHeaderSize,
+                    0, kMaxInt);
   if (settings.enablePush !== undefined &&
       typeof settings.enablePush !== 'boolean') {
     throw new ERR_HTTP2_INVALID_SETTING_VALUE('enablePush',
@@ -3112,7 +3115,7 @@ function getUnpackedSettings(buf, options = {}) {
         settings.maxFrameSize = value;
         break;
       case NGHTTP2_SETTINGS_MAX_HEADER_LIST_SIZE:
-        settings.maxHeaderListSize = value;
+        settings.maxHeaderListSize = settings.maxHeaderSize = value;
         break;
       case NGHTTP2_SETTINGS_ENABLE_CONNECT_PROTOCOL:
         settings.enableConnectProtocol = value !== 0;

--- a/lib/internal/http2/util.js
+++ b/lib/internal/http2/util.js
@@ -294,8 +294,12 @@ function getDefaultSettings() {
 
   if ((flags & (1 << IDX_SETTINGS_MAX_HEADER_LIST_SIZE)) ===
       (1 << IDX_SETTINGS_MAX_HEADER_LIST_SIZE)) {
-    holder.maxHeaderListSize =
+    holder.maxHeaderListSize = holder.maxHeaderSize =
       settingsBuffer[IDX_SETTINGS_MAX_HEADER_LIST_SIZE];
+  }
+  if ((flags & (1 << IDX_SETTINGS_MAX_HEADER_LIST_SIZE)) ===
+      (1 << IDX_SETTINGS_MAX_HEADER_LIST_SIZE)) {
+    holder.maxHeaderSize = settingsBuffer[IDX_SETTINGS_MAX_HEADER_LIST_SIZE];
   }
 
   if ((flags & (1 << IDX_SETTINGS_ENABLE_CONNECT_PROTOCOL)) ===
@@ -322,6 +326,7 @@ function getSettings(session, remote) {
     maxFrameSize: settingsBuffer[IDX_SETTINGS_MAX_FRAME_SIZE],
     maxConcurrentStreams: settingsBuffer[IDX_SETTINGS_MAX_CONCURRENT_STREAMS],
     maxHeaderListSize: settingsBuffer[IDX_SETTINGS_MAX_HEADER_LIST_SIZE],
+    maxHeaderSize: settingsBuffer[IDX_SETTINGS_MAX_HEADER_LIST_SIZE],
     enableConnectProtocol:
       !!settingsBuffer[IDX_SETTINGS_ENABLE_CONNECT_PROTOCOL]
   };
@@ -349,10 +354,19 @@ function updateSettingsBuffer(settings) {
     settingsBuffer[IDX_SETTINGS_MAX_FRAME_SIZE] =
       settings.maxFrameSize;
   }
-  if (typeof settings.maxHeaderListSize === 'number') {
+  if (typeof settings.maxHeaderListSize === 'number' ||
+      typeof settings.maxHeaderSize === 'number') {
     flags |= (1 << IDX_SETTINGS_MAX_HEADER_LIST_SIZE);
+    if (settings.maxHeaderSize && settings.maxHeaderListSize) {
+      if (settings.maxHeaderSize !== settings.maxHeaderListSize) {
+        throw new ERR_HTTP2_INVALID_SETTING_VALUE.RangeError(
+          'maxHeaderListSize', settings.maxHeaderListSize
+        );
+      }
+    }
     settingsBuffer[IDX_SETTINGS_MAX_HEADER_LIST_SIZE] =
-      settings.maxHeaderListSize;
+      settings.maxHeaderListSize !== undefined ?
+        settings.maxHeaderListSize : settings.maxHeaderSize;
   }
   if (typeof settings.enablePush === 'boolean') {
     flags |= (1 << IDX_SETTINGS_ENABLE_PUSH);

--- a/lib/internal/http2/util.js
+++ b/lib/internal/http2/util.js
@@ -297,10 +297,6 @@ function getDefaultSettings() {
     holder.maxHeaderListSize = holder.maxHeaderSize =
       settingsBuffer[IDX_SETTINGS_MAX_HEADER_LIST_SIZE];
   }
-  if ((flags & (1 << IDX_SETTINGS_MAX_HEADER_LIST_SIZE)) ===
-      (1 << IDX_SETTINGS_MAX_HEADER_LIST_SIZE)) {
-    holder.maxHeaderSize = settingsBuffer[IDX_SETTINGS_MAX_HEADER_LIST_SIZE];
-  }
 
   if ((flags & (1 << IDX_SETTINGS_ENABLE_CONNECT_PROTOCOL)) ===
       (1 << IDX_SETTINGS_ENABLE_CONNECT_PROTOCOL)) {
@@ -357,12 +353,11 @@ function updateSettingsBuffer(settings) {
   if (typeof settings.maxHeaderListSize === 'number' ||
       typeof settings.maxHeaderSize === 'number') {
     flags |= (1 << IDX_SETTINGS_MAX_HEADER_LIST_SIZE);
-    if (settings.maxHeaderSize && settings.maxHeaderListSize) {
-      if (settings.maxHeaderSize !== settings.maxHeaderListSize) {
-        throw new ERR_HTTP2_INVALID_SETTING_VALUE.RangeError(
-          'maxHeaderListSize', settings.maxHeaderListSize
-        );
-      }
+    if(settings.maxHeaderListSize !== undefined &&
+      (settings.maxHeaderListSize !== maxHeaderSize)) {
+      throw new ERR_HTTP2_INVALID_SETTING_VALUE.RangeError(
+        'maxHeaderListSize', settings.maxHeaderListSize
+      );
     }
     settingsBuffer[IDX_SETTINGS_MAX_HEADER_LIST_SIZE] =
       settings.maxHeaderListSize !== undefined ?

--- a/lib/internal/http2/util.js
+++ b/lib/internal/http2/util.js
@@ -354,6 +354,7 @@ function updateSettingsBuffer(settings) {
       typeof settings.maxHeaderSize === 'number') {
     flags |= (1 << IDX_SETTINGS_MAX_HEADER_LIST_SIZE);
     if (settings.maxHeaderListSize !== undefined &&
+      settings.maxHeaderSize !== undefined &&
       (settings.maxHeaderListSize !== settings.maxHeaderSize)) {
       throw new ERR_HTTP2_INVALID_SETTING_VALUE.RangeError(
         'maxHeaderListSize', settings.maxHeaderListSize

--- a/lib/internal/http2/util.js
+++ b/lib/internal/http2/util.js
@@ -353,8 +353,8 @@ function updateSettingsBuffer(settings) {
   if (typeof settings.maxHeaderListSize === 'number' ||
       typeof settings.maxHeaderSize === 'number') {
     flags |= (1 << IDX_SETTINGS_MAX_HEADER_LIST_SIZE);
-    if(settings.maxHeaderListSize !== undefined &&
-      (settings.maxHeaderListSize !== maxHeaderSize)) {
+    if (settings.maxHeaderListSize !== undefined &&
+      (settings.maxHeaderListSize !== settings.maxHeaderSize)) {
       throw new ERR_HTTP2_INVALID_SETTING_VALUE.RangeError(
         'maxHeaderListSize', settings.maxHeaderListSize
       );

--- a/lib/internal/http2/util.js
+++ b/lib/internal/http2/util.js
@@ -353,16 +353,17 @@ function updateSettingsBuffer(settings) {
   if (typeof settings.maxHeaderListSize === 'number' ||
       typeof settings.maxHeaderSize === 'number') {
     flags |= (1 << IDX_SETTINGS_MAX_HEADER_LIST_SIZE);
-    if (settings.maxHeaderListSize !== undefined &&
-      settings.maxHeaderSize !== undefined &&
-      (settings.maxHeaderListSize !== settings.maxHeaderSize)) {
-      throw new ERR_HTTP2_INVALID_SETTING_VALUE.RangeError(
-        'maxHeaderListSize', settings.maxHeaderListSize
+    if (settings.maxHeaderSize !== undefined &&
+      (settings.maxHeaderSize !== settings.maxHeaderListSize)) {
+      process.emitWarning(
+        'settings.maxHeaderSize overwrite settings.maxHeaderListSize'
       );
+      settingsBuffer[IDX_SETTINGS_MAX_HEADER_LIST_SIZE] =
+        settings.maxHeaderSize;
+    } else {
+      settingsBuffer[IDX_SETTINGS_MAX_HEADER_LIST_SIZE] =
+        settings.maxHeaderListSize;
     }
-    settingsBuffer[IDX_SETTINGS_MAX_HEADER_LIST_SIZE] =
-      settings.maxHeaderListSize !== undefined ?
-        settings.maxHeaderListSize : settings.maxHeaderSize;
   }
   if (typeof settings.enablePush === 'boolean') {
     flags |= (1 << IDX_SETTINGS_ENABLE_PUSH);

--- a/test/parallel/test-http2-client-settings-before-connect.js
+++ b/test/parallel/test-http2-client-settings-before-connect.js
@@ -32,6 +32,8 @@ server.listen(0, common.mustCall(() => {
     ['maxConcurrentStreams', 2 ** 32, RangeError],
     ['maxHeaderListSize', -1, RangeError],
     ['maxHeaderListSize', 2 ** 32, RangeError],
+    ['maxHeaderSize', -1, RangeError],
+    ['maxHeaderSize', 2 ** 32, RangeError],
     ['enablePush', 'a', TypeError],
     ['enablePush', 1, TypeError],
     ['enablePush', 0, TypeError],

--- a/test/parallel/test-http2-getpackedsettings.js
+++ b/test/parallel/test-http2-getpackedsettings.js
@@ -26,7 +26,9 @@ assert.deepStrictEqual(val, check);
   ['maxConcurrentStreams', 0],
   ['maxConcurrentStreams', 2 ** 31 - 1],
   ['maxHeaderListSize', 0],
-  ['maxHeaderListSize', 2 ** 32 - 1]
+  ['maxHeaderListSize', 2 ** 32 - 1],
+  ['maxHeaderSize', 0],
+  ['maxHeaderSize', 2 ** 32 - 1]
 ].forEach((i) => {
   // Valid options should not throw.
   http2.getPackedSettings({ [i[0]]: i[1] });
@@ -45,7 +47,9 @@ http2.getPackedSettings({ enablePush: false });
   ['maxConcurrentStreams', -1],
   ['maxConcurrentStreams', 2 ** 32],
   ['maxHeaderListSize', -1],
-  ['maxHeaderListSize', 2 ** 32]
+  ['maxHeaderListSize', 2 ** 32],
+  ['maxHeaderSize', -1],
+  ['maxHeaderSize', 2 ** 32]
 ].forEach((i) => {
   assert.throws(() => {
     http2.getPackedSettings({ [i[0]]: i[1] });
@@ -97,6 +101,7 @@ http2.getPackedSettings({ enablePush: false });
     maxFrameSize: 20000,
     maxConcurrentStreams: 200,
     maxHeaderListSize: 100,
+    maxHeaderSize: 100,
     enablePush: true,
     enableConnectProtocol: false,
     foo: 'ignored'
@@ -149,6 +154,7 @@ http2.getPackedSettings({ enablePush: false });
   assert.strictEqual(settings.maxFrameSize, 20000);
   assert.strictEqual(settings.maxConcurrentStreams, 200);
   assert.strictEqual(settings.maxHeaderListSize, 100);
+  assert.strictEqual(settings.maxHeaderSize, 100);
   assert.strictEqual(settings.enablePush, true);
   assert.strictEqual(settings.enableConnectProtocol, false);
 }

--- a/test/parallel/test-http2-session-settings.js
+++ b/test/parallel/test-http2-session-settings.js
@@ -19,6 +19,7 @@ server.on(
       assert.strictEqual(typeof settings.maxFrameSize, 'number');
       assert.strictEqual(typeof settings.maxConcurrentStreams, 'number');
       assert.strictEqual(typeof settings.maxHeaderListSize, 'number');
+      assert.strictEqual(typeof settings.maxHeaderSize, 'number');
     };
 
     const localSettings = stream.session.localSettings;
@@ -100,7 +101,9 @@ server.listen(
         ['maxFrameSize', 16383],
         ['maxFrameSize', 2 ** 24],
         ['maxHeaderListSize', -1],
-        ['maxHeaderListSize', 2 ** 32]
+        ['maxHeaderListSize', 2 ** 32],
+        ['maxHeaderSize', -1],
+        ['maxHeaderSize', 2 ** 32]
       ].forEach((i) => {
         const settings = {};
         settings[i[0]] = i[1];

--- a/test/parallel/test-http2-too-large-headers.js
+++ b/test/parallel/test-http2-too-large-headers.js
@@ -9,7 +9,10 @@ const {
   NGHTTP2_ENHANCE_YOUR_CALM
 } = http2.constants;
 
-const server = http2.createServer({ settings: { maxHeaderListSize: 100 } });
+let server = http2.createServer({ settings: { maxHeaderListSize: 100 } });
+server.on('stream', common.mustNotCall());
+
+server = http2.createServer({ settings: {maxHeaderSize: 100 } });
 server.on('stream', common.mustNotCall());
 
 server.listen(0, common.mustCall(() => {

--- a/test/parallel/test-http2-too-large-headers.js
+++ b/test/parallel/test-http2-too-large-headers.js
@@ -12,7 +12,7 @@ const {
 let server = http2.createServer({ settings: { maxHeaderListSize: 100 } });
 server.on('stream', common.mustNotCall());
 
-server = http2.createServer({ settings: {maxHeaderSize: 100 } });
+server = http2.createServer({ settings: { maxHeaderSize: 100 } });
 server.on('stream', common.mustNotCall());
 
 server.listen(0, common.mustCall(() => {

--- a/test/parallel/test-http2-too-large-headers.js
+++ b/test/parallel/test-http2-too-large-headers.js
@@ -9,27 +9,26 @@ const {
   NGHTTP2_ENHANCE_YOUR_CALM
 } = http2.constants;
 
-let server = http2.createServer({ settings: { maxHeaderListSize: 100 } });
-server.on('stream', common.mustNotCall());
+for (const prototype of ['maxHeaderListSize', 'maxHeaderSize']) {
+  const server = http2.createServer({ settings: { [prototype]: 100 } });
+  server.on('stream', common.mustNotCall());
 
-server = http2.createServer({ settings: { maxHeaderSize: 100 } });
-server.on('stream', common.mustNotCall());
+  server.listen(0, common.mustCall(() => {
+    const client = http2.connect(`http://localhost:${server.address().port}`);
 
-server.listen(0, common.mustCall(() => {
-  const client = http2.connect(`http://localhost:${server.address().port}`);
+    client.on('remoteSettings', () => {
+      const req = client.request({ 'foo': 'a'.repeat(1000) });
+      req.on('error', common.expectsError({
+        code: 'ERR_HTTP2_STREAM_ERROR',
+        name: 'Error',
+        message: 'Stream closed with error code NGHTTP2_ENHANCE_YOUR_CALM'
+      }));
+      req.on('close', common.mustCall(() => {
+        assert.strictEqual(req.rstCode, NGHTTP2_ENHANCE_YOUR_CALM);
+        server.close();
+        client.close();
+      }));
+    });
 
-  client.on('remoteSettings', () => {
-    const req = client.request({ 'foo': 'a'.repeat(1000) });
-    req.on('error', common.expectsError({
-      code: 'ERR_HTTP2_STREAM_ERROR',
-      name: 'Error',
-      message: 'Stream closed with error code NGHTTP2_ENHANCE_YOUR_CALM'
-    }));
-    req.on('close', common.mustCall(() => {
-      assert.strictEqual(req.rstCode, NGHTTP2_ENHANCE_YOUR_CALM);
-      server.close();
-      client.close();
-    }));
-  });
-
-}));
+  }));
+}


### PR DESCRIPTION
add maxHeaderSize to http2 as an alias for maxHeaderListSize.

Fixes: https://github.com/nodejs/node/issues/33517

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
