### PR TITLE
Allowing HEAD method to work with keep-alive

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -457,7 +457,8 @@ function _storeHeader(firstLine, headers) {
   }
 
   if (!state.contLen && !state.te) {
-    if (!this._hasBody) {
+    if (!this._hasBody && (this.statusCode === 204 ||
+                           this.statusCode === 304)) {
       // Make sure we don't end the 0\r\n\r\n at the end of the message.
       this.chunkedEncoding = false;
     } else if (!this.useChunkedEncodingByDefault) {

--- a/test/parallel/test-http-reuse-socket.js
+++ b/test/parallel/test-http-reuse-socket.js
@@ -1,0 +1,51 @@
+'use strict';
+const common = require('../common');
+const http = require('http');
+const assert = require('assert');
+const Countdown = require('../common/countdown');
+
+// The HEAD:204, GET:200 is the most pathological test case.
+// GETs following a 204 response with a content-encoding header failed.
+// Responses without bodies and without content-length or encoding caused
+// the socket to be closed.
+const codes = [204, 200, 200, 304, 200];
+const methods = ['HEAD', 'HEAD', 'GET', 'HEAD', 'GET'];
+
+const sockets = [];
+const agent = new http.Agent();
+agent.maxSockets = 1;
+
+const countdown = new Countdown(codes.length, () => server.close());
+
+const server = http.createServer(common.mustCall((req, res) => {
+  const code = codes.shift();
+  assert.strictEqual(typeof code, 'number');
+  assert.ok(code > 0);
+  res.writeHead(code, {});
+  res.end();
+}, codes.length));
+
+function nextRequest() {
+  const request = http.request({
+    port: server.address().port,
+    path: '/',
+    agent: agent,
+    method: methods.shift()
+  }, common.mustCall((response) => {
+    response.on('end', common.mustCall(() => {
+      if (countdown.dec()) {
+        nextRequest();
+      }
+      assert.strictEqual(sockets.length, 1);
+    }));
+    response.resume();
+  }));
+  request.on('socket', common.mustCall((socket) => {
+    if (!sockets.includes(socket)) {
+      sockets.push(socket);
+    }
+  }));
+  request.end();
+}
+
+server.listen(0, common.mustCall(nextRequest));


### PR DESCRIPTION
Fixes: #28438 

This approach specifically retains the non-hanging of 204 requests while allowing HEAD to function correctly with keeping sockets open. I check for 204 + 304 specifically rather than the HEAD method because the method is in _http_server, not _http_outgoing, though it could be passed along if that's preferred.

# Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
