### PR TITLE
tools,doc: remove "toc" anchor name

### DIFF
--- a/doc/template.html
+++ b/doc/template.html
@@ -27,7 +27,7 @@
         <div id="gtoc">
           <ul>
             <li>
-              <a href="index.html" name="toc">Index</a>
+              <a href="index.html">Index</a>
             </li>
             <li>
               <a href="all.html">View on single page</a>

--- a/tools/doc/allhtml.js
+++ b/tools/doc/allhtml.js
@@ -49,7 +49,7 @@ for (const link of toc.match(/<a.*?>/g)) {
 
 // Replace various mentions of index with all.
 let all = toc.replace(/index\.html/g, 'all.html')
-  .replace('<a href="all.html" name="toc">', '<a href="index.html" name="toc">')
+  .replace('<a href="all.html">', '<a href="index.html">')
   .replace('index.json', 'all.json')
   .replace('api-section-index', 'api-section-all')
   .replace('data-id="index"', 'data-id="all"')


### PR DESCRIPTION
The _name_ attribute is obsolete. Changing it to _id_ in the case of
"toc" would result in a conflict with an existing id. However, there are
no links to "#toc" in our docs. And if there were, it would be more
appropriate to link to the id toc which is the toc for the individual
documents. So remove the anchor name entirely.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
