### PR TITLE
http: reset headers timeout on headers complete

### DIFF
--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -297,6 +297,8 @@ class Parser : public AsyncWrap, public StreamListener {
       A_MAX
     };
 
+    header_parsing_start_time_ = 0;
+
     Local<Value> argv[A_MAX];
     Local<Object> obj = object();
     Local<Value> cb = obj->Get(env()->context(),

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -280,6 +280,7 @@ class Parser : public AsyncWrap, public StreamListener {
 
   int on_headers_complete() {
     header_nread_ = 0;
+    header_parsing_start_time_ = 0;
 
     // Arguments for the on-headers-complete javascript callback. This
     // list needs to be kept in sync with the actual argument list for
@@ -296,8 +297,6 @@ class Parser : public AsyncWrap, public StreamListener {
       A_SHOULD_KEEP_ALIVE,
       A_MAX
     };
-
-    header_parsing_start_time_ = 0;
 
     Local<Value> argv[A_MAX];
     Local<Object> obj = object();

--- a/test/parallel/test-http-parser-timeout-reset.js
+++ b/test/parallel/test-http-parser-timeout-reset.js
@@ -2,7 +2,7 @@
 const common = require('../common');
 
 const net = require('net');
-const { HTTPParser } = process.binding('http_parser'); // eslint-disable-line
+const { HTTPParser } = process.binding('http_parser');
 
 const server = net.createServer((socket) => {
   socket.write('HTTP/1.1 200 OK\r\n');

--- a/test/parallel/test-http-parser-timeout-reset.js
+++ b/test/parallel/test-http-parser-timeout-reset.js
@@ -1,0 +1,46 @@
+'use strict';
+const common = require('../common');
+
+const net = require('net');
+const { HTTPParser } = process.binding('http_parser'); // eslint-disable-line
+
+const server = net.createServer((socket) => {
+  socket.write('HTTP/1.1 200 OK\r\n');
+  socket.write('Transfer-Encoding: chunked\r\n\r\n');
+  setTimeout(() => {
+    socket.write('1\r\n');
+    socket.write('\n\r\n');
+    setTimeout(() => {
+      socket.write('1\r\n');
+      socket.write('\n\r\n');
+      setImmediate(() => {
+        socket.destroy();
+        server.close();
+      });
+    }, 500);
+  }, 500);
+}).listen(0, () => {
+  const socket = net.connect(server.address().port);
+  const parser = new HTTPParser(HTTPParser.RESPONSE, false);
+  parser.initialize(
+    HTTPParser.RESPONSE,
+    {},
+    0,
+    false,
+    1e3
+  );
+
+  parser[HTTPParser.kOnTimeout] = common.mustNotCall();
+
+  parser[HTTPParser.kOnHeaders] = common.mustNotCall();
+
+  parser[HTTPParser.kOnExecute] = common.mustCall(3);
+
+  parser[HTTPParser.kOnHeadersComplete] = common.mustCall();
+
+  parser[HTTPParser.kOnBody] = common.mustCall(2);
+
+  parser[HTTPParser.kOnMessageComplete] = common.mustNotCall();
+
+  parser.consume(socket._handle);
+});


### PR DESCRIPTION
headers timeout should not occur *after* headers have been received.
    
Fixes: https://github.com/nodejs/node/issues/34576

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
