### PR TITLE
doc: sync deprecation numbers with v14.x

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2719,12 +2719,24 @@ native modules. It was incomplete so far and instead it's better to rely upon
 `require('module').builtinModules`.
 
 <a id="DEP0143"></a>
-### DEP0143: `module.parent`
+### DEP0143: `Transform._transformState`
 <!-- YAML
 changes:
   - version: v14.5.0
     pr-url: https://github.com/nodejs/node/pull/33126
     description: Runtime deprecation.
+-->
+Type: Runtime
+`Transform._transformState` will be removed in future versions where it is
+no longer required due to simplification of the implementation.
+
+<a id="DEP0144"></a>
+### DEP0144: `module.parent`
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/32217
+    description: Documentation-only deprecation.
 -->
 
 Type: Documentation-only (supports [`--pending-deprecation`][])
@@ -2751,12 +2763,12 @@ const moduleParents = Object.values(require.cache)
   .filter((m) => m.children.includes(module));
 ```
 
-<a id="DEP0XXX"></a>
-### DEP0XXX: `socket.bufferSize`
+<a id="DEP0145"></a>
+### DEP0145: `socket.bufferSize`
 <!-- YAML
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/34088
     description: Documentation-only deprecation.
 -->
 

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -248,7 +248,7 @@ ObjectDefineProperty(Module.prototype, 'parent', {
     getModuleParent,
     'module.parent is deprecated due to accuracy issues. Please use ' +
       'require.main to find program entry point instead.',
-    'DEP0143'
+    'DEP0144'
   ) : getModuleParent
 });
 

--- a/test/parallel/test-module-parent-deprecation.js
+++ b/test/parallel/test-module-parent-deprecation.js
@@ -8,7 +8,7 @@ common.expectWarning(
   'DeprecationWarning',
   'module.parent is deprecated due to accuracy issues. Please use ' +
     'require.main to find program entry point instead.',
-  'DEP0143'
+  'DEP0144'
 );
 
 assert.strictEqual(module.parent, null);


### PR DESCRIPTION
DEP numbers are out of sync between master and v14.x because DEP0143 - `Transform._transformState` landed on v14.x first. 

This PR adds DEP0143 - `Transform._transformState` to `doc/api/deprecations.md` on master. This forces the `module.parent` deprecation to move from DEP0143 to DEP0144. The `module.parent` deprecation has not been formally released (excluding nightly builds) so updating the DEP number should be low risk. 

Refs: https://github.com/nodejs/node/pull/33533#issuecomment-658241298

---
Syncs master and v14.x for DEP0143 - `Transform._transformState`.
Bumps `module.parent` from DEP0143 to DEP0144 on master. Adds
missing DEP number and  metadata for DEP0145: `socket.bufferSize`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
