### PR TITLE
lib: always initialize esm loader callbackMap

### DIFF
--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -59,10 +59,7 @@ function prepareMainThreadExecution(expandArgv1 = false) {
   initializeDeprecations();
   initializeWASI();
   initializeCJSLoader();
-
-  if (!shouldNotRegisterESMLoader) {
-    initializeESMLoader();
-  }
+  initializeESMLoader();
 
   const CJSLoader = require('internal/modules/cjs/loader');
   assert(!CJSLoader.hasLoadedAnyUserCJSModule);
@@ -405,6 +402,8 @@ function initializeCJSLoader() {
 function initializeESMLoader() {
   // Create this WeakMap in js-land because V8 has no C++ API for WeakMap.
   internalBinding('module_wrap').callbackMap = new SafeWeakMap();
+
+  if (shouldNotRegisterESMLoader) return;
 
   const {
     setImportModuleDynamicallyCallback,


### PR DESCRIPTION
Refs https://github.com/nodejs/node/pull/34060.

We should instead unilaterally initialize the `callbackMap`  and return early if an embedder is choosing  to not use the Node.js esm loader is in an embedder context.

I also updated the corresponding tests to more directly check `importModuleDynamically` functionality affected by a decision to not use the esm loader provided by Node.js.

cc @addaleax @joyeecheung 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
