### PR TITLE
module: fix error message about importing names from cjs

### DIFF
--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -8,6 +8,7 @@ const {
   SafePromise,
   StringPrototypeIncludes,
   StringPrototypeMatch,
+  StringPrototypeReplace,
   StringPrototypeSplit,
 } = primordials;
 
@@ -109,13 +110,14 @@ class ModuleJob {
         if (format === 'commonjs') {
           const importStatement = splitStack[1];
           const namedImports = StringPrototypeMatch(importStatement, /{.*}/)[0];
+          const destructuringAssignment = StringPrototypeReplace(namedImports, /\s+as\s+/g, ': ');
           e.message = `The requested module '${childSpecifier}' is expected ` +
             'to be of type CommonJS, which does not support named exports. ' +
             'CommonJS modules can be imported by importing the default ' +
             'export.\n' +
             'For example:\n' +
             `import pkg from '${childSpecifier}';\n` +
-            `const ${namedImports} = pkg;`;
+            `const ${destructuringAssignment} = pkg;`;
           const newStack = StringPrototypeSplit(e.stack, '\n');
           newStack[3] = `SyntaxError: ${e.message}`;
           e.stack = ArrayPrototypeJoin(newStack, '\n');

--- a/test/es-module/test-esm-cjs-named-error.mjs
+++ b/test/es-module/test-esm-cjs-named-error.mjs
@@ -10,6 +10,13 @@ const expectedRelative = 'The requested module \'./fail.cjs\' is expected to ' +
   'import pkg from \'./fail.cjs\';\n' +
   'const { comeOn } = pkg;';
 
+const expectedRenamed = 'The requested module \'./fail.cjs\' is expected to ' +
+  'be of type CommonJS, which does not support named exports. CommonJS ' +
+  'modules can be imported by importing the default export.\n' +
+  'For example:\n' +
+  'import pkg from \'./fail.cjs\';\n' +
+  'const { comeOn: comeOnRenamed } = pkg;';
+
 const expectedPackageHack = 'The requested module \'./json-hack/fail.js\' is ' +
   'expected to be of type CommonJS, which does not support named exports. ' +
   'CommonJS modules can be imported by importing the default export.\n' +
@@ -37,6 +44,13 @@ rejects(async () => {
   name: 'SyntaxError',
   message: expectedRelative
 }, 'should support relative specifiers with double quotes');
+
+rejects(async () => {
+  await import(`${fixtureBase}/renamed-import.mjs`);
+}, {
+  name: 'SyntaxError',
+  message: expectedRenamed
+}, 'should correctly format named imports with renames');
 
 rejects(async () => {
   await import(`${fixtureBase}/json-hack.mjs`);

--- a/test/fixtures/es-modules/package-cjs-named-error/renamed-import.mjs
+++ b/test/fixtures/es-modules/package-cjs-named-error/renamed-import.mjs
@@ -1,0 +1,1 @@
+import { comeOn as comeOnRenamed } from "./fail.cjs"


### PR DESCRIPTION
When importing specific names from a CJS module, and renaming them using `as`, the example fix in the error message erroneously contains the keyword `as` in the destructuring variable declaration.

Example of this issue:

```
import { parse as acornParse } from "acorn";
         ^^^^^
SyntaxError: The requested module 'acorn' is expected to be of type CommonJS, which does not support named exports. CommonJS modules can be imported by importing the default export.
For example:
import pkg from 'acorn';
const { parse as acornParse } = pkg;
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
