### PR TITLE
test: fix test-cluster-net-listen-relative-path.js to run in /

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,9 @@ _UpgradeReport_Files/
 # Ignore dependencies fetched by deps/v8/tools/node/fetch_deps.py
 /deps/.cipd
 
+# === Rules for Windows vcbuild.bat ===
+/temp-vcbuild
+
 # === Global Rules ===
 # Keep last to avoid being excluded
 *.pyc

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -544,6 +544,8 @@ Optional requirements to build the MSI installer package:
 
 * The [WiX Toolset v3.11](https://wixtoolset.org/releases/) and the
   [Wix Toolset Visual Studio 2019 Extension](https://marketplace.visualstudio.com/items?itemName=WixToolset.WixToolsetVisualStudio2019Extension).
+* The [WiX Toolset v3.14](https://wixtoolset.org/releases/) if
+  building for Windows 10 on ARM (ARM64).
 
 Optional requirements for compiling for Windows 10 on ARM (ARM64):
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -237,7 +237,7 @@ test with Python 3.
 * GNU Make 3.81 or newer
 * Python (see note above)
   * Python 2.7
-  * Python 3.5, 3.6, 3.7, and 3.8.
+  * Python 3.5, 3.6, 3.7, and 3.8
 
 Installation via Linux package manager can be achieved with:
 
@@ -256,7 +256,7 @@ Python 3 users may also need to install `python3-distutils`.
 * Xcode Command Line Tools >= 10 for macOS
 * Python (see note above)
   * Python 2.7
-  * Python 3.5, 3.6, 3.7, and 3.8.
+  * Python 3.5, 3.6, 3.7, and 3.8
 
 macOS users can install the `Xcode Command Line Tools` by running
 `xcode-select --install`. Alternatively, if you already have the full Xcode
@@ -531,7 +531,7 @@ to run it again before invoking `make -j4`.
   [Visual Studio 2019](https://visualstudio.microsoft.com/downloads/) or
   the "Visual C++ build tools" workload from the
   [Build Tools](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2019),
-  with the default optional components.
+  with the default optional components
 * Basic Unix tools required for some tests,
   [Git for Windows](https://git-scm.com/download/win) includes Git Bash
   and tools which can be included in the global `PATH`.
@@ -543,9 +543,9 @@ to run it again before invoking `make -j4`.
 Optional requirements to build the MSI installer package:
 
 * The [WiX Toolset v3.11](https://wixtoolset.org/releases/) and the
-  [Wix Toolset Visual Studio 2019 Extension](https://marketplace.visualstudio.com/items?itemName=WixToolset.WixToolsetVisualStudio2019Extension).
+  [Wix Toolset Visual Studio 2019 Extension](https://marketplace.visualstudio.com/items?itemName=WixToolset.WixToolsetVisualStudio2019Extension)
 * The [WiX Toolset v3.14](https://wixtoolset.org/releases/) if
-  building for Windows 10 on ARM (ARM64).
+  building for Windows 10 on ARM (ARM64)
 
 Optional requirements for compiling for Windows 10 on ARM (ARM64):
 
@@ -563,7 +563,7 @@ This script will install the following [Chocolatey](https://chocolatey.org/)
 packages:
 
 * [Git for Windows](https://chocolatey.org/packages/git) with the `git` and
-  Unix tools added to the `PATH`.
+  Unix tools added to the `PATH`
 * [Python 3.x](https://chocolatey.org/packages/python) and
   [legacy Python](https://chocolatey.org/packages/python2)
 * [Visual Studio 2019 Build Tools](https://chocolatey.org/packages/visualstudio2019buildtools)

--- a/README.md
+++ b/README.md
@@ -153,8 +153,6 @@ For information about the governance of the Node.js project, see
 ### TSC (Technical Steering Committee)
 
 <!--lint disable prohibited-strings-->
-* [addaleax](https://github.com/addaleax) -
-**Anna Henningsen** &lt;anna@addaleax.net&gt; (she/her)
 * [apapirovski](https://github.com/apapirovski) -
 **Anatoli Papirovski** &lt;apapirovski@mac.com&gt; (he/him)
 * [BethGriggs](https://github.com/BethGriggs) -
@@ -196,6 +194,8 @@ For information about the governance of the Node.js project, see
 
 ### TSC Emeriti
 
+* [addaleax](https://github.com/addaleax) -
+**Anna Henningsen** &lt;anna@addaleax.net&gt; (she/her)
 * [bnoordhuis](https://github.com/bnoordhuis) -
 **Ben Noordhuis** &lt;info@bnoordhuis.nl&gt;
 * [chrisdickinson](https://github.com/chrisdickinson) -

--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -184,11 +184,11 @@ consists of the following keys:
 * originalLine: {number}
 * originalColumn: {number}
 
+[Source map v3 format]: https://sourcemaps.info/spec.html#h.mofvlxcwqzej
+[`--enable-source-maps`]: cli.html#cli_enable_source_maps
+[`Error.prepareStackTrace(error, trace)`]: https://v8.dev/docs/stack-trace-api#customizing-stack-traces
+[`NODE_V8_COVERAGE=dir`]: cli.html#cli_node_v8_coverage_dir
+[`SourceMap`]: #module_class_module_sourcemap
 [`createRequire()`]: #module_module_createrequire_filename
 [module wrapper]: modules_cjs.html#modules_cjs_the_module_wrapper
 [source map include directives]: https://sourcemaps.info/spec.html#h.lmz475t4mvbx
-[`--enable-source-maps`]: cli.html#cli_enable_source_maps
-[`NODE_V8_COVERAGE=dir`]: cli.html#cli_node_v8_coverage_dir
-[`Error.prepareStackTrace(error, trace)`]: https://v8.dev/docs/stack-trace-api#customizing-stack-traces
-[`SourceMap`]: #module_class_module_sourcemap
-[Source map v3 format]: https://sourcemaps.info/spec.html#h.mofvlxcwqzej

--- a/test/parallel/test-cluster-net-listen-relative-path.js
+++ b/test/parallel/test-cluster-net-listen-relative-path.js
@@ -17,7 +17,7 @@ const tmpdir = require('../common/tmpdir');
 
 // Choose a socket name such that the absolute path would exceed 100 bytes.
 const socketDir = './unix-socket-dir';
-const socketName = 'A'.repeat(100 - socketDir.length - 1);
+const socketName = 'A'.repeat(101 - socketDir.length);
 
 // Make sure we're not in a weird environment.
 assert.ok(path.resolve(socketDir, socketName).length > 100,

--- a/test/parallel/test-repl-preview.js
+++ b/test/parallel/test-repl-preview.js
@@ -7,8 +7,9 @@ const { Stream } = require('stream');
 const { inspect } = require('util');
 
 common.skipIfInspectorDisabled();
-common.skipIfDumbTerminal();
 
+// Ignore terminal settings. This is so the test can be run intact if TERM=dumb.
+process.env.TERM = '';
 const PROMPT = 'repl > ';
 
 class REPLStream extends Stream {

--- a/test/parallel/test-unicode-node-options.js
+++ b/test/parallel/test-unicode-node-options.js
@@ -1,0 +1,26 @@
+'use strict';
+// Flags: --expose-internals
+require('../common');
+const { getOptionValue } = require('internal/options');
+const assert = require('assert');
+const cp = require('child_process');
+
+const expected_redirect_value = 'foó';
+
+if (process.argv.length === 2) {
+  const NODE_OPTIONS = `--redirect-warnings=${expected_redirect_value}`;
+  const result = cp.spawnSync(process.argv0,
+                              ['--expose-internals', __filename, 'test'],
+                              {
+                                env: {
+                                  ...process.env,
+                                  NODE_OPTIONS
+                                },
+                                stdio: 'inherit'
+                              });
+  assert.strictEqual(result.status, 0);
+} else {
+  const redirect_value = getOptionValue('--redirect-warnings');
+  console.log(`--redirect-warings=${redirect_value}`);
+  assert.strictEqual(redirect_value, expected_redirect_value);
+}


### PR DESCRIPTION
test-cluster-net-listen-relative-path fails if run from the root
directory on POSIX because the socket filename isn't quite long enough.
Increase it by 2 so that the path length always exceeds 100 characters.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
