### PR TITLE
child_process: Pass `child` in execFile resolve/reject too

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -169,13 +169,14 @@ const customPromiseExecFunction = (orig) => {
       reject = rej;
     });
 
-    promise.child = orig(...args, (err, stdout, stderr) => {
+    const child = promise.child = orig(...args, (err, stdout, stderr) => {
       if (err !== null) {
+        err.child = child;
         err.stdout = stdout;
         err.stderr = stderr;
         reject(err);
       } else {
-        resolve({ stdout, stderr });
+        resolve({ child, stdout, stderr });
       }
     });
 

--- a/test/parallel/test-child-process-promisified.js
+++ b/test/parallel/test-child-process-promisified.js
@@ -12,7 +12,9 @@ const execFile = promisify(child_process.execFile);
 
   assert(promise.child instanceof child_process.ChildProcess);
   promise.then(common.mustCall((obj) => {
-    assert.deepStrictEqual(obj, { stdout: '42\n', stderr: '' });
+    assert(obj.child instanceof child_process.ChildProcess);
+    assert.strictEqual(obj.stdout, '42\n');
+    assert.strictEqual(obj.stderr, '');
   }));
 }
 
@@ -21,7 +23,9 @@ const execFile = promisify(child_process.execFile);
 
   assert(promise.child instanceof child_process.ChildProcess);
   promise.then(common.mustCall((obj) => {
-    assert.deepStrictEqual(obj, { stdout: '42\n', stderr: '' });
+    assert(obj.child instanceof child_process.ChildProcess);
+    assert.strictEqual(obj.stdout, '42\n');
+    assert.strictEqual(obj.stderr, '');
   }));
 }
 
@@ -31,6 +35,7 @@ const execFile = promisify(child_process.execFile);
   assert(promise.child instanceof child_process.ChildProcess);
   promise.catch(common.mustCall((err) => {
     assert(err.message.includes('doesntexist'));
+    assert(err.child instanceof child_process.ChildProcess);
   }));
 }
 
@@ -40,6 +45,7 @@ const execFile = promisify(child_process.execFile);
   assert(promise.child instanceof child_process.ChildProcess);
   promise.catch(common.mustCall((err) => {
     assert(err.message.includes('doesntexist'));
+    assert(err.child instanceof child_process.ChildProcess);
   }));
 }
 const failingCodeWithStdoutErr =
@@ -47,6 +53,7 @@ const failingCodeWithStdoutErr =
 {
   exec(`${process.execPath} -e "${failingCodeWithStdoutErr}"`)
     .catch(common.mustCall((err) => {
+      assert(err.child instanceof child_process.ChildProcess);
       assert.strictEqual(err.code, 1);
       assert.strictEqual(err.stdout, '42\n');
       assert.strictEqual(err.stderr, '43\n');
@@ -56,6 +63,7 @@ const failingCodeWithStdoutErr =
 {
   execFile(process.execPath, ['-e', failingCodeWithStdoutErr])
     .catch(common.mustCall((err) => {
+      assert(err.child instanceof child_process.ChildProcess);
       assert.strictEqual(err.code, 1);
       assert.strictEqual(err.stdout, '42\n');
       assert.strictEqual(err.stderr, '43\n');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

This PR adds a `child` property to the resolve & reject values to a promisify'd `execFile` & `exec`. This simplifies the ability to get at the `ChildProcess` instance when it's only necessary once the process has exited. (For example, to retrieve the process id).

As discussed in #34234.

Still needed are tests.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
