### PR TITLE
stream: propagate write error to end callback

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -56,6 +56,7 @@ const {
   ERR_STREAM_WRITE_AFTER_END,
   ERR_UNKNOWN_ENCODING
 } = require('internal/errors').codes;
+const { once } = require('internal/util');
 
 const { errorOrDestroy } = destroyImpl;
 
@@ -586,8 +587,17 @@ Writable.prototype.end = function(chunk, encoding, cb) {
     encoding = null;
   }
 
-  if (chunk !== null && chunk !== undefined)
-    this.write(chunk, encoding);
+  if (typeof cb === 'function') {
+    cb = once(cb);
+  }
+
+  if (chunk != null) {
+    this.write(chunk, encoding, cb ? function(err) {
+      if (err) {
+        cb(err);
+      }
+    } : null);
+  }
 
   // .end() fully uncorks.
   if (state.corked) {

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -591,7 +591,7 @@ Writable.prototype.end = function(chunk, encoding, cb) {
     cb = once(cb);
   }
 
-  if (chunk != null) {
+  if (chunk !== null && chunk !== undefined) {
     this.write(chunk, encoding, cb ? function(err) {
       if (err) {
         cb(err);

--- a/test/parallel/test-stream-writable-end-cb-error.js
+++ b/test/parallel/test-stream-writable-end-cb-error.js
@@ -46,3 +46,23 @@ const stream = require('stream');
     writable.emit('error', new Error('kaboom'));
   }));
 }
+
+{
+  // Invoke end with write error
+  const writable = new stream.Writable();
+
+  writable._write = (chunk, encoding, cb) => {
+    process.nextTick(cb);
+  };
+  writable._final = (cb) => {
+    process.nextTick(cb);
+  };
+
+  writable.end();
+  writable.end('asd', common.mustCall((err) => {
+    assert.strictEqual(err.code, 'ERR_STREAM_WRITE_AFTER_END');
+  }));
+  writable.on('error', common.mustCall((err) => {
+    assert.strictEqual(err.code, 'ERR_STREAM_WRITE_AFTER_END');
+  }));
+}


### PR DESCRIPTION
Properly propagate all write errors throught to
end callback.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
