### PR TITLE
n-api: run all finalizers via SetImmediate()

### DIFF
--- a/benchmark/napi/ref/index.js
+++ b/benchmark/napi/ref/index.js
@@ -10,8 +10,10 @@ function callNewWeak() {
 function main({ n }) {
   addon.count = 0;
   bench.start();
-  while (addon.count < n) {
-    callNewWeak();
-  }
-  bench.end(n);
+  new Promise((resolve) => {
+    (function oneIteration() {
+      callNewWeak();
+      setImmediate(() => ((addon.count < n) ? oneIteration() : resolve()));
+    })();
+  }).then(() => bench.end(n));
 }

--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -267,13 +267,7 @@ class RefBase : protected Finalizer, RefTracker {
  protected:
   inline void Finalize(bool is_env_teardown = false) override {
     if (_finalize_callback != nullptr) {
-      v8::HandleScope handle_scope(_env->isolate);
-      _env->CallIntoModule([&](napi_env env) {
-        _finalize_callback(
-            env,
-            _finalize_data,
-            _finalize_hint);
-      });
+      _env->CallFinalizer(_finalize_callback, _finalize_data, _finalize_hint);
     }
 
     // this is safe because if a request to delete the reference

--- a/src/js_native_api_v8.h
+++ b/src/js_native_api_v8.h
@@ -101,6 +101,13 @@ struct napi_env__ {
     }
   }
 
+  virtual void CallFinalizer(napi_finalize cb, void* data, void* hint) {
+    v8::HandleScope handle_scope(isolate);
+    CallIntoModule([&](napi_env env) {
+      cb(env, data, hint);
+    });
+  }
+
   v8impl::Persistent<v8::Value> last_exception;
 
   // We store references in two different lists, depending on whether they have

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -32,6 +32,17 @@ struct node_napi_env__ : public napi_env__ {
         node_env()->untransferable_object_private_symbol(),
         v8::True(isolate));
   }
+
+  void CallFinalizer(napi_finalize cb, void* data, void* hint) override {
+    napi_env env = static_cast<napi_env>(this);
+    node_env()->SetImmediate([=](node::Environment* node_env) {
+      v8::HandleScope handle_scope(env->isolate);
+      v8::Context::Scope context_scope(env->context());
+      env->CallIntoModule([&](napi_env env) {
+        cb(env, data, hint);
+      });
+    });
+  }
 };
 
 typedef node_napi_env__* node_napi_env;

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -664,6 +664,30 @@ function skipIfDumbTerminal() {
   }
 }
 
