### PR TITLE
util: gracefully handle unknown colors

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -478,7 +478,8 @@ function stylizeWithColor(str, styleType) {
   const style = inspect.styles[styleType];
   if (style !== undefined) {
     const color = inspect.colors[style];
-    return `\u001b[${color[0]}m${str}\u001b[${color[1]}m`;
+    if (color !== undefined)
+      return `\u001b[${color[0]}m${str}\u001b[${color[1]}m`;
   }
   return str;
 }

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -2249,7 +2249,7 @@ assert.strictEqual(
   // Unknown colors are handled gracefully:
   const stringStyle = inspect.styles.string;
   inspect.styles.string = 'UNKNOWN';
-  assert.strictEqual(inspect('foobar', { colors: true }), 'foobar');
+  assert.strictEqual(inspect('foobar', { colors: true }), "'foobar'");
   inspect.styles.string = stringStyle;
 }
 

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -2245,6 +2245,12 @@ assert.strictEqual(
     assert.deepStrictEqual(inspect.colors[bgColor], [40 + i, 49]);
     assert.deepStrictEqual(inspect.colors[`${bgColor}Bright`], [100 + i, 49]);
   });
+
+  // Unknown colors are handled gracefully:
+  const stringStyle = inspect.styles.string;
+  inspect.styles.string = 'UNKNOWN';
+  assert.strictEqual(inspect('foobar', { colors: true }), 'foobar');
+  inspect.styles.string = stringStyle;
 }
 
 assert.strictEqual(


### PR DESCRIPTION
This makes sure colors that are unknown won't cause an error. This
is especially important in case a library wants to use colors
defined by Node.js core, if available and fall back to the default
otherwise.

Signed-off-by: Ruben Bridgewater <ruben@bridgewater.de>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
