### PR TITLE
fs: fix realpath inode link caching

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1650,7 +1650,7 @@ function realpathSync(p, options) {
 
       const baseLong = pathModule.toNamespacedPath(base);
       const ctx = { path: base };
-      const stats = binding.lstat(baseLong, false, undefined, ctx);
+      const stats = binding.lstat(baseLong, true, undefined, ctx);
       handleErrorFromBinding(ctx);
 
       if (!isFileType(stats, S_IFLNK)) {
@@ -1783,7 +1783,7 @@ function realpath(p, options, callback) {
       return process.nextTick(LOOP);
     }
 
-    return fs.lstat(base, gotStat);
+    return fs.lstat(base, { bigint: true }, gotStat);
   }
 
   function gotStat(err, stats) {

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -31,6 +31,7 @@ const kIoMaxLength = 2 ** 31 - 1;
 const {
   Map,
   MathMax,
+  Number,
   NumberIsSafeInteger,
   ObjectCreate,
   ObjectDefineProperties,
@@ -182,7 +183,10 @@ const isFd = isUint32;
 function isFileType(stats, fileType) {
   // Use stats array directly to avoid creating an fs.Stats instance just for
   // our internal use.
-  return (stats[1/* mode */] & S_IFMT) === fileType;
+  let mode = stats[1];
+  if (typeof mode === 'bigint')
+    mode = Number(mode);
+  return (mode & S_IFMT) === fileType;
 }
 
 function access(path, mode, callback) {


### PR DESCRIPTION
The `fs.realpath` / `fs.realpathSync` cache already seen symbolic links
using the inode number which may be longer that max supported
JS number (2**53) and will therefore be incorrectly handled by possibly
entering infinite loop of calling stat on the same node.

This PR changes those functions (where appropriate) to use
bigint for inode numbers.

Fixes: https://github.com/nodejs/node/issues/33936

I don't think it is possible to write a test for this as it depends on specific inode numbers being bigger than 2**53.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
/cc @nodejs/fs @bnoordhuis 