### PR TITLE
quic: another round of refactorings

### DIFF
--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -1385,9 +1385,59 @@ The `'ready'` event will not be emitted multiple times.
 added: REPLACEME
 -->
 
-Emitted when a new `QuicServerSession` has been created.
+Emitted when a new `QuicServerSession` has been created. The callback is
+invoked with a single argument providing the newly created `QuicServerSession`
+object.
+
+```js
+const { createQuicSocket } = require('net');
+
+const options = getOptionsSomehow();
+const server = createQuicSocket({ server: options });
+server.listen();
+
+server.on('session', (session) => {
+  // Attach session event listeners.
+});
+```
 
 The `'session'` event will be emitted multiple times.
+
+The `'session'` event handler *may* be an async function.
+
+If the `'session'` event handler throws an error, or if it returns a `Promise`
+that is rejected, the error will be handled by destroying the `QuicServerSession`
+automatically and emitting a `'sessionError'` event on the `QuicSocket`.
+
+#### Event: `'sessionError'`
+<!--YAML
+added: REPLACEME
+-->
+
+Emitted when an error occurs processing an event related to a specific
+`QuicSession` instance. The callback is invoked with two arguments:
+
+* `error` {Error} The error that was either thrown or rejected.
+* `session` {QuicSession} The `QuicSession` instance that was destroyed.
+
+The `QuicSession` instance will have been destroyed by the time the
+`'sessionError'` event is emitted.
+
+```js
+const { createQuicSocket } = require('net');
+
+const options = getOptionsSomehow();
+const server = createQuicSocket({ server: options });
+server.listen();
+
+server.on('session', (session) => {
+  throw new Error('boom');
+});
+
+server.on('sessionError', (error, session) => {
+  console.log('error:', error.message);
+});
+```
 
 #### quicsocket.addEndpoint(options)
 <!-- YAML

--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -1319,10 +1319,7 @@ added: REPLACEME
 -->
 
 New instances of `QuicSocket` are created using the `net.createQuicSocket()`
-method.
-
-Once created, a `QuicSocket` can be configured to work as both a client and a
-server.
+method, and can be used as both a client and a server.
 
 #### Event: `'busy'`
 <!-- YAML
@@ -1477,46 +1474,60 @@ added: REPLACEME
 
 * Type: {boolean}
 
-Will be `true` if the `QuicSocket` has been successfully bound to the local UDP
-port.
+Will be `true` if the `QuicSocket` has been successfully bound to a local UDP
+port. Initially the value is `false`.
+
+`QuicSocket` instances are not bound to a local UDP port until the first time
+eithe `quicsocket.listen()` or `quicsocket.connect()` is called. The `'ready'`
+event will be emitted once the `QuicSocket` has been bound and the value of
+`quicsocket.bound` will become `true`.
+
+Read-only.
 
 #### quicsocket.boundDuration
 <!-- YAML
 added: REPLACEME
 -->
 
-* Type: {bigint}
+* Type: {number}
 
-A `BigInt` representing the length of time this `QuicSocket` has been bound
-to a local port.
+The length of time this `QuicSocket` has been bound to a local port.
+
+Read-only.
 
 #### quicsocket.bytesReceived
 <!-- YAML
 added: REPLACEME
 -->
 
-* Type: {bigint}
+* Type: {number}
 
-A `BigInt` representing the number of bytes received by this `QuicSocket`.
+The number of bytes received by this `QuicSocket`.
+
+Read-only.
 
 #### quicsocket.bytesSent
 <!-- YAML
 added: REPLACEME
 -->
 
-* Type: {bigint}
+* Type: {number}
 
-A `BigInt` representing the number of bytes sent by this `QuicSocket`.
+The number of bytes sent by this `QuicSocket`.
+
+Read-only.
 
 #### quicsocket.clientSessions
 <!-- YAML
 added: REPLACEME
 -->
 
-* Type: {bigint}
+* Type: {number}
 
-A `BigInt` representing the number of client `QuicSession` instances that
-have been associated with this `QuicSocket`.
+The number of client `QuicSession` instances that have been associated
+with this `QuicSocket`.
+
+Read-only.
 
 #### quicsocket.close(\[callback\])
 <!-- YAML
@@ -1690,9 +1701,11 @@ Will be `true` if the `QuicSocket` has been destroyed.
 added: REPLACEME
 -->
 
-* Type: {bigint}
+* Type: {number}
 
-A `BigInt` representing the length of time this `QuicSocket` has been active,
+The length of time this `QuicSocket` has been active,
+
+Read-only.
 
 #### quicsocket.endpoints
 <!-- YAML
@@ -1828,10 +1841,11 @@ If a `callback` is given, it is registered as a handler for the
 added: REPLACEME
 -->
 
-* Type: {bigint}
+* Type: {number}
 
-A `BigInt` representing the length of time this `QuicSocket` has been listening
-for connections.
+The length of time this `QuicSocket` has been listening for connections.
+
+Read-only
 
 #### quicsocket.listening
 <!-- YAML
@@ -1847,29 +1861,33 @@ Set to `true` if the `QuicSocket` is listening for new connections.
 added: REPLACEME
 -->
 
-* Type: {bigint}
+* Type: {number}
 
-A `BigInt` representing the number of packets received by this `QuicSocket` that
-have been ignored.
+The number of packets received by this `QuicSocket` that have been ignored.
+
+Read-only.
 
 #### quicsocket.packetsReceived
 <!-- YAML
 added: REPLACEME
 -->
 
-* Type: {bigint}
+* Type: {number}
 
-A `BigInt` representing the number of packets successfully received by this
-`QuicSocket`.
+The number of packets successfully received by this `QuicSocket`.
+
+Read-only
 
 #### quicsocket.packetsSent
 <!-- YAML
 added: REPLACEME
 -->
 
-* Type: {bigint}
+* Type: {number}
 
-A `BigInt` representing the number of packets sent by this `QuicSocket`.
+The number of packets sent by this `QuicSocket`.
+
+Read-only
 
 #### quicsocket.pending
 <!-- YAML
@@ -1902,20 +1920,23 @@ error code. To begin receiving connections again, disable busy mode by setting
 added: REPLACEME
 -->
 
-* Type: {bigint}
+* Type: {number}
 
-A `BigInt` representing the number of `QuicSession` instances rejected
-due to server busy status.
+The number of `QuicSession` instances rejected due to server busy status.
+
+Read-only.
 
 #### quicsocket.serverSessions
 <!-- YAML
 added: REPLACEME
 -->
 
-* Type: {bigint}
+* Type: {number}
 
-A `BigInt` representing the number of server `QuicSession` instances that
-have been associated with this `QuicSocket`.
+The number of server `QuicSession` instances that have been associated with
+this `QuicSocket`.
+
+Read-only.
 
 #### quicsocket.setDiagnosticPacketLoss(options)
 <!-- YAML
@@ -1939,9 +1960,11 @@ This method is *not* to be used in production applications.
 added: REPLACEME
 -->
 
-* Type: {bigint}
+* Type: {number}
 
