### PR TITLE
quic: refactor QuicSession stats and use net.BlockList

### DIFF
--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -1445,6 +1445,24 @@ error will be thrown if `quicsock.addEndpoint()` is called either after
 the `QuicSocket` has already started binding to the local ports, or after
 the `QuicSocket` has been destroyed.
 
+#### `quicsocket.blockList`
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {net.BlockList}
+
+A {net.BlockList} instance used to define rules for remote IPv4 or IPv6
+addresses that this `QuicSocket` is not permitted to interact with. The
+rules can be specified as either specific individual addresses, ranges
+of addresses, or CIDR subnet ranges.
+
+When listening as a server, if a packet is received from a blocked address,
+the packet will be ignored.
+
+When connecting as a client, if the remote IP address is blocked, the
+connection attempt will be rejected.
+
 #### `quicsocket.bound`
 <!-- YAML
 added: REPLACEME

--- a/lib/internal/blocklist.js
+++ b/lib/internal/blocklist.js
@@ -26,8 +26,13 @@ const {
 } = require('internal/errors').codes;
 
 class BlockList {
-  constructor() {
-    this[kHandle] = new BlockListHandle();
+  constructor(handle = new BlockListHandle()) {
+    // The handle argument is an intentionally undocumented
+    // internal API. User code will not be able to create
+    // a BlockListHandle object directly.
+    if (!(handle instanceof BlockListHandle))
+      throw new ERR_INVALID_ARG_TYPE('handle', 'BlockListHandle', handle);
+    this[kHandle] = handle;
     this[kHandle][owner_symbol] = this;
   }
 

--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -54,6 +54,7 @@ const { Duplex } = require('stream');
 const {
   createSecureContext: _createSecureContext
 } = require('tls');
+const BlockList = require('internal/blocklist');
 const {
   translatePeerCertificate
 } = require('_tls_common');
@@ -891,6 +892,7 @@ class QuicSocket extends EventEmitter {
   [kInternalState] = {
     alpn: undefined,
     bindPromise: undefined,
+    blockList: undefined,
     client: undefined,
     closePromise: undefined,
     closePromiseResolve: undefined,
@@ -1007,8 +1009,10 @@ class QuicSocket extends EventEmitter {
       this[async_id_symbol] = handle.getAsyncId();
       this[kInternalState].sharedState =
         new QuicSocketSharedState(handle.state);
+      this[kInternalState].blockList = new BlockList(handle.blockList);
     } else {
       this[kInternalState].sharedState = undefined;
+      this[kInternalState].blockList = undefined;
     }
   }
 
@@ -1303,6 +1307,9 @@ class QuicSocket extends EventEmitter {
     if (this.closing)
       throw new ERR_INVALID_STATE('QuicSocket is closing');
 
+    if (this.blockList.check(ip, type === AF_INET6 ? 'ipv6' : 'ipv4'))
+      throw new ERR_OPERATION_FAILED(`${ip} failed BlockList check`);
+
     return new QuicClientSession(this, options, type, ip);
   }
 
@@ -1456,6 +1463,10 @@ class QuicSocket extends EventEmitter {
     for (const endpoint of state.endpoints)
       endpoint.unref();
     return this;
+  }
+
+  get blockList() {
+    return this[kInternalState]?.blockList;
   }
 
   get endpoints() {

--- a/src/env.h
+++ b/src/env.h
@@ -182,6 +182,7 @@ constexpr size_t kFsStatsBufferLength =
   V(asn1curve_string, "asn1Curve")                                             \
   V(async_ids_stack_string, "async_ids_stack")                                 \
   V(bits_string, "bits")                                                       \
+  V(block_list_string, "blockList")                                            \
   V(buffer_string, "buffer")                                                   \
   V(bytes_parsed_string, "bytesParsed")                                        \
   V(bytes_read_string, "bytesRead")                                            \
@@ -423,6 +424,7 @@ constexpr size_t kFsStatsBufferLength =
   V(async_wrap_object_ctor_template, v8::FunctionTemplate)                     \
   V(base_object_ctor_template, v8::FunctionTemplate)                           \
   V(binding_data_ctor_template, v8::FunctionTemplate)                          \
+  V(blocklist_instance_template, v8::ObjectTemplate)                           \
   V(compiled_fn_entry_template, v8::ObjectTemplate)                            \
   V(dir_instance_template, v8::ObjectTemplate)                                 \
   V(fd_constructor_template, v8::ObjectTemplate)                               \

--- a/src/node_sockaddr.cc
+++ b/src/node_sockaddr.cc
@@ -524,6 +524,19 @@ SocketAddressBlockListWrap::SocketAddressBlockListWrap(
   MakeWeak();
 }
 
+BaseObjectPtr<SocketAddressBlockListWrap> SocketAddressBlockListWrap::New(
+    Environment* env) {
+  Local<Object> obj;
+  if (!env->blocklist_instance_template()
+          ->NewInstance(env->context()).ToLocal(&obj)) {
+    return {};
+  }
+  BaseObjectPtr<SocketAddressBlockListWrap> wrap =
+      MakeDetachedBaseObject<SocketAddressBlockListWrap>(env, obj);
+  CHECK(wrap);
+  return wrap;
+}
+
 void SocketAddressBlockListWrap::New(
     const FunctionCallbackInfo<Value>& args) {
   CHECK(args.IsConstructCall());
@@ -673,6 +686,7 @@ void SocketAddressBlockListWrap::Initialize(
   env->SetProtoMethod(t, "check", SocketAddressBlockListWrap::Check);
   env->SetProtoMethod(t, "getRules", SocketAddressBlockListWrap::GetRules);
 
+  env->set_blocklist_instance_template(t->InstanceTemplate());
   target->Set(env->context(), name,
               t->GetFunction(env->context()).ToLocalChecked()).FromJust();
 

--- a/src/node_sockaddr.h
+++ b/src/node_sockaddr.h
@@ -280,6 +280,7 @@ class SocketAddressBlockListWrap :
                          v8::Local<v8::Context> context,
                          void* priv);
 
+  static BaseObjectPtr<SocketAddressBlockListWrap> New(Environment* env);
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void AddAddress(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void AddRange(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/src/quic/node_quic_crypto.cc
+++ b/src/quic/node_quic_crypto.cc
@@ -602,8 +602,6 @@ void InitializeSecureContext(
     BaseObjectPtr<crypto::SecureContext> sc,
     bool early_data,
     ngtcp2_crypto_side side) {
-  // TODO(@jasnell): Using a static value for this at the moment but
-  // we need to determine if a non-static or per-session value is better.
   constexpr static unsigned char session_id_ctx[] = "node.js quic server";
   switch (side) {
     case NGTCP2_CRYPTO_SIDE_SERVER:

--- a/src/quic/node_quic_http3_application.cc
+++ b/src/quic/node_quic_http3_application.cc
@@ -79,11 +79,10 @@ Http3Application::Http3Application(
 // Push streams in HTTP/3 are a bit complicated.
 // First, it's important to know that only an HTTP/3 server can
 // create a push stream.
-// Second, it's important to recognize that a push stream is
-// essentially an *assumed* request. For instance, if a client
-// requests a webpage that has links to css and js files, and
-// the server expects the client to send subsequent requests
-// for those css and js files, the server can shortcut the
+// Second, a push stream is essentially an *assumed* request. For
+// instance, if a client requests a webpage that has links to css
+// and js files, and the server expects the client to send subsequent
+// requests for those css and js files, the server can shortcut the
 // process by opening a push stream for each additional resource
 // it assumes the client to make.
 // Third, a push stream can only be opened within the context

--- a/src/quic/node_quic_session.cc
+++ b/src/quic/node_quic_session.cc
@@ -263,6 +263,16 @@ void QuicSessionConfig::Set(
   // TODO(@jasnell): QUIC allows both IPv4 and IPv6 addresses to be
   // specified. Here we're specifying one or the other. Need to
   // determine if that's what we want or should we support both.
+  //
+  // TODO(@jasnell): Currently, this is specified as a single value
+  // that is used for all connections. In the future, it may be
+  // necessary to determine the preferred address based on the
+  // remote address. The trick, however, is that the preferred
+  // address must be selected before the QuicSession is created,
+  // before the handshake can be started. That is, it may need
+  // to be an optional callback on QuicSocket. That would incur
+  // a performance penalty so we'd really have to be sure of the
+  // utility.
   if (preferred_addr != nullptr) {
     transport_params.preferred_address_present = 1;
     switch (preferred_addr->sa_family) {

--- a/src/quic/node_quic_session.h
+++ b/src/quic/node_quic_session.h
@@ -204,7 +204,10 @@ enum QuicSessionStateFields {
   V(BLOCK_COUNT, block_count, "Block Count")                                   \
   V(MIN_RTT, min_rtt, "Minimum RTT")                                           \
   V(LATEST_RTT, latest_rtt, "Latest RTT")                                      \
-  V(SMOOTHED_RTT, smoothed_rtt, "Smoothed RTT")
+  V(SMOOTHED_RTT, smoothed_rtt, "Smoothed RTT")                                \
+  V(CWND, cwnd, "Cwnd")                                                        \
+  V(RECEIVE_RATE, receive_rate, "Receive Rate / Sec")                          \
+  V(SEND_RATE, send_rate, "Send Rate  Sec")
 
 #define V(name, _, __) IDX_QUIC_SESSION_STATS_##name,
 enum QuicSessionStatsIdx : int {
@@ -1271,8 +1274,6 @@ class QuicSession final : public AsyncWrap,
       uint64_t app_error_code);
 
   bool WritePackets(const char* diagnostic_label = nullptr);
-
-  void UpdateRecoveryStats();
 
   void UpdateConnectionID(
       int type,

--- a/src/quic/node_quic_session.h
+++ b/src/quic/node_quic_session.h
@@ -207,7 +207,7 @@ enum QuicSessionStateFields {
   V(SMOOTHED_RTT, smoothed_rtt, "Smoothed RTT")                                \
   V(CWND, cwnd, "Cwnd")                                                        \
   V(RECEIVE_RATE, receive_rate, "Receive Rate / Sec")                          \
-  V(SEND_RATE, send_rate, "Send Rate  Sec")
+  V(SEND_RATE, send_rate, "Send Rate  Sec")                                    \
 
 #define V(name, _, __) IDX_QUIC_SESSION_STATS_##name,
 enum QuicSessionStatsIdx : int {

--- a/src/quic/node_quic_session.h
+++ b/src/quic/node_quic_session.h
@@ -616,20 +616,17 @@ class QuicApplication : public MemoryRetainer,
 
   virtual void ResumeStream(int64_t stream_id) {}
 
-  virtual void SetSessionTicketAppData(const SessionTicketAppData& app_data) {
-    // TODO(@jasnell): Different QUIC applications may wish to set some
-    // application data in the session ticket (e.g. http/3 would set
-    // server settings in the application data). For now, doing nothing
-    // as I'm just adding the basic mechanism.
-  }
+  // Different QUIC applications may set some application data in
+  // the session ticket (e.g. http/3 would set server settings in the
+  // application data). By default, there's nothing to set.
+  virtual void SetSessionTicketAppData(const SessionTicketAppData& app_data) {}
 
+  // Different QUIC applications may set some application data in
+  // the session ticket (e.g. http/3 would set server settings in the
+  // application data). By default, there's nothing to get.
   virtual SessionTicketAppData::Status GetSessionTicketAppData(
       const SessionTicketAppData& app_data,
       SessionTicketAppData::Flag flag) {
-    // TODO(@jasnell): Different QUIC application may wish to set some
-    // application data in the session ticket (e.g. http/3 would set
-    // server settings in the application data). For now, doing nothing
-    // as I'm just adding the basic mechanism.
     return flag == SessionTicketAppData::Flag::STATUS_RENEW ?
       SessionTicketAppData::Status::TICKET_USE_RENEW :
       SessionTicketAppData::Status::TICKET_USE;

--- a/src/quic/node_quic_socket.h
+++ b/src/quic/node_quic_socket.h
@@ -516,6 +516,7 @@ class QuicSocket : public AsyncWrap,
   std::vector<BaseObjectPtr<QuicEndpoint>> endpoints_;
   SocketAddress::Map<BaseObjectWeakPtr<QuicEndpoint>> bound_endpoints_;
   BaseObjectWeakPtr<QuicEndpoint> preferred_endpoint_;
+  BaseObjectPtr<SocketAddressBlockListWrap> block_list_;
 
   uint32_t flags_ = 0;
   uint32_t options_ = 0;

--- a/test/parallel/test-quic-blocklist.js
+++ b/test/parallel/test-quic-blocklist.js
@@ -1,0 +1,52 @@
+// Flags: --no-warnings
+'use strict';
+
+const common = require('../common');
+
+if (!common.hasQuic)
+  common.skip('missing quic');
+
+const { createQuicSocket, BlockList } = require('net');
+const assert = require('assert');
+
+const { key, cert, ca } = require('../common/quic');
+const { once } = require('events');
+
+const idleTimeout = common.platformTimeout(1);
+const options = { key, cert, ca, alpn: 'zzz', idleTimeout };
+
+const client = createQuicSocket({ client: options });
+const server = createQuicSocket({ server: options });
+
+assert(client.blockList instanceof BlockList);
+assert(server.blockList instanceof BlockList);
+
+client.blockList.addAddress('10.0.0.1');
+
+assert(client.blockList.check('10.0.0.1'));
+
+// Connection fails because the IP address is blocked
+assert.rejects(client.connect({ address: '10.0.0.1' }), {
+  code: 'ERR_OPERATION_FAILED'
+}).then(common.mustCall());
+
+server.blockList.addAddress('127.0.0.1');
+
+(async () => {
+  server.on('session', common.mustNotCall());
+
+  await server.listen();
+
+  const session = await client.connect({
+    address: common.localhostIPv4,
+    port: server.endpoints[0].address.port,
+    idleTimeout,
+  });
+
+  session.on('secure', common.mustNotCall());
+
+  await once(session, 'close');
+
+  await Promise.all([server.close(), client.close()]);
+
+})().then(common.mustCall());

--- a/tools/doc/type-parser.js
+++ b/tools/doc/type-parser.js
@@ -122,6 +122,7 @@ const customTypesMap = {
   'require': 'modules.html#modules_require_id',
 
   'Handle': 'net.html#net_server_listen_handle_backlog_callback',
+  'net.BlockList': 'net.html#net_class_net_blocklist',
   'net.Server': 'net.html#net_class_net_server',
   'net.Socket': 'net.html#net_class_net_socket',
 


### PR DESCRIPTION
This depends on #34655 and #34669, both of which must land first. The first 6 commits here are from those earlier PRs.

There are several commits here:

* quic: fixup session ticket app data todo comments
* quic: resolve InitializeSecureContext TODO comment …
* quic: clarify TODO statements

These first three are minor and resolve several outstanding TODO items

* quic: consolidate stats collecting in QuicSession

Simplifies some of the stats collection

* src: allow instances of net.BlockList to be created internally …
* quic: use net.BlockList for limiting access to a QuicSocket

Enables use of the new `net.BlockList` for both client and server side.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
