### PR TITLE
meta: fix a typo in the flaky test template

### DIFF
--- a/.github/ISSUE_TEMPLATE/4-report-a-flaky-test.md
+++ b/.github/ISSUE_TEMPLATE/4-report-a-flaky-test.md
@@ -8,9 +8,9 @@ labels: "CI / flaky test"
 <!--
 Thank you for reporting a flaky test.
 
-Flaky tests are tests that fail occaisonally in Node.js CI, but not consistently
-enough to block PRs from landing, or that are failing in CI jobs or test modes
-that are not run for every PR.
+Flaky tests are tests that fail occasionally in the Node.js CI, but not
+consistently enough to block PRs from landing, or that are failing in CI jobs or
+test modes that are not run for every PR.
 
 Please fill in as much of the template below as you're able.
 

--- a/.github/ISSUE_TEMPLATE/4-report-a-flaky-test.md
+++ b/.github/ISSUE_TEMPLATE/4-report-a-flaky-test.md
@@ -8,17 +8,21 @@ labels: "CI / flaky test"
 <!--
 Thank you for reporting a flaky test.
 
-Flaky tests are tests that fail occaisonally in Node.js CI, but not consistently enough to block PRs from landing,
-or that are failing in CI jobs or test modes that are not run for every PR.
+Flaky tests are tests that fail occaisonally in Node.js CI, but not consistently
+enough to block PRs from landing, or that are failing in CI jobs or test modes
+that are not run for every PR.
 
 Please fill in as much of the template below as you're able.
 
 Test: The test that is flaky - e.g. `test-fs-stat-bigint`
 Platform: The platform the test is flaky on - e.g. `macos` or `linux`
-Console Output: A pasted console output from a failed CI job showing the whole failure of the test
+Console Output: A pasted console output from a failed CI job showing the whole
+failure of the test
 Build Links: Links to builds affected by the flaky test
 
-If any investigation has been done, please include any information found, such as how consistently the test fails, whether the failure could be reproduced locally, when the test started failing, or anything else you think is relevant.
+If any investigation has been done, please include any information found, such
+as how consistently the test fails, whether the failure could be reproduced
+locally, when the test started failing, or anything else you think is relevant.
 -->
 
 * **Test**:


### PR DESCRIPTION
"occasionally" was spelled incorrectly. I also wrapped the lines at 80 characters for consistency with the other templates.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)