### PR TITLE
src: minor updates to FastHrtime

### DIFF
--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -1,6 +1,7 @@
 #include "base_object-inl.h"
 #include "debug_utils-inl.h"
 #include "env-inl.h"
+#include "memory_tracker-inl.h"
 #include "node.h"
 #include "node_errors.h"
 #include "node_internals.h"

--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -450,7 +450,8 @@ class FastHrtime : public BaseObject {
     Local<Object> obj = otmpl->NewInstance(env->context()).ToLocalChecked();
 
     Local<ArrayBuffer> ab =
-        ArrayBuffer::New(env->isolate(), sizeof(uint32_t) * 3);
+        ArrayBuffer::New(env->isolate(),
+            std::max(sizeof(uint64_t), sizeof(uint32_t) * 3));
     new FastHrtime(env, obj, ab);
     obj->Set(
            env->context(), FIXED_ONE_BYTE_STRING(env->isolate(), "buffer"), ab)


### PR DESCRIPTION
- Don’t use 12 as a magic number for the buffer size
- Mark the object as weak (which is conceptually the right thing to do,
  even if there is little practical impact)
- Keep a reference to the `ArrayBuffer` in question for memory tracking

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
