### PR TITLE
src: avoid OOB read in URL parser

### DIFF
--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -1488,7 +1488,7 @@ void URL::Parse(const char* input,
             state = kSpecialRelativeOrAuthority;
           } else if (special) {
             state = kSpecialAuthoritySlashes;
-          } else if (p[1] == '/') {
+          } else if (p + 1 < end && p[1] == '/') {
             state = kPathOrAuthority;
             p++;
           } else {
@@ -1548,7 +1548,7 @@ void URL::Parse(const char* input,
         }
         break;
       case kSpecialRelativeOrAuthority:
-        if (ch == '/' && p[1] == '/') {
+        if (ch == '/' && p + 1 < end && p[1] == '/') {
           state = kSpecialAuthorityIgnoreSlashes;
           p++;
         } else {
@@ -1696,7 +1696,7 @@ void URL::Parse(const char* input,
         break;
       case kSpecialAuthoritySlashes:
         state = kSpecialAuthorityIgnoreSlashes;
-        if (ch == '/' && p[1] == '/') {
+        if (ch == '/' && p + 1 < end && p[1] == '/') {
           p++;
         } else {
           continue;

--- a/test/cctest/test_url.cc
+++ b/test/cctest/test_url.cc
@@ -81,6 +81,26 @@ TEST_F(URLTest, Base3) {
   EXPECT_EQ(simple.path(), "/baz");
 }
 
+TEST_F(URLTest, TruncatedAfterProtocol) {
+  char input[2] = { 'q', ':' };
+  URL simple(input, sizeof(input));
+
+  EXPECT_FALSE(simple.flags() & URL_FLAGS_FAILED);
+  EXPECT_EQ(simple.protocol(), "q:");
+  EXPECT_EQ(simple.host(), "");
+  EXPECT_EQ(simple.path(), "/");
+}
+
+TEST_F(URLTest, TruncatedAfterProtocol2) {
+  char input[6] = { 'h', 't', 't', 'p', ':', '/' };
+  URL simple(input, sizeof(input));
+
+  EXPECT_FALSE(simple.flags() & URL_FLAGS_FAILED);
+  EXPECT_EQ(simple.protocol(), "http:");
+  EXPECT_EQ(simple.host(), "");
+  EXPECT_EQ(simple.path(), "/");
+}
+
 TEST_F(URLTest, ToFilePath) {
 #define T(url, path) EXPECT_EQ(path, URL(url).ToFilePath())
   T("http://example.org/foo/bar", "");

--- a/test/cctest/test_url.cc
+++ b/test/cctest/test_url.cc
@@ -95,10 +95,10 @@ TEST_F(URLTest, TruncatedAfterProtocol2) {
   char input[6] = { 'h', 't', 't', 'p', ':', '/' };
   URL simple(input, sizeof(input));
 
-  EXPECT_FALSE(simple.flags() & URL_FLAGS_FAILED);
+  EXPECT_TRUE(simple.flags() & URL_FLAGS_FAILED);
   EXPECT_EQ(simple.protocol(), "http:");
   EXPECT_EQ(simple.host(), "");
-  EXPECT_EQ(simple.path(), "/");
+  EXPECT_EQ(simple.path(), "");
 }
 
 TEST_F(URLTest, ToFilePath) {


### PR DESCRIPTION
This is not a big concern, because right now, all (non-test) inputs
to the parser are `'\0'`-terminated, but we should be future-proof
here and not perform these OOB reads.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
