### PR TITLE
net: avoid monkey patching Readable methods

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -357,6 +357,7 @@ function Socket(options) {
 
   // Shut down the socket when we're finished with it.
   this.on('end', onReadableStreamEnd);
+  this.on('pause', onReadableStreamPause);
 
   initSocketHandle(this);
 
@@ -553,15 +554,6 @@ ObjectDefineProperty(Socket.prototype, kUpdateTimer, {
 });
 
 
-function tryReadStart(socket) {
-  // Not already reading, start the flow
-  debug('Socket._handle.readStart');
-  socket._handle.reading = true;
-  const err = socket._handle.readStart();
-  if (err)
-    socket.destroy(errnoException(err, 'read'));
-}
-
 // Just call handle.readStart until we have enough in the buffer
 Socket.prototype._read = function(n) {
   debug('_read');
@@ -570,7 +562,12 @@ Socket.prototype._read = function(n) {
     debug('_read wait for connection');
     this.once('connect', () => this._read(n));
   } else if (!this._handle.reading) {
-    tryReadStart(this);
+    // Not already reading, start the flow
+    debug('Socket._handle.readStart');
+    this._handle.reading = true;
+    const err = this._handle.readStart();
+    if (err)
+      this.destroy(errnoException(err, 'read'));
   }
 };
 
@@ -582,9 +579,9 @@ Socket.prototype.end = function(data, encoding, callback) {
 };
 
 
-Socket.prototype.pause = function() {
+function onReadableStreamPause() {
   if (this[kBuffer] && !this.connecting && this._handle &&
-      this._handle.reading) {
+    this._handle.reading) {
     this._handle.reading = false;
     if (!this.destroyed) {
       const err = this._handle.readStop();
@@ -592,26 +589,7 @@ Socket.prototype.pause = function() {
         this.destroy(errnoException(err, 'read'));
     }
   }
-  return stream.Duplex.prototype.pause.call(this);
-};
-
-
-Socket.prototype.resume = function() {
-  if (this[kBuffer] && !this.connecting && this._handle &&
-      !this._handle.reading) {
-    tryReadStart(this);
-  }
-  return stream.Duplex.prototype.resume.call(this);
-};
-
-
-Socket.prototype.read = function(n) {
-  if (this[kBuffer] && !this.connecting && this._handle &&
-      !this._handle.reading) {
-    tryReadStart(this);
-  }
-  return stream.Duplex.prototype.read.call(this, n);
-};
+}
 
 
 // Called when the 'end' event is emitted.


### PR DESCRIPTION
Try to avoid monkey patching Readable methods as this
can affect the Readable state in unexpected ways.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
