### PR TITLE
net: make blocklist family case insensitive

### DIFF
--- a/lib/internal/blocklist.js
+++ b/lib/internal/blocklist.js
@@ -55,6 +55,7 @@ class BlockList {
       throw new ERR_INVALID_ARG_TYPE('address', 'string', address);
     if (typeof family !== 'string')
       throw new ERR_INVALID_ARG_TYPE('family', 'string', family);
+    family = family.toLowerCase();
     if (family !== 'ipv4' && family !== 'ipv6')
       throw new ERR_INVALID_ARG_VALUE('family', family);
     const type = family === 'ipv4' ? AF_INET : AF_INET6;
@@ -68,6 +69,7 @@ class BlockList {
       throw new ERR_INVALID_ARG_TYPE('end', 'string', end);
     if (typeof family !== 'string')
       throw new ERR_INVALID_ARG_TYPE('family', 'string', family);
+    family = family.toLowerCase();
     if (family !== 'ipv4' && family !== 'ipv6')
       throw new ERR_INVALID_ARG_VALUE('family', family);
     const type = family === 'ipv4' ? AF_INET : AF_INET6;
@@ -83,6 +85,7 @@ class BlockList {
       throw new ERR_INVALID_ARG_TYPE('prefix', 'number', prefix);
     if (typeof family !== 'string')
       throw new ERR_INVALID_ARG_TYPE('family', 'string', family);
+    family = family.toLowerCase();
     let type;
     switch (family) {
       case 'ipv4':
@@ -106,6 +109,7 @@ class BlockList {
       throw new ERR_INVALID_ARG_TYPE('address', 'string', address);
     if (typeof family !== 'string')
       throw new ERR_INVALID_ARG_TYPE('family', 'string', family);
+    family = family.toLowerCase();
     if (family !== 'ipv4' && family !== 'ipv6')
       throw new ERR_INVALID_ARG_VALUE('family', family);
     const type = family === 'ipv4' ? AF_INET : AF_INET6;

--- a/test/parallel/test-blocklist.js
+++ b/test/parallel/test-blocklist.js
@@ -56,6 +56,7 @@ const assert = require('assert');
   assert(blockList.check('8592:757c:efae:4e45:fb5d:d62a:0d00:8e17', 'ipv6'));
 
   assert(blockList.check('::ffff:1.1.1.1', 'ipv6'));
+  assert(blockList.check('::ffff:1.1.1.1', 'IPV6'));
 
   assert(blockList.check('1.1.1.2'));
 
@@ -100,7 +101,7 @@ const assert = require('assert');
   const blockList = new BlockList();
   blockList.addAddress('1.1.1.1');
   blockList.addRange('10.0.0.1', '10.0.0.10');
-  blockList.addSubnet('8592:757c:efae:4e45::', 64, 'ipv6');
+  blockList.addSubnet('8592:757c:efae:4e45::', 64, 'IpV6'); // Case insensitive
 
   const rulesCheck = [
     'Subnet: IPv6 8592:757c:efae:4e45::/64',


### PR DESCRIPTION
Make the family argument case-insensitive to help ergonomics.

Signed-off-by: James M Snell <jasnell@gmail.com>

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
