### PR TITLE
quic: clear clang warning

### DIFF
--- a/src/quic/node_quic_buffer.cc
+++ b/src/quic/node_quic_buffer.cc
@@ -157,7 +157,7 @@ int QuicBuffer::DoPull(
       status,
       data,
       len,
-      std::move([this](size_t len) { Seek(len); }));
+      [this](size_t len) { Seek(len); });
 
   return status;
 }


### PR DESCRIPTION
```console
[2945/2986] CXX obj/src/quic/libnode.node_quic_buffer.o
../../src/quic/node_quic_buffer.cc:160:7: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
std::move([this](size_t len) { Seek(len); }));
^
../../src/quic/node_quic_buffer.cc:160:7: note: remove std::move call here
std::move([this](size_t len) { Seek(len); }));
^~~~~~~~~~ ~
1 warning generated.
[2986/2986] LINK node
```