### PR TITLE
test: report actual error code on failure

### DIFF
--- a/test/parallel/test-dgram-error-message-address.js
+++ b/test/parallel/test-dgram-error-message-address.js
@@ -47,7 +47,7 @@ socket_ipv6.on('listening', common.mustNotCall());
 socket_ipv6.on('error', common.mustCall(function(e) {
   // EAFNOSUPPORT or EPROTONOSUPPORT means IPv6 is disabled on this system.
   const allowed = ['EADDRNOTAVAIL', 'EAFNOSUPPORT', 'EPROTONOSUPPORT'];
-  assert(allowed.includes(e.code));
+  assert(allowed.includes(e.code), `'${e.code}' was not one of ${allowed}.`);
   assert.strictEqual(e.port, undefined);
   assert.strictEqual(e.message, `bind ${e.code} 111::1`);
   assert.strictEqual(e.address, '111::1');


### PR DESCRIPTION
Add a message to an assertion in parallel/test-dgram-error-message-address to
output the actual error code that doesn't match the allowed errors.

For some context I've been setting up IBM i CI machines to build Node.js on IBM i
and this test is failing. The change in this PR has helped diagnose how the test is
failing by revealing the actual error code.

Before:
```
    AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:

      assert(allowed.includes(e.code))
```

After:
```
     AssertionError [ERR_ASSERTION]: 'Unknown system error -42' was not one of EADDRNOTAVAIL,EAFNOSUPPORT,EPROTONOSUPPORT.
```
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
