### PR TITLE
net:support TCP_KEEPINTVL,TCP_KEEPCNT,TCP_USER_TIMEOUT for tcp keep-a…

### DIFF
--- a/deps/uv/include/uv.h
+++ b/deps/uv/include/uv.h
@@ -556,6 +556,12 @@ UV_EXTERN int uv_tcp_nodelay(uv_tcp_t* handle, int enable);
 UV_EXTERN int uv_tcp_keepalive(uv_tcp_t* handle,
                                int enable,
                                unsigned int delay);
+UV_EXTERN int uv_tcp_keepalive_ex(uv_tcp_t* handle,
+                                  int enable,
+                                  unsigned int delay,
+                                  unsigned int interval,
+                                  unsigned int count);
+UV_EXTERN int uv_tcp_timeout(uv_tcp_t* handle, unsigned int timeout);
 UV_EXTERN int uv_tcp_simultaneous_accepts(uv_tcp_t* handle, int enable);
 
 enum uv_tcp_flags {

--- a/deps/uv/src/unix/internal.h
+++ b/deps/uv/src/unix/internal.h
@@ -235,7 +235,12 @@ int uv__open_cloexec(const char* path, int flags);
 int uv_tcp_listen(uv_tcp_t* tcp, int backlog, uv_connection_cb cb);
 int uv__tcp_nodelay(int fd, int on);
 int uv__tcp_keepalive(int fd, int on, unsigned int delay);
-
+int uv_tcp_keepalive_ex(uv_tcp_t* handle,
+                        int enable,
+                        unsigned int delay,
+                        unsigned int interval,
+                        unsigned int count);
+int uv_tcp_timeout(uv_tcp_t* handle, unsigned int timeout);
 /* pipe */
 int uv_pipe_listen(uv_pipe_t* handle, int backlog, uv_connection_cb cb);
 

--- a/deps/uv/src/win/tcp.c
+++ b/deps/uv/src/win/tcp.c
@@ -68,7 +68,7 @@ static int uv__tcp_keepalive(uv_tcp_t* handle, SOCKET socket, int enable, unsign
 
   if (enable && setsockopt(socket,
                            IPPROTO_TCP,
-                           TCP_KEEPALIVE,
+                           TCP_KEEPIDLE,
                            (const char*)&delay,
                            sizeof delay) == -1) {
     return WSAGetLastError();
@@ -77,6 +77,87 @@ static int uv__tcp_keepalive(uv_tcp_t* handle, SOCKET socket, int enable, unsign
   return 0;
 }
 
+
+/* windows don't support this */
+int uv_tcp_timeout(uv_tcp_t* handle, unsigned int timeout) {
+	return 0;
+} 
+
+
+static int uv__tcp_keepalive_ex(uv_tcp_t* handle, 
+                                SOCKET socket, 
+                                int enable, 
+                                unsigned int delay, 
+                                unsigned int interval, 
+                                unsigned int count) {
+  if (setsockopt(socket,
+                 SOL_SOCKET,
+                 SO_KEEPALIVE,
+                 (const char*)&enable,
+                 sizeof enable) == -1) {
+    return WSAGetLastError();
+  }
+
+ #ifdef TCP_KEEPIDLE
+  if (enable && delay && setsockopt(socket,
+                                    IPPROTO_TCP,
+                                    TCP_KEEPIDLE,
+                                    (const char*)&delay,
+                                    sizeof delay) == -1) {
+    return WSAGetLastError();
+  }
+#endif
+#ifdef TCP_KEEPINTVL
+  if (enable && interval && setsockopt(socket,
+                                       IPPROTO_TCP,
+                                       TCP_KEEPINTVL,
+                                       (const char*)&interval,
+                                       sizeof interval) == -1) {
+    return WSAGetLastError();
+  }
+#endif
+#ifdef TCP_KEEPCNT
+  if (enable && count && setsockopt(socket,
+                                    IPPROTO_TCP,
+                                    TCP_KEEPCNT,
+                                    (const char*)&count,
+                                    sizeof count) == -1) {
+    return WSAGetLastError();
+  }
+#endif
+
+  return 0;
+}
+
+
+int uv_tcp_keepalive_ex(uv_tcp_t* handle,
+                        int enable,
+                        unsigned int delay,
+                        unsigned int interval,
+                        unsigned int count) {
+  int err;
+
+  if (handle->socket != INVALID_SOCKET) {
+    err = uv__tcp_keepalive_ex(handle,
+                               handle->socket,
+                               enable,
+                               delay,
+                               interval,
+                               count);
+    if (err)
+      return err;
+  }
+
+  if (enable) {
+    handle->flags |= UV_HANDLE_TCP_KEEPALIVE;
+  } else {
+    handle->flags &= ~UV_HANDLE_TCP_KEEPALIVE;
+  }
+
+  /* TODO: Store delay if handle->socket isn't created yet. */
+
+  return 0;
+}
 
 static int uv_tcp_set_socket(uv_loop_t* loop,
                              uv_tcp_t* handle,

--- a/deps/uv/test/test-tcp-flags.c
+++ b/deps/uv/test/test-tcp-flags.c
@@ -42,6 +42,12 @@ TEST_IMPL(tcp_flags) {
   r = uv_tcp_keepalive(&handle, 1, 60);
   ASSERT(r == 0);
 
+  r = uv_tcp_keepalive_ex(&handle, 1, 60, 60, 60);
+  ASSERT(r == 0);
+
+  r = uv_tcp_timeout(&handle, 1000);
+  ASSERT(r == 0);
+  
   uv_close((uv_handle_t*)&handle, NULL);
 
   r = uv_run(loop, UV_RUN_DEFAULT);

--- a/lib/net.js
+++ b/lib/net.js
@@ -502,6 +502,38 @@ Socket.prototype.setKeepAlive = function(setting, msecs) {
   return this;
 };
 
+Socket.prototype.setKeepAliveEx = function(setting,
+                                           secs,
+                                           interval,
+                                           count) {
+  if (!this._handle) {
+    this.once('connect', () => this.setKeepAliveEx(setting,
+                                                   secs,
+                                                   interval,
+                                                   count));
+    return this;
+  }
+
+  if (this._handle.setKeepAliveEx)
+    this._handle.setKeepAliveEx(setting,
+                                ~~secs > 0 ? ~~secs : 0,
+                                ~~interval > 0 ? ~~interval : 0,
+                                ~~count > 0 ? ~~count : 0);
+
+  return this;
+};
+
+Socket.prototype.setKeepAliveTimeout = function(timeout) {
+  if (!this._handle) {
+    this.once('connect', () => this.setKeepAliveTimeout(timeout));
+    return this;
+  }
+
+  if (this._handle.setKeepAliveTimeout)
+    this._handle.setKeepAliveTimeout(~~timeout > 0 ? ~~timeout : 0);
+
+  return this;
+};
 
 Socket.prototype.address = function() {
   return this._getsockname();

--- a/src/env.cc
+++ b/src/env.cc
@@ -27,7 +27,7 @@
 namespace node {
 
 using errors::TryCatchScope;
-using v8::ArrayBuffer;
+/* using v8::ArrayBuffer; */
 using v8::Boolean;
 using v8::Context;
 using v8::EmbedderGraph;

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -98,7 +98,8 @@ void TCPWrap::Initialize(Local<Object> target,
                       GetSockOrPeerName<TCPWrap, uv_tcp_getpeername>);
   env->SetProtoMethod(t, "setNoDelay", SetNoDelay);
   env->SetProtoMethod(t, "setKeepAlive", SetKeepAlive);
-
+  env->SetProtoMethod(t, "setKeepAliveEx", SetKeepAliveEx);
+  env->SetProtoMethod(t, "setKeepAliveTimeout", SetKeepAliveTimeout);
 #ifdef _WIN32
   env->SetProtoMethod(t, "setSimultaneousAccepts", SetSimultaneousAccepts);
 #endif
@@ -189,6 +190,30 @@ void TCPWrap::SetKeepAlive(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(err);
 }
 
+void TCPWrap::SetKeepAliveEx(const FunctionCallbackInfo<Value>& args) {
+  TCPWrap* wrap;
+  ASSIGN_OR_RETURN_UNWRAP(&wrap,
+                          args.Holder(),
+                          args.GetReturnValue().Set(UV_EBADF));
+  Environment* env = wrap->env();
+  int enable;
+  if (!args[0]->Int32Value(env->context()).To(&enable)) return;
+  unsigned int delay = static_cast<unsigned int>(args[1].As<Uint32>()->Value());
+  unsigned int detal = static_cast<unsigned int>(args[2].As<Uint32>()->Value());
+  unsigned int count = static_cast<unsigned int>(args[3].As<Uint32>()->Value());
+  int err = uv_tcp_keepalive_ex(&wrap->handle_, enable, delay, detal, count);
+  args.GetReturnValue().Set(err);
+}
+
+void TCPWrap::SetKeepAliveTimeout(const FunctionCallbackInfo<Value>& args) {
+  TCPWrap* wrap;
+  ASSIGN_OR_RETURN_UNWRAP(&wrap,
+                          args.Holder(),
+                          args.GetReturnValue().Set(UV_EBADF));
+  unsigned int time = static_cast<unsigned int>(args[0].As<Uint32>()->Value());
+  int err = uv_tcp_timeout(&wrap->handle_, time);
+  args.GetReturnValue().Set(err);
+}
 
 #ifdef _WIN32
 void TCPWrap::SetSimultaneousAccepts(const FunctionCallbackInfo<Value>& args) {

--- a/src/tcp_wrap.h
+++ b/src/tcp_wrap.h
@@ -72,6 +72,9 @@ class TCPWrap : public ConnectionWrap<TCPWrap, uv_tcp_t> {
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetNoDelay(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetKeepAlive(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void SetKeepAliveEx(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void SetKeepAliveTimeout(
+      const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Bind(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Bind6(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Listen(const v8::FunctionCallbackInfo<v8::Value>& args);


### PR DESCRIPTION
…live in nodejs

except TCP_KEEPIDLE, linux provide TCP_KEEPINTVL,TCP_KEEPCNT,TCP_USER_TIMEOUT for tcp keep-alive.

support this in nodejs,and users can control tcp keep-alive more flexibly

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
