### PR TITLE
tls: remove setMaxSendFragment guards

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -1757,9 +1757,7 @@ void SSLWrap<Base>::AddMethods(Environment* env, Local<FunctionTemplate> t) {
                                   GetEphemeralKeyInfo);
   env->SetProtoMethodNoSideEffect(t, "getProtocol", GetProtocol);
 
-#ifdef SSL_set_max_send_fragment
   env->SetProtoMethod(t, "setMaxSendFragment", SetMaxSendFragment);
-#endif  // SSL_set_max_send_fragment
 
   env->SetProtoMethodNoSideEffect(t, "getALPNNegotiatedProtocol",
                                   GetALPNNegotiatedProto);
@@ -2118,8 +2116,6 @@ void SSLWrap<Base>::GetEphemeralKeyInfo(
   // ERR_get_error())
 }
 
-
-#ifdef SSL_set_max_send_fragment
 template <class Base>
 void SSLWrap<Base>::SetMaxSendFragment(
     const FunctionCallbackInfo<Value>& args) {
@@ -2133,7 +2129,6 @@ void SSLWrap<Base>::SetMaxSendFragment(
       args[0]->Int32Value(w->ssl_env()->context()).FromJust());
   args.GetReturnValue().Set(rv);
 }
-#endif  // SSL_set_max_send_fragment
 
 
 template <class Base>


### PR DESCRIPTION
BoringSSL implements `SSL_set_max_send_fragment` as a function, while OpenSSL implements it as a macro. I can't test it right now, but I suspect that calling `setMaxSendFragment` in Electron throws (maybe @codebytere can confirm?). AFAICT, all current OpenSSL versions have the macro, so removing these guards should not break anything. (Unless we still support 1.0.2, even though it is at EOL?)

Refs: https://github.com/nodejs/node-v0.x-archive/pull/6900
Refs: https://github.com/nodejs/node-v0.x-archive/issues/6889

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
