### PR TITLE
dns: add setLocalAddress to Resolver

### DIFF
--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -119,12 +119,14 @@ callbacks will be called with an error with code `ECANCELLED`.
 
 ### `resolver.setLocalAddress(addr)`
 <!-- YAML
-added: v15.0.0
+added: REPLACEME
 -->
 
 * `addr` {string} A string representation of an IPv4 or IPv6 address.
 
-The resolver instance will send its requests from the specified IP address.  This allows programs to specify outbound interfaces when used on multi-homed systems.
+The resolver instance will send its requests from the specified IP address.
+This allows programs to specify outbound interfaces when used on multi-homed
+systems.
 
 ## `dns.getServers()`
 <!-- YAML

--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -131,9 +131,7 @@ The resolver instance will send its requests from the specified IP address.
 This allows programs to specify outbound interfaces when used on multi-homed
 systems.
 
-If a v4 or v6 address is not specified, it is set to `0.0.0.0` or `::0`
-respectively, which is the default and means "choose automatically from
-available IP addresses".
+If a v4 or v6 address is not specified, it is set to the default, and the operating system will choose a local address automatically.
 
 The resolver will use the v4 local address when making requests to IPv4 DNS
 servers, and the v6 local address when making requests to IPv6 DNS servers.

--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -117,6 +117,15 @@ added: v8.3.0
 Cancel all outstanding DNS queries made by this resolver. The corresponding
 callbacks will be called with an error with code `ECANCELLED`.
 
+### `resolver.setLocalAddress(addr)`
+<!-- YAML
+added: v15.0.0
+-->
+
+* `addr` {string} A string representation of an IPv4 or IPv6 address.
+
+The resolver instance will send its requests from the specified IP address.  This allows programs to specify outbound interfaces when used on multi-homed systems.
+
 ## `dns.getServers()`
 <!-- YAML
 added: v0.11.3

--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -131,7 +131,8 @@ The resolver instance will send its requests from the specified IP address.
 This allows programs to specify outbound interfaces when used on multi-homed
 systems.
 
-If a v4 or v6 address is not specified, it is set to the default, and the operating system will choose a local address automatically.
+If a v4 or v6 address is not specified, it is set to the default, and the
+operating system will choose a local address automatically.
 
 The resolver will use the v4 local address when making requests to IPv4 DNS
 servers, and the v6 local address when making requests to IPv6 DNS servers.

--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -117,16 +117,27 @@ added: v8.3.0
 Cancel all outstanding DNS queries made by this resolver. The corresponding
 callbacks will be called with an error with code `ECANCELLED`.
 
-### `resolver.setLocalAddress(addr)`
+### `resolver.setLocalAddress([ipv4][, ipv6])`
 <!-- YAML
 added: REPLACEME
 -->
 
-* `addr` {string} A string representation of an IPv4 or IPv6 address.
+* `ipv4` {string} A string representation of an IPv4 address.
+  **Default:** `'0.0.0.0'`
+* `ipv6` {string} A string representation of an IPv6 address.
+  **Default:** `'::0'`
 
 The resolver instance will send its requests from the specified IP address.
 This allows programs to specify outbound interfaces when used on multi-homed
 systems.
+
+If a v4 or v6 address is not specified, it is set to `0.0.0.0` or `::0`
+respectively, which is the default and means "choose automatically from
+available IP addresses".
+
+The resolver will use the v4 local address when making requests to IPv4 DNS
+servers, and the v6 local address when making requests to IPv6 DNS servers.
+The `rrtype` of resolution requests has no impact on the local address used.
 
 ## `dns.getServers()`
 <!-- YAML

--- a/lib/internal/dns/promises.js
+++ b/lib/internal/dns/promises.js
@@ -217,6 +217,7 @@ class Resolver {
 
 Resolver.prototype.getServers = CallbackResolver.prototype.getServers;
 Resolver.prototype.setServers = CallbackResolver.prototype.setServers;
+Resolver.prototype.setLocalAddress = CallbackResolver.prototype.setLocalAddress;
 Resolver.prototype.resolveAny = resolveMap.ANY = resolver('queryAny');
 Resolver.prototype.resolve4 = resolveMap.A = resolver('queryA');
 Resolver.prototype.resolve6 = resolveMap.AAAA = resolver('queryAaaa');

--- a/lib/internal/dns/utils.js
+++ b/lib/internal/dns/utils.js
@@ -114,6 +114,14 @@ class Resolver {
       throw new ERR_DNS_SET_SERVERS_FAILED(err, servers);
     }
   }
