### PR TITLE
http: Add OutgoingMessage#addHeader

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -550,6 +550,25 @@ OutgoingMessage.prototype.setHeader = function setHeader(name, value) {
 };
 
 
+OutgoingMessage.prototype.addHeader = function addHeader(name, value) {
+  if (this._header) {
+    throw new ERR_HTTP_HEADERS_SENT('set');
+  }
+  validateHeaderName(name);
+  validateHeaderValue(name, value);
+
+  let headers = this[kOutHeaders];
+  if (headers === null)
+    this[kOutHeaders] = headers = ObjectCreate(null);
+
+  const record = headers[name.toLowerCase()];
+  if (record) record[1] = ArrayIsArray(record[1]) ?
+    record[1].concat([value]) :
+    [record[1], value];
+  else headers[name.toLowerCase()] = [name, value];
+};
+
+
 OutgoingMessage.prototype.getHeader = function getHeader(name) {
   validateString(name, 'name');
 

--- a/test/parallel/test-http-mutable-headers.js
+++ b/test/parallel/test-http-mutable-headers.js
@@ -38,6 +38,12 @@ const cookies = [
   'session_token=; path=/; expires=Sun, 15-Sep-2030 13:48:52 GMT',
   'prefers_open_id=; path=/; expires=Thu, 01-Jan-1970 00:00:00 GMT'
 ];
+const links = [
+  '</>;rel=up',
+  '</who?q=foo>;rel="http://example.com/rel/left"',
+  '</page/3>;rel=next',
+  '</page/1>;rel=prev'
+];
 
 const s = http.createServer(common.mustCall((req, res) => {
   switch (test) {
@@ -67,6 +73,14 @@ const s = http.createServer(common.mustCall((req, res) => {
         }
       );
       assert.throws(
+        () => res.addHeader('someHeader'),
+        {
+          code: 'ERR_HTTP_INVALID_HEADER_VALUE',
+          name: 'TypeError',
+          message: 'Invalid value "undefined" for header "someHeader"'
+        }
+      );
+      assert.throws(
         () => res.getHeader(),
         {
           code: 'ERR_INVALID_ARG_TYPE',
@@ -89,6 +103,10 @@ const s = http.createServer(common.mustCall((req, res) => {
       res.setHeader('x-test-header', 'testing');
       res.setHeader('X-TEST-HEADER2', 'testing');
       res.setHeader('set-cookie', cookies);
+      res.addHeader('Link', links[0]);
+      res.addHeader('Link', links[1]);
+      res.addHeader('Link', links[2]);
+      res.addHeader('Link', links[3]);
       res.setHeader('x-test-array-header', arrayValues);
 
       assert.strictEqual(res.getHeader('x-test-header'), 'testing');
@@ -99,6 +117,7 @@ const s = http.createServer(common.mustCall((req, res) => {
         'x-test-header': 'testing',
         'x-test-header2': 'testing',
         'set-cookie': cookies,
+        'link': links,
         'x-test-array-header': arrayValues
       };
       Object.setPrototypeOf(expected, null);
@@ -106,7 +125,7 @@ const s = http.createServer(common.mustCall((req, res) => {
 
       assert.deepStrictEqual(res.getHeaderNames(),
                              ['x-test-header', 'x-test-header2',
-                              'set-cookie', 'x-test-array-header']);
+                              'set-cookie', 'link', 'x-test-array-header']);
 
       assert.strictEqual(res.hasHeader('x-test-header2'), true);
       assert.strictEqual(res.hasHeader('X-TEST-HEADER2'), true);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

On occasion I've needed to _append_ an HTTP header instead of set one. For example, Link and Set-Cookie often specify message headers in multiple places, all of which need to appear in the message.

Doing this with `setHeader` is awkward, requiring three different branches, depending on the current value of the header. Here is a simple polyfill:

```javascript
if(!OutboundMessage.prototype.addHeader)
OutboundMessage.prototype.addHeader = function addHeader(n, v){
	const u = res.getHeader(n);
	if(u === undefined) res.setHeader(n, v);
	else if(typeof w === 'string') res.setHeader(n, [u, v] );
	else res.setHeader(n, u.concat([v]) );
}
```

It seems to me that userland code shouldn't have to concern itself with the current state of the headers if it doesn't need to, therefore, there should be a function that adds a new header (in addition to any existing).

I don't have documentation started yet, but this is a fairly straightforward feature; and this needs an http2 implementation. I can get started on those, if this feature looks reasonable.

Note this will re-use the capitalization of the existing header, if it exists.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
