### PR TITLE
doc: document the connection event for HTTP2 & TLS servers

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1727,6 +1727,20 @@ the request body.
 When this event is emitted and handled, the [`'request'`][] event will
 not be emitted.
 
+### Event: `'connection'`
+<!-- YAML
+added: v8.4.0
+-->
+
+* `socket` {stream.Duplex}
+
+This event is emitted when a new TCP stream is established. `socket` is
+typically an object of type [`net.Socket`][]. Usually users will not want to
+access this event.
+
+This event can also be explicitly emitted by users to inject connections
+into the HTTP server. In that case, any [`Duplex`][] stream can be passed.
+
 #### Event: `'request'`
 <!-- YAML
 added: v8.4.0
@@ -1887,6 +1901,20 @@ the request body.
 
 When this event is emitted and handled, the [`'request'`][] event will
 not be emitted.
+
+### Event: `'connection'`
+<!-- YAML
+added: v8.4.0
+-->
+
+* `socket` {stream.Duplex}
+
+This event is emitted when a new TCP stream is established, before the TLS
+handshake begins. `socket` is typically an object of type [`net.Socket`][].
+Usually users will not want to access this event.
+
+This event can also be explicitly emitted by users to inject connections
+into the HTTP server. In that case, any [`Duplex`][] stream can be passed.
 
 #### Event: `'request'`
 <!-- YAML

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -1987,6 +1987,7 @@ where `secureSocket` has the same API as `pair.cleartext`.
 [`SSL_export_keying_material`]: https://www.openssl.org/docs/man1.1.1/man3/SSL_export_keying_material.html
 [`SSL_get_version`]: https://www.openssl.org/docs/man1.1.1/man3/SSL_get_version.html
 [`crypto.getCurves()`]: crypto.html#crypto_crypto_getcurves
+[`Duplex`]: stream.html#stream_class_stream_duplex
 [`net.createServer()`]: net.html#net_net_createserver_options_connectionlistener
 [`net.Server.address()`]: net.html#net_server_address
 [`net.Server`]: net.html#net_class_net_server

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -379,6 +379,20 @@ added: v0.3.2
 
 Accepts encrypted connections using TLS or SSL.
 
+### Event: `'connection'`
+<!-- YAML
+added: v0.3.2
+-->
+
+* `socket` {stream.Duplex}
+
+This event is emitted when a new TCP stream is established, before the TLS
+handshake begins. `socket` is typically an object of type [`net.Socket`][].
+Usually users will not want to access this event.
+
+This event can also be explicitly emitted by users to inject connections
+into the TLS server. In that case, any [`Duplex`][] stream can be passed.
+
 ### Event: `'keylog'`
 <!-- YAML
 added:


### PR DESCRIPTION
As discussed in #34296, the documentation isn't totally clear on where 'connection' events can be manually emitted, or that doing so is an officially supported use case for those events.

This PR is a quick first step to improve that - taking the text from the same event in the HTTP module (where this is already documented) and including it in the docs for TLS servers, HTTP2 servers & HTTP2 secure servers.

I've simplified the text from the [HTTP event](https://nodejs.org/api/http.html#http_event_connection) to remove details that I'm not 100% sure are true for non-HTTP servers: setTimeout handling, and the specific class of sockets that could ever possibly be emitted here. I don't think either is required for this to be useful, but happy to add those details here too if somebody can confirm they're equally relevant & true.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
