### PR TITLE
tls default SNICallback should Check the servername and select the appropriate secure context in Reverse order  

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -1435,7 +1435,7 @@ Server.prototype[EE.captureRejectionSymbol] = function(
 
 function SNICallback(servername, callback) {
   const contexts = this.server._contexts;
-
+//Fixes: https://github.com//issues/34110
   for (let i=contexts.length-1;i>=0;i--){
     const elem = contexts[i]
     if (elem[0].test(servername)) {

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -1412,6 +1412,12 @@ Server.prototype.addContext = function(servername, context) {
   if (!servername) {
     throw new ERR_TLS_REQUIRED_SERVER_NAME();
   }
+//https://github.com/nodejs/node/issues/34110
+servername=servername.toLowerCase()
+
+
+
+
 
   const re = new RegExp('^' +
                       servername.replace(/([.^$+?\-\\[\]{}])/g, '\\$1')

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -1415,10 +1415,6 @@ Server.prototype.addContext = function(servername, context) {
 //https://github.com/nodejs/node/issues/34110
 servername=servername.toLowerCase()
 
-
-
-
-
   const re = new RegExp('^' +
                       servername.replace(/([.^$+?\-\\[\]{}])/g, '\\$1')
                                 .replace(/\*/g, '[^.]*') +

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -1436,8 +1436,7 @@ Server.prototype[EE.captureRejectionSymbol] = function(
 
 function SNICallback(servername, callback) {
   const contexts = this.server._contexts;
-//Fixes: https://github.com/nodejs/node/issues/34110
-  for (let i=contexts.length-1;i>=0;i--){
+  for (let i = contexts.length - 1; i >= 0 ; i--) {
     const elem = contexts[i]
     if (elem[0].test(servername)) {
       callback(null, elem[1]);

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -1412,8 +1412,7 @@ Server.prototype.addContext = function(servername, context) {
   if (!servername) {
     throw new ERR_TLS_REQUIRED_SERVER_NAME();
   }
-//https://github.com/nodejs/node/issues/34110
-servername=servername.toLowerCase()
+servername = servername.toLowerCase()
 
   const re = new RegExp('^' +
                       servername.replace(/([.^$+?\-\\[\]{}])/g, '\\$1')

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -1435,7 +1435,7 @@ Server.prototype[EE.captureRejectionSymbol] = function(
 
 function SNICallback(servername, callback) {
   const contexts = this.server._contexts;
-//Fixes: https://github.com//issues/34110
+//Fixes: https://github.com/nodejs/node/issues/34110
   for (let i=contexts.length-1;i>=0;i--){
     const elem = contexts[i]
     if (elem[0].test(servername)) {

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -1436,7 +1436,8 @@ Server.prototype[EE.captureRejectionSymbol] = function(
 function SNICallback(servername, callback) {
   const contexts = this.server._contexts;
 
-  for (const elem of contexts) {
+  for (let i=contexts.length-1;i>=0;i--){
+    const elem = contexts[i]
     if (elem[0].test(servername)) {
       callback(null, elem[1]);
       return;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ x] tests and/or benchmarks are included
- [ x] documentation is changed or added
- [ x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

tls default SNICallback should Check the servername and select the appropriate secure context in Reverse order  

This is useful on HTTPS servers that need to replace ssl/tls certificates frequently, such as using "let's encrypt". When the certificate needs to be replaced, you don't want to restart the HTTPS server, you just need to replace the certificate and key.


If multiple secure contexts are added to the same domain name, the last one added should take effect

```javascript
 const server = https.createServer();
const hostname = 'foo.bar.com';
const keypath = 'key.pem';
const certpath = 'cert.pem';
function debounce(callback, timeout) {
    let timer;
    return function (...args) {
        timer && clearTimeout(timer);
        timer = setTimeout(callback, timeout, ...args);
    };
}
const reloadcertkey = debounce(function () {
    let key = fs.readFileSync(keypath);
    let cert = fs.readFileSync(certpath);
    let context = tls.createSecureContext({
        key,
        cert
    });
    server.addContext(hostname, context);
}, 1000);
reloadcertkey();
fs.watch(keypath, reloadcertkey);
fs.watch(certpath, reloadcertkey);
```
