### PR TITLE
doc: use Class: consistently

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,76 @@
+# Node.js Project Codeowners
+
+# 1. Codeowners must always be teams, never individuals
+# 2. Each codeowner team should contain at least one TSC member
+# 3. PRs touching any code with a codeowner must be signed off by at least one
+#    person on the code owner team.
+
+./.github/CODEOWNERS @nodejs/tsc
+
+# net
+
+# ./deps/cares @nodejs/net
+# ./doc/api/dns.md @nodejs/net
+# ./doc/api/dgram.md @nodejs/net
+# ./doc/api/net.md @nodejs/net
+# ./lib/dgram.js @nodejs/net
+# ./lib/dns.js @nodejs/net
+# ./lib/net.js @nodejs/net @nodejs/quic
+# ./lib/internal/dgram.js @nodejs/net
+# ./lib/internal/dns/* @nodejs/net
+# ./lib/internal/net.js @nodejs/net
+# ./lib/internal/socket_list.js @nodejs/net
+# ./lib/internal/js_stream_socket.js @nodejs/net
+# ./src/cares_wrap.h @nodejs/net
+# ./src/connect_wrap.* @nodejs/net
+# ./src/connection_wrap.* @nodejs/net
+# ./src/node_sockaddr* @nodejs/net
+# ./src/tcp_wrap.* @nodejs/net
+# ./src/udp_wrap.* @nodejs/net
+
+# tls/crypto
+
+# ./lib/internal/crypto/* @nodejs/crypto
+# ./lib/internal/tls.js @nodejs/crypto @nodejs/net
+# ./lib/crypto.js @nodejs/crypto
+# ./lib/tls.js @nodejs/crypto @nodejs/net
+# ./src/node_crypto* @nodejs/crypto
+# ./src/node_crypto_common* @nodejs/crypto @nodejs/quic
+
+# http
+
+# ./deps/llhttp/* @nodejs/http @nodejs/net
+# ./doc/api/http.md @nodejs/http @nodejs/net
+# ./doc/api/http2.md @nodejs/http @nodejs/net
+# ./lib/_http_* @nodejs/http @nodejs/net
+# ./lib/http.js @nodejs/http @nodejs/net
+# ./lib/https.js @nodejs/crypto @nodejs/net @nodejs/http
+# ./src/node_http_common* @nodejs/http @nodejs/http2 @nodejs/quic @nodejs/net
+# ./src/node_http_parser.cc @nodejs/http @nodejs/net
+
+# http2
+
+# ./deps/nghttp2/* @nodejs/http2 @nodejs/net
+# ./doc/api/http2.md @nodejs/http2 @nodejs/net
+# ./lib/http2.js @nodejs/http2 @nodejs/net
+# ./lib/internal/http2/* @nodejs/http2 @nodejs/net
+# ./src/node_http2* @nodejs/http2 @nodejs/net
+# ./src/node_mem* @nodejs/http2
+
+# quic
+
+./deps/ngtcp2/* @nodejs/quic
+./deps/nghttp3/* @nodejs/quic
+./doc/api/quic.md @nodejs/quic
+./lib/internal/quic/* @nodejs/quic
+./src/node_bob* @nodejs/quic
+./src/quic/* @nodejs/quic
+
+# modules
+
+# ./doc/api/modules.md @nodejs/modules
+# ./doc/api/esm.md @nodejs/modules
+# ./lib/module.js @nodejs/modules
+# ./lib/internal/modules/* @nodejs/modules
+# ./lib/internal/bootstrap/loaders.js @nodejs/modules
+# ./src/module_wrap* @nodejs/modules @nodejs/vm

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -4440,7 +4440,7 @@ The `fs.promises` API provides an alternative set of asynchronous file system
 methods that return `Promise` objects rather than using callbacks. The
 API is accessible via `require('fs').promises` or `require('fs/promises')`.
 
-### class: `FileHandle`
+### Class: `FileHandle`
 <!-- YAML
 added: v10.0.0
 -->

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -300,6 +300,16 @@ added: v0.3.6
 By default set to `Infinity`. Determines how many concurrent sockets the agent
 can have open per origin. Origin is the returned value of [`agent.getName()`][].
 
+### `agent.maxTotalSockets`
+<!-- YAML
+added: REPLACEME
+-->
+
+* {number}
+
+By default set to `Infinity`. Determines how many concurrent sockets the agent
+can have open. Unlike `maxSockets`, this parameter applies across all origins.
+
 ### `agent.requests`
 <!-- YAML
 added: v0.5.9

--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -22,6 +22,7 @@
 'use strict';
 
 const {
+  NumberIsNaN,
   ObjectKeys,
   ObjectSetPrototypeOf,
   ObjectValues,
@@ -38,11 +39,14 @@ const {
   codes: {
     ERR_INVALID_ARG_TYPE,
     ERR_INVALID_OPT_VALUE,
+    ERR_OUT_OF_RANGE,
   },
 } = require('internal/errors');
 const { once } = require('internal/util');
+const { validateNumber } = require('internal/validators');
 
 const kOnKeylog = Symbol('onkeylog');
+const kRequestOptions = Symbol('requestOptions');
 // New Agent code.
 
 // The largest departure from the previous implementation is that
@@ -90,9 +94,20 @@ function Agent(options) {
   this.maxSockets = this.options.maxSockets || Agent.defaultMaxSockets;
   this.maxFreeSockets = this.options.maxFreeSockets || 256;
   this.scheduling = this.options.scheduling || 'fifo';
+  this.maxTotalSockets = this.options.maxTotalSockets;
+  this.totalSocketCount = 0;
 
   if (this.scheduling !== 'fifo' && this.scheduling !== 'lifo') {
     throw new ERR_INVALID_OPT_VALUE('scheduling', this.scheduling);
+  }
+
+  if (this.maxTotalSockets !== undefined) {
+    validateNumber(this.maxTotalSockets, 'maxTotalSockets');
+    if (this.maxTotalSockets <= 0 || NumberIsNaN(this.maxTotalSockets))
+      throw new ERR_OUT_OF_RANGE('maxTotalSockets', '> 0',
+                                 this.maxTotalSockets);
+  } else {
+    this.maxTotalSockets = Infinity;
   }
 
   this.on('free', (socket, options) => {
@@ -133,7 +148,8 @@ function Agent(options) {
     if (this.sockets[name])
       count += this.sockets[name].length;
 
-    if (count > this.maxSockets ||
+    if (this.totalSocketCount > this.maxTotalSockets ||
+        count > this.maxSockets ||
         freeLen >= this.maxFreeSockets ||
         !this.keepSocketAlive(socket)) {
       socket.destroy();
@@ -248,7 +264,9 @@ Agent.prototype.addRequest = function addRequest(req, options, port/* legacy */,
     this.reuseSocket(socket, req);
     setRequestSocket(this, req, socket);
     this.sockets[name].push(socket);
