### PR TITLE
async_hooks: avoid GC tracking of AsyncResource in ALS

### DIFF
--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -253,6 +253,7 @@ const storageHook = createHook({
   }
 });
 
+const defaultAlsResourceOpts = { requireManualDestroy: true };
 class AsyncLocalStorage {
   constructor() {
     this.kResourceStore = Symbol('kResourceStore');
@@ -293,8 +294,11 @@ class AsyncLocalStorage {
     if (ObjectIs(store, this.getStore())) {
       return callback(...args);
     }
-    const resource = new AsyncResource('AsyncLocalStorage');
-    return resource.runInAsyncScope(() => {
+    const resource = new AsyncResource('AsyncLocalStorage',
+                                       defaultAlsResourceOpts);
+    // Calling emitDestroy before runInAsyncScope avoids a try/finally
+    // It is ok because emitDestroy only schedules calling the hook
+    return resource.emitDestroy().runInAsyncScope(() => {
       this.enterWith(store);
       return callback(...args);
     });


### PR DESCRIPTION
Manually destroy the `AsyncResource` created by `AsyncLocalStore.run()` to avoid unneeded GC tracking in case a destroy hooks is present.
