### PR TITLE
meta: introduce codeowners again

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,77 @@
+# Node.js Project Codeowners
+
+# 1. Codeowners must always be teams, never individuals
+# 2. Each codeowner team should contain at least one TSC member
+# 3. PRs touching any code with a codeowner must be signed off by at least one
+#    person on the code owner team.
+
+./.github/CODEOWNERS @nodejs/tsc
+
+# net
+
+# ./deps/cares @nodejs/net
+# ./doc/api/dns.md @nodejs/net
+# ./doc/api/dgram.md @nodejs/net
+# ./doc/api/net.md @nodejs/net
+# ./lib/dgram.js @nodejs/net
+# ./lib/dns.js @nodejs/net
+# ./lib/net.js @nodejs/net @nodejs/quic
+# ./lib/internal/dgram.js @nodejs/net
+# ./lib/internal/dns/* @nodejs/net
+# ./lib/internal/net.js @nodejs/net
+# ./lib/internal/socket_list.js @nodejs/net
+# ./lib/internal/js_stream_socket.js @nodejs/net
+# ./src/cares_wrap.h @nodejs/net
+# ./src/connect_wrap.* @nodejs/net
+# ./src/connection_wrap.* @nodejs/net
+# ./src/node_sockaddr* @nodejs/net
+# ./src/tcp_wrap.* @nodejs/net
+# ./src/udp_wrap.* @nodejs/net
+
+# tls/crypto
+
+# ./lib/internal/crypto/* @nodejs/crypto
+# ./lib/internal/tls.js @nodejs/crypto @nodejs/net
+# ./lib/crypto.js @nodejs/crypto
+# ./lib/tls.js @nodejs/crypto @nodejs/net
+# ./src/node_crypto* @nodejs/crypto
+# ./src/node_crypto_common* @nodejs/crypto @nodejs/quic
+
+# http
+
+# ./deps/llhttp/* @nodejs/http @nodejs/net
+# ./doc/api/http.md @nodejs/http @nodejs/net
+# ./doc/api/http2.md @nodejs/http @nodejs/net
+# ./lib/_http_* @nodejs/http @nodejs/net
+# ./lib/http.js @nodejs/http @nodejs/net
+# ./lib/https.js @nodejs/crypto @nodejs/net @nodejs/http
+# ./src/node_http_common* @nodejs/http @nodejs/http2 @nodejs/quic @nodejs/net
+# ./src/node_http_parser.cc @nodejs/http @nodejs/net
+
+# http2
+
+# ./deps/nghttp2/* @nodejs/http2 @nodejs/net
+# ./doc/api/http2.md @nodejs/http2 @nodejs/net
+# ./lib/http2.js @nodejs/http2 @nodejs/net
+# ./lib/internal/http2/* @nodejs/http2 @nodejs/net
+# ./src/node_http2* @nodejs/http2 @nodejs/net
+# ./src/node_mem* @nodejs/http2
+
+# quic
+
+./deps/ngtcp2/* @nodejs/quic
+./deps/nghttp3/* @nodejs/quic
+./doc/api/quic.md @nodejs/quic
+./lib/internal/quic/* @nodejs/quic
+./src/node_bob* @nodejs/quic
+./src/quic/* @nodejs/quic
+
+# modules
+
+# ./doc/api/modules.md @nodejs/modules
+# ./doc/api/esm.md @nodejs/modules
+# ./lib/module.js @nodejs/modules
+# ./lib/internal/modules/* @nodejs/modules
+# ./lib/internal/bootstrap/loaders.js @nodejs/modules
+# ./src/module_wrap* @nodejs/modules @nodejs/vm
+


### PR DESCRIPTION
The [Contributor's Survey
results](https://github.com/nodejs/TSC/pull/882) highlight the fact that
it is often not easy for contributors to know who the right people are
to talk to about a proposed change or who to ask for reviews of a given
subsystem. We briefly toyed around with codeowners before when GitHub
introduced it but just as quickly disabled it because the structure of
our repository made it exceedingly difficult to get right.

Rather than start with a codeowners for the entire project, I propose
that we start with a small experiment focused on specific subsystems.
Specifically, codeowners for modules, streams, net/tls, http/http2, and
quic (once that lands). We can expand out from there as we see how
things go with the minimal starter set.

A couple of points:

1. A codeowner should always be a team, never an individual person
2. Each codeowner team should contain at least one TSC member (to
provide coverage for signing off on semver-major changes)
3. PRs touching any code with a codeowner must be signed off by at least
one person on the codeowner team

/cc @nodejs/tsc 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
