### PR TITLE
src: set SA_SIGINFO flag when using sa_sigaction

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -543,7 +543,7 @@ void RegisterSignalHandler(int signal,
   struct sigaction sa;
   memset(&sa, 0, sizeof(sa));
   sa.sa_sigaction = handler;
-  sa.sa_flags = reset_handler ? SA_RESETHAND | SA_SIGINFO : SA_SIGINFO;
+  sa.sa_flags = SA_SIGINFO | (reset_handler ? SA_RESETHAND : 0);
   sigfillset(&sa.sa_mask);
   CHECK_EQ(sigaction(signal, &sa, nullptr), 0);
 }

--- a/src/node.cc
+++ b/src/node.cc
@@ -543,7 +543,7 @@ void RegisterSignalHandler(int signal,
   struct sigaction sa;
   memset(&sa, 0, sizeof(sa));
   sa.sa_sigaction = handler;
-  sa.sa_flags = reset_handler ? SA_RESETHAND : 0;
+  sa.sa_flags = reset_handler ? SA_RESETHAND | SA_SIGINFO : SA_SIGINFO;
   sigfillset(&sa.sa_mask);
   CHECK_EQ(sigaction(signal, &sa, nullptr), 0);
 }
@@ -638,6 +638,7 @@ inline void PlatformInit() {
     struct sigaction sa;
     memset(&sa, 0, sizeof(sa));
     sa.sa_sigaction = TrapWebAssemblyOrContinue;
+    sa.sa_flags = SA_SIGINFO;
     CHECK_EQ(sigaction(SIGSEGV, &sa, nullptr), 0);
   }
   V8::EnableWebAssemblyTrapHandler(false);

--- a/test/addons/register-signal-handler/binding.cc
+++ b/test/addons/register-signal-handler/binding.cc
@@ -13,6 +13,7 @@ using v8::Value;
 void Handler(int signo, siginfo_t* siginfo, void* ucontext) {
   char signo_char = signo;
   int written;
+  assert(signo == siginfo->si_signo);
   do {
     written = write(1, &signo_char, 1);  // write() is signal-safe.
   } while (written == -1 && errno == EINTR);


### PR DESCRIPTION
For `sigaction()` the `SA_SIGINFO` flag should be set when setting
the handler via the `sa_sigaction` member of the `sigaction` struct.

This unfortunately doesn't fix https://github.com/nodejs/node/issues/34410 but AFAICT looks correct based 
on the [`sigaction()` docs](https://pubs.opengroup.org/onlinepubs/9699919799/functions/sigaction.html).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
