### PR TITLE
win,msi: use x64 node executable when cross-compiling for arm64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,9 @@ _UpgradeReport_Files/
 # Ignore dependencies fetched by deps/v8/tools/node/fetch_deps.py
 /deps/.cipd
 
+# === Rules for Windows vcbuild.bat ===
+/temp-vcbuild
+
 # === Global Rules ===
 # Keep last to avoid being excluded
 *.pyc

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -544,12 +544,12 @@ Optional requirements to build the MSI installer package:
 
 * The [WiX Toolset v3.11](https://wixtoolset.org/releases/) and the
   [Wix Toolset Visual Studio 2019 Extension](https://marketplace.visualstudio.com/items?itemName=WixToolset.WixToolsetVisualStudio2019Extension).
+* The [WiX Toolset v3.14](https://wixtoolset.org/releases/) if building for Windows 10 on ARM (ARM64).
 
 Optional requirements for compiling for Windows 10 on ARM (ARM64):
 
-* ARM64 Windows build machine
-  * Due to a GYP limitation, this is required to run compiled code
-    generation tools (like V8's builtins and mksnapshot tools)
+* ARM64 or x64 Windows build machine
+  * ARM64 builds can be created on a x64 host by running `.\vcbuild arm64`
 * Visual Studio 15.9.0 or newer
 * Visual Studio optional components
   * Visual C++ compilers and libraries for ARM64

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -544,7 +544,8 @@ Optional requirements to build the MSI installer package:
 
 * The [WiX Toolset v3.11](https://wixtoolset.org/releases/) and the
   [Wix Toolset Visual Studio 2019 Extension](https://marketplace.visualstudio.com/items?itemName=WixToolset.WixToolsetVisualStudio2019Extension).
-* The [WiX Toolset v3.14](https://wixtoolset.org/releases/) if building for Windows 10 on ARM (ARM64).
+* The [WiX Toolset v3.14](https://wixtoolset.org/releases/) if
+  building for Windows 10 on ARM (ARM64).
 
 Optional requirements for compiling for Windows 10 on ARM (ARM64):
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -549,8 +549,6 @@ Optional requirements to build the MSI installer package:
 
 Optional requirements for compiling for Windows 10 on ARM (ARM64):
 
-* ARM64 or x64 Windows build machine
-  * ARM64 builds can be created on a x64 host by running `.\vcbuild arm64`
 * Visual Studio 15.9.0 or newer
 * Visual Studio optional components
   * Visual C++ compilers and libraries for ARM64

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -174,6 +174,20 @@ if defined package set stage_package=1
 
 :: assign path to node_exe
 set "node_exe=%config%\node.exe"
+if "%target_arch%"=="arm64" if "%PROCESSOR_ARCHITECTURE%"=="AMD64" (
+  if not defined "%x64_node_exe%" set "x64_node_exe=temp-vcbuild\node-x64-cross-compiling.exe"
+  if not exist "%x64_node_exe%" (
+    echo Downloading x64 node.exe...
+    if not exist "temp-vcbuild" mkdir temp-vcbuild
+    powershell -c "Invoke-WebRequest -Uri 'https://nodejs.org/dist/latest/win-x64/node.exe' -OutFile 'temp-vcbuild\node-x64-cross-compiling.exe'"
+  )
+  if not exist "%x64_node_exe%" (
+    echo Could not find the Node executable at the given x64_node_exe path. Aborting. 
+    goto exit
+  )
+  echo Using x64 Node executable because we're cross-compiling for arm64: %x64_node_exe%
+  set "node_exe=%x64_node_exe%"
+)
 set "node_gyp_exe="%node_exe%" deps\npm\node_modules\node-gyp\bin\node-gyp"
 set "npm_exe="%~dp0%node_exe%" %~dp0deps\npm\bin\npm-cli.js"
 if "%target_env%"=="vs2019" set "node_gyp_exe=%node_gyp_exe% --msvs_version=2019"

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -174,20 +174,6 @@ if defined package set stage_package=1
 
 :: assign path to node_exe
 set "node_exe=%config%\node.exe"
-if "%target_arch%"=="arm64" if "%PROCESSOR_ARCHITECTURE%"=="AMD64" (
-  if not defined "%x64_node_exe%" set "x64_node_exe=temp-vcbuild\node-x64-cross-compiling.exe"
-  if not exist "%x64_node_exe%" (
-    echo Downloading x64 node.exe...
-    if not exist "temp-vcbuild" mkdir temp-vcbuild
-    powershell -c "Invoke-WebRequest -Uri 'https://nodejs.org/dist/latest/win-x64/node.exe' -OutFile 'temp-vcbuild\node-x64-cross-compiling.exe'"
-  )
-  if not exist "%x64_node_exe%" (
-    echo Could not find the Node executable at the given x64_node_exe path. Aborting. 
-    goto exit
-  )
-  echo Using x64 Node executable because we're cross-compiling for arm64: %x64_node_exe%
-  set "node_exe=%x64_node_exe%"
-)
 set "node_gyp_exe="%node_exe%" deps\npm\node_modules\node-gyp\bin\node-gyp"
 set "npm_exe="%~dp0%node_exe%" %~dp0deps\npm\bin\npm-cli.js"
 if "%target_env%"=="vs2019" set "node_gyp_exe=%node_gyp_exe% --msvs_version=2019"
@@ -376,7 +362,24 @@ if errorlevel 1 echo Failed to sign exe&goto exit
 @rem Skip license.rtf generation if not requested.
 if not defined licensertf goto stage_package
 
-%node_exe% tools\license2rtf.js < LICENSE > %config%\license.rtf
+if "%target_arch%"=="arm64" if "%PROCESSOR_ARCHITECTURE%"=="AMD64" (
+  echo Cross-compilation to ARM64 detected. We'll use the x64 Node executable for license2rtf.
+  if not defined "%x64_node_exe%" set "x64_node_exe=temp-vcbuild\node-x64-cross-compiling.exe"
+  if not exist "%x64_node_exe%" (
+    echo Downloading x64 node.exe...
+    if not exist "temp-vcbuild" mkdir temp-vcbuild
+    powershell -c "Invoke-WebRequest -Uri 'https://nodejs.org/dist/latest/win-x64/node.exe' -OutFile 'temp-vcbuild\node-x64-cross-compiling.exe'"
+  )
+  if not exist "%x64_node_exe%" (
+    echo Could not find the Node executable at the given x64_node_exe path. Aborting.
+    set exit_code=1
+    goto exit
+  )
+  %x64_node_exe% tools\license2rtf.js < LICENSE > %config%\license.rtf
+) else (
+  %node_exe% tools\license2rtf.js < LICENSE > %config%\license.rtf
+)
+
 if errorlevel 1 echo Failed to generate license.rtf&goto exit
 
 :stage_package

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -362,7 +362,9 @@ if errorlevel 1 echo Failed to sign exe&goto exit
 @rem Skip license.rtf generation if not requested.
 if not defined licensertf goto stage_package
 
-if "%target_arch%"=="arm64" if "%PROCESSOR_ARCHITECTURE%"=="AMD64" (
+set "use_x64_node_exe=false"
+if "%target_arch%"=="arm64" if "%PROCESSOR_ARCHITECTURE%"=="AMD64" set "use_x64_node_exe=true"
+if "%use_x64_node_exe%"=="true" (
   echo Cross-compilation to ARM64 detected. We'll use the x64 Node executable for license2rtf.
   if not defined "%x64_node_exe%" set "x64_node_exe=temp-vcbuild\node-x64-cross-compiling.exe"
   if not exist "%x64_node_exe%" (


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Builds further on https://github.com/nodejs/node/pull/33689

The last step to successfully create MSI installers for arm64 on a x64 host is to run the `license2rtf` script on the x64 host using a x64 Node executable. Based on @joaocgreis's comment in https://github.com/nodejs/node/pull/33689#pullrequestreview-426759240 I came up with some logic in `vcbuild.bat` which downloads the latest x64 Node executable if it's not present on the machine yet.

A variable called `%x64_node_exe%` can be passed by your CI pipeline so that the build machines don't have to download the x64 executable all the time. 

**IMPORTANT**: when building an MSI for ARM64, WIX 3.14 or higher is required, as [that version includes support for ARM64](https://github.com/wixtoolset/issues/issues/5558#issuecomment-610665979).

**How to test**
- Run `vcbuild.bat release msi arm64`

**Before applying this PR**, the process fails with `Failed to generate license.rtf` (because the generated `node.exe` is for the arm64 architecture and therefore can't run on the x64 host).

**After applying this PR**, the process finishes successfully.

Refs: #25998
Refs: #32582

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
