### PR TITLE
async_hooks: don't read resource if ALS is disabled

### DIFF
--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -280,8 +280,8 @@ class AsyncLocalStorage {
   }
 
   getStore() {
-    const resource = executionAsyncResource();
     if (this.enabled) {
+      const resource = executionAsyncResource();
       return resource[this.kResourceStore];
     }
   }


### PR DESCRIPTION
Only call `executionAsyncResource()` in `getStore()` if the ALS instance is enabled because the resource is not needed otherwise.
