### PR TITLE
build: enable build for node-v8 push

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - canary
 
 env:
   PYTHON_VERSION: 3.8

--- a/.github/workflows/test-asan.yml
+++ b/.github/workflows/test-asan.yml
@@ -3,12 +3,13 @@ name: test-asan
 on:
   push:
     branches:
-    - master
+      - master
+      - canary
     paths-ignore:
-    - 'doc/**'
+      - 'doc/**'
   pull_request:
     paths-ignore:
-    - 'doc/**'
+      - 'doc/**'
 
 env:
   PYTHON_VERSION: 3.8

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - canary
 
 env:
   PYTHON_VERSION: 3.8

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - canary
 
 env:
   PYTHON_VERSION: 3.8


### PR DESCRIPTION
This mainly enable daily check for https://github.com/nodejs/node-v8.
This is pretty useful when talk to v8 team when build failure.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
