### PR TITLE
build: run link checker in linter workflow

### DIFF
--- a/.github/workflows/misc.yml
+++ b/.github/workflows/misc.yml
@@ -28,3 +28,5 @@ jobs:
         with:
           name: docs
           path: out/doc
+      - name: Check links
+        run: node tools/doc/checkLinks.js .

--- a/tools/doc/checkLinks.js
+++ b/tools/doc/checkLinks.js
@@ -50,7 +50,9 @@ function checkFile(path) {
     const targetURL = new URL(node.url, base);
     if (targetURL.protocol === 'file:' && !fs.existsSync(targetURL)) {
       const { line, column } = node.position.start;
-      console.error(`Broken link at ${path}:${line}:${column} (${node.url})`);
+      console.error((process.env.GITHUB_ACTIONS ?
+        `::error file=${path},line=${line},col=${column}::` : '') +
+        `Broken link at ${path}:${line}:${column} (${node.url})`);
       process.exitCode = 1;
     }
   }


### PR DESCRIPTION
Run the `checkLinks.js` tool on our actions workflow. 
Change format of logged messages when run on GitHub Actions (i.e.
when the `GITHUB_ACTIONS` environment variable is true) so that
broken links are highlighted inline in pull requests.

Refs: https://github.com/nodejs/node/issues/34787

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
