### PR TITLE
Build structure for OSS-Fuzz integration

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -441,7 +441,6 @@ parser.add_option('--v8-options',
 
 parser.add_option('--with-ossfuzz',
     action='store_true',
-    default=False,
     dest='ossfuzz',
     help='Enables building of fuzzers. This command should be run in an OSS-Fuzz Docker image.')
 

--- a/configure.py
+++ b/configure.py
@@ -439,6 +439,11 @@ parser.add_option('--v8-options',
     dest='v8_options',
     help='v8 options to pass, see `node --v8-options` for examples.')
 
+parser.add_option('--with-ossfuzz',
+    action='store_true',
+    default=False,
+    dest='ossfuzz')
+
 parser.add_option('--with-arm-float-abi',
     action='store',
     dest='arm_float_abi',
@@ -1826,6 +1831,9 @@ configure_openssl(output)
 configure_intl(output)
 configure_static(output)
 configure_inspector(output)
+
+# Forward OSS-Fuzz settings
+output['variables']['ossfuzz'] = b(options.ossfuzz)
 
 # variables should be a root level element,
 # move everything else to target_defaults

--- a/configure.py
+++ b/configure.py
@@ -442,7 +442,8 @@ parser.add_option('--v8-options',
 parser.add_option('--with-ossfuzz',
     action='store_true',
     default=False,
-    dest='ossfuzz')
+    dest='ossfuzz',
+    help='Enables building of fuzzers. This command should be run in an OSS-Fuzz Docker image.')
 
 parser.add_option('--with-arm-float-abi',
     action='store',

--- a/node.gyp
+++ b/node.gyp
@@ -1173,31 +1173,25 @@
     { # fuzz_url
       'target_name': 'fuzz_url',
       'type': 'executable',
-
       'dependencies': [
         '<(node_lib_target_name)',
       ],
-
       'includes': [
         'node.gypi'
       ],
-
       'include_dirs': [
         'src',
       ],
-
       'defines': [
         'NODE_ARCH="<(target_arch)"',
         'NODE_PLATFORM="<(OS)"',
         'NODE_WANT_INTERNALS=1',
       ],
-
       'sources': [
         'src/node_snapshot_stub.cc',
         'src/node_code_cache_stub.cc',
         'test/fuzzers/fuzz_url.cc',
       ],
-
       'conditions': [
         ['OS=="linux"', {
           'ldflags': [ '-fsanitize=fuzzer' ]
@@ -1208,8 +1202,6 @@
         }],
       ],
     }, # fuzz_url
-
-
     {
       'target_name': 'cctest',
       'type': 'executable',

--- a/node.gyp
+++ b/node.gyp
@@ -13,6 +13,7 @@
     'node_use_bundled_v8%': 'true',
     'node_shared%': 'false',
     'force_dynamic_crt%': 0,
+    'ossfuzz' : 'true',
     'node_module_version%': '',
     'node_shared_brotli%': 'false',
     'node_shared_zlib%': 'false',
@@ -1169,6 +1170,61 @@
         } ],
       ]
     }, # specialize_node_d
