### PR TITLE
src: allow preventing SetPromiseRejectCallback

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -242,9 +242,11 @@ void SetIsolateMiscHandlers(v8::Isolate* isolate, const IsolateSettings& s) {
     s.allow_wasm_code_generation_callback : AllowWasmCodeGenerationCallback;
   isolate->SetAllowWasmCodeGenerationCallback(allow_wasm_codegen_cb);
 
-  auto* promise_reject_cb = s.promise_reject_callback ?
-    s.promise_reject_callback : task_queue::PromiseRejectCallback;
-  isolate->SetPromiseRejectCallback(promise_reject_cb);
+  if ((s.flags & SHOULD_NOT_SET_PROMISE_REJECTION_CALLBACK) == 0) {
+    auto* promise_reject_cb = s.promise_reject_callback ?
+      s.promise_reject_callback : task_queue::PromiseRejectCallback;
+    isolate->SetPromiseRejectCallback(promise_reject_cb);
+  }
 
   if (s.flags & DETAILED_SOURCE_POSITIONS_FOR_PROFILING)
     v8::CpuProfiler::UseDetailedSourcePositionsForProfiling(isolate);

--- a/src/node.h
+++ b/src/node.h
@@ -328,7 +328,8 @@ class NODE_EXTERN MultiIsolatePlatform : public v8::Platform {
 
 enum IsolateSettingsFlags {
   MESSAGE_LISTENER_WITH_ERROR_LEVEL = 1 << 0,
-  DETAILED_SOURCE_POSITIONS_FOR_PROFILING = 1 << 1
+  DETAILED_SOURCE_POSITIONS_FOR_PROFILING = 1 << 1,
+  SHOULD_NOT_SET_PROMISE_REJECTION_CALLBACK = 1 << 2
 };
 
 struct IsolateSettings {


### PR DESCRIPTION
This PR slightly augments the existing `IsolateSettings` struct for embedder purposes.

Electron does not want to use the promise rejection callback that Node.js uses,
because it does not send `PromiseRejectionEvents` to the global script context in the browser (for fairly obvious reasons).

Therefore, if we want to use Node.js setup logic in the renderer process (as opposed to standalone embedded mode, where we already do this) we would not be able to allow users to do things such as:

```
window.addEventListener('unhandledrejection', function (event) {
  // ...your code here to handle the unhandled rejection...

  // Prevent the default handling (such as outputting the
  // error to the console)

  event.preventDefault();
});
```

since the `'unhandledrejection'` event would never be fired.

We need to use the one Blink already provides and sets on the Isolate we're given, and so we need to slightly augment `IsolateSettings` to allow for that.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
