### PR TITLE
quic: fix memory fragmentation

### DIFF
--- a/src/quic/node_quic_socket-inl.h
+++ b/src/quic/node_quic_socket-inl.h
@@ -18,6 +18,7 @@ namespace quic {
 std::unique_ptr<QuicPacket> QuicPacket::Create(
     const char* diagnostic_label,
     size_t len) {
+  CHECK_LE(len, MAX_PKTLEN);
   return std::make_unique<QuicPacket>(diagnostic_label, len);
 }
 
@@ -27,8 +28,8 @@ std::unique_ptr<QuicPacket> QuicPacket::Copy(
 }
 
 void QuicPacket::set_length(size_t len) {
-  CHECK_LE(len, data_.size());
-  data_.resize(len);
+  CHECK_LE(len, MAX_PKTLEN);
+  len_ = len;
 }
 
 int QuicEndpoint::Send(

--- a/src/quic/node_quic_socket.cc
+++ b/src/quic/node_quic_socket.cc
@@ -83,14 +83,15 @@ bool IsShortHeader(
 }  // namespace
 
 QuicPacket::QuicPacket(const char* diagnostic_label, size_t len) :
-    data_(len),
+    data_{0},
+    len_(len),
     diagnostic_label_(diagnostic_label) {
-  CHECK_LE(len, NGTCP2_MAX_PKT_SIZE);
+  CHECK_LE(len, MAX_PKTLEN);
 }
 
 QuicPacket::QuicPacket(const QuicPacket& other) :
-  QuicPacket(other.diagnostic_label_, other.data_.size()) {
-  memcpy(data_.data(), other.data_.data(), other.data_.size());
+  QuicPacket(other.diagnostic_label_, other.len_) {
+  memcpy(&data_, &other.data_, other.len_);
 }
 
 const char* QuicPacket::diagnostic_label() const {
@@ -98,9 +99,7 @@ const char* QuicPacket::diagnostic_label() const {
       diagnostic_label_ : "unspecified";
 }
 
-void QuicPacket::MemoryInfo(MemoryTracker* tracker) const {
-  tracker->TrackField("data", data_);
-}
+void QuicPacket::MemoryInfo(MemoryTracker* tracker) const {}
 
 QuicSocketListener::~QuicSocketListener() {
   if (socket_)


### PR DESCRIPTION
Previously, QuicPacket was allocating an std::vector<uint8_t> of NGTCP2_MAX_PKT_SIZE bytes, then the packet would be serialized into the buffer, and the std::vector would be resized based on the number of bytes serialized. I suspect the memory fragmentation that you're seeing is because of those resize operations not freeing memory in chunks that are aligned with the allocation. This changes QuicPacket to use a stack allocation that is always NGTCP2_MAX_PKT_SIZE bytes and the size of the serialized packet is just recorded without any resizing. When the memory is freed now, it should be freed in large enough chunks to cover subsequent allocations.

Original PR: https://github.com/nodejs/quic/pull/388

cc: @nodejs/quic

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
