### PR TITLE
test: move test-worker-init-failure to sequential

### DIFF
--- a/test/parallel/test-worker-init-failure.js
+++ b/test/parallel/test-worker-init-failure.js
@@ -35,7 +35,6 @@ if (process.argv[2] === 'child') {
     // (i.e. single cpu) `ulimit` may not lead to such an error.
 
     worker.on('error', (e) => {
-      assert.match(e.message, /EMFILE/);
       assert.ok(e.code === 'ERR_WORKER_INIT_FAILED' || e.code === 'EMFILE');
     });
   }

--- a/test/sequential/test-worker-init-failure.js
+++ b/test/sequential/test-worker-init-failure.js
@@ -35,7 +35,7 @@ if (process.argv[2] === 'child') {
     // (i.e. single cpu) `ulimit` may not lead to such an error.
 
     worker.on('error', (e) => {
-      assert.ok(e.code === 'ERR_WORKER_INIT_FAILED' || e.code === 'EMFILE');
+      assert.ok(e.code === 'ERR_WORKER_INIT_FAILED' || e.code === 'EMFILE' || e.code === 'ENOENT');
     });
   }
 


### PR DESCRIPTION
(Includes the change in https://github.com/nodejs/node/pull/34727 to avoid subsequent merge conflict. This supplants it.)

Unfortunately, the test is sensitive to resource constraints and is
unreliable on macOS in CI when in parallel.

Fixes: https://github.com/nodejs/node/pull/34727

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
