### PR TITLE
Add direct access to rss without iterating pages

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1589,6 +1589,28 @@ Will generate:
 When using [`Worker`][] threads, `rss` will be a value that is valid for the
 entire process, while the other fields will only refer to the current thread.
 
+The `process.memoryUsage()` method iterate over each page to gather
+informations about memory usage which can be slow depending on the
+program memory allocations.
+
+## `process.memoryUsage.rss()`
+
+* Returns: {integer}
+
+The `process.memoryUsage.rss()` method returns an integer representing the
+Resident Set Size (RSS) in bytes.
+
+The Resident Set Size, is the amount of space occupied in the main
+memory device (that is a subset of the total allocated memory) for the
+process, including all C++ and JavaScript objects and code.
+
+This is the same value as the one returned by `process.memoryUsage()`.
+
+```js
+console.log(process.memoryUsage.rss());
+// 35655680
+```
+
 ## `process.nextTick(callback[, ...args])`
 <!-- YAML
 added: v0.1.26

--- a/lib/internal/process/per_thread.js
+++ b/lib/internal/process/per_thread.js
@@ -93,6 +93,7 @@ function wrapProcessMethods(binding) {
   const {
     cpuUsage: _cpuUsage,
     memoryUsage: _memoryUsage,
+    rss,
     resourceUsage: _resourceUsage
   } = binding;
 
@@ -167,6 +168,8 @@ function wrapProcessMethods(binding) {
       arrayBuffers: memValues[4]
     };
   }
+
+  memoryUsage.rss = rss;
 
   function exit(code) {
     if (code || code === 0)

--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -172,13 +172,19 @@ static void Kill(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(err);
 }
 
-static void MemoryUsage(const FunctionCallbackInfo<Value>& args) {
+static void Rss(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
   size_t rss;
   int err = uv_resident_set_memory(&rss);
   if (err)
     return env->ThrowUVException(err, "uv_resident_set_memory");
+
+  args.GetReturnValue().Set(static_cast<double>(rss));
+}
+
+static void MemoryUsage(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
 
   Isolate* isolate = env->isolate();
   // V8 memory usage
@@ -191,6 +197,11 @@ static void MemoryUsage(const FunctionCallbackInfo<Value>& args) {
   // Get the double array pointer from the Float64Array argument.
   Local<ArrayBuffer> ab = get_fields_array_buffer(args, 0, 5);
   double* fields = static_cast<double*>(ab->GetBackingStore()->Data());
+
+  size_t rss;
+  int err = uv_resident_set_memory(&rss);
+  if (err)
+    return env->ThrowUVException(err, "uv_resident_set_memory");
 
   fields[0] = rss;
   fields[1] = v8_heap_stats.total_heap_size();
@@ -542,6 +553,7 @@ static void InitializeProcessMethods(Local<Object> target,
   env->SetMethod(target, "umask", Umask);
   env->SetMethod(target, "_rawDebug", RawDebug);
   env->SetMethod(target, "memoryUsage", MemoryUsage);
+  env->SetMethod(target, "rss", Rss);
   env->SetMethod(target, "cpuUsage", CPUUsage);
   env->SetMethod(target, "resourceUsage", ResourceUsage);
 
@@ -568,6 +580,7 @@ void RegisterProcessMethodsExternalReferences(
   registry->Register(Umask);
   registry->Register(RawDebug);
   registry->Register(MemoryUsage);
+  registry->Register(Rss);
   registry->Register(CPUUsage);
   registry->Register(ResourceUsage);
 

--- a/test/parallel/test-memory-usage.js
+++ b/test/parallel/test-memory-usage.js
@@ -44,3 +44,5 @@ if (r.arrayBuffers > 0) {
   assert.strictEqual(after.arrayBuffers - r.arrayBuffers, size,
                      `${after.arrayBuffers} - ${r.arrayBuffers} === ${size}`);
 }
+
+assert(process.memoryUsage.rss() > 0);


### PR DESCRIPTION
Accessing the rss value through `process.memoryUsage().rss` can be expensive because this method will also generate  memory usage statistics by iterating on each page.

The overhead can be quite huge when a lot of memory has been allocated, consider this snippet:
<details><summary>rss-access.js</summary>

```
const ar = []

for (let i = parseInt(process.argv[2], 10); i--; ) {
  ar.push({
    very: 'This is a lot of datazzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz',
    big: {
      object: 'I m blue tadoudidadouda I m blue tadoudidadouda I m blue tadoudidadouda'
    }
  })
}

let start = process.hrtime();

process.memoryUsage().rss

let hrend = process.hrtime(start);

console.log(hrend[1] / 1000000, 'memoryUsage()');

start = process.hrtime();

process.rss()

hrend = process.hrtime(start);

console.log(hrend[1] / 1000000, 'rss()')
```

</details>

```bash
$ ./out/Release/node test.js 1000
0.361226 memoryUsage()
0.05305 rss()

$ ./out/Release/node test.js 10000000
1.208851 memoryUsage()
0.075418 rss()
```

This PR aim to offer an API to access directly the rss value in a (almost) constant time.

```js
// Don't
process.memoryUsage().rss;

// Do
process.memoryUsage.rss();
```

<details><summary>EDIT: 2020-07-13</summary>

Following @bnoordhuis  proposal I added a `rssOnly` option to `process.memoryUsage` instead of adding the new `process.rss` method:
```js
process.memoryUsage({ rssOnly: true });
{
  rss: 36270080,
  heapTotal: 0,
  heapUsed: 0,
  external: 0,
  arrayBuffers: 0
}
```

</details>

<details><summary>EDIT: 2020-08-11</summary>

Following @jasnell and @bnoordhuis advices the rss value is now accessible through `process.memoryUsage.rss`

</details>

See https://github.com/nodejs/node/issues/33384


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [/] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes (Unix is ok but unfortunately I don't have a windows computer)
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added (I will add the documentation once we agree on the API)
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