-A `BigInt` that represents the number of stateless resets that have been sent.
+The number of stateless resets that have been sent.
+
+Read-only.
 
 #### quicsocket.toggleStatelessReset()
 <!-- YAML

--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -1371,6 +1371,17 @@ Emitted before the `'close'` event if the `QuicSocket` was destroyed with an
 
 The `'error'` event will not be emitted multiple times.
 
+#### Event: `'listening'`
+<!-- YAML
+added: REPLACEME
+-->
+
+Emitted after `quicsocket.listen()` is called and the `QuicSocket` has started
+listening for incoming `QuicServerSession`s.  The callback is invoked with
+no arguments.
+
+The `'listening'` event will not be emitted multiple times.
+
 #### Event: `'ready'`
 <!-- YAML
 added: REPLACEME

--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -1330,8 +1330,8 @@ added: REPLACEME
 -->
 
 Emitted when the server busy state has been toggled using
-`quicSocket.setServerBusy()`. The callback is invoked with a single
-boolean argument indicating `true` if busy status is enabled,
+`quicSocket.serverBusy = true | false`. The callback is invoked with a
+single boolean argument indicating `true` if busy status is enabled,
 `false` otherwise. This event is strictly informational.
 
 ```js
@@ -1346,8 +1346,8 @@ socket.on('busy', (busy) => {
     console.log('Server is not busy');
 });
 
-socket.setServerBusy(true);
-socket.setServerBusy(false);
+socket.serverBusy = true;
+socket.serverBusy = false;
 ```
 
 This `'busy'` event may be emitted multiple times.
@@ -1874,6 +1874,18 @@ Set to `true` if the socket is not yet bound to the local UDP port.
 added: REPLACEME
 -->
 
+#### quicsocket.serverBusy
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {boolean} When `true`, the `QuicSocket` will reject new connections.
+
+Setting `quicsocket.serverBusy` to `true` will tell the `QuicSocket`
+to reject all new incoming connection requests using the `SERVER_BUSY` QUIC
+error code. To begin receiving connections again, disable busy mode by setting
+`quicsocket.serverBusy = false`.
+
 #### quicsocket.serverBusyCount
 <!-- YAML
 added: REPLACEME
@@ -1910,19 +1922,6 @@ that can be used to *simulate* packet loss conditions for this `QuicSocket`
 by artificially dropping received or transmitted packets.
 
 This method is *not* to be used in production applications.
-
-#### quicsocket.setServerBusy(\[on\])
-<!-- YAML
-added: REPLACEME
--->
-
-* `on` {boolean} When `true`, the `QuicSocket` will reject new connections.
-  **Defaults**: `true`.
-
-Calling `setServerBusy()` or `setServerBusy(true)` will tell the `QuicSocket`
-to reject all new incoming connection requests using the `SERVER_BUSY` QUIC
-error code. To begin receiving connections again, disable busy mode by calling
-`setServerBusy(false)`.
 
 #### quicsocket.statelessResetCount
 <!-- YAML

--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -1327,17 +1327,17 @@ added: REPLACEME
 -->
 
 Emitted when the server busy state has been toggled using
