### PR TITLE
lib: remove ERR_INVALID_OPT_VALUE and ERR_INVALID_OPT_VALUE_ENCODING

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -289,7 +289,7 @@ It can be constructed in a variety of ways.
 added: v5.10.0
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/#####
+    pr-url: https://github.com/nodejs/node/pull/34682
     description: Throw ERR_INVALID_ARG_VALUE instead of ERR_INVALID_OPT_VALUE
                  for invalid input arguments.
   - version: v10.0.0
@@ -358,7 +358,7 @@ A `TypeError` will be thrown if `size` is not a number.
 added: v5.10.0
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/#####
+    pr-url: https://github.com/nodejs/node/pull/34682
     description: Throw ERR_INVALID_ARG_VALUE instead of ERR_INVALID_OPT_VALUE
                  for invalid input arguments.
   - version: v7.0.0
@@ -411,7 +411,7 @@ additional performance that [`Buffer.allocUnsafe()`][] provides.
 added: v5.12.0
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/#####
+    pr-url: https://github.com/nodejs/node/pull/34682
     description: Throw ERR_INVALID_ARG_VALUE instead of ERR_INVALID_OPT_VALUE
                  for invalid input arguments.
 -->

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -288,6 +288,10 @@ It can be constructed in a variety of ways.
 <!-- YAML
 added: v5.10.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/#####
+    description: Throw ERR_INVALID_ARG_VALUE instead of ERR_INVALID_OPT_VALUE
+                 for invalid input arguments.
   - version: v10.0.0
     pr-url: https://github.com/nodejs/node/pull/18129
     description: Attempting to fill a non-zero length buffer with a zero length
