### PR TITLE
build,tools: fix cmd_regen_makefile

### DIFF
--- a/tools/gyp_node.py
+++ b/tools/gyp_node.py
@@ -52,7 +52,7 @@ def run_gyp(args):
   args.append('-Dlinux_use_gold_flags=0')
 
   # Set the current program to this module. This is done because gyp
-  # will the program path in targets it generates. If this script was called
+  # will use the program path in targets it generates. If this script was called
   # by another script the program name will not be gyp_node.py but whatever
   # the name of the script that called it is, leading to incorrect commands
   # in generated targets (for example cmd_regen_makefile).

--- a/tools/gyp_node.py
+++ b/tools/gyp_node.py
@@ -51,6 +51,12 @@ def run_gyp(args):
   args.append('-Dlinux_use_bundled_gold=0')
   args.append('-Dlinux_use_gold_flags=0')
 
+  # Set the current program to this module. This is done because gyp
+  # will the program path in targets it generates. If this script was called
+  # by another script the program name will not be gyp_node.py but whatever
+  # the name of the script that called it is, leading to incorrect commands
+  # in generated targets (for example cmd_regen_makefile).
+  sys.argv[0] = os.path.abspath(__file__)
   rc = gyp.main(args)
   if rc != 0:
     print('Error running GYP')


### PR DESCRIPTION
Currently, after having configured and built node and then updating a
dependent target the following error is produced when trying to rebuild
the project:
```console
$ ./configure && make -j8
$ touch node.gypi
$ make -j8
configure: error: no such option: -f
make[1]: *** [Makefile:685: Makefile] Error 2
```
The reason for this is that the target `cmd_regen_makefile` is using the
command `configure` instead of `gyp_node.py` in out/Makefile:
```
cmd_regen_makefile = cd $(srcdir); /work/nodejs/node/configure -fmake
```
As far as I can tell gyp is using `sys.argv[0]` as the `gyp_binary` in
`__init__.py`:
```pyton
params = {'options': options,
              ...
              'gyp_binary': sys.argv[0],
```
But when called via 'configure' sys.argv[0] is 'configure' instead of gyp_node.py 
leading to the above error.

This commit suggests setting the program name explicitly in
gyp_node.py. Alternatively perhaps this could be done in configure.py
instead but I was not sure what would be best.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
