### PR TITLE
tls: make 'createSecureContext' honor more options.

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -1622,6 +1622,11 @@ changes:
     **Default:** none, see `minVersion`.
   * `sessionIdContext` {string} Opaque identifier used by servers to ensure
     session state is not shared between applications. Unused by clients.
+  * `ticketKeys`: {Buffer} 48-bytes of cryptographically strong pseudo-random
+    data. See [Session Resumption][] for more information.
+  * `sessionTimeout` {number} The number of seconds after which a TLS session
+    created by the server will no longer be resumable. See
+    [Session Resumption][] for more information. **Default:** `300`.
 
 [`tls.createServer()`][] sets the default value of the `honorCipherOrder` option
 to `true`, other APIs that create secure contexts leave it unset.

--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -294,6 +294,14 @@ exports.createSecureContext = function createSecureContext(options) {
                                    options.clientCertEngine);
   }
 
+  if (options.ticketKeys) {
+    c.context.setTicketKeys(options.ticketKeys);
+  }
+
+  if (options.sessionTimeout) {
+    c.context.setSessionTimeout(options.sessionTimeout);
+  }
+
   return c;
 };
 

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -1315,6 +1315,12 @@ Server.prototype.setSecureContext = function(options) {
                                   .slice(0, 32);
   }
 
+  if (options.sessionTimeout)
+    this.sessionTimeout = options.sessionTimeout;
+
+  if (options.ticketKeys)
+    this.ticketKeys = options.ticketKeys;
+
   this._sharedCreds = tls.createSecureContext({
     pfx: this.pfx,
     key: this.key,
@@ -1332,16 +1338,10 @@ Server.prototype.setSecureContext = function(options) {
     secureOptions: this.secureOptions,
     honorCipherOrder: this.honorCipherOrder,
     crl: this.crl,
-    sessionIdContext: this.sessionIdContext
+    sessionIdContext: this.sessionIdContext,
+    ticketKeys: this.ticketKeys,
+    sessionTimeout: this.sessionTimeout
   });
-
-  if (this.sessionTimeout)
-    this._sharedCreds.context.setSessionTimeout(this.sessionTimeout);
-
-  if (options.ticketKeys) {
-    this.ticketKeys = options.ticketKeys;
-    this.setTicketKeys(this.ticketKeys);
-  }
 };
 
 


### PR DESCRIPTION
Added options: `ticketKeys` and `sessionTimeout`, that are honored by
`createServer`, that calls `createSecureContext`.

This also introduces a minor code simplification.

Fixes: #20908
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)