### PR TITLE
build,deps: add gen-openssl target

### DIFF
--- a/deps/openssl/config/Dockerfile
+++ b/deps/openssl/config/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:20.04
+
+VOLUME /node
+
+RUN buildDeps='binutils build-essential vim nasm git' \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends --force-yes $buildDeps \
+  && apt-get clean \
+  && apt-get autoremove -y \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+WORKDIR /node

--- a/doc/guides/maintaining-openssl.md
+++ b/doc/guides/maintaining-openssl.md
@@ -80,6 +80,10 @@ The patch is currently supported only for openssl-1.1.1e.
 Use `make` to regenerate all platform dependent files in
 `deps/openssl/config/archs/`:
 ```console
+# On non-linux machines
+% make gen-openssl
+
+# On Linux machine
 % make -C deps/openssl/config
 ```
 


### PR DESCRIPTION
This adds a new make target to generate platform dependent
files for openssl on non-linux machines. The scripts we currently
have in place require linux. This adds a Dockerfile that installs
the necessary dependencies to be able to generate these files.

Previously, it was necessary to run `make -C deps/openssl/config`
on a linux machine. Now, as long as docker is installed and in
your `PATH`, it is possible to run `make gen-openssl`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
