### PR TITLE
build: do not run auto-start-ci on forks

### DIFF
--- a/.github/workflows/auto-start-ci.yml
+++ b/.github/workflows/auto-start-ci.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   startCI:
+    if: github.repository == 'nodejs/node'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master


### PR DESCRIPTION
Previously, the auto-start-ci action would run on forks.
Without the secrets, the action would fail over and over again.
This caused a lot of email spam. Now, we only run this action
when the repository is nodejs/node.

/cc @mmarchini I think this should work, although I'm not sure how to test...

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
