### PR TITLE
test,tools: use `.then(common.mustCall())` for all async IIFEs + linter rule

### DIFF
--- a/test/.eslintrc.yaml
+++ b/test/.eslintrc.yaml
@@ -53,6 +53,7 @@ rules:
   node-core/prefer-common-mustnotcall: error
   node-core/crypto-check: error
   node-core/eslint-check: error
+  node-core/async-iife-no-unused-result: error
   node-core/inspector-check: error
   ## common module is mandatory in tests
   node-core/required-modules:

--- a/test/es-module/test-esm-error-cache.js
+++ b/test/es-module/test-esm-error-cache.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 const file = '../fixtures/syntax/bad_syntax.mjs';
@@ -23,4 +23,4 @@ let error;
       return true;
     }
   );
-})();
+})().then(common.mustCall());

--- a/test/es-module/test-esm-import-meta-resolve.mjs
+++ b/test/es-module/test-esm-import-meta-resolve.mjs
@@ -1,5 +1,5 @@
 // Flags: --experimental-import-meta-resolve
-import '../common/index.mjs';
+import { mustCall } from '../common/index.mjs';
 import assert from 'assert';
 
 const dirname = import.meta.url.slice(0, import.meta.url.lastIndexOf('/') + 1);
@@ -21,4 +21,4 @@ const fixtures = dirname.slice(0, dirname.lastIndexOf('/', dirname.length - 2) +
   assert.strictEqual(await import.meta.resolve('../fixtures/'), fixtures);
   assert.strictEqual(await import.meta.resolve('baz/', fixtures),
                      fixtures + 'node_modules/baz/');
-})();
+})().then(mustCall());

--- a/test/internet/test-dns-promises-resolve.js
+++ b/test/internet/test-dns-promises-resolve.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 const dnsPromises = require('dns').promises;
@@ -38,5 +38,5 @@ const dnsPromises = require('dns').promises;
     const result = await dnsPromises.resolve('example.org', rrtype);
     assert.ok(result !== undefined);
     assert.ok(result.length > 0);
-  })();
+  })().then(common.mustCall());
 }

--- a/test/internet/test-dns-txt-sigsegv.js
+++ b/test/internet/test-dns-txt-sigsegv.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const dns = require('dns');
 const dnsPromises = dns.promises;
@@ -7,7 +7,7 @@ const dnsPromises = dns.promises;
 (async function() {
   const result = await dnsPromises.resolveTxt('www.microsoft.com');
   assert.strictEqual(result.length, 0);
-})();
+})().then(common.mustCall());
 
 dns.resolveTxt('www.microsoft.com', function(err, records) {
   assert.strictEqual(err, null);

--- a/test/internet/test-dns.js
+++ b/test/internet/test-dns.js
@@ -708,4 +708,4 @@ dns.lookupService('0.0.0.0', 0, common.mustCall());
 (async function() {
   await dnsPromises.lookup(addresses.INET6_HOST, 6);
   await dnsPromises.lookup(addresses.INET_HOST, {});
-})();
+})().then(common.mustCall());

--- a/test/parallel/test-c-ares.js
+++ b/test/parallel/test-c-ares.js
@@ -40,7 +40,7 @@ const dnsPromises = dns.promises;
   res = await dnsPromises.lookup('::1');
   assert.strictEqual(res.address, '::1');
   assert.strictEqual(res.family, 6);
-})();
+})().then(common.mustCall());
 
 // Try resolution without callback
 
@@ -94,5 +94,5 @@ if (!common.isWindows && !common.isIBMi) {
 
   (async function() {
     assert.ok(Array.isArray(await dnsPromises.reverse('127.0.0.1')));
-  })();
+  })().then(common.mustCall());
 }

--- a/test/parallel/test-child-process-spawn-args.js
+++ b/test/parallel/test-child-process-spawn-args.js
@@ -52,4 +52,4 @@ const expectedResult = tmpdir.path.trim().toLowerCase();
   );
 
   assert.deepStrictEqual([...new Set(results)], [expectedResult]);
-})();
+})().then(common.mustCall());

