### PR TITLE
doc: use "previous"/"preceding" instead of "above" as modifier

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -95,7 +95,7 @@ until the root of the volume is reached.
 ```
 
 ```bash
-# In same folder as above package.json
+# In same folder as preceding package.json
 node my-app.js # Runs as ES module
 ```
 
@@ -542,7 +542,7 @@ import { something } from 'a-package'; // Imports "something" from ./main.mjs.
 
 Self-referencing is available only if `package.json` has `exports`, and will
 allow importing only what that `exports` (in the `package.json`) allows.
-So the code below, given the package above, will generate a runtime error:
+So the code below, given the previous package, will generate a runtime error:
 
 ```js
 // ./another-module.mjs
@@ -689,7 +689,7 @@ CommonJS entry point for `require`.
 }
 ```
 
-The above example uses explicit extensions `.mjs` and `.cjs`.
+The preceding example uses explicit extensions `.mjs` and `.cjs`.
 If your files use the `.js` extension, `"type": "module"` will cause such files
 to be treated as ES modules, just as `"type": "commonjs"` would cause them
 to be treated as CommonJS.
@@ -1309,7 +1309,7 @@ export async function getFormat(url, context, defaultGetFormat) {
   if (Math.random() > 0.5) { // Some condition.
     // For some or all URLs, do some custom logic for determining format.
     // Always return an object of the form {format: <string>}, where the
-    // format is one of the strings in the table above.
+    // format is one of the strings in the preceding table.
     return {
       format: 'module',
     };


### PR DESCRIPTION
Refs: https://docs.microsoft.com/en-us/style-guide/a-z-word-list-term-collections/a/above

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
