### PR TITLE
timers: fix multipleResolves in promisified timeouts/immediates

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -190,8 +190,10 @@ setTimeout[customPromisify] = function(after, value, options = {}) {
     insert(timeout, timeout._idleTimeout);
     if (signal) {
       signal.addEventListener('abort', () => {
-        clearTimeout(timeout);
-        reject(lazyDOMException('AbortError'));
+        if (!timeout._destroyed) {
+          clearTimeout(timeout);
+          reject(lazyDOMException('AbortError'));
+        }
       }, { once: true });
     }
   });
@@ -340,8 +342,10 @@ setImmediate[customPromisify] = function(value, options = {}) {
     const immediate = new Immediate(resolve, [value]);
     if (signal) {
       signal.addEventListener('abort', () => {
-        clearImmediate(immediate);
-        reject(lazyDOMException('AbortError'));
+        if (!immediate._destroyed) {
+          clearImmediate(immediate);
+          reject(lazyDOMException('AbortError'));
+        }
       }, { once: true });
     }
   });

--- a/test/parallel/test-timers-promisified.js
+++ b/test/parallel/test-timers-promisified.js
@@ -10,10 +10,7 @@ const { promisify } = require('util');
 const setTimeout = promisify(timers.setTimeout);
 const setImmediate = promisify(timers.setImmediate);
 
-process.on('multipleResolves', (type, promise, reason) => {
-  console.error('multipleResolves', type, promise, reason);
-  throw new Error('multipleResolves');
-});
+process.on('multipleResolves', common.mustNotCall());
 
 {
   const promise = setTimeout(1);

--- a/test/parallel/test-timers-promisified.js
+++ b/test/parallel/test-timers-promisified.js
@@ -10,6 +10,11 @@ const { promisify } = require('util');
 const setTimeout = promisify(timers.setTimeout);
 const setImmediate = promisify(timers.setImmediate);
 
+process.on('multipleResolves', (type, promise, reason) => {
+  console.error('multipleResolves', type, promise, reason);
+  throw new Error('multipleResolves');
+});
+
 {
   const promise = setTimeout(1);
   promise.then(common.mustCall((value) => {
@@ -64,6 +69,23 @@ const setImmediate = promisify(timers.setImmediate);
   const signal = ac.signal;
   ac.abort(); // Abort in advance
   assert.rejects(setImmediate(10, { signal }), /AbortError/);
+}
+
+{
+  // Check that aborting after resolve will not reject.
+  const ac = new AbortController();
+  const signal = ac.signal;
+  setTimeout(10, undefined, { signal }).then(() => {
+    ac.abort();
+  });
+}
+{
+  // Check that aborting after resolve will not reject.
+  const ac = new AbortController();
+  const signal = ac.signal;
+  setImmediate(10, { signal }).then(() => {
+    ac.abort();
+  });
 }
 
 {


### PR DESCRIPTION
After successful timer finish the abort event callback would still
reject (already resolved promise) upon calling abortController.abort().

Signed-off-by: Denys Otrishko <shishugi@gmail.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
/cc @jasnell @nodejs/timers 