### PR TITLE
quic: set up FunctionTemplates more cleanly

### DIFF
--- a/src/quic/node_quic_session.cc
+++ b/src/quic/node_quic_session.cc
@@ -3723,7 +3723,7 @@ void QuicSession::Initialize(
     session->SetClassName(class_name);
     session->Inherit(AsyncWrap::GetConstructorTemplate(env));
     Local<ObjectTemplate> sessiont = session->InstanceTemplate();
-    sessiont->SetInternalFieldCount(1);
+    sessiont->SetInternalFieldCount(QuicSession::kInternalFieldCount);
     sessiont->Set(env->owner_symbol(), Null(env->isolate()));
     AddMethods(env, session);
     env->set_quicserversession_instance_template(sessiont);
@@ -3736,7 +3736,7 @@ void QuicSession::Initialize(
     session->SetClassName(class_name);
     session->Inherit(AsyncWrap::GetConstructorTemplate(env));
     Local<ObjectTemplate> sessiont = session->InstanceTemplate();
-    sessiont->SetInternalFieldCount(1);
+    sessiont->SetInternalFieldCount(QuicSession::kInternalFieldCount);
     sessiont->Set(env->owner_symbol(), Null(env->isolate()));
     AddMethods(env, session);
     env->SetProtoMethod(session,

--- a/src/quic/node_quic_socket.cc
+++ b/src/quic/node_quic_socket.cc
@@ -1121,8 +1121,10 @@ void QuicEndpoint::Initialize(
   Isolate* isolate = env->isolate();
   Local<String> class_name = FIXED_ONE_BYTE_STRING(isolate, "QuicEndpoint");
   Local<FunctionTemplate> endpoint = env->NewFunctionTemplate(NewQuicEndpoint);
+  endpoint->Inherit(BaseObject::GetConstructorTemplate(env));
   endpoint->SetClassName(class_name);
-  endpoint->InstanceTemplate()->SetInternalFieldCount(1);
+  endpoint->InstanceTemplate()->SetInternalFieldCount(
+      QuicEndpoint::kInternalFieldCount);
   env->SetProtoMethod(endpoint,
                       "waitForPendingCallbacks",
                       QuicEndpointWaitForPendingCallbacks);
@@ -1142,8 +1144,10 @@ void QuicSocket::Initialize(
   Isolate* isolate = env->isolate();
   Local<String> class_name = FIXED_ONE_BYTE_STRING(isolate, "QuicSocket");
   Local<FunctionTemplate> socket = env->NewFunctionTemplate(NewQuicSocket);
+  socket->Inherit(AsyncWrap::GetConstructorTemplate(env));
   socket->SetClassName(class_name);
-  socket->InstanceTemplate()->SetInternalFieldCount(1);
+  socket->InstanceTemplate()->SetInternalFieldCount(
+      QuicSocket::kInternalFieldCount);
   socket->InstanceTemplate()->Set(env->owner_symbol(), Null(isolate));
   env->SetProtoMethod(socket,
                       "addEndpoint",
@@ -1170,9 +1174,11 @@ void QuicSocket::Initialize(
   target->Set(context, class_name,
               socket->GetFunction(env->context()).ToLocalChecked()).FromJust();
 
-  // TODO(addaleax): None of these templates actually are constructor templates.
-  Local<ObjectTemplate> sendwrap_template = ObjectTemplate::New(isolate);
-  sendwrap_template->SetInternalFieldCount(1);
+  Local<FunctionTemplate> sendwrap_ctor = FunctionTemplate::New(isolate);
+  sendwrap_ctor->Inherit(AsyncWrap::GetConstructorTemplate(env));
+  sendwrap_ctor->SetClassName(FIXED_ONE_BYTE_STRING(isolate, "SendWrap"));
+  Local<ObjectTemplate> sendwrap_template = sendwrap_ctor->InstanceTemplate();
+  sendwrap_template->SetInternalFieldCount(SendWrap::kInternalFieldCount);
   env->set_quicsocketsendwrap_instance_template(sendwrap_template);
 }
 


### PR DESCRIPTION
- Use `kInternalFieldCount`, similar to 0fac393d.
- Always inherit from the correct parent template, similar to 8a7201b2.
- Always provide a template class name.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
