### PR TITLE
lib: add throws option to fs.f/l/statSync

### DIFF
--- a/benchmark/fs/bench-statSync-failure.js
+++ b/benchmark/fs/bench-statSync-failure.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const common = require('../common');
+const fs = require('fs');
+const path = require('path');
+
+const bench = common.createBenchmark(main, {
+  n: [1e6],
+  statSyncType: ['throw', 'noThrow']
+});
+
+
+function main({ n, statSyncType }) {
+  const arg = path.join(__dirname, 'non.existent');
+
+  bench.start();
+  for (let i = 0; i < n; i++) {
+    if (statSyncType === 'noThrow') {
+      fs.statSync(arg, { throws: false });
+    } else {
+      try {
+        fs.statSync(arg);
+      } catch {
+      }
+    }
+  }
+  bench.end(n);
+}

--- a/benchmark/fs/bench-statSync-failure.js
+++ b/benchmark/fs/bench-statSync-failure.js
@@ -16,7 +16,7 @@ function main({ n, statSyncType }) {
   bench.start();
   for (let i = 0; i < n; i++) {
     if (statSyncType === 'noThrow') {
-      fs.statSync(arg, { throws: false });
+      fs.statSync(arg, { throwIfNoEntry: false });
     } else {
       try {
         fs.statSync(arg);

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2202,8 +2202,8 @@ changes:
 * `options` {Object}
   * `bigint` {boolean} Whether the numeric values in the returned
     [`fs.Stats`][] object should be `bigint`. **Default:** `false`.
-  * `throws` {boolean} Whether an exception will be thrown
-    if stats are not available, rather than returning `undefined`.
+  * `throwIfNoEntry` {boolean} Whether an exception will be thrown
+    if no file system entry exists, rather than returning `undefined`.
     **Default:** `true`.
 * Returns: {fs.Stats}
 
@@ -2571,8 +2571,8 @@ changes:
 * `options` {Object}
   * `bigint` {boolean} Whether the numeric values in the returned
     [`fs.Stats`][] object should be `bigint`. **Default:** `false`.
-  * `throws` {boolean} Whether an exception will be thrown
-    if stats are not available, rather than returning `undefined`.
+  * `throwIfNoEntry` {boolean} Whether an exception will be thrown
+    if no file system entry exists, rather than returning `undefined`.
     **Default:** `true`.
 * Returns: {fs.Stats}
 
@@ -3816,8 +3816,8 @@ changes:
 * `options` {Object}
   * `bigint` {boolean} Whether the numeric values in the returned
     [`fs.Stats`][] object should be `bigint`. **Default:** `false`.
-  * `throws` {boolean} Whether an exception will be thrown
-    if stats are not available, rather than returning `undefined`.
+  * `throwIfNoEntry` {boolean} Whether an exception will be thrown
+    if no file system entry exists, rather than returning `undefined`.
     **Default:** `true`.
 * Returns: {fs.Stats}
 

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2202,9 +2202,6 @@ changes:
 * `options` {Object}
   * `bigint` {boolean} Whether the numeric values in the returned
     [`fs.Stats`][] object should be `bigint`. **Default:** `false`.
-  * `throwIfNoEntry` {boolean} Whether an exception will be thrown
-    if no file system entry exists, rather than returning `undefined`.
-    **Default:** `true`.
 * Returns: {fs.Stats}
 
 Synchronous fstat(2).

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2202,6 +2202,9 @@ changes:
 * `options` {Object}
   * `bigint` {boolean} Whether the numeric values in the returned
     [`fs.Stats`][] object should be `bigint`. **Default:** `false`.
+  * `throws` {boolean} Whether an exception will be thrown
+    if stats are not available, rather than returning `undefined`.
+    **Default:** `true`.
 * Returns: {fs.Stats}
 
 Synchronous fstat(2).
@@ -2568,6 +2571,9 @@ changes:
 * `options` {Object}
   * `bigint` {boolean} Whether the numeric values in the returned
     [`fs.Stats`][] object should be `bigint`. **Default:** `false`.
+  * `throws` {boolean} Whether an exception will be thrown
+    if stats are not available, rather than returning `undefined`.
+    **Default:** `true`.
 * Returns: {fs.Stats}
 
 Synchronous lstat(2).
@@ -3810,6 +3816,9 @@ changes:
 * `options` {Object}
   * `bigint` {boolean} Whether the numeric values in the returned
     [`fs.Stats`][] object should be `bigint`. **Default:** `false`.
+  * `throws` {boolean} Whether an exception will be thrown
+    if stats are not available, rather than returning `undefined`.
+    **Default:** `true`.
 * Returns: {fs.Stats}
 
 Synchronous stat(2).

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1076,29 +1076,47 @@ function stat(path, options = { bigint: false }, callback) {
   binding.stat(pathModule.toNamespacedPath(path), options.bigint, req);
 }
 
-function fstatSync(fd, options = { bigint: false }) {
+function fstatSync(fd, options = { bigint: false, throws: true }) {
   validateInt32(fd, 'fd', 0);
   const ctx = { fd };
   const stats = binding.fstat(fd, options.bigint, undefined, ctx);
-  handleErrorFromBinding(ctx);
+  if (options.throws === false) {
+    if (ctx.errno || ctx.error) {
+      return undefined;
+    }
+  } else {
+    handleErrorFromBinding(ctx);
+  }
   return getStatsFromBinding(stats);
 }
 
-function lstatSync(path, options = { bigint: false }) {
+function lstatSync(path, options = { bigint: false, throws: true }) {
   path = getValidatedPath(path);
   const ctx = { path };
   const stats = binding.lstat(pathModule.toNamespacedPath(path),
                               options.bigint, undefined, ctx);
-  handleErrorFromBinding(ctx);
+  if (options.throws === false) {
+    if (ctx.errno || ctx.error) {
+      return undefined;
+    }
+  } else {
+    handleErrorFromBinding(ctx);
+  }
   return getStatsFromBinding(stats);
 }
 
-function statSync(path, options = { bigint: false }) {
+function statSync(path, options = { bigint: false, throws: true }) {
   path = getValidatedPath(path);
   const ctx = { path };
   const stats = binding.stat(pathModule.toNamespacedPath(path),
                              options.bigint, undefined, ctx);
-  handleErrorFromBinding(ctx);
+  if (options.throws === false) {
+    if (ctx.errno || ctx.error) {
+      return undefined;
+    }
+  } else {
+    handleErrorFromBinding(ctx);
+  }
   return getStatsFromBinding(stats);
 }
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -72,6 +72,7 @@ const {
     ERR_FEATURE_UNAVAILABLE_ON_PLATFORM
   },
   hideStackFrames,
+  uvErrmapGet,
   uvException
 } = require('internal/errors');
 
@@ -1076,47 +1077,51 @@ function stat(path, options = { bigint: false }, callback) {
   binding.stat(pathModule.toNamespacedPath(path), options.bigint, req);
 }
 
-function fstatSync(fd, options = { bigint: false, throws: true }) {
+function hasNoEntryError(ctx) {
+  if (ctx.errno) {
+    const uvErr = uvErrmapGet(ctx.errno);
+    return uvErr && uvErr[0] === 'ENOENT';
+  }
+
+  if (ctx.error) {
+    return ctx.error.code === 'ENOENT';
+  }
+
+  return false;
+}
+
+function fstatSync(fd, options = { bigint: false, throwIfNoEntry: true }) {
   validateInt32(fd, 'fd', 0);
   const ctx = { fd };
   const stats = binding.fstat(fd, options.bigint, undefined, ctx);
-  if (options.throws === false) {
-    if (ctx.errno || ctx.error) {
-      return undefined;
-    }
-  } else {
-    handleErrorFromBinding(ctx);
+  if (options.throwIfNoEntry === false && hasNoEntryError(ctx)) {
+    return undefined;
   }
+  handleErrorFromBinding(ctx);
   return getStatsFromBinding(stats);
 }
 
-function lstatSync(path, options = { bigint: false, throws: true }) {
+function lstatSync(path, options = { bigint: false, throwIfNoEntry: true }) {
   path = getValidatedPath(path);
   const ctx = { path };
   const stats = binding.lstat(pathModule.toNamespacedPath(path),
                               options.bigint, undefined, ctx);
-  if (options.throws === false) {
-    if (ctx.errno || ctx.error) {
-      return undefined;
-    }
-  } else {
-    handleErrorFromBinding(ctx);
+  if (options.throwIfNoEntry === false && hasNoEntryError(ctx)) {
+    return undefined;
   }
+  handleErrorFromBinding(ctx);
   return getStatsFromBinding(stats);
 }
 
-function statSync(path, options = { bigint: false, throws: true }) {
+function statSync(path, options = { bigint: false, throwIfNoEntry: true }) {
   path = getValidatedPath(path);
   const ctx = { path };
   const stats = binding.stat(pathModule.toNamespacedPath(path),
                              options.bigint, undefined, ctx);
-  if (options.throws === false) {
-    if (ctx.errno || ctx.error) {
-      return undefined;
-    }
-  } else {
-    handleErrorFromBinding(ctx);
+  if (options.throwIfNoEntry === false && hasNoEntryError(ctx)) {
+    return undefined;
   }
+  handleErrorFromBinding(ctx);
   return getStatsFromBinding(stats);
 }
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1094,9 +1094,6 @@ function fstatSync(fd, options = { bigint: false, throwIfNoEntry: true }) {
   validateInt32(fd, 'fd', 0);
   const ctx = { fd };
   const stats = binding.fstat(fd, options.bigint, undefined, ctx);
-  if (options.throwIfNoEntry === false && hasNoEntryError(ctx)) {
-    return undefined;
-  }
   handleErrorFromBinding(ctx);
   return getStatsFromBinding(stats);
 }

--- a/test/parallel/test-fs-stat-bigint.js
+++ b/test/parallel/test-fs-stat-bigint.js
@@ -141,12 +141,7 @@ if (!common.isWindows) {
 }
 
 {
-  assert.throws(
-    () => fs.fstatSync(9999),
-    { code: 'EBADF' });
-  assert.throws(
-    () => fs.fstatSync(9999, { throwIfNoEntry: false }),
-    { code: 'EBADF' });
+  assert.throws(() => fs.fstatSync(9999), { code: 'EBADF' });
 }
 
 const runCallbackTest = (func, arg, done) => {

--- a/test/parallel/test-fs-stat-bigint.js
+++ b/test/parallel/test-fs-stat-bigint.js
@@ -141,7 +141,12 @@ if (!common.isWindows) {
 }
 
 {
-  assert.throws(() => fs.fstatSync(9999), { code: 'EBADF' });
+  assert.throws(
+    () => fs.fstatSync(9999),
+    { code: 'EBADF' });
+  assert.throws(
+    () => fs.fstatSync(9999, { throwIfNoEntry: false }),
+    { code: 'EBADF' });
 }
 
 const runCallbackTest = (func, arg, done) => {

--- a/test/parallel/test-fs-stat-bigint.js
+++ b/test/parallel/test-fs-stat-bigint.js
@@ -122,21 +122,31 @@ if (!common.isWindows) {
   fs.closeSync(fd);
 }
 
-const runSyncFailureTest = (func, arg, error) => {
-  assert.throws(() => func(arg), error);
-  assert.strictEqual(func(arg, { throws: false }), undefined);
-};
-
 {
-  runSyncFailureTest(fs.statSync, 'does_not_exist', { code: 'ENOENT' });
+  assert.throws(
+    () => fs.statSync('does_not_exist'),
+    { code: 'ENOENT' });
+  assert.strictEqual(
+    fs.statSync('does_not_exist', { throwIfNoEntry: false }),
+    undefined);
 }
 
 {
-  runSyncFailureTest(fs.lstatSync, 'does_not_exist', { code: 'ENOENT' });
+  assert.throws(
+    () => fs.lstatSync('does_not_exist'),
+    { code: 'ENOENT' });
+  assert.strictEqual(
+    fs.lstatSync('does_not_exist', { throwIfNoEntry: false }),
+    undefined);
 }
 
 {
-  runSyncFailureTest(fs.fstatSync, 9999, { code: 'EBADF' });
+  assert.throws(
+    () => fs.fstatSync(9999),
+    { code: 'EBADF' });
+  assert.throws(
+    () => fs.fstatSync(9999, { throwIfNoEntry: false }),
+    { code: 'EBADF' });
 }
 
 const runCallbackTest = (func, arg, done) => {

--- a/test/parallel/test-fs-stat-bigint.js
+++ b/test/parallel/test-fs-stat-bigint.js
@@ -122,6 +122,23 @@ if (!common.isWindows) {
   fs.closeSync(fd);
 }
 
+const runSyncFailureTest = (func, arg, error) => {
+  assert.throws(() => func(arg), error);
+  assert.strictEqual(func(arg, { throws: false }), undefined);
+};
+
+{
+  runSyncFailureTest(fs.statSync, 'does_not_exist', { code: 'ENOENT' });
+}
+
+{
+  runSyncFailureTest(fs.lstatSync, 'does_not_exist', { code: 'ENOENT' });
+}
+
+{
+  runSyncFailureTest(fs.fstatSync, 9999, { code: 'EBADF' });
+}
+
 const runCallbackTest = (func, arg, done) => {
   const startTime = process.hrtime.bigint();
   func(arg, { bigint: true }, common.mustCall((err, bigintStats) => {


### PR DESCRIPTION
For consumers that aren't interested in *why* a `statSync` call failed,
allocating and throwing an exception is an unnecessary expense.  This PR
adds an option that will cause it to return `undefined` in such cases
instead.

As a motivating example, the JavaScript & TypeScript language service
shared between Visual Studio and Visual Studio Code is stuck with
synchronous file IO for architectural and backward-compatibility
reasons.  It frequently needs to speculatively check for the existence
of files and directories that may not exist (and cares about file vs
directory, so `existsSync` is insufficient), but ignores file system
entries it can't access, regardless of the reason.

Benchmarking the language service is difficult because it's so hard to
get good coverage of both code bases and user behaviors, but, as a
representative metric, we measured batch compilation of a few hundred
popular projects (by star count) from GitHub and found that, on average,
we saved about 1-2% of total compilation time.  We speculate that the
savings could be even more significant in interactive (language service
or watch mode) scenarios, where the same (non-existent) files need to be
polled over and over again.  It's not a huge improvement, but it's a
very small change and it will affect a lot of users (and CI runs).

For reference, our measurements were against `v12.x` (3637a061a at the
time) on an Ubuntu Server desktop with an SSD.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
