### PR TITLE
http: emit 'close' when sockets are not constructed

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -296,6 +296,11 @@ OutgoingMessage.prototype.destroy = function destroy(error) {
     });
   }
 
+  if (this instanceof OutgoingMessage) {
+    process.nextTick(() => {
+      this.emit('close');
+    });
+  }
   return this;
 };
 

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -297,9 +297,7 @@ OutgoingMessage.prototype.destroy = function destroy(error) {
   }
 
   if (this instanceof OutgoingMessage) {
-    process.nextTick(() => {
-      this.emit('close');
-    });
+    process.nextTick(() => this.emit('close'));
   }
   return this;
 };

--- a/test/parallel/test-http-outgoing-destroy.js
+++ b/test/parallel/test-http-outgoing-destroy.js
@@ -10,6 +10,9 @@ const OutgoingMessage = http.OutgoingMessage;
   assert.strictEqual(msg.destroyed, false);
   msg.destroy();
   assert.strictEqual(msg.destroyed, true);
+  msg.on('close', common.mustCall(() => {
+    assert.strictEqual(msg.destroyed, true);
+  }));
   let callbackCalled = false;
   msg.write('asd', common.mustCall((err) => {
     assert.strictEqual(err.code, 'ERR_STREAM_DESTROYED');


### PR DESCRIPTION
`OutgoingMessage#socket` is `null` for such cases at all times.
Hence, we emit a 'close' event, imitating `destroyImpl.destroy`,
without the socket operations.

Fixes: https://github.com/nodejs/node/issues/33653

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
