### PR TITLE
quic: refactor ocsp handling

### DIFF
--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -209,11 +209,11 @@ const kAddSession = Symbol('kAddSession');
 const kAddStream = Symbol('kAddStream');
 const kBind = Symbol('kBind');
 const kClose = Symbol('kClose');
-const kCert = Symbol('kCert');
 const kClientHello = Symbol('kClientHello');
 const kDestroy = Symbol('kDestroy');
 const kEndpointBound = Symbol('kEndpointBound');
 const kEndpointClose = Symbol('kEndpointClose');
+const kHandleOcsp = Symbol('kHandleOcsp');
 const kHandshake = Symbol('kHandshake');
 const kHandshakeComplete = Symbol('kHandshakeComplete');
 const kHandshakePost = Symbol('kHandshakePost');
@@ -323,52 +323,37 @@ function onSessionClientHello(alpn, servername, ciphers) {
     clientHelloCallback.bind(this));
 }
 
-// Used only within the onSessionCert function. Invoked
-// to complete the session cert process.
-function sessionCertCallback(err, context, ocspResponse) {
-  if (err) {
-    this[owner_symbol].destroy(err);
-    return;
-  }
-  if (context != null && !context.context) {
-    this[owner_symbol].destroy(
-      new ERR_INVALID_ARG_TYPE(
-        'context',
-        'SecureContext',
-        context));
-  }
-  if (ocspResponse != null) {
-    if (typeof ocspResponse === 'string')
-      ocspResponse = Buffer.from(ocspResponse);
-    if (!isArrayBufferView(ocspResponse)) {
-      this[owner_symbol].destroy(
-        new ERR_INVALID_ARG_TYPE(
-          'ocspResponse',
-          ['string', 'Buffer', 'TypedArray', 'DataView'],
-          ocspResponse));
-    }
-  }
-  try {
-    this.onCertDone(context ? context.context : undefined, ocspResponse);
-  } catch (err) {
-    this[owner_symbol].destroy(err);
-  }
-}
-
 // This callback is only ever invoked for QuicServerSession instances,
 // and is used to trigger OCSP request processing when needed. The
 // user callback must invoke .onCertDone() in order for the
 // TLS handshake to continue.
 function onSessionCert(servername) {
-  this[owner_symbol][kCert](servername, sessionCertCallback.bind(this));
+  this[owner_symbol][kHandleOcsp](servername)
+    .then(({ context, data }) => {
+      if (context !== undefined && !context?.context)
+        throw new ERR_INVALID_ARG_TYPE('context', 'SecureContext', context);
+      if (data !== undefined) {
+        if (typeof data === 'string')
+          data = Buffer.from(data);
+        if (!isArrayBufferView(data)) {
+          throw new ERR_INVALID_ARG_TYPE(
+            'data',
+            ['string', 'Buffer', 'TypedArray', 'DataView'],
+            data);
+        }
+      }
+      this.onCertDone(context?.context, data);
+    })
+    .catch((error) => this[owner_symbol].destroy(error));
 }
 
 // This callback is only ever invoked for QuicClientSession instances,
 // and is used to deliver the OCSP response as provided by the server.
 // If the requestOCSP configuration option is false, this will never
 // be called.
