### PR TITLE
stream: cleanup and fix Readable.wrap

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -26,6 +26,7 @@ const {
   NumberIsInteger,
   NumberIsNaN,
   ObjectDefineProperties,
+  ObjectKeys,
   ObjectSetPrototypeOf,
   Set,
   SymbolAsyncIterator,
@@ -1007,40 +1008,44 @@ function flow(stream) {
 // This is *not* part of the readable stream interface.
 // It is an ugly unfortunate mess of history.
 Readable.prototype.wrap = function(stream) {
-  const state = this._readableState;
-  let paused = false;
+  let paused;
 
-  stream.on('end', () => {
-    debug('wrapped end');
-    if (state.decoder && !state.ended) {
-      const chunk = state.decoder.end();
-      if (chunk && chunk.length)
-        this.push(chunk);
-    }
-
-    this.push(null);
-  });
+  // TODO (ronag): Should this.destroy(err) emit
+  // 'error' on the wrapped stream? Would require
+  // a static factory method, e.g. Readable.wrap(stream).
 
   stream.on('data', (chunk) => {
-    debug('wrapped data');
-    if (state.decoder)
-      chunk = state.decoder.write(chunk);
-
-    // Don't skip over falsy values in objectMode.
-    if (state.objectMode && (chunk === null || chunk === undefined))
-      return;
-    else if (!state.objectMode && (!chunk || !chunk.length))
-      return;
-
-    const ret = this.push(chunk);
-    if (!ret) {
+    if (!this.push(chunk) && stream.pause) {
       paused = true;
       stream.pause();
     }
   });
 
+  stream.on('end', () => {
+    this.push(null);
+  });
+
+  stream.on('error', (err) => {
+    errorOrDestroy(this, err);
+  });
+
+  stream.on('close', () => {
+    this.destroy();
+  });
+
+  stream.on('destroy', () => {
+    this.destroy();
+  });
+
+  this._read = () => {
+    if (paused && stream.resume) {
+      paused = false;
+      stream.resume();
+    }
+  };
+
   // Proxy all the other methods. Important when wrapping filters and duplexes.
-  for (const i in stream) {
+  for (const i of ObjectKeys(stream)) {
     if (this[i] === undefined && typeof stream[i] === 'function') {
       this[i] = function methodWrap(method) {
         return function methodWrapReturnFunction() {
@@ -1049,40 +1054,6 @@ Readable.prototype.wrap = function(stream) {
       }(i);
     }
   }
-
-  stream.on('error', (err) => {
-    errorOrDestroy(this, err);
-  });
-
-  stream.on('close', () => {
-    // TODO(ronag): Update readable state?
-    this.emit('close');
-  });
-
-  stream.on('destroy', () => {
-    // TODO(ronag): this.destroy()?
-    this.emit('destroy');
-  });
-
-  stream.on('pause', () => {
-    // TODO(ronag): this.pause()?
-    this.emit('pause');
-  });
-
-  stream.on('resume', () => {
-    // TODO(ronag): this.resume()?
-    this.emit('resume');
-  });
-
-  // When we try to consume some more bytes, simply unpause the
-  // underlying stream.
-  this._read = (n) => {
-    debug('wrapped _read', n);
-    if (paused) {
-      paused = false;
-      stream.resume();
-    }
-  };
 
   return this;
 };

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -1047,11 +1047,7 @@ Readable.prototype.wrap = function(stream) {
   // Proxy all the other methods. Important when wrapping filters and duplexes.
   for (const i of ObjectKeys(stream)) {
     if (this[i] === undefined && typeof stream[i] === 'function') {
-      this[i] = function methodWrap(method) {
-        return function methodWrapReturnFunction() {
-          return stream[method].apply(stream, arguments);
-        };
-      }(i);
+      this[i] = stream[i].bind(stream);
     }
   }
 

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -1008,7 +1008,7 @@ function flow(stream) {
 // This is *not* part of the readable stream interface.
 // It is an ugly unfortunate mess of history.
 Readable.prototype.wrap = function(stream) {
-  let paused;
+  let paused = false;
 
   // TODO (ronag): Should this.destroy(err) emit
   // 'error' on the wrapped stream? Would require

--- a/test/parallel/test-stream2-readable-wrap-destroy.js
+++ b/test/parallel/test-stream2-readable-wrap-destroy.js
@@ -1,0 +1,27 @@
+'use strict';
+const common = require('../common');
+
+const Readable = require('_stream_readable');
+const EE = require('events').EventEmitter;
+
+const oldStream = new EE();
+oldStream.pause = () => {};
+oldStream.resume = () => {};
+
+{
+  new Readable({
+    autoDestroy: false,
+    destroy: common.mustCall()
+  })
+    .wrap(oldStream);
+  oldStream.emit('destroy');
+}
+
+{
+  new Readable({
+    autoDestroy: false,
+    destroy: common.mustCall()
+  })
+    .wrap(oldStream);
+  oldStream.emit('close');
+}

--- a/test/parallel/test-stream2-readable-wrap.js
+++ b/test/parallel/test-stream2-readable-wrap.js
@@ -44,6 +44,16 @@ function runTest(highWaterMark, objectMode, produce) {
     flow();
   };
 
+  // Make sure pause is only emitted once.
+  let pausing = false;
+  r.on('pause', () => {
+    assert.strictEqual(pausing, false);
+    pausing = true;
+    process.nextTick(() => {
+      pausing = false;
+    });
+  });
+
   let flowing;
   let chunks = 10;
   let oldEnded = false;


### PR DESCRIPTION
Cleans up Readable.wrap and also ensures destroy is called for certain events.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
