### PR TITLE
build: add LINT_CPP_FILES to checkimports check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1334,7 +1334,7 @@ lint-cpp: tools/.cpplintstamp
 tools/.cpplintstamp: $(LINT_CPP_FILES)
 	@echo "Running C++ linter..."
 	@$(PYTHON) tools/cpplint.py $(CPPLINT_QUIET) $?
-	@$(PYTHON) tools/checkimports.py
+	@$(PYTHON) tools/checkimports.py $?
 	@touch $@
 
 .PHONY: lint-addon-docs

--- a/tools/code_cache/cache_builder.cc
+++ b/tools/code_cache/cache_builder.cc
@@ -13,10 +13,7 @@ namespace node {
 namespace native_module {
 
 using v8::Context;
-using v8::Function;
-using v8::Isolate;
 using v8::Local;
-using v8::MaybeLocal;
 using v8::ScriptCompiler;
 
 static std::string GetDefName(const std::string& id) {


### PR DESCRIPTION
This commit adds the prerequisites which contains all the files to lint.
Currently the only the files in 'src' will be checked.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
