### PR TITLE
src: at StringType to avoid V8 warnings

### DIFF
--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -1143,7 +1143,7 @@ unsigned int TLSWrap::PskServerCallback(SSL* s,
   HandleScope scope(isolate);
 
   MaybeLocal<String> maybe_identity_str =
-      String::NewFromUtf8(isolate, identity);
+      String::NewFromUtf8(isolate, identity, v8::NewStringType::kNormal);
 
   v8::Local<v8::String> identity_str;
   if (!maybe_identity_str.ToLocal(&identity_str)) return 0;
@@ -1186,7 +1186,8 @@ unsigned int TLSWrap::PskClientCallback(SSL* s,
                          Integer::NewFromUnsigned(isolate, max_psk_len),
                          Integer::NewFromUnsigned(isolate, max_identity_len)};
   if (hint != nullptr) {
-    MaybeLocal<String> maybe_hint = String::NewFromUtf8(isolate, hint);
+    MaybeLocal<String> maybe_hint =
+      String::NewFromUtf8(isolate, hint, v8::NewStringType::kNormal);
 
     Local<String> local_hint;
     if (!maybe_hint.ToLocal(&local_hint)) return 0;


### PR DESCRIPTION
The usage of `v8::String::NewFromUtf8(isolate, char)`
is deprecated, the string type should be specified at the
third param `v8::String::NewFromUtf8(isolate, char, v8::NewStringType)`

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
