### PR TITLE
stringify function could accept a Map params

### DIFF
--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -29,6 +29,7 @@ const {
   MathAbs,
   ObjectCreate,
   ObjectKeys,
+  Map
 } = primordials;
 
 const { Buffer } = require('buffer');
@@ -194,6 +195,9 @@ function stringify(obj, sep, eq, options) {
     (encode === qsEscape ? encodeStringified : encodeStringifiedCustom);
 
   if (obj !== null && typeof obj === 'object') {
+    obj = obj instanceof Map ? [...obj.entries()].reduce(
+      (acc, [key, value]) => (acc[key] = value, acc), {}) : obj;
+
     const keys = ObjectKeys(obj);
     const len = keys.length;
     let fields = '';

--- a/test/parallel/test-querystring.js
+++ b/test/parallel/test-querystring.js
@@ -321,6 +321,16 @@ assert.strictEqual(qs.stringify([]), '');
 assert.strictEqual(qs.stringify(null), '');
 assert.strictEqual(qs.stringify(true), '');
 
+// map
+{
+  const f = qs.stringify(new Map([
+    ['a', [1, 2]],
+    ['b', '1'],
+    ['b', '2'],
+  ]));
+  assert.strictEqual(f, 'a=1&a=2&b=2');
+}
+
 check(qs.parse(), {});
 
 // empty sep


### PR DESCRIPTION
querystring.stringify() could accept a Map params, I think it's would be valuable. 

Fixes:  https://github.com/nodejs/node/issues/22782

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
