### PR TITLE
doc: add author-ready label ref to onboarding-extras guide

### DIFF
--- a/doc/guides/onboarding-extras.md
+++ b/doc/guides/onboarding-extras.md
@@ -24,7 +24,19 @@ request.
 * `tsc-agenda` - Open issues and pull requests with this label will be added to
   the Technical Steering Committee meeting agenda
 
---
+---
+
+* `author-ready` - A pull request is _author ready_ when:
+  * There is a CI run in progress or completed.
+  * There is at least one Collaborator approval (or two TSC approvals
+  for semver-major PRs).
+  * There are no outstanding review comments.
+
+Please always add the `author ready` label to the pull request in that case.
+Please always remove it again as soon as the conditions are not met anymore,
+such as if CI run fails or a new outstanding review comment is posted.
+
+---
 
 * `semver-{minor,major}`
   * be conservative – that is, if a change has the remote *chance* of breaking


### PR DESCRIPTION
The "Labels" section of `doc/guides/onboarding-extras.md` was missing a reference to the `author-ready` label. This commit adds a description similar to the definition found in `doc/guides/collaborator-guide.md` with the goal of making it easier for new contributors to find labels info all in one place.

Just a small improvement suggested during the onboarding session 😊 

/cc @addaleax 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make lint` passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
