### PR TITLE
path: add Buffer support to join

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -370,20 +370,48 @@ const win32 = {
 
     let joined;
     let firstPart;
+    let isType;
     for (let i = 0; i < args.length; ++i) {
       const arg = args[i];
-      validateString(arg, 'path');
-      if (arg.length > 0) {
-        if (joined === undefined)
-          joined = firstPart = arg;
-        else
-          joined += `\\${arg}`;
+      if (typeof arg == 'string'){
+        if (arg.length > 0) {
+          if (joined === undefined){
+            joined = firstPart = arg;
+            isType = 'string';
+          }
+          else{
+            if (isType == 'string'){
+              joined += `\\${arg}`;
+            } else {
+              const argBuffer = Buffer.from(`\\${arg}`);
+              joined = Buffer.concat([joined, argBuffer]);
+            }
+          }
+        }
+      } else if (typeof arg == 'buffer'){
+        if (arg.length > 0) {
+          if (joined === undefined){
+            joined = firstPart = arg;
+            isType = 'buffer';
+          }
+          else{
+            if (isType == 'string'){
+              const joinedBuffer = Buffer.from(joined);
+              joined = Buffer.concat([joinedBuffer,Buffer.from(pathModule.sep),arg]);
+            } else {
+              joined = Buffer.concat([joined,Buffer.from(pathModule.sep),arg]);
+            }
+          }
+        }
+      } else {
+        validateString(arg, 'path');
       }
     }
 
     if (joined === undefined)
       return '.';
 
+    
     // Make sure that the joined path doesn't start with two slashes, because
     // normalize() will mistake it for a UNC path then.
     //

--- a/test/parallel/test-fs-readdir-buffer.js
+++ b/test/parallel/test-fs-readdir-buffer.js
@@ -1,0 +1,17 @@
+'use strict';
+const fs = require('fs');
+
+const common = require('../common');
+if (common.isWindows) {
+    common.skip('windows doesnt support /dev');
+}
+
+const assert = require('assert');
+
+fs.readdir(
+    Buffer.from("/dev"),
+    {withFileTypes: true, encoding: "buffer"},
+    common.mustCall((e,d) => {
+        assert.strictEqual(e, null);
+    })
+);

--- a/test/parallel/test-path-join-buffer.js
+++ b/test/parallel/test-path-join-buffer.js
@@ -1,0 +1,51 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const path = require('path');
+
+const failures = [];
+const backslashRE = /\\/g;
+
+const joinTests = [
+  [ [path.posix.join, path.win32.join],
+    // Arguments                     result
+    [[[Buffer.from('.'), Buffer.from('x/b'), '..', Buffer.from('/b/c.js')], 'x/b/c.js'],
+     [[], '.'],
+     [[Buffer.from('/.'), 'x/b', '..', '/b/c.js'], '/x/b/c.js'],
+     [['/foo', Buffer.from('../../../bar')], '/bar'],
+     [['foo', '../../../bar'], '../../bar'],
+     [['/', Buffer.from(''), '/foo'], '/foo'],
+     [['', '/', Buffer.from('foo')], '/foo'],
+     [['', '/', '/foo'], '/foo']
+    ]
+  ]
+];
+
+joinTests.forEach((test) => {
+  if (!Array.isArray(test[0]))
+    test[0] = [test[0]];
+  test[0].forEach((join) => {
+    test[1].forEach((test) => {
+      const actual = join.apply(null, test[0]);
+      const expected = test[1];
+      // For non-Windows specific tests with the Windows join(), we need to try
+      // replacing the slashes since the non-Windows specific tests' `expected`
+      // use forward slashes
+      let actualAlt;
+      let os;
+      if (join === path.win32.join) {
+        actualAlt = actual.replace(backslashRE, '/');
+        os = 'win32';
+      } else {
+        os = 'posix';
+      }
+      if (actual !== expected && actualAlt !== expected) {
+        const delimiter = test[0].map(JSON.stringify).join(',');
+        const message = `path.${os}.join(${delimiter})\n  expect=${
+          JSON.stringify(expected)}\n  actual=${JSON.stringify(actual)}`;
+        failures.push(`\n${message}`);
+      }
+    });
+  });
+});
+assert.strictEqual(failures.length, 0, failures.join(''));


### PR DESCRIPTION
Internalized the handling of Buffer type in the join function in path.js,