### PR TITLE
net: handle net.connect() without arguments

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1253,7 +1253,10 @@ E('ERR_MISSING_ARGS',
     assert(args.length > 0, 'At least one arg needs to be specified');
     let msg = 'The ';
     const len = args.length;
-    args = args.map((a) => `"${a}"`);
+    const wrap = (a) => `"${a}"`;
+    args = args.map(
+      (a) => (ArrayIsArray(a) ? a.map(wrap).join(' or ') : wrap(a))
+    );
     switch (len) {
       case 1:
         msg += `${args[0]} argument`;

--- a/lib/net.js
+++ b/lib/net.js
@@ -95,7 +95,8 @@ const {
     ERR_INVALID_OPT_VALUE,
     ERR_SERVER_ALREADY_LISTEN,
     ERR_SERVER_NOT_RUNNING,
-    ERR_SOCKET_CLOSED
+    ERR_SOCKET_CLOSED,
+    ERR_MISSING_ARGS,
   },
   errnoException,
   exceptionWithHostPort,
@@ -920,6 +921,10 @@ Socket.prototype.connect = function(...args) {
   }
   const options = normalized[0];
   const cb = normalized[1];
+
+  // options.port === null will be checked later.
+  if (options.port === undefined && options.path == null)
+    throw new ERR_MISSING_ARGS(['options', 'port', 'path']);
 
   if (this.write !== Socket.prototype.write)
     this.write = Socket.prototype.write;

--- a/test/parallel/test-net-connect-no-arg.js
+++ b/test/parallel/test-net-connect-no-arg.js
@@ -1,0 +1,35 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const net = require('net');
+
+// Tests that net.connect() called without arguments throws ERR_MISSING_ARGS.
+
+assert.throws(() => {
+  net.connect();
+}, {
+  code: 'ERR_MISSING_ARGS',
+  message: 'The "options" or "port" or "path" argument must be specified',
+});
+
+assert.throws(() => {
+  new net.Socket().connect();
+}, {
+  code: 'ERR_MISSING_ARGS',
+  message: 'The "options" or "port" or "path" argument must be specified',
+});
+
+assert.throws(() => {
+  net.connect({});
+}, {
+  code: 'ERR_MISSING_ARGS',
+  message: 'The "options" or "port" or "path" argument must be specified',
+});
+
+assert.throws(() => {
+  new net.Socket().connect({});
+}, {
+  code: 'ERR_MISSING_ARGS',
+  message: 'The "options" or "port" or "path" argument must be specified',
+});

--- a/test/parallel/test-net-connect-options-port.js
+++ b/test/parallel/test-net-connect-options-port.js
@@ -60,7 +60,7 @@ const net = require('net');
 {
   // connect({hint}, cb) and connect({hint})
   const hints = (dns.ADDRCONFIG | dns.V4MAPPED | dns.ALL) + 42;
-  const hintOptBlocks = doConnect([{ hints }],
+  const hintOptBlocks = doConnect([{ port: 42, hints }],
                                   () => common.mustNotCall());
   for (const fn of hintOptBlocks) {
     assert.throws(fn, {
@@ -95,7 +95,6 @@ const net = require('net');
   // Try connecting to random ports, but do so once the server is closed
   server.on('close', () => {
     asyncFailToConnect(0);
-    asyncFailToConnect(/* undefined */);
   });
 }
 

--- a/test/parallel/test-net-normalize-args.js
+++ b/test/parallel/test-net-normalize-args.js
@@ -4,7 +4,6 @@ const common = require('../common');
 const assert = require('assert');
 const net = require('net');
 const { normalizedArgsSymbol } = require('internal/net');
-const { getSystemErrorName } = require('util');
 
 function validateNormalizedArgs(input, output) {
   const args = net._normalizeArgs(input);
@@ -27,18 +26,15 @@ validateNormalizedArgs([{ port: 1234 }, assert.fail], res);
   const server = net.createServer(common.mustNotCall('should not connect'));
 
   server.listen(common.mustCall(() => {
-    const possibleErrors = ['ECONNREFUSED', 'EADDRNOTAVAIL'];
     const port = server.address().port;
     const socket = new net.Socket();
 
-    socket.on('error', common.mustCall((err) => {
-      assert(possibleErrors.includes(err.code));
-      assert(possibleErrors.includes(getSystemErrorName(err.errno)));
-      assert.strictEqual(err.syscall, 'connect');
-      server.close();
-    }));
-
-    socket.connect([{ port }, assert.fail]);
+    assert.throws(() => {
+      socket.connect([{ port }, assert.fail]);
+    }, {
+      code: 'ERR_MISSING_ARGS'
+    });
+    server.close();
   }));
 }
 

--- a/test/parallel/test-tls-connect-allow-half-open-option.js
+++ b/test/parallel/test-tls-connect-allow-half-open-option.js
@@ -12,12 +12,12 @@ const fixtures = require('../common/fixtures');
 const tls = require('tls');
 
 {
-  const socket = tls.connect({ lookup() {} });
+  const socket = tls.connect({ port: 42, lookup() {} });
   assert.strictEqual(socket.allowHalfOpen, false);
 }
 
 {
-  const socket = tls.connect({ allowHalfOpen: false, lookup() {} });
+  const socket = tls.connect({ port: 42, allowHalfOpen: false, lookup() {} });
   assert.strictEqual(socket.allowHalfOpen, false);
 }
 

--- a/test/parallel/test-tls-connect-hints-option.js
+++ b/test/parallel/test-tls-connect-hints-option.js
@@ -22,6 +22,7 @@ assert.notStrictEqual(hints, dns.V4MAPPED | dns.ALL);
 assert.notStrictEqual(hints, dns.ADDRCONFIG | dns.V4MAPPED | dns.ALL);
 
 tls.connect({
+  port: 42,
   lookup: common.mustCall((host, options) => {
     assert.strictEqual(host, 'localhost');
     assert.deepStrictEqual(options, { family: undefined, hints });

--- a/test/parallel/test-tls-connect-timeout-option.js
+++ b/test/parallel/test-tls-connect-timeout-option.js
@@ -12,6 +12,7 @@ const assert = require('assert');
 const tls = require('tls');
 
 const socket = tls.connect({
+  port: 42,
   lookup: () => {},
   timeout: 1000
 });


### PR DESCRIPTION
* lib: handle one of args case in ERR_MISSING_ARGS

  This makes ERR_MISSING_ARGS handle nested arrays in argument names as
one-of case and will print them as '"arg1" or "arg2" or "arg3"'.
  Example:
```js
throw new ERR_MISSING_ARGS(['a', 'b', 'c']);
// will result in message:
// The "a" or "b" or "c" argument must be specified
```

* net: check args in net.connect() call
  
  Previously Node.js would handle empty `net.connect()` call as if the
user passed empty options object which doesn't really make sense. This
was due to the fact that it uses the same `normalizeArgs` function as
`.listen()` call where such call is perfectly fine.
  This will make it clear what is the problem with such call and how it
can be resolved. It now throws `ERR_MISSING_ARGS` if no arguments were
passed or neither `path` nor `port` is specified.

  Fixes: #33930

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
/cc @nodejs/net 