### PR TITLE
meta: add N-API to codeowners coverage

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -74,3 +74,8 @@
 # ./lib/internal/modules/* @nodejs/modules
 # ./lib/internal/bootstrap/loaders.js @nodejs/modules
 # ./src/module_wrap* @nodejs/modules @nodejs/vm
+
+# N-API
+
+# ./src/node_api* @nodejs/n-api
+# ./src/js_native_api* @nodejs/n-api

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -79,5 +79,5 @@
 
 # ./src/node_api* @nodejs/n-api
 # ./src/js_native_api* @nodejs/n-api
-# ./doc/guides/adding-new-napi-api.md
-# ./doc/api/n-api.md
+# ./doc/guides/adding-new-napi-api.md @nodejs/n-api
+# ./doc/api/n-api.md @nodejs/n-api

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -79,3 +79,5 @@
 
 # ./src/node_api* @nodejs/n-api
 # ./src/js_native_api* @nodejs/n-api
+# ./doc/guides/adding-new-napi-api.md
+# ./doc/api/n-api.md

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -77,7 +77,7 @@
 
 # N-API
 
-# ./src/node_api* @nodejs/n-api
-# ./src/js_native_api* @nodejs/n-api
-# ./doc/guides/adding-new-napi-api.md @nodejs/n-api
-# ./doc/api/n-api.md @nodejs/n-api
+# /src/node_api* @nodejs/n-api
+# /src/js_native_api* @nodejs/n-api
+# /doc/guides/adding-new-napi-api.md @nodejs/n-api
+# /doc/api/n-api.md @nodejs/n-api


### PR DESCRIPTION
We have this guidance for contributing to N-API:
https://github.com/nodejs/node/blob/master/doc/guides/adding-new-napi-api.md

It makes sense to have one of the N-API team sign off on commits
that changes N-API

Signed-off-by: Michael Dawson <michael_dawson@ca.ibm.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