-  } else if (sockLen < this.maxSockets) {
+    this.totalSocketCount++;
+  } else if (sockLen < this.maxSockets &&
+             this.totalSocketCount < this.maxTotalSockets) {
     debug('call onSocket', sockLen, freeLen);
     // If we are under maxSockets create a new one.
     this.createSocket(req, options, (err, socket) => {
@@ -263,6 +281,10 @@ Agent.prototype.addRequest = function addRequest(req, options, port/* legacy */,
     if (!this.requests[name]) {
       this.requests[name] = [];
     }
+
+    // Used to create sockets for pending requests from different origin
+    req[kRequestOptions] = options;
+
     this.requests[name].push(req);
   }
 };
@@ -288,7 +310,8 @@ Agent.prototype.createSocket = function createSocket(req, options, cb) {
       this.sockets[name] = [];
     }
     this.sockets[name].push(s);
-    debug('sockets', name, this.sockets[name].length);
+    this.totalSocketCount++;
+    debug('sockets', name, this.sockets[name].length, this.totalSocketCount);
     installListeners(this, s, options);
     cb(null, s);
   });
@@ -394,13 +417,33 @@ Agent.prototype.removeSocket = function removeSocket(s, options) {
         // Don't leak
         if (sockets[name].length === 0)
           delete sockets[name];
+        this.totalSocketCount--;
       }
     }
   }
 
