### PR TITLE
http: don't write error to socket

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1074,8 +1074,8 @@ type other than {net.Socket}.
 
 Default behavior is to try close the socket with a HTTP '400 Bad Request',
 or a HTTP '431 Request Header Fields Too Large' in the case of a
-[`HPE_HEADER_OVERFLOW`][] error. If the socket is not writable it is
-immediately destroyed.
+[`HPE_HEADER_OVERFLOW`][] error. If the socket is not writable or has already
+written data it is immediately destroyed.
 
 `socket` is the [`net.Socket`][] object that the error originated from.
 

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -71,7 +71,6 @@ const {
   validateInteger,
   validateBoolean
 } = require('internal/validators');
-const Buffer = require('buffer').Buffer;
 const {
   DTRACE_HTTP_SERVER_REQUEST,
   DTRACE_HTTP_SERVER_RESPONSE

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -604,25 +604,12 @@ function onParserTimeout(server, socket) {
 }
 
 const noop = () => {};
-const badRequestResponse = Buffer.from(
-  `HTTP/1.1 400 ${STATUS_CODES[400]}${CRLF}` +
-  `Connection: close${CRLF}${CRLF}`, 'ascii'
-);
-const requestHeaderFieldsTooLargeResponse = Buffer.from(
-  `HTTP/1.1 431 ${STATUS_CODES[431]}${CRLF}` +
-  `Connection: close${CRLF}${CRLF}`, 'ascii'
-);
 function socketOnError(e) {
   // Ignore further errors
   this.removeListener('error', socketOnError);
   this.on('error', noop);
 
   if (!this.server.emit('clientError', e, this)) {
-    if (this.writable) {
-      const response = e.code === 'HPE_HEADER_OVERFLOW' ?
-        requestHeaderFieldsTooLargeResponse : badRequestResponse;
-      this.write(response);
-    }
     this.destroy(e);
   }
 }

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -71,6 +71,7 @@ const {
   validateInteger,
   validateBoolean
 } = require('internal/validators');
+const Buffer = require('buffer').Buffer;
 const {
   DTRACE_HTTP_SERVER_REQUEST,
   DTRACE_HTTP_SERVER_RESPONSE
@@ -603,12 +604,25 @@ function onParserTimeout(server, socket) {
 }
 
 const noop = () => {};
+const badRequestResponse = Buffer.from(
+  `HTTP/1.1 400 ${STATUS_CODES[400]}${CRLF}` +
+  `Connection: close${CRLF}${CRLF}`, 'ascii'
+);
+const requestHeaderFieldsTooLargeResponse = Buffer.from(
+  `HTTP/1.1 431 ${STATUS_CODES[431]}${CRLF}` +
+  `Connection: close${CRLF}${CRLF}`, 'ascii'
+);
 function socketOnError(e) {
   // Ignore further errors
   this.removeListener('error', socketOnError);
   this.on('error', noop);
 
   if (!this.server.emit('clientError', e, this)) {
+    if (this.writable && this.bytesWritten === 0) {
+      const response = e.code === 'HPE_HEADER_OVERFLOW' ?
+        requestHeaderFieldsTooLargeResponse : badRequestResponse;
+      this.write(response);
+    }
     this.destroy(e);
   }
 }

--- a/test/parallel/test-http-header-badrequest.js
+++ b/test/parallel/test-http-header-badrequest.js
@@ -1,0 +1,31 @@
+'use strict';
+const { mustCall } = require('../common');
+const assert = require('assert');
+const { createServer } = require('http');
+const { createConnection } = require('net');
+
+const server = createServer();
+
+server.on('request', mustCall((req, res) => {
+  res.write('asd', () => {
+    res.socket.emit('error', new Error('kaboom'));
+  });
+}));
+
+server.listen(0, mustCall(() => {
+  const c = createConnection(server.address().port);
+  let received = '';
+
+  c.on('connect', mustCall(() => {
+    c.write('GET /blah HTTP/1.1\r\n\r\n');
+  }));
+  c.on('data', mustCall((data) => {
+    received += data.toString();
+  }));
+  c.on('end', mustCall(() => {
+    // Should not include anything else after asd.
+    assert.strictEqual(received.indexOf('asd\r\n'), received.length - 5);
+    c.end();
+  }));
+  c.on('close', mustCall(() => server.close()));
+}));


### PR DESCRIPTION
The state of the connection is unknown at this point and
writing to it can corrupt client state before it is aware
of an error.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
