### PR TITLE
tools: fix C++ import checker argument expansion

### DIFF
--- a/src/api/hooks.cc
+++ b/src/api/hooks.cc
@@ -10,10 +10,10 @@ using v8::HandleScope;
 using v8::Integer;
 using v8::Isolate;
 using v8::Local;
+using v8::NewStringType;
 using v8::Object;
 using v8::String;
 using v8::Value;
-using v8::NewStringType;
 
 void RunAtExit(Environment* env) {
   env->RunAtExitCallbacks();

--- a/src/inspector/main_thread_interface.cc
+++ b/src/inspector/main_thread_interface.cc
@@ -14,8 +14,8 @@ namespace node {
 namespace inspector {
 namespace {
 
-using v8_inspector::StringView;
 using v8_inspector::StringBuffer;
+using v8_inspector::StringView;
 
 template <typename T>
 class DeletableWrapper : public Deletable {

--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -43,13 +43,11 @@ using v8::HeapSpaceStatistics;
 using v8::HeapStatistics;
 using v8::Isolate;
 using v8::Local;
-using v8::Number;
 using v8::Object;
-using v8::StackTrace;
 using v8::String;
 using v8::TryCatch;
-using v8::Value;
 using v8::V8;
+using v8::Value;
 
 namespace per_process = node::per_process;
 

--- a/src/quic/node_quic_session.cc
+++ b/src/quic/node_quic_session.cc
@@ -43,7 +43,6 @@ using crypto::SecureContext;
 using v8::Array;
 using v8::ArrayBufferView;
 using v8::Context;
-using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
 using v8::HandleScope;

--- a/src/quic/node_quic_socket.cc
+++ b/src/quic/node_quic_socket.cc
@@ -29,7 +29,6 @@ using crypto::EntropySource;
 using crypto::SecureContext;
 
 using v8::ArrayBufferView;
-using v8::Boolean;
 using v8::Context;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;

--- a/src/quic/node_quic_socket.h
+++ b/src/quic/node_quic_socket.h
@@ -27,10 +27,8 @@
 namespace node {
 
 using v8::Context;
-using v8::FunctionCallbackInfo;
 using v8::Local;
 using v8::Object;
-using v8::Value;
 
 namespace quic {
 

--- a/test/addons/async-hooks-promise/binding.cc
+++ b/test/addons/async-hooks-promise/binding.cc
@@ -6,7 +6,6 @@ namespace {
 using v8::FunctionCallbackInfo;
 using v8::Isolate;
 using v8::Local;
-using v8::NewStringType;
 using v8::Object;
 using v8::Promise;
 using v8::String;

--- a/test/addons/dlopen-ping-pong/binding.cc
+++ b/test/addons/dlopen-ping-pong/binding.cc
@@ -17,7 +17,6 @@ using v8::FunctionCallbackInfo;
 using v8::Isolate;
 using v8::Local;
 using v8::Object;
-using v8::NewStringType;
 using v8::String;
 using v8::Value;
 

--- a/test/addons/non-node-context/binding.cc
+++ b/test/addons/non-node-context/binding.cc
@@ -5,12 +5,9 @@
 namespace {
 
 using v8::Context;
-using v8::Function;
-using v8::FunctionTemplate;
 using v8::Isolate;
 using v8::Local;
 using v8::MaybeLocal;
-using v8::NewStringType;
 using v8::Object;
 using v8::Script;
 using v8::String;

--- a/test/addons/repl-domain-abort/binding.cc
+++ b/test/addons/repl-domain-abort/binding.cc
@@ -25,8 +25,8 @@
 using v8::Boolean;
 using v8::Function;
 using v8::FunctionCallbackInfo;
-using v8::Local;
 using v8::Isolate;
+using v8::Local;
 using v8::Object;
 using v8::Value;
 

--- a/test/addons/uv-handle-leak/binding.cc
+++ b/test/addons/uv-handle-leak/binding.cc
@@ -6,7 +6,6 @@ using v8::Context;
 using v8::FunctionCallbackInfo;
 using v8::Isolate;
 using v8::Local;
-using v8::Object;
 using v8::Value;
 
 // Give these things names in the public namespace so that we can see

--- a/test/cctest/test_base64.cc
+++ b/test/cctest/test_base64.cc
@@ -5,8 +5,8 @@
 
 #include "gtest/gtest.h"
 
-using node::base64_encode;
 using node::base64_decode;
+using node::base64_encode;
 
 TEST(Base64Test, Encode) {
   auto test = [](const char* string, const char* base64_string) {

--- a/test/cctest/test_util.cc
+++ b/test/cctest/test_util.cc
@@ -3,6 +3,16 @@
 #include "env-inl.h"
 #include "gtest/gtest.h"
 
+using node::Calloc;
+using node::Malloc;
+using node::MaybeStackBuffer;
+using node::SPrintF;
+using node::StringEqualNoCase;
+using node::StringEqualNoCaseN;
+using node::ToLower;
+using node::UncheckedCalloc;
+using node::UncheckedMalloc;
+
 TEST(UtilTest, ListHead) {
   struct Item { node::ListNode<Item> node_; };
   typedef node::ListHead<Item, &Item::node_> List;
@@ -58,7 +68,6 @@ TEST(UtilTest, ListHead) {
 }
 
 TEST(UtilTest, StringEqualNoCase) {
-  using node::StringEqualNoCase;
   EXPECT_FALSE(StringEqualNoCase("a", "b"));
   EXPECT_TRUE(StringEqualNoCase("", ""));
   EXPECT_TRUE(StringEqualNoCase("equal", "equal"));
@@ -69,7 +78,6 @@ TEST(UtilTest, StringEqualNoCase) {
 }
 
 TEST(UtilTest, StringEqualNoCaseN) {
-  using node::StringEqualNoCaseN;
   EXPECT_FALSE(StringEqualNoCaseN("a", "b", strlen("a")));
   EXPECT_TRUE(StringEqualNoCaseN("", "", strlen("")));
   EXPECT_TRUE(StringEqualNoCaseN("equal", "equal", strlen("equal")));
@@ -84,7 +92,6 @@ TEST(UtilTest, StringEqualNoCaseN) {
 }
 
 TEST(UtilTest, ToLower) {
-  using node::ToLower;
   EXPECT_EQ('0', ToLower('0'));
   EXPECT_EQ('a', ToLower('a'));
   EXPECT_EQ('a', ToLower('A'));
@@ -98,7 +105,6 @@ TEST(UtilTest, ToLower) {
   } while (0)
 
 TEST(UtilTest, Malloc) {
-  using node::Malloc;
   TEST_AND_FREE(Malloc<char>(0));
   TEST_AND_FREE(Malloc<char>(1));
   TEST_AND_FREE(Malloc(0));
@@ -106,7 +112,6 @@ TEST(UtilTest, Malloc) {
 }
 
 TEST(UtilTest, Calloc) {
-  using node::Calloc;
   TEST_AND_FREE(Calloc<char>(0));
   TEST_AND_FREE(Calloc<char>(1));
   TEST_AND_FREE(Calloc(0));
@@ -114,7 +119,6 @@ TEST(UtilTest, Calloc) {
 }
 
 TEST(UtilTest, UncheckedMalloc) {
-  using node::UncheckedMalloc;
   TEST_AND_FREE(UncheckedMalloc<char>(0));
   TEST_AND_FREE(UncheckedMalloc<char>(1));
   TEST_AND_FREE(UncheckedMalloc(0));
@@ -122,7 +126,6 @@ TEST(UtilTest, UncheckedMalloc) {
 }
 
 TEST(UtilTest, UncheckedCalloc) {
-  using node::UncheckedCalloc;
   TEST_AND_FREE(UncheckedCalloc<char>(0));
   TEST_AND_FREE(UncheckedCalloc<char>(1));
   TEST_AND_FREE(UncheckedCalloc(0));
@@ -131,8 +134,6 @@ TEST(UtilTest, UncheckedCalloc) {
 
 template <typename T>
 static void MaybeStackBufferBasic() {
-  using node::MaybeStackBuffer;
-
   MaybeStackBuffer<T> buf;
   size_t old_length;
   size_t old_capacity;
@@ -211,8 +212,6 @@ static void MaybeStackBufferBasic() {
 }
 
 TEST(UtilTest, MaybeStackBuffer) {
-  using node::MaybeStackBuffer;
-
   MaybeStackBufferBasic<uint8_t>();
   MaybeStackBufferBasic<uint16_t>();
 
@@ -254,8 +253,6 @@ TEST(UtilTest, MaybeStackBuffer) {
 }
 
 TEST(UtilTest, SPrintF) {
-  using node::SPrintF;
-
   // %d, %u and %s all do the same thing. The actual C++ type is used to infer
   // the right representation.
   EXPECT_EQ(SPrintF("%s", false), "false");

--- a/test/embedding/embedtest.cc
+++ b/test/embedding/embedtest.cc
@@ -16,8 +16,8 @@ using v8::Local;
 using v8::Locker;
 using v8::MaybeLocal;
 using v8::SealHandleScope;
-using v8::Value;
 using v8::V8;
+using v8::Value;
 
 static int RunNodeInstance(MultiIsolatePlatform* platform,
                            const std::vector<std::string>& args,

--- a/tools/checkimports.py
+++ b/tools/checkimports.py
@@ -5,7 +5,7 @@ import glob
 import io
 import re
 import sys
-
+import itertools
 
 def do_exist(file_name, lines, imported):
   if not any(not re.match('using \w+::{0};'.format(imported), line) and
@@ -41,5 +41,10 @@ def is_valid(file_name):
     return valid
 
 if __name__ == '__main__':
-  files = glob.iglob(sys.argv[1] if len(sys.argv) > 1 else 'src/*.cc')
+  if len(sys.argv) > 1:
+    files = []
+    for pattern in sys.argv[1:]:
+      files = itertools.chain(files, glob.iglob(pattern))
+  else:
+    files = glob.iglob('src/*.cc')
   sys.exit(0 if all(map(is_valid, files)) else 1)

--- a/tools/checkimports.py
+++ b/tools/checkimports.py
@@ -47,4 +47,4 @@ if __name__ == '__main__':
       files = itertools.chain(files, glob.iglob(pattern))
   else:
     files = glob.iglob('src/*.cc')
-  sys.exit(0 if all(map(is_valid, files)) else 1)
+  sys.exit(0 if all(list(map(is_valid, files))) else 1)


### PR DESCRIPTION
##### src: fix linter failures

Fix linter failures when running the linter on all source files.

##### tools: fix C++ import checker argument expansion

Makefile assumes that it can pass a list of files to the import
checker, whereas the import checker expects a single argument
that is interpreted as a blob.

Fix that mismatch by accepting multiple arguments in the import
checker.

Refs: https://github.com/nodejs/node/pull/34565


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
