### PR TITLE
timers: allow promisified timeouts/immediates to be canceled

### DIFF
--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -232,8 +232,47 @@ The [`setImmediate()`][], [`setInterval()`][], and [`setTimeout()`][] methods
 each return objects that represent the scheduled timers. These can be used to
 cancel the timer and prevent it from triggering.
 
-It is not possible to cancel timers that were created using the promisified
-variants of [`setImmediate()`][], [`setTimeout()`][].
+For the promisified variants of [`setImmediate()`][] and [`setTimeout()`][],
+an [`AbortController`][] may be used to cancel the timer. When canceled, the
+returned Promises will be rejected with an `'AbortError'`.
+
+For `setImmediate()`:
+
+```js
+const util = require('util');
+const setImmediatePromise = util.promisify(setImmediate);
+
+const ac = new AbortController();
+const signal = ac.signal;
+
+setImmediatePromise('foobar', { signal })
+  .then(console.log)
+  .catch((err) => {
+    if (err.message === 'AbortError')
+      console.log('The immediate was aborted');
+  });
+
+ac.abort();
+```
+
+For `setTimeout()`:
+
+```js
+const util = require('util');
+const setTimeoutPromise = util.promisify(setTimeout);
+
+const ac = new AbortController();
+const signal = ac.signal;
+
+setTimeoutPromise(1000, 'foobar', { signal })
+  .then(console.log)
+  .catch((err) => {
+    if (err.message === 'AbortError')
+      console.log('The timeout was aborted');
+  });
+
+ac.abort();
+```
 
 ### `clearImmediate(immediate)`
 <!-- YAML
@@ -264,6 +303,7 @@ added: v0.0.1
 Cancels a `Timeout` object created by [`setTimeout()`][].
 
 [Event Loop]: https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick/#setimmediate-vs-settimeout
+[`AbortController`]: globals.html#globals_class_abortcontroller
 [`TypeError`]: errors.html#errors_class_typeerror
 [`clearImmediate()`]: timers.html#timers_clearimmediate_immediate
 [`clearInterval()`]: timers.html#timers_clearinterval_timeout

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -27,6 +27,12 @@ const {
 } = primordials;
 
 const {
+  codes: { ERR_INVALID_ARG_TYPE }
+} = require('internal/errors');
+
+let DOMException;
+
+const {
   immediateInfo,
   toggleImmediateRef
 } = internalBinding('timers');