@@ -319,7 +323,7 @@ console.log(buf);
 ```
 
 If `size` is larger than
-[`buffer.constants.MAX_LENGTH`][] or smaller than 0, [`ERR_INVALID_OPT_VALUE`][]
+[`buffer.constants.MAX_LENGTH`][] or smaller than 0, [`ERR_INVALID_ARG_VALUE`][]
 is thrown.
 
 If `fill` is specified, the allocated `Buffer` will be initialized by calling
@@ -353,6 +357,10 @@ A `TypeError` will be thrown if `size` is not a number.
 <!-- YAML
 added: v5.10.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/#####
+    description: Throw ERR_INVALID_ARG_VALUE instead of ERR_INVALID_OPT_VALUE
+                 for invalid input arguments.
   - version: v7.0.0
     pr-url: https://github.com/nodejs/node/pull/7079
     description: Passing a negative `size` will now throw an error.
@@ -361,7 +369,7 @@ changes:
 * `size` {integer} The desired length of the new `Buffer`.
 
 Allocates a new `Buffer` of `size` bytes. If `size` is larger than
-[`buffer.constants.MAX_LENGTH`][] or smaller than 0, [`ERR_INVALID_OPT_VALUE`][]
+[`buffer.constants.MAX_LENGTH`][] or smaller than 0, [`ERR_INVALID_ARG_VALUE`][]
 is thrown.
 
 The underlying memory for `Buffer` instances created in this way is *not
@@ -401,12 +409,17 @@ additional performance that [`Buffer.allocUnsafe()`][] provides.
 ### Static method: `Buffer.allocUnsafeSlow(size)`
 <!-- YAML
 added: v5.12.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/#####
+    description: Throw ERR_INVALID_ARG_VALUE instead of ERR_INVALID_OPT_VALUE
+                 for invalid input arguments.
 -->
 
 * `size` {integer} The desired length of the new `Buffer`.
 
 Allocates a new `Buffer` of `size` bytes. If `size` is larger than
-[`buffer.constants.MAX_LENGTH`][] or smaller than 0, [`ERR_INVALID_OPT_VALUE`][]
+[`buffer.constants.MAX_LENGTH`][] or smaller than 0, [`ERR_INVALID_ARG_VALUE`][]
 is thrown. A zero-length `Buffer` is created if `size` is 0.
 
 The underlying memory for `Buffer` instances created in this way is *not
@@ -3258,7 +3271,7 @@ introducing security vulnerabilities into an application.
 [`Buffer.poolSize`]: #buffer_class_property_buffer_poolsize
 [`DataView`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView
 [`ERR_INVALID_BUFFER_SIZE`]: errors.html#ERR_INVALID_BUFFER_SIZE
-[`ERR_INVALID_OPT_VALUE`]: errors.html#ERR_INVALID_OPT_VALUE
+[`ERR_INVALID_ARG_VALUE`]: errors.html#ERR_INVALID_ARG_VALUE
 [`ERR_OUT_OF_RANGE`]: errors.html#ERR_OUT_OF_RANGE
 [`JSON.stringify()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
 [`SharedArrayBuffer`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1378,16 +1378,6 @@ An IP address is not valid.
 The imported module string is an invalid URL, package name, or package subpath
 specifier.
 
-<a id="ERR_INVALID_OPT_VALUE"></a>
-### `ERR_INVALID_OPT_VALUE`
-
-An invalid or unexpected value was passed in an options object.
-
-<a id="ERR_INVALID_OPT_VALUE_ENCODING"></a>
-### `ERR_INVALID_OPT_VALUE_ENCODING`
-
-An invalid or unknown file encoding was passed.
-
 <a id="ERR_INVALID_PACKAGE_CONFIG"></a>
 ### `ERR_INVALID_PACKAGE_CONFIG`
 
@@ -2390,6 +2380,16 @@ Used when an invalid character is found in an HTTP response status message
   removed: v11.0.0
 -->
 A given index was out of the accepted range (e.g. negative offsets).
+
+<a id="ERR_INVALID_OPT_VALUE"></a>
+### `ERR_INVALID_OPT_VALUE`
+
+An invalid or unexpected value was passed in an options object.
+
+<a id="ERR_INVALID_OPT_VALUE_ENCODING"></a>
+### `ERR_INVALID_OPT_VALUE_ENCODING`
+
+An invalid or unknown file encoding was passed.
 
 <a id="ERR_MISSING_MESSAGE_PORT_IN_TRANSFER_LIST"></a>
 ### `ERR_MISSING_MESSAGE_PORT_IN_TRANSFER_LIST`

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -2383,11 +2383,19 @@ A given index was out of the accepted range (e.g. negative offsets).
 
 <a id="ERR_INVALID_OPT_VALUE"></a>
 ### `ERR_INVALID_OPT_VALUE`
+<!-- YAML
+added: v8.0.0
+removed: REPLACEME
+-->
 
 An invalid or unexpected value was passed in an options object.
 
 <a id="ERR_INVALID_OPT_VALUE_ENCODING"></a>
 ### `ERR_INVALID_OPT_VALUE_ENCODING`
+<!-- YAML
+added: v9.0.0
+removed: REPLACEME
+-->
 
 An invalid or unknown file encoding was passed.
 

--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -98,7 +98,7 @@ function Agent(options) {
   this.maxTotalSockets = this.options.maxTotalSockets;
   this.totalSocketCount = 0;
 
-  validateOneOf(this.scheduling, 'scheduling', ['fifo', 'lifo'], true);
+  validateOneOf(this.scheduling, 'scheduling', ['fifo', 'lifo']);
 
   if (this.maxTotalSockets !== undefined) {
     validateNumber(this.maxTotalSockets, 'maxTotalSockets');

--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -32,7 +32,7 @@ const tls = require('tls');
 const {
   ERR_CRYPTO_CUSTOM_ENGINE_NOT_SUPPORTED,
   ERR_INVALID_ARG_TYPE,
-  ERR_INVALID_OPT_VALUE,
+  ERR_INVALID_ARG_VALUE,
   ERR_TLS_INVALID_PROTOCOL_VERSION,
   ERR_TLS_PROTOCOL_VERSION_CONFLICT,
 } = require('internal/errors').codes;
@@ -157,7 +157,7 @@ exports.createSecureContext = function createSecureContext(options) {
     }
 
     if (sigalgs === '') {
-      throw new ERR_INVALID_OPT_VALUE('sigalgs', sigalgs);
+      throw new ERR_INVALID_ARG_VALUE('options.sigalgs', sigalgs);
     }
 
     c.context.setSigalgs(sigalgs);
@@ -167,12 +167,12 @@ exports.createSecureContext = function createSecureContext(options) {
   if (privateKeyIdentifier !== undefined) {
     if (privateKeyEngine === undefined) {
       // Engine is required when privateKeyIdentifier is present
-      throw new ERR_INVALID_OPT_VALUE('privateKeyEngine',
+      throw new ERR_INVALID_ARG_VALUE('options.privateKeyEngine',
                                       privateKeyEngine);
     }
     if (key) {
       // Both data key and engine key can't be set at the same time
-      throw new ERR_INVALID_OPT_VALUE('privateKeyIdentifier',
+      throw new ERR_INVALID_ARG_VALUE('options.privateKeyIdentifier',
                                       privateKeyIdentifier);
     }
 
@@ -210,7 +210,7 @@ exports.createSecureContext = function createSecureContext(options) {
   if (cipherSuites === '' && cipherList === '') {
     // Specifying empty cipher suites for both TLS1.2 and TLS1.3 is invalid, its
     // not possible to handshake with no suites.
-    throw new ERR_INVALID_OPT_VALUE('ciphers', ciphers);
+    throw new ERR_INVALID_ARG_VALUE('options.ciphers', ciphers);
   }
 
   c.context.setCipherSuites(cipherSuites);

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -86,7 +86,6 @@ const {
     ERR_INVALID_ARG_TYPE,
     ERR_INVALID_ARG_VALUE,
     ERR_INVALID_BUFFER_SIZE,
-    ERR_INVALID_OPT_VALUE,
     ERR_OUT_OF_RANGE,
     ERR_UNKNOWN_ENCODING
   },
@@ -342,7 +341,7 @@ const assertSize = hideStackFrames((size) => {
     throw new ERR_INVALID_ARG_TYPE('size', 'number', size);
   }
   if (!(size >= 0 && size <= kMaxLength)) {
-    throw new ERR_INVALID_OPT_VALUE.RangeError('size', size);
+    throw new ERR_INVALID_ARG_VALUE.RangeError('size', size);
   }
 });
 

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -42,8 +42,8 @@ const {
 } = require('internal/dns/utils');
 const {
   ERR_INVALID_ARG_TYPE,
+  ERR_INVALID_ARG_VALUE,
   ERR_INVALID_CALLBACK,
-  ERR_INVALID_OPT_VALUE,
   ERR_MISSING_ARGS,
 } = errors.codes;
 const {
@@ -115,7 +115,7 @@ function lookup(hostname, options, callback) {
     family = options >>> 0;
   }
 
-  validateOneOf(family, 'family', [0, 4, 6], true);
+  validateOneOf(family, 'family', [0, 4, 6]);
 
   if (!hostname) {
     emitInvalidHostnameWarning(hostname);
@@ -171,7 +171,7 @@ function lookupService(address, port, callback) {
     throw new ERR_MISSING_ARGS('address', 'port', 'callback');
 
   if (isIP(address) === 0)
-    throw new ERR_INVALID_OPT_VALUE('address', address);
+    throw new ERR_INVALID_ARG_VALUE('address', address);
 
   validatePort(port);
 
@@ -262,7 +262,7 @@ function resolve(hostname, rrtype, callback) {
   if (typeof resolver === 'function') {
     return resolver.call(this, hostname, callback);
   }
-  throw new ERR_INVALID_OPT_VALUE('rrtype', rrtype);
+  throw new ERR_INVALID_ARG_VALUE('rrtype', rrtype);
 }
 
 function defaultResolverSetServers(servers) {

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -11,8 +11,8 @@ const {
   errnoException,
   codes: {
     ERR_INVALID_ARG_TYPE,
+    ERR_INVALID_ARG_VALUE,
     ERR_INVALID_HANDLE_TYPE,
-    ERR_INVALID_OPT_VALUE,
     ERR_INVALID_SYNC_FORK_INPUT,
     ERR_IPC_CHANNEL_CLOSED,
     ERR_IPC_DISCONNECTED,
@@ -226,7 +226,7 @@ function stdioStringToArray(stdio, channel) {
     case 'pipe': options.push(stdio, stdio, stdio); break;
     case 'inherit': options.push(0, 1, 2); break;
     default:
-      throw new ERR_INVALID_OPT_VALUE('stdio', stdio);
+      throw new ERR_INVALID_ARG_VALUE('stdio', stdio);
   }
 
   if (channel) options.push(channel);
@@ -347,7 +347,7 @@ ChildProcess.prototype.spawn = function(options) {
 
 
   validateOneOf(options.serialization, 'options.serialization',
-                [undefined, 'json', 'advanced'], true);
+                [undefined, 'json', 'advanced']);
   const serialization = options.serialization || 'json';
 
   if (ipc !== undefined) {
@@ -934,7 +934,7 @@ function getValidStdio(stdio, sync) {
   if (typeof stdio === 'string') {
     stdio = stdioStringToArray(stdio);
   } else if (!ArrayIsArray(stdio)) {
-    throw new ERR_INVALID_OPT_VALUE('stdio', stdio);
+    throw new ERR_INVALID_ARG_VALUE('stdio', stdio);
   }
 
   // At least 3 stdio will be created
@@ -1019,7 +1019,7 @@ function getValidStdio(stdio, sync) {
     } else {
       // Cleanup
       cleanup();
-      throw new ERR_INVALID_OPT_VALUE('stdio', stdio);
+      throw new ERR_INVALID_ARG_VALUE('stdio', stdio);
     }
 
     return acc;

--- a/lib/internal/crypto/cipher.js
+++ b/lib/internal/crypto/cipher.js
@@ -12,7 +12,7 @@ const {
 const {
   ERR_CRYPTO_INVALID_STATE,
   ERR_INVALID_ARG_TYPE,
-  ERR_INVALID_OPT_VALUE
+  ERR_INVALID_ARG_VALUE
 } = require('internal/errors').codes;
 const { validateEncoding, validateString } = require('internal/validators');
 
@@ -87,7 +87,7 @@ function getUIntOption(options, key) {
   let value;
   if (options && (value = options[key]) != null) {
     if (value >>> 0 !== value)
-      throw new ERR_INVALID_OPT_VALUE(key, value);
+      throw new ERR_INVALID_ARG_VALUE(`options.${key}`, value);
     return value;
   }
   return -1;

--- a/lib/internal/crypto/diffiehellman.js
+++ b/lib/internal/crypto/diffiehellman.js
@@ -12,7 +12,7 @@ const {
   ERR_CRYPTO_INCOMPATIBLE_KEY,
   ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE,
   ERR_INVALID_ARG_TYPE,
-  ERR_INVALID_OPT_VALUE
+  ERR_INVALID_ARG_VALUE,
 } = require('internal/errors').codes;
 const {
   validateString,
@@ -258,10 +258,10 @@ function diffieHellman(options) {
 
   const { privateKey, publicKey } = options;
   if (!(privateKey instanceof KeyObject))
-    throw new ERR_INVALID_OPT_VALUE('privateKey', privateKey);
+    throw new ERR_INVALID_ARG_VALUE('options.privateKey', privateKey);
 
   if (!(publicKey instanceof KeyObject))
-    throw new ERR_INVALID_OPT_VALUE('publicKey', publicKey);
+    throw new ERR_INVALID_ARG_VALUE('options.publicKey', publicKey);
 
   if (privateKey.type !== 'private')
     throw new ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE(privateKey.type, 'private');

--- a/lib/internal/crypto/keygen.js
+++ b/lib/internal/crypto/keygen.js
@@ -27,13 +27,15 @@ const {
   PrivateKeyObject
 } = require('internal/crypto/keys');
 const { customPromisifyArgs } = require('internal/util');
-const { isUint32, validateString } = require('internal/validators');
+const {
+  isUint32,
+  validateString,
+  validateObject,
+} = require('internal/validators');
 const {
   ERR_INCOMPATIBLE_OPTION_PAIR,
-  ERR_INVALID_ARG_TYPE,
   ERR_INVALID_ARG_VALUE,
   ERR_INVALID_CALLBACK,
-  ERR_INVALID_OPT_VALUE,
   ERR_MISSING_OPTION
 } = require('internal/errors').codes;
 
@@ -106,7 +108,8 @@ function parseKeyEncoding(keyType, options) {
     } = parsePublicKeyEncoding(publicKeyEncoding, keyType,
                                'publicKeyEncoding'));
   } else {
-    throw new ERR_INVALID_OPT_VALUE('publicKeyEncoding', publicKeyEncoding);
+    throw new ERR_INVALID_ARG_VALUE('options.publicKeyEncoding',
+                                    publicKeyEncoding);
   }
 
   let privateFormat, privateType, cipher, passphrase;
@@ -121,7 +124,8 @@ function parseKeyEncoding(keyType, options) {
     } = parsePrivateKeyEncoding(privateKeyEncoding, keyType,
                                 'privateKeyEncoding'));
   } else {
-    throw new ERR_INVALID_OPT_VALUE('privateKeyEncoding', privateKeyEncoding);
+    throw new ERR_INVALID_ARG_VALUE('options.privateKeyEncoding',
+                                    privateKeyEncoding);
   }
 
   return {
@@ -136,29 +140,26 @@ function check(type, options, callback) {
   // the order a bit more intuitive.
   let cipher, passphrase, publicType, publicFormat, privateType, privateFormat;
 
-  if (options !== undefined && typeof options !== 'object')
-    throw new ERR_INVALID_ARG_TYPE('options', 'object', options);
-
-  function needOptions() {
-    if (options == null)
-      throw new ERR_INVALID_ARG_TYPE('options', 'object', options);
-    return options;
-  }
+  if (options !== undefined)
+    validateObject(options, 'options');
 
   let impl;
   switch (type) {
     case 'rsa':
     case 'rsa-pss':
       {
-        const { modulusLength } = needOptions();
+        validateObject(options, 'options');
+        const { modulusLength } = options;
         if (!isUint32(modulusLength))
-          throw new ERR_INVALID_OPT_VALUE('modulusLength', modulusLength);
+          throw new ERR_INVALID_ARG_VALUE('options.modulusLength',
+                                          modulusLength);
 
         let { publicExponent } = options;
         if (publicExponent == null) {
           publicExponent = 0x10001;
         } else if (!isUint32(publicExponent)) {
-          throw new ERR_INVALID_OPT_VALUE('publicExponent', publicExponent);
+          throw new ERR_INVALID_ARG_VALUE('options.publicExponent',
+                                          publicExponent);
         }
 
         if (type === 'rsa') {
@@ -171,11 +172,11 @@ function check(type, options, callback) {
 
         const { hash, mgf1Hash, saltLength } = options;
         if (hash !== undefined && typeof hash !== 'string')
-          throw new ERR_INVALID_OPT_VALUE('hash', hash);
+          throw new ERR_INVALID_ARG_VALUE('options.hash', hash);
         if (mgf1Hash !== undefined && typeof mgf1Hash !== 'string')
-          throw new ERR_INVALID_OPT_VALUE('mgf1Hash', mgf1Hash);
+          throw new ERR_INVALID_ARG_VALUE('options.mgf1Hash', mgf1Hash);
         if (saltLength !== undefined && !isUint32(saltLength))
-          throw new ERR_INVALID_OPT_VALUE('saltLength', saltLength);
+          throw new ERR_INVALID_ARG_VALUE('options.saltLength', saltLength);
 
         impl = (wrap) => generateKeyPairRSAPSS(modulusLength, publicExponent,
                                                hash, mgf1Hash, saltLength,
@@ -186,15 +187,18 @@ function check(type, options, callback) {
       break;
     case 'dsa':
       {
-        const { modulusLength } = needOptions();
+        validateObject(options, 'options');
+        const { modulusLength } = options;
         if (!isUint32(modulusLength))
-          throw new ERR_INVALID_OPT_VALUE('modulusLength', modulusLength);
+          throw new ERR_INVALID_ARG_VALUE('options.modulusLength',
+                                          modulusLength);
 
         let { divisorLength } = options;
         if (divisorLength == null) {
           divisorLength = -1;
         } else if (!isUint32(divisorLength)) {
-          throw new ERR_INVALID_OPT_VALUE('divisorLength', divisorLength);
+          throw new ERR_INVALID_ARG_VALUE('options.divisorLength',
+                                          divisorLength);
         }
 
         impl = (wrap) => generateKeyPairDSA(modulusLength, divisorLength,
@@ -205,16 +209,18 @@ function check(type, options, callback) {
       break;
     case 'ec':
       {
-        const { namedCurve } = needOptions();
+        validateObject(options, 'options');
+        const { namedCurve } = options;
         if (typeof namedCurve !== 'string')
-          throw new ERR_INVALID_OPT_VALUE('namedCurve', namedCurve);
+          throw new ERR_INVALID_ARG_VALUE('options.namedCurve', namedCurve);
         let { paramEncoding } = options;
         if (paramEncoding == null || paramEncoding === 'named')
           paramEncoding = OPENSSL_EC_NAMED_CURVE;
         else if (paramEncoding === 'explicit')
           paramEncoding = OPENSSL_EC_EXPLICIT_CURVE;
         else
-          throw new ERR_INVALID_OPT_VALUE('paramEncoding', paramEncoding);
+          throw new ERR_INVALID_ARG_VALUE('options.paramEncoding',
+                                          paramEncoding);
 
         impl = (wrap) => generateKeyPairEC(namedCurve, paramEncoding,
                                            publicFormat, publicType,
@@ -250,7 +256,8 @@ function check(type, options, callback) {
       break;
     case 'dh':
       {
-        const { group, primeLength, prime, generator } = needOptions();
+        validateObject(options, 'options');
+        const { group, primeLength, prime, generator } = options;
         let args;
         if (group != null) {
           if (prime != null)
@@ -260,17 +267,18 @@ function check(type, options, callback) {
           if (generator != null)
             throw new ERR_INCOMPATIBLE_OPTION_PAIR('group', 'generator');
           if (typeof group !== 'string')
-            throw new ERR_INVALID_OPT_VALUE('group', group);
+            throw new ERR_INVALID_ARG_VALUE('options.group', group);
           args = [group];
         } else {
           if (prime != null) {
             if (primeLength != null)
               throw new ERR_INCOMPATIBLE_OPTION_PAIR('prime', 'primeLength');
             if (!isArrayBufferView(prime))
-              throw new ERR_INVALID_OPT_VALUE('prime', prime);
+              throw new ERR_INVALID_ARG_VALUE('options.prime', prime);
           } else if (primeLength != null) {
             if (!isUint32(primeLength))
-              throw new ERR_INVALID_OPT_VALUE('primeLength', primeLength);
+              throw new ERR_INVALID_ARG_VALUE('options.primeLength',
+                                              primeLength);
           } else {
             throw new ERR_MISSING_OPTION(
               'At least one of the group, prime, or primeLength options');
@@ -278,7 +286,7 @@ function check(type, options, callback) {
 
           if (generator != null) {
             if (!isUint32(generator))
-              throw new ERR_INVALID_OPT_VALUE('generator', generator);
+              throw new ERR_INVALID_ARG_VALUE('options.generator', generator);
           }
 
           args = [prime != null ? prime : primeLength,

--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -23,7 +23,6 @@ const {
   ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE,
   ERR_INVALID_ARG_TYPE,
   ERR_INVALID_ARG_VALUE,
-  ERR_INVALID_OPT_VALUE,
   ERR_OUT_OF_RANGE
 } = require('internal/errors').codes;
 const { kHandle } = require('internal/crypto/util');
@@ -144,7 +143,7 @@ function parseKeyFormat(formatStr, defaultFormat, optionName) {
     return kKeyFormatPEM;
   else if (formatStr === 'der')
     return kKeyFormatDER;
-  throw new ERR_INVALID_OPT_VALUE(optionName, formatStr);
+  throw new ERR_INVALID_ARG_VALUE(optionName, formatStr);
 }
 
 function parseKeyType(typeStr, required, keyType, isPublic, optionName) {
@@ -168,11 +167,12 @@ function parseKeyType(typeStr, required, keyType, isPublic, optionName) {
     return kKeyEncodingSEC1;
   }
 
-  throw new ERR_INVALID_OPT_VALUE(optionName, typeStr);
+  throw new ERR_INVALID_ARG_VALUE(optionName, typeStr);
 }
 
 function option(name, objName) {
-  return objName === undefined ? name : `${objName}.${name}`;
+  return objName === undefined ?
+    `options.${name}` : `options.${objName}.${name}`;
 }
 
 function parseKeyFormatAndType(enc, keyType, isPublic, objName) {
@@ -214,7 +214,7 @@ function parseKeyEncoding(enc, keyType, isPublic, objName) {
     if (!isInput) {
       if (cipher != null) {
         if (typeof cipher !== 'string')
-          throw new ERR_INVALID_OPT_VALUE(option('cipher', objName), cipher);
+          throw new ERR_INVALID_ARG_VALUE(option('cipher', objName), cipher);
         if (format === kKeyFormatDER &&
             (type === kKeyEncodingPKCS1 ||
              type === kKeyEncodingSEC1)) {
@@ -222,14 +222,14 @@ function parseKeyEncoding(enc, keyType, isPublic, objName) {
             encodingNames[type], 'does not support encryption');
         }
       } else if (passphrase !== undefined) {
-        throw new ERR_INVALID_OPT_VALUE(option('cipher', objName), cipher);
+        throw new ERR_INVALID_ARG_VALUE(option('cipher', objName), cipher);
       }
     }
 
     if ((isInput && passphrase !== undefined &&
          !isStringOrBuffer(passphrase)) ||
         (!isInput && cipher != null && !isStringOrBuffer(passphrase))) {
-      throw new ERR_INVALID_OPT_VALUE(option('passphrase', objName),
+      throw new ERR_INVALID_ARG_VALUE(option('passphrase', objName),
                                       passphrase);
     }
   }

--- a/lib/internal/crypto/sig.js
+++ b/lib/internal/crypto/sig.js
@@ -7,7 +7,7 @@ const {
 const {
   ERR_CRYPTO_SIGN_KEY_REQUIRED,
   ERR_INVALID_ARG_TYPE,
-  ERR_INVALID_OPT_VALUE
+  ERR_INVALID_ARG_VALUE,
 } = require('internal/errors').codes;
 const { validateEncoding, validateString } = require('internal/validators');
 const {
@@ -77,7 +77,7 @@ function getDSASignatureEncoding(options) {
       return kSigEncDER;
     else if (dsaEncoding === 'ieee-p1363')
       return kSigEncP1363;
-    throw new ERR_INVALID_OPT_VALUE('dsaEncoding', dsaEncoding);
+    throw new ERR_INVALID_ARG_VALUE('options.dsaEncoding', dsaEncoding);
   }
 
   return kSigEncDER;
@@ -89,7 +89,7 @@ function getIntOption(name, options) {
     if (value === value >> 0) {
       return value;
     }
-    throw new ERR_INVALID_OPT_VALUE(name, value);
+    throw new ERR_INVALID_ARG_VALUE(`options.${name}`, value);
   }
   return undefined;
 }

--- a/lib/internal/dns/promises.js
+++ b/lib/internal/dns/promises.js
@@ -26,7 +26,7 @@ const {
 } = internalBinding('cares_wrap');
 const {
   ERR_INVALID_ARG_TYPE,
-  ERR_INVALID_OPT_VALUE,
+  ERR_INVALID_ARG_VALUE,
   ERR_MISSING_ARGS,
 } = codes;
 const {
@@ -154,7 +154,7 @@ function lookupService(address, port) {
     throw new ERR_MISSING_ARGS('address', 'port');
 
   if (isIP(address) === 0)
-    throw new ERR_INVALID_OPT_VALUE('address', address);
+    throw new ERR_INVALID_ARG_VALUE('address', address);
 
   validatePort(port);
 
@@ -236,7 +236,7 @@ Resolver.prototype.resolve = function resolve(hostname, rrtype) {
     resolver = resolveMap[rrtype];
 
     if (typeof resolver !== 'function')
-      throw new ERR_INVALID_OPT_VALUE('rrtype', rrtype);
+      throw new ERR_INVALID_ARG_VALUE('rrtype', rrtype);
   } else if (rrtype === undefined) {
     resolver = resolveMap.A;
   } else {

--- a/lib/internal/dns/utils.js
+++ b/lib/internal/dns/utils.js
@@ -20,8 +20,8 @@ const addrSplitRE = /(^.+?)(?::(\d+))?$/;
 const {
   ERR_DNS_SET_SERVERS_FAILED,
   ERR_INVALID_ARG_TYPE,
+  ERR_INVALID_ARG_VALUE,
   ERR_INVALID_IP_ADDRESS,
-  ERR_INVALID_OPT_VALUE
 } = errors.codes;
 
 function validateTimeout(options) {
@@ -146,7 +146,7 @@ function bindDefaultResolver(target, source) {
 
 function validateHints(hints) {
   if ((hints & ~(AI_ADDRCONFIG | AI_ALL | AI_V4MAPPED)) !== 0) {
-    throw new ERR_INVALID_OPT_VALUE('hints', hints);
+    throw new ERR_INVALID_ARG_VALUE('hints', hints);
   }
 }
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1080,7 +1080,8 @@ E('ERR_INVALID_ARG_VALUE', (name, value, reason = 'is invalid') => {
   if (inspected.length > 128) {
     inspected = `${inspected.slice(0, 128)}...`;
   }
-  return `The argument '${name}' ${reason}. Received ${inspected}`;
+  const type = name.includes('.') ? 'property' : 'argument';
+  return `The ${type} '${name}' ${reason}. Received ${inspected}`;
 }, TypeError, RangeError);
 E('ERR_INVALID_ASYNC_ID', 'Invalid %s value: %s', RangeError);
 E('ERR_INVALID_BUFFER_SIZE',
@@ -1112,15 +1113,6 @@ E('ERR_INVALID_MODULE_SPECIFIER', (request, reason, base = undefined) => {
   return `Invalid module "${request}" ${reason}${base ?
     ` imported from ${base}` : ''}`;
 }, TypeError);
-E('ERR_INVALID_OPT_VALUE', (name, value, reason = '') => {
-  let inspected = typeof value === 'string' ?
-    value : lazyInternalUtilInspect().inspect(value);
-  if (inspected.length > 128) inspected = `${inspected.slice(0, 128)}...`;
-  if (reason) reason = '. ' + reason;
-  return `The value "${inspected}" is invalid for option "${name}"` + reason;
-}, TypeError, RangeError);
-E('ERR_INVALID_OPT_VALUE_ENCODING',
-  'The value "%s" is invalid for option "encoding"', TypeError);
 E('ERR_INVALID_PACKAGE_CONFIG', (path, base, message) => {
   return `Invalid package config ${path}${base ? ` imported from ${base}` :
     ''}${message ? `. ${message}` : ''}`;

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -19,8 +19,6 @@ const {
     ERR_FS_INVALID_SYMLINK_TYPE,
     ERR_INVALID_ARG_TYPE,
     ERR_INVALID_ARG_VALUE,
-    ERR_INVALID_OPT_VALUE,
-    ERR_INVALID_OPT_VALUE_ENCODING,
     ERR_OUT_OF_RANGE
   },
   hideStackFrames,
@@ -111,7 +109,8 @@ function lazyLoadFs() {
 
 function assertEncoding(encoding) {
   if (encoding && !Buffer.isEncoding(encoding)) {
-    throw new ERR_INVALID_OPT_VALUE_ENCODING(encoding);
+    const reason = 'is invalid encoding';
+    throw new ERR_INVALID_ARG_VALUE(encoding, 'encoding', reason);
   }
 }
 
@@ -540,7 +539,7 @@ function stringToFlags(flags) {
     case 'sa+': return O_APPEND | O_CREAT | O_RDWR | O_SYNC;
   }
 
-  throw new ERR_INVALID_OPT_VALUE('flags', flags);
+  throw new ERR_INVALID_ARG_VALUE('flags', flags);
 }
 
 const stringToSymlinkType = hideStackFrames((type) => {

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -90,10 +90,10 @@ const {
     ERR_HTTP2_TRAILERS_NOT_READY,
     ERR_HTTP2_UNSUPPORTED_PROTOCOL,
     ERR_INVALID_ARG_TYPE,
+    ERR_INVALID_ARG_VALUE,
     ERR_INVALID_CALLBACK,
     ERR_INVALID_CHAR,
     ERR_INVALID_HTTP_TOKEN,
-    ERR_INVALID_OPT_VALUE,
     ERR_OUT_OF_RANGE,
     ERR_SOCKET_CLOSED
   },
@@ -727,25 +727,25 @@ const setAndValidatePriorityOptions = hideStackFrames((options) => {
   if (options.weight === undefined) {
     options.weight = NGHTTP2_DEFAULT_WEIGHT;
   } else if (typeof options.weight !== 'number') {
-    throw new ERR_INVALID_OPT_VALUE('weight', options.weight);
+    throw new ERR_INVALID_ARG_VALUE('options.weight', options.weight);
   }
 
   if (options.parent === undefined) {
     options.parent = 0;
   } else if (typeof options.parent !== 'number' || options.parent < 0) {
-    throw new ERR_INVALID_OPT_VALUE('parent', options.parent);
+    throw new ERR_INVALID_ARG_VALUE('options.parent', options.parent);
   }
 
   if (options.exclusive === undefined) {
     options.exclusive = false;
   } else if (typeof options.exclusive !== 'boolean') {
-    throw new ERR_INVALID_OPT_VALUE('exclusive', options.exclusive);
+    throw new ERR_INVALID_ARG_VALUE('options.exclusive', options.exclusive);
   }
 
   if (options.silent === undefined) {
     options.silent = false;
   } else if (typeof options.silent !== 'boolean') {
-    throw new ERR_INVALID_OPT_VALUE('silent', options.silent);
+    throw new ERR_INVALID_ARG_VALUE('options.silent', options.silent);
   }
 });
 
@@ -1661,7 +1661,7 @@ class ClientHttp2Session extends Http2Session {
       // preference.
       options.endStream = isPayloadMeaningless(headers[HTTP2_HEADER_METHOD]);
     } else if (typeof options.endStream !== 'boolean') {
-      throw new ERR_INVALID_OPT_VALUE('endStream', options.endStream);
+      throw new ERR_INVALID_ARG_VALUE('options.endStream', options.endStream);
     }
 
     const headersList = mapToHeaders(headers);
@@ -2307,7 +2307,7 @@ function processHeaders(oldHeaders) {
 
   const neverIndex = headers[kSensitiveHeaders];
   if (neverIndex !== undefined && !ArrayIsArray(neverIndex))
-    throw new ERR_INVALID_OPT_VALUE('headers[http2.neverIndex]', neverIndex);
+    throw new ERR_INVALID_ARG_VALUE('headers[http2.neverIndex]', neverIndex);
 
   return headers;
 }
@@ -2665,14 +2665,14 @@ class ServerHttp2Stream extends Http2Stream {
     options = { ...options };
 
     if (options.offset !== undefined && typeof options.offset !== 'number')
-      throw new ERR_INVALID_OPT_VALUE('offset', options.offset);
+      throw new ERR_INVALID_ARG_VALUE('options.offset', options.offset);
 
     if (options.length !== undefined && typeof options.length !== 'number')
-      throw new ERR_INVALID_OPT_VALUE('length', options.length);
+      throw new ERR_INVALID_ARG_VALUE('options.length', options.length);
 
     if (options.statCheck !== undefined &&
         typeof options.statCheck !== 'function') {
-      throw new ERR_INVALID_OPT_VALUE('statCheck', options.statCheck);
+      throw new ERR_INVALID_ARG_VALUE('options.statCheck', options.statCheck);
     }
 
     let streamOptions = 0;
@@ -2730,14 +2730,14 @@ class ServerHttp2Stream extends Http2Stream {
     options = { ...options };
 
     if (options.offset !== undefined && typeof options.offset !== 'number')
-      throw new ERR_INVALID_OPT_VALUE('offset', options.offset);
+      throw new ERR_INVALID_ARG_VALUE('options.offset', options.offset);
 
     if (options.length !== undefined && typeof options.length !== 'number')
-      throw new ERR_INVALID_OPT_VALUE('length', options.length);
+      throw new ERR_INVALID_ARG_VALUE('options.length', options.length);
 
     if (options.statCheck !== undefined &&
         typeof options.statCheck !== 'function') {
-      throw new ERR_INVALID_OPT_VALUE('statCheck', options.statCheck);
+      throw new ERR_INVALID_ARG_VALUE('options.statCheck', options.statCheck);
     }
 
     let streamOptions = 0;

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -93,7 +93,6 @@ let hasLoadedAnyUserCJSModule = false;
 
 const {
   ERR_INVALID_ARG_VALUE,
-  ERR_INVALID_OPT_VALUE,
   ERR_INVALID_MODULE_SPECIFIER,
   ERR_REQUIRE_ESM
 } = require('internal/errors').codes;
@@ -854,7 +853,7 @@ Module._resolveFilename = function(request, parent, isMain, options) {
     } else if (options.paths === undefined) {
       paths = Module._resolveLookupPaths(request, parent);
     } else {
-      throw new ERR_INVALID_OPT_VALUE('options.paths', options.paths);
+      throw new ERR_INVALID_ARG_VALUE('options.paths', options.paths);
     }
   } else {
     paths = Module._resolveLookupPaths(request, parent);

--- a/lib/internal/process/per_thread.js
+++ b/lib/internal/process/per_thread.js
@@ -25,7 +25,7 @@ const {
     ERR_ASSERTION,
     ERR_CPU_USAGE,
     ERR_INVALID_ARG_TYPE,
-    ERR_INVALID_OPT_VALUE,
+    ERR_INVALID_ARG_VALUE,
     ERR_OUT_OF_RANGE,
     ERR_UNKNOWN_SIGNAL
   }
@@ -112,7 +112,7 @@ function wrapProcessMethods(binding) {
           throw new ERR_INVALID_ARG_TYPE('prevValue.user',
                                          'number', prevValue.user);
         }
-        throw new ERR_INVALID_OPT_VALUE.RangeError('prevValue.user',
+        throw new ERR_INVALID_ARG_VALUE.RangeError('prevValue.user',
                                                    prevValue.user);
       }
 
@@ -121,7 +121,7 @@ function wrapProcessMethods(binding) {
           throw new ERR_INVALID_ARG_TYPE('prevValue.system',
                                          'number', prevValue.system);
         }
-        throw new ERR_INVALID_OPT_VALUE.RangeError('prevValue.system',
+        throw new ERR_INVALID_ARG_VALUE.RangeError('prevValue.system',
                                                    prevValue.system);
       }
     }

--- a/lib/internal/streams/state.js
+++ b/lib/internal/streams/state.js
@@ -5,7 +5,7 @@ const {
   NumberIsInteger,
 } = primordials;
 
-const { ERR_INVALID_OPT_VALUE } = require('internal/errors').codes;
+const { ERR_INVALID_ARG_VALUE } = require('internal/errors').codes;
 
 function highWaterMarkFrom(options, isDuplex, duplexKey) {
   return options.highWaterMark != null ? options.highWaterMark :
@@ -20,8 +20,8 @@ function getHighWaterMark(state, options, duplexKey, isDuplex) {
   const hwm = highWaterMarkFrom(options, isDuplex, duplexKey);
   if (hwm != null) {
     if (!NumberIsInteger(hwm) || hwm < 0) {
-      const name = isDuplex ? duplexKey : 'highWaterMark';
-      throw new ERR_INVALID_OPT_VALUE(name, hwm);
+      const name = isDuplex ? `options.${duplexKey}` : 'options.highWaterMark';
+      throw new ERR_INVALID_ARG_VALUE(name, hwm);
     }
     return MathFloor(hwm);
   }

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -13,7 +13,6 @@ const {
     ERR_SOCKET_BAD_PORT,
     ERR_INVALID_ARG_TYPE,
     ERR_INVALID_ARG_VALUE,
-    ERR_INVALID_OPT_VALUE,
     ERR_OUT_OF_RANGE,
     ERR_UNKNOWN_SIGNAL,
     ERR_INVALID_CALLBACK,
@@ -127,18 +126,13 @@ function validateNumber(value, name) {
     throw new ERR_INVALID_ARG_TYPE(name, 'number', value);
 }
 
-const validateOneOf = hideStackFrames((value, name, oneOf, option = false) => {
+const validateOneOf = hideStackFrames((value, name, oneOf) => {
   if (!oneOf.includes(value)) {
     const allowed = oneOf
       .map((v) => (typeof v === 'string' ? `'${v}'` : String(v)))
       .join(', ');
-    if (!option) {
-      const reason = 'must be one of: ' + allowed;
-      throw new ERR_INVALID_ARG_VALUE(name, value, reason);
-    } else {
-      const reason = 'Must be one of: ' + allowed;
-      throw new ERR_INVALID_OPT_VALUE(name, value, reason);
-    }
+    const reason = 'must be one of: ' + allowed;
+    throw new ERR_INVALID_ARG_VALUE(name, value, reason);
   }
 });
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -91,7 +91,6 @@ const {
     ERR_INVALID_ARG_VALUE,
     ERR_INVALID_FD_TYPE,
     ERR_INVALID_IP_ADDRESS,
-    ERR_INVALID_OPT_VALUE,
     ERR_SERVER_ALREADY_LISTEN,
     ERR_SERVER_NOT_RUNNING,
     ERR_SOCKET_CLOSED,
@@ -1460,7 +1459,7 @@ Server.prototype.listen = function(...args) {
                                     'must have the property "port" or "path"');
   }
 
-  throw new ERR_INVALID_OPT_VALUE('options', options);
+  throw new ERR_INVALID_ARG_VALUE('options', options);
 };
 
 function lookupAndListen(self, port, address, backlog, exclusive, flags) {

--- a/lib/perf_hooks.js
+++ b/lib/perf_hooks.js
@@ -52,7 +52,7 @@ const kInspect = require('internal/util').customInspectSymbol;
 const {
   ERR_INVALID_CALLBACK,
   ERR_INVALID_ARG_TYPE,
-  ERR_INVALID_OPT_VALUE,
+  ERR_INVALID_ARG_VALUE,
   ERR_VALID_PERFORMANCE_ENTRY_TYPE,
   ERR_INVALID_PERFORMANCE_MARK
 } = require('internal/errors').codes;
@@ -343,7 +343,7 @@ class PerformanceObserver extends AsyncResource {
     }
     const { entryTypes } = options;
     if (!ArrayIsArray(entryTypes)) {
-      throw new ERR_INVALID_OPT_VALUE('entryTypes', entryTypes);
+      throw new ERR_INVALID_ARG_VALUE('options.entryTypes', entryTypes);
     }
     const filteredEntryTypes = entryTypes.filter(filterTypes).map(mapTypes);
     if (filteredEntryTypes.length === 0) {
@@ -576,7 +576,7 @@ function monitorEventLoopDelay(options = {}) {
                                    'number', resolution);
   }
   if (resolution <= 0 || !NumberIsSafeInteger(resolution)) {
-    throw new ERR_INVALID_OPT_VALUE.RangeError('resolution', resolution);
+    throw new ERR_INVALID_ARG_VALUE.RangeError('resolution', resolution);
   }
   return new ELDHistogram(new _ELDHistogram(resolution));
 }

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -41,9 +41,9 @@ const {
 } = primordials;
 
 const {
+  ERR_INVALID_ARG_VALUE,
   ERR_INVALID_CALLBACK,
   ERR_INVALID_CURSOR_POS,
-  ERR_INVALID_OPT_VALUE
 } = require('internal/errors').codes;
 const {
   validateString,
@@ -134,8 +134,8 @@ function Interface(input, output, completer, terminal) {
       if (NumberIsFinite(input.escapeCodeTimeout)) {
         this.escapeCodeTimeout = input.escapeCodeTimeout;
       } else {
-        throw new ERR_INVALID_OPT_VALUE(
-          'escapeCodeTimeout',
+        throw new ERR_INVALID_ARG_VALUE(
+          'input.escapeCodeTimeout',
           this.escapeCodeTimeout
         );
       }
@@ -145,7 +145,7 @@ function Interface(input, output, completer, terminal) {
   }
 
   if (completer !== undefined && typeof completer !== 'function') {
-    throw new ERR_INVALID_OPT_VALUE('completer', completer);
+    throw new ERR_INVALID_ARG_VALUE('completer', completer);
   }
 
   if (historySize === undefined) {
@@ -155,7 +155,7 @@ function Interface(input, output, completer, terminal) {
   if (typeof historySize !== 'number' ||
       NumberIsNaN(historySize) ||
       historySize < 0) {
-    throw new ERR_INVALID_OPT_VALUE.RangeError('historySize', historySize);
+    throw new ERR_INVALID_ARG_VALUE.RangeError('historySize', historySize);
   }
 
   // Backwards compat; check the isTTY prop of the output stream

--- a/test/es-module/test-esm-dns-promises.mjs
+++ b/test/es-module/test-esm-dns-promises.mjs
@@ -8,7 +8,7 @@ const invalidAddress = 'fasdfdsaf';
 assert.throws(() => {
   lookupService(invalidAddress, 0);
 }, {
-  code: 'ERR_INVALID_OPT_VALUE',
+  code: 'ERR_INVALID_ARG_VALUE',
   name: 'TypeError',
-  message: `The value "${invalidAddress}" is invalid for option "address"`
+  message: `The argument 'address' is invalid. Received '${invalidAddress}'`
 });

--- a/test/fixtures/require-resolve.js
+++ b/test/fixtures/require-resolve.js
@@ -89,7 +89,7 @@ assert.throws(() => {
 assert.throws(() => {
   require.resolve('.\\three.js', { paths: 'foo' })
 }, {
-  code: 'ERR_INVALID_OPT_VALUE',
+  code: 'ERR_INVALID_ARG_VALUE',
   name: 'TypeError',
 });
 

--- a/test/internet/test-dns-promises-resolve.js
+++ b/test/internet/test-dns-promises-resolve.js
@@ -10,9 +10,9 @@ const dnsPromises = require('dns').promises;
   assert.throws(
     () => dnsPromises.resolve('example.org', rrtype),
     {
-      code: 'ERR_INVALID_OPT_VALUE',
+      code: 'ERR_INVALID_ARG_VALUE',
       name: 'TypeError',
-      message: `The value "${rrtype}" is invalid for option "rrtype"`
+      message: `The argument 'rrtype' is invalid. Received '${rrtype}'`
     }
   );
 }

--- a/test/parallel/test-buffer-no-negative-allocation.js
+++ b/test/parallel/test-buffer-no-negative-allocation.js
@@ -5,9 +5,9 @@ const assert = require('assert');
 const { SlowBuffer } = require('buffer');
 
 const msg = {
-  code: 'ERR_INVALID_OPT_VALUE',
+  code: 'ERR_INVALID_ARG_VALUE',
   name: 'RangeError',
-  message: /^The value "[^"]*" is invalid for option "size"$/
+  message: /^The argument 'size' is invalid\. Received [^"]*$/
 };
 
 // Test that negative Buffer length inputs throw errors.

--- a/test/parallel/test-buffer-over-max-length.js
+++ b/test/parallel/test-buffer-over-max-length.js
@@ -7,9 +7,9 @@ const SlowBuffer = buffer.SlowBuffer;
 
 const kMaxLength = buffer.kMaxLength;
 const bufferMaxSizeMsg = {
-  code: 'ERR_INVALID_OPT_VALUE',
+  code: 'ERR_INVALID_ARG_VALUE',
   name: 'RangeError',
-  message: /^The value "[^"]*" is invalid for option "size"$/
+  message: /^The argument 'size' is invalid\. Received [^"]*$/
 };
 
 assert.throws(() => Buffer((-1 >>> 0) + 1), bufferMaxSizeMsg);

--- a/test/parallel/test-buffer-slow.js
+++ b/test/parallel/test-buffer-slow.js
@@ -52,9 +52,9 @@ assert.throws(() => SlowBuffer(true), bufferInvalidTypeMsg);
 
 // Should throw with invalid length value
 const bufferMaxSizeMsg = {
-  code: 'ERR_INVALID_OPT_VALUE',
+  code: 'ERR_INVALID_ARG_VALUE',
   name: 'RangeError',
-  message: /^The value "[^"]*" is invalid for option "size"$/
+  message: /^The argument 'size' is invalid\. Received [^"]*$/
 };
 assert.throws(() => SlowBuffer(NaN), bufferMaxSizeMsg);
 assert.throws(() => SlowBuffer(Infinity), bufferMaxSizeMsg);

--- a/test/parallel/test-buffer-tostring-rangeerror.js
+++ b/test/parallel/test-buffer-tostring-rangeerror.js
@@ -10,9 +10,9 @@ const SlowBuffer = require('buffer').SlowBuffer;
 
 const len = 1422561062959;
 const message = {
-  code: 'ERR_INVALID_OPT_VALUE',
+  code: 'ERR_INVALID_ARG_VALUE',
   name: 'RangeError',
-  message: /^The value "[^"]*" is invalid for option "size"$/
+  message: /^The argument 'size' is invalid\. Received [^"]*$/
 };
 assert.throws(() => Buffer(len).toString('utf8'), message);
 assert.throws(() => SlowBuffer(len).toString('utf8'), message);

--- a/test/parallel/test-c-ares.js
+++ b/test/parallel/test-c-ares.js
@@ -66,12 +66,12 @@ dns.lookup('::1', common.mustCall((error, result, addressType) => {
   // Try calling resolve with an unsupported type.
   'HI',
   // Try calling resolve with an unsupported type that's an object key
-  'toString'
+  'toString',
 ].forEach((val) => {
   const err = {
-    code: 'ERR_INVALID_OPT_VALUE',
+    code: 'ERR_INVALID_ARG_VALUE',
     name: 'TypeError',
-    message: `The value "${val}" is invalid for option "rrtype"`
+    message: `The argument 'rrtype' is invalid. Received '${val}'`,
   };
 
   assert.throws(

--- a/test/parallel/test-child-process-advanced-serialization.js
+++ b/test/parallel/test-child-process-advanced-serialization.js
@@ -3,16 +3,17 @@ const common = require('../common');
 const assert = require('assert');
 const child_process = require('child_process');
 const { once } = require('events');
+const { inspect } = require('util');
 
 if (process.argv[2] !== 'child') {
   for (const value of [null, 42, Infinity, 'foo']) {
     assert.throws(() => {
       child_process.spawn(process.execPath, [], { serialization: value });
     }, {
-      code: 'ERR_INVALID_OPT_VALUE',
-      message: `The value "${value}" is invalid ` +
-      'for option "options.serialization". ' +
-      "Must be one of: undefined, 'json', 'advanced'"
+      code: 'ERR_INVALID_ARG_VALUE',
+      message: "The property 'options.serialization' " +
+        "must be one of: undefined, 'json', 'advanced'. " +
+        `Received ${inspect(value)}`
     });
   }
 

--- a/test/parallel/test-child-process-fork-stdio-string-variant.js
+++ b/test/parallel/test-child-process-fork-stdio-string-variant.js
@@ -15,7 +15,7 @@ const payload = { hello: 'world' };
 
 assert.throws(
   () => fork(childScript, malFormedOpts),
-  { code: 'ERR_INVALID_OPT_VALUE', name: 'TypeError' });
+  { code: 'ERR_INVALID_ARG_VALUE', name: 'TypeError' });
 
 function test(stringVariant) {
   const child = fork(childScript, { stdio: stringVariant });

--- a/test/parallel/test-child-process-validate-stdio.js
+++ b/test/parallel/test-child-process-validate-stdio.js
@@ -5,7 +5,7 @@ const common = require('../common');
 const assert = require('assert');
 const getValidStdio = require('internal/child_process').getValidStdio;
 
-const expectedError = { code: 'ERR_INVALID_OPT_VALUE', name: 'TypeError' };
+const expectedError = { code: 'ERR_INVALID_ARG_VALUE', name: 'TypeError' };
 
 // Should throw if string and not ignore, pipe, or inherit
 assert.throws(() => getValidStdio('foo'), expectedError);

--- a/test/parallel/test-crypto-authenticated.js
+++ b/test/parallel/test-crypto-authenticated.js
@@ -26,6 +26,7 @@ if (!common.hasCrypto)
 
 const assert = require('assert');
 const crypto = require('crypto');
+const { inspect } = require('util');
 const fixtures = require('../common/fixtures');
 
 crypto.DEFAULT_ENCODING = 'buffer';
@@ -328,9 +329,9 @@ for (const test of TEST_CASES) {
                             });
     }, {
       name: 'TypeError',
-      code: 'ERR_INVALID_OPT_VALUE',
-      message: `The value "${authTagLength}" is invalid for option ` +
-               '"authTagLength"'
+      code: 'ERR_INVALID_ARG_VALUE',
+      message: "The property 'options.authTagLength' is invalid. " +
+               `Received ${inspect(authTagLength)}`
     });
 
     assert.throws(() => {
@@ -342,9 +343,9 @@ for (const test of TEST_CASES) {
                               });
     }, {
       name: 'TypeError',
-      code: 'ERR_INVALID_OPT_VALUE',
-      message: `The value "${authTagLength}" is invalid for option ` +
-               '"authTagLength"'
+      code: 'ERR_INVALID_ARG_VALUE',
+      message: "The property 'options.authTagLength' is invalid. " +
+        `Received ${inspect(authTagLength)}`
     });
 
     if (!common.hasFipsCrypto) {
@@ -352,18 +353,18 @@ for (const test of TEST_CASES) {
         crypto.createCipher('aes-256-ccm', 'bad password', { authTagLength });
       }, {
         name: 'TypeError',
-        code: 'ERR_INVALID_OPT_VALUE',
-        message: `The value "${authTagLength}" is invalid for option ` +
-                 '"authTagLength"'
+        code: 'ERR_INVALID_ARG_VALUE',
+        message: "The property 'options.authTagLength' is invalid. " +
+          `Received ${inspect(authTagLength)}`
       });
 
       assert.throws(() => {
         crypto.createDecipher('aes-256-ccm', 'bad password', { authTagLength });
       }, {
         name: 'TypeError',
-        code: 'ERR_INVALID_OPT_VALUE',
-        message: `The value "${authTagLength}" is invalid for option ` +
-                 '"authTagLength"'
+        code: 'ERR_INVALID_ARG_VALUE',
+        message: "The property 'options.authTagLength' is invalid. " +
+          `Received ${inspect(authTagLength)}`
       });
     }
   }
@@ -452,9 +453,9 @@ for (const test of TEST_CASES) {
       cipher.setAAD(Buffer.from('0123456789', 'hex'), { plaintextLength });
     }, {
       name: 'TypeError',
-      code: 'ERR_INVALID_OPT_VALUE',
-      message: `The value "${plaintextLength}" is invalid for option ` +
-               '"plaintextLength"'
+      code: 'ERR_INVALID_ARG_VALUE',
+      message: "The property 'options.plaintextLength' is invalid. " +
+        `Received ${inspect(plaintextLength)}`
     });
   }
 }

--- a/test/parallel/test-crypto-dh-stateless.js
+++ b/test/parallel/test-crypto-dh-stateless.js
@@ -91,14 +91,14 @@ const bobPublicKey = crypto.createPublicKey({
 
 assert.throws(() => crypto.diffieHellman({ privateKey: alicePrivateKey }), {
   name: 'TypeError',
-  code: 'ERR_INVALID_OPT_VALUE',
-  message: 'The value "undefined" is invalid for option "publicKey"'
+  code: 'ERR_INVALID_ARG_VALUE',
+  message: "The property 'options.publicKey' is invalid. Received undefined"
 });
 
 assert.throws(() => crypto.diffieHellman({ publicKey: alicePublicKey }), {
   name: 'TypeError',
-  code: 'ERR_INVALID_OPT_VALUE',
-  message: 'The value "undefined" is invalid for option "privateKey"'
+  code: 'ERR_INVALID_ARG_VALUE',
+  message: "The property 'options.privateKey' is invalid. Received undefined"
 });
 
 const privateKey = Buffer.from(

--- a/test/parallel/test-crypto-key-objects.js
+++ b/test/parallel/test-crypto-key-objects.js
@@ -223,8 +223,8 @@ const privateDsa = fixtures.readKey('dsa_private_encrypted_1025.pem',
   assert.throws(() => {
     createPrivateKey({ key: Buffer.alloc(0), format: 'der', type: 'spki' });
   }, {
-    code: 'ERR_INVALID_OPT_VALUE',
-    message: 'The value "spki" is invalid for option "type"'
+    code: 'ERR_INVALID_ARG_VALUE',
+    message: "The property 'options.type' is invalid. Received 'spki'"
   });
 
   // Unlike SPKI, PKCS#1 is a valid encoding for private keys (and public keys),
@@ -471,7 +471,7 @@ const privateDsa = fixtures.readKey('dsa_private_encrypted_1025.pem',
     });
   }, {
     name: 'TypeError',
-    code: 'ERR_INVALID_OPT_VALUE',
-    message: 'The value "undefined" is invalid for option "cipher"'
+    code: 'ERR_INVALID_ARG_VALUE',
+    message: "The property 'options.cipher' is invalid. Received undefined"
   });
 }

--- a/test/parallel/test-crypto-keygen.js
+++ b/test/parallel/test-crypto-keygen.js
@@ -558,9 +558,9 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     }
   }), {
     name: 'TypeError',
-    code: 'ERR_INVALID_OPT_VALUE',
-    message: 'The value "otherEncoding" is invalid for ' +
-    'option "paramEncoding"'
+    code: 'ERR_INVALID_ARG_VALUE',
+    message: "The property 'options.paramEncoding' is invalid. " +
+      "Received 'otherEncoding'"
   });
 }
 
@@ -685,8 +685,9 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
       }
     }), {
       name: 'TypeError',
-      code: 'ERR_INVALID_OPT_VALUE',
-      message: `The value "${enc}" is invalid for option "publicKeyEncoding"`
+      code: 'ERR_INVALID_ARG_VALUE',
+      message: "The property 'options.publicKeyEncoding' is invalid. " +
+        `Received ${inspect(enc)}`
     });
   }
 
@@ -704,15 +705,14 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
       }
     }), {
       name: 'TypeError',
-      code: 'ERR_INVALID_OPT_VALUE',
-      message: `The value "${inspect(type)}" is invalid for option ` +
-               '"publicKeyEncoding.type"'
+      code: 'ERR_INVALID_ARG_VALUE',
+      message: "The property 'options.publicKeyEncoding.type' is invalid. " +
+        `Received ${inspect(type)}`
     });
   }
 
   // Missing / invalid publicKeyEncoding.format.
   for (const format of [undefined, null, 0, false, 'a', {}]) {
-    const expected = typeof format === 'string' ? format : inspect(format);
     assert.throws(() => generateKeyPairSync('rsa', {
       modulusLength: 4096,
       publicKeyEncoding: {
@@ -725,9 +725,9 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
       }
     }), {
       name: 'TypeError',
-      code: 'ERR_INVALID_OPT_VALUE',
-      message: `The value "${expected}" is invalid for option ` +
-               '"publicKeyEncoding.format"'
+      code: 'ERR_INVALID_ARG_VALUE',
+      message: "The property 'options.publicKeyEncoding.format' is invalid. " +
+        `Received ${inspect(format)}`
     });
   }
 
@@ -742,8 +742,9 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
       privateKeyEncoding: enc
     }), {
       name: 'TypeError',
-      code: 'ERR_INVALID_OPT_VALUE',
-      message: `The value "${enc}" is invalid for option "privateKeyEncoding"`
+      code: 'ERR_INVALID_ARG_VALUE',
+      message: "The property 'options.privateKeyEncoding' is invalid. " +
+        `Received ${inspect(enc)}`
     });
   }
 
@@ -761,15 +762,14 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
       }
     }), {
       name: 'TypeError',
-      code: 'ERR_INVALID_OPT_VALUE',
-      message: `The value "${inspect(type)}" is invalid for option ` +
-               '"privateKeyEncoding.type"'
+      code: 'ERR_INVALID_ARG_VALUE',
+      message: "The property 'options.privateKeyEncoding.type' is invalid. " +
+        `Received ${inspect(type)}`
     });
   }
 
   // Missing / invalid privateKeyEncoding.format.
   for (const format of [undefined, null, 0, false, 'a', {}]) {
-    const expected = typeof format === 'string' ? format : inspect(format);
     assert.throws(() => generateKeyPairSync('rsa', {
       modulusLength: 4096,
       publicKeyEncoding: {
@@ -782,9 +782,9 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
       }
     }), {
       name: 'TypeError',
-      code: 'ERR_INVALID_OPT_VALUE',
-      message: `The value "${expected}" is invalid for option ` +
-               '"privateKeyEncoding.format"'
+      code: 'ERR_INVALID_ARG_VALUE',
+      message: "The property 'options.privateKeyEncoding.format' is invalid. " +
+        `Received ${inspect(format)}`
     });
   }
 
@@ -803,9 +803,9 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
       }
     }), {
       name: 'TypeError',
-      code: 'ERR_INVALID_OPT_VALUE',
-      message: `The value "${inspect(cipher)}" is invalid for option ` +
-               '"privateKeyEncoding.cipher"'
+      code: 'ERR_INVALID_ARG_VALUE',
+      message: "The property 'options.privateKeyEncoding.cipher' is invalid. " +
+        `Received ${inspect(cipher)}`
     });
   }
 
@@ -844,9 +844,9 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
       }
     }), {
       name: 'TypeError',
-      code: 'ERR_INVALID_OPT_VALUE',
-      message: `The value "${passphrase}" is invalid for option ` +
-               '"privateKeyEncoding.passphrase"'
+      code: 'ERR_INVALID_ARG_VALUE',
+      message: "The property 'options.privateKeyEncoding.passphrase' " +
+        `is invalid. Received ${inspect(passphrase)}`
     });
   }
 
@@ -867,30 +867,26 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
 {
   // Test invalid modulus lengths.
   for (const modulusLength of [undefined, null, 'a', true, {}, [], 512.1, -1]) {
-    const expected = typeof modulusLength === 'string' ?
-      modulusLength : inspect(modulusLength);
     assert.throws(() => generateKeyPair('rsa', {
       modulusLength
     }), {
       name: 'TypeError',
-      code: 'ERR_INVALID_OPT_VALUE',
-      message: `The value "${expected}" is invalid for option ` +
-               '"modulusLength"'
+      code: 'ERR_INVALID_ARG_VALUE',
+      message: "The property 'options.modulusLength' is invalid. " +
+        `Received ${inspect(modulusLength)}`
     });
   }
 
   // Test invalid exponents.
   for (const publicExponent of ['a', true, {}, [], 3.5, -1]) {
-    const expected = typeof publicExponent === 'string' ?
-      publicExponent : inspect(publicExponent);
     assert.throws(() => generateKeyPair('rsa', {
       modulusLength: 4096,
       publicExponent
     }), {
       name: 'TypeError',
-      code: 'ERR_INVALID_OPT_VALUE',
-      message: `The value "${expected}" is invalid for option ` +
-               '"publicExponent"'
+      code: 'ERR_INVALID_ARG_VALUE',
+      message: "The property 'options.publicExponent' is invalid. " +
+        `Received ${inspect(publicExponent)}`
     });
   }
 }
@@ -899,30 +895,26 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
 {
   // Test invalid modulus lengths.
   for (const modulusLength of [undefined, null, 'a', true, {}, [], 4096.1]) {
-    const expected = typeof modulusLength === 'string' ?
-      modulusLength : inspect(modulusLength);
     assert.throws(() => generateKeyPair('dsa', {
       modulusLength
     }), {
       name: 'TypeError',
-      code: 'ERR_INVALID_OPT_VALUE',
-      message: `The value "${expected}" is invalid for option ` +
-               '"modulusLength"'
+      code: 'ERR_INVALID_ARG_VALUE',
+      message: "The property 'options.modulusLength' is invalid. " +
+        `Received ${inspect(modulusLength)}`
     });
   }
 
   // Test invalid divisor lengths.
   for (const divisorLength of ['a', true, {}, [], 4096.1]) {
-    const expected = typeof divisorLength === 'string' ?
-      divisorLength : inspect(divisorLength);
     assert.throws(() => generateKeyPair('dsa', {
       modulusLength: 2048,
       divisorLength
     }), {
       name: 'TypeError',
-      code: 'ERR_INVALID_OPT_VALUE',
-      message: `The value "${expected}" is invalid for option ` +
-               '"divisorLength"'
+      code: 'ERR_INVALID_ARG_VALUE',
+      message: "The property 'options.divisorLength' is invalid. " +
+        `Received ${inspect(divisorLength)}`
     });
   }
 }
@@ -951,9 +943,9 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
       });
     }, {
       name: 'TypeError',
-      code: 'ERR_INVALID_OPT_VALUE',
-      message: `The value "${inspect(namedCurve)}" is invalid for option ` +
-               '"namedCurve"'
+      code: 'ERR_INVALID_ARG_VALUE',
+      message: "The property 'options.namedCurve' is invalid. " +
+        `Received ${inspect(namedCurve)}`
     });
   }
 
@@ -1073,9 +1065,9 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
       });
     }, {
       name: 'TypeError',
-      code: 'ERR_INVALID_OPT_VALUE',
-      message: `The value "${type}" is invalid for option ` +
-               '"publicKeyEncoding.type"'
+      code: 'ERR_INVALID_ARG_VALUE',
+      message: "The property 'options.publicKeyEncoding.type' is invalid. " +
+        `Received ${inspect(type)}`
     });
   }
 
@@ -1088,8 +1080,9 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
       });
     }, {
       name: 'TypeError',
-      code: 'ERR_INVALID_OPT_VALUE',
-      message: `The value "${inspect(hashValue)}" is invalid for option "hash"`
+      code: 'ERR_INVALID_ARG_VALUE',
+      message: "The property 'options.hash' is invalid. " +
+        `Received ${inspect(hashValue)}`
     });
   }
 
@@ -1103,9 +1096,9 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
       });
     }, {
       name: 'TypeError',
-      code: 'ERR_INVALID_OPT_VALUE',
-      message: `The value "${type}" is invalid for option ` +
-               '"privateKeyEncoding.type"'
+      code: 'ERR_INVALID_ARG_VALUE',
+      message: "The property 'options.privateKeyEncoding.type' is invalid. " +
+        `Received ${inspect(type)}`
     });
   }
 
@@ -1192,7 +1185,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
   );
 
   for (const mgf1Hash of [null, 0, false, {}, []]) {
-    const expected = inspect(mgf1Hash);
     assert.throws(
       () => {
         generateKeyPair('rsa-pss', {
@@ -1204,8 +1196,10 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
       },
       {
         name: 'TypeError',
-        code: 'ERR_INVALID_OPT_VALUE',
-        message: `The value "${expected}" is invalid for option "mgf1Hash"`
+        code: 'ERR_INVALID_ARG_VALUE',
+        message: "The property 'options.mgf1Hash' is invalid. " +
+          `Received ${inspect(mgf1Hash)}`
+
       }
     );
   }

--- a/test/parallel/test-crypto-sign-verify.js
+++ b/test/parallel/test-crypto-sign-verify.js
@@ -74,9 +74,9 @@ assert.throws(
     padding: null,
   }, ''),
   {
-    code: 'ERR_INVALID_OPT_VALUE',
+    code: 'ERR_INVALID_ARG_VALUE',
     name: 'TypeError',
-    message: 'The value "null" is invalid for option "padding"'
+    message: "The property 'options.padding' is invalid. Received null",
   });
 
 assert.throws(
@@ -85,9 +85,9 @@ assert.throws(
     saltLength: null,
   }, ''),
   {
-    code: 'ERR_INVALID_OPT_VALUE',
+    code: 'ERR_INVALID_ARG_VALUE',
     name: 'TypeError',
-    message: 'The value "null" is invalid for option "saltLength"'
+    message: "The property 'options.saltLength' is invalid. Received null",
   });
 
 // Test signing and verifying
