### PR TITLE
build: fix compiling addons with older versions of Node.js

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -57,6 +57,12 @@
     # https://github.com/nodejs/node/pull/22920/files#r222779926
     'v8_enable_handle_zapping': 0,
 
+    # Disable pointer compression. Can be enabled at build time via configure
+    # options but default values are required here as this file is also used by
+    # node-gyp to build addons.
+    'v8_enable_pointer_compression%': 0,
+    'v8_enable_31bit_smis_on_64bit_arch%': 0,
+
     # Disable V8 untrusted code mitigations.
     # See https://github.com/v8/v8/wiki/Untrusted-code-mitigations
     'v8_untrusted_code_mitigations': 0,


### PR DESCRIPTION
`common.gypi` is used by `node-gyp` to compile addons. Default values
must be provided for variables that may not exist on older versions of
Node.js so that older versions of Node.js can be used to compile addons
for later versions of Node.js.

Add default values for `v8_enable_pointer_compression` and
`v8_enable_31bit_smis_on_64bit_arch`.

Refs: https://github.com/nodejs/node/pull/30463
Refs: https://github.com/nodejs/node-gyp/issues/1004#issuecomment-636987125

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
