### PR TITLE
fix(cluster): respect the backlog from workers

### DIFF
--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -367,6 +367,10 @@ server.listen({
 });
 ```
 
+When `exclusive` is `true` and the underlying handle is shared, it's
+possible that several workers query a handle with different backlogs.
+In this case, the first `backlog` passed to the master process will be used.
+
 Starting an IPC server as root may cause the server path to be inaccessible for
 unprivileged users. Using `readableAll` and `writableAll` will make the server
 accessible for all users.

--- a/lib/internal/cluster/round_robin_handle.js
+++ b/lib/internal/cluster/round_robin_handle.js
@@ -13,7 +13,7 @@ const { constants } = internalBinding('tcp_wrap');
 
 module.exports = RoundRobinHandle;
 
-function RoundRobinHandle(key, address, { port, fd, flags }) {
+function RoundRobinHandle(key, address, { port, fd, flags, backlog }) {
   this.key = key;
   this.all = new Map();
   this.free = new Map();
@@ -22,16 +22,17 @@ function RoundRobinHandle(key, address, { port, fd, flags }) {
   this.server = net.createServer(assert.fail);
 
   if (fd >= 0)
-    this.server.listen({ fd });
+    this.server.listen({ fd, backlog });
   else if (port >= 0) {
     this.server.listen({
       port,
       host: address,
       // Currently, net module only supports `ipv6Only` option in `flags`.
       ipv6Only: Boolean(flags & constants.UV_TCP_IPV6ONLY),
+      backlog,
     });
   } else
-    this.server.listen(address);  // UNIX socket path.
+    this.server.listen(address, backlog);  // UNIX socket path.
 
   this.server.once('listening', () => {
     this.handle = this.server._handle;

--- a/lib/net.js
+++ b/lib/net.js
@@ -1343,6 +1343,7 @@ function listenInCluster(server, address, port, addressType,
     addressType: addressType,
     fd: fd,
     flags,
+    backlog,
   };
 
   // Get the master's server handle, and listen on it

--- a/test/parallel/test-cluster-net-listen-backlog.js
+++ b/test/parallel/test-cluster-net-listen-backlog.js
@@ -1,37 +1,35 @@
 'use strict';
 
 const common = require('../common');
-const Countdown = require('../common/countdown');
 const assert = require('assert');
-// Monkey-patch `net.Server._listen2`
+// Monkey-patch `net.Server.listen`
 const net = require('net');
 const cluster = require('cluster');
 
 // Ensures that the `backlog` is used to create a `net.Server`.
 const kExpectedBacklog = 127;
 if (cluster.isMaster) {
-  let worker
+  const listen = net.Server.prototype.listen;
 
-  const nativeListen = net.Server.prototype._listen2;
-  const countdown = new Countdown(2, () => {
-    worker.disconnect();
-  });
-
-  net.Server.prototype._listen2 = common.mustCall(
-    function(address, port, addressType, backlog, fd, flags) {
-      assert(backlog, kExpectedBacklog);
-      countdown.dec();
-      return nativeListen.call(this, address, port, addressType, backlog, fd, flags);
+  net.Server.prototype.listen = common.mustCall(
+    function(...args) {
+      const options = args[0];
+      if (typeof options === 'object') {
+        assert(options.backlog, kExpectedBacklog);
+      } else {
+        assert(args[1], kExpectedBacklog);
+      }
+      return listen.call(this, ...args);
     }
   );
 
-  worker = cluster.fork();
+  const worker = cluster.fork();
   worker.on('message', () => {
-    countdown.dec();
+    worker.disconnect();
   });
 } else {
-  const server = net.createServer()
-  
+  const server = net.createServer();
+
   server.listen({
     host: common.localhostIPv4,
     port: 0,

--- a/test/parallel/test-cluster-net-listen-backlog.js
+++ b/test/parallel/test-cluster-net-listen-backlog.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const common = require('../common');
+const Countdown = require('../common/countdown');
+const assert = require('assert');
+// Monkey-patch `net.Server._listen2`
+const net = require('net');
+const cluster = require('cluster');
+
+// Ensures that the `backlog` is used to create a `net.Server`.
+const kExpectedBacklog = 127;
+if (cluster.isMaster) {
+  let worker
+
+  const nativeListen = net.Server.prototype._listen2;
+  const countdown = new Countdown(2, () => {
+    worker.disconnect();
+  });
+
+  net.Server.prototype._listen2 = common.mustCall(
+    function(address, port, addressType, backlog, fd, flags) {
+      assert(backlog, kExpectedBacklog);
+      countdown.dec();
+      return nativeListen.call(this, address, port, addressType, backlog, fd, flags);
+    }
+  );
+
+  worker = cluster.fork();
+  worker.on('message', () => {
+    countdown.dec();
+  });
+} else {
+  const server = net.createServer()
+  
+  server.listen({
+    host: common.localhostIPv4,
+    port: 0,
+    backlog: kExpectedBacklog,
+  }, common.mustCall(() => {
+    process.send(true);
+  }));
+}


### PR DESCRIPTION
Encounter the same issue of https://github.com/nodejs/node/pull/4056.

Currently, the master process would ignore `backlog` passed from worker processes and use the default value instead. This commit will respect the first `backlog` passed to the master process for a specific handle.

It seems hard to test `backlog` in a Node.js script. I use the script below and `ss` to check `backlog`. It's correct on my Linux(Ubuntu):
```js
const net = require('net');
const cluster = require('cluster');
const path = require('path');

if (cluster.isMaster) {
  const workers = [];

  for (let i = 0; i < 2; i += 1) {
    const worker = cluster.fork();
    workers.push(worker);
  }
} else {
  net.createServer().listen(9230, 7); // ss -l
  net.createServer().listen(path.resolve(__dirname, './test.sock'), 7); // ss -x -l
}
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
