### PR TITLE
benchmark: fix async-resource benchmark

### DIFF
--- a/benchmark/async_hooks/async-resource-vs-destroy.js
+++ b/benchmark/async_hooks/async-resource-vs-destroy.js
@@ -138,6 +138,7 @@ function getServeAwait(getCLS, setCLS) {
     setCLS(Math.random());
     await sleep(10);
     await read(__filename);
+    if (res.destroyed) return;
     res.setHeader('content-type', 'application/json');
     res.end(JSON.stringify({ cls: getCLS() }));
   };
@@ -148,6 +149,7 @@ function getServeCallbacks(getCLS, setCLS) {
     setCLS(Math.random());
     setTimeout(() => {
       readFile(__filename, () => {
+        if (res.destroyed) return;
         res.setHeader('content-type', 'application/json');
         res.end(JSON.stringify({ cls: getCLS() }));
       });


### PR DESCRIPTION
In the benchmark, because it performs asynchronous operations before
writing its HTTP replies, the underlying socket can be closed by the
peer before the response is written. Since 28e6626ce7020, that means
that attempting to `.end()` the HTTP response results in an uncaught
exception, breaking the benchmark.

Fix that by checking whether the response object has been destroyed
or not before attempting to call `.end()`.

https://github.com/nodejs/node/issues/33591

(As noted in the issue, I’m not really happy with this solution.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
