### PR TITLE
test: add testcases for getConstructorOf in internal/util.js

### DIFF
--- a/test/parallel/test-internal-util-helpers.js
+++ b/test/parallel/test-internal-util-helpers.js
@@ -4,7 +4,10 @@
 require('../common');
 const assert = require('assert');
 const { types } = require('util');
-const { isError } = require('internal/util');
+const {
+  isError,
+  getConstructorOf
+} = require('internal/util');
 const vm = require('vm');
 
 // Special cased errors. Test the internal function which is used in
@@ -35,3 +38,12 @@ const vm = require('vm');
   assert(!(differentRealmErr instanceof Error));
   assert(isError(differentRealmErr));
 }
+
+// getConstructorOf
+assert.strictEqual(getConstructorOf(Object.create(null)), null);
+assert.strictEqual(getConstructorOf([]), Array);
+assert.strictEqual(getConstructorOf({}), Object);
+assert.strictEqual(getConstructorOf(1), Number);
+assert.strictEqual(getConstructorOf(true), Boolean);
+assert.strictEqual(getConstructorOf(/regexp/), RegExp);
+assert.strictEqual(getConstructorOf('String'), String);


### PR DESCRIPTION
Added testcases for getConstructorOf about null and some objects,
to achieve full statements coverage of internal/util.js.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
