### PR TITLE
async_hooks: add AsyncResource.bind utility

### DIFF
--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -729,6 +729,26 @@ class DBQuery extends AsyncResource {
 }
 ```
 
+#### `static AsyncResource.bind(fn[, type])`
+<!-- YAML
+added: REPLACEME
+-->
+
+* `fn` {Function} The function to bind to the current execution context.
+* `type` {string} An optional name to associate with the underlying
+  `AsyncResource`.
+
+Binds the given function to the current execution context.
+
+#### `asyncResource.bind(fn)`
+<!-- YAML
+added: REPLACEME
+-->
+
+* `fn` {Function} The function to bind to the current `AsyncResource`.
+
+Binds the given function to execute to this `AsyncResource`'s scope.
+
 #### `asyncResource.runInAsyncScope(fn[, thisArg, ...args])`
 <!-- YAML
 added: v9.6.0
@@ -900,12 +920,12 @@ const { createServer } = require('http');
 const { AsyncResource, executionAsyncId } = require('async_hooks');
 
 const server = createServer((req, res) => {
-  const asyncResource = new AsyncResource('request');
-  // The listener will always run in the execution context of `asyncResource`.
-  req.on('close', asyncResource.runInAsyncScope.bind(asyncResource, () => {
-    // Prints: true
-    console.log(asyncResource.asyncId() === executionAsyncId());
+  req.on('close', AsyncResource.bind(() => {
+    // Execution context is bound to the current outer scope.
   }));
+  req.on('close', () => {
+    // Execution context is bound to the scope that caused 'close' to emit.
+  });
   res.end();
 }).listen(3000);
 ```

--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -740,6 +740,9 @@ added: REPLACEME
 
 Binds the given function to the current execution context.
 
+The returned function will have an `asyncResource` property referencing
+the `AsyncResource` to which the function is bound.
+
 #### `asyncResource.bind(fn)`
 <!-- YAML
 added: REPLACEME
@@ -748,6 +751,9 @@ added: REPLACEME
 * `fn` {Function} The function to bind to the current `AsyncResource`.
 
 Binds the given function to execute to this `AsyncResource`'s scope.
+
+The returned function will have an `asyncResource` property referencing
+the `AsyncResource` to which the function is bound.
 
 #### `asyncResource.runInAsyncScope(fn[, thisArg, ...args])`
 <!-- YAML

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -2,6 +2,7 @@
 
 const {
   NumberIsSafeInteger,
+  ObjectDefineProperties,
   ReflectApply,
   Symbol,
 } = primordials;
@@ -9,6 +10,7 @@ const {
 const {
   ERR_ASYNC_CALLBACK,
   ERR_ASYNC_TYPE,
+  ERR_INVALID_ARG_TYPE,
   ERR_INVALID_ASYNC_ID
 } = require('internal/errors').codes;
 const { validateString } = require('internal/validators');
@@ -213,7 +215,20 @@ class AsyncResource {
   }
 
   bind(fn) {
-    return this.runInAsyncScope.bind(this, fn);
+    if (typeof fn !== 'function')
+      throw new ERR_INVALID_ARG_TYPE('fn', 'Function', fn);
+    const ret = this.runInAsyncScope.bind(this, fn);
+    ObjectDefineProperties(ret, {
+      'length': {
+        enumerable: true,
+        value: fn.length,
+      },
+      'asyncResource': {
+        enumerable: true,
+        value: this,
+      }
+    });
+    return ret;
   }
 
   static bind(fn, type) {

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -211,6 +211,15 @@ class AsyncResource {
   triggerAsyncId() {
     return this[trigger_async_id_symbol];
   }
+
+  bind(fn) {
+    return this.runInAsyncScope.bind(this, fn);
+  }
+
+  static bind(fn, type) {
+    type = type || fn.name;
+    return (new AsyncResource(type || 'bound-anonymous-fn')).bind(fn);
+  }
 }
 
 const storageList = [];

--- a/test/parallel/test-asyncresource-bind.js
+++ b/test/parallel/test-asyncresource-bind.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { AsyncResource, executionAsyncId } = require('async_hooks');
+
+const fn = common.mustCall(AsyncResource.bind(() => {
+  return executionAsyncId();
+}));
+
+setImmediate(() => {
+  const asyncId = executionAsyncId();
+  assert.notStrictEqual(asyncId, fn());
+});
+
+const asyncResource = new AsyncResource('test');
+
+const fn2 = asyncResource.bind(() => {
+  return executionAsyncId();
+});
+
+setImmediate(() => {
+  const asyncId = executionAsyncId();
+  assert.strictEqual(asyncResource.asyncId(), fn2());
+  assert.notStrictEqual(asyncId, fn2());
+});

--- a/test/parallel/test-asyncresource-bind.js
+++ b/test/parallel/test-asyncresource-bind.js
@@ -15,9 +15,18 @@ setImmediate(() => {
 
 const asyncResource = new AsyncResource('test');
 
-const fn2 = asyncResource.bind(() => {
+[1, false, '', {}, []].forEach((i) => {
+  assert.throws(() => asyncResource.bind(i), {
+    code: 'ERR_INVALID_ARG_TYPE'
+  });
+});
+
+const fn2 = asyncResource.bind((a, b) => {
   return executionAsyncId();
 });
+
+assert.strictEqual(fn2.asyncResource, asyncResource);
+assert.strictEqual(fn2.length, 2);
 
 setImmediate(() => {
   const asyncId = executionAsyncId();


### PR DESCRIPTION
Creates an internal AsyncResource and binds a function to it,
ensuring that the function is invoked within execution context
in which bind was called.

This is suggested as a solution for #33723 and is a simple utility over what can already be done with `AsyncResource`.

/cc @addaleax @puzpuzpuz @ronag @Qard @devsnek @targos 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
