### PR TITLE
errors: use `ErrorPrototypeToString` from `primordials` object

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -13,6 +13,7 @@
 const {
   ArrayIsArray,
   Error,
+  ErrorPrototypeToString,
   JSONStringify,
   Map,
   MathAbs,
@@ -47,7 +48,6 @@ const kTypes = [
 ];
 
 const MainContextError = Error;
-const ErrorToString = Error.prototype.toString;
 const overrideStackTrace = new WeakMap();
 const kNoOverride = Symbol('kNoOverride');
 const prepareStackTrace = (globalThis, error, trace) => {
@@ -68,7 +68,7 @@ const prepareStackTrace = (globalThis, error, trace) => {
   // Error: Message
   //     at function (file)
   //     at file
-  const errorString = ErrorToString.call(error);
+  const errorString = ErrorPrototypeToString(error);
   if (trace.length === 0) {
     return errorString;
   }


### PR DESCRIPTION
This ensures that the `prepareStackTrace` no override fallback path doesn’t get broken by `Error.prototype.toString.call` not being `Function.prototype.call`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
