### PR TITLE
doc: fix deprecation "End-of-Life" capitalization

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -494,7 +494,7 @@ changes:
     description: Runtime deprecation.
 -->
 
-Type: End-of-life
+Type: End-of-Life
 
 The `Server.connections` property was deprecated in Node.js v0.9.7 and has
 been removed. Please use the [`Server.getConnections()`][] method instead.
@@ -1446,7 +1446,7 @@ changes:
     description: Runtime deprecation.
 -->
 
-Type: End-of-life
+Type: End-of-Life
 
 `node debug` corresponds to the legacy CLI debugger which has been replaced with
 a V8-inspector based CLI debugger available through `node inspect`.


### PR DESCRIPTION
Update the "End-of-Life" casing in the deprecation documentation for consistency. Similar to #26251.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)