### PR TITLE
build: use pull_request_target to start Jenkins

### DIFF
--- a/.github/workflows/auto-start-ci.yml
+++ b/.github/workflows/auto-start-ci.yml
@@ -2,25 +2,18 @@
 name: Auto Start CI
 
 on:
-  schedule:
-    # `schedule` event is used instead of `pull_request` because when a
-    # `pull_requesst` event is triggered on a PR from a fork, GITHUB_TOKEN will
-    # be read-only, and the Action won't have access to any other repository
-    # secrets, which it needs to access Jenkins API. Runs every five minutes
-    # (fastest the scheduler can run). Five minutes is optimistic, it can take
-    # longer to run.
-    - cron: "*/5 * * * *"
+  pull_request_target:
+    types:
+      - labeled
 
 jobs:
   startCI:
-    if: github.repository == 'nodejs/node'
     runs-on: ubuntu-latest
+    if: github.event.label.name == 'request-ci'
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
 
       # Install dependencies
-      - name: Install jq
-        run: sudo apt-get install jq -y
       - name: Install Node.js
         uses: actions/setup-node@v2-beta
         with:
@@ -33,26 +26,6 @@ jobs:
           echo "::set-env name=REPOSITORY::$(echo ${{ github.repository }} | cut -d/ -f2)"
           echo "::set-env name=OWNER::${{ github.repository_owner }}"
 
-      # Get Pull Requests
-      - name: Get Pull Requests
-        uses: octokit/graphql-action@v2.x
-        id: get_prs_for_ci
-        with:
-          query: |
-            query prs($owner:String!, $repo:String!) {
-              repository(owner:$owner, name:$repo) {
-                pullRequests(labels: ["request-ci"], states: OPEN, last: 100) {
-                  nodes {
-                    number
-                  }
-                }
-              }
-            }
-          owner: ${{ env.OWNER }}
-          repo: ${{ env.REPOSITORY }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Setup node-core-utils
         run: |
           ncu-config set username ${{ secrets.JENKINS_USER }}
@@ -62,4 +35,4 @@ jobs:
           ncu-config set repo ${{ env.REPOSITORY }}
 
       - name: Start CI
-        run: ./tools/actions/start-ci.sh ${{ secrets.GITHUB_TOKEN }} ${{ env.OWNER }} ${{ env.REPOSITORY }} $(echo '${{ steps.get_prs_for_ci.outputs.data }}' | jq '.repository.pullRequests.nodes | map(.number) | .[]')
+        run: ./tools/actions/start-ci.sh ${{ secrets.GITHUB_TOKEN }} ${{ env.OWNER }} ${{ env.REPOSITORY }} ${{ github.event.number }}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

GitHub recently introduced a new Pull Request event for Actions with
access to Secrets and GITHUB_TOKEN with write access. Therefore, we
don't need to use the scheduler event to start Jenkins anymore.

Ref: https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
