### PR TITLE
doc: warn that tls.connect() doesn't set SNI

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -1402,6 +1402,12 @@ The `callback` function, if specified, will be added as a listener for the
 
 `tls.connect()` returns a [`tls.TLSSocket`][] object.
 
+**Note:** Unlike the `https` API, `tls.connect()` does not enable the
+SNI (Server Name Indication) extension by default, which may cause some
+servers to return an incorrect certificate or reject the connection
+altogether. To enable SNI, set the `servername` option in addition
+to `host`.
+
 The following illustrates a client for the echo server example from
 [`tls.createServer()`][]:
 

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -1402,7 +1402,7 @@ The `callback` function, if specified, will be added as a listener for the
 
 `tls.connect()` returns a [`tls.TLSSocket`][] object.
 
-**Note:** Unlike the `https` API, `tls.connect()` does not enable the
+Unlike the `https` API, `tls.connect()` does not enable the
 SNI (Server Name Indication) extension by default, which may cause some
 servers to return an incorrect certificate or reject the connection
 altogether. To enable SNI, set the `servername` option in addition


### PR DESCRIPTION
Add a note warning users that when using tls.connect(), the `servername` option must be set explicitely to enable SNI, otherwise the connection could fail.

Maybe the warning is a bit verbose? But it doesn't hurt, I suppose.

Fixes: https://github.com/nodejs/node/issues/28167