### PR TITLE
events: improve argument handling, start passive

### DIFF
--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -193,6 +193,14 @@ class EventTarget {
 
     if (!shouldAddListener(listener)) {
       // The DOM silently allows passing undefined as a second argument
+      // No error code for this since it is a Warning
+      // eslint-disable-next-line no-restricted-syntax
+      const w = new Error(`addEventListener called with ${listener}` +
+                          ` which has no effect.`);
+      w.name = 'AddEventListenerArgumentTypeWarning';
+      w.target = this;
+      w.type = type;
+      process.emitWarning(w);
       return;
     }
     type = String(type);

--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -196,7 +196,7 @@ class EventTarget {
       // No error code for this since it is a Warning
       // eslint-disable-next-line no-restricted-syntax
       const w = new Error(`addEventListener called with ${listener}` +
-                          ` which has no effect.`);
+                          ' which has no effect.');
       w.name = 'AddEventListenerArgumentTypeWarning';
       w.target = this;
       w.type = type;

--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -15,7 +15,7 @@ const {
     ERR_INVALID_ARG_TYPE,
     ERR_EVENT_RECURSION,
     ERR_OUT_OF_RANGE,
-    ERR_MISSING_ARGS
+    ERR_MISSING_ARGS,
   }
 } = require('internal/errors');
 
