### PR TITLE
async_hooks: fix resource stack for deep stacks

### DIFF
--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -499,11 +499,11 @@ function hasAsyncIdStack() {
 // This is the equivalent of the native push_async_ids() call.
 function pushAsyncContext(asyncId, triggerAsyncId, resource) {
   const offset = async_hook_fields[kStackLength];
+  execution_async_resources[offset] = resource;
   if (offset * 2 >= async_wrap.async_ids_stack.length)
     return pushAsyncContext_(asyncId, triggerAsyncId);
   async_wrap.async_ids_stack[offset * 2] = async_id_fields[kExecutionAsyncId];
   async_wrap.async_ids_stack[offset * 2 + 1] = async_id_fields[kTriggerAsyncId];
-  execution_async_resources[offset] = resource;
   async_hook_fields[kStackLength]++;
   async_id_fields[kExecutionAsyncId] = asyncId;
   async_id_fields[kTriggerAsyncId] = triggerAsyncId;

--- a/test/parallel/test-async-local-storage-deep-stack.js
+++ b/test/parallel/test-async-local-storage-deep-stack.js
@@ -1,0 +1,15 @@
+'use strict';
+const common = require('../common');
+const { AsyncLocalStorage } = require('async_hooks');
+
+// Regression test for: https://github.com/nodejs/node/issues/34556
+
+const als = new AsyncLocalStorage();
+
+const done = common.mustCall();
+
+function run(count) {
+  if (count !== 0) return als.run({}, run, --count);
+  done();
+}
+run(1000);


### PR DESCRIPTION
460c81dc0e0 introduced a bug where the execution resource was not
stored properly if we needed to call into C++ to extend the stack size.
Fix that bug by always storing the resource.

Refs: https://github.com/nodejs/node/pull/34319
Fixes: https://github.com/nodejs/node/issues/34556

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
