### PR TITLE
doc: add a reference to the list of OpenSSL flags.

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -3388,6 +3388,8 @@ the `crypto`, `tls`, and `https` modules and are generally specific to OpenSSL.
 
 ### Other OpenSSL constants
 
+See the [list of SSL OP Flags][] for details.
+
 <table>
   <tr>
     <th>Constant</th>
@@ -3556,3 +3558,4 @@ the `crypto`, `tls`, and `https` modules and are generally specific to OpenSSL.
 [scrypt]: https://en.wikipedia.org/wiki/Scrypt
 [stream-writable-write]: stream.html#stream_writable_write_chunk_encoding_callback
 [stream]: stream.html
+[list of SSL OP Flags]: wiki.openssl.org/index.php/List_of_SSL_OP_Flags#Table_of_Options


### PR DESCRIPTION
Some of the SSL_OP_* constants are missing description in the documentation.
Instead of rewriting the description from OpenSSL's wiki, I have decided to put
a link to a detailed list in the 'OpenSSL Options' section.

I see no point of doing both - adding a reference to the wiki and adding
constant descriptions - but I might do if presented with convincing arguments.

This is a follow-up to #33929.
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
