### PR TITLE
querystring: fix stringify for empty array

### DIFF
--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -196,7 +196,6 @@ function stringify(obj, sep, eq, options) {
   if (obj !== null && typeof obj === 'object') {
     const keys = ObjectKeys(obj);
     const len = keys.length;
-    const flast = len - 1;
     let fields = '';
     for (let i = 0; i < len; ++i) {
       const k = keys[i];
@@ -207,20 +206,20 @@ function stringify(obj, sep, eq, options) {
       if (ArrayIsArray(v)) {
         const vlen = v.length;
         if (vlen === 0) continue;
-        const vlast = vlen - 1;
+        if (fields)
+          fields += sep;
         for (let j = 0; j < vlen; ++j) {
+          if (j)
+            fields += sep;
           fields += ks;
           fields += convert(v[j], encode);
-          if (j < vlast)
-            fields += sep;
         }
       } else {
+        if (fields)
+          fields += sep;
         fields += ks;
         fields += convert(v, encode);
       }
-
-      if (i < flast)
-        fields += sep;
     }
     return fields;
   }

--- a/test/parallel/test-querystring.js
+++ b/test/parallel/test-querystring.js
@@ -144,7 +144,8 @@ const qsWeirdObjects = [
   [{ n: null }, 'n=', { 'n': '' }],
   [{ nan: NaN }, 'nan=', { 'nan': '' }],
   [{ inf: Infinity }, 'inf=', { 'inf': '' }],
-  [{ a: [], b: [] }, '', {}]
+  [{ a: [], b: [] }, '', {}],
+  [{ a: 1, b: [] }, 'a=1', { 'a': '1' }]
 ];
 // }}}
 


### PR DESCRIPTION
Fixes #33910 

Currently
`querystring.stringify({a:1, b:[]})` return `"a=1&"`
and
`querystring.stringify({a:1})` return `"a=1"`
and
`querystring.stringify({a:[], b:[]})` return `""`

If this PR is merged, first one will change to
`querystring.stringify({a:1, b:[]})` return `"a=1"`.

I think that this is better for consistency.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
