### PR TITLE
test: move execution of WPT to worker threads

### DIFF
--- a/test/common/README.md
+++ b/test/common/README.md
@@ -963,7 +963,7 @@ the original WPT harness, see [the WPT tests README][].
 
 ### Class: WPTRunner
 
-A driver class for running WPT with the WPT harness in a vm.
+A driver class for running WPT with the WPT harness in a worker thread.
 
 See [the WPT tests README][] for details.
 

--- a/test/common/wpt/worker.js
+++ b/test/common/wpt/worker.js
@@ -1,0 +1,55 @@
+/* eslint-disable node-core/required-modules,node-core/require-common-first */
+
+'use strict';
+
+const { runInThisContext } = require('vm');
+const { parentPort, workerData } = require('worker_threads');
+
+const { ResourceLoader } = require(workerData.wptRunner);
+const resource = new ResourceLoader(workerData.wptPath);
+
+global.self = global;
+global.GLOBAL = {
+  isWindow() { return false; }
+};
+global.require = require;
+
+// This is a mock, because at the moment fetch is not implemented
+// in Node.js, but some tests and harness depend on this to pull
+// resources.
+global.fetch = function fetch(file) {
+  return resource.read(workerData.filename, file, true);
+};
+
+if (workerData.initScript) {
+  runInThisContext(workerData.initScript);
+}
+
+runInThisContext(workerData.harness.code, {
+  filename: workerData.harness.filename
+});
+
+// eslint-disable-next-line no-undef
+add_result_callback((result) => {
+  parentPort.postMessage({
+    type: 'result',
+    result: {
+      status: result.status,
+      name: result.name,
+      message: result.message,
+      stack: result.stack,
+    },
+  });
+});
+
+// eslint-disable-next-line no-undef
+add_completion_callback((_, status) => {
+  parentPort.postMessage({
+    type: 'completion',
+    status,
+  });
+});
+
+for (const scriptToRun of workerData.scriptsToRun) {
+  runInThisContext(scriptToRun.code, { filename: scriptToRun.filename });
+}

--- a/test/wpt/test-console.js
+++ b/test/wpt/test-console.js
@@ -4,7 +4,4 @@ const { WPTRunner } = require('../common/wpt');
 
 const runner = new WPTRunner('console');
 
-// Copy global descriptors from the global object
-runner.copyGlobalsFromObject(global, ['console']);
-
 runner.runJsTests();

--- a/test/wpt/test-encoding.js
+++ b/test/wpt/test-encoding.js
@@ -1,16 +1,11 @@
 'use strict';
 require('../common');
-const { MessageChannel } = require('worker_threads');
 const { WPTRunner } = require('../common/wpt');
 const runner = new WPTRunner('encoding');
 
-// Copy global descriptors from the global object
-runner.copyGlobalsFromObject(global, ['TextDecoder', 'TextEncoder']);
-
-runner.defineGlobal('MessageChannel', {
-  get() {
-    return MessageChannel;
-  }
-});
+runner.setInitScript(`
+  const { MessageChannel } = require('worker_threads');
+  global.MessageChannel = MessageChannel;
+`);
 
 runner.runJsTests();

--- a/test/wpt/test-hr-time.js
+++ b/test/wpt/test-hr-time.js
@@ -1,27 +1,14 @@
 'use strict';
 
-// Flags: --expose-internals
-
 require('../common');
 const { WPTRunner } = require('../common/wpt');
-const { performance, PerformanceObserver } = require('perf_hooks');
 
 const runner = new WPTRunner('hr-time');
 
-runner.copyGlobalsFromObject(global, [
-  'setInterval',
-  'clearInterval',
-  'setTimeout',
-  'clearTimeout'
-]);
-
-runner.defineGlobal('performance', {
-  get() {
-    return performance;
-  }
-});
-runner.defineGlobal('PerformanceObserver', {
-  value: PerformanceObserver
-});
+runner.setInitScript(`
+  const { performance, PerformanceObserver } = require('perf_hooks');
+  global.performance = performance;
+  global.PerformanceObserver = PerformanceObserver;
+`);
 
 runner.runJsTests();

--- a/test/wpt/test-microtask-queuing.js
+++ b/test/wpt/test-microtask-queuing.js
@@ -5,7 +5,4 @@ const { WPTRunner } = require('../common/wpt');
 
 const runner = new WPTRunner('html/webappapis/microtask-queuing');
 
-// Copy global descriptors from the global object
-runner.copyGlobalsFromObject(global, ['queueMicrotask']);
-
 runner.runJsTests();

--- a/test/wpt/test-timers.js
+++ b/test/wpt/test-timers.js
@@ -5,12 +5,4 @@ const { WPTRunner } = require('../common/wpt');
 
 const runner = new WPTRunner('html/webappapis/timers');
 
-// Copy global descriptors from the global object
-runner.copyGlobalsFromObject(global, [
-  'setInterval',
-  'clearInterval',
-  'setTimeout',
-  'clearTimeout'
-]);
-
 runner.runJsTests();

--- a/test/wpt/test-url.js
+++ b/test/wpt/test-url.js
@@ -1,20 +1,18 @@
 'use strict';
 
-// Flags: --expose-internals
-
 require('../common');
 const { WPTRunner } = require('../common/wpt');
-const { internalBinding } = require('internal/test/binding');
-const { DOMException } = internalBinding('messaging');
+
 const runner = new WPTRunner('url');
 
-// Copy global descriptors from the global object
-runner.copyGlobalsFromObject(global, ['URL', 'URLSearchParams']);
-// Needed by urlsearchparams-constructor.any.js
-runner.defineGlobal('DOMException', {
-  get() {
-    return DOMException;
-  }
-});
+// Needed to access to DOMException.
+runner.setFlags(['--expose-internals']);
+
+// DOMException is needed by urlsearchparams-constructor.any.js
+runner.setInitScript(`
+  const { internalBinding } = require('internal/test/binding');
+  const { DOMException } = internalBinding('messaging');
+  global.DOMException = DOMException;
+`);
 
 runner.runJsTests();


### PR DESCRIPTION
Running outside of the main Node.js context prevents us from upgrading
the WPT harness because new versions more aggressively check the
identity of globals like error constructors. Instead of exposing
globals used by the tests on vm sandboxes, use worker threads to run
everything.