### PR TITLE
doc: replace bash references with sh

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -361,7 +361,7 @@ loopback interface must also have '::1' enabled. For some default installations
 on Ubuntu that does not seem to be the case. To enable '::1' on the
 loopback interface on Ubuntu:
 
-```bash
+```sh
 sudo sysctl -w net.ipv6.conf.lo.disable_ipv6=0
 ```
 

--- a/README.md
+++ b/README.md
@@ -594,7 +594,7 @@ Primary GPG keys for Node.js Releasers (some Releasers sign with subkeys):
 
 To import the full set of trusted release keys:
 
-```bash
+```sh
 gpg --keyserver pool.sks-keyservers.net --recv-keys 4ED778F539E3634C779C87C6D7062848A1AB005C
 gpg --keyserver pool.sks-keyservers.net --recv-keys 94AE36675C464D64BAFA68DD7434390BDBE9B9C5
 gpg --keyserver pool.sks-keyservers.net --recv-keys 71DCFD284A79C3B38668286BC97EC7A07EDE3FC1

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1223,14 +1223,14 @@ script file.
 In case an option value happens to contain a space (for example a path listed
 in `--require`), it must be escaped using double quotes. For example:
 
-```bash
+```sh
 NODE_OPTIONS='--require "./my path/file.js"'
 ```
 
 A singleton flag passed as a command line option will override the same flag
 passed into `NODE_OPTIONS`:
 
-```bash
+```sh
 # The inspector will be available on port 5555
 NODE_OPTIONS='--inspect=localhost:4444' node --inspect=localhost:5555
 ```
@@ -1239,7 +1239,7 @@ A flag that can be passed multiple times will be treated as if its
 `NODE_OPTIONS` instances were passed first, and then its command line
 instances afterwards:
 
-```bash
+```sh
 NODE_OPTIONS='--require "./a.js"' node --require "./b.js"
 # is equivalent to:
 node --require "./a.js" --require "./b.js"

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -94,7 +94,7 @@ until the root of the volume is reached.
 }
 ```
 
-```bash
+```sh
 # In same folder as above package.json
 node my-app.js # Runs as ES module
 ```
@@ -184,7 +184,7 @@ Strings passed in as an argument to `--eval` (or `-e`), or piped to `node` via
 `STDIN`, will be treated as ES modules when the `--input-type=module` flag is
 set.
 
-```bash
+```sh
 node --input-type=module --eval "import { sep } from 'path'; console.log(sep);"
 
 echo "import { sep } from 'path'; console.log(sep);" | node --input-type=module
@@ -506,7 +506,7 @@ conditions behave analogously to nested JavaScript `if` statements.
 When running Node.js, custom user conditions can be added with the
 `--conditions` or `-u` flag:
 
-```bash
+```sh
 node --conditions=development main.js
 ```
 
@@ -1130,7 +1130,7 @@ import packageConfig from './package.json';
 The `--experimental-json-modules` flag is needed for the module
 to work.
 
-```bash
+```sh
 node index.mjs # fails
 node --experimental-json-modules index.mjs # works
 ```
@@ -1153,7 +1153,7 @@ console.log(M);
 
 executed under:
 
-```bash
+```sh
 node --experimental-wasm-modules index.mjs
 ```
 
@@ -1179,7 +1179,7 @@ import { five } from './a.mjs';
 console.log(five); // Logs `5`
 ```
 
-```bash
+```sh
 node b.mjs # works
 ```
 
@@ -1506,7 +1506,7 @@ console.log(VERSION);
 
 With this loader, running:
 
-```bash
+```sh
 node --experimental-loader ./https-loader.mjs ./main.mjs
 ```
 

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -3732,7 +3732,7 @@ fs.symlink('./mew', './example/mewtwo', callback);
 The above example creates a symbolic link `mewtwo` in the `example` which points
 to `mew` in the same directory:
 
-```bash
+```console
 $ tree example/
 example/
 ├── mew

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -66,7 +66,7 @@ server.listen(8443);
 
 To generate the certificate and key for this example, run:
 
-```bash
+```sh
 openssl req -x509 -newkey rsa:2048 -nodes -sha256 -subj '/CN=localhost' \
   -keyout localhost-privkey.pem -out localhost-cert.pem
 ```

--- a/doc/api/intl.md
+++ b/doc/api/intl.md
@@ -115,13 +115,13 @@ through either:
 
 * The [`NODE_ICU_DATA`][] environment variable:
 
