### PR TITLE
module: disable cjs snapshotting into esm loader

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -31,7 +31,6 @@ const {
   ArrayIsArray,
   Error,
   JSONParse,
-  Map,
   Number,
   ObjectCreate,
   ObjectDefineProperty,
@@ -112,8 +111,6 @@ const {
 } = require('internal/util/types');
 
 const asyncESM = require('internal/process/esm_loader');
-const ModuleJob = require('internal/modules/esm/module_job');
-const { ModuleWrap, kInstantiated } = internalBinding('module_wrap');
 const {
   encodedSepRegEx,
   packageInternalResolve
@@ -373,7 +370,7 @@ function tryPackage(requestPath, exts, isMain, originalPath) {
 // In order to minimize unnecessary lstat() calls,
 // this cache is a list of known-real paths.
 // Set to an empty Map to reset.
-const realpathCache = new Map();
+const realpathCache = new SafeMap();
 
 // Check if the file exists and is not a directory
 // if using --preserve-symlinks and isMain is false,
@@ -1098,31 +1095,6 @@ Module.prototype.load = function(filename) {
   }
   Module._extensions[extension](this, filename);
   this.loaded = true;
-
-  const ESMLoader = asyncESM.ESMLoader;
-  const url = `${pathToFileURL(filename)}`;
-  const module = ESMLoader.moduleMap.get(url);
-  // Create module entry at load time to snapshot exports correctly
-  const exports = this.exports;
-  // Called from cjs translator
-  if (module !== undefined && module.module !== undefined) {
-    if (module.module.getStatus() >= kInstantiated)
-      module.module.setExport('default', exports);
-  } else {
-    // Preemptively cache
-    // We use a function to defer promise creation for async hooks.
-    ESMLoader.moduleMap.set(
-      url,
-      // Module job creation will start promises.
-      // We make it a function to lazily trigger those promises
-      // for async hooks compatibility.
-      () => new ModuleJob(ESMLoader, url, () =>
-        new ModuleWrap(url, undefined, ['default'], function() {
-          this.setExport('default', exports);
-        })
-      , false /* isMain */, false /* inspectBrk */)
-    );
-  }
 };
 
 
@@ -1242,7 +1214,7 @@ Module.prototype._compile = function(content, filename) {
   const exports = this.exports;
   const thisValue = exports;
   const module = this;
-  if (requireDepth === 0) statCache = new Map();
+  if (requireDepth === 0) statCache = new SafeMap();
   if (inspectorWrapper) {
     result = inspectorWrapper(compiledWrapper, thisValue, exports,
                               require, module, filename, dirname);

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -2,8 +2,7 @@
 
 const {
   FunctionPrototypeBind,
-  ObjectSetPrototypeOf,
-  SafeMap,
+  ObjectSetPrototypeOf
 } = primordials;
 
 const {
@@ -42,9 +41,6 @@ class Loader {
 
     // Registry of loaded modules, akin to `require.cache`
     this.moduleMap = new ModuleMap();
-
-    // Map of already-loaded CJS modules to use
-    this.cjsCache = new SafeMap();
 
     // This hook is called before the first root module is imported. It's a
     // function that returns a piece of code that runs as a sloppy-mode script.

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -11,6 +11,8 @@ const {
   StringPrototypeReplace,
 } = primordials;
 
+const assert = require('internal/assert');
+
 let _TYPES = null;
 function lazyTypes() {
   if (_TYPES !== null) return _TYPES;
@@ -132,27 +134,21 @@ const isWindows = process.platform === 'win32';
 const winSepRegEx = /\//g;
 translators.set('commonjs', function commonjsStrategy(url, isMain) {
   debug(`Translating CJSModule ${url}`);
-  const pathname = internalURLModule.fileURLToPath(new URL(url));
-  const cached = this.cjsCache.get(url);
-  if (cached) {
-    this.cjsCache.delete(url);
-    return cached;
-  }
-  const module = CJSModule._cache[
-    isWindows ? StringPrototypeReplace(pathname, winSepRegEx, '\\') : pathname
-  ];
-  if (module && module.loaded) {
-    const exports = module.exports;
-    return new ModuleWrap(url, undefined, ['default'], function() {
-      this.setExport('default', exports);
-    });
-  }
+  let filename = internalURLModule.fileURLToPath(new URL(url));
+  if (isWindows)
+    filename = StringPrototypeReplace(filename, winSepRegEx, '\\');
   return new ModuleWrap(url, undefined, ['default'], function() {
     debug(`Loading CJSModule ${url}`);
-    // We don't care about the return val of _load here because Module#load
-    // will handle it for us by checking the loader registry and filling the
-    // exports like above
-    CJSModule._load(pathname, undefined, isMain);
+    let module = CJSModule._cache[filename];
+    if (!module || !module.loaded) {
+      module = new CJSModule(filename);
+      module.filename = filename;
+      module.paths = CJSModule._nodeModulePaths(module.path);
+      CJSModule._cache[filename] = module;
+      module.load(filename);
+      assert(module && module.loaded);
+    }
+    this.setExport('default', module.exports);
   });
 });
 

--- a/test/es-module/test-esm-snapshot.mjs
+++ b/test/es-module/test-esm-snapshot.mjs
@@ -3,4 +3,4 @@ import '../fixtures/es-modules/esm-snapshot-mutator.js';
 import one from '../fixtures/es-modules/esm-snapshot.js';
 import assert from 'assert';
 
-assert.strictEqual(one, 1);
+assert.strictEqual(one, 2);


### PR DESCRIPTION
This disables the instant snapshotting of CJS modules into the ESM loader as soon as they are loaded, regardless of whether those modules are loaded as ESM.

This allows loaders to support named exports for CJS modules, which isn't currently possible with the loader hook module as the snapshot process bypasses the loader hooks.

Since the PR at https://github.com/nodejs/node/pull/33416 for CommonJS named exports has stalled due to a remaining blocker, this will allow loaders to enable that use case.

This was originally implemented in order to ensure that the snapshot of the `module.exports` value was always a sync exact snapshot at execution completion. In addition this allows CJS modules to be more easily garbage collected since they are not by default injected into the ESM loader if not directly loaded from it.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
