### PR TITLE
readline: add questionCancel() method to cancel ongoing question

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -57,15 +57,21 @@ const {
   StringPrototypeSplit,
   StringPrototypeStartsWith,
   StringPrototypeTrim,
+  Promise,
   Symbol,
   SymbolAsyncIterator,
   SafeStringIterator,
 } = primordials;
 
 const {
+  AbortError,
+  codes
+} = require('internal/errors');
+
+const {
   ERR_INVALID_ARG_VALUE,
   ERR_INVALID_CURSOR_POS,
-} = require('internal/errors').codes;
+} = codes;
 const {
   validateCallback,
   validateString,
@@ -86,6 +92,8 @@ const {
   kSubstringSearch,
 } = require('internal/readline/utils');
 
+const { promisify } = require('internal/util');
+
 const { clearTimeout, setTimeout } = require('timers');
 const {
   kEscape,
@@ -94,6 +102,7 @@ const {
   kClearLine,
   kClearScreenDown
 } = CSI;
+
 
 const { StringDecoder } = require('string_decoder');
 
@@ -188,6 +197,7 @@ function Interface(input, output, completer, terminal) {
 
   const self = this;
 
+  this.line = '';
   this[kSubstringSearch] = null;
   this.output = output;
   this.input = input;
@@ -203,6 +213,8 @@ function Interface(input, output, completer, terminal) {
         cb(null, completer(v));
       };
   }
+
+  this._questionCancel = FunctionPrototypeBind(_questionCancel, this);
 
   this.setPrompt(prompt);
 
@@ -348,7 +360,16 @@ Interface.prototype.prompt = function(preserveCursor) {
 };
 
 
-Interface.prototype.question = function(query, cb) {
+Interface.prototype.question = function(query, options, cb) {
+  cb = typeof options === 'function' ? options : cb;
+  options = typeof options === 'object' ? options : {};
+
+  if (options.signal) {
+    options.signal.addEventListener('abort', () => {
+      this._questionCancel();
+    }, { once: true });
+  }
+
   if (typeof cb === 'function') {
     if (this._questionCallback) {
       this.prompt();
@@ -360,6 +381,28 @@ Interface.prototype.question = function(query, cb) {
     }
   }
 };
+
+Interface.prototype.question[promisify.custom] = function(query, options) {
+  options = typeof options === 'object' ? options : {};
+
+  return new Promise((resolve, reject) => {
+    this.question(query, options, resolve);
+
+    if (options.signal) {
+      options.signal.addEventListener('abort', () => {
+        reject(new AbortError());
+      }, { once: true });
+    }
+  });
+};
+
+function _questionCancel() {
+  if (this._questionCallback) {
+    this._questionCallback = null;
+    this.setPrompt(this._oldPrompt);
+    this.clearLine();
+  }
+}
 
 
 Interface.prototype._onLine = function(line) {


### PR DESCRIPTION
In some cases a question asked needs to be canceled. For instance
it might be desirable to cancel a question when a user presses
ctrl+c and triggers the SIGINT event.
Also an initial empty string was set for this.line since the
cursor methods fail if line is not initialized. This happend
in the tests when a question is asked and canceled before any
input has been received which would set line to a string. This
is due to questionCancel calling clearline.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
