### PR TITLE
quic: minor cleanups in quic_buffer

### DIFF
--- a/src/quic/node_quic_buffer-inl.h
+++ b/src/quic/node_quic_buffer-inl.h
@@ -64,7 +64,6 @@ QuicBuffer::QuicBuffer(QuicBuffer&& src) noexcept
   src.ended_ = false;
 }
 
-
 QuicBuffer& QuicBuffer::operator=(QuicBuffer&& src) noexcept {
   if (this == &src) return *this;
   this->~QuicBuffer();

--- a/src/quic/node_quic_buffer.cc
+++ b/src/quic/node_quic_buffer.cc
@@ -17,7 +17,7 @@ void QuicBufferChunk::MemoryInfo(MemoryTracker* tracker) const {
 
 size_t QuicBuffer::Push(uv_buf_t* bufs, size_t nbufs, DoneCB done) {
   size_t len = 0;
-  if (nbufs == 0 || bufs == nullptr || is_empty(bufs[0])) {
+  if (UNLIKELY(nbufs == 0 || bufs == nullptr || is_empty(bufs[0]))) {
     done(0);
     return 0;
   }

--- a/src/quic/node_quic_buffer.cc
+++ b/src/quic/node_quic_buffer.cc
@@ -17,10 +17,11 @@ void QuicBufferChunk::MemoryInfo(MemoryTracker* tracker) const {
 
 size_t QuicBuffer::Push(uv_buf_t* bufs, size_t nbufs, DoneCB done) {
   size_t len = 0;
-  if (UNLIKELY(nbufs == 0 || bufs == nullptr || is_empty(bufs[0]))) {
+  if (UNLIKELY(nbufs == 0)) {
     done(0);
     return 0;
   }
+  DCHECK_NOT_NULL(bufs);
   size_t n = 0;
   while (nbufs > 1) {
     if (!is_empty(bufs[n])) {
@@ -30,8 +31,14 @@ size_t QuicBuffer::Push(uv_buf_t* bufs, size_t nbufs, DoneCB done) {
     n++;
     nbufs--;
   }
-  len += bufs[n].len;
-  Push(bufs[n], done);
+  if (!is_empty(bufs[n])) {
+    Push(bufs[n], done);
+    len += bufs[n].len;
+  }
+  // Special case if all the bufs were empty.
+  if (UNLIKELY(len == 0))
+    done(0);
+
   return len;
 }
 

--- a/src/quic/node_quic_buffer.h
+++ b/src/quic/node_quic_buffer.h
@@ -24,7 +24,7 @@ using DoneCB = std::function<void(int)>;
 
 // When data is sent over QUIC, we are required to retain it in memory
 // until we receive an acknowledgement that it has been successfully
-// acknowledged. The QuicBuffer object is what we use to handle that
+// received. The QuicBuffer object is what we use to handle that
 // and track until it is acknowledged. To understand the QuicBuffer
 // object itself, it is important to understand how ngtcp2 and nghttp3
 // handle data that is given to it to serialize into QUIC packets.
@@ -52,7 +52,7 @@ using DoneCB = std::function<void(int)>;
 // QuicBuffer is further complicated by design quirks and limitations
 // of the StreamBase API and how it interacts with the JavaScript side.
 //
-// QuicBuffer is essentially a linked list of QuicBufferChunk instances.
+// QuicBuffer is a linked list of QuicBufferChunk instances.
 // A single QuicBufferChunk wraps a single non-zero-length uv_buf_t.
 // When the QuicBufferChunk is created, we capture the total length
 // of the buffer and the total number of bytes remaining to be sent.
@@ -79,7 +79,7 @@ using DoneCB = std::function<void(int)>;
 // along with a callback to be called when the data has
 // been consumed.
 //
-// Any given chunk as a remaining-to-be-acknowledged length (length()) and a
+// Any given chunk has a remaining-to-be-acknowledged length (length()) and a
 // remaining-to-be-read-length (remaining()). The former tracks the number
 // of bytes that have yet to be acknowledged by the QUIC peer. Once the
 // remaining-to-be-acknowledged length reaches zero, the done callback
@@ -88,7 +88,7 @@ using DoneCB = std::function<void(int)>;
 // serialized into QUIC packets and sent.
 // The remaining-to-be-acknowledged length is adjusted using consume(),
 // while the remaining-to-be-ead length is adjusted using seek().
-class QuicBufferChunk : public MemoryRetainer {
+class QuicBufferChunk final : public MemoryRetainer {
  public:
   // Default non-op done handler.
   static void default_done(int status) {}
@@ -149,8 +149,8 @@ class QuicBufferChunk : public MemoryRetainer {
   friend class QuicBuffer;
 };
 
-class QuicBuffer : public bob::SourceImpl<ngtcp2_vec>,
-                   public MemoryRetainer {
+class QuicBuffer final : public bob::SourceImpl<ngtcp2_vec>,
+                         public MemoryRetainer {
  public:
   QuicBuffer() = default;
 


### PR DESCRIPTION
Minor additional cleanup to `QuicBuffer`

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
