### PR TITLE
assert: add `assert/strict` alias module

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -11,6 +11,9 @@ invariants.
 <!-- YAML
 added: v9.9.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/34001
+    description: Exposed as `require('assert/strict')`
   - version:
       - v13.9.0
       - v12.16.2
@@ -36,6 +39,9 @@ To use strict assertion mode:
 
 ```js
 const assert = require('assert').strict;
+```
+```js
+const assert = require('assert/strict');
 ```
 
 Example error diff:

--- a/lib/assert/strict.js
+++ b/lib/assert/strict.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('assert').strict;

--- a/node.gyp
+++ b/node.gyp
@@ -43,6 +43,7 @@
       'lib/internal/per_context/messageport.js',
       'lib/async_hooks.js',
       'lib/assert.js',
+      'lib/assert/strict.js',
       'lib/buffer.js',
       'lib/child_process.js',
       'lib/console.js',

--- a/test/es-module/test-esm-assert-strict.mjs
+++ b/test/es-module/test-esm-assert-strict.mjs
@@ -1,0 +1,5 @@
+import '../common/index.mjs';
+import assert, { strict } from 'assert';
+import assertStrict from 'assert/strict';
+
+assert.strictEqual(strict, assertStrict);

--- a/test/parallel/test-assert-strict-exists.js
+++ b/test/parallel/test-assert-strict-exists.js
@@ -1,0 +1,6 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+
+assert.strictEqual(require('assert/strict'), assert.strict);


### PR DESCRIPTION
**Refs:** <https://github.com/nodejs/node/pull/31553>
**Refs:** <https://github.com/nodejs/node/pull/32953>
**Refs:** <https://github.com/nodejs/node/pull/34002>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