@@ -314,7 +314,7 @@ assert.throws(
             padding: invalidValue
           });
       }, {
-        code: 'ERR_INVALID_OPT_VALUE',
+        code: 'ERR_INVALID_ARG_VALUE',
         name: 'TypeError'
       });
 
@@ -327,7 +327,7 @@ assert.throws(
             saltLength: invalidValue
           });
       }, {
-        code: 'ERR_INVALID_OPT_VALUE',
+        code: 'ERR_INVALID_ARG_VALUE',
         name: 'TypeError'
       });
     });
@@ -608,7 +608,7 @@ assert.throws(
         dsaEncoding
       });
     }, {
-      code: 'ERR_INVALID_OPT_VALUE'
+      code: 'ERR_INVALID_ARG_VALUE'
     });
   }
 }

--- a/test/parallel/test-dns-lookup.js
+++ b/test/parallel/test-dns-lookup.js
@@ -52,9 +52,9 @@ assert.throws(() => {
 
 {
   const err = {
-    code: 'ERR_INVALID_OPT_VALUE',
+    code: 'ERR_INVALID_ARG_VALUE',
     name: 'TypeError',
-    message: 'The value "100" is invalid for option "hints"'
+    message: "The argument 'hints' is invalid. Received 100"
   };
   const options = {
     hints: 100,
@@ -70,10 +70,9 @@ assert.throws(() => {
 
 {
   const err = {
-    code: 'ERR_INVALID_OPT_VALUE',
+    code: 'ERR_INVALID_ARG_VALUE',
     name: 'TypeError',
-    message: 'The value "20" is invalid for option "family". ' +
-    'Must be one of: 0, 4, 6'
+    message: "The argument 'family' must be one of: 0, 4, 6. Received 20"
   };
   const options = {
     hints: 0,

--- a/test/parallel/test-dns.js
+++ b/test/parallel/test-dns.js
@@ -218,9 +218,9 @@ assert.deepStrictEqual(dns.getServers(), []);
   */
   const hints = (dns.V4MAPPED | dns.ADDRCONFIG | dns.ALL) + 1;
   const err = {
-    code: 'ERR_INVALID_OPT_VALUE',
+    code: 'ERR_INVALID_ARG_VALUE',
     name: 'TypeError',
-    message: /The value "\d+" is invalid for option "hints"/
+    message: /The argument 'hints' is invalid\. Received \d+/
   };
 
   assert.throws(() => {
@@ -294,9 +294,9 @@ dns.lookup('', {
 {
   const invalidAddress = 'fasdfdsaf';
   const err = {
-    code: 'ERR_INVALID_OPT_VALUE',
+    code: 'ERR_INVALID_ARG_VALUE',
     name: 'TypeError',
-    message: `The value "${invalidAddress}" is invalid for option "address"`
+    message: `The argument 'address' is invalid. Received '${invalidAddress}'`
   };
 
   assert.throws(() => {

--- a/test/parallel/test-fs-assert-encoding-error.js
+++ b/test/parallel/test-fs-assert-encoding-error.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 
 const options = 'test';
 const expectedError = {
-  code: 'ERR_INVALID_OPT_VALUE_ENCODING',
+  code: 'ERR_INVALID_ARG_VALUE',
   name: 'TypeError',
 };
 

--- a/test/parallel/test-fs-open-flags.js
+++ b/test/parallel/test-fs-open-flags.js
@@ -70,18 +70,18 @@ assert.strictEqual(stringToFlags('sa+'), O_APPEND | O_CREAT | O_RDWR | O_SYNC);
   .forEach(function(flags) {
     assert.throws(
       () => stringToFlags(flags),
-      { code: 'ERR_INVALID_OPT_VALUE', name: 'TypeError' }
+      { code: 'ERR_INVALID_ARG_VALUE', name: 'TypeError' }
     );
   });
 
 assert.throws(
   () => stringToFlags({}),
-  { code: 'ERR_INVALID_OPT_VALUE', name: 'TypeError' }
+  { code: 'ERR_INVALID_ARG_VALUE', name: 'TypeError' }
 );
 
 assert.throws(
   () => stringToFlags(true),
-  { code: 'ERR_INVALID_OPT_VALUE', name: 'TypeError' }
+  { code: 'ERR_INVALID_ARG_VALUE', name: 'TypeError' }
 );
 
 if (common.isLinux || common.isOSX) {

--- a/test/parallel/test-fs-read-file-assert-encoding.js
+++ b/test/parallel/test-fs-read-file-assert-encoding.js
@@ -8,5 +8,5 @@ const encoding = 'foo-8';
 const filename = 'bar.txt';
 assert.throws(
   () => fs.readFile(filename, { encoding }, common.mustNotCall()),
-  { code: 'ERR_INVALID_OPT_VALUE_ENCODING', name: 'TypeError' }
+  { code: 'ERR_INVALID_ARG_VALUE', name: 'TypeError' }
 );

--- a/test/parallel/test-http-agent-scheduling.js
+++ b/test/parallel/test-http-agent-scheduling.js
@@ -134,11 +134,11 @@ function badSchedulingOptionTest() {
       scheduling: 'filo'
     });
   } catch (err) {
-    assert.strictEqual(err.code, 'ERR_INVALID_OPT_VALUE');
+    assert.strictEqual(err.code, 'ERR_INVALID_ARG_VALUE');
     assert.strictEqual(
       err.message,
-      'The value "filo" is invalid for option "scheduling". ' +
-      "Must be one of: 'fifo', 'lifo'"
+      "The argument 'scheduling' must be one of: 'fifo', 'lifo'. " +
+        "Received 'filo'"
     );
   }
 }

--- a/test/parallel/test-http2-client-request-options-errors.js
+++ b/test/parallel/test-http2-client-request-options-errors.js
@@ -48,9 +48,9 @@ server.listen(0, common.mustCall(() => {
             [option]: types[type]
           }), {
             name: 'TypeError',
-            code: 'ERR_INVALID_OPT_VALUE',
-            message: `The value "${inspect(types[type])}" is invalid ` +
-                    `for option "${option}"`
+            code: 'ERR_INVALID_ARG_VALUE',
+            message: `The property 'options.${option}' is invalid. ` +
+                    `Received ${inspect(types[type])}`
           });
       });
     });

--- a/test/parallel/test-http2-respond-file-errors.js
+++ b/test/parallel/test-http2-respond-file-errors.js
@@ -45,9 +45,9 @@ server.on('stream', common.mustCall((stream) => {
         }),
         {
           name: 'TypeError',
-          code: 'ERR_INVALID_OPT_VALUE',
-          message: `The value "${inspect(types[type])}" is invalid ` +
-                   `for option "${option}"`
+          code: 'ERR_INVALID_ARG_VALUE',
+          message: `The property 'options.${option}' is invalid. ` +
+            `Received ${inspect(types[type])}`
         }
       );
     });

--- a/test/parallel/test-http2-respond-file-fd-errors.js
+++ b/test/parallel/test-http2-respond-file-fd-errors.js
@@ -65,9 +65,9 @@ server.on('stream', common.mustCall((stream) => {
         }),
         {
           name: 'TypeError',
-          code: 'ERR_INVALID_OPT_VALUE',
-          message: `The value "${inspect(types[type])}" is invalid ` +
-                   `for option "${option}"`
+          code: 'ERR_INVALID_ARG_VALUE',
+          message: `The property 'options.${option}' is invalid. ` +
+            `Received ${inspect(types[type])}`
         }
       );
     });

--- a/test/parallel/test-internal-fs.js
+++ b/test/parallel/test-internal-fs.js
@@ -11,7 +11,7 @@ fs.assertEncoding('utf8');
 
 assert.throws(
   () => fs.assertEncoding('foo'),
-  { code: 'ERR_INVALID_OPT_VALUE_ENCODING', name: 'TypeError' }
+  { code: 'ERR_INVALID_ARG_VALUE', name: 'TypeError' }
 );
 
 // Test junction symlinks

--- a/test/parallel/test-internal-validators-validateoneof.js
+++ b/test/parallel/test-internal-validators-validateoneof.js
@@ -13,11 +13,6 @@ const { validateOneOf } = require('internal/validators');
     // eslint-disable-next-line quotes
     message: `The argument 'name' must be one of: 2, 3. Received 1`
   });
-  assert.throws(() => validateOneOf(1, 'name', allowed, true), {
-    code: 'ERR_INVALID_OPT_VALUE',
-    message: 'The value "1" is invalid for option "name". ' +
-      'Must be one of: 2, 3'
-  });
 }
 
 {
@@ -32,12 +27,6 @@ const { validateOneOf } = require('internal/validators');
     code: 'ERR_INVALID_ARG_VALUE',
     // eslint-disable-next-line quotes
     message: `The argument 'name' must be one of: 'b', 'c'. Received 'a'`
-  });
-  assert.throws(() => validateOneOf('a', 'name', allowed, true), {
-    code: 'ERR_INVALID_OPT_VALUE',
-    // eslint-disable-next-line quotes
-    message: `The value "a" is invalid for option "name". ` +
-    "Must be one of: 'b', 'c'",
   });
 }
 
