### PR TITLE
repl: use _Node.js_ in user-facing REPL text

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -790,7 +790,7 @@ function REPLServer(prompt,
 
       if (e && !self[kBufferedCommandSymbol] && cmd.trim().startsWith('npm ')) {
         self.output.write('npm should be run outside of the ' +
-                                'node REPL, in your normal shell.\n' +
+                                'Node.js REPL, in your normal shell.\n' +
                                 '(Press Control-D to exit.)\n');
         self.displayPrompt();
         return;

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -372,7 +372,7 @@ const errorTests = [
   {
     send: 'npm install foobar',
     expect: [
-      'npm should be run outside of the node REPL, in your normal shell.',
+      'npm should be run outside of the Node.js REPL, in your normal shell.',
       '(Press Control-D to exit.)'
     ]
   },


### PR DESCRIPTION
We use _node (REPL)_ in one place and _Node.js (REPL)_ in another place
in error messages in repl.js. Use _Node.js_ in both places.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
