### PR TITLE
v8: introduce v8.emitCodeGenFromStringEvent()

### DIFF
--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -513,7 +513,7 @@ will emit a `codeGenerationFromString` event on `process` with the value
 of `code`. The call to `eval` or `new Function` will happen after the
 event is emitted.
 
-Calls made through the `vm` module will not emit the event.
+Calls to the `vm` module such as `vm.runInContext` will not emit the event.
 
 Calling `v8.emitCodeGenFromStringEvent()` when the
 `--disallow-code-generation-from-strings` flag is used will be a noop.

--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -503,6 +503,36 @@ added: v8.0.0
 A subclass of [`Deserializer`][] corresponding to the format written by
 [`DefaultSerializer`][].
 
+## `v8.emitCodeGenFromStringEvent()`
+<!-- YAML
+added: REPLACEME
+-->
+
+After this methode is called, calling `eval(code)` or `new Function(code)`
+will emit a `codeGenerationFromString` event on `process` with the value
+of `code`. The call to `eval` or `new Function` will happen after the
+event is emitted.
+
+Calls made through the `vm` module will not emit the event.
+
+Calling `v8.emitCodeGenFromStringEvent()` when the
+`--disallow-code-generation-from-strings` flag is used will be a noop.
+
+```js
+const v8 = require('v8');
+v8.emitCodeGenFromStringEvent();
+process.on('codeGenerationFromString', (code) => {
+  console.log('Generating code from string`', code, '`');
+});
+const item = { foo: 0 };
+eval('item.foo++');
+```
+
+will log
+```text
+Generating code from string` item.foo++ `
+```
+
 [`Buffer`]: buffer.html
 [`DefaultDeserializer`]: #v8_class_v8_defaultdeserializer
 [`DefaultSerializer`]: #v8_class_v8_defaultserializer

--- a/lib/v8.js
+++ b/lib/v8.js
@@ -72,6 +72,7 @@ class Deserializer extends _Deserializer { }
 
 const {
   cachedDataVersionTag,
+  emitCodeGenFromStringEvent,
   setFlagsFromString: _setFlagsFromString,
   heapStatisticsBuffer,
   heapSpaceStatisticsBuffer,
@@ -265,6 +266,7 @@ function deserialize(buffer) {
 
 module.exports = {
   cachedDataVersionTag,
+  emitCodeGenFromStringEvent,
   getHeapSnapshot,
   getHeapStatistics,
   getHeapSpaceStatistics,

--- a/test/parallel/test-v8-codegen-from-string.js
+++ b/test/parallel/test-v8-codegen-from-string.js
@@ -1,0 +1,23 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const v8 = require('v8');
+
+const beforeSetupHandler =
+    common.mustNotCall('called before v8.emitCodeGenFromStringEvent()');
+
+process.on('codeGenerationFromString', beforeSetupHandler);
+
+const item = { foo: 0 };
+eval('++item.foo');
+process.off('codeGenerationFromString', beforeSetupHandler);
+
+assert.strictEqual(item.foo, 1);
+
+v8.emitCodeGenFromStringEvent();
+process.on('codeGenerationFromString', common.mustCall((code) => {
+  assert.strictEqual(code, 'item.foo++');
+}));
+
+eval('item.foo++');
+assert.strictEqual(item.foo, 2);


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

As of today, it is not possible to intercept calls made to `eval` as the method can't really be monkeypatched without breaking its behavior.
Thanksfully there is an API in V8 that can be used to place a callback when code is generated from string (`eval` and `new Function(string)`. This PR introduces a way to listen on theses events from userland.

If the `--disallow-code-generation-from-strings` flag is used, calling `emitCodeGenFromStringEvent` will have no effect as calls to `eval` and `new Function` will fail anyway.

After calling `v8.emitCodeGenFromStringEvent()`, each time a call is made to `eval` or `new function`, an `codeGenerationFromString` event will be emitted on process with the code as argument.

cc @fraxken @bmeck @cjihrig @targos :) 