### PR TITLE
src: add GetCipherValue function

### DIFF
--- a/src/node_crypto_common.cc
+++ b/src/node_crypto_common.cc
@@ -386,31 +386,27 @@ Local<Value> ToV8Value(Environment* env, const BIOPointer& bio) {
   return ret.FromMaybe(Local<Value>());
 }
 
-MaybeLocal<Value> GetCipherName(
-    Environment* env,
-    const SSL_CIPHER* cipher) {
+MaybeLocal<Value> GetCipherValue(Environment* env,
+    const SSL_CIPHER* cipher,
+    std::function<const char*(const SSL_CIPHER* cipher)> getstr) {
   if (cipher == nullptr)
     return Undefined(env->isolate());
 
-  return OneByteString(env->isolate(), SSL_CIPHER_get_name(cipher));
+  return OneByteString(env->isolate(), getstr(cipher));
+}
+
+MaybeLocal<Value> GetCipherName(Environment* env, const SSL_CIPHER* cipher) {
+  return GetCipherValue(env, cipher, SSL_CIPHER_get_name);
 }
 
 MaybeLocal<Value> GetCipherStandardName(
     Environment* env,
     const SSL_CIPHER* cipher) {
-  if (cipher == nullptr)
-    return Undefined(env->isolate());
-
-  return OneByteString(env->isolate(), SSL_CIPHER_standard_name(cipher));
+  return GetCipherValue(env, cipher, SSL_CIPHER_standard_name);
 }
 
-MaybeLocal<Value> GetCipherVersion(
-    Environment* env,
-    const SSL_CIPHER* cipher) {
-  if (cipher == nullptr)
-    return Undefined(env->isolate());
-
-  return OneByteString(env->isolate(), SSL_CIPHER_get_version(cipher));
+MaybeLocal<Value> GetCipherVersion(Environment* env, const SSL_CIPHER* cipher) {
+  return GetCipherValue(env, cipher, SSL_CIPHER_get_version);
 }
 
 StackOfX509 CloneSSLCerts(X509Pointer&& cert,

--- a/src/node_crypto_common.cc
+++ b/src/node_crypto_common.cc
@@ -388,7 +388,7 @@ Local<Value> ToV8Value(Environment* env, const BIOPointer& bio) {
 
 MaybeLocal<Value> GetCipherValue(Environment* env,
     const SSL_CIPHER* cipher,
-    std::function<const char*(const SSL_CIPHER* cipher)> getstr) {
+    const char* (*getstr)(const SSL_CIPHER* cipher)) {
   if (cipher == nullptr)
     return Undefined(env->isolate());
 


### PR DESCRIPTION
This commit extracts the code that is the same in `GetCipherName`,
`GetCipherStandardName`, and `GetCipherVersion` into function named
`GetCipherValue`.

The motivation for this change is to improve readabilty by removing the
duplicated code.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