+  let req;
   if (this.requests[name] && this.requests[name].length) {
     debug('removeSocket, have a request, make a socket');
-    const req = this.requests[name][0];
+    req = this.requests[name][0];
+  } else {
+    // TODO(rickyes): this logic will not be FIFO across origins.
+    // There might be older requests in a different origin, but
+    // if the origin which releases the socket has pending requests
+    // that will be prioritized.
+    for (const prop in this.requests) {
+      // Check whether this specific origin is already at maxSockets
+      if (this.sockets[prop] && this.sockets[prop].length) break;
+      debug('removeSocket, have a request with different origin,' +
+        ' make a socket');
+      req = this.requests[prop][0];
+      options = req[kRequestOptions];
+      break;
+    }
+  }
+
+  if (req && options) {
+    req[kRequestOptions] = undefined;
     // If we have pending requests and a socket gets closed make a new one
     this.createSocket(req, options, (err, socket) => {
       if (err)
@@ -409,6 +452,7 @@ Agent.prototype.removeSocket = function removeSocket(s, options) {
         socket.emit('free');
     });
   }
+
 };
 
 Agent.prototype.keepSocketAlive = function keepSocketAlive(socket) {

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -49,7 +49,7 @@ const Agent = require('_http_agent');
 const { Buffer } = require('buffer');
 const { defaultTriggerAsyncIdScope } = require('internal/async_hooks');
 const { URL, urlToOptions, searchParamsSymbol } = require('internal/url');
-const { kOutHeaders, kNeedDrain } = require('internal/http');
+const { kOutHeaders, kNeedDrain, kClosed } = require('internal/http');
 const { connResetException, codes } = require('internal/errors');
 const {
   ERR_HTTP_HEADERS_SENT,
@@ -385,6 +385,7 @@ function _destroy(req, socket, err) {
     if (err) {
       req.emit('error', err);
     }
+    req[kClosed] = true;
     req.emit('close');
   }
 }
@@ -427,6 +428,7 @@ function socketCloseListener() {
         res.emit('error', connResetException('aborted'));
       }
     }
