### PR TITLE
test: Verify request payload is uploaded consistently

### DIFF
--- a/test/known_issues/test-http-clientrequest-end-contentlength.js
+++ b/test/known_issues/test-http-clientrequest-end-contentlength.js
@@ -1,0 +1,51 @@
+'use strict';
+
+// Refs: https://github.com/nodejs/node/pull/34066
+
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+// Test that ClientRequest#end with default options
+// computes and sends a Content-Length header
+const upload = 'PUT / HTTP/1.1\r\n\r\n';
+const response = 'content-length: 19\r\n';
+
+// Test that the upload is properly received with the same headers,
+// regardless of request method
+const methods = [ 'GET', 'HEAD', 'DELETE', 'POST', 'PATCH', 'PUT', 'OPTIONS' ];
+
+const server = http.createServer(common.mustCall(function(req, res) {
+  req.on('data', function(chunk) {
+    assert.strictEqual(chunk, Buffer.from(upload));
+  });
+  res.setHeader('Content-Type', 'text/plain');
+  let payload = `${req.method}\r\n`;
+  for (let i = 0; i < req.rawHeaders.length; i += 2) {
+    // Ignore a couple headers that may vary
+    if (req.rawHeaders[i].toLowerCase() === 'host') continue;
+    if (req.rawHeaders[i].toLowerCase() === 'connection') continue;
+    payload += `${req.rawHeaders[i]}: ${req.rawHeaders[i + 1]}\r\n`;
+  }
+  res.end(payload);
+}), methods.length);
+
+server.listen(0, function tryNextRequest() {
+  const method = methods.pop();
+  if (method === undefined) return;
+  const port = server.address().port;
+  const req = http.request({ method, port }, function(res) {
+    const chunks = [];
+    res.on('data', function(chunk) {
+      chunks.push(chunk);
+    });
+    res.on('end', function() {
+      const received = Buffer.concat(chunks).toString();
+      const expected = method.toLowerCase() + '\r\n' + response;
+      assert.strictEqual(received.toLowerCase(), expected);
+      tryNextRequest();
+    });
+  });
+
+  req.end(upload);
+}).unref();

--- a/test/known_issues/test-http-clientrequest-end-empty-response-body.js
+++ b/test/known_issues/test-http-clientrequest-end-empty-response-body.js
@@ -1,0 +1,52 @@
+'use strict';
+
+// Refs: https://github.com/nodejs/node/pull/34066
+
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+// Test that ClientRequest#end with default options
+// and empty payload sends neither Content-Length nor Transfer-Encoding.
+// Sending Content-Length: 0 would be acceptable, but is unnecessary.
+const upload = 'PUT / HTTP/1.1\r\n\r\n';
+const response = '';
+
+// Test that the upload is properly received with the same headers,
+// regardless of request method.
+const methods = [ 'GET', 'HEAD', 'DELETE', 'POST', 'PATCH', 'PUT', 'OPTIONS' ];
+
+const server = http.createServer(common.mustCall(function(req, res) {
+  req.on('data', function(chunk) {
+    assert.strictEqual(chunk.toString(), upload);
+  });
+  res.setHeader('Content-Type', 'text/plain');
+  res.write(`${req.method}\r\n`);
+  for (let i = 0; i < req.rawHeaders.length; i += 2) {
+    // Ignore a couple headers that may vary
+    if (req.rawHeaders[i].toLowerCase() === 'host') continue;
+    if (req.rawHeaders[i].toLowerCase() === 'connection') continue;
+    res.write(`${req.rawHeaders[i]}: ${req.rawHeaders[i + 1]}\r\n`);
+  }
+  res.end();
+}), methods.length);
+
+server.listen(0, function tryNextRequest() {
+  const method = methods.pop();
+  if (method === undefined) return;
+  const port = server.address().port;
+  const req = http.request({ method, port }, function(res) {
+    const chunks = [];
+    res.on('data', function(chunk) {
+      chunks.push(chunk);
+    });
+    res.on('end', function() {
+      const received = Buffer.concat(chunks).toString();
+      const expected = method.toLowerCase() + '\r\n' + response;
+      assert.strictEqual(received.toLowerCase(), expected);
+      tryNextRequest();
+    });
+  });
+
+  req.end();
+}).unref();

