### PR TITLE
src: skip weak references for memory tracking

### DIFF
--- a/src/memory_tracker-inl.h
+++ b/src/memory_tracker-inl.h
@@ -131,7 +131,7 @@ template <typename T, bool kIsWeak>
 void MemoryTracker::TrackField(const char* edge_name,
                                const BaseObjectPtrImpl<T, kIsWeak>& value,
                                const char* node_name) {
-  if (value.get() == nullptr) return;
+  if (value.get() == nullptr || kIsWeak) return;
   TrackField(edge_name, value.get(), node_name);
 }
 
@@ -214,6 +214,7 @@ template <typename T>
 void MemoryTracker::TrackField(const char* edge_name,
                                const v8::PersistentBase<T>& value,
                                const char* node_name) {
+  if (value.IsWeak()) return;
   TrackField(edge_name, value.Get(isolate_));
 }
 


### PR DESCRIPTION
The memory tracking is supposed to represent the “keeps-alive”
relations between objects for a heap dump, in order to enable
developers to figure out which objects keep which other objects
on the heap.

Weak references do not participate in that relation. Therefore,
we should not be tracking them.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
