### PR TITLE
build: run CI on release branches

### DIFF
--- a/.github/workflows/build-tarball.yml
+++ b/.github/workflows/build-tarball.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - master
+      - v[0-9]+.x-staging
+      - v[0-9]+.x
 
 env:
   FLAKY_TESTS: dontcare

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - master
       - canary
+      - v[0-9]+.x-staging
+      - v[0-9]+.x
 
 env:
   PYTHON_VERSION: 3.8

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - master
+      - v[0-9]+.x-staging
+      - v[0-9]+.x
 
 env:
   PYTHON_VERSION: 3.8

--- a/.github/workflows/misc.yml
+++ b/.github/workflows/misc.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - master
+      - v[0-9]+.x-staging
+      - v[0-9]+.x
 
 env:
   NODE_VERSION: 12.x

--- a/.github/workflows/test-asan.yml
+++ b/.github/workflows/test-asan.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - master
       - canary
+      - v[0-9]+.x-staging
+      - v[0-9]+.x
     paths-ignore:
       - 'doc/**'
   pull_request:

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - master
       - canary
+      - v[0-9]+.x-staging
+      - v[0-9]+.x
 
 env:
   PYTHON_VERSION: 3.8

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - master
       - canary
+      - v[0-9]+.x-staging
+      - v[0-9]+.x
 
 env:
   PYTHON_VERSION: 3.8


### PR DESCRIPTION
We also want to run CI on release-related branches, e.g [`v14.x-staging`](https://github.com/nodejs/node/commits/v14.x-staging) so that Releasers can see if any commits they pushed may have caused issues before opening proposal branches.

cc @MylesBorins 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
