### PR TITLE
test: use isMainThread for test with workers

### DIFF
--- a/test/parallel/test-http2-reset-flood.js
+++ b/test/parallel/test-http2-reset-flood.js
@@ -5,14 +5,14 @@ if (!common.hasCrypto)
 
 const http2 = require('http2');
 const net = require('net');
-const { Worker, parentPort } = require('worker_threads');
+const { Worker, isMainThread, parentPort } = require('worker_threads');
 
 // Verify that creating a number of invalid HTTP/2 streams will eventually
 // result in the peer closing the session.
 // This test uses separate threads for client and server to avoid
 // the two event loops intermixing, as we are writing in a busy loop here.
 
-if (process.env.HAS_STARTED_WORKER) {
+if (!isMainThread) {
   const server = http2.createServer({ maxSessionInvalidFrames: 100 });
   server.on('stream', (stream) => {
     stream.respond({
@@ -25,7 +25,6 @@ if (process.env.HAS_STARTED_WORKER) {
   return;
 }
 
-process.env.HAS_STARTED_WORKER = 1;
 const worker = new Worker(__filename).on('message', common.mustCall((port) => {
   const h2header = Buffer.alloc(9);
   const conn = net.connect(port);


### PR DESCRIPTION
Debugging why test-http2-reset-flood and noticed it's using an
environment variable to signal whether or not we're in the main thread.
The worker threads module has a property for that already, so use it
instead.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
