### PR TITLE
async_hooks: add bindToAsyncScope method to AsyncResource

### DIFF
--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -662,6 +662,10 @@ const asyncResource = new AsyncResource(
 // * restore the original execution context
 asyncResource.runInAsyncScope(fn, thisArg, ...args);
 
+// Return a wrapper function that always runs in the execution context
+// of the resource.
+asyncResource.bindToAsyncScope(fn);
+
 // Call AsyncHooks destroy callbacks.
 asyncResource.emitDestroy();
 
@@ -722,6 +726,34 @@ Call the provided function with the provided arguments in the execution context
 of the async resource. This will establish the context, trigger the AsyncHooks
 before callbacks, call the function, trigger the AsyncHooks after callbacks, and
 then restore the original execution context.
+
+#### `asyncResource.bindToAsyncScope(fn)`
+<!-- YAML
+added: REPLACEME
+-->
+
+* `fn` {Function} The function to be wrapped.
+
+Return a wrapper function for the supplied function. The returned funtion, when
+it is run, will have the same context as if it was run with
+`asyncResource.runInAsyncScope()`.
+
+The following is a simple demonstration of `asyncResource.bindToAsyncScope()`:
+
+```js
+const { createServer } = require('http');
+const { AsyncResource, executionAsyncId } = require('async_hooks');
+
+const server = createServer(function(req, res) {
+  const asyncResource = new AsyncResource('request');
+  const asyncId = asyncResource.asyncId();
+  // The listener will always run in the execution context of `asyncResource`.
+  req.on('close', asyncResource.bindToAsyncScope(() => {
+    console.log(executionAsyncId()); // Prints the value of `asyncId`.
+  }));
+  res.end();
+}).listen(3000);
+```
 
 #### `asyncResource.emitDestroy()`
 

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -196,6 +196,13 @@ class AsyncResource {
     }
   }
 
+  bindToAsyncScope(fn) {
+    const self = this;
+    return function() {
+      return self.runInAsyncScope(fn, this, ...arguments);
+    };
+  }
+
   emitDestroy() {
     if (this[destroyedSymbol] !== undefined) {
       this[destroyedSymbol].destroyed = true;

--- a/test/async-hooks/test-embedder.api.async-resource.bindToAsyncScope.js
+++ b/test/async-hooks/test-embedder.api.async-resource.bindToAsyncScope.js
@@ -1,0 +1,14 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const { AsyncResource, executionAsyncId } = require('async_hooks');
+
+const a = new AsyncResource('foobar');
+
+function foo(bar) {
+  assert.strictEqual(executionAsyncId(), a.asyncId());
+  return bar;
+}
+
+const ret = a.bindToAsyncScope(foo)('baz');
+assert.strictEqual(ret, 'baz');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Closes #33723

Adds `bindToAsyncScope()` method to `AsyncResource` class. This method should be handy for `AsyncLocalStorage` users (and not only them). Say, it allows binding EE/stream listeners to the specific resource:

```js
const { createServer } = require('http');
const { AsyncResource, executionAsyncId } = require('async_hooks');

const server = createServer(function(req, res) {
  const asyncResource = new AsyncResource('request');
  const asyncId = asyncResource.asyncId();
  // The listener will always run in the execution context of `asyncResource`.
  req.on('close', asyncResource.bindToAsyncScope(() => {
    console.log(executionAsyncId()); // Prints the value of `asyncId`.
  }));
  res.end();
}).listen(3000);
```

cc @nodejs/async_hooks 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