--- a/test/parallel/test-dns-lookup-promises.js
+++ b/test/parallel/test-dns-lookup-promises.js
@@ -135,5 +135,5 @@ async function lookupallNegative() {
     lookupNegative(),
     lookupallPositive(),
     lookupallNegative()
-  ]).then(common.mustCall());
-})();
+  ]);
+})().then(common.mustCall());

--- a/test/parallel/test-dns-lookup.js
+++ b/test/parallel/test-dns-lookup.js
@@ -109,7 +109,7 @@ assert.throws(() => {
     all: false
   });
   assert.deepStrictEqual(res, { address: '127.0.0.1', family: 4 });
-})();
+})().then(common.mustCall());
 
 dns.lookup(false, {
   hints: 0,

--- a/test/parallel/test-dns-setservers-type-check.js
+++ b/test/parallel/test-dns-setservers-type-check.js
@@ -95,7 +95,7 @@ const promiseResolver = new dns.promises.Resolver();
   // This should not throw any error.
   (async () => {
     setServers([ '127.0.0.1' ]);
-  })();
+  })().then(common.mustCall());
 
   [
     [null],

--- a/test/parallel/test-dns.js
+++ b/test/parallel/test-dns.js
@@ -276,7 +276,7 @@ dns.lookup('', {
   await dnsPromises.lookup('', {
     hints: dns.ADDRCONFIG | dns.V4MAPPED | dns.ALL
   });
-})();
+})().then(common.mustCall());
 
 {
   const err = {
@@ -450,7 +450,7 @@ assert.throws(() => {
         cases.shift();
         nextCase();
       }));
-    })();
+    })().then(common.mustCall());
 
   }));
 }

--- a/test/parallel/test-eslint-async-iife-no-unused-result.js
+++ b/test/parallel/test-eslint-async-iife-no-unused-result.js
@@ -1,5 +1,7 @@
 'use strict';
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 common.skipIfEslintMissing();
 
 const RuleTester = require('../../tools/node_modules/eslint').RuleTester;

--- a/test/parallel/test-eslint-async-iife-no-unused-result.js
+++ b/test/parallel/test-eslint-async-iife-no-unused-result.js
@@ -1,0 +1,47 @@
+'use strict';
+const common = require('../common');
+common.skipIfEslintMissing();
+
+const RuleTester = require('../../tools/node_modules/eslint').RuleTester;
+const rule = require('../../tools/eslint-rules/async-iife-no-unused-result');
+
+const message = 'The result of an immediately-invoked async function needs ' +
+  'to be used (e.g. with `.then(common.mustCall())`)';
+
+const tester = new RuleTester({ parserOptions: { ecmaVersion: 8 } });
+tester.run('async-iife-no-unused-result', rule, {
+  valid: [
+    '(() => {})()',
+    '(async () => {})',
+    '(async () => {})().then()',
+    '(async () => {})().catch()',
+    '(function () {})()',
+    '(async function () {})',
+    '(async function () {})().then()',
+    '(async function () {})().catch()',
+  ],
+  invalid: [
+    {
+      code: '(async () => {})()',
+      errors: [{ message }],
+      output: '(async () => {})()',
+    },
+    {
+      code: '(async function() {})()',
+      errors: [{ message }],
+      output: '(async function() {})()',
+    },
+    {
+      code: "const common = require('../common');(async () => {})()",
+      errors: [{ message }],
+      output: "const common = require('../common');(async () => {})()" +
+        '.then(common.mustCall())',
+    },
+    {
+      code: "const common = require('../common');(async function() {})()",
+      errors: [{ message }],
+      output: "const common = require('../common');(async function() {})()" +
+        '.then(common.mustCall())',
+    },
+  ]
+});

--- a/test/parallel/test-fs-copyfile-respect-permissions.js
+++ b/test/parallel/test-fs-copyfile-respect-permissions.js
@@ -49,7 +49,7 @@ function beforeEach() {
   const { source, dest, check } = beforeEach();
   (async () => {
     await assert.rejects(fs.promises.copyFile(source, dest), check);
-  })();
+  })().then(common.mustCall());
 }
 
 // Test callback API.

--- a/test/parallel/test-fs-read-empty-buffer.js
+++ b/test/parallel/test-fs-read-empty-buffer.js
@@ -38,4 +38,4 @@ assert.throws(
                'Received Uint8Array(0) []'
     }
   );
