### PR TITLE
net: validate custom lookup() output

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -1039,6 +1039,9 @@ function lookupAndConnect(self, options) {
         // calls net.Socket.connect() on it (that's us). There are no event
         // listeners registered yet so defer the error event to the next tick.
         process.nextTick(connectErrorNT, self, err);
+      } else if (!isIP(ip)) {
+        err = new ERR_INVALID_IP_ADDRESS(ip);
+        process.nextTick(connectErrorNT, self, err);
       } else if (addressType !== 4 && addressType !== 6) {
         err = new ERR_INVALID_ADDRESS_FAMILY(addressType,
                                              options.host,

--- a/test/parallel/test-net-dns-custom-lookup.js
+++ b/test/parallel/test-net-dns-custom-lookup.js
@@ -41,3 +41,14 @@ function check(addressType, cb) {
 check(4, function() {
   common.hasIPv6 && check(6);
 });
+
+// Verify that bad lookup() IPs are handled.
+{
+  net.connect({
+    host: 'localhost',
+    port: 80,
+    lookup(host, dnsopts, cb) {
+      cb(null, undefined, 4);
+    }
+  }).on('error', common.expectsError({ code: 'ERR_INVALID_IP_ADDRESS' }));
+}


### PR DESCRIPTION
This commit adds validation to the IP address returned by the
`net` module's custom DNS `lookup()` function.

Fixes: https://github.com/nodejs/node/issues/34812

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
