### PR TITLE
esm: shorten ERR_UNSUPPORTED_ESM_URL_SCHEME message

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1434,8 +1434,8 @@ E('ERR_UNSUPPORTED_DIR_IMPORT', "Directory import '%s' is not supported " +
 E('ERR_UNSUPPORTED_ESM_URL_SCHEME', (url) => {
   let msg = 'Only file and data URLs are supported by the default ESM loader';
   if (isWindows && url.protocol.length === 2) {
-    msg += '. Absolute Windows paths without prefix are not valid URLs, ' +
-      "consider using 'file://' prefix";
+    msg +=
+      '. On Windows, absolute paths must be valid file:// URLs';
   }
   msg += `. Received protocol '${url.protocol}'`;
   return msg;

--- a/test/es-module/test-esm-dynamic-import.js
+++ b/test/es-module/test-esm-dynamic-import.js
@@ -59,8 +59,8 @@ function expectFsNamespace(result) {
   if (common.isWindows) {
     const msg =
       'Only file and data URLs are supported by the default ESM loader. ' +
-      'Absolute Windows paths without prefix are not valid URLs, ' +
-      "consider using 'file://' prefix. Received protocol 'c:'";
+      'On Windows, absolute paths must be valid file:// URLs. ' +
+      "Received protocol 'c:'";
     expectModuleError(import('C:\\example\\foo.mjs'),
                       'ERR_UNSUPPORTED_ESM_URL_SCHEME',
                       msg);


### PR DESCRIPTION
I know it just got modified to include new information, but this
shortens the message a bit without (I hope) losing clarity or meaning.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
