### PR TITLE
lib: remove empty and redundant catch block

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -240,13 +240,11 @@ function identicalSequenceRange(a, b) {
 
 function enhanceStackTrace(err, own) {
   let ctorInfo = '';
-  try {
-    const { name } = this.constructor;
-    if (name !== 'EventEmitter')
+  const { name } = this.constructor || {};
+  if (name !== 'EventEmitter')
       ctorInfo = ` on ${name} instance`;
-  } catch {}
-  const sep = `\nEmitted 'error' event${ctorInfo} at:\n`;
 
+  const sep = `\nEmitted 'error' event${ctorInfo} at:\n`;
   const errStack = err.stack.split('\n').slice(1);
   const ownStack = own.stack.split('\n').slice(1);
 

--- a/lib/events.js
+++ b/lib/events.js
@@ -241,7 +241,7 @@ function identicalSequenceRange(a, b) {
 function enhanceStackTrace(err, own) {
   let ctorInfo = '';
   const { name } = this.constructor || {};
-  if (name !== 'EventEmitter')
+  if (name && name !== 'EventEmitter')
       ctorInfo = ` on ${name} instance`;
 
   const sep = `\nEmitted 'error' event${ctorInfo} at:\n`;

--- a/lib/events.js
+++ b/lib/events.js
@@ -242,7 +242,7 @@ function enhanceStackTrace(err, own) {
   let ctorInfo = '';
   const { name } = this.constructor || {};
   if (name && name !== 'EventEmitter')
-      ctorInfo = ` on ${name} instance`;
+    ctorInfo = ` on ${name} instance`;
 
   const sep = `\nEmitted 'error' event${ctorInfo} at:\n`;
   const errStack = err.stack.split('\n').slice(1);


### PR DESCRIPTION
This file contains two empty catch blocks, which is a bad practice by itself.
This PR fixes one empty catch block, which probably tried to avoid object destructuring error.

 Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)


