### PR TITLE
meta: reduce 7 day rule to 4 days (96 hours)

### DIFF
--- a/doc/guides/contributing/pull-requests.md
+++ b/doc/guides/contributing/pull-requests.md
@@ -346,7 +346,7 @@ unhelpful is likely safe to ignore.
 
 In order to land, a Pull Request needs to be reviewed and [approved][] by
 at least two Node.js Collaborators (one Collaborator approval is enough if the
-pull request has been open for more than 7 days) and pass a
+pull request has been open for more than 96 hours) and pass a
 [CI (Continuous Integration) test run][]. After that, as long as there are no
 objections from other contributors, the Pull Request can be merged. If you find
 your Pull Request waiting longer than you expect, see the


### PR DESCRIPTION
There is no evidence the 7 day rule encourages additional review. Let's make things easier and reduce it down to 96 hours (double the minimal review time).

/cc @addaleax @nodejs/tsc

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
