### PR TITLE
lib: use non-symbols in isURLInstance check

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -1390,8 +1390,7 @@ function pathToFileURL(filepath) {
 }
 
 function isURLInstance(fileURLOrPath) {
-  return fileURLOrPath != null && fileURLOrPath[searchParams] &&
-    fileURLOrPath[searchParams][searchParams];
+  return fileURLOrPath != null && fileURLOrPath.href && fileURLOrPath.origin;
 }
 
 function toPathIfFileURL(fileURLOrPath) {


### PR DESCRIPTION
This slightly changes the conditional used to determine whether or not something is a URL instance. Since Node.js adds symbols to the URL not specified by the WHATWG, those symbols are not present in other implementations (like Blink's) and therefore can cause false negatives. In Electron's renderer process, running e.g. this code:

```js
const fs = require('fs');
const path = require('path');

const url = new URL('file://' + path.resolve('index.html'));

const stream = fs.createReadStream(url);

stream.pipe(process.stdout);
```

would cause the following error:

```
"Uncaught TypeError: The "path" argument must be of type string or an instance of Buffer or URL. Received an instance of URL", source: internal/fs/utils.js (541)
```

To remedy this, I think we should instead switch on properties guaranteed to be present in all URL instances as specified by the WHATWG.

cc @jasnell 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-  [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
