### PR TITLE
stream: fix Readable stream state properties

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -1218,14 +1218,14 @@ ObjectDefineProperties(Readable.prototype, {
 });
 
 ObjectDefineProperties(ReadableState.prototype, {
-  // Legacy getter for `pipesCount`
+  // Legacy getter for `pipesCount`.
   pipesCount: {
     get() {
       return this.pipes.length;
     }
   },
 
-  // Legacy property for `paused`
+  // Legacy property for `paused`.
   paused: {
     get() {
       return this[kPaused] !== false;

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -1215,6 +1215,9 @@ ObjectDefineProperties(Readable.prototype, {
     }
   },
 
+});
+
+ObjectDefineProperties(ReadableState.prototype, {
   // Legacy getter for `pipesCount`
   pipesCount: {
     get() {
@@ -1222,6 +1225,7 @@ ObjectDefineProperties(Readable.prototype, {
     }
   },
 
+  // Legacy property for `paused`
   paused: {
     get() {
       return this[kPaused] !== false;


### PR DESCRIPTION
Looks like they have been accidentally moved in
https://github.com/nodejs/node/pull/31144. This also adds the proxy
properties to Readable since they have been present all this time
and removing them would be breaking.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
/cc @nodejs/streams @antsmartian 