+function gcUntil(name, condition) {
+  if (typeof name === 'function') {
+    condition = name;
+    name = undefined;
+  }
+  return new Promise((resolve, reject) => {
+    let count = 0;
+    function gcAndCheck() {
+      setImmediate(() => {
+        count++;
+        global.gc();
+        if (condition()) {
+          resolve();
+        } else if (count < 10) {
+          gcAndCheck();
+        } else {
+          reject(name === undefined ? undefined : 'Test ' + name + ' failed');
+        }
+      });
+    }
+    gcAndCheck();
+  });
+}
+
 const common = {
   allowGlobals,
   buildType,
@@ -673,6 +697,7 @@ const common = {
   disableCrashOnUnhandledRejection,
   expectsError,
   expectWarning,
+  gcUntil,
   getArrayBufferViews,
   getBufferSources,
   getCallSite,

--- a/test/js-native-api/7_factory_wrap/test.js
+++ b/test/js-native-api/7_factory_wrap/test.js
@@ -6,20 +6,21 @@ const assert = require('assert');
 const test = require(`./build/${common.buildType}/binding`);
 
 assert.strictEqual(test.finalizeCount, 0);
-(() => {
-  const obj = test.createObject(10);
-  assert.strictEqual(obj.plusOne(), 11);
-  assert.strictEqual(obj.plusOne(), 12);
-  assert.strictEqual(obj.plusOne(), 13);
-})();
-global.gc();
-assert.strictEqual(test.finalizeCount, 1);
+async function runGCTests() {
+  (() => {
+    const obj = test.createObject(10);
+    assert.strictEqual(obj.plusOne(), 11);
+    assert.strictEqual(obj.plusOne(), 12);
+    assert.strictEqual(obj.plusOne(), 13);
+  })();
+  await common.gcUntil('test 1', () => (test.finalizeCount === 1));
 
-(() => {
-  const obj2 = test.createObject(20);
-  assert.strictEqual(obj2.plusOne(), 21);
-  assert.strictEqual(obj2.plusOne(), 22);
-  assert.strictEqual(obj2.plusOne(), 23);
-})();
-global.gc();
-assert.strictEqual(test.finalizeCount, 2);
+  (() => {
+    const obj2 = test.createObject(20);
+    assert.strictEqual(obj2.plusOne(), 21);
+    assert.strictEqual(obj2.plusOne(), 22);
+    assert.strictEqual(obj2.plusOne(), 23);
+  })();
+  await common.gcUntil('test 2', () => (test.finalizeCount === 2));
+}
+runGCTests();

--- a/test/js-native-api/8_passing_wrapped/test.js
+++ b/test/js-native-api/8_passing_wrapped/test.js
@@ -5,13 +5,16 @@ const common = require('../../common');
 const assert = require('assert');
 const addon = require(`./build/${common.buildType}/binding`);
 
-let obj1 = addon.createObject(10);
-let obj2 = addon.createObject(20);
-const result = addon.add(obj1, obj2);
-assert.strictEqual(result, 30);
+async function runTest() {
+  let obj1 = addon.createObject(10);
+  let obj2 = addon.createObject(20);
+  const result = addon.add(obj1, obj2);
+  assert.strictEqual(result, 30);
 
-// Make sure the native destructor gets called.
-obj1 = null;
-obj2 = null;
-global.gc();
-assert.strictEqual(addon.finalizeCount(), 2);
+  // Make sure the native destructor gets called.
+  obj1 = null;
+  obj2 = null;
+  await common.gcUntil('8_passing_wrapped',
+                       () => (addon.finalizeCount() === 2));
+}
+runTest();

--- a/test/js-native-api/test_exception/test.js
+++ b/test/js-native-api/test_exception/test.js
@@ -66,14 +66,3 @@ const test_exception = (function() {
                      'Exception state did not remain clear as expected,' +
                      ` .wasPending() returned ${exception_pending}`);
 }
-
-// Make sure that exceptions that occur during finalization are propagated.
-function testFinalize(binding) {
-  let x = test_exception[binding]();
-  x = null;
-  assert.throws(() => { global.gc(); }, /Error during Finalize/);
-
-  // To assuage the linter's concerns.
-  (function() {})(x);
-}
-testFinalize('createExternal');

--- a/test/js-native-api/test_exception/testFinalizerException.js
+++ b/test/js-native-api/test_exception/testFinalizerException.js
@@ -1,0 +1,22 @@
+'use strict';
+if (process.argv[2] === 'child') {
+  const common = require('../../common');
+  // Trying, catching the exception, and finding the bindings at the `Error`'s
+  // `binding` property is done intentionally, because we're also testing what
+  // happens when the add-on entry point throws. See test.js.
+  try {
+    require(`./build/${common.buildType}/test_exception`);
+  } catch (anException) {
+    anException.binding.createExternal();
+  }
+  const interval = setInterval(() => {
+    clearInterval(interval);
+  }, 100);
+  return;
+}
+
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+const child = spawnSync(process.execPath, [ __filename, 'child' ]);
+assert.strictEqual(child.signal, null);
+assert.match(child.stderr.toString(), /Error during Finalize/m);

--- a/test/js-native-api/test_general/testFinalizer.js
+++ b/test/js-native-api/test_general/testFinalizer.js
@@ -24,9 +24,13 @@ global.gc();
 
 // Add an item to an object that is already wrapped, and ensure that its
 // finalizer as well as the wrap finalizer gets called.
-let finalizeAndWrap = {};
-test_general.wrap(finalizeAndWrap);
-test_general.addFinalizerOnly(finalizeAndWrap, common.mustCall());
-finalizeAndWrap = null;
-global.gc();
-assert.strictEqual(test_general.derefItemWasCalled(), true);
+async function testFinalizeAndWrap() {
+  assert.strictEqual(test_general.derefItemWasCalled(), false);
+  let finalizeAndWrap = {};
+  test_general.wrap(finalizeAndWrap);
+  test_general.addFinalizerOnly(finalizeAndWrap, common.mustCall());
+  finalizeAndWrap = null;
+  await common.gcUntil('test finalize and wrap',
+                       () => test_general.derefItemWasCalled());
+}
+testFinalizeAndWrap();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
