### PR TITLE
process: improve rejections tracking performance

### DIFF
--- a/lib/internal/process/promises.js
+++ b/lib/internal/process/promises.js
@@ -202,7 +202,7 @@ function processPromiseRejections() {
   const pending = pendingUnhandledRejections;
   pendingUnhandledRejections = new Map();
   for (const [promise, promiseInfo] of pending.entries()) {
-    pendingUnhandledRejections.delete(promise);
+    pending.delete(promise);
     maybeUnhandledPromises.set(promise, promiseInfo);
     const { reason, uid } = promiseInfo;
     switch (unhandledRejectionsMode) {

--- a/lib/internal/process/promises.js
+++ b/lib/internal/process/promises.js
@@ -4,6 +4,7 @@ const {
   Error,
   ObjectDefineProperty,
   WeakMap,
+  Map,
 } = primordials;
 
 const {
@@ -26,7 +27,7 @@ const {
 const kHasRejectionToWarn = 1;
 
 const maybeUnhandledPromises = new WeakMap();
-const pendingUnhandledRejections = [];
+let pendingUnhandledRejections = new Map();
 const asyncHandledRejections = [];
 let lastPromiseId = 0;
 
@@ -119,32 +120,33 @@ function resolveError(type, promise, reason) {
 }
 
 function unhandledRejection(promise, reason) {
-  maybeUnhandledPromises.set(promise, {
-    reason,
-    uid: ++lastPromiseId,
-    warned: false
-  });
+  const uid = ++lastPromiseId;
   // This causes the promise to be referenced at least for one tick.
-  pendingUnhandledRejections.push(promise);
+  pendingUnhandledRejections.set(promise, {
+    reason,
+    uid
+  });
   setHasRejectionToWarn(true);
 }
 
 function handledRejection(promise) {
+  if (pendingUnhandledRejections.has(promise)) {
+    pendingUnhandledRejections.delete(promise);
+    return;
+  }
   const promiseInfo = maybeUnhandledPromises.get(promise);
   if (promiseInfo !== undefined) {
     maybeUnhandledPromises.delete(promise);
-    if (promiseInfo.warned) {
-      const { uid } = promiseInfo;
-      // Generate the warning object early to get a good stack trace.
-      // eslint-disable-next-line no-restricted-syntax
-      const warning = new Error('Promise rejection was handled ' +
-                                `asynchronously (rejection id: ${uid})`);
-      warning.name = 'PromiseRejectionHandledWarning';
-      warning.id = uid;
-      asyncHandledRejections.push({ promise, warning });
-      setHasRejectionToWarn(true);
-      return;
-    }
+    const { uid } = promiseInfo;
+    // Generate the warning object early to get a good stack trace.
+    // eslint-disable-next-line no-restricted-syntax
+    const warning = new Error('Promise rejection was handled ' +
+                              `asynchronously (rejection id: ${uid})`);
+    warning.name = 'PromiseRejectionHandledWarning';
+    warning.id = uid;
+    asyncHandledRejections.push({ promise, warning });
+    setHasRejectionToWarn(true);
+    return;
   }
   if (maybeUnhandledPromises.size === 0 && asyncHandledRejections.length === 0)
     setHasRejectionToWarn(false);
@@ -197,14 +199,11 @@ function processPromiseRejections() {
     }
   }
 
-  let len = pendingUnhandledRejections.length;
-  while (len--) {
-    const promise = pendingUnhandledRejections.shift();
-    const promiseInfo = maybeUnhandledPromises.get(promise);
-    if (promiseInfo === undefined) {
-      continue;
-    }
-    promiseInfo.warned = true;
+  const pending = pendingUnhandledRejections;
+  pendingUnhandledRejections = new Map();
+  for (const [promise, promiseInfo] of pending.entries()) {
+    pendingUnhandledRejections.delete(promise);
+    maybeUnhandledPromises.set(promise, promiseInfo);
     const { reason, uid } = promiseInfo;
     switch (unhandledRejectionsMode) {
       case kStrictUnhandledRejections: {
@@ -256,7 +255,7 @@ function processPromiseRejections() {
     maybeScheduledTicksOrMicrotasks = true;
   }
   return maybeScheduledTicksOrMicrotasks ||
-         pendingUnhandledRejections.length !== 0;
+         pendingUnhandledRejections.size !== 0;
 }
 
 function getErrorWithoutStack(name, message) {


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/34851

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Before landing

 - [ ] Explain why this works on commit message
 - [ ] Add comments to the code to explain what's going on

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
