### PR TITLE
doc: fix broken markdown/display in cli.html

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -887,14 +887,14 @@ Print short summaries of calls to [`Atomics.wait()`][] to stderr.
 The output could look like this:
 
 ```text
-(node:15701) [Thread 0] Atomics.wait(<address> + 0, 1, inf) started
-(node:15701) [Thread 0] Atomics.wait(<address> + 0, 1, inf) did not wait because the values mismatched
-(node:15701) [Thread 0] Atomics.wait(<address> + 0, 0, 10) started
-(node:15701) [Thread 0] Atomics.wait(<address> + 0, 0, 10) timed out
-(node:15701) [Thread 0] Atomics.wait(<address> + 4, 0, inf) started
-(node:15701) [Thread 1] Atomics.wait(<address> + 4, -1, inf) started
-(node:15701) [Thread 0] Atomics.wait(<address> + 4, 0, inf) was woken up by another thread
-(node:15701) [Thread 1] Atomics.wait(<address> + 4, -1, inf) was woken up by another thread
+(node:15701) [Thread 0] Atomics.wait(&lt;address> + 0, 1, inf) started
+(node:15701) [Thread 0] Atomics.wait(&lt;address> + 0, 1, inf) did not wait because the values mismatched
+(node:15701) [Thread 0] Atomics.wait(&lt;address> + 0, 0, 10) started
+(node:15701) [Thread 0] Atomics.wait(&lt;address> + 0, 0, 10) timed out
+(node:15701) [Thread 0] Atomics.wait(&lt;address> + 4, 0, inf) started
+(node:15701) [Thread 1] Atomics.wait(&lt;address> + 4, -1, inf) started
+(node:15701) [Thread 0] Atomics.wait(&lt;address> + 4, 0, inf) was woken up by another thread
+(node:15701) [Thread 1] Atomics.wait(&lt;address> + 4, -1, inf) was woken up by another thread
 ```
 
 The fields here correspond to:


### PR DESCRIPTION
The `<` character is interpreted as the start of an HTML tag, making the
word `address` not render and the rest of the document rendered with a
grey background and in italics. Use `&lt;` instead.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Before: 

![image](https://user-images.githubusercontent.com/718899/90984902-08abfe80-e52d-11ea-8670-332e1c4e42ec.png)


After:

![image](https://user-images.githubusercontent.com/718899/90984907-12cdfd00-e52d-11ea-96b8-43255c4d85de.png)



