### PR TITLE
esm: treat modules with no extension as .js

### DIFF
--- a/lib/internal/modules/esm/get_format.js
+++ b/lib/internal/modules/esm/get_format.js
@@ -50,7 +50,7 @@ function defaultGetFormat(url, context, defaultGetFormatUnused) {
   } else if (parsed.protocol === 'file:') {
     const ext = extname(parsed.pathname);
     let format;
-    if (ext === '.js') {
+    if (!ext || ext === '.js') {
       format = getPackageType(parsed.href) === 'module' ? 'module' : 'commonjs';
     } else {
       format = extensionFormatMap[ext];

--- a/test/es-module/test-esm-no-extension.js
+++ b/test/es-module/test-esm-no-extension.js
@@ -5,15 +5,13 @@ const fixtures = require('../common/fixtures');
 const { spawn } = require('child_process');
 const assert = require('assert');
 
-// In a "type": "module" package scope, files with unknown extensions or no
-// extensions should throw; both when used as a main entry point and also when
+// In a "type": "module" package scope, files with no extensions should
+// not throw; both when used as a main entry point and also when
 // referenced via `import`.
 
 [
   '/es-modules/package-type-module/noext-esm',
   '/es-modules/package-type-module/imports-noext.mjs',
-  '/es-modules/package-type-module/extension.unknown',
-  '/es-modules/package-type-module/imports-unknownext.mjs',
 ].forEach((fixturePath) => {
   const entry = fixtures.path(fixturePath);
   const child = spawn(process.execPath, [entry]);
@@ -28,9 +26,9 @@ const assert = require('assert');
     stderr += data;
   });
   child.on('close', common.mustCall((code, signal) => {
-    assert.strictEqual(code, 1);
+    assert.strictEqual(code, 0);
     assert.strictEqual(signal, null);
-    assert.strictEqual(stdout, '');
-    assert.ok(stderr.indexOf('ERR_UNKNOWN_FILE_EXTENSION') !== -1);
+    assert.strictEqual(stdout, 'executed\n');
+    assert.ok(stderr.indexOf('ERR_UNKNOWN_FILE_EXTENSION') === -1);
   }));
 });

--- a/test/es-module/test-esm-unknown-extension.js
+++ b/test/es-module/test-esm-unknown-extension.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const common = require('../common');
+const fixtures = require('../common/fixtures');
+const { spawn } = require('child_process');
+const assert = require('assert');
+
+// In a "type": "module" package scope, files with unknown extensions
+// should throw; both when used as a main entry point and also when
+// referenced via `import`.
+
+[
+  '/es-modules/package-type-module/extension.unknown',
+  '/es-modules/package-type-module/imports-unknownext.mjs',
+].forEach((fixturePath) => {
+  const entry = fixtures.path(fixturePath);
+  const child = spawn(process.execPath, [entry]);
+  let stdout = '';
+  let stderr = '';
+  child.stderr.setEncoding('utf8');
+  child.stdout.setEncoding('utf8');
+  child.stdout.on('data', (data) => {
+    stdout += data;
+  });
+  child.stderr.on('data', (data) => {
+    stderr += data;
+  });
+  child.on('close', common.mustCall((code, signal) => {
+    assert.strictEqual(code, 1);
+    assert.strictEqual(signal, null);
+    assert.strictEqual(stdout, '');
+    assert.ok(stderr.indexOf('ERR_UNKNOWN_FILE_EXTENSION') !== -1);
+  }));
+});


### PR DESCRIPTION

with this change, extensionless modules loaded with esm loader will be 
loaded with the same behavior as .js files:

1. if `"type": "module"` is specified, load as an esm module
2. otherwise, load as cjs module

Fixes: https://github.com/nodejs/node/issues/34049
Fixes: https://github.com/nodejs/node/issues/33226

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
