### PR TITLE
console: document the behavior of console.assert()

### DIFF
--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -153,6 +153,7 @@ changes:
 * `...message` {any} All arguments besides `value` are used as error message.
 
 A simple assertion test that verifies whether `value` is truthy. If it is not,
+or `value` is not passed,
 `Assertion failed` is logged. If provided, the error `message` is formatted
 using [`util.format()`][] by passing along all message arguments. The output is
 used as the error message.
@@ -162,6 +163,8 @@ console.assert(true, 'does nothing');
 // OK
 console.assert(false, 'Whoops %s work', 'didn\'t');
 // Assertion failed: Whoops didn't work
+console.assert();
+// Assertion failed
 ```
 
 Calling `console.assert()` with a falsy assertion will only cause the `message`


### PR DESCRIPTION
Add a description and an example of `console.assert()` call with no arguments. If called this way, the method should output: `Assertion failed`.

Fixes: https://github.com/nodejs/node/issues/34500
Refs: https://nodejs.org/dist/latest-v14.x/docs/api/console.html#console_console_assert_value_message
Refs: https://console.spec.whatwg.org/#assert

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
