### PR TITLE
module: exports patterns

### DIFF
--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -215,17 +215,17 @@ Alternatively a project could choose to export entire folders:
   "exports": {
     ".": "./lib/index.js",
     "./lib": "./lib/index.js",
-    "./lib/": "./lib/",
+    "./lib/*": "./lib/*.js",
     "./feature": "./feature/index.js",
-    "./feature/": "./feature/",
+    "./feature/*": "./feature/*.js",
     "./package.json": "./package.json"
   }
 }
 ```
 
 As a last resort, package encapsulation can be disabled entirely by creating an
-export for the root of the package `"./": "./"`. This will expose every file in
-the package at the cost of disabling the encapsulation and potential tooling
+export for the root of the package `"./*": "./*"`. This will expose every file
+in the package at the cost of disabling the encapsulation and potential tooling
 benefits this provides. As the ES Module loader in Node.js enforces the use of
 [the full specifier path][], exporting the root rather than being explicit
 about entry is less expressive than either of the prior examples. Not only
@@ -289,29 +289,46 @@ import submodule from 'es-module-package/private-module.js';
 // Throws ERR_PACKAGE_PATH_NOT_EXPORTED
 ```
 
-Entire folders can also be mapped with package exports:
+### Subpath export patterns
+
+> Stability: 1 - Experimental
+
+Explicitly listing each exports subpath entry is recommended for packages with
+a small number of exports. But for packages that have very large numbers of
+subpaths this can start to cause package.json bloat and maintenanec issues.
+
+For these use cases, subpath export patterns can be used instead:
 
 ```json
 // ./node_modules/es-module-package/package.json
 {
   "exports": {
-    "./features/": "./src/features/"
+    "./features/*": "./src/features/*.js"
   }
 }
 ```
 
-With the preceding, all modules within the `./src/features/` folder
-are exposed deeply to `import` and `require`:
+The left hand matching pattern must always end in `*`, and all instances of `*`
+on the right hand side will then be replaced with this value, including if it
+contains any `/` separators.
 
 ```js
-import feature from 'es-module-package/features/x.js';
+import featureX from 'es-module-package/features/x';
 // Loads ./node_modules/es-module-package/src/features/x.js
+
+import featureY from 'es-module-package/features/y/y';
+// Loads ./node_modules/es-module-package/src/features/y/y.js
 ```
 
-When using folder mappings, ensure that you do want to expose every
-module inside the subfolder. Any modules which are not public
-should be moved to another folder to retain the encapsulation
-benefits of exports.
+This is a direct static replacement without any special handling for file
+extensions. In the previous example, `pkg/features/x.json` would be resolved to
+`./src/featrues/x.json.js` in the mapping.
+
+The property of exports being statically enumerable is maintained with exports
+patterns since the individual exports for a package can be determined by
+treating the right hand side target pattern as a `**` glob against the list of
+files within the package. Because `node_modules` paths are forbidden in exports
+targets, this expansion is dependent on only the files of the package itself.
 
 ### Package exports fallbacks
 

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -322,7 +322,7 @@ import featureY from 'es-module-package/features/y/y';
 
 This is a direct static replacement without any special handling for file
 extensions. In the previous example, `pkg/features/x.json` would be resolved to
-`./src/featrues/x.json.js` in the mapping.
+`./src/features/x.json.js` in the mapping.
 
 The property of exports being statically enumerable is maintained with exports
 patterns since the individual exports for a package can be determined by

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -307,10 +307,11 @@ function throwInvalidPackageTarget(
 }
 
 const invalidSegmentRegEx = /(^|\\|\/)(\.\.?|node_modules)(\\|\/|$)/;
+const patternRegEx = /\*/g;
 
 function resolvePackageTargetString(
-  target, subpath, match, packageJSONUrl, base, internal, conditions) {
-  if (subpath !== '' && target[target.length - 1] !== '/')
+  target, subpath, match, packageJSONUrl, base, pattern, internal, conditions) {
+  if (subpath !== '' && !pattern && target[target.length - 1] !== '/')
     throwInvalidPackageTarget(match, target, packageJSONUrl, internal, base);
 
   if (!StringPrototypeStartsWith(target, './')) {
@@ -321,8 +322,12 @@ function resolvePackageTargetString(
         new URL(target);
         isURL = true;
       } catch {}
-      if (!isURL)
-        return packageResolve(target + subpath, packageJSONUrl, conditions);
+      if (!isURL) {
+        const exportTarget = pattern ?
+          StringPrototypeReplace(target, patternRegEx, subpath) :
+          target + subpath;
+        return packageResolve(exportTarget, packageJSONUrl, conditions);
+      }
     }
     throwInvalidPackageTarget(match, target, packageJSONUrl, internal, base);
   }
