### PR TITLE
quic: fixup `setSocket` support

### DIFF
--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -1246,12 +1246,16 @@ empty object when the key exchange is not ephemeral. The supported types are
 
 For example: `{ type: 'ECDH', name: 'prime256v1', size: 256 }`.
 
-#### `quicclientsession.setSocket(socket])`
+#### `quicclientsession.setSocket(socket[, natRebinding])`
 <!-- YAML
 added: REPLACEME
 -->
 
 * `socket` {QuicSocket} A `QuicSocket` instance to move this session to.
+* `natRebinding` {boolean} When `true`, indicates that the local address is to
+  be changed without triggering address validation. This will be rare and will
+  typically be used only to test resiliency in NAT rebind scenarios.
+  **Default**: `false`.
 * Returns: {Promise}
 
 Migrates the `QuicClientSession` to the given `QuicSocket` instance. If the new

--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -1803,8 +1803,10 @@ class QuicSession extends EventEmitter {
     }, depth, options);
   }
 
-  [kSetSocket](socket) {
+  [kSetSocket](socket, natRebinding = false) {
     this[kInternalState].socket = socket;
+    if (socket !== undefined)
+      this[kHandle].setSocket(socket[kHandle], natRebinding);
   }
 
   // Called at the completion of the TLS handshake for the local peer
@@ -2432,7 +2434,7 @@ class QuicClientSession extends QuicSession {
       {};
   }
 
-  async setSocket(socket) {
+  async setSocket(socket, natRebinding = false) {
     if (this.destroyed)
       throw new ERR_INVALID_STATE('QuicClientSession is already destroyed');
     if (this.closing)
@@ -2460,7 +2462,7 @@ class QuicClientSession extends QuicSession {
       this[kSetSocket](undefined);
     }
     socket[kAddSession](this);
-    this[kSetSocket](socket);
+    this[kSetSocket](socket, natRebinding);
   }
 }
 

--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -2445,6 +2445,8 @@ class QuicClientSession extends QuicSession {
       throw new ERR_INVALID_STATE('QuicSocket is already destroyed');
     if (socket.closing)
       throw new ERR_INVALID_STATE('QuicSocket is closing');
+    if (typeof natRebinding !== 'boolean')
+      throw new ERR_INVALID_ARG_TYPE('natRebinding', 'boolean', true);
 
     await socket[kMaybeBind]();
 

--- a/test/parallel/test-quic-simple-client-migrate.js
+++ b/test/parallel/test-quic-simple-client-migrate.js
@@ -69,6 +69,17 @@ const server = createQuicSocket({ server: options });
     const s1 = req.socket;
     const a1 = req.socket.endpoints[0].address;
 
+    await Promise.all([1, {}, 'test', false, null, undefined].map((i) => {
+      return assert.rejects(req.setSocket(i), {
+        code: 'ERR_INVALID_ARG_TYPE'
+      });
+    }));
+    await Promise.all([1, {}, 'test', null].map((i) => {
+      return assert.rejects(req.setSocket(req.socket, i), {
+        code: 'ERR_INVALID_ARG_TYPE'
+      });
+    }));
+
     await req.setSocket(client2);
 
     // Verify that it is using a different network endpoint


### PR DESCRIPTION
Ensures that migration to a new `QuicSocket` is working.

This depends on #34618 and #34655, both of which should land first. All but the final three commits in this PR are from those earlier PRs.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
