### PR TITLE
child_process: document the error when cwd does not exist

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -466,7 +466,10 @@ const defaults = {
 ```
 
 Use `cwd` to specify the working directory from which the process is spawned.
-If not given, the default is to inherit the current working directory.
+If not given, the default is to inherit the current working directory. If given,
+but the path does not exist, the child process will emit an `ENOENT` then
+exit immediately, **this is the same as the error emitted when the command
+does not exist**.
 
 Use `env` to specify environment variables that will be visible to the new
 process, the default is [`process.env`][].

--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -467,9 +467,9 @@ const defaults = {
 
 Use `cwd` to specify the working directory from which the process is spawned.
 If not given, the default is to inherit the current working directory. If given,
-but the path does not exist, the child process will emit an `ENOENT` then
-exit immediately, **this is the same as the error emitted when the command
-does not exist**.
+but the path does not exist, the child process emits an `ENOENT` error
+and exits immediately. `ENOENT` is also emitted when the command
+does not exist.
 
 Use `env` to specify environment variables that will be visible to the new
 process, the default is [`process.env`][].


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
If the option cwd does not exist, the error `ENOENT ` is the same as the error emitted when the command does not exist, it's confusing.
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
