### PR TITLE
src,doc: fix wording to refer to context, not environment

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -239,7 +239,7 @@ Node.js, and a sufficiently committed person could restructure Node.js to
 provide built-in modules inside of `vm.Context`s.
 
 Often, the `Context` is passed around for [exception handling][].
-Typical ways of accessing the current `Environment` in the Node.js code are:
+Typical ways of accessing the current `Context` in the Node.js code are:
 
 * Given an [`Isolate`][], using `isolate->GetCurrentContext()`.
 * Given an [`Environment`][], using `env->context()` to get the `Environment`’s


### PR DESCRIPTION
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines]

