### PR TITLE
quic: fix lint error in node_quic_crypto

### DIFF
--- a/src/quic/node_quic_crypto.cc
+++ b/src/quic/node_quic_crypto.cc
@@ -31,7 +31,6 @@ namespace node {
 
 using crypto::EntropySource;
 using v8::Local;
-using v8::String;
 using v8::Value;
 
 namespace quic {


### PR DESCRIPTION
Currently, the following lint error is generated:
```console
Running C++ linter...
File "src/quic/node_quic_crypto.cc" does not use "String"
make[1]: *** [Makefile:1336: tools/.cpplintstamp] Error 1
```
This commit removes the unused using declaration.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
