### PR TITLE
quic: refactor and improve ipv6Only

### DIFF
--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -261,8 +261,11 @@ added: REPLACEME
       to an IP address.
     * `port` {number} The local port to bind to.
     * `type` {string} Either `'udp4'` or `'upd6'` to use either IPv4 or IPv6,
-      respectively.
-    * `ipv6Only` {boolean}
+      respectively. **Default**: `'udp4'`.
+    * `ipv6Only` {boolean} If `type` is `'udp6'`, then setting `ipv6Only` to
+      `true` will disable dual-stack support on the UDP binding -- that is,
+      binding to address `'::'` will not make `'0.0.0.0'` be bound. The option
+      is ignored if `type` is `'udp4'`. **Default**: `false`.
   * `lookup` {Function} A custom DNS lookup function. Default `dns.lookup()`.
   * `maxConnections` {number} The maximum number of total active inbound
     connections.
@@ -1387,8 +1390,11 @@ added: REPLACEME
     to an IP address.
   * `port` {number} The local port to bind to.
   * `type` {string} Either `'udp4'` or `'upd6'` to use either IPv4 or IPv6,
-    respectively.
-  * `ipv6Only` {boolean}
+    respectively. **Default**: `'udp4'`.
+  * `ipv6Only` {boolean} If `type` is `'udp6'`, then setting `ipv6Only` to
+    `true` will disable dual-stack support on the UDP binding -- that is,
+    binding to address `'::'` will not make `'0.0.0.0'` be bound. The option
+    is ignored if `type` is `'udp4'`. **Default**: `false`.
 * Returns: {QuicEndpoint}
 
 Creates and adds a new `QuicEndpoint` to the `QuicSocket` instance.
@@ -1519,7 +1525,10 @@ added: REPLACEME
     `SSL_OP_CIPHER_SERVER_PREFERENCE` to be set in `secureOptions`, see
     [OpenSSL Options][] for more information.
   * `idleTimeout` {number}
-  * `ipv6Only` {boolean}
+  * `ipv6Only` {boolean} If `type` is `'udp6'`, then setting `ipv6Only` to
+    `true` will disable dual-stack support on the UDP binding -- that is,
+    binding to address `'::'` will not make `'0.0.0.0'` be bound. The option
+    is ignored if `type` is `'udp4'`. **Default**: `false`.
   * `key` {string|string[]|Buffer|Buffer[]|Object[]} Private keys in PEM format.
     PEM allows the option of private keys being encrypted. Encrypted keys will
     be decrypted with `options.passphrase`. Multiple keys using different
@@ -1578,7 +1587,7 @@ added: REPLACEME
     `QuicClientSession` object.
   * `type`: {string} Identifies the type of UDP socket. The value must either
     be `'udp4'`, indicating UDP over IPv4, or `'udp6'`, indicating UDP over
-    IPv6. Defaults to `'udp4'`.
+    IPv6. **Default**: `'udp4'`.
 
 Create a new `QuicClientSession`. This function can be called multiple times
 to create sessions associated with different endpoints on the same

--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -667,6 +667,7 @@ class QuicEndpoint {
     this.#lookup = lookup || (type === AF_INET6 ? lookup6 : lookup4);
     this.#port = port;
     this.#reuseAddr = !!reuseAddr;
+    this.#type = type;
     this.#udpSocket = dgram.createSocket(type === AF_INET6 ? 'udp6' : 'udp4');
 
     // kUDPHandleForTesting is only used in the Node.js test suite to
@@ -688,7 +689,7 @@ class QuicEndpoint {
     const obj = {
       address: this.address,
       fd: this.#fd,
-      type: this.#type
+      type: this.#type === AF_INET6 ? 'udp6' : 'udp4'
     };
     return `QuicEndpoint ${util.format(obj)}`;
   }
@@ -726,9 +727,10 @@ class QuicEndpoint {
       // what conditions does this happen?
       return;
     }
+
     const flags =
       (this.#reuseAddr ? UV_UDP_REUSEADDR : 0) |
-      (this.#ipv6Only ? UV_UDP_IPV6ONLY : 0);
+      (this.#type === AF_INET6 && this.#ipv6Only ? UV_UDP_IPV6ONLY : 0);
 
     const ret = udpHandle.bind(ip, this.#port, flags);
     if (ret) {


### PR DESCRIPTION
Ignore `ipv6Only: true` when binding to `'udp4'` (this differs from
dgram which will still attempt to apply the flag and will fail during
bind). Improve the test so that it should work consistently.

/cc @nodejs/quic

Signed-off-by: James M Snell <jasnell@gmail.com>

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
