### PR TITLE
src: add encoding_type variable in WritePrivateKey

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3151,7 +3151,8 @@ static MaybeLocal<Value> WritePrivateKey(
 
   bool err;
 
-  if (config.type_.ToChecked() == kKeyEncodingPKCS1) {
+  PKEncodingType encoding_type = config.type_.ToChecked();
+  if (encoding_type == kKeyEncodingPKCS1) {
     // PKCS#1 is only permitted for RSA keys.
     CHECK_EQ(EVP_PKEY_id(pkey), EVP_PKEY_RSA);
 
@@ -3171,7 +3172,7 @@ static MaybeLocal<Value> WritePrivateKey(
       CHECK_NULL(config.cipher_);
       err = i2d_RSAPrivateKey_bio(bio.get(), rsa.get()) != 1;
     }
-  } else if (config.type_.ToChecked() == kKeyEncodingPKCS8) {
+  } else if (encoding_type == kKeyEncodingPKCS8) {
     if (config.format_ == kKeyFormatPEM) {
       // Encode PKCS#8 as PEM.
       err = PEM_write_bio_PKCS8PrivateKey(
@@ -3191,7 +3192,7 @@ static MaybeLocal<Value> WritePrivateKey(
                 nullptr, nullptr) != 1;
     }
   } else {
-    CHECK_EQ(config.type_.ToChecked(), kKeyEncodingSEC1);
+    CHECK_EQ(encoding_type, kKeyEncodingSEC1);
 
     // SEC1 is only permitted for EC keys.
     CHECK_EQ(EVP_PKEY_id(pkey), EVP_PKEY_EC);


### PR DESCRIPTION
This commit adds a local variable named encoding_type which is set to
the value of the Maybe using ToChecked().

The motivation for this is the code for ToChecked() could be executed
multiple times depending on path taken at runtime. I also think this
improves readability, or at least it is as readable as before this
change.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
