### PR TITLE
doc: fix linting in doc-style-guide.md [master-failing]

### DIFF
--- a/doc/guides/doc-style-guide.md
+++ b/doc/guides/doc-style-guide.md
@@ -61,11 +61,11 @@
   <!-- lint disable prohibited-strings remark-lint-->
   * NOT OK: It is important to note that, in all cases, the return value will be
     a string regardless.
-  <!-- lint enable prohibited-strings remark-lint-->
 * When referring to a version of Node.js in prose, use _Node.js_ and the version
   number. Do not prefix the version number with _v_ in prose. This is to avoid
   confusion about whether _v8_ refers to Node.js 8.x or the V8 JavaScript
   engine.
+  <!-- lint enable prohibited-strings remark-lint-->
   * OK: _Node.js 14.x_, _Node.js 14.3.1_
   * NOT OK: _Node.js v14_
 


### PR DESCRIPTION
Disable lint checks (enable prohibited-strings remark-lint) for
doc-style-guide.md:66. This is producing lint errors in builds
on master.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