+
+  setLocalAddress(addr) {
+    if (typeof addr != 'string') {
+      throw new ERR_INVALID_ARG_TYPE('addr', 'String', addr);
+    }
+
+    this._handle.setLocalAddress(addr);
+  }
 }
 
 let defaultResolver = new Resolver();

--- a/lib/internal/dns/utils.js
+++ b/lib/internal/dns/utils.js
@@ -115,12 +115,16 @@ class Resolver {
     }
   }
 
-  setLocalAddress(addr) {
-    if (typeof addr !== 'string') {
-      throw new ERR_INVALID_ARG_TYPE('addr', 'String', addr);
+  setLocalAddress(ipv4, ipv6) {
+    if (typeof ipv4 !== 'string') {
+      throw new ERR_INVALID_ARG_TYPE('ipv4', 'String', ipv4);
     }
 
-    this._handle.setLocalAddress(addr);
+    if (typeof ipv6 !== 'string' && ipv6 !== undefined) {
+      throw new ERR_INVALID_ARG_TYPE('ipv6', ['String', 'undefined'], ipv6);
+    }
+
+    this._handle.setLocalAddress(ipv4, ipv6);
   }
 }
 

--- a/lib/internal/dns/utils.js
+++ b/lib/internal/dns/utils.js
@@ -116,7 +116,7 @@ class Resolver {
   }
 
   setLocalAddress(addr) {
-    if (typeof addr != 'string') {
+    if (typeof addr !== 'string') {
       throw new ERR_INVALID_ARG_TYPE('addr', 'String', addr);
     }
 

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -2249,7 +2249,7 @@ void SetLocalAddress(const FunctionCallbackInfo<Value>& args) {
   // to 0 (any).
 
   if (uv_inet_pton(AF_INET, *ip0, &addr0) == 0) {
-    ares_set_local_ip4(channel->cares_channel(), cares_get_32bit(addr0));
+    ares_set_local_ip4(channel->cares_channel(), ReadUint32BE(addr0));
     type0 = 4;
   } else if (uv_inet_pton(AF_INET6, *ip0, &addr0) == 0) {
     ares_set_local_ip6(channel->cares_channel(), addr0);
@@ -2268,7 +2268,7 @@ void SetLocalAddress(const FunctionCallbackInfo<Value>& args) {
         THROW_ERR_INVALID_ARG_VALUE(env, "Cannot specify two IPv4 addresses.");
         return;
       } else {
-        ares_set_local_ip4(channel->cares_channel(), cares_get_32bit(addr1));
+        ares_set_local_ip4(channel->cares_channel(), ReadUint32BE(addr1));
       }
     } else if (uv_inet_pton(AF_INET6, *ip1, &addr1) == 0) {
       if (type0 == 6) {

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -2232,7 +2232,7 @@ void SetLocalAddress(const FunctionCallbackInfo<Value>& args) {
   ChannelWrap* channel;
   ASSIGN_OR_RETURN_UNWRAP(&channel, args.Holder());
 
-  CHECK(args.Length() == 2);
+  CHECK_EQ(args.Length(), 2);
   CHECK(args[0]->IsString());
 
   Isolate* isolate = args.GetIsolate();
@@ -2263,13 +2263,15 @@ void SetLocalAddress(const FunctionCallbackInfo<Value>& args) {
 
     if (uv_inet_pton(AF_INET, *ip1, &addr1) == 0) {
       if (type0 == 4) {
-        return env->ThrowError("Invalid argument.  Cannot specify two IPv4 addresses.");
+        return env->ThrowError(
+          "Invalid argument.  Cannot specify two IPv4 addresses.");
       } else {
         ares_set_local_ip4(channel->cares_channel(), cares_get_32bit(addr1));
       }
     } else if (uv_inet_pton(AF_INET6, *ip1, &addr1) == 0) {
       if (type0 == 6) {
-        return env->ThrowError("Invalid argument.  Cannot specify two IPv6 addresses.");
+        return env->ThrowError(
+          "Invalid argument.  Cannot specify two IPv6 addresses.");
       } else {
         ares_set_local_ip6(channel->cares_channel(), addr1);
       }

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -2240,15 +2240,9 @@ void SetLocalAddress(const FunctionCallbackInfo<Value>& args) {
   unsigned char addr[sizeof(struct in6_addr)];
 
   if (uv_inet_pton(AF_INET, *ip, &addr) == 0) {
-    unsigned int ip4 = (addr[0] << 24) +
-      (addr[1] << 16) +
-      (addr[2] << 8) +
-      addr[3];
-    ares_set_local_ip4(channel->cares_channel(), ip4);
+    ares_set_local_ip4(channel->cares_channel(), cares_get_32bit(addr));
   } else if (uv_inet_pton(AF_INET6, *ip, &addr) == 0) {
-    ares_set_local_ip6(
-      channel->cares_channel(),
-      reinterpret_cast<const unsigned char*>(&addr));
+    ares_set_local_ip6(channel->cares_channel(), addr);
   } else {
     return env->ThrowError("Invalid IP address.");
   }

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -2240,14 +2240,18 @@ void SetLocalAddress(const FunctionCallbackInfo<Value>& args) {
   unsigned char addr[sizeof(struct in6_addr)];
 
   if (uv_inet_pton(AF_INET, *ip, &addr) == 0) {
-    unsigned int ip4 = (addr[0] << 24) + (addr[1] << 16) + (addr[2] << 8) + addr[3];
+    unsigned int ip4 = (addr[0] << 24) +
+      (addr[1] << 16) +
+      (addr[2] << 8) +
+      addr[3];
     ares_set_local_ip4(channel->cares_channel(), ip4);
   } else if (uv_inet_pton(AF_INET6, *ip, &addr) == 0) {
-    ares_set_local_ip6(channel->cares_channel(), reinterpret_cast<const unsigned char*>(&addr));
+    ares_set_local_ip6(
+      channel->cares_channel(),
+      reinterpret_cast<const unsigned char*>(&addr));
   } else {
     return env->ThrowError("Invalid IP address.");
   }
-
 }
 
 void Cancel(const FunctionCallbackInfo<Value>& args) {

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -29,6 +29,7 @@
 #include "req_wrap-inl.h"
 #include "util-inl.h"
 #include "uv.h"
+#include "node_errors.h"
 
 #include <cerrno>
 #include <cstring>
@@ -2254,7 +2255,8 @@ void SetLocalAddress(const FunctionCallbackInfo<Value>& args) {
     ares_set_local_ip6(channel->cares_channel(), addr0);
     type0 = 6;
   } else {
-    return env->ThrowError("Invalid IP address.");
+    THROW_ERR_INVALID_ARG_VALUE(env, "Invalid IP address.");
+    return;
   }
 
   if (!args[1]->IsUndefined()) {
@@ -2263,20 +2265,21 @@ void SetLocalAddress(const FunctionCallbackInfo<Value>& args) {
 
     if (uv_inet_pton(AF_INET, *ip1, &addr1) == 0) {
       if (type0 == 4) {
-        return env->ThrowError(
-          "Invalid argument.  Cannot specify two IPv4 addresses.");
+        THROW_ERR_INVALID_ARG_VALUE(env, "Cannot specify two IPv4 addresses.");
+        return;
       } else {
         ares_set_local_ip4(channel->cares_channel(), cares_get_32bit(addr1));
       }
     } else if (uv_inet_pton(AF_INET6, *ip1, &addr1) == 0) {
       if (type0 == 6) {
-        return env->ThrowError(
-          "Invalid argument.  Cannot specify two IPv6 addresses.");
+        THROW_ERR_INVALID_ARG_VALUE(env, "Cannot specify two IPv6 addresses.");
+        return;
       } else {
         ares_set_local_ip6(channel->cares_channel(), addr1);
       }
     } else {
-      return env->ThrowError("Invalid IP address.");
+      THROW_ERR_INVALID_ARG_VALUE(env, "Invalid IP address.");
+      return;
     }
   } else {
     // No second arg specifed

--- a/test/parallel/test-dns-setlocaladdress.js
+++ b/test/parallel/test-dns-setlocaladdress.js
@@ -11,7 +11,7 @@ const resolver = new dns.Resolver();
   resolver.setLocalAddress('::1');
 }
 
-// Verifiy that setLocalAddress throws if called with an invalid address
+// Verify that setLocalAddress throws if called with an invalid address
 {
   assert.throws(() => {
     resolver.setLocalAddress('bad');

--- a/test/parallel/test-dns-setlocaladdress.js
+++ b/test/parallel/test-dns-setlocaladdress.js
@@ -4,11 +4,14 @@ const assert = require('assert');
 
 const dns = require('dns');
 const resolver = new dns.Resolver();
+const promiseResolver = new dns.promises.Resolver();
 
 // Verifies that setLocalAddress succeeds with IPv4 and IPv6 addresses
 {
   resolver.setLocalAddress('127.0.0.1');
   resolver.setLocalAddress('::1');
+  promiseResolver.setLocalAddress('127.0.0.1');
+  promiseResolver.setLocalAddress('::1');
 }
 
 // Verify that setLocalAddress throws if called with an invalid address
@@ -21,5 +24,8 @@ const resolver = new dns.Resolver();
   }, Error);
   assert.throws(() => {
     resolver.setLocalAddress();
+  }, Error);
+  assert.throws(() => {
+    promiseResolver.setLocalAddress();
   }, Error);
 }

--- a/test/parallel/test-dns-setlocaladdress.js
+++ b/test/parallel/test-dns-setlocaladdress.js
@@ -1,6 +1,5 @@
 'use strict';
-const common = require('../common');
-const { addresses } = require('../common/internet');
+require('../common');
 const assert = require('assert');
 
 const dns = require('dns');
@@ -16,11 +15,11 @@ const resolver = new dns.Resolver();
 {
   assert.throws(() => {
     resolver.setLocalAddress('bad');
-  });
+  }, Error);
   assert.throws(() => {
     resolver.setLocalAddress(123);
-  });
+  }, Error);
   assert.throws(() => {
     resolver.setLocalAddress();
-  });
+  }, Error);
 }

--- a/test/parallel/test-dns-setlocaladdress.js
+++ b/test/parallel/test-dns-setlocaladdress.js
@@ -1,0 +1,26 @@
+'use strict';
+const common = require('../common');
+const { addresses } = require('../common/internet');
+const assert = require('assert');
+
+const dns = require('dns');
+const resolver = new dns.Resolver();
+
+// Verifies that setLocalAddress succeeds with IPv4 and IPv6 addresses
+{
+  resolver.setLocalAddress('127.0.0.1');
+  resolver.setLocalAddress('::1');
+}
+
+// Verifiy that setLocalAddress throws if called with an invalid address
+{
+  assert.throws(() => {
+    resolver.setLocalAddress('bad');
+  });
+  assert.throws(() => {
+    resolver.setLocalAddress(123);
+  });
+  assert.throws(() => {
+    resolver.setLocalAddress();
+  });
+}

--- a/test/parallel/test-dns-setlocaladdress.js
+++ b/test/parallel/test-dns-setlocaladdress.js
@@ -10,12 +10,18 @@ const promiseResolver = new dns.promises.Resolver();
 {
   resolver.setLocalAddress('127.0.0.1');
   resolver.setLocalAddress('::1');
-  promiseResolver.setLocalAddress('127.0.0.1');
-  promiseResolver.setLocalAddress('::1');
+  resolver.setLocalAddress('127.0.0.1', '::1');
+  promiseResolver.setLocalAddress('127.0.0.1', '::1');
 }
 
 // Verify that setLocalAddress throws if called with an invalid address
 {
+  assert.throws(() => {
+    resolver.setLocalAddress('127.0.0.1', '127.0.0.1');
+  }, Error);
+  assert.throws(() => {
+    resolver.setLocalAddress('::1', '::1');
+  }, Error);
   assert.throws(() => {
     resolver.setLocalAddress('bad');
   }, Error);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This allows users to specify the (local source) IP address used when a `dns.Resolver` instance makes DNS requests.

Closes #34818