### PR TITLE
zlib: remove redundant variable in zlibBufferOnEnd

### DIFF
--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -138,7 +138,6 @@ function zlibBufferOnError(err) {
 
 function zlibBufferOnEnd() {
   let buf;
-  let err;
   if (this.nread === 0) {
     buf = Buffer.alloc(0);
   } else {
@@ -146,9 +145,7 @@ function zlibBufferOnEnd() {
     buf = (bufs.length === 1 ? bufs[0] : Buffer.concat(bufs, this.nread));
   }
   this.close();
-  if (err)
-    this.cb(err);
-  else if (this._info)
+  if (this._info)
     this.cb(null, { buffer: buf, engine: this });
   else
     this.cb(null, buf);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Removes a redundant variable, which is never assigned, from the `zlibBufferOnEnd` function. Most likely it's a leftover from one of recent refactorings.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
