### PR TITLE
quic: always copy stateless reset token

### DIFF
--- a/src/quic/node_quic_util-inl.h
+++ b/src/quic/node_quic_util-inl.h
@@ -287,22 +287,27 @@ bool PreferredAddress::ResolvePreferredAddress(
 StatelessResetToken::StatelessResetToken(
     uint8_t* token,
     const uint8_t* secret,
-    const QuicCID& cid) : token_(token) {
+    const QuicCID& cid) {
   GenerateResetToken(token, secret, cid);
+  memcpy(buf_, token, sizeof(buf_));
 }
 
 StatelessResetToken::StatelessResetToken(
     const uint8_t* secret,
-    const QuicCID& cid)
-    : token_(buf_) {
+    const QuicCID& cid)  {
   GenerateResetToken(buf_, secret, cid);
+}
+
+StatelessResetToken::StatelessResetToken(
+    const uint8_t* token) {
+  memcpy(buf_, token, sizeof(buf_));
 }
 
 std::string StatelessResetToken::ToString() const {
   std::vector<char> dest(NGTCP2_STATELESS_RESET_TOKENLEN * 2 + 1);
   dest[dest.size() - 1] = '\0';
   size_t written = StringBytes::hex_encode(
-      reinterpret_cast<const char*>(token_),
+      reinterpret_cast<const char*>(buf_),
       NGTCP2_STATELESS_RESET_TOKENLEN,
       dest.data(),
       dest.size());
@@ -313,7 +318,7 @@ size_t StatelessResetToken::Hash::operator()(
     const StatelessResetToken& token) const {
   size_t hash = 0;
   for (size_t n = 0; n < NGTCP2_STATELESS_RESET_TOKENLEN; n++)
-    hash ^= std::hash<uint8_t>{}(token.token_[n]) + 0x9e3779b9 +
+    hash ^= std::hash<uint8_t>{}(token.buf_[n]) + 0x9e3779b9 +
             (hash << 6) + (hash >> 2);
   return hash;
 }

--- a/src/quic/node_quic_util.h
+++ b/src/quic/node_quic_util.h
@@ -386,13 +386,12 @@ class StatelessResetToken : public MemoryRetainer {
       const uint8_t* secret,
       const QuicCID& cid);
 
-  explicit StatelessResetToken(
-      const uint8_t* token)
-      : token_(token) {}
+  explicit inline StatelessResetToken(
+      const uint8_t* token);
 
   inline std::string ToString() const;
 
-  const uint8_t* data() const { return token_; }
+  const uint8_t* data() const { return buf_; }
 
   struct Hash {
     inline size_t operator()(const StatelessResetToken& token) const;
@@ -414,7 +413,6 @@ class StatelessResetToken : public MemoryRetainer {
 
  private:
   uint8_t buf_[NGTCP2_STATELESS_RESET_TOKENLEN]{};
-  const uint8_t* token_;
 };
 
 template <typename T>


### PR DESCRIPTION
Take ownership of the token value, since the memory for it is allocated
anyway and the buffer size is just 16, i.e. copyable very cheaply.

This makes valgrind stop complaining about a use-after-free error
when running `sequential/test-quic-preferred-address-ipv6`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