@@ -54,11 +43,6 @@ const { validateOneOf } = require('internal/validators');
     // eslint-disable-next-line quotes
     message: `The argument 'name' must be one of: Symbol(b), Symbol(c). ` +
       'Received Symbol(a)'
-  });
-  assert.throws(() => validateOneOf(Symbol.for('a'), 'name', allowed, true), {
-    code: 'ERR_INVALID_OPT_VALUE',
-    message: 'The value "Symbol(a)" is invalid for option "name". ' +
-      'Must be one of: Symbol(b), Symbol(c)',
   });
 }
 

--- a/test/parallel/test-net-connect-options-port.js
+++ b/test/parallel/test-net-connect-options-port.js
@@ -64,9 +64,9 @@ const net = require('net');
                                   () => common.mustNotCall());
   for (const fn of hintOptBlocks) {
     assert.throws(fn, {
-      code: 'ERR_INVALID_OPT_VALUE',
+      code: 'ERR_INVALID_ARG_VALUE',
       name: 'TypeError',
-      message: /The value "\d+" is invalid for option "hints"/
+      message: /The argument 'hints' is invalid\. Received \d+/
     });
   }
 }

--- a/test/parallel/test-net-server-listen-options.js
+++ b/test/parallel/test-net-server-listen-options.js
@@ -69,9 +69,9 @@ const listenOnPort = [
     } else {
       assert.throws(fn,
                     {
-                      code: 'ERR_INVALID_OPT_VALUE',
+                      code: 'ERR_INVALID_ARG_VALUE',
                       name: 'TypeError',
-                      message: /^The value "{.*}" is invalid for option "options"(?:\. .+)?$/,
+                      message: /^The argument 'options' is invalid\. Received .+$/,
                     });
     }
   }

