### PR TITLE
src: reduce scope of code cache mutex

### DIFF
--- a/src/node_native_module.cc
+++ b/src/node_native_module.cc
@@ -263,10 +263,13 @@ MaybeLocal<Function> NativeModuleLoader::LookupAndCompile(
   Local<Integer> column_offset = Integer::New(isolate, 0);
   ScriptOrigin origin(filename, line_offset, column_offset, True(isolate));
 
-  Mutex::ScopedLock lock(code_cache_mutex_);
-
   ScriptCompiler::CachedData* cached_data = nullptr;
   {
+    // Note: The lock here should not extend into the
+    // `CompileFunctionInContext()` call below, because this function may
+    // recurse if there is a syntax error during bootstrap (because the fatal
+    // exception handler is invoked, which may load built-in modules).
+    Mutex::ScopedLock lock(code_cache_mutex_);
     auto cache_it = code_cache_.find(id);
     if (cache_it != code_cache_.end()) {
       // Transfer ownership to ScriptCompiler::Source later.
@@ -313,8 +316,13 @@ MaybeLocal<Function> NativeModuleLoader::LookupAndCompile(
       ScriptCompiler::CreateCodeCacheForFunction(fun));
   CHECK_NOT_NULL(new_cached_data);
 
-  // The old entry should've been erased by now so we can just emplace
-  code_cache_.emplace(id, std::move(new_cached_data));
+  {
+    Mutex::ScopedLock lock(code_cache_mutex_);
+    // The old entry should've been erased by now so we can just emplace.
+    // If another thread did the same thing in the meantime, that should not
+    // be an issue.
+    code_cache_.emplace(id, std::move(new_cached_data));
+  }
 
   return scope.Escape(fun);
 }


### PR DESCRIPTION
As indicated in the added comment, this can lead to a deadlock
otherwise. In the concrete instance in which I encountered this,
the relevant nested call is the one to `require('internal/tty')`
inside of the `afterInspector()` function for uncaught exception
handling.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
