### PR TITLE
ci: don't run Actions on non-master pushes

### DIFF
--- a/.github/workflows/build-tarball.yml
+++ b/.github/workflows/build-tarball.yml
@@ -1,6 +1,10 @@
 name: Build from tarball
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 env:
   FLAKY_TESTS: dontcare

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,6 +1,10 @@
 name: build-windows
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 env:
   PYTHON_VERSION: 3.8

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,6 +1,10 @@
 name: linters
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 env:
   PYTHON_VERSION: 3.8

--- a/.github/workflows/misc.yml
+++ b/.github/workflows/misc.yml
@@ -1,6 +1,10 @@
 name: misc
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 env:
   NODE_VERSION: 12.x

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -1,6 +1,10 @@
 name: test-linux
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 env:
   PYTHON_VERSION: 3.8

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -1,6 +1,10 @@
 name: test-macOS
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 env:
   PYTHON_VERSION: 3.8


### PR DESCRIPTION
This PR cleans up duplicate workflow runs for PRs by making it such that workflows are triggered on `push` only for the `master` branch. Not all PRs target master, so we still want to trigger workflows on all PRs targeting any branch for the `pull_request` event.

cc @MylesBorins

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
