### PR TITLE
module: Private internal exports subpaths

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1697,6 +1697,14 @@ The `package.json` [exports][] field does not export the requested subpath.
 Because exports are encapsulated, private internal modules that are not exported
 cannot be imported through the package resolution, unless using an absolute URL.
 
+<a id="ERR_PRIVATE_PACKAGE_PATH"></a>
+### `ERR_PRIVATE_PACKAGE_PATH`
+
+Thrown when trying to access a private exports subpath from outside a package.
+Private package subpaths starting with `#` defined in the `package.json`
+[exports][] field can only be resolved from within modules of the same package
+using [package internal self-resolution][].
+
 <a id="ERR_PROTO_ACCESS"></a>
 ### `ERR_PROTO_ACCESS`
 
@@ -2059,9 +2067,9 @@ signal (such as [`subprocess.kill()`][]).
 <a id="ERR_UNSUPPORTED_DIR_IMPORT"></a>
 ### `ERR_UNSUPPORTED_DIR_IMPORT`
 
-`import` a directory URL is unsupported. Instead, you can
-[self-reference a package using its name][] and [define a custom subpath][] in
-the `"exports"` field of the `package.json` file.
+`import` a directory URL is unsupported. Instead use explicit file paths
+or the package author can [define a custom subpath][] in the `"exports"` field
+of the `package.json` file.
 
 <!-- eslint-skip -->
 ```js
@@ -2624,5 +2632,5 @@ such as `process.stdout.on('data')`.
 [Subresource Integrity specification]: https://www.w3.org/TR/SRI/#the-integrity-attribute
 [try-catch]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch
 [vm]: vm.html
-[self-reference a package using its name]: esm.html#esm_self_referencing_a_package_using_its_name
+[package internal self-resolution]: esm.html#esm_self_referencing_a_package_using_its_name
 [define a custom subpath]: esm.html#esm_subpath_exports

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -1634,6 +1634,8 @@ The resolver can throw the following errors:
 >       1. If _pjson_ is not **null** and _pjson_ has an _"exports"_ key, then
 >          1. Let _exports_ be _pjson.exports_.
 >          1. If _exports_ is not **null** or **undefined**, then
+>             1. If _packageSubpath_ starts with _"#"_, then
+>                1. Throw a _Private Package Path_ error.
 >             1. Return **PACKAGE_EXPORTS_RESOLVE**(_packageURL_,
 >                _packageSubpath_, _pjson.exports_).
 >       1. Return the URL resolution of _packageSubpath_ in _packageURL_.
@@ -1656,9 +1658,9 @@ The resolver can throw the following errors:
 >       1. If _pjson_ is not **null** and _pjson_ has an _"exports"_ key, then
 >          1. Let _exports_ be _pjson.exports_.
 >          1. If _exports_ is not **null** or **undefined**, then
->             1. Return **PACKAGE_EXPORTS_RESOLVE**(_packageURL_, _subpath_,
->                _pjson.exports_).
->       1. Return the URL resolution of _subpath_ in _packageURL_.
+>             1. Return **PACKAGE_EXPORTS_RESOLVE**(_packageURL_,
+>                _packageSubpath_, _pjson.exports_).
+>       1. Return the URL resolution of _packageSubpath_ in _packageURL_.
 > 1. Otherwise, return **undefined**.
 
 **PACKAGE_MAIN_RESOLVE**(_packageURL_, _pjson_)
@@ -1682,7 +1684,7 @@ The resolver can throw the following errors:
 >    _Module Not Found_ error for no resolution.
 > 1. Return _legacyMainURL_.
 
-**PACKAGE_EXPORTS_RESOLVE**(_packageURL_, _packagePath_, _exports_)
+**PACKAGE_EXPORTS_RESOLVE**(_packageURL_, _packageSubpath_, _exports_)
 > 1. If _exports_ is an Object with both a key starting with _"."_ and a key not
 >    starting with _"."_, throw an _Invalid Package Configuration_ error.
 > 1. If _exports_ is an Object and all keys of _exports_ start with _"."_, then

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1314,6 +1314,10 @@ E('ERR_PACKAGE_PATH_NOT_EXPORTED', (pkgPath, subpath, base = undefined) => {
   return `Package subpath '${subpath}' is not defined by "exports" in ${
     pkgPath} imported from ${base}`;
 }, Error);
+E('ERR_PRIVATE_PACKAGE_PATH', (pkgPath, subpath, base = undefined) => {
+  return `Private package subpath '${subpath}' can only be resolved from within
+      the package ${pkgPath}${base ? `, imported from ${base}` : ''}`;
+}, Error);
 E('ERR_REQUIRE_ESM',
   (filename, parentPath = null, packageJsonPath = null) => {
     let msg = `Must use import to load ES Module: ${filename}`;

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -90,6 +90,7 @@ const {
   ERR_INVALID_PACKAGE_TARGET,
   ERR_INVALID_MODULE_SPECIFIER,
   ERR_PACKAGE_PATH_NOT_EXPORTED,
+  ERR_PRIVATE_PACKAGE_PATH,
   ERR_REQUIRE_ESM
 } = require('internal/errors').codes;
 const { validateString } = require('internal/validators');
@@ -527,6 +528,15 @@ function resolveExports(nmPath, request) {
   }
 
   const basePath = path.resolve(nmPath, name);
+
+  if (StringPrototypeStartsWith(expansion, '/#')) {
+    // Only throw private subpath errors when exports field is defined.
+    const pkgExports = readPackageExports(basePath);
+    if (pkgExports === undefined || pkgExports === null)
+      return false;
+    throw new ERR_PRIVATE_PACKAGE_PATH(basePath, '.' + expansion, request);
+  }
+
   const fromExports = applyExports(basePath, expansion);
   if (fromExports) {
     return tryFile(fromExports, false);

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -45,6 +45,7 @@ const {
   ERR_INVALID_PACKAGE_TARGET,
   ERR_MODULE_NOT_FOUND,
   ERR_PACKAGE_PATH_NOT_EXPORTED,
+  ERR_PRIVATE_PACKAGE_PATH,
   ERR_UNSUPPORTED_DIR_IMPORT,
   ERR_UNSUPPORTED_ESM_URL_SCHEME,
 } = require('internal/errors').codes;
@@ -121,7 +122,7 @@ function getPackageConfig(path) {
     main,
     name,
     type,
-    exports
+    exports: exports === null ? undefined : exports
   };
   packageJSONCache.set(path, packageConfig);
   return packageConfig;
@@ -581,6 +582,12 @@ function packageResolve(specifier, base, conditions) {
       return packageMainResolve(packageJSONUrl, packageConfig, base,
                                 conditions);
     } else if (packageConfig.exports !== undefined) {
+      if (StringPrototypeStartsWith(packageSubpath, './#') &&
+          packageConfig.exports !== undefined) {
+        throw new ERR_PRIVATE_PACKAGE_PATH(
+          removePackageJsonFromPath(fileURLToPath(packageJSONUrl)),
+          packageSubpath, fileURLToPath(base));
+      }
       return packageExportsResolve(
         packageJSONUrl, packageSubpath, packageConfig, base, conditions);
     }

--- a/test/es-module/test-esm-exports.mjs
+++ b/test/es-module/test-esm-exports.mjs
@@ -179,15 +179,24 @@ import fromInside from '../fixtures/node_modules/pkgexports/lib/hole.js';
     'package subpath keys or an object of main entry condition name keys ' +
     'only.');
   }));
+
+  // Private mappings should throw a private error when imported externally
+  loadFixture('pkgexports/#private').catch(mustCall((err) => {
+    strictEqual(err.code, 'ERR_PRIVATE_PACKAGE_PATH');
+    assertStartsWith(err.message, 'Private package subpath \'./#private\'');
+  }));
 });
 
 const { requireFromInside, importFromInside } = fromInside;
 [importFromInside, requireFromInside].forEach((loadFromInside) => {
+  const isRequire = loadFromInside === requireFromInside;
   const validSpecifiers = new Map([
     // A file not visible from outside of the package
     ['../not-exported.js', { default: 'not-exported' }],
     // Part of the public interface
     ['pkgexports/valid-cjs', { default: 'asdf' }],
+    // Private mappings
+    ['pkg-exports/#private', { default: isRequire ? 'cjs' : 'esm' }],
   ]);
   for (const [validSpecifier, expected] of validSpecifiers) {
     if (validSpecifier === null) continue;

--- a/test/fixtures/node_modules/pkgexports/package.json
+++ b/test/fixtures/node_modules/pkgexports/package.json
@@ -1,6 +1,10 @@
 {
   "name": "pkg-exports",
   "exports": {
+    "./#private": {
+      "require": "./private-cjs.cjs",
+      "import": "./private-esm.mjs"
+    },
     "./hole": "./lib/hole.js",
     "./space": "./sp%20ce.js",
     "./valid-cjs": "./asdf.js",

--- a/test/fixtures/node_modules/pkgexports/private-cjs.cjs
+++ b/test/fixtures/node_modules/pkgexports/private-cjs.cjs
@@ -1,0 +1,2 @@
+module.exports = 'cjs';
+

--- a/test/fixtures/node_modules/pkgexports/private-esm.mjs
+++ b/test/fixtures/node_modules/pkgexports/private-esm.mjs
@@ -1,0 +1,1 @@
+export default 'esm';

--- a/test/fixtures/node_modules/pkgexports/private-importer.mjs
+++ b/test/fixtures/node_modules/pkgexports/private-importer.mjs
@@ -1,0 +1,2 @@
+export { default } from 'pkg-exports/#private';
+


### PR DESCRIPTION
This PR defines private exports subpaths to be those exports starting with `./#`, and then throws an `ERR_PRIVATE_PACKAGE_PATH` when attempting to resolve these exports from outside of the package, so that they can only be resolved via package self-resolution.

