### PR TITLE
test,doc: add missing uv_setup_args() calls

### DIFF
--- a/doc/api/embedding.md
+++ b/doc/api/embedding.md
@@ -35,6 +35,7 @@ the `node` and `v8` C++ namespaces, respectively.
 
 ```cpp
 int main(int argc, char** argv) {
+  argv = uv_setup_args(argc, argv);
   std::vector<std::string> args(argv, argv + argc);
   std::vector<std::string> exec_args;
   std::vector<std::string> errors;

--- a/test/cctest/gtest/gtest_main.cc
+++ b/test/cctest/gtest/gtest_main.cc
@@ -28,6 +28,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <cstdio>
+#include <uv.h>
 #include "gtest.h"
 
 #ifdef ARDUINO
@@ -40,6 +41,7 @@ void loop() { RUN_ALL_TESTS(); }
 #else
 
 GTEST_API_ int main(int argc, char **argv) {
+  argv = uv_setup_args(argc, argv);
   printf("Running main() from %s\n", __FILE__);
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/test/embedding/embedtest.cc
+++ b/test/embedding/embedtest.cc
@@ -24,6 +24,7 @@ static int RunNodeInstance(MultiIsolatePlatform* platform,
                            const std::vector<std::string>& exec_args);
 
 int main(int argc, char** argv) {
+  argv = uv_setup_args(argc, argv);
   std::vector<std::string> args(argv, argv + argc);
   std::vector<std::string> exec_args;
   std::vector<std::string> errors;


### PR DESCRIPTION
libuv 1.39.0 will begin requiring `uv_setup_args()` to be called
before attempting to access the process title. This commit adds
`uv_setup_args()` calls that were missing in order for the test
suite to pass (and updates the documentation).

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)