### PR TITLE
fs: deprecate .close on streams

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2751,6 +2751,32 @@ const moduleParents = Object.values(require.cache)
   .filter((m) => m.children.includes(module));
 ```
 
+<a id="DEPXXXX"></a>
+### DEP0143: `WriteStream.close`
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    description: Runtime deprecation.
+-->
+
+Type: Runtime
+
+For graceful completion use `WriteStream.end()`.
+
+<a id="DEPXXXX"></a>
+### DEP0143: `ReadStream.close`
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    description: Runtime deprecation.
+-->
+
+Type: Runtime
+
+Use `ReadStream.destroy()`. For callback use `stream.finished()`
+
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`--throw-deprecation`]: cli.html#cli_throw_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -441,7 +441,7 @@ WriteStream.prototype.close = deprecate(function(cb) {
   // We use end() instead of destroy() because of
   // https://github.com/nodejs/node/issues/2006
   this.end();
-}, 'WriteStream.prototype.cloes is deprecated', 'DEPXXXX');
+}, 'WriteStream.prototype.close is deprecated', 'DEPXXXX');
 
 // There is no shutdown() for files.
 WriteStream.prototype.destroySoon = WriteStream.prototype.end;

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -262,10 +262,10 @@ ReadStream.prototype._destroy = function(err, cb) {
   }
 };
 
-ReadStream.prototype.close = function(cb) {
+ReadStream.prototype.close = deprecate(function(cb) {
   if (typeof cb === 'function') finished(this, cb);
   this.destroy();
-};
+}, 'ReadStream.prototype.close is deprecated', 'DEPXXXX');
 
 ObjectDefineProperty(ReadStream.prototype, 'pending', {
   get() { return this.fd === null; },
@@ -422,7 +422,8 @@ WriteStream.prototype._destroy = function(err, cb) {
     close(this, err, cb);
   }
 };
-WriteStream.prototype.close = function(cb) {
+
+WriteStream.prototype.close = deprecate(function(cb) {
   if (cb) {
     if (this.closed) {
       process.nextTick(cb);
@@ -440,7 +441,7 @@ WriteStream.prototype.close = function(cb) {
   // We use end() instead of destroy() because of
   // https://github.com/nodejs/node/issues/2006
   this.end();
-};
+}, 'WriteStream.prototype.cloes is deprecated', 'DEPXXXX');
 
 // There is no shutdown() for files.
 WriteStream.prototype.destroySoon = WriteStream.prototype.end;


### PR DESCRIPTION
The semantics of close is unclear for users and not necessary. Instead encourage usage of explicit stream methods.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