@@ -180,14 +180,22 @@ class EventTarget {
   [kRemoveListener](size, type, listener, capture) {}
 
   addEventListener(type, listener, options = {}) {
-    validateListener(listener);
-    type = String(type);
-
+    if (arguments.length < 2) {
+      throw new ERR_MISSING_ARGS('type', 'listener');
+    }
+    // We validateOptions before the shouldAddListeners check because the spec
+    // requires us to hit getters.
     const {
       once,
       capture,
       passive
     } = validateEventListenerOptions(options);
+
+    if (!shouldAddListener(listener)) {
+      // The DOM silently allows passing undefined as a second argument
+      return;
+    }
+    type = String(type);
 
     let root = this[kEvents].get(type);
 
@@ -219,9 +227,11 @@ class EventTarget {
   }
 
   removeEventListener(type, listener, options = {}) {
-    validateListener(listener);
+    if (!shouldAddListener(listener)) {
+      return;
+    }
     type = String(type);
-    const { capture } = validateEventListenerOptions(options);
+    const capture = !!(options?.capture);
     const root = this[kEvents].get(type);
     if (root === undefined || root.next === undefined)
       return;
@@ -402,12 +412,15 @@ Object.defineProperties(NodeEventTarget.prototype, {
 
 // EventTarget API
 
-function validateListener(listener) {
+function shouldAddListener(listener) {
   if (typeof listener === 'function' ||
       (listener != null &&
        typeof listener === 'object' &&
        typeof listener.handleEvent === 'function')) {
-    return;
+    return true;
+  }
+  if (listener === null || listener === undefined) {
+    return false;
   }
   throw new ERR_INVALID_ARG_TYPE('listener', 'EventListener', listener);
 }

--- a/test/parallel/test-eventtarget-whatwg-passive.js
+++ b/test/parallel/test-eventtarget-whatwg-passive.js
@@ -65,7 +65,4 @@ const {
   testPassiveValue({ passive: 1 }, false);
   testPassiveValue({ passive: true }, false);
   testPassiveValue({ passive: 0 }, true);
-
-
-
 }

--- a/test/parallel/test-eventtarget-whatwg-passive.js
+++ b/test/parallel/test-eventtarget-whatwg-passive.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const common = require('../common');
+
+const {
+  Event,
+  EventTarget,
+} = require('internal/event_target');
+
+const {
+  fail,
+  ok,
+  strictEqual
+} = require('assert');
+
+// Manually ported from WPT AddEventListenerOptions-passive.html
+{
+  const document = new EventTarget();
+  let supportsPassive = false;
+  const query_options = {
+    get passive() {
+      supportsPassive = true;
+      return false;
+    },
+    get dummy() {
+      fail('dummy value getter invoked');
+      return false;
+    }
+  };
+
+  document.addEventListener('test_event', null, query_options);
+  ok(supportsPassive);
+
+  supportsPassive = false;
+  document.removeEventListener('test_event', null, query_options);
+  strictEqual(supportsPassive, false);
+}
+{
+  function testPassiveValue(optionsValue, expectedDefaultPrevented) {
+    const document = new EventTarget();
+    let defaultPrevented;
+    function handler(e) {
+      if (e.defaultPrevented) {
+        fail('Event prematurely marked defaultPrevented');
+      }
+      e.preventDefault();
+      defaultPrevented = e.defaultPrevented;
+    }
+    document.addEventListener('test', handler, optionsValue);
+    // TODO the WHATWG test is more extensive here and tests dispatching on
+    // document.body, if we ever support getParent we should amend this
+    const ev = new Event('test', { bubbles: true, cancelable: true });
+    const uncanceled = document.dispatchEvent(ev);
+
+    strictEqual(defaultPrevented, expectedDefaultPrevented);
+    strictEqual(uncanceled, !expectedDefaultPrevented);
+
+    document.removeEventListener('test', handler, optionsValue);
+  }
+  testPassiveValue(undefined, true);
+  testPassiveValue({}, true);
+  testPassiveValue({ passive: false }, true);
+
+  common.skip('TODO: passive listeners is still broken');
+  testPassiveValue({ passive: 1 }, false);
+  testPassiveValue({ passive: true }, false);
+  testPassiveValue({ passive: 0 }, true);
+
+
+
+}

--- a/test/parallel/test-eventtarget.js
+++ b/test/parallel/test-eventtarget.js
@@ -31,6 +31,7 @@ process.on('warning', (e) => {
 
 // Utility promise for parts of the test that need to wait for eachother -
 // Namely tests for warning events
+/* eslint-disable no-unused-vars */
 let asyncTest = Promise.resolve();
 
 // First, test Event
@@ -389,14 +390,15 @@ let asyncTest = Promise.resolve();
     target.on('foo', () => {});
     target.on('foo', () => {});
 
-    // warnings are always emitted asynchronously so wait for a tick
-    await delay(0)
+    // Warnings are always emitted asynchronously so wait for a tick
+    await delay(0);
     ok(lastWarning instanceof Error);
     strictEqual(lastWarning.name, 'MaxListenersExceededWarning');
     strictEqual(lastWarning.target, target);
     strictEqual(lastWarning.count, 2);
     strictEqual(lastWarning.type, 'foo');
-    ok(lastWarning.message.includes('2 foo listeners added to NodeEventTarget'));
+    const warning = '2 foo listeners added to NodeEventTarget';
+    ok(lastWarning.message.includes(warning));
   }).then(common.mustCall());
 }
 

--- a/test/parallel/test-eventtarget.js
+++ b/test/parallel/test-eventtarget.js
@@ -115,6 +115,18 @@ ok(EventTarget);
   const fn = common.mustCall((event) => strictEqual(event, ev));
   eventTarget.addEventListener('foo', fn, { once: true });
   eventTarget.dispatchEvent(ev);
+  const eventTarget = new EventTarget();
+  // single argument throws
+  throws(() => eventTarget.addEventListener('foo'), TypeError);
+  // Null events - does not throw
+  eventTarget.addEventListener('foo', null);
+  eventTarget.removeEventListener('foo', null);
+  eventTarget.addEventListener('foo', undefined);
+  eventTarget.removeEventListener('foo', undefined);
+  // strings, booleans
+  throws(() => eventTarget.addEventListener('foo', 'hello'), TypeError);
+  throws(() => eventTarget.addEventListener('foo', false), TypeError);
+  throws(() => eventTarget.addEventListener('foo', Symbol()), TypeError);
 }
 {
   const eventTarget = new NodeEventTarget();
@@ -309,8 +321,6 @@ ok(EventTarget);
     'foo',
     1,
     {},  // No handleEvent function
-    false,
-    undefined
   ].forEach((i) => {
     throws(() => target.addEventListener('foo', i), {
       code: 'ERR_INVALID_ARG_TYPE'
@@ -321,8 +331,6 @@ ok(EventTarget);
     'foo',
     1,
     {},  // No handleEvent function
-    false,
-    undefined
   ].forEach((i) => {
     throws(() => target.removeEventListener('foo', i), {
       code: 'ERR_INVALID_ARG_TYPE'

--- a/test/parallel/test-eventtarget.js
+++ b/test/parallel/test-eventtarget.js
@@ -116,14 +116,14 @@ ok(EventTarget);
   eventTarget.addEventListener('foo', fn, { once: true });
   eventTarget.dispatchEvent(ev);
   const eventTarget = new EventTarget();
-  // single argument throws
+  // Single argument throws
   throws(() => eventTarget.addEventListener('foo'), TypeError);
   // Null events - does not throw
   eventTarget.addEventListener('foo', null);
   eventTarget.removeEventListener('foo', null);
   eventTarget.addEventListener('foo', undefined);
   eventTarget.removeEventListener('foo', undefined);
-  // strings, booleans
+  // Strings, booleans
   throws(() => eventTarget.addEventListener('foo', 'hello'), TypeError);
   throws(() => eventTarget.addEventListener('foo', false), TypeError);
   throws(() => eventTarget.addEventListener('foo', Symbol()), TypeError);


### PR DESCRIPTION
Hey, this PR fixes argument handling for cases like `addEventListener('foo', undefined)` which is allowed as well as add a whatwg WPT test that tests this.

Note the actual passive tests don't pass (because we don't deal with passive).

IIUC passive means "if event.preventDefault is called from within a passive listener - don't preventDefault". I will make a PR fixing this after https://github.com/nodejs/node/pull/33613 lands.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
