### PR TITLE
[v10.x] doc: update tls.md

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -1416,7 +1416,7 @@ added: v10.6.0
 
 * {string} The default value of the `maxVersion` option of
   [`tls.createSecureContext()`][]. It can be assigned any of the supported TLS
-  protocol versions, `TLSv1.2'`, `'TLSv1.1'`, or `'TLSv1'`.
+  protocol versions, `'TLSv1.2'`, `'TLSv1.1'`, or `'TLSv1'`.
   **Default:** `'TLSv1.2'`.
 
 ## tls.DEFAULT_MIN_VERSION
@@ -1426,7 +1426,7 @@ added: v10.6.0
 
 * {string} The default value of the `minVersion` option of
   [`tls.createSecureContext()`][]. It can be assigned any of the supported TLS
-  protocol versions, `TLSv1.2'`, `'TLSv1.1'`, or `'TLSv1'`.
+  protocol versions, `'TLSv1.2'`, `'TLSv1.1'`, or `'TLSv1'`.
   **Default:** `'TLSv1'`, unless changed using CLI options. Using
   `--tls-min-v1.0` sets the default to `'TLSv1'`. Using `--tls-min-v1.1` sets
   the default to `'TLSv1.1'`. Using `--tls-min-v1.2` sets the default to


### PR DESCRIPTION
#33631 
Added the missing single quotes in minVersion and maxVersion of api/tls doc before TLSv1.2

**Version:** v10.x
**Platform:** n/a
**Subsystem:** doc, tls

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines]

