### PR TITLE
lib: apply native V8 join for better performance

### DIFF
--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -3,6 +3,7 @@
 const {
   ArrayFrom,
   ArrayIsArray,
+  ArrayPrototypeJoin,
   Error,
   Map,
   ObjectCreate,
@@ -323,10 +324,14 @@ function promisify(original) {
 
 promisify.custom = kCustomPromisifiedSymbol;
 
-// The build-in Array#join is slower in v8 6.0
+// The built-in Array#join is slower in v8 6.0
 function join(output, separator) {
   let str = '';
   if (output.length !== 0) {
+    // The built-in Array#join is faster in v8 7.8
+    if (ArrayIsArray(output)) {
+      return ArrayPrototypeJoin(output, separator);
+    }
     const lastIndex = output.length - 1;
     for (let i = 0; i < lastIndex; i++) {
       // It is faster not to use a template string here


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

As reported in #33732, built-in Array#join is faster than lib/internal/util.js#join function.
This PR would close #33732.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
