### PR TITLE
repl: give repl entries unique names. fixes #33233

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -128,6 +128,10 @@ const {
 } = internalBinding('contextify');
 
 const history = require('internal/repl/history');
+let nextREPLResourceNumber = 1;
+function getREPLResourceName() {
+  return `REPL${nextREPLResourceNumber++}`;
+}
 
 // Lazy-loaded.
 let processTopLevelAwait;
@@ -767,7 +771,7 @@ function REPLServer(prompt,
     const evalCmd = self[kBufferedCommandSymbol] + cmd + '\n';
 
     debug('eval %j', evalCmd);
-    self.eval(evalCmd, self.context, 'repl', finish);
+    self.eval(evalCmd, self.context, getREPLResourceName(), finish);
 
     function finish(e, ret) {
       debug('finish', e, ret);
@@ -1248,7 +1252,7 @@ function complete(line, callback) {
 
     const memberGroups = [];
     const evalExpr = `try { ${expr} } catch {}`;
-    this.eval(evalExpr, this.context, 'repl', (e, obj) => {
+    this.eval(evalExpr, this.context, getREPLResourceName(), (e, obj) => {
       try {
         let p;
         if ((typeof obj === 'object' && obj !== null) ||

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -129,7 +129,7 @@ const {
 
 const history = require('internal/repl/history');
 let nextREPLResourceNumber = 1;
-// this prevents v8 code cache from getting confused and using a different
+// This prevents v8 code cache from getting confused and using a different
 // cache from a resource of the same name
 function getREPLResourceName() {
   return `REPL${nextREPLResourceNumber++}`;

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -572,10 +572,10 @@ function REPLServer(prompt,
           if (e.name === 'SyntaxError') {
             // Remove stack trace.
             e.stack = e.stack
-              .replace(/^repl:\d+\r?\n/, '')
+              .replace(/^REPL\d+:\d+\r?\n/, '')
               .replace(/^\s+at\s.*\n?/gm, '');
           } else if (self.replMode === module.exports.REPL_MODE_STRICT) {
-            e.stack = e.stack.replace(/(\s+at\s+repl:)(\d+)/,
+            e.stack = e.stack.replace(/(\s+at\s+REPL\d+:)(\d+)/,
                                       (_, pre, line) => pre + (line - 1));
           }
         }

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -129,6 +129,8 @@ const {
 
 const history = require('internal/repl/history');
 let nextREPLResourceNumber = 1;
+// this prevents v8 code cache from getting confused and using a different
+// cache from a resource of the same name
 function getREPLResourceName() {
   return `REPL${nextREPLResourceNumber++}`;
 }

--- a/test/parallel/test-repl-dynamic-import.js
+++ b/test/parallel/test-repl-dynamic-import.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const child_process = require('child_process');
 const child = child_process.spawn(process.execPath, [

--- a/test/parallel/test-repl-dynamic-import.js
+++ b/test/parallel/test-repl-dynamic-import.js
@@ -13,7 +13,7 @@ child.stdin.write('\nimport("fs");\n_.then(gc);\n');
 setTimeout(() => {
   child.stdin.write('\nimport("fs");\n');
   child.stdin.write('\nprocess.exit(0);\n');
-}, 500);
+}, common.platformTimeout(50));
 child.on('exit', (code, signal) => {
   assert.strictEqual(code, 0);
   assert.strictEqual(signal, null);

--- a/test/parallel/test-repl-dynamic-import.js
+++ b/test/parallel/test-repl-dynamic-import.js
@@ -1,0 +1,20 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const child_process = require('child_process');
+const child = child_process.spawn(process.execPath, [
+  '--interactive',
+  '--expose-gc'
+], {
+  stdio: 'pipe'
+});
+child.stdin.write('\nimport("fs");\n_.then(gc);\n');
+// Wait for concurrent GC to finish
+setTimeout(() => {
+  child.stdin.write('\nimport("fs");\n');
+  child.stdin.write('\nprocess.exit(0);\n');
+}, 500);
+child.on('exit', (code, signal) => {
+  assert.strictEqual(code, 0);
+  assert.strictEqual(signal, null);
+});

--- a/test/parallel/test-repl-pretty-custom-stack.js
+++ b/test/parallel/test-repl-pretty-custom-stack.js
@@ -5,7 +5,7 @@ const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const repl = require('repl');
 
-const stackRegExp = /repl:[0-9]+:[0-9]+/g;
+const stackRegExp = /(REPL\d+):[0-9]+:[0-9]+/g;
 
 function run({ command, expected }) {
   let accum = '';
@@ -25,8 +25,8 @@ function run({ command, expected }) {
 
   r.write(`${command}\n`);
   assert.strictEqual(
-    accum.replace(stackRegExp, 'repl:*:*'),
-    expected.replace(stackRegExp, 'repl:*:*')
+    accum.replace(stackRegExp, '$1:*:*'),
+    expected.replace(stackRegExp, '$1:*:*')
   );
   r.close();
 }
@@ -48,8 +48,8 @@ const tests = [
   {
     // test .load for a file that throws
     command: `.load ${fixtures.path('repl-pretty-stack.js')}`,
-    expected: 'Uncaught Error: Whoops!--->\nrepl:*:*--->\nd (repl:*:*)' +
-              '--->\nc (repl:*:*)--->\nb (repl:*:*)--->\na (repl:*:*)\n'
+    expected: 'Uncaught Error: Whoops!--->\nREPL1:*:*--->\nd (REPL1:*:*)' +
+              '--->\nc (REPL1:*:*)--->\nb (REPL1:*:*)--->\na (REPL1:*:*)\n'
   },
   {
     command: 'let x y;',
@@ -67,7 +67,7 @@ const tests = [
   // test anonymous IIFE
   {
     command: '(function() { throw new Error(\'Whoops!\'); })()',
-    expected: 'Uncaught Error: Whoops!--->\nrepl:*:*\n'
+    expected: 'Uncaught Error: Whoops!--->\nREPL5:*:*\n'
   }
 ];
 

--- a/test/parallel/test-repl-pretty-stack.js
+++ b/test/parallel/test-repl-pretty-stack.js
@@ -5,7 +5,7 @@ const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const repl = require('repl');
 
-const stackRegExp = /(at .*repl:)[0-9]+:[0-9]+/g;
+const stackRegExp = /(at .*REPL\d+:)[0-9]+:[0-9]+/g;
 
 function run({ command, expected, ...extraREPLOptions }, i) {
   let accum = '';
@@ -37,9 +37,9 @@ const tests = [
   {
     // Test .load for a file that throws.
     command: `.load ${fixtures.path('repl-pretty-stack.js')}`,
-    expected: 'Uncaught Error: Whoops!\n    at repl:*:*\n' +
-              '    at d (repl:*:*)\n    at c (repl:*:*)\n' +
-              '    at b (repl:*:*)\n    at a (repl:*:*)\n'
+    expected: 'Uncaught Error: Whoops!\n    at REPL1:*:*\n' +
+              '    at d (REPL1:*:*)\n    at c (REPL1:*:*)\n' +
+              '    at b (REPL1:*:*)\n    at a (REPL1:*:*)\n'
   },
   {
     command: 'let x y;',
@@ -53,12 +53,12 @@ const tests = [
   {
     command: '(() => { const err = Error(\'Whoops!\'); ' +
              'err.foo = \'bar\'; throw err; })()',
-    expected: "Uncaught Error: Whoops!\n    at repl:*:* {\n  foo: 'bar'\n}\n",
+    expected: "Uncaught Error: Whoops!\n    at REPL4:*:* {\n  foo: 'bar'\n}\n",
   },
   {
     command: '(() => { const err = Error(\'Whoops!\'); ' +
              'err.foo = \'bar\'; throw err; })()',
-    expected: 'Uncaught Error: Whoops!\n    at repl:*:* {\n  foo: ' +
+    expected: 'Uncaught Error: Whoops!\n    at REPL5:*:* {\n  foo: ' +
               "\u001b[32m'bar'\u001b[39m\n}\n",
     useColors: true
   },
@@ -69,7 +69,7 @@ const tests = [
   // Test anonymous IIFE.
   {
     command: '(function() { throw new Error(\'Whoops!\'); })()',
-    expected: 'Uncaught Error: Whoops!\n    at repl:*:*\n'
+    expected: 'Uncaught Error: Whoops!\n    at REPL7:*:*\n'
   }
 ];
 


### PR DESCRIPTION
this is a workaround for the REPL for https://bugs.chromium.org/p/v8/issues/detail?id=10284

this does not fix vm.* as that requires upstream fixes

this does make the inspector UI have less confusing naming (no synthetic VM*** names for repl entries), but is not the main reason for the PR.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
