### PR TITLE
http: introduce new http Client

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -27,6 +27,7 @@ const {
 
 const httpAgent = require('_http_agent');
 const { ClientRequest } = require('_http_client');
+const Client = require('internal/http/client');
 const { methods } = require('_http_common');
 const { IncomingMessage } = require('_http_incoming');
 const {
@@ -61,6 +62,7 @@ module.exports = {
   METHODS: methods.slice().sort(),
   STATUS_CODES,
   Agent: httpAgent.Agent,
+  Client,
   ClientRequest,
   IncomingMessage,
   OutgoingMessage,

--- a/lib/http/client/client-base.js
+++ b/lib/http/client/client-base.js
@@ -1,0 +1,798 @@
+'use strict';
+
+/* eslint-disable no-restricted-syntax */
+
+const {
+  NumberIsInteger,
+  Promise,
+  ArrayIsArray,
+  MathMin,
+  Error
+} = primordials;
+const { URL } = require('url');
+const net = require('net');
+const tls = require('tls');
+const EventEmitter = require('events');
+const Request = require('./request');
+const assert = require('assert');
+const { clearTimeout, setTimeout } = require('timers');
+const { Buffer } = require('buffer');
+const {
+  kUrl,
+  kWriting,
+  kQueue,
+  kServerName,
+  kSocketTimeout,
+  kRequestTimeout,
+  kTLSOpts,
+  kClosed,
+  kDestroyed,
+  kPendingIdx,
+  kRunningIdx,
+  kError,
+  kOnDestroyed,
+  kPipelining,
+  kRetryDelay,
+  kRetryTimeout,
+  kMaxAbortedPayload,
+  kParser,
+  kSocket,
+  kEnqueue,
+  kClient,
+  kMaxHeadersSize
+} = require('./symbols');
+const { HTTPParser } = process.binding('http_parser');
+
+const CRLF = Buffer.from('\r\n', 'ascii');
+const TE_CHUNKED = Buffer.from('transfer-encoding: chunked\r\n', 'ascii');
+const TE_CHUNKED_EOF = Buffer.from('\r\n0\r\n\r\n', 'ascii');
+
+function nop() {}
+
+const NODE_MAJOR_VERSION = parseInt(process.version.split('.')[0].slice(1));
+
+class ClientBase extends EventEmitter {
+  constructor(url, {
+    maxAbortedPayload,
+    maxHeaderSize,
+    socketTimeout,
+    requestTimeout,
+    pipelining,
+    tls
+  } = {}) {
+    super();
+
+    if (typeof url === 'string') {
+      url = new URL(url);
+    }
+
+    if (!url || typeof url !== 'object') {
+      throw new Error('invalid url');
+    }
+
+    if (url.port != null && url.port !== '' &&
+        !NumberIsInteger(parseInt(url.port))) {
+      throw new Error('invalid port');
+    }
+
+    if (url.hostname != null && typeof url.hostname !== 'string') {
+      throw new Error('invalid hostname');
+    }
+
+    if (!/https?/.test(url.protocol)) {
+      throw new Error('invalid protocol');
+    }
+
+    if (/\/.+/.test(url.pathname) || url.search || url.hash) {
+      throw new Error('invalid url');
+    }
+
+    if (maxAbortedPayload != null && !NumberIsInteger(maxAbortedPayload)) {
+      throw new Error('invalid maxAbortedPayload');
+    }
+
+    if (maxHeaderSize != null && !NumberIsInteger(maxHeaderSize)) {
+      throw new Error('invalid maxHeaderSize');
+    }
+
+    if (socketTimeout != null && !NumberIsInteger(socketTimeout)) {
+      throw new Error('invalid socketTimeout');
+    }
+
+    if (requestTimeout != null && !NumberIsInteger(requestTimeout)) {
+      throw new Error('invalid requestTimeout');
+    }
+
+    this[kSocket] = null;
+    this[kPipelining] = pipelining || 1;
+    this[kMaxHeadersSize] = maxHeaderSize || 16384;
+    this[kUrl] = url;
+    this[kSocketTimeout] = socketTimeout == null ? 30e3 : socketTimeout;
+    this[kRequestTimeout] = requestTimeout == null ? 30e3 : requestTimeout;
+    this[kClosed] = false;
+    this[kDestroyed] = false;
+    this[kServerName] = null;
+    this[kTLSOpts] = tls;
+    this[kRetryDelay] = 0;
+    this[kRetryTimeout] = null;
+    this[kOnDestroyed] = [];
+    this[kWriting] = false;
+    this[kMaxAbortedPayload] = maxAbortedPayload || 1048576;
+
+    // kQueue is built up of 3 sections separated by
+    // the kRunningIdx and kPendingIdx indices.
+    // |   complete   |   running   |   pending   |
+    //                ^ kRunningIdx ^ kPendingIdx ^ kQueue.length
+    // kRunningIdx points to the first running element.
+    // kPendingIdx points to the first pending element.
+    // This implements a fast queue with an amortized
+    // time of O(1).
+
+    this[kQueue] = [];
+    this[kRunningIdx] = 0;
+    this[kPendingIdx] = 0;
+  }
+
+  get pipelining() {
+    return this[kPipelining];
+  }
+
+  set pipelining(value) {
+    this[kPipelining] = value;
+    resume(this);
+  }
+
+  get connected() {
+    return (
+      this[kSocket] &&
+      this[kSocket].connecting !== true &&
+      // Older versions of Node don't set secureConnecting to false.
+      (this[kSocket].authorized !== false ||
+       this[kSocket].authorizationError
+      ) &&
+      !this[kSocket].destroyed
+    );
+  }
+
+  get pending() {
+    return this[kQueue].length - this[kPendingIdx];
+  }
+
+  get running() {
+    return this[kPendingIdx] - this[kRunningIdx];
+  }
+
+  get size() {
+    return this[kQueue].length - this[kRunningIdx];
+  }
+
+  get full() {
+    return this.size > this[kPipelining];
+  }
+
+  get destroyed() {
+    return this[kDestroyed];
+  }
+
+  get closed() {
+    return this[kClosed];
+  }
+
+  [kEnqueue](opts, callback) {
+    if (typeof callback !== 'function') {
+      throw new Error('invalid callback');
+    }
+
+    if (!opts || typeof opts !== 'object') {
+      process.nextTick(callback,
+                       new Error('invalid opts'), null);
+      return;
+    }
+
+    if (this[kDestroyed]) {
+      process.nextTick(callback, new Error('destroyed'), null);
+      return;
+    }
+
+    if (this[kClosed]) {
+      process.nextTick(callback, new Error('closed'), null);
+      return;
+    }
+
+    if (opts.requestTimeout == null && this[kRequestTimeout]) {
+      // TODO: Avoid copy.
+      opts = { ...opts, requestTimeout: this[kRequestTimeout] };
+    }
+
+    let request;
+    try {
+      request = new Request(opts, this[kUrl].hostname, callback);
+    } catch (err) {
+      process.nextTick(callback, err, null);
+      return;
+    }
+
+    this[kQueue].push(request);
+
+    resume(this);
+
+    return request;
+  }
+
+  close(callback) {
+    if (callback === undefined) {
+      return new Promise((resolve, reject) => {
+        this.close((err, data) => {
+          return err ? reject(err) : resolve(data);
+        });
+      });
+    }
+
+    if (typeof callback !== 'function') {
+      throw new Error('invalid callback');
+    }
+
+    if (this[kDestroyed]) {
+      process.nextTick(callback, new Error('destroyed'), null);
+      return;
+    }
+
+    this[kClosed] = true;
+    this[kOnDestroyed].push(callback);
+
+    resume(this);
+  }
+
+  destroy(err, callback) {
+    if (typeof err === 'function') {
+      callback = err;
+      err = null;
+    }
+
+    if (callback === undefined) {
+      return new Promise((resolve, reject) => {
+        this.destroy(err, (err, data) => {
+          return err ? reject(err) : resolve(data);
+        });
+      });
+    }
+
+    if (typeof callback !== 'function') {
+      throw new Error('invalid callback');
+    }
+
+    if (this[kDestroyed]) {
+      if (this[kOnDestroyed]) {
+        this[kOnDestroyed].push(callback);
+      } else {
+        process.nextTick(callback, null, null);
+      }
+      return;
+    }
+
+    clearTimeout(this[kRetryTimeout]);
+    this[kRetryTimeout] = null;
+    this[kClosed] = true;
+    this[kDestroyed] = true;
+    this[kOnDestroyed].push(callback);
+
+    const onDestroyed = () => {
+      const callbacks = this[kOnDestroyed];
+      this[kOnDestroyed] = null;
+      for (const callback of callbacks) {
+        callback(null, null);
+      }
+    };
+
+    if (!this[kSocket] || this[kSocket][kClosed]) {
+      process.nextTick(onDestroyed);
+    } else {
+      this[kSocket]
+        .on('close', onDestroyed)
+        .destroy(err);
+    }
+
+    // Resume will invoke callbacks and must happen in nextTick
+    // TODO: Implement in a more elegant way.
+    process.nextTick(resume, this);
+  }
+}
+
+class Parser extends HTTPParser {
+  constructor(client, socket) {
+    if (NODE_MAJOR_VERSION >= 12) {
+      super();
+      this.initialize(
+        HTTPParser.RESPONSE,
+        {},
+        client[kMaxHeadersSize],
+        false,
+        0
+      );
+    } else {
+      super(HTTPParser.RESPONSE, false);
+    }
+
+    this.client = client;
+    this.socket = socket;
+    this.resumeSocket = () => socket.resume();
+    this.read = 0;
+    this.body = null;
+  }
+
+  [HTTPParser.kOnHeaders]() {
+    // TODO: Handle trailers.
+  }
+
+  [HTTPParser.kOnHeadersComplete](versionMajor, versionMinor, headers, method,
+                                  url, statusCode, statusMessage, upgrade,
+                                  shouldKeepAlive) {
+    const { client, resumeSocket } = this;
+    const request = client[kQueue][client[kRunningIdx]];
+    const { signal, opaque } = request;
+    const skipBody = request.method === 'HEAD';
+
+    assert(!this.read);
+    assert(!this.body);
+
+    if (statusCode === 101) {
+      request.invoke(new Error('101 response not supported'));
+      return true;
+    }
+
+    if (statusCode < 200) {
+      // TODO: Informational response.
+      return true;
+    }
+
+    let body = request.invoke(null, {
+      statusCode,
+      headers: parseHeaders(headers),
+      opaque,
+      resume: resumeSocket
+    });
+
+    if (body && skipBody) {
+      body(null, null);
+      body = null;
+    }
+
+    if (body) {
+      this.body = body;
+
+      if (signal) {
+        signal.once('error', body);
+      }
+    } else {
+      this.next();
+    }
+
+    return skipBody;
+  }
+
+  [HTTPParser.kOnBody](chunk, offset, length) {
+    this.read += length;
+
+    const { client, socket, body, read } = this;
+
+    const ret = body ? body(null, chunk.slice(offset, offset + length)) : null;
+
+    if (ret == null && read > client[kMaxAbortedPayload]) {
+      socket.destroy();
+    } else if (ret === false) {
+      socket.pause();
+    }
+  }
+
+  [HTTPParser.kOnMessageComplete]() {
+    const { body } = this;
+
+    this.read = 0;
+    this.body = null;
+
+    if (body) {
+      body(null, null);
+      this.next();
+    }
+  }
+
+  next() {
+    const { client, resumeSocket } = this;
+
+    resumeSocket();
+
+    client[kQueue][client[kRunningIdx]++] = null;
+
+    resume(client);
+  }
+
+  destroy(err) {
+    const { client, body } = this;
+
+    assert(err);
+
+    if (client[kRunningIdx] >= client[kPendingIdx]) {
+      assert(!body);
+      return;
+    }
+
+    this.read = 0;
+    this.body = null;
+
+    // Retry all idempotent requests except for the one
+    // at the head of the pipeline.
+
+    const retryRequests = [];
+    const errorRequests = [];
+
+    errorRequests.push(client[kQueue][client[kRunningIdx]++]);
+
+    const requests = client[kQueue].slice(client[kRunningIdx],
+                                          client[kPendingIdx]);
+    for (const request of requests) {
+      const { idempotent, body } = request;
+      if (idempotent && (!body || typeof body.pipe !== 'function')) {
+        retryRequests.push(request);
+      } else {
+        errorRequests.push(request);
+      }
+    }
+
+    client[kQueue].splice(0, client[kPendingIdx], ...retryRequests);
+
+    client[kPendingIdx] = 0;
+    client[kRunningIdx] = 0;
+
+    if (body) {
+      body(err, null);
+    }
+
+    for (const request of errorRequests) {
+      request.invoke(err, null);
+    }
+
+    this.close();
+  }
+}
+
+function connect(client) {
+  assert(!client[kSocket]);
+  assert(!client[kRetryTimeout]);
+
+  const { protocol, port, hostname } = client[kUrl];
+  const servername = client[kServerName] ||
+    (client[kTLSOpts] && client[kTLSOpts].servername);
+  const socket = protocol === 'https:' ?
+    tls.connect(port || 443, hostname, {
+      ...client[kTLSOpts],
+      servername
+    }) : net.connect(port || 80, hostname);
+
+  client[kSocket] = socket;
+
+  socket[kClient] = client;
+  socket[kParser] = new Parser(client, socket);
+  socket[kClosed] = false;
+  socket[kError] = null;
+  socket.setTimeout(client[kSocketTimeout], function() {
+    this.destroy(new Error('socket timeout'));
+  });
+  socket
+    .setNoDelay(true)
+    .on(protocol === 'https:' ? 'secureConnect' : 'connect', function() {
+      const client = this[kClient];
+
+      client[kRetryDelay] = 0;
+      client.emit('connect');
+      resume(client);
+    })
+    .on('data', function(chunk) {
+      const parser = this[kParser];
+
+      const err = parser.execute(chunk);
+      if (err instanceof Error && !this.destroyed) {
+        this.destroy(err);
+      }
+    })
+    .on('error', function(err) {
+      if (err.code === 'ERR_TLS_CERT_ALTNAME_INVALID') {
+        assert(!client.running);
+        while (client.pending &&
+               client[kQueue][client[kPendingIdx]].servername === servername) {
+          client[kQueue][client[kPendingIdx]++].invoke(err, null);
+        }
+      } else if (
+        !client.running &&
+        err.code !== 'ECONNRESET' &&
+        err.code !== 'ECONNREFUSED' &&
+        err.code !== 'EHOSTUNREACH' &&
+        err.code !== 'EHOSTDOWN' &&
+        err.message !== 'closed' &&
+        err.message !== 'other side closed'
+      ) {
+        // Error is not caused by running request and not a recoverable
+        // socket error.
+        for (const request of client[kQueue].splice(client[kPendingIdx])) {
+          request.invoke(err, null);
+        }
+      }
+
+      this[kError] = err;
+    })
+    .on('end', function() {
+      this.destroy(new Error('other side closed'));
+    })
+    .on('close', function() {
+      const client = this[kClient];
+      const parser = this[kParser];
+
+      this[kClosed] = true;
+
+      if (!socket[kError]) {
+        socket[kError] = new Error('closed');
+      }
+
+      const err = socket[kError];
+
+      parser.destroy(err);
+
+      resume(client);
+
+      if (client.destroyed) {
+        return;
+      }
+
+      // reset events
+      client[kSocket]
+        .removeAllListeners('data')
+        .removeAllListeners('end')
+        .removeAllListeners('finish')
+        .removeAllListeners('error');
+      client[kSocket]
+        .on('error', nop);
+      client[kSocket] = null;
+
+      if (client.pending > 0) {
+        if (client[kRetryDelay]) {
+          client[kRetryTimeout] = setTimeout(() => {
+            client[kRetryTimeout] = null;
+            connect(client);
+          }, client[kRetryDelay]);
+          client[kRetryDelay] = MathMin(client[kRetryDelay] * 2,
+                                        client[kSocketTimeout]);
+        } else {
+          connect(client);
+          client[kRetryDelay] = 1e3;
+        }
+      }
+
+      client.emit('disconnect', err);
+    });
+}
+
+function resume(client) {
+  while (true) {
+    if (client[kDestroyed]) {
+      const requests = client[kQueue].splice(client[kPendingIdx]);
+      for (const request of requests) {
+        request.invoke(new Error('destroyed'), null);
+      }
+      return;
+    }
+
+    if (client.size === 0) {
+      if (client[kClosed]) {
+        client.destroy(nop);
+      }
+      if (client[kRunningIdx] > 0) {
+        client[kQueue].length = 0;
+        client[kPendingIdx] = 0;
+        client[kRunningIdx] = 0;
+      }
+      return;
+    }
+
+    if (client[kRunningIdx] > 256) {
+      client[kQueue].splice(0, client[kRunningIdx]);
+      client[kPendingIdx] -= client[kRunningIdx];
+      client[kRunningIdx] = 0;
+    }
+
+    if (client.running >= client.pipelining) {
+      return;
+    }
+
+    if (!client.pending) {
+      return;
+    }
+
+    const request = client[kQueue][client[kPendingIdx]];
+
+    if (!request.callback) {
+      // Request was aborted.
+      // TODO: Avoid splice one by one.
+      client[kQueue].splice(client[kPendingIdx], 1);
+      continue;
+    }
+
+    if (client[kServerName] !== request.servername) {
+      if (client.running) {
+        return;
+      }
+
+      client[kServerName] = request.servername;
+
+      if (client[kSocket]) {
+        client[kSocket].destroy();
+      }
+    }
+
+    if (!client[kSocket] && !client[kRetryTimeout]) {
+      connect(client);
+      return;
+    }
+
+    if (!client.connected) {
+      return;
+    }
+
+    if (client[kWriting]) {
+      return;
+    }
+
+    if (!request.idempotent && client.running) {
+      // Non-idempotent request cannot be retried.
+      // Ensure that no other requests are inflight and
+      // could cause failure.
+      return;
+    }
+
+    if (request.streaming && client.running) {
+      // Request with stream body can error while other requests
+      // are inflight and indirectly error those as well.
+      // Ensure this doesn't happen by waiting for inflight
+      // to complete before dispatching.
+
+      // TODO: This is to strict. Would be better if when
+      // request body fails, the client waits for inflight
+      // before resetting the connection.
+      return;
+    }
+
+    client[kPendingIdx]++;
+
+    write(client, request);
+
+    // Release memory for no longer required properties.
+    request.headers = null;
+    request.body = null;
+  }
+}
+
+function write(client, {
+  header,
+  body,
+  streaming,
+  chunked,
+  signal
+}) {
+  const socket = client[kSocket];
+
+  socket.cork();
+  socket.write(header);
+
+  if (!body) {
+    socket.write(CRLF);
+    socket.uncork();
+  } else if (!streaming) {
+    socket.write(CRLF);
+    socket.write(body);
+    socket.write(CRLF);
+    socket.uncork();
+  } else {
+    if (chunked) {
+      socket.write(TE_CHUNKED);
+    } else {
+      socket.write(CRLF);
+    }
+
+    const onData = (chunk) => {
+      if (chunked) {
+        socket.write(`\r\n${Buffer.byteLength(chunk).toString(16)}\r\n`,
+                     'ascii');
+      }
+      if (!socket.write(chunk) && body.pause) {
+        body.pause();
+      }
+    };
+    const onDrain = () => {
+      if (body.resume) {
+        body.resume();
+      }
+    };
+    const onAbort = () => {
+      onFinished(new Error('aborted'));
+    };
+
+    let finished = false;
+    const onFinished = (err) => {
+      if (finished) {
+        return;
+      }
+      finished = true;
+
+      err = err || socket[kError];
+
+      if (signal) {
+        signal.removeListener('error', onFinished);
+      }
+
+      socket
+        .removeListener('drain', onDrain)
+        .removeListener('error', onFinished)
+        .removeListener('close', onFinished);
+      body
+        .removeListener('data', onData)
+        .removeListener('end', onFinished)
+        .removeListener('error', onFinished)
+        .removeListener('close', onAbort)
+        .on('error', nop);
+
+      if (err) {
+        if (typeof body.destroy === 'function' && !body.destroyed) {
+          body.destroy(err);
+        }
+
+        if (!socket.destroyed) {
+          assert(client.running);
+          socket.destroy(err);
+        }
+      } else if (chunked) {
+        socket.write(TE_CHUNKED_EOF);
+      } else {
+        socket.write(CRLF);
+      }
+
+      client[kWriting] = false;
+      resume(client);
+    };
+
+    if (signal) {
+      signal.on('error', onFinished);
+    }
+
+    body
+      .on('data', onData)
+      .on('end', onFinished)
+      .on('error', onFinished)
+      .on('close', onAbort);
+
+    socket
+      .on('drain', onDrain)
+      .on('error', onFinished)
+      .on('close', onFinished)
+      .uncork();
+
+    client[kWriting] = true;
+  }
+}
+
+function parseHeaders(headers) {
+  const obj = {};
+  for (var i = 0; i < headers.length; i += 2) {
+    var key = headers[i].toLowerCase();
+    var val = obj[key];
+    if (!val) {
+      obj[key] = headers[i + 1];
+    } else {
+      if (!ArrayIsArray(val)) {
+        val = [val];
+        obj[key] = val;
+      }
+      val.push(headers[i + 1]);
+    }
+  }
+  return obj;
+}
+
+module.exports = ClientBase;

--- a/lib/http/client/index.js
+++ b/lib/http/client/index.js
@@ -1,0 +1,367 @@
+'use strict';
+
+/* eslint-disable no-restricted-syntax */
+
+const {
+  Promise,
+  Error
+} = primordials;
+
+const {
+  Readable,
+  Duplex,
+  PassThrough,
+  finished
+} = require('stream');
+const {
+  kEnqueue,
+  kResume
+} = require('./symbols');
+const ClientBase = require('./client-base');
+const assert = require('assert');
+
+function nop() {}
+
+class Client extends ClientBase {
+  request(opts, callback) {
+    if (callback === undefined) {
+      return new Promise((resolve, reject) => {
+        this.request(opts, (err, data) => {
+          return err ? reject(err) : resolve(data);
+        });
+      });
+    }
+
+    if (typeof callback !== 'function') {
+      throw new Error('invalid callback');
+    }
+
+    if (!opts || typeof opts !== 'object') {
+      process.nextTick(callback,
+                       new Error('invalid opts'), null);
+      return;
+    }
+
+    // TODO: Avoid closure due to callback capture.
+    this[kEnqueue](opts, function(err, data) {
+      if (err) {
+        callback(err, null);
+        return;
+      }
+
+      const {
+        statusCode,
+        headers,
+        opaque,
+        resume
+      } = data;
+
+      const body = new Readable({
+        autoDestroy: true,
+        read: resume,
+        destroy(err, callback) {
+          if (!err && !this._readableState.endEmitted) {
+            err = new Error('aborted');
+          }
+          if (err) {
+            resume();
+          }
+          callback(err, null);
+        }
+      });
+      body.destroy = this.wrap(body, body.destroy);
+
+      callback(null, {
+        statusCode,
+        headers,
+        opaque,
+        body
+      });
+
+      return this.wrap(body, function(err, chunk) {
+        if (this.destroyed) {
+          return null;
+        } else if (err) {
+          this.destroy(err);
+        } else {
+          const ret = this.push(chunk);
+          return this.destroyed ? null : ret;
+        }
+      });
+    });
+  }
+
+  pipeline(opts, handler) {
+    if (!opts || typeof opts !== 'object') {
+      return new PassThrough()
+        .destroy(new Error('invalid opts'));
+    }
+
+    if (typeof handler !== 'function') {
+      return new PassThrough()
+        .destroy(new Error('invalid handler'));
+    }
+
+    const req = new Readable({
+      autoDestroy: true,
+      read() {
+        if (this[kResume]) {
+          const resume = this[kResume];
+          this[kResume] = null;
+          resume();
+        }
+      },
+      destroy(err, callback) {
+        if (err) {
+          if (this[kResume]) {
+            const resume = this[kResume];
+            this[kResume] = null;
+            resume(err);
+          } else if (!ret.destroyed) {
+            // Stop ret from scheduling more writes.
+            ret.destroy(err);
+          }
+        } else {
+          assert(this._readableState.endEmitted);
+          assert(!this[kResume]);
+        }
+
+        callback(err);
+      }
+    });
+    let res;
+    let body;
+
+    const ret = new Duplex({
+      readableObjectMode: opts.objectMode,
+      autoDestroy: true,
+      read() {
+        if (body && body.resume) {
+          body.resume();
+        }
+      },
+      write(chunk, encoding, callback) {
+        assert(!req.destroyed);
+        if (req.push(chunk, encoding)) {
+          callback();
+        } else {
+          req[kResume] = callback;
+        }
+      },
+      final(callback) {
+        req.push(null);
+        callback();
+      },
+      destroy(err, callback) {
+        if (!err && !this._readableState.endEmitted) {
+          err = new Error('aborted');
+        }
+        if (!req.destroyed) {
+          req.destroy(err);
+        }
+        if (res && !res.destroyed) {
+          res.destroy(err);
+        }
+        callback(err);
+      }
+    });
+
+    // TODO: Avoid copy.
+    opts = { ...opts, body: req };
+
+    const request = this[kEnqueue](opts, function(err, data) {
+      if (err) {
+        if (!ret.destroyed) {
+          ret.destroy(err);
+        }
+        return;
+      }
+
+      const {
+        statusCode,
+        headers,
+        opaque,
+        resume
+      } = data;
+
+      res = new Readable({
+        autoDestroy: true,
+        read: resume,
+        destroy(err, callback) {
+          if (!err && !this._readableState.endEmitted) {
+            err = new Error('aborted');
+          }
+          if (err) {
+            if (!ret.destroyed) {
+              ret.destroy(err);
+            }
+            resume();
+          }
+          callback(err, null);
+        }
+      });
+      res.destroy = this.wrap(res, res.destroy);
+
+      try {
+        body = handler({
+          statusCode,
+          headers,
+          opaque,
+          body: res
+        });
+      } catch (err) {
+        res.on('error', nop);
+        if (!ret.destroyed) {
+          ret.destroy(err);
+        }
+        return;
+      }
+
+      // TODO: Should we allow !body?
+      if (!body || typeof body.pipe !== 'function') {
+        if (!ret.destroyed) {
+          ret.destroy(new Error('expected Readable'));
+        }
+        return;
+      }
+
+      // TODO: If body === res then avoid intermediate
+      // and write directly to ret.push? Or should this
+      // happen when body is null?
+
+      // TODO: body.destroy?
+
+      body
+        .on('data', function(chunk) {
+          if (!ret.push(chunk) && this.pause) {
+            this.pause();
+          }
+        })
+        .on('error', function(err) {
+          if (!ret.destroyed) {
+            ret.destroy(err);
+          }
+        })
+        .on('end', function() {
+          ret.push(null);
+        })
+        .on('close', function() {
+          if (!this._readableState.endEmitted && !ret.destroyed) {
+            ret.destroy(new Error('aborted'));
+          }
+        });
+
+      return this.wrap(res, function(err, chunk) {
+        if (this.destroyed) {
+          return null;
+        } else if (err) {
+          this.destroy(err);
+        } else {
+          const ret = this.push(chunk);
+          return this.destroyed ? null : ret;
+        }
+      });
+    });
+
+    ret.destroy = request.wrap(ret, ret.destroy);
+
+    return ret;
+  }
+
+  stream(opts, factory, callback) {
+    if (callback === undefined) {
+      return new Promise((resolve, reject) => {
+        this.stream(opts, factory, (err, data) => {
+          return err ? reject(err) : resolve(data);
+        });
+      });
+    }
+
+    if (typeof callback !== 'function') {
+      throw new Error('invalid callback');
+    }
+
+    if (!opts || typeof opts !== 'object') {
+      process.nextTick(callback,
+                       new Error('invalid opts'), null);
+      return;
+    }
+
+    if (typeof factory !== 'function') {
+      process.nextTick(callback,
+                       new Error('invalid factory'), null);
+      return;
+    }
+
+    // TODO: Avoid closure due to callback capture.
+    this[kEnqueue](opts, function(err, data) {
+      if (err) {
+        callback(err);
+        return;
+      }
+
+      const {
+        statusCode,
+        headers,
+        opaque,
+        resume
+      } = data;
+
+      let body;
+      try {
+        body = factory({
+          statusCode,
+          headers,
+          opaque
+        });
+      } catch (err) {
+        callback(err, null);
+        return;
+      }
+
+      if (!body) {
+        callback(null, null);
+        return;
+      }
+
+      if (
+        typeof body.write !== 'function' ||
+        typeof body.destroy !== 'function' ||
+        typeof body.destroyed !== 'boolean'
+      ) {
+        callback(new Error('expected Writable'), null);
+        return;
+      }
+
+      body.on('drain', resume);
+      // TODO: Avoid finished. It registers an unecessary amount of listeners.
+      finished(body, { readable: false }, (err) => {
+        body.removeListener('drain', resume);
+        if (err) {
+          if (!body.destroyed) {
+            body.destroy(err);
+          }
+          resume();
+        }
+        callback(err, null);
+      });
+
+      body.destroy = this.wrap(body, body.destroy);
+
+      return this.wrap(body, function(err, chunk) {
+        if (this.destroyed) {
+          return null;
+        } else if (err) {
+          this.destroy(err);
+        } else if (chunk == null) {
+          this.end();
+        } else {
+          const ret = this.write(chunk);
+          return this.destroyed ? null : ret;
+        }
+      });
+    });
+  }
+}
+
+module.exports = Client;

--- a/lib/http/client/request.js
+++ b/lib/http/client/request.js
@@ -1,0 +1,193 @@
+'use strict';
+
+/* eslint-disable no-restricted-syntax */
+
+const {
+  NumberIsInteger,
+  ObjectKeys,
+  Error
+} = primordials;
+
+const { AsyncResource } = require('async_hooks');
+const EE = require('events');
+const assert = require('assert');
+const net = require('net');
+const { Buffer } = require('buffer');
+const { clearTimeout, setTimeout } = require('timers');
+
+function isValidBody(body) {
+  return body == null ||
+    body instanceof Uint8Array ||
+    typeof body === 'string' ||
+    typeof body.pipe === 'function';
+}
+
+class Request extends AsyncResource {
+  constructor({
+    path,
+    method,
+    body,
+    headers,
+    idempotent,
+    opaque,
+    servername,
+    signal,
+    requestTimeout
+  }, hostname, callback) {
+    super('UNDICI_REQ');
+
+    assert(typeof hostname === 'string');
+    assert(typeof callback === 'function');
+
+    if (typeof path !== 'string' || path[0] !== '/') {
+      throw new Error('path must be a valid path');
+    }
+
+    if (typeof method !== 'string') {
+      throw new Error('method must be a string');
+    }
+
+    if (requestTimeout != null && (!NumberIsInteger(requestTimeout) ||
+        requestTimeout < 0)) {
+      throw new Error(
+        'requestTimeout must be a positive integer or zero');
+    }
+
+    if (signal && typeof signal.on !== 'function' &&
+        typeof signal.addEventListener !== 'function') {
+      throw new Error(
+        'signal must implement .on(name, callback)');
+    }
+
+    if (!isValidBody(body)) {
+      throw new Error(
+        'body must be a string, a Buffer or a Readable stream');
+    }
+
+    this.timeout = null;
+
+    this.signal = null;
+
+    this.method = method;
+
+    this.streaming = body && typeof body.pipe === 'function';
+
+    this.body = typeof body === 'string' ? Buffer.from(body) : body;
+
+    const hostHeader = headers && (headers.host || headers.Host);
+
+    this.servername = servername || hostHeader || hostname;
+    if (net.isIP(this.servername) || this.servername.startsWith('[')) {
+      this.servername = null;
+    }
+
+    this.chunked = !headers || headers['content-length'] === undefined;
+
+    this.callback = callback;
+
+    this.opaque = opaque;
+
+    this.idempotent = idempotent == null ?
+      method === 'HEAD' || method === 'GET' : idempotent;
+
+    if (this.streaming) {
+      this.body.on('error', (err) => {
+        this.invoke(err, null);
+      });
+    }
+
+    {
+      // TODO (perf): Build directy into buffer instead of
+      // using an intermediate string.
+
+      let header = `${method} ${path} HTTP/1.1\r\n`;
+
+      if (headers) {
+        const headerNames = ObjectKeys(headers);
+        for (let i = 0; i < headerNames.length; i++) {
+          const name = headerNames[i];
+          header += name + ': ' + headers[name] + '\r\n';
+        }
+      }
+
+      if (!hostHeader) {
+        header += `host: ${hostname}\r\n`;
+      }
+
+      header += 'connection: keep-alive\r\n';
+
+      if (this.body && this.chunked && !this.streaming) {
+        header += `content-length: ${Buffer.byteLength(this.body)}\r\n`;
+      }
+
+      this.header = Buffer.from(header, 'ascii');
+    }
+
+    if (signal) {
+      if (!this.signal) {
+        this.signal = new EE();
+      }
+
+      const onAbort = () => {
+        this.signal.emit('error', new Error('aborted'));
+      };
+
+      if ('addEventListener' in signal) {
+        signal.addEventListener('abort', onAbort);
+      } else {
+        signal.once('abort', onAbort);
+      }
+    }
+
+    if (requestTimeout) {
+      if (!this.signal) {
+        this.signal = new EE();
+      }
+
+      const onTimeout = () => {
+        this.signal.emit('error', new Error('request timeout'));
+      };
+
+      this.timeout = setTimeout(onTimeout, requestTimeout);
+    }
+
+    if (this.signal) {
+      this.signal.on('error', (err) => {
+        assert(err);
+        this.invoke(err, null);
+      });
+    }
+  }
+
+  wrap(that, cb) {
+    return this.runInAsyncScope.bind(this, cb, that);
+  }
+
+  invoke(err, val) {
+    const { callback } = this;
+
+    if (!callback) {
+      return;
+    }
+
+    if (
+      this.body &&
+      typeof this.body.destroy === 'function' &&
+      !this.body.destroyed
+    ) {
+      this.body.destroy(err);
+    }
+
+    clearTimeout(this.timeout);
+    this.timeout = null;
+    this.body = null;
+    this.servername = null;
+    this.callback = null;
+    this.opaque = null;
+    this.headers = null;
+
+    return this.runInAsyncScope(callback, this, err, val);
+  }
+}
+
+module.exports = Request;

--- a/lib/http/client/symbols.js
+++ b/lib/http/client/symbols.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const {
+  Symbol,
+} = primordials;
+
+module.exports = {
+  kUrl: Symbol('url'),
+  kWriting: Symbol('writing'),
+  kQueue: Symbol('queue'),
+  kSocketTimeout: Symbol('socket timeout'),
+  kRequestTimeout: Symbol('request timeout'),
+  kServerName: Symbol('server name'),
+  kTLSOpts: Symbol('TLS Options'),
+  kClosed: Symbol('closed'),
+  kDestroyed: Symbol('destroyed'),
+  kMaxHeadersSize: Symbol('maxHeaderSize'),
+  kRunningIdx: Symbol('running index'),
+  kPendingIdx: Symbol('pending index'),
+  kResume: Symbol('resume'),
+  kError: Symbol('error'),
+  kOnDestroyed: Symbol('destroy callbacks'),
+  kPipelining: Symbol('pipelinig'),
+  kRetryDelay: Symbol('retry delay'),
+  kSocket: Symbol('socket'),
+  kParser: Symbol('parser'),
+  kClients: Symbol('clients'),
+  kRetryTimeout: Symbol('retry timeout'),
+  kClient: Symbol('client'),
+  kEnqueue: Symbol('enqueue'),
+  kMaxAbortedPayload: Symbol('max aborted payload')
+};


### PR DESCRIPTION
I'm opening this PR mostly as a forum for discussion and expect it to probably end up being closed. Not sure if this is the right approach so feel free to point me in a better direction if possible.

During the OpenJS conference session yesterday we discussed the future of HTTP. Mostly focused on the server side but also the client side was briefly mentioned. In particular @jasnell pointed out that in HTTP2/3 the difference between server and client side is much smaller. Though, we all agreed that any plans in this regard is probably a few years away. We basically ended up with two issues ([#1](https://github.com/nodejs/web-server-frameworks/issues/54), [#2](https://github.com/nodejs/web-server-frameworks/issues/55)) in the web-server-frameworks working group. Again this mostly focuses on the server side so I'm a little unsure where client side discussions should go. Given the mentioned decrease in difference, maybe it should land in the web-server-frameworks WG at some point?

That being said, I have been looking into implementing a simpler and faster http client and ended up working on @mcollina's [undici](https://github.com/mcollina/undici) library. It might or might not make sense to include in node core or possibly some kind of WG package. The idea is that this client should provide a building block for higher level client implementations.

I think most of us are familiar with the issues with the current http client in Node core and that it can be a challenge to maintain. How do we get past this?

In this PR I have included undici to discuss whether or not it might make sense to include in core, and if so what things are missing, should be changed or needs further consideration?

As a quick summary:

- more than 2x faster than the current http client.
- Uses llhttp for parsing (through Node).
- Simpler implementation.
- [Testing suite](https://github.com/mcollina/undici/tree/master/test) with near 99.99% coverage.
- HTTP pipelining support.
- 5 different API's `request`, `pipeline`, `stream`, `upgrade` and `connect`.
- Hopefully less edge cases and semi compliant behavior (e.g. in relation to streams).
- Async Hook support.
- https support
- Works on all LTS versions of Node.
- keep-alive timeout hint support

For further details it's easiest to check the [README](https://github.com/mcollina/undici).

Some challenges:

- What should the API be? Could we fit http2/3 into it?
- Should this be in core, WG package or just leave it separate?
- Does not sanity check input (i.e. method headers etc...). Should it?
- Do we end up with 2 different http client API's in core that we need to maintain indefinitely?
- Does not cache TLS sessions. Does it need to?
~~- Missing 1xx support (in particular 101).~~
~~- Missing trailers support.~~
- Missing 100 continue support (won't fix is current opinion)
- [Pool](https://github.com/mcollina/undici/blob/master/lib/pool.js) vs Agent? [What pool strategies?](https://github.com/mcollina/undici/issues/73)
- [Other possible enhancements](https://github.com/mcollina/undici/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Aenhancement)?

Some TODOs:

- Port of [tests](https://github.com/mcollina/undici/tree/master/test) to Node.
- Port of [docs](https://github.com/mcollina/undici/blob/master/README.md) to Node.
- Port of [errors](https://github.com/mcollina/undici/blob/master/lib/errors.js) to Node.

Benchmarks:
```js
http - keepalive - pipe x 5,768 ops/sec ±4.17% (71 runs sampled)
undici - pipeline - pipe x 7,151 ops/sec ±2.59% (80 runs sampled)
undici - request - pipe x 11,618 ops/sec ±4.43% (72 runs sampled)
undici - stream - pipe x 12,592 ops/sec ±1.03% (81 runs sampled)
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
