### PR TITLE
doc: fix typo in path.md

### DIFF
--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -549,7 +549,7 @@ On Windows systems only, returns an equivalent [namespace-prefixed path][] for
 the given `path`. If `path` is not a string, `path` will be returned without
 modifications.
 
-This method is meaningful only on Windows system. On POSIX systems, the
+This method is meaningful only on Windows systems. On POSIX systems, the
 method is non-operational and always returns `path` without modifications.
 
 ## `path.win32`


### PR DESCRIPTION
found a small grammatical typo in the path module API docs - hope a PR this small is still fine :+1: 

##### Checklist
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
