### PR TITLE
buffer: expose FastBuffer

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -3045,6 +3045,14 @@ console.log(newBuf.toString('ascii'));
 Because the Euro (`€`) sign is not representable in US-ASCII, it is replaced
 with `?` in the transcoded `Buffer`.
 
+### Class: `FastBuffer`
+<!-- YAML
+added: REPLACEME
+-->
+
+This is essentially a `Uint8Array` constructor that returns a `Buffer` instance
+(which does not utilize any pooling).
+
 ### Class: `SlowBuffer`
 <!-- YAML
 deprecated: v6.0.0

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -1185,6 +1185,7 @@ if (internalBinding('config').hasIntl) {
 
 module.exports = {
   Buffer,
+  FastBuffer,
   SlowBuffer,
   transcode,
   // Legacy

--- a/test/parallel/test-buffer-fast.js
+++ b/test/parallel/test-buffer-fast.js
@@ -1,0 +1,48 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const buffer = require('buffer');
+const { FastBuffer } = buffer;
+
+const ones = [1, 1, 1, 1];
+
+// Should create a Buffer
+const fb = new FastBuffer(4);
+assert(fb instanceof Buffer);
+assert.strictEqual(fb.length, 4);
+fb.fill(1);
+for (const [key, value] of fb.entries()) {
+  assert.deepStrictEqual(value, ones[key]);
+}
+
+// Underlying ArrayBuffer should have the same length
+assert.strictEqual(fb.buffer.byteLength, 4);
+
+// Should not work without new
+assert.throws(() => FastBuffer(4), /new/);
+
+// Should work with edge cases
+assert.strictEqual((new FastBuffer()).length, 0);
+assert.strictEqual((new FastBuffer({})).length, 0);
+assert.strictEqual((new FastBuffer(0)).length, 0);
+assert.strictEqual((new FastBuffer('6')).length, 6);
+assert.strictEqual((new FastBuffer(true)).length, 1);
+assert.strictEqual((new FastBuffer(NaN)).length, 0);
+try {
+  assert.strictEqual(
+    (new FastBuffer(buffer.kMaxLength)).length, buffer.kMaxLength);
+} catch (e) {
+  // Don't match on message as it is from the JavaScript engine. V8 and
+  // ChakraCore provide different messages.
+  assert.strictEqual(e.name, 'RangeError');
+}
+
+// Should throw with invalid length value
+const bufferMaxSizeMsg = {
+  name: 'RangeError',
+  message: /^Invalid typed array length/i
+};
+assert.throws(() => new FastBuffer(Infinity), bufferMaxSizeMsg);
+assert.throws(() => new FastBuffer(-1), bufferMaxSizeMsg);
+assert.throws(() => new FastBuffer(buffer.kMaxLength + 1), bufferMaxSizeMsg);


### PR DESCRIPTION
Ref: https://github.com/nodejs/node/issues/33477

As mentioned in the linked issue, having access to the `FastBuffer` is really useful in userland as it provides a more performant and direct method of creating a `Buffer` instance. Currently this constructor has already been exposed via `Buffer[Symbol.species]`, but since support for `Symbol.species` may be removed later this year (by V8) and some see this current method as an unofficial/unsupported method of obtaining a reference to the constructor, this PR adds an official, explicit method.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