-  ```bash
+  ```sh
   env NODE_ICU_DATA=/some/directory node
   ```
 
 * The [`--icu-data-dir`][] CLI parameter:
 
-  ```bash
+  ```sh
   node --icu-data-dir=/some/directory
   ```
 

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -689,7 +689,7 @@ In `entry.js` script:
 console.log(require.main);
 ```
 
-```bash
+```sh
 node entry.js
 ```
 

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -134,7 +134,7 @@ For Mac developers, [Xcode][] offers all the required compiler tools.
 However, it is not necessary to install the entire Xcode IDE. The following
 command installs the necessary toolchain:
 
-```bash
+```sh
 xcode-select --install
 ```
 
@@ -142,7 +142,7 @@ For Windows developers, [Visual Studio][] offers all the required compiler
 tools. However, it is not necessary to install the entire Visual Studio
 IDE. The following command installs the necessary toolchain:
 
-```bash
+```sh
 npm install --global --production windows-build-tools
 ```
 

--- a/doc/api/policy.md
+++ b/doc/api/policy.md
@@ -31,7 +31,7 @@ when loading modules.
 Once this has been set, all modules must conform to a policy manifest file
 passed to the flag:
 
-```bash
+```sh
 node --experimental-policy=policy.json app.js
 ```
 
@@ -43,7 +43,7 @@ the policy file itself may be provided via `--policy-integrity`.
 This allows running `node` and asserting the policy file contents
 even if the file is changed on disk.
 
-```bash
+```sh
 node --experimental-policy=policy.json --policy-integrity="sha384-SggXRQHwCG8g+DktYYzxkXRIkTiEYWBHqev0xnpCxYlqMBufKZHAHQM3/boDaI/0" app.js
 ```
 

--- a/doc/api/report.md
+++ b/doc/api/report.md
@@ -390,7 +390,7 @@ is provided below for reference.
 
 ## Usage
 
-```bash
+```sh
 node --report-uncaught-exception --report-on-signal \
 --report-on-fatalerror app.js
 ```
@@ -567,7 +567,7 @@ process.report.signal = 'SIGQUIT';
 Configuration on module initialization is also available via
 environment variables:
 
-```bash
+```sh
 NODE_OPTIONS="--report-uncaught-exception \
   --report-on-fatalerror --report-on-signal \
   --report-signal=SIGUSR2  --report-filename=./report.json \

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -23,7 +23,7 @@ Private keys can be generated in multiple ways. The example below illustrates
 use of the OpenSSL command-line interface to generate a 2048-bit RSA private
 key:
 
-```bash
+```sh
 openssl genrsa -out ryans-key.pem 2048
 ```
 
@@ -37,7 +37,7 @@ step to obtaining a certificate is to create a *Certificate Signing Request*
 The OpenSSL command-line interface can be used to generate a CSR for a private
 key:
 
-```bash
+```sh
 openssl req -new -sha256 -key ryans-key.pem -out ryans-csr.pem
 ```
 
@@ -47,14 +47,14 @@ Authority for signing or used to generate a self-signed certificate.
 Creating a self-signed certificate using the OpenSSL command-line interface
 is illustrated in the example below:
 
-```bash
+```sh
 openssl x509 -req -in ryans-csr.pem -signkey ryans-key.pem -out ryans-cert.pem
 ```
 
 Once the certificate is generated, it can be used to generate a `.pfx` or
 `.p12` file:
 
-```bash
+```sh
 openssl pkcs12 -export -in ryans-cert.pem -inkey ryans-key.pem \
       -certfile ca-cert.pem -out ryans.pfx
 ```
@@ -97,7 +97,7 @@ to generate Diffie-Hellman parameters and specify them with the `dhparam`
 option to [`tls.createSecureContext()`][]. The following illustrates the use of
 the OpenSSL command-line interface to generate such parameters:
 
-```bash
+```sh
 openssl dhparam -outform PEM -out dhparam.pem 2048
 ```
 
@@ -313,7 +313,7 @@ line switch (directly, or via the [`NODE_OPTIONS`][] environment variable). For
 instance, the following makes `ECDHE-RSA-AES128-GCM-SHA256:!RC4` the default TLS
 cipher suite:
 
-```bash
+```sh
 node --tls-cipher-list='ECDHE-RSA-AES128-GCM-SHA256:!RC4' server.js
 
 export NODE_OPTIONS=--tls-cipher-list='ECDHE-RSA-AES128-GCM-SHA256:!RC4'

