### PR TITLE
module: custom --conditions flag option

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -76,7 +76,7 @@ $ node --completion-bash > node_bash_completion
 $ source node_bash_completion
 ```
 
-### `-cc`, `--conditions=conditionA,conditionB`
+### `--conditions=conditionA,conditionB`
 <!-- YAML
 added: REPLACEME
 -->
@@ -1247,6 +1247,7 @@ node --require "./a.js" --require "./b.js"
 
 Node.js options that are allowed are:
 <!-- node-options-node start -->
+* `--conditions`
 * `--diagnostic-dir`
 * `--disable-proto`
 * `--enable-fips`

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -76,7 +76,7 @@ $ node --completion-bash > node_bash_completion
 $ source node_bash_completion
 ```
 
-### `--conditions=conditionA,conditionB`
+### `-m`, `--conditions=conditionA,conditionB`
 <!-- YAML
 added: REPLACEME
 -->
@@ -1247,7 +1247,7 @@ node --require "./a.js" --require "./b.js"
 
 Node.js options that are allowed are:
 <!-- node-options-node start -->
-* `--conditions`
+* `--conditions`, `-m`
 * `--diagnostic-dir`
 * `--disable-proto`
 * `--enable-fips`

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -88,7 +88,7 @@ conditions.
 
 Any custom comma-separated string condition names are permitted.
 
-The default Node.js conditions of `"node"`, `"default"`, `"import"` and
+The default Node.js conditions of `"node"`, `"default"`, `"import"`, and
 `"require"` will always apply as defined.
 
 ### `--cpu-prof`

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -76,6 +76,21 @@ $ node --completion-bash > node_bash_completion
 $ source node_bash_completion
 ```
 
+### `-cc`, `--conditions=conditionA,conditionB`
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+Enable experimental support for custom conditional exports resolution
+conditions.
+
+Any custom comma-separated string condition names are permitted.
+
+The default Node.js conditions of `"node"`, `"default"`, `"import"` and
+`"require"` will always apply as defined.
+
 ### `--cpu-prof`
 <!-- YAML
 added: v12.0.0

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -76,7 +76,7 @@ $ node --completion-bash > node_bash_completion
 $ source node_bash_completion
 ```
 
-### `-u`, `--conditions=conditionA,conditionB`
+### `-u`, `--conditions=condition`
 <!-- YAML
 added: REPLACEME
 -->
@@ -86,7 +86,7 @@ added: REPLACEME
 Enable experimental support for custom conditional exports resolution
 conditions.
 
