### PR TITLE
Fix an assertion failure at exit in the macOS app sandbox

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -737,7 +737,10 @@ void ResetStdio() {
         err = tcsetattr(fd, TCSANOW, &s.termios);
       while (err == -1 && errno == EINTR);  // NOLINT
       CHECK_EQ(0, pthread_sigmask(SIG_UNBLOCK, &sa, nullptr));
-      CHECK_EQ(0, err);
+
+      // Normally we expect err == 0. But if macOS App Sandbox is enabled,
+      // tcsetattr will fail with err == -1 and errno == EPERM.
+      CHECK_IMPLIES(err != 0, err == -1 && errno == EPERM);
     }
   }
 #endif  // __POSIX__

--- a/test/fixtures/macos-app-sandbox/Info.plist
+++ b/test/fixtures/macos-app-sandbox/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleExecutable</key>
+	<string>node</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.nodejs.test.node_sandboxed</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>node_sandboxed</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/test/fixtures/macos-app-sandbox/node_sandboxed.entitlements
+++ b/test/fixtures/macos-app-sandbox/node_sandboxed.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+</dict>
+</plist>

--- a/test/parallel/test-macos-app-sandbox.js
+++ b/test/parallel/test-macos-app-sandbox.js
@@ -1,0 +1,67 @@
+'use strict';
+const common = require('../common');
+if (process.platform !== 'darwin')
+  common.skip('App Sandbox is only avaliable on Darwin');
+
+const fixtures = require('../common/fixtures');
+const tmpdir = require('../common/tmpdir');
+const assert = require('assert');
+const child_process = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const nodeBinary = path.resolve(
+  __dirname, '..', '..',
+  `out/${common.buildType}/node`);
+
+tmpdir.refresh();
+
+const appBundlePath = path.join(tmpdir.path, 'node_sandboxed.app');
+const appBundleContentPath = path.join(appBundlePath, 'Contents');
+const appExecutablePath = path.join(
+  appBundleContentPath, 'MacOS', 'node');
+
+// Construct the app bundle and put the node executable in it:
+// node_sandboxed.app/
+// └── Contents
+//     ├── Info.plist
+//     ├── MacOS
+//     │   └── node
+fs.mkdirSync(appBundlePath);
+fs.mkdirSync(appBundleContentPath);
+fs.mkdirSync(path.join(appBundleContentPath, 'MacOS'));
+fs.copyFileSync(
+  fixtures.path('macos-app-sandbox', 'Info.plist'),
+  path.join(appBundleContentPath, 'Info.plist'));
+fs.copyFileSync(
+  nodeBinary,
+  appExecutablePath);
+
+
+// Sign the app bundle with sandbox entitlements:
+assert.strictEqual(
+  child_process.spawnSync('/usr/bin/codesign', [
+    '--entitlements', fixtures.path(
+      'macos-app-sandbox', 'node_sandboxed.entitlements'),
+    '-s', '-',
+    appBundlePath
+  ]).status,
+  0);
+
+// Sandboxed app shouldn't be able to read the home dir
+assert.notStrictEqual(
+  child_process.spawnSync(appExecutablePath, [
+    '-e', 'fs.readdirSync(process.argv[1])', os.homedir()
+  ]).status,
+  0);
+
+if (process.stdin.isTTY) {
+  // Run the sandboxed node instance with inherited tty stdin
+  const spawnResult = child_process.spawnSync(
+    appExecutablePath, ['-e', ''],
+    { stdio: 'inherit' }
+  );
+
+  assert.strictEqual(spawnResult.signal, null);
+}

--- a/test/parallel/test-macos-app-sandbox.js
+++ b/test/parallel/test-macos-app-sandbox.js
@@ -38,19 +38,14 @@ fs.copyFileSync(
 
 
 // Sign the app bundle with sandbox entitlements:
-const codesignResult = child_process.spawnSync(
-  '/usr/bin/codesign',
-  [
+assert.strictEqual(
+  child_process.spawnSync('/usr/bin/codesign', [
     '--entitlements', fixtures.path(
       'macos-app-sandbox', 'node_sandboxed.entitlements'),
     '-s', '-',
     appBundlePath
-  ])
-
-console.error(codesignResult)
-console.error(codesignResult.stdout?.toString())
-console.error(codesignResult.stderr?.toString())
-assert.strictEqual(codesignResult.status, 0);
+  ]).status,
+  0);
 
 // Sandboxed app shouldn't be able to read the home dir
 assert.notStrictEqual(

--- a/test/parallel/test-macos-app-sandbox.js
+++ b/test/parallel/test-macos-app-sandbox.js
@@ -38,14 +38,19 @@ fs.copyFileSync(
 
 
 // Sign the app bundle with sandbox entitlements:
-assert.strictEqual(
-  child_process.spawnSync('/usr/bin/codesign', [
+const codesignResult = child_process.spawnSync(
+  '/usr/bin/codesign',
+  [
     '--entitlements', fixtures.path(
       'macos-app-sandbox', 'node_sandboxed.entitlements'),
     '-s', '-',
     appBundlePath
-  ]).status,
-  0);
+  ])
+
+console.error(codesignResult)
+console.error(codesignResult.stdout?.toString())
+console.error(codesignResult.stderr?.toString())
+assert.strictEqual(codesignResult.status, 0);
 
 // Sandboxed app shouldn't be able to read the home dir
 assert.notStrictEqual(

--- a/test/parallel/test-macos-app-sandbox.js
+++ b/test/parallel/test-macos-app-sandbox.js
@@ -11,9 +11,7 @@ const path = require('path');
 const fs = require('fs');
 const os = require('os');
 
-const nodeBinary = path.resolve(
-  __dirname, '..', '..',
-  `out/${common.buildType}/node`);
+const nodeBinary = process.execPath;
 
 tmpdir.refresh();
 


### PR DESCRIPTION
The node process raises at exit an assertion failure at https://github.com/nodejs/node/blob/a85ce885bddaf5fca00dc7d13eb3c5a99663e60f/src/node.cc#L740 when it runs in macOS app sandbox.

This PR includes

- A basic test that verifies Node.js is able to run in the macOS app sandbox,
- A fix of the problem described above,
- A test of the fix.

### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
