### PR TITLE
stream: finished on closed OutgoingMessage

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -49,7 +49,7 @@ const Agent = require('_http_agent');
 const { Buffer } = require('buffer');
 const { defaultTriggerAsyncIdScope } = require('internal/async_hooks');
 const { URL, urlToOptions, searchParamsSymbol } = require('internal/url');
-const { kOutHeaders, kNeedDrain, kClosed } = require('internal/http');
+const { kOutHeaders, kNeedDrain } = require('internal/http');
 const { connResetException, codes } = require('internal/errors');
 const {
   ERR_HTTP_HEADERS_SENT,
@@ -387,7 +387,7 @@ function _destroy(req, socket, err) {
     if (err) {
       req.emit('error', err);
     }
-    req[kClosed] = true;
+    req._closed = true;
     req.emit('close');
   }
 }
@@ -430,7 +430,7 @@ function socketCloseListener() {
         res.emit('error', connResetException('aborted'));
       }
     }
-    req[kClosed] = true;
+    req._closed = true;
     req.emit('close');
     if (!res.aborted && res.readable) {
       res.on('end', function() {
@@ -450,7 +450,7 @@ function socketCloseListener() {
       req.socket._hadError = true;
       req.emit('error', connResetException('socket hang up'));
     }
-    req[kClosed] = true;
+    req._closed = true;
     req.emit('close');
   }
 
@@ -555,7 +555,7 @@ function socketOnData(d) {
 
       req.emit(eventName, res, socket, bodyHead);
       req.destroyed = true;
-      req[kClosed] = true;
+      req._closed = true;
       req.emit('close');
     } else {
       // Requested Upgrade or used CONNECT method, but have no handler.
@@ -727,7 +727,7 @@ function requestOnPrefinish() {
 }
 
 function emitFreeNT(req) {
-  req[kClosed] = true;
+  req._closed = true;
   req.emit('close');
   if (req.res) {
     req.res.emit('close');

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -36,7 +36,7 @@ const assert = require('internal/assert');
 const EE = require('events');
 const Stream = require('stream');
 const internalUtil = require('internal/util');
-const { kOutHeaders, utcDate, kNeedDrain, kClosed } = require('internal/http');
+const { kOutHeaders, utcDate, kNeedDrain } = require('internal/http');
 const { Buffer } = require('buffer');
 const common = require('_http_common');
 const checkIsHttpToken = common._checkIsHttpToken;
@@ -117,7 +117,7 @@ function OutgoingMessage() {
   this.finished = false;
   this._headerSent = false;
   this[kCorked] = 0;
-  this[kClosed] = false;
+  this._closed = false;
 
   this.socket = null;
   this._header = null;
@@ -664,7 +664,7 @@ function onError(msg, err, callback) {
 
 function emitErrorNt(msg, err, callback) {
   callback(err);
-  if (typeof msg.emit === 'function' && !msg[kClosed]) {
+  if (typeof msg.emit === 'function' && !msg._closed) {
     msg.emit('error', err);
   }
 }

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -49,7 +49,6 @@ const { OutgoingMessage } = require('_http_outgoing');
 const {
   kOutHeaders,
   kNeedDrain,
-  kClosed,
   emitStatistics
 } = require('internal/http');
 const {
@@ -216,7 +215,7 @@ function onServerResponseClose() {
   // Fortunately, that requires only a single if check. :-)
   if (this._httpMessage) {
     this._httpMessage.destroyed = true;
-    this._httpMessage[kClosed] = true;
+    this._httpMessage._closed = true;
     this._httpMessage.emit('close');
   }
 }
@@ -733,7 +732,7 @@ function resOnFinish(req, res, socket, state, server) {
 
 function emitCloseNT(self) {
   self.destroyed = true;
-  self[kClosed] = true;
+  self._closed = true;
   self.emit('close');
 }
 

--- a/lib/internal/http.js
+++ b/lib/internal/http.js
@@ -51,7 +51,6 @@ function emitStatistics(statistics) {
 module.exports = {
   kOutHeaders: Symbol('kOutHeaders'),
   kNeedDrain: Symbol('kNeedDrain'),
-  kClosed: Symbol('kClosed'),
   nowDate,
   utcDate,
   emitStatistics

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -7,6 +7,7 @@ const {
   ERR_INVALID_ARG_TYPE,
   ERR_STREAM_PREMATURE_CLOSE
 } = require('internal/errors').codes;
+const { kClosed } = require('internal/http');
 const { once } = require('internal/util');
 
 function isRequest(stream) {
@@ -147,7 +148,7 @@ function eos(stream, opts, callback) {
   if (opts.error !== false) stream.on('error', onerror);
   stream.on('close', onclose);
 
-  const closed = (
+  const closed = stream[kClosed] === true || (
     (wState && wState.closed) ||
     (rState && rState.closed) ||
     (wState && wState.errorEmitted) ||

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -7,7 +7,6 @@ const {
   ERR_INVALID_ARG_TYPE,
   ERR_STREAM_PREMATURE_CLOSE
 } = require('internal/errors').codes;
-const { kClosed } = require('internal/http');
 const { once } = require('internal/util');
 
 function isRequest(stream) {
@@ -148,7 +147,7 @@ function eos(stream, opts, callback) {
   if (opts.error !== false) stream.on('error', onerror);
   stream.on('close', onclose);
 
-  const closed = stream[kClosed] === true || (
+  const closed = (!wState && !rState && stream._closed === true) || (
     (wState && wState.closed) ||
     (rState && rState.closed) ||
     (wState && wState.errorEmitted) ||

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -147,6 +147,7 @@ function eos(stream, opts, callback) {
   if (opts.error !== false) stream.on('error', onerror);
   stream.on('close', onclose);
 
+  // _closed is for OutgoingMessage which is not a proper Writable.
   const closed = (!wState && !rState && stream._closed === true) || (
     (wState && wState.closed) ||
     (rState && rState.closed) ||


### PR DESCRIPTION
finished should invoke callback on closed OutgoingMessage the
same way as for regular streams.

Fixes: https://github.com/nodejs/node/issues/34274

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
