### PR TITLE
http: add RFC references for each status code

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -107,7 +107,7 @@ const STATUS_CODES = {
   403: 'Forbidden',                  // RFC 7231 6.5.3
   404: 'Not Found',                  // RFC 7231 6.5.4
   405: 'Method Not Allowed',         // RFC 7231 6.5.5
-  406: 'Not Acceptable',             // RFC 7231 6.5.6  
+  406: 'Not Acceptable',             // RFC 7231 6.5.6
   407: 'Proxy Authentication Required', // RFC 7235 3.2
   408: 'Request Timeout',            // RFC 7231 6.5.7
   409: 'Conflict',                   // RFC 7231 6.5.8

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -79,69 +79,69 @@ const kServerResponse = Symbol('ServerResponse');
 const kServerResponseStatistics = Symbol('ServerResponseStatistics');
 
 const STATUS_CODES = {
-  100: 'Continue',
-  101: 'Switching Protocols',
-  102: 'Processing',                 // RFC 2518, obsoleted by RFC 4918
-  103: 'Early Hints',
-  200: 'OK',
-  201: 'Created',
-  202: 'Accepted',
-  203: 'Non-Authoritative Information',
-  204: 'No Content',
-  205: 'Reset Content',
-  206: 'Partial Content',
-  207: 'Multi-Status',               // RFC 4918
-  208: 'Already Reported',
-  226: 'IM Used',
-  300: 'Multiple Choices',           // RFC 7231
-  301: 'Moved Permanently',
-  302: 'Found',
-  303: 'See Other',
-  304: 'Not Modified',
-  305: 'Use Proxy',
-  307: 'Temporary Redirect',
-  308: 'Permanent Redirect',         // RFC 7238
-  400: 'Bad Request',
-  401: 'Unauthorized',
-  402: 'Payment Required',
-  403: 'Forbidden',
-  404: 'Not Found',
-  405: 'Method Not Allowed',
-  406: 'Not Acceptable',
-  407: 'Proxy Authentication Required',
-  408: 'Request Timeout',
-  409: 'Conflict',
-  410: 'Gone',
-  411: 'Length Required',
-  412: 'Precondition Failed',
-  413: 'Payload Too Large',
-  414: 'URI Too Long',
-  415: 'Unsupported Media Type',
-  416: 'Range Not Satisfiable',
-  417: 'Expectation Failed',
-  418: 'I\'m a Teapot',              // RFC 7168
-  421: 'Misdirected Request',
-  422: 'Unprocessable Entity',       // RFC 4918
-  423: 'Locked',                     // RFC 4918
-  424: 'Failed Dependency',          // RFC 4918
-  425: 'Too Early',                  // RFC 8470
-  426: 'Upgrade Required',           // RFC 2817
-  428: 'Precondition Required',      // RFC 6585
-  429: 'Too Many Requests',          // RFC 6585
-  431: 'Request Header Fields Too Large', // RFC 6585
-  451: 'Unavailable For Legal Reasons',
-  500: 'Internal Server Error',
-  501: 'Not Implemented',
-  502: 'Bad Gateway',
-  503: 'Service Unavailable',
-  504: 'Gateway Timeout',
-  505: 'HTTP Version Not Supported',
-  506: 'Variant Also Negotiates',    // RFC 2295
-  507: 'Insufficient Storage',       // RFC 4918
-  508: 'Loop Detected',
+  100: 'Continue',                   // RFC 7231 6.2.1
+  101: 'Switching Protocols',        // RFC 7231 6.2.2
+  102: 'Processing',                 // RFC 2518 10.1 (obsoleted by RFC 4918)
+  103: 'Early Hints',                // RFC 8297 2
+  200: 'OK',                         // RFC 7231 6.3.1
+  201: 'Created',                    // RFC 7231 6.3.2
+  202: 'Accepted',                   // RFC 7231 6.3.3
+  203: 'Non-Authoritative Information', // RFC 7231 6.3.4
+  204: 'No Content',                 // RFC 7231 6.3.5
+  205: 'Reset Content',              // RFC 7231 6.3.6
+  206: 'Partial Content',            // RFC 7233 4.1
+  207: 'Multi-Status',               // RFC 4918 11.1
+  208: 'Already Reported',           // RFC 5842 7.1
+  226: 'IM Used',                    // RFC 3229 10.4.1
+  300: 'Multiple Choices',           // RFC 7231 6.4.1
+  301: 'Moved Permanently',          // RFC 7231 6.4.2
+  302: 'Found',                      // RFC 7231 6.4.3
+  303: 'See Other',                  // RFC 7231 6.4.4
+  304: 'Not Modified',               // RFC 7232 4.1
+  305: 'Use Proxy',                  // RFC 7231 6.4.5
+  307: 'Temporary Redirect',         // RFC 7231 6.4.7
+  308: 'Permanent Redirect',         // RFC 7238 3
+  400: 'Bad Request',                // RFC 7231 6.5.1
+  401: 'Unauthorized',               // RFC 7235 3.1
+  402: 'Payment Required',           // RFC 7231 6.5.2
+  403: 'Forbidden',                  // RFC 7231 6.5.3
+  404: 'Not Found',                  // RFC 7231 6.5.4
+  405: 'Method Not Allowed',         // RFC 7231 6.5.5
+  406: 'Not Acceptable',             // RFC 7231 6.5.6  
+  407: 'Proxy Authentication Required', // RFC 7235 3.2
+  408: 'Request Timeout',            // RFC 7231 6.5.7
+  409: 'Conflict',                   // RFC 7231 6.5.8
+  410: 'Gone',                       // RFC 7231 6.5.9
+  411: 'Length Required',            // RFC 7231 6.5.10
+  412: 'Precondition Failed',        // RFC 7232 4.2
+  413: 'Payload Too Large',          // RFC 7231 6.5.11
+  414: 'URI Too Long',               // RFC 7231 6.5.12
+  415: 'Unsupported Media Type',     // RFC 7231 6.5.13
+  416: 'Range Not Satisfiable',      // RFC 7233 4.4
+  417: 'Expectation Failed',         // RFC 7231 6.5.14
+  418: 'I\'m a Teapot',              // RFC 7168 2.3.3
+  421: 'Misdirected Request',        // RFC 7540 9.1.2
+  422: 'Unprocessable Entity',       // RFC 4918 11.2
+  423: 'Locked',                     // RFC 4918 11.3
+  424: 'Failed Dependency',          // RFC 4918 11.4
+  425: 'Too Early',                  // RFC 8470 5.2
+  426: 'Upgrade Required',           // RFC 2817 and RFC 7231 6.5.15
+  428: 'Precondition Required',      // RFC 6585 3
+  429: 'Too Many Requests',          // RFC 6585 4
+  431: 'Request Header Fields Too Large', // RFC 6585 5
+  451: 'Unavailable For Legal Reasons', // RFC 7725 3
+  500: 'Internal Server Error',      // RFC 7231 6.6.1
+  501: 'Not Implemented',            // RFC 7231 6.6.2
+  502: 'Bad Gateway',                // RFC 7231 6.6.3
+  503: 'Service Unavailable',        // RFC 7231 6.6.4
+  504: 'Gateway Timeout',            // RFC 7231 6.6.5
+  505: 'HTTP Version Not Supported', // RFC 7231 6.6.6
+  506: 'Variant Also Negotiates',    // RFC 2295 8.1
+  507: 'Insufficient Storage',       // RFC 4918 11.5
+  508: 'Loop Detected',              // RFC 5842 7.2
   509: 'Bandwidth Limit Exceeded',
-  510: 'Not Extended',               // RFC 2774
-  511: 'Network Authentication Required' // RFC 6585
+  510: 'Not Extended',               // RFC 2774 7
+  511: 'Network Authentication Required' // RFC 6585 6
 };
 
 const kOnExecute = HTTPParser.kOnExecute | 0;


### PR DESCRIPTION
Reference format is as follows `RFC <rfc id> <section path>`. Using the RFC reference makes it easier to get more information regarding the status code directly from IETF.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
