### PR TITLE
doc: Fix the typo in example output in url.md for url.hostname

### DIFF
--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -208,6 +208,7 @@ const myURL = new URL('https://example.org:81/foo');
 console.log(myURL.hostname);
 // Prints example.org
 
+// Setting the hostname does not change the port
 myURL.hostname = 'example.com:82';
 console.log(myURL.href);
 // Prints https://example.com:82/foo

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -210,7 +210,7 @@ console.log(myURL.hostname);
 
 myURL.hostname = 'example.com:82';
 console.log(myURL.href);
-// Prints https://example.com:81/foo
+// Prints https://example.com:82/foo
 ```
 
 Invalid host name values assigned to the `hostname` property are ignored.

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -211,6 +211,11 @@ console.log(myURL.hostname);
 myURL.hostname = 'example.com:82';
 console.log(myURL.href);
 // Prints https://example.com:82/foo
+
+// Use, myURL.host to change the hostname and port
+myURL.host = 'example.org:82';
+console.log(myURL.href);
+// Prints https://example.org:82/foo
 ```
 
 Invalid host name values assigned to the `hostname` property are ignored.

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -211,7 +211,7 @@ console.log(myURL.hostname);
 // Setting the hostname does not change the port
 myURL.hostname = 'example.com:82';
 console.log(myURL.href);
-// Prints https://example.com:82/foo
+// Prints https://example.com:81/foo
 
 // Use, myURL.host to change the hostname and port
 myURL.host = 'example.org:82';


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
Currently in the [`url.hostname`](https://nodejs.org/api/url.html#url_url_hostname), the replacement example updates the hostname to use `example.com:82` but in the comment it's showing the expected output for the operation to be `// Prints https://example.com:81/foo`

It should be `// Prints https://example.com:82/foo`

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added



<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
