### PR TITLE
events: re-use the same isTrusted getter

### DIFF
--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -7,6 +7,7 @@ const {
   Map,
   NumberIsInteger,
   Object,
+  ObjectDefineProperty,
   Symbol,
   SymbolFor,
   SymbolToStringTag,
@@ -52,6 +53,9 @@ const kTimestamp = Symbol('timestamp');
 const kBubbles = Symbol('bubbles');
 const kComposed = Symbol('composed');
 const kPropagationStopped = Symbol('propagationStopped');
+
+const isTrusted = () => false;
+
 class Event {
   constructor(type, options) {
     if (arguments.length === 0)
@@ -67,8 +71,8 @@ class Event {
     this[kTimestamp] = lazyNow();
     this[kPropagationStopped] = false;
     // isTrusted is special (LegacyUnforgeable)
-    Object.defineProperty(this, 'isTrusted', {
-      get() { return false; },
+    ObjectDefineProperty(this, 'isTrusted', {
+      get: isTrusted,
       enumerable: true,
       configurable: false
     });


### PR DESCRIPTION
Creating a new function each time the property descriptor is set
comes with performance overhead, since these functions have different
identities, even if they contain the same code.

Refs: https://twitter.com/tverwaes/status/1285496612618473472

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
