### PR TITLE
net: enable use of BlockList with net.server

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -113,6 +113,8 @@ const {
   DTRACE_NET_STREAM_END
 } = require('internal/dtrace');
 
+const kBlockList = Symbol('kBlockList');
+
 // Lazy loaded to improve startup performance.
 let cluster;
 let dns;
@@ -1169,6 +1171,7 @@ function Server(options, connectionListener) {
   this._usingWorkers = false;
   this._workers = [];
   this._unref = false;
+  this[kBlockList] = new module.exports.BlockList();
 
   this.allowHalfOpen = options.allowHalfOpen || false;
   this.pauseOnConnect = !!options.pauseOnConnect;
@@ -1176,6 +1179,11 @@ function Server(options, connectionListener) {
 ObjectSetPrototypeOf(Server.prototype, EventEmitter.prototype);
 ObjectSetPrototypeOf(Server, EventEmitter);
 
+ObjectDefineProperty(Server.prototype, 'blockList', {
+  configurable: true,
+  enumerable: true,
+  get() { return this[kBlockList]; }
+});
 
 function toNumber(x) { return (x = Number(x)) >= 0 ? x : false; }
 
@@ -1513,6 +1521,15 @@ function onconnection(err, clientHandle) {
     clientHandle.close();
     return;
   }
+
+  // Check to see if the remote address has been blocked.
+  // TODO(@jasnell): Performance would be better if this was checked down
+  // in the C++ layer as close to libuv as possible, but that's a bit of
+  // a larger change. Will do that as a follow up step.
+  const addr = {};
+  err = clientHandle.getpeername(addr);
+  if (err || self[kBlockList].check(addr.address, addr.family.toLowerCase()))
+    return clientHandle.close();
 
   const socket = new Socket({
     handle: clientHandle,


### PR DESCRIPTION
This is starting the process of enabling `net.BlockList` support in `net.Server`. This is a work in progress opened to start getting early feedback.

Still todo:

* [ ] Review implementation approach
* [ ] Add support for tls.Server
* [ ] Add tests
* [ ] Add documentation
* [ ] Benchmark

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
