### PR TITLE
lib: cache length prop in classic for loop

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -246,7 +246,7 @@ function ClientRequest(input, options, cb) {
       const keys = ObjectKeys(options.headers);
       // Retain for(;;) loop for performance reasons
       // Refs: https://github.com/nodejs/node/pull/30958
-      for (let i = 0; i < keys.length; i++) {
+      for (let i = 0, len = keys.length; i < len; i++) {
         const key = keys[i];
         this.setHeader(key, options.headers[key]);
       }

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -175,7 +175,7 @@ ObjectDefineProperty(OutgoingMessage.prototype, '_headers', {
       const keys = ObjectKeys(val);
       // Retain for(;;) loop for performance reasons
       // Refs: https://github.com/nodejs/node/pull/30958
-      for (let i = 0; i < keys.length; ++i) {
+      for (let i = 0, len = keys.length; i < len; ++i) {
         const name = keys[i];
         headers[name.toLowerCase()] = [name, val[name]];
       }
@@ -200,7 +200,7 @@ ObjectDefineProperty(OutgoingMessage.prototype, '_headerNames', {
       const keys = ObjectKeys(headers);
       // Retain for(;;) loop for performance reasons
       // Refs: https://github.com/nodejs/node/pull/30958
-      for (let i = 0; i < keys.length; ++i) {
+      for (let i = 0, len = keys.length; i < len; ++i) {
         const key = keys[i];
         const val = headers[key][0];
         out[key] = val;
@@ -217,7 +217,7 @@ ObjectDefineProperty(OutgoingMessage.prototype, '_headerNames', {
       const keys = ObjectKeys(val);
       // Retain for(;;) loop for performance reasons
       // Refs: https://github.com/nodejs/node/pull/30958
-      for (let i = 0; i < keys.length; ++i) {
+      for (let i = 0, len = keys.length; i < len; ++i) {
         const header = headers[keys[i]];
         if (header)
           header[0] = val[keys[i]];
@@ -471,10 +471,11 @@ function processHeader(self, state, key, value, validate) {
   if (validate)
     validateHeaderName(key);
   if (ArrayIsArray(value)) {
-    if (value.length < 2 || !isCookieField(key)) {
+    const valueLen = value.length;
+    if (valueLen < 2 || !isCookieField(key)) {
       // Retain for(;;) loop for performance reasons
       // Refs: https://github.com/nodejs/node/pull/30958
-      for (let i = 0; i < value.length; i++)
+      for (let i = 0; i < valueLen; i++)
         storeHeader(self, state, key, value[i], validate);
       return;
     }
@@ -577,7 +578,7 @@ OutgoingMessage.prototype.getHeaders = function getHeaders() {
     const keys = ObjectKeys(headers);
     // Retain for(;;) loop for performance reasons
     // Refs: https://github.com/nodejs/node/pull/30958
-    for (let i = 0; i < keys.length; ++i) {
+    for (let i = 0, len = keys.length; i < len; ++i) {
       const key = keys[i];
       const val = headers[key][1];
       ret[key] = val;

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -279,7 +279,7 @@ function writeHead(statusCode, reason, obj) {
       const keys = ObjectKeys(obj);
       // Retain for(;;) loop for performance reasons
       // Refs: https://github.com/nodejs/node/pull/30958
-      for (let i = 0; i < keys.length; i++) {
+      for (let i = 0, len = keys.length; i < len; i++) {
         k = keys[i];
         if (k) this.setHeader(k, obj[k]);
       }

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -556,7 +556,7 @@ class Http2ServerResponse extends Stream {
   addTrailers(headers) {
     const keys = ObjectKeys(headers);
     let key = '';
-    for (let i = 0; i < keys.length; i++) {
+    for (let i = 0, len = keys.length; i < len; i++) {
       key = keys[i];
       this.setTrailer(key, headers[key]);
     }

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -357,7 +357,7 @@ function resolveExportsTarget(
     throw lastException;
   } else if (typeof target === 'object' && target !== null) {
     const keys = ObjectGetOwnPropertyNames(target);
-    for (let i = 0; i < keys.length; i++) {
+    for (let i = 0, len = keys.length; i < len; i++) {
       const key = keys[i];
       if (isArrayIndex(key)) {
         throw new ERR_INVALID_PACKAGE_CONFIG(
@@ -365,7 +365,7 @@ function resolveExportsTarget(
           '"exports" cannot contain numeric property keys');
       }
     }
-    for (let i = 0; i < keys.length; i++) {
+    for (let i = 0, len = keys.length; i < len; i++) {
       const key = keys[i];
       if (key === 'default' || conditions.has(key)) {
         const conditionalTarget = target[key];
@@ -467,7 +467,7 @@ function packageExportsResolve(
 
   let bestMatch = '';
   const keys = ObjectGetOwnPropertyNames(exports);
-  for (let i = 0; i < keys.length; i++) {
+  for (let i = 0, len = keys.length; i < len; i++) {
     const key = keys[i];
     if (key[key.length - 1] !== '/') continue;
     if (StringPrototypeStartsWith(packageSubpath, key) &&

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -179,7 +179,7 @@ class URLSearchParams {
         // Need to use reflection APIs for full spec compliance.
         this[searchParams] = [];
         const keys = ReflectOwnKeys(init);
-        for (let i = 0; i < keys.length; i++) {
+        for (let i = 0, len = keys.length; i < len; i++) {
           const key = keys[i];
           const desc = ReflectGetOwnPropertyDescriptor(init, key);
           if (desc !== undefined && desc.enumerable) {

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -1410,7 +1410,7 @@ function formatPrimitive(fn, value, ctx) {
 
 function formatNamespaceObject(keys, ctx, value, recurseTimes) {
   const output = new Array(keys.length);
-  for (let i = 0; i < keys.length; i++) {
+  for (let i = 0, len = keys.length; i < len; i++) {
     try {
       output[i] = formatProperty(ctx, value, recurseTimes, keys[i],
                                  kObjectType);


### PR DESCRIPTION
Cache length prop in classic for loop for performance purpose.

Refs: https://github.com/nodejs/node/pull/30958

----

There is a common view that the modern javascript engine *will* perform the optimization in `for (;;)` loop (classic for loop). But according to my own practices, cache `length` prop manually is still at least 7% (mostly 15%) faster.

According to https://github.com/nodejs/node/pull/30958#pullrequestreview-332230092, some `for (;;)` is retained for performance concern, IMHO adding such a "optimization" should be accepted then.

FYI, I have noticed that `lib/_http_outgoing.js` already uses the same syntax when I bring up the PR:

https://github.com/nodejs/node/blob/30cc54275d570a804ced31843d1ff237dd701f85/lib/_http_outgoing.js#L242-L245

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
