### PR TITLE
quic: remove noop code

### DIFF
--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -2585,6 +2585,7 @@ class QuicStream extends Duplex {
       highWaterMark,
       defaultEncoding,
     } = options;
+
     super({
       highWaterMark,
       defaultEncoding,
@@ -2600,27 +2601,6 @@ class QuicStream extends Duplex {
     this.#push_id = push_id;
     this._readableState.readingMore = true;
     this.on('pause', streamOnPause);
-
-    // See src/node_quic_stream.h for an explanation
-    // of the initial states for unidirectional streams.
-    if (this.unidirectional) {
-      if (session instanceof QuicServerSession) {
-        if (this.serverInitiated) {
-          // Close the readable side
-          this.push(null);
-          this.read();
-        } else {
-          // Close the writable side
-          this.end();
-        }
-      } else if (this.serverInitiated) {
-        // Close the writable side
-        this.end();
-      } else {
-        this.push(null);
-        this.read();
-      }
-    }
 
     // The QuicStream writes are corked until kSetHandle
     // is set, ensuring that writes are buffered in JavaScript


### PR DESCRIPTION
`this.unidirectional` depends on `#id` which is never set in the constructor, hence this condition will never run and should be possible to removed.

I'm probably missing something here? I guess this might be more of a question in the form of a PR. However, the tests seem to pass. 

My original intent was to try and remove the explicit push/end and instead send in `readable`/`writable` to the `Duplex`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
