### PR TITLE
test: skip an ipv6 test on IBM i

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -75,3 +75,5 @@ test-net-socket-connecting: SKIP
 test-net-socket-ready-without-cb: SKIP
 test-net-write-after-end-nt: SKIP
 test-tls-env-extra-ca: SKIP
+# https://github.com/nodejs/node/pull/34209
+test-dgram-error-message-address: SKIP


### PR DESCRIPTION
Due to some unknown system configuration, the code `socket_ipv6.bind(0, 111::1)` does not throw the expected error EADDRNOTAVAIL on some IBM i systems. 
This issue is still being investigated. 
To get the IBM i CI passing, skip it for now.