-})();
+})().then(common.mustCall());

--- a/test/parallel/test-fs-readdir-types.js
+++ b/test/parallel/test-fs-readdir-types.js
@@ -77,7 +77,7 @@ fs.readdir(readdirDir, {
     withFileTypes: true
   });
   assertDirents(dirents);
-})();
+})().then(common.mustCall());
 
 // Check for correct types when the binding returns unknowns
 const UNKNOWN = constants.UV_DIRENT_UNKNOWN;

--- a/test/parallel/test-fs-readv-promises.js
+++ b/test/parallel/test-fs-readv-promises.js
@@ -1,6 +1,5 @@
 'use strict';
-
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const path = require('path');
 const fs = require('fs').promises;
@@ -64,4 +63,4 @@ const allocateEmptyBuffers = (combinedLength) => {
     assert(Buffer.concat(bufferArr).equals(await fs.readFile(filename)));
     handle.close();
   }
-})();
+})().then(common.mustCall());

--- a/test/parallel/test-fs-rmdir-recursive.js
+++ b/test/parallel/test-fs-rmdir-recursive.js
@@ -149,7 +149,7 @@ function removeAsync(dir) {
 
   // Attempted removal should fail now because the directory is gone.
   assert.rejects(fs.promises.rmdir(dir), { syscall: 'rmdir' });
-})();
+})().then(common.mustCall());
 
 // Test input validation.
 {

--- a/test/parallel/test-fs-stat-bigint.js
+++ b/test/parallel/test-fs-stat-bigint.js
@@ -185,4 +185,4 @@ if (!common.isWindows) {
   const allowableDelta = Math.ceil(Number(endTime - startTime) / 1e6);
   verifyStats(bigintStats, numStats, allowableDelta);
   await handle.close();
-})();
+})().then(common.mustCall());

--- a/test/parallel/test-fs-writev-promises.js
+++ b/test/parallel/test-fs-writev-promises.js
@@ -1,6 +1,5 @@
 'use strict';
-
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const path = require('path');
 const fs = require('fs').promises;
@@ -48,4 +47,4 @@ tmpdir.refresh();
     assert(Buffer.concat(bufferArr).equals(await fs.readFile(filename)));
     handle.close();
   }
-})();
+})().then(common.mustCall());

--- a/test/parallel/test-inspect-publish-uid.js
+++ b/test/parallel/test-inspect-publish-uid.js
@@ -10,7 +10,7 @@ const { spawnSync } = require('child_process');
   await testArg('stderr');
   await testArg('http');
   await testArg('http,stderr');
-})();
+})().then(common.mustCall());
 
 async function testArg(argValue) {
   console.log('Checks ' + argValue + '..');

--- a/test/parallel/test-internal-module-wrap.js
+++ b/test/parallel/test-internal-module-wrap.js
@@ -1,8 +1,6 @@
-'use strict';
-
 // Flags: --expose-internals
-
-require('../common');
+'use strict';
+const common = require('../common');
 const assert = require('assert');
 
 const { internalBinding } = require('internal/test/binding');
@@ -26,4 +24,4 @@ const bar = new ModuleWrap('bar', undefined, 'export const five = 5', 0, 0);
 
   assert.strictEqual(await foo.evaluate(-1, false), undefined);
   assert.strictEqual(foo.getNamespace().five, 5);
-})();
+})().then(common.mustCall());

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -827,7 +827,7 @@ const tcpTests = [
     socket.end();
   }
   common.allowGlobals(...Object.values(global));
-})();
+})().then(common.mustCall());
 
 function startTCPRepl() {
   let resolveSocket, resolveReplServer;

--- a/test/parallel/test-util-inspect-namespace.js
+++ b/test/parallel/test-util-inspect-namespace.js
@@ -1,8 +1,6 @@
-'use strict';
-
 // Flags: --experimental-vm-modules
-
-require('../common');
+'use strict';
+const common = require('../common');
 const assert = require('assert');
 
 const { SourceTextModule } = require('vm');
@@ -16,4 +14,4 @@ const { inspect } = require('util');
     '[Module] { a: <uninitialized>, b: undefined }');
   await m.evaluate();
   assert.strictEqual(inspect(m.namespace), '[Module] { a: 1, b: 2 }');
