### PR TITLE
async_hooks: fix id assignment in fast-path promise hook

### DIFF
--- a/test/parallel/test-async-hooks-enable-before-promise-resolve.js
+++ b/test/parallel/test-async-hooks-enable-before-promise-resolve.js
@@ -1,0 +1,25 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const async_hooks = require('async_hooks');
+
+// This test ensures that fast-path PromiseHook assigns async ids
+// to already created promises when the native hook function is
+// triggered on before event.
+
+let initialAsyncId;
+const promise = new Promise((resolve) => {
+  setTimeout(() => {
+    initialAsyncId = async_hooks.executionAsyncId();
+    async_hooks.createHook({
+      after: common.mustCall(() => {}, 2)
+    }).enable();
+    resolve();
+  }, 0);
+});
+
+promise.then(common.mustCall(() => {
+  const id = async_hooks.executionAsyncId();
+  assert.notStrictEqual(id, initialAsyncId);
+  assert.ok(id > 0);
+}));


### PR DESCRIPTION
This PR fixes a bug introduced by #34512.

Native side of fast-path promise hook was not calling JS `fastPromiseHook` function when there were no async ids previously assigned to the promise. Because of that already created promises could not get id assigned in situations when an async hook without a before listener function is enabled after their creation. As the result `executionAsyncId` could return wrong id when called within promise's `.then()`.

Refs: #34512

cc @nodejs/async_hooks 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
