### PR TITLE
build: auto start Jenkins CI via PR labels

### DIFF
--- a/.github/workflows/auto-start-ci.yml
+++ b/.github/workflows/auto-start-ci.yml
@@ -1,0 +1,65 @@
+---
+name: Auto Start CI
+
+on:
+  push:
+  schedule:
+    # `schedule` event is used instead of `pull_request` because when a
+    # `pull_requesst` event is triggered on a PR from a fork, GITHUB_TOKEN will
+    # be read-only, and the Action won't have access to any other repository
+    # secrets, which it needs to access Jenkins API. Runs every five minutes
+    # (fastest the scheduler can run). Five minutes is optimistic, it can take
+    # longer to run.
+    - cron: "*/5 * * * *"
+
+jobs:
+  commitQueue:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+
+      # Install dependencies
+      - name: Install jq
+        run: sudo apt-get install jq -y
+      - name: Install Node.js
+        uses: actions/setup-node@v2-beta
+        with:
+          node-version: '12'
+      - name: Install node-core-utils
+        run: npm install -g node-core-utils
+
+      - name: Set variables
+        run: |
+          echo "::set-env name=REPOSITORY::$(echo ${{ github.repository }} | cut -d/ -f2)"
+          echo "::set-env name=OWNER::${{ github.repository_owner }}"
+
+      # Get Pull Requests
+      - name: Get Pull Requests
+        uses: octokit/graphql-action@v2.x
+        id: get_prs_for_ci
+        with:
+          query: |
+            query prs($owner:String!, $repo:String!) {
+              repository(owner:$owner, name:$repo) {
+                pullRequests(labels: ["request-ci"], states: OPEN, last: 100) {
+                  nodes {
+                    number
+                  }
+                }
+              }
+            }
+          owner: ${{ env.OWNER }}
+          repo: ${{ env.REPOSITORY }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup node-core-utils
+        run: |
+          ncu-config set username ${{ secrets.JENKINS_USER }}
+          ncu-config set token none
+          ncu-config set jenkins_token ${{ secrets.JENKINS_TOKEN }}
+          ncu-config set owner ${{ env.OWNER }}
+          ncu-config set repo ${{ env.REPOSITORY }}
+
+      - name: Start CI
+        run: ./tools/start-ci.sh ${{ secrets.GITHUB_TOKEN }} ${{ env.OWNER }} ${{ env.REPOSITORY }} $(echo '${{ steps.get_prs_for_ci.outputs.data }}' | jq '.repository.pullRequests.nodes | map(.number) | .[]')

--- a/tools/actions/start-ci.sh
+++ b/tools/actions/start-ci.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -xe
+
+GITHUB_TOKEN=$1
+OWNER=$2
+REPOSITORY=$3
+API_URL=https://api.github.com
+REQUEST_CI_LABEL='request-ci'
+REQUEST_CI_FAILED_LABEL='request-ci-failed'
+shift 3
+
+function issueUrl() {
+  echo "$API_URL/repos/${OWNER}/${REPOSITORY}/issues/${1}"
+}
+
+function labelsUrl() {
+  echo "$(issueUrl "${1}")/labels"
+}
+
+function commentsUrl() {
+  echo "$(issueUrl "${1}")/comments"
+}
+
+for pr in "$@"; do
+  curl -sL --request DELETE \
+       --url "$(labelsUrl "$pr")"/"$REQUEST_CI_LABEL" \
+       --header "authorization: Bearer ${GITHUB_TOKEN}" \
+       --header 'content-type: application/json'
+
+  ci_started=yes
+  rm -f output;
+  ncu-ci run "$pr" >output 2>&1 || ci_started=no
+
+  if [ "$ci_started" == "no" ]; then
+    # Do we need to reset?
+    curl -sL --request PUT \
+       --url "$(labelsUrl "$pr")" \
+       --header "authorization: Bearer ${GITHUB_TOKEN}" \
+       --header 'content-type: application/json' \
+       --data '{"labels": ["'"${REQUEST_CI_FAILED_LABEL}"'"]}'
+
+    jq -n --arg content "<details><summary>Couldn't start CI</summary><pre>$(cat output)</pre></details>" '{body: $content}' > output.json
+
+    curl -sL --request POST \
+       --url "$(commentsUrl "$pr")" \
+       --header "authorization: Bearer ${GITHUB_TOKEN}" \
+       --header 'content-type: application/json' \
+       --data @output.json
+
+    rm output.json;
+  fi
+done;


### PR DESCRIPTION
Add an Action that will find every PR with the `request-ci` label and
will start a Jenkins CI for each of these Pull Requests. The scheduler
event is used to circumvent GitHub Actions limitations on Pull Requests
from forks (where secrets are not accessible and the GITHUB_TOKEN is
read-only).

If the Action fails to start a CI, it will add a `request-ci-failed`
label and will leave a comment with the error message from NCU.

#### Requirements to land

- [x] Create a Jenkins token for @nodejs-github-bot 
- [x] Add `JENKINS_USER` and `JENKINS_TOKEN` secrets to this repository (or to the entire org, if we want this to work on forks such as quic and node-auto-test as well)
- [x] Land https://github.com/nodejs/node-core-utils/pull/445 and wait for the next NCU release
- [x] Test more extensively on node-auto-test before landing
- [x] Create `request-ci` and `request-ci-failed` labels in this repository

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