--- a/test/known_issues/test-http-clientrequest-write-chunked.js
+++ b/test/known_issues/test-http-clientrequest-write-chunked.js
@@ -1,0 +1,52 @@
+'use strict';
+
+// Refs: https://github.com/nodejs/node/pull/34066
+
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+// Test that ClientRequest#write with default options
+// uses a chunked Transfer-Encoding
+const upload = 'PUT / HTTP/1.1\r\n\r\n';
+const response = 'transfer-encoding: chunked\r\n';
+
+// Test that the upload is properly received with the same headers,
+// regardless of request method.
+const methods = [ 'GET', 'HEAD', 'DELETE', 'POST', 'PATCH', 'PUT', 'OPTIONS' ];
+
+const server = http.createServer(common.mustCall(function(req, res) {
+  req.on('data', function(chunk) {
+    assert.strictEqual(chunk.toString(), upload);
+  });
+  res.setHeader('Content-Type', 'text/plain');
+  res.write(`${req.method}\r\n`);
+  for (let i = 0; i < req.rawHeaders.length; i += 2) {
+    // Ignore a couple headers that may vary
+    if (req.rawHeaders[i].toLowerCase() === 'host') continue;
+    if (req.rawHeaders[i].toLowerCase() === 'connection') continue;
+    res.write(`${req.rawHeaders[i]}: ${req.rawHeaders[i + 1]}\r\n`);
+  }
+  res.end();
+}), methods.length);
+
+server.listen(0, function tryNextRequest() {
+  const method = methods.pop();
+  if (method === undefined) return;
+  const port = server.address().port;
+  const req = http.request({ method, port }, function(res) {
+    const chunks = [];
+    res.on('data', function(chunk) {
+      chunks.push(chunk);
+    });
+    res.on('end', function() {
+      const received = Buffer.concat(chunks).toString();
+      const expected = method.toLowerCase() + '\r\n' + response;
+      assert.strictEqual(received.toLowerCase(), expected);
+      tryNextRequest();
+    });
+  });
+
+  req.write(upload);
+  req.end();
+}).unref();

--- a/test/parallel/test-http-request-method-delete-payload.js
+++ b/test/parallel/test-http-request-method-delete-payload.js
@@ -1,0 +1,30 @@
+'use strict';
+const common = require('../common');
+
+const assert = require('assert');
+const http = require('http');
+
+const data = 'PUT / HTTP/1.1\r\n\r\n';
+
+const server = http.createServer(common.mustCall(function(req, res) {
+  req.on('data', function(chunk) {
+    assert.strictEqual(chunk, Buffer.from(data));
+  });
+  res.setHeader('Content-Type', 'text/plain');
+  for (let i = 0; i < req.rawHeaders.length; i += 2) {
+    if (req.rawHeaders[i].toLowerCase() === 'host') continue;
+    if (req.rawHeaders[i].toLowerCase() === 'connection') continue;
+    res.write(`${req.rawHeaders[i]}: ${req.rawHeaders[i + 1]}\r\n`);
+  }
+  res.end();
+})).unref();
+
+server.listen(0, common.mustCall(() => {
+  const port = server.address().port;
+  const req = http.request({ method: 'DELETE', port }, function(res) {
+    res.resume();
+  });
+
+  req.write(data);
+  req.end();
+}));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

This adds several HTTP tests testing for the behavior identified in #27880:

* test-http-27880-bug.js — shows how, if you make a DELETE request with a payload, the payload will actually be written to the server where a second HTTP/1.1 request is expected; if the payload is a valid HTTP message, it will be interpreted as a second request by the server. (But the first request is sent with `Connection: close` so shouldn't the server close the connection by this point?)
* test-http-27880-chunked.js — tests that the default behavior for `ClientRequest#write` should be a chunked encoding.
* test-http-27880-content-length.js — tests that the default behavior for `ClientRequest#end` should be a standard message, with an automatically computed Content-Length header.
* test-http-27880-empty.js — tests that the default behavior for `ClientRequest#end` should have no payload headers if there's no response body

Naming for the test files will probably need to be reconsidered; suggestions welcome.

Refs: https://github.com/nodejs/node/issues/27880

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
<!-- - [ ] documentation is changed or added -->
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
