### PR TITLE
doc: mention errors thrown by methods called on an unbound dgram.Socket

### DIFF
--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -108,8 +108,8 @@ Tells the kernel to join a multicast group at the given `multicastAddress` and
 one interface and will add membership to it. To add membership to every
 available interface, call `addMembership` multiple times, once per interface.
 
-When called on an unbound socket, it will implicitly bind to a random port,
-listening on all interfaces.
+When called on an unbound socket, this method will implicitly bind to a random
+port, listening on all interfaces.
 
 When sharing a UDP socket across multiple `cluster` workers, the
 `socket.addMembership()` function must be called only once or an
@@ -146,8 +146,8 @@ is not specified, the operating system will choose one interface and will add
 membership to it. To add membership to every available interface, call
 `socket.addSourceSpecificMembership()` multiple times, once per interface.
 
-When called on an unbound socket, it will implicitly bind to a random port,
-listening on all interfaces.
+When called on an unbound socket, this method will implicitly bind to a random
+port, listening on all interfaces.
 
 ### `socket.address()`
 <!-- YAML
@@ -160,7 +160,7 @@ Returns an object containing the address information for a socket.
 For UDP sockets, this object will contain `address`, `family` and `port`
 properties.
 
-It throws `EBADF` if called on an unbound socket.
+This method throws `EBADF` if called on an unbound socket.
 
 ### `socket.bind([port][, address][, callback])`
 <!-- YAML
@@ -353,7 +353,7 @@ added: v8.7.0
 
 * Returns: {number} the `SO_RCVBUF` socket receive buffer size in bytes.
 
-It throws [`ERR_SOCKET_BUFFER_SIZE`][] if called on an unbound socket.
+This method throws [`ERR_SOCKET_BUFFER_SIZE`][] if called on an unbound socket.
 
 ### `socket.getSendBufferSize()`
 <!-- YAML
@@ -362,7 +362,7 @@ added: v8.7.0
 
 * Returns: {number} the `SO_SNDBUF` socket send buffer size in bytes.
 
-It throws [`ERR_SOCKET_BUFFER_SIZE`][] if called on an unbound socket.
+This method throws [`ERR_SOCKET_BUFFER_SIZE`][] if called on an unbound socket.
 
 ### `socket.ref()`
 <!-- YAML
@@ -390,8 +390,8 @@ added: v12.0.0
 * Returns: {Object}
 
 Returns an object containing the `address`, `family`, and `port` of the remote
-endpoint. It throws an [`ERR_SOCKET_DGRAM_NOT_CONNECTED`][] exception if the
-socket is not connected.
+endpoint. This method throws an [`ERR_SOCKET_DGRAM_NOT_CONNECTED`][] exception
+if the socket is not connected.
 
 ### `socket.send(msg[, offset, length][, port][, address][, callback])`
 <!-- YAML
@@ -465,7 +465,7 @@ Offset and length are optional but both *must* be set if either are used.
 They are supported only when the first argument is a `Buffer`, a `TypedArray`,
 or a `DataView`.
 
-It throws [`ERR_SOCKET_BAD_PORT`][] if called on an unbound socket.
+This method throws [`ERR_SOCKET_BAD_PORT`][] if called on an unbound socket.
 
 Example of sending a UDP packet to a port on `localhost`;
 
@@ -547,7 +547,7 @@ added: v0.6.9
 Sets or clears the `SO_BROADCAST` socket option. When set to `true`, UDP
 packets may be sent to a local interface's broadcast address.
 
-It throws `EBADF` if called on an unbound socket.
+This method throws `EBADF` if called on an unbound socket.
 
 ### `socket.setMulticastInterface(multicastInterface)`
 <!-- YAML
@@ -575,7 +575,7 @@ also use explicit scope in addresses, so only packets sent to a multicast
 address without specifying an explicit scope are affected by the most recent
 successful use of this call.
 
-It throws `EBADF` if called on an unbound socket.
+This method throws `EBADF` if called on an unbound socket.
 
 #### Example: IPv6 outgoing multicast interface
 
@@ -639,7 +639,7 @@ added: v0.3.8
 Sets or clears the `IP_MULTICAST_LOOP` socket option. When set to `true`,
 multicast packets will also be received on the local interface.
 
-It throws `EBADF` if called on an unbound socket.
+This method throws `EBADF` if called on an unbound socket.
 
 ### `socket.setMulticastTTL(ttl)`
 <!-- YAML
