### PR TITLE
stream: add closed property

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -413,7 +413,8 @@ added: REPLACEME
 
 * {boolean}
 
-Is `true` after `callback` in [`writable._destroy(err, callback)`][writable-_destroy]
+Is `true` after `callback` in
+[`writable._destroy(err, callback)`][writable-_destroy]
 has been called.
 
 ##### `writable.end([chunk[, encoding]][, callback])`
@@ -1000,7 +1001,8 @@ added: REPLACEME
 
 * {boolean}
 
-Is `true` after `callback` in [`readable._destroy(err, callback)`][readable-_destroy]
+Is `true` after `callback` in
+[`readable._destroy(err, callback)`][readable-_destroy]
 has been called.
 
 ##### `readable.isPaused()`

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -406,6 +406,16 @@ added: v8.0.0
 
 Is `true` after [`writable.destroy()`][writable-destroy] has been called.
 
+##### `writable.closed`
+<!-- YAML
+added: REPLACEME
+-->
+
+* {boolean}
+
+Is `true` after `callback` in [`writable._destroy(err, callback)`][writable-_destroy]
+has been called.
+
 ##### `writable.end([chunk[, encoding]][, callback])`
 <!-- YAML
 added: v0.9.4
@@ -982,6 +992,16 @@ added: v8.0.0
 * {boolean}
 
 Is `true` after [`readable.destroy()`][readable-destroy] has been called.
+
+##### `readable.closed`
+<!-- YAML
+added: REPLACEME
+-->
+
+* {boolean}
+
+Is `true` after `callback` in [`readable._destroy(err, callback)`][readable-_destroy]
+has been called.
 
 ##### `readable.isPaused()`
 <!-- YAML

--- a/lib/_stream_duplex.js
+++ b/lib/_stream_duplex.js
@@ -104,5 +104,23 @@ ObjectDefineProperties(Duplex.prototype, {
         this._writableState.destroyed = value;
       }
     }
+  },
+
+  closed: {
+    get() {
+      if (this._readableState === undefined ||
+        this._writableState === undefined) {
+        return false;
+      }
+      return this._readableState.closed && this._writableState.closed;
+    },
+    set(value) {
+      // Backward compatibility, the user is explicitly
+      // managing closed.
+      if (this._readableState && this._writableState) {
+        this._readableState.closed = value;
+        this._writableState.closed = value;
+      }
+    }
   }
 });

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -1167,6 +1167,18 @@ ObjectDefineProperties(Readable.prototype, {
     }
   },
 
+  closed: {
+    get() {
+      return this._readableState ? this._readableState.closed : false;
+    },
+    set(value) {
+      // Backward compatibility, the user is explicitly managing closed.
+      if (this._readableState) {
+        this._readableState.closed = value;
+      }
+    }
+  },
+
   readableEnded: {
     enumerable: false,
     get() {

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -735,6 +735,18 @@ ObjectDefineProperties(Writable.prototype, {
     }
   },
 
+  closed: {
+    get() {
+      return this._writableState ? this._writableState.closed : false;
+    },
+    set(value) {
+      // Backward compatibility, the user is explicitly managing closed.
+      if (this._writableState) {
+        this._writableState.closed = value;
+      }
+    }
+  },
+
   writable: {
     get() {
       const w = this._writableState;

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -88,12 +88,9 @@ function _construct(callback) {
 
 function close(stream, err, cb) {
   if (!stream.fd) {
-    // TODO(ronag)
-    // stream.closed = true;
     cb(err);
   } else {
     stream[kFs].close(stream.fd, (er) => {
-      stream.closed = true;
       cb(er || err);
     });
     stream.fd = null;
@@ -143,7 +140,6 @@ function ReadStream(path, options) {
   this.end = options.end;
   this.pos = undefined;
   this.bytesRead = 0;
-  this.closed = false;
   this[kIsPerformingIO] = false;
 
   if (this.start !== undefined) {
@@ -327,7 +323,6 @@ function WriteStream(path, options) {
   this.start = options.start;
   this.pos = undefined;
   this.bytesWritten = 0;
-  this.closed = false;
   this[kIsPerformingIO] = false;
 
   if (this.start !== undefined) {

--- a/test/parallel/test-fs-read-stream-inherit.js
+++ b/test/parallel/test-fs-read-stream-inherit.js
@@ -199,7 +199,7 @@ const rangeFile = fixtures.path('x.txt');
   file.on('error', common.mustCall());
 
   process.on('exit', function() {
-    assert(!file.closed);
+    assert(file.closed);
     assert(file.destroyed);
   });
 }

--- a/test/parallel/test-fs-read-stream.js
+++ b/test/parallel/test-fs-read-stream.js
@@ -271,7 +271,7 @@ if (!common.isWindows) {
   file.on('error', common.mustCall());
 
   process.on('exit', function() {
-    assert(!file.closed);
+    assert(file.closed);
     assert(file.destroyed);
   });
 }

--- a/test/parallel/test-stream-readable-destroy.js
+++ b/test/parallel/test-stream-readable-destroy.js
@@ -6,14 +6,21 @@ const assert = require('assert');
 
 {
   const read = new Readable({
-    read() {}
+    read() {},
+    destroy(err, cb) {
+      assert.strictEqual(read.closed, false);
+      cb();
+      assert.strictEqual(read.closed, true);
+    }
   });
   read.resume();
 
   read.on('close', common.mustCall());
 
+  assert.strictEqual(read.closed, false);
   read.destroy();
   assert.strictEqual(read.destroyed, true);
+  assert.strictEqual(read.closed, true);
 }
 
 {
@@ -101,7 +108,9 @@ const assert = require('assert');
     assert.strictEqual(err, null);
     process.nextTick(() => {
       this.push(null);
+      assert.strictEqual(read.closed, false);
       cb();
+      assert.strictEqual(read.closed, true);
     });
   });
 
@@ -112,9 +121,11 @@ const assert = require('assert');
 
   read.destroy();
 
+  assert.strictEqual(read.closed, false);
   read.removeListener('end', fail);
   read.on('end', common.mustNotCall());
   assert.strictEqual(read.destroyed, true);
+  assert.strictEqual(read.closed, false);
 }
 
 {

--- a/test/parallel/test-stream-writable-destroy.js
+++ b/test/parallel/test-stream-writable-destroy.js
@@ -6,14 +6,21 @@ const assert = require('assert');
 
 {
   const write = new Writable({
-    write(chunk, enc, cb) { cb(); }
+    write(chunk, enc, cb) { cb(); },
+    destroy(err, cb) {
+      assert.strictEqual(write.closed, false);
+      cb();
+      assert.strictEqual(write.closed, true);
+    }
   });
 
   write.on('finish', common.mustNotCall());
   write.on('close', common.mustCall());
 
+  assert.strictEqual(write.closed, false);
   write.destroy();
   assert.strictEqual(write.destroyed, true);
+  assert.strictEqual(write.closed, true);
 }
 
 {
@@ -113,7 +120,9 @@ const assert = require('assert');
     assert.strictEqual(err, null);
     process.nextTick(() => {
       this.end();
+      assert.strictEqual(write.closed, false);
       cb();
+      assert.strictEqual(write.closed, true);
     });
   });
 
@@ -127,6 +136,7 @@ const assert = require('assert');
   write.removeListener('finish', fail);
   write.on('finish', common.mustCall());
   assert.strictEqual(write.destroyed, true);
+  assert.strictEqual(write.closed, false);
 }
 
 {


### PR DESCRIPTION
fs streams already have a closed property. This PR standardized
it and brings it inline with rest of streams.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
