### PR TITLE
tools: fix checkimports.py when passed arguments

### DIFF
--- a/tools/checkimports.py
+++ b/tools/checkimports.py
@@ -42,4 +42,5 @@ def is_valid(file_name):
 
 if __name__ == '__main__':
   files = sys.argv[1:] if len(sys.argv) > 1 else glob.iglob('src/*.cc')
+  print(list(files))
   sys.exit(0 if all(map(is_valid, files)) else 1)

--- a/tools/checkimports.py
+++ b/tools/checkimports.py
@@ -41,5 +41,5 @@ def is_valid(file_name):
     return valid
 
 if __name__ == '__main__':
-  files = glob.iglob(sys.argv[1] if len(sys.argv) > 1 else 'src/*.cc')
+  files = sys.argv[1:] if len(sys.argv) > 1 else glob.iglob('src/*.cc')
   sys.exit(0 if all(map(is_valid, files)) else 1)


### PR DESCRIPTION
Fix checkimports.py so that all passed arguments are checked instead
of just the first one.

Opening as a draft to check that our actions/CI jobs fail properly now.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
