### PR TITLE
worker: fix --abort-on-uncaught-exception handling

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -43,6 +43,7 @@ static bool ShouldAbortOnUncaughtException(Isolate* isolate) {
   Environment* env = Environment::GetCurrent(isolate);
   return env != nullptr &&
          (env->is_main_thread() || !env->is_stopping()) &&
+         env->abort_on_uncaught_exception() &&
          env->should_abort_on_uncaught_toggle()[0] &&
          !env->inside_should_not_abort_on_uncaught_scope();
 }

--- a/src/env.cc
+++ b/src/env.cc
@@ -359,7 +359,7 @@ Environment::Environment(IsolateData* isolate_data,
   inspector_host_port_.reset(
       new ExclusiveAccess<HostPort>(options_->debug_options().host_port));
 
-  if (flags & EnvironmentFlags::kOwnsProcessState) {
+  if (!(flags_ & EnvironmentFlags::kOwnsProcessState)) {
     set_abort_on_uncaught_exception(false);
   }
 

--- a/test/parallel/test-worker-abort-on-uncaught-exception.js
+++ b/test/parallel/test-worker-abort-on-uncaught-exception.js
@@ -1,0 +1,12 @@
+// Flags: --abort-on-uncaught-exception
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { Worker } = require('worker_threads');
+
+// Tests that --abort-on-uncaught-exception does not apply to
+// Workers.
+
+const w = new Worker('throw new Error()', { eval: true });
+w.on('error', common.mustCall());
+w.on('exit', common.mustCall((code) => assert.strictEqual(code, 1)));


### PR DESCRIPTION
The `set_abort_on_uncaught_exception(false)` line was supposed to
prevent aborting when running Workers in
`--abort-on-uncaught-exception` mode, but it was incorrectly set
and not checked properly in the should-abort callback.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
