### PR TITLE
doc: clarify that the ctx argument is optional

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -1696,12 +1696,16 @@ changes:
   * `sessionTimeout` {number} The number of seconds after which a TLS session
     created by the server will no longer be resumable. See
     [Session Resumption][] for more information. **Default:** `300`.
-  * `SNICallback(servername, cb)` {Function} A function that will be called if
-    the client supports SNI TLS extension. Two arguments will be passed when
-    called: `servername` and `cb`. `SNICallback` should invoke `cb(null, ctx)`,
-    where `ctx` is a `SecureContext` instance. (`tls.createSecureContext(...)`
-    can be used to get a proper `SecureContext`.) If `SNICallback` wasn't
-    provided the default callback with high-level API will be used (see below).
+  * `SNICallback(servername, callback)` {Function} A function that will be
+    called if the client supports SNI TLS extension. Two arguments will be
+    passed when called: `servername` and `callback`. `callback` is an
+    error-first callback that must be called synchronously and takes two
+    optional arguments: `error` and `ctx`. `ctx`, if provided, is a
+    `SecureContext` instance. [`tls.createSecureContext()`][] can be used to get
+    a proper `SecureContext`. If `callback` is called with a falsy `ctx`
+    argument, the default secure context of the server will be used. If
+    `SNICallback` wasn't provided the default callback with high-level API will
+    be used (see below).
   * `ticketKeys`: {Buffer} 48-bytes of cryptographically strong pseudo-random
     data. See [Session Resumption][] for more information.
   * `pskCallback` {Function}

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -1699,13 +1699,12 @@ changes:
   * `SNICallback(servername, callback)` {Function} A function that will be
     called if the client supports SNI TLS extension. Two arguments will be
     passed when called: `servername` and `callback`. `callback` is an
-    error-first callback that must be called synchronously and takes two
-    optional arguments: `error` and `ctx`. `ctx`, if provided, is a
-    `SecureContext` instance. [`tls.createSecureContext()`][] can be used to get
-    a proper `SecureContext`. If `callback` is called with a falsy `ctx`
-    argument, the default secure context of the server will be used. If
-    `SNICallback` wasn't provided the default callback with high-level API will
-    be used (see below).
+    error-first callback that takes two optional arguments: `error` and `ctx`.
+    `ctx`, if provided, is a `SecureContext` instance.
+    [`tls.createSecureContext()`][] can be used to get a proper `SecureContext`.
+    If `callback` is called with a falsy `ctx` argument, the default secure
+    context of the server will be used. If `SNICallback` wasn't provided the
+    default callback with high-level API will be used (see below).
   * `ticketKeys`: {Buffer} 48-bytes of cryptographically strong pseudo-random
     data. See [Session Resumption][] for more information.
   * `pskCallback` {Function}


### PR DESCRIPTION
Clarify that the `ctx` argument of the `SNICallback` callback is
optional.

Fixes: https://github.com/nodejs/node/issues/34085

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
