### PR TITLE
[v12.x] http2: use and support non-empty DATA frame with END_STREAM flag

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -927,8 +927,9 @@ the value is `undefined`, the stream is not yet ready for use.
 All [`Http2Stream`][] instances are destroyed either when:
 
 * An `RST_STREAM` frame for the stream is received by the connected peer,
-  and pending data has been read.
-* The `http2stream.close()` method is called, and pending data has been read.
+  and (for client streams only) pending data has been read.
+* The `http2stream.close()` method is called, and (for client streams only)
+  pending data has been read.
 * The `http2stream.destroy()` or `http2session.destroy()` methods are called.
 
 When an `Http2Stream` instance is destroyed, an attempt will be made to send an

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1020,6 +1020,8 @@ function emitClose(self, error) {
 }
 
 function finishSessionDestroy(session, error) {
+  debugSessionObj(session, 'finishSessionDestroy');
+
   const socket = session[kSocket];
   if (!socket.destroyed)
     socket.destroy(error);
@@ -1388,16 +1390,12 @@ class Http2Session extends EventEmitter {
     const handle = this[kHandle];
 
     // Destroy the handle if it exists at this point
-    if (handle !== undefined)
+    if (handle !== undefined) {
+      handle.ondone = finishSessionDestroy.bind(null, this, error);
       handle.destroy(code, socket.destroyed);
-
-    // If the socket is alive, use setImmediate to destroy the session on the
-    // next iteration of the event loop in order to give data time to transmit.
-    // Otherwise, destroy immediately.
-    if (!socket.destroyed)
-      setImmediate(finishSessionDestroy, this, error);
-    else
+    } else {
       finishSessionDestroy(this, error);
+    }
   }
 
   // Closing the session will:

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -499,7 +499,10 @@ function onStreamClose(code) {
   if (!stream || stream.destroyed)
     return false;
 
-  debugStreamObj(stream, 'closed with code %d', code);
+  debugStreamObj(
+    stream, 'closed with code %d, closed %s, readable %s',
+    code, stream.closed, stream.readable
+  );
 
   if (!stream.closed)
     closeStream(stream, code, kNoRstStream);
@@ -508,7 +511,7 @@ function onStreamClose(code) {
   // Defer destroy we actually emit end.
   if (!stream.readable || code !== NGHTTP2_NO_ERROR) {
     // If errored or ended, we can destroy immediately.
-    stream[kMaybeDestroy](code);
+    stream.destroy();
   } else {
     // Wait for end to destroy.
     stream.on('end', stream[kMaybeDestroy]);
@@ -1019,22 +1022,76 @@ function emitClose(self, error) {
   self.emit('close');
 }
 
-function finishSessionDestroy(session, error) {
-  debugSessionObj(session, 'finishSessionDestroy');
-
+function cleanupSession(session) {
   const socket = session[kSocket];
-  if (!socket.destroyed)
-    socket.destroy(error);
-
+  const handle = session[kHandle];
   session[kProxySocket] = undefined;
   session[kSocket] = undefined;
   session[kHandle] = undefined;
   session[kNativeFields] = new Uint8Array(kSessionUint8FieldCount);
-  socket[kSession] = undefined;
-  socket[kServer] = undefined;
+  if (handle)
+    handle.ondone = null;
+  if (socket) {
+    socket[kSession] = undefined;
+    socket[kServer] = undefined;
+  }
+}
 
-  // Finally, emit the close and error events (if necessary) on next tick.
-  process.nextTick(emitClose, session, error);
+function finishSessionClose(session, error) {
+  debugSessionObj(session, 'finishSessionClose');
+
+  const socket = session[kSocket];
+  cleanupSession(session);
+
+  if (socket && !socket.destroyed) {
+    // Always wait for writable side to finish.
+    socket.end((err) => {
+      debugSessionObj(session, 'finishSessionClose socket end', err);
+      // Due to the way the underlying stream is handled in Http2Session we
+      // won't get graceful Readable end from the other side even if it was sent
+      // as the stream is already considered closed and will neither be read
+      // from nor keep the event loop alive.
+      // Therefore destroy the socket immediately.
+      // Fixing this would require some heavy juggling of ReadStart/ReadStop
+      // mostly on Windows as on Unix it will be fine with just ReadStart
+      // after this 'ondone' callback.
+      socket.destroy(error);
+      emitClose(session, error);
+    });
+  } else {
+    process.nextTick(emitClose, session, error);
+  }
+}
+
+function closeSession(session, code, error) {
+  debugSessionObj(session, 'start closing/destroying');
+
+  const state = session[kState];
+  state.flags |= SESSION_FLAGS_DESTROYED;
+  state.destroyCode = code;
+
+  // Clear timeout and remove timeout listeners.
+  session.setTimeout(0);
+  session.removeAllListeners('timeout');
+
+  // Destroy any pending and open streams
+  if (state.pendingStreams.size > 0 || state.streams.size > 0) {
+    const cancel = new ERR_HTTP2_STREAM_CANCEL(error);
+    state.pendingStreams.forEach((stream) => stream.destroy(cancel));
+    state.streams.forEach((stream) => stream.destroy(error));
+  }
+
+  // Disassociate from the socket and server.
+  const socket = session[kSocket];
+  const handle = session[kHandle];
+
+  // Destroy the handle if it exists at this point.
+  if (handle !== undefined) {
+    handle.ondone = finishSessionClose.bind(null, session, error);
+    handle.destroy(code, socket.destroyed);
+  } else {
+    finishSessionClose(session, error);
+  }
 }
 
 // Upon creation, the Http2Session takes ownership of the socket. The session
@@ -1361,6 +1418,7 @@ class Http2Session extends EventEmitter {
   destroy(error = NGHTTP2_NO_ERROR, code) {
     if (this.destroyed)
       return;
+
     debugSessionObj(this, 'destroying');
 
     if (typeof error === 'number') {
@@ -1372,30 +1430,7 @@ class Http2Session extends EventEmitter {
     if (code === undefined && error != null)
       code = NGHTTP2_INTERNAL_ERROR;
 
-    const state = this[kState];
-    state.flags |= SESSION_FLAGS_DESTROYED;
-    state.destroyCode = code;
-
-    // Clear timeout and remove timeout listeners
-    this.setTimeout(0);
-    this.removeAllListeners('timeout');
-
-    // Destroy any pending and open streams
-    const cancel = new ERR_HTTP2_STREAM_CANCEL(error);
-    state.pendingStreams.forEach((stream) => stream.destroy(cancel));
-    state.streams.forEach((stream) => stream.destroy(error));
-
-    // Disassociate from the socket and server
-    const socket = this[kSocket];
-    const handle = this[kHandle];
-
-    // Destroy the handle if it exists at this point
-    if (handle !== undefined) {
-      handle.ondone = finishSessionDestroy.bind(null, this, error);
-      handle.destroy(code, socket.destroyed);
-    } else {
-      finishSessionDestroy(this, error);
-    }
+    closeSession(this, code, error);
   }
 
   // Closing the session will:

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1156,6 +1156,7 @@ class Http2Session extends EventEmitter {
       streams: new Map(),
       pendingStreams: new Set(),
       pendingAck: 0,
+      shutdownWritableCalled: false,
       writeQueueSize: 0,
       originSet: undefined
     };
@@ -1722,6 +1723,26 @@ function afterShutdown(status) {
     stream[kMaybeDestroy]();
 }
 
+function shutdownWritable(callback) {
+  const handle = this[kHandle];
+  if (!handle) return callback();
+  const state = this[kState];
+  if (state.shutdownWritableCalled) {
+    // Backport v12.x: Session required for debugging stream object
+    // debugStreamObj(this, 'shutdownWritable() already called');
+    return callback();
+  }
+  state.shutdownWritableCalled = true;
+
+  const req = new ShutdownWrap();
+  req.oncomplete = afterShutdown;
+  req.callback = callback;
+  req.handle = handle;
+  const err = handle.shutdown(req);
+  if (err === 1)  // synchronous finish
+    return afterShutdown.call(req, 0);
+}
+
 function finishSendTrailers(stream, headersList) {
   // The stream might be destroyed and in that case
   // there is nothing to do.
@@ -1981,10 +2002,50 @@ class Http2Stream extends Duplex {
 
     let req;
 
+    let waitingForWriteCallback = true;
+    let waitingForEndCheck = true;
+    let writeCallbackErr;
+    let endCheckCallbackErr;
+    const done = () => {
+      if (waitingForEndCheck || waitingForWriteCallback) return;
+      const err = writeCallbackErr || endCheckCallbackErr;
+      // writeGeneric does not destroy on error and
+      // we cannot enable autoDestroy,
+      // so make sure to destroy on error.
+      if (err) {
+        this.destroy(err);
+      }
+      cb(err);
+    };
+    const writeCallback = (err) => {
+      waitingForWriteCallback = false;
+      writeCallbackErr = err;
+      done();
+    };
+    const endCheckCallback = (err) => {
+      waitingForEndCheck = false;
+      endCheckCallbackErr = err;
+      done();
+    };
+    // Shutdown write stream right after last chunk is sent
+    // so final DATA frame can include END_STREAM flag
+    process.nextTick(() => {
+      if (writeCallbackErr ||
+        !this._writableState.ending ||
+        // Backport v12.x: _writableState.buffered does not exist
+        // this._writableState.buffered.length ||
+        this._writableState.bufferedRequest ||
+        (this[kState].flags & STREAM_FLAGS_HAS_TRAILERS))
+        return endCheckCallback();
+      // Backport v12.x: Session required for debugging stream object
+      // debugStreamObj(this, 'shutting down writable on last write');
+      shutdownWritable.call(this, endCheckCallback);
+    });
+
     if (writev)
-      req = writevGeneric(this, data, cb);
+      req = writevGeneric(this, data, writeCallback);
     else
-      req = writeGeneric(this, data, encoding, cb);
+      req = writeGeneric(this, data, encoding, writeCallback);
 
     trackWriteState(this, req.bytes);
   }
@@ -1998,21 +2059,13 @@ class Http2Stream extends Duplex {
   }
 
   _final(cb) {
-    const handle = this[kHandle];
     if (this.pending) {
       this.once('ready', () => this._final(cb));
-    } else if (handle !== undefined) {
-      debugStreamObj(this, '_final shutting down');
-      const req = new ShutdownWrap();
-      req.oncomplete = afterShutdown;
-      req.callback = cb;
-      req.handle = handle;
-      const err = handle.shutdown(req);
-      if (err === 1)  // synchronous finish
-        return afterShutdown.call(req, 0);
-    } else {
-      cb();
+      return;
     }
+    // Backport v12.x: Session required for debugging stream object
+    // debugStreamObj(this, 'shutting down writable on _final');
+    shutdownWritable.call(this, cb);
   }
 
   _read(nread) {
@@ -2117,11 +2170,20 @@ class Http2Stream extends Duplex {
     debugStream(this[kID] || 'pending', session[kType], 'destroying stream');
 
     const state = this[kState];
-    const sessionCode = session[kState].goawayCode ||
-                        session[kState].destroyCode;
-    const code = err != null ?
-      sessionCode || NGHTTP2_INTERNAL_ERROR :
-      state.rstCode || sessionCode;
+    const sessionState = session[kState];
+    const sessionCode = sessionState.goawayCode || sessionState.destroyCode;
+
+    // If a stream has already closed successfully, there is no error
+    // to report from this stream, even if the session has errored.
+    // This can happen if the stream was already in process of destroying
+    // after a successful close, but the session had a error between
+    // this stream's close and destroy operations.
+    // Previously, this always overrode a successful close operation code
+    // NGHTTP2_NO_ERROR (0) with sessionCode because the use of the || operator.
+    const code = (err != null ?
+      (sessionCode || NGHTTP2_INTERNAL_ERROR) :
+      (this.closed ? this.rstCode : sessionCode)
+    );
     const hasHandle = handle !== undefined;
 
     if (!this.closed)
@@ -2130,13 +2192,13 @@ class Http2Stream extends Duplex {
 
     if (hasHandle) {
       handle.destroy();
-      session[kState].streams.delete(id);
+      sessionState.streams.delete(id);
     } else {
-      session[kState].pendingStreams.delete(this);
+      sessionState.pendingStreams.delete(this);
     }
 
     // Adjust the write queue size for accounting
-    session[kState].writeQueueSize -= state.writeQueueSize;
+    sessionState.writeQueueSize -= state.writeQueueSize;
     state.writeQueueSize = 0;
 
     // RST code 8 not emitted as an error as its used by clients to signify

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -693,6 +693,13 @@ void Http2Session::Close(uint32_t code, bool socket_closed) {
 
   flags_ |= SESSION_STATE_CLOSED;
 
+  // If we are writing we will get to make the callback in OnStreamAfterWrite.
+  if ((flags_ & SESSION_STATE_WRITE_IN_PROGRESS) == 0) {
+    Debug(this, "make done session callback");
+    HandleScope scope(env()->isolate());
+    MakeCallback(env()->ondone_string(), 0, nullptr);
+  }
+
   // If there are outstanding pings, those will need to be canceled, do
   // so on the next iteration of the event loop to avoid calling out into
   // javascript since this may be called during garbage collection.
@@ -1528,6 +1535,12 @@ void Http2Session::OnStreamAfterWrite(WriteWrap* w, int status) {
       nghttp2_session_want_read(session_)) {
     flags_ &= ~SESSION_STATE_READING_STOPPED;
     stream_->ReadStart();
+  }
+
+  if ((flags_ & SESSION_STATE_CLOSED) != 0) {
+    HandleScope scope(env()->isolate());
+    MakeCallback(env()->ondone_string(), 0, nullptr);
+    return;
   }
 
   // If there is more incoming data queued up, consume it.

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -1840,11 +1840,7 @@ void Http2Session::OnStreamRead(ssize_t nread, const uv_buf_t& buf_) {
 
   statistics_.data_received += nread;
 
-  if (LIKELY(stream_buf_offset_ == 0)) {
-    // Shrink to the actual amount of used data.
-    buf.Resize(nread);
-    IncrementCurrentSessionMemory(nread);
-  } else {
+  if (UNLIKELY(stream_buf_offset_ > 0)) {
     // This is a very unlikely case, and should only happen if the ReadStart()
     // call in OnStreamAfterWrite() immediately provides data. If that does
     // happen, we concatenate the data we received with the already-stored
@@ -1854,16 +1850,19 @@ void Http2Session::OnStreamRead(ssize_t nread, const uv_buf_t& buf_) {
     memcpy(new_buf.data(), stream_buf_.base + stream_buf_offset_, pending_len);
     memcpy(new_buf.data() + pending_len, buf.data(), nread);
 
-    // The data in stream_buf_ is already accounted for, add nread received
-    // bytes to session memory but remove the already processed
-    // stream_buf_offset_ bytes.
-    IncrementCurrentSessionMemory(nread - stream_buf_offset_);
-
     buf = std::move(new_buf);
     nread = buf.size();
     stream_buf_offset_ = 0;
     stream_buf_ab_.Reset();
+
+    // We have now fully processed the stream_buf_ input chunk (by moving the
+    // remaining part into buf, which will be accounted for below).
+    DecrementCurrentSessionMemory(stream_buf_.len);
   }
+
+  // Shrink to the actual amount of used data.
+  buf.Resize(nread);
+  IncrementCurrentSessionMemory(nread);
 
   // Remember the current buffer, so that OnDataChunkReceived knows the
   // offset of a DATA frame's data into the socket read buffer.

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -2367,7 +2367,7 @@ ssize_t Http2Stream::Provider::Stream::OnRead(nghttp2_session* handle,
     return NGHTTP2_ERR_DEFERRED;
   }
 
-  if (stream->queue_.empty() && !stream->IsWritable()) {
+  if (stream->available_outbound_length_ == 0 && !stream->IsWritable()) {
     Debug(session, "no more data for stream %d", id);
     *flags |= NGHTTP2_DATA_FLAG_EOF;
     if (stream->HasTrailers()) {

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -1827,7 +1827,7 @@ void Http2Session::OnStreamRead(ssize_t nread, const uv_buf_t& buf_) {
   Context::Scope context_scope(env()->context());
   Http2Scope h2scope(this);
   CHECK_NOT_NULL(stream_);
-  Debug(this, "receiving %d bytes", nread);
+  Debug(this, "receiving %d bytes, offset %d", nread, stream_buf_offset_);
   AllocatedBuffer buf(env(), buf_);
 
   // Only pass data on if nread > 0

--- a/test/parallel/test-http2-capture-rejection.js
+++ b/test/parallel/test-http2-capture-rejection.js
@@ -72,7 +72,6 @@ events.captureRejections = true;
   }));
 }
 
-
 {
   // Test error thrown in 'request' event
 
@@ -136,6 +135,7 @@ events.captureRejections = true;
     const session = connect(`http://localhost:${port}`);
 
     const req = session.request();
+    req.resume();
 
     session.on('stream', common.mustCall(async (stream) => {
       session.close();

--- a/test/parallel/test-http2-client-destroy.js
+++ b/test/parallel/test-http2-client-destroy.js
@@ -145,6 +145,7 @@ const Countdown = require('../common/countdown');
   server.on('stream', common.mustNotCall());
   server.listen(0, common.mustCall(() => {
     const client = h2.connect(`http://localhost:${server.address().port}`);
+    client.on('close', common.mustCall());
     const socket = client[kSocket];
     socket.on('close', common.mustCall(() => {
       assert(socket.destroyed);

--- a/test/parallel/test-http2-compat-client-upload-reject.js
+++ b/test/parallel/test-http2-compat-client-upload-reject.js
@@ -23,9 +23,11 @@ fs.readFile(loc, common.mustCall((err, data) => {
       res.end();
     });
   }));
+  server.on('close', common.mustCall());
 
   server.listen(0, common.mustCall(() => {
     const client = http2.connect(`http://localhost:${server.address().port}`);
+    client.on('close', common.mustCall());
 
     const req = client.request({ ':method': 'POST' });
     req.on('response', common.mustCall((headers) => {

--- a/test/parallel/test-http2-create-client-connect.js
+++ b/test/parallel/test-http2-create-client-connect.js
@@ -38,11 +38,13 @@ const URL = url.URL;
       const client =
         h2.connect.apply(null, i)
           .on('connect', common.mustCall(() => maybeClose(client)));
+      client.on('close', common.mustCall());
     });
 
     // Will fail because protocol does not match the server.
-    h2.connect({ port: port, protocol: 'https:' })
+    const client = h2.connect({ port: port, protocol: 'https:' })
       .on('error', common.mustCall(() => serverClose.dec()));
+    client.on('close', common.mustCall());
   }));
 }
 

--- a/test/parallel/test-http2-goaway-opaquedata.js
+++ b/test/parallel/test-http2-goaway-opaquedata.js
@@ -8,20 +8,24 @@ const http2 = require('http2');
 
 const server = http2.createServer();
 const data = Buffer.from([0x1, 0x2, 0x3, 0x4, 0x5]);
+let session;
 
 server.on('stream', common.mustCall((stream) => {
-  stream.session.goaway(0, 0, data);
+  session = stream.session;
+  session.on('close', common.mustCall());
+  session.goaway(0, 0, data);
   stream.respond();
   stream.end();
 }));
+server.on('close', common.mustCall());
 
 server.listen(0, () => {
-
   const client = http2.connect(`http://localhost:${server.address().port}`);
   client.once('goaway', common.mustCall((code, lastStreamID, buf) => {
     assert.deepStrictEqual(code, 0);
     assert.deepStrictEqual(lastStreamID, 1);
     assert.deepStrictEqual(data, buf);
+    session.close();
     server.close();
   }));
   const req = client.request();

--- a/test/parallel/test-http2-misbehaving-multiplex.js
+++ b/test/parallel/test-http2-misbehaving-multiplex.js
@@ -2,6 +2,7 @@
 // Flags: --expose-internals
 
 const common = require('../common');
+const assert = require('assert');
 
 if (!common.hasCrypto)
   common.skip('missing crypto');
@@ -13,16 +14,36 @@ const h2test = require('../common/http2');
 let client;
 
 const server = h2.createServer();
+let gotFirstStreamId1;
 server.on('stream', common.mustCall((stream) => {
   stream.respond();
   stream.end('ok');
 
-  // The error will be emitted asynchronously
-  stream.on('error', common.expectsError({
-    constructor: NghttpError,
-    code: 'ERR_HTTP2_ERROR',
-    message: 'Stream was already closed or invalid'
-  }));
+  // Http2Server should be fast enough to respond to and close
+  // the first streams with ID 1 and ID 3 without errors.
+
+  // Test for errors in 'close' event to ensure no errors on some streams.
+  stream.on('error', () => {});
+  stream.on('close', (err) => {
+    if (stream.id === 1) {
+      if (gotFirstStreamId1) {
+        // We expect our outgoing frames to fail on Stream ID 1 the second time
+        // because a stream with ID 1 was already closed before.
+        common.expectsError({
+          constructor: NghttpError,
+          code: 'ERR_HTTP2_ERROR',
+          message: 'Stream was already closed or invalid'
+        });
+        return;
+      }
+      gotFirstStreamId1 = true;
+    }
+    assert.strictEqual(err, undefined);
+  });
+
+  // Stream ID 5 should never reach the server
+  assert.notStrictEqual(stream.id, 5);
+
 }, 2));
 
 server.on('session', common.mustCall((session) => {
@@ -35,26 +56,27 @@ server.on('session', common.mustCall((session) => {
 
 const settings = new h2test.SettingsFrame();
 const settingsAck = new h2test.SettingsFrame(true);
-const head1 = new h2test.HeadersFrame(1, h2test.kFakeRequestHeaders, 0, true);
-const head2 = new h2test.HeadersFrame(3, h2test.kFakeRequestHeaders, 0, true);
-const head3 = new h2test.HeadersFrame(1, h2test.kFakeRequestHeaders, 0, true);
-const head4 = new h2test.HeadersFrame(5, h2test.kFakeRequestHeaders, 0, true);
+// HeadersFrame(id, payload, padding, END_STREAM)
+const id1 = new h2test.HeadersFrame(1, h2test.kFakeRequestHeaders, 0, true);
+const id3 = new h2test.HeadersFrame(3, h2test.kFakeRequestHeaders, 0, true);
+const id5 = new h2test.HeadersFrame(5, h2test.kFakeRequestHeaders, 0, true);
 
 server.listen(0, () => {
   client = net.connect(server.address().port, () => {
     client.write(h2test.kClientMagic, () => {
       client.write(settings.data, () => {
         client.write(settingsAck.data);
-        // This will make it ok.
-        client.write(head1.data, () => {
-          // This will make it ok.
-          client.write(head2.data, () => {
+        // Stream ID 1 frame will make it OK.
+        client.write(id1.data, () => {
+          // Stream ID 3 frame will make it OK.
+          client.write(id3.data, () => {
+            // A second Stream ID 1 frame should fail.
             // This will cause an error to occur because the client is
             // attempting to reuse an already closed stream. This must
             // cause the server session to be torn down.
-            client.write(head3.data, () => {
-              // This won't ever make it to the server
-              client.write(head4.data);
+            client.write(id1.data, () => {
+              // This Stream ID 5 frame will never make it to the server
+              client.write(id5.data);
             });
           });
         });

--- a/test/parallel/test-http2-pack-end-stream-flag.js
+++ b/test/parallel/test-http2-pack-end-stream-flag.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const http2 = require('http2');
+
+const { PerformanceObserver } = require('perf_hooks');
+
+const server = http2.createServer();
+
+server.on('stream', (stream, headers) => {
+  stream.respond({
+    'content-type': 'text/html',
+    ':status': 200
+  });
+  switch (headers[':path']) {
+    case '/singleEnd':
+      stream.end('OK');
+      break;
+    case '/sequentialEnd':
+      stream.write('OK');
+      stream.end();
+      break;
+    case '/delayedEnd':
+      stream.write('OK', () => stream.end());
+      break;
+  }
+});
+
+function testRequest(path, targetFrameCount, callback) {
+  const obs = new PerformanceObserver((list, observer) => {
+    const entry = list.getEntries()[0];
+    if (entry.name !== 'Http2Session') return;
+    if (entry.type !== 'client') return;
+    assert.strictEqual(entry.framesReceived, targetFrameCount);
+    observer.disconnect();
+    callback();
+  });
+  obs.observe({ entryTypes: ['http2'] });
+  const client = http2.connect(`http://localhost:${server.address().port}`, () => {
+    const req = client.request({ ':path': path });
+    req.resume();
+    req.end();
+    req.on('end', () => client.close());
+  });
+}
+
+// SETTINGS => SETTINGS => HEADERS => DATA
+const MIN_FRAME_COUNT = 4;
+
+server.listen(0, () => {
+  testRequest('/singleEnd', MIN_FRAME_COUNT, () => {
+    testRequest('/sequentialEnd', MIN_FRAME_COUNT, () => {
+      testRequest('/delayedEnd', MIN_FRAME_COUNT + 1, () => {
+        server.close();
+      });
+    });
+  });
+});

--- a/test/parallel/test-http2-padding-aligned.js
+++ b/test/parallel/test-http2-padding-aligned.js
@@ -26,7 +26,7 @@ const makeDuplexPair = require('../common/duplexpair');
   // The lengths of the expected writes... note that this is highly
   // sensitive to how the internals are implemented.
   const serverLengths = [24, 9, 9, 32];
-  const clientLengths = [9, 9, 48, 9, 1, 21, 1, 16];
+  const clientLengths = [9, 9, 48, 9, 1, 21, 1];
 
   // Adjust for the 24-byte preamble and two 9-byte settings frames, and
   // the result must be equally divisible by 8

--- a/test/parallel/test-http2-perf_hooks.js
+++ b/test/parallel/test-http2-perf_hooks.js
@@ -30,7 +30,7 @@ const obs = new PerformanceObserver(common.mustCall((items) => {
           break;
         case 'client':
           assert.strictEqual(entry.streamCount, 1);
-          assert.strictEqual(entry.framesReceived, 8);
+          assert.strictEqual(entry.framesReceived, 7);
           break;
         default:
           assert.fail('invalid Http2Session type');

--- a/test/parallel/test-http2-ping-settings-heapdump.js
+++ b/test/parallel/test-http2-ping-settings-heapdump.js
@@ -30,7 +30,12 @@ for (const variant of ['ping', 'settings']) {
   }));
 
   server.listen(0, common.mustCall(() => {
-    http2.connect(`http://localhost:${server.address().port}`,
-                  common.mustCall());
+    const client = http2.connect(`http://localhost:${server.address().port}`,
+                                 common.mustCall());
+    client.on('error', (err) => {
+      // We destroy the session so it's possible to get ECONNRESET here.
+      if (err.code !== 'ECONNRESET')
+        throw err;
+    });
   }));
 }

--- a/test/parallel/test-http2-server-push-stream.js
+++ b/test/parallel/test-http2-server-push-stream.js
@@ -55,6 +55,8 @@ server.listen(0, common.mustCall(() => {
       assert.strictEqual(headers['x-push-data'], 'pushed by server');
     }));
     stream.on('aborted', common.mustNotCall());
+    // We have to read the data of the push stream to end gracefully.
+    stream.resume();
   }));
 
   let data = '';


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
