### PR TITLE
doc: update http server response 'close' event

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1338,7 +1338,8 @@ passed as the second parameter to the [`'request'`][] event.
 added: v0.6.7
 -->
 
-Indicates that the underlying connection was terminated.
+Indicates that the the response is completed, or its underlying connection was
+terminated prematurely (before the response completion).
 
 ### Event: `'finish'`
 <!-- YAML


### PR DESCRIPTION
Two places emits `close` events:

### 1 - On result completion:
 `resOnFinish` calls `emitCloseNT`, which happens when the result is completed:
https://github.com/nodejs/node/blob/687dbd85263f433cc351c6daa83f9296a1d0bb4f/lib/_http_server.js#L695


### 2 - When the connection is terminated

It gets attached once the socket is assigned:
https://github.com/nodejs/node/blob/687dbd85263f433cc351c6daa83f9296a1d0bb4f/lib/_http_server.js#L226

And detached if the response is completed:
https://github.com/nodejs/node/blob/master/lib/_http_server.js#L709
https://github.com/nodejs/node/blob/687dbd85263f433cc351c6daa83f9296a1d0bb4f/lib/_http_server.js#L232

Which means, it can only be reached in this case, for premature socket termination.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
