### PR TITLE
doc: fixes ESM/CJS wrapper example

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -665,11 +665,10 @@ CommonJS entry point for `require`.
 ```js
 // ./node_modules/pkg/package.json
 {
-  "type": "module",
-  "main": "./index.cjs",
+  "main": "./index.js",
   "exports": {
     "import": "./wrapper.mjs",
-    "require": "./index.cjs"
+    "require": "./index.js"
   }
 }
 ```
@@ -727,10 +726,9 @@ stateless):
 ```js
 // ./node_modules/pkg/package.json
 {
-  "type": "module",
-  "main": "./index.cjs",
+  "main": "./index.js",
   "exports": {
-    ".": "./index.cjs",
+    ".": "./index.js",
     "./module": "./wrapper.mjs"
   }
 }


### PR DESCRIPTION
This PR updates ESM wrapper example to prevent package maintainers to broke packages after copy-pasting.

Ref: https://github.com/nodejs/node/issues/34714

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

