### PR TITLE
build: automate winget package creation

### DIFF
--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -1,0 +1,74 @@
+# Create winget pacakge YAML file and open a PR in the repository
+# 
+# Required secrets:
+# - WINGET_UPSTREAM_REPO - repository with the YAML files, by default microsoft/winget-pkgs
+# - WINGET_WORKER_NAME - GitHub username of the machine account that will create the PR. The account
+#                        must have a fork of the upstream repo
+# - WINGET_WORKER_EMAIL - machine account e-mail
+# - WINGET_WORKER_PAT- machine account Personal Access Token
+
+name: publish-winget
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-winget:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "::set-env name=VERSION::${GITHUB_REF:11}"
+      - name: Test if the package isn't already published
+        run: |
+          echo Looking for https://raw.githubusercontent.com/${{ secrets.WINGET_UPSTREAM_REPO }}/master/manifests/OpenJS/NodeJS/$VERSION.yaml
+          if curl --output /dev/null --silent --head --fail https://raw.githubusercontent.com/${{ secrets.WINGET_UPSTREAM_REPO }}/master/manifests/OpenJS/NodeJS/$VERSION.yaml; then
+            echo "Package already exists, exiting"
+            exit 1
+          fi
+      - name: Setup repository
+        run: |
+          git config --global user.name ${{ secrets.WINGET_WORKER_NAME }}
+          git config --global user.email ${{ secrets.WINGET_WORKER_EMAIL }}
+          git clone https://github.com/${{ secrets.WINGET_WORKER_NAME }}/winget-pkgs
+          cd winget-pkgs
+          git remote add upstream https://github.com/${{ secrets.WINGET_UPSTREAM_REPO }}
+          git fetch upstream
+          git checkout -b add-v$VERSION -t upstream/master
+      - run: echo "::set-env name=YAMLFILE::manifests/OpenJS/NodeJS/$VERSION.yaml"
+      - name: Create YAML file
+        run: |
+          cd winget-pkgs
+          MSISHA256=`curl --silent https://nodejs.org/dist/v$VERSION/SHASUMS256.txt | grep node-v$VERSION-x64.msi | awk '{print $1;}'`
+          echo "Id: OpenJS.Nodejs" > $YAMLFILE
+          echo "Version: $VERSION" >> $YAMLFILE
+          echo "Name: Node.js" >> $YAMLFILE
+          echo "Publisher: OpenJS Foundation" >> $YAMLFILE
+          echo "AppMoniker: node" >> $YAMLFILE
+          echo "License: Copyright Node.js contributors. All rights reserved." >> $YAMLFILE
+          echo "LicenseUrl: https://raw.githubusercontent.com/nodejs/node/master/LICENSE" >> $YAMLFILE
+          echo "Homepage: https://nodejs.org/" >> $YAMLFILE
+          echo "Description: Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine." >> $YAMLFILE
+          echo "InstallerType: msi" >> $YAMLFILE
+          echo "Installers:" >> $YAMLFILE
+          echo "  - Arch: x64" >> $YAMLFILE
+          echo "    Url: https://nodejs.org/dist/v$VERSION/node-v$VERSION-x64.msi" >> $YAMLFILE
+          echo "    Sha256: $MSISHA256" >> $YAMLFILE
+          cat $YAMLFILE;
+      - name: Create commit
+        run: |
+          cd winget-pkgs
+          git add $YAMLFILE;
+          git commit -m "Add Node.js $VERSION package";
+          git push https://${{ secrets.WINGET_WORKER_NAME }}:${{ secrets.WINGET_WORKER_PAT }}@github.com/${{ secrets.WINGET_WORKER_NAME }}/winget-pkgs add-v$VERSION
+      - name: Open PR
+        run: |
+          curl --request POST \
+               --url "https://api.github.com/repos/${{ secrets.WINGET_UPSTREAM_REPO }}/pulls" \
+               --header "authorization: Bearer ${{ secrets.WINGET_WORKER_PAT }}" \
+               --header 'content-type: application/json' \
+               --data "{ \
+                        \"title\": \"Add Node.js v$VERSION\", \
+                        \"body\": \"Add Node.js installer $VERSION\", \
+                        \"head\": \"${{ secrets.WINGET_WORKER_NAME }}:add-v$VERSION\", \
+                        \"base\": \"master\" \
+                      }"


### PR DESCRIPTION
Add GitHub action that will automatically create a PR adding new Node installers to the winget-pckg repository.

The action is triggered when a new GitHub release is made. At this point, the new installer should already be published. The script will:
 * check if the new installer isn't already present in [winget-pckg Node.js installers list](https://github.com/microsoft/winget-pkgs/tree/master/manifests/OpenJS/NodeJS)
 * create a new YAML file for Node.js [like this](https://github.com/bzoz/winget-pkgs/blob/1a3cc69f7bab128184de44b5873f0b551b855a38/manifests/OpenJS/NodeJS/12.18.1.yaml)
 * make a PR in the winget-pckg repo [like this one](https://github.com/microsoft/winget-pkgs/pull/2043).

The action requires some outside setup. A machine user needs to be created and have a fork of the [microsft/winget-pckg](https://github.com/microsoft/winget-pkgs) repository. The machine user PAT, email, etc. need to be added as repository secrets.

One thing we might want to customize more is the license and description fields. For now I went with:
```
License: Copyright Node.js contributors. All rights reserved.
LicenseUrl: https://raw.githubusercontent.com/nodejs/node/master/LICENSE
...
Description: Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine.
```

Ref: https://github.com/nodejs/Release/issues/587

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
