### PR TITLE
src: refactor TimerWrap class

### DIFF
--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -525,7 +525,7 @@ class NodeInspectorClient : public V8InspectorClient {
                            void* data) override {
     auto result =
         timers_.emplace(std::piecewise_construct, std::make_tuple(data),
-                        std::make_tuple(env_, callback, data));
+                        std::make_tuple(env_, [=]() { callback(data); }));
     CHECK(result.second);
     uint64_t interval = 1000 * interval_s;
     result.first->second.Update(interval, interval);

--- a/src/quic/node_quic_session-inl.h
+++ b/src/quic/node_quic_session-inl.h
@@ -511,11 +511,11 @@ void QuicSession::set_remote_transport_params() {
 }
 
 void QuicSession::StopIdleTimer() {
-  idle_.Stop();
+  idle_.Close();
 }
 
 void QuicSession::StopRetransmitTimer() {
-  retransmit_.Stop();
+  retransmit_.Close();
 }
 
 // Called by the OnVersionNegotiation callback when a version

--- a/src/quic/node_quic_session.cc
+++ b/src/quic/node_quic_session.cc
@@ -1431,8 +1431,8 @@ QuicSession::QuicSession(
     socket_(socket),
     alpn_(alpn),
     hostname_(hostname),
-    idle_(socket->env(), [this](void* data) { OnIdleTimeout(); }),
-    retransmit_(socket->env(), [this](void* data) { MaybeTimeout(); }),
+    idle_(socket->env(), [this]() { OnIdleTimeout(); }),
+    retransmit_(socket->env(), [this]() { MaybeTimeout(); }),
     dcid_(dcid),
     state_(env()->isolate()),
     quic_state_(socket->quic_state()) {

--- a/src/timer_wrap.cc
+++ b/src/timer_wrap.cc
@@ -5,10 +5,9 @@
 
 namespace node {
 
-TimerWrap::TimerWrap(Environment* env, TimerCb fn, void* user_data)
+TimerWrap::TimerWrap(Environment* env, const TimerCb& fn)
     : env_(env),
-      fn_(fn),
-      user_data_(user_data) {
+      fn_(fn) {
   uv_timer_init(env->event_loop(), &timer_);
   timer_.data = this;
 }
@@ -45,14 +44,13 @@ void TimerWrap::Unref() {
 
 void TimerWrap::OnTimeout(uv_timer_t* timer) {
   TimerWrap* t = ContainerOf(&TimerWrap::timer_, timer);
-  t->fn_(t->user_data_);
+  t->fn_();
 }
 
 TimerWrapHandle::TimerWrapHandle(
     Environment* env,
-    TimerWrap::TimerCb fn,
-    void* user_data) {
-  timer_ = new TimerWrap(env, fn, user_data);
+    const TimerWrap::TimerCb& fn) {
+  timer_ = new TimerWrap(env, fn);
   env->AddCleanupHook(CleanupHook, this);
 }
 

--- a/src/timer_wrap.h
+++ b/src/timer_wrap.h
@@ -14,9 +14,9 @@ namespace node {
 // Utility class that makes working with libuv timers a bit easier.
 class TimerWrap final : public MemoryRetainer {
  public:
-  using TimerCb = std::function<void(void*)>;
+  using TimerCb = std::function<void()>;
 
-  TimerWrap(Environment* env, TimerCb fn, void* user_data);
+  TimerWrap(Environment* env, const TimerCb& fn);
   TimerWrap(const TimerWrap&) = delete;
 
   inline Environment* env() const { return env_; }
@@ -43,7 +43,6 @@ class TimerWrap final : public MemoryRetainer {
   Environment* env_;
   TimerCb fn_;
   uv_timer_t timer_;
-  void* user_data_ = nullptr;
 
   friend std::unique_ptr<TimerWrap>::deleter_type;
 };
@@ -52,8 +51,7 @@ class TimerWrapHandle : public MemoryRetainer  {
  public:
   TimerWrapHandle(
       Environment* env,
-      TimerWrap::TimerCb fn,
-      void* user_data = nullptr);
+      const TimerWrap::TimerCb& fn);
 
   TimerWrapHandle(const TimerWrapHandle&) = delete;
 

--- a/src/timer_wrap.h
+++ b/src/timer_wrap.h
@@ -21,14 +21,15 @@ class TimerWrap final : public MemoryRetainer {
 
   inline Environment* env() const { return env_; }
 
-  // Completely stops the timer, making it no longer usable.
-  void Stop(bool close = true);
+  // Stop calling the timer callback.
+  void Stop();
+  // Render the timer unusable and delete this object.
+  void Close();
 
   // Starts / Restarts the Timer
   void Update(uint64_t interval, uint64_t repeat = 0);
 
   void Ref();
-
   void Unref();
 
   SET_NO_MEMORY_INFO();
@@ -55,15 +56,15 @@ class TimerWrapHandle : public MemoryRetainer  {
 
   TimerWrapHandle(const TimerWrapHandle&) = delete;
 
-  ~TimerWrapHandle() { Stop(); }
+  ~TimerWrapHandle() { Close(); }
 
   void Update(uint64_t interval, uint64_t repeat = 0);
 
   void Ref();
-
   void Unref();
 
-  void Stop(bool close = true);
+  void Stop();
+  void Close();
 
   void MemoryInfo(node::MemoryTracker* tracker) const override;
 
@@ -72,6 +73,7 @@ class TimerWrapHandle : public MemoryRetainer  {
 
  private:
   static void CleanupHook(void* data);
+
   TimerWrap* timer_;
 };
 


### PR DESCRIPTION
##### src: remove user_data from TimerWrap

There’s no point in having an opaque user data pointer when we’re
already using `std::function`.

##### src: refactor TimerWrap lifetime management

~~Move the cleanup hook into the `TimerWrap`, because it should
always be present when that class is being used, and~~ split
`Stop(true)` and `Stop(false)` into separate methods since the
actions performed by these are fully distinct.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
