### PR TITLE
[async_hooks] improve property descriptors in als.bind

### DIFF
--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -220,12 +220,16 @@ class AsyncResource {
     const ret = this.runInAsyncScope.bind(this, fn);
     ObjectDefineProperties(ret, {
       'length': {
-        enumerable: true,
+        configurable: true,
+        enumerable: false,
         value: fn.length,
+        writable: false,
       },
       'asyncResource': {
+        configurable: true,
         enumerable: true,
         value: this,
+        writable: true,
       }
     });
     return ret;


### PR DESCRIPTION
The `length` property should be non enumerable to match behavior of normal functions.

The `asyncResource` property is enumerable and therefore it should be also writable to avoid issues like there: https://github.com/nodejs/node/pull/30932#discussion_r379679982

Both properties should be configurable.

Refs: https://github.com/nodejs/node/pull/34574

fyi @jasnell 


