### PR TITLE
src: fix error reporting on CPUUsage

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -729,11 +729,6 @@ when an error occurs (and is caught) during the creation of the
 context, for example, when the allocation fails or the maximum call stack
 size is reached when the context is created.
 
-<a id="ERR_CPU_USAGE"></a>
-### `ERR_CPU_USAGE`
-
-The native call from `process.cpuUsage` could not be processed.
-
 <a id="ERR_CRYPTO_CUSTOM_ENGINE_NOT_SUPPORTED"></a>
 ### `ERR_CRYPTO_CUSTOM_ENGINE_NOT_SUPPORTED`
 
@@ -2724,6 +2719,11 @@ removed: v10.0.0
 
 Used when an attempt is made to use a `zlib` object after it has already been
 closed.
+
+<a id="ERR_CPU_USAGE"></a>
+### `ERR_CPU_USAGE`
+
+The native call from `process.cpuUsage` could not be processed.
 
 [ES Module]: esm.md
 [ICU]: intl.md#intl_internationalization_support

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -2722,6 +2722,9 @@ closed.
 
 <a id="ERR_CPU_USAGE"></a>
 ### `ERR_CPU_USAGE`
+<!-- YAML
+removed: REPLACEME
+-->
 
 The native call from `process.cpuUsage` could not be processed.
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -787,7 +787,6 @@ E('ERR_CHILD_PROCESS_STDIO_MAXBUFFER', '%s maxBuffer length exceeded',
 E('ERR_CONSOLE_WRITABLE_STREAM',
   'Console expects a writable stream instance for %s', TypeError);
 E('ERR_CONTEXT_NOT_INITIALIZED', 'context used is not initialized', Error);
-E('ERR_CPU_USAGE', 'Unable to obtain cpu usage %s', Error);
 E('ERR_CRYPTO_CUSTOM_ENGINE_NOT_SUPPORTED',
   'Custom engines not supported by this OpenSSL', Error);
 E('ERR_CRYPTO_ECDH_INVALID_FORMAT', 'Invalid ECDH format: %s', TypeError);

--- a/lib/internal/process/per_thread.js
+++ b/lib/internal/process/per_thread.js
@@ -25,7 +25,6 @@ const {
   errnoException,
   codes: {
     ERR_ASSERTION,
-    ERR_CPU_USAGE,
     ERR_INVALID_ARG_TYPE,
     ERR_INVALID_ARG_VALUE,
     ERR_OUT_OF_RANGE,
@@ -129,10 +128,7 @@ function wrapProcessMethods(binding) {
     }
 
     // Call the native function to get the current values.
-    const errmsg = _cpuUsage(cpuValues);
-    if (errmsg) {
-      throw new ERR_CPU_USAGE(errmsg);
-    }
+    _cpuUsage(cpuValues);
 
     // If a previous value was passed in, return diff of current from previous.
     if (prevValue) {

--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -95,15 +95,13 @@ static void Chdir(const FunctionCallbackInfo<Value>& args) {
 // Returns those values as Float64 microseconds in the elements of the array
 // passed to the function.
 static void CPUUsage(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
   uv_rusage_t rusage;
 
   // Call libuv to get the values we'll return.
   int err = uv_getrusage(&rusage);
-  if (err) {
-    // On error, return the strerror version of the error code.
-    Local<String> errmsg = OneByteString(args.GetIsolate(), uv_strerror(err));
-    return args.GetReturnValue().Set(errmsg);
-  }
+  if (err)
+    return env->ThrowUVException(err, "uv_getrusage");
 
   // Get the double array pointer from the Float64Array argument.
   CHECK(args[0]->IsFloat64Array());


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Currently we are returning the stringified error code while in other
process methods we are throwin a UVException and only exclusion is in
the CPUUsage. Converted it to follow the convention, which is being written in the
file.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->