### PR TITLE
repl: unflag Top-Level Await

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -279,7 +279,7 @@ added: v11.8.0
 
 Use the specified file as a security policy.
 
-### `--no-experimetal-repl-await`
+### `--no-experimental-repl-await`
 <!-- YAML
 added: v16.4.3
  -->

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -279,6 +279,12 @@ added: v11.8.0
 
 Use the specified file as a security policy.
 
+### `--no-experimetal-repl-await`
+<!-- YAML
+addded: v16.4.3
+ -->
+ Use this flag to disable top-level await in REPL.
+
 ### `--experimental-specifier-resolution=mode`
 <!-- YAML
 added:
@@ -1396,6 +1402,7 @@ Node.js options that are allowed are:
 * `--experimental-policy`
 * `--experimental-specifier-resolution`
 * `--experimental-top-level-await`
+* `--no-experimental-repl-await`
 * `--experimental-vm-modules`
 * `--experimental-wasi-unstable-preview1`
 * `--experimental-wasm-modules`

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1402,7 +1402,6 @@ Node.js options that are allowed are:
 * `--experimental-policy`
 * `--experimental-specifier-resolution`
 * `--experimental-top-level-await`
-* `--no-experimental-repl-await`
 * `--experimental-vm-modules`
 * `--experimental-wasi-unstable-preview1`
 * `--experimental-wasm-modules`
@@ -1422,6 +1421,7 @@ Node.js options that are allowed are:
 * `--max-http-header-size`
 * `--napi-modules`
 * `--no-deprecation`
+* `--no-experimental-repl-await`
 * `--no-force-async-hooks-checks`
 * `--no-warnings`
 * `--node-memory-debug`

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -279,13 +279,6 @@ added: v11.8.0
 
 Use the specified file as a security policy.
 
-### `--experimental-repl-await`
-<!-- YAML
-added: v10.0.0
--->
-
-Enable experimental top-level `await` keyword support in REPL.
-
 ### `--experimental-specifier-resolution=mode`
 <!-- YAML
 added:
@@ -1401,7 +1394,6 @@ Node.js options that are allowed are:
 * `--experimental-loader`
 * `--experimental-modules`
 * `--experimental-policy`
-* `--experimental-repl-await`
 * `--experimental-specifier-resolution`
 * `--experimental-top-level-await`
 * `--experimental-vm-modules`

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -281,7 +281,7 @@ Use the specified file as a security policy.
 
 ### `--no-experimetal-repl-await`
 <!-- YAML
-addded: v16.4.3
+added: v16.4.3
  -->
  Use this flag to disable top-level await in REPL.
 

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -281,7 +281,7 @@ Use the specified file as a security policy.
 
 ### `--no-experimental-repl-await`
 <!-- YAML
-added: v16.4.3
+added: REPLACEME
  -->
  Use this flag to disable top-level await in REPL.
 

--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -217,8 +217,7 @@ Error: foo
 
 #### `await` keyword
 
-With the [`--experimental-repl-await`][] command-line option specified,
-experimental support for the `await` keyword is enabled.
+Support for the `await` keyword is enabled at the top level.
 
 ```console
 > await Promise.resolve(123)
@@ -764,7 +763,6 @@ For an example of running a REPL instance over [`curl(1)`][], see:
 [TTY keybindings]: readline.md#readline_tty_keybindings
 [ZSH]: https://en.wikipedia.org/wiki/Z_shell
 [`'uncaughtException'`]: process.md#process_event_uncaughtexception
-[`--experimental-repl-await`]: cli.md#cli_experimental_repl_await
 [`ERR_DOMAIN_CANNOT_SET_UNCAUGHT_EXCEPTION_CAPTURE`]: errors.md#errors_err_domain_cannot_set_uncaught_exception_capture
 [`ERR_INVALID_REPL_INPUT`]: errors.md#errors_err_invalid_repl_input
 [`curl(1)`]: https://curl.haxx.se/docs/manpage.html

--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -249,7 +249,7 @@ undefined
 234
 ```
 
-P.S: Use [`--no-experimental-repl-await`][] if you ever wish to disable top-level await in your REPL.
+[`--no-experimental-repl-await`][] shall disable top-level await in REPL.
 
 ### Reverse-i-search
 <!-- YAML
@@ -765,6 +765,7 @@ For an example of running a REPL instance over [`curl(1)`][], see:
 [TTY keybindings]: readline.md#readline_tty_keybindings
 [ZSH]: https://en.wikipedia.org/wiki/Z_shell
 [`'uncaughtException'`]: process.md#process_event_uncaughtexception
