### PR TITLE
doc: clarify require/import complement exclusivity

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -424,10 +424,10 @@ Node.js supports the following conditions:
 * `"import"` - matched when the package is loaded via `import` or
    `import()`. Can reference either an ES module or CommonJS file, as both
    `import` and `import()` can load either ES module or CommonJS sources.
-   _Mutually exclusive with the `"require"` condition._
+   _Always matched when the `"require"` condition is not matched._
 * `"require"` - matched when the package is loaded via `require()`.
    As `require()` only supports CommonJS, the referenced file must be CommonJS.
-   _Mutually exclusive with the `"import"` condition._
+   _Always matched when the `"import"` condition is not matched._
 * `"node"` - matched for any Node.js environment. Can be a CommonJS or ES
    module file. _This condition should always come after `"import"` or
    `"require"`._

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -424,8 +424,10 @@ Node.js supports the following conditions:
 * `"import"` - matched when the package is loaded via `import` or
    `import()`. Can reference either an ES module or CommonJS file, as both
    `import` and `import()` can load either ES module or CommonJS sources.
+   _Mutually exclusive with the `"require"` condition._
 * `"require"` - matched when the package is loaded via `require()`.
    As `require()` only supports CommonJS, the referenced file must be CommonJS.
+   _Mutually exclusive with the `"import"` condition._
 * `"node"` - matched for any Node.js environment. Can be a CommonJS or ES
    module file. _This condition should always come after `"import"` or
    `"require"`._


### PR DESCRIPTION
This PR adds a small doc change to clearly define that `"import"` and `"require"` are always mutually exclusive in exports (if something was not required then it definitely was imported) when loading an ES module.

Currently there isn't clear guidance that when defining in "exports":

```js
{
  "exports": {
    "import": "./main.mjs",
    "require": "./main.cjs",
    "default": "./main.js"
  }
}
```

that it **should never be possible to resolve to `./main.js`**.

For example, other tools and bundlers could interpret `new Worker('pkg')` to not be an `import` or `require` path at all. Or similarly for other mechanisms of loading in future. When we should always define that loading an ES module goes through the `import` path.

Otherwise, this leaves a semantic gap where users might find `default` matched by some tools in the above example. By narrowing this gap we ensure we can continue to provide predictability between tools.

//cc @nodejs/modules-active-members 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
