### PR TITLE
doc: update events docs for consistency

### DIFF
--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -974,9 +974,8 @@ There are two key differences between the Node.js `EventTarget` and the
 
 The `NodeEventTarget` object implements a modified subset of the
 `EventEmitter` API that allows it to closely *emulate* an `EventEmitter` in
-certain situations. It is important to understand, however, that an
-`NodeEventTarget` is *not* an instance of `EventEmitter` and cannot be used in
-place of an `EventEmitter` in most cases.
+certain situations. A `NodeEventTarget` is *not* an instance of `EventEmitter`
+and cannot be used in place of an `EventEmitter` in most cases.
 
 1. Unlike `EventEmitter`, any given `listener` can be registered at most once
    per event `type`. Attempts to register a `listener` multiple times will be

--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -244,7 +244,7 @@ It supports the following option:
 
 * `captureRejections` {boolean} It enables
   [automatic capturing of promise rejection][capturerejections].
-  Default: `false`.
+  **Default:** `false`.
 
 ### Event: `'newListener'`
 <!-- YAML
@@ -1218,11 +1218,12 @@ added: REPLACEME
 * `listener` {Function|EventListener}
 * `options` {Object}
   * `once` {boolean} When `true`, the listener will be automatically removed
-    when it is first invoked. *Default*: `false`
+    when it is first invoked. **Default:** `false`.
   * `passive` {boolean} When `true`, serves as a hint that the listener will
-    not call the `Event` object's `preventDefault()` method. *Default*: `false`
+    not call the `Event` object's `preventDefault()` method.
+    **Default:** `false`.
   * `capture` {boolean} Not directly used by Node.js. Added for API
-    completeness. *Default*: `false`
+    completeness. **Default:** `false`.
 
 Adds a new handler for the `type` event. Any given `listener` will be added
 only once per `type` and per `capture` option value.


### PR DESCRIPTION
This PR updates the events docs to remove language that is advised against in our doc style guide, and make default values consistent.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)