### PR TITLE
test: fix test-heapdump-zlib

### DIFF
--- a/test/pummel/test-heapdump-zlib.js
+++ b/test/pummel/test-heapdump-zlib.js
@@ -11,7 +11,7 @@ validateSnapshotNodes('Node / ZlibStream', [
   {
     children: [
       { node_name: 'Zlib', edge_name: 'wrapped' }
-      // zlib memory is initialized lazily
+      // No entry for memory because zlib memory is initialized lazily.
     ]
   }
 ]);

--- a/test/pummel/test-heapdump-zlib.js
+++ b/test/pummel/test-heapdump-zlib.js
@@ -1,17 +1,28 @@
 // Flags: --expose-internals
 'use strict';
-require('../common');
+const common = require('../common');
 const { validateSnapshotNodes } = require('../common/heap');
 const zlib = require('zlib');
 
 validateSnapshotNodes('Node / ZlibStream', []);
-// eslint-disable-next-line no-unused-vars
-const gunzip = zlib.createGunzip();
+
+const gzip = zlib.createGzip();
 validateSnapshotNodes('Node / ZlibStream', [
   {
     children: [
-      { node_name: 'Zlib', edge_name: 'wrapped' },
-      { node_name: 'Node / zlib_memory', edge_name: 'zlib_memory' }
+      { node_name: 'Zlib', edge_name: 'wrapped' }
+      // zlib memory is initialized lazily
     ]
   }
 ]);
+
+gzip.write('hello world', common.mustCall(() => {
+  validateSnapshotNodes('Node / ZlibStream', [
+    {
+      children: [
+        { node_name: 'Zlib', edge_name: 'wrapped' },
+        { node_name: 'Node / zlib_memory', edge_name: 'zlib_memory' }
+      ]
+    }
+  ]);
+}));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Refs: #34048

Fixes `test/pummel/test-heapdump-zlib.js` which was broken by #34048.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
