### PR TITLE
readline: add getPrompt to get the current prompt

### DIFF
--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -281,6 +281,15 @@ added: v0.1.98
 The `rl.setPrompt()` method sets the prompt that will be written to `output`
 whenever `rl.prompt()` is called.
 
+### `rl.getPrompt()`
+<!-- YAML
+added: REPLACEME
+-->
+
+* Returns: {string} the current prompt string
+
+The `rl.getPrompt()` method returns the current prompt used by `rl.prompt()`.
+
 ### `rl.write(data[, key])`
 <!-- YAML
 added: v0.1.98

--- a/lib/internal/repl/utils.js
+++ b/lib/internal/repl/utils.js
@@ -147,7 +147,7 @@ function setupPreview(repl, contextSymbol, bufferSymbol, active) {
   let escaped = null;
 
   function getPreviewPos() {
-    const displayPos = repl._getDisplayPos(`${repl._prompt}${repl.line}`);
+    const displayPos = repl._getDisplayPos(`${repl.getPrompt()}${repl.line}`);
     const cursorPos = repl.line.length !== repl.cursor ?
       repl.getCursorPos() :
       displayPos;
@@ -180,7 +180,7 @@ function setupPreview(repl, contextSymbol, bufferSymbol, active) {
         rows = pos.displayPos.rows - pos.cursorPos.rows;
         moveCursor(repl.output, 0, rows);
       }
-      const totalLine = `${repl._prompt}${repl.line}${completionPreview}`;
+      const totalLine = `${repl.getPrompt()}${repl.line}${completionPreview}`;
       const newPos = repl._getDisplayPos(totalLine);
       // Minimize work for the terminal. It is enough to clear the right part of
       // the current line in case the preview is visible on a single line.
@@ -266,7 +266,7 @@ function setupPreview(repl, contextSymbol, bufferSymbol, active) {
       }
       repl.output.write(result);
       cursorTo(repl.output, cursorPos.cols);
-      const totalLine = `${repl._prompt}${repl.line}${suffix}`;
+      const totalLine = `${repl.getPrompt()}${repl.line}${suffix}`;
       const newPos = repl._getDisplayPos(totalLine);
       const rows = newPos.rows - cursorPos.rows - (newPos.cols === 0 ? 1 : 0);
       moveCursor(repl.output, 0, -rows);
@@ -614,7 +614,7 @@ function setupReverseSearch(repl) {
     let rows = 0;
     if (lastMatch !== -1) {
       const line = repl.history[lastMatch].slice(0, lastCursor);
-      rows = repl._getDisplayPos(`${repl._prompt}${line}`).rows;
+      rows = repl._getDisplayPos(`${repl.getPrompt()}${line}`).rows;
       cursorTo(repl.output, promptPos.cols);
     } else if (isInReverseSearch && repl.line !== '') {
       rows = repl.getCursorPos().rows;
@@ -634,7 +634,7 @@ function setupReverseSearch(repl) {
 
     // To know exactly how many rows we have to move the cursor back we need the
     // cursor rows, the output rows and the input rows.
-    const prompt = repl._prompt;
+    const prompt = repl.getPrompt();
     const cursorLine = `${prompt}${outputLine.slice(0, cursor)}`;
     const cursorPos = repl._getDisplayPos(cursorLine);
     const outputPos = repl._getDisplayPos(`${prompt}${outputLine}`);
@@ -685,7 +685,7 @@ function setupReverseSearch(repl) {
     if (!isInReverseSearch) {
       if (key.ctrl && checkAndSetDirectionKey(key.name)) {
         historyIndex = repl.historyIndex;
-        promptPos = repl._getDisplayPos(`${repl._prompt}`);
+        promptPos = repl._getDisplayPos(`${repl.getPrompt()}`);
         print(repl.line, `${labels[dir]}_`);
         isInReverseSearch = true;
       }

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -291,6 +291,11 @@ Interface.prototype.setPrompt = function(prompt) {
 };
 
 
+Interface.prototype.getPrompt = function() {
+  return this._prompt;
+};
+
+
 Interface.prototype._setRawMode = function(mode) {
   const wasInRawMode = this.input.isRaw;
 

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -898,6 +898,16 @@ for (let i = 0; i < 12; i++) {
     });
   }
 
+  // Calling the getPrompt method
+  {
+    const expectedPrompts = ['$ ', '> '];
+    const [rli] = getInterface({ terminal });
+    for (const prompt of expectedPrompts) {
+      rli.setPrompt(prompt);
+      assert.strictEqual(rli.getPrompt(), prompt);
+    }
+  }
+
   {
     const expected = terminal ?
       ['\u001b[1G', '\u001b[0J', '$ ', '\u001b[3G'] :
@@ -920,7 +930,7 @@ for (let i = 0; i < 12; i++) {
 
     rl.prompt();
 
-    assert.strictEqual(rl._prompt, '$ ');
+    assert.strictEqual(rl.getPrompt(), '$ ');
   }
 
   {

--- a/test/parallel/test-repl-options.js
+++ b/test/parallel/test-repl-options.js
@@ -104,7 +104,7 @@ assert.throws(r3, {
 // 4, Verify that defaults are used when no arguments are provided
 const r4 = repl.start();
 
-assert.strictEqual(r4._prompt, '> ');
+assert.strictEqual(r4.getPrompt(), '> ');
 assert.strictEqual(r4.input, process.stdin);
 assert.strictEqual(r4.output, process.stdout);
 assert.strictEqual(r4.terminal, !!r4.output.isTTY);


### PR DESCRIPTION
Since there is a setPrompt() there should be a getPrompt().
There are use-cases where it is needed to know what the
current prompt is. Adding a getPrompt() negates the need
to store the set prompt externally or read the internal
_prompt which would be bad practice.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
