### PR TITLE
test: make test-tls-reuse-host-from-socket pass without internet

### DIFF
--- a/test/parallel/test-tls-reuse-host-from-socket.js
+++ b/test/parallel/test-tls-reuse-host-from-socket.js
@@ -25,13 +25,19 @@ const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
-const tls = require('tls');
-
 const net = require('net');
+const tls = require('tls');
+const fixtures = require('../common/fixtures');
 
-const socket = net.connect(443, 'www.example.org', common.mustCall(() => {
-  const secureSocket = tls.connect({ socket }, common.mustCall(() => {
-    secureSocket.destroy();
-    console.log('ok');
+const server = tls.createServer({
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem')
+}).listen(0, common.mustCall(() => {
+  const socket = net.connect(server.address().port, common.mustCall(() => {
+    const opts = { socket, rejectUnauthorized: false };
+    const secureSocket = tls.connect(opts, common.mustCall(() => {
+      secureSocket.destroy();
+      server.close();
+    }));
   }));
 }));


### PR DESCRIPTION
Start up a TLS server on localhost rather than using example.org.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