@@ -656,7 +656,7 @@ decremented to 0 by a router, it will not be forwarded.
 
 The `ttl` argument may be between 0 and 255. The default on most systems is `1`.
 
-It throws `EBADF` if called on an unbound socket.
+This method throws `EBADF` if called on an unbound socket.
 
 ### `socket.setRecvBufferSize(size)`
 <!-- YAML
@@ -668,7 +668,7 @@ added: v8.7.0
 Sets the `SO_RCVBUF` socket option. Sets the maximum socket receive buffer
 in bytes.
 
-It throws [`ERR_SOCKET_BUFFER_SIZE`][] if called on an unbound socket.
+This method throws [`ERR_SOCKET_BUFFER_SIZE`][] if called on an unbound socket.
 
 ### `socket.setSendBufferSize(size)`
 <!-- YAML
@@ -680,7 +680,7 @@ added: v8.7.0
 Sets the `SO_SNDBUF` socket option. Sets the maximum socket send buffer
 in bytes.
 
-It throws [`ERR_SOCKET_BUFFER_SIZE`][] if called on an unbound socket.
+This method throws [`ERR_SOCKET_BUFFER_SIZE`][] if called on an unbound socket.
 
 ### `socket.setTTL(ttl)`
 <!-- YAML
@@ -698,7 +698,7 @@ Changing TTL values is typically done for network probes or when multicasting.
 The `ttl` argument may be between between 1 and 255. The default on most systems
 is 64.
 
-It throws `EBADF` if called on an unbound socket.
+This method throws `EBADF` if called on an unbound socket.
 
 ### `socket.unref()`
 <!-- YAML

--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -108,6 +108,9 @@ Tells the kernel to join a multicast group at the given `multicastAddress` and
 one interface and will add membership to it. To add membership to every
 available interface, call `addMembership` multiple times, once per interface.
 
+When called on an unbound socket, implicitly binds to a random port, listening
+on all interfaces.
+
 When sharing a UDP socket across multiple `cluster` workers, the
 `socket.addMembership()` function must be called only once or an
 `EADDRINUSE` error will occur:
@@ -143,6 +146,10 @@ is not specified, the operating system will choose one interface and will add
 membership to it. To add membership to every available interface, call
 `socket.addSourceSpecificMembership()` multiple times, once per interface.
 
+
+When called on an unbound socket, implicitly binds to a random port, listening
+on all interfaces.
+
 ### `socket.address()`
 <!-- YAML
 added: v0.1.99
@@ -153,6 +160,8 @@ added: v0.1.99
 Returns an object containing the address information for a socket.
 For UDP sockets, this object will contain `address`, `family` and `port`
 properties.
+
+Throws `EBADF` if called on an unbound socket.
 
 ### `socket.bind([port][, address][, callback])`
 <!-- YAML
@@ -298,8 +307,9 @@ added: v12.0.0
 -->
 
 A synchronous function that disassociates a connected `dgram.Socket` from
-its remote address. Trying to call `disconnect()` on an already disconnected
-socket will result in an [`ERR_SOCKET_DGRAM_NOT_CONNECTED`][] exception.
+its remote address. Trying to call `disconnect()` on an unbound or already
+disconnected socket will result in an [`ERR_SOCKET_DGRAM_NOT_CONNECTED`][]
+exception.
 
 ### `socket.dropMembership(multicastAddress[, multicastInterface])`
 <!-- YAML
@@ -344,12 +354,16 @@ added: v8.7.0
 
 * Returns: {number} the `SO_RCVBUF` socket receive buffer size in bytes.
 
+Throws [`ERR_SOCKET_BUFFER_SIZE`][] if called on an unbound socket.
+
 ### `socket.getSendBufferSize()`
 <!-- YAML
 added: v8.7.0
 -->
 
 * Returns: {number} the `SO_SNDBUF` socket send buffer size in bytes.
+
+Throws [`ERR_SOCKET_BUFFER_SIZE`][] if called on an unbound socket.
 
 ### `socket.ref()`
 <!-- YAML
@@ -452,6 +466,8 @@ Offset and length are optional but both *must* be set if either are used.
 They are supported only when the first argument is a `Buffer`, a `TypedArray`,
 or a `DataView`.
 
