### PR TITLE
stream: save error in state

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -155,7 +155,7 @@ function ReadableState(options, stream, isDuplex) {
   // _read calls, 'data' or 'readable' events should occur. This is needed
   // since when autoDestroy is disabled we need a way to tell whether the
   // stream has failed.
-  this.errored = false;
+  this.errored = null;
 
   // Indicates whether the stream has finished destroying.
   this.closed = false;

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -432,6 +432,9 @@ function onwrite(stream, er) {
   state.writelen = 0;
 
   if (er) {
+    // Avoid V8 leak, https://github.com/nodejs/node/pull/34103#issuecomment-652002364
+    er.stack;
+
     if (!state.errored) {
       state.errored = er;
     }

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -177,7 +177,7 @@ function WritableState(options, stream, isDuplex) {
   // Indicates whether the stream has errored. When true all write() calls
   // should return false. This is needed since when autoDestroy
   // is disabled we need a way to tell whether the stream has failed.
-  this.errored = false;
+  this.errored = null;
 
   // Indicates whether the stream has finished destroying.
   this.closed = false;
@@ -432,12 +432,14 @@ function onwrite(stream, er) {
   state.writelen = 0;
 
   if (er) {
-    state.errored = true;
+    if (!state.errored) {
+      state.errored = er;
+    }
 
     // In case of duplex streams we need to notify the readable side of the
     // error.
-    if (stream._readableState) {
-      stream._readableState.errored = true;
+    if (stream._readableState && !stream._readableState.errored) {
+      stream._readableState.errored = er;
     }
 
     if (sync) {

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -625,10 +625,7 @@ function defineHandleReading(socket, handle) {
 
 function onSocketCloseDestroySSL() {
   // Make sure we are not doing it on OpenSSL's stack
-  // This should not be using .bind(). However, doing so appears necessary
-  // to work around a garbage collection bug:
-  // Refs: https://github.com/nodejs/node/pull/34103#issuecomment-651040237
-  setImmediate(destroySSL.bind(null, this));
+  setImmediate(destroySSL, this);
   this[kRes] = null;
 }
 

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -625,7 +625,7 @@ function defineHandleReading(socket, handle) {
 
 function onSocketCloseDestroySSL() {
   // Make sure we are not doing it on OpenSSL's stack
-  setImmediate(destroySSL, this);
+  setImmediate(destroySSL.bind(null, this));
   this[kRes] = null;
 }
 

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -625,6 +625,9 @@ function defineHandleReading(socket, handle) {
 
 function onSocketCloseDestroySSL() {
   // Make sure we are not doing it on OpenSSL's stack
+  // This should not be using .bind(). However, doing so appears necessary
+  // to work around a garbage collection bug:
+  // Refs: https://github.com/nodejs/node/pull/34103#issuecomment-651040237
   setImmediate(destroySSL.bind(null, this));
   this[kRes] = null;
 }

--- a/lib/internal/streams/destroy.js
+++ b/lib/internal/streams/destroy.js
@@ -175,10 +175,10 @@ function errorOrDestroy(stream, err, sync) {
   if ((r && r.autoDestroy) || (w && w.autoDestroy))
     stream.destroy(err);
   else if (err) {
-    if (w && w.errored) {
+    if (w && !w.errored) {
       w.errored = err;
     }
-    if (r && r.errored) {
+    if (r && !r.errored) {
       r.errored = err;
     }
     if (sync) {

--- a/lib/internal/streams/destroy.js
+++ b/lib/internal/streams/destroy.js
@@ -25,11 +25,11 @@ function destroy(err, cb) {
   }
 
   if (err) {
-    if (w) {
-      w.errored = true;
+    if (w && !w.errored) {
+      w.errored = err;
     }
-    if (r) {
-      r.errored = true;
+    if (r && !r.errored) {
+      r.errored = err;
     }
   }
 
@@ -61,11 +61,11 @@ function _destroy(self, err, cb) {
     const w = self._writableState;
 
     if (err) {
-      if (w) {
-        w.errored = true;
+      if (w && !w.errored) {
+        w.errored = err;
       }
-      if (r) {
-        r.errored = true;
+      if (r && !r.errored) {
+        r.errored = err;
       }
     }
 
@@ -136,7 +136,7 @@ function undestroy() {
     r.closed = false;
     r.closeEmitted = false;
     r.destroyed = false;
-    r.errored = false;
+    r.errored = null;
     r.errorEmitted = false;
     r.reading = false;
     r.ended = false;
@@ -148,7 +148,7 @@ function undestroy() {
     w.destroyed = false;
     w.closed = false;
     w.closeEmitted = false;
-    w.errored = false;
+    w.errored = null;
     w.errorEmitted = false;
     w.ended = false;
     w.ending = false;
@@ -175,11 +175,11 @@ function errorOrDestroy(stream, err, sync) {
   if ((r && r.autoDestroy) || (w && w.autoDestroy))
     stream.destroy(err);
   else if (err) {
-    if (w) {
-      w.errored = true;
+    if (w && w.errored) {
+      w.errored = err;
     }
-    if (r) {
-      r.errored = true;
+    if (r && r.errored) {
+      r.errored = err;
     }
     if (sync) {
       process.nextTick(emitErrorNT, stream, err);

--- a/lib/internal/streams/destroy.js
+++ b/lib/internal/streams/destroy.js
@@ -25,6 +25,9 @@ function destroy(err, cb) {
   }
 
   if (err) {
+    // Avoid V8 leak, https://github.com/nodejs/node/pull/34103#issuecomment-652002364
+    err.stack;
+
     if (w && !w.errored) {
       w.errored = err;
     }
@@ -61,6 +64,9 @@ function _destroy(self, err, cb) {
     const w = self._writableState;
 
     if (err) {
+      // Avoid V8 leak, https://github.com/nodejs/node/pull/34103#issuecomment-652002364
+      err.stack;
+
       if (w && !w.errored) {
         w.errored = err;
       }
@@ -175,6 +181,9 @@ function errorOrDestroy(stream, err, sync) {
   if ((r && r.autoDestroy) || (w && w.autoDestroy))
     stream.destroy(err);
   else if (err) {
+    // Avoid V8 leak, https://github.com/nodejs/node/pull/34103#issuecomment-652002364
+    err.stack;
+
     if (w && !w.errored) {
       w.errored = err;
     }

--- a/test/parallel/test-stream-readable-destroy.js
+++ b/test/parallel/test-stream-readable-destroy.js
@@ -253,3 +253,18 @@ const assert = require('assert');
   assert.strictEqual(read.destroyed, true);
   read.read();
 }
+
+{
+  const read = new Readable({
+    autoDestroy: false,
+    read() {
+      this.push(null);
+      this.push('asd');
+    }
+  });
+
+  read.on('error', common.mustCall(() => {
+    assert(read._readableState.errored);
+  }));
+  read.resume();
+}

--- a/test/parallel/test-stream-readable-destroy.js
+++ b/test/parallel/test-stream-readable-destroy.js
@@ -134,13 +134,13 @@ const assert = require('assert');
   read.on('error', common.mustCall((err) => {
     assert.strictEqual(ticked, true);
     assert.strictEqual(read._readableState.errorEmitted, true);
-    assert.strictEqual(read._readableState.errored, true);
+    assert.strictEqual(read._readableState.errored, expected);
     assert.strictEqual(err, expected);
   }));
 
   read.destroy();
   assert.strictEqual(read._readableState.errorEmitted, false);
-  assert.strictEqual(read._readableState.errored, true);
+  assert.strictEqual(read._readableState.errored, expected);
   assert.strictEqual(read.destroyed, true);
   ticked = true;
 }
@@ -190,15 +190,15 @@ const assert = require('assert');
     assert.strictEqual(err, expected);
   }));
 
-  assert.strictEqual(read._readableState.errored, false);
+  assert.strictEqual(read._readableState.errored, null);
   assert.strictEqual(read._readableState.errorEmitted, false);
 
   read.destroy(expected, common.mustCall(function(err) {
-    assert.strictEqual(read._readableState.errored, true);
+    assert.strictEqual(read._readableState.errored, expected);
     assert.strictEqual(err, expected);
   }));
   assert.strictEqual(read._readableState.errorEmitted, false);
-  assert.strictEqual(read._readableState.errored, true);
+  assert.strictEqual(read._readableState.errored, expected);
   ticked = true;
 }
 
@@ -223,14 +223,14 @@ const assert = require('assert');
 
   readable.destroy();
   assert.strictEqual(readable.destroyed, true);
-  assert.strictEqual(readable._readableState.errored, false);
+  assert.strictEqual(readable._readableState.errored, null);
   assert.strictEqual(readable._readableState.errorEmitted, false);
 
   // Test case where `readable.destroy()` is called again with an error before
   // the `_destroy()` callback is called.
   readable.destroy(new Error('kaboom 2'));
   assert.strictEqual(readable._readableState.errorEmitted, false);
-  assert.strictEqual(readable._readableState.errored, false);
+  assert.strictEqual(readable._readableState.errored, null);
 
   ticked = true;
 }

--- a/test/parallel/test-stream-writable-destroy.js
+++ b/test/parallel/test-stream-writable-destroy.js
@@ -402,3 +402,18 @@ const assert = require('assert');
   }));
   write.destroy();
 }
+
+{
+  const write = new Writable({
+    autoDestroy: false,
+    write(chunk, enc, cb) {
+      cb();
+      cb();
+    }
+  });
+
+  write.on('error', common.mustCall(() => {
+    assert(write._writableState.errored);
+  }));
+  write.write('asd');
+}

--- a/test/parallel/test-stream-writable-destroy.js
+++ b/test/parallel/test-stream-writable-destroy.js
@@ -167,9 +167,10 @@ const assert = require('assert');
     assert.strictEqual(write._writableState.errorEmitted, true);
   }));
 
-  write.destroy(new Error('kaboom 1'));
+  const expected = new Error('kaboom 1');
+  write.destroy(expected);
   write.destroy(new Error('kaboom 2'));
-  assert.strictEqual(write._writableState.errored, true);
+  assert.strictEqual(write._writableState.errored, expected);
   assert.strictEqual(write._writableState.errorEmitted, false);
   assert.strictEqual(write.destroyed, true);
   ticked = true;
@@ -200,14 +201,14 @@ const assert = require('assert');
 
   writable.destroy();
   assert.strictEqual(writable.destroyed, true);
-  assert.strictEqual(writable._writableState.errored, false);
+  assert.strictEqual(writable._writableState.errored, null);
   assert.strictEqual(writable._writableState.errorEmitted, false);
 
   // Test case where `writable.destroy()` is called again with an error before
   // the `_destroy()` callback is called.
   writable.destroy(new Error('kaboom 2'));
   assert.strictEqual(writable._writableState.errorEmitted, false);
-  assert.strictEqual(writable._writableState.errored, false);
+  assert.strictEqual(writable._writableState.errored, null);
 
   ticked = true;
 }

--- a/test/parallel/test-stream2-readable-wrap-error.js
+++ b/test/parallel/test-stream2-readable-wrap-error.js
@@ -10,23 +10,25 @@ oldStream.pause = () => {};
 oldStream.resume = () => {};
 
 {
+  const err = new Error();
   const r = new Readable({ autoDestroy: true })
     .wrap(oldStream)
     .on('error', common.mustCall(() => {
       assert.strictEqual(r._readableState.errorEmitted, true);
-      assert.strictEqual(r._readableState.errored, true);
+      assert.strictEqual(r._readableState.errored, err);
       assert.strictEqual(r.destroyed, true);
     }));
-  oldStream.emit('error', new Error());
+  oldStream.emit('error', err);
 }
 
 {
+  const err = new Error();
   const r = new Readable({ autoDestroy: false })
     .wrap(oldStream)
     .on('error', common.mustCall(() => {
       assert.strictEqual(r._readableState.errorEmitted, true);
-      assert.strictEqual(r._readableState.errored, true);
+      assert.strictEqual(r._readableState.errored, err);
       assert.strictEqual(r.destroyed, false);
     }));
-  oldStream.emit('error', new Error());
+  oldStream.emit('error', err);
 }


### PR DESCRIPTION
Useful for future PR's to resolve situations where various API's are invoked on an already errored stream.

Extracted from https://github.com/nodejs/node/pull/34035

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
