### PR TITLE
stream: fix Duplex._construct race

### DIFF
--- a/lib/internal/streams/destroy.js
+++ b/lib/internal/streams/destroy.js
@@ -203,13 +203,6 @@ function construct(stream, cb) {
     return;
   }
 
-  stream.once(kConstruct, cb);
-
-  if (stream.listenerCount(kConstruct) > 1) {
-    // Duplex
-    return;
-  }
-
   const r = stream._readableState;
   const w = stream._writableState;
 
@@ -218,6 +211,13 @@ function construct(stream, cb) {
   }
   if (w) {
     w.constructed = false;
+  }
+
+  stream.once(kConstruct, cb);
+
+  if (stream.listenerCount(kConstruct) > 1) {
+    // Duplex
+    return;
   }
 
   process.nextTick(constructNT, stream);


### PR DESCRIPTION
Ensures that _construct has finished before invoking
_destroy.

The 'constructed' property was not properly set to false
for both writable and readable state.

Fixes: https://github.com/nodejs/node/issues/34448

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
