### PR TITLE
inspector: drop 'chrome-' from inspector url

### DIFF
--- a/doc/api/debugger.md
+++ b/doc/api/debugger.md
@@ -185,9 +185,8 @@ flag instead of `--inspect`.
 
 ```console
 $ node --inspect index.js
-Debugger listening on 127.0.0.1:9229.
-To start debugging, open the following URL in Chrome:
-    chrome-devtools://devtools/bundled/js_app.html?experiments=true&v8only=true&ws=127.0.0.1:9229/dc9010dd-f8b8-4ac5-a510-c1a114ec7d29
+Debugger listening on ws://127.0.0.1:9229/dc9010dd-f8b8-4ac5-a510-c1a114ec7d29
+For help, see: https://nodejs.org/en/docs/inspector
 ```
 
 (In the example above, the UUID dc9010dd-f8b8-4ac5-a510-c1a114ec7d29

--- a/src/inspector_socket_server.cc
+++ b/src/inspector_socket_server.cc
@@ -373,7 +373,7 @@ void InspectorSocketServer::SendListResponse(InspectorSocket* socket,
 std::string InspectorSocketServer::GetFrontendURL(bool is_compat,
     const std::string &formatted_address) {
   std::ostringstream frontend_url;
-  frontend_url << "chrome-devtools://devtools/bundled/";
+  frontend_url << "devtools://devtools/bundled/";
   frontend_url << (is_compat ? "inspector" : "js_app");
   frontend_url << ".html?experiments=true&v8only=true&ws=";
   frontend_url << formatted_address;


### PR DESCRIPTION
It has been reported that the [V8 inspector extension](https://github.com/cjihrig/node-v8-inspector) can no longer connect to DevTools (despite no code changes to the extension since Feb. 2017). Upon investigation, Chrome dropped support for the `'chrome-devtools:'` scheme recently. I've confirmed that dropping `'chrome-'` from the URL here allows the debugger to function properly with modern Chrome.

Refs: https://chromium.googlesource.com/chromium/src/+/6700d12448f76712c62a6d2372a95b97a26d4779

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)