--- a/test/parallel/test-performanceobserver.js
+++ b/test/parallel/test-performanceobserver.js
@@ -56,10 +56,10 @@ assert.strictEqual(counts[NODE_PERFORMANCE_ENTRY_TYPE_FUNCTION], 0);
   [1, undefined, null, {}, Infinity].forEach((i) => {
     assert.throws(() => observer.observe({ entryTypes: i }),
                   {
-                    code: 'ERR_INVALID_OPT_VALUE',
+                    code: 'ERR_INVALID_ARG_VALUE',
                     name: 'TypeError',
-                    message: `The value "${inspect(i)}" is invalid ` +
-                                   'for option "entryTypes"'
+                    message: "The property 'options.entryTypes' is invalid. " +
+                      `Received ${inspect(i)}`
                   });
   });
 

--- a/test/parallel/test-process-cpuUsage.js
+++ b/test/parallel/test-process-cpuUsage.js
@@ -83,10 +83,10 @@ assert.throws(
   assert.throws(
     () => process.cpuUsage(value),
     {
-      code: 'ERR_INVALID_OPT_VALUE',
+      code: 'ERR_INVALID_ARG_VALUE',
       name: 'RangeError',
-      message: `The value "${value.user}" is invalid ` +
-               'for option "prevValue.user"'
+      message: "The property 'prevValue.user' is invalid. " +
+        `Received ${value.user}`,
     }
   );
 });
