### PR TITLE
benchmark: fix EADDRNOTAVAIL error in http2

### DIFF
--- a/benchmark/http2/compat.js
+++ b/benchmark/http2/compat.js
@@ -10,7 +10,7 @@ const bench = common.createBenchmark(main, {
   streams: [1, 10, 20, 40, 100, 200],
   clients: [2],
   benchmarker: ['test-double-http2'],
-  duration: 5
+  duration: 2
 }, { flags: ['--no-warnings'] });
 
 function main({ requests, streams, clients, duration }) {

--- a/benchmark/http2/respond-with-fd.js
+++ b/benchmark/http2/respond-with-fd.js
@@ -11,7 +11,7 @@ const bench = common.createBenchmark(main, {
   streams: [1, 10, 20, 40, 100, 200],
   clients: [2],
   benchmarker: ['test-double-http2'],
-  duration: 5
+  duration: 2
 }, { flags: ['--no-warnings'] });
 
 function main({ requests, streams, clients, duration }) {

--- a/benchmark/http2/simple.js
+++ b/benchmark/http2/simple.js
@@ -10,7 +10,7 @@ const bench = common.createBenchmark(main, {
   streams: [1, 10, 20, 40, 100, 200],
   clients: [2],
   benchmarker: ['test-double-http2'],
-  duration: 5
+  duration: 2
 }, { flags: ['--no-warnings'] });
 
 function main({ requests, streams, clients, duration }) {

--- a/benchmark/http2/write.js
+++ b/benchmark/http2/write.js
@@ -7,7 +7,7 @@ const bench = common.createBenchmark(main, {
   length: [64 * 1024, 128 * 1024, 256 * 1024, 1024 * 1024],
   size: [100000],
   benchmarker: ['test-double-http2'],
-  duration: 5
+  duration: 2
 }, { flags: ['--no-warnings'] });
 
 function main({ streams, length, size, duration }) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Fixes: https://github.com/nodejs/node/issues/34061

It is found that there may be errors caused by too many TCP connections. This PR is only to reduce the number of connections to avoid `benchmark` tests crashing. On my macOS, when the value of `duration` is `2`, there will be no errors basically.

/cc @addaleax @BridgeAR @jasnell 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
