### PR TITLE
test: account for non-node basename

### DIFF
--- a/test/message/eval_messages.out
+++ b/test/message/eval_messages.out
@@ -55,11 +55,11 @@ ReferenceError: y is not defined
 var ______________________________________________; throw 10
                                                     ^
 10
-(Use `node --trace-uncaught ...` to show where the exception was thrown)
+(Use `* --trace-uncaught ...` to show where the exception was thrown)
 
 [eval]:1
 var ______________________________________________; throw 10
                                                     ^
 10
-(Use `node --trace-uncaught ...` to show where the exception was thrown)
+(Use `* --trace-uncaught ...` to show where the exception was thrown)
 done

--- a/test/message/stdin_messages.out
+++ b/test/message/stdin_messages.out
@@ -67,11 +67,11 @@ ReferenceError: y is not defined
 let ______________________________________________; throw 10
                                                     ^
 10
-(Use `node --trace-uncaught ...` to show where the exception was thrown)
+(Use `* --trace-uncaught ...` to show where the exception was thrown)
 
 [stdin]:1
 let ______________________________________________; throw 10
                                                     ^
 10
-(Use `node --trace-uncaught ...` to show where the exception was thrown)
+(Use `* --trace-uncaught ...` to show where the exception was thrown)
 done

--- a/test/message/throw_error_with_getter_throw.out
+++ b/test/message/throw_error_with_getter_throw.out
@@ -3,4 +3,4 @@
 throw {  // eslint-disable-line no-throw-literal
 ^
 [object Object]
-(Use `node --trace-uncaught ...` to show where the exception was thrown)
+(Use `* --trace-uncaught ...` to show where the exception was thrown)

--- a/test/message/throw_null.out
+++ b/test/message/throw_null.out
@@ -3,4 +3,4 @@
 throw null;
 ^
 null
-(Use `node --trace-uncaught ...` to show where the exception was thrown)
+(Use `* --trace-uncaught ...` to show where the exception was thrown)

--- a/test/message/throw_undefined.out
+++ b/test/message/throw_undefined.out
@@ -3,4 +3,4 @@
 throw undefined;
 ^
 undefined
-(Use `node --trace-uncaught ...` to show where the exception was thrown)
+(Use `* --trace-uncaught ...` to show where the exception was thrown)


### PR DESCRIPTION
Refs https://github.com/nodejs/node/commit/edf75e4299219d57e53f98956b8e27e4945dd5d6.

Electron runs smoke tests with Node.js' own specs against our emulated version of Node.js, and so it's the case for us that the basename is `Electron`. These tests were failing as they're hardcoded to assume it's `node` so this makes them more flexible for embedders.

cc @addaleax 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