+    req[kClosed] = true;
     req.emit('close');
     if (!res.aborted && res.readable) {
       res.on('end', function() {
@@ -446,6 +448,7 @@ function socketCloseListener() {
       req.socket._hadError = true;
       req.emit('error', connResetException('socket hang up'));
     }
+    req[kClosed] = true;
     req.emit('close');
   }
 
@@ -550,6 +553,7 @@ function socketOnData(d) {
 
       req.emit(eventName, res, socket, bodyHead);
       req.destroyed = true;
+      req[kClosed] = true;
       req.emit('close');
     } else {
       // Requested Upgrade or used CONNECT method, but have no handler.
@@ -721,6 +725,7 @@ function requestOnPrefinish() {
 }
 
 function emitFreeNT(req) {
+  req[kClosed] = true;
   req.emit('close');
   if (req.res) {
     req.res.emit('close');

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -36,7 +36,7 @@ const assert = require('internal/assert');
 const EE = require('events');
 const Stream = require('stream');
 const internalUtil = require('internal/util');
-const { kOutHeaders, utcDate, kNeedDrain } = require('internal/http');
+const { kOutHeaders, utcDate, kNeedDrain, kClosed } = require('internal/http');
 const { Buffer } = require('buffer');
 const common = require('_http_common');
 const checkIsHttpToken = common._checkIsHttpToken;
@@ -117,6 +117,7 @@ function OutgoingMessage() {
   this.finished = false;
   this._headerSent = false;
   this[kCorked] = 0;
+  this[kClosed] = false;
 
   this.socket = null;
   this._header = null;
@@ -663,7 +664,9 @@ function onError(msg, err, callback) {
 
 function emitErrorNt(msg, err, callback) {
   callback(err);
-  if (typeof msg.emit === 'function') msg.emit('error', err);
+  if (typeof msg.emit === 'function' && !msg[kClosed]) {
+    msg.emit('error', err);
+  }
 }
 
 function write_(msg, chunk, encoding, callback, fromEnd) {
@@ -690,7 +693,11 @@ function write_(msg, chunk, encoding, callback, fromEnd) {
   }
 
   if (err) {
-    onError(msg, err, callback);
+    if (!msg.destroyed) {
+      onError(msg, err, callback);
+    } else {
+      process.nextTick(callback, err);
+    }
     return false;
   }
 

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -49,6 +49,7 @@ const { OutgoingMessage } = require('_http_outgoing');
 const {
   kOutHeaders,
   kNeedDrain,
+  kClosed,
   emitStatistics
 } = require('internal/http');
 const {
@@ -212,6 +213,7 @@ function onServerResponseClose() {
   // Fortunately, that requires only a single if check. :-)
   if (this._httpMessage) {
     this._httpMessage.destroyed = true;
+    this._httpMessage[kClosed] = true;
     this._httpMessage.emit('close');
   }
 }
@@ -729,6 +731,7 @@ function resOnFinish(req, res, socket, state, server) {
 
 function emitCloseNT(self) {
   self.destroyed = true;
+  self[kClosed] = true;
   self.emit('close');
 }
 

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -255,6 +255,12 @@ ReadStream.prototype._read = function(n) {
 };
 
 ReadStream.prototype._destroy = function(err, cb) {
+  // Usually for async IO it is safe to close a file descriptor
+  // even when there are pending operations. However, due to platform
+  // differences file IO is implemented using synchronous operations
+  // running in a thread pool. Therefore, file descriptors are not safe
+  // to close while used in a pending read or write operation. Wait for
+  // any pending IO (kIsPerformingIO) to complete (kIoDone).
   if (this[kIsPerformingIO]) {
     this.once(kIoDone, (er) => close(this, err || er, cb));
   } else {
@@ -416,12 +422,19 @@ WriteStream.prototype._writev = function(data, cb) {
 };
 
 WriteStream.prototype._destroy = function(err, cb) {
+  // Usually for async IO it is safe to close a file descriptor
+  // even when there are pending operations. However, due to platform
+  // differences file IO is implemented using synchronous operations
+  // running in a thread pool. Therefore, file descriptors are not safe
+  // to close while used in a pending read or write operation. Wait for
+  // any pending IO (kIsPerformingIO) to complete (kIoDone).
   if (this[kIsPerformingIO]) {
     this.once(kIoDone, (er) => close(this, err || er, cb));
   } else {
     close(this, err, cb);
   }
 };
+
 WriteStream.prototype.close = function(cb) {
   if (cb) {
     if (this.closed) {

--- a/lib/internal/http.js
+++ b/lib/internal/http.js
@@ -51,6 +51,7 @@ function emitStatistics(statistics) {
 module.exports = {
   kOutHeaders: Symbol('kOutHeaders'),
   kNeedDrain: Symbol('kNeedDrain'),
+  kClosed: Symbol('kClosed'),
   nowDate,
   utcDate,
   emitStatistics

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -190,8 +190,10 @@ setTimeout[customPromisify] = function(after, value, options = {}) {
     insert(timeout, timeout._idleTimeout);
     if (signal) {
       signal.addEventListener('abort', () => {
-        clearTimeout(timeout);
-        reject(lazyDOMException('AbortError'));
+        if (!timeout._destroyed) {
+          clearTimeout(timeout);
+          reject(lazyDOMException('AbortError'));
+        }
       }, { once: true });
     }
   });
@@ -340,8 +342,10 @@ setImmediate[customPromisify] = function(value, options = {}) {
     const immediate = new Immediate(resolve, [value]);
     if (signal) {
       signal.addEventListener('abort', () => {
-        clearImmediate(immediate);
-        reject(lazyDOMException('AbortError'));
+        if (!immediate._destroyed) {
+          clearImmediate(immediate);
+          reject(lazyDOMException('AbortError'));
+        }
       }, { once: true });
     }
   });

--- a/test/parallel/test-http-agent-maxtotalsockets.js
+++ b/test/parallel/test-http-agent-maxtotalsockets.js
@@ -1,0 +1,113 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+const Countdown = require('../common/countdown');
+
+assert.throws(() => new http.Agent({
+  maxTotalSockets: 'test',
+}), {
+  code: 'ERR_INVALID_ARG_TYPE',
+  name: 'TypeError',
+  message: 'The "maxTotalSockets" argument must be of type number. ' +
+    "Received type string ('test')",
+});
+
+[-1, 0, NaN].forEach((item) => {
+  assert.throws(() => new http.Agent({
+    maxTotalSockets: item,
+  }), {
+    code: 'ERR_OUT_OF_RANGE',
+    name: 'RangeError',
+    message: 'The value of "maxTotalSockets" is out of range. ' +
+      `It must be > 0. Received ${item}`,
+  });
+});
+
+assert.ok(new http.Agent({
+  maxTotalSockets: Infinity,
+}));
+
+function start(param = {}) {
+  const { maxTotalSockets, maxSockets } = param;
+
+  const agent = new http.Agent({
+    keepAlive: true,
+    keepAliveMsecs: 1000,
+    maxTotalSockets,
+    maxSockets,
+    maxFreeSockets: 3
+  });
+
+  const server = http.createServer(common.mustCall((req, res) => {
+    res.end('hello world');
+  }, 6));
+  const server2 = http.createServer(common.mustCall((req, res) => {
+    res.end('hello world');
+  }, 6));
+
+  server.keepAliveTimeout = 0;
+  server2.keepAliveTimeout = 0;
+
+  const countdown = new Countdown(12, () => {
+    assert.strictEqual(getRequestCount(), 0);
+    agent.destroy();
+    server.close();
+    server2.close();
+  });
+
+  function handler(s) {
+    for (let i = 0; i < 6; i++) {
+      http.get({
+        host: 'localhost',
+        port: s.address().port,
+        agent,
+        path: `/${i}`,
+      }, common.mustCall((res) => {
+        assert.strictEqual(res.statusCode, 200);
+        res.resume();
+        res.on('end', common.mustCall(() => {
+          for (const key of Object.keys(agent.sockets)) {
+            assert(agent.sockets[key].length <= maxSockets);
+          }
+          assert(getTotalSocketsCount() <= maxTotalSockets);
+          countdown.dec();
+        }));
+      }));
+    }
+  }
+
+  function getTotalSocketsCount() {
+    let num = 0;
+    for (const key of Object.keys(agent.sockets)) {
+      num += agent.sockets[key].length;
+    }
+    return num;
+  }
+
+  function getRequestCount() {
+    let num = 0;
+    for (const key of Object.keys(agent.requests)) {
+      num += agent.requests[key].length;
+    }
+    return num;
+  }
+
+  server.listen(0, common.mustCall(() => handler(server)));
+  server2.listen(0, common.mustCall(() => handler(server2)));
+}
+
+// If maxTotalSockets is larger than maxSockets,
+// then the origin check will be skipped
+// when the socket is removed.
+[{
+  maxTotalSockets: 2,
+  maxSockets: 3,
+}, {
+  maxTotalSockets: 3,
+  maxSockets: 2,
+}, {
+  maxTotalSockets: 2,
+  maxSockets: 2,
+}].forEach(start);

--- a/test/parallel/test-http-outgoing-destroy.js
+++ b/test/parallel/test-http-outgoing-destroy.js
@@ -10,13 +10,8 @@ const OutgoingMessage = http.OutgoingMessage;
   assert.strictEqual(msg.destroyed, false);
   msg.destroy();
   assert.strictEqual(msg.destroyed, true);
-  let callbackCalled = false;
   msg.write('asd', common.mustCall((err) => {
     assert.strictEqual(err.code, 'ERR_STREAM_DESTROYED');
-    callbackCalled = true;
   }));
-  msg.on('error', common.mustCall((err) => {
-    assert.strictEqual(err.code, 'ERR_STREAM_DESTROYED');
-    assert.strictEqual(callbackCalled, true);
-  }));
+  msg.on('error', common.mustNotCall());
 }

--- a/test/parallel/test-http-outgoing-destroyed.js
+++ b/test/parallel/test-http-outgoing-destroyed.js
@@ -1,0 +1,24 @@
+'use strict';
+const common = require('../common');
+const http = require('http');
+
+const server = http.createServer(common.mustCall((req, res) => {
+  req.pipe(res);
+  res.on('error', common.mustNotCall());
+  res.on('close', common.mustCall(() => {
+    res.end('asd');
+    process.nextTick(() => {
+      server.close();
+    });
+  }));
+})).listen(0, () => {
+  http
+    .request({
+      port: server.address().port,
+      method: 'PUT'
+    })
+    .on('response', (res) => {
+      res.destroy();
+    })
+    .write('asd');
+});

--- a/test/parallel/test-http-server-write-after-end.js
+++ b/test/parallel/test-http-server-write-after-end.js
@@ -8,19 +8,19 @@ const http = require('http');
 const server = http.createServer(handle);
 
 function handle(req, res) {
-  res.on('error', common.mustCall((err) => {
-    common.expectsError({
-      code: 'ERR_STREAM_WRITE_AFTER_END',
-      name: 'Error'
-    })(err);
-    server.close();
-  }));
+  res.on('error', common.mustNotCall());
 
   res.write('hello');
   res.end();
 
   setImmediate(common.mustCall(() => {
-    res.write('world');
+    res.write('world', common.mustCall((err) => {
+      common.expectsError({
+        code: 'ERR_STREAM_WRITE_AFTER_END',
+        name: 'Error'
+      })(err);
+      server.close();
+    }));
   }));
 }
 

--- a/test/parallel/test-http-server-write-end-after-end.js
+++ b/test/parallel/test-http-server-write-end-after-end.js
@@ -6,19 +6,23 @@ const http = require('http');
 const server = http.createServer(handle);
 
 function handle(req, res) {
-  res.on('error', common.mustCall((err) => {
-    common.expectsError({
-      code: 'ERR_STREAM_WRITE_AFTER_END',
-      name: 'Error'
-    })(err);
-    server.close();
-  }));
+  res.on('error', common.mustNotCall());
 
   res.write('hello');
   res.end();
 
   setImmediate(common.mustCall(() => {
     res.end('world');
+    process.nextTick(() => {
+      server.close();
+    });
+    res.write('world', common.mustCall((err) => {
+      common.expectsError({
+        code: 'ERR_STREAM_WRITE_AFTER_END',
+        name: 'Error'
+      })(err);
+      server.close();
+    }));
   }));
 }
 

--- a/test/parallel/test-timers-promisified.js
+++ b/test/parallel/test-timers-promisified.js
@@ -10,6 +10,8 @@ const { promisify } = require('util');
 const setTimeout = promisify(timers.setTimeout);
 const setImmediate = promisify(timers.setImmediate);
 
+process.on('multipleResolves', common.mustNotCall());
+
 {
   const promise = setTimeout(1);
   promise.then(common.mustCall((value) => {
@@ -64,6 +66,23 @@ const setImmediate = promisify(timers.setImmediate);
   const signal = ac.signal;
   ac.abort(); // Abort in advance
   assert.rejects(setImmediate(10, { signal }), /AbortError/);
+}
+
+{
+  // Check that aborting after resolve will not reject.
+  const ac = new AbortController();
+  const signal = ac.signal;
+  setTimeout(10, undefined, { signal }).then(() => {
+    ac.abort();
+  });
+}
+{
+  // Check that aborting after resolve will not reject.
+  const ac = new AbortController();
+  const signal = ac.signal;
+  setImmediate(10, { signal }).then(() => {
+    ac.abort();
+  });
 }
 
 {


### PR DESCRIPTION
The docs contain 122 uses of `Class:` in headers and one use of `class:`
in headers. This changes that one instance to conform with the other
instances.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
