### PR TITLE
http2: fix Http2Response.sendDate

### DIFF
--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -590,6 +590,13 @@ class Http2ServerResponse extends Stream {
       throw new ERR_HTTP2_HEADERS_SENT();
 
     name = name.trim().toLowerCase();
+
+    if (name === 'date') {
+      this[kState].sendDate = false;
+
+      return;
+    }
+
     delete this[kHeaders][name];
   }
 
@@ -787,6 +794,7 @@ class Http2ServerResponse extends Stream {
     const options = {
       endStream: state.ending,
       waitForTrailers: true,
+      sendDate: state.sendDate
     };
     this[kStream].respond(headers, options);
   }

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -2274,7 +2274,7 @@ function callStreamClose(stream) {
   stream.close();
 }
 
-function processHeaders(oldHeaders) {
+function processHeaders(oldHeaders, options) {
   assertIsObject(oldHeaders, 'headers');
   const headers = ObjectCreate(null);
 
@@ -2292,8 +2292,12 @@ function processHeaders(oldHeaders) {
     headers[HTTP2_HEADER_STATUS] =
       headers[HTTP2_HEADER_STATUS] | 0 || HTTP_STATUS_OK;
 
-  if (headers[HTTP2_HEADER_DATE] === null ||
-      headers[HTTP2_HEADER_DATE] === undefined)
+  let sendDate = true;
+  if (options.sendDate !== null && options.sendDate !== undefined)
+    sendDate = options.sendDate;
+
+  if (sendDate && (headers[HTTP2_HEADER_DATE] === null ||
+      headers[HTTP2_HEADER_DATE] === undefined))
     headers[HTTP2_HEADER_DATE] = utcDate();
 
   // This is intentionally stricter than the HTTP/1 implementation, which
@@ -2624,7 +2628,7 @@ class ServerHttp2Stream extends Http2Stream {
       state.flags |= STREAM_FLAGS_HAS_TRAILERS;
     }
 
-    headers = processHeaders(headers);
+    headers = processHeaders(headers, options);
     const headersList = mapToHeaders(headers, assertValidPseudoHeaderResponse);
     this[kSentHeaders] = headers;
 
@@ -2690,7 +2694,7 @@ class ServerHttp2Stream extends Http2Stream {
     this[kUpdateTimer]();
     this.ownsFd = false;
 
-    headers = processHeaders(headers);
+    headers = processHeaders(headers, options);
     const statusCode = headers[HTTP2_HEADER_STATUS] |= 0;
     // Payload/DATA frames are not permitted in these cases
     if (statusCode === HTTP_STATUS_NO_CONTENT ||
@@ -2751,7 +2755,7 @@ class ServerHttp2Stream extends Http2Stream {
     this[kUpdateTimer]();
     this.ownsFd = true;
 
-    headers = processHeaders(headers);
+    headers = processHeaders(headers, options);
     const statusCode = headers[HTTP2_HEADER_STATUS] |= 0;
     // Payload/DATA frames are not permitted in these cases
     if (statusCode === HTTP_STATUS_NO_CONTENT ||

--- a/test/parallel/test-http2-compat-serverresponse-headers-send-date.js
+++ b/test/parallel/test-http2-compat-serverresponse-headers-send-date.js
@@ -1,0 +1,26 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto) { common.skip('missing crypto'); }
+const assert = require('assert');
+const http2 = require('http2');
+
+const server = http2.createServer(common.mustCall((request, response) => {
+  response.sendDate = false;
+  response.writeHead(200);
+  response.end();
+}));
+
+server.listen(0, common.mustCall(() => {
+  const session = http2.connect(`http://localhost:${server.address().port}`);
+  const req = session.request();
+
+  req.on('response', (headers, flags) => {
+    assert.strictEqual('Date' in headers, false);
+    assert.strictEqual('date' in headers, false);
+  });
+
+  req.on('end', () => {
+    session.close();
+    server.close();
+  });
+}));

--- a/test/parallel/test-http2-compat-serverresponse-headers.js
+++ b/test/parallel/test-http2-compat-serverresponse-headers.js
@@ -114,6 +114,11 @@ server.listen(0, common.mustCall(function() {
     response.sendDate = false;
     assert.strictEqual(response.sendDate, false);
 
+    response.sendDate = true;
+    assert.strictEqual(response.sendDate, true);
+    response.removeHeader('Date');
+    assert.strictEqual(response.sendDate, false);
+
     response.on('finish', common.mustCall(function() {
       assert.strictEqual(response.headersSent, true);
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
The `sendDate` flag was not being respectedby the current implementation and the `Date`
header was being sent regardless of the config.

This commit fixes that and adds tests for this case.

Fixes: https://github.com/nodejs/node/issues/34841

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
