### PR TITLE
http: align OutgoingMessage.writable with streams

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -69,6 +69,7 @@ const HIGH_WATER_MARK = getDefaultHighWaterMark();
 const { CRLF, debug } = common;
 
 const kCorked = Symbol('corked');
+const kWritable = Symbol('writable');
 
 function nop() {}
 
@@ -97,7 +98,6 @@ function OutgoingMessage() {
   // TCP socket and HTTP Parser and thus handle the backpressure.
   this.outputSize = 0;
 
-  this.writable = true;
   this.destroyed = false;
 
   this._last = false;
@@ -126,6 +126,18 @@ function OutgoingMessage() {
 }
 ObjectSetPrototypeOf(OutgoingMessage.prototype, Stream.prototype);
 ObjectSetPrototypeOf(OutgoingMessage, Stream);
+
+ObjectDefineProperty(OutgoingMessage.prototype, 'writable', {
+  get() {
+    // TODO (ronag): Add errored state? write/end might error/destroy one
+    // tick later.
+    return this[kWritable] !== false && !this.destroyed && !this.finished;
+  },
+  set(val) {
+    // Backwards compatible.
+    this[kWritable] = !!val;
+  }
+});
 
 ObjectDefineProperty(OutgoingMessage.prototype, 'writableFinished', {
   get() {

--- a/test/parallel/test-http-outgoing-destroy.js
+++ b/test/parallel/test-http-outgoing-destroy.js
@@ -8,8 +8,10 @@ const OutgoingMessage = http.OutgoingMessage;
 {
   const msg = new OutgoingMessage();
   assert.strictEqual(msg.destroyed, false);
+  assert.strictEqual(msg.writable, true);
   msg.destroy();
   assert.strictEqual(msg.destroyed, true);
+  assert.strictEqual(msg.writable, false);
   let callbackCalled = false;
   msg.write('asd', common.mustCall((err) => {
     assert.strictEqual(err.code, 'ERR_STREAM_DESTROYED');

--- a/test/parallel/test-http-outgoing-finish-writable.js
+++ b/test/parallel/test-http-outgoing-finish-writable.js
@@ -3,9 +3,6 @@ const common = require('../common');
 const assert = require('assert');
 const http = require('http');
 
-// Verify that after calling end() on an `OutgoingMessage` (or a type that
-// inherits from `OutgoingMessage`), its `writable` property is not set to false
-
 const server = http.createServer(common.mustCall(function(req, res) {
   assert.strictEqual(res.writable, true);
   assert.strictEqual(res.finished, false);
@@ -14,7 +11,7 @@ const server = http.createServer(common.mustCall(function(req, res) {
 
   // res.writable is set to false after it has finished sending
   // Ref: https://github.com/nodejs/node/issues/15029
-  assert.strictEqual(res.writable, true);
+  assert.strictEqual(res.writable, false);
   assert.strictEqual(res.finished, true);
   assert.strictEqual(res.writableEnded, true);
 
@@ -32,9 +29,5 @@ server.on('listening', common.mustCall(function() {
 
   assert.strictEqual(clientRequest.writable, true);
   clientRequest.end();
-
-  // Writable is still true when close
-  // THIS IS LEGACY, we cannot change it
-  // unless we break error detection
-  assert.strictEqual(clientRequest.writable, true);
+  assert.strictEqual(clientRequest.writable, false);
 }));

--- a/test/parallel/test-http-outgoing-finish.js
+++ b/test/parallel/test-http-outgoing-finish.js
@@ -73,4 +73,5 @@ function write(out) {
       console.log(`ok - ${name} endCb`);
     });
   }));
+  assert.strictEqual(out.writable, false);
 }

--- a/test/parallel/test-http-outgoing-writableFinished.js
+++ b/test/parallel/test-http-outgoing-writableFinished.js
@@ -22,11 +22,14 @@ server.on('listening', common.mustCall(function() {
     path: '/'
   });
 
+  assert.strictEqual(clientRequest.writable, true);
   assert.strictEqual(clientRequest.writableFinished, false);
   clientRequest
     .on('finish', common.mustCall(() => {
+      assert.strictEqual(clientRequest.writable, false);
       assert.strictEqual(clientRequest.writableFinished, true);
     }))
     .end();
+  assert.strictEqual(clientRequest.writable, false);
   assert.strictEqual(clientRequest.writableFinished, false);
 }));

--- a/test/parallel/test-http-writable-true-after-close.js
+++ b/test/parallel/test-http-writable-true-after-close.js
@@ -4,16 +4,13 @@ const common = require('../common');
 const assert = require('assert');
 const { get, createServer } = require('http');
 
-// res.writable should not be set to false after it has finished sending
-// Ref: https://github.com/nodejs/node/issues/15029
-
 let internal;
 let external;
 
 // Proxy server
 const server = createServer(common.mustCall((req, res) => {
   const listener = common.mustCall(() => {
-    assert.strictEqual(res.writable, true);
+    assert.strictEqual(res.writable, false);
   });
 
   // on CentOS 5, 'finish' is emitted


### PR DESCRIPTION
Should be a computed value that looks at finished and
destroyed state.

Fixes: https://github.com/nodejs/node/issues/33643

Please keep [this](https://github.com/nodejs/node/issues/15029) in mind when approving this PR.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
