### PR TITLE
quic: support AbortSignal in QuicSocket connect/listen

### DIFF
--- a/deps/nghttp3/lib/nghttp3_ringbuf.c
+++ b/deps/nghttp3/lib/nghttp3_ringbuf.c
@@ -33,21 +33,25 @@
 
 #include "nghttp3_macro.h"
 
-#if defined(_MSC_VER) && defined(_M_ARM64)
-unsigned int __popcnt(unsigned int x) {
+#if defined(_WIN32)
+#  if defined(_M_ARM64)
+unsigned int __nghttp3_popcnt(unsigned int x) {
   unsigned int c = 0;
   for (; x; ++c) {
     x &= x - 1;
   }
   return c;
 }
+#  else
+#    define __nghttp3_popcnt __popcnt
+#  endif
 #endif
 
 int nghttp3_ringbuf_init(nghttp3_ringbuf *rb, size_t nmemb, size_t size,
                          const nghttp3_mem *mem) {
   if (nmemb) {
 #ifdef WIN32
-    assert(1 == __popcnt((unsigned int)nmemb));
+    assert(1 == __nghttp3_popcnt((unsigned int)nmemb));
 #else
     assert(1 == __builtin_popcount((unsigned int)nmemb));
 #endif
@@ -127,7 +131,7 @@ int nghttp3_ringbuf_reserve(nghttp3_ringbuf *rb, size_t nmemb) {
   }
 
 #ifdef WIN32
-  assert(1 == __popcnt((unsigned int)nmemb));
+  assert(1 == __nghttp3_popcnt((unsigned int)nmemb));
 #else
   assert(1 == __builtin_popcount((unsigned int)nmemb));
 #endif

--- a/deps/ngtcp2/lib/ngtcp2_ringbuf.c
+++ b/deps/ngtcp2/lib/ngtcp2_ringbuf.c
@@ -31,20 +31,24 @@
 
 #include "ngtcp2_macro.h"
 
-#if defined(_MSC_VER) && defined(_M_ARM64)
-unsigned int __popcnt(unsigned int x) {
+#if defined(_WIN32)
+#  if defined(_M_ARM64)
+unsigned int __ngtcp2_popcnt(unsigned int x) {
   unsigned int c = 0;
   for (; x; ++c) {
     x &= x - 1;
   }
   return c;
 }
+#  else
+#    define __ngtcp2_popcnt __popcnt
+#  endif
 #endif
 
 int ngtcp2_ringbuf_init(ngtcp2_ringbuf *rb, size_t nmemb, size_t size,
                         const ngtcp2_mem *mem) {
 #ifdef WIN32
-  assert(1 == __popcnt((unsigned int)nmemb));
+  assert(1 == __ngtcp2_popcnt((unsigned int)nmemb));
 #else
   assert(1 == __builtin_popcount((unsigned int)nmemb));
 #endif

--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -1626,6 +1626,8 @@ added: REPLACEME
   * `maxStreamDataUni` {number}
   * `maxStreamsBidi` {number}
   * `maxStreamsUni` {number}
+  * `signal` {AbortSignal} Optionally allows the `connect()` to be canceled
+    using an `AbortController`.
   * `h3` {Object} HTTP/3 Specific Configuration Options
     * `qpackMaxTableCapacity` {number}
     * `qpackBlockedStreams` {number}
@@ -1830,6 +1832,8 @@ added: REPLACEME
     [OpenSSL Options][].
   * `sessionIdContext` {string} Opaque identifier used by servers to ensure
     session state is not shared between applications. Unused by clients.
+  * `signal` {AbortSignal} Optionally allows the `listen()` to be canceled
+    using an `AbortController`.
 * Returns: {Promise}
 
 Listen for new peer-initiated sessions. Returns a `Promise` that is resolved

--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -639,7 +639,7 @@ class QuicEndpoint {
     if (state.bindPromise !== undefined)
       return state.bindPromise;
 
-    return state.bindPromise = this[kBind]().finally(() => {
+    return state.bindPromise = this[kBind](options).finally(() => {
       state.bindPromise = undefined;
     });
   }
@@ -1187,6 +1187,15 @@ class QuicSocket extends EventEmitter {
       ...options,
     };
 
+    const { signal } = options;
+    if (signal != null && !('aborted' in signal))
+      throw new ERR_INVALID_ARG_TYPE('options.signal', 'AbortSignal', signal);
+
+    // If an AbortSignal was passed in, check to make sure it is not already
+    // aborted before we continue on to do any work.
+    if (signal && signal.aborted)
+      throw new lazyDOMException('The operation was aborted', 'AbortError');
+
     // The ALPN protocol identifier is strictly required.
     const {
       alpn,
@@ -1211,7 +1220,10 @@ class QuicSocket extends EventEmitter {
     state.ocspHandler = ocspHandler;
     state.clientHelloHandler = clientHelloHandler;
 
-    await this[kMaybeBind]();
+    await this[kMaybeBind]({ signal });
+
+    if (signal && signal.aborted)
+      throw new lazyDOMException('The operation was aborted', 'AbortError');
 
     // It's possible that the QuicSocket was destroyed or closed while
     // the bind was pending. Check for that and handle accordingly.
@@ -1225,6 +1237,9 @@ class QuicSocket extends EventEmitter {
       port,
       type
     } = await resolvePreferredAddress(lookup, transportParams.preferredAddress);
+
+    if (signal && signal.aborted)
+      throw new lazyDOMException('The operation was aborted', 'AbortError');
 
     // It's possible that the QuicSocket was destroyed or closed while
     // the preferred address resolution was pending. Check for that and handle
@@ -1264,6 +1279,14 @@ class QuicSocket extends EventEmitter {
       // while the nextTick is pending. If that happens, do nothing.
       if (this.destroyed || this.closing)
         return;
+
+      // The abort signal was triggered while this was pending,
+      // destroy the QuicSocket with an error.
+      if (signal && signal.aborted) {
+        this.destroy(
+          new lazyDOMException('The operation was aborted', 'AbortError'));
+        return;
+      }
       try {
         this.emit('listening');
       } catch (error) {
@@ -1284,13 +1307,25 @@ class QuicSocket extends EventEmitter {
       ...options
     };
 
+    const { signal } = options;
+    if (signal != null && !('aborted' in signal))
+      throw new ERR_INVALID_ARG_TYPE('options.signal', 'AbortSignal', signal);
+
+    // If an AbortSignal was passed in, check to make sure it is not already
+    // aborted before we continue on to do any work.
+    if (signal && signal.aborted)
+      throw new lazyDOMException('The operation was aborted', 'AbortError');
+
     const {
       type,
       address,
       lookup = state.lookup
     } = validateQuicSocketConnectOptions(options);
 
-    await this[kMaybeBind]();
+    await this[kMaybeBind]({ signal });
+
+    if (signal && signal.aborted)
+      throw new lazyDOMException('The operation was aborted', 'AbortError');
 
     if (this.destroyed)
       throw new ERR_INVALID_STATE('QuicSocket was destroyed');
@@ -1301,6 +1336,9 @@ class QuicSocket extends EventEmitter {
       address: ip
     } = await lookup(addressOrLocalhost(address, type),
                      type === AF_INET6 ? 6 : 4);
+
+    if (signal && signal.aborted)
+      throw new lazyDOMException('The operation was aborted', 'AbortError');
 
     if (this.destroyed)
       throw new ERR_INVALID_STATE('QuicSocket was destroyed');

--- a/src/quic/node_quic_http3_application.h
+++ b/src/quic/node_quic_http3_application.h
@@ -174,7 +174,7 @@ class Http3Application final :
   void BeginHeaders(
       int64_t stream_id,
       QuicStreamHeadersKind kind = QUICSTREAM_HEADERS_KIND_NONE);
-  bool ReceiveHeader(
+  void ReceiveHeader(
       int64_t stream_id,
       int32_t token,
       nghttp3_rcbuf* name,

--- a/src/quic/node_quic_http3_application.h
+++ b/src/quic/node_quic_http3_application.h
@@ -152,10 +152,14 @@ class Http3Application final :
   bool BlockStream(int64_t stream_id) override;
   bool StreamCommit(StreamData* stream_data, size_t datalen) override;
   bool ShouldSetFin(const StreamData& data) override;
-  bool SubmitPushPromise(
+
+  struct PushInfo {
+    int64_t push_id;
+    int64_t stream_id;
+  };
+
+  PushInfo SubmitPushPromise(
       int64_t id,
-      int64_t* push_id,
-      int64_t* stream_id,
       const Http3Headers& headers);
   bool SubmitInformation(int64_t id, const Http3Headers& headers);
   bool SubmitTrailers(int64_t id, const Http3Headers& headers);

--- a/src/quic/node_quic_session.cc
+++ b/src/quic/node_quic_session.cc
@@ -3613,8 +3613,6 @@ void QuicSession::OnQlogWrite(
 BaseObjectPtr<QLogStream> QLogStream::Create(Environment* env) {
   HandleScope scope(env->isolate());
 
-  // TODO(@jasnell): There is identical code in heap_utils for the
-  // HeapSnapshotStream. We can consolidate the two.
   if (env->qlogoutputstream_constructor_template().IsEmpty()) {
     // Create FunctionTemplate for QLogStream
     Local<FunctionTemplate> os = FunctionTemplate::New(env->isolate());

--- a/src/quic/node_quic_session.cc
+++ b/src/quic/node_quic_session.cc
@@ -178,12 +178,8 @@ std::string QuicSession::RemoteTransportParamsDebug::ToString() const {
       out += "  Original Connection ID: N/A \n";
     }
 
-    if (params.preferred_address_present) {
-      out += "  Preferred Address Present: Yes\n";
-      // TODO(@jasnell): Serialize the IPv4 and IPv6 address options
-    } else {
-      out += "  Preferred Address Present: No\n";
-    }
+    out += "  Preferred Address Present: " +
+           params.preferred_address_present ? "Yes" : "No";
 
     if (params.stateless_reset_token_present) {
       StatelessResetToken token(params.stateless_reset_token);

--- a/src/quic/node_quic_socket.cc
+++ b/src/quic/node_quic_socket.cc
@@ -542,19 +542,17 @@ void QuicSocket::OnReceive(
       // a stateless reset. The stateless reset contains a token derived
       // from the received destination connection ID.
       //
-      // TODO(@jasnell): Stateless resets are generated programmatically
-      // using HKDF with the sender provided dcid and a locally provided
-      // secret as input. It is entirely possible that a malicious
-      // peer could send multiple stateless reset eliciting packets
-      // with the specific intent of using the returned stateless
-      // reset to guess the stateless reset token secret used by
-      // the server. Once guessed, the malicious peer could use
+      // Stateless resets are generated programmatically using HKDF with
+      // the sender provided dcid and a locally provided secret as input.
+      // It is entirely possible that a malicious peer could send multiple
+      // stateless reset eliciting packets with the specific intent of using
+      // the returned stateless reset to guess the stateless reset token
+      // secret used by the server. Once guessed, the malicious peer could use
       // that secret as a DOS vector against other peers. We currently
       // implement some mitigations for this by limiting the number
       // of stateless resets that can be sent to a specific remote
-      // address but there are other possible mitigations, such as
-      // including the remote address as input in the generation of
-      // the stateless token.
+      // address and we generate a random nonce used in creation of the
+      // token.
       if (is_short_header &&
           SendStatelessReset(dcid, local_addr, remote_addr, nread)) {
         Debug(this, "Sent stateless reset");
@@ -620,7 +618,7 @@ void QuicSocket::SendVersionNegotiation(
   SendPacket(local_addr, remote_address, std::move(packet));
 }
 
-// Possible generates and sends a stateless reset packet.
+// Possibly generates and sends a stateless reset packet.
 // This is terminal for the connection. It is possible
 // that a malicious packet triggered this so we need to
 // be careful not to commit too many resources.

--- a/test/parallel/test-quic-quicsocket-abortsignal.js
+++ b/test/parallel/test-quic-quicsocket-abortsignal.js
@@ -1,0 +1,63 @@
+// Flags: --no-warnings
+'use strict';
+
+const common = require('../common');
+if (!common.hasQuic)
+  common.skip('missing quic');
+
+const assert = require('assert');
+
+const { createQuicSocket } = require('net');
+
+{
+  const socket = createQuicSocket();
+  const ac = new AbortController();
+
+  // Abort before call.
+  ac.abort();
+
+  assert.rejects(socket.connect({ signal: ac.signal }), {
+    name: 'AbortError'
+  });
+  assert.rejects(socket.listen({ signal: ac.signal }), {
+    name: 'AbortError'
+  });
+}
+
+{
+  const socket = createQuicSocket();
+  const ac = new AbortController();
+
+  assert.rejects(socket.connect({ signal: ac.signal }), {
+    name: 'AbortError'
+  });
+  assert.rejects(socket.listen({ signal: ac.signal }), {
+    name: 'AbortError'
+  });
+
+  // Abort after call, not awaiting previously created Promises.
+  ac.abort();
+}
+
+{
+  const socket = createQuicSocket();
+  const ac = new AbortController();
+
+  async function lookup() {
+    ac.abort();
+    return { address: '1.1.1.1' };
+  }
+
+  assert.rejects(
+    socket.connect({ address: 'foo', lookup, signal: ac.signal }), {
+      name: 'AbortError'
+    });
+
+  assert.rejects(
+    socket.listen({
+      preferredAddress: { address: 'foo' },
+      lookup,
+      signal: ac.signal }), {
+      name: 'AbortError'
+    });
+}


### PR DESCRIPTION
This builds on #34865, which must land first (the first five commits are from that PR)

This does two things:

* Minor cleanups on http3 native internals
* Adds support for AbortSignal in QuicSocket connect and listen 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
