### PR TITLE
events:use property, primordials

### DIFF
--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -8,6 +8,7 @@ const {
   Set,
   Symbol,
   NumberIsNaN,
+  SymbolToStringTag,
 } = primordials;
 
 const {
@@ -125,9 +126,14 @@ class Event {
   stopPropagation() {
     this.#propagationStopped = true;
   }
-
-  get [Symbol.toStringTag]() { return 'Event'; }
 }
+
+Object.defineProperty(Event.prototype, SymbolToStringTag, {
+  writable: false,
+  enumerable: false,
+  configurable: true,
+  value: 'Event',
+});
 
 // The listeners for an EventTarget are maintained as a linked list.
 // Unfortunately, the way EventTarget is defined, listeners are accounted
@@ -298,13 +304,18 @@ class EventTarget {
 
     return `${name} ${inspect({}, opts)}`;
   }
-  get [Symbol.toStringTag]() { return 'EventTarget'; }
 }
 
 Object.defineProperties(EventTarget.prototype, {
   addEventListener: { enumerable: true },
   removeEventListener: { enumerable: true },
   dispatchEvent: { enumerable: true }
+});
+Object.defineProperty(EventTarget.prototype, SymbolToStringTag, {
+  writable: false,
+  enumerable: false,
+  configurable: true,
+  value: 'EventTarget',
 });
 
 class NodeEventTarget extends EventTarget {

--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -61,7 +61,6 @@ class Event {
     // isTrusted is special (LegacyUnforgeable)
     Object.defineProperty(this, 'isTrusted', {
       get() { return false; },
-      set(ignoredValue) { return false; },
       enumerable: true,
       configurable: false
     });


### PR DESCRIPTION
Per Web IDL, EventTarget.prototype[Symbol.toStringTag] should be a data property, not a getter. Commit https://github.com/nodejs/node/commit/56e44601d285483ffe3c6efa3b80743900d84856 introduced it as a getter.

This commit uses SymbolToStringTag from primordials and sets it as a property and not a getter.

Thank you Domenic for pointing this out!

Fixes: #33773
cc @jasnell 


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
