### PR TITLE
quic: refactor clientHello

### DIFF
--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -2287,12 +2287,11 @@ class QuicServerSession extends QuicSession {
   async [kHandleOcsp](servername) {
     const internalState = this[kInternalState];
     const { context } = this[kInternalServerState];
-    const certificate = context?.context.getCertificate?.();
-    const issuer = context?.context.getIssuer?.();
-    return internalState.ocspHandler?.('request', {
+    if (!internalState.ocspHandler || !context) return undefined;
+    return internalState.ocspHandler('request', {
       servername,
-      certificate,
-      issuer
+      certificate: context.context.getCertificate(),
+      issuer: context.context.getIssuer()
     });
   }
 

--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -20,7 +20,6 @@ const {
   PromiseAll,
   PromiseReject,
   PromiseResolve,
-  RegExp,
   Set,
   Symbol,
 } = primordials;
@@ -200,7 +199,6 @@ const {
   validateBoolean,
   validateInteger,
   validateObject,
-  validateString,
 } = require('internal/validators');
 
 const emit = EventEmitter.prototype.emit;
@@ -297,30 +295,18 @@ function onSessionClose(code, family, silent, statelessReset) {
   this[owner_symbol][kDestroy](code, family, silent, statelessReset);
 }
 
-// Used only within the onSessionClientHello function. Invoked
-// to complete the client hello process.
-function clientHelloCallback(err, ...args) {
-  if (err) {
-    this[owner_symbol].destroy(err);
-    return;
-  }
-  try {
-    this.onClientHelloDone(...args);
-  } catch (err) {
-    this[owner_symbol].destroy(err);
-  }
-}
-
 // This callback is invoked at the start of the TLS handshake to provide
 // some basic information about the ALPN, SNI, and Ciphers that are
-// being requested. It is only called if the 'clientHello' event is
-// listened for.
+// being requested. It is only called if the 'clientHelloHandler' option is
+// specified on listen().
 function onSessionClientHello(alpn, servername, ciphers) {
-  this[owner_symbol][kClientHello](
-    alpn,
-    servername,
-    ciphers,
-    clientHelloCallback.bind(this));
+  this[owner_symbol][kClientHello](alpn, servername, ciphers)
+    .then((context) => {
+      if (context !== undefined && !context?.context)
+        throw new ERR_INVALID_ARG_TYPE('context', 'SecureContext', context);
+      this.onClientHelloDone(context?.context);
+    })
+    .catch((error) => this[owner_symbol].destroy(error));
 }
 
 // This callback is only ever invoked for QuicServerSession instances,
@@ -329,9 +315,7 @@ function onSessionClientHello(alpn, servername, ciphers) {
 // TLS handshake to continue.
 function onSessionCert(servername) {
   this[owner_symbol][kHandleOcsp](servername)
-    .then(({ context, data }) => {
-      if (context !== undefined && !context?.context)
-        throw new ERR_INVALID_ARG_TYPE('context', 'SecureContext', context);
+    .then((data) => {
       if (data !== undefined) {
         if (typeof data === 'string')
           data = Buffer.from(data);
@@ -342,7 +326,7 @@ function onSessionCert(servername) {
             data);
         }
       }
-      this.onCertDone(context?.context, data);
+      this.onCertDone(data);
     })
     .catch((error) => this[owner_symbol].destroy(error));
 }
@@ -919,6 +903,7 @@ class QuicSocket extends EventEmitter {
     listenPromise: undefined,
     lookup: undefined,
     ocspHandler: undefined,
+    clientHelloHandler: undefined,
     server: undefined,
     serverSecureContext: undefined,
     sessions: new Set(),
@@ -1010,15 +995,14 @@ class QuicSocket extends EventEmitter {
     this.destroy(err);
   }
 
-  // Returns the default QuicStream options for peer-initiated
-  // streams. These are passed on to new client and server
-  // QuicSession instances when they are created.
   get [kStreamOptions]() {
     const state = this[kInternalState];
     return {
       highWaterMark: state.highWaterMark,
       defaultEncoding: state.defaultEncoding,
       ocspHandler: state.ocspHandler,
+      clientHelloHandler: state.clientHelloHandler,
+      context: state.serverSecureContext,
     };
   }
 
@@ -1212,11 +1196,10 @@ class QuicSocket extends EventEmitter {
       defaultEncoding,
       highWaterMark,
       ocspHandler,
+      clientHelloHandler,
       transportParams,
     } = validateQuicSocketListenOptions(options);
 
-    // Store the secure context so that it is not garbage collected
-    // while we still need to make use of it.
     state.serverSecureContext =
       createSecureContext({
         ...options,
@@ -1228,6 +1211,7 @@ class QuicSocket extends EventEmitter {
     state.alpn = alpn;
     state.listenPending = true;
     state.ocspHandler = ocspHandler;
+    state.clientHelloHandler = clientHelloHandler;
 
     await this[kMaybeBind]();
 
@@ -1484,9 +1468,6 @@ class QuicSocket extends EventEmitter {
     return Array.from(this[kInternalState].endpoints);
   }
 
-  // The sever secure context is the SecureContext specified when calling
-  // listen. It is the context that will be used with all new server
-  // QuicSession instances.
   get serverSecureContext() {
     return this[kInternalState].serverSecureContext;
   }
@@ -1639,6 +1620,7 @@ class QuicSession extends EventEmitter {
     alpn: undefined,
     cipher: undefined,
     cipherVersion: undefined,
+    clientHelloHandler: undefined,
     closeCode: NGTCP2_NO_ERROR,
     closeFamily: QUIC_ERROR_APPLICATION,
     closePromise: undefined,
@@ -1676,6 +1658,7 @@ class QuicSession extends EventEmitter {
       highWaterMark,
       defaultEncoding,
       ocspHandler,
+      clientHelloHandler,
     } = options;
     super({ captureRejections: true });
     this.on('newListener', onNewListener);
@@ -1687,6 +1670,7 @@ class QuicSession extends EventEmitter {
     state.highWaterMark = highWaterMark;
     state.defaultEncoding = defaultEncoding;
     state.ocspHandler = ocspHandler;
+    state.clientHelloHandler = clientHelloHandler;
     socket[kAddSession](this);
   }
 
@@ -1751,6 +1735,7 @@ class QuicSession extends EventEmitter {
       state.handshakeAckHistogram = new Histogram(handle.ack);
       state.handshakeContinuationHistogram = new Histogram(handle.rate);
       state.state.ocspEnabled = state.ocspHandler !== undefined;
+      state.state.clientHelloEnabled = state.clientHelloHandler !== undefined;
       if (handle.qlogStream !== undefined) {
         this[kSetQLogStream](handle.qlogStream);
         handle.qlogStream = undefined;
@@ -2270,7 +2255,7 @@ class QuicSession extends EventEmitter {
 }
 class QuicServerSession extends QuicSession {
   [kInternalServerState] = {
-    contexts: []
+    context: undefined
   };
 
   constructor(socket, handle, options) {
@@ -2278,51 +2263,40 @@ class QuicServerSession extends QuicSession {
       highWaterMark,
       defaultEncoding,
       ocspHandler,
+      clientHelloHandler,
+      context,
     } = options;
-    super(socket, { highWaterMark, defaultEncoding, ocspHandler });
+    super(socket, {
+      highWaterMark,
+      defaultEncoding,
+      ocspHandler,
+      clientHelloHandler
+    });
+    this[kInternalServerState].context = context;
     this[kSetHandle](handle);
   }
 
   // Called only when a clientHello event handler is registered.
   // Allows user code an opportunity to interject into the start
   // of the TLS handshake.
-  [kClientHello](alpn, servername, ciphers, callback) {
-    this.emit(
-      'clientHello',
-      alpn,
-      servername,
-      ciphers,
-      callback.bind(this[kHandle]));
+  async [kClientHello](alpn, servername, ciphers) {
+    const internalState = this[kInternalState];
+    return internalState.clientHelloHandler?.(alpn, servername, ciphers);
   }
 
   async [kHandleOcsp](servername) {
     const internalState = this[kInternalState];
-    const state = this[kInternalServerState];
-    const { context } = this.socket.serverSecureContext;
-
-    return internalState.ocspHandler?.(
-      'request',
-      {
-        servername,
-        context,
-        contexts: Array.from(state.contexts)
-      });
+    const { context } = this[kInternalServerState];
+    const certificate = context?.context.getCertificate?.();
+    const issuer = context?.context.getIssuer?.();
+    return internalState.ocspHandler?.('request', {
+      servername,
+      certificate,
+      issuer
+    });
   }
 
   get allowEarlyData() { return false; }
-
-  addContext(servername, context = {}) {
-    validateString(servername, 'servername');
-    validateObject(context, 'context');
-
-    // TODO(@jasnell): Consider unrolling regex
-    const re = new RegExp('^' +
-    servername.replace(/([.^$+?\-\\[\]{}])/g, '\\$1')
-              .replace(/\*/g, '[^.]*') +
-    '$');
-    this[kInternalServerState].contexts.push(
-      [re, _createSecureContext(context)]);
-  }
 }
 
 class QuicClientSession extends QuicSession {

--- a/lib/internal/quic/util.js
+++ b/lib/internal/quic/util.js
@@ -612,6 +612,7 @@ function validateQuicSocketListenOptions(options = {}) {
     defaultEncoding,
     highWaterMark,
     ocspHandler,
+    clientHelloHandler,
     requestCert,
     rejectUnauthorized,
     lookup,
@@ -626,8 +627,15 @@ function validateQuicSocketListenOptions(options = {}) {
   if (ocspHandler !== undefined && typeof ocspHandler !== 'function') {
     throw new ERR_INVALID_ARG_TYPE(
       'options.ocspHandler',
-      'functon',
+      'function',
       ocspHandler);
+  }
+  if (clientHelloHandler !== undefined &&
+      typeof clientHelloHandler !== 'function') {
+    throw new ERR_INVALID_ARG_TYPE(
+      'options.clientHelloHandler',
+      'function',
+      clientHelloHandler);
   }
   const transportParams =
     validateTransportParams(
@@ -639,6 +647,7 @@ function validateQuicSocketListenOptions(options = {}) {
     alpn,
     lookup,
     ocspHandler,
+    clientHelloHandler,
     rejectUnauthorized,
     requestCert,
     transportParams,
@@ -811,9 +820,6 @@ function toggleListeners(state, event, on) {
   switch (event) {
     case 'keylog':
       state.keylogEnabled = on;
-      break;
-    case 'clientHello':
-      state.clientHelloEnabled = on;
       break;
     case 'pathValidation':
       state.pathValidatedEnabled = on;

--- a/src/quic/node_quic_session-inl.h
+++ b/src/quic/node_quic_session-inl.h
@@ -109,17 +109,6 @@ void QuicCryptoContext::Keylog(const char* line) {
     session_->listener()->OnKeylog(line, strlen(line));
 }
 
-void QuicCryptoContext::OnClientHelloDone() {
-  // Continue the TLS handshake when this function exits
-  // otherwise it will stall and fail.
-  TLSHandshakeScope handshake_scope(
-      this,
-      [&]() { set_in_client_hello(false); });
-
-  // Disable the callback at this point so we don't loop continuously
-  session_->state_->client_hello_enabled = 0;
-}
-
 // Following a pause in the handshake for OCSP or client hello, we kickstart
 // the handshake again here by triggering ngtcp2 to serialize data.
 void QuicCryptoContext::ResumeHandshake() {

--- a/src/quic/node_quic_session.h
+++ b/src/quic/node_quic_session.h
@@ -407,13 +407,11 @@ class QuicCryptoContext final : public MemoryRetainer {
 
   int OnClientHello();
 
-  inline void OnClientHelloDone();
+  void OnClientHelloDone(BaseObjectPtr<crypto::SecureContext> context);
 
   int OnOCSP();
 
-  void OnOCSPDone(
-      BaseObjectPtr<crypto::SecureContext> secure_context,
-      v8::Local<v8::Value> ocsp_response);
+  void OnOCSPDone(v8::Local<v8::Value> ocsp_response);
 
   bool OnSecrets(
       ngtcp2_crypto_level level,

--- a/src/quic/node_quic_session.h
+++ b/src/quic/node_quic_session.h
@@ -1507,6 +1507,22 @@ class QuicSession final : public AsyncWrap,
   friend class JSQuicSessionListener;
 };
 
+class QuicCallbackScope {
+ public:
+  explicit QuicCallbackScope(QuicSession* session);
+  ~QuicCallbackScope();
+
+  void operator=(const QuicCallbackScope&) = delete;
+  void operator=(QuicCallbackScope&&) = delete;
+  QuicCallbackScope(const QuicCallbackScope&) = delete;
+  QuicCallbackScope(QuicCallbackScope&&) = delete;
+
+ private:
+  BaseObjectPtr<QuicSession> session_;
+  std::unique_ptr<InternalCallbackScope> private_;
+  v8::TryCatch try_catch_;
+};
+
 }  // namespace quic
 }  // namespace node
 


### PR DESCRIPTION
First commit here is from #34533 which needs to land first.

Second commit here is the important one in this PR. This refactors the `'clientHello'` event into an async function passed as an `quicsocket.listen()` option. This function is only ever called once at a very specific point in the `QuicServerSession` lifecycle, using it as an event is unnecessary. The commit changes the way it works. If appropriate to do so, user code may return a new `SecureContext` from the function (previously that was done in the OCSP function, which really didn't make sense). 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
