### PR TITLE
process: stricter sourceMappingURL regex

### DIFF
--- a/lib/internal/source_map/source_map_cache.js
+++ b/lib/internal/source_map/source_map_cache.js
@@ -74,7 +74,7 @@ function maybeCacheSourceMap(filename, content, cjsModuleInstance) {
     return;
   }
 
-  const match = content.match(/\/[*/]#\s+sourceMappingURL=(?<sourceMappingURL>[^\s]+)/);
+  const match = content.match(/(\n|^)\s*\/?\/[*/]#\s+sourceMappingURL=(?<sourceMappingURL>[^\s]+)/);
   if (match) {
     const data = dataFromUrl(basePath, match.groups.sourceMappingURL);
     const url = data ? null : match.groups.sourceMappingURL;

--- a/test/fixtures/source-map/fake-source-map-url.js
+++ b/test/fixtures/source-map/fake-source-map-url.js
@@ -1,0 +1,7 @@
+const a = 99;
+if (true) {
+  const b = 101;
+} else {
+  const c = 102;
+}
+const sm = '//# sourceMappingURL=https://ci.nodejs.org/402'

--- a/test/parallel/test-source-map-enable.js
+++ b/test/parallel/test-source-map-enable.js
@@ -265,6 +265,25 @@ function nextdir() {
   );
 }
 
+// Does not attempt to load source map URLs with leading characters other
+// than /* or //, e.g., const sm = '// sourceMappingUrl ...'.
+{
+  const coverageDirectory = nextdir();
+  const output = spawnSync(process.execPath, [
+    require.resolve('../fixtures/source-map/fake-source-map-url.js')
+  ], { env: { ...process.env, NODE_V8_COVERAGE: coverageDirectory } });
+  if (output.status !== 0) {
+    console.log(output.stderr.toString());
+  }
+  assert.strictEqual(output.status, 0);
+  assert.strictEqual(output.stderr.toString(), '');
+  const sourceMap = getSourceMapFromCache(
+    'fake-source-map-url.js',
+    coverageDirectory
+  );
+  assert.strictEqual(sourceMap, undefined);
+}
+
 function getSourceMapFromCache(fixtureFile, coverageDirectory) {
   const jsonFiles = fs.readdirSync(coverageDirectory);
   for (const jsonFile of jsonFiles) {


### PR DESCRIPTION
The library brrp, which itself processes source maps, had its
processing logic erroneously loaded as a source map URL.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

@jasnell I screwed up a rebase in such a way that I couldn't get https://github.com/nodejs/node/pull/34305 to reopen.

This is #34305 rebased against the main branch.