### PR TITLE
doc: clarify conditional exports guidance

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -467,7 +467,7 @@ Defines a package where `require('pkg/feature')` and `import 'pkg/feature'`
 could provide different implementations between Node.js and other JS
 environments.
 
-Whenever using environment branches, it is highly recommended to always include
+When using environment branches, include
 a `"defaut"` condition where possible. Always providing a `"default"` condition
 ensures that any unknown JS environments are able to use a universal
 implementation where possible, which helps avoid JS environments from having to

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -456,7 +456,7 @@ Conditional exports can also be extended to exports subpaths, for example:
   "exports": {
     ".": "./main.js",
     "./feature": {
-      "browser": "./feature-browser.js",
+      "node": "./feature-node.js",
       "default": "./feature.js"
     }
   }
@@ -464,8 +464,16 @@ Conditional exports can also be extended to exports subpaths, for example:
 ```
 
 Defines a package where `require('pkg/feature')` and `import 'pkg/feature'`
-could provide different implementations between the browser and Node.js,
-given third-party tool support for a `"browser"` condition.
+could provide different implementations between Node.js and other JS
+environments.
+
+Whenever using environment branches, it is highly recommended to always include
+a `"defaut"` condition where possible. Always providing a `"default"` condition
+ensures that any unknown JS environments are able to use a universal
+implementation where possible, which helps avoid JS environments from having to
+pretend to be existing environments to support packages with conditional
+exports. Where possible, `"node"` and `"default"` conditions can be preferable
+to `"browser"` conditions.
 
 #### Nested conditions
 
@@ -479,11 +487,11 @@ use in Node.js but not the browser:
 {
   "main": "./main.js",
   "exports": {
-    "browser": "./feature-browser.mjs",
     "node": {
       "import": "./feature-node.mjs",
       "require": "./feature-node.cjs"
-    }
+    },
+    "default": "./feature.mjs",
   }
 }
 ```

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -467,13 +467,13 @@ Defines a package where `require('pkg/feature')` and `import 'pkg/feature'`
 could provide different implementations between Node.js and other JS
 environments.
 
-When using environment branches, include
-a `"defaut"` condition where possible. Always providing a `"default"` condition
-ensures that any unknown JS environments are able to use a universal
-implementation where possible, which helps avoid JS environments from having to
-pretend to be existing environments to support packages with conditional
-exports. Where possible, `"node"` and `"default"` conditions can be preferable
-to `"browser"` conditions.
+When using environment branches, always include a `"default"` condition where
+possible. Providing a `"default"` condition ensures that any unknown JS
+environments are able to use this universal implementation, which helps avoid
+these JS environments from having to pretend to be existing environments in
+order to support packages with conditional exports. For this reason, using
+`"node"` and `"default"` condition branches is usually preferable to using
+`"node"` and `"browser"` condition branches.
 
 #### Nested conditions
 


### PR DESCRIPTION
This updates the conditional exports examples to split on the `"node"` and `"default"` conditions over encouraging a `"browser"` and `"default"` split by default.

The notes are also updated to provide this guidance that a `"default"` fallback as the more universal style code is a recommended pattern to ensure package forward compatibility in JS workflows.

Wording adjustments welcome.

//cc @nodejs/modules-active-members

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
