### PR TITLE
crypto: add OP flag constants added in OpenSSL v1.1.1

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -3183,6 +3183,11 @@ the `crypto`, `tls`, and `https` modules and are generally specific to OpenSSL.
     for detail.</td>
   </tr>
   <tr>
+    <td><code>SSL_OP_ALLOW_NO_DHE_KEX</code></td>
+    <td>Instructs OpenSSL to allow a non-[EC]DHE-based key exchane mode
+    for TLS v1.3</td>
+  </tr>
+  <tr>
     <td><code>SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION</code></td>
     <td>Allows legacy insecure renegotiation between OpenSSL and unpatched
     clients or servers. See
@@ -3255,8 +3260,16 @@ the `crypto`, `tls`, and `https` modules and are generally specific to OpenSSL.
     <td>Instructs OpenSSL to disable support for SSL/TLS compression.</td>
   </tr>
   <tr>
+    <td><code>SSL_OP_NO_ENCRYPT_THEN_MAC</code></td>
+    <td>Instructs OpenSSL to disable encrypt-then-MAC.</td>
+  </tr>
+  <tr>
     <td><code>SSL_OP_NO_QUERY_MTU</code></td>
     <td></td>
+  </tr>
+  <tr>
+    <td><code>SSL_OP_NO_RENEGOTIATION</code></td>
+    <td>Instructs OpenSSL to disable renegotiation.</td>
   </tr>
   <tr>
     <td><code>SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION</code></td>
@@ -3287,12 +3300,23 @@ the `crypto`, `tls`, and `https` modules and are generally specific to OpenSSL.
     <td><code>SSL_OP_NO_TLSv1_2</code></td>
     <td>Instructs OpenSSL to turn off TLS v1.2</td>
   </tr>
+  <tr>
+    <td><code>SSL_OP_NO_TLSv1_3</code></td>
+    <td>Instructs OpenSSL to turn off TLS v1.3</td>
+  </tr>
     <td><code>SSL_OP_PKCS1_CHECK_1</code></td>
     <td></td>
   </tr>
   <tr>
     <td><code>SSL_OP_PKCS1_CHECK_2</code></td>
     <td></td>
+  </tr>
+  <tr>
+    <td><code>SSL_OP_PRIORITIZE_CHACHA</code></td>
+    <td>Instructs OpenSSL server to prioritize ChaCha20Poly1305
+    when client does.
+    This option has no effect if SSL_OP_CIPHER_SERVER_PREFERENCE
+    is not enabled.</td>
   </tr>
   <tr>
     <td><code>SSL_OP_SINGLE_DH_USE</code></td>

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -3184,7 +3184,7 @@ the `crypto`, `tls`, and `https` modules and are generally specific to OpenSSL.
   </tr>
   <tr>
     <td><code>SSL_OP_ALLOW_NO_DHE_KEX</code></td>
-    <td>Instructs OpenSSL to allow a non-[EC]DHE-based key exchane mode
+    <td>Instructs OpenSSL to allow a non-[EC]DHE-based key exchange mode
     for TLS v1.3</td>
   </tr>
   <tr>
@@ -3315,7 +3315,8 @@ the `crypto`, `tls`, and `https` modules and are generally specific to OpenSSL.
     <td><code>SSL_OP_PRIORITIZE_CHACHA</code></td>
     <td>Instructs OpenSSL server to prioritize ChaCha20Poly1305
     when client does.
-    This option has no effect if SSL_OP_CIPHER_SERVER_PREFERENCE
+    This option has no effect if
+    <code>SSL_OP_CIPHER_SERVER_PREFERENCE</code>
     is not enabled.</td>
   </tr>
   <tr>

--- a/src/node_constants.cc
+++ b/src/node_constants.cc
@@ -806,6 +806,10 @@ void DefineCryptoConstants(Local<Object> target) {
     NODE_DEFINE_CONSTANT(target, SSL_OP_ALL);
 #endif
 
+#ifdef SSL_OP_ALLOW_NO_DHE_KEX
+    NODE_DEFINE_CONSTANT(target, SSL_OP_ALLOW_NO_DHE_KEX);
+#endif
+
 #ifdef SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION
     NODE_DEFINE_CONSTANT(target, SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION);
 #endif
@@ -870,8 +874,16 @@ void DefineCryptoConstants(Local<Object> target) {
     NODE_DEFINE_CONSTANT(target, SSL_OP_NO_COMPRESSION);
 #endif
 
+#ifdef SSL_OP_NO_ENCRYPT_THEN_MAC
+    NODE_DEFINE_CONSTANT(target, SSL_OP_NO_ENCRYPT_THEN_MAC);
+#endif
+
 #ifdef SSL_OP_NO_QUERY_MTU
     NODE_DEFINE_CONSTANT(target, SSL_OP_NO_QUERY_MTU);
+#endif
+
+#ifdef SSL_OP_NO_RENEGOTIATION
+    NODE_DEFINE_CONSTANT(target, SSL_OP_NO_RENEGOTIATION);
 #endif
 
 #ifdef SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION
@@ -902,12 +914,20 @@ void DefineCryptoConstants(Local<Object> target) {
     NODE_DEFINE_CONSTANT(target, SSL_OP_NO_TLSv1_2);
 #endif
 
+#ifdef SSL_OP_NO_TLSv1_3
+    NODE_DEFINE_CONSTANT(target, SSL_OP_NO_TLSv1_3);
+#endif
+
 #ifdef SSL_OP_PKCS1_CHECK_1
     NODE_DEFINE_CONSTANT(target, SSL_OP_PKCS1_CHECK_1);
 #endif
 
 #ifdef SSL_OP_PKCS1_CHECK_2
     NODE_DEFINE_CONSTANT(target, SSL_OP_PKCS1_CHECK_2);
+#endif
+
+#ifdef SSL_OP_PRIORITIZE_CHACHA
+    NODE_DEFINE_CONSTANT(target, SSL_OP_PRIORITIZE_CHACHA);
 #endif
 
 #ifdef SSL_OP_SINGLE_DH_USE


### PR DESCRIPTION
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines]