### PR TITLE
stream: try to wait for flush to complete before 'finish'

### DIFF
--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -106,11 +106,15 @@ function Transform(options) {
   this.on('prefinish', prefinish);
 }
 
-function prefinish() {
+function final(cb) {
   if (typeof this._flush === 'function' && !this.destroyed) {
     this._flush((er, data) => {
       if (er) {
-        this.destroy(er);
+        if (cb) {
+          cb(er);
+        } else {
+          this.destroy(er);
+        }
         return;
       }
 
@@ -118,11 +122,25 @@ function prefinish() {
         this.push(data);
       }
       this.push(null);
+      if (cb) {
+        cb();
+      }
     });
   } else {
     this.push(null);
+    if (cb) {
+      cb();
+    }
   }
 }
+
+function prefinish() {
+  if (this._final !== final) {
+    final.call(this);
+  }
+}
+
+Transform.prototype._final = final;
 
 Transform.prototype._transform = function(chunk, encoding, callback) {
   throw new ERR_METHOD_NOT_IMPLEMENTED('_transform()');

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -323,6 +323,11 @@ ZlibBase.prototype._flush = function(callback) {
   this._transform(Buffer.alloc(0), '', callback);
 };
 
+// Force Transform compat behavior.
+ZlibBase.prototype._final = function(callback) {
+  callback();
+};
+
 // If a flush is scheduled while another flush is still pending, a way to figure
 // out which one is the "stronger" flush is needed.
 // This is currently only used to figure out which flush flag to use for the

--- a/test/parallel/test-stream-pipeline.js
+++ b/test/parallel/test-stream-pipeline.js
@@ -1231,3 +1231,27 @@ const net = require('net');
     assert.strictEqual(res, 'helloworld');
   }));
 }
+
+{
+  let flushed = false;
+  const makeStream = () =>
+    new Transform({
+      transform: (chunk, enc, cb) => cb(null, chunk),
+      flush: (cb) =>
+        setTimeout(() => {
+          flushed = true;
+          cb(null);
+        }, 1),
+    });
+
+  const input = new Readable();
+  input.push(null);
+
+  pipeline(
+    input,
+    makeStream(),
+    common.mustCall(() => {
+      assert.strictEqual(flushed, true);
+    }),
+  );
+}


### PR DESCRIPTION
Due to compat reasons Transform streams don't always wait
for flush to complete before finishing the stream.

Try to wait when possible, i.e. when the user does not
override _final.

Fixes: https://github.com/nodejs/node/issues/34274

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
