### PR TITLE
test: fixup worker + source map test

### DIFF
--- a/test/parallel/test-worker-terminate-source-map.js
+++ b/test/parallel/test-worker-terminate-source-map.js
@@ -32,9 +32,11 @@ Map.prototype.entries = increaseCallCount;
 Object.keys = increaseCallCount;
 Object.create = increaseCallCount;
 Object.hasOwnProperty = increaseCallCount;
-Object.defineProperty(Object.prototype, 'value', {
-  get: increaseCallCount,
-  set: increaseCallCount
-});
+for (const property of ['_cache', 'lineLengths', 'url']) {
+  Object.defineProperty(Object.prototype, property, {
+    get: increaseCallCount,
+    set: increaseCallCount
+  });
+}
 
 parentPort.postMessage('done');


### PR DESCRIPTION
The messaging code uses `Object.defineProperty()`, which accesses
`value` on `Object.prototype` by default, so some calls to the
getter here would actually be expected. Instead, make the list
of accessed properties more specific to the tested source map
code to avoid flakiness.

Refs: https://twitter.com/addaleax/status/1276289101671608320
Refs: https://github.com/nodejs/node/pull/34057

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
