### PR TITLE
doc:  assert example typo on syncBuiltinESMExports of module

### DIFF
--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -79,6 +79,7 @@ not add or remove exported names from the ES Modules.
 
 ```js
 const fs = require('fs');
+const assert = require('assert');
 const { syncBuiltinESMExports } = require('module');
 
 fs.readFile = null;
@@ -93,7 +94,7 @@ syncBuiltinESMExports();
 
 import('fs').then((esmFS) => {
   assert.strictEqual(esmFS.readFile, null);
-  assert.strictEqual('readFileSync' in fs, true);
+  assert.strictEqual('readFileSync' in esmFS, true);
   assert.strictEqual(esmFS.newAPI, undefined);
 });
 ```


### PR DESCRIPTION
The `module.syncBuiltinESMExports()`
method updates all the live bindings
for builtin ES Modules to match the
properties of the CommonJS exports.
It does not add or remove exported
names from the ES Modules. So after
import `fs` from the ES module, should
use `esmFS`  rather than `fs` which from
CommonJS exports.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
