### PR TITLE
stream: allow using `.push()`/`.unshift()` during `once('data')`

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -310,7 +310,8 @@ function readableAddChunk(stream, chunk, encoding, addToFront) {
 }
 
 function addChunk(stream, state, chunk, addToFront) {
-  if (state.flowing && state.length === 0 && !state.sync) {
+  if (state.flowing && state.length === 0 && !state.sync &&
+      stream.listenerCount('data') > 0) {
     // Use the guard to avoid creating `Set()` repeatedly
     // when we have multiple pipes.
     if (state.multiAwaitDrain) {

--- a/test/parallel/test-stream-readable-add-chunk-during-data.js
+++ b/test/parallel/test-stream-readable-add-chunk-during-data.js
@@ -1,0 +1,21 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { Readable } = require('stream');
+
+// Verify that .push() and .unshift() can be called from 'data' listeners.
+
+for (const method of ['push', 'unshift']) {
+  const r = new Readable({ read() {} });
+  r.once('data', common.mustCall((chunk) => {
+    assert.strictEqual(r.readableLength, 0);
+    r[method](chunk);
+    assert.strictEqual(r.readableLength, chunk.length);
+
+    r.on('data', common.mustCall((chunk) => {
+      assert.strictEqual(chunk.toString(), 'Hello, world');
+    }));
+  }));
+
+  r.push('Hello, world');
+}


### PR DESCRIPTION
Previously, the `.push()` or `.unshift()` call would just have jumped
straight to emitting a `'data'` event, even if there were no listeners,
effectively just silently dropping the chunk.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
