### PR TITLE
[v14.x] worker: fix --abort-on-uncaught-exception handling

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -42,6 +42,7 @@ static bool ShouldAbortOnUncaughtException(Isolate* isolate) {
   Environment* env = Environment::GetCurrent(isolate);
   return env != nullptr &&
          (env->is_main_thread() || !env->is_stopping()) &&
+         env->abort_on_uncaught_exception() &&
          env->should_abort_on_uncaught_toggle()[0] &&
          !env->inside_should_not_abort_on_uncaught_scope();
 }
@@ -355,9 +356,6 @@ Environment* CreateEnvironment(
       exec_args,
       flags,
       thread_id);
-  if (flags & EnvironmentFlags::kOwnsProcessState) {
-    env->set_abort_on_uncaught_exception(false);
-  }
 
 #if HAVE_INSPECTOR
   if (inspector_parent_handle) {

--- a/src/env.cc
+++ b/src/env.cc
@@ -348,6 +348,10 @@ Environment::Environment(IsolateData* isolate_data,
   inspector_host_port_.reset(
       new ExclusiveAccess<HostPort>(options_->debug_options().host_port));
 
+  if (!(flags_ & EnvironmentFlags::kOwnsProcessState)) {
+    set_abort_on_uncaught_exception(false);
+  }
+
 #if HAVE_INSPECTOR
   // We can only create the inspector agent after having cloned the options.
   inspector_agent_ = std::make_unique<inspector::Agent>(this);

--- a/test/parallel/test-worker-abort-on-uncaught-exception.js
+++ b/test/parallel/test-worker-abort-on-uncaught-exception.js
@@ -1,0 +1,12 @@
+// Flags: --abort-on-uncaught-exception
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { Worker } = require('worker_threads');
+
+// Tests that --abort-on-uncaught-exception does not apply to
+// Workers.
+
+const w = new Worker('throw new Error()', { eval: true });
+w.on('error', common.mustCall());
+w.on('exit', common.mustCall((code) => assert.strictEqual(code, 1)));


### PR DESCRIPTION
The `set_abort_on_uncaught_exception(false)` line was supposed to
prevent aborting when running Workers in
`--abort-on-uncaught-exception` mode, but it was incorrectly set
and not checked properly in the should-abort callback.

PR-URL: https://github.com/nodejs/node/pull/34724
Reviewed-By: Colin Ihrig <cjihrig@gmail.com>
Reviewed-By: Richard Lau <riclau@uk.ibm.com>
Reviewed-By: James M Snell <jasnell@gmail.com>
Reviewed-By: Mary Marchini <oss@mmarchini.me>
