### PR TITLE
http2: run Http2ServerResponse.end's callback after 'finish' event is emitted

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -715,9 +715,7 @@ function onFinished(stream, cb) {
   function onfinish() {
     stream.removeListener('finish', onfinish);
     stream.removeListener('error', onerror);
-    process.nextTick(() => {
-      cb();
-    });
+    process.nextTick(cb);
   }
   stream.on('finish', onfinish);
   stream.prependListener('error', onerror);

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -715,7 +715,9 @@ function onFinished(stream, cb) {
   function onfinish() {
     stream.removeListener('finish', onfinish);
     stream.removeListener('error', onerror);
-    cb();
+    process.nextTick(() => {
+      cb();
+    });
   }
   stream.on('finish', onfinish);
   stream.prependListener('error', onerror);

--- a/test/parallel/test-stream-transform-final-sync.js
+++ b/test/parallel/test-stream-transform-final-sync.js
@@ -95,7 +95,7 @@ t.on('finish', common.mustCall(function() {
 t.on('end', common.mustCall(function() {
   state++;
   // endEvent
-  assert.strictEqual(state, 16);
+  assert.strictEqual(state, 15);
 }, 1));
 t.on('data', common.mustCall(function(d) {
   // dataListener
@@ -106,5 +106,5 @@ t.write(4);
 t.end(7, common.mustCall(function() {
   state++;
   // endMethodCallback
-  assert.strictEqual(state, 15);
+  assert.strictEqual(state, 16);
 }, 1));

--- a/test/parallel/test-stream-transform-final.js
+++ b/test/parallel/test-stream-transform-final.js
@@ -97,7 +97,7 @@ t.on('finish', common.mustCall(function() {
 t.on('end', common.mustCall(function() {
   state++;
   // end event
-  assert.strictEqual(state, 16);
+  assert.strictEqual(state, 15);
 }, 1));
 t.on('data', common.mustCall(function(d) {
   // dataListener
@@ -108,5 +108,5 @@ t.write(4);
 t.end(7, common.mustCall(function() {
   state++;
   // endMethodCallback
-  assert.strictEqual(state, 15);
+  assert.strictEqual(state, 16);
 }, 1));

--- a/test/parallel/test-stream-writable-end-cb-error.js
+++ b/test/parallel/test-stream-writable-end-cb-error.js
@@ -42,7 +42,10 @@ const stream = require('stream');
     assert.strictEqual(err.message, 'kaboom');
   }));
   writable.on('finish', common.mustCall(() => {
-    assert.strictEqual(called, true);
+    assert.strictEqual(called, false);
+    process.nextTick(() => {
+      assert.strictEqual(called, true);
+    });
     writable.emit('error', new Error('kaboom'));
   }));
 }

--- a/test/parallel/test-stream-write-destroy.js
+++ b/test/parallel/test-stream-write-destroy.js
@@ -57,7 +57,9 @@ for (const withPendingData of [ false, true ]) {
     w.destroy();
     assert.strictEqual(chunksWritten, 1);
     callbacks.shift()();
-    assert.strictEqual(chunksWritten, 2);
+    process.nextTick(() => {
+      assert.strictEqual(chunksWritten, 2);
+    });
     assert.strictEqual(callbacks.length, 0);
     assert.strictEqual(drains, 1);
 

--- a/test/parallel/test-stream-writev.js
+++ b/test/parallel/test-stream-writev.js
@@ -110,7 +110,7 @@ function test(decode, uncork, multi, next) {
   if (uncork)
     w.uncork();
 
-  w.end(cnt('end'));
+  w.end();
 
   w.on('finish', function() {
     // Make sure finish comes after all the write cb


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/29829

fixup: don't check for w.end

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