+    { # fuzz_url
+      'target_name': 'fuzz_url',
+      'type': 'executable',
+
+      'dependencies': [
+        '<(node_lib_target_name)',
+        'deps/histogram/histogram.gyp:histogram',
+        'deps/uvwasi/uvwasi.gyp:uvwasi',
+        'node_dtrace_header',
+        'node_dtrace_ustack',
+        'node_dtrace_provider',
+      ],
+
+      'includes': [
+        'node.gypi'
+      ],
+
+      'include_dirs': [
+        'src',
+        'tools/msvs/genfiles',
+        'deps/v8/include',
+        'deps/cares/include',
+        'deps/uv/include',
+        'deps/uvwasi/include',
+      ],
+
+      'defines': [
+        'NODE_ARCH="<(target_arch)"',
+        'NODE_PLATFORM="<(OS)"',
+        'NODE_WANT_INTERNALS=1',
+      ],
+
+      'sources': [
+        'src/node_snapshot_stub.cc',
+        'src/node_code_cache_stub.cc',
+        'test/fuzzers/fuzz_url.cc',
+      ],
+
+      'conditions': [
+        [ 'node_use_openssl=="true"', {
+          'defines': [
+            'HAVE_OPENSSL=1',
+          ],
+        }],
+        ['OS=="linux"', {
+          'ldflags': [ '-fsanitize=fuzzer' ]
+        }],
+        # Skip cctest while building shared lib node for Windows
+        [ 'OS!="linux" or ossfuzz!="true"', {
+          'type': 'none',
+        }],
+      ],
+    }, # fuzz_url
+
+
     {
       'target_name': 'cctest',
       'type': 'executable',

--- a/node.gyp
+++ b/node.gyp
@@ -13,7 +13,7 @@
     'node_use_bundled_v8%': 'true',
     'node_shared%': 'false',
     'force_dynamic_crt%': 0,
-    'ossfuzz' : 'true',
+    'ossfuzz' : 'false',
     'node_module_version%': '',
     'node_shared_brotli%': 'false',
     'node_shared_zlib%': 'false',

--- a/node.gyp
+++ b/node.gyp
@@ -1176,11 +1176,6 @@
 
       'dependencies': [
         '<(node_lib_target_name)',
-        'deps/histogram/histogram.gyp:histogram',
-        'deps/uvwasi/uvwasi.gyp:uvwasi',
-        'node_dtrace_header',
-        'node_dtrace_ustack',
-        'node_dtrace_provider',
       ],
 
       'includes': [
@@ -1189,11 +1184,6 @@
 
       'include_dirs': [
         'src',
-        'tools/msvs/genfiles',
-        'deps/v8/include',
-        'deps/cares/include',
-        'deps/uv/include',
-        'deps/uvwasi/include',
       ],
 
       'defines': [
@@ -1209,15 +1199,10 @@
       ],
 
       'conditions': [
-        [ 'node_use_openssl=="true"', {
-          'defines': [
-            'HAVE_OPENSSL=1',
-          ],
-        }],
         ['OS=="linux"', {
           'ldflags': [ '-fsanitize=fuzzer' ]
         }],
-        # Skip cctest while building shared lib node for Windows
+        # Ensure that ossfuzz flag has been set and that we are on Linux
         [ 'OS!="linux" or ossfuzz!="true"', {
           'type': 'none',
         }],

--- a/test/fuzzers/fuzz_url.cc
+++ b/test/fuzzers/fuzz_url.cc
@@ -5,7 +5,7 @@
 #include "node_url.h"
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
-    node::url::URL url2((char*)data, size);
+    node::url::URL url2(reinterpret_cast<const char*>(data), size);
 
     return 0;
 }

--- a/test/fuzzers/fuzz_url.cc
+++ b/test/fuzzers/fuzz_url.cc
@@ -1,0 +1,11 @@
+#include <stdlib.h>
+
+#include "node.h"
+#include "node_internals.h"
+#include "node_url.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    node::url::URL url2((char*)data, size);
+
+    return 0;
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->


This PR sets up integration with OSS-Fuzz continuous fuzzing. 

Fixes: https://github.com/nodejs/node/issues/33724
Also fixes the integration described here https://github.com/google/oss-fuzz/pull/3860 by @bnoordhuis 

The idea is that we can avoid having a complicated build script on the OSS-Fuzz repository: 
https://github.com/google/oss-fuzz/blob/master/projects/nodejs/build.sh

The code has been tested with oss-fuzz and simplifies things a lot, as well as make it much easier to write more fuzzers. Once this PR is merged I have several fuzzers that will be added, but I figured doing it step-by-step makes most sense. 

The basic idea is to add a `--with-ossfuzz` flag in `configure.py` that is then used by the fuzzer targets inside `node.gyp`. 