### PR TITLE
child_process: allow promisified exec to be cancel

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -770,16 +770,10 @@ function sanitizeKillSignal(killSignal) {
 function spawnWithSignal(file, args, options) {
   // Remove signal from options to spawn
   // to avoid double emitting of AbortError
-  let child;
-
-  if (options && typeof options === 'object' && ('signal' in options)) {
-    const opts = { ...options };
-    delete opts.signal;
-
-    child = spawn(file, args, opts);
-  } else {
-    child = spawn(file, args, options);
-  }
+  const opts = options && typeof options === 'object' && ('signal' in options) ?
+    { ...options, signal: undefined } :
+    options;
+  const child = spawn(file, args, opts);
 
   if (options && options.signal) {
     // Validate signal, if present

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -606,13 +606,11 @@ function spawn(file, args, options) {
     if (signal.aborted) {
       onAbortListener();
     } else {
-      const config = { once: true };
-
-      signal.addEventListener('abort', onAbortListener, config);
+      signal.addEventListener('abort', onAbortListener, { once: true });
       child.once('close',
                  () =>
                    signal
-                    .removeEventListener('abort', onAbortListener, config)
+                    .removeEventListener('abort', onAbortListener)
       );
     }
 

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -42,7 +42,6 @@ const {
   SafeSet,
   StringPrototypeSlice,
   StringPrototypeToUpperCase,
-  PromiseReject,
 } = primordials;
 
 const {
@@ -615,16 +614,21 @@ function spawn(file, args, options) {
     if (signal.aborted) {
       onAbortListener();
     } else {
-      signal.addEventListener('abort', onAbortListener, { once: true });
-      child.once('close', () => signal.removeEventListener('abort', onAbortListener, { once: true }));
+      const config = { once: true };
+      const remove = () => {
+        signal.removeEventListener('abort', onAbortListener, config);
+      };
+
+      signal.addEventListener('abort', onAbortListener, config);
+      child.once('close', remove);
     }
 
     function onAbortSignal(childProcess) {
       return function abortListener() {
         if (childProcess.stdout) childProcess.stdout.destroy();
-  
+
         if (childProcess.stderr) childProcess.stderr.destroy();
-  
+
         process.nextTick(() => {
           if (childProcess && childProcess.kill) {
             childProcess.kill(options.killSignal);
@@ -632,13 +636,12 @@ function spawn(file, args, options) {
 
           childProcess.emit('error', new AbortError());
         });
-      }
+      };
     }
   }
 
   debug('spawn', options);
   child.spawn(options);
-  
 
   return child;
 }

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -183,16 +183,15 @@ function exec(command, options, callback) {
 }
 
 const customPromiseExecFunction = (orig) => {
-  return (...file) => {
+  return (...args) => {
     let resolve;
     let reject;
-
     const promise = new Promise((res, rej) => {
       resolve = res;
       reject = rej;
     });
 
-    promise.child = orig(...file, (err, stdout, stderr) => {
+    promise.child = orig(...args, (err, stdout, stderr) => {
       if (err !== null) {
         err.stdout = stdout;
         err.stderr = stderr;
@@ -608,19 +607,18 @@ function spawn(file, args, options) {
       onAbortListener();
     } else {
       const config = { once: true };
-      const remove = () => {
-        signal.removeEventListener('abort', onAbortListener, config);
-      };
 
       signal.addEventListener('abort', onAbortListener, config);
-      child.once('close', remove);
+      child.once('close',
+                 () =>
+                   signal
+                    .removeEventListener('abort', onAbortListener, config)
+      );
     }
 
     function onAbortListener() {
       process.nextTick(() => {
-        if (child?.kill) {
-          child.kill(options.killSignal);
-        }
+        child?.kill?.(options.killSignal);
 
         child.emit('error', new AbortError());
       });

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -188,11 +188,6 @@ const customPromiseExecFunction = (orig) => {
   return (...file) => {
     let child;
 
-    // Check if a callback is passed somehow
-    if (typeof file[file.length - 1] === 'function') {
-      file.pop();
-    }
-
     const promise = new Promise((resolve, reject) => {
       child = orig(...file, (err, stdout, stderr) => {
         if (err !== null) {

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -620,10 +620,6 @@ function spawn(file, args, options) {
 
     function onAbortSignal(childProcess) {
       return function abortListener() {
-        if (childProcess.stdout) childProcess.stdout.destroy();
-
-        if (childProcess.stderr) childProcess.stderr.destroy();
-
         process.nextTick(() => {
           if (childProcess && childProcess.kill) {
             childProcess.kill(options.killSignal);
@@ -774,14 +770,22 @@ function sanitizeKillSignal(killSignal) {
 // This level of indirection is here because the other child_process methods
 // call spawn internally but should use different cancellation logic.
 function spawnWithSignal(file, args, options) {
-  const child = spawn(file, args, options);
-
+  // Remove signal from options to spawn 
+  // to avoid double emitting of AbortError
+  const opts = 
+    options != null && typeof options === 'object' 
+      ? { ...options, signal: undefined }
+      : options;
+  
+  const child = spawn(file, args, opts);
+  
+  
   if (options && options.signal) {
     // Validate signal, if present
     validateAbortSignal(options.signal, 'options.signal');
     function kill() {
       if (child._handle) {
-        child.kill('SIGTERM');
+        child._handle.kill(options.killSignal || 'SIGTERM');
         child.emit('error', new AbortError());
       }
     }

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -259,11 +259,11 @@ function execFile(file /* , args, options, callback */) {
     cwd: options.cwd,
     env: options.env,
     gid: options.gid,
-    uid: options.uid,
     shell: options.shell,
+    signal: options.signal,
+    uid: options.uid,
     windowsHide: !!options.windowsHide,
-    windowsVerbatimArguments: !!options.windowsVerbatimArguments,
-    signal: options.signal
+    windowsVerbatimArguments: !!options.windowsVerbatimArguments
   });
 
   let encoding;

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -184,21 +184,23 @@ function exec(command, options, callback) {
 
 const customPromiseExecFunction = (orig) => {
   return (...file) => {
-    let child;
+    let resolve;
+    let reject;
 
-    const promise = new Promise((resolve, reject) => {
-      child = orig(...file, (err, stdout, stderr) => {
-        if (err !== null) {
-          err.stdout = stdout;
-          err.stderr = stderr;
-          reject(err);
-        } else {
-          resolve({ stdout, stderr });
-        }
-      });
+    const promise = new Promise((res, rej) => {
+      resolve = res;
+      reject = rej;
     });
 
-    promise.child = child;
+    promise.child = orig(...file, (err, stdout, stderr) => {
+      if (err !== null) {
+        err.stdout = stdout;
+        err.stderr = stderr;
+        reject(err);
+      } else {
+        resolve({ stdout, stderr });
+      }
+    });
 
     return promise;
   };

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -58,12 +58,7 @@ let debug = require('internal/util/debuglog').debuglog(
     debug = fn;
   }
 );
-let DOMException;
-function lazyDOMException(message) {
-  if (DOMException === undefined)
-    DOMException = internalBinding('messaging').DOMException;
-  return new DOMException(message);
-}
+
 const { Buffer } = require('buffer');
 const { Pipe, constants: PipeConstants } = internalBinding('pipe_wrap');
 
@@ -191,76 +186,27 @@ function exec(command, options, callback) {
 }
 
 const customPromiseExecFunction = (orig) => {
-  return (file, options = {}) => {
+  return (...file) => {
     let child;
 
-    if (typeof options !== 'object' || options === null) {
-      return PromiseReject(
-        new ERR_INVALID_ARG_TYPE(
-          'options',
-          'Object',
-          options));
-    }
-
-    const { signal } = options;
-    const hasSignal = signal != null;
-
-    // Lets check if an AbortSignal is passed
-    if (hasSignal) {
-      const isNotValidSignal =
-        typeof signal !== 'object' || !('aborted' in signal);
-
-      if (isNotValidSignal) return PromiseReject(
-        new ERR_INVALID_ARG_TYPE(
-          'options.signal',
-          'AbortSignal',
-          signal));
-
-      // Already aborted
-      if (signal.aborted) return PromiseReject(lazyDOMException('AbortError'));
+    // Check if a callback is passed somehow
+    if (typeof file[file.length - 1] === 'function') {
+      file.pop();
     }
 
     const promise = new Promise((resolve, reject) => {
-      if (hasSignal) {
-        signal.addEventListener(
-          'abort',
-          rejectOnAbortSignal(reject),
-          { once: true }
-        );
-      }
-
-      child = orig(file, options, (err, stdout, stderr) => {
-        if (hasSignal && signal.aborted) {
-          reject(err);
-        } else if (err !== null) {
+      child = orig(...file, (err, stdout, stderr) => {
+        if (err !== null) {
           err.stdout = stdout;
           err.stderr = stderr;
           reject(err);
         } else {
           resolve({ stdout, stderr });
         }
-
-        // Let's cleanup once exec is finished
-        if (hasSignal)
-          signal
-            .removeEventListener(
-              'abort',
-              rejectOnAbortSignal(reject),
-              { once: true }
-            );
       });
     });
 
     promise.child = child;
-
-    function rejectOnAbortSignal(reject) {
-      return () => {
-        if (promise && promise.child)
-          promise.child.kill(options.killSignal || 'SIGTERM');
-
-        reject(lazyDOMException('AbortError'));
-      };
-    }
 
     return promise;
   };
@@ -315,9 +261,6 @@ function execFile(file /* , args, options, callback */) {
   // Validate maxBuffer, if present.
   validateMaxBuffer(options.maxBuffer);
 
-  // Validate signal, if present
-  validateAbortSignal(options.signal, 'options.signal');
-
   options.killSignal = sanitizeKillSignal(options.killSignal);
 
   const child = spawn(file, args, {
@@ -327,7 +270,8 @@ function execFile(file /* , args, options, callback */) {
     uid: options.uid,
     shell: options.shell,
     windowsHide: !!options.windowsHide,
-    windowsVerbatimArguments: !!options.windowsVerbatimArguments
+    windowsVerbatimArguments: !!options.windowsVerbatimArguments,
+    signal: options.signal
   });
 
   let encoding;
@@ -429,27 +373,11 @@ function execFile(file /* , args, options, callback */) {
     }
   }
 
-  function abortHandler() {
-    if (!ex)
-      ex = new AbortError();
-    process.nextTick(() => kill());
-  }
-
   if (options.timeout > 0) {
     timeoutId = setTimeout(function delayedKill() {
       kill();
       timeoutId = null;
     }, options.timeout);
-  }
-  if (options.signal) {
-    if (options.signal.aborted) {
-      process.nextTick(abortHandler);
-    } else {
-      const childController = new AbortController();
-      options.signal.addEventListener('abort', abortHandler,
-                                      { signal: childController.signal });
-      child.once('close', () => childController.abort());
-    }
   }
 
   if (child.stdout) {
@@ -674,10 +602,43 @@ function normalizeSpawnArguments(file, args, options) {
 
 function spawn(file, args, options) {
   const child = new ChildProcess();
-
   options = normalizeSpawnArguments(file, args, options);
+
+  if (options.signal) {
+    const signal = options.signal;
+    // Validate signal, if present
+    validateAbortSignal(signal, 'options.signal');
+
+    const onAbortListener = onAbortSignal(child);
+
+    // Do nothing and throw if already aborted
+    if (signal.aborted) {
+      onAbortListener();
+    } else {
+      signal.addEventListener('abort', onAbortListener, { once: true });
+      child.once('close', () => signal.removeEventListener('abort', onAbortListener, { once: true }));
+    }
+
+    function onAbortSignal(childProcess) {
+      return function abortListener() {
+        if (childProcess.stdout) childProcess.stdout.destroy();
+  
+        if (childProcess.stderr) childProcess.stderr.destroy();
+  
+        process.nextTick(() => {
+          if (childProcess && childProcess.kill) {
+            childProcess.kill(options.killSignal);
+          }
+
+          childProcess.emit('error', new AbortError());
+        });
+      }
+    }
+  }
+
   debug('spawn', options);
   child.spawn(options);
+  
 
   return child;
 }

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -207,7 +207,8 @@ const customPromiseExecFunction = (orig) => {
 
     // Lets check if an AbortSignal is passed
     if (hasSignal) {
-      const isNotValidSignal = typeof signal !== 'object' || !('aborted' in signal);
+      const isNotValidSignal =
+        typeof signal !== 'object' || !('aborted' in signal);
 
       if (isNotValidSignal) return PromiseReject(
         new ERR_INVALID_ARG_TYPE(
@@ -220,7 +221,13 @@ const customPromiseExecFunction = (orig) => {
     }
 
     const promise = new Promise((resolve, reject) => {
-      if (hasSignal) signal.addEventListener('abort', rejectOnAbortSignal(reject), { once: true });
+      if (hasSignal)
+        signal
+          .addEventListener(
+            'abort',
+            rejectOnAbortSignal(reject),
+            { once: true }
+          );
 
       child = orig(file, options, (err, stdout, stderr) => {
         if (err !== null) {
@@ -232,7 +239,13 @@ const customPromiseExecFunction = (orig) => {
         }
 
         // Let's cleanup once exec is finished
-        if (hasSignal) signal.removeEventListener('abort', rejectOnAbortSignal(reject), { once: true });
+        if (hasSignal)
+          signal
+            .removeEventListener(
+              'abort',
+              rejectOnAbortSignal(reject),
+              { once: true }
+            );
       });
     });
 
@@ -240,11 +253,12 @@ const customPromiseExecFunction = (orig) => {
 
     function rejectOnAbortSignal(reject) {
       return () => {
-        if (promise && promise.child) promise.child.kill(options.killSignal || 'SIGTERM');
-        
+        if (promise && promise.child)
+          promise.child.kill(options.killSignal || 'SIGTERM');
+
         reject(lazyDOMException('AbortError'));
       };
-    };
+    }
 
     return promise;
   };

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -624,7 +624,7 @@ function spawn(file, args, options) {
 
         child.emit('error', new AbortError());
       });
-    };
+    }
   }
 
   debug('spawn', options);

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -42,6 +42,7 @@ const {
   SafeSet,
   StringPrototypeSlice,
   StringPrototypeToUpperCase,
+  PromiseReject,
 } = primordials;
 
 const {
@@ -198,8 +199,8 @@ const customPromiseExecFunction = (orig) => {
       reject = rej;
     });
 
-    if (typeof options !== 'object') {
-      return Promise.reject(
+    if (typeof options !== 'object' || options === null) {
+      return PromiseReject(
         new ERR_INVALID_ARG_TYPE(
           'options',
           'Object',
@@ -212,15 +213,16 @@ const customPromiseExecFunction = (orig) => {
       !('aborted' in signal);
 
     if (hasSignal) {
-      if (isNotValidSignal) return Promise.reject(
+      const isNotValidSignal = typeof signal !== 'object' || !('aborted' in signal);
+
+      if (isNotValidSignal) return PromiseReject(
         new ERR_INVALID_ARG_TYPE(
           'options.signal',
           'AbortSignal',
           signal));
 
-      signal.addEventListener('abort', () => {
-        reject(lazyDOMException('AbortError'));
-      }, { once: true });
+      // Already aborted
+      if (signal.aborted) return PromiseReject(lazyDOMException('AbortError'));
     }
 
     promise.child = orig(file, options, (err, stdout, stderr) => {

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -142,7 +142,7 @@ function fork(modulePath /* , args, options */) {
   options.execPath = options.execPath || process.execPath;
   options.shell = false;
 
-  return spawnWithSignal(options.execPath, args, options);
+  return spawn(options.execPath, args, options);
 }
 
 function _forkChild(fd, serializationMode) {
@@ -772,12 +772,16 @@ function sanitizeKillSignal(killSignal) {
 function spawnWithSignal(file, args, options) {
   // Remove signal from options to spawn
   // to avoid double emitting of AbortError
-  const opts =
-    options != null && typeof options === 'object' ?
-      { ...options, signal: undefined } :
-      options;
+  let child;
 
-  const child = spawn(file, args, opts);
+  if (options && typeof options === 'object' && ('signal' in options)) {
+    const opts = { ...options };
+    delete opts.signal;
+
+    child = spawn(file, args, opts);
+  } else {
+    child = spawn(file, args, options);
+  }
 
   if (options && options.signal) {
     // Validate signal, if present

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -601,8 +601,6 @@ function spawn(file, args, options) {
     // Validate signal, if present
     validateAbortSignal(signal, 'options.signal');
 
-    const onAbortListener = onAbortSignal(child);
-
     // Do nothing and throw if already aborted
     if (signal.aborted) {
       onAbortListener();
@@ -616,17 +614,15 @@ function spawn(file, args, options) {
       child.once('close', remove);
     }
 
-    function onAbortSignal(childProcess) {
-      return function abortListener() {
-        process.nextTick(() => {
-          if (childProcess && childProcess.kill) {
-            childProcess.kill(options.killSignal);
-          }
+    function onAbortListener() {
+      process.nextTick(() => {
+        if (child?.kill) {
+          child.kill(options.killSignal);
+        }
 
-          childProcess.emit('error', new AbortError());
-        });
-      };
-    }
+        child.emit('error', new AbortError());
+      });
+    };
   }
 
   debug('spawn', options);

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -770,16 +770,15 @@ function sanitizeKillSignal(killSignal) {
 // This level of indirection is here because the other child_process methods
 // call spawn internally but should use different cancellation logic.
 function spawnWithSignal(file, args, options) {
-  // Remove signal from options to spawn 
+  // Remove signal from options to spawn
   // to avoid double emitting of AbortError
-  const opts = 
-    options != null && typeof options === 'object' 
-      ? { ...options, signal: undefined }
-      : options;
-  
+  const opts =
+    options != null && typeof options === 'object' ?
+      { ...options, signal: undefined } :
+      options;
+
   const child = spawn(file, args, opts);
-  
-  
+
   if (options && options.signal) {
     // Validate signal, if present
     validateAbortSignal(options.signal, 'options.signal');

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -49,6 +49,7 @@ const {
   convertToValidSignal,
   getSystemErrorName
 } = require('internal/util');
+
 const { isArrayBufferView } = require('internal/util/types');
 let debug = require('internal/util/debuglog').debuglog(
   'child_process',
@@ -56,6 +57,12 @@ let debug = require('internal/util/debuglog').debuglog(
     debug = fn;
   }
 );
+let DOMException;
+function lazyDOMException(message) {
+  if (DOMException === undefined)
+    DOMException = internalBinding('messaging').DOMException;
+  return new DOMException(message);
+}
 const { Buffer } = require('buffer');
 const { Pipe, constants: PipeConstants } = internalBinding('pipe_wrap');
 
@@ -183,7 +190,7 @@ function exec(command, options, callback) {
 }
 
 const customPromiseExecFunction = (orig) => {
-  return (...args) => {
+  return (file, options = {}) => {
     let resolve;
     let reject;
     const promise = new Promise((res, rej) => {
@@ -191,7 +198,30 @@ const customPromiseExecFunction = (orig) => {
       reject = rej;
     });
 
-    promise.child = orig(...args, (err, stdout, stderr) => {
+    if (options == null || typeof options !== 'object') {
+      return Promise.reject(
+        new ERR_INVALID_ARG_TYPE(
+          'options',
+          'Object',
+          options));
+    }
+
+    const { signal } = options;
+    if (signal == null ||
+        typeof signal !== 'object' ||
+        !('aborted' in signal)) {
+      return Promise.reject(
+        new ERR_INVALID_ARG_TYPE(
+          'options.signal',
+          'AbortSignal',
+          signal));
+    }
+
+    signal.addEventListener('abort', () => {
+      reject(lazyDOMException('AbortError'));
+    }, { once: true });
+
+    promise.child = orig(file, options, (err, stdout, stderr) => {
       if (err !== null) {
         err.stdout = stdout;
         err.stderr = stderr;

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -221,16 +221,16 @@ const customPromiseExecFunction = (orig) => {
     }
 
     const promise = new Promise((resolve, reject) => {
-      if (hasSignal)
-        signal
-          .addEventListener(
-            'abort',
-            rejectOnAbortSignal(reject),
-            { once: true }
-          );
+      if (hasSignal) {
+        signal.addEventListener(
+          'abort',
+          rejectOnAbortSignal(reject),
+          { once: true }
+        );
+      }
 
       child = orig(file, options, (err, stdout, stderr) => {
-        if (signal.aborted) {
+        if (hasSignal && signal.aborted) {
           reject(err);
         } else if (err !== null) {
           err.stdout = stdout;

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -230,7 +230,9 @@ const customPromiseExecFunction = (orig) => {
           );
 
       child = orig(file, options, (err, stdout, stderr) => {
-        if (err !== null) {
+        if (signal.aborted) {
+          reject(err);
+        } else if (err !== null) {
           err.stdout = stdout;
           err.stderr = stderr;
           reject(err);

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -192,12 +192,7 @@ function exec(command, options, callback) {
 
 const customPromiseExecFunction = (orig) => {
   return (file, options = {}) => {
-    let resolve;
-    let reject;
-    const promise = new Promise((res, rej) => {
-      resolve = res;
-      reject = rej;
-    });
+    let child;
 
     if (typeof options !== 'object' || options === null) {
       return PromiseReject(
@@ -209,9 +204,8 @@ const customPromiseExecFunction = (orig) => {
 
     const { signal } = options;
     const hasSignal = signal != null;
-    const isNotValidSignal = typeof signal !== 'object' ||
-      !('aborted' in signal);
 
+    // Lets check if an AbortSignal is passed
     if (hasSignal) {
       const isNotValidSignal = typeof signal !== 'object' || !('aborted' in signal);
 
@@ -225,15 +219,32 @@ const customPromiseExecFunction = (orig) => {
       if (signal.aborted) return PromiseReject(lazyDOMException('AbortError'));
     }
 
-    promise.child = orig(file, options, (err, stdout, stderr) => {
-      if (err !== null) {
-        err.stdout = stdout;
-        err.stderr = stderr;
-        reject(err);
-      } else {
-        resolve({ stdout, stderr });
-      }
+    const promise = new Promise((resolve, reject) => {
+      if (hasSignal) signal.addEventListener('abort', rejectOnAbortSignal(reject), { once: true });
+
+      child = orig(file, options, (err, stdout, stderr) => {
+        if (err !== null) {
+          err.stdout = stdout;
+          err.stderr = stderr;
+          reject(err);
+        } else {
+          resolve({ stdout, stderr });
+        }
+
+        // Let's cleanup once exec is finished
+        if (hasSignal) signal.removeEventListener('abort', rejectOnAbortSignal(reject), { once: true });
+      });
     });
+
+    promise.child = child;
+
+    function rejectOnAbortSignal(reject) {
+      return () => {
+        if (promise && promise.child) promise.child.kill(options.killSignal || 'SIGTERM');
+        
+        reject(lazyDOMException('AbortError'));
+      };
+    };
 
     return promise;
   };

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -49,7 +49,6 @@ const {
   convertToValidSignal,
   getSystemErrorName
 } = require('internal/util');
-
 const { isArrayBufferView } = require('internal/util/types');
 let debug = require('internal/util/debuglog').debuglog(
   'child_process',
@@ -57,7 +56,6 @@ let debug = require('internal/util/debuglog').debuglog(
     debug = fn;
   }
 );
-
 const { Buffer } = require('buffer');
 const { Pipe, constants: PipeConstants } = internalBinding('pipe_wrap');
 

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -608,10 +608,7 @@ function spawn(file, args, options) {
     } else {
       signal.addEventListener('abort', onAbortListener, { once: true });
       child.once('close',
-                 () =>
-                   signal
-                    .removeEventListener('abort', onAbortListener)
-      );
+                 () => signal.removeEventListener('abort', onAbortListener));
     }
 
     function onAbortListener() {

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -198,7 +198,7 @@ const customPromiseExecFunction = (orig) => {
       reject = rej;
     });
 
-    if (options == null || typeof options !== 'object') {
+    if (typeof options !== 'object') {
       return Promise.reject(
         new ERR_INVALID_ARG_TYPE(
           'options',
@@ -207,19 +207,21 @@ const customPromiseExecFunction = (orig) => {
     }
 
     const { signal } = options;
-    if (signal == null ||
-        typeof signal !== 'object' ||
-        !('aborted' in signal)) {
-      return Promise.reject(
+    const hasSignal = signal != null;
+    const isNotValidSignal = typeof signal !== 'object' ||
+      !('aborted' in signal);
+
+    if (hasSignal) {
+      if (isNotValidSignal) return Promise.reject(
         new ERR_INVALID_ARG_TYPE(
           'options.signal',
           'AbortSignal',
           signal));
-    }
 
-    signal.addEventListener('abort', () => {
-      reject(lazyDOMException('AbortError'));
-    }, { once: true });
+      signal.addEventListener('abort', () => {
+        reject(lazyDOMException('AbortError'));
+      }, { once: true });
+    }
 
     promise.child = orig(file, options, (err, stdout, stderr) => {
       if (err !== null) {

--- a/test/parallel/test-child-process-exec-abortcontroller-promisified.js
+++ b/test/parallel/test-child-process-exec-abortcontroller-promisified.js
@@ -1,24 +1,3 @@
-// Copyright Joyent, Inc. and other Node contributors.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a
-// copy of this software and associated documentation files (the
-// "Software"), to deal in the Software without restriction, including
-// without limitation the rights to use, copy, modify, merge, publish,
-// distribute, sublicense, and/or sell copies of the Software, and to permit
-// persons to whom the Software is furnished to do so, subject to the
-// following conditions:
-//
-// The above copyright notice and this permission notice shall be included
-// in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
-// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
-// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
-// USE OR OTHER DEALINGS IN THE SOFTWARE.
-
 'use strict';
 const common = require('../common');
 const assert = require('assert');

--- a/test/parallel/test-child-process-exec-abortcontroller-promisified.js
+++ b/test/parallel/test-child-process-exec-abortcontroller-promisified.js
@@ -22,7 +22,6 @@ if (common.isWindows) {
   const promise = execPromisifed(pwdcommand, { cwd: dir, signal });
   assert.rejects(promise, /AbortError/);
   ac.abort();
-  assert.strictEqual(promise.child.killed, true);
 }
 
 {
@@ -50,5 +49,4 @@ if (common.isWindows) {
   const promise = execPromisifed(pwdcommand, { cwd: dir, signal });
 
   assert.rejects(promise, /AbortError/);
-  assert.strictEqual(promise.child, undefined);
 }

--- a/test/parallel/test-child-process-exec-abortcontroller-promisified.js
+++ b/test/parallel/test-child-process-exec-abortcontroller-promisified.js
@@ -62,3 +62,9 @@ if (common.isWindows) {
              'instance of AbortSignal. Received function signal'
   });
 }
+
+{
+  const ac = new AbortController();
+  const signal = (ac.abort(), ac.signal);
+  assert.rejects(execPromisifed(pwdcommand, { cwd: dir, signal }), /AbortError/);
+}

--- a/test/parallel/test-child-process-exec-abortcontroller-promisified.js
+++ b/test/parallel/test-child-process-exec-abortcontroller-promisified.js
@@ -25,7 +25,7 @@ if (common.isWindows) {
   const ac = new AbortController();
   const signal = ac.signal;
   const promise = execPromisifed(pwdcommand, { cwd: dir, signal });
-  assert.rejects(promise, /AbortError/);
+  assert.rejects(promise, /AbortError/).then(common.mustCall());
   ac.abort();
 }
 
@@ -37,7 +37,7 @@ if (common.isWindows) {
 
 {
   function signal() {}
-  assert.throws(function() {
+  assert.throws(() => {
     execPromisifed(pwdcommand, { cwd: dir, signal });
   }, invalidArgTypeError);
 }
@@ -47,5 +47,5 @@ if (common.isWindows) {
   const signal = (ac.abort(), ac.signal);
   const promise = execPromisifed(pwdcommand, { cwd: dir, signal });
 
-  assert.rejects(promise, /AbortError/);
+  assert.rejects(promise, /AbortError/).then(common.mustCall());
 }

--- a/test/parallel/test-child-process-exec-abortcontroller-promisified.js
+++ b/test/parallel/test-child-process-exec-abortcontroller-promisified.js
@@ -1,0 +1,64 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const exec = require('child_process').exec;
+const { promisify } = require('util');
+
+let pwdcommand, dir;
+const execPromisifed = promisify(exec);
+
+if (common.isWindows) {
+  pwdcommand = 'echo %cd%';
+  dir = 'c:\\windows';
+} else {
+  pwdcommand = 'pwd';
+  dir = '/dev';
+}
+
+
+{
+  const ac = new AbortController();
+  const signal = ac.signal;
+  assert.rejects(execPromisifed(pwdcommand, { cwd: dir, signal }), /AbortError/);
+  ac.abort();
+}
+
+{
+  assert.rejects(execPromisifed(pwdcommand, { cwd: dir, signal: {} }), {
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError',
+    message: 'The "options.signal" property must be an ' +
+             'instance of AbortSignal. Received an instance of Object'
+  });
+}
+
+{
+  function signal() {}
+  assert.rejects(execPromisifed(pwdcommand, { cwd: dir, signal }), {
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError',
+    message: 'The "options.signal" property must be an ' +
+             'instance of AbortSignal. Received function signal'
+  });
+}

--- a/test/parallel/test-child-process-exec-abortcontroller-promisified.js
+++ b/test/parallel/test-child-process-exec-abortcontroller-promisified.js
@@ -19,8 +19,10 @@ if (common.isWindows) {
 {
   const ac = new AbortController();
   const signal = ac.signal;
-  assert.rejects(execPromisifed(pwdcommand, { cwd: dir, signal }), /AbortError/);
+  const promise = execPromisifed(pwdcommand, { cwd: dir, signal });
+  assert.rejects(promise, /AbortError/);
   ac.abort();
+  assert.strictEqual(promise.child.killed, true);
 }
 
 {
@@ -45,5 +47,8 @@ if (common.isWindows) {
 {
   const ac = new AbortController();
   const signal = (ac.abort(), ac.signal);
-  assert.rejects(execPromisifed(pwdcommand, { cwd: dir, signal }), /AbortError/);
+  const promise = execPromisifed(pwdcommand, { cwd: dir, signal });
+
+  assert.rejects(promise, /AbortError/);
+  assert.strictEqual(promise.child, undefined);
 }

--- a/test/parallel/test-child-process-exec-abortcontroller-promisified.js
+++ b/test/parallel/test-child-process-exec-abortcontroller-promisified.js
@@ -6,6 +6,11 @@ const { promisify } = require('util');
 
 let pwdcommand, dir;
 const execPromisifed = promisify(exec);
+const invalidArgTypeError = {
+  code: 'ERR_INVALID_ARG_TYPE',
+  name: 'TypeError'
+};
+
 
 if (common.isWindows) {
   pwdcommand = 'echo %cd%';
@@ -25,22 +30,16 @@ if (common.isWindows) {
 }
 
 {
-  assert.rejects(execPromisifed(pwdcommand, { cwd: dir, signal: {} }), {
-    code: 'ERR_INVALID_ARG_TYPE',
-    name: 'TypeError',
-    message: 'The "options.signal" property must be an ' +
-             'instance of AbortSignal. Received an instance of Object'
-  });
+  assert.throws(() => {
+    execPromisifed(pwdcommand, { cwd: dir, signal: {} });
+  }, invalidArgTypeError);
 }
 
 {
   function signal() {}
-  assert.rejects(execPromisifed(pwdcommand, { cwd: dir, signal }), {
-    code: 'ERR_INVALID_ARG_TYPE',
-    name: 'TypeError',
-    message: 'The "options.signal" property must be an ' +
-             'instance of AbortSignal. Received function signal'
-  });
+  assert.throws(function() {
+    execPromisifed(pwdcommand, { cwd: dir, signal });
+  }, invalidArgTypeError);
 }
 
 {

--- a/test/parallel/test-child-process-execFile-promisified-abortController.js
+++ b/test/parallel/test-child-process-execFile-promisified-abortController.js
@@ -64,3 +64,18 @@ const promisified = promisify(execFile);
     "instance of AbortSignal. Received type string ('world!')");
   }));
 }
+
+{
+  // Verify that if something different than Abortcontroller.signal
+  // is passed, ERR_INVALID_ARG_TYPE is thrown
+  const signal = 'world!';
+  const promise = promisified(process.execPath, [echoFixture, 0], { signal });
+
+
+  promise.catch(common.mustCall((e) => {
+    assert.strictEqual(e.name, 'TypeError');
+    assert.strictEqual(e.code, 'ERR_INVALID_ARG_TYPE');
+    assert.strictEqual(e.message, 'The "options.signal" property must be an ' +
+    "instance of AbortSignal. Received type string ('world!')");
+  }));
+}

--- a/test/parallel/test-child-process-execFile-promisified-abortController.js
+++ b/test/parallel/test-child-process-execFile-promisified-abortController.js
@@ -4,23 +4,22 @@ const common = require('../common');
 const assert = require('assert');
 const { promisify } = require('util');
 const execFile = require('child_process').execFile;
-const { getSystemErrorName } = require('util');
 const fixtures = require('../common/fixtures');
 
-const fixture = fixtures.path('exit.js');
 const echoFixture = fixtures.path('echo.js');
-const execOpts = { encoding: 'utf8', shell: true };
-const execFilePromisified = promisify(execFile);
+const promisified = promisify(execFile);
 
 {
   // Verify that the signal option works properly
   const ac = new AbortController();
   const signal = ac.signal;
-  const promise = execFilePromisified(process.execPath, [echoFixture, 0], { signal });
-  
+  const promise = promisified(process.execPath, [echoFixture, 0], { signal });
+
   ac.abort();
 
-  assert.rejects(promise, /AbortError/);
+  promise.catch(common.mustCall((e) => {
+    assert.strictEqual(e.name, 'AbortError');
+  }));
 }
 
 {
@@ -29,35 +28,39 @@ const execFilePromisified = promisify(execFile);
   const { signal } = ac;
   ac.abort();
 
-  const promise = execFilePromisified(process.execPath, [echoFixture, 0], { signal });
+  const promise = promisified(process.execPath, [echoFixture, 0], { signal });
 
-  assert.rejects(promise, /AbortError/);
+  promise.catch(common.mustCall((e) => {
+    assert.strictEqual(e.name, 'AbortError');
+  }));
 }
 
 {
   // Verify that if something different than Abortcontroller.signal
   // is passed, ERR_INVALID_ARG_TYPE is thrown
-  const promise = execFilePromisified(process.execPath, [echoFixture, 0], { signal: {} });
+  const signal = {};
+  const promise = promisified(process.execPath, [echoFixture, 0], { signal });
 
-  assert.rejects(promise, {
-    code: 'ERR_INVALID_ARG_TYPE',
-    name: 'TypeError',
-    message: 'The "options.signal" property must be an ' +
-             'instance of AbortSignal. Received an instance of Object'
-  });
+  promise.catch(common.mustCall((e) => {
+    assert.strictEqual(e.name, 'TypeError');
+    assert.strictEqual(e.code, 'ERR_INVALID_ARG_TYPE');
+    assert.strictEqual(e.message, 'The "options.signal" property must be an ' +
+    'instance of AbortSignal. Received an instance of Object');
+  }));
 
 }
 
 {
   // Verify that if something different than Abortcontroller.signal
   // is passed, ERR_INVALID_ARG_TYPE is thrown
-  const promise = execFilePromisified(process.execPath, [echoFixture, 0], { signal: 'world!' });
+  const signal = 'world!';
+  const promise = promisified(process.execPath, [echoFixture, 0], { signal });
 
-  assert.rejects(promise, {
-    code: 'ERR_INVALID_ARG_TYPE',
-    name: 'TypeError',
-    message: 'The "options.signal" property must be an ' +
-             `instance of AbortSignal. Received type string ('world!')`
-  });
 
+  promise.catch(common.mustCall((e) => {
+    assert.strictEqual(e.name, 'TypeError');
+    assert.strictEqual(e.code, 'ERR_INVALID_ARG_TYPE');
+    assert.strictEqual(e.message, 'The "options.signal" property must be an ' +
+    "instance of AbortSignal. Received type string ('world!')");
+  }));
 }

--- a/test/parallel/test-child-process-execFile-promisified-abortController.js
+++ b/test/parallel/test-child-process-execFile-promisified-abortController.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { promisify } = require('util');
+const execFile = require('child_process').execFile;
+const { getSystemErrorName } = require('util');
+const fixtures = require('../common/fixtures');
+
+const fixture = fixtures.path('exit.js');
+const echoFixture = fixtures.path('echo.js');
+const execOpts = { encoding: 'utf8', shell: true };
+const execFilePromisified = promisify(execFile);
+
+{
+  // Verify that the signal option works properly
+  const ac = new AbortController();
+  const signal = ac.signal;
+  const promise = execFilePromisified(process.execPath, [echoFixture, 0], { signal });
+  
+  ac.abort();
+
+  assert.rejects(promise, /AbortError/);
+}
+
+{
+  // Verify that the signal option works properly when already aborted
+  const ac = new AbortController();
+  const { signal } = ac;
+  ac.abort();
+
+  const promise = execFilePromisified(process.execPath, [echoFixture, 0], { signal });
+
+  assert.rejects(promise, /AbortError/);
+}
+
+{
+  // Verify that if something different than Abortcontroller.signal
+  // is passed, ERR_INVALID_ARG_TYPE is thrown
+  const promise = execFilePromisified(process.execPath, [echoFixture, 0], { signal: {} });
+
+  assert.rejects(promise, {
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError',
+    message: 'The "options.signal" property must be an ' +
+             'instance of AbortSignal. Received an instance of Object'
+  });
+
+}
+
+{
+  // Verify that if something different than Abortcontroller.signal
+  // is passed, ERR_INVALID_ARG_TYPE is thrown
+  const promise = execFilePromisified(process.execPath, [echoFixture, 0], { signal: 'world!' });
+
+  assert.rejects(promise, {
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError',
+    message: 'The "options.signal" property must be an ' +
+             `instance of AbortSignal. Received type string ('world!')`
+  });
+
+}

--- a/test/parallel/test-child-process-execFile-promisified-abortController.js
+++ b/test/parallel/test-child-process-execFile-promisified-abortController.js
@@ -8,6 +8,10 @@ const fixtures = require('../common/fixtures');
 
 const echoFixture = fixtures.path('echo.js');
 const promisified = promisify(execFile);
+const invalidArgTypeError = {
+  code: 'ERR_INVALID_ARG_TYPE',
+  name: 'TypeError'
+};
 
 {
   // Verify that the signal option works properly
@@ -39,43 +43,16 @@ const promisified = promisify(execFile);
   // Verify that if something different than Abortcontroller.signal
   // is passed, ERR_INVALID_ARG_TYPE is thrown
   const signal = {};
-  const promise = promisified(process.execPath, [echoFixture, 0], { signal });
-
-  promise.catch(common.mustCall((e) => {
-    assert.strictEqual(e.name, 'TypeError');
-    assert.strictEqual(e.code, 'ERR_INVALID_ARG_TYPE');
-    assert.strictEqual(e.message, 'The "options.signal" property must be an ' +
-    'instance of AbortSignal. Received an instance of Object');
-  }));
-
+  assert.throws(() => {
+    promisified(process.execPath, [echoFixture, 0], { signal });
+  }, invalidArgTypeError);
 }
 
 {
   // Verify that if something different than Abortcontroller.signal
   // is passed, ERR_INVALID_ARG_TYPE is thrown
   const signal = 'world!';
-  const promise = promisified(process.execPath, [echoFixture, 0], { signal });
-
-
-  promise.catch(common.mustCall((e) => {
-    assert.strictEqual(e.name, 'TypeError');
-    assert.strictEqual(e.code, 'ERR_INVALID_ARG_TYPE');
-    assert.strictEqual(e.message, 'The "options.signal" property must be an ' +
-    "instance of AbortSignal. Received type string ('world!')");
-  }));
-}
-
-{
-  // Verify that if something different than Abortcontroller.signal
-  // is passed, ERR_INVALID_ARG_TYPE is thrown
-  const signal = 'world!';
-  const promise = promisified(process.execPath, [echoFixture, 0], { signal });
-
-
-  promise.catch(common.mustCall((e) => {
-    assert.strictEqual(e.name, 'TypeError');
-    assert.strictEqual(e.code, 'ERR_INVALID_ARG_TYPE');
-    assert.strictEqual(e.message, 'The "options.signal" property must be an ' +
-    "instance of AbortSignal. Received type string ('world!')");
-  }));
+  assert.throws(() => {
+    promisified(process.execPath, [echoFixture, 0], { signal });
+  }, invalidArgTypeError);
 }

--- a/test/parallel/test-child-process-execFile-promisified-abortController.js
+++ b/test/parallel/test-child-process-execFile-promisified-abortController.js
@@ -21,9 +21,10 @@ const invalidArgTypeError = {
 
   ac.abort();
 
-  promise.catch(common.mustCall((e) => {
-    assert.strictEqual(e.name, 'AbortError');
-  }));
+  assert.rejects(
+    promise,
+    { name: 'AbortError' }
+  ).then(common.mustCall());
 }
 
 {
@@ -32,11 +33,10 @@ const invalidArgTypeError = {
   const { signal } = ac;
   ac.abort();
 
-  const promise = promisified(process.execPath, [echoFixture, 0], { signal });
-
-  promise.catch(common.mustCall((e) => {
-    assert.strictEqual(e.name, 'AbortError');
-  }));
+  assert.rejects(
+    promisified(process.execPath, [echoFixture, 0], { signal }),
+    { name: 'AbortError' }
+  ).then(common.mustCall());
 }
 
 {

--- a/test/parallel/test-child-process-execfile.js
+++ b/test/parallel/test-child-process-execfile.js
@@ -53,19 +53,30 @@ const execOpts = { encoding: 'utf8', shell: true };
   const ac = new AbortController();
   const { signal } = ac;
 
-  const test = () => {
-    const check = common.mustCall((err) => {
-      assert.strictEqual(err.code, 'ABORT_ERR');
-      assert.strictEqual(err.name, 'AbortError');
-      assert.strictEqual(err.signal, undefined);
-    });
-    execFile(process.execPath, [echoFixture, 0], { signal }, check);
-  };
+  const callback = common.mustCall((err) => {
+    assert.strictEqual(err.code, 'ABORT_ERR');
+    assert.strictEqual(err.name, 'AbortError');
+  });
 
-  test();
+  execFile(process.execPath, [echoFixture, 0], { signal }, callback);
   ac.abort();
   // Verify that it still works the same way now that the signal is aborted.
   test();
+}
+
+{
+  // Verify that does not spawn a child if already aborted
+  const ac = new AbortController();
+  const { signal } = ac;
+  ac.abort();
+
+  try {
+      execFile(process.execPath, [echoFixture, 0], { signal }); 
+  } catch (err) {
+      assert.strictEqual(err.code, 'ABORT_ERR');
+      assert.strictEqual(err.name, 'AbortError');
+  }
+  
 }
 
 {

--- a/test/parallel/test-child-process-execfile.js
+++ b/test/parallel/test-child-process-execfile.js
@@ -71,12 +71,12 @@ const execOpts = { encoding: 'utf8', shell: true };
   ac.abort();
 
   try {
-      execFile(process.execPath, [echoFixture, 0], { signal }); 
+    execFile(process.execPath, [echoFixture, 0], { signal });
   } catch (err) {
-      assert.strictEqual(err.code, 'ABORT_ERR');
-      assert.strictEqual(err.name, 'AbortError');
+    assert.strictEqual(err.code, 'ABORT_ERR');
+    assert.strictEqual(err.name, 'AbortError');
   }
-  
+
 }
 
 {

--- a/test/parallel/test-child-process-execfile.js
+++ b/test/parallel/test-child-process-execfile.js
@@ -73,12 +73,12 @@ const execOpts = { encoding: 'utf8', shell: true };
   const { signal } = ac;
   ac.abort();
 
-  try {
-    execFile(process.execPath, [echoFixture, 0], { signal });
-  } catch (err) {
+  const check = common.mustCall((err) => {
     assert.strictEqual(err.code, 'ABORT_ERR');
     assert.strictEqual(err.name, 'AbortError');
-  }
+    assert.strictEqual(err.signal, undefined);
+  });
+  execFile(process.execPath, [echoFixture, 0], { signal }, check);
 }
 
 {

--- a/test/parallel/test-child-process-execfile.js
+++ b/test/parallel/test-child-process-execfile.js
@@ -53,15 +53,18 @@ const execOpts = { encoding: 'utf8', shell: true };
   const ac = new AbortController();
   const { signal } = ac;
 
-  const callback = common.mustCall((err) => {
-    assert.strictEqual(err.code, 'ABORT_ERR');
-    assert.strictEqual(err.name, 'AbortError');
-  });
+  const test = () => {
+    const check = common.mustCall((err) => {
+      assert.strictEqual(err.code, 'ABORT_ERR');
+      assert.strictEqual(err.name, 'AbortError');
+      assert.strictEqual(err.signal, undefined);
+    });
+    execFile(process.execPath, [echoFixture, 0], { signal }, check);
+  };
 
-  execFile(process.execPath, [echoFixture, 0], { signal }, callback);
-  ac.abort();
   // Verify that it still works the same way now that the signal is aborted.
   test();
+  ac.abort();
 }
 
 {
@@ -76,7 +79,6 @@ const execOpts = { encoding: 'utf8', shell: true };
     assert.strictEqual(err.code, 'ABORT_ERR');
     assert.strictEqual(err.name, 'AbortError');
   }
-
 }
 
 {


### PR DESCRIPTION
Using new experimental AbortController, add support for promised
exec to be canceled.

Through `AbortController`, add support to promisified version of `exec` and `execFile` being able to be canceled using AbortController.
e.g.

```javascript
const { promisify } = require('util');
const { exec } = require('child_process');
const execPromisifed = promisify(exec);

const pwdcommand = 'pwd';
const dir = '/dev';
const ac = new AbortController();
const signal = ac.signal;

execPromisifed(pwdcommand, { cwd: dir, signal })

ac.abort();
```
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
