### PR TITLE
src: use ToLocal in SafeGetenv

### DIFF
--- a/src/node_credentials.cc
+++ b/src/node_credentials.cc
@@ -44,12 +44,13 @@ bool SafeGetenv(const char* key, std::string* text, Environment* env) {
   if (env != nullptr) {
     HandleScope handle_scope(env->isolate());
     TryCatch ignore_errors(env->isolate());
-    MaybeLocal<String> value = env->env_vars()->Get(
+    MaybeLocal<String> maybe_value = env->env_vars()->Get(
         env->isolate(),
         String::NewFromUtf8(env->isolate(), key, NewStringType::kNormal)
             .ToLocalChecked());
-    if (value.IsEmpty()) goto fail;
-    String::Utf8Value utf8_value(env->isolate(), value.ToLocalChecked());
+    Local<String> value;
+    if (!maybe_value.ToLocal(&value)) goto fail;
+    String::Utf8Value utf8_value(env->isolate(), value);
     if (*utf8_value == nullptr) goto fail;
     *text = std::string(*utf8_value, utf8_value.length());
     return true;


### PR DESCRIPTION
This commit replaces the IsEmpty call to use ToLocal instead which
allows for the following ToLocalChecked function call to be avoided.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
