### PR TITLE
win,fs: improve realpathSync performance

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1562,6 +1562,7 @@ if (isWindows) {
 }
 
 const emptyObj = ObjectCreate(null);
+const knownHard = ObjectCreate(null);
 function realpathSync(p, options) {
   if (!options)
     options = emptyObj;
@@ -1581,7 +1582,6 @@ function realpathSync(p, options) {
   }
 
   const seenLinks = ObjectCreate(null);
-  const knownHard = ObjectCreate(null);
   const original = p;
 
   // Current character position in p


### PR DESCRIPTION
Moving `knownHard` object improves `realpathSync` perfomance.
This results in require being 10% faster on Windows and
`realpathSync` itself 50x faster.
Ref: https://github.com/nodejs/node/issues/28946

```
..>cat results.csv | Rscript compare.R
                                                       confidence improvement accuracy (*)      (**)     (***)
 fs\\bench-realpath.js pathType='relative' n=10000                     0.79 %      A±2.99%   A±3.98%   A±5.19%
 fs\\bench-realpath.js pathType='resolved' n=10000              *      2.29 %      A±2.26%   A±3.00%   A±3.91%
 fs\\bench-realpathSync.js pathType='relative' n=10000        ***   5178.34 %     A±81.16% A±109.38% A±145.22%
 fs\\bench-realpathSync.js pathType='resolved' n=10000        ***   6179.63 %     A±72.30%  A±97.45% A±129.37%
```

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes