### PR TITLE
querystring: improve stringify() performance

### DIFF
--- a/benchmark/querystring/querystring-stringify.js
+++ b/benchmark/querystring/querystring-stringify.js
@@ -3,7 +3,7 @@ const common = require('../common.js');
 const querystring = require('querystring');
 
 const bench = common.createBenchmark(main, {
-  type: ['noencode', 'encodemany', 'encodelast', 'array'],
+  type: ['noencode', 'encodemany', 'encodelast', 'array', 'multiprimitives'],
   n: [1e6],
 });
 
@@ -28,7 +28,12 @@ function main({ type, n }) {
       foo: [],
       baz: ['bar'],
       xyzzy: ['bar', 'quux', 'thud']
-    }
+    },
+    multiprimitives: {
+      foo: false,
+      bar: -13.37,
+      baz: '',
+    },
   };
   const input = inputs[type];
 

--- a/lib/internal/querystring.js
+++ b/lib/internal/querystring.js
@@ -36,19 +36,25 @@ function encodeStr(str, noEscapeTable, hexTable) {
 
   let out = '';
   let lastPos = 0;
+  let i = 0;
 
-  for (let i = 0; i < len; i++) {
+  outer:
+  for (; i < len; i++) {
     let c = str.charCodeAt(i);
 
     // ASCII
-    if (c < 0x80) {
-      if (noEscapeTable[c] === 1)
-        continue;
-      if (lastPos < i)
-        out += str.slice(lastPos, i);
-      lastPos = i + 1;
-      out += hexTable[c];
-      continue;
+    while (c < 0x80) {
+      if (noEscapeTable[c] !== 1) {
+        if (lastPos < i)
+          out += str.slice(lastPos, i);
+        lastPos = i + 1;
+        out += hexTable[c];
+      }
+
+      if (++i === len)
+        break outer;
+
+      c = str.charCodeAt(i);
     }
 
     if (lastPos < i)

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -26,6 +26,7 @@
 const {
   Array,
   ArrayIsArray,
+  MathAbs,
   ObjectCreate,
   ObjectKeys,
 } = primordials;
@@ -162,6 +163,25 @@ function stringifyPrimitive(v) {
 }
 
 
+function encodeStringified(v, encode) {
+  if (typeof v === 'string')
+    return (v.length ? encode(v) : '');
+  if (typeof v === 'number' && isFinite(v)) {
+    // Values >= 1e21 automatically switch to scientific notation which requires
+    // escaping due to the inclusion of a '+' in the output
+    return (MathAbs(v) < 1e21 ? '' + v : encode('' + v));
+  }
+  if (typeof v === 'boolean')
+    return v ? 'true' : 'false';
+  return '';
+}
+
+
+function encodeStringifiedCustom(v, encode) {
+  return encode(stringifyPrimitive(v));
+}
+
+
 function stringify(obj, sep, eq, options) {
   sep = sep || '&';
   eq = eq || '=';
@@ -170,6 +190,8 @@ function stringify(obj, sep, eq, options) {
   if (options && typeof options.encodeURIComponent === 'function') {
     encode = options.encodeURIComponent;
   }
+  const convert =
+    (encode === qsEscape ? encodeStringified : encodeStringifiedCustom);
 
   if (obj !== null && typeof obj === 'object') {
     const keys = ObjectKeys(obj);
@@ -179,7 +201,7 @@ function stringify(obj, sep, eq, options) {
     for (let i = 0; i < len; ++i) {
       const k = keys[i];
       const v = obj[k];
-      let ks = encode(stringifyPrimitive(k));
+      let ks = convert(k, encode);
       ks += eq;
 
       if (ArrayIsArray(v)) {
@@ -188,13 +210,13 @@ function stringify(obj, sep, eq, options) {
         const vlast = vlen - 1;
         for (let j = 0; j < vlen; ++j) {
           fields += ks;
-          fields += encode(stringifyPrimitive(v[j]));
+          fields += convert(v[j], encode);
           if (j < vlast)
             fields += sep;
         }
       } else {
         fields += ks;
-        fields += encode(stringifyPrimitive(v));
+        fields += convert(v, encode);
       }
 
       if (i < flast)


### PR DESCRIPTION
Benchmark results:

```
                                                                        confidence improvement accuracy (*)   (**)  (***)
 querystring/querystring-stringify.js n=1000000 type='array'                  ***     27.37 %       ±0.86% ±1.15% ±1.50%
 querystring/querystring-stringify.js n=1000000 type='encodelast'             ***     19.40 %       ±1.27% ±1.70% ±2.24%
 querystring/querystring-stringify.js n=1000000 type='encodemany'             ***      9.39 %       ±1.33% ±1.78% ±2.34%
 querystring/querystring-stringify.js n=1000000 type='multiprimitives'        ***     56.64 %       ±1.93% ±2.59% ±3.43%
 querystring/querystring-stringify.js n=1000000 type='noencode'               ***     26.66 %       ±4.15% ±5.59% ±7.41%
```


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