+[`--no-experimental-repl-await`]: cli.md#cli_no_experimental_repl_await
 [`ERR_DOMAIN_CANNOT_SET_UNCAUGHT_EXCEPTION_CAPTURE`]: errors.md#errors_err_domain_cannot_set_uncaught_exception_capture
 [`ERR_INVALID_REPL_INPUT`]: errors.md#errors_err_invalid_repl_input
 [`curl(1)`]: https://curl.haxx.se/docs/manpage.html
@@ -776,4 +777,3 @@ For an example of running a REPL instance over [`curl(1)`][], see:
 [`reverse-i-search`]: #repl_reverse_i_search
 [`util.inspect()`]: util.md#util_util_inspect_object_options
 [stream]: stream.md
-[`--no-experimental-repl-await`]: cli.md#cli_no_experimental_repl_await

--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -249,6 +249,8 @@ undefined
 234
 ```
 
+P.S: Use [`--no-experimental-repl-await`][] if you ever wish to disable top-level await in your REPL.
+
 ### Reverse-i-search
 <!-- YAML
 added:
@@ -774,3 +776,4 @@ For an example of running a REPL instance over [`curl(1)`][], see:
 [`reverse-i-search`]: #repl_reverse_i_search
 [`util.inspect()`]: util.md#util_util_inspect_object_options
 [stream]: stream.md
+[`--no-experimental-repl-await`]: cli.md#cli_no_experimental_repl_await

--- a/doc/node.1
+++ b/doc/node.1
@@ -153,11 +153,6 @@ to use as a custom module loader.
 .It Fl -experimental-policy
 Use the specified file as a security policy.
 .
-.It Fl -experimental-repl-await
-Enable experimental top-level
-.Sy await
-keyword support in REPL.
-.
 .It Fl -experimental-specifier-resolution
 Select extension resolution algorithm for ES Modules; either 'explicit' (default) or 'node'.
 .

--- a/doc/node.1
+++ b/doc/node.1
@@ -153,6 +153,9 @@ to use as a custom module loader.
 .It Fl -experimental-policy
 Use the specified file as a security policy.
 .
+.It Fl -no-experimental-repl-await
+Disable top-level await keyword support in REPL.
+.
 .It Fl -experimental-specifier-resolution
 Select extension resolution algorithm for ES Modules; either 'explicit' (default) or 'node'.
 .

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -149,9 +149,6 @@ const {
   validateObject,
 } = require('internal/validators');
 
-const experimentalREPLAwait = getOptionValue(
-  '--experimental-repl-await'
-);
 const pendingDeprecation = getOptionValue('--pending-deprecation');
 const {
   REPL_MODE_SLOPPY,
@@ -421,7 +418,7 @@ function REPLServer(prompt,
       wrappedCmd = true;
     }
 
-    if (experimentalREPLAwait && StringPrototypeIncludes(code, 'await')) {
+    if (StringPrototypeIncludes(code, 'await')) {
       if (processTopLevelAwait === undefined) {
         ({ processTopLevelAwait } = require('internal/repl/await'));
       }

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -148,7 +148,9 @@ const {
   validateFunction,
   validateObject,
 } = require('internal/validators');
-
+const experimentalREPLAwait = getOptionValue(
+  '--experimental-repl-await'
+);
 const pendingDeprecation = getOptionValue('--pending-deprecation');
 const {
   REPL_MODE_SLOPPY,
@@ -418,7 +420,9 @@ function REPLServer(prompt,
       wrappedCmd = true;
     }
 
-    if (StringPrototypeIncludes(code, 'await')) {
+    // `experimentalREPLAwait` is set to true by default.
+    // Shall be false in case `--no-experimental-repl-await` flag is used.
+    if (experimentalREPLAwait && StringPrototypeIncludes(code, 'await')) {
       if (processTopLevelAwait === undefined) {
         ({ processTopLevelAwait } = require('internal/repl/await'));
       }

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -350,6 +350,7 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "experimental await keyword support in REPL",
             NoOp{},
             kAllowedInEnvironment);
+  ImpliesNot("--experimental-repl-await", "--no-experimental-repl-await");
   AddOption("--experimental-vm-modules",
             "experimental ES Module support in vm module",
             &EnvironmentOptions::experimental_vm_modules,

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -350,7 +350,6 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "experimental await keyword support in REPL",
             NoOp{},
             kAllowedInEnvironment);
-  ImpliesNot("--experimental-repl-await", "--no-experimental-repl-await");
   AddOption("--experimental-vm-modules",
             "experimental ES Module support in vm module",
             &EnvironmentOptions::experimental_vm_modules,

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -348,8 +348,9 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
   Implies("--policy-integrity", "[has_policy_integrity_string]");
   AddOption("--experimental-repl-await",
             "experimental await keyword support in REPL",
-            NoOp{},
-            kAllowedInEnvironment);
+            &EnvironmentOptions::experimental_repl_await,
+            kAllowedInEnvironment,
+            true);
   AddOption("--experimental-vm-modules",
             "experimental ES Module support in vm module",
             &EnvironmentOptions::experimental_vm_modules,

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -348,7 +348,7 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
   Implies("--policy-integrity", "[has_policy_integrity_string]");
   AddOption("--experimental-repl-await",
             "experimental await keyword support in REPL",
-            &EnvironmentOptions::experimental_repl_await,
+            NoOp{},
             kAllowedInEnvironment);
   AddOption("--experimental-vm-modules",
             "experimental ES Module support in vm module",

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -112,7 +112,6 @@ class EnvironmentOptions : public Options {
   std::string experimental_policy;
   std::string experimental_policy_integrity;
   bool has_policy_integrity_string;
-  bool experimental_repl_await = false;
   bool experimental_vm_modules = false;
   bool expose_internals = false;
   bool frozen_intrinsics = false;

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -112,6 +112,7 @@ class EnvironmentOptions : public Options {
   std::string experimental_policy;
   std::string experimental_policy_integrity;
   bool has_policy_integrity_string;
+  bool experimental_repl_await = true;
   bool experimental_vm_modules = false;
   bool expose_internals = false;
   bool frozen_intrinsics = false;

--- a/test/parallel/test-process-env-allowed-flags-are-documented.js
+++ b/test/parallel/test-process-env-allowed-flags-are-documented.js
@@ -91,7 +91,6 @@ assert(undocumented.delete('--no-debug-arraybuffer-allocations'));
 assert(undocumented.delete('--es-module-specifier-resolution'));
 assert(undocumented.delete('--experimental-report'));
 assert(undocumented.delete('--experimental-worker'));
-assert(undocumented.delete('--experimental-repl-await'));
 assert(undocumented.delete('--node-snapshot'));
 assert(undocumented.delete('--no-node-snapshot'));
 assert(undocumented.delete('--loader'));

--- a/test/parallel/test-process-env-allowed-flags-are-documented.js
+++ b/test/parallel/test-process-env-allowed-flags-are-documented.js
@@ -91,6 +91,7 @@ assert(undocumented.delete('--no-debug-arraybuffer-allocations'));
 assert(undocumented.delete('--es-module-specifier-resolution'));
 assert(undocumented.delete('--experimental-report'));
 assert(undocumented.delete('--experimental-worker'));
+assert(undocumented.delete('--experimental-repl-await'));
 assert(undocumented.delete('--node-snapshot'));
 assert(undocumented.delete('--no-node-snapshot'));
 assert(undocumented.delete('--loader'));

--- a/test/parallel/test-repl-import-referrer.js
+++ b/test/parallel/test-repl-import-referrer.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 const cp = require('child_process');
 const fixtures = require('../common/fixtures');
 
-const args = ['--interactive', '--experimental-repl-await'];
+const args = ['--interactive'];
 const opts = { cwd: fixtures.path('es-modules') };
 const child = cp.spawn(process.execPath, args, opts);
 

--- a/test/parallel/test-repl-top-level-await.js
+++ b/test/parallel/test-repl-top-level-await.js
@@ -8,7 +8,7 @@ const repl = require('repl');
 
 common.skipIfInspectorDisabled();
 
-// Flags: --expose-internals --experimental-repl-await
+// Flags: --expose-internals
 
 const PROMPT = 'await repl > ';
 


### PR DESCRIPTION
Now that we have #34558 it makes sense to unflag Top-Level await for the REPL?

This PR is getting rid of `--experimental-repl-await` flag and the checks related to the same.

```
❯ node
Welcome to Node.js v14.8.0.
Type ".help" for more information.
> process.version
'v14.8.0'
> await Promise.resolve(123)
await Promise.resolve(42)
^^^^^

Uncaught SyntaxError: await is only valid in async function
```

```
❯ ./node
Welcome to Node.js v15.0.0-pre.
Type ".help" for more information.
> await Promise.resolve(42)
42
```
