### PR TITLE
events: `on` EventTarget support + once compliance

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -616,41 +616,18 @@ function unwrapListeners(arr) {
 
 function once(emitter, name) {
   return new Promise((resolve, reject) => {
-    if (typeof emitter.addEventListener === 'function') {
-      // EventTarget does not have `error` event semantics like Node
-      // EventEmitters, we do not listen to `error` events here.
-      emitter.addEventListener(
-        name,
-        (...args) => { resolve(args); },
-        { once: true }
-      );
-      return;
-    }
-
-    const eventListener = (...args) => {
-      if (errorListener !== undefined) {
+    const errorListener = (err) => {
+      emitter.removeListener(name, resolver);
+      reject(err);
+    };
+    const resolver = (...args) => {
+      if (typeof emitter.removeListener === 'function') {
         emitter.removeListener('error', errorListener);
       }
       resolve(args);
     };
-    let errorListener;
-
-    // Adding an error listener is not optional because
-    // if an error is thrown on an event emitter we cannot
-    // guarantee that the actual event we are waiting will
-    // be fired. The result could be a silent way to create
-    // memory or file descriptor leaks, which is something
-    // we should avoid.
-    if (name !== 'error') {
-      errorListener = (err) => {
-        emitter.removeListener(name, eventListener);
-        reject(err);
-      };
-
-      emitter.once('error', errorListener);
-    }
-
-    emitter.once(name, eventListener);
+    eventTargetAgnosticAddListener(emitter, name, resolver, { once: true });
+    addErrorHandlerIfEventEmitter(emitter, errorListener, { once: true });
   });
 }
 
@@ -659,6 +636,28 @@ const AsyncIteratorPrototype = ObjectGetPrototypeOf(
 
 function createIterResult(value, done) {
   return { value, done };
+}
+
+function addErrorHandlerIfEventEmitter(emitter, handler, flags) {
+  if (typeof emitter.on === 'function') {
+    eventTargetAgnosticAddListener(emitter, 'error', handler, flags);
+  }
+}
+function eventTargetAgnosticAddListener(emitter, name, listener, flags) {
+  if (typeof emitter.addEventListener === 'function') {
+    // EventTarget does not have `error` event semantics like Node
+    // EventEmitters, we do not listen to `error` events here.
+    emitter.addEventListener(name, (arg) => { listener(arg); }, flags);
+    return;
+  } else if (typeof emitter.on === 'function') {
+    if (flags.once) {
+      emitter.once(name, listener);
+    } else {
+      emitter.on(name, listener);
+    }
+  } else {
+    throw new ERR_INVALID_ARG_TYPE('emitter', 'EventEmitter', typeof emitter);
+  }
 }
 
 function on(emitter, event) {

--- a/lib/events.js
+++ b/lib/events.js
@@ -643,20 +643,30 @@ function addErrorHandlerIfEventEmitter(emitter, handler, flags) {
     eventTargetAgnosticAddListener(emitter, 'error', handler, flags);
   }
 }
+
+function eventTargetAgnosticRemoveListener(emitter, name, listener, flags) {
+  if (typeof emitter.removeEventListener === 'function') {
+    emitter.removeEventListener(name, listener, flags);
+  } else if (typeof emitter.removeListener === 'function') {
+    emitter.removeListener(name, listener);
+  } else {
+    throw new ERR_INVALID_ARG_TYPE('emitter', 'EventEmitter', emitter);
+  }
+}
+
 function eventTargetAgnosticAddListener(emitter, name, listener, flags) {
   if (typeof emitter.addEventListener === 'function') {
     // EventTarget does not have `error` event semantics like Node
     // EventEmitters, we do not listen to `error` events here.
     emitter.addEventListener(name, (arg) => { listener(arg); }, flags);
-    return;
   } else if (typeof emitter.on === 'function') {
-    if (flags.once) {
+    if (flags?.once) {
       emitter.once(name, listener);
     } else {
       emitter.on(name, listener);
     }
   } else {
-    throw new ERR_INVALID_ARG_TYPE('emitter', 'EventEmitter', typeof emitter);
+    throw new ERR_INVALID_ARG_TYPE('emitter', 'EventEmitter', emitter);
   }
 }
 
@@ -696,8 +706,8 @@ function on(emitter, event) {
     },
 
     return() {
-      emitter.removeListener(event, eventHandler);
-      emitter.removeListener('error', errorHandler);
+      eventTargetAgnosticRemoveListener(emitter, event, eventHandler);
+      eventTargetAgnosticRemoveListener(emitter, 'error', errorHandler);
       finished = true;
 
       for (const promise of unconsumedPromises) {
@@ -713,8 +723,8 @@ function on(emitter, event) {
                                        'Error', err);
       }
       error = err;
-      emitter.removeListener(event, eventHandler);
-      emitter.removeListener('error', errorHandler);
+      eventTargetAgnosticRemoveListener(emitter, event, eventHandler);
+      eventTargetAgnosticRemoveListener(emitter, 'error', errorHandler);
     },
 
     [SymbolAsyncIterator]() {
@@ -722,8 +732,9 @@ function on(emitter, event) {
     }
   }, AsyncIteratorPrototype);
 
-  emitter.on(event, eventHandler);
-  emitter.on('error', errorHandler);
+  eventTargetAgnosticAddListener(emitter, event, eventHandler);
+  addErrorHandlerIfEventEmitter(emitter, errorHandler);
+
 
   return iterator;
 

--- a/lib/events.js
+++ b/lib/events.js
@@ -627,7 +627,9 @@ function once(emitter, name) {
       resolve(args);
     };
     eventTargetAgnosticAddListener(emitter, name, resolver, { once: true });
-    addErrorHandlerIfEventEmitter(emitter, errorListener, { once: true });
+    if (name !== 'error') {
+      addErrorHandlerIfEventEmitter(emitter, errorListener, { once: true });
+    }
   });
 }
 
@@ -733,7 +735,9 @@ function on(emitter, event) {
   }, AsyncIteratorPrototype);
 
   eventTargetAgnosticAddListener(emitter, event, eventHandler);
