### PR TITLE
n-api: add version to wasm registration

### DIFF
--- a/src/node_api.h
+++ b/src/node_api.h
@@ -73,11 +73,17 @@ typedef struct {
     }                                                                 \
   EXTERN_C_END
 
+#define NAPI_MODULE_INITIALIZER_X(base, version)                               \
+  NAPI_MODULE_INITIALIZER_X_HELPER(base, version)
+#define NAPI_MODULE_INITIALIZER_X_HELPER(base, version) base##version
+
 #ifdef __wasm32__
+#define NAPI_WASM_INITIALIZER                                                  \
+  NAPI_MODULE_INITIALIZER_X(napi_register_wasm_v, NAPI_MODULE_VERSION)
 #define NAPI_MODULE(modname, regfunc)                                          \
   EXTERN_C_START                                                               \
-  NAPI_MODULE_EXPORT napi_value _napi_register(napi_env env,                   \
-                                               napi_value exports) {           \
+  NAPI_MODULE_EXPORT napi_value NAPI_WASM_INITIALIZER(napi_env env,            \
+                                                      napi_value exports) {    \
     return regfunc(env, exports);                                              \
   }                                                                            \
   EXTERN_C_END
@@ -87,10 +93,6 @@ typedef struct {
 #endif
 
 #define NAPI_MODULE_INITIALIZER_BASE napi_register_module_v
-
-#define NAPI_MODULE_INITIALIZER_X(base, version)                      \
-    NAPI_MODULE_INITIALIZER_X_HELPER(base, version)
-#define NAPI_MODULE_INITIALIZER_X_HELPER(base, version) base##version
 
 #define NAPI_MODULE_INITIALIZER                                       \
   NAPI_MODULE_INITIALIZER_X(NAPI_MODULE_INITIALIZER_BASE,             \


### PR DESCRIPTION
This changes the wasm entrypoint from `_napi_register` to `napi_register_wasm_v##NAPI_API_VERSION`.

cc @nodejs/n-api 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
