### PR TITLE
test: handle app already signed error

### DIFF
--- a/test/parallel/test-macos-app-sandbox.js
+++ b/test/parallel/test-macos-app-sandbox.js
@@ -42,7 +42,7 @@ assert.strictEqual(
   child_process.spawnSync('/usr/bin/codesign', [
     '--entitlements', fixtures.path(
       'macos-app-sandbox', 'node_sandboxed.entitlements'),
-    '-s', '-',
+    '--force', '-s', '-',
     appBundlePath
   ]).status,
   0);


### PR DESCRIPTION
In the GitHub Actions CI, test-macos-app-sandbox.js can fail due
to the application already being signed. This commit updates
the test to handle that condition.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)