-`quicSocket.serverBusy = true | false`. The callback is invoked with a
-single boolean argument indicating `true` if busy status is enabled,
-`false` otherwise. This event is strictly informational.
+`quicSocket.serverBusy = true | false`. The callback is invoked with no
+arguments. Use the `quicsocket.serverBusy` property to determine the
+current status. This event is strictly informational.
 
 ```js
 const { createQuicSocket } = require('net');
 
 const socket = createQuicSocket();
 
-socket.on('busy', (busy) => {
-  if (busy)
+socket.on('busy', () => {
+  if (socket.serverBusy)
     console.log('Server is busy');
   else
     console.log('Server is not busy');

--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -14,6 +14,7 @@ const {
   BigInt64Array,
   Error,
   Map,
+  Number,
   RegExp,
   Set,
   Symbol,
@@ -1527,58 +1528,58 @@ class QuicSocket extends EventEmitter {
   get duration() {
     // TODO(@jasnell): If the object is destroyed, it should
     // use a fixed duration rather than calculating from now
-    return process.hrtime.bigint() -
-      getStats(this, IDX_QUIC_SOCKET_STATS_CREATED_AT);
+    return Number(process.hrtime.bigint() -
+      getStats(this, IDX_QUIC_SOCKET_STATS_CREATED_AT));
   }
 
   get boundDuration() {
     // TODO(@jasnell): If the object is destroyed, it should
     // use a fixed duration rather than calculating from now
-    return process.hrtime.bigint() -
-      getStats(this, IDX_QUIC_SOCKET_STATS_BOUND_AT);
+    return Number(process.hrtime.bigint() -
+      getStats(this, IDX_QUIC_SOCKET_STATS_BOUND_AT));
   }
 
   get listenDuration() {
     // TODO(@jasnell): If the object is destroyed, it should
     // use a fixed duration rather than calculating from now
-    return process.hrtime.bigint() -
-      getStats(this, IDX_QUIC_SOCKET_STATS_LISTEN_AT);
+    return Number(process.hrtime.bigint() -
+      getStats(this, IDX_QUIC_SOCKET_STATS_LISTEN_AT));
   }
 
   get bytesReceived() {
-    return getStats(this, IDX_QUIC_SOCKET_STATS_BYTES_RECEIVED);
+    return Number(getStats(this, IDX_QUIC_SOCKET_STATS_BYTES_RECEIVED));
   }
 
   get bytesSent() {
-    return getStats(this, IDX_QUIC_SOCKET_STATS_BYTES_SENT);
+    return Number(getStats(this, IDX_QUIC_SOCKET_STATS_BYTES_SENT));
   }
 
   get packetsReceived() {
-    return getStats(this, IDX_QUIC_SOCKET_STATS_PACKETS_RECEIVED);
+    return Number(getStats(this, IDX_QUIC_SOCKET_STATS_PACKETS_RECEIVED));
   }
 
   get packetsSent() {
-    return getStats(this, IDX_QUIC_SOCKET_STATS_PACKETS_SENT);
+    return Number(getStats(this, IDX_QUIC_SOCKET_STATS_PACKETS_SENT));
   }
 
   get packetsIgnored() {
-    return getStats(this, IDX_QUIC_SOCKET_STATS_PACKETS_IGNORED);
+    return Number(getStats(this, IDX_QUIC_SOCKET_STATS_PACKETS_IGNORED));
   }
 
   get serverSessions() {
-    return getStats(this, IDX_QUIC_SOCKET_STATS_SERVER_SESSIONS);
+    return Number(getStats(this, IDX_QUIC_SOCKET_STATS_SERVER_SESSIONS));
   }
 
   get clientSessions() {
-    return getStats(this, IDX_QUIC_SOCKET_STATS_CLIENT_SESSIONS);
+    return Number(getStats(this, IDX_QUIC_SOCKET_STATS_CLIENT_SESSIONS));
   }
 
   get statelessResetCount() {
-    return getStats(this, IDX_QUIC_SOCKET_STATS_STATELESS_RESET_COUNT);
+    return Number(getStats(this, IDX_QUIC_SOCKET_STATS_STATELESS_RESET_COUNT));
   }
 
   get serverBusyCount() {
-    return getStats(this, IDX_QUIC_SOCKET_STATS_SERVER_BUSY_COUNT);
+    return Number(getStats(this, IDX_QUIC_SOCKET_STATS_SERVER_BUSY_COUNT));
   }
 
   // Diagnostic packet loss is a testing mechanism that allows simulating

--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -246,6 +246,8 @@ const kUsePreferredAddress = Symbol('kUsePreferredAddress');
 const kVersionNegotiation = Symbol('kVersionNegotiation');
 const kWriteGeneric = Symbol('kWriteGeneric');
 
+const kRejections = Symbol.for('nodejs.rejection');
+
 const kSocketUnbound = 0;
 const kSocketPending = 1;
 const kSocketBound = 2;
@@ -278,7 +280,11 @@ function onSessionReady(handle) {
       socket,
       handle,
       socket[kGetStreamOptions]());
-  process.nextTick(emit.bind(socket, 'session', session));
+  try {
+    socket.emit('session', session);
+  } catch (error) {
+    socket[kRejections](error, 'session', session);
+  }
 }
 
 // Called when the C++ QuicSession::Close() method has been called.
@@ -935,6 +941,21 @@ class QuicSocket extends EventEmitter {
       ...endpoint,
       preferred: true
     });
+  }
+
+  [kRejections](err, eventname, ...args) {
+    switch (eventname) {
+      case 'session':
+        const session = args[0];
+        session.destroy(err);
+        process.nextTick(() => {
+          this.emit('sessionError', err, session);
+        });
+        return;
+      default:
+        // Fall through
+    }
+    this.destroy(err);
   }
 
   // Returns the default QuicStream options for peer-initiated

--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -44,7 +44,6 @@ const {
   QuicSessionSharedState,
   QLogStream,
 } = require('internal/quic/util');
-const util = require('util');
 const assert = require('internal/assert');
 const EventEmitter = require('events');
 const fs = require('fs');
@@ -2713,23 +2712,17 @@ class QuicStream extends Duplex {
     // TODO(@jasnell): Implement this
   }
 
-  [kInspect]() {
+  [kInspect](depth, options) {
     // TODO(@jasnell): Proper custom inspect implementation
     const direction = this.bidirectional ? 'bidirectional' : 'unidirectional';
     const initiated = this.serverInitiated ? 'server' : 'client';
-    const obj = {
+    return customInspect(this, {
       id: this[kInternalState].id,
       direction,
       initiated,
       writableState: this._writableState,
-      readableState: this._readableState,
-      stats: {
-        dataRate: this.dataRateHistogram,
-        dataSize: this.dataSizeHistogram,
-        dataAck: this.dataAckHistogram,
-      }
-    };
-    return `QuicStream ${util.format(obj)}`;
+      readableState: this._readableState
+    }, depth, options);
   }
 
   [kTrackWriteState](stream, bytes) {

--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -857,6 +857,7 @@ class QuicSocket extends EventEmitter {
     serverSecureContext: undefined,
     sessions: new Set(),
     state: kSocketUnbound,
+    statelessResetEnabled: true,
     stats: undefined,
   };
 
@@ -1613,16 +1614,19 @@ class QuicSocket extends EventEmitter {
     this[kHandle].setDiagnosticPacketLoss(rx, tx);
   }
 
-  // Toggles stateless reset on/off. By default, stateless reset tokens
-  // are generated when necessary. The disableStatelessReset option may
-  // be used when the QuicSocket is created to disable generation of
-  // stateless resets. The toggleStatelessReset method allows the setting
-  // to be switched on/off dynamically through the lifetime of the
-  // socket.
-  toggleStatelessReset() {
-    if (this[kInternalState].state === kSocketDestroyed)
-      throw new ERR_QUICSOCKET_DESTROYED('toggleStatelessReset');
-    return this[kHandle].toggleStatelessReset();
+  get statelessResetEnabled() {
+    return this[kInternalState].statelessResetEnabled;
+  }
+
+  set statelessResetEnabled(on) {
+    const state = this[kInternalState];
+    if (state.state === kSocketDestroyed)
+      throw new ERR_QUICSOCKET_DESTROYED('serverBusy');
+    validateBoolean(on, 'on');
+    if (state.statelessResetEnabled !== on) {
+      this[kHandle].enableStatelessReset(on);
+      state.statelessResetEnabled = on;
+    }
   }
 }
 

--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -1777,10 +1777,9 @@ class QuicSession extends EventEmitter {
     stream[kStreamReset](code);
   }
 
-  [kInspect]() {
-    // TODO(@jasnell): A proper custom inspect implementation
+  [kInspect](depth, options) {
     const state = this[kInternalState];
-    const obj = {
+    return customInspect(this, {
       alpn: state.alpn,
       cipher: this.cipher,
       closing: this.closing,
@@ -1790,12 +1789,7 @@ class QuicSession extends EventEmitter {
       maxStreams: this.maxStreams,
       servername: this.servername,
       streams: state.streams.size,
-      stats: {
-        handshakeAck: this.handshakeAckHistogram,
-        handshakeContinuation: this.handshakeContinuationHistogram,
-      }
-    };
-    return `${this.constructor.name} ${util.format(obj)}`;
+    }, depth, options);
   }
 
   [kSetSocket](socket) {

--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -1166,7 +1166,13 @@ class QuicSocket extends EventEmitter {
       port,
       state.alpn,
       options);
-    process.nextTick(emit.bind(this, 'listening'));
+    process.nextTick(() => {
+      try {
+        this.emit('listening');
+      } catch (error) {
+        this.destroy(error);
+      }
+    });
   }
 
   // When the QuicSocket listen() function is called, the first step is to bind

--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -267,7 +267,7 @@ function onSocketClose(err) {
 // Called by the C++ internals when the server busy state of
 // the QuicSocket has been changed.
 function onSocketServerBusy(on) {
-  this[owner_symbol][kServerBusy](!!on);
+  this[owner_symbol][kServerBusy](on);
 }
 
 // Called by the C++ internals when a new server QuicSession has been created.

--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -977,14 +977,18 @@ class QuicSocket extends EventEmitter {
     }
   }
 
-  [kInspect]() {
-    // TODO(@jasnell): Proper custom inspect implementation
-    const state = this[kInternalState];
-    const obj = {
+  [kInspect](depth, options) {
+    return customInspect(this, {
       endpoints: this.endpoints,
-      sessions: state.sessions,
-    };
-    return `QuicSocket ${util.format(obj)}`;
+      sessions: this.sessions,
+      bound: this.bound,
+      pending: this.pending,
+      closing: this.closing,
+      destroyed: this.destroyed,
+      listening: this.listening,
+      serverBusy: this.serverBusy,
+      statelessResetDisabled: this.statelessResetDisabled,
+    }, depth, options);
   }
 
   [kAddSession](session) {

--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -851,7 +851,7 @@ class QuicSocket extends EventEmitter {
     highWaterMark: undefined,
     lookup: undefined,
     server: undefined,
-    serverBusy: undefined,
+    serverBusy: false,
     serverListening: false,
     serverSecureContext: undefined,
     sessions: new Set(),
@@ -1075,7 +1075,16 @@ class QuicSocket extends EventEmitter {
   // Called by the C++ internals to notify when server busy status is toggled.
   [kServerBusy](on) {
     this[kInternalState].serverBusy = on;
-    process.nextTick(emit.bind(this, 'busy', on));
+    // In a nextTick because the event ends up being
+    // emitted synchronously when quicSocket.serverBusy
+    // is called.
+    process.nextTick(() => {
+      try {
+        this.emit('busy', on);
+      } catch (error) {
+        this[kRejections](error, 'busy', on);
+      }
+    });
   }
 
   addEndpoint(options = {}) {
@@ -1490,10 +1499,10 @@ class QuicSocket extends EventEmitter {
 
   // Marking a server as busy will cause all new
   // connection attempts to fail with a SERVER_BUSY CONNECTION_CLOSE.
-  setServerBusy(on = true) {
+  set serverBusy(on) {
     const state = this[kInternalState];
     if (state.state === kSocketDestroyed)
-      throw new ERR_QUICSOCKET_DESTROYED('setServerBusy');
+      throw new ERR_QUICSOCKET_DESTROYED('serverBusy');
     validateBoolean(on, 'on');
     if (state.serverBusy !== on)
       this[kHandle].setServerBusy(on);

--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -12,6 +12,7 @@ assertCrypto();
 const {
   Array,
   BigInt64Array,
+  Boolean,
   Error,
   Map,
   Number,
@@ -38,6 +39,7 @@ const {
   validateQuicEndpointOptions,
   validateCreateSecureContextOptions,
   validateQuicSocketConnectOptions,
+  QuicSocketSharedState,
   QuicSessionSharedState,
   QLogStream,
 } = require('internal/quic/util');
@@ -269,8 +271,8 @@ function onSocketClose(err) {
 
 // Called by the C++ internals when the server busy state of
 // the QuicSocket has been changed.
-function onSocketServerBusy(on) {
-  this[owner_symbol][kServerBusy](on);
+function onSocketServerBusy() {
+  this[owner_symbol][kServerBusy]();
 }
 
 // Called by the C++ internals when a new server QuicSession has been created.
@@ -845,30 +847,23 @@ class QuicEndpoint {
 class QuicSocket extends EventEmitter {
   [kInternalState] = {
     alpn: undefined,
-    autoClose: undefined,
     client: undefined,
     defaultEncoding: undefined,
     endpoints: new Set(),
     highWaterMark: undefined,
+    listenPending: false,
     lookup: undefined,
     server: undefined,
-    serverBusy: false,
-    serverListening: false,
     serverSecureContext: undefined,
     sessions: new Set(),
     state: kSocketUnbound,
-    statelessResetEnabled: true,
+    sharedState: undefined,
     stats: undefined,
   };
 
   constructor(options) {
     const {
       endpoint,
-
-      // True if the QuicSocket should automatically enter a graceful shutdown
-      // if it is not listening as a server and the last QuicClientSession
-      // closes
-      autoClose,
 
       // Default configuration for QuicClientSessions
       client,
@@ -913,7 +908,6 @@ class QuicSocket extends EventEmitter {
 
     const state = this[kInternalState];
 
-    state.autoClose = autoClose;
     state.client = client;
     state.lookup = lookup || (type === AF_INET6 ? lookup6 : lookup4);
     state.server = server;
@@ -976,6 +970,10 @@ class QuicSocket extends EventEmitter {
     if (handle !== undefined) {
       handle[owner_symbol] = this;
       this[async_id_symbol] = handle.getAsyncId();
+      this[kInternalState].sharedState =
+        new QuicSocketSharedState(handle.state);
+    } else {
+      this[kInternalState].sharedState = undefined;
     }
   }
 
@@ -1081,16 +1079,13 @@ class QuicSocket extends EventEmitter {
   }
 
   // Called by the C++ internals to notify when server busy status is toggled.
-  [kServerBusy](on) {
-    this[kInternalState].serverBusy = on;
-    // In a nextTick because the event ends up being
-    // emitted synchronously when quicSocket.serverBusy
-    // is called.
+  [kServerBusy]() {
+    const busy = this.serverBusy;
     process.nextTick(() => {
       try {
-        this.emit('busy', on);
+        this.emit('busy', busy);
       } catch (error) {
-        this[kRejections](error, 'busy', on);
+        this[kRejections](error, 'busy', busy);
       }
     });
   }
@@ -1161,6 +1156,7 @@ class QuicSocket extends EventEmitter {
     // server and will emit session events whenever a new QuicServerSession
     // is created.
     const state = this[kInternalState];
+    state.listenPending = false;
     this[kHandle].listen(
       state.serverSecureContext.context,
       address,
@@ -1225,14 +1221,12 @@ class QuicSocket extends EventEmitter {
   // function.
   listen(options, callback) {
     const state = this[kInternalState];
-    if (state.serverListening)
-      throw new ERR_QUICSOCKET_LISTENING();
-
     if (state.state === kSocketDestroyed ||
         state.state === kSocketClosing) {
       throw new ERR_QUICSOCKET_DESTROYED('listen');
     }
-
+    if (this.listening || state.listenPending)
+      throw new ERR_QUICSOCKET_LISTENING();
     if (typeof options === 'function') {
       callback = options;
       options = {};
@@ -1265,8 +1259,8 @@ class QuicSocket extends EventEmitter {
 
     state.highWaterMark = highWaterMark;
     state.defaultEncoding = defaultEncoding;
-    state.serverListening = true;
     state.alpn = alpn;
+    state.listenPending = true;
 
     // If the callback function is provided, it is registered as a
     // handler for the on('session') event and will be called whenever
@@ -1403,10 +1397,8 @@ class QuicSocket extends EventEmitter {
     // listening for new QuicServerSession connections.
     // New initial connection packets for currently unknown
     // DCID's will be ignored.
-    if (this[kHandle]) {
-      this[kHandle].stopListening();
-    }
-    state.serverListening = false;
+    if (this[kHandle])
+      this[kInternalState].sharedState.serverListening = false;
 
     // If there are no sessions, calling maybeDestroy
     // will immediately and synchronously destroy the
@@ -1502,7 +1494,7 @@ class QuicSocket extends EventEmitter {
 
   // True if listen() has been called successfully
   get listening() {
-    return this[kInternalState].serverListening;
+    return Boolean(this[kInternalState].sharedState?.serverListening);
   }
 
   // True if the QuicSocket is currently waiting on at least one
@@ -1518,12 +1510,27 @@ class QuicSocket extends EventEmitter {
     if (state.state === kSocketDestroyed)
       throw new ERR_QUICSOCKET_DESTROYED('serverBusy');
     validateBoolean(on, 'on');
-    if (state.serverBusy !== on)
-      this[kHandle].setServerBusy(on);
+    if (state.sharedState.serverBusy !== on) {
+      state.sharedState.serverBusy = on;
+      this[kServerBusy]();
+    }
   }
 
   get serverBusy() {
-    return this[kInternalState].serverBusy;
+    return Boolean(this[kInternalState].sharedState?.serverBusy);
+  }
+
+  set statelessResetDisabled(on) {
+    const state = this[kInternalState];
+    if (state.state === kSocketDestroyed)
+      throw new ERR_QUICSOCKET_DESTROYED('statelessResetDisabled');
+    validateBoolean(on, 'on');
+    if (state.sharedState.statelessResetDisabled !== on)
+      state.sharedState.statelessResetDisabled = on;
+  }
+
+  get statelessResetDisabled() {
+    return Boolean(this[kInternalState].sharedState?.statelessResetDisabled);
   }
 
   get duration() {
@@ -1612,21 +1619,6 @@ class QuicSocket extends EventEmitter {
         'network packet loss.');
     }
     this[kHandle].setDiagnosticPacketLoss(rx, tx);
-  }
-
-  get statelessResetEnabled() {
-    return this[kInternalState].statelessResetEnabled;
-  }
-
-  set statelessResetEnabled(on) {
-    const state = this[kInternalState];
-    if (state.state === kSocketDestroyed)
-      throw new ERR_QUICSOCKET_DESTROYED('serverBusy');
-    validateBoolean(on, 'on');
-    if (state.statelessResetEnabled !== on) {
-      this[kHandle].enableStatelessReset(on);
-      state.statelessResetEnabled = on;
-    }
   }
 }
 

--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -1031,7 +1031,13 @@ class QuicSocket extends EventEmitter {
     // used to either listen or connect. No QuicServerSession should
     // exist before this event, and all QuicClientSession will remain
     // in Initial states until ready is invoked.
-    process.nextTick(emit.bind(this, 'ready'));
+    process.nextTick(() => {
+      try {
+        this.emit('ready');
+      } catch (error) {
+        this.destroy(error);
+      }
+    });
   }
 
   // Called when a QuicEndpoint closes

--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -24,6 +24,7 @@ const {
 const { Buffer } = require('buffer');
 const { isArrayBufferView } = require('internal/util/types');
 const {
+  customInspect,
   getAllowUnauthorized,
   getSocketType,
   lookup4,
@@ -638,14 +639,12 @@ class QuicEndpoint {
     socket[kHandle].addEndpoint(handle, preferred);
   }
 
-  [kInspect]() {
-    // TODO(@jasnell): Proper custom inspect implementation
-    const obj = {
+  [kInspect](depth, options) {
+    return customInspect(this, {
       address: this.address,
-      fd: this[kInternalState].fd,
+      fd: this.fd,
       type: this[kInternalState].type === AF_INET6 ? 'udp6' : 'udp4'
-    };
-    return `QuicEndpoint ${util.format(obj)}`;
+    }, depth, options);
   }
 
   // afterLookup is invoked when binding a QuicEndpoint. The first
@@ -741,7 +740,8 @@ class QuicEndpoint {
   }
 
   get fd() {
-    return this[kInternalState].fd;
+    return this[kInternalState].fd >= 0 ?
+      this[kInternalState].fd : undefined;
   }
 
   // True if the QuicEndpoint has been destroyed and is

--- a/lib/internal/quic/util.js
+++ b/lib/internal/quic/util.js
@@ -82,6 +82,10 @@ const {
     IDX_QUICSESSION_STATE_MAX_DATA_LEFT,
     IDX_QUICSESSION_STATE_BYTES_IN_FLIGHT,
 
+    IDX_QUICSOCKET_STATE_SERVER_LISTENING,
+    IDX_QUICSOCKET_STATE_SERVER_BUSY,
+    IDX_QUICSOCKET_STATE_STATELESS_RESET_DISABLED,
+
     IDX_HTTP3_QPACK_MAX_TABLE_CAPACITY,
     IDX_HTTP3_QPACK_BLOCKED_STREAMS,
     IDX_HTTP3_MAX_HEADER_LIST_SIZE,
@@ -514,7 +518,6 @@ function validateQuicSocketOptions(options = {}) {
   validateObject(options, 'options');
 
   const {
-    autoClose = false,
     client = {},
     disableStatelessReset = false,
     endpoint = { port: 0, type: 'udp4' },
@@ -538,7 +541,6 @@ function validateQuicSocketOptions(options = {}) {
   validateLookup(lookup);
   validateBoolean(validateAddress, 'options.validateAddress');
   validateBoolean(validateAddressLRU, 'options.validateAddressLRU');
-  validateBoolean(autoClose, 'options.autoClose');
   validateBoolean(qlog, 'options.qlog');
   validateBoolean(disableStatelessReset, 'options.disableStatelessReset');
 
@@ -576,7 +578,6 @@ function validateQuicSocketOptions(options = {}) {
 
   return {
     endpoint,
-    autoClose,
     client,
     lookup,
     maxConnections,
@@ -803,6 +804,39 @@ function toggleListeners(state, event, on) {
   }
 }
 
+class QuicSocketSharedState {
+  constructor(state) {
+    this[kHandle] = Buffer.from(state);
+  }
+
+  get serverListening() {
+    return Boolean(this[kHandle]
+      .readUInt8(IDX_QUICSOCKET_STATE_SERVER_LISTENING));
+  }
+
+  set serverListening(on) {
+    this[kHandle].writeUInt8(on ? 1 : 0, IDX_QUICSOCKET_STATE_SERVER_LISTENING);
+  }
+
+  get serverBusy() {
+    return Boolean(this[kHandle].readUInt8(IDX_QUICSOCKET_STATE_SERVER_BUSY));
+  }
+
+  set serverBusy(on) {
+    this[kHandle].writeUInt8(on ? 1 : 0, IDX_QUICSOCKET_STATE_SERVER_BUSY);
+  }
+
+  get statelessResetDisabled() {
+    return Boolean(this[kHandle]
+      .readUInt8(IDX_QUICSOCKET_STATE_STATELESS_RESET_DISABLED));
+  }
+
+  set statelessResetDisabled(on) {
+    this[kHandle].writeUInt8(on ? 1 : 0,
+                             IDX_QUICSOCKET_STATE_STATELESS_RESET_DISABLED);
+  }
+}
+
 // A utility class used to handle reading / modifying shared JS/C++
 // state associated with a QuicSession
 class QuicSessionSharedState {
@@ -938,6 +972,7 @@ module.exports = {
   validateQuicEndpointOptions,
   validateCreateSecureContextOptions,
   validateQuicSocketConnectOptions,
+  QuicSocketSharedState,
   QuicSessionSharedState,
   QLogStream,
 };

--- a/lib/internal/quic/util.js
+++ b/lib/internal/quic/util.js
@@ -23,6 +23,8 @@ const {
   },
 } = require('internal/async_hooks');
 
+const { inspect } = require('internal/util/inspect');
+
 const { Readable } = require('stream');
 const {
   kHandle,
@@ -955,7 +957,20 @@ class QLogStream extends Readable {
   }
 }
 
+function customInspect(self, obj, depth, options) {
+  if (depth < 0)
+    return self;
+
+  const opts = {
+    ...options,
+    depth: options.depth == null ? null : options.depth - 1
+  };
+
+  return `${self.constructor.name} ${inspect(obj, opts)}`;
+}
+
 module.exports = {
+  customInspect,
   getAllowUnauthorized,
   getSocketType,
   lookup4,

--- a/src/quic/node_quic.cc
+++ b/src/quic/node_quic.cc
@@ -205,6 +205,11 @@ void Initialize(Local<Object> target,
   QUICSESSION_SHARED_STATE(V)
 #undef V
 
+#define V(id, _, __)                                                           \
+  NODE_DEFINE_CONSTANT(constants, IDX_QUICSOCKET_STATE_##id);
+  QUICSOCKET_SHARED_STATE(V)
+#undef V
+
 #define V(name, _, __)                                                         \
   NODE_DEFINE_CONSTANT(constants, IDX_QUIC_SESSION_STATS_##name);
   SESSION_STATS(V)

--- a/src/quic/node_quic_session.cc
+++ b/src/quic/node_quic_session.cc
@@ -1453,6 +1453,9 @@ QuicSession::QuicSession(
       state_.GetArrayBuffer(),
       PropertyAttribute::ReadOnly).Check();
 
+  idle_.Unref();
+  retransmit_.Unref();
+
   // TODO(@jasnell): memory accounting
   // env_->isolate()->AdjustAmountOfExternalAllocatedMemory(kExternalSize);
 }

--- a/src/quic/node_quic_session.cc
+++ b/src/quic/node_quic_session.cc
@@ -1682,11 +1682,6 @@ void QuicSession::Close(int close_flags) {
     listener()->OnSessionClose(error, close_flags);
   else
     Destroy();
-
-  // At this point, the QuicSession should have been destroyed, indicating
-  // that all cleanup on the JavaScript side has completed and the
-  // QuicSession::Destroy() method has been called.
-  CHECK(is_destroyed());
 }
 
 // Mark the QuicSession instance destroyed. This will either be invoked

--- a/src/quic/node_quic_socket-inl.h
+++ b/src/quic/node_quic_socket-inl.h
@@ -173,8 +173,8 @@ void QuicSocket::set_diagnostic_packet_loss(double rx, double tx) {
   tx_loss_ = tx;
 }
 
-bool QuicSocket::ToggleStatelessReset() {
-  set_stateless_reset_disabled(!is_stateless_reset_disabled());
+bool QuicSocket::EnableStatelessReset(bool on) {
+  set_stateless_reset_disabled(!on);
   return !is_stateless_reset_disabled();
 }
 

--- a/src/quic/node_quic_socket.cc
+++ b/src/quic/node_quic_socket.cc
@@ -1128,10 +1128,11 @@ void QuicSocketSetServerBusy(const FunctionCallbackInfo<Value>& args) {
   socket->ServerBusy(args[0]->IsTrue());
 }
 
-void QuicSocketToggleStatelessReset(const FunctionCallbackInfo<Value>& args) {
+void QuicSocketEnableStatelessReset(const FunctionCallbackInfo<Value>& args) {
   QuicSocket* socket;
   ASSIGN_OR_RETURN_UNWRAP(&socket, args.Holder());
-  args.GetReturnValue().Set(socket->ToggleStatelessReset());
+  CHECK_EQ(args.Length(), 1);
+  args.GetReturnValue().Set(socket->EnableStatelessReset(args[0]->IsTrue()));
 }
 
 void QuicEndpointWaitForPendingCallbacks(
@@ -1197,8 +1198,8 @@ void QuicSocket::Initialize(
                       "stopListening",
                       QuicSocketStopListening);
   env->SetProtoMethod(socket,
-                      "toggleStatelessReset",
-                      QuicSocketToggleStatelessReset);
+                      "enableStatelessReset",
+                      QuicSocketEnableStatelessReset);
   socket->Inherit(HandleWrap::GetConstructorTemplate(env));
   target->Set(context, class_name,
               socket->GetFunction(env->context()).ToLocalChecked()).FromJust();

--- a/src/quic/node_quic_socket.h
+++ b/src/quic/node_quic_socket.h
@@ -384,7 +384,7 @@ class QuicSocket : public AsyncWrap,
   // Toggles whether or not stateless reset is enabled or not.
   // Returns true if stateless reset is enabled, false if it
   // is not.
-  inline bool ToggleStatelessReset();
+  inline bool EnableStatelessReset(bool on = true);
 
   BaseObjectPtr<crypto::SecureContext> server_secure_context() const {
     return server_secure_context_;

--- a/test/parallel/test-quic-client-server.js
+++ b/test/parallel/test-quic-client-server.js
@@ -58,6 +58,7 @@ server.listen({
   rejectUnauthorized: false,
   alpn: kALPN,
 });
+
 server.on('session', common.mustCall((session) => {
   debug('QuicServerSession Created');
 

--- a/test/parallel/test-quic-errors-quicsocket-create.js
+++ b/test/parallel/test-quic-errors-quicsocket-create.js
@@ -82,13 +82,6 @@ const { createQuicSocket } = require('net');
   });
 });
 
-// Test invalid QuicSocket autoClose argument option
-[1, NaN, 1n, null, {}, []].forEach((autoClose) => {
-  assert.throws(() => createQuicSocket({ autoClose }), {
-    code: 'ERR_INVALID_ARG_TYPE'
-  });
-});
-
 // Test invalid QuicSocket qlog argument option
 [1, NaN, 1n, null, {}, []].forEach((qlog) => {
   assert.throws(() => createQuicSocket({ qlog }), {

--- a/test/parallel/test-quic-maxconnectionsperhost.js
+++ b/test/parallel/test-quic-maxconnectionsperhost.js
@@ -56,7 +56,7 @@ const kALPN = 'zzz';
   server.on('session', common.mustCall(() => {}, kMaxConnectionsPerHost));
 
   server.on('close', common.mustCall(() => {
-    assert.strictEqual(server.serverBusyCount, 1n);
+    assert.strictEqual(server.serverBusyCount, 1);
   }));
 
   server.on('ready', common.mustCall(() => {

--- a/test/parallel/test-quic-quicsocket-serverbusy.js
+++ b/test/parallel/test-quic-quicsocket-serverbusy.js
@@ -32,7 +32,7 @@ server.on('busy', common.mustCall((busy) => {
 
 // When the server is set as busy, all connections
 // will be rejected with a SERVER_BUSY response.
-server.setServerBusy();
+server.serverBusy = true;
 server.listen();
 
 server.on('close', common.mustCall());

--- a/test/parallel/test-quic-quicsocket.js
+++ b/test/parallel/test-quic-quicsocket.js
@@ -31,16 +31,16 @@ assert(!socket.pending);
 // Socket is not destroyed
 assert(!socket.destroyed);
 
-assert.strictEqual(typeof socket.duration, 'bigint');
-assert.strictEqual(typeof socket.boundDuration, 'bigint');
-assert.strictEqual(typeof socket.listenDuration, 'bigint');
-assert.strictEqual(typeof socket.bytesReceived, 'bigint');
-assert.strictEqual(socket.bytesReceived, 0n);
-assert.strictEqual(socket.bytesSent, 0n);
-assert.strictEqual(socket.packetsReceived, 0n);
-assert.strictEqual(socket.packetsSent, 0n);
-assert.strictEqual(socket.serverSessions, 0n);
-assert.strictEqual(socket.clientSessions, 0n);
+assert.strictEqual(typeof socket.duration, 'number');
+assert.strictEqual(typeof socket.boundDuration, 'number');
+assert.strictEqual(typeof socket.listenDuration, 'number');
+assert.strictEqual(typeof socket.bytesReceived, 'number');
+assert.strictEqual(socket.bytesReceived, 0);
+assert.strictEqual(socket.bytesSent, 0);
+assert.strictEqual(socket.packetsReceived, 0);
+assert.strictEqual(socket.packetsSent, 0);
+assert.strictEqual(socket.serverSessions, 0);
+assert.strictEqual(socket.clientSessions, 0);
 
 const endpoint = socket.endpoints[0];
 assert(endpoint);
@@ -83,8 +83,8 @@ assert(endpoint);
   });
 });
 
-[1, 1n, [], {}, null].forEach((args) => {
-  assert.throws(() => socket.setServerBusy(args), {
+[1, 1n, [], {}, null].forEach((arg) => {
+  assert.throws(() => socket.serverBusy = arg, {
     code: 'ERR_INVALID_ARG_TYPE'
   });
 });
@@ -143,12 +143,7 @@ socket.on('close', common.mustCall(() => {
     });
   });
 
-  [
-    'setServerBusy',
-  ].forEach((op) => {
-    assert.throws(() => socket[op](), {
-      code: 'ERR_QUICSOCKET_DESTROYED',
-      message: `Cannot call ${op} after a QuicSocket has been destroyed`
-    });
+  assert.throws(() => { socket.serverBusy = true; }, {
+    code: 'ERR_QUICSOCKET_DESTROYED'
   });
 }));

--- a/test/parallel/test-quic-server-busy-event-error-async.js
+++ b/test/parallel/test-quic-server-busy-event-error-async.js
@@ -1,0 +1,32 @@
+// Flags: --no-warnings
+'use strict';
+
+const common = require('../common');
+if (!common.hasQuic)
+  common.skip('missing quic');
+
+const assert = require('assert');
+const {
+  key,
+  cert,
+  ca,
+} = require('../common/quic');
+
+const { createQuicSocket } = require('net');
+
+const options = { key, cert, ca, alpn: 'zzz' };
+
+const server = createQuicSocket({ server: options });
+
+server.on('busy', common.mustCall(async () => {
+  throw new Error('boom');
+}));
+
+server.on('close', common.mustCall());
+
+server.on('error', common.mustCall((err) => {
+  assert.strictEqual(err.message, 'boom');
+}));
+
+assert.strictEqual(server.serverBusy, false);
+server.serverBusy = true;

--- a/test/parallel/test-quic-server-busy-event-error.js
+++ b/test/parallel/test-quic-server-busy-event-error.js
@@ -1,0 +1,32 @@
+// Flags: --no-warnings
+'use strict';
+
+const common = require('../common');
+if (!common.hasQuic)
+  common.skip('missing quic');
+
+const assert = require('assert');
+const {
+  key,
+  cert,
+  ca,
+} = require('../common/quic');
+
+const { createQuicSocket } = require('net');
+
+const options = { key, cert, ca, alpn: 'zzz' };
+
+const server = createQuicSocket({ server: options });
+
+server.on('busy', common.mustCall(() => {
+  throw new Error('boom');
+}));
+
+server.on('close', common.mustCall());
+
+server.on('error', common.mustCall((err) => {
+  assert.strictEqual(err.message, 'boom');
+}));
+
+assert.strictEqual(server.serverBusy, false);
+server.serverBusy = true;

--- a/test/parallel/test-quic-server-listening-event-error-async.js
+++ b/test/parallel/test-quic-server-listening-event-error-async.js
@@ -1,0 +1,33 @@
+// Flags: --no-warnings
+'use strict';
+
+const common = require('../common');
+if (!common.hasQuic)
+  common.skip('missing quic');
+
+const assert = require('assert');
+const {
+  key,
+  cert,
+  ca,
+} = require('../common/quic');
+
+const { createQuicSocket } = require('net');
+
+const options = { key, cert, ca, alpn: 'zzz' };
+
+const server = createQuicSocket({ server: options });
+
+server.on('session', common.mustNotCall());
+
+server.listen();
+
+server.on('error', common.mustCall((error) => {
+  assert.strictEqual(error.message, 'boom');
+}));
+
+server.on('ready', common.mustCall());
+
+server.on('listening', common.mustCall(async () => {
+  throw new Error('boom');
+}));

--- a/test/parallel/test-quic-server-listening-event-error.js
+++ b/test/parallel/test-quic-server-listening-event-error.js
@@ -1,0 +1,33 @@
+// Flags: --no-warnings
+'use strict';
+
+const common = require('../common');
+if (!common.hasQuic)
+  common.skip('missing quic');
+
+const assert = require('assert');
+const {
+  key,
+  cert,
+  ca,
+} = require('../common/quic');
+
+const { createQuicSocket } = require('net');
+
+const options = { key, cert, ca, alpn: 'zzz' };
+
+const server = createQuicSocket({ server: options });
+
+server.on('session', common.mustNotCall());
+
+server.listen();
+
+server.on('error', common.mustCall((error) => {
+  assert.strictEqual(error.message, 'boom');
+}));
+
+server.on('ready', common.mustCall());
+
+server.on('listening', common.mustCall(() => {
+  throw new Error('boom');
+}));

--- a/test/parallel/test-quic-server-ready-event-error-async.js
+++ b/test/parallel/test-quic-server-ready-event-error-async.js
@@ -1,0 +1,31 @@
+// Flags: --no-warnings
+'use strict';
+
+const common = require('../common');
+if (!common.hasQuic)
+  common.skip('missing quic');
+
+const assert = require('assert');
+const {
+  key,
+  cert,
+  ca,
+} = require('../common/quic');
+
+const { createQuicSocket } = require('net');
+
+const options = { key, cert, ca, alpn: 'zzz' };
+
+const server = createQuicSocket({ server: options });
+
+server.on('session', common.mustNotCall());
+
+server.listen();
+
+server.on('error', common.mustCall((error) => {
+  assert.strictEqual(error.message, 'boom');
+}));
+
+server.on('ready', common.mustCall(async () => {
+  throw new Error('boom');
+}));

--- a/test/parallel/test-quic-server-ready-event-error.js
+++ b/test/parallel/test-quic-server-ready-event-error.js
@@ -1,0 +1,31 @@
+// Flags: --no-warnings
+'use strict';
+
+const common = require('../common');
+if (!common.hasQuic)
+  common.skip('missing quic');
+
+const assert = require('assert');
+const {
+  key,
+  cert,
+  ca,
+} = require('../common/quic');
+
+const { createQuicSocket } = require('net');
+
+const options = { key, cert, ca, alpn: 'zzz' };
+
+const server = createQuicSocket({ server: options });
+
+server.on('session', common.mustNotCall());
+
+server.listen();
+
+server.on('error', common.mustCall((error) => {
+  assert.strictEqual(error.message, 'boom');
+}));
+
+server.on('ready', common.mustCall(() => {
+  throw new Error('boom');
+}));

--- a/test/parallel/test-quic-server-session-event-error-async.js
+++ b/test/parallel/test-quic-server-session-event-error-async.js
@@ -1,0 +1,58 @@
+// Flags: --expose-internals --no-warnings
+'use strict';
+
+const common = require('../common');
+if (!common.hasQuic)
+  common.skip('missing quic');
+
+const { internalBinding } = require('internal/test/binding');
+const {
+  constants: {
+    NGTCP2_CONNECTION_REFUSED
+  }
+} = internalBinding('quic');
+
+const assert = require('assert');
+const {
+  key,
+  cert,
+  ca,
+} = require('../common/quic');
+
+const { createQuicSocket } = require('net');
+
+const options = { key, cert, ca, alpn: 'zzz' };
+
+const server = createQuicSocket({ server: options });
+
+server.on('session', common.mustCall(async (session) => {
+  session.on('close', common.mustCall());
+  session.on('error', common.mustCall((err) => {
+    assert.strictEqual(err.message, 'boom');
+  }));
+  // Throwing inside the session event handler should cause
+  // the session to be destroyed immediately. This should
+  // cause the client side to be closed also.
+  throw new Error('boom');
+}));
+
+server.on('sessionError', common.mustCall((err, session) => {
+  assert.strictEqual(err.message, 'boom');
+  assert(session.destroyed);
+}));
+
+server.listen();
+
+server.once('listening', common.mustCall(() => {
+  const client = createQuicSocket({ client: options });
+  const req = client.connect({
+    address: 'localhost',
+    port: server.endpoints[0].address.port
+  });
+  req.on('close', common.mustCall(() => {
+    assert.strictEqual(req.closeCode.code, NGTCP2_CONNECTION_REFUSED);
+    assert.strictEqual(req.closeCode.silent, true);
+    server.close();
+    client.close();
+  }));
+}));

--- a/test/parallel/test-quic-server-session-event-error.js
+++ b/test/parallel/test-quic-server-session-event-error.js
@@ -1,0 +1,58 @@
+// Flags: --expose-internals --no-warnings
+'use strict';
+
+const common = require('../common');
+if (!common.hasQuic)
+  common.skip('missing quic');
+
+const { internalBinding } = require('internal/test/binding');
+const {
+  constants: {
+    NGTCP2_CONNECTION_REFUSED
+  }
+} = internalBinding('quic');
+
+const assert = require('assert');
+const {
+  key,
+  cert,
+  ca,
+} = require('../common/quic');
+
+const { createQuicSocket } = require('net');
+
+const options = { key, cert, ca, alpn: 'zzz' };
+
+const server = createQuicSocket({ server: options });
+
+server.on('session', common.mustCall((session) => {
+  session.on('close', common.mustCall());
+  session.on('error', common.mustCall((err) => {
+    assert.strictEqual(err.message, 'boom');
+  }));
+  // Throwing inside the session event handler should cause
+  // the session to be destroyed immediately. This should
+  // cause the client side to be closed also.
+  throw new Error('boom');
+}));
+
+server.on('sessionError', common.mustCall((err, session) => {
+  assert.strictEqual(err.message, 'boom');
+  assert(session.destroyed);
+}));
+
+server.listen();
+
+server.once('listening', common.mustCall(() => {
+  const client = createQuicSocket({ client: options });
+  const req = client.connect({
+    address: 'localhost',
+    port: server.endpoints[0].address.port
+  });
+  req.on('close', common.mustCall(() => {
+    assert.strictEqual(req.closeCode.code, NGTCP2_CONNECTION_REFUSED);
+    assert.strictEqual(req.closeCode.silent, true);
+    server.close();
+    client.close();
+  }));
+}));

--- a/test/parallel/test-quic-socket-close-event-error-async.js
+++ b/test/parallel/test-quic-socket-close-event-error-async.js
@@ -1,0 +1,31 @@
+// Flags: --no-warnings
+'use strict';
+
+const common = require('../common');
+if (!common.hasQuic)
+  common.skip('missing quic');
+
+const assert = require('assert');
+const {
+  key,
+  cert,
+  ca,
+} = require('../common/quic');
+
+const { createQuicSocket } = require('net');
+
+const options = { key, cert, ca, alpn: 'zzz' };
+
+const server = createQuicSocket({ server: options });
+
+server.on('error', common.mustNotCall());
+
+server.on('close', common.mustCall(async () => {
+  throw new Error('boom');
+}));
+
+process.on('uncaughtException', (error) => {
+  assert.strictEqual(error.message, 'boom');
+});
+
+server.destroy();

--- a/test/parallel/test-quic-socket-close-event-error.js
+++ b/test/parallel/test-quic-socket-close-event-error.js
@@ -1,0 +1,31 @@
+// Flags: --no-warnings
+'use strict';
+
+const common = require('../common');
+if (!common.hasQuic)
+  common.skip('missing quic');
+
+const assert = require('assert');
+const {
+  key,
+  cert,
+  ca,
+} = require('../common/quic');
+
+const { createQuicSocket } = require('net');
+
+const options = { key, cert, ca, alpn: 'zzz' };
+
+const server = createQuicSocket({ server: options });
+
+server.on('error', common.mustNotCall());
+
+server.on('close', common.mustCall(() => {
+  throw new Error('boom');
+}));
+
+process.on('uncaughtException', (error) => {
+  assert.strictEqual(error.message, 'boom');
+});
+
+server.destroy();


### PR DESCRIPTION
This is a WIP, more will be added:

Commits:

* quic: additional minor cleanups in node_quic_session.h

  Minor miscellaneous cleanups

* quic: remove unnecessary bool conversion

  Self-explanatory

* quic: handle errors thrown / rejections in the session event
* quic: refactor/improve error handling for busy event
* quic: add tests confirming error handling for QuicSocket close event
* quic: refactor/improve QuicSocket ready event handling
* quic: refactor/improve QuicSocket ready event handling

  Starting to improve/refactor/verify error handling on events

* quic: use Number() instead of bigint for QuicSocket stats

* quic: unref timers again

  Fix a bug

* quic: use getter/setting for stateless reset toggle

  Improve API ergonomics

* quic: cleanup QuicSocketFlags, used shared state struct

  Use AliasedStruct for QuicSocket shared state, cleanup no longer used state flags

* quic: proper custom inspect for QuicEndpoint/QuicSocket/QuicSession/QuicStream

  Self explanatory

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
