### PR TITLE
meta: update module pages in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -86,6 +86,8 @@
 
 /doc/api/modules.md @nodejs/modules
 /doc/api/esm.md @nodejs/modules
+/doc/api/module.md @nodejs/modules
+/doc/api/packages.md @nodejs/modules
 /lib/module.js @nodejs/modules
 /lib/internal/modules/* @nodejs/modules
 /lib/internal/bootstrap/loaders.js @nodejs/modules


### PR DESCRIPTION
I figured that should explain why the bot didn't tag @nodejs/modules in https://github.com/nodejs/node/pull/34875.

Maybe we could add a test to check if every file is listed to the CODEOWNERS to avoid it happening again?

I've also added `/doc/api/packages.md`, which will be introduced by https://github.com/nodejs/node/pull/34748, it's probably a good idea to wait for it to land first before landing this PR.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
