### PR TITLE
tools: prevent js2c from running if nothing changed

### DIFF
--- a/tools/js2c.py
+++ b/tools/js2c.py
@@ -178,6 +178,7 @@ def write_if_chaged(content, target):
   else:
     old_content = ''
   if old_content == content:
+    os.utime(target, None)
     return
   with open(target, "wt") as output:
     output.write(content)


### PR DESCRIPTION
This commit updates tools/js2c.py to touch the target output file
, <(SHARED_INTERMEDIATE_DIR)/node_javascript.cc, even if the content
has not changed. This is to "help" the build system so that it can
compare the inputs against the output to determine if the gyp action
should be run.

I believe the issue here is that if js2c.py is updated this can
cause the action to be run as the node_javascript.cc target would be
older than js2c.py. But when the target is run the timestamp for
node_javascript.cc will not be updated (because we have not changed
anything that would change the contents of the file) so the js2c.py
prerequisite will always be passed and the target always run.

Using the update in this commit one would have to touch/modify one of
the js files specified in the library_files list, config.gypi, or
tools/js2c.py for this action to be run again.

@nodejs/build-files 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
