### PR TITLE
domain: fix unintentional deprecation warning

### DIFF
--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -112,7 +112,7 @@ function useDomainTrampoline(fn) {
 }
 
 function callbackTrampoline(asyncId, cb, ...args) {
-  if (asyncId && hasHooks(kBefore))
+  if (asyncId !== 0 && hasHooks(kBefore))
     emitBeforeNative(asyncId);
 
   let result;
@@ -123,7 +123,7 @@ function callbackTrampoline(asyncId, cb, ...args) {
     result = ReflectApply(cb, this, args);
   }
 
-  if (asyncId && hasHooks(kAfter))
+  if (asyncId !== 0 && hasHooks(kAfter))
     emitAfterNative(asyncId);
 
   return result;

--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -116,7 +116,7 @@ function callbackTrampoline(asyncId, cb, ...args) {
     emitBeforeNative(asyncId);
 
   let result;
-  if (typeof domain_cb === 'function') {
+  if (asyncId === 0 && typeof domain_cb === 'function') {
     ArrayPrototypeUnshift(args, cb);
     result = ReflectApply(domain_cb, this, args);
   } else {

--- a/test/parallel/test-domain-http-server.js
+++ b/test/parallel/test-domain-http-server.js
@@ -20,11 +20,13 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+const common = require('../common');
 const domain = require('domain');
 const http = require('http');
 const assert = require('assert');
 const debug = require('util').debuglog('test');
+
+process.on('warning', common.mustNotCall());
 
 const objects = { foo: 'bar', baz: {}, num: 42, arr: [1, 2, 3] };
 objects.baz.asdf = objects;

--- a/test/parallel/test-domain-implicit-binding.js
+++ b/test/parallel/test-domain-implicit-binding.js
@@ -6,6 +6,8 @@ const domain = require('domain');
 const fs = require('fs');
 const isEnumerable = Function.call.bind(Object.prototype.propertyIsEnumerable);
 
+process.on('warning', common.mustNotCall());
+
 {
   const d = new domain.Domain();
 

--- a/test/parallel/test-domain-implicit-fs.js
+++ b/test/parallel/test-domain-implicit-fs.js
@@ -26,6 +26,8 @@ const common = require('../common');
 const assert = require('assert');
 const domain = require('domain');
 
+process.on('warning', common.mustNotCall());
+
 const d = new domain.Domain();
 
 d.on('error', common.mustCall(function(er) {

--- a/test/parallel/test-domain-multi.js
+++ b/test/parallel/test-domain-multi.js
@@ -26,6 +26,8 @@ const common = require('../common');
 const domain = require('domain');
 const http = require('http');
 
+process.on('warning', common.mustNotCall());
+
 const a = domain.create();
 a.enter(); // This will be our "root" domain
 

--- a/test/parallel/test-domain-promise.js
+++ b/test/parallel/test-domain-promise.js
@@ -5,6 +5,8 @@ const domain = require('domain');
 const fs = require('fs');
 const vm = require('vm');
 
+process.on('warning', common.mustNotCall());
+
 {
   const d = domain.create();
 


### PR DESCRIPTION
646e5a471766e27e8317bb changed the way that the domain hook callback
is called. Previously, the callback was only used in the case that
async_hooks were *not* being used (since domains already integrate
with async hooks the way they should), and the corresponding
deprecation warning also only emitted in that case.

However, that commit didn’t move that condition along when the code
was ported from C++ to JS. As a consequence, the domain hook callback
was used when it wasn’t necessary to use it, and the deprecation
warning emitted accidentally along with it.

Refs: https://github.com/nodejs/node/commit/646e5a471766e27e8317bb54d1fd1d2c72cffb69#diff-9f21ce1b9d6d46fdd07b969e8a04e140L192
Refs: https://github.com/nodejs/node/commit/646e5a471766e27e8317bb54d1fd1d2c72cffb69#diff-e6db408e12db906ead6ddfac3de15a6fR119
Refs: https://github.com/nodejs/node/pull/33801#issuecomment-654744913
Fixes: https://github.com/nodejs/node/issues/34069

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
