### PR TITLE
worker_threads: add support for data: URLs

### DIFF
--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -622,6 +622,10 @@ if (isMainThread) {
 added: v10.5.0
 changes:
   - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/34584
+    description: The `filename` parameter can be a WHATWG `URL` object using
+                 `data:` protocol.
+  - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/34394
     description: The `trackUnmanagedFds` option was set to `true` by default.
   - version:
@@ -654,7 +658,9 @@ changes:
 * `filename` {string|URL} The path to the Worker’s main script or module. Must
   be either an absolute path or a relative path (i.e. relative to the
   current working directory) starting with `./` or `../`, or a WHATWG `URL`
-  object using `file:` protocol.
+  object using `file:` or `data:` protocol.
+  When using a [`data:` URL][], the data is interpreted based on MIME type using
+  the [ECMAScript module loader][].
   If `options.eval` is `true`, this is a string containing JavaScript code
   rather than a path.
 * `options` {Object}
@@ -902,6 +908,7 @@ active handle in the event system. If the worker is already `unref()`ed calling
 [`AsyncResource`]: async_hooks.html#async_hooks_class_asyncresource
 [`Buffer`]: buffer.html
 [`Buffer.allocUnsafe()`]: buffer.html#buffer_static_method_buffer_allocunsafe_size
+[ECMAScript module loader]: esm.html#esm_data_imports
 [`ERR_MISSING_MESSAGE_PORT_IN_TRANSFER_LIST`]: errors.html#errors_err_missing_message_port_in_transfer_list
 [`ERR_WORKER_NOT_RUNNING`]: errors.html#ERR_WORKER_NOT_RUNNING
 [`EventEmitter`]: events.html
@@ -953,3 +960,4 @@ active handle in the event system. If the worker is already `unref()`ed calling
 [child processes]: child_process.html
 [contextified]: vm.html#vm_what_does_it_mean_to_contextify_an_object
 [v8.serdes]: v8.html#v8_serialization_api
+[`data:` URL]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1465,6 +1465,9 @@ E('ERR_WORKER_PATH', (filename) =>
   (filename.startsWith('file://') ?
     ' Wrap file:// URLs with `new URL`.' : ''
   ) +
+  (filename.startsWith('data:text/javascript') ?
+    ' Wrap data: URLs with `new URL`.' : ''
+  ) +
   ` Received "${filename}"`,
   TypeError);
 E('ERR_WORKER_UNSERIALIZABLE_ERROR',

--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -149,7 +149,7 @@ port.on('message', (message) => {
     debug(`[${threadId}] starts worker script ${filename} ` +
           `(eval = ${eval}) at cwd = ${process.cwd()}`);
     port.postMessage({ type: UP_AND_RUNNING });
-    if (doEval) {
+    if (doEval === 'classic') {
       const { evalScript } = require('internal/process/execution');
       const name = '[worker eval]';
       // This is necessary for CJS module compilation.
@@ -161,6 +161,11 @@ port.on('message', (message) => {
       });
       process.argv.splice(1, 0, name);
       evalScript(name, filename);
+    } else if (doEval === 'module') {
+      const { evalModule } = require('internal/process/execution');
+      evalModule(filename).catch((e) => {
+        workerOnGlobalUncaughtException(e, true);
+      });
     } else {
       // script filename
       // runMain here might be monkey-patched by users in --require.

--- a/lib/internal/process/execution.js
+++ b/lib/internal/process/execution.js
@@ -45,7 +45,7 @@ function evalModule(source, print) {
   const { log } = require('internal/console/global');
   const { loadESM } = require('internal/process/esm_loader');
   const { handleMainPromise } = require('internal/modules/run_main');
-  handleMainPromise(loadESM(async (loader) => {
+  return handleMainPromise(loadESM(async (loader) => {
     const { result } = await loader.eval(source);
     if (print) {
       log(result);

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -4,6 +4,7 @@
 
 const {
   ArrayIsArray,
+  JSONStringify,
   MathMax,
   ObjectCreate,
   ObjectEntries,
@@ -100,7 +101,7 @@ class Worker extends EventEmitter {
       argv = options.argv.map(String);
     }
 
-    let url;
+    let url, doEval;
     if (options.eval) {
       if (typeof filename !== 'string') {
         throw new ERR_INVALID_ARG_VALUE(
@@ -110,7 +111,13 @@ class Worker extends EventEmitter {
         );
       }
       url = null;
+      doEval = 'classic';
+    } else if (isURLInstance(filename) && filename.protocol === 'data:') {
+      url = null;
+      doEval = 'module';
+      filename = `import ${JSONStringify(`${filename}`)}`;
     } else {
+      doEval = false;
       if (isURLInstance(filename)) {
         url = filename;
         filename = fileURLToPath(filename);
@@ -201,7 +208,7 @@ class Worker extends EventEmitter {
       argv,
       type: messageTypes.LOAD_SCRIPT,
       filename,
-      doEval: !!options.eval,
+      doEval,
       cwdCounter: cwdCounter || workerIo.sharedCwdCounter,
       workerData: options.workerData,
       publicPort: port2,

--- a/test/parallel/test-worker-data-url.js
+++ b/test/parallel/test-worker-data-url.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const common = require('../common');
+const { Worker } = require('worker_threads');
+
+new Worker(new URL('data:text/javascript,'))
+  .on('error', common.mustNotCall(() => {}));
+new Worker(new URL('data:text/javascript,export{}'))
+  .on('error', common.mustNotCall(() => {}));
+
+new Worker(new URL('data:text/plain,'))
+  .on('error', common.mustCall(() => {}));
+new Worker(new URL('data:text/javascript,module.exports={}'))
+  .on('error', common.mustCall(() => {}));

--- a/test/parallel/test-worker-data-url.js
+++ b/test/parallel/test-worker-data-url.js
@@ -2,6 +2,7 @@
 
 const common = require('../common');
 const { Worker } = require('worker_threads');
+const assert = require('assert');
 
 new Worker(new URL('data:text/javascript,'))
   .on('error', common.mustNotCall(() => {}));
@@ -12,3 +13,13 @@ new Worker(new URL('data:text/plain,'))
   .on('error', common.mustCall(() => {}));
 new Worker(new URL('data:text/javascript,module.exports={}'))
   .on('error', common.mustCall(() => {}));
+
+new Worker(new URL('data:text/javascript,await Promise.resolve()'))
+  .on('error', common.mustNotCall(() => {}));
+new Worker(new URL('data:text/javascript,await Promise.reject()'))
+  .on('error', common.mustCall(() => {}));
+new Worker(new URL('data:text/javascript,await new Promise(()=>{})'))
+  .on(
+    'exit',
+    common.mustCall((exitCode) => { assert.strictEqual(exitCode, 13); })
+  );

--- a/test/parallel/test-worker-unsupported-path.js
+++ b/test/parallel/test-worker-unsupported-path.js
@@ -34,6 +34,10 @@ const { Worker } = require('worker_threads');
     /Wrap file:\/\/ URLs with `new URL`/
   );
   assert.throws(
+    () => { new Worker('data:text/javascript,'); },
+    /Wrap data: URLs with `new URL`/
+  );
+  assert.throws(
     () => { new Worker('relative_no_dot'); },
     // eslint-disable-next-line node-core/no-unescaped-regexp-dot
     /^((?!Wrap file:\/\/ URLs with `new URL`).)*$/s
@@ -46,7 +50,5 @@ const { Worker } = require('worker_threads');
     name: 'TypeError'
   };
   assert.throws(() => { new Worker(new URL('https://www.url.com')); },
-                expectedErr);
-  assert.throws(() => { new Worker(new URL('data:application/javascript,')); },
                 expectedErr);
 }


### PR DESCRIPTION
This PR adds support for data URLs using the same implementation provided by the ESM implementation. This covers the use case of a user wanting to use eval in a worker thread with ESM syntax. 


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
