### PR TITLE
events: Handle a range of this values for dispatchEvent

### DIFF
--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -8,6 +8,7 @@ const {
   Set,
   Symbol,
   NumberIsNaN,
+  SymbolFor,
   SymbolToStringTag,
 } = primordials;
 
@@ -16,12 +17,15 @@ const {
     ERR_INVALID_ARG_TYPE,
     ERR_EVENT_RECURSION,
     ERR_OUT_OF_RANGE,
-    ERR_MISSING_ARGS
+    ERR_MISSING_ARGS,
+    ERR_INVALID_THIS,
   }
 } = require('internal/errors');
 
 const { customInspectSymbol } = require('internal/util');
 const { inspect } = require('util');
+
+const kIsEventTarget = SymbolFor('nodejs.event_target');
 
 const kEvents = Symbol('kEvents');
 const kStop = Symbol('kStop');
@@ -185,6 +189,10 @@ class Listener {
 }
 
 class EventTarget {
+  // Used in checking whether an object is an EventTarget. This is a well-known
+  // symbol as EventTarget may be used cross-realm. See discussion in #33661.
+  static [kIsEventTarget] = true;
+
   [kEvents] = new Map();
   #emitting = new Set();
 
@@ -255,6 +263,10 @@ class EventTarget {
   dispatchEvent(event) {
     if (!(event instanceof Event)) {
       throw new ERR_INVALID_ARG_TYPE('event', 'Event', event);
+    }
+
+    if (!isEventTarget(this)) {
+      throw new ERR_INVALID_THIS('EventTarget');
     }
 
     if (this.#emitting.has(event.type) ||
@@ -445,6 +457,15 @@ function validateEventListenerOptions(options) {
     capture: !!capture,
     passive: !!passive,
   };
+}
+
+// Test whether the argument is an event object. This is far from a fool-proof
+// test, for example this input will result in a false positive:
+// > isEventTarget({ constructor: EventTarget })
+// It stands in its current implementation as a compromise. For the relevant
+// discussion, see #33661.
+function isEventTarget(obj) {
+  return obj && obj.constructor && obj.constructor[kIsEventTarget];
 }
 
 function addCatch(that, promise, event) {

--- a/test/parallel/test-eventtarget.js
+++ b/test/parallel/test-eventtarget.js
@@ -439,3 +439,28 @@ ok(EventTarget);
   const event = new Event('');
   strictEqual(event.toString(), '[object Event]');
 }
+
+{
+  // `this` value of dispatchEvent
+  const target = new EventTarget();
+  const target2 = new EventTarget();
+  const event = new Event('foo');
+
+  ok(target.dispatchEvent.call(target2, event));
+
+  [
+    'foo',
+    {},
+    [],
+    1,
+    null,
+    undefined,
+    false,
+    Symbol(),
+    /a/
+  ].forEach((i) => {
+    throws(() => target.dispatchEvent.call(i, event), {
+      code: 'ERR_INVALID_THIS'
+    });
+  });
+}


### PR DESCRIPTION
On the web, dispatchEvent is finicky about its `this` value. An exception is
thrown for `this` values which are not an EventTarget. However, null-ish
values (null and undefined) do not throw and return immediately.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
