### PR TITLE
Revert "test: stop testing --interpreted-frames-native-stack for s390x"

### DIFF
--- a/test/parallel/test-cli-node-options.js
+++ b/test/parallel/test-cli-node-options.js
@@ -74,8 +74,8 @@ expect('--stack-trace-limit=100',
        /(\s*at f \(\[(eval|worker eval)\]:1:\d*\)\r?\n)/,
        '(function f() { f(); })();',
        true);
-// Unsupported on arm and s390. See https://crbug.com/v8/8713.
-if (!['arm', 'arm64', 's390x'].includes(process.arch))
+// Unsupported on arm. See https://crbug.com/v8/8713.
+if (!['arm', 'arm64'].includes(process.arch))
   expect('--interpreted-frames-native-stack', 'B\n');
 
 // Workers can't eval as ES Modules. https://github.com/nodejs/node/issues/30682


### PR DESCRIPTION
Revert "test: stop testing --interpreted-frames-native-stack for s390x"

This reverts commit 38fd93c9a8669929dac09ad9441937bc0bb58c6c.

Refs: https://github.com/nodejs/node/pull/33702

@nodejs/platform-s390 