### PR TITLE
esm: improve packageResolve

### DIFF
--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -151,8 +151,7 @@ function getPackageScopeConfig(resolved, base) {
     type: 'none',
     exports: undefined
   };
-  const filePath = fileURLToPath(packageJSONUrl);
-  packageJSONCache.set(filePath, packageConfig);
+  packageJSONCache.set(fileURLToPath(packageJSONUrl), packageConfig);
   return { packageConfig };
 }
 

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -535,9 +535,9 @@ function packageResolve(specifier, base, conditions) {
     '' : '.' + StringPrototypeSlice(specifier, separatorIndex);
 
   // ResolveSelf
-  const { path: _path, packageConfig } = getPackageScopeConfig(base, base);
+  const { path, packageConfig } = getPackageScopeConfig(base, base);
   if (packageConfig.exists) {
-    const packageJSONUrl = _path;
+    const packageJSONUrl = path;
     if (packageJSONUrl !== undefined &&
         packageConfig.name === packageName &&
         packageConfig.exports !== undefined) {

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -133,8 +133,9 @@ function getPackageScopeConfig(resolved, base) {
     const packageJSONPath = packageJSONUrl.pathname;
     if (StringPrototypeEndsWith(packageJSONPath, 'node_modules/package.json'))
       break;
-    const packageConfig = getPackageConfig(fileURLToPath(packageJSONUrl), base);
-    if (packageConfig.exists) return packageConfig;
+    const filePath = fileURLToPath(packageJSONUrl);
+    const packageConfig = getPackageConfig(filePath, base);
+    if (packageConfig.exists) return { path: filePath, packageConfig };
 
     const lastPackageJSONUrl = packageJSONUrl;
     packageJSONUrl = new URL('../package.json', packageJSONUrl);
@@ -150,8 +151,9 @@ function getPackageScopeConfig(resolved, base) {
     type: 'none',
     exports: undefined
   };
-  packageJSONCache.set(fileURLToPath(packageJSONUrl), packageConfig);
-  return packageConfig;
+  const filePath = fileURLToPath(packageJSONUrl);
+  packageJSONCache.set(filePath, packageConfig);
+  return { path: filePath, packageConfig };
 }
 
 /*
@@ -488,7 +490,7 @@ function packageExportsResolve(
 }
 
 function getPackageType(url) {
-  const packageConfig = getPackageScopeConfig(url, url);
+  const { packageConfig } = getPackageScopeConfig(url, url);
   return packageConfig.type;
 }
 
@@ -533,17 +535,9 @@ function packageResolve(specifier, base, conditions) {
     '' : '.' + StringPrototypeSlice(specifier, separatorIndex);
 
   // ResolveSelf
-  const packageConfig = getPackageScopeConfig(base, base);
+  const { path: _path, packageConfig } = getPackageScopeConfig(base, base);
   if (packageConfig.exists) {
-    // TODO(jkrems): Find a way to forward the pair/iterator already generated
-    // while executing GetPackageScopeConfig
-    let packageJSONUrl;
-    for (const [ filename, packageConfigCandidate ] of packageJSONCache) {
-      if (packageConfig === packageConfigCandidate) {
-        packageJSONUrl = pathToFileURL(filename);
-        break;
-      }
-    }
+    const packageJSONUrl = _path;
     if (packageJSONUrl !== undefined &&
         packageConfig.name === packageName &&
         packageConfig.exports !== undefined) {

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -537,7 +537,7 @@ function packageResolve(specifier, base, conditions) {
   // ResolveSelf
   const { path, packageConfig } = getPackageScopeConfig(base, base);
   if (packageConfig.exists) {
-    // If path not exist, then packageConfig not exists too
+    // If path not exist, then packageConfig.exists is false too
     const packageJSONUrl = path;
     if (packageJSONUrl !== undefined &&
         packageConfig.name === packageName &&

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -537,7 +537,7 @@ function packageResolve(specifier, base, conditions) {
   const { path, packageConfig } = getPackageScopeConfig(base, base);
   if (packageConfig.exists) {
     // If path not exist, then packageConfig.exists is false too
-    const packageJSONUrl = path;
+    const packageJSONUrl = pathToFileURL(path);
     if (packageJSONUrl !== undefined &&
         packageConfig.name === packageName &&
         packageConfig.exports !== undefined) {

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -153,7 +153,7 @@ function getPackageScopeConfig(resolved, base) {
   };
   const filePath = fileURLToPath(packageJSONUrl);
   packageJSONCache.set(filePath, packageConfig);
-  return { path: filePath, packageConfig };
+  return { packageConfig };
 }
 
 /*
@@ -537,6 +537,7 @@ function packageResolve(specifier, base, conditions) {
   // ResolveSelf
   const { path, packageConfig } = getPackageScopeConfig(base, base);
   if (packageConfig.exists) {
+    // If path not exist, then packageConfig not exists too
     const packageJSONUrl = path;
     if (packageJSONUrl !== undefined &&
         packageConfig.name === packageName &&


### PR DESCRIPTION
enhance time complexity from `O(n)` to `O(1)`

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
