### PR TITLE
src,doc,test: remove String::New default parameter

### DIFF
--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -65,7 +65,6 @@ namespace demo {
 using v8::FunctionCallbackInfo;
 using v8::Isolate;
 using v8::Local;
-using v8::NewStringType;
 using v8::Object;
 using v8::String;
 using v8::Value;
@@ -73,7 +72,7 @@ using v8::Value;
 void Method(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
   args.GetReturnValue().Set(String::NewFromUtf8(
-      isolate, "world", NewStringType::kNormal).ToLocalChecked());
+      isolate, "world").ToLocalChecked());
 }
 
 void Initialize(Local<Object> exports) {
@@ -226,8 +225,7 @@ NODE_MODULE_INIT(/* exports, module, context */) {
   // per-addon-instance data we created above by passing `external` as the
   // third parameter to the `FunctionTemplate` constructor.
   exports->Set(context,
-               String::NewFromUtf8(isolate, "method", NewStringType::kNormal)
-                  .ToLocalChecked(),
+               String::NewFromUtf8(isolate, "method").ToLocalChecked(),
                FunctionTemplate::New(isolate, Method, external)
                   ->GetFunction(context).ToLocalChecked()).FromJust();
 }
@@ -538,7 +536,6 @@ using v8::Exception;
 using v8::FunctionCallbackInfo;
 using v8::Isolate;
 using v8::Local;
-using v8::NewStringType;
 using v8::Number;
 using v8::Object;
 using v8::String;
@@ -555,8 +552,7 @@ void Add(const FunctionCallbackInfo<Value>& args) {
     // Throw an Error that is passed back to JavaScript
     isolate->ThrowException(Exception::TypeError(
         String::NewFromUtf8(isolate,
-                            "Wrong number of arguments",
-                            NewStringType::kNormal).ToLocalChecked()));
+                            "Wrong number of arguments").ToLocalChecked()));
     return;
   }
 
@@ -564,8 +560,7 @@ void Add(const FunctionCallbackInfo<Value>& args) {
   if (!args[0]->IsNumber() || !args[1]->IsNumber()) {
     isolate->ThrowException(Exception::TypeError(
         String::NewFromUtf8(isolate,
-                            "Wrong arguments",
-                            NewStringType::kNormal).ToLocalChecked()));
+                            "Wrong arguments").ToLocalChecked()));
     return;
   }
 
@@ -614,7 +609,6 @@ using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::Isolate;
 using v8::Local;
-using v8::NewStringType;
 using v8::Null;
 using v8::Object;
 using v8::String;
@@ -627,8 +621,7 @@ void RunCallback(const FunctionCallbackInfo<Value>& args) {
   const unsigned argc = 1;
   Local<Value> argv[argc] = {
       String::NewFromUtf8(isolate,
-                          "hello world",
-                          NewStringType::kNormal).ToLocalChecked() };
+                          "hello world").ToLocalChecked() };
   cb->Call(context, Null(isolate), argc, argv).ToLocalChecked();
 }
 
@@ -676,7 +669,6 @@ using v8::Context;
 using v8::FunctionCallbackInfo;
 using v8::Isolate;
 using v8::Local;
-using v8::NewStringType;
 using v8::Object;
 using v8::String;
 using v8::Value;
@@ -688,8 +680,7 @@ void CreateObject(const FunctionCallbackInfo<Value>& args) {
   Local<Object> obj = Object::New(isolate);
   obj->Set(context,
            String::NewFromUtf8(isolate,
-                               "msg",
-                               NewStringType::kNormal).ToLocalChecked(),
+                               "msg").ToLocalChecked(),
                                args[0]->ToString(context).ToLocalChecked())
            .FromJust();
 
@@ -734,7 +725,6 @@ using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
 using v8::Isolate;
 using v8::Local;
-using v8::NewStringType;
 using v8::Object;
 using v8::String;
 using v8::Value;
@@ -742,7 +732,7 @@ using v8::Value;
 void MyFunction(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
   args.GetReturnValue().Set(String::NewFromUtf8(
-      isolate, "hello world", NewStringType::kNormal).ToLocalChecked());
+      isolate, "hello world").ToLocalChecked());
 }
 
 void CreateFunction(const FunctionCallbackInfo<Value>& args) {
@@ -754,7 +744,7 @@ void CreateFunction(const FunctionCallbackInfo<Value>& args) {
 
   // omit this to make it anonymous
   fn->SetName(String::NewFromUtf8(
-      isolate, "theFunction", NewStringType::kNormal).ToLocalChecked());
+      isolate, "theFunction").ToLocalChecked());
 
   args.GetReturnValue().Set(fn);
 }
@@ -850,7 +840,6 @@ using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
 using v8::Isolate;
 using v8::Local;
-using v8::NewStringType;
 using v8::Number;
 using v8::Object;
 using v8::ObjectTemplate;
