### PR TITLE
fs: document why isPerformingIO is required

### DIFF
--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -255,6 +255,12 @@ ReadStream.prototype._read = function(n) {
 };
 
 ReadStream.prototype._destroy = function(err, cb) {
+  // Usually for async io it is safe to close a file descriptor
+  // even when there are pending operations. However, due to platform
+  // differences file IO is implemented using synchronous operations
+  // running in a thread pool. Therefore, file descriptors are not safe
+  // to close while used in a pending read or write operation. Wait for
+  // any pending IO (kIsPerformingIO) to complete (kIoDone).
   if (this[kIsPerformingIO]) {
     this.once(kIoDone, (er) => close(this, err || er, cb));
   } else {
@@ -416,12 +422,19 @@ WriteStream.prototype._writev = function(data, cb) {
 };
 
 WriteStream.prototype._destroy = function(err, cb) {
+  // Usually for async io it is safe to close a file descriptor
+  // even when there are pending operations. However, due to platform
+  // differences file IO is implemented using synchronous operations
+  // running in a thread pool. Therefore, file descriptors are not safe
+  // to close while used in a pending read or write operation. Wait for
+  // any pending IO (kIsPerformingIO) to complete (kIoDone).
   if (this[kIsPerformingIO]) {
     this.once(kIoDone, (er) => close(this, err || er, cb));
   } else {
     close(this, err, cb);
   }
 };
+
 WriteStream.prototype.close = function(cb) {
   if (cb) {
     if (this.closed) {

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -255,7 +255,7 @@ ReadStream.prototype._read = function(n) {
 };
 
 ReadStream.prototype._destroy = function(err, cb) {
-  // Usually for async io it is safe to close a file descriptor
+  // Usually for async IO it is safe to close a file descriptor
   // even when there are pending operations. However, due to platform
   // differences file IO is implemented using synchronous operations
   // running in a thread pool. Therefore, file descriptors are not safe
@@ -422,7 +422,7 @@ WriteStream.prototype._writev = function(data, cb) {
 };
 
 WriteStream.prototype._destroy = function(err, cb) {
-  // Usually for async io it is safe to close a file descriptor
+  // Usually for async IO it is safe to close a file descriptor
   // even when there are pending operations. However, due to platform
   // differences file IO is implemented using synchronous operations
   // running in a thread pool. Therefore, file descriptors are not safe


### PR DESCRIPTION
Adds some notes to motivate why isPerformingIO is required for any future developers unfamiliar with it.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
