### PR TITLE
tools: add debug entitlements for macOS 10.15+

### DIFF
--- a/tools/osx-entitlements.plist
+++ b/tools/osx-entitlements.plist
@@ -12,5 +12,7 @@
     <true/>
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
+    <key>com.apple.security.get-task-allow</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
To debug native modules node should be a debuggable process, from MacOS 10.15, Catalina, that will require the **com.apple.security.get-task-allow** entitlement to be added to the codesign process.

Fixes: https://github.com/nodejs/node/issues/34340


##### Checklist

- [X ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

By making a contribution to this project, I certify that:

The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file

