### PR TITLE
process: correctly parse Unicode in NODE_OPTIONS

### DIFF
--- a/src/node_credentials.cc
+++ b/src/node_credentials.cc
@@ -57,7 +57,7 @@ bool SafeGetenv(const char* key, std::string* text, Environment* env) {
 
   {
     Mutex::ScopedLock lock(per_process::env_var_mutex);
-  
+
     size_t init_sz = 256;
     MaybeStackBuffer<char, 256> val;
     int ret = uv_os_getenv(key, *val, &init_sz);

--- a/src/node_credentials.cc
+++ b/src/node_credentials.cc
@@ -57,8 +57,20 @@ bool SafeGetenv(const char* key, std::string* text, Environment* env) {
 
   {
     Mutex::ScopedLock lock(per_process::env_var_mutex);
-    if (const char* value = getenv(key)) {
-      *text = value;
+  
+    size_t init_sz = 256;
+    MaybeStackBuffer<char, 256> val;
+    int ret = uv_os_getenv(key, *val, &init_sz);
+
+    if (ret == UV_ENOBUFS) {
+      // Buffer is not large enough, reallocate to the updated init_sz
+      // and fetch env value again.
+      val.AllocateSufficientStorage(init_sz);
+      ret = uv_os_getenv(key, *val, &init_sz);
+    }
+
+    if (ret >= 0) {  // Env key value fetch success.
+      *text = *val;
       return true;
     }
   }

--- a/test/parallel/test-unicode-node-options.js
+++ b/test/parallel/test-unicode-node-options.js
@@ -11,13 +11,8 @@ if (process.argv.length === 2) {
   const NODE_OPTIONS = `--redirect-warnings=${expected_redirect_value}`;
   const result = cp.spawnSync(process.argv0,
                               ['--expose-internals', __filename, 'test'],
-                              {
-                                env: {
-                                  NODE_OPTIONS
-                                }
-                              });
+                              { env: { NODE_OPTIONS } });
   assert.strictEqual(result.status, 0);
-  process.exit(0);
 } else {
   const redirect_value = getOptionValue('--redirect-warnings');
   assert.strictEqual(redirect_value, expected_redirect_value);

--- a/test/parallel/test-unicode-node-options.js
+++ b/test/parallel/test-unicode-node-options.js
@@ -1,0 +1,24 @@
+'use strict';
+// Flags: --expose-internals
+require('../common');
+const { getOptionValue } = require('internal/options');
+const assert = require('assert');
+const cp = require('child_process');
+
+const expected_redirect_value = 'foó';
+
+if (process.argv.length === 2) {
+  const NODE_OPTIONS = `--redirect-warnings=${expected_redirect_value}`;
+  const result = cp.spawnSync(process.argv0,
+                              ['--expose-internals', __filename, 'test'],
+                              {
+                                env: {
+                                  NODE_OPTIONS
+                                }
+                              });
+  assert.strictEqual(result.status, 0);
+  process.exit(0);
+} else {
+  const redirect_value = getOptionValue('--redirect-warnings');
+  assert.strictEqual(redirect_value, expected_redirect_value);
+}

--- a/test/parallel/test-unicode-node-options.js
+++ b/test/parallel/test-unicode-node-options.js
@@ -11,9 +11,13 @@ if (process.argv.length === 2) {
   const NODE_OPTIONS = `--redirect-warnings=${expected_redirect_value}`;
   const result = cp.spawnSync(process.argv0,
                               ['--expose-internals', __filename, 'test'],
-                              { env: { NODE_OPTIONS } });
+                              {
+                                env: { NODE_OPTIONS },
+                                stdio: 'inherit'
+                              });
   assert.strictEqual(result.status, 0);
 } else {
   const redirect_value = getOptionValue('--redirect-warnings');
+  console.log(`--redirect-warings=${redirect_value}`);
   assert.strictEqual(redirect_value, expected_redirect_value);
 }

--- a/test/parallel/test-unicode-node-options.js
+++ b/test/parallel/test-unicode-node-options.js
@@ -12,7 +12,10 @@ if (process.argv.length === 2) {
   const result = cp.spawnSync(process.argv0,
                               ['--expose-internals', __filename, 'test'],
                               {
-                                env: { NODE_OPTIONS },
+                                env: {
+                                  ...process.env,
+                                  NODE_OPTIONS
+                                },
                                 stdio: 'inherit'
                               });
   assert.strictEqual(result.status, 0);


### PR DESCRIPTION
Fixes an issue on Windows, where Unicode in NODE_OPTIONS was not parsed
correctly.

Fixes: https://github.com/nodejs/node/issues/34399

Reused the code from `node_env_var.cc` for getting the enviroment variable value.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
