### PR TITLE
tls: stronger validation for 'servername' in server.addContext

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -2528,6 +2528,12 @@ removed: v10.0.0
 
 Used when a TLS renegotiation request has failed in a non-specific way.
 
+<a id="ERR_TLS_REQUIRED_SERVER_NAME"></a>
+### `ERR_TLS_REQUIRED_SERVER_NAME`
+
+While using TLS, the `server.addContext()` method was called without providing
+a host name in the first parameter.
+
 <a id="ERR_TRANSFERRING_EXTERNALIZED_SHAREDARRAYBUFFER"></a>
 ### `ERR_TRANSFERRING_EXTERNALIZED_SHAREDARRAYBUFFER`
 <!-- YAML

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -2530,6 +2530,10 @@ Used when a TLS renegotiation request has failed in a non-specific way.
 
 <a id="ERR_TLS_REQUIRED_SERVER_NAME"></a>
 ### `ERR_TLS_REQUIRED_SERVER_NAME`
+<!-- YAML
+added: v9.0.0
+removed: REPLACEME
+-->
 
 While using TLS, the `server.addContext()` method was called without providing
 a host name in the first parameter.

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -2063,12 +2063,6 @@ attempt to set the `secureProtocol` explicitly. Use one mechanism or the other.
 
 An attempt was made to renegotiate TLS on a socket instance with TLS disabled.
 
-<a id="ERR_TLS_REQUIRED_SERVER_NAME"></a>
-### `ERR_TLS_REQUIRED_SERVER_NAME`
-
-While using TLS, the `server.addContext()` method was called without providing
-a host name in the first parameter.
-
 <a id="ERR_TLS_SESSION_ATTACK"></a>
 ### `ERR_TLS_SESSION_ATTACK`
 

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -545,18 +545,19 @@ called:
 * `tlsSocket` {tls.TLSSocket} The `tls.TLSSocket` instance from which the
   error originated.
 
-### `server.addContext(hostname, context)`
+### `server.addContext(servername, context)`
 <!-- YAML
 added: v0.5.3
 -->
-
-* `hostname` {string} A SNI host name or wildcard (e.g. `'*'`)
+`
+* `servername` {string} A SNI server name or wildcard (e.g. `'*'`). Must not be
+  an IP address.
 * `context` {Object} An object containing any of the possible properties
   from the [`tls.createSecureContext()`][] `options` arguments (e.g. `key`,
   `cert`, `ca`, etc).
 
 The `server.addContext()` method adds a secure context that will be used if
-the client request's SNI name matches the supplied `hostname` (or wildcard).
+the client request's SNI name matches the supplied `servername` (or wildcard).
 
 ### `server.address()`
 <!-- YAML

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -549,7 +549,7 @@ called:
 <!-- YAML
 added: v0.5.3
 -->
-`
+
 * `servername` {string} A SNI server name or wildcard (e.g. `'*'`). Must not be
   an IP address.
 * `context` {Object} An object containing any of the possible properties

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -1954,7 +1954,7 @@ where `secureSocket` has the same API as `pair.cleartext`.
 [`net.Server.address()`]: net.html#net_server_address
 [`net.Server`]: net.html#net_class_net_server
 [`net.Socket`]: net.html#net_class_net_socket
-[`server.addContext()`]: #tls_server_addcontext_hostname_context
+[`server.addContext()`]: #tls_server_addcontext_servername_context
 [`server.getTicketKeys()`]: #tls_server_getticketkeys
 [`server.listen()`]: net.html#net_server_listen
 [`server.setTicketKeys()`]: #tls_server_setticketkeys_keys

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -60,13 +60,13 @@ const {
   ERR_INVALID_ARG_TYPE,
   ERR_INVALID_ARG_VALUE,
   ERR_INVALID_CALLBACK,
+  ERR_MISSING_ARGS,
   ERR_MULTIPLE_CALLBACK,
   ERR_SOCKET_CLOSED,
   ERR_TLS_DH_PARAM_SIZE,
   ERR_TLS_HANDSHAKE_TIMEOUT,
   ERR_TLS_INVALID_CONTEXT,
   ERR_TLS_RENEGOTIATION_DISABLED,
-  ERR_TLS_REQUIRED_SERVER_NAME,
   ERR_TLS_SESSION_ATTACK,
   ERR_TLS_SNI_FROM_SERVER,
   ERR_TLS_INVALID_STATE
@@ -1411,7 +1411,19 @@ Server.prototype.setOptions = deprecate(function(options) {
 // SNI Contexts High-Level API
 Server.prototype.addContext = function(servername, context) {
   if (!servername) {
-    throw new ERR_TLS_REQUIRED_SERVER_NAME();
+    throw new ERR_MISSING_ARGS('servername');
+  }
+
+  if (typeof servername !== 'string') {
+    throw new ERR_INVALID_ARG_TYPE('servername', 'string', servername);
+  }
+
+  if (net.isIP(servername)) {
+    throw new ERR_INVALID_ARG_VALUE(
+      'servername',
+      servername,
+      'must not be an IP address'
+    );
   }
 
   const re = new RegExp('^' +

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1445,9 +1445,6 @@ E('ERR_TLS_PROTOCOL_VERSION_CONFLICT',
 E('ERR_TLS_RENEGOTIATION_DISABLED',
   'TLS session renegotiation disabled for this socket', Error);
 
-// This should probably be a `TypeError`.
-E('ERR_TLS_REQUIRED_SERVER_NAME',
-  '"servername" is required parameter for Server.addContext', Error);
 E('ERR_TLS_SESSION_ATTACK', 'TLS session renegotiation attack detected', Error);
 E('ERR_TLS_SNI_FROM_SERVER',
   'Cannot issue SNI from a TLS server-side socket', Error);

--- a/test/parallel/test-tls-sni-server-client.js
+++ b/test/parallel/test-tls-sni-server-client.js
@@ -128,3 +128,26 @@ function test(options, clientResult, serverResult) {
     }));
   });
 }
+
+// Ensure an error is thrown if 'servername' is not specified.
+assert.throws(() =>
+  tls.createServer(serverOptions, () => {}).addContext(),
+              {
+                code: 'ERR_MISSING_ARGS'
+              });
+
+// Ensure an error is thrown is 'servername' is not a string.
+assert.throws(() =>
+  tls.createServer(serverOptions, () => {}).addContext(7),
+              {
+                code: 'ERR_INVALID_ARG_TYPE'
+              });
+
+// Ensure an error is thrown if 'servername' is an IP address.
+assert.throws(() =>
+  tls.createServer(serverOptions, () => {}).addContext('::'),
+              {
+                code: 'ERR_INVALID_ARG_VALUE',
+                message: 'The argument \'servername\' must not be an IP ' +
+                'address. Received \'::\''
+              });


### PR DESCRIPTION
If 'servername' is not provided, 'ERR_MISSING_ARGS is thrown.
If 'servername' is not a string, 'ERR_INVALID_ARG_TYPE' is thrown.
If 'servername' is an IP address, 'ERR_INVALID_ARG_VALUE' is thrown, since
literal IPv4 and IPv6 addresses are not permitted in SNI.

Fixed API documentation ('hostname' -> 'servername').

Also removed a redundant error 'ERR_TLS_REQUIRED_SERVER_NAME'.

This PR was inspired by: https://github.com/nodejs/node/pull/19988
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)