### PR TITLE
util: restrict custom inspect function + vm.Context interaction

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -399,7 +399,7 @@ stream.write('With ES6');
 added: v0.3.0
 changes:
   - version: REPLACEME
-    pr-url: ???
+    pr-url: https://github.com/nodejs/node/pull/33690
     description: If `object` is from a different `vm.Context` now, a custom
                  inspection function on it will not receive context-specific
                  arguments anymore.

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -398,6 +398,11 @@ stream.write('With ES6');
 <!-- YAML
 added: v0.3.0
 changes:
+  - version: REPLACEME
+    pr-url: ???
+    description: If `object` is from a different `vm.Context` now, a custom
+                 inspection function on it will not receive context-specific
+                 arguments anymore.
   - version:
      - v13.13.0
      - v12.17.0

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -12,6 +12,7 @@ const {
   DatePrototypeToString,
   ErrorPrototypeToString,
   Float32Array,
+  FunctionPrototypeCall,
   FunctionPrototypeToString,
   JSONStringify,
   Map,
@@ -25,6 +26,7 @@ const {
   Number,
   NumberIsNaN,
   NumberPrototypeValueOf,
+  Object,
   ObjectAssign,
   ObjectCreate,
   ObjectDefineProperty,
@@ -37,6 +39,7 @@ const {
   ObjectPrototypeHasOwnProperty,
   ObjectPrototypePropertyIsEnumerable,
   ObjectSeal,
+  ObjectSetPrototypeOf,
   RegExp,
   RegExpPrototypeToString,
   Set,
@@ -212,8 +215,8 @@ const ansi = new RegExp(ansiPattern, 'g');
 
 let getStringWidth;
 
-function getUserOptions(ctx) {
-  return {
+function getUserOptions(ctx, targetValue) {
+  const ret = {
     stylize: ctx.stylize,
     showHidden: ctx.showHidden,
     depth: ctx.depth,
@@ -228,6 +231,33 @@ function getUserOptions(ctx) {
     getters: ctx.getters,
     ...ctx.userOptions
   };
+
+  // Typically, the target value will be an instance of `Object`. If that is
+  // *not* the case, the object may come from another vm.Context, and we want
+  // to avoid passing it objects from this Context in that case, so we remove
+  // the prototype from the returned object itself + the `stylize()` function,
+  // and remove all other non-primitives, including non-primitive user options.
+  if (!(targetValue instanceof Object)) {
+    ObjectSetPrototypeOf(ret, null);
+    for (const key of ObjectKeys(ret)) {
+      if ((typeof ret[key] === 'object' || typeof ret[key] === 'function') &&
+          ret[key] !== null) {
+        delete ret[key];
+      }
+    }
+    ret.stylize = ObjectSetPrototypeOf((value, flavour) => {
+      let stylized;
+      try {
+        stylized = ctx.stylize(value, flavour);
+      } catch {}
+
+      if (typeof stylized !== 'string') return value;
+      // `stylized` is a string as it should be, which is safe to pass along.
+      return stylized;
+    }, null);
+  }
+
+  return ret;
 }
 
 /**
@@ -726,7 +756,8 @@ function formatValue(ctx, value, recurseTimes, typedArray) {
       // This makes sure the recurseTimes are reported as before while using
       // a counter internally.
       const depth = ctx.depth === null ? null : ctx.depth - recurseTimes;
-      const ret = maybeCustom.call(context, depth, getUserOptions(ctx));
+      const ret = FunctionPrototypeCall(
+        maybeCustom, context, depth, getUserOptions(ctx, context));
       // If the custom inspection method returned `this`, don't go into
       // infinite recursion.
       if (ret !== context) {

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -248,7 +248,7 @@ function getUserOptions(ctx, isCrossContext) {
     ret.stylize = ObjectSetPrototypeOf((value, flavour) => {
       let stylized;
       try {
-        stylized = ctx.stylize(value, flavour);
+        stylized = `${ctx.stylize(value, flavour)}`;
       } catch {}
 
       if (typeof stylized !== 'string') return value;

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -215,7 +215,7 @@ const ansi = new RegExp(ansiPattern, 'g');
 
 let getStringWidth;
 
-function getUserOptions(ctx, targetValue) {
+function getUserOptions(ctx, isCrossContext) {
   const ret = {
     stylize: ctx.stylize,
     showHidden: ctx.showHidden,
@@ -237,7 +237,7 @@ function getUserOptions(ctx, targetValue) {
   // to avoid passing it objects from this Context in that case, so we remove
   // the prototype from the returned object itself + the `stylize()` function,
   // and remove all other non-primitives, including non-primitive user options.
-  if (!(targetValue instanceof Object)) {
+  if (isCrossContext) {
     ObjectSetPrototypeOf(ret, null);
     for (const key of ObjectKeys(ret)) {
       if ((typeof ret[key] === 'object' || typeof ret[key] === 'function') &&
@@ -756,8 +756,10 @@ function formatValue(ctx, value, recurseTimes, typedArray) {
       // This makes sure the recurseTimes are reported as before while using
       // a counter internally.
       const depth = ctx.depth === null ? null : ctx.depth - recurseTimes;
+      const isCrossContext =
+        proxy !== undefined || !(context instanceof Object);
       const ret = FunctionPrototypeCall(
-        maybeCustom, context, depth, getUserOptions(ctx, context));
+        maybeCustom, context, depth, getUserOptions(ctx, isCrossContext));
       // If the custom inspection method returned `this`, don't go into
       // infinite recursion.
       if (ret !== context) {

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -2938,7 +2938,7 @@ assert.strictEqual(
         return {};
       })
     });
-    assert.strictEqual(output, '🐈');
+    assert.strictEqual(output, '[object Object]');
     assert.strictEqual(typeof target.ctx, 'object');
     const objectGraph = fullObjectGraph(target);
     assert(!objectGraph.has(Object));

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -2901,3 +2901,85 @@ assert.strictEqual(
     "'aaaa'... 999996 more characters"
   );
 }
+
+{
+  // Verify that util.inspect() invokes custom inspect functions on objects
+  // from other vm.Contexts but does not pass data from its own Context to that
+  // function.
+  const target = vm.runInNewContext(`
+    ({
+      [Symbol.for('nodejs.util.inspect.custom')](depth, ctx) {
+        this.depth = depth;
+        this.ctx = ctx;
+        try {
+          this.stylized = ctx.stylize('🐈');
+        } catch (e) {
+          this.stylizeException = e;
+        }
+        return this.stylized;
+      }
+    })
+  `, Object.create(null));
+  assert.strictEqual(target.ctx, undefined);
+
+  {
+    // Subtest 1: Just try to inspect the object with default options.
+    assert.strictEqual(util.inspect(target), '🐈');
+    assert.strictEqual(typeof target.ctx, 'object');
+    const objectGraph = fullObjectGraph(target);
+    assert(!objectGraph.has(Object));
+    assert(!objectGraph.has(Function));
+  }
+
+  {
+    // Subtest 2: Use a stylize function that returns a non-primitive.
+    const output = util.inspect(target, {
+      stylize: common.mustCall((str) => {
+        return {};
+      })
+    });
+    assert.strictEqual(output, '🐈');
+    assert.strictEqual(typeof target.ctx, 'object');
+    const objectGraph = fullObjectGraph(target);
+    assert(!objectGraph.has(Object));
+    assert(!objectGraph.has(Function));
+  }
+
+  {
+    // Subtest 3: Use a stylize function that throws an exception.
+    const output = util.inspect(target, {
+      stylize: common.mustCall((str) => {
+        throw new Error('oops');
+      })
+    });
+    assert.strictEqual(output, '🐈');
+    assert.strictEqual(typeof target.ctx, 'object');
+    const objectGraph = fullObjectGraph(target);
+    assert(!objectGraph.has(Object));
+    assert(!objectGraph.has(Function));
+  }
+
+  function fullObjectGraph(value) {
+    const graph = new Set([value]);
+
+    for (const entry of graph) {
+      if ((typeof entry !== 'object' && typeof entry !== 'function') ||
+          entry === null) {
+        continue;
+      }
+
+      graph.add(Object.getPrototypeOf(entry));
+      const descriptors = Object.values(Object.getOwnPropertyDescriptors(entry));
+      for (const descriptor of descriptors) {
+        graph.add(descriptor.value);
+        graph.add(descriptor.set);
+        graph.add(descriptor.get);
+      }
+    }
+
+    return graph;
+  }
+
+  // Consistency check.
+  assert(fullObjectGraph(global).includes(Function.prototype));
+}

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -2969,7 +2969,8 @@ assert.strictEqual(
       }
 
       graph.add(Object.getPrototypeOf(entry));
-      const descriptors = Object.values(Object.getOwnPropertyDescriptors(entry));
+      const descriptors = Object.values(
+        Object.getOwnPropertyDescriptors(entry));
       for (const descriptor of descriptors) {
         graph.add(descriptor.value);
         graph.add(descriptor.set);
@@ -2981,5 +2982,5 @@ assert.strictEqual(
   }
 
   // Consistency check.
-  assert(fullObjectGraph(global).includes(Function.prototype));
+  assert(fullObjectGraph(global).has(Function.prototype));
 }


### PR DESCRIPTION
When `util.inspect()` is called on an object with a custom inspect
function, and that object is from a different `vm.Context`,
that function will not receive any arguments that access
context-specific data anymore.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
