### PR TITLE
src: perform bounds checking on error source line

### DIFF
--- a/src/node_errors.cc
+++ b/src/node_errors.cc
@@ -114,8 +114,9 @@ static std::string GetErrorSource(Isolate* isolate,
                             linenum,
                             sourceline.c_str());
   CHECK_GT(buf.size(), 0);
+  *added_exception_line = true;
 
-  if (start >= end ||
+  if (start > end ||
       start < 0 ||
       static_cast<size_t>(end) > sourceline.size()) {
     return buf;
@@ -142,7 +143,6 @@ static std::string GetErrorSource(Isolate* isolate,
   CHECK_LE(off, kUnderlineBufsize);
   underline_buf[off++] = '\n';
 
-  *added_exception_line = true;
   return buf + std::string(underline_buf, off);
 }
 


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/33578

/cc @devsnek Since I can’t reproduce, I didn’t feel 100 % comfortable to add a test here. If you can put your repro into the form of a regression test, feel free to push to this branch.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
