### PR TITLE
buffer: alias UInt ➡️ Uint in buffer methods

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1709,6 +1709,9 @@ console.log(buf.readIntLE(0, 6).toString(16));
 <!-- YAML
 added: v0.5.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/34729
+    description: This function is also available as `buf.readUint8()`.
   - version: v10.0.0
     pr-url: https://github.com/nodejs/node/pull/18395
     description: Removed `noAssert` and no implicit coercion of the offset
@@ -1736,6 +1739,9 @@ console.log(buf.readUInt8(2));
 <!-- YAML
 added: v0.5.5
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/34729
+    description: This function is also available as `buf.readUint16BE()`.
   - version: v10.0.0
     pr-url: https://github.com/nodejs/node/pull/18395
     description: Removed `noAssert` and no implicit coercion of the offset
@@ -1762,6 +1768,9 @@ console.log(buf.readUInt16BE(1).toString(16));
 <!-- YAML
 added: v0.5.5
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/34729
+    description: This function is also available as `buf.readUint16LE()`.
   - version: v10.0.0
     pr-url: https://github.com/nodejs/node/pull/18395
     description: Removed `noAssert` and no implicit coercion of the offset
@@ -1790,6 +1799,9 @@ console.log(buf.readUInt16LE(2).toString(16));
 <!-- YAML
 added: v0.5.5
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/34729
+    description: This function is also available as `buf.readUint32BE()`.
   - version: v10.0.0
     pr-url: https://github.com/nodejs/node/pull/18395
     description: Removed `noAssert` and no implicit coercion of the offset
@@ -1814,6 +1826,9 @@ console.log(buf.readUInt32BE(0).toString(16));
 <!-- YAML
 added: v0.5.5
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/34729
+    description: This function is also available as `buf.readUint32LE()`.
   - version: v10.0.0
     pr-url: https://github.com/nodejs/node/pull/18395
     description: Removed `noAssert` and no implicit coercion of the offset
@@ -1840,6 +1855,9 @@ console.log(buf.readUInt32LE(1).toString(16));
 <!-- YAML
 added: v0.11.15
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/34729
+    description: This function is also available as `buf.readUintBE()`.
   - version: v10.0.0
     pr-url: https://github.com/nodejs/node/pull/18395
     description: Removed `noAssert` and no implicit coercion of the offset
@@ -1869,6 +1887,9 @@ console.log(buf.readUIntBE(1, 6).toString(16));
 <!-- YAML
 added: v0.11.15
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/34729
+    description: This function is also available as `buf.readUintLE()`.
   - version: v10.0.0
     pr-url: https://github.com/nodejs/node/pull/18395
     description: Removed `noAssert` and no implicit coercion of the offset
@@ -2651,6 +2672,9 @@ console.log(buf);
 <!-- YAML
 added: v0.5.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/34729
+    description: This function is also available as `buf.writeUint8()`.
   - version: v10.0.0
     pr-url: https://github.com/nodejs/node/pull/18395
     description: Removed `noAssert` and no implicit coercion of the offset
@@ -2682,6 +2706,9 @@ console.log(buf);
 <!-- YAML
 added: v0.5.5
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/34729
+    description: This function is also available as `buf.writeUint16BE()`.
   - version: v10.0.0
     pr-url: https://github.com/nodejs/node/pull/18395
     description: Removed `noAssert` and no implicit coercion of the offset
@@ -2711,6 +2738,9 @@ console.log(buf);
 <!-- YAML
 added: v0.5.5
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/34729
+    description: This function is also available as `buf.writeUint16LE()`.
   - version: v10.0.0
     pr-url: https://github.com/nodejs/node/pull/18395
     description: Removed `noAssert` and no implicit coercion of the offset
@@ -2740,6 +2770,9 @@ console.log(buf);
 <!-- YAML
 added: v0.5.5
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/34729
+    description: This function is also available as `buf.writeUint32BE()`.
   - version: v10.0.0
     pr-url: https://github.com/nodejs/node/pull/18395
     description: Removed `noAssert` and no implicit coercion of the offset
@@ -2768,6 +2801,9 @@ console.log(buf);
 <!-- YAML
 added: v0.5.5
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/34729
+    description: This function is also available as `buf.writeUint32LE()`.
   - version: v10.0.0
     pr-url: https://github.com/nodejs/node/pull/18395
     description: Removed `noAssert` and no implicit coercion of the offset
@@ -2796,6 +2832,9 @@ console.log(buf);
 <!-- YAML
 added: v0.5.5
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/34729
+    description: This function is also available as `buf.writeUintBE()`.
   - version: v10.0.0
     pr-url: https://github.com/nodejs/node/pull/18395
     description: Removed `noAssert` and no implicit coercion of the offset
@@ -2826,6 +2865,9 @@ console.log(buf);
 <!-- YAML
 added: v0.5.5
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/34729
+    description: This function is also available as `buf.writeUintLE()`.
   - version: v10.0.0
     pr-url: https://github.com/nodejs/node/pull/18395
     description: Removed `noAssert` and no implicit coercion of the offset

--- a/lib/internal/buffer.js
+++ b/lib/internal/buffer.js
@@ -966,6 +966,13 @@ function addBufferPrototypeMethods(proto) {
   proto.readUIntBE = readUIntBE;
   proto.readUInt32BE = readUInt32BE;
   proto.readUInt16BE = readUInt16BE;
+  proto.readUintLE = readUIntLE;
+  proto.readUint32LE = readUInt32LE;
+  proto.readUint16LE = readUInt16LE;
+  proto.readUint8 = readUInt8;
+  proto.readUintBE = readUIntBE;
+  proto.readUint32BE = readUInt32BE;
+  proto.readUint16BE = readUInt16BE;
   proto.readIntLE = readIntLE;
   proto.readInt32LE = readInt32LE;
   proto.readInt16LE = readInt16LE;
@@ -981,6 +988,13 @@ function addBufferPrototypeMethods(proto) {
   proto.writeUIntBE = writeUIntBE;
   proto.writeUInt32BE = writeUInt32BE;
   proto.writeUInt16BE = writeUInt16BE;
+  proto.writeUintLE = writeUIntLE;
+  proto.writeUint32LE = writeUInt32LE;
+  proto.writeUint16LE = writeUInt16LE;
+  proto.writeUint8 = writeUInt8;
+  proto.writeUintBE = writeUIntBE;
+  proto.writeUint32BE = writeUInt32BE;
+  proto.writeUint16BE = writeUInt16BE;
   proto.writeIntLE = writeIntLE;
   proto.writeInt32LE = writeInt32LE;
   proto.writeInt16LE = writeInt16LE;

--- a/test/parallel/test-buffer-writeuint.js
+++ b/test/parallel/test-buffer-writeuint.js
@@ -220,3 +220,12 @@ const assert = require('assert');
     val *= 0x100;
   }
 }
+
+for (const fn of [
+  'UInt8', 'UInt16LE', 'UInt16BE', 'UInt32LE', 'UInt32BE', 'UIntLE', 'UIntBE'
+]) {
+  const p = Buffer.prototype;
+  const lowerFn = fn.replace(/UInt/, 'Uint');
+  assert.strictEqual(p[`write${fn}`], p[`write${lowerFn}`]);
+  assert.strictEqual(p[`read${fn}`], p[`read${lowerFn}`]);
+}


### PR DESCRIPTION
It’s *so* hard to remember that it’s `UintXArray` but not
`(write|read)UintX`. Let’s fix that by just providing aliases. 😊

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