-function onSessionStatus(response) {
-  this[owner_symbol][kCert](response);
+function onSessionStatus(data) {
+  this[owner_symbol][kHandleOcsp](data)
+    .catch((error) => this[owner_symbol].destroy(error));
 }
 
 // Called by the C++ internals when the TLS handshake is completed.
@@ -524,12 +509,12 @@ setCallbacks({
   onSocketServerBusy,
   onSessionReady,
   onSessionCert,
+  onSessionStatus,
   onSessionClientHello,
   onSessionClose,
   onSessionHandshake,
   onSessionKeylog,
   onSessionQlog,
-  onSessionStatus,
   onSessionTicket,
   onSessionVersionNegotiation,
   onStreamReady,
@@ -933,6 +918,7 @@ class QuicSocket extends EventEmitter {
     listenPending: false,
     listenPromise: undefined,
     lookup: undefined,
+    ocspHandler: undefined,
     server: undefined,
     serverSecureContext: undefined,
     sessions: new Set(),
@@ -1032,6 +1018,7 @@ class QuicSocket extends EventEmitter {
     return {
       highWaterMark: state.highWaterMark,
       defaultEncoding: state.defaultEncoding,
+      ocspHandler: state.ocspHandler,
     };
   }
 
@@ -1224,6 +1211,7 @@ class QuicSocket extends EventEmitter {
       lookup = state.lookup,
       defaultEncoding,
       highWaterMark,
+      ocspHandler,
       transportParams,
     } = validateQuicSocketListenOptions(options);
 
@@ -1239,6 +1227,7 @@ class QuicSocket extends EventEmitter {
     state.defaultEncoding = defaultEncoding;
     state.alpn = alpn;
     state.listenPending = true;
+    state.ocspHandler = ocspHandler;
 
     await this[kMaybeBind]();
 
@@ -1663,6 +1652,7 @@ class QuicSession extends EventEmitter {
     handshakeCompletePromiseReject: undefined,
     idleTimeout: false,
     maxPacketLength: NGTCP2_DEFAULT_MAX_PKTLEN,
+    ocspHandler: undefined,
     servername: undefined,
     socket: undefined,
     silentClose: false,
@@ -1685,6 +1675,7 @@ class QuicSession extends EventEmitter {
       servername,
       highWaterMark,
       defaultEncoding,
+      ocspHandler,
     } = options;
     super({ captureRejections: true });
     this.on('newListener', onNewListener);
@@ -1695,6 +1686,7 @@ class QuicSession extends EventEmitter {
     state.alpn = alpn;
     state.highWaterMark = highWaterMark;
     state.defaultEncoding = defaultEncoding;
+    state.ocspHandler = ocspHandler;
     socket[kAddSession](this);
   }
 
@@ -1758,6 +1750,7 @@ class QuicSession extends EventEmitter {
       state.state = new QuicSessionSharedState(handle.state);
       state.handshakeAckHistogram = new Histogram(handle.ack);
       state.handshakeContinuationHistogram = new Histogram(handle.rate);
+      state.state.ocspEnabled = state.ocspHandler !== undefined;
       if (handle.qlogStream !== undefined) {
         this[kSetQLogStream](handle.qlogStream);
         handle.qlogStream = undefined;
@@ -2284,8 +2277,9 @@ class QuicServerSession extends QuicSession {
     const {
       highWaterMark,
       defaultEncoding,
+      ocspHandler,
     } = options;
-    super(socket, { highWaterMark, defaultEncoding });
+    super(socket, { highWaterMark, defaultEncoding, ocspHandler });
     this[kSetHandle](handle);
   }
 
@@ -2301,26 +2295,18 @@ class QuicServerSession extends QuicSession {
       callback.bind(this[kHandle]));
   }
 
-  // Called only when an OCSPRequest event handler is registered.
-  // Allows user code the ability to answer the OCSP query.
-  [kCert](servername, callback) {
+  async [kHandleOcsp](servername) {
+    const internalState = this[kInternalState];
     const state = this[kInternalServerState];
-    const { serverSecureContext } = this.socket;
-    let { context } = serverSecureContext;
+    const { context } = this.socket.serverSecureContext;
 
-    for (var i = 0; i < state.contexts.length; i++) {
-      const elem = state.contexts[i];
-      if (elem[0].test(servername)) {
-        context = elem[1];
-        break;
-      }
-    }
-
-    this.emit(
-      'OCSPRequest',
-      servername,
-      context,
-      callback.bind(this[kHandle]));
+    return internalState.ocspHandler?.(
+      'request',
+      {
+        servername,
+        context,
+        contexts: Array.from(state.contexts)
+      });
   }
 
   get allowEarlyData() { return false; }
@@ -2358,10 +2344,10 @@ class QuicClientSession extends QuicSession {
       alpn,
       dcid,
       minDHSize,
+      ocspHandler,
       port,
       preferredAddressPolicy,
       remoteTransportParams,
-      requestOCSP,
       servername,
       sessionTicket,
       verifyHostnameIdentity,
@@ -2379,7 +2365,13 @@ class QuicClientSession extends QuicSession {
       );
     }
 
-    super(socket, { servername, alpn, highWaterMark, defaultEncoding });
+    super(socket, {
+      servername,
+      alpn,
+      highWaterMark,
+      defaultEncoding,
+      ocspHandler
+    });
     const state = this[kInternalClientState];
     state.handshakeStarted = autoStart;
     state.minDHSize = minDHSize;
@@ -2412,7 +2404,7 @@ class QuicClientSession extends QuicSession {
         this.alpnProtocol,
         (verifyHostnameIdentity ?
           QUICCLIENTSESSION_OPTION_VERIFY_HOSTNAME_IDENTITY : 0) |
-        (requestOCSP ?
+        (ocspHandler !== undefined ?
           QUICCLIENTSESSION_OPTION_REQUEST_OCSP : 0),
         qlog,
         autoStart);
@@ -2444,8 +2436,9 @@ class QuicClientSession extends QuicSession {
     return true;
   }
 
-  [kCert](response) {
-    this.emit('OCSPResponse', response);
+  async [kHandleOcsp](data) {
+    const internalState = this[kInternalState];
+    return internalState.ocspHandler?.('response', { data });
   }
 
   get allowEarlyData() {

--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -1858,7 +1858,6 @@ class QuicSession extends EventEmitter {
 
     if (!this[kHandshakePost]()) {
       if (typeof state.handshakeCompletePromiseReject === 'function') {
-        // TODO(@jasnell): Proper error
         state.handshakeCompletePromiseReject(
           new ERR_OPERATION_FAILED('Handshake failed'));
       }
@@ -2005,7 +2004,6 @@ class QuicSession extends EventEmitter {
       state.closePromiseResolve();
 
     if (typeof state.handshakeCompletePromiseReject === 'function') {
-      // TODO(@jasnell): Proper error
       state.handshakeCompletePromiseReject(
         new ERR_OPERATION_FAILED('Handshake failed'));
     }

--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -2518,7 +2518,6 @@ function streamOnPause() {
     this[kHandle].readStop();
 }
 class QuicStream extends Duplex {
-  #count = 0;
   [kInternalState] = {
     closed: false,
     closePromise: undefined,

--- a/lib/internal/quic/util.js
+++ b/lib/internal/quic/util.js
@@ -72,7 +72,7 @@ const {
 
     IDX_QUICSESSION_STATE_KEYLOG_ENABLED,
     IDX_QUICSESSION_STATE_CLIENT_HELLO_ENABLED,
-    IDX_QUICSESSION_STATE_CERT_ENABLED,
+    IDX_QUICSESSION_STATE_OCSP_ENABLED,
     IDX_QUICSESSION_STATE_PATH_VALIDATED_ENABLED,
     IDX_QUICSESSION_STATE_USE_PREFERRED_ADDRESS_ENABLED,
     IDX_QUICSESSION_STATE_HANDSHAKE_CONFIRMED,
@@ -368,10 +368,10 @@ function validateQuicClientSessionOptions(options = {}) {
     alpn = '',
     dcid: dcid_value,
     minDHSize = 1024,
+    ocspHandler,
     port = 0,
     preferredAddressPolicy = 'ignore',
     remoteTransportParams,
-    requestOCSP = false,
     servername = (isIP(address) ? '' : address),
     sessionTicket,
     verifyHostnameIdentity = true,
@@ -434,9 +434,15 @@ function validateQuicClientSessionOptions(options = {}) {
   if (preferredAddressPolicy !== undefined)
     validateString(preferredAddressPolicy, 'options.preferredAddressPolicy');
 
-  validateBoolean(requestOCSP, 'options.requestOCSP');
   validateBoolean(verifyHostnameIdentity, 'options.verifyHostnameIdentity');
   validateBoolean(qlog, 'options.qlog');
+
+  if (ocspHandler !== undefined && typeof ocspHandler !== 'function') {
+    throw new ERR_INVALID_ARG_TYPE(
+      'options.ocspHandler',
+      'functon',
+      ocspHandler);
+  }
 
   return {
     autoStart,
@@ -444,13 +450,13 @@ function validateQuicClientSessionOptions(options = {}) {
     alpn,
     dcid,
     minDHSize,
+    ocspHandler,
     port,
     preferredAddressPolicy:
       preferredAddressPolicy === 'accept' ?
         QUIC_PREFERRED_ADDRESS_USE :
         QUIC_PREFERRED_ADDRESS_IGNORE,
     remoteTransportParams,
-    requestOCSP,
     servername,
     sessionTicket,
     verifyHostnameIdentity,
@@ -605,6 +611,7 @@ function validateQuicSocketListenOptions(options = {}) {
     alpn = NGHTTP3_ALPN_H3,
     defaultEncoding,
     highWaterMark,
+    ocspHandler,
     requestCert,
     rejectUnauthorized,
     lookup,
@@ -616,6 +623,12 @@ function validateQuicSocketListenOptions(options = {}) {
     validateBoolean(requestCert, 'options.requestCert');
   if (lookup !== undefined)
     validateLookup(lookup);
+  if (ocspHandler !== undefined && typeof ocspHandler !== 'function') {
+    throw new ERR_INVALID_ARG_TYPE(
+      'options.ocspHandler',
+      'functon',
+      ocspHandler);
+  }
   const transportParams =
     validateTransportParams(
       options,
@@ -625,6 +638,7 @@ function validateQuicSocketListenOptions(options = {}) {
   return {
     alpn,
     lookup,
+    ocspHandler,
     rejectUnauthorized,
     requestCert,
     transportParams,
@@ -804,9 +818,6 @@ function toggleListeners(state, event, on) {
     case 'pathValidation':
       state.pathValidatedEnabled = on;
       break;
-    case 'OCSPRequest':
-      state.certEnabled = on;
-      break;
     case 'usePreferredAddress':
       state.usePreferredAddressEnabled = on;
       break;
@@ -915,14 +926,14 @@ class QuicSessionSharedState {
       .writeUInt8(on ? 1 : 0, IDX_QUICSESSION_STATE_CLIENT_HELLO_ENABLED);
   }
 
-  get certEnabled() {
+  get ocspEnabled() {
     return Boolean(this[kHandle]
-      .readUInt8(IDX_QUICSESSION_STATE_CERT_ENABLED));
+      .readUInt8(IDX_QUICSESSION_STATE_OCSP_ENABLED));
   }
 
-  set certEnabled(on) {
+  set ocspEnabled(on) {
     this[kHandle]
-      .writeUInt8(on ? 1 : 0, IDX_QUICSESSION_STATE_CERT_ENABLED);
+      .writeUInt8(on ? 1 : 0, IDX_QUICSESSION_STATE_OCSP_ENABLED);
   }
 
   get pathValidatedEnabled() {

--- a/src/quic/node_quic_session.h
+++ b/src/quic/node_quic_session.h
@@ -147,7 +147,7 @@ enum QuicClientSessionOptions : uint32_t {
 #define QUICSESSION_SHARED_STATE(V)                                            \
   V(KEYLOG_ENABLED, keylog_enabled, uint8_t)                                   \
   V(CLIENT_HELLO_ENABLED, client_hello_enabled, uint8_t)                       \
-  V(CERT_ENABLED, cert_enabled, uint8_t)                                       \
+  V(OCSP_ENABLED, ocsp_enabled, uint8_t)                                       \
   V(PATH_VALIDATED_ENABLED, path_validated_enabled, uint8_t)                   \
   V(USE_PREFERRED_ADDRESS_ENABLED, use_preferred_address_enabled, uint8_t)     \
   V(HANDSHAKE_CONFIRMED, handshake_confirmed, uint8_t)                         \

--- a/test/parallel/test-quic-errors-quicsocket-connect.js
+++ b/test/parallel/test-quic-errors-quicsocket-connect.js
@@ -142,8 +142,8 @@ const client = createQuicSocket();
     });
   }));
 
-  await Promise.all([1, 1n, 'test', [], {}].map((requestOCSP) => {
-    return assert.rejects(client.connect({ requestOCSP }), {
+  await Promise.all([1, 1n, 'test', [], {}].map((ocspHandler) => {
+    return assert.rejects(client.connect({ ocspHandler }), {
       code: 'ERR_INVALID_ARG_TYPE'
     });
   }));


### PR DESCRIPTION
First two commits are cleanup.

Third commit refactors the OCSP handling, converting it from a callback-oriented event to a configuration-based async function, which makes a lot more sense given that it's only ever called once at a very specific point in the `QuicSession` lifecycle.

~~Fourth commit removes the `'clientHello'` event. Use cases supporting the event are tenuous at best and do not justify the additional machinery necessary for it to work.~~

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