@@ -98,10 +98,10 @@ assert.throws(
   assert.throws(
     () => process.cpuUsage(value),
     {
-      code: 'ERR_INVALID_OPT_VALUE',
+      code: 'ERR_INVALID_ARG_VALUE',
       name: 'RangeError',
-      message: `The value "${value.system}" is invalid ` +
-               'for option "prevValue.system"'
+      message: "The property 'prevValue.system' is invalid. " +
+        `Received ${value.system}`,
     }
   );
 });

--- a/test/parallel/test-readline-interface-escapecodetimeout.js
+++ b/test/parallel/test-readline-interface-escapecodetimeout.js
@@ -41,6 +41,6 @@ class FakeInput extends EventEmitter {
     rli.close();
   }, {
     name: 'TypeError',
-    code: 'ERR_INVALID_OPT_VALUE'
+    code: 'ERR_INVALID_ARG_VALUE'
   });
 });

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -86,7 +86,7 @@ function assertCursorRowsAndCols(rli, rows, cols) {
     });
   }, {
     name: 'TypeError',
-    code: 'ERR_INVALID_OPT_VALUE'
+    code: 'ERR_INVALID_ARG_VALUE'
   });
 
   assert.throws(() => {
@@ -96,7 +96,7 @@ function assertCursorRowsAndCols(rli, rows, cols) {
     });
   }, {
     name: 'TypeError',
-    code: 'ERR_INVALID_OPT_VALUE'
+    code: 'ERR_INVALID_ARG_VALUE'
   });
 
   assert.throws(() => {
@@ -106,7 +106,7 @@ function assertCursorRowsAndCols(rli, rows, cols) {
     });
   }, {
     name: 'TypeError',
-    code: 'ERR_INVALID_OPT_VALUE'
+    code: 'ERR_INVALID_ARG_VALUE'
   });
 
   // Constructor throws if historySize is not a positive number
