### PR TITLE
doc: harden policy around objections

### DIFF
--- a/doc/guides/collaborator-guide.md
+++ b/doc/guides/collaborator-guide.md
@@ -128,7 +128,7 @@ not land until all objections are satisfied. Collaborators should not block a
 pull request without providing a reason. **Providing a set of actionable steps
 alongside the objection is recommended, and the objector must be willing to
 work with the pull request author to reach a consensus about the direction of
-the pull reuqest**. If reaching consensus is not possible, a Collaborator may
+the pull request**. If reaching consensus is not possible, a Collaborator may
 escalate the issue to the TSC.
 
 If the objection is not clear to others, another Collaborator may ask an

--- a/doc/guides/collaborator-guide.md
+++ b/doc/guides/collaborator-guide.md
@@ -120,14 +120,22 @@ needed [approvals](#code-reviews), [CI](#testing-and-ci), and
 except the [wait time](#waiting-for-approvals), please add the
 [`author ready`](#author-ready-pull-requests) label.
 
-Where there is disagreement among Collaborators, consensus should be sought if
-possible. If reaching consensus is not possible, a Collaborator may escalate the
-issue to the TSC.
+If a collaborator believes a pull request should not land as is, **the "Reuqest
+Changes" GitHub feature must be used to make the objection explicit**. An
+implicit objection not using the "Request Changes" feature is not considered a
+blocker for a  pull requests. Pull requests with an explicit objection should
+not land until all objections are satisfied. Collaborators should not block a
+pull request without providing a reason. **Providing a set of actionable steps
+alongside the objection is recommended, and the objector must be willing to
+work with the pull request author to reach a consensus about the direction of
+the pull reuqest**. If reaching consensus is not possible, a Collaborator may
+escalate the issue to the TSC.
 
-Collaborators should not block a pull request without providing a reason.
-Another Collaborator may ask an objecting Collaborator to explain their
-objection. If the objector is unresponsive, another Collaborator may dismiss the
-objection.
+If the objection is not clear to others, another Collaborator may ask an
+objecting Collaborator to explain their objection or to provide actionable
+steps to resolve the objection. **If the objector is unresponsive for seven
+days after a collaborator asks for clarification, another Collaborator may
+dismiss the objection**.
 
 [Breaking changes](#breaking-changes) must receive
 [TSC review](#involving-the-tsc). If two TSC members approve the pull request

--- a/doc/guides/collaborator-guide.md
+++ b/doc/guides/collaborator-guide.md
@@ -120,7 +120,7 @@ needed [approvals](#code-reviews), [CI](#testing-and-ci), and
 except the [wait time](#waiting-for-approvals), please add the
 [`author ready`](#author-ready-pull-requests) label.
 
-If a collaborator believes a pull request should not land as is, **the "Reuqest
+If a collaborator believes a pull request should not land as is, **the "Request
 Changes" GitHub feature must be used to make the objection explicit**. An
 implicit objection not using the "Request Changes" feature is not considered a
 blocker for a  pull requests. Pull requests with an explicit objection should

--- a/doc/guides/collaborator-guide.md
+++ b/doc/guides/collaborator-guide.md
@@ -123,7 +123,7 @@ except the [wait time](#waiting-for-approvals), please add the
 If a collaborator believes a pull request should not land as is, **the "Request
 Changes" GitHub feature must be used to make the objection explicit**. An
 implicit objection not using the "Request Changes" feature is not considered a
-blocker for a  pull requests. Pull requests with an explicit objection should
+blocker for a pull request. Pull requests with an explicit objection should
 not land until all objections are satisfied. Collaborators should not block a
 pull request without providing a reason. **Providing a set of actionable steps
 alongside the objection is recommended, and the objector must be willing to

--- a/doc/guides/collaborator-guide.md
+++ b/doc/guides/collaborator-guide.md
@@ -122,7 +122,7 @@ except the [wait time](#waiting-for-approvals), please add the
 
 If a collaborator believes a pull request should not land as is, **the "Request
 Changes" GitHub feature must be used to make the objection explicit**. An
-implicit objection not using the "Request Changes" feature is not considered a
+implicit objection not using the "Request Changes" feature is not a
 blocker for a pull request. Pull requests with an explicit objection should
 not land until all objections are satisfied. Collaborators should not block a
 pull request without providing a reason. **Providing a set of actionable steps


### PR DESCRIPTION
Harden policy around objections to avoid misunderstanding and to
encourage collaboration between pull request authors and objectors.

Fixes: https://github.com/nodejs/node/issues/34564

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
