### PR TITLE
src: allow embedders to disable esm loader

### DIFF
--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -6,7 +6,10 @@ const {
   SafeWeakMap,
 } = primordials;
 
-const { getOptionValue } = require('internal/options');
+const {
+  getOptionValue,
+  shouldNotRegisterESMLoader
+} = require('internal/options');
 const { Buffer } = require('buffer');
 const { ERR_MANIFEST_ASSERT_INTEGRITY } = require('internal/errors').codes;
 const assert = require('internal/assert');
@@ -56,7 +59,10 @@ function prepareMainThreadExecution(expandArgv1 = false) {
   initializeDeprecations();
   initializeWASI();
   initializeCJSLoader();
-  initializeESMLoader();
+
+  if (!shouldNotRegisterESMLoader) {
+    initializeESMLoader();
+  }
 
   const CJSLoader = require('internal/modules/cjs/loader');
   assert(!CJSLoader.hasLoadedAnyUserCJSModule);

--- a/lib/internal/options.js
+++ b/lib/internal/options.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { getOptions } = internalBinding('options');
+const { getOptions, shouldNotRegisterESMLoader } = internalBinding('options');
 const { options, aliases } = getOptions();
 
 let warnOnAllowUnauthorized = true;
@@ -32,4 +32,5 @@ module.exports = {
   aliases,
   getOptionValue,
   getAllowUnauthorized,
+  shouldNotRegisterESMLoader
 };

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -771,6 +771,10 @@ inline bool Environment::is_main_thread() const {
   return worker_context() == nullptr;
 }
 
+inline bool Environment::should_not_register_esm_loader() const {
+  return flags_ & EnvironmentFlags::kNoRegisterESMLoader;
+}
+
 inline bool Environment::owns_process_state() const {
   return flags_ & EnvironmentFlags::kOwnsProcessState;
 }

--- a/src/env.h
+++ b/src/env.h
@@ -1057,6 +1057,7 @@ class Environment : public MemoryRetainer {
   inline void set_has_serialized_options(bool has_serialized_options);
 
   inline bool is_main_thread() const;
+  inline bool should_not_register_esm_loader() const;
   inline bool owns_process_state() const;
   inline bool owns_inspector() const;
   inline uint64_t thread_id() const;

--- a/src/node.h
+++ b/src/node.h
@@ -408,7 +408,11 @@ enum Flags : uint64_t {
   // Set if this Environment instance is associated with the global inspector
   // handling code (i.e. listening on SIGUSR1).
   // This is set when using kDefaultFlags.
-  kOwnsInspector = 1 << 2
+  kOwnsInspector = 1 << 2,
+  // Set if Node.js should not run its own esm loader. This is needed by some
+  // embedders, because it's possible for the Node.js esm loader to conflict
+  // with another one in an embedder environment, e.g. Blink's in Chromium.
+  kNoRegisterESMLoader = 1 << 3
 };
 }  // namespace EnvironmentFlags
 

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -979,6 +979,12 @@ void Initialize(Local<Object> target,
           context, FIXED_ONE_BYTE_STRING(isolate, "envSettings"), env_settings)
       .Check();
 
+  target
+      ->Set(context,
+            FIXED_ONE_BYTE_STRING(env->isolate(), "shouldNotRegisterESMLoader"),
+            Boolean::New(isolate, env->should_not_register_esm_loader()))
+      .Check();
+
   Local<Object> types = Object::New(isolate);
   NODE_DEFINE_CONSTANT(types, kNoOp);
   NODE_DEFINE_CONSTANT(types, kV8Option);


### PR DESCRIPTION
This PR addresses a recent embedder-specific issue Electron is facing.

Blink has its own independent ESM loader, which is set up in the renderer process of Electron. When ESM was unilaterally unflagged, this meant that there would be two competing ESM loaders in the same process, both of which made assumptions about code being run.

For example, what can happen is that the devtools windows uses Node.js' implementation of the esmodule loader, which is at present incapable of loading modules from URLs (for good reason). This causes a bunch of devtools failures. There's no real way to specifically enable sandbox (and therefore force the Blink loader to take precedence) for devtools only, since at the time we're calling `CreateContentRendererClient()` we don't know what url we're loading (and therefore can't verify it's devtools or not). Thus, it makes more sense to allow embedders to specify that we don't want to register the ESM loader when creating an Environment via flag.

I also considered adding a new cli flag and just checking it via `getOptionValue` in `pre_execution.js`, but i think that (after chatting a bit with Anna) since this use case is quite specific to embedders that it makes more sense to make it an `EnvironmentFlag`. The only thing i wasn't sure of here was where specifically to expose it. I chose `node_options` but welcome any feedback or alternate preferences.

cc @addaleax 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