@@ -342,6 +347,9 @@ function resolvePackageTargetString(
   if (RegExpPrototypeTest(invalidSegmentRegEx, subpath))
     throwInvalidSubpath(match + subpath, packageJSONUrl, internal, base);
 
+  if (pattern)
+    return new URL(StringPrototypeReplace(resolved.href, patternRegEx,
+                                          subpath));
   return new URL(subpath, resolved);
 }
 
@@ -356,10 +364,10 @@ function isArrayIndex(key) {
 }
 
 function resolvePackageTarget(packageJSONUrl, target, subpath, packageSubpath,
-                              base, internal, conditions) {
+                              base, pattern, internal, conditions) {
   if (typeof target === 'string') {
     return resolvePackageTargetString(
-      target, subpath, packageSubpath, packageJSONUrl, base, internal,
+      target, subpath, packageSubpath, packageJSONUrl, base, pattern, internal,
       conditions);
   } else if (ArrayIsArray(target)) {
     if (target.length === 0)
@@ -371,8 +379,8 @@ function resolvePackageTarget(packageJSONUrl, target, subpath, packageSubpath,
       let resolved;
       try {
         resolved = resolvePackageTarget(
-          packageJSONUrl, targetItem, subpath, packageSubpath, base, internal,
-          conditions);
+          packageJSONUrl, targetItem, subpath, packageSubpath, base, pattern,
+          internal, conditions);
       } catch (e) {
         lastException = e;
         if (e.code === 'ERR_INVALID_PACKAGE_TARGET')
@@ -406,7 +414,7 @@ function resolvePackageTarget(packageJSONUrl, target, subpath, packageSubpath,
         const conditionalTarget = target[key];
         const resolved = resolvePackageTarget(
           packageJSONUrl, conditionalTarget, subpath, packageSubpath, base,
-          internal, conditions);
+          pattern, internal, conditions);
         if (resolved === undefined)
           continue;
         return resolved;
@@ -460,7 +468,7 @@ function packageExportsResolve(
   if (ObjectPrototypeHasOwnProperty(exports, packageSubpath)) {
     const target = exports[packageSubpath];
     const resolved = resolvePackageTarget(
-      packageJSONUrl, target, '', packageSubpath, base, false, conditions
+      packageJSONUrl, target, '', packageSubpath, base, false, false, conditions
     );
     if (resolved === null || resolved === undefined)
       throwExportsNotFound(packageSubpath, packageJSONUrl, base);
@@ -471,7 +479,13 @@ function packageExportsResolve(
   const keys = ObjectGetOwnPropertyNames(exports);
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i];
-    if (key[key.length - 1] === '/' &&
+    if (key[key.length - 1] === '*' &&
+        StringPrototypeStartsWith(packageSubpath,
+                                  StringPrototypeSlice(key, 0, -1)) &&
+        packageSubpath.length >= key.length &&
+        key.length > bestMatch.length) {
+      bestMatch = key;
+    } else if (key[key.length - 1] === '/' &&
       StringPrototypeStartsWith(packageSubpath, key) &&
       key.length > bestMatch.length) {
       bestMatch = key;
@@ -480,12 +494,15 @@ function packageExportsResolve(
 
   if (bestMatch) {
     const target = exports[bestMatch];
-    const subpath = StringPrototypeSubstr(packageSubpath, bestMatch.length);
+    const pattern = bestMatch[bestMatch.length - 1] === '*';
+    const subpath = StringPrototypeSubstr(packageSubpath, bestMatch.length -
+      (pattern ? 1 : 0));
     const resolved = resolvePackageTarget(packageJSONUrl, target, subpath,
-                                          bestMatch, base, false, conditions);
+                                          bestMatch, base, pattern, false,
+                                          conditions);
     if (resolved === null || resolved === undefined)
       throwExportsNotFound(packageSubpath, packageJSONUrl, base);
-    return { resolved, exact: false };
+    return { resolved, exact: pattern };
   }
 
   throwExportsNotFound(packageSubpath, packageJSONUrl, base);
@@ -504,7 +521,7 @@ function packageImportsResolve(name, base, conditions) {
     if (imports) {
       if (ObjectPrototypeHasOwnProperty(imports, name)) {
         const resolved = resolvePackageTarget(
-          packageJSONUrl, imports[name], '', name, base, true, conditions
+          packageJSONUrl, imports[name], '', name, base, false, true, conditions
         );
         if (resolved !== null)
           return { resolved, exact: true };
@@ -513,7 +530,13 @@ function packageImportsResolve(name, base, conditions) {
         const keys = ObjectGetOwnPropertyNames(imports);
         for (let i = 0; i < keys.length; i++) {
           const key = keys[i];
-          if (key[key.length - 1] === '/' &&
+          if (key[key.length - 1] === '*' &&
+              StringPrototypeStartsWith(name,
+                                        StringPrototypeSlice(key, 0, -1)) &&
+              name.length >= key.length &&
+              key.length > bestMatch.length) {
+            bestMatch = key;
+          } else if (key[key.length - 1] === '/' &&
             StringPrototypeStartsWith(name, key) &&
             key.length > bestMatch.length) {
             bestMatch = key;
@@ -522,11 +545,14 @@ function packageImportsResolve(name, base, conditions) {
 
         if (bestMatch) {
           const target = imports[bestMatch];
-          const subpath = StringPrototypeSubstr(name, bestMatch.length);
+          const pattern = bestMatch[bestMatch.length - 1] === '*';
+          const subpath = StringPrototypeSubstr(name, bestMatch.length -
+            (pattern ? 1 : 0));
           const resolved = resolvePackageTarget(
-            packageJSONUrl, target, subpath, bestMatch, base, true, conditions);
+            packageJSONUrl, target, subpath, bestMatch, base, pattern, true,
+            conditions);
           if (resolved !== null)
-            return { resolved, exact: false };
+            return { resolved, exact: pattern };
         }
       }
     }

--- a/test/es-module/test-esm-exports.mjs
+++ b/test/es-module/test-esm-exports.mjs
@@ -33,6 +33,9 @@ import fromInside from '../fixtures/node_modules/pkgexports/lib/hole.js';
       { default: 'self-cjs' } : { default: 'self-mjs' }],
     // Resolve self sugar
     ['pkgexports-sugar', { default: 'main' }],
+    // Path patterns
+    ['pkgexports/subpath/sub-dir1', { default: 'main' }],
+    ['pkgexports/features/dir1', { default: 'main' }]
   ]);
 
   if (isRequire) {

--- a/test/fixtures/es-modules/pkgimports/package.json
+++ b/test/fixtures/es-modules/pkgimports/package.json
@@ -5,9 +5,9 @@
       "import": "./importbranch.js",
       "require": "./requirebranch.js"
     },
-    "#subpath/": "./sub/",
+    "#subpath/*": "./sub/*",
     "#external": "pkgexports/valid-cjs",
-    "#external/subpath/": "pkgexports/sub/",
+    "#external/subpath/*": "pkgexports/sub/*",
     "#external/invalidsubpath/": "pkgexports/sub",
     "#belowbase": "../belowbase",
     "#url": "some:url",

--- a/test/fixtures/node_modules/pkgexports/package.json
+++ b/test/fixtures/node_modules/pkgexports/package.json
@@ -47,6 +47,8 @@
       "require": "./resolve-self-invalid.js",
       "import": "./resolve-self-invalid.mjs"
     },
-    "./subpath/": "./subpath/"
+    "./subpath/": "./subpath/",
+    "./subpath/sub-*": "./subpath/dir1/*.js",
+    "./features/*": "./subpath/*/*.js"
   }
 }


### PR DESCRIPTION
This PR implements an exports pattern scheme, as discussed in https://github.com/nodejs/modules/issues/535. The gist of the implementation is that exports entries can be written:

```js
{
  "exports": {
    "./features/*": "./dist/features/*/*.js"
  }
}
```

such that `import 'pkg/features/x'` is written into `pkg/dist/features/x/x.js`.

This PR has been based to the refactoring in https://github.com/nodejs/node/pull/34744.

One of the complexities of the implementation was that currently path exports support extension searching for CommonJS, while these new pattern exports don't. To distinguish these cases properly the exports resolution function in both the spec and implementation has been upgraded to return an object with a boolean flag indicating this state.

Previously validations of target subpaths were based on ensuring the subpath belonged to the target folder, which is no longer possible with patterns. Instead, we validate that the replacement components contain no `.`, `..` or `node_modules` segments to disallow the backtracking and node_modules paths as before.

Whether this should merge or not comes down to whether the usefulness justifies the extra complexity. The actual implementation complexity for this ended up not being very large with most of this PR being the refactoring (hence the negative diff!). Adding the modules agenda label, but this is already on the agenda for the meeting under the modules group issue.

Use cases gist with more examples: https://gist.github.com/guybedford/4cb418f93ef51f81343d711bbcd80dd5

@nodejs/modules-active-members 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
