### PR TITLE
util: improve getStringWidth performance

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -1960,13 +1960,6 @@ function formatWithOptionsInternal(inspectOptions, ...args) {
   return str;
 }
 
-function prepareStringForGetStringWidth(str, removeControlChars) {
-  str = str.normalize('NFC');
-  if (removeControlChars)
-    str = stripVTControlCharacters(str);
-  return str;
-}
-
 if (internalBinding('config').hasIntl) {
   const icu = internalBinding('icu');
   // icu.getStringWidth(string, ambiguousAsFullWidth, expandEmojiSequence)
@@ -1977,13 +1970,14 @@ if (internalBinding('config').hasIntl) {
   getStringWidth = function getStringWidth(str, removeControlChars = true) {
     let width = 0;
 
-    str = prepareStringForGetStringWidth(str, removeControlChars);
+    if (removeControlChars)
+      str = stripVTControlCharacters(str);
     for (let i = 0; i < str.length; i++) {
       // Try to avoid calling into C++ by first handling the ASCII portion of
       // the string. If it is fully ASCII, we skip the C++ part.
       const code = str.charCodeAt(i);
       if (code >= 127) {
-        width += icu.getStringWidth(str.slice(i));
+        width += icu.getStringWidth(str.slice(i).normalize('NFC'));
         break;
       }
       width += code >= 32 ? 1 : 0;
@@ -1997,7 +1991,9 @@ if (internalBinding('config').hasIntl) {
   getStringWidth = function getStringWidth(str, removeControlChars = true) {
     let width = 0;
 
-    str = prepareStringForGetStringWidth(str, removeControlChars);
+    if (removeControlChars)
+      str = stripVTControlCharacters(str);
+    str = str.normalize('NFC');
     for (const char of str) {
       const code = char.codePointAt(0);
       if (isFullWidthCodePoint(code)) {


### PR DESCRIPTION
This makes sure the common path does not normalize the input string.
It's only required for characters that are outside of the ASCII range.

Signed-off-by: Ruben Bridgewater <ruben@bridgewater.de>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
