### PR TITLE
util: add `util/types` alias module

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1237,6 +1237,10 @@ The encoding supported by the `TextEncoder` instance. Always set to `'utf-8'`.
 ## `util.types`
 <!-- YAML
 added: v10.0.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/34055
+    description: Exposed as `require('util/types')`
 -->
 
 `util.types` provides type checks for different kinds of built-in objects.
@@ -1247,6 +1251,8 @@ their prototype), and usually have the overhead of calling into C++.
 The result generally does not make any guarantees about what kinds of
 properties or behavior a value exposes in JavaScript. They are primarily
 useful for addon developers who prefer to do type checking in JavaScript.
+
+The API is accessible via `require('util').types` or `require('util/types')`.
 
 ### `util.types.isAnyArrayBuffer(value)`
 <!-- YAML

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1240,7 +1240,7 @@ added: v10.0.0
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/34055
-    description: Exposed as `require('util/types')`
+    description: Exposed as `require('util/types')`.
 -->
 
 `util.types` provides type checks for different kinds of built-in objects.

--- a/lib/util/types.js
+++ b/lib/util/types.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('internal/util/types');

--- a/node.gyp
+++ b/node.gyp
@@ -95,6 +95,7 @@
       'lib/tty.js',
       'lib/url.js',
       'lib/util.js',
+      'lib/util/types.js',
       'lib/v8.js',
       'lib/vm.js',
       'lib/wasi.js',

--- a/test/es-module/test-esm-util-types.mjs
+++ b/test/es-module/test-esm-util-types.mjs
@@ -1,0 +1,6 @@
+import '../common/index.mjs';
+import assert from 'assert';
+import { types } from 'util';
+import utilTypes from 'util/types';
+
+assert.strictEqual(types, utilTypes);

--- a/test/parallel/test-util-types-exists.js
+++ b/test/parallel/test-util-types-exists.js
@@ -1,0 +1,6 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+
+assert.strictEqual(require('util/types'), require('util').types);


### PR DESCRIPTION
This should be the last alias module, unless we also want to add alias modules for the `constants` exports.

---

**Refs:** <https://github.com/nodejs/node/pull/31553>
**Refs:** <https://github.com/nodejs/node/pull/32953>
**Refs:** <https://github.com/nodejs/node/pull/33950>
**Refs:** <https://github.com/nodejs/node/pull/34001>
**Refs:** <https://github.com/nodejs/node/pull/34002>
**Refs:** <https://github.com/nodejs/node/pull/34962>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
