### PR TITLE
querystring: reduce memory usage

### DIFF
--- a/lib/internal/querystring.js
+++ b/lib/internal/querystring.js
@@ -2,6 +2,7 @@
 
 const {
   Array,
+  Int8Array,
 } = primordials;
 
 const { ERR_INVALID_URI } = require('internal/errors').codes;
@@ -10,7 +11,7 @@ const hexTable = new Array(256);
 for (let i = 0; i < 256; ++i)
   hexTable[i] = '%' + ((i < 16 ? '0' : '') + i.toString(16)).toUpperCase();
 
-const isHexTable = [
+const isHexTable = new Int8Array([
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 0 - 15
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 16 - 31
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 32 - 47
@@ -27,7 +28,7 @@ const isHexTable = [
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0  // ... 256
-];
+]);
 
 function encodeStr(str, noEscapeTable, hexTable) {
   const len = str.length;

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -2,6 +2,7 @@
 
 const {
   Array,
+  Int8Array,
   Number,
   ObjectCreate,
   ObjectDefineProperties,
@@ -814,7 +815,7 @@ function parseParams(qs) {
 
 // Adapted from querystring's implementation.
 // Ref: https://url.spec.whatwg.org/#concept-urlencoded-byte-serializer
-const noEscape = [
+const noEscape = new Int8Array([
 /*
   0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F
 */
@@ -826,7 +827,7 @@ const noEscape = [
   1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 1, // 0x50 - 0x5F
   0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 0x60 - 0x6F
   1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0  // 0x70 - 0x7F
-];
+]);
 
 // Special version of hexTable that uses `+` for U+0020 SPACE.
 const paramHexTable = hexTable.slice();

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -26,6 +26,7 @@
 const {
   Array,
   ArrayIsArray,
+  Int8Array,
   MathAbs,
   ObjectCreate,
   ObjectKeys,
@@ -52,7 +53,7 @@ const QueryString = module.exports = {
   decode: parse
 };
 
-const unhexTable = [
+const unhexTable = new Int8Array([
   -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 0 - 15
   -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 16 - 31
   -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 32 - 47
@@ -69,7 +70,7 @@ const unhexTable = [
   -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
   -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
   -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1  // ... 255
-];
+]);
 // A safe fast alternative to decodeURIComponent
 function unescapeBuffer(s, decodeSpaces) {
   const out = Buffer.allocUnsafe(s.length);
@@ -129,7 +130,7 @@ function qsUnescape(s, decodeSpaces) {
 // digits
 // alpha (uppercase)
 // alpha (lowercase)
-const noEscape = [
+const noEscape = new Int8Array([
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 0 - 15
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 16 - 31
   0, 1, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 1, 1, 0, // 32 - 47
@@ -138,7 +139,7 @@ const noEscape = [
   1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 1, // 80 - 95
   0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 96 - 111
   1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 1, 0  // 112 - 127
-];
+]);
 // QueryString.escape() replaces encodeURIComponent()
 // http://www.ecma-international.org/ecma-262/5.1/#sec-15.1.3.4
 function qsEscape(str) {

--- a/lib/url.js
+++ b/lib/url.js
@@ -22,6 +22,7 @@
 'use strict';
 
 const {
+  Int8Array,
   ObjectCreate,
   ObjectKeys,
   SafeSet,
@@ -561,7 +562,7 @@ function urlFormat(urlObject, options) {
 // digits
 // alpha (uppercase)
 // alpha (lowercase)
-const noEscapeAuth = [
+const noEscapeAuth = new Int8Array([
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 0x00 - 0x0F
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 0x10 - 0x1F
   0, 1, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 1, 1, 0, // 0x20 - 0x2F
@@ -570,7 +571,7 @@ const noEscapeAuth = [
   1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 1, // 0x50 - 0x5F
   0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 0x60 - 0x6F
   1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 1, 0  // 0x70 - 0x7F
-];
+]);
 
 Url.prototype.format = function format() {
   let auth = this.auth || '';


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

This PR will reduce the memory usage when program loads `querystring` or `internal/querystring`.  (reduce about 8 Byte * (256 - 103) count = 1,224 Byte, for each)
It is also possible to remove `isHexTable` by replacing `if(isHexTable[code])` to `if(unhexTable[code]>=0)`, which reduce 8 * 103 Byte. Currently, I did not replace that for simplicity. If you feel better to replace it, please notice me.


To avoid number->boolean casting, I did not do following replacement as https://github.com/nodejs/node/pull/34179#discussion_r449875096
~I also change the conditional expression as~
```diff
- if (isHexTable[code] === 1) {
+ if (isHexTable[code]) {
```
~because I feel that the name of variable `isHexTable` looks boolean name.~


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
