### PR TITLE
worker: fix nested uncaught exception handling

### DIFF
--- a/lib/internal/error_serdes.js
+++ b/lib/internal/error_serdes.js
@@ -14,6 +14,7 @@ const {
   ObjectKeys,
   ObjectPrototypeToString,
   SafeSet,
+  SymbolToStringTag,
 } = primordials;
 
 const kSerializedError = 0;
@@ -116,7 +117,7 @@ function deserializeError(error) {
     case kSerializedError:
       const { constructor, properties } = deserialize(error.subarray(1));
       const ctor = errors[constructor];
-      ObjectDefineProperty(properties, Symbol.toStringTag, {
+      ObjectDefineProperty(properties, SymbolToStringTag, {
         value: { value: 'Error', configurable: true },
         enumerable: true
       });

--- a/lib/internal/error_serdes.js
+++ b/lib/internal/error_serdes.js
@@ -116,6 +116,10 @@ function deserializeError(error) {
     case kSerializedError:
       const { constructor, properties } = deserialize(error.subarray(1));
       const ctor = errors[constructor];
+      ObjectDefineProperty(properties, Symbol.toStringTag, {
+        value: { value: 'Error', configurable: true },
+        enumerable: true
+      });
       return ObjectCreate(ctor.prototype, properties);
     case kSerializedObject:
       return deserialize(error.subarray(1));

--- a/test/parallel/test-error-serdes.js
+++ b/test/parallel/test-error-serdes.js
@@ -16,12 +16,17 @@ assert.strictEqual(cycle(null), null);
 assert.strictEqual(cycle(undefined), undefined);
 assert.strictEqual(cycle('foo'), 'foo');
 
-{
-  const err = cycle(new Error('foo'));
+let err = new Error('foo');
+for (let i = 0; i < 10; i++) {
   assert(err instanceof Error);
+  assert(Object.prototype.toString.call(err), '[object Error]');
   assert.strictEqual(err.name, 'Error');
   assert.strictEqual(err.message, 'foo');
   assert(/^Error: foo\n/.test(err.stack));
+
+  const prev = err;
+  err = cycle(err);
+  assert.deepStrictEqual(err, prev);
 }
 
 assert.strictEqual(cycle(new RangeError('foo')).name, 'RangeError');

--- a/test/parallel/test-worker-nested-uncaught.js
+++ b/test/parallel/test-worker-nested-uncaught.js
@@ -9,6 +9,6 @@ const w = new Worker(
   new Worker("throw new Error('uncaught')", { eval:true })`,
   { eval: true });
 w.on('error', common.expectsError({
-    name: 'Error',
-    message: 'uncaught'
-  }));
+  name: 'Error',
+  message: 'uncaught'
+}));

--- a/test/parallel/test-worker-nested-uncaught.js
+++ b/test/parallel/test-worker-nested-uncaught.js
@@ -1,0 +1,14 @@
+'use strict';
+const common = require('../common');
+const { Worker } = require('worker_threads');
+
+// Regression test for https://github.com/nodejs/node/issues/34309
+
+const w = new Worker(
+  `const { Worker } = require('worker_threads');
+  new Worker("throw new Error('uncaught')", { eval:true })`,
+  { eval: true });
+w.on('error', common.expectsError({
+    name: 'Error',
+    message: 'uncaught'
+  }));


### PR DESCRIPTION
We are using `ObjectPrototypeToString()` as a cross-context brand check
for built-in errors, but weren’t making sure to set that when
deserializing errors back into JS objects.

Fix that by setting `[Symbol.toStringTag]` manually, to make sure that
multiple serialize-and-deserialize cycles keep giving the same result.

Fixes: https://github.com/nodejs/node/issues/34309

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
