### PR TITLE
src: exit explicitly after printing V8 help

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -939,9 +939,8 @@ void Init(int* argc,
   }
 
   if (per_process::cli_options->print_v8_help) {
-    // Doesn't return.
     V8::SetFlagsFromString("--help", static_cast<size_t>(6));
-    UNREACHABLE();
+    exit(0);
   }
 
   *argc = argv_.size();
@@ -1003,13 +1002,16 @@ InitializationResult InitializeOncePerProcess(int argc, char** argv) {
   if (per_process::cli_options->print_bash_completion) {
     std::string completion = options_parser::GetBashCompletion();
     printf("%s\n", completion.c_str());
-    exit(0);
+    result.exit_code = 0;
+    result.early_return = true;
+    return result;
   }
 
   if (per_process::cli_options->print_v8_help) {
-    // Doesn't return.
     V8::SetFlagsFromString("--help", static_cast<size_t>(6));
-    UNREACHABLE();
+    result.exit_code = 0;
+    result.early_return = true;
+    return result;
   }
 
 #if HAVE_OPENSSL


### PR DESCRIPTION
V8 will not exit the process after handling --help anymore:
https://chromium-review.googlesource.com/c/v8/v8/+/2276276

As a drive-by fix, correctly return in the `print_bash_completion`
case as well.

Refs: https://github.com/nodejs/node/pull/34135
Co-authored-by: Ulan Degenbaev <ulan@chromium.org>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
