### PR TITLE
test: AsyncLocalStorage works with thenables

### DIFF
--- a/test/async-hooks/test-async-local-storage-thenable.js
+++ b/test/async-hooks/test-async-local-storage-thenable.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const common = require('../common');
+
+const assert = require('assert');
+const { AsyncLocalStorage } = require('async_hooks');
+
+// This test verifies that async local storage works with thenables
+
+const store = new AsyncLocalStorage();
+const data = Symbol('verifier');
+
+const then = common.mustCall((cb) => {
+  assert.strictEqual(store.getStore(), data);
+  setImmediate(cb);
+}, 4);
+
+function thenable() {
+  return {
+    then
+  };
+}
+
+// Await a thenable
+store.run(data, async () => {
+  assert.strictEqual(store.getStore(), data);
+  await thenable();
+  assert.strictEqual(store.getStore(), data);
+});
+
+// Returning a thenable in an async function
+store.run(data, async () => {
+  try {
+    assert.strictEqual(store.getStore(), data);
+    return thenable();
+  } finally {
+    assert.strictEqual(store.getStore(), data);
+  }
+});
+
+// Resolving a thenable
+store.run(data, () => {
+  assert.strictEqual(store.getStore(), data);
+  Promise.resolve(thenable());
+  assert.strictEqual(store.getStore(), data);
+});
+
+// Returning a thenable in a then handler
+store.run(data, () => {
+  assert.strictEqual(store.getStore(), data);
+  Promise.resolve().then(() => thenable());
+  assert.strictEqual(store.getStore(), data);
+});


### PR DESCRIPTION
This adds a test to verify that AsyncLocalStorage works with thenables which works since the v8 fix done in #33778.

The test is based on the samples done by @Qard in https://gist.github.com/Qard/faad53ba2368db54c95828365751d7bc

Refs: #33778

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

