### PR TITLE
quic,timers: use AbortController with correct name/message

### DIFF
--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -253,10 +253,10 @@ let warnedVerifyHostnameIdentity = false;
 
 let DOMException;
 
-const lazyDOMException = hideStackFrames((message) => {
+const lazyDOMException = hideStackFrames((message, name) => {
   if (DOMException === undefined)
     DOMException = internalBinding('messaging').DOMException;
-  return new DOMException(message);
+  return new DOMException(message, name);
 });
 
 assert(process.versions.ngtcp2 !== undefined);
@@ -664,10 +664,10 @@ class QuicEndpoint {
     if (signal != null && !('aborted' in signal))
       throw new ERR_INVALID_ARG_TYPE('options.signal', 'AbortSignal', signal);
 
-    // If an AbotSignal was passed in, check to make sure it is not already
+    // If an AbortSignal was passed in, check to make sure it is not already
     // aborted before we continue on to do any work.
     if (signal && signal.aborted)
-      throw new lazyDOMException('AbortError');
+      throw new lazyDOMException('The operation was aborted', 'AbortError');
 
     state.state = kSocketPending;
 
@@ -685,7 +685,7 @@ class QuicEndpoint {
     // while we were waiting.
     if (signal && signal.aborted) {
       state.state = kSocketUnbound;
-      throw new lazyDOMException('AbortError');
+      throw new lazyDOMException('The operation was aborted', 'AbortError');
     }
 
     // From here on, any errors are fatal for the QuicEndpoint. Keep in
@@ -1064,7 +1064,7 @@ class QuicSocket extends EventEmitter {
     // If an AbotSignal was passed in, check to make sure it is not already
     // aborted before we continue on to do any work.
     if (signal && signal.aborted)
-      throw new lazyDOMException('AbortError');
+      throw new lazyDOMException('The operation was aborted', 'AbortError');
 
     state.state = kSocketPending;
 
@@ -1086,7 +1086,7 @@ class QuicSocket extends EventEmitter {
       // Some number of endpoints may have successfully bound, while
       // others have not
       if (signal && signal.aborted)
-        throw lazyDOMException('AbortError');
+        throw lazyDOMException('The operation was aborted', 'AbortError');
 
       state.state = kSocketBound;
 

--- a/lib/timers/promises.js
+++ b/lib/timers/promises.js
@@ -18,10 +18,10 @@ const {
 
 let DOMException;
 
-const lazyDOMException = hideStackFrames((message) => {
+const lazyDOMException = hideStackFrames((message, name) => {
   if (DOMException === undefined)
     DOMException = internalBinding('messaging').DOMException;
-  return new DOMException(message);
+  return new DOMException(message, name);
 });
 
 function setTimeout(after, value, options = {}) {
@@ -54,8 +54,10 @@ function setTimeout(after, value, options = {}) {
   // TODO(@jasnell): If a decision is made that this cannot be backported
   // to 12.x, then this can be converted to use optional chaining to
   // simplify the check.
-  if (signal && signal.aborted)
-    return PromiseReject(lazyDOMException('AbortError'));
+  if (signal && signal.aborted) {
+    return PromiseReject(
+      lazyDOMException('The operation was aborted', 'AbortError'));
+  }
   return new Promise((resolve, reject) => {
     const timeout = new Timeout(resolve, after, args, false, true);
     if (!ref) timeout.unref();
@@ -65,7 +67,7 @@ function setTimeout(after, value, options = {}) {
         if (!timeout._destroyed) {
           // eslint-disable-next-line no-undef
           clearTimeout(timeout);
-          reject(lazyDOMException('AbortError'));
+          reject(lazyDOMException('The operation was aborted', 'AbortError'));
         }
       }, { once: true });
     }
@@ -101,8 +103,10 @@ function setImmediate(value, options = {}) {
   // TODO(@jasnell): If a decision is made that this cannot be backported
   // to 12.x, then this can be converted to use optional chaining to
   // simplify the check.
-  if (signal && signal.aborted)
-    return PromiseReject(lazyDOMException('AbortError'));
+  if (signal && signal.aborted) {
+    return PromiseReject(
+      lazyDOMException('The operation was aborted', 'AbortError'));
+  }
   return new Promise((resolve, reject) => {
     const immediate = new Immediate(resolve, [value]);
     if (!ref) immediate.unref();
@@ -111,7 +115,7 @@ function setImmediate(value, options = {}) {
         if (!immediate._destroyed) {
           // eslint-disable-next-line no-undef
           clearImmediate(immediate);
-          reject(lazyDOMException('AbortError'));
+          reject(lazyDOMException('The operation was aborted', 'AbortError'));
         }
       }, { once: true });
     }


### PR DESCRIPTION
##### quic: use AbortController with correct name/message

On the web, `AbortError` is the error name, not the error
message. Change the code to match that.

##### timers: use AbortController with correct name/message

On the web, `AbortError` is the error name, not the error
message. Change the code to match that.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
