### PR TITLE
[14.x] meta: remove non-existent quic from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -73,15 +73,6 @@
 /src/node_http2* @nodejs/http2 @nodejs/net
 /src/node_mem* @nodejs/http2
 
-# quic
-
-/deps/ngtcp2/ @nodejs/quic
-/deps/nghttp3/ @nodejs/quic
-/doc/api/quic.md @nodejs/quic
-/lib/internal/quic/ @nodejs/quic
-/src/node_bob* @nodejs/quic
-/src/quic/ @nodejs/quic
-
 # modules
 
 /doc/api/modules.md @nodejs/modules


### PR DESCRIPTION
quic support doesn't exist prior to Node.js 15 and is unlikely to
due to requiring patches on top of openssl. Remove the entries
from CODEOWNERS to fix the CODEOWNERS linting, which currently fails
as it refers to non-existent paths.

@nodejs/releasers on its own this isn't worth holding up v14.9.0 for, you
can just ignore the CODEOWNERS lint action failure for now.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
