### PR TITLE
Draft: Cancellation of FSReq

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -517,6 +517,21 @@ MaybeLocal<Object> GetPerContextExports(Local<Context> context) {
   return handle_scope.Escape(exports);
 }
 
+MaybeLocal<Function> GetDOMException(Local<Context> context) {
+  Isolate* isolate = context->GetIsolate();
+  Local<Object> per_context_bindings;
+  Local<Value> domexception_ctor_val;
+  if (!GetPerContextExports(context).ToLocal(&per_context_bindings) ||
+      !per_context_bindings
+           ->Get(context, FIXED_ONE_BYTE_STRING(isolate, "DOMException"))
+           .ToLocal(&domexception_ctor_val)) {
+    return MaybeLocal<Function>();
+  }
+  CHECK(domexception_ctor_val->IsFunction());
+  Local<Function> domexception_ctor = domexception_ctor_val.As<Function>();
+  return domexception_ctor;
+}
+
 // Any initialization logic should be performed in
 // InitializeContext, because embedders don't necessarily
 // call NewContext and so they will experience breakages.

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -85,6 +85,9 @@ class FSReqBase : public ReqWrap<uv_fs_t> {
   virtual void SetReturnValue(
       const v8::FunctionCallbackInfo<v8::Value>& args) = 0;
 
+  // JS-exposed method to cancel the UV request.
+  static void Cancel(const v8::FunctionCallbackInfo<v8::Value>& args);
+
   const char* syscall() const { return syscall_; }
   const char* data() const { return has_data_ ? *buffer_ : nullptr; }
   enum encoding encoding() const { return encoding_; }
@@ -111,12 +114,17 @@ class FSReqBase : public ReqWrap<uv_fs_t> {
 
   BindingData* binding_data() { return binding_data_.get(); }
 
+ protected:
+  bool IsCanceled() { return is_canceled_; }
+  void MaybeReplaceWithAbortError(v8::Local<v8::Value>* value);
+
  private:
   std::unique_ptr<FSContinuationData> continuation_data_;
   enum encoding encoding_ = UTF8;
   bool has_data_ = false;
   bool use_bigint_ = false;
   bool is_plain_open_ = false;
+  bool is_canceled_ = false;
   const char* syscall_ = nullptr;
 
   BaseObjectPtr<BindingData> binding_data_;

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -301,6 +301,7 @@ v8::Isolate* NewIsolate(v8::Isolate::CreateParams* params,
 v8::MaybeLocal<v8::Value> StartExecution(Environment* env,
                                          StartExecutionCallback cb = nullptr);
 v8::MaybeLocal<v8::Object> GetPerContextExports(v8::Local<v8::Context> context);
+v8::MaybeLocal<v8::Function> GetDOMException(v8::Local<v8::Context> context);
 v8::MaybeLocal<v8::Value> ExecuteBootstrapper(
     Environment* env,
     const char* id,

--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -225,21 +225,6 @@ MaybeLocal<Function> GetEmitMessageFunction(Local<Context> context) {
   return emit_message_val.As<Function>();
 }
 
-MaybeLocal<Function> GetDOMException(Local<Context> context) {
-  Isolate* isolate = context->GetIsolate();
-  Local<Object> per_context_bindings;
-  Local<Value> domexception_ctor_val;
-  if (!GetPerContextExports(context).ToLocal(&per_context_bindings) ||
-      !per_context_bindings->Get(context,
-                                FIXED_ONE_BYTE_STRING(isolate, "DOMException"))
-          .ToLocal(&domexception_ctor_val)) {
-    return MaybeLocal<Function>();
-  }
-  CHECK(domexception_ctor_val->IsFunction());
-  Local<Function> domexception_ctor = domexception_ctor_val.As<Function>();
-  return domexception_ctor;
-}
-
 void ThrowDataCloneException(Local<Context> context, Local<String> message) {
   Isolate* isolate = context->GetIsolate();
   Local<Value> argv[] = {message,

--- a/test/cctest/test_environment.cc
+++ b/test/cctest/test_environment.cc
@@ -559,3 +559,22 @@ TEST_F(EnvironmentTest, SetImmediateMicrotasks) {
 
   EXPECT_EQ(called, 1);
 }
+
+TEST_F(EnvironmentTest, GetDOMExceptionTest) {
+  // Test that GetDOMException() returns a constructor named "DOMException"
+  const v8::HandleScope handle_scope(isolate_);
+  const Argv argv;
+  Env env{handle_scope, argv};
+
+  v8::Local<v8::Function> domexception_ctor =
+      node::GetDOMException(env.context()).ToLocalChecked();
+
+  CHECK(domexception_ctor->IsConstructor());
+
+  char domexception[13];
+  v8::Local<v8::Value> v_name = domexception_ctor->GetName();
+  CHECK(v_name->IsString());
+  v8::Local<v8::String> name = v_name->ToString(env.context()).ToLocalChecked();
+  name->WriteUtf8(isolate_, domexception, 13);
+  EXPECT_STREQ(domexception, "DOMException");
+}

--- a/test/parallel/test-fsreqcallback-cancel.js
+++ b/test/parallel/test-fsreqcallback-cancel.js
@@ -1,0 +1,65 @@
+'use strict';
+// Flags: --no-warnings --expose-internals
+
+const common = require('../common');
+const assert = require('assert');
+const { internalBinding } = require('internal/test/binding');
+const path = require('path');
+
+const { FSReqCallback, readdir } = internalBinding('fs');
+
+{
+  // Return value of cancel() is undefined
+  const req = new FSReqCallback();
+  req.oncomplete = () => {};
+  assert.strictEqual(req.cancel(), undefined);
+}
+
+
+{
+  // Callback is called with AbortError if request is canceled
+  const req = new FSReqCallback();
+  req.oncomplete = common.mustCall((err, files) => {
+    assert.strictEqual(files, undefined);
+    assert.strictEqual(err.name, 'AbortError');
+  }, 1);
+  req.cancel();
+  readdir(path.toNamespacedPath('../'), 'utf8', false, req);
+}
+
+
+{
+  // Request is canceled if cancel() called before control returns to main loop
+  const req = new FSReqCallback();
+  req.oncomplete = common.mustCall((err, files) => {
+    assert.strictEqual(files, undefined);
+    assert.strictEqual(err.name, 'AbortError');
+  }, 1);
+  readdir(path.toNamespacedPath('../'), 'utf8', false, req);
+  req.cancel();
+}
+
+
+{
+  // Request is still canceled on next tick
+  const req = new FSReqCallback();
+  req.oncomplete = common.mustCall((err, files) => {
+    assert.strictEqual(files, undefined);
+    assert.strictEqual(err.name, 'AbortError');
+  }, 1);
+  readdir(path.toNamespacedPath('../'), 'utf8', false, req);
+  process.nextTick(common.mustCall(() => req.cancel()));
+}
+
+
+{
+  // Callback is not called a second time if request canceled after it has
+  // already completed
+  const req = new FSReqCallback();
+  req.oncomplete = common.mustCall((err, files) => {
+    assert.strictEqual(err, null);
+    assert.notStrictEqual(files, undefined);
+    req.cancel();
+  }, 1);
+  readdir(path.toNamespacedPath('../'), 'utf8', false, req);
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Draft for early feedback. This adds a `cancel()` method accessible from JS to `FSReqBase` which calls `uv_cancel()` via `ReqWrap::Cancel()` on the request. This would be a prerequisite for effectively integrating support for AbortController into the `fs` APIs (#31971).

Looking for feedback on the approach, if that seems sound then I will write tests and documentation.

To see how this is used in my experiments with cancellation, see https://github.com/nodejs/node/compare/master...ptomato:31971-abortcontroller?expand=1