@@ -117,7 +117,7 @@ function assertCursorRowsAndCols(rli, rows, cols) {
     });
   }, {
     name: 'RangeError',
-    code: 'ERR_INVALID_OPT_VALUE'
+    code: 'ERR_INVALID_ARG_VALUE'
   });
 
   assert.throws(() => {
@@ -127,7 +127,7 @@ function assertCursorRowsAndCols(rli, rows, cols) {
     });
   }, {
     name: 'RangeError',
-    code: 'ERR_INVALID_OPT_VALUE'
+    code: 'ERR_INVALID_ARG_VALUE'
   });
 
   assert.throws(() => {
@@ -137,7 +137,7 @@ function assertCursorRowsAndCols(rli, rows, cols) {
     });
   }, {
     name: 'RangeError',
-    code: 'ERR_INVALID_OPT_VALUE'
+    code: 'ERR_INVALID_ARG_VALUE'
   });
 
   // Check for invalid tab sizes.

--- a/test/parallel/test-stream-transform-split-highwatermark.js
+++ b/test/parallel/test-stream-transform-split-highwatermark.js
@@ -68,16 +68,18 @@ testTransform(0, 0, {
     new Transform({ readableHighWaterMark: NaN });
   }, {
     name: 'TypeError',
-    code: 'ERR_INVALID_OPT_VALUE',
-    message: 'The value "NaN" is invalid for option "readableHighWaterMark"'
+    code: 'ERR_INVALID_ARG_VALUE',
+    message: "The property 'options.readableHighWaterMark' is invalid. " +
+      'Received NaN'
   });
 
   assert.throws(() => {
     new Transform({ writableHighWaterMark: NaN });
   }, {
     name: 'TypeError',
-    code: 'ERR_INVALID_OPT_VALUE',
-    message: 'The value "NaN" is invalid for option "writableHighWaterMark"'
+    code: 'ERR_INVALID_ARG_VALUE',
+    message: "The property 'options.writableHighWaterMark' is invalid. " +
+      'Received NaN'
   });
 }
 

