### PR TITLE
doc: clarify process.title inconsistencies

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -2423,8 +2423,8 @@ allowed for longer process title strings by also overwriting the `environ`
 memory but that was potentially insecure and confusing in some (rather obscure)
 cases.
 
-Note that assigning a value to `process.title` _may_ not reflect an accurate
-(or any) label within the process manager application of the underlying 
+Assigning a value to `process.title` _may_ not reflect an accurate
+(or any) label within the process manager application of the underlying
 operating system (i.e. macOS Activity Monitor, Windows Services Manager, etc).
 Inconsistencies and breaking changes within the _operating systems process
 interface_ make synchronization with these applications unreliable.

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -2423,6 +2423,12 @@ allowed for longer process title strings by also overwriting the `environ`
 memory but that was potentially insecure and confusing in some (rather obscure)
 cases.
 
+Note that assigning a value to `process.title` _may_ not reflect an accurate
+(or any) label within the process manager application of the underlying 
+operating system (i.e. macOS Activity Monitor, Windows Services Manager, etc).
+Inconsistencies and breaking changes within the _operating systems process
+interface_ make synchronization with these applications unreliable.
+
 ## `process.traceDeprecation`
 <!-- YAML
 added: v0.8.0


### PR DESCRIPTION
Many users [assume](https://github.com/nodejs/node/issues/28945) the act of assigning a value to `process.title` will update 
the name of their process in apps like macOS Activity Monitor or Windows
Services Manager. This has worked in the past, but fails in some versions of 
Node.js. Ultimately developers are left confused, especially when it works in
one version of Node.js and not another. Given the recurring nature and
complexity of the underlying issue, it does not seem like a resolvable problem.
This note clarifies the source of the problem and sets developer expectations.

Fixes: https://github.com/nodejs/node/issues/34280

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
