### PR TITLE
esm: Modify getFormat and getSource loader hooks

### DIFF
--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -134,6 +134,33 @@ class Loader {
     return format;
   }
 
+  async getSource(url, format) {
+    const getSourceResponse = await this._getSource(
+      url, { format: format }, defaultGetSource);
+    if (typeof getSourceResponse !== 'object') {
+      throw new ERR_INVALID_RETURN_VALUE(
+        'object', 'loader getSource', getSourceResponse);
+    }
+
+    // Validate optional format that getSource can return
+    ({ format } = getSourceResponse);
+    if (typeof format !== 'string' && typeof format !== 'undefined') {
+      throw new ERR_INVALID_RETURN_PROPERTY_VALUE(
+        'string', 'loader getSource', 'format', format);
+    }
+
+    const { source } = getSourceResponse;
+    if (typeof source !== 'string' && !Buffer.isBuffer(source)) {
+      throw new ERR_INVALID_RETURN_PROPERTY_VALUE(
+        'string|buffer', 'loader getSource', 'source', source);
+    }
+
+    return {
+      source: source,
+      format: format
+    }
+  }
+
   async eval(
     source,
     url = pathToFileURL(`${process.cwd()}/[eval${++this.evalIndex}]`).href
@@ -227,7 +254,7 @@ class Loader {
     let format = await this.getFormat(url);
     let source;
     if(format !== "builtin" && format !== "commonjs"){
-      const sourceObj = await this._getSource(url, { format: format }, defaultGetSource);
+      const sourceObj = await this.getSource(url, format);
       ({ source } = sourceObj);
       format = sourceObj.format? sourceObj.format : format;
     }

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -224,7 +224,13 @@ class Loader {
 
   async getModuleJob(specifier, parentURL) {
     const url = await this.resolve(specifier, parentURL);
-    const format = await this.getFormat(url);
+    let format = await this.getFormat(url);
+    let source;
+    if(format !== "builtin" && format !== "commonjs"){
+      const sourceObj = await this._getSource(url, { format: format }, defaultGetSource);
+      ({ source } = sourceObj);
+      format = sourceObj.format? sourceObj.format : format;
+    }
     let job = this.moduleMap.get(url);
     // CommonJS will set functions for lazy job evaluation.
     if (typeof job === 'function')
@@ -239,7 +245,7 @@ class Loader {
 
     const inspectBrk = parentURL === undefined &&
         format === 'module' && getOptionValue('--inspect-brk');
-    job = new ModuleJob(this, url, loaderInstance, parentURL === undefined,
+    job = new ModuleJob(this, url, loaderInstance, source, parentURL === undefined,
                         inspectBrk);
     this.moduleMap.set(url, job);
     return job;

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -142,14 +142,14 @@ class Loader {
         'object', 'loader getSource', getSourceResponse);
     }
 
+    const { source } = getSourceResponse;
+
     // Validate optional format that getSource can return
     ({ format } = getSourceResponse);
     if (typeof format !== 'string' && typeof format !== 'undefined') {
       throw new ERR_INVALID_RETURN_PROPERTY_VALUE(
         'string', 'loader getSource', 'format', format);
     }
-
-    const { source } = getSourceResponse;
 
     return {
       source: source,

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -149,12 +149,6 @@ class Loader {
         'string', 'loader getSource', 'format', format);
     }
 
-    const { source } = getSourceResponse;
-    if (typeof source !== 'string' && !Buffer.isBuffer(source)) {
-      throw new ERR_INVALID_RETURN_PROPERTY_VALUE(
-        'string|buffer', 'loader getSource', 'source', source);
-    }
-
     return {
       source: source,
       format: format

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -154,7 +154,7 @@ class Loader {
     return {
       source: source,
       format: format
-    }
+    };
   }
 
   async eval(
@@ -249,10 +249,12 @@ class Loader {
     const url = await this.resolve(specifier, parentURL);
     let format = await this.getFormat(url);
     let source;
-    if(format !== "builtin" && format !== "commonjs" && translators.get(format)){
+    if (format !== 'builtin' &&
+        format !== 'commonjs' &&
+        translators.get(format)) {
       const sourceObj = await this.getSource(url, format);
       ({ source } = sourceObj);
-      format = sourceObj.format? sourceObj.format : format;
+      format = sourceObj.format ? sourceObj.format : format;
     }
     let job = this.moduleMap.get(url);
     // CommonJS will set functions for lazy job evaluation.
@@ -268,8 +270,13 @@ class Loader {
 
     const inspectBrk = parentURL === undefined &&
         format === 'module' && getOptionValue('--inspect-brk');
-    job = new ModuleJob(this, url, loaderInstance, source, parentURL === undefined,
-                        inspectBrk);
+    job = new ModuleJob(
+      this,
+      url,
+      loaderInstance,
+      source,
+      parentURL === undefined,
+      inspectBrk);
     this.moduleMap.set(url, job);
     return job;
   }

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -149,6 +149,8 @@ class Loader {
         'string', 'loader getSource', 'format', format);
     }
 
+    const { source } = getSourceResponse;
+
     return {
       source: source,
       format: format

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -253,7 +253,7 @@ class Loader {
     const url = await this.resolve(specifier, parentURL);
     let format = await this.getFormat(url);
     let source;
-    if(format !== "builtin" && format !== "commonjs"){
+    if(format !== "builtin" && format !== "commonjs" && translators.get(format)){
       const sourceObj = await this.getSource(url, format);
       ({ source } = sourceObj);
       format = sourceObj.format? sourceObj.format : format;

--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -27,7 +27,7 @@ let hasPausedEntry = false;
 class ModuleJob {
   // `loader` is the Loader instance used for loading dependencies.
   // `moduleProvider` is a function
-  constructor(loader, url, moduleProvider, isMain, inspectBrk) {
+  constructor(loader, url, moduleProvider, source, isMain, inspectBrk) {
     this.loader = loader;
     this.isMain = isMain;
     this.inspectBrk = inspectBrk;
@@ -35,8 +35,7 @@ class ModuleJob {
     this.module = undefined;
     // Expose the promise to the ModuleWrap directly for linking below.
     // `this.module` is also filled in below.
-    this.modulePromise = moduleProvider.call(loader, url, isMain);
-
+    this.modulePromise = moduleProvider.call(loader, url, source, isMain);
     // Wait for the ModuleWrap instance being linked with all dependencies.
     const link = async () => {
       this.module = await this.modulePromise;

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -23,8 +23,6 @@ const {
 } = require('internal/modules/cjs/helpers');
 const CJSModule = require('internal/modules/cjs/loader').Module;
 const internalURLModule = require('internal/url');
-const { defaultGetSource } = require(
-  'internal/modules/esm/get_source');
 const { defaultTransformSource } = require(
   'internal/modules/esm/transform_source');
 const createDynamicModule = require(
@@ -128,7 +126,7 @@ translators.set('module', async function moduleStrategy(url, source) {
 // Strategy for loading a node-style CommonJS module
 const isWindows = process.platform === 'win32';
 const winSepRegEx = /\//g;
-translators.set('commonjs', function commonjsStrategy(url, isMain) {
+translators.set('commonjs', function commonjsStrategy(url, source, isMain) {
   debug(`Translating CJSModule ${url}`);
   const pathname = internalURLModule.fileURLToPath(new URL(url));
   const cached = this.cjsCache.get(url);

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -110,9 +110,7 @@ function initializeImportMeta(meta, { url }) {
 }
 
 // Strategy for loading a standard JavaScript module
-translators.set('module', async function moduleStrategy(url) {
-  let { source } = await this._getSource(
-    url, { format: 'module' }, defaultGetSource);
+translators.set('module', async function moduleStrategy(url, source) {
   assertBufferSource(source, true, 'getSource');
   ({ source } = await this._transformSource(
     source, { url, format: 'module' }, defaultTransformSource));
@@ -171,7 +169,7 @@ translators.set('builtin', async function builtinStrategy(url) {
 });
 
 // Strategy for loading a JSON file
-translators.set('json', async function jsonStrategy(url) {
+translators.set('json', async function jsonStrategy(url, source) {
   emitExperimentalWarning('Importing JSON modules');
   debug(`Translating JSONModule ${url}`);
   debug(`Loading JSONModule ${url}`);
@@ -189,8 +187,6 @@ translators.set('json', async function jsonStrategy(url) {
       });
     }
   }
-  let { source } = await this._getSource(
-    url, { format: 'json' }, defaultGetSource);
   assertBufferSource(source, true, 'getSource');
   ({ source } = await this._transformSource(
     source, { url, format: 'json' }, defaultTransformSource));
@@ -231,10 +227,8 @@ translators.set('json', async function jsonStrategy(url) {
 });
 
 // Strategy for loading a wasm module
-translators.set('wasm', async function(url) {
+translators.set('wasm', async function(url, source) {
   emitExperimentalWarning('Importing Web Assembly modules');
-  let { source } = await this._getSource(
-    url, { format: 'wasm' }, defaultGetSource);
   assertBufferSource(source, false, 'getSource');
   ({ source } = await this._transformSource(
     source, { url, format: 'wasm' }, defaultTransformSource));

--- a/test/message/esm_display_syntax_error_module.out
+++ b/test/message/esm_display_syntax_error_module.out
@@ -4,3 +4,4 @@ await async () => 0;
 
 SyntaxError: Unexpected reserved word
     at Loader.moduleStrategy (internal/modules/esm/translators.js:*:*)
+    at async link (internal/modules/esm/module_job.js:*:*)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

This PR aims to amend the current behavior of the `getFormat` and `getSource` experimental loader hooks by allowing `getSource` to optionally override the format of the source that had been defined by `getFormat`.

This is an active WIP ; I am working under the guidance of contributor @jkrems 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
