### PR TITLE
module: use cjsCache over esm injection

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -1122,7 +1122,7 @@ Module.prototype.load = function(filename) {
   // Create module entry at load time to snapshot exports correctly
   const exports = this.exports;
   // Preemptively cache
-  if ((module === undefined || module.module === undefined ||
+  if ((module?.module === undefined ||
        module.module.getStatus() < kEvaluated) &&
       !ESMLoader.cjsCache.has(this))
     ESMLoader.cjsCache.set(this, exports);

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -1119,15 +1119,13 @@ Module.prototype.load = function(filename) {
   this.loaded = true;
 
   const ESMLoader = asyncESM.ESMLoader;
-  const url = `${pathToFileURL(filename)}`;
-  const module = ESMLoader.moduleMap.get(url);
   // Create module entry at load time to snapshot exports correctly
   const exports = this.exports;
   // Preemptively cache
   if ((module === undefined || module.module === undefined ||
        module.module.getStatus() < kEvaluated) &&
-      !ESMLoader.cjsCache.has(url))
-    ESMLoader.cjsCache.set(url, exports);
+      !ESMLoader.cjsCache.has(this))
+    ESMLoader.cjsCache.set(this, exports);
 };
 
 

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -113,8 +113,7 @@ const {
 } = require('internal/util/types');
 
 const asyncESM = require('internal/process/esm_loader');
-const ModuleJob = require('internal/modules/esm/module_job');
-const { ModuleWrap, kInstantiated } = internalBinding('module_wrap');
+const { kEvaluated } = internalBinding('module_wrap');
 const {
   encodedSepRegEx,
   packageInternalResolve
@@ -1124,25 +1123,11 @@ Module.prototype.load = function(filename) {
   const module = ESMLoader.moduleMap.get(url);
   // Create module entry at load time to snapshot exports correctly
   const exports = this.exports;
-  // Called from cjs translator
-  if (module !== undefined && module.module !== undefined) {
-    if (module.module.getStatus() >= kInstantiated)
-      module.module.setExport('default', exports);
-  } else {
-    // Preemptively cache
-    // We use a function to defer promise creation for async hooks.
-    ESMLoader.moduleMap.set(
-      url,
-      // Module job creation will start promises.
-      // We make it a function to lazily trigger those promises
-      // for async hooks compatibility.
-      () => new ModuleJob(ESMLoader, url, () =>
-        new ModuleWrap(url, undefined, ['default'], function() {
-          this.setExport('default', exports);
-        })
-      , false /* isMain */, false /* inspectBrk */)
-    );
-  }
+  // Preemptively cache
+  if ((module === undefined || module.module === undefined ||
+       module.module.getStatus() < kEvaluated) &&
+      !ESMLoader.cjsCache.has(url))
+    ESMLoader.cjsCache.set(url, exports);
 };
 
 

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -6,7 +6,7 @@ require('internal/modules/cjs/loader');
 const {
   FunctionPrototypeBind,
   ObjectSetPrototypeOf,
-  SafeMap,
+  SafeWeakMap,
 } = primordials;
 
 const {
@@ -47,7 +47,7 @@ class Loader {
     this.moduleMap = new ModuleMap();
 
     // Map of already-loaded CJS modules to use
-    this.cjsCache = new SafeMap();
+    this.cjsCache = new SafeWeakMap();
 
     // This hook is called before the first root module is imported. It's a
     // function that returns a piece of code that runs as a sloppy-mode script.

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -48,6 +48,8 @@ const experimentalImportMetaResolve =
 const translators = new SafeMap();
 exports.translators = translators;
 
+const asyncESM = require('internal/process/esm_loader');
+
 let DECODER = null;
 function assertBufferSource(body, allowString, hookName) {
   if (allowString && typeof body === 'string') {
@@ -80,21 +82,14 @@ function errPath(url) {
   return url;
 }
 
-let esmLoader;
 async function importModuleDynamically(specifier, { url }) {
-  if (!esmLoader) {
-    esmLoader = require('internal/process/esm_loader').ESMLoader;
-  }
-  return esmLoader.import(specifier, url);
+  return asyncESM.ESMLoader.import(specifier, url);
 }
 
 function createImportMetaResolve(defaultParentUrl) {
   return async function resolve(specifier, parentUrl = defaultParentUrl) {
-    if (!esmLoader) {
-      esmLoader = require('internal/process/esm_loader').ESMLoader;
-    }
     return PromisePrototypeCatch(
-      esmLoader.resolve(specifier, parentUrl),
+      asyncESM.ESMLoader.resolve(specifier, parentUrl),
       (error) => (
         error.code === 'ERR_UNSUPPORTED_DIR_IMPORT' ?
           error.url : PromiseReject(error))
@@ -132,27 +127,17 @@ const isWindows = process.platform === 'win32';
 const winSepRegEx = /\//g;
 translators.set('commonjs', function commonjsStrategy(url, isMain) {
   debug(`Translating CJSModule ${url}`);
-  const pathname = internalURLModule.fileURLToPath(new URL(url));
-  const cached = this.cjsCache.get(url);
-  if (cached) {
-    this.cjsCache.delete(url);
-    return cached;
-  }
-  const module = CJSModule._cache[
-    isWindows ? StringPrototypeReplace(pathname, winSepRegEx, '\\') : pathname
-  ];
-  if (module && module.loaded) {
-    const exports = module.exports;
-    return new ModuleWrap(url, undefined, ['default'], function() {
-      this.setExport('default', exports);
-    });
-  }
   return new ModuleWrap(url, undefined, ['default'], function() {
     debug(`Loading CJSModule ${url}`);
-    // We don't care about the return val of _load here because Module#load
-    // will handle it for us by checking the loader registry and filling the
-    // exports like above
-    CJSModule._load(pathname, undefined, isMain);
+    const pathname = internalURLModule.fileURLToPath(new URL(url));
+    let exports;
+    if (asyncESM.ESMLoader.cjsCache.has(url)) {
+      exports = asyncESM.ESMLoader.cjsCache.get(url);
+      asyncESM.ESMLoader.cjsCache.delete(url);
+    } else {
+      exports = CJSModule._load(pathname, undefined, isMain);
+    }
+    this.setExport('default', exports);
   });
 });
 

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -131,9 +131,10 @@ translators.set('commonjs', function commonjsStrategy(url, isMain) {
     debug(`Loading CJSModule ${url}`);
     const pathname = internalURLModule.fileURLToPath(new URL(url));
     let exports;
-    if (asyncESM.ESMLoader.cjsCache.has(url)) {
-      exports = asyncESM.ESMLoader.cjsCache.get(url);
-      asyncESM.ESMLoader.cjsCache.delete(url);
+    const cachedModule = CJSModule._cache[pathname];
+    if (cachedModule && asyncESM.ESMLoader.cjsCache.has(cachedModule)) {
+      exports = asyncESM.ESMLoader.cjsCache.get(cachedModule);
+      asyncESM.ESMLoader.cjsCache.delete(cachedModule);
     } else {
       exports = CJSModule._load(pathname, undefined, isMain);
     }


### PR DESCRIPTION
This is the replacement for https://github.com/nodejs/node/pull/34467 as an alternative mechanism to ensure that named exports loaders (such as https://github.com/guybedford/cjs-named-exports-loader) are fully possible without issues. Without this PR such loaders cannot work for CJS loaded via `require()` before it is loaded via `import()`.

As discussed, this PR retains the existing CJS snapshotting behaviour so that the `module.exports` value is captured for all CommonJS modules and stored in the `ESMLoader.cjsCache` map. This map is changed to be a weakmap keyed by the module object so that deletions in `Module._cache` allow this map to be GC'd.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
