### PR TITLE
test: fix test-eventtarget

### DIFF
--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -64,6 +64,7 @@ class Event {
       enumerable: true,
       configurable: false
     });
+    this[kTarget] = null;
   }
 
   [customInspectSymbol](depth, options) {
@@ -245,7 +246,7 @@ class EventTarget {
     }
 
     if (this.#emitting.has(event.type) ||
-        event[kTarget] !== undefined) {
+        event[kTarget] !== null) {
       throw new ERR_EVENT_RECURSION(event.type);
     }
 

--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -412,6 +412,9 @@ function validateListener(listener) {
 }
 
 function validateEventListenerOptions(options) {
+  if (typeof options === 'boolean') {
+    options = { capture: options };
+  }
   if (options == null || typeof options !== 'object')
     throw new ERR_INVALID_ARG_TYPE('options', 'object', options);
   const {

--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -36,12 +36,13 @@ class Event {
   #cancelable = false;
   #timestamp = perf_hooks.performance.now();
 
-  // Neither of these are currently used in the Node.js implementation
+  // None of these are currently used in the Node.js implementation
   // of EventTarget because there is no concept of bubbling or
   // composition. We preserve their values in Event but they are
   // non-ops and do not carry any semantics in Node.js
   #bubbles = false;
   #composed = false;
+  #propagationStopped = false;
 
 
   constructor(type, options) {
@@ -54,6 +55,7 @@ class Event {
     this.#cancelable = !!cancelable;
     this.#bubbles = !!bubbles;
     this.#composed = !!composed;
+    this.#propagationStopped = false;
     this.#type = String(type);
     // isTrusted is special (LegacyUnforgeable)
     Object.defineProperty(this, 'isTrusted', {
@@ -113,11 +115,14 @@ class Event {
   get eventPhase() {
     return this[kTarget] ? 2 : 0;  // Equivalent to AT_TARGET or NONE
   }
-  cancelBubble() {
-    // Non-op in Node.js. Alias for stopPropagation
+  get cancelBubble() { return this.#propagationStopped; }
+  set cancelBubble(value) {
+    if (value) {
+      this.stopPropagation();
+    }
   }
   stopPropagation() {
-    // Non-op in Node.js
+    this.#propagationStopped = true;
   }
 
   get [Symbol.toStringTag]() { return 'Event'; }

--- a/test/parallel/test-eventtarget.js
+++ b/test/parallel/test-eventtarget.js
@@ -151,7 +151,14 @@ const ev = new Event('foo');
   eventTarget.addEventListener('foo', (event) => event.preventDefault());
   ok(!eventTarget.dispatchEvent(event));
 }
-
+{
+  // Adding event listeners with a boolean useCapture
+  const eventTarget = new EventTarget();
+  const event = new Event('foo');
+  const fn = common.mustCall((event) => strictEqual(event.type, 'foo'));
+  eventTarget.addEventListener('foo', fn, false);
+  eventTarget.dispatchEvent(event);
+}
 {
   const eventTarget = new NodeEventTarget();
   strictEqual(eventTarget.listenerCount('foo'), 0);

--- a/test/parallel/test-eventtarget.js
+++ b/test/parallel/test-eventtarget.js
@@ -15,7 +15,7 @@ const {
   throws,
 } = require('assert');
 
-const { once, on } = require('events');
+const { once } = require('events');
 
 // The globals are defined.
 ok(Event);
@@ -435,7 +435,7 @@ ok(EventTarget);
 {
   const target = new EventTarget();
   strictEqual(target.toString(), '[object EventTarget]');
-  const event = new Event();
+  const event = new Event('foo');
   strictEqual(event.toString(), '[object Event]');
 }
 {
@@ -452,19 +452,3 @@ ok(EventTarget);
   target.addEventListener('__proto__', fn);
   target.dispatchEvent(ev);
 }
-
-(async () => {
-  // test NodeEventTarget async-iterability
-  const emitter = new NodeEventTarget();
-  const event = new Event('foo');
-  const interval = setInterval(() => emitter.dispatchEvent(event), 0);
-  let count = 0;
-  for await (const [ item ] of on(emitter, 'foo')) {
-    count++;
-    strictEqual(item.type, 'foo');
-    if (count > 5) {
-      break;
-    }
-  }
-  clearInterval(interval);
-})().then(common.mustCall());

--- a/test/parallel/test-eventtarget.js
+++ b/test/parallel/test-eventtarget.js
@@ -36,6 +36,7 @@ ok(EventTarget);
   strictEqual(ev.composed, false);
   strictEqual(ev.isTrusted, false);
   strictEqual(ev.eventPhase, 0);
+  strictEqual(ev.cancelBubble, false);
 
   // Not cancelable
   ev.preventDefault();
@@ -49,6 +50,24 @@ ok(EventTarget);
   // Too many arguments passed behavior - ignore additional arguments
   const ev = new Event('foo', {}, {});
   strictEqual(ev.type, 'foo');
+}
+{
+const ev = new Event('foo');
+  strictEqual(ev.cancelBubble, false);
+  ev.cancelBubble = true;
+  strictEqual(ev.cancelBubble, true);
+}
+{
+  const ev = new Event('foo');
+  strictEqual(ev.cancelBubble, false);
+  ev.stopPropagation();
+  strictEqual(ev.cancelBubble, true);
+}
+{
+  const ev = new Event('foo');
+  strictEqual(ev.cancelBubble, false);
+  ev.cancelBubble = 'some-truthy-value';
+  strictEqual(ev.cancelBubble, true);
 }
 {
   const ev = new Event('foo', { cancelable: true });

--- a/test/parallel/test-eventtarget.js
+++ b/test/parallel/test-eventtarget.js
@@ -385,6 +385,7 @@ const ev = new Event('foo');
 {
   const target = new EventTarget();
   const event = new Event('foo');
+  strictEqual(event.target, null);
   target.addEventListener('foo', common.mustCall((event) => {
     strictEqual(event.target, target);
     strictEqual(event.currentTarget, target);


### PR DESCRIPTION
Looks like this slipped through while lending https://github.com/nodejs/node/pull/33611 and https://github.com/nodejs/node/pull/33622 due to the 'old' (3 days) CI.

The NodeEventTarget target test at the end of a file fails with 
```
Error [ERR_EVENT_RECURSION]: The event "foo" is already being dispatched
    at NodeEventTarget.dispatchEvent (internal/event_target.js:250:13)
    at Timeout._onTimeout (/home/lundibundi/dev/node/node/test/parallel/test-eventtarget.js:460:46)
    at listOnTimeout (internal/timers.js:551:17)
    at processTimers (internal/timers.js:494:7) {
  code: 'ERR_EVENT_RECURSION'
}
```
But since it is being removed anyway (https://github.com/nodejs/node/pull/33665) I decided to just delete it.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
/cc @benjamingr @jasnell @nodejs/events 