### PR TITLE
[12.x] fs: Backport eadc385, fix for fsPromises.truncate

### DIFF
--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -305,7 +305,8 @@ async function rename(oldPath, newPath) {
 }
 
 async function truncate(path, len = 0) {
-  return ftruncate(await open(path, 'r+'), len);
+  const fd = await open(path, 'r+');
+  return ftruncate(fd, len).finally(fd.close.bind(fd));
 }
 
 async function ftruncate(handle, len = 0) {


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/34189

fsPromises.truncate() was not closing the opened FileHandle.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
