### PR TITLE
worker: rename error code to be more accurate

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1597,12 +1597,20 @@ strict compliance with the API specification (which in some cases may accept
 For APIs that accept options objects, some options might be mandatory. This code
 is thrown if a required option is missing.
 
-<a id="ERR_MISSING_MESSAGE_PORT_IN_TRANSFER_LIST"></a>
-### `ERR_MISSING_MESSAGE_PORT_IN_TRANSFER_LIST`
+<a id="ERR_MISSING_TRANSFERABLE_IN_TRANSFER_LIST"></a>
+### `ERR_MISSING_TRANSFERABLE_IN_TRANSFER_LIST`
+<!-- YAML
+added: REPLACEME
+-->
 
 An object that needs to be explicitly listed in the `transferList` argument
-was found in the object passed to a `postMessage()` call, but not provided in
-the `transferList` for that call. Usually, this is a `MessagePort`.
+was found in the object passed to a [`postMessage()`][] call, but not provided
+in the `transferList` for that call. Usually, this is a `MessagePort`.
+
+In Node.js versions prior to REPLACEME, the error code being used here was
+[`ERR_MISSING_MESSAGE_PORT_IN_TRANSFER_LIST`][]. However, the set of
+transferable object types has been expanded to cover more types than
+`MessagePort`.
 
 <a id="ERR_MISSING_PASSPHRASE"></a>
 ### `ERR_MISSING_PASSPHRASE`
@@ -2323,6 +2331,16 @@ Used when an invalid character is found in an HTTP response status message
 -->
 A given index was out of the accepted range (e.g. negative offsets).
 
+<a id="ERR_MISSING_MESSAGE_PORT_IN_TRANSFER_LIST"></a>
+### `ERR_MISSING_MESSAGE_PORT_IN_TRANSFER_LIST`
+<!-- YAML
+removed: REPLACEME
+-->
+
+This error code was replaced by [`ERR_MISSING_TRANSFERABLE_IN_TRANSFER_LIST`][]
+in Node.js REPLACEME, because it is no longer accurate as other types of
+transferable objects also exist now.
+
 <a id="ERR_NAPI_CONS_PROTOTYPE_OBJECT"></a>
 ### `ERR_NAPI_CONS_PROTOTYPE_OBJECT`
 <!-- YAML
@@ -2574,6 +2592,8 @@ such as `process.stdout.on('data')`.
 [`--force-fips`]: cli.html#cli_force_fips
 [`Class: assert.AssertionError`]: assert.html#assert_class_assert_assertionerror
 [`ERR_INVALID_ARG_TYPE`]: #ERR_INVALID_ARG_TYPE
+[`ERR_MISSING_MESSAGE_PORT_IN_TRANSFER_LIST`]: #ERR_MISSING_MESSAGE_PORT_IN_TRANSFER_LIST
+[`ERR_MISSING_TRANSFERABLE_IN_TRANSFER_LIST`]: #ERR_MISSING_TRANSFERABLE_IN_TRANSFER_LIST
 [`EventEmitter`]: events.html#events_class_eventemitter
 [`MessagePort`]: worker_threads.html#worker_threads_class_messageport
 [`Object.getPrototypeOf`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getPrototypeOf
@@ -2606,6 +2626,7 @@ such as `process.stdout.on('data')`.
 [`net`]: net.html
 [`new URL(input)`]: url.html#url_new_url_input_base
 [`new URLSearchParams(iterable)`]: url.html#url_new_urlsearchparams_iterable
+[`postMessage()`]: worker_threads.html#worker_threads_port_postmessage_value_transferlist
 [`process.on('exit')`]: process.html#Event:-`'exit'`
 [`process.send()`]: process.html#process_process_send_message_sendhandle_options_callback
 [`process.setUncaughtExceptionCaptureCallback()`]: process.html#process_process_setuncaughtexceptioncapturecallback_fn

--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -43,7 +43,7 @@ void OnFatalError(const char* location, const char* message);
   V(ERR_MEMORY_ALLOCATION_FAILED, Error)                                       \
   V(ERR_MESSAGE_TARGET_CONTEXT_UNAVAILABLE, Error)                             \
   V(ERR_MISSING_ARGS, TypeError)                                               \
-  V(ERR_MISSING_MESSAGE_PORT_IN_TRANSFER_LIST, TypeError)                      \
+  V(ERR_MISSING_TRANSFERABLE_IN_TRANSFER_LIST, TypeError)                      \
   V(ERR_MISSING_PASSPHRASE, TypeError)                                         \
   V(ERR_MISSING_PLATFORM_FOR_WORKER, Error)                                    \
   V(ERR_NON_CONTEXT_AWARE_DISABLED, Error)                                     \
@@ -96,7 +96,7 @@ void OnFatalError(const char* location, const char* message);
   V(ERR_MESSAGE_TARGET_CONTEXT_UNAVAILABLE,                                    \
     "A message object could not be deserialized successfully in the target "   \
     "vm.Context")                                                              \
-  V(ERR_MISSING_MESSAGE_PORT_IN_TRANSFER_LIST,                                 \
+  V(ERR_MISSING_TRANSFERABLE_IN_TRANSFER_LIST,                                 \
     "Object that needs transfer was found in message but not listed "          \
     "in transferList")                                                         \
   V(ERR_MISSING_PLATFORM_FOR_WORKER,                                           \

--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -354,9 +354,7 @@ class SerializerDelegate : public ValueSerializer::Delegate {
       ThrowDataCloneError(env_->clone_unsupported_type_str());
       return Nothing<bool>();
     } else if (mode == BaseObject::TransferMode::kTransferable) {
-      // TODO(addaleax): This message code is too specific. Fix that in a
-      // semver-major follow-up.
-      THROW_ERR_MISSING_MESSAGE_PORT_IN_TRANSFER_LIST(env_);
+      THROW_ERR_MISSING_TRANSFERABLE_IN_TRANSFER_LIST(env_);
       return Nothing<bool>();
     }
 

--- a/test/parallel/test-worker-message-port-transfer-filehandle.js
+++ b/test/parallel/test-worker-message-port-transfer-filehandle.js
@@ -14,8 +14,7 @@ const { once } = require('events');
   assert.throws(() => {
     port1.postMessage(fh);
   }, {
-    // See the TODO about error code in node_messaging.cc.
-    code: 'ERR_MISSING_MESSAGE_PORT_IN_TRANSFER_LIST'
+    code: 'ERR_MISSING_TRANSFERABLE_IN_TRANSFER_LIST'
   });
 
   // Check that transferring FileHandle instances works.

--- a/test/parallel/test-worker-workerdata-messageport.js
+++ b/test/parallel/test-worker-workerdata-messageport.js
@@ -54,7 +54,7 @@ const meowScript = () => 'meow';
     workerData,
     transferList: []
   }), {
-    code: 'ERR_MISSING_MESSAGE_PORT_IN_TRANSFER_LIST',
+    code: 'ERR_MISSING_TRANSFERABLE_IN_TRANSFER_LIST',
     message: 'Object that needs transfer was found in message but not ' +
              'listed in transferList'
   });


### PR DESCRIPTION
Rename `ERR_MISSING_MESSAGE_PORT_IN_TRANSFER_LIST`
to `ERR_MISSING_TRANSFERABLE_IN_TRANSFER_LIST` in order to be more
accurate.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
