### PR TITLE
[v12.x] tls: reset secureConnecting on client socket

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -1521,10 +1521,12 @@ function onConnectSecure() {
     debug('client emit secureConnect. rejectUnauthorized: %s, ' +
           'authorizationError: %s', options.rejectUnauthorized,
           this.authorizationError);
+    this.secureConnecting = false;
     this.emit('secureConnect');
   } else {
     this.authorized = true;
     debug('client emit secureConnect. authorized:', this.authorized);
+    this.secureConnecting = false;
     this.emit('secureConnect');
   }
 

--- a/test/parallel/test-http2-connect.js
+++ b/test/parallel/test-http2-connect.js
@@ -95,6 +95,7 @@ const { connect: tlsConnect } = require('tls');
     };
 
     const clientOptions = {
+      ALPNProtocols: ['h2'],
       port,
       rejectUnauthorized: false
     };


### PR DESCRIPTION
secureConnecting is never set to false on client TLS sockets.
So if Http2Session constructor (in lib/internal/http2/core.js) is
called after secureConnect is emitted, then it will wrongly wait
for a secureConnect event.

This fix sets secureConnecting to false when a client TLS socket
has connected.

PR-URL: https://github.com/nodejs/node/pull/33209
Reviewed-By: Luigi Pinca <luigipinca@gmail.com>
Reviewed-By: Sam Roberts <vieuxtech@gmail.com>
