### PR TITLE
[v10.x] Backport createRequire to v10

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,6 +38,7 @@ module.exports = {
     {
       files: [
         'doc/api/esm.md',
+        'doc/api/modules.md',
         '*.mjs',
         'test/es-module/test-esm-example-loader.js',
       ],

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2107,7 +2107,6 @@ Type: Documentation-only
 [`fs.read()`]: fs.html#fs_fs_read_fd_buffer_offset_length_position_callback
 [`fs.readSync()`]: fs.html#fs_fs_readsync_fd_buffer_offset_length_position
 [`fs.stat()`]: fs.html#fs_fs_stat_path_options_callback
-[`os.networkInterfaces`]: os.html#os_os_networkinterfaces
 [`os.tmpdir()`]: os.html#os_os_tmpdir
 [`process.env`]: process.html#process_process_env
 [`punycode`]: punycode.html

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -905,6 +905,26 @@ by the [module wrapper][]. To access it, require the `Module` module:
 const builtin = require('module').builtinModules;
 ```
 
+### module.createRequire(filename)
+<!-- YAML
+added:
+  - REPLACEME
+  - v12.2.0
+-->
+
+* `filename` {string|URL} Filename to be used to construct the require
+  function. Must be a file URL object, file URL string, or absolute path
+  string.
+* Returns: {[`require`][]} Require function
+
+```js
+const { createRequire } = require('module');
+const requireUtil = createRequire(require.resolve('../src/utils/'));
+
+// Require `../src/utils/some-tool`
+requireUtil('./some-tool');
+```
+
 ### module.createRequireFromPath(filename)
 <!-- YAML
 added: v10.12.0

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -918,11 +918,11 @@ added:
 * Returns: {[`require`][]} Require function
 
 ```js
-const { createRequire } = require('module');
-const requireUtil = createRequire(require.resolve('../src/utils/'));
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
 
-// Require `../src/utils/some-tool`
-requireUtil('./some-tool');
+// sibling-module.js is a CommonJS module.
+const siblingModule = require('./sibling-module');
 ```
 
 ### module.createRequireFromPath(filename)

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -23,7 +23,7 @@
 
 const { NativeModule } = require('internal/bootstrap/loaders');
 const util = require('util');
-const { pathToFileURL } = require('internal/url');
+const { pathToFileURL, fileURLToPath, URL } = require('internal/url');
 const vm = require('vm');
 const assert = require('assert').ok;
 const fs = require('fs');
@@ -834,12 +834,48 @@ Module.runMain = function() {
   process._tickCallback();
 };
 
-Module.createRequireFromPath = (filename) => {
-  const m = new Module(filename);
-  m.filename = filename;
-  m.paths = Module._nodeModulePaths(path.dirname(filename));
+function createRequireFromPath(filename) {
+  // Allow a directory to be passed as the filename
+  const trailingSlash =
+    filename.endsWith(path.sep) || path.sep !== '/' && filename.endsWith('\\');
+
+  const proxyPath = trailingSlash ?
+    path.join(filename, 'noop.js') :
+    filename;
+
+  const m = new Module(proxyPath);
+  m.filename = proxyPath;
+
+  m.paths = Module._nodeModulePaths(path.dirname(proxyPath));
   return makeRequireFunction(m);
-};
+}
+
+Module.createRequireFromPath = createRequireFromPath;
+
+const createRequireError = 'must be a file URL object, file URL string, or' +
+  'absolute path string';
+
+function createRequire(filename) {
+  let filepath;
+  if (typeof filename === 'object' && !(filename instanceof URL)) {
+    throw new ERR_INVALID_ARG_VALUE('filename', filename, createRequireError);
+  } else if (typeof filename === 'object' ||
+    typeof filename === 'string' && !path.isAbsolute(filename)) {
+    try {
+      filepath = fileURLToPath(filename);
+    } catch {
+      throw new ERR_INVALID_ARG_VALUE('filename', filename,
+                                      createRequireError);
+    }
+  } else if (typeof filename !== 'string') {
+    throw new ERR_INVALID_ARG_VALUE('filename', filename, createRequireError);
+  } else {
+    filepath = filename;
+  }
+  return createRequireFromPath(filepath);
+}
+
+Module.createRequire = createRequire;
 
 Module._initPaths = function() {
   const isWindows = process.platform === 'win32';

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -857,10 +857,9 @@ const createRequireError = 'must be a file URL object, file URL string, or' +
 
 function createRequire(filename) {
   let filepath;
-  if (typeof filename === 'object' && !(filename instanceof URL)) {
-    throw new ERR_INVALID_ARG_VALUE('filename', filename, createRequireError);
-  } else if (typeof filename === 'object' ||
-    typeof filename === 'string' && !path.isAbsolute(filename)) {
+
+  if (filename instanceof URL ||
+      (typeof filename === 'string' && !path.isAbsolute(filename))) {
     try {
       filepath = fileURLToPath(filename);
     } catch {

--- a/test/fixtures/experimental
+++ b/test/fixtures/experimental
@@ -1,0 +1,1 @@
+module.exports.ofLife=42

--- a/test/parallel/test-module-create-require.js
+++ b/test/parallel/test-module-create-require.js
@@ -4,9 +4,31 @@ require('../common');
 const assert = require('assert');
 const path = require('path');
 
-const { createRequireFromPath } = require('module');
+const { createRequire, createRequireFromPath } = require('module');
 
 const p = path.resolve(__dirname, '..', 'fixtures', 'fake.js');
+const u = new URL(`file://${p}`);
 
 const req = createRequireFromPath(p);
 assert.strictEqual(req('./baz'), 'perhaps I work');
+
+const reqToo = createRequire(u);
+assert.deepStrictEqual(reqToo('./experimental'), { ofLife: 42 });
+
+assert.throws(() => {
+  createRequire('https://github.com/nodejs/node/pull/27405/');
+}, {
+  code: 'ERR_INVALID_ARG_VALUE'
+});
+
+assert.throws(() => {
+  createRequire('../');
+}, {
+  code: 'ERR_INVALID_ARG_VALUE'
+});
+
+assert.throws(() => {
+  createRequire({});
+}, {
+  code: 'ERR_INVALID_ARG_VALUE'
+});


### PR DESCRIPTION
This PR adds the `createRequire` API to Node.js v10 – which currently only has the deprecated `createRequireFromPath` available.

Note that this does not backport the deprecation of `createRequireFromPath`, given the fact that v10 is on maintenance mode, I figured that would not make sense to introduce a deprecation at this point.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
