### PR TITLE
module: drop `-u` alias for `--conditions`

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -76,7 +76,7 @@ $ node --completion-bash > node_bash_completion
 $ source node_bash_completion
 ```
 
-### `-u`, `--conditions=condition`
+### `--conditions=condition`
 <!-- YAML
 added: REPLACEME
 -->
@@ -1247,7 +1247,7 @@ node --require "./a.js" --require "./b.js"
 
 Node.js options that are allowed are:
 <!-- node-options-node start -->
-* `--conditions`, `-u`
+* `--conditions`
 * `--diagnostic-dir`
 * `--disable-proto`
 * `--enable-fips`

--- a/doc/node.1
+++ b/doc/node.1
@@ -78,7 +78,7 @@ Aborting instead of exiting causes a core file to be generated for analysis.
 .It Fl -completion-bash
 Print source-able bash completion script for Node.js.
 .
-.It Fl u , Fl -conditions Ar string
+.It Fl -conditions Ar string
 Use custom conditional exports conditions
 .Ar string
 .

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -285,7 +285,6 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "additional user conditions for conditional exports and imports",
             &EnvironmentOptions::conditions,
             kAllowedInEnvironment);
-  AddAlias("-u", "--conditions");
   AddOption("--diagnostic-dir",
             "set dir for all output files"
             " (default: current working directory)",

--- a/test/es-module/test-esm-custom-exports.mjs
+++ b/test/es-module/test-esm-custom-exports.mjs
@@ -1,4 +1,4 @@
-// Flags: --conditions=custom-condition -u another
+// Flags: --conditions=custom-condition --conditions another
 import { mustCall } from '../common/index.mjs';
 import { strictEqual } from 'assert';
 import { requireFixture, importFixture } from '../fixtures/pkgexports.mjs';


### PR DESCRIPTION
Opening this for discussion. Perfectly happy if the consensus is
to close.

https://github.com/nodejs/node/pull/34637 has exposed a bug in mocha which we see in CITGM for 
the [proposed 14.9.0 release](https://github.com/nodejs/node/pull/34852). The bug has been fixed in mocha, 
but several modules being tested in CITGM are pinned to older 
versions of mocha and would need to be updated as they will 
not automatically pick up the fix.

---

Old versions of mocha break after https://github.com/nodejs/node/pull/34637.

This was a bug in mocha, but since this is a widely used module
we can expect ecosystem breakage until modules are updated to
the latest version of mocha. Drop the conflicting `-u` alias --
we can potentially bring it back once modules have been updated.

Refs: https://github.com/mochajs/mocha/issues/4417
Refs: https://github.com/nodejs/node/pull/34637
Refs: https://github.com/nodejs/node/pull/34852#issuecomment-680842892

cc @nodejs/modules-active-members @nodejs/releasers @boneskull 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
