### PR TITLE
doc: add a line to specify fs.createWriteStream instance

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1074,6 +1074,7 @@ of 0.12, `ctime` is not "creation time", and on Unix systems, it never was.
 <!-- YAML
 added: v0.1.93
 -->
+A successful call to `fs.createWriteStream()` will return a new `fs.WriteStream` object.
 
 * Extends {stream.Writable}
 


### PR DESCRIPTION
Add a line to specify which `fs` method to call that returns an instance of `fs.WriteStream`.
This was specifed in the fs.ReadStream section of the fs documentation

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
