### PR TITLE
src: use getauxval in node_main.cc

### DIFF
--- a/src/node_main.cc
+++ b/src/node_main.cc
@@ -89,13 +89,7 @@ int wmain(int argc, wchar_t* wargv[]) {
 #else
 // UNIX
 #ifdef __linux__
-#include <elf.h>
-#ifdef __LP64__
-#define Elf_auxv_t Elf64_auxv_t
-#else
-#define Elf_auxv_t Elf32_auxv_t
-#endif  // __LP64__
-extern char** environ;
+#include <sys/auxv.h>
 #endif  // __linux__
 #if defined(__POSIX__) && defined(NODE_SHARED_MODE)
 #include <string.h>
@@ -124,15 +118,7 @@ int main(int argc, char* argv[]) {
 #endif
 
 #if defined(__linux__)
-  char** envp = environ;
-  while (*envp++ != nullptr) {}
-  Elf_auxv_t* auxv = reinterpret_cast<Elf_auxv_t*>(envp);
-  for (; auxv->a_type != AT_NULL; auxv++) {
-    if (auxv->a_type == AT_SECURE) {
-      node::per_process::linux_at_secure = auxv->a_un.a_val;
-      break;
-    }
-  }
+  node::per_process::linux_at_secure = getauxval(AT_SECURE);
 #endif
   // Disable stdio buffering, it interacts poorly with printf()
   // calls elsewhere in the program (e.g., any logging from V8.)


### PR DESCRIPTION
This commit suggests using getauxval in node_main.cc.

The motivation for this is that getauxval was introduced in glibc 2.16
and looking at BUILDING.md, in the 'Platform list' section, it looks
like we now support glibc >= 2.17 and perhaps this change would be
alright now.

Refs: https://github.com/nodejs/node/pull/12548


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
