### PR TITLE
events: improve listeners() performance

### DIFF
--- a/benchmark/events/ee-listeners.js
+++ b/benchmark/events/ee-listeners.js
@@ -14,7 +14,7 @@ function main({ n, listeners, raw }) {
 
   for (let k = 0; k < listeners; k += 1) {
     ee.on('dummy0', () => {});
-    ee.on('dummy1', () => {});
+    ee.once('dummy1', () => {});
   }
 
   if (raw === 'true') {

--- a/lib/events.js
+++ b/lib/events.js
@@ -22,7 +22,6 @@
 'use strict';
 
 const {
-  Array,
   Boolean,
   Error,
   MathMin,
@@ -613,9 +612,11 @@ function arrayClone(arr) {
 }
 
 function unwrapListeners(arr) {
-  const ret = new Array(arr.length);
+  const ret = arrayClone(arr);
   for (let i = 0; i < ret.length; ++i) {
-    ret[i] = arr[i].listener || arr[i];
+    const orig = ret[i].listener;
+    if (typeof orig === 'function')
+      ret[i] = orig;
   }
   return ret;
 }


### PR DESCRIPTION
Benchmark results (keep in mind `listeners` is always implicitly multiplied by 2 by the benchmark):

```
                                                             confidence improvement accuracy (*)   (**)  (***)
 events/ee-listeners.js raw='false' listeners=1 n=5000000                  -0.96 %       ±2.89% ±3.85% ±5.03%
 events/ee-listeners.js raw='false' listeners=10 n=5000000         ***      7.71 %       ±1.48% ±1.98% ±2.61%
 events/ee-listeners.js raw='false' listeners=100 n=5000000        ***     35.04 %       ±0.89% ±1.19% ±1.58%
 events/ee-listeners.js raw='false' listeners=2 n=5000000          ***     20.62 %       ±1.41% ±1.89% ±2.47%
 events/ee-listeners.js raw='false' listeners=5 n=5000000          ***     27.57 %       ±0.80% ±1.07% ±1.40%
```


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
