### PR TITLE
test: add regression test for C++-created Buffer transfer

### DIFF
--- a/test/parallel/test-worker-crypto-sign-transfer-result.js
+++ b/test/parallel/test-worker-crypto-sign-transfer-result.js
@@ -1,0 +1,30 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const { Worker } = require('worker_threads');
+const fixturesPath = require.resolve('../common/fixtures');
+
+// Test that transferring the result of e.g. crypto.sign() from Worker to parent
+// thread does not crash
+
+const w = new Worker(`
+const { parentPort } = require('worker_threads');
+const crypto = require('crypto');
+const assert = require('assert');
+const fixtures = require(${JSON.stringify(fixturesPath)});
+
+const keyPem = fixtures.readKey('rsa_private.pem');
+
+const buf = crypto.sign('sha256', Buffer.from('hello'), keyPem);
+assert.notStrictEqual(buf.byteLength, 0);
+parentPort.postMessage(buf, [buf.buffer]);
+assert.strictEqual(buf.byteLength, 0);
+`, { eval: true });
+
+w.on('message', common.mustCall((buf) => {
+  assert.notStrictEqual(buf.byteLength, 0);
+}));
+w.on('exit', common.mustCall());


### PR DESCRIPTION
Add a test for a regression that occurs when transferring some
`Buffer` objects that were created from C++ to a parent thread.

Fixes: https://github.com/nodejs/node/issues/34126

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
