### PR TITLE
fs: filehandle read now accepts object as argument

### DIFF
--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -348,15 +348,17 @@ async function open(path, flags, mode) {
 
 async function read(handle, bufferOrOptions, offset, length, position) {
   let buffer = bufferOrOptions;
-
   if (!isArrayBufferView(buffer)) {
-    buffer = bufferOrOptions.buffer || Buffer.alloc(16384);
+    if (bufferOrOptions.buffer) {
+      buffer = bufferOrOptions.buffer;
+      validateBuffer(buffer);
+    } else {
+      buffer = Buffer.alloc(16384);
+    }
     offset = bufferOrOptions.offset || 0;
     length = buffer.length;
     position = bufferOrOptions.position || null;
   }
-
-  validateBuffer(buffer);
 
   if (offset == null) {
     offset = 0;

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -346,7 +346,16 @@ async function open(path, flags, mode) {
                                  flagsNumber, mode, kUsePromises));
 }
 
-async function read(handle, buffer, offset, length, position) {
+async function read(handle, bufferOrOptions, offset, length, position) {
+  let buffer = bufferOrOptions;
+
+  if (!isArrayBufferView(buffer)) {
+    buffer = bufferOrOptions.buffer || Buffer.alloc(16384);
+    offset = bufferOrOptions.offset || 0;
+    length = buffer.length;
+    position = bufferOrOptions.position || null;
+  }
+
   validateBuffer(buffer);
 
   if (offset == null) {


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/34176
Refs: https://nodejs.org/api/fs.html#fs_filehandle_read_options

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
