### PR TITLE
http: provide keep-alive timeout response header

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -428,7 +428,7 @@ function _storeHeader(firstLine, headers) {
     if (shouldSendKeepAlive) {
       header += 'Connection: keep-alive\r\n';
       if (this._keepAliveTimeout) {
-        const timeoutSeconds = MathFloor(this._keepAliveTimeout - 500) / 1000;
+        const timeoutSeconds = MathFloor(this._keepAliveTimeout) / 1000;
         header += `Keep-Alive: timeout=${timeoutSeconds}\r\n`;
       }
     } else {

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -28,6 +28,7 @@ const {
   ObjectKeys,
   ObjectPrototypeHasOwnProperty,
   ObjectSetPrototypeOf,
+  MathFloor,
   Symbol,
 } = primordials;
 
@@ -122,6 +123,8 @@ function OutgoingMessage() {
   this.socket = null;
   this._header = null;
   this[kOutHeaders] = null;
+
+  this._keepAliveTimeout = 0;
 
   this._onPendingData = noopPendingOutput;
 }
@@ -424,6 +427,10 @@ function _storeHeader(firstLine, headers) {
         (state.contLen || this.useChunkedEncodingByDefault || this.agent);
     if (shouldSendKeepAlive) {
       header += 'Connection: keep-alive\r\n';
+      if (this._keepAliveTimeout) {
+        const timeoutSeconds = MathFloor(this._keepAliveTimeout - 500) / 1000;
+        header += `Keep-Alive: timeout=${timeoutSeconds}\r\n`;
+      }
     } else {
       this._last = true;
       header += 'Connection: close\r\n';

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -766,6 +766,7 @@ function parserOnIncoming(server, socket, state, req, keepAlive) {
   }
 
   const res = new server[kServerResponse](req);
+  res._keepAliveTimeout = server.keepAliveTimeout;
   res._onPendingData = updateOutgoingData.bind(undefined, socket, state);
 
   res.shouldKeepAlive = keepAlive;

--- a/test/parallel/test-http-keep-alive-timeout.js
+++ b/test/parallel/test-http-keep-alive-timeout.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const common = require('../common');
+const http = require('http');
+const assert = require('assert');
+
+const server = http.createServer(common.mustCall((req, res) => {
+  const body = 'hello world\n';
+
+  res.writeHead(200, { 'Content-Length': body.length });
+  res.write(body);
+  res.end();
+}));
+server.keepAliveTimeout = 12000;
+
+const agent = new http.Agent({ maxSockets: 1, keepAlive: true });
+
+server.listen(0, common.mustCall(function() {
+  http.get({
+    path: '/', port: this.address().port, agent: agent
+  }, common.mustCall((response) => {
+    response.resume();
+    assert.strictEqual(
+      response.headers['keep-alive'], 'timeout=11.5');
+    server.close();
+    agent.destroy();
+  }));
+}));

--- a/test/parallel/test-http-keep-alive-timeout.js
+++ b/test/parallel/test-http-keep-alive-timeout.js
@@ -21,7 +21,7 @@ server.listen(0, common.mustCall(function() {
   }, common.mustCall((response) => {
     response.resume();
     assert.strictEqual(
-      response.headers['keep-alive'], 'timeout=11.5');
+      response.headers['keep-alive'], 'timeout=12');
     server.close();
     agent.destroy();
   }));


### PR DESCRIPTION
In http 1.1 persistent connection protocol there is a timing race where the
client sends the request and then the server kills the connection
(due to inactivity) before receiving the client's request.

By providing a keep-alive header it is possible to provide the client a
hint of when idle timeout would occur and avoid the race.

Fixes: https://github.com/nodejs/node/issues/34560

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
