### PR TITLE
build: define NODE_EXPERIMENTAL_QUIC in mkcodecache and node_mksnapshot

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -1376,6 +1376,11 @@
             'HAVE_OPENSSL=1',
           ],
         }],
+        [ 'node_use_openssl=="true" and experimental_quic==1', {
+          'defines': [
+            'NODE_EXPERIMENTAL_QUIC=1',
+          ],
+        }],
         ['v8_enable_inspector==1', {
           'defines': [
             'HAVE_INSPECTOR=1',
@@ -1428,6 +1433,11 @@
         [ 'node_use_openssl=="true"', {
           'defines': [
             'HAVE_OPENSSL=1',
+          ],
+        }],
+        [ 'node_use_openssl=="true" and experimental_quic==1', {
+          'defines': [
+            'NODE_EXPERIMENTAL_QUIC=1',
           ],
         }],
         ['v8_enable_inspector==1', {


### PR DESCRIPTION
#### build: define NODE_EXPERIMENTAL_QUIC in mkcodecache and node_mksnapshot

Otherwise the build would fail with
`./configure --experimental-quic --ninja` as the list of per-Environment
values would not match and the code cache builder would not generate
code cache for the quic JS sources. This is more or less a band-aid -
a proper fix would be to aggregate these flags into something
that can be included by all these different binary targets.
See https://github.com/nodejs/node/issues/31074.

Fixes: https://github.com/nodejs/node/issues/34435

<del>

#### Revert "src: refactor TimerWrap lifetime management"

This reverts commit 874460a1d19e149b58428c88890abe4407cd116e.

@addaleax I have no idea why but it seems the TimerWrap lifetime management refactoring 874460a1d19e149b58428c88890abe4407cd116e is also causing the build to fail a bunch of quic tests, crashing with

```
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x40)
    frame #0: 0x000000010019c3c8 node`node::TimerWrapHandle::Stop() [inlined] node::TimerWrap::Stop(this=0x0000000000000000) at timer_wrap.cc:16:19 [opt]
   13  	}
   14
   15  	void TimerWrap::Stop() {
-> 16  	  if (timer_.data == nullptr) return;
   17  	  uv_timer_stop(&timer_);
   18  	}
   19

```
So I revereted it as well to make the tests pass
</del>


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
