### PR TITLE
url: runtime deprecate legacy api

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2279,7 +2279,7 @@ changes:
     description: Documentation-only deprecation.
 -->
 
-Type: Documentation-only
+Type: Runtime
 
 The [Legacy URL API][] is deprecated. This includes [`url.format()`][],
 [`url.parse()`][], [`url.resolve()`][], and the [legacy `urlObject`][]. Please

--- a/lib/url.js
+++ b/lib/url.js
@@ -37,7 +37,7 @@ const { validateString } = require('internal/validators');
 
 // This ensures setURLConstructor() is called before the native
 // URL::ToObject() method is used.
-const { spliceOne } = require('internal/util');
+const { spliceOne, deprecate } = require('internal/util');
 
 // WHATWG URL implementation provided by internal/url
 const {
@@ -964,11 +964,22 @@ Url.prototype.parseHost = function parseHost() {
 
 module.exports = {
   // Original API
-  Url,
-  parse: urlParse,
-  resolve: urlResolve,
-  resolveObject: urlResolveObject,
-  format: urlFormat,
+  Url: deprecate(Url,
+                 'Url() is deprecated. Use the URL object.',
+                 'DEP0116'),
+  parse: deprecate(urlParse,
+                   'url.parse() is deprecated. Use the URL object.',
+                   'DEP0116'),
+  resolve: deprecate(urlResolve,
+                     'url.resolve() is deprecated. Use the URL object.',
+                     'DEP0116'),
+  resolveObject: deprecate(urlResolveObject,
+                           'url.resolveObject() is deprecated. ' +
+                           'Use the URL object.',
+                           'DEP0116'),
+  format: deprecate(urlFormat,
+                    'url.format() is deprecated. Use the URL object.',
+                    'DEP0116'),
 
   // WHATWG API
   URL,


### PR DESCRIPTION
This *might* be a bit controversial. The legacy `url.parse()`/`url.format()`/`url.resolve()` API has been runtime deprecated for a few years now and developers really should be using the `URL` object instead. It's time we elevated to a runtime deprecation to more actively discourage use of the old API.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
