### PR TITLE
[Experiment] async_hooks: optimize fast-path promise hook for ALS

### DIFF
--- a/benchmark/async_hooks/promises.js
+++ b/benchmark/async_hooks/promises.js
@@ -19,6 +19,11 @@ const tests = {
       promiseResolve() {},
       destroy() {}
     }).enable();
+  },
+  enabledWithInitOnly() {
+    hook = createHook({
+      init() {}
+    }).enable();
   }
 };
 
@@ -27,6 +32,7 @@ const bench = common.createBenchmark(main, {
   asyncHooks: [
     'enabled',
     'enabledWithDestroy',
+    'enabledWithInitOnly',
     'disabled',
   ]
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

This experiment attempts to remove unnecessary native-to-JS code switches in fast-path for PromiseHooks introduced in #32891. Those switches happen even if certain type of hook (say, `before`) is not installed, which may lead to sub-optimal performance in the `AsyncLocalStorage` scenario (as ALS uses only `init` hook).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
