### PR TITLE
meta: fixup CODEOWNERS so it hopefully works

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -59,12 +59,12 @@
 
 # quic
 
-./deps/ngtcp2/* @nodejs/quic
-./deps/nghttp3/* @nodejs/quic
-./doc/api/quic.md @nodejs/quic
-./lib/internal/quic/* @nodejs/quic
-./src/node_bob* @nodejs/quic
-./src/quic/* @nodejs/quic
+/deps/ngtcp2/ @nodejs/quic
+/deps/nghttp3/ @nodejs/quic
+/doc/api/quic.md @nodejs/quic
+/lib/internal/quic/ @nodejs/quic
+/src/node_bob* @nodejs/quic
+/src/quic/ @nodejs/quic
 
 # modules
 


### PR DESCRIPTION
the CODEOWNERS rules for QUIC are not working and it's not entirely clear why.
Hoping it's just the way the paths were specified.

Fast-track?

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
