### PR TITLE
test: add Actions annotation output

### DIFF
--- a/.github/workflows/test-asan.yml
+++ b/.github/workflows/test-asan.yml
@@ -33,4 +33,4 @@ jobs:
       - name: Build
         run: make build-ci -j2 V=1
       - name: Test
-        run: make run-ci -j2 V=1 TEST_CI_ARGS="-p dots"
+        run: make run-ci -j2 V=1 TEST_CI_ARGS="-p actions"

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Build
         run: make build-ci -j2 V=1 CONFIG_FLAGS="--error-on-warn"
       - name: Test
-        run: make run-ci -j2 V=1 TEST_CI_ARGS="-p dots"
+        run: make run-ci -j2 V=1 TEST_CI_ARGS="-p actions"
 
   test-linux-with-quic:
     runs-on: ubuntu-latest
@@ -39,4 +39,4 @@ jobs:
       - name: Build
         run: make build-ci -j2 V=1 CONFIG_FLAGS="--error-on-warn --experimental-quic"
       - name: Test
-        run: make run-ci -j2 V=1 TEST_CI_ARGS="-p dots"
+        run: make run-ci -j2 V=1 TEST_CI_ARGS="-p actions"

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -24,4 +24,4 @@ jobs:
       - name: Build
         run: make build-ci -j8 V=1 CONFIG_FLAGS="--error-on-warn --experimental-quic"
       - name: Test
-        run: make run-ci -j8 V=1 TEST_CI_ARGS="-p dots"
+        run: make run-ci -j8 V=1 TEST_CI_ARGS="-p actions"

--- a/test/parallel/test-http-outgoing-finish-writable.js
+++ b/test/parallel/test-http-outgoing-finish-writable.js
@@ -9,7 +9,7 @@ const http = require('http');
 const server = http.createServer(common.mustCall(function(req, res) {
   assert.strictEqual(res.writable, true);
   assert.strictEqual(res.finished, false);
-  assert.strictEqual(res.writableEnded, false);
+  assert.strictEqual(res.writableEnded, true);
   res.end();
 
   // res.writable is set to false after it has finished sending


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

It's possible to annotate failures in Actions by printing `::error file={},line={},col={}::{message}`. This methos is preferrable over using a problem matcher because problem matchers only allow single-line messages, whereas ::error allows multi-line messages.

When the test being annotated is edited in a Pull Request, GitHub will show it inline where the error happened:

![image](https://user-images.githubusercontent.com/4048656/89096213-bb9f9700-d389-11ea-96cc-b2ff687c683d.png)

If the failing test was not edited, it will still be possible to see the error with the following steps:

![image](https://user-images.githubusercontent.com/4048656/89096282-5ac48e80-d38a-11ea-8290-60832603749e.png)

![image](https://user-images.githubusercontent.com/4048656/89096310-8fd0e100-d38a-11ea-8823-1df63572ee08.png)

![image](https://user-images.githubusercontent.com/4048656/89096321-b858db00-d38a-11ea-8405-68d70688918e.png)

The link on the annotation in this case will point to the last commit in the PR instead of pointing to the file (which is a bit unfortunate, but that's a [GitHub Actions Runner limitation](https://github.com/actions/runner/issues/566) apparently). The filename on the annotation is still correct though, so this is still an improvement over the current situation where we need to look at the logs (which can be confusing for newcomers).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
