### PR TITLE
Revert "module: fix check for package.json at volume root"

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -49,7 +49,6 @@ const {
   SafeSet,
   String,
   StringPrototypeIndexOf,
-  StringPrototypeLastIndexOf,
   StringPrototypeMatch,
   StringPrototypeSlice,
   StringPrototypeStartsWith,
@@ -310,13 +309,12 @@ function readPackageScope(checkPath) {
   const rootSeparatorIndex = checkPath.indexOf(path.sep);
   let separatorIndex;
   while (
-    (separatorIndex = StringPrototypeLastIndexOf(checkPath, path.sep)) >=
-     rootSeparatorIndex
+    (separatorIndex = checkPath.lastIndexOf(path.sep)) > rootSeparatorIndex
   ) {
     checkPath = checkPath.slice(0, separatorIndex);
     if (checkPath.endsWith(path.sep + 'node_modules'))
       return false;
-    const pjson = readPackage(checkPath + path.sep);
+    const pjson = readPackage(checkPath);
     if (pjson) return {
       path: checkPath,
       data: pjson


### PR DESCRIPTION
This reverts commit 51af89fe453738262e2c10c831705a385ec78530.

This has needed to be backed out of both the 14.5.0 and 14.6.0
releases due to creating regressions across multiple projects
including:

* coffeescript
* JSONStream
* gulp
* and more

We should reopen a PR to figure out how to land this in a way
that is non-breaking.

Refs: https://github.com/nodejs/node/pull/33476