### PR TITLE
stream: don't read when paused

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -633,7 +633,7 @@ function maybeReadMore_(stream, state) {
   //   called push() with new data. In this case we skip performing more
   //   read()s. The execution ends in this method again after the _read() ends
   //   up calling push() with more data.
-  while (!state.reading && !state.ended &&
+  while (!state.reading && !state.ended && state[kPaused] !== true &&
          (state.length < state.highWaterMark ||
           (state.flowing && state.length === 0))) {
     const len = state.length;

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -213,7 +213,9 @@ function Readable(options) {
   Stream.call(this, options);
 
   destroyImpl.construct(this, () => {
-    maybeReadMore(this, this._readableState);
+    if (!this.isPaused()) {
+      maybeReadMore(this, this._readableState);
+    }
   });
 }
 
@@ -633,7 +635,7 @@ function maybeReadMore_(stream, state) {
   //   called push() with new data. In this case we skip performing more
   //   read()s. The execution ends in this method again after the _read() ends
   //   up calling push() with more data.
-  while (!state.reading && !state.ended && state[kPaused] !== true &&
+  while (!state.reading && !state.ended &&
          (state.length < state.highWaterMark ||
           (state.flowing && state.length === 0))) {
     const len = state.length;

--- a/test/parallel/test-stream-construct.js
+++ b/test/parallel/test-stream-construct.js
@@ -242,3 +242,14 @@ testDestroy((opts) => new Writable({
     construct: common.mustCall()
   });
 }
+
+{
+  // Readable paused
+  const readable = new Readable({
+    construct: common.mustCall((callback) => {
+      readable.pause();
+      callback();
+    }),
+    read: common.mustNotCall()
+  });
+}


### PR DESCRIPTION
Readable should not read when paused. Noticed while working
on further streamifying net with _construct.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
