### PR TITLE
doc: add net.Socket#timeout

### DIFF
--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -919,9 +919,10 @@ The optional `callback` parameter will be added as a one-time listener for the
 added: v10.7.0
 -->
 
-* {number}
+* {number|undefined}
 
-Returns the read-only socket timeout in milliseconds.
+The socket timeout in milliseconds as set by [`socket.setTimeout()`][].
+It is `undefined` if a timeout has not been set.
 
 ### `socket.unref()`
 <!-- YAML

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -914,6 +914,15 @@ If `timeout` is 0, then the existing idle timeout is disabled.
 The optional `callback` parameter will be added as a one-time listener for the
 [`'timeout'`][] event.
 
+### `socket.timeout`
+<!-- YAML
+added: v10.7.0
+-->
+
+* {number}
+
+Gets the read-only socket timeout in milliseconds.
+
 ### `socket.unref()`
 <!-- YAML
 added: v0.9.1

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -921,7 +921,7 @@ added: v10.7.0
 
 * {number}
 
-Gets the read-only socket timeout in milliseconds.
+Returns the read-only socket timeout in milliseconds.
 
 ### `socket.unref()`
 <!-- YAML


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

net.Socket#timeout was originally added in https://github.com/nodejs/node/pull/21204, first being released in version 10.7.0. It's being defined [here](https://github.com/nodejs/node/pull/21204/files#diff-e6ef024c3775d787c38487a6309e491dR408) and then later consumed [here](https://github.com/nodejs/node/pull/21204/files#diff-5f7fb0850412c6be189faeddea6c5359R365); however, it's not currently documented.  