### PR TITLE
stream: doc deprecate end with chunk

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2751,6 +2751,21 @@ const moduleParents = Object.values(require.cache)
   .filter((m) => m.children.includes(module));
 ```
 
+<a id="DEP0XXX"></a>
+### DEP0XXX: `writable.end(chunk, encoding)`
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/34068
+    description: Documentation-only deprecation.
+-->
+
+Type: Documentation-only
+
+The `writable.end()` method has optional `chunk` and `encoding`
+parameters that are subtly broken in various ways. Instead,
+call `writable.write(chunk, encoding)` before `writable.end()`.
+
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`--throw-deprecation`]: cli.html#cli_throw_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2766,6 +2766,8 @@ The `writable.end()` method has optional `chunk` and `encoding`
 parameters that are subtly broken in various ways. Instead,
 call `writable.write(chunk, encoding)` before `writable.end()`.
 
+The same applies for `request.end()`.
+
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`--throw-deprecation`]: cli.html#cli_throw_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2768,6 +2768,12 @@ call `writable.write(chunk, encoding)` before `writable.end()`.
 
 The same applies for `request.end()`.
 
+Some known issues motivating deprecation:
+
+- `end` is unable to determine whether `undefined` or `null`
+  is an opt-out optional `chunk` argument or not.
+- `callback` will not be invoked with write failure.
+
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`--throw-deprecation`]: cli.html#cli_throw_deprecation
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2770,9 +2770,9 @@ The same applies for `request.end()`.
 
 Some known issues motivating deprecation:
 
-- `end` is unable to determine whether `undefined` or `null`
+* `end` is unable to determine whether `undefined` or `null`
   is an opt-out optional `chunk` argument or not.
-- `callback` will not be invoked with write failure.
+* `callback` will not be invoked with write failure.
 
 [`--pending-deprecation`]: cli.html#cli_pending_deprecation
 [`--throw-deprecation`]: cli.html#cli_throw_deprecation

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -635,8 +635,8 @@ See [`request.socket`][].
 added: v0.1.90
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/29747
-    description: The `chunk` and `encoding` parameters are doc deprecated.
+    pr-url: https://github.com/nodejs/node/pull/34068
+    description: The `chunk` and `encoding` parameters are deprecated.
   - version: v10.0.0
     pr-url: https://github.com/nodejs/node/pull/18780
     description: This method now returns a reference to `ClientRequest`.

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -630,26 +630,24 @@ deprecated: v13.0.0
 
 See [`request.socket`][].
 
-### `request.end([data[, encoding]][, callback])`
+### `request.end([callback])`
 <!-- YAML
 added: v0.1.90
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/29747
+    description: The `chunk` and `encoding` parameters are doc deprecated.
   - version: v10.0.0
     pr-url: https://github.com/nodejs/node/pull/18780
     description: This method now returns a reference to `ClientRequest`.
 -->
 
-* `data` {string|Buffer}
-* `encoding` {string}
 * `callback` {Function}
 * Returns: {this}
 
 Finishes sending the request. If any parts of the body are
 unsent, it will flush them to the stream. If the request is
 chunked, this will send the terminating `'0\r\n\r\n'`.
-
-If `data` is specified, it is equivalent to calling
-[`request.write(data, encoding)`][] followed by `request.end(callback)`.
 
 If `callback` is specified, it will be called when the request stream
 is finished.

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -411,8 +411,8 @@ Is `true` after [`writable.destroy()`][writable-destroy] has been called.
 added: v0.9.4
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/29747
-    description: The `chunk` and `encoding` parameters are doc deprecated.
+    pr-url: https://github.com/nodejs/node/pull/34068
+    description: The `chunk` and `encoding` parameters are deprecated.
   - version: v14.0.0
     pr-url: https://github.com/nodejs/node/pull/29747
     description: The `callback` is invoked if 'finish' or 'error' is emitted.

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -406,10 +406,13 @@ added: v8.0.0
 
 Is `true` after [`writable.destroy()`][writable-destroy] has been called.
 
-##### `writable.end([chunk[, encoding]][, callback])`
+##### `writable.end([callback])`
 <!-- YAML
 added: v0.9.4
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/29747
+    description: The `chunk` and `encoding` parameters are doc deprecated.
   - version: v14.0.0
     pr-url: https://github.com/nodejs/node/pull/29747
     description: The `callback` is invoked if 'finish' or 'error' is emitted.
@@ -421,20 +424,13 @@ changes:
     description: The `chunk` argument can now be a `Uint8Array` instance.
 -->
 
-* `chunk` {string|Buffer|Uint8Array|any} Optional data to write. For streams
-  not operating in object mode, `chunk` must be a string, `Buffer` or
-  `Uint8Array`. For object mode streams, `chunk` may be any JavaScript value
-  other than `null`.
-* `encoding` {string} The encoding if `chunk` is a string
 * `callback` {Function} Optional callback for when the stream finishes
   or errors
 * Returns: {this}
 
 Calling the `writable.end()` method signals that no more data will be written
-to the [`Writable`][]. The optional `chunk` and `encoding` arguments allow one
-final additional chunk of data to be written immediately before closing the
-stream. If provided, the optional `callback` function is attached as a listener
-for the [`'finish'`][] and the `'error'` event.
+to the [`Writable`][]. If provided, the optional `callback` function is
+attached as a listener for the [`'finish'`][] and the `'error'` event.
 
 Calling the [`stream.write()`][stream-write] method after calling
 [`stream.end()`][stream-end] will raise an error.
@@ -444,7 +440,7 @@ Calling the [`stream.write()`][stream-write] method after calling
 const fs = require('fs');
 const file = fs.createWriteStream('example.txt');
 file.write('hello, ');
-file.end('world!');
+file.end();
 // Writing more now is not allowed!
 ```
 


### PR DESCRIPTION
end with chunk is subtly broken in various ways which are
difficult to resolve. Maintain current functionality, discourage
usage through doc deprecation and close any related issues as wontfix.

Fixes: https://github.com/nodejs/node/issues/27787
Refs: https://github.com/nodejs/node/pull/34003

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