--- a/test/parallel/test-streams-highwatermark.js
+++ b/test/parallel/test-streams-highwatermark.js
@@ -21,16 +21,14 @@ const { inspect } = require('util');
   assert.strictEqual(writable._writableState.highWaterMark, ovfl);
 
   for (const invalidHwm of [true, false, '5', {}, -5, NaN]) {
-    const expected = typeof invalidHwm === 'string' ?
-      invalidHwm : inspect(invalidHwm);
     for (const type of [stream.Readable, stream.Writable]) {
       assert.throws(() => {
         type({ highWaterMark: invalidHwm });
       }, {
         name: 'TypeError',
-        code: 'ERR_INVALID_OPT_VALUE',
-        message:
-          `The value "${expected}" is invalid for option "highWaterMark"`
+        code: 'ERR_INVALID_ARG_VALUE',
+        message: "The property 'options.highWaterMark' is invalid. " +
+          `Received ${inspect(invalidHwm)}`
       });
     }
   }

--- a/test/parallel/test-tls-set-ciphers.js
+++ b/test/parallel/test-tls-set-ciphers.js
@@ -98,8 +98,8 @@ test('TLS_AES_128_CCM_8_SHA256', 'TLS_AES_128_CCM_8_SHA256',
 // Invalid cipher values
 test(9, 'AES256-SHA', U, 'ERR_INVALID_ARG_TYPE', U);
 test('AES256-SHA', 9, U, U, 'ERR_INVALID_ARG_TYPE');
-test(':', 'AES256-SHA', U, 'ERR_INVALID_OPT_VALUE', U);
-test('AES256-SHA', ':', U, U, 'ERR_INVALID_OPT_VALUE');
+test(':', 'AES256-SHA', U, 'ERR_INVALID_ARG_VALUE', U);
+test('AES256-SHA', ':', U, U, 'ERR_INVALID_ARG_VALUE');
 
 // Using '' is synonymous for "use default ciphers"
 test('TLS_AES_256_GCM_SHA384', '', 'TLS_AES_256_GCM_SHA384');

--- a/test/parallel/test-vm-module-basic.js
+++ b/test/parallel/test-vm-module-basic.js
@@ -138,7 +138,7 @@ const util = require('util');
 // https://github.com/nodejs/node/issues/32806
 {
   assert.throws(() => new SyntheticModule(['x', 'x'], () => {}, {}), {
-    message: 'The argument \'exportNames.x\' is duplicated. Received \'x\'',
+    message: 'The property \'exportNames.x\' is duplicated. Received \'x\'',
     name: 'TypeError',
   });
 }

--- a/test/parallel/test-worker-unsupported-eval-on-url.mjs
+++ b/test/parallel/test-worker-unsupported-eval-on-url.mjs
@@ -2,5 +2,5 @@ import '../common/index.mjs';
 import assert from 'assert';
 import { Worker } from 'worker_threads';
 
-const re = /The argument 'options\.eval' must be false when 'filename' is not a string\./;
+const re = /The property 'options\.eval' must be false when 'filename' is not a string\./;
 assert.throws(() => new Worker(new URL(import.meta.url), { eval: true }), re);

--- a/test/sequential/test-performance-eventloopdelay.js
+++ b/test/sequential/test-performance-eventloopdelay.js
@@ -44,7 +44,7 @@ const { sleep } = require('internal/util');
       () => monitorEventLoopDelay({ resolution: i }),
       {
         name: 'RangeError',
-        code: 'ERR_INVALID_OPT_VALUE'
+        code: 'ERR_INVALID_ARG_VALUE'
       }
     );
   });


### PR DESCRIPTION
This will be a start to generalize all argument validation
errors. As currently we throw ARG/OPT, OUT_OF_RANGE, and other more
specific errors.
The OPT errors didn't bring much to the errors as it's just another
variant of ARG error which is sometimes more confusing (some of our code
used OPT errors to denote just argument validation errors presumably
because of similarity of OPT to 'option' and not 'options-object')
and they don't specify the name of the options object where the invalid
value is located. Much better approach would be to just specify path
to the invalid value in the name of the value as it is done in this PR
(i.e. 'options.format', 'options.publicKey.type' etc)

Also since this decreases a variety of errors we have it'd be easier to
reuse validation code across the codebase.

Refs: https://github.com/nodejs/node/pull/31251
Refs: https://github.com/nodejs/node/pull/34070#discussion_r467251009
Signed-off-by: Denys Otrishko <shishugi@gmail.com>

----------------------------------------
Since this is a semver-major anyway I'm also considering integrating `ERR_OUT_OF_RANGE` into `ERR_INVALID_ARG_VALUE.RangeError` as I don't see much benefit of it having a separate error code since everything will be stated in the message anyways, wdyt?

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
/cc @nodejs/crypto @nodejs/buffer @nodejs/http2 as most affected systems
/cc @jasnell @tniessen 