-})();
+})().then(common.mustCall());

--- a/test/parallel/test-util-promisify.js
+++ b/test/parallel/test-util-promisify.js
@@ -131,7 +131,7 @@ const stat = promisify(fs.stat);
   (async () => {
     const value = await promisify(fn)(null, 42);
     assert.strictEqual(value, 42);
-  })();
+  })().then(common.mustCall());
 }
 
 {
@@ -159,7 +159,7 @@ const stat = promisify(fs.stat);
     await fn();
     await Promise.resolve();
     return assert.strictEqual(stack, err.stack);
-  })();
+  })().then(common.mustCall());
 }
 
 {

--- a/test/parallel/test-util-types.js
+++ b/test/parallel/test-util-types.js
@@ -1,6 +1,6 @@
 // Flags: --experimental-vm-modules --expose-internals
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const { types, inspect } = require('util');
 const vm = require('vm');
@@ -280,4 +280,4 @@ for (const [ value, _method ] of [
   await m.link(() => 0);
   await m.evaluate();
   assert.ok(types.isModuleNamespaceObject(m.namespace));
-})();
+})().then(common.mustCall());

--- a/test/parallel/test-vm-module-basic.js
+++ b/test/parallel/test-vm-module-basic.js
@@ -32,7 +32,7 @@ const util = require('util');
     baz: 'bar',
     typeofProcess: 'undefined'
   });