--- a/doc/api/tracing.md
+++ b/doc/api/tracing.md
@@ -38,7 +38,7 @@ The available categories are:
 
 By default the `node`, `node.async_hooks`, and `v8` categories are enabled.
 
-```bash
+```sh
 node --trace-event-categories v8,node,node.async_hooks server.js
 ```
 
@@ -47,7 +47,7 @@ flag to enable trace events. This requirement has been removed. However, the
 `--trace-events-enabled` flag *may* still be used and will enable the
 `node`, `node.async_hooks`, and `v8` trace event categories by default.
 
-```bash
+```sh
 node --trace-events-enabled
 
 # is equivalent to
@@ -76,7 +76,7 @@ The logging file is by default called `node_trace.${rotation}.log`, where
 be specified with `--trace-event-file-pattern` that accepts a template
 string that supports `${rotation}` and `${pid}`:
 
-```bash
+```sh
 node --trace-event-categories v8 --trace-event-file-pattern '${pid}-${rotation}.log' server.js
 ```
 

--- a/doc/guides/backporting-to-release-lines.md
+++ b/doc/guides/backporting-to-release-lines.md
@@ -35,7 +35,7 @@ replace that with the staging branch for the targeted release line.
 2. Make sure that the local staging branch is up to date with the remote.
 3. Create a new branch off of the staging branch, as shown below.
 
-    ```bash
+    ```sh
     # Assuming your fork of Node.js is checked out in $NODE_DIR,
     # the origin remote points to your fork, and the upstream remote points
     # to git://github.com/nodejs/node

