### PR TITLE
benchmark: fix EventTarget benchmark

### DIFF
--- a/benchmark/events/eventtarget.js
+++ b/benchmark/events/eventtarget.js
@@ -2,7 +2,7 @@
 const common = require('../common.js');
 
 const bench = common.createBenchmark(main, {
-  n: [2e7],
+  n: [1e6],
   listeners: [1, 5, 10]
 }, { flags: ['--expose-internals'] });
 
@@ -13,11 +13,9 @@ function main({ n, listeners }) {
   for (let n = 0; n < listeners; n++)
     target.addEventListener('foo', () => {});
 
-  const event = new Event('foo');
-
   bench.start();
   for (let i = 0; i < n; i++) {
-    target.dispatchEvent(event);
+    target.dispatchEvent(new Event('foo'));
   }
   bench.end(n);
 


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/33782

Instead of removing the benchmark completely, I've opted to simply tweak it as little as possible so that it no longer crashes.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)