### PR TITLE
crypto: move typechecking for timingSafeEqual into C++

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -44,7 +44,11 @@ const { getOptionValue } = require('internal/options');
 const pendingDeprecation = getOptionValue('--pending-deprecation');
 const { fipsMode } = internalBinding('config');
 const fipsForced = getOptionValue('--force-fips');
-const { getFipsCrypto, setFipsCrypto } = internalBinding('crypto');
+const {
+  getFipsCrypto,
+  setFipsCrypto,
+  timingSafeEqual,
+} = internalBinding('crypto');
 const {
   randomBytes,
   randomFill,
@@ -101,7 +105,6 @@ const {
   getHashes,
   setDefaultEncoding,
   setEngine,
-  timingSafeEqual
 } = require('internal/crypto/util');
 const Certificate = require('internal/crypto/certificate');
 

--- a/lib/internal/crypto/util.js
+++ b/lib/internal/crypto/util.js
@@ -9,7 +9,6 @@ const {
   getCurves: _getCurves,
   getHashes: _getHashes,
   setEngine: _setEngine,
-  timingSafeEqual: _timingSafeEqual
 } = internalBinding('crypto');
 
 const {
@@ -20,7 +19,6 @@ const {
   hideStackFrames,
   codes: {
     ERR_CRYPTO_ENGINE_UNKNOWN,
-    ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH,
     ERR_INVALID_ARG_TYPE,
   }
 } = require('internal/errors');
@@ -76,21 +74,6 @@ function setEngine(id, flags) {
     throw new ERR_CRYPTO_ENGINE_UNKNOWN(id);
 }
 
-function timingSafeEqual(buf1, buf2) {
-  if (!isArrayBufferView(buf1)) {
-    throw new ERR_INVALID_ARG_TYPE('buf1',
-                                   ['Buffer', 'TypedArray', 'DataView'], buf1);
-  }
-  if (!isArrayBufferView(buf2)) {
-    throw new ERR_INVALID_ARG_TYPE('buf2',
-                                   ['Buffer', 'TypedArray', 'DataView'], buf2);
-  }
-  if (buf1.byteLength !== buf2.byteLength) {
-    throw new ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH();
-  }
-  return _timingSafeEqual(buf1, buf2);
-}
-
 const getArrayBufferView = hideStackFrames((buffer, name, encoding) => {
   if (typeof buffer === 'string') {
     if (encoding === 'buffer')
@@ -116,6 +99,5 @@ module.exports = {
   kHandle,
   setDefaultEncoding,
   setEngine,
-  timingSafeEqual,
   toBuf
 };

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -808,8 +808,6 @@ E('ERR_CRYPTO_SCRYPT_INVALID_PARAMETER', 'Invalid scrypt parameter', Error);
 E('ERR_CRYPTO_SCRYPT_NOT_SUPPORTED', 'Scrypt algorithm not supported', Error);
 // Switch to TypeError. The current implementation does not seem right.
 E('ERR_CRYPTO_SIGN_KEY_REQUIRED', 'No key provided to sign', Error);
-E('ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH',
-  'Input buffers must have the same byte length', RangeError);
 E('ERR_DIR_CLOSED', 'Directory handle was closed', Error);
 E('ERR_DIR_CONCURRENT_OPERATION',
   'Cannot do synchronous work on directory handle with concurrent ' +

--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -33,6 +33,7 @@ void OnFatalError(const char* location, const char* message);
   V(ERR_BUFFER_TOO_LARGE, Error)                                               \
   V(ERR_CONSTRUCT_CALL_REQUIRED, TypeError)                                    \
   V(ERR_CONSTRUCT_CALL_INVALID, TypeError)                                     \
+  V(ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH, RangeError)                           \
   V(ERR_CRYPTO_UNKNOWN_CIPHER, Error)                                          \
   V(ERR_CRYPTO_UNKNOWN_DH_GROUP, Error)                                        \
   V(ERR_EXECUTION_ENVIRONMENT_NOT_AVAILABLE, Error)                            \
@@ -88,6 +89,8 @@ void OnFatalError(const char* location, const char* message);
     "Buffer is not available for the current Context")                         \
   V(ERR_CONSTRUCT_CALL_INVALID, "Constructor cannot be called")                \
   V(ERR_CONSTRUCT_CALL_REQUIRED, "Cannot call constructor without `new`")      \
+  V(ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH,                                       \
+    "Input buffers must have the same byte length")                            \
   V(ERR_CRYPTO_UNKNOWN_CIPHER, "Unknown cipher")                               \
   V(ERR_CRYPTO_UNKNOWN_DH_GROUP, "Unknown DH group")                           \
   V(ERR_EXECUTION_ENVIRONMENT_NOT_AVAILABLE,                                   \

--- a/test/sequential/test-crypto-timing-safe-equal.js
+++ b/test/sequential/test-crypto-timing-safe-equal.js
@@ -48,7 +48,7 @@ assert.throws(
     name: 'TypeError',
     message:
       'The "buf1" argument must be an instance of Buffer, TypedArray, or ' +
-      "DataView. Received type string ('not a buffer')"
+      'DataView.'
   }
 );
 
@@ -59,6 +59,6 @@ assert.throws(
     name: 'TypeError',
     message:
       'The "buf2" argument must be an instance of Buffer, TypedArray, or ' +
-      "DataView. Received type string ('not a buffer')"
+      'DataView.'
   }
 );


### PR DESCRIPTION
This makes the function more robust against V8 inlining.

Fixes: https://github.com/nodejs/node/issues/34073

@nodejs/crypto 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
