### PR TITLE
http: allow Content-Length header for 304 responses

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -654,6 +654,11 @@ function parserOnIncomingClient(res, shouldKeepAlive) {
   if (method === 'HEAD')
     return 1;  // Skip body but don't treat as Upgrade.
 
+  if (res.statusCode === 304) {
+    res.complete = true;
+    return 1; // Skip body as there won't be any
+  }
+
   return 0;  // No special treatment.
 }
 

--- a/test/parallel/test-http-allow-content-length-304.js
+++ b/test/parallel/test-http-allow-content-length-304.js
@@ -1,0 +1,32 @@
+'use strict';
+const common = require('../common');
+
+// This test ensures that the http-parser doesn't expect a body when
+// a 304 Not Modified response has a non-zero Content-Length header
+
+const assert = require('assert');
+const http = require('http');
+
+const server = http.createServer(common.mustCall((req, res) => {
+  res.setHeader('Content-Length', 11);
+  res.statusCode = 304;
+  res.end(null);
+}));
+
+server.listen(0, () => {
+  const request = http.request({
+    port: server.address().port,
+  });
+
+  request.on('response', common.mustCall((response) => {
+    response.on('data', common.mustNotCall());
+    response.on('aborted', common.mustNotCall());
+    response.on('end', common.mustCall(() => {
+      assert.strictEqual(response.headers['content-length'], '11');
+      assert.strictEqual(response.statusCode, 304);
+      server.close();
+    }));
+  }));
+
+  request.end(null);
+});


### PR DESCRIPTION
According to the [HTTP spec](https://tools.ietf.org/html/rfc7230#section-3.3.2), a `304 Not Modified` response can have a `Content-Length` header:

`A server MAY send a Content-Length header field in a 304 (Not Modified) response to a conditional GET request (Section 4.1 of [RFC7232]); a server MUST NOT send Content-Length in such a response unless its field-value equals the decimal number of octets that would have been sent in the payload body of a 200 (OK) response to the same request.`

On the other hand, the spec [doesn't allow a 304 response to have a body](https://tools.ietf.org/html/rfc7232#section-4.1): `A 304 response cannot contain a message-body; it is always terminated by the first empty line after the header fields.`

Currently, the `http` request module will emit an `aborted` event if the response has a status code of `304` with a `Content-Length` header. This pull request fixes this behavior and the request can successfully finish. 

This fixes issue https://github.com/nodejs/node/issues/31037

I tried to integrate the fix in the best place I could find, let me know if there are better ways to fix this!

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)