### PR TITLE
[v10.x backport] inspector: more conservative minimum stack size

### DIFF
--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -14,6 +14,7 @@
 
 #include "libplatform/libplatform.h"
 
+#include <algorithm>
 #include <string.h>
 #include <sstream>
 #include <unordered_map>
@@ -101,12 +102,18 @@ static int StartDebugSignalHandler() {
   CHECK_EQ(0, uv_sem_init(&start_io_thread_semaphore, 0));
   pthread_attr_t attr;
   CHECK_EQ(0, pthread_attr_init(&attr));
-  // Don't shrink the thread's stack on FreeBSD.  Said platform decided to
-  // follow the pthreads specification to the letter rather than in spirit:
-  // https://lists.freebsd.org/pipermail/freebsd-current/2014-March/048885.html
-#ifndef __FreeBSD__
-  CHECK_EQ(0, pthread_attr_setstacksize(&attr, PTHREAD_STACK_MIN));
-#endif  // __FreeBSD__
+#if defined(PTHREAD_STACK_MIN) && !defined(__FreeBSD__)
+  // PTHREAD_STACK_MIN is 2 KB with musl libc, which is too small to safely
+  // receive signals. PTHREAD_STACK_MIN + MINSIGSTKSZ is 8 KB on arm64, which
+  // is the musl architecture with the biggest MINSIGSTKSZ so let's use that
+  // as a lower bound and let's quadruple it just in case. The goal is to avoid
+  // creating a big 2 or 4 MB address space gap (problematic on 32 bits
+  // because of fragmentation), not squeeze out every last byte.
+  // Omitted on FreeBSD because it doesn't seem to like small stacks.
+  const size_t stack_size = std::max(static_cast<size_t>(4 * 8192),
+                                     static_cast<size_t>(PTHREAD_STACK_MIN));
+  CHECK_EQ(0, pthread_attr_setstacksize(&attr, stack_size));
+#endif  // defined(PTHREAD_STACK_MIN) && !defined(__FreeBSD__)
   CHECK_EQ(0, pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED));
   sigset_t sigmask;
   // Mask all signals.


### PR DESCRIPTION
We see crashes in some musl docker environments caused by stack overflow in inspector thread. This happens during signal handling which is used as fallback by musl-libc in case syscall membarrier is not allowed by the secprofile.

fyi @bnoordhuis - the initial PR was done by you

PTHREAD_STACK_MIN is 2 KB with musl, which is too small to safely
receive signals. PTHREAD_STACK_MIN + MINSIGSTKSZ is 8 KB on arm64,
which is the musl architecture with the biggest MINSIGSTKSZ so let's
use that as a lower bound and let's quadruple it just in case.

PR-URL: https://github.com/nodejs/node/pull/27855
Reviewed-By: Colin Ihrig <cjihrig@gmail.com>
Reviewed-By: James M Snell <jasnell@gmail.com>
Reviewed-By: Eugene Ostroukhov <eostroukhov@google.com>
Reviewed-By: Anna Henningsen <anna@addaleax.net>
Reviewed-By: Rich Trott <rtrott@gmail.com>