@@ -118,6 +124,11 @@ function enroll(item, msecs) {
  * DOM-style timers
  */
 
+function lazyDOMException(message) {
+  if (DOMException === undefined)
+    DOMException = internalBinding('messaging').DOMException;
+  return new DOMException(message);
+}
 
 function setTimeout(callback, after, arg1, arg2, arg3) {
   validateCallback(callback);
@@ -149,11 +160,40 @@ function setTimeout(callback, after, arg1, arg2, arg3) {
   return timeout;
 }
 
-setTimeout[customPromisify] = function(after, value) {
+setTimeout[customPromisify] = function(after, value, options = {}) {
   const args = value !== undefined ? [value] : value;
-  return new Promise((resolve) => {
+  if (options == null || typeof options !== 'object') {
+    return Promise.reject(
+      new ERR_INVALID_ARG_TYPE(
+        'options',
+        'Object',
+        options));
+  }
+  const { signal } = options;
+  if (signal !== undefined &&
+      (signal === null ||
+       typeof signal !== 'object' ||
+       !('aborted' in signal))) {
+    return Promise.reject(
+      new ERR_INVALID_ARG_TYPE(
+        'options.signal',
+        'AbortSignal',
+        signal));
+  }
+  // TODO(@jasnell): If a decision is made that this cannot be backported
+  // to 12.x, then this can be converted to use optional chaining to
+  // simplify the check.
+  if (signal && signal.aborted)
+    return Promise.reject(lazyDOMException('AbortError'));
+  return new Promise((resolve, reject) => {
     const timeout = new Timeout(resolve, after, args, false, true);
     insert(timeout, timeout._idleTimeout);
+    if (signal) {
+      signal.addEventListener('abort', () => {
+        clearTimeout(timeout);
+        reject(lazyDOMException('AbortError'));
+      }, { once: true });
+    }
   });
 };
 
@@ -272,8 +312,39 @@ function setImmediate(callback, arg1, arg2, arg3) {
   return new Immediate(callback, args);
 }
 
-setImmediate[customPromisify] = function(value) {
-  return new Promise((resolve) => new Immediate(resolve, [value]));
+setImmediate[customPromisify] = function(value, options = {}) {
+  if (options == null || typeof options !== 'object') {
+    return Promise.reject(
+      new ERR_INVALID_ARG_TYPE(
+        'options',
+        'Object',
+        options));
+  }
+  const { signal } = options;
+  if (signal !== undefined &&
+    (signal === null ||
+     typeof signal !== 'object' ||
+     !('aborted' in signal))) {
+    return Promise.reject(
+      new ERR_INVALID_ARG_TYPE(
+        'options.signal',
+        'AbortSignal',
+        signal));
+  }
+  // TODO(@jasnell): If a decision is made that this cannot be backported
+  // to 12.x, then this can be converted to use optional chaining to
+  // simplify the check.
+  if (signal && signal.aborted)
+    return Promise.reject(lazyDOMException('AbortError'));
+  return new Promise((resolve, reject) => {
+    const immediate = new Immediate(resolve, [value]);
+    if (signal) {
+      signal.addEventListener('abort', () => {
+        clearImmediate(immediate);
+        reject(lazyDOMException('AbortError'));
+      }, { once: true });
+    }
+  });
 };
 
 function clearImmediate(immediate) {

--- a/test/parallel/test-timers-promisified.js
+++ b/test/parallel/test-timers-promisified.js
@@ -1,3 +1,4 @@
+// Flags: --no-warnings
 'use strict';
 const common = require('../common');
 const assert = require('assert');
@@ -35,4 +36,57 @@ const setImmediate = promisify(timers.setImmediate);
   promise.then(common.mustCall((value) => {
     assert.strictEqual(value, 'foobar');
   }));
+}
+
+{
+  const ac = new AbortController();
+  const signal = ac.signal;
+  assert.rejects(setTimeout(10, undefined, { signal }), /AbortError/);
+  ac.abort();
+}
+
+{
+  const ac = new AbortController();
+  const signal = ac.signal;
+  ac.abort(); // Abort in advance
+  assert.rejects(setTimeout(10, undefined, { signal }), /AbortError/);
+}
+
+{
+  const ac = new AbortController();
+  const signal = ac.signal;
+  assert.rejects(setImmediate(10, { signal }), /AbortError/);
+  ac.abort();
+}
+
+{
+  const ac = new AbortController();
+  const signal = ac.signal;
+  ac.abort(); // Abort in advance
+  assert.rejects(setImmediate(10, { signal }), /AbortError/);
+}
+
+{
+  Promise.all(
+    [1, '', false, Infinity].map((i) => assert.rejects(setImmediate(10, i)), {
+      code: 'ERR_INVALID_ARG_TYPE'
+    })).then(common.mustCall());
+
+  Promise.all(
+    [1, '', false, Infinity, null, {}].map(
+      (signal) => assert.rejects(setImmediate(10, { signal })), {
+        code: 'ERR_INVALID_ARG_TYPE'
+      })).then(common.mustCall());
+
+  Promise.all(
+    [1, '', false, Infinity].map(
+      (i) => assert.rejects(setTimeout(10, null, i)), {
+        code: 'ERR_INVALID_ARG_TYPE'
+      })).then(common.mustCall());
+
+  Promise.all(
+    [1, '', false, Infinity, null, {}].map(
+      (signal) => assert.rejects(setTimeout(10, null, { signal })), {
+        code: 'ERR_INVALID_ARG_TYPE'
+      })).then(common.mustCall());
 }


### PR DESCRIPTION
Using the new experimental AbortController...

```js
const { promisify } = require('util');
const sleep = promisify(setTimeout);

const ac = new AbortController();
const signal = ac.signal;

sleep(1000, undefined, { signal });

ac.abort(); // cancels the setTimeout and rejects the Promise
```

```js
const { promisify } = require('util');
const immediate = promisify(setImmediate);

const ac = new AbortController();
const signal = ac.signal;

immediate(undefined, { signal });

ac.abort(); // cancels the setImmediate and rejects the Promise
```

This will necessarily be experimental for as long as `AbortController` is experimental.

Signed-off-by: James M Snell <jasnell@gmail.com>

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