A package that defines these mappings today, for example:

```js
{
  "exports": {
    ".": "./main.js",
    "./#internal": "./internal.js"
  }
}
```

will already work correctly under the current exports implementation in Node.js 12 such that `pkg/#internal` can be imported and required from outside of the package and from within the package using package own name self-resolution.

This PR only adds a new validation phase to these resolutions that throws the error when importing from outside of the package, thereby creating a new private encapsulation layer. This keeps the implementation simple and backwards compatible as opposed to defining a whole new type of private resolution.

### Motivation

Package exports provide a number of features both to the external API of the package imported by consumers of the package (`import 'pkg/x'`) and also to the internal resolutions used by the package author themselves when using self-resolution (`import 'pkg/x'` from within modules of the package itself).

The issue is that any time a package author might want to take advantage of exports features using own-name self-resolution such as for internal directory mappings, avoiding the need for file extensions, or providing internal conditional resolutions, by using the `"exports"` field they must make these modules public by default.

For these use cases, it can be useful to allow package authors to have private internal resolutions that only apply for internal self-resolution but aren't defined as part of the public exports interface of the package.

The `#` symbol has been chosen as its meaning matches that of private fields in classes.

This effectively then also provides a solution to the browser field "internal file mappings" use case for the exports field, allowing packages to swap out internal modules based on environment conditions, thus fully replacing the functionality of the browser field for arbitrary condition handling in exports.

Prior art:
* [Browser field internal mappings](https://github.com/defunctzombie/package-browser-field-spec#replace-specific-files---advanced)
* [Imports field](https://github.com/jkrems/proposal-pkg-exports/#3-imports-field)
* [Recent discussion on this topic started by @jkrems](https://github.com/jkrems/proposal-pkg-exports/issues/47)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