+Throws [`ERR_SOCKET_BAD_PORT`][] if called on an unbound socket.
+
 Example of sending a UDP packet to a port on `localhost`;
 
 ```js
@@ -532,6 +548,8 @@ added: v0.6.9
 Sets or clears the `SO_BROADCAST` socket option. When set to `true`, UDP
 packets may be sent to a local interface's broadcast address.
 
+Throws `EBADF` if called on an unbound socket.
+
 ### `socket.setMulticastInterface(multicastInterface)`
 <!-- YAML
 added: v8.6.0
@@ -557,6 +575,8 @@ interface as in the examples that follow. In IPv6, individual `send` calls can
 also use explicit scope in addresses, so only packets sent to a multicast
 address without specifying an explicit scope are affected by the most recent
 successful use of this call.
+
+Throws `EBADF` if called on an unbound socket.
 
 #### Example: IPv6 outgoing multicast interface
 
@@ -620,6 +640,8 @@ added: v0.3.8
 Sets or clears the `IP_MULTICAST_LOOP` socket option. When set to `true`,
 multicast packets will also be received on the local interface.
 
+Throws `EBADF` if called on an unbound socket.
+
 ### `socket.setMulticastTTL(ttl)`
 <!-- YAML
 added: v0.3.8
@@ -635,6 +657,8 @@ decremented to 0 by a router, it will not be forwarded.
 
 The `ttl` argument may be between 0 and 255. The default on most systems is `1`.
 
+Throws `EBADF` if called on an unbound socket.
+
 ### `socket.setRecvBufferSize(size)`
 <!-- YAML
 added: v8.7.0
@@ -645,6 +669,8 @@ added: v8.7.0
 Sets the `SO_RCVBUF` socket option. Sets the maximum socket receive buffer
 in bytes.
 
+Throws [`ERR_SOCKET_BUFFER_SIZE`][] if called on an unbound socket.
+
 ### `socket.setSendBufferSize(size)`
 <!-- YAML
 added: v8.7.0
@@ -654,6 +680,8 @@ added: v8.7.0
 
 Sets the `SO_SNDBUF` socket option. Sets the maximum socket send buffer
 in bytes.
+
+Throws [`ERR_SOCKET_BUFFER_SIZE`][] if called on an unbound socket.
 
 ### `socket.setTTL(ttl)`
 <!-- YAML
@@ -670,6 +698,8 @@ Changing TTL values is typically done for network probes or when multicasting.
 
 The `ttl` argument may be between between 1 and 255. The default on most systems
 is 64.
+
+Throws `EBADF` if called on an unbound socket.
 
 ### `socket.unref()`
 <!-- YAML
@@ -749,6 +779,8 @@ and `udp6` sockets). The bound address and port can be retrieved using
 [`socket.address().address`][] and [`socket.address().port`][].
 
 [`'close'`]: #dgram_event_close
+[`ERR_SOCKET_BAD_PORT`]: errors.html#errors_err_socket_bad_port
+[`ERR_SOCKET_BUFFER_SIZE`]: errors.html#errors_err_socket_buffer_size
 [`ERR_SOCKET_DGRAM_IS_CONNECTED`]: errors.html#errors_err_socket_dgram_is_connected
 [`ERR_SOCKET_DGRAM_NOT_CONNECTED`]: errors.html#errors_err_socket_dgram_not_connected
 [`Error`]: errors.html#errors_class_error

--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -108,8 +108,8 @@ Tells the kernel to join a multicast group at the given `multicastAddress` and
 one interface and will add membership to it. To add membership to every
 available interface, call `addMembership` multiple times, once per interface.
 
-When called on an unbound socket, implicitly binds to a random port, listening
-on all interfaces.
+When called on an unbound socket, it will implicitly bind to a random port,
+listening on all interfaces.
 
 When sharing a UDP socket across multiple `cluster` workers, the
 `socket.addMembership()` function must be called only once or an
@@ -146,9 +146,8 @@ is not specified, the operating system will choose one interface and will add
 membership to it. To add membership to every available interface, call
 `socket.addSourceSpecificMembership()` multiple times, once per interface.
 
-
-When called on an unbound socket, implicitly binds to a random port, listening
-on all interfaces.
+When called on an unbound socket, it will implicitly bind to a random port,
+listening on all interfaces.
 
 ### `socket.address()`
 <!-- YAML
@@ -161,7 +160,7 @@ Returns an object containing the address information for a socket.
 For UDP sockets, this object will contain `address`, `family` and `port`
 properties.
 
-Throws `EBADF` if called on an unbound socket.
+It throws `EBADF` if called on an unbound socket.
 
 ### `socket.bind([port][, address][, callback])`
 <!-- YAML
@@ -354,7 +353,7 @@ added: v8.7.0
 
 * Returns: {number} the `SO_RCVBUF` socket receive buffer size in bytes.
 
-Throws [`ERR_SOCKET_BUFFER_SIZE`][] if called on an unbound socket.
+It throws [`ERR_SOCKET_BUFFER_SIZE`][] if called on an unbound socket.
 
 ### `socket.getSendBufferSize()`
 <!-- YAML
@@ -363,7 +362,7 @@ added: v8.7.0
 
 * Returns: {number} the `SO_SNDBUF` socket send buffer size in bytes.
 
-Throws [`ERR_SOCKET_BUFFER_SIZE`][] if called on an unbound socket.
+It throws [`ERR_SOCKET_BUFFER_SIZE`][] if called on an unbound socket.
 
 ### `socket.ref()`
 <!-- YAML
@@ -466,7 +465,7 @@ Offset and length are optional but both *must* be set if either are used.
 They are supported only when the first argument is a `Buffer`, a `TypedArray`,
 or a `DataView`.
 
-Throws [`ERR_SOCKET_BAD_PORT`][] if called on an unbound socket.
+It throws [`ERR_SOCKET_BAD_PORT`][] if called on an unbound socket.
 
 Example of sending a UDP packet to a port on `localhost`;
 
@@ -548,7 +547,7 @@ added: v0.6.9
 Sets or clears the `SO_BROADCAST` socket option. When set to `true`, UDP
 packets may be sent to a local interface's broadcast address.
 
-Throws `EBADF` if called on an unbound socket.
+It throws `EBADF` if called on an unbound socket.
 
 ### `socket.setMulticastInterface(multicastInterface)`
 <!-- YAML
@@ -576,7 +575,7 @@ also use explicit scope in addresses, so only packets sent to a multicast
 address without specifying an explicit scope are affected by the most recent
 successful use of this call.
 
-Throws `EBADF` if called on an unbound socket.
+It throws `EBADF` if called on an unbound socket.
 
 #### Example: IPv6 outgoing multicast interface
 
@@ -640,7 +639,7 @@ added: v0.3.8
 Sets or clears the `IP_MULTICAST_LOOP` socket option. When set to `true`,
 multicast packets will also be received on the local interface.
 
-Throws `EBADF` if called on an unbound socket.
+It throws `EBADF` if called on an unbound socket.
 
 ### `socket.setMulticastTTL(ttl)`
 <!-- YAML
@@ -657,7 +656,7 @@ decremented to 0 by a router, it will not be forwarded.
 
 The `ttl` argument may be between 0 and 255. The default on most systems is `1`.
 
-Throws `EBADF` if called on an unbound socket.
+It throws `EBADF` if called on an unbound socket.
 
 ### `socket.setRecvBufferSize(size)`
 <!-- YAML
@@ -669,7 +668,7 @@ added: v8.7.0
 Sets the `SO_RCVBUF` socket option. Sets the maximum socket receive buffer
 in bytes.
 
-Throws [`ERR_SOCKET_BUFFER_SIZE`][] if called on an unbound socket.
+It throws [`ERR_SOCKET_BUFFER_SIZE`][] if called on an unbound socket.
 
 ### `socket.setSendBufferSize(size)`
 <!-- YAML
@@ -681,7 +680,7 @@ added: v8.7.0
 Sets the `SO_SNDBUF` socket option. Sets the maximum socket send buffer
 in bytes.
 
-Throws [`ERR_SOCKET_BUFFER_SIZE`][] if called on an unbound socket.
+It throws [`ERR_SOCKET_BUFFER_SIZE`][] if called on an unbound socket.
 
 ### `socket.setTTL(ttl)`
 <!-- YAML
@@ -699,7 +698,7 @@ Changing TTL values is typically done for network probes or when multicasting.
 The `ttl` argument may be between between 1 and 255. The default on most systems
 is 64.
 
-Throws `EBADF` if called on an unbound socket.
+It throws `EBADF` if called on an unbound socket.
 
 ### `socket.unref()`
 <!-- YAML


### PR DESCRIPTION
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

While working on this I have discovered an inconsistency: given `dgram.Socket` instance is undbound, calling `address()` on it results in a system error `EBADF` being thrown, while calling `remoteAddress()` results in `ERR_SOCKET_DGRAM_NOT_CONNECTED`.

Also, calling `send()` on an unbound socket throws `ERR_SOCKET_BAD_PORT` which might also be found misguiding.

These I believe are easy fixes. Once the documentation resembles the current state of things I can open another PR introducing a fix to it.

Also mentioned a side effect caused by `socket.addMembership()` and `socket.addSourceSpecificMembership()`. Not sure if it is desired.