### PR TITLE
src: avoid strcmp in SecureContext::Init

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -568,77 +568,76 @@ void SecureContext::Init(const FunctionCallbackInfo<Value>& args) {
 
   if (args[0]->IsString()) {
     const node::Utf8Value sslmethod(env->isolate(), args[0]);
-    const std::string methodstr(*sslmethod);
 
     // Note that SSLv2 and SSLv3 are disallowed but SSLv23_method and friends
     // are still accepted.  They are OpenSSL's way of saying that all known
     // protocols below TLS 1.3 are supported unless explicitly disabled (which
     // we do below for SSLv2 and SSLv3.)
-    if (methodstr == "SSLv2_method" ||
-        methodstr == "SSLv2_server_method" ||
-        methodstr == "SSLv2_client_method") {
+    if (sslmethod == "SSLv2_method" ||
+        sslmethod == "SSLv2_server_method" ||
+        sslmethod == "SSLv2_client_method") {
       THROW_ERR_TLS_INVALID_PROTOCOL_METHOD(env, "SSLv2 methods disabled");
       return;
-    } else if (methodstr == "SSLv3_method" ||
-               methodstr == "SSLv3_server_method" ||
-               methodstr == "SSLv3_client_method") {
+    } else if (sslmethod == "SSLv3_method" ||
+               sslmethod == "SSLv3_server_method" ||
+               sslmethod == "SSLv3_client_method") {
       THROW_ERR_TLS_INVALID_PROTOCOL_METHOD(env, "SSLv3 methods disabled");
       return;
-    } else if (methodstr == "SSLv23_method") {
+    } else if (sslmethod == "SSLv23_method") {
       max_version = TLS1_2_VERSION;
-    } else if (methodstr == "SSLv23_server_method") {
+    } else if (sslmethod == "SSLv23_server_method") {
       max_version = TLS1_2_VERSION;
       method = TLS_server_method();
-    } else if (methodstr == "SSLv23_client_method") {
+    } else if (sslmethod == "SSLv23_client_method") {
       max_version = TLS1_2_VERSION;
       method = TLS_client_method();
-    } else if (methodstr == "TLS_method") {
+    } else if (sslmethod == "TLS_method") {
       min_version = 0;
       max_version = MAX_SUPPORTED_VERSION;
-    } else if (methodstr == "TLS_server_method") {
+    } else if (sslmethod == "TLS_server_method") {
       min_version = 0;
       max_version = MAX_SUPPORTED_VERSION;
       method = TLS_server_method();
-    } else if (methodstr == "TLS_client_method") {
+    } else if (sslmethod == "TLS_client_method") {
       min_version = 0;
       max_version = MAX_SUPPORTED_VERSION;
       method = TLS_client_method();
-    } else if (methodstr == "TLSv1_method") {
+    } else if (sslmethod == "TLSv1_method") {
       min_version = TLS1_VERSION;
       max_version = TLS1_VERSION;
-    } else if (methodstr == "TLSv1_server_method") {
+    } else if (sslmethod == "TLSv1_server_method") {
       min_version = TLS1_VERSION;
       max_version = TLS1_VERSION;
       method = TLS_server_method();
-    } else if (methodstr == "TLSv1_client_method") {
+    } else if (sslmethod == "TLSv1_client_method") {
       min_version = TLS1_VERSION;
       max_version = TLS1_VERSION;
       method = TLS_client_method();
-    } else if (methodstr == "TLSv1_1_method") {
+    } else if (sslmethod == "TLSv1_1_method") {
       min_version = TLS1_1_VERSION;
       max_version = TLS1_1_VERSION;
-    } else if (methodstr == "TLSv1_1_server_method") {
+    } else if (sslmethod == "TLSv1_1_server_method") {
       min_version = TLS1_1_VERSION;
       max_version = TLS1_1_VERSION;
       method = TLS_server_method();
-    } else if (methodstr == "TLSv1_1_client_method") {
+    } else if (sslmethod == "TLSv1_1_client_method") {
       min_version = TLS1_1_VERSION;
       max_version = TLS1_1_VERSION;
       method = TLS_client_method();
-    } else if (methodstr == "TLSv1_2_method") {
+    } else if (sslmethod == "TLSv1_2_method") {
       min_version = TLS1_2_VERSION;
       max_version = TLS1_2_VERSION;
-    } else if (methodstr == "TLSv1_2_server_method") {
+    } else if (sslmethod == "TLSv1_2_server_method") {
       min_version = TLS1_2_VERSION;
       max_version = TLS1_2_VERSION;
       method = TLS_server_method();
-    } else if (methodstr == "TLSv1_2_client_method") {
+    } else if (sslmethod == "TLSv1_2_client_method") {
       min_version = TLS1_2_VERSION;
       max_version = TLS1_2_VERSION;
       method = TLS_client_method();
     } else {
       const std::string msg("Unknown method: ");
-      THROW_ERR_TLS_INVALID_PROTOCOL_METHOD(env, (msg + methodstr).c_str());
+      THROW_ERR_TLS_INVALID_PROTOCOL_METHOD(env, (msg + *sslmethod).c_str());
       return;
     }
   }

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -568,84 +568,77 @@ void SecureContext::Init(const FunctionCallbackInfo<Value>& args) {
 
   if (args[0]->IsString()) {
     const node::Utf8Value sslmethod(env->isolate(), args[0]);
+    const std::string methodstr(*sslmethod);
 
     // Note that SSLv2 and SSLv3 are disallowed but SSLv23_method and friends
     // are still accepted.  They are OpenSSL's way of saying that all known
     // protocols below TLS 1.3 are supported unless explicitly disabled (which
     // we do below for SSLv2 and SSLv3.)
-    if (strcmp(*sslmethod, "SSLv2_method") == 0) {
+    if (methodstr == "SSLv2_method" ||
+        methodstr == "SSLv2_server_method" ||
+        methodstr == "SSLv2_client_method") {
       THROW_ERR_TLS_INVALID_PROTOCOL_METHOD(env, "SSLv2 methods disabled");
       return;
-    } else if (strcmp(*sslmethod, "SSLv2_server_method") == 0) {
-      THROW_ERR_TLS_INVALID_PROTOCOL_METHOD(env, "SSLv2 methods disabled");
-      return;
-    } else if (strcmp(*sslmethod, "SSLv2_client_method") == 0) {
-      THROW_ERR_TLS_INVALID_PROTOCOL_METHOD(env, "SSLv2 methods disabled");
-      return;
-    } else if (strcmp(*sslmethod, "SSLv3_method") == 0) {
+    } else if (methodstr == "SSLv3_method" ||
+               methodstr == "SSLv3_server_method" ||
+               methodstr == "SSLv3_client_method") {
       THROW_ERR_TLS_INVALID_PROTOCOL_METHOD(env, "SSLv3 methods disabled");
       return;
-    } else if (strcmp(*sslmethod, "SSLv3_server_method") == 0) {
-      THROW_ERR_TLS_INVALID_PROTOCOL_METHOD(env, "SSLv3 methods disabled");
-      return;
-    } else if (strcmp(*sslmethod, "SSLv3_client_method") == 0) {
-      THROW_ERR_TLS_INVALID_PROTOCOL_METHOD(env, "SSLv3 methods disabled");
-      return;
-    } else if (strcmp(*sslmethod, "SSLv23_method") == 0) {
+    } else if (methodstr == "SSLv23_method") {
       max_version = TLS1_2_VERSION;
-    } else if (strcmp(*sslmethod, "SSLv23_server_method") == 0) {
+    } else if (methodstr == "SSLv23_server_method") {
       max_version = TLS1_2_VERSION;
       method = TLS_server_method();
-    } else if (strcmp(*sslmethod, "SSLv23_client_method") == 0) {
+    } else if (methodstr == "SSLv23_client_method") {
       max_version = TLS1_2_VERSION;
       method = TLS_client_method();
-    } else if (strcmp(*sslmethod, "TLS_method") == 0) {
+    } else if (methodstr == "TLS_method") {
       min_version = 0;
       max_version = MAX_SUPPORTED_VERSION;
-    } else if (strcmp(*sslmethod, "TLS_server_method") == 0) {
+    } else if (methodstr == "TLS_server_method") {
       min_version = 0;
       max_version = MAX_SUPPORTED_VERSION;
       method = TLS_server_method();
-    } else if (strcmp(*sslmethod, "TLS_client_method") == 0) {
+    } else if (methodstr == "TLS_client_method") {
       min_version = 0;
       max_version = MAX_SUPPORTED_VERSION;
       method = TLS_client_method();
-    } else if (strcmp(*sslmethod, "TLSv1_method") == 0) {
+    } else if (methodstr == "TLSv1_method") {
       min_version = TLS1_VERSION;
       max_version = TLS1_VERSION;
-    } else if (strcmp(*sslmethod, "TLSv1_server_method") == 0) {
+    } else if (methodstr == "TLSv1_server_method") {
       min_version = TLS1_VERSION;
       max_version = TLS1_VERSION;
       method = TLS_server_method();
-    } else if (strcmp(*sslmethod, "TLSv1_client_method") == 0) {
+    } else if (methodstr == "TLSv1_client_method") {
       min_version = TLS1_VERSION;
       max_version = TLS1_VERSION;
       method = TLS_client_method();
-    } else if (strcmp(*sslmethod, "TLSv1_1_method") == 0) {
+    } else if (methodstr == "TLSv1_1_method") {
       min_version = TLS1_1_VERSION;
       max_version = TLS1_1_VERSION;
-    } else if (strcmp(*sslmethod, "TLSv1_1_server_method") == 0) {
+    } else if (methodstr == "TLSv1_1_server_method") {
       min_version = TLS1_1_VERSION;
       max_version = TLS1_1_VERSION;
       method = TLS_server_method();
-    } else if (strcmp(*sslmethod, "TLSv1_1_client_method") == 0) {
+    } else if (methodstr == "TLSv1_1_client_method") {
       min_version = TLS1_1_VERSION;
       max_version = TLS1_1_VERSION;
       method = TLS_client_method();
-    } else if (strcmp(*sslmethod, "TLSv1_2_method") == 0) {
+    } else if (methodstr == "TLSv1_2_method") {
       min_version = TLS1_2_VERSION;
       max_version = TLS1_2_VERSION;
-    } else if (strcmp(*sslmethod, "TLSv1_2_server_method") == 0) {
+    } else if (methodstr == "TLSv1_2_server_method") {
       min_version = TLS1_2_VERSION;
       max_version = TLS1_2_VERSION;
       method = TLS_server_method();
-    } else if (strcmp(*sslmethod, "TLSv1_2_client_method") == 0) {
+    } else if (methodstr == "TLSv1_2_client_method") {
       min_version = TLS1_2_VERSION;
       max_version = TLS1_2_VERSION;
       method = TLS_client_method();
     } else {
       const std::string msg("Unknown method: ");
-      THROW_ERR_TLS_INVALID_PROTOCOL_METHOD(env, (msg + * sslmethod).c_str());
+      THROW_ERR_TLS_INVALID_PROTOCOL_METHOD(env, (msg + methodstr).c_str());
       return;
     }
   }

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -637,7 +637,7 @@ void SecureContext::Init(const FunctionCallbackInfo<Value>& args) {
       method = TLS_client_method();
     } else {
       const std::string msg("Unknown method: ");
-      THROW_ERR_TLS_INVALID_PROTOCOL_METHOD(env, (msg + *sslmethod).c_str());
+      THROW_ERR_TLS_INVALID_PROTOCOL_METHOD(env, (msg + * sslmethod).c_str());
       return;
     }
   }

--- a/src/util.h
+++ b/src/util.h
@@ -491,6 +491,10 @@ class Utf8Value : public MaybeStackBuffer<char> {
   explicit Utf8Value(v8::Isolate* isolate, v8::Local<v8::Value> value);
 
   inline std::string ToString() const { return std::string(out(), length()); }
+
+  inline bool operator==(const char* a) const {
+    return strcmp(out(), a) == 0;
+  }
 };
 
 class TwoByteValue : public MaybeStackBuffer<uint16_t> {


### PR DESCRIPTION
This change uses `std::string::operator==` instead of `strcmp`, and de-duplicates some code.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
