### PR TITLE
src: fix unused namespace member

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -27,7 +27,6 @@
 namespace node {
 
 using errors::TryCatchScope;
-using v8::ArrayBuffer;
 using v8::Boolean;
 using v8::Context;
 using v8::EmbedderGraph;


### PR DESCRIPTION
```make -j4 test``` fails because of C++ linter saying:
```
Running C++ linter...
File "src/env.cc" does not use "ArrayBuffer"
make[2]: *** [Makefile:1337: tools/.cpplintstamp] Error 1
make[1]: *** [Makefile:1376: lint] Error 2
make: *** [Makefile:320: test] Error 2
```

Reverting commit [ee3243f](https://github.com/nodejs/node/commit/ee3243fe3f29f317e910a2424eabd279dec2eb00) removes problem.

After removing ```using v8::ArrayBuffer;``` build passes.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
