### PR TITLE
src: add "missing" bash completion options

### DIFF
--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -831,7 +831,8 @@ std::string GetBashCompletion() {
          "    return 0\n"
          "  fi\n"
          "}\n"
-         "complete -F _node_complete node node_g";
+         "complete -o filenames -o nospace -o bashdefault "
+         "-F _node_complete node node_g";
   return out.str();
 }
 

--- a/test/parallel/test-bash-completion.js
+++ b/test/parallel/test-bash-completion.js
@@ -24,7 +24,8 @@ const suffix = `' -- "\${cur_word}") )
     return 0
   fi
 }
-complete -F _node_complete node node_g`.replace(/\r/g, '');
+complete -o filenames -o nospace -o bashdefault -F _node_complete node node_g`
+  .replace(/\r/g, '');
 
 assert.ok(
   output.includes(prefix),


### PR DESCRIPTION
Currently, when using the bash completions for node the normal
completions for filenames directories do not work. For example, after
using finding a node completion and then wanting to use tab completion
for a filename in the test directory it is only possible to get the name
of the test directory completed, followed by a space. What is expected
is to be able to continue with tab completion for directories.

This commit adds options to the complete command to enable default bash
completions.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