-  addErrorHandlerIfEventEmitter(emitter, errorHandler);
+  if (event !== 'error') {
+    addErrorHandlerIfEventEmitter(emitter, errorHandler);
+  }
 
 
   return iterator;

--- a/lib/events.js
+++ b/lib/events.js
@@ -647,26 +647,26 @@ function addErrorHandlerIfEventEmitter(emitter, handler, flags) {
 }
 
 function eventTargetAgnosticRemoveListener(emitter, name, listener, flags) {
-  if (typeof emitter.removeEventListener === 'function') {
-    emitter.removeEventListener(name, listener, flags);
-  } else if (typeof emitter.removeListener === 'function') {
+  if (typeof emitter.removeListener === 'function') {
     emitter.removeListener(name, listener);
+  } else if (typeof emitter.removeEventListener === 'function') {
+    emitter.removeEventListener(name, listener, flags);
   } else {
     throw new ERR_INVALID_ARG_TYPE('emitter', 'EventEmitter', emitter);
   }
 }
 
 function eventTargetAgnosticAddListener(emitter, name, listener, flags) {
-  if (typeof emitter.addEventListener === 'function') {
-    // EventTarget does not have `error` event semantics like Node
-    // EventEmitters, we do not listen to `error` events here.
-    emitter.addEventListener(name, (arg) => { listener(arg); }, flags);
-  } else if (typeof emitter.on === 'function') {
+  if (typeof emitter.on === 'function') {
     if (flags && flags.once) {
       emitter.once(name, listener);
     } else {
       emitter.on(name, listener);
     }
+  } else if (typeof emitter.addEventListener === 'function') {
+    // EventTarget does not have `error` event semantics like Node
+    // EventEmitters, we do not listen to `error` events here.
+    emitter.addEventListener(name, (arg) => { listener(arg); }, flags);
   } else {
     throw new ERR_INVALID_ARG_TYPE('emitter', 'EventEmitter', emitter);
   }

--- a/lib/events.js
+++ b/lib/events.js
@@ -660,7 +660,7 @@ function eventTargetAgnosticAddListener(emitter, name, listener, flags) {
     // EventEmitters, we do not listen to `error` events here.
     emitter.addEventListener(name, (arg) => { listener(arg); }, flags);
   } else if (typeof emitter.on === 'function') {
-    if (flags?.once) {
+    if (flags && flags.once) {
       emitter.once(name, listener);
     } else {
       emitter.on(name, listener);

--- a/test/parallel/test-event-on-async-iterator.js
+++ b/test/parallel/test-event-on-async-iterator.js
@@ -225,6 +225,12 @@ async function eventTarget() {
   clearInterval(interval);
 }
 
+async function errorListenerCount() {
+  const et = new EventEmitter();
+  on(et, 'foo');
+  assert.strictEqual(et.listenerCount('error'), 1);
+}
+
 async function nodeEventTarget() {
   const et = new NodeEventTarget();
   const tick = () => et.dispatchEvent(new Event('tick'));
@@ -252,6 +258,7 @@ async function run() {
     nextError,
     iterableThrow,
     eventTarget,
+    errorListenerCount,
     nodeEventTarget
   ];
 

--- a/test/parallel/test-events-once.js
+++ b/test/parallel/test-events-once.js
@@ -1,55 +1,10 @@
 'use strict';
+// Flags: --expose-internals
 
 const common = require('../common');
 const { once, EventEmitter } = require('events');
 const { strictEqual, deepStrictEqual } = require('assert');
-
-class EventTargetMock {
-  constructor() {
-    this.events = {};
-  }
-
-  addEventListener = common.mustCall(function(name, listener, options) {
-    if (!(name in this.events)) {
-      this.events[name] = { listeners: [], options };
-    }
-    this.events[name].listeners.push(listener);
-  });
-
-  removeEventListener = common.mustCall(function(name, callback) {
-    if (!(name in this.events)) {
-      return;
-    }
-    const event = this.events[name];
-    const stack = event.listeners;
-
-    for (let i = 0, l = stack.length; i < l; i++) {
-      if (stack[i] === callback) {
-        stack.splice(i, 1);
-        if (stack.length === 0) {
-          Reflect.deleteProperty(this.events, name);
-        }
-        return;
-      }
-    }
-  });
-
-  dispatchEvent = function(name, ...arg) {
-    if (!(name in this.events)) {
-      return true;
-    }
-    const event = this.events[name];
-    const stack = event.listeners.slice();
-
-    for (let i = 0, l = stack.length; i < l; i++) {
-      stack[i].apply(this, arg);
-      if (event.options.once) {
-        this.removeEventListener(name, stack[i]);
-      }
-    }
-    return !name.defaultPrevented;
-  };
-}
+const { EventTarget, Event } = require('internal/event_target');
 
 async function onceAnEvent() {
   const ee = new EventEmitter();
@@ -104,8 +59,6 @@ async function stopListeningAfterCatchingError() {
     ee.emit('myevent', 42, 24);
   });
 
-  process.on('multipleResolves', common.mustNotCall());
-
   try {
     await once(ee, 'myevent');
   } catch (_e) {
@@ -132,38 +85,24 @@ async function onceError() {
 }
 
 async function onceWithEventTarget() {
-  const et = new EventTargetMock();
-
+  const et = new EventTarget();
+  const event = new Event('myevent');
   process.nextTick(() => {
-    et.dispatchEvent('myevent', 42);
+    et.dispatchEvent(event);
   });
   const [ value ] = await once(et, 'myevent');
-  strictEqual(value, 42);
-  strictEqual(Reflect.has(et.events, 'myevent'), false);
-}
-
-async function onceWithEventTargetTwoArgs() {
-  const et = new EventTargetMock();
-
-  process.nextTick(() => {
-    et.dispatchEvent('myevent', 42, 24);
-  });
-
-  const value = await once(et, 'myevent');
-  deepStrictEqual(value, [42, 24]);
+  strictEqual(value, event);
 }
 
 async function onceWithEventTargetError() {
-  const et = new EventTargetMock();
-
-  const expected = new Error('kaboom');
+  const et = new EventTarget();
+  const error = new Event('error');
   process.nextTick(() => {
-    et.dispatchEvent('error', expected);
+    et.dispatchEvent(error);
   });
 
-  const [err] = await once(et, 'error');
-  strictEqual(err, expected);
-  strictEqual(Reflect.has(et.events, 'error'), false);
+  const [ err ] = await once(et, 'error');
+  strictEqual(err, error);
 }
 
 Promise.all([
@@ -173,6 +112,5 @@ Promise.all([
   stopListeningAfterCatchingError(),
   onceError(),
   onceWithEventTarget(),
-  onceWithEventTargetTwoArgs(),
   onceWithEventTargetError(),
 ]).then(common.mustCall());

--- a/test/parallel/test-events-once.js
+++ b/test/parallel/test-events-once.js
@@ -3,7 +3,7 @@
 
 const common = require('../common');
 const { once, EventEmitter } = require('events');
-const { strictEqual, deepStrictEqual } = require('assert');
+const { strictEqual, deepStrictEqual, fail } = require('assert');
 const { EventTarget, Event } = require('internal/event_target');
 
 async function onceAnEvent() {
@@ -107,6 +107,13 @@ async function onceWithEventTargetError() {
   strictEqual(err, error);
 }
 
+async function prioritizesEventEmitter() {
+  const ee = new EventEmitter();
+  ee.addEventListener = fail;
+  ee.removeAllListeners = fail;
+  process.nextTick(() => ee.emit('foo'));
+  await once(ee, 'foo');
+}
 Promise.all([
   onceAnEvent(),
   onceAnEventWithTwoArgs(),
@@ -115,4 +122,5 @@ Promise.all([
   onceError(),
   onceWithEventTarget(),
   onceWithEventTargetError(),
+  prioritizesEventEmitter(),
 ]).then(common.mustCall());

--- a/test/parallel/test-events-once.js
+++ b/test/parallel/test-events-once.js
@@ -78,7 +78,9 @@ async function onceError() {
     ee.emit('error', expected);
   });
 
-  const [err] = await once(ee, 'error');
+  const promise = once(ee, 'error');
+  strictEqual(ee.listenerCount('error'), 1);
+  const [ err ] = await promise;
   strictEqual(err, expected);
   strictEqual(ee.listenerCount('error'), 0);
   strictEqual(ee.listenerCount('myevent'), 0);


### PR DESCRIPTION
There are two commits here:

 - One makes the code used in `once` more generic and fixes the behavior on `EventTarget`s. We had tests for behavior that can't actually exist. Removed the test + made sure our behavior was correct. It also makes the test use our EventTarget implementation rather than a mock.
 - One makes `.on` work with `EventTarget`s using the same generic functions.

CC @mcollina @jasnell @BridgeAR 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
