### PR TITLE
test: add readline test for escape sequence

### DIFF
--- a/test/parallel/test-readline-keys.js
+++ b/test/parallel/test-readline-keys.js
@@ -114,6 +114,9 @@ addTest('\x1b\x1b\x1b', [
   { name: 'escape', sequence: '\x1b\x1b\x1b', meta: true },
 ]);
 
+// Escape sequence
+addTest('\x1b]', [{ name: undefined, sequence: '\x1B]', meta: true }]);
+
 // Control keys
 addTest('\x01\x0b\x10', [
   { name: 'a', sequence: '\x01', ctrl: true },


### PR DESCRIPTION
Tests do not cover a small piece of code in
lib/internal/readline/utils.js for consuming an escape sequence.
This adds a minimal test to cover the code.

Refs: https://coverage.nodejs.org/coverage-0848f56cb3943209/lib/internal/readline/utils.js.html#L327

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
