### PR TITLE
[v14.x] Backport 33570 and 33508 to v14.x

### DIFF
--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -267,7 +267,7 @@ class RefBase : protected Finalizer, RefTracker {
  protected:
   inline void Finalize(bool is_env_teardown = false) override {
     if (_finalize_callback != nullptr) {
-      _env->CallIntoModuleThrow([&](napi_env env) {
+      _env->CallIntoModule([&](napi_env env) {
         _finalize_callback(
             env,
             _finalize_data,
@@ -475,7 +475,7 @@ class CallbackWrapperBase : public CallbackWrapper {
     napi_callback cb = _bundle->*FunctionField;
 
     napi_value result;
-    env->CallIntoModuleThrow([&](napi_env env) {
+    env->CallIntoModule([&](napi_env env) {
       result = cb(env, cbinfo_wrapper);
     });
 

--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -267,6 +267,7 @@ class RefBase : protected Finalizer, RefTracker {
  protected:
   inline void Finalize(bool is_env_teardown = false) override {
     if (_finalize_callback != nullptr) {
+      v8::HandleScope handle_scope(_env->isolate);
       _env->CallIntoModule([&](napi_env env) {
         _finalize_callback(
             env,

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -57,7 +57,7 @@ class BufferFinalizer : private Finalizer {
       v8::HandleScope handle_scope(finalizer->_env->isolate);
       v8::Context::Scope context_scope(finalizer->_env->context());
 
-      finalizer->_env->CallIntoModuleThrow([&](napi_env env) {
+      finalizer->_env->CallIntoModule([&](napi_env env) {
         finalizer->_finalize_callback(
             env,
             finalizer->_finalize_data,
@@ -331,7 +331,7 @@ class ThreadSafeFunction : public node::AsyncResource {
           v8::Local<v8::Function>::New(env->isolate, ref);
         js_callback = v8impl::JsValueFromV8LocalValue(js_cb);
       }
-      env->CallIntoModuleThrow([&](napi_env env) {
+      env->CallIntoModule([&](napi_env env) {
         call_js_cb(env, js_callback, context, data);
       });
     }
@@ -341,7 +341,7 @@ class ThreadSafeFunction : public node::AsyncResource {
     v8::HandleScope scope(env->isolate);
     if (finalize_cb) {
       CallbackScope cb_scope(this);
-      env->CallIntoModuleThrow([&](napi_env env) {
+      env->CallIntoModule([&](napi_env env) {
         finalize_cb(env, finalize_data, context);
       });
     }
@@ -478,7 +478,7 @@ void napi_module_register_by_symbol(v8::Local<v8::Object> exports,
   napi_env env = v8impl::NewEnv(context);
 
   napi_value _exports;
-  env->CallIntoModuleThrow([&](napi_env env) {
+  env->CallIntoModule([&](napi_env env) {
     _exports = init(env, v8impl::JsValueFromV8LocalValue(exports));
   });
 

--- a/test/node-api/test_worker_terminate_finalization/binding.gyp
+++ b/test/node-api/test_worker_terminate_finalization/binding.gyp
@@ -1,0 +1,8 @@
+{
+  "targets": [
+    {
+      "target_name": "test_worker_terminate_finalization",
+      "sources": [ "test_worker_terminate_finalization.c" ]
+    }
+  ]
+}

--- a/test/node-api/test_worker_terminate_finalization/test.js
+++ b/test/node-api/test_worker_terminate_finalization/test.js
@@ -1,0 +1,18 @@
+'use strict';
+const common = require('../../common');
+const { Worker, isMainThread } = require('worker_threads');
+
+if (isMainThread) {
+  const worker = new Worker(__filename);
+  worker.on('error', common.mustNotCall());
+} else {
+  const { Test } =
+    require(`./build/${common.buildType}/test_worker_terminate_finalization`);
+
+  // Spin up thread and call add-on create the right sequence
+  // of rerences to hit the case reported in
+  // https://github.com/nodejs/node-addon-api/issues/722
+  // will crash if run under debug and its not possible to
+  // create object in the specific finalizer
+  Test(new Object());
+}

--- a/test/node-api/test_worker_terminate_finalization/test_worker_terminate_finalization.c
+++ b/test/node-api/test_worker_terminate_finalization/test_worker_terminate_finalization.c
@@ -1,0 +1,48 @@
+#include <stdio.h>
+#include <node_api.h>
+#include <assert.h>
+#include <stdlib.h>
+#include "../../js-native-api/common.h"
+
+#define BUFFER_SIZE 4
+
+int wrappedNativeData;
+napi_ref ref;
+void WrapFinalizer(napi_env env, void* data, void* hint) {
+  uint32_t count;
+  NAPI_CALL_RETURN_VOID(env, napi_reference_unref(env, ref, &count));
+  NAPI_CALL_RETURN_VOID(env, napi_delete_reference(env, ref));
+}
+
+void BufferFinalizer(napi_env env, void* data, void* hint) {
+  free(hint);
+}
+
+napi_value Test(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value argv[1];
+  napi_value result;
+  napi_ref ref;
+  void* bufferData = malloc(BUFFER_SIZE);
+
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, argv, NULL, NULL));
+  NAPI_CALL(env, napi_create_external_buffer(env, BUFFER_SIZE, bufferData, BufferFinalizer, bufferData, &result));
+  NAPI_CALL(env, napi_create_reference(env, result, 1, &ref));
+  NAPI_CALL(env, napi_wrap(env, argv[0], (void*) &wrappedNativeData, WrapFinalizer, NULL, NULL));
+  return NULL;
+}
+
+napi_value Init(napi_env env, napi_value exports) {
+  napi_property_descriptor properties[] = {
+    DECLARE_NAPI_PROPERTY("Test", Test)
+  };
+
+  NAPI_CALL(env, napi_define_properties(
+      env, exports, sizeof(properties) / sizeof(*properties), properties));
+
+  return exports;
+}
+
+// Do not start using NAPI_MODULE_INIT() here, so that we can test
+// compatibility of Workers with NAPI_MODULE().
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)


### PR DESCRIPTION
#33508 cannot be backported directly, but must be preceded with a backport of #33570.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
