### PR TITLE
src: add callback scope for native immediates

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -657,6 +657,9 @@ void Environment::RunAndClearInterrupts() {
 void Environment::RunAndClearNativeImmediates(bool only_refed) {
   TraceEventScope trace_scope(TRACING_CATEGORY_NODE1(environment),
                               "RunAndClearNativeImmediates", this);
+  HandleScope handle_scope(isolate_);
+  InternalCallbackScope cb_scope(this, Object::New(isolate_), { 0, 0 });
+
   size_t ref_count = 0;
 
   // Handle interrupts first. These functions are not allowed to throw

--- a/test/async-hooks/test-late-hook-enable.js
+++ b/test/async-hooks/test-late-hook-enable.js
@@ -17,14 +17,16 @@ const fnsToTest = [setTimeout, (cb) => {
     });
   });
 }, (cb) => {
-  process.nextTick(() => {
-    cb();
+  setImmediate(() => {
+    process.nextTick(() => {
+      cb();
 
-    // We need to keep the event loop open for this to actually work
-    // since destroy hooks are triggered in unrefed Immediates
-    setImmediate(() => {
-      hook.disable();
-      assert.strictEqual(fnsToTest.length, 0);
+      // We need to keep the event loop open for this to actually work
+      // since destroy hooks are triggered in unrefed Immediates
+      setImmediate(() => {
+        hook.disable();
+        assert.strictEqual(fnsToTest.length, 0);
+      });
     });
   });
 }];


### PR DESCRIPTION
This ensures that microtasks scheduled by native immediates are run
after the tasks are done. In particular, this affects the inspector
integration since 6f9f546406820dc.

Fixes: https://github.com/nodejs/node/issues/33002
Refs: https://github.com/nodejs/node/pull/32523

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