@@ -874,8 +863,7 @@ void MyObject::Init(Local<Object> exports) {
 
   // Prepare constructor template
   Local<FunctionTemplate> tpl = FunctionTemplate::New(isolate, New, addon_data);
-  tpl->SetClassName(String::NewFromUtf8(
-      isolate, "MyObject", NewStringType::kNormal).ToLocalChecked());
+  tpl->SetClassName(String::NewFromUtf8(isolate, "MyObject").ToLocalChecked());
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
   // Prototype
@@ -884,8 +872,8 @@ void MyObject::Init(Local<Object> exports) {
   Local<Function> constructor = tpl->GetFunction(context).ToLocalChecked();
   addon_data->SetInternalField(0, constructor);
   exports->Set(context, String::NewFromUtf8(
-      isolate, "MyObject", NewStringType::kNormal).ToLocalChecked(),
-               constructor).FromJust();
+      isolate, "MyObject").ToLocalChecked(),
+      constructor).FromJust();
 }
 
 void MyObject::New(const FunctionCallbackInfo<Value>& args) {
@@ -1055,7 +1043,6 @@ using v8::FunctionTemplate;
 using v8::Global;
 using v8::Isolate;
 using v8::Local;
-using v8::NewStringType;
 using v8::Number;
 using v8::Object;
 using v8::String;
@@ -1074,8 +1061,7 @@ MyObject::~MyObject() {
 void MyObject::Init(Isolate* isolate) {
   // Prepare constructor template
   Local<FunctionTemplate> tpl = FunctionTemplate::New(isolate, New);
-  tpl->SetClassName(String::NewFromUtf8(
-      isolate, "MyObject", NewStringType::kNormal).ToLocalChecked());
+  tpl->SetClassName(String::NewFromUtf8(isolate, "MyObject").ToLocalChecked());
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
   // Prototype
@@ -1279,7 +1265,6 @@ using v8::FunctionTemplate;
 using v8::Global;
 using v8::Isolate;
 using v8::Local;
-using v8::NewStringType;
 using v8::Object;
 using v8::String;
 using v8::Value;
@@ -1297,8 +1282,7 @@ MyObject::~MyObject() {
 void MyObject::Init(Isolate* isolate) {
   // Prepare constructor template
   Local<FunctionTemplate> tpl = FunctionTemplate::New(isolate, New);
-  tpl->SetClassName(String::NewFromUtf8(
-      isolate, "MyObject", NewStringType::kNormal).ToLocalChecked());
+  tpl->SetClassName(String::NewFromUtf8(isolate, "MyObject").ToLocalChecked());
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
   Local<Context> context = isolate->GetCurrentContext();

--- a/src/README.md
+++ b/src/README.md
@@ -146,9 +146,7 @@ v8::Local<v8::Value> GetFoo(v8::Local<v8::Context> context,
   // The 'foo_string' handle cannot be returned from this function because
   // it is not “escaped” with `.Escape()`.
   v8::Local<v8::String> foo_string =
-      v8::String::NewFromUtf8(isolate,
-                              "foo",
-                              v8::NewStringType::kNormal).ToLocalChecked();
+      v8::String::NewFromUtf8(isolate, "foo").ToLocalChecked();
 
   v8::Local<v8::Value> return_value;
   if (obj->Get(context, foo_string).ToLocal(&return_value)) {

--- a/src/api/callback.cc
+++ b/src/api/callback.cc
@@ -13,7 +13,6 @@ using v8::Isolate;
 using v8::Local;
 using v8::MaybeLocal;
 using v8::MicrotasksScope;
-using v8::NewStringType;
 using v8::Object;
 using v8::String;
 using v8::Value;
@@ -209,8 +208,7 @@ MaybeLocal<Value> MakeCallback(Isolate* isolate,
                                Local<Value> argv[],
                                async_context asyncContext) {
   Local<String> method_string =
-      String::NewFromUtf8(isolate, method, NewStringType::kNormal)
-          .ToLocalChecked();
+      String::NewFromUtf8(isolate, method).ToLocalChecked();
   return MakeCallback(isolate, recv, method_string, argc, argv, asyncContext);
 }
 

--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -443,8 +443,7 @@ MaybeLocal<Value> LoadEnvironment(
         // This is a slightly hacky way to convert UTF-8 to UTF-16.
         Local<String> str =
             String::NewFromUtf8(env->isolate(),
-                                main_script_source_utf8,
-                                v8::NewStringType::kNormal).ToLocalChecked();
+                                main_script_source_utf8).ToLocalChecked();
         auto main_utf16 = std::make_unique<String::Value>(env->isolate(), str);
 
         // TODO(addaleax): Avoid having a global table for all scripts.

--- a/src/api/exceptions.cc
+++ b/src/api/exceptions.cc
@@ -15,7 +15,6 @@ using v8::Exception;
 using v8::Integer;
 using v8::Isolate;
 using v8::Local;
-using v8::NewStringType;
 using v8::Object;
 using v8::String;
 using v8::Value;
@@ -42,8 +41,7 @@ Local<Value> ErrnoException(Isolate* isolate,
   Local<String> path_string;
   if (path != nullptr) {
     // FIXME(bnoordhuis) It's questionable to interpret the file path as UTF-8.
-    path_string = String::NewFromUtf8(isolate, path, NewStringType::kNormal)
-                      .ToLocalChecked();
+    path_string = String::NewFromUtf8(isolate, path).ToLocalChecked();
   }
 
   if (path_string.IsEmpty() == false) {
@@ -78,16 +76,13 @@ static Local<String> StringFromPath(Isolate* isolate, const char* path) {
     return String::Concat(
         isolate,
         FIXED_ONE_BYTE_STRING(isolate, "\\\\"),
-        String::NewFromUtf8(isolate, path + 8, NewStringType::kNormal)
-            .ToLocalChecked());
+        String::NewFromUtf8(isolate, path + 8).ToLocalChecked());
   } else if (strncmp(path, "\\\\?\\", 4) == 0) {
-    return String::NewFromUtf8(isolate, path + 4, NewStringType::kNormal)
-        .ToLocalChecked();
+    return String::NewFromUtf8(isolate, path + 4).ToLocalChecked();
   }
 #endif
 
-  return String::NewFromUtf8(isolate, path, NewStringType::kNormal)
-      .ToLocalChecked();
+  return String::NewFromUtf8(isolate, path).ToLocalChecked();
 }
 
 
@@ -206,8 +201,7 @@ Local<Value> WinapiErrnoException(Isolate* isolate,
     Local<String> cons2 = String::Concat(
         isolate,
         cons1,
-        String::NewFromUtf8(isolate, path, NewStringType::kNormal)
-            .ToLocalChecked());
+        String::NewFromUtf8(isolate, path).ToLocalChecked());
     Local<String> cons3 =
         String::Concat(isolate, cons2, FIXED_ONE_BYTE_STRING(isolate, "'"));
     e = Exception::Error(cons3);
@@ -222,8 +216,7 @@ Local<Value> WinapiErrnoException(Isolate* isolate,
   if (path != nullptr) {
     obj->Set(env->context(),
              env->path_string(),
-             String::NewFromUtf8(isolate, path, NewStringType::kNormal)
-                 .ToLocalChecked())
+             String::NewFromUtf8(isolate, path).ToLocalChecked())
         .Check();
   }
 

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -66,7 +66,6 @@ using v8::Int32;
 using v8::Integer;
 using v8::Isolate;
 using v8::Local;
-using v8::NewStringType;
 using v8::Null;
 using v8::Object;
 using v8::String;
@@ -1937,8 +1936,8 @@ void CanonicalizeIP(const FunctionCallbackInfo<Value>& args) {
   char canonical_ip[INET6_ADDRSTRLEN];
   const int af = (rc == 4 ? AF_INET : AF_INET6);
   CHECK_EQ(0, uv_inet_ntop(af, &result, canonical_ip, sizeof(canonical_ip)));
-  Local<String> val = String::NewFromUtf8(isolate, canonical_ip,
-      NewStringType::kNormal).ToLocalChecked();
+  Local<String> val = String::NewFromUtf8(isolate, canonical_ip)
+      .ToLocalChecked();
   args.GetReturnValue().Set(val);
 }
 

--- a/src/heap_utils.cc
+++ b/src/heap_utils.cc
@@ -118,8 +118,7 @@ class JSGraph : public EmbedderGraph {
           name_str += " ";
           name_str += n->Name();
         }
-        if (!String::NewFromUtf8(
-                 isolate_, name_str.c_str(), v8::NewStringType::kNormal)
+        if (!String::NewFromUtf8(isolate_, name_str.c_str())
                  .ToLocal(&value) ||
             obj->Set(context, name_string, value).IsNothing() ||
             obj->Set(context,
@@ -168,9 +167,8 @@ class JSGraph : public EmbedderGraph {
         Local<Value> edge_name_value;
         const char* edge_name = edge.first;
         if (edge_name != nullptr) {
-          if (!String::NewFromUtf8(
-                  isolate_, edge_name, v8::NewStringType::kNormal)
-                  .ToLocal(&edge_name_value)) {
+          if (!String::NewFromUtf8(isolate_, edge_name)
+              .ToLocal(&edge_name_value)) {
             return MaybeLocal<Array>();
           }
         } else {
@@ -377,8 +375,7 @@ void TriggerHeapSnapshot(const FunctionCallbackInfo<Value>& args) {
     DiagnosticFilename name(env, "Heap", "heapsnapshot");
     if (!WriteSnapshot(isolate, *name))
       return;
-    if (String::NewFromUtf8(isolate, *name, v8::NewStringType::kNormal)
-            .ToLocal(&filename_v)) {
+    if (String::NewFromUtf8(isolate, *name).ToLocal(&filename_v)) {
       args.GetReturnValue().Set(filename_v);
     }
     return;

--- a/src/node_credentials.cc
+++ b/src/node_credentials.cc
@@ -20,7 +20,6 @@ using v8::HandleScope;
 using v8::Isolate;
 using v8::Local;
 using v8::MaybeLocal;
-using v8::NewStringType;
 using v8::Object;
 using v8::String;
 using v8::TryCatch;
@@ -46,8 +45,7 @@ bool SafeGetenv(const char* key, std::string* text, Environment* env) {
     TryCatch ignore_errors(env->isolate());
     MaybeLocal<String> maybe_value = env->env_vars()->Get(
         env->isolate(),
-        String::NewFromUtf8(env->isolate(), key, NewStringType::kNormal)
-            .ToLocalChecked());
+        String::NewFromUtf8(env->isolate(), key).ToLocalChecked());
     Local<String> value;
     if (!maybe_value.ToLocal(&value)) goto fail;
     String::Utf8Value utf8_value(env->isolate(), value);

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -392,8 +392,7 @@ void ThrowCryptoError(Environment* env,
   }
   HandleScope scope(env->isolate());
   Local<String> exception_string =
-      String::NewFromUtf8(env->isolate(), message, NewStringType::kNormal)
-      .ToLocalChecked();
+      String::NewFromUtf8(env->isolate(), message).ToLocalChecked();
   CryptoErrorVector errors;
   errors.Capture();
   Local<Value> exception;
@@ -1017,8 +1016,8 @@ void GetRootCertificates(const FunctionCallbackInfo<Value>& args) {
   for (size_t i = 0; i < arraysize(root_certs); i++) {
     if (!String::NewFromOneByte(
             env->isolate(),
-            reinterpret_cast<const uint8_t*>(root_certs[i]),
-            NewStringType::kNormal).ToLocal(&result[i])) {
+            reinterpret_cast<const uint8_t*>(root_certs[i]))
+            .ToLocal(&result[i])) {
       return;
     }
   }

--- a/src/node_env_var.cc
+++ b/src/node_env_var.cc
@@ -179,8 +179,7 @@ Local<Array> RealEnvStore::Enumerate(Isolate* isolate) const {
     // https://github.com/libuv/libuv/pull/2473 and can be removed later.
     if (items[i].name[0] == '=' || items[i].name[0] == '\0') continue;
 #endif
-    MaybeLocal<String> str = String::NewFromUtf8(
-        isolate, items[i].name, NewStringType::kNormal);
+    MaybeLocal<String> str = String::NewFromUtf8(isolate, items[i].name);
     if (str.IsEmpty()) {
       isolate->ThrowException(ERR_STRING_TOO_LONG(isolate));
       return Local<Array>();

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -338,8 +338,7 @@ void ICUErrorName(const FunctionCallbackInfo<Value>& args) {
   UErrorCode status = static_cast<UErrorCode>(args[0].As<Int32>()->Value());
   args.GetReturnValue().Set(
       String::NewFromUtf8(env->isolate(),
-                          u_errorName(status),
-                          NewStringType::kNormal).ToLocalChecked());
+                          u_errorName(status)).ToLocalChecked());
 }
 
 }  // anonymous namespace

--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -71,8 +71,7 @@ static void GetHostname(const FunctionCallbackInfo<Value>& args) {
   }
 
   args.GetReturnValue().Set(
-      String::NewFromUtf8(env->isolate(), buf, NewStringType::kNormal)
-          .ToLocalChecked());
+      String::NewFromUtf8(env->isolate(), buf).ToLocalChecked());
 }
 
 static void GetOSInformation(const FunctionCallbackInfo<Value>& args) {
@@ -192,8 +191,7 @@ static void GetInterfaceAddresses(const FunctionCallbackInfo<Value>& args) {
     // to assume UTF8 as the default as well. It’s what people will expect if
     // they name the interface from any input that uses UTF-8, which should be
     // the most frequent case by far these days.)
-    name = String::NewFromUtf8(isolate, raw_name,
-        NewStringType::kNormal).ToLocalChecked();
+    name = String::NewFromUtf8(isolate, raw_name).ToLocalChecked();
 
     snprintf(mac.data(),
              mac.size(),

--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -24,7 +24,6 @@ using v8::Isolate;
 using v8::Local;
 using v8::Map;
 using v8::MaybeLocal;
-using v8::NewStringType;
 using v8::Number;
 using v8::Object;
 using v8::PropertyAttribute;
@@ -60,16 +59,14 @@ inline void InitObject(const PerformanceEntry& entry, Local<Object> obj) {
   obj->DefineOwnProperty(context,
                          env->name_string(),
                          String::NewFromUtf8(isolate,
-                                             entry.name().c_str(),
-                                             NewStringType::kNormal)
+                                             entry.name().c_str())
                              .ToLocalChecked(),
                          attr)
       .Check();
   obj->DefineOwnProperty(context,
                          env->entry_type_string(),
                          String::NewFromUtf8(isolate,
-                                             entry.type().c_str(),
-                                             NewStringType::kNormal)
+                                             entry.type().c_str())
                              .ToLocalChecked(),
                          attr)
       .Check();

--- a/src/node_process_events.cc
+++ b/src/node_process_events.cc
@@ -14,7 +14,6 @@ using v8::Just;
 using v8::Local;
 using v8::Maybe;
 using v8::MaybeLocal;
-using v8::NewStringType;
 using v8::Nothing;
 using v8::Object;
 using v8::String;
@@ -58,21 +57,18 @@ Maybe<bool> ProcessEmitWarningGeneric(Environment* env,
 
   // The caller has to be able to handle a failure anyway, so we might as well
   // do proper error checking for string creation.
-  if (!String::NewFromUtf8(env->isolate(), warning, NewStringType::kNormal)
-           .ToLocal(&args[argc++])) {
+  if (!String::NewFromUtf8(env->isolate(), warning).ToLocal(&args[argc++]))
     return Nothing<bool>();
-  }
+
   if (type != nullptr) {
     if (!String::NewFromOneByte(env->isolate(),
-                                reinterpret_cast<const uint8_t*>(type),
-                                NewStringType::kNormal)
+                                reinterpret_cast<const uint8_t*>(type))
              .ToLocal(&args[argc++])) {
       return Nothing<bool>();
     }
     if (code != nullptr &&
         !String::NewFromOneByte(env->isolate(),
-                                reinterpret_cast<const uint8_t*>(code),
-                                NewStringType::kNormal)
+                                reinterpret_cast<const uint8_t*>(code))
              .ToLocal(&args[argc++])) {
       return Nothing<bool>();
     }

--- a/src/node_report_module.cc
+++ b/src/node_report_module.cc
@@ -49,8 +49,7 @@ void WriteReport(const FunctionCallbackInfo<Value>& info) {
       isolate, env, *message, *trigger, filename, error);
   // Return value is the report filename
   info.GetReturnValue().Set(
-      String::NewFromUtf8(isolate, filename.c_str(), v8::NewStringType::kNormal)
-          .ToLocalChecked());
+      String::NewFromUtf8(isolate, filename.c_str()).ToLocalChecked());
 }
 
 // External JavaScript API for returning a report
@@ -71,10 +70,8 @@ void GetReport(const FunctionCallbackInfo<Value>& info) {
       isolate, env, "JavaScript API", __func__, error, out);
 
   // Return value is the contents of a report as a string.
-  info.GetReturnValue().Set(String::NewFromUtf8(isolate,
-                                                out.str().c_str(),
-                                                v8::NewStringType::kNormal)
-                                .ToLocalChecked());
+  info.GetReturnValue().Set(
+      String::NewFromUtf8(isolate, out.str().c_str()).ToLocalChecked());
 }
 
 static void GetCompact(const FunctionCallbackInfo<Value>& info) {
@@ -94,9 +91,7 @@ static void GetDirectory(const FunctionCallbackInfo<Value>& info) {
   node::Mutex::ScopedLock lock(node::per_process::cli_options_mutex);
   Environment* env = Environment::GetCurrent(info);
   std::string directory = node::per_process::cli_options->report_directory;
-  auto result = String::NewFromUtf8(env->isolate(),
-                                    directory.c_str(),
-                                    v8::NewStringType::kNormal);
+  auto result = String::NewFromUtf8(env->isolate(), directory.c_str());
   info.GetReturnValue().Set(result.ToLocalChecked());
 }
 
@@ -112,9 +107,7 @@ static void GetFilename(const FunctionCallbackInfo<Value>& info) {
   node::Mutex::ScopedLock lock(node::per_process::cli_options_mutex);
   Environment* env = Environment::GetCurrent(info);
   std::string filename = node::per_process::cli_options->report_filename;
-  auto result = String::NewFromUtf8(env->isolate(),
-                                    filename.c_str(),
-                                    v8::NewStringType::kNormal);
+  auto result = String::NewFromUtf8(env->isolate(), filename.c_str());
   info.GetReturnValue().Set(result.ToLocalChecked());
 }
 
@@ -129,9 +122,7 @@ static void SetFilename(const FunctionCallbackInfo<Value>& info) {
 static void GetSignal(const FunctionCallbackInfo<Value>& info) {
   Environment* env = Environment::GetCurrent(info);
   std::string signal = env->isolate_data()->options()->report_signal;
-  auto result = String::NewFromUtf8(env->isolate(),
-                                    signal.c_str(),
-                                    v8::NewStringType::kNormal);
+  auto result = String::NewFromUtf8(env->isolate(), signal.c_str());
   info.GetReturnValue().Set(result.ToLocalChecked());
 }
 

--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -2175,9 +2175,7 @@ void Parse(Environment* env,
     Local<Value> argv[2] = { undef, undef };
     argv[ERR_ARG_FLAGS] = Integer::NewFromUnsigned(isolate, url.flags);
     argv[ERR_ARG_INPUT] =
-      String::NewFromUtf8(env->isolate(),
-                          input,
-                          NewStringType::kNormal).ToLocalChecked();
+      String::NewFromUtf8(env->isolate(), input).ToLocalChecked();
     error_cb.As<Function>()->Call(context, recv, arraysize(argv), argv)
         .FromMaybe(Local<Value>());
   }
@@ -2225,9 +2223,7 @@ void EncodeAuthSet(const FunctionCallbackInfo<Value>& args) {
     AppendOrEscape(&output, ch, USERINFO_ENCODE_SET);
   }
   args.GetReturnValue().Set(
-      String::NewFromUtf8(env->isolate(),
-                          output.c_str(),
-                          NewStringType::kNormal).ToLocalChecked());
+      String::NewFromUtf8(env->isolate(), output.c_str()).ToLocalChecked());
 }
 
 void ToUSVString(const FunctionCallbackInfo<Value>& args) {
@@ -2279,9 +2275,7 @@ void DomainToASCII(const FunctionCallbackInfo<Value>& args) {
   }
   std::string out = host.ToStringMove();
   args.GetReturnValue().Set(
-      String::NewFromUtf8(env->isolate(),
-                          out.c_str(),
-                          NewStringType::kNormal).ToLocalChecked());
+      String::NewFromUtf8(env->isolate(), out.c_str()).ToLocalChecked());
 }
 
 void DomainToUnicode(const FunctionCallbackInfo<Value>& args) {
@@ -2299,9 +2293,7 @@ void DomainToUnicode(const FunctionCallbackInfo<Value>& args) {
   }
   std::string out = host.ToStringMove();
   args.GetReturnValue().Set(
-      String::NewFromUtf8(env->isolate(),
-                          out.c_str(),
-                          NewStringType::kNormal).ToLocalChecked());
+      String::NewFromUtf8(env->isolate(), out.c_str()).ToLocalChecked());
 }
 
 void SetURLConstructor(const FunctionCallbackInfo<Value>& args) {

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -37,7 +37,6 @@ using v8::HeapStatistics;
 using v8::Integer;
 using v8::Isolate;
 using v8::Local;
-using v8::NewStringType;
 using v8::Object;
 using v8::ScriptCompiler;
 using v8::String;
@@ -225,9 +224,7 @@ void Initialize(Local<Object> target,
   MaybeStackBuffer<Local<Value>, 16> heap_spaces(number_of_heap_spaces);
   for (size_t i = 0; i < number_of_heap_spaces; i++) {
     env->isolate()->GetHeapSpaceStatistics(&s, i);
-    heap_spaces[i] = String::NewFromUtf8(env->isolate(),
-                                         s.space_name(),
-                                         NewStringType::kNormal)
+    heap_spaces[i] = String::NewFromUtf8(env->isolate(), s.space_name())
                                              .ToLocalChecked();
   }
   target->Set(env->context(),

--- a/src/quic/node_quic_session.cc
+++ b/src/quic/node_quic_session.cc
@@ -386,16 +386,10 @@ void JSQuicSessionListener::OnClientHello(
   };
 
   if (alpn != nullptr) {
-    argv[0] = String::NewFromUtf8(
-        env->isolate(),
-        alpn,
-        v8::NewStringType::kNormal).ToLocalChecked();
+    argv[0] = String::NewFromUtf8(env->isolate(), alpn).ToLocalChecked();
   }
   if (server_name != nullptr) {
-    argv[1] = String::NewFromUtf8(
-        env->isolate(),
-        server_name,
-        v8::NewStringType::kNormal).ToLocalChecked();
+    argv[1] = String::NewFromUtf8(env->isolate(), server_name).ToLocalChecked();
   }
 
   // Grab a shared pointer to this to prevent the QuicSession
@@ -559,10 +553,7 @@ void JSQuicSessionListener::OnHandshakeCompleted() {
   const char* hostname = ctx->servername();
   if (hostname != nullptr) {
     servername =
-        String::NewFromUtf8(
-            env->isolate(),
-            hostname,
-            v8::NewStringType::kNormal).ToLocalChecked();
+        String::NewFromUtf8(env->isolate(), hostname).ToLocalChecked();
   }
 
   int err = ctx->VerifyPeerIdentity(

--- a/src/spawn_sync.cc
+++ b/src/spawn_sync.cc
@@ -695,8 +695,7 @@ Local<Object> SyncProcessRunner::BuildResultObject() {
   if (term_signal_ > 0)
     js_result->Set(context, env()->signal_string(),
                    String::NewFromUtf8(env()->isolate(),
-                                       signo_string(term_signal_),
-                                       v8::NewStringType::kNormal)
+                                       signo_string(term_signal_))
                        .ToLocalChecked())
         .Check();
   else

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -1143,7 +1143,7 @@ unsigned int TLSWrap::PskServerCallback(SSL* s,
   HandleScope scope(isolate);
 
   MaybeLocal<String> maybe_identity_str =
-      v8::String::NewFromUtf8(isolate, identity, v8::NewStringType::kNormal);
+      String::NewFromUtf8(isolate, identity);
 
   v8::Local<v8::String> identity_str;
   if (!maybe_identity_str.ToLocal(&identity_str)) return 0;

--- a/src/util.h
+++ b/src/util.h
@@ -686,11 +686,9 @@ inline v8::MaybeLocal<v8::Value> ToV8Value(v8::Local<v8::Context> context,
   do {                                                                         \
     v8::Isolate* isolate = target->GetIsolate();                               \
     v8::Local<v8::String> constant_name =                                      \
-        v8::String::NewFromUtf8(isolate, name, v8::NewStringType::kNormal)     \
-            .ToLocalChecked();                                                 \
+        v8::String::NewFromUtf8(isolate, name).ToLocalChecked();               \
     v8::Local<v8::String> constant_value =                                     \
-        v8::String::NewFromUtf8(isolate, constant, v8::NewStringType::kNormal) \
-            .ToLocalChecked();                                                 \
+        v8::String::NewFromUtf8(isolate, constant).ToLocalChecked();           \
     v8::PropertyAttribute constant_attributes =                                \
         static_cast<v8::PropertyAttribute>(v8::ReadOnly | v8::DontDelete);     \
     target                                                                     \

--- a/test/addons/async-hooks-promise/binding.cc
+++ b/test/addons/async-hooks-promise/binding.cc
@@ -15,8 +15,7 @@ using v8::Value;
 static void ThrowError(Isolate* isolate, const char* err_msg) {
   Local<String> str = String::NewFromOneByte(
       isolate,
-      reinterpret_cast<const uint8_t*>(err_msg),
-      NewStringType::kNormal).ToLocalChecked();
+      reinterpret_cast<const uint8_t*>(err_msg)).ToLocalChecked();
   isolate->ThrowException(str);
 }
 

--- a/test/addons/async-resource/binding.cc
+++ b/test/addons/async-resource/binding.cc
@@ -55,8 +55,7 @@ void CallViaFunction(const FunctionCallbackInfo<Value>& args) {
   auto r = static_cast<AsyncResource*>(args[0].As<External>()->Value());
 
   Local<String> name =
-      String::NewFromUtf8(isolate, "methöd", v8::NewStringType::kNormal)
-      .ToLocalChecked();
+      String::NewFromUtf8(isolate, "methöd").ToLocalChecked();
   Local<Value> fn =
       r->get_resource()->Get(isolate->GetCurrentContext(), name)
       .ToLocalChecked();
@@ -73,8 +72,7 @@ void CallViaString(const FunctionCallbackInfo<Value>& args) {
   auto r = static_cast<AsyncResource*>(args[0].As<External>()->Value());
 
   Local<String> name =
-      String::NewFromUtf8(isolate, "methöd", v8::NewStringType::kNormal)
-      .ToLocalChecked();
+      String::NewFromUtf8(isolate, "methöd").ToLocalChecked();
 
   Local<Value> arg = Integer::New(isolate, 42);
   MaybeLocal<Value> ret = r->MakeCallback(name, 1, &arg);

--- a/test/addons/dlopen-ping-pong/binding.cc
+++ b/test/addons/dlopen-ping-pong/binding.cc
@@ -38,7 +38,7 @@ void Ping(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
   assert(ping_func != nullptr);
   args.GetReturnValue().Set(String::NewFromUtf8(
-        isolate, ping_func(), NewStringType::kNormal).ToLocalChecked());
+        isolate, ping_func()).ToLocalChecked());
 }
 
 void init(Local<Object> exports) {

--- a/test/addons/heap-profiler/binding.cc
+++ b/test/addons/heap-profiler/binding.cc
@@ -20,7 +20,7 @@ inline void Initialize(v8::Local<v8::Object> binding) {
   v8::Isolate* const isolate = binding->GetIsolate();
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
   binding->Set(context, v8::String::NewFromUtf8(
-        isolate, "test", v8::NewStringType::kNormal).ToLocalChecked(),
+        isolate, "test").ToLocalChecked(),
                v8::FunctionTemplate::New(isolate, Test)
                    ->GetFunction(context)
                    .ToLocalChecked()).FromJust();

--- a/test/addons/hello-world-function-export/binding.cc
+++ b/test/addons/hello-world-function-export/binding.cc
@@ -4,7 +4,7 @@
 void Method(const v8::FunctionCallbackInfo<v8::Value>& args) {
   v8::Isolate* isolate = args.GetIsolate();
   args.GetReturnValue().Set(v8::String::NewFromUtf8(
-        isolate, "world", v8::NewStringType::kNormal).ToLocalChecked());
+        isolate, "world").ToLocalChecked());
 }
 
 void init(v8::Local<v8::Object> exports, v8::Local<v8::Object> module) {

--- a/test/addons/hello-world/binding.cc
+++ b/test/addons/hello-world/binding.cc
@@ -4,7 +4,7 @@
 static void Method(const v8::FunctionCallbackInfo<v8::Value>& args) {
   v8::Isolate* isolate = args.GetIsolate();
   args.GetReturnValue().Set(v8::String::NewFromUtf8(
-        isolate, "world", v8::NewStringType::kNormal).ToLocalChecked());
+        isolate, "world").ToLocalChecked());
 }
 
 // Not using the full NODE_MODULE_INIT() macro here because we want to test the
@@ -21,8 +21,7 @@ static void FakeInit(v8::Local<v8::Object> exports,
                      v8::Local<v8::Context> context) {
   auto isolate = context->GetIsolate();
   auto exception = v8::Exception::Error(v8::String::NewFromUtf8(isolate,
-      "FakeInit should never run!", v8::NewStringType::kNormal)
-          .ToLocalChecked());
+      "FakeInit should never run!").ToLocalChecked());
   isolate->ThrowException(exception);
 }
 

--- a/test/addons/load-long-path/binding.cc
+++ b/test/addons/load-long-path/binding.cc
@@ -4,7 +4,7 @@
 void Method(const v8::FunctionCallbackInfo<v8::Value>& args) {
   v8::Isolate* isolate = args.GetIsolate();
   args.GetReturnValue().Set(v8::String::NewFromUtf8(
-        isolate, "world", v8::NewStringType::kNormal).ToLocalChecked());
+        isolate, "world").ToLocalChecked());
 }
 
 void init(v8::Local<v8::Object> exports) {

--- a/test/addons/new-target/binding.cc
+++ b/test/addons/new-target/binding.cc
@@ -13,7 +13,7 @@ inline void Initialize(v8::Local<v8::Object> binding) {
   auto isolate = binding->GetIsolate();
   auto context = isolate->GetCurrentContext();
   binding->Set(context, v8::String::NewFromUtf8(
-        isolate, "Class", v8::NewStringType::kNormal).ToLocalChecked(),
+        isolate, "Class").ToLocalChecked(),
                v8::FunctionTemplate::New(isolate, NewClass)
                    ->GetFunction(context)
                    .ToLocalChecked()).FromJust();

--- a/test/addons/non-node-context/binding.cc
+++ b/test/addons/non-node-context/binding.cc
@@ -35,8 +35,7 @@ inline void RunInNewContext(
 
   context->Global()->Set(
       context,
-      String::NewFromUtf8(isolate, "data", NewStringType::kNormal)
-          .ToLocalChecked(),
+      String::NewFromUtf8(isolate, "data").ToLocalChecked(),
       args[1]).FromJust();
 
   assert(args[0]->IsString());  // source code

--- a/test/addons/openssl-binding/binding.cc
+++ b/test/addons/openssl-binding/binding.cc
@@ -24,7 +24,7 @@ inline void Initialize(v8::Local<v8::Object> exports,
                        v8::Local<v8::Context> context) {
   auto isolate = context->GetIsolate();
   auto key = v8::String::NewFromUtf8(
-      isolate, "randomBytes", v8::NewStringType::kNormal).ToLocalChecked();
+      isolate, "randomBytes").ToLocalChecked();
   auto value = v8::FunctionTemplate::New(isolate, RandomBytes)
                    ->GetFunction(context)
                    .ToLocalChecked();

--- a/test/addons/parse-encoding/binding.cc
+++ b/test/addons/parse-encoding/binding.cc
@@ -23,8 +23,7 @@ void ParseEncoding(const v8::FunctionCallbackInfo<v8::Value>& args) {
   ENCODING_MAP(V)
 #undef V
   auto encoding_string =
-      v8::String::NewFromUtf8(args.GetIsolate(), encoding_name,
-                              v8::NewStringType::kNormal)
+      v8::String::NewFromUtf8(args.GetIsolate(), encoding_name)
       .ToLocalChecked();
   args.GetReturnValue().Set(encoding_string);
 }

--- a/test/addons/symlinked-module/binding.cc
+++ b/test/addons/symlinked-module/binding.cc
@@ -4,7 +4,7 @@
 void Method(const v8::FunctionCallbackInfo<v8::Value>& args) {
   v8::Isolate* isolate = args.GetIsolate();
   args.GetReturnValue().Set(v8::String::NewFromUtf8(
-        isolate, "world", v8::NewStringType::kNormal).ToLocalChecked());
+        isolate, "world").ToLocalChecked());
 }
 
 void init(v8::Local<v8::Object> exports) {

--- a/test/addons/worker-buffer-callback/binding.cc
+++ b/test/addons/worker-buffer-callback/binding.cc
@@ -25,8 +25,7 @@ void Initialize(Local<Object> exports,
 
   exports->Set(context,
                v8::String::NewFromUtf8(
-                   isolate, "buffer", v8::NewStringType::kNormal)
-                   .ToLocalChecked(),
+                   isolate, "buffer").ToLocalChecked(),
                node::Buffer::New(
                    isolate,
                    data,

--- a/test/addons/zlib-binding/binding.cc
+++ b/test/addons/zlib-binding/binding.cc
@@ -46,7 +46,7 @@ inline void Initialize(v8::Local<v8::Object> exports,
                        v8::Local<v8::Context> context) {
   auto isolate = context->GetIsolate();
   auto key = v8::String::NewFromUtf8(
-      isolate, "compressBytes", v8::NewStringType::kNormal).ToLocalChecked();
+      isolate, "compressBytes").ToLocalChecked();
   auto value = v8::FunctionTemplate::New(isolate, CompressBytes)
                    ->GetFunction(context)
                    .ToLocalChecked();

--- a/test/cctest/test_environment.cc
+++ b/test/cctest/test_environment.cc
@@ -114,8 +114,8 @@ TEST_F(EnvironmentTest, PreExecutionPreparation) {
   v8::Local<v8::Script> script = v8::Script::Compile(
       context,
       v8::String::NewFromOneByte(isolate_,
-                                 reinterpret_cast<const uint8_t*>(run_script),
-                                 v8::NewStringType::kNormal).ToLocalChecked())
+                                 reinterpret_cast<const uint8_t*>(run_script))
+                                 .ToLocalChecked())
       .ToLocalChecked();
   v8::Local<v8::Value> result = script->Run(context).ToLocalChecked();
   CHECK(result->IsString());
@@ -140,8 +140,8 @@ TEST_F(EnvironmentTest, LoadEnvironmentWithCallback) {
         context,
         v8::String::NewFromOneByte(
             isolate_,
-            reinterpret_cast<const uint8_t*>("argv0"),
-            v8::NewStringType::kNormal).ToLocalChecked()).ToLocalChecked();
+            reinterpret_cast<const uint8_t*>("argv0"))
+            .ToLocalChecked()).ToLocalChecked();
     CHECK(argv0->IsString());
 
     return info.process_object;
@@ -165,15 +165,15 @@ TEST_F(EnvironmentTest, LoadEnvironmentWithSource) {
       context,
       v8::String::NewFromOneByte(
           isolate_,
-          reinterpret_cast<const uint8_t*>("process"),
-          v8::NewStringType::kNormal).ToLocalChecked())
+          reinterpret_cast<const uint8_t*>("process"))
+          .ToLocalChecked())
           .ToLocalChecked()->IsObject());
   CHECK(main_ret.As<v8::Object>()->Get(
       context,
       v8::String::NewFromOneByte(
           isolate_,
-          reinterpret_cast<const uint8_t*>("require"),
-          v8::NewStringType::kNormal).ToLocalChecked())
+          reinterpret_cast<const uint8_t*>("require"))
+          .ToLocalChecked())
           .ToLocalChecked()->IsFunction());
 }
 
@@ -509,8 +509,8 @@ TEST_F(EnvironmentTest, InspectorMultipleEmbeddedEnvironments) {
           context,
           v8::String::NewFromOneByte(
               isolate_,
-              reinterpret_cast<const uint8_t*>("messageFromWorker"),
-              v8::NewStringType::kNormal).ToLocalChecked())
+              reinterpret_cast<const uint8_t*>("messageFromWorker"))
+              .ToLocalChecked())
               .ToLocalChecked();
   CHECK_EQ(data.extracted_value, 42);
   CHECK_EQ(from_inspector->IntegerValue(context).FromJust(), 42);

--- a/test/cctest/test_linked_binding.cc
+++ b/test/cctest/test_linked_binding.cc
@@ -9,11 +9,11 @@ void InitializeBinding(v8::Local<v8::Object> exports,
   exports->Set(
       context,
       v8::String::NewFromOneByte(isolate,
-                                 reinterpret_cast<const uint8_t*>("key"),
-                                 v8::NewStringType::kNormal).ToLocalChecked(),
+                                 reinterpret_cast<const uint8_t*>("key"))
+                                 .ToLocalChecked(),
       v8::String::NewFromOneByte(isolate,
-                                 reinterpret_cast<const uint8_t*>("value"),
-                                 v8::NewStringType::kNormal).ToLocalChecked())
+                                 reinterpret_cast<const uint8_t*>("value"))
+                                 .ToLocalChecked())
       .FromJust();
 }
 
