### PR TITLE
test: fix test_worker_terminate_finalization

### DIFF
--- a/test/node-api/test_worker_terminate_finalization/test_worker_terminate_finalization.c
+++ b/test/node-api/test_worker_terminate_finalization/test_worker_terminate_finalization.c
@@ -22,7 +22,6 @@ napi_value Test(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value argv[1];
   napi_value result;
-  napi_ref ref;
   void* bufferData = malloc(BUFFER_SIZE);
 
   NAPI_CALL(env, napi_get_cb_info(env, info, &argc, argv, NULL, NULL));


### PR DESCRIPTION
The test was missing an initialization of the global `ref` variable
because there was also an unused local one, leading to failures
like the one seen in https://github.com/nodejs/node/pull/34625.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
