### PR TITLE
events: support event handlers

### DIFF
--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -445,10 +445,27 @@ function emitUnhandledRejectionOrErr(that, err, event) {
   process.emit('error', err, event);
 }
 
-// EventEmitter-ish API:
-
+function defineEventHandler(emitter, name) {
+  // 8.1.5.1 Event handlers - basically `on[eventName]` attributes
+  let eventHandlerValue = undefined;
+  Object.defineProperty(emitter, `on${name}`, {
+    get() {
+      return eventHandlerValue;
+    },
+    set(value) {
+      if (eventHandlerValue) {
+        emitter.removeEventListener(name, eventHandlerValue);
+      }
+      if (typeof value === 'function') {
+        emitter.addEventListener(name, value);
+      }
+      eventHandlerValue = value;
+    }
+  });
+}
 module.exports = {
   Event,
   EventTarget,
   NodeEventTarget,
+  defineEventHandler,
 };

--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -447,7 +447,7 @@ function emitUnhandledRejectionOrErr(that, err, event) {
 
 function defineEventHandler(emitter, name) {
   // 8.1.5.1 Event handlers - basically `on[eventName]` attributes
-  let eventHandlerValue = undefined;
+  let eventHandlerValue;
   Object.defineProperty(emitter, `on${name}`, {
     get() {
       return eventHandlerValue;

--- a/test/parallel/test-eventtarget.js
+++ b/test/parallel/test-eventtarget.js
@@ -466,7 +466,7 @@ ok(EventTarget);
 {
   const target = new EventTarget();
   defineEventHandler(target, 'foo');
-  let fn = common.mustNotCall(() => count++);
+  const fn = common.mustNotCall();
   target.onfoo = fn;
   strictEqual(target.onfoo, fn);
   target.onfoo = null;

--- a/test/parallel/test-eventtarget.js
+++ b/test/parallel/test-eventtarget.js
@@ -6,6 +6,7 @@ const {
   Event,
   EventTarget,
   NodeEventTarget,
+  defineEventHandler
 } = require('internal/event_target');
 
 const {
@@ -438,4 +439,36 @@ ok(EventTarget);
   strictEqual(target.toString(), '[object EventTarget]');
   const event = new Event('');
   strictEqual(event.toString(), '[object Event]');
+{
+  const target = new EventTarget();
+  defineEventHandler(target, 'foo');
+  target.onfoo = common.mustCall();
+  target.dispatchEvent(new Event('foo'));
+}
+{
+  const target = new EventTarget();
+  defineEventHandler(target, 'foo');
+  let count = 0;
+  target.onfoo = () => count++;
+  target.onfoo = common.mustCall(() => count++);
+  target.dispatchEvent(new Event('foo'));
+  strictEqual(count, 1);
+}
+{
+  const target = new EventTarget();
+  defineEventHandler(target, 'foo');
+  let count = 0;
+  target.addEventListener('foo', () => count++);
+  target.onfoo = common.mustCall(() => count++);
+  target.dispatchEvent(new Event('foo'));
+  strictEqual(count, 2);
+}
+{
+  const target = new EventTarget();
+  defineEventHandler(target, 'foo');
+  let fn = common.mustNotCall(() => count++);
+  target.onfoo = fn;
+  strictEqual(target.onfoo, fn);
+  target.onfoo = null;
+  target.dispatchEvent(new Event('foo'));
 }

--- a/test/parallel/test-eventtarget.js
+++ b/test/parallel/test-eventtarget.js
@@ -439,6 +439,7 @@ ok(EventTarget);
   strictEqual(target.toString(), '[object EventTarget]');
   const event = new Event('');
   strictEqual(event.toString(), '[object Event]');
+}
 {
   const target = new EventTarget();
   defineEventHandler(target, 'foo');


### PR DESCRIPTION
Adds a utility function to add support for `EventTarget`s with [event handlers](https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers). These are things like `document.body.onclick` where there is special behavior. See [the note about inline handlers here](https://docs.google.com/document/d/1NFARs04-4U_2y6Ssw9Lqu1GMXBUM981-NO9PLJWifTI/edit?ts=5eb509ec#) for more info.

This PR adds a utility function `defineEventHandler` that defines an event handler. 

cc @addaleax you asked about this :]
cc @janell, you might want to use this for `onabort` rather than defining it ad-hoc.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
