### PR TITLE
src: fix FastStringKey equal operator

### DIFF
--- a/src/util-inl.h
+++ b/src/util-inl.h
@@ -303,7 +303,7 @@ bool StringEqualNoCase(const char* a, const char* b) {
     if (*a == '\0')
       return *b == '\0';
     if (*b == '\0')
-      return *a == '\0';
+      return false;
   } while (ToLower(*a++) == ToLower(*b++));
   return false;
 }
@@ -536,9 +536,9 @@ inline bool IsSafeJsInt(v8::Local<v8::Value> v) {
 constexpr size_t FastStringKey::HashImpl(const char* str) {
   // Low-quality hash (djb2), but just fine for current use cases.
   size_t h = 5381;
-  do {
-    h = h * 33 + *str;  // NOLINT(readability/pointer_notation)
-  } while (*(str++) != '\0');
+  while (*str != '\0') {
+    h = h * 33 + *(str++);  // NOLINT(readability/pointer_notation)
+  }
   return h;
 }
 
@@ -554,7 +554,7 @@ constexpr bool FastStringKey::operator==(const FastStringKey& other) const {
   do {
     if (*(p1++) != *(p2++)) return false;
   } while (*p1 != '\0');
-  return true;
+  return *p2 == '\0';
 }
 
 constexpr FastStringKey::FastStringKey(const char* name)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

1. This PR fixes the FastStringKey `==` operator. (Currently, there are some cases which return `true`, when the length of string is not same).
2. Currently, `FastStringKey::HashImpl` return multiple of 33, thus it would be better to move `while` to first.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