--- a/doc/guides/building-node-with-ninja.md
+++ b/doc/guides/building-node-with-ninja.md
@@ -28,7 +28,7 @@ compile much faster than even `make -j4` (or
 number of processes to run for [Ninja][] using the environment variable `JOBS`.
 This will be the equivalent to the `-j` parameter in the regular `make`:
 
-```bash
+```sh
 JOBS=12 make
 ```
 
@@ -36,7 +36,7 @@ JOBS=12 make
 
 To create a debug build rather than a release build:
 
-```bash
+```sh
 ./configure --ninja --debug && make
 ```
 

--- a/doc/guides/collaborator-guide.md
+++ b/doc/guides/collaborator-guide.md
@@ -645,7 +645,7 @@ That means a commit has landed since your last rebase against `upstream/master`.
 To fix this, pull with rebase from upstream, run the tests again, and (if the
 tests pass) push again:
 
-```bash
+```sh
 git pull upstream master --rebase
 make -j4 test
 git push upstream master

--- a/doc/guides/maintaining-V8.md
+++ b/doc/guides/maintaining-V8.md
@@ -328,7 +328,7 @@ that Node.js may be floating (or else cause a merge conflict).
 
 The rough outline of the process is:
 
-```bash
+```sh
 # Assuming your fork of Node.js is checked out in $NODE_DIR
 # and you want to update the Node.js master branch.
 # Find the current (OLD) version in
@@ -367,7 +367,7 @@ above. A better strategy is to
 
 To audit for floating patches:
 
-```bash
+```sh
 git log --oneline deps/v8
 ```
 
@@ -375,7 +375,7 @@ To replace the copy of V8 in Node.js, use the [`git-node`][] tool. For example,
 if you want to replace the copy of V8 in Node.js with the branch-head for V8 5.1
 branch:
 
-```bash
+```sh
 cd $NODE_DIR
 git node v8 major --branch=5.1-lkgr
 ```

--- a/doc/guides/maintaining-icu.md
+++ b/doc/guides/maintaining-icu.md
@@ -101,7 +101,7 @@ should be sufficient).
 * Configure Node.js with the specific [ICU version](http://site.icu-project.org/download)
   you want to upgrade to, for example:
 
-```bash
+```sh
 ./configure \
     --with-intl=full-icu \
     --with-icu-source=http://download.icu-project.org/files/icu4c/58.1/icu4c-58_1-src.tgz
@@ -118,7 +118,7 @@ make
 
 * Verify the Node.js build works:
 
-```bash
+```sh
 make test-ci
 ```
 
@@ -137,13 +137,13 @@ new Intl.DateTimeFormat('es', { month: 'long' }).format(new Date(9E8));
 > :warning: Do not modify any source code in `deps/icu-small` !
 > See section below about floating patches to ICU.
 
-```bash
+```sh
 python tools/icu/shrink-icu-src.py
 ```
 
 * Now, do a clean rebuild of Node.js to test:
 
-```bash
+```sh
 make -k distclean
 ./configure
 make
@@ -168,7 +168,7 @@ so make this a separate commit from the smaller changes.
 
 * Now, rebuild the Node.js license.
 
-```bash
+```sh
 # clean up - remove deps/icu
 make clean
 tools/license-builder.sh
@@ -178,7 +178,7 @@ tools/license-builder.sh
 It should match the ICU URL used in the first step.  When this is done, the
 following should build with small ICU.
 
-```bash
+```sh
 # clean up
 rm -rf out deps/icu deps/icu4c*
 ./configure --with-intl=small-icu --download=all
@@ -210,7 +210,7 @@ version.
 For example, to patch `source/tools/toolutil/pkg_genc.cpp` for
 ICU version 63:
 
-```bash
+```sh
 # go to your Node.js source directory
 cd <node>
 

--- a/doc/guides/maintaining-ngtcp2-nghttp3.md
+++ b/doc/guides/maintaining-ngtcp2-nghttp3.md
@@ -10,7 +10,7 @@ updated together.
 ## Updating ngtcp2
 
 Update ngtcp2:
-```bash
+```sh
 git clone https://github.com/ngtcp2/ngtcp2
 cd ngtcp2
 autoreconf -i
@@ -29,7 +29,7 @@ Check that Node.js still builds and tests.
 ## Updating nghttp3
 
 Update nghttp3:
-```bash
+```sh
 git clone https://github.com/ngtcp2/nghttp3
 cd nghttp3
 autoreconf -i

--- a/doc/guides/maintaining-root-certs.md
+++ b/doc/guides/maintaining-root-certs.md
@@ -30,7 +30,7 @@ the nodejs/node repository.
 
     Update the tag in the commands below, and run:
 
-    ```bash
+    ```sh
     cd tools/
     ./mk-ca-bundle.pl -v 2>_before
     curl -O https://hg.mozilla.org/projects/nss/raw-file/NSS_3_41_RTM/lib/ckfw/builtins/certdata.txt
@@ -57,7 +57,7 @@ the nodejs/node repository.
 
     Run the command below:
 
-    ```bash
+    ```sh
     ./mk-ca-bundle.pl -v 2>_after
     ```
 

--- a/doc/guides/maintaining-zlib.md
+++ b/doc/guides/maintaining-zlib.md
@@ -6,7 +6,7 @@ performance improvements not currently available in standard zlib.
 ## Updating zlib
 
 Update zlib:
-```bash
+```sh
 git clone https://chromium.googlesource.com/chromium/src/third_party/zlib
 cp deps/zlib/zlib.gyp deps/zlib/win32/zlib.def deps
 rm -rf deps/zlib zlib/.git

--- a/test/fixtures/wpt/resources/webidl2/README.md
+++ b/test/fixtures/wpt/resources/webidl2/README.md
@@ -14,7 +14,7 @@ not the test suite).
 
 Just the usual. For Node:
 
-```Bash
+```sh
 npm install webidl2
 ```
 
@@ -604,21 +604,21 @@ should be enough once you're set up.
 Current test coverage, as documented in `coverage.html`, is 95%. You can run your own
 coverage analysis with:
 
-```Bash
+```sh
 jscoverage lib lib-cov
 ```
 
 That will create the lib-cov directory with instrumented code; the test suite knows
 to use that if needed. You can then run the tests with:
 
-```Bash
+```sh
 JSCOV=1 mocha --reporter html-cov > coverage.html
 ```
 
 Note that I've been getting weirdly overescaped results from the html-cov reporter,
 so you might wish to try this instead:
 
-```Bash
+```sh
 JSCOV=1 mocha  --reporter html-cov | sed "s/&lt;/</g" | sed "s/&gt;/>/g" | sed "s/&quot;/\"/g" > coverage.html
 ```
 ### Browser tests


### PR DESCRIPTION
`sh` means [the POSIX interface](https://pubs.opengroup.org/onlinepubs/009695399/utilities/xcu_chap02.html), and could be `bash`, `zsh`, etc. — even just plain old [`sh`](https://pubs.opengroup.org/onlinepubs/009695399/utilities/sh.html).

refs: #34837 

##### Checklist

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)


