### PR TITLE
test: convert most N-API tests from C++ to C

### DIFF
--- a/test/node-api/test_async/binding.gyp
+++ b/test/node-api/test_async/binding.gyp
@@ -2,7 +2,7 @@
   "targets": [
     {
       "target_name": "test_async",
-      "sources": [ "test_async.cc" ]
+      "sources": [ "test_async.c" ]
     }
   ]
 }

--- a/test/node-api/test_async/test_async.c
+++ b/test/node-api/test_async/test_async.c
@@ -22,29 +22,29 @@ typedef struct {
 carrier the_carrier;
 carrier async_carrier[MAX_CANCEL_THREADS];
 
-void Execute(napi_env env, void* data) {
+static void Execute(napi_env env, void* data) {
 #if defined _WIN32
   Sleep(1000);
 #else
   sleep(1);
 #endif
-  carrier* c = static_cast<carrier*>(data);
+  carrier* c = (carrier*)(data);
 
   assert(c == &the_carrier);
 
   c->_output = c->_input * 2;
 }
 
-void Complete(napi_env env, napi_status status, void* data) {
-  carrier* c = static_cast<carrier*>(data);
+static void Complete(napi_env env, napi_status status, void* data) {
+  carrier* c = (carrier*)(data);
 
   if (c != &the_carrier) {
-    napi_throw_type_error(env, nullptr, "Wrong data parameter to Complete.");
+    napi_throw_type_error(env, NULL, "Wrong data parameter to Complete.");
     return;
   }
 
   if (status != napi_ok) {
-    napi_throw_type_error(env, nullptr, "Execute callback failed.");
+    napi_throw_type_error(env, NULL, "Execute callback failed.");
     return;
   }
 
@@ -66,7 +66,7 @@ void Complete(napi_env env, napi_status status, void* data) {
   NAPI_CALL_RETURN_VOID(env, napi_delete_async_work(env, c->_request));
 }
 
-napi_value Test(napi_env env, napi_callback_info info) {
+static napi_value Test(napi_env env, napi_callback_info info) {
   size_t argc = 3;
   napi_value argv[3];
   napi_value _this;
@@ -101,16 +101,16 @@ napi_value Test(napi_env env, napi_callback_info info) {
   NAPI_CALL(env,
       napi_queue_async_work(env, the_carrier._request));
 
-  return nullptr;
+  return NULL;
 }
 
-void BusyCancelComplete(napi_env env, napi_status status, void* data) {
-  carrier* c = static_cast<carrier*>(data);
+static void BusyCancelComplete(napi_env env, napi_status status, void* data) {
+  carrier* c = (carrier*)(data);
   NAPI_CALL_RETURN_VOID(env, napi_delete_async_work(env, c->_request));
 }
 
-void CancelComplete(napi_env env, napi_status status, void* data) {
-  carrier* c = static_cast<carrier*>(data);
+static void CancelComplete(napi_env env, napi_status status, void* data) {
+  carrier* c = (carrier*)(data);
 
   if (status == napi_cancelled) {
     // ok we got the status we expected so make the callback to
@@ -122,14 +122,14 @@ void CancelComplete(napi_env env, napi_status status, void* data) {
     NAPI_CALL_RETURN_VOID(env, napi_get_global(env, &global));
     napi_value result;
     NAPI_CALL_RETURN_VOID(env,
-      napi_call_function(env, global, callback, 0, nullptr, &result));
+      napi_call_function(env, global, callback, 0, NULL, &result));
   }
 
   NAPI_CALL_RETURN_VOID(env, napi_delete_async_work(env, c->_request));
   NAPI_CALL_RETURN_VOID(env, napi_delete_reference(env, c->_callback));
 }
 
-void CancelExecute(napi_env env, void* data) {
+static void CancelExecute(napi_env env, void* data) {
 #if defined _WIN32
   Sleep(1000);
 #else
@@ -137,7 +137,7 @@ void CancelExecute(napi_env env, void* data) {
 #endif
 }
 
-napi_value TestCancel(napi_env env, napi_callback_info info) {
+static napi_value TestCancel(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value argv[1];
   napi_value _this;
@@ -150,7 +150,7 @@ napi_value TestCancel(napi_env env, napi_callback_info info) {
   // make sure the work we are going to cancel will not be
   // able to start by using all the threads in the pool
   for (int i = 1; i < MAX_CANCEL_THREADS; i++) {
-    NAPI_CALL(env, napi_create_async_work(env, nullptr, resource_name,
+    NAPI_CALL(env, napi_create_async_work(env, NULL, resource_name,
       CancelExecute, BusyCancelComplete,
       &async_carrier[i], &async_carrier[i]._request));
     NAPI_CALL(env, napi_queue_async_work(env, async_carrier[i]._request));
@@ -162,20 +162,20 @@ napi_value TestCancel(napi_env env, napi_callback_info info) {
   // workers above.
   NAPI_CALL(env,
     napi_get_cb_info(env, info, &argc, argv, &_this, &data));
-  NAPI_CALL(env, napi_create_async_work(env, nullptr, resource_name,
+  NAPI_CALL(env, napi_create_async_work(env, NULL, resource_name,
     CancelExecute, CancelComplete,
     &async_carrier[0], &async_carrier[0]._request));
   NAPI_CALL(env,
       napi_create_reference(env, argv[0], 1, &async_carrier[0]._callback));
   NAPI_CALL(env, napi_queue_async_work(env, async_carrier[0]._request));
   NAPI_CALL(env, napi_cancel_async_work(env, async_carrier[0]._request));
-  return nullptr;
+  return NULL;
 }
 
 struct {
   napi_ref ref;
   napi_async_work work;
-} repeated_work_info = { nullptr, nullptr };
+} repeated_work_info = { NULL, NULL };
 
 static void RepeatedWorkerThread(napi_env env, void* data) {}
 
@@ -187,33 +187,33 @@ static void RepeatedWorkComplete(napi_env env, napi_status status, void* data) {
       napi_delete_async_work(env, repeated_work_info.work));
   NAPI_CALL_RETURN_VOID(env,
       napi_delete_reference(env, repeated_work_info.ref));
-  repeated_work_info.work = nullptr;
-  repeated_work_info.ref = nullptr;
+  repeated_work_info.work = NULL;
+  repeated_work_info.ref = NULL;
   NAPI_CALL_RETURN_VOID(env,
       napi_create_uint32(env, (uint32_t)status, &js_status));
   NAPI_CALL_RETURN_VOID(env,
-      napi_call_function(env, cb, cb, 1, &js_status, nullptr));
+      napi_call_function(env, cb, cb, 1, &js_status, NULL));
 }
 
 static napi_value DoRepeatedWork(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value cb, name;
-  NAPI_ASSERT(env, repeated_work_info.ref == nullptr,
+  NAPI_ASSERT(env, repeated_work_info.ref == NULL,
       "Reference left over from previous work");
-  NAPI_ASSERT(env, repeated_work_info.work == nullptr,
+  NAPI_ASSERT(env, repeated_work_info.work == NULL,
       "Work pointer left over from previous work");
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, &cb, nullptr, nullptr));
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, &cb, NULL, NULL));
   NAPI_CALL(env, napi_create_reference(env, cb, 1, &repeated_work_info.ref));
   NAPI_CALL(env,
       napi_create_string_utf8(env, "Repeated Work", NAPI_AUTO_LENGTH, &name));
   NAPI_CALL(env,
-      napi_create_async_work(env, nullptr, name, RepeatedWorkerThread,
+      napi_create_async_work(env, NULL, name, RepeatedWorkerThread,
           RepeatedWorkComplete, &repeated_work_info, &repeated_work_info.work));
   NAPI_CALL(env, napi_queue_async_work(env, repeated_work_info.work));
-  return nullptr;
+  return NULL;
 }
 
-napi_value Init(napi_env env, napi_value exports) {
+static napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor properties[] = {
     DECLARE_NAPI_PROPERTY("Test", Test),
     DECLARE_NAPI_PROPERTY("TestCancel", TestCancel),

--- a/test/node-api/test_async/test_async.c
+++ b/test/node-api/test_async/test_async.c
@@ -19,8 +19,8 @@ typedef struct {
   napi_async_work _request;
 } carrier;
 
-carrier the_carrier;
-carrier async_carrier[MAX_CANCEL_THREADS];
+static carrier the_carrier;
+static carrier async_carrier[MAX_CANCEL_THREADS];
 
 static void Execute(napi_env env, void* data) {
 #if defined _WIN32

--- a/test/node-api/test_callback_scope/binding.gyp
+++ b/test/node-api/test_callback_scope/binding.gyp
@@ -3,7 +3,7 @@
     {
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
-      'sources': [ 'binding.cc' ]
+      'sources': [ 'binding.c' ]
     }
   ]
 }

--- a/test/node-api/test_cleanup_hook/binding.c
+++ b/test/node-api/test_cleanup_hook/binding.c
@@ -6,8 +6,8 @@ static void cleanup(void* arg) {
   printf("cleanup(%d)\n", *(int*)(arg));
 }
 
-int secret = 42;
-int wrong_secret = 17;
+static int secret = 42;
+static int wrong_secret = 17;
 
 static napi_value Init(napi_env env, napi_value exports) {
   napi_add_env_cleanup_hook(env, cleanup, &wrong_secret);

--- a/test/node-api/test_cleanup_hook/binding.c
+++ b/test/node-api/test_cleanup_hook/binding.c
@@ -2,23 +2,19 @@
 #include "uv.h"
 #include "../../js-native-api/common.h"
 
-namespace {
-
-void cleanup(void* arg) {
-  printf("cleanup(%d)\n", *static_cast<int*>(arg));
+static void cleanup(void* arg) {
+  printf("cleanup(%d)\n", *(int*)(arg));
 }
 
 int secret = 42;
 int wrong_secret = 17;
 
-napi_value Init(napi_env env, napi_value exports) {
+static napi_value Init(napi_env env, napi_value exports) {
   napi_add_env_cleanup_hook(env, cleanup, &wrong_secret);
   napi_add_env_cleanup_hook(env, cleanup, &secret);
   napi_remove_env_cleanup_hook(env, cleanup, &wrong_secret);
 
-  return nullptr;
+  return NULL;
 }
-
-}  // anonymous namespace
 
 NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/node-api/test_cleanup_hook/binding.gyp
+++ b/test/node-api/test_cleanup_hook/binding.gyp
@@ -3,7 +3,7 @@
     {
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
-      'sources': [ 'binding.cc' ]
+      'sources': [ 'binding.c' ]
     }
   ]
 }

--- a/test/node-api/test_make_callback_recurse/binding.c
+++ b/test/node-api/test_make_callback_recurse/binding.c
@@ -1,10 +1,7 @@
 #include <node_api.h>
 #include "../../js-native-api/common.h"
-#include <vector>
 
-namespace {
-
-napi_value MakeCallback(napi_env env, napi_callback_info info) {
+static napi_value MakeCallback(napi_env env, napi_callback_info info) {
   size_t argc = 2;
   napi_value args[2];
   // NOLINTNEXTLINE (readability/null_usage)
@@ -13,8 +10,8 @@ napi_value MakeCallback(napi_env env, napi_callback_info info) {
   napi_value recv = args[0];
   napi_value func = args[1];
 
-  napi_status status = napi_make_callback(env, nullptr /* async_context */,
-    recv, func, 0 /* argc */, nullptr /* argv */, nullptr /* result */);
+  napi_status status = napi_make_callback(env, NULL /* async_context */,
+    recv, func, 0 /* argc */, NULL /* argv */, NULL /* result */);
 
   bool isExceptionPending;
   NAPI_CALL(env, napi_is_exception_pending(env, &isExceptionPending));
@@ -25,14 +22,14 @@ napi_value MakeCallback(napi_env env, napi_callback_info info) {
     status = napi_get_and_clear_last_exception(env, &pending_error);
     NAPI_CALL(env,
       napi_throw_error((env),
-                        nullptr,
+                        NULL,
                         "error when only pending exception expected"));
   }
 
   return recv;
 }
 
-napi_value Init(napi_env env, napi_value exports) {
+static napi_value Init(napi_env env, napi_value exports) {
   napi_value fn;
   NAPI_CALL(env, napi_create_function(
       // NOLINTNEXTLINE (readability/null_usage)
@@ -40,7 +37,5 @@ napi_value Init(napi_env env, napi_value exports) {
   NAPI_CALL(env, napi_set_named_property(env, exports, "makeCallback", fn));
   return exports;
 }
-
-}  // anonymous namespace
 
 NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/node-api/test_make_callback_recurse/binding.gyp
+++ b/test/node-api/test_make_callback_recurse/binding.gyp
@@ -3,7 +3,7 @@
     {
       'target_name': 'binding',
       'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
-      'sources': [ 'binding.cc' ]
+      'sources': [ 'binding.c' ]
     }
   ]
 }


### PR DESCRIPTION
* Prefix functions with `static` to make them local
* Remove anonymous namespaces
* `nullptr` -> `NULL`
* .cc -> .c and update binding.gyp
* `static_cast<x>()` -> `(x)()`
* Replace `new`/`delete` with `malloc()`/`free()`
  (only in test_callback_scope)
* Move lambda out and convert to local function
  (only in test_callback_scope)
* Remove superfluous `#include <vector>`
  (only in test_callback_scope_recurse)

Some tests are best left as C++.

```bash
ls -l test/{node-api,js-native-api}/*/*.cc
```

for the rest.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
