### PR TITLE
build: speed up source tarball creation

### DIFF
--- a/.github/workflows/build-tarball.yml
+++ b/.github/workflows/build-tarball.yml
@@ -26,8 +26,8 @@ jobs:
         run: |
           export DISTTYPE=nightly
           export DATESTRING=`date "+%Y-%m-%d"`
-          export COMMIT=xxxx
-          ./configure && make tar -j8
+          export COMMIT=$(git rev-parse --short=10 "$GITHUB_SHA")
+          ./configure && make tar -j8 SKIP_XZ=1
           mkdir tarballs
           mv *.tar.gz tarballs
       - name: Upload tarball artifact

--- a/Makefile
+++ b/Makefile
@@ -1036,7 +1036,7 @@ pkg-upload: pkg
 	scp -p $(TARNAME).pkg $(STAGINGSERVER):nodejs/$(DISTTYPEDIR)/$(FULLVERSION)/$(TARNAME).pkg
 	ssh $(STAGINGSERVER) "touch nodejs/$(DISTTYPEDIR)/$(FULLVERSION)/$(TARNAME).pkg.done"
 
-$(TARBALL): release-only $(NODE_EXE) doc
+$(TARBALL): release-only doc-only
 	git checkout-index -a -f --prefix=$(TARNAME)/
 	mkdir -p $(TARNAME)/doc/api
 	cp doc/node.1 $(TARNAME)/doc/node.1


### PR DESCRIPTION
Avoid building the node binary when building the source tarball. We
need a node binary to build the docs, but it doesn't have to be one
we build from scratch and can reuse any available node binary.

Skip building the xz compressed tarball in the build-tarball workflow
as we only use the gzip compressed tarball in the subsequent build
jobs.

This significantly cuts the time for the "build-tarball" job from the
"Build from tarball" workflow from ~50mins to ~2mins.

Our release CI shouldn't be affected as the job the builds the source
tarball builds the binary tarball first so will always have a built `node` 
binary to run.

![image](https://user-images.githubusercontent.com/5445507/88434443-12402a80-cdf8-11ea-818c-48365f947b9b.png)

Here's a test build on the release CI: https://ci-release.nodejs.org/job/iojs+release/6206/
Download: https://nodejs.org/download/test/v15.0.0-test20200724221167a148/

cc @nodejs/build-files 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
