### PR TITLE
n-api: simplify bigint-from-word creation

### DIFF
--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -1602,13 +1602,10 @@ napi_status napi_create_bigint_words(napi_env env,
   v8::MaybeLocal<v8::BigInt> b = v8::BigInt::NewFromWords(
       context, sign_bit, word_count, words);
 
-  if (try_catch.HasCaught()) {
-    return napi_set_last_error(env, napi_pending_exception);
-  } else {
-    CHECK_MAYBE_EMPTY(env, b, napi_generic_failure);
-    *result = v8impl::JsValueFromV8LocalValue(b.ToLocalChecked());
-    return napi_clear_last_error(env);
-  }
+  CHECK_MAYBE_EMPTY_WITH_PREAMBLE(env, b, napi_generic_failure);
+
+  *result = v8impl::JsValueFromV8LocalValue(b.ToLocalChecked());
+  return GET_RETURN_STATUS(env);
 }
 
 napi_status napi_get_boolean(napi_env env, bool value, napi_value* result) {

--- a/test/js-native-api/test_bigint/test.js
+++ b/test/js-native-api/test_bigint/test.js
@@ -7,6 +7,7 @@ const {
   TestUint64,
   TestWords,
   CreateTooBigBigInt,
+  MakeBigIntWordsThrow,
 } = require(`./build/${common.buildType}/test_bigint`);
 
 [
@@ -42,4 +43,10 @@ const {
 assert.throws(CreateTooBigBigInt, {
   name: 'Error',
   message: 'Invalid argument',
+});
+
+// Test that we correctly forward exceptions from the engine.
+assert.throws(MakeBigIntWordsThrow, {
+  name: 'RangeError',
+  message: 'Maximum BigInt size exceeded'
 });

--- a/test/js-native-api/test_bigint/test_bigint.c
+++ b/test/js-native-api/test_bigint/test_bigint.c
@@ -1,3 +1,4 @@
+#include <limits.h>
 #include <inttypes.h>
 #include <stdio.h>
 #include <js_native_api.h>
@@ -122,6 +123,22 @@ static napi_value CreateTooBigBigInt(napi_env env, napi_callback_info info) {
   return output;
 }
 
+// Test that we correctly forward exceptions from the engine.
+static napi_value MakeBigIntWordsThrow(napi_env env, napi_callback_info info) {
+  uint64_t words[10];
+  napi_value output;
+
+  napi_status status = napi_create_bigint_words(env,
+                                                0,
+                                                INT_MAX,
+                                                words,
+                                                &output);
+  if (status != napi_pending_exception)
+    napi_throw_error(env, NULL, "Expected status `napi_pending_exception`");
+
+  return NULL;
+}
+
 EXTERN_C_START
 napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
@@ -130,6 +147,7 @@ napi_value Init(napi_env env, napi_value exports) {
     DECLARE_NAPI_PROPERTY("TestUint64", TestUint64),
     DECLARE_NAPI_PROPERTY("TestWords", TestWords),
     DECLARE_NAPI_PROPERTY("CreateTooBigBigInt", CreateTooBigBigInt),
+    DECLARE_NAPI_PROPERTY("MakeBigIntWordsThrow", MakeBigIntWordsThrow),
   };
 
   NAPI_CALL(env, napi_define_properties(


### PR DESCRIPTION
Macro `CHECK_MAYBE_EMPTY_WITH_PREAMBLE()` does the work of checking
the `TryCatch` and returning `napi_pending_exception` so this change
reuses it for `napi_create_bigint_words()`.

Signed-off-by: Gabriel Schulhof @gabrielschulhof

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
