### PR TITLE
src: prefer internal fields in ModuleWrap

### DIFF
--- a/src/module_wrap.h
+++ b/src/module_wrap.h
@@ -32,6 +32,14 @@ enum HostDefinedOptions : int {
 
 class ModuleWrap : public BaseObject {
  public:
+  enum InternalFields {
+    kModuleWrapBaseField = BaseObject::kInternalFieldCount,
+    kURLSlot,
+    kSyntheticEvaluationStepsSlot,
+    kContextObjectSlot,  // Object whose creation context is the target Context
+    kInternalFieldCount
+  };
+
   static void Initialize(v8::Local<v8::Object> target,
                          v8::Local<v8::Value> unused,
                          v8::Local<v8::Context> context,
@@ -42,11 +50,11 @@ class ModuleWrap : public BaseObject {
       v8::Local<v8::Object> meta);
 
   void MemoryInfo(MemoryTracker* tracker) const override {
-    tracker->TrackField("url", url_);
     tracker->TrackField("resolve_cache", resolve_cache_);
   }
 
   inline uint32_t id() { return id_; }
+  v8::Local<v8::Context> context() const;
   static ModuleWrap* GetFromID(node::Environment*, uint32_t id);
 
   SET_MEMORY_INFO_NAME(ModuleWrap)
@@ -85,11 +93,8 @@ class ModuleWrap : public BaseObject {
       v8::Local<v8::Module> referrer);
   static ModuleWrap* GetFromModule(node::Environment*, v8::Local<v8::Module>);
 
-  v8::Global<v8::Function> synthetic_evaluation_steps_;
   v8::Global<v8::Module> module_;
-  v8::Global<v8::String> url_;
   std::unordered_map<std::string, v8::Global<v8::Promise>> resolve_cache_;
-  v8::Global<v8::Context> context_;
   contextify::ContextifyContext* contextify_context_ = nullptr;
   bool synthetic_ = false;
   bool linked_ = false;


### PR DESCRIPTION
Use internal fields instead of `v8::Global`s where possible, since
they generally come with lower overhead and it’s much harder to
introduce memory leaks with them.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