-Any custom comma-separated string condition names are permitted.
+Any number of custom string condition names are permitted.
 
 The default Node.js conditions of `"node"`, `"default"`, `"import"`, and
 `"require"` will always apply as defined.

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -76,7 +76,7 @@ $ node --completion-bash > node_bash_completion
 $ source node_bash_completion
 ```
 
-### `-m`, `--conditions=conditionA,conditionB`
+### `-u`, `--conditions=conditionA,conditionB`
 <!-- YAML
 added: REPLACEME
 -->
@@ -1247,7 +1247,7 @@ node --require "./a.js" --require "./b.js"
 
 Node.js options that are allowed are:
 <!-- node-options-node start -->
-* `--conditions`, `-m`
+* `--conditions`, `-u`
 * `--diagnostic-dir`
 * `--disable-proto`
 * `--enable-fips`

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -504,14 +504,14 @@ conditions behave analogously to nested JavaScript `if` statements.
 #### Resolving custom conditions
 
 When running Node.js, custom comma-separated conditions can be set with the
-`--conditions` or `-m` flag:
+`--conditions` or `-u` flag:
 
 ```bash
 node --conditions=development main.js
 ```
 
 which would then resolve the `"development"` condition in exports, along with
-the existing `"node"`, `"default"`, `"import"` and `"require"` conditions as
+the existing `"node"`, `"default"`, `"import"`, and `"require"` conditions as
 appropriate.
 
 #### Self-referencing a package using its name

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -475,6 +475,17 @@ order to support packages with conditional exports. For this reason, using
 `"node"` and `"default"` condition branches is usually preferable to using
 `"node"` and `"browser"` condition branches.
 
+When running Node.js, custom comma-separated conditions can be set with the
+`--conditions` or `-m` flag:
+
+```bash
+node --conditions=development main.js
+```
+
+which would then resolve the `"development"` condition in exports, along with
+the existing `"node"`, `"default"`, `"import"` and `"require"` conditions as
+appropriate.
+
 #### Nested conditions
 
 In addition to direct mappings, Node.js also supports nested condition objects.

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -501,18 +501,20 @@ a nested conditional does not have any mapping it will continue checking
 the remaining conditions of the parent condition. In this way nested
 conditions behave analogously to nested JavaScript `if` statements.
 
-#### Resolving custom conditions
+#### Resolving user conditions
 
-When running Node.js, custom comma-separated conditions can be set with the
+When running Node.js, custom user conditions can be added with the
 `--conditions` or `-u` flag:
 
 ```bash
 node --conditions=development main.js
 ```
 
-which would then resolve the `"development"` condition in exports, along with
-the existing `"node"`, `"default"`, `"import"`, and `"require"` conditions as
-appropriate.
+which would then resolve the `"development"` condition in package imports and
+exports, while resolving the existing `"node"`, `"default"`, `"import"`, and
+`"require"` conditions as appropriate.
+
+Any number of custom conditions can be set with repeat flags.
 
 #### Self-referencing a package using its name
 

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -501,7 +501,7 @@ a nested conditional does not have any mapping it will continue checking
 the remaining conditions of the parent condition. In this way nested
 conditions behave analogously to nested JavaScript `if` statements.
 
-#### Executing custom conditions
+#### Resolving custom conditions
 
 When running Node.js, custom comma-separated conditions can be set with the
 `--conditions` or `-m` flag:

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -475,17 +475,6 @@ order to support packages with conditional exports. For this reason, using
 `"node"` and `"default"` condition branches is usually preferable to using
 `"node"` and `"browser"` condition branches.
 
-When running Node.js, custom comma-separated conditions can be set with the
-`--conditions` or `-m` flag:
-
-```bash
-node --conditions=development main.js
-```
-
-which would then resolve the `"development"` condition in exports, along with
-the existing `"node"`, `"default"`, `"import"` and `"require"` conditions as
-appropriate.
-
 #### Nested conditions
 
 In addition to direct mappings, Node.js also supports nested condition objects.
@@ -511,6 +500,19 @@ Conditions continue to be matched in order as with flat conditions. If
 a nested conditional does not have any mapping it will continue checking
 the remaining conditions of the parent condition. In this way nested
 conditions behave analogously to nested JavaScript `if` statements.
+
+#### Executing custom conditions
+
+When running Node.js, custom comma-separated conditions can be set with the
+`--conditions` or `-m` flag:
+
+```bash
+node --conditions=development main.js
+```
+
+which would then resolve the `"development"` condition in exports, along with
+the existing `"node"`, `"default"`, `"import"` and `"require"` conditions as
+appropriate.
 
 #### Self-referencing a package using its name
 

--- a/doc/node.1
+++ b/doc/node.1
@@ -78,7 +78,7 @@ Aborting instead of exiting causes a core file to be generated for analysis.
 .It Fl -completion-bash
 Print source-able bash completion script for Node.js.
 .
-.It Fl m , Fl -conditions Ar string
+.It Fl u , Fl -conditions Ar string
 Use custom conditional exports conditions
 .Ar string
 .

--- a/doc/node.1
+++ b/doc/node.1
@@ -78,7 +78,7 @@ Aborting instead of exiting causes a core file to be generated for analysis.
 .It Fl -completion-bash
 Print source-able bash completion script for Node.js.
 .
-.It Fl cc , Fl -conditions Ar string
+.It Fl -conditions Ar string
 Use custom conditional exports conditions
 .Ar string
 .

--- a/doc/node.1
+++ b/doc/node.1
@@ -78,7 +78,7 @@ Aborting instead of exiting causes a core file to be generated for analysis.
 .It Fl -completion-bash
 Print source-able bash completion script for Node.js.
 .
-.It Fl -conditions Ar string
+.It Fl m , Fl -conditions Ar string
 Use custom conditional exports conditions
 .Ar string
 .

--- a/doc/node.1
+++ b/doc/node.1
@@ -78,6 +78,10 @@ Aborting instead of exiting causes a core file to be generated for analysis.
 .It Fl -completion-bash
 Print source-able bash completion script for Node.js.
 .
+.It Fl cc , Fl -conditions Ar string
+Use custom conditional exports conditions
+.Ar string
+.
 .It Fl -cpu-prof
 Start the V8 CPU profiler on start up, and write the CPU profile to disk
 before exit. If

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -85,8 +85,7 @@ const manifest = getOptionValue('--experimental-policy') ?
   require('internal/process/policy').manifest :
   null;
 const { compileFunction } = internalBinding('contextify');
-const userConditions = getOptionValue('--conditions') &&
-    StringPrototypeSplit(getOptionValue('--conditions'), ',');
+const userConditions = getOptionValue('--conditions');
 
 // Whether any user-provided CJS modules had been loaded (executed).
 // Used for internal assertions.

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -85,6 +85,7 @@ const manifest = getOptionValue('--experimental-policy') ?
   require('internal/process/policy').manifest :
   null;
 const { compileFunction } = internalBinding('contextify');
+const userConditions = (getOptionValue('--conditions') || '').split(',');
 
 // Whether any user-provided CJS modules had been loaded (executed).
 // Used for internal assertions.
@@ -625,23 +626,14 @@ function resolveExportsTarget(baseUrl, target, subpath, mappingKey) {
           'contain numeric property keys.');
     }
     for (const p of keys) {
-      switch (p) {
-        case 'node':
-        case 'require':
-          try {
-            return resolveExportsTarget(baseUrl, target[p], subpath,
-                                        mappingKey);
-          } catch (e) {
-            if (e.code !== 'ERR_PACKAGE_PATH_NOT_EXPORTED') throw e;
-          }
-          break;
-        case 'default':
-          try {
-            return resolveExportsTarget(baseUrl, target.default, subpath,
-                                        mappingKey);
-          } catch (e) {
-            if (e.code !== 'ERR_PACKAGE_PATH_NOT_EXPORTED') throw e;
-          }
+      if (cjsConditions.has(p) || p === 'default') {
+        try {
+          return resolveExportsTarget(baseUrl, target[p], subpath,
+                                      mappingKey);
+        } catch (e) {
+          if (e.code !== 'ERR_PACKAGE_PATH_NOT_EXPORTED') throw e;
+        }
+        break;
       }
     }
     throw new ERR_PACKAGE_PATH_NOT_EXPORTED(
@@ -1006,7 +998,7 @@ Module._load = function(request, parent, isMain) {
 };
 
 // TODO: Use this set when resolving pkg#exports conditions.
-const cjsConditions = new SafeSet(['require', 'node']);
+const cjsConditions = new SafeSet(['require', 'node', ...userConditions]);
 Module._resolveFilename = function(request, parent, isMain, options) {
   if (NativeModule.canBeRequiredByUsers(request)) {
     return request;

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -1009,7 +1009,6 @@ Module._load = function(request, parent, isMain) {
   return module.exports;
 };
 
-// TODO: Use this set when resolving pkg#exports conditions.
 const cjsConditions = new SafeSet(['require', 'node', ...userConditions]);
 Module._resolveFilename = function(request, parent, isMain, options) {
   if (NativeModule.canBeRequiredByUsers(request)) {

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -86,7 +86,7 @@ const manifest = getOptionValue('--experimental-policy') ?
   null;
 const { compileFunction } = internalBinding('contextify');
 const userConditions = getOptionValue('--conditions') &&
-    getOptionValue('--conditions').split(',');
+    StringPrototypeSplit(getOptionValue('--conditions'), ',');
 
 // Whether any user-provided CJS modules had been loaded (executed).
 // Used for internal assertions.

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -85,7 +85,8 @@ const manifest = getOptionValue('--experimental-policy') ?
   require('internal/process/policy').manifest :
   null;
 const { compileFunction } = internalBinding('contextify');
-const userConditions = (getOptionValue('--conditions') || '').split(',');
+const userConditions = getOptionValue('--conditions') &&
+    getOptionValue('--conditions').split(',');
 
 // Whether any user-provided CJS modules had been loaded (executed).
 // Used for internal assertions.
@@ -498,8 +499,12 @@ function applyExports(basePath, expansion) {
   if (typeof pkgExports === 'object') {
     if (ObjectPrototypeHasOwnProperty(pkgExports, mappingKey)) {
       const mapping = pkgExports[mappingKey];
-      return resolveExportsTarget(pathToFileURL(basePath + '/'), mapping, '',
-                                  mappingKey);
+      const resolved = resolveExportsTarget(
+        pathToFileURL(basePath + '/'), mapping, '', mappingKey);
+      if (resolved === null || resolved === undefined)
+        throw new ERR_PACKAGE_PATH_NOT_EXPORTED(
+          basePath, mappingKey);
+      return resolved;
     }
 
     let dirMatch = '';
@@ -516,6 +521,9 @@ function applyExports(basePath, expansion) {
       const subpath = StringPrototypeSlice(mappingKey, dirMatch.length);
       const resolved = resolveExportsTarget(pathToFileURL(basePath + '/'),
                                             mapping, subpath, mappingKey);
+      if (resolved === null || resolved === undefined)
+        throw new ERR_PACKAGE_PATH_NOT_EXPORTED(
+          basePath, mappingKey + subpath);
       // Extension searching for folder exports only
       const rc = stat(resolved);
       if (rc === 0) return resolved;
@@ -603,21 +611,29 @@ function resolveExportsTarget(baseUrl, target, subpath, mappingKey) {
     throw new ERR_INVALID_MODULE_SPECIFIER(mappingKey + subpath, reason);
   } else if (ArrayIsArray(target)) {
     if (target.length === 0)
-      throw new ERR_PACKAGE_PATH_NOT_EXPORTED(
-        baseUrl.pathname, mappingKey + subpath);
+      return null;
     let lastException;
     for (const targetValue of target) {
+      let resolved;
       try {
-        return resolveExportsTarget(baseUrl, targetValue, subpath, mappingKey);
+        resolved = resolveExportsTarget(baseUrl, targetValue, subpath,
+                                        mappingKey);
       } catch (e) {
         lastException = e;
-        if (e.code !== 'ERR_PACKAGE_PATH_NOT_EXPORTED' &&
-            e.code !== 'ERR_INVALID_PACKAGE_TARGET')
+        if (e.code !== 'ERR_INVALID_PACKAGE_TARGET')
           throw e;
       }
+      if (resolved === undefined)
+        continue;
+      if (resolved === null) {
+        lastException = null;
+        continue;
+      }
+      return resolved;
     }
     // Throw last fallback error
-    assert(lastException !== undefined);
+    if (lastException === undefined || lastException === null)
+      return lastException;
     throw lastException;
   } else if (typeof target === 'object' && target !== null) {
     const keys = ObjectKeys(target);
@@ -627,20 +643,16 @@ function resolveExportsTarget(baseUrl, target, subpath, mappingKey) {
     }
     for (const p of keys) {
       if (cjsConditions.has(p) || p === 'default') {
-        try {
-          return resolveExportsTarget(baseUrl, target[p], subpath,
-                                      mappingKey);
-        } catch (e) {
-          if (e.code !== 'ERR_PACKAGE_PATH_NOT_EXPORTED') throw e;
-        }
-        break;
+        const resolved = resolveExportsTarget(baseUrl, target[p], subpath,
+                                              mappingKey);
+        if (resolved === undefined)
+          continue;
+        return resolved;
       }
     }
-    throw new ERR_PACKAGE_PATH_NOT_EXPORTED(
-      baseUrl.pathname, mappingKey + subpath);
+    return undefined;
   } else if (target === null) {
-    throw new ERR_PACKAGE_PATH_NOT_EXPORTED(
-      baseUrl.pathname, mappingKey + subpath);
+    return null;
   }
   throw new ERR_INVALID_PACKAGE_TARGET(baseUrl.pathname, mappingKey, target);
 }

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -51,7 +51,8 @@ const {
 const { Module: CJSModule } = require('internal/modules/cjs/loader');
 
 const packageJsonReader = require('internal/modules/package_json_reader');
-const DEFAULT_CONDITIONS = ObjectFreeze(['node', 'import']);
+const userConditions = (getOptionValue('--conditions') || '').split(',');
+const DEFAULT_CONDITIONS = ObjectFreeze(['node', 'import', ...userConditions]);
 const DEFAULT_CONDITIONS_SET = new SafeSet(DEFAULT_CONDITIONS);
 
 

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -52,7 +52,7 @@ const { Module: CJSModule } = require('internal/modules/cjs/loader');
 
 const packageJsonReader = require('internal/modules/package_json_reader');
 const userConditions = getOptionValue('--conditions') &&
-    getOptionValue('--conditions').split(',');
+    StringPrototypeSplit(getOptionValue('--conditions'), ',');
 const DEFAULT_CONDITIONS = ObjectFreeze(['node', 'import', ...userConditions]);
 const DEFAULT_CONDITIONS_SET = new SafeSet(DEFAULT_CONDITIONS);
 

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -51,7 +51,8 @@ const {
 const { Module: CJSModule } = require('internal/modules/cjs/loader');
 
 const packageJsonReader = require('internal/modules/package_json_reader');
-const userConditions = (getOptionValue('--conditions') || '').split(',');
+const userConditions = getOptionValue('--conditions') &&
+    getOptionValue('--conditions').split(',');
 const DEFAULT_CONDITIONS = ObjectFreeze(['node', 'import', ...userConditions]);
 const DEFAULT_CONDITIONS_SET = new SafeSet(DEFAULT_CONDITIONS);
 
@@ -360,12 +361,9 @@ function isArrayIndex(key) {
 function resolvePackageTarget(
   packageJSONUrl, target, subpath, packageSubpath, base, internal, conditions) {
   if (typeof target === 'string') {
-    const resolved = resolvePackageTargetString(
+    return finalizeResolution(resolvePackageTargetString(
       target, subpath, packageSubpath, packageJSONUrl, base, internal,
-      conditions);
-    if (resolved === null)
-      return null;
-    return finalizeResolution(resolved, base);
+      conditions), base);
   } else if (ArrayIsArray(target)) {
     if (target.length === 0)
       return null;

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -51,8 +51,7 @@ const {
 const { Module: CJSModule } = require('internal/modules/cjs/loader');
 
 const packageJsonReader = require('internal/modules/package_json_reader');
-const userConditions = getOptionValue('--conditions') &&
-    StringPrototypeSplit(getOptionValue('--conditions'), ',');
+const userConditions = getOptionValue('--conditions');
 const DEFAULT_CONDITIONS = ObjectFreeze(['node', 'import', ...userConditions]);
 const DEFAULT_CONDITIONS_SET = new SafeSet(DEFAULT_CONDITIONS);
 

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -285,7 +285,7 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "set the conditional exports conditions",
             &EnvironmentOptions::conditions,
             kAllowedInEnvironment);
-  AddAlias("-m", "--conditions");
+  AddAlias("-u", "--conditions");
   AddOption("--diagnostic-dir",
             "set dir for all output files"
             " (default: current working directory)",

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -281,6 +281,11 @@ DebugOptionsParser::DebugOptionsParser() {
 }
 
 EnvironmentOptionsParser::EnvironmentOptionsParser() {
+  AddOption("--conditions",
+            "set the conditional exports conditions",
+            &EnvironmentOptions::conditions,
+            kAllowedInEnvironment);
+  AddAlias("-cc", "--conditions");
   AddOption("--diagnostic-dir",
             "set dir for all output files"
             " (default: current working directory)",

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -285,7 +285,6 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "set the conditional exports conditions",
             &EnvironmentOptions::conditions,
             kAllowedInEnvironment);
-  AddAlias("-cc", "--conditions");
   AddOption("--diagnostic-dir",
             "set dir for all output files"
             " (default: current working directory)",

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -282,7 +282,7 @@ DebugOptionsParser::DebugOptionsParser() {
 
 EnvironmentOptionsParser::EnvironmentOptionsParser() {
   AddOption("--conditions",
-            "set the conditional exports conditions",
+            "additional user conditions for conditional exports and imports",
             &EnvironmentOptions::conditions,
             kAllowedInEnvironment);
   AddAlias("-u", "--conditions");

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -285,6 +285,7 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "set the conditional exports conditions",
             &EnvironmentOptions::conditions,
             kAllowedInEnvironment);
+  AddAlias("-m", "--conditions");
   AddOption("--diagnostic-dir",
             "set dir for all output files"
             " (default: current working directory)",

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -100,7 +100,7 @@ class DebugOptions : public Options {
 class EnvironmentOptions : public Options {
  public:
   bool abort_on_uncaught_exception = false;
-  std::string conditions;
+  std::vector<std::string> conditions;
   bool enable_source_maps = false;
   bool experimental_json_modules = false;
   bool experimental_modules = false;

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -100,6 +100,7 @@ class DebugOptions : public Options {
 class EnvironmentOptions : public Options {
  public:
   bool abort_on_uncaught_exception = false;
+  std::string conditions;
   bool enable_source_maps = false;
   bool experimental_json_modules = false;
   bool experimental_modules = false;

--- a/test/es-module/test-esm-custom-exports.mjs
+++ b/test/es-module/test-esm-custom-exports.mjs
@@ -1,0 +1,10 @@
+// Flags: --conditions=custom-condition,another
+import { mustCall } from '../common/index.mjs';
+import { strictEqual } from 'assert';
+import { requireFixture, importFixture } from '../fixtures/pkgexports.mjs';
+[requireFixture, importFixture].forEach((loadFixture) => {
+  loadFixture('pkgexports/condition')
+    .then(mustCall((actual) => {
+      strictEqual(actual.default, 'from custom condition');
+    }));
+});

--- a/test/es-module/test-esm-custom-exports.mjs
+++ b/test/es-module/test-esm-custom-exports.mjs
@@ -1,4 +1,4 @@
-// Flags: --conditions=custom-condition,another
+// Flags: --conditions=custom-condition -u another
 import { mustCall } from '../common/index.mjs';
 import { strictEqual } from 'assert';
 import { requireFixture, importFixture } from '../fixtures/pkgexports.mjs';

--- a/test/fixtures/node_modules/pkgexports/custom-condition.js
+++ b/test/fixtures/node_modules/pkgexports/custom-condition.js
@@ -1,0 +1,1 @@
+module.exports = 'from custom condition';

--- a/test/fixtures/node_modules/pkgexports/package.json
+++ b/test/fixtures/node_modules/pkgexports/package.json
@@ -21,7 +21,10 @@
     "./nofallback2": [null, {}, "builtin:x"],
     "./nodemodules": "./node_modules/internalpkg/x.js",
     "./condition": [{
-      "custom-condition": "./custom-condition.mjs",
+      "custom-condition": {
+        "import": "./custom-condition.mjs",
+        "require": "./custom-condition.js"
+      },
       "import": "///overridden",
       "require": {
         "require": {


### PR DESCRIPTION
This implements a `node --conditions=custom` flag for supporting custom resolution conditions in conditional exports, as previously discussed in https://github.com/nodejs/modules/issues/537. A short alias variant, `-u=custom` is also provided, which stands for "user conditions".

Any custom condition names can be provided as repeated flags, but the core `node`, `default`, `require` and `import` conditions cannot be changed.

In the process a couple of conditional resolution edge ase bugs are fixed as well here.

@nodejs/modules-active-members 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