@@ -33,8 +33,8 @@ TEST_F(LinkedBindingTest, SimpleTest) {
   v8::Local<v8::Script> script = v8::Script::Compile(
       context,
       v8::String::NewFromOneByte(isolate_,
-                                 reinterpret_cast<const uint8_t*>(run_script),
-                                 v8::NewStringType::kNormal).ToLocalChecked())
+                                 reinterpret_cast<const uint8_t*>(run_script))
+                                 .ToLocalChecked())
       .ToLocalChecked();
   v8::Local<v8::Value> completion_value = script->Run(context).ToLocalChecked();
   v8::String::Utf8Value utf8val(isolate_, completion_value);
@@ -51,11 +51,11 @@ void InitializeLocalBinding(v8::Local<v8::Object> exports,
   exports->Set(
       context,
       v8::String::NewFromOneByte(isolate,
-                                 reinterpret_cast<const uint8_t*>("key"),
-                                 v8::NewStringType::kNormal).ToLocalChecked(),
+                                 reinterpret_cast<const uint8_t*>("key"))
+                                 .ToLocalChecked(),
       v8::String::NewFromOneByte(isolate,
-                                 reinterpret_cast<const uint8_t*>("value"),
-                                 v8::NewStringType::kNormal).ToLocalChecked())
+                                 reinterpret_cast<const uint8_t*>("value"))
+                                 .ToLocalChecked())
       .FromJust();
 }
 
@@ -74,8 +74,8 @@ TEST_F(LinkedBindingTest, LocallyDefinedLinkedBindingTest) {
   v8::Local<v8::Script> script = v8::Script::Compile(
       context,
       v8::String::NewFromOneByte(isolate_,
-                                 reinterpret_cast<const uint8_t*>(run_script),
-                                 v8::NewStringType::kNormal).ToLocalChecked())
+                                 reinterpret_cast<const uint8_t*>(run_script))
+                                 .ToLocalChecked())
       .ToLocalChecked();
   v8::Local<v8::Value> completion_value = script->Run(context).ToLocalChecked();
   v8::String::Utf8Value utf8val(isolate_, completion_value);


### PR DESCRIPTION
`kNormal` has been the implicit default for a while now (since V8 7.6).

Refs: https://github.com/v8/v8/commit/e0d7f816990ada28ebe1281ca9431236ef8c6e4f

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
