### PR TITLE
src: prefer C++ empty() in boolean expressions

### DIFF
--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -366,7 +366,7 @@ bool IsFilePath(const std::string& path) {
 }
 #else
 bool IsFilePath(const std::string& path) {
-  return path.length() && path[0] == '/';
+  return !path.empty() && path[0] == '/';
 }
 #endif  // __POSIX__
 

--- a/src/inspector_js_api.cc
+++ b/src/inspector_js_api.cc
@@ -303,7 +303,7 @@ void WaitForDebugger(const FunctionCallbackInfo<Value>& args) {
 void Url(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   std::string url = env->inspector_agent()->GetWsUrl();
-  if (url.length() == 0) {
+  if (url.empty()) {
     return;
   }
   args.GetReturnValue().Set(OneByteString(env->isolate(), url.c_str()));

--- a/src/node_file-inl.h
+++ b/src/node_file-inl.h
@@ -28,7 +28,7 @@ void FSContinuationData::MaybeSetFirstPath(const std::string& path) {
 }
 
 std::string FSContinuationData::PopPath() {
-  CHECK_GT(paths_.size(), 0);
+  CHECK(!paths_.empty());
   std::string path = std::move(paths_.back());
   paths_.pop_back();
   return path;

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -1517,7 +1517,7 @@ void Http2Session::ClearOutgoing(int status) {
 
   set_sending(false);
 
-  if (outgoing_buffers_.size() > 0) {
+  if (!outgoing_buffers_.empty()) {
     outgoing_storage_.clear();
     outgoing_length_ = 0;
 
@@ -1536,7 +1536,7 @@ void Http2Session::ClearOutgoing(int status) {
 
   // Now that we've finished sending queued data, if there are any pending
   // RstStreams we should try sending again and then flush them one by one.
-  if (pending_rst_streams_.size() > 0) {
+  if (!pending_rst_streams_.empty()) {
     std::vector<int32_t> current_pending_rst_streams;
     pending_rst_streams_.swap(current_pending_rst_streams);
 
@@ -1595,8 +1595,8 @@ uint8_t Http2Session::SendPendingData() {
   ssize_t src_length;
   const uint8_t* src;
 
-  CHECK_EQ(outgoing_buffers_.size(), 0);
-  CHECK_EQ(outgoing_storage_.size(), 0);
+  CHECK(outgoing_buffers_.empty());
+  CHECK(outgoing_storage_.empty());
 
   // Part One: Gather data from nghttp2
 

--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -1170,7 +1170,7 @@ bool ParseHost(const std::string& input,
                std::string* output,
                bool is_special,
                bool unicode = false) {
-  if (input.length() == 0) {
+  if (input.empty()) {
     output->clear();
     return true;
   }
@@ -2037,7 +2037,7 @@ void URL::Parse(const char* input,
               (ch == kEOL ||
                ch == '?' ||
                ch == '#')) {
-            while (url->path.size() > 1 && url->path[0].length() == 0) {
+            while (url->path.size() > 1 && url->path[0].empty()) {
               url->path.erase(url->path.begin());
             }
           }
@@ -2060,9 +2060,9 @@ void URL::Parse(const char* input,
             state = kFragment;
             break;
           default:
-            if (url->path.size() == 0)
+            if (url->path.empty())
               url->path.emplace_back("");
-            if (url->path.size() > 0 && ch != kEOL)
+            else if (ch != kEOL)
               AppendOrEscape(&url->path[0], ch, C0_CONTROL_ENCODE_SET);
         }
         break;

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -497,7 +497,7 @@ void Worker::New(const FunctionCallbackInfo<Value>& args) {
                             per_isolate_opts.get(),
                             kAllowedInEnvironment,
                             &errors);
-      if (errors.size() > 0 && args[1]->IsObject()) {
+      if (!errors.empty() && args[1]->IsObject()) {
         // Only fail for explicitly provided env, this protects from failures
         // when NODE_OPTIONS from parent's env is used (which is the default).
         Local<Value> error;


### PR DESCRIPTION
This changes occurrences of `length()` and `size()` to `empty()` where it makes the code simpler.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
