### PR TITLE
quic: return 0 from SSL_CTX_sess_set_new_cb callback

### DIFF
--- a/src/quic/node_quic_session.cc
+++ b/src/quic/node_quic_session.cc
@@ -2295,7 +2295,7 @@ int QuicSession::set_session(SSL_SESSION* session) {
   if (size > SecureContext::kMaxSessionSize)
     return 0;
   listener_->OnSessionTicket(size, session);
-  return 1;
+  return 0;
 }
 
 // A client QuicSession can be migrated to a different QuicSocket instance.


### PR DESCRIPTION
The callback passed to `SSL_CTX_sess_set_new_cb()` should return 1
if it takes ownership (i.e. holds a reference that is later freed
through `SSL_SESSION_free()`) of the passed session, and 0
otherwise.

Since we don’t take ownership of the session and instead only save
a serialized version of it, return 0 instead of 1. This closes
a memory leak reported when running
`sequential/test-quic-preferred-address-ipv6`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
