### PR TITLE
doc: mention null special-case for `napi_typeof`

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -3149,7 +3149,12 @@ Returns `napi_ok` if the API succeeded.
 
 This API represents behavior similar to invoking the `typeof` Operator on
 the object as defined in [Section 12.5.5][] of the ECMAScript Language
-Specification. However, it has support for detecting an External value.
+Specification. However, there are some differences:
+
+1. It has support for detecting an External value.
+2. It detects `null` as a separate type, while ECMAScript `typeof` would detect
+   `object`.
+
 If `value` has a type that is invalid, an error is returned.
 
 ### napi_instanceof


### PR DESCRIPTION
The documentation said `napi_typeof` is similar to the `typeof`
operator, but `typeof null` detects `'object'` while
`napi_typeof(a_null_value)` detects `napi_null`.

##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)