-}());
+}().then(common.mustCall()));
 
 (async () => {
   const m = new SourceTextModule(`
@@ -45,14 +45,14 @@ const util = require('util');
   assert.strictEqual(global.vmResultTypeofProcess, '[object process]');
   delete global.vmResultFoo;
   delete global.vmResultTypeofProcess;
-})();
+})().then(common.mustCall());
 
 (async () => {
   const m = new SourceTextModule('while (true) {}');
   await m.link(common.mustNotCall());
   await m.evaluate({ timeout: 500 })
     .then(() => assert(false), () => {});
-})();
+})().then(common.mustCall());
 
 // Check the generated identifier for each module
 (async () => {
@@ -65,7 +65,7 @@ const util = require('util');
   assert.strictEqual(m2.identifier, 'vm:module(1)');
   const m3 = new SourceTextModule('3', { context: context2 });
   assert.strictEqual(m3.identifier, 'vm:module(0)');
-})();
+})().then(common.mustCall());
 
 // Check inspection of the instance
 {

--- a/test/parallel/test-vm-module-errors.js
+++ b/test/parallel/test-vm-module-errors.js
@@ -233,4 +233,4 @@ const finished = common.mustCall();
   await checkInvalidOptionForEvaluate();
   checkInvalidCachedData();
   finished();
-})();
+})().then(common.mustCall());

--- a/test/parallel/test-vm-module-import-meta.js
+++ b/test/parallel/test-vm-module-import-meta.js
@@ -41,4 +41,4 @@ async function testInvalid() {
 (async () => {
   await testBasic();
   await testInvalid();
-})();
+})().then(common.mustCall());

--- a/test/parallel/test-vm-module-link.js
+++ b/test/parallel/test-vm-module-link.js
@@ -133,4 +133,4 @@ const finished = common.mustCall();
   await circular();
   await circular2();
   finished();
-})();
+})().then(common.mustCall());

--- a/test/parallel/test-vm-module-reevaluate.js
+++ b/test/parallel/test-vm-module-reevaluate.js
@@ -48,4 +48,4 @@ const finished = common.mustCall();
   }
 
   finished();
-})();
+})().then(common.mustCall());

--- a/test/parallel/test-vm-module-synthetic.js
+++ b/test/parallel/test-vm-module-synthetic.js
@@ -65,4 +65,4 @@ const assert = require('assert');
       code: 'ERR_VM_MODULE_STATUS',
     });
   }
-})();
+})().then(common.mustCall());

--- a/test/parallel/test-zlib-empty-buffer.js
+++ b/test/parallel/test-zlib-empty-buffer.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const zlib = require('zlib');
 const { inspect, promisify } = require('util');
 const assert = require('assert');
@@ -23,4 +23,4 @@ const emptyBuffer = Buffer.alloc(0);
       `Expected ${inspect(compressed)} to match ${inspect(decompressed)} ` +
       `to match for ${method}`);
   }
-})();
+})().then(common.mustCall());

--- a/test/sequential/test-inspector-async-call-stack-abort.js
+++ b/test/sequential/test-inspector-async-call-stack-abort.js
@@ -25,7 +25,7 @@ if (process.argv[2] === 'child') {
     await session.post('Debugger.setAsyncCallStackDepth', { maxDepth: 42 });
     strictEqual(enabled, 1);
     throw new Error(eyecatcher);
-  })();
+  })().finally(common.mustCall());
 } else {
   const { spawnSync } = require('child_process');
   const options = { encoding: 'utf8' };

--- a/test/wasi/test-wasi-stdio.js
+++ b/test/wasi/test-wasi-stdio.js
@@ -1,6 +1,6 @@
 // Flags: --experimental-wasi-unstable-preview1 --experimental-wasm-bigint
 'use strict';
-require('../common');
+const common = require('../common');
 const tmpdir = require('../common/tmpdir');
 const { strictEqual } = require('assert');
 const { closeSync, openSync, readFileSync, writeFileSync } = require('fs');
@@ -31,4 +31,4 @@ const importObject = { wasi_snapshot_preview1: wasi.wasiImport };
   closeSync(stderr);
   strictEqual(readFileSync(stdoutFile, 'utf8').trim(), 'x'.repeat(31));
   strictEqual(readFileSync(stderrFile, 'utf8').trim(), '');
-})();
+})().then(common.mustCall());

--- a/test/wasi/test-wasi-symlinks.js
+++ b/test/wasi/test-wasi-symlinks.js
@@ -25,7 +25,7 @@ if (process.argv[2] === 'wasi-child') {
     const { instance } = await WebAssembly.instantiate(buffer, importObject);
 
     wasi.start(instance);
-  })();
+  })().then(common.mustCall());
 } else {
   if (!common.canCreateSymLink()) {
     common.skip('insufficient privileges');

--- a/test/wasi/test-wasi.js
+++ b/test/wasi/test-wasi.js
@@ -30,7 +30,7 @@ if (process.argv[2] === 'wasi-child') {
     const { instance } = await WebAssembly.instantiate(buffer, importObject);
 
     wasi.start(instance);
-  })();
+  })().then(common.mustCall());
 } else {
   const assert = require('assert');
   const cp = require('child_process');

--- a/tools/eslint-rules/async-iife-no-unused-result.js
+++ b/tools/eslint-rules/async-iife-no-unused-result.js
@@ -1,0 +1,37 @@
+'use strict';
+const { isCommonModule } = require('./rules-utils.js');
+
+function isAsyncIIFE(node) {
+  const { callee: { type, async } } = node;
+  const types = ['FunctionExpression', 'ArrowFunctionExpression'];
+  return types.includes(type) && async;
+}
+
+const message =
+  'The result of an immediately-invoked async function needs to be used ' +
+  '(e.g. with `.then(common.mustCall())`)';
+
+module.exports = {
+  create: function(context) {
+    let hasCommonModule = false;
+    return {
+      CallExpression: function(node) {
+        if (isCommonModule(node) && node.parent.type === 'VariableDeclarator') {
+          hasCommonModule = true;
+        }
+
+        if (!isAsyncIIFE(node)) return;
+        if (node.parent && node.parent.type === 'ExpressionStatement') {
+          context.report({
+            node,
+            message,
+            fix: (fixer) => {
+              if (hasCommonModule)
+                return fixer.insertTextAfter(node, '.then(common.mustCall())');
+            }
+          });
+        }
+      }
+    };
+  }
+};


### PR DESCRIPTION
##### test: use `.then(common.mustCall())` for all async IIFEs

This makes sure that all async functions finish as expected.

##### tools: add linting rule for async IIFEs

The result of an async IIFE should always be handled in our tests,
typically by adding `.then(common.mustCall())` to verify that the
async function actually finishes executing at some point.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
