### PR TITLE
[v10.x] deps: V8: backport cd21f71f9cb5

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -33,7 +33,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.56',
+    'v8_embedder_string': '-node.57',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,

--- a/deps/v8/src/parsing/parser-base.h
+++ b/deps/v8/src/parsing/parser-base.h
@@ -2977,13 +2977,13 @@ ParserBase<Impl>::ParseAssignmentExpression(bool accept_IN, bool* ok) {
     // This is definitely not an expression so don't accumulate
     // expression-related errors.
     productions &= ~ExpressionClassifier::ExpressionProduction;
+    ValidateAssignmentPattern(CHECK_OK);
   }
 
   Accumulate(productions);
   if (!Token::IsAssignmentOp(peek())) return expression;
 
   if (is_destructuring_assignment) {
-    ValidateAssignmentPattern(CHECK_OK);
   } else {
     expression = CheckAndRewriteReferenceExpression(
         expression, lhs_beg_pos, scanner()->location().end_pos,

--- a/deps/v8/test/mjsunit/regress/regress-8241.js
+++ b/deps/v8/test/mjsunit/regress/regress-8241.js
@@ -1,0 +1,6 @@
+// Copyright 2018 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+function f(x) { }
+f(x=>x, [x,y] = [1,2]);


### PR DESCRIPTION
Original commit message:

    [parser] Validate destructuring assignment pattern in correct classifier

    Previously we'd first accumulate errors to the parent and validate the
    destructuring pattern in the parent. In the case of ParseArguments this
    will invalidly propagate binding pattern errors from one argument to the
    next. The reason why ParseArguments keeps track of binding pattern errors
    is because it could also be used to parse async arrow function parameters.
    If we see async(a,b) we don't yet know whether this is the head of an
    async arrow function, or a call to async with arguments a and b.

    Bug: v8:8241
    Change-Id: I670ab9a9c6f2e0bee399808b02a465ae1afa7c3f
    Reviewed-on: https://chromium-review.googlesource.com/c/1296229
    Commit-Queue: Toon Verwaest <verwaest@chromium.org>
    Reviewed-by: Marja Hölttä <marja@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#56887}

Refs: https://github.com/v8/v8/commit/cd21f71f9cb592b2f9520b97c86eb5456e0e8e6d
Fixes: https://github.com/nodejs/node/issues/23142
