### PR TITLE
util: check more unicode code points length

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -2057,6 +2057,8 @@ if (internalBinding('config').hasIntl) {
       (code > 0x7F && code <= 0x9F) || // C1 control codes
       (code >= 0x300 && code <= 0x36F) || // Combining Diacritical Marks
       (code >= 0x200B && code <= 0x200F) || // Modifying Invisible Characters
+      // Combining Diacritical Marks for Symbols
+      (code >= 0x20D0 && code <= 0x20FF) ||
       (code >= 0xFE00 && code <= 0xFE0F) || // Variation Selectors
       (code >= 0xFE20 && code <= 0xFE2F) || // Combining Half Marks
       (code >= 0xE0100 && code <= 0xE01EF); // Variation Selectors

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -2054,7 +2054,7 @@ if (internalBinding('config').hasIntl) {
 
   const isZeroWidthCodePoint = (code) => {
     return code <= 0x1F || // C0 control codes
-      (code > 0x7F && code <= 0x9F) || // C1 control codes
+      (code >= 0x7F && code <= 0x9F) || // C1 control codes
       (code >= 0x300 && code <= 0x36F) || // Combining Diacritical Marks
       (code >= 0x200B && code <= 0x200F) || // Modifying Invisible Characters
       // Combining Diacritical Marks for Symbols

--- a/test/parallel/test-icu-stringwidth.js
+++ b/test/parallel/test-icu-stringwidth.js
@@ -2,9 +2,6 @@
 'use strict';
 const common = require('../common');
 
-if (!common.hasIntl)
-  common.skip('missing Intl');
-
 const assert = require('assert');
 const { getStringWidth } = require('internal/util/inspect');
 
@@ -88,7 +85,7 @@ for (let i = 0; i < 256; i++) {
   }
 }
 
-{
+if (common.hasIntl) {
   const a = '한글'.normalize('NFD'); // 한글
   const b = '한글'.normalize('NFC'); // 한글
   assert.strictEqual(a.length, 6);

--- a/test/parallel/test-readline-position.js
+++ b/test/parallel/test-readline-position.js
@@ -1,7 +1,6 @@
 // Flags: --expose-internals
 'use strict';
 const common = require('../common');
-const { internalBinding } = require('internal/test/binding');
 const { PassThrough } = require('stream');
 const readline = require('readline');
 const assert = require('assert');
@@ -21,21 +20,13 @@ common.skipIfDumbTerminal();
   const tests = [
     [1, 'a'],
     [2, 'ab'],
-    [2, '丁']
+    [2, '丁'],
+    [0, '\u0301'],   // COMBINING ACUTE ACCENT
+    [1, 'a\u0301'],  // á
+    [0, '\u20DD'],   // COMBINING ENCLOSING CIRCLE
+    [2, 'a\u20DDb'], // a⃝b
+    [0, '\u200E'],   // LEFT-TO-RIGHT MARK
   ];
-
-  // The non-ICU JS implementation of character width calculation is only aware
-  // of the wide/narrow distinction. Only test these more advanced cases when
-  // ICU is available.
-  if (internalBinding('config').hasIntl) {
-    tests.push(
-      [0, '\u0301'],   // COMBINING ACUTE ACCENT
-      [1, 'a\u0301'],  // á
-      [0, '\u20DD'],   // COMBINING ENCLOSING CIRCLE
-      [2, 'a\u20DDb'], // a⃝b
-      [0, '\u200E']    // LEFT-TO-RIGHT MARK
-    );
-  }
 
   for (const [cursor, string] of tests) {
     rl.write(string);


### PR DESCRIPTION
#### util: support Combining Diacritical Marks for Symbols

This adds support for the "Combining Diacritical Marks for Symbols"
unicode group to calculate a zero length width even if Node.js is
built without ICU.

#### util: fix width detection for DEL without ICU

This makes sure the DEL character (ASCII 127) is detected as a zero
width character even if Node.js is not built with ICU.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
