### PR TITLE
doc: add ESM examples in `module` API doc page

### DIFF
--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -7,8 +7,8 @@
 * {Object}
 
 Provides general utility methods when interacting with instances of
-`Module`, the `module` variable often seen in file modules. Accessed
-via `require('module')`.
+`Module`, the [`module`][] variable often seen in CommonJS modules. Accessed
+via `import 'module'` or `require('module')`.
 
 ### `module.builtinModules`
 <!-- YAML
@@ -27,6 +27,14 @@ if a module is maintained by a third party or not.
 by the [module wrapper][]. To access it, require the `Module` module:
 
 ```js
+// module.mjs
+// In an ECMAScript module
+import { builtinModules } from 'module';
+```
+
+```js
+// module.cjs
+// In a CommonJS module
 const builtin = require('module').builtinModules;
 ```
 
@@ -74,8 +82,8 @@ added: v12.12.0
 -->
 
 The `module.syncBuiltinESMExports()` method updates all the live bindings for
-builtin ES Modules to match the properties of the CommonJS exports. It does
-not add or remove exported names from the ES Modules.
+builtin [ES Modules][] to match the properties of the [CommonJS][] exports. It
+does not add or remove exported names from the [ES Modules][].
 
 ```js
 const fs = require('fs');
@@ -116,6 +124,14 @@ To enable source map parsing, Node.js must be run with the flag
 [`NODE_V8_COVERAGE=dir`][].
 
 ```js
+// module.mjs
+// In an ECMAScript module
+import { findSourceMap, SourceMap } from 'module';
+```
+
+```js
+// module.cjs
+// In a CommonJS module
 const { findSourceMap, SourceMap } = require('module');
 ```
 
@@ -192,3 +208,6 @@ consists of the following keys:
 [`createRequire()`]: #module_module_createrequire_filename
 [module wrapper]: modules_cjs.html#modules_cjs_the_module_wrapper
 [source map include directives]: https://sourcemaps.info/spec.html#h.lmz475t4mvbx
+[`module`]: modules.html#modules_the_module_object
+[CommonJS]: modules.html
+[ES Modules]: esm.html

--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -7,7 +7,7 @@
 * {Object}
 
 Provides general utility methods when interacting with instances of
-`Module`, the [`module`][] variable often seen in CommonJS modules. Accessed
+`Module`, the [`module`][] variable often seen in [CommonJS][] modules. Accessed
 via `import 'module'` or `require('module')`.
 
 ### `module.builtinModules`

--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -29,7 +29,7 @@ by the [module wrapper][]. To access it, require the `Module` module:
 ```js
 // module.mjs
 // In an ECMAScript module
-import { builtinModules } from 'module';
+import { builtinModules as builtin } from 'module';
 ```
 
 ```js


### PR DESCRIPTION
In an effort to promote ESM usage, add examples using this syntax alongside CJS ones. I've also added some links where it was missing.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
