### PR TITLE
lib: delete unreachable code at lib/internal/vm/module.js

### DIFF
--- a/lib/internal/vm/module.js
+++ b/lib/internal/vm/module.js
@@ -136,23 +136,14 @@ class Module {
   }
 
   get identifier() {
-    if (this[kWrap] === undefined) {
-      throw new ERR_VM_MODULE_NOT_MODULE();
-    }
     return this[kWrap].url;
   }
 
   get context() {
-    if (this[kWrap] === undefined) {
-      throw new ERR_VM_MODULE_NOT_MODULE();
-    }
     return this[kContext];
   }
 
   get namespace() {
-    if (this[kWrap] === undefined) {
-      throw new ERR_VM_MODULE_NOT_MODULE();
-    }
     if (this[kWrap].getStatus() < kInstantiated) {
       throw new ERR_VM_MODULE_STATUS('must not be unlinked or linking');
     }
@@ -160,16 +151,10 @@ class Module {
   }
 
   get status() {
-    if (this[kWrap] === undefined) {
-      throw new ERR_VM_MODULE_NOT_MODULE();
-    }
     return STATUS_MAP[this[kWrap].getStatus()];
   }
 
   get error() {
-    if (this[kWrap] === undefined) {
-      throw new ERR_VM_MODULE_NOT_MODULE();
-    }
     if (this[kWrap].getStatus() !== kErrored) {
       throw new ERR_VM_MODULE_STATUS('must be errored');
     }
@@ -194,10 +179,6 @@ class Module {
   }
 
   async evaluate(options = {}) {
-    if (this[kWrap] === undefined) {
-      throw new ERR_VM_MODULE_NOT_MODULE();
-    }
-
     if (typeof options !== 'object' || options === null) {
       throw new ERR_INVALID_ARG_TYPE('options', 'Object', options);
     }
@@ -344,9 +325,6 @@ class SourceTextModule extends Module {
   }
 
   get dependencySpecifiers() {
-    if (this[kWrap] === undefined) {
-      throw new ERR_VM_MODULE_NOT_MODULE();
-    }
     if (this[kDependencySpecifiers] === undefined) {
       this[kDependencySpecifiers] = this[kWrap].getStaticDependencySpecifiers();
     }
@@ -354,9 +332,6 @@ class SourceTextModule extends Module {
   }
 
   get status() {
-    if (this[kWrap] === undefined) {
-      throw new ERR_VM_MODULE_NOT_MODULE();
-    }
     if (this.#error !== kNoError) {
       return 'errored';
     }
@@ -367,9 +342,6 @@ class SourceTextModule extends Module {
   }
 
   get error() {
-    if (this[kWrap] === undefined) {
-      throw new ERR_VM_MODULE_NOT_MODULE();
-    }
     if (this.#error !== kNoError) {
       return this.#error;
     }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)


Well, I'm pretty sure about this, but I did not found a way to reach that `this[kWrap] === undefined`, that is defined in constructor ([you may want to give a check](https://github.com/nodejs/node/blob/master/lib/internal/vm/module.js#L115))
