### PR TITLE
http2,tls: account for buffered data before creating socket wraps

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -479,7 +479,10 @@ function TLSSocket(socket, opts) {
   this[kPendingSession] = null;
 
   let wrap;
-  if ((socket instanceof net.Socket && socket._handle) || !socket) {
+  // Ideally, the readableLength check would not be necessary, and we would
+  // have a way to handle the buffered data at the C++ StreamBase level.
+  if (((socket instanceof net.Socket && socket._handle) || !socket) &&
+      socket.readableLength === 0) {
     // 1. connected socket
     // 2. no socket, one will be created with net.Socket().connect
     wrap = socket;

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -481,8 +481,9 @@ function TLSSocket(socket, opts) {
   let wrap;
   // Ideally, the readableLength check would not be necessary, and we would
   // have a way to handle the buffered data at the C++ StreamBase level.
-  if (((socket instanceof net.Socket && socket._handle) || !socket) &&
-      socket.readableLength === 0) {
+  if ((socket instanceof net.Socket &&
+       socket._handle &&
+       socket.readableLength === 0) || !socket) {
     // 1. connected socket
     // 2. no socket, one will be created with net.Socket().connect
     wrap = socket;

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1122,7 +1122,11 @@ class Http2Session extends EventEmitter {
   constructor(type, options, socket) {
     super();
 
-    if (!socket._handle || !socket._handle.isStreamBase) {
+    // Ideally, the readableLength check would not be necessary, and we would
+    // have a way to handle the buffered data at the C++ StreamBase level.
+    if (!socket._handle ||
+        !socket._handle.isStreamBase ||
+        socket.readableLength > 0) {
       socket = new JSStreamSocket(socket);
     }
 

--- a/test/parallel/test-http2-autoselect-protocol.js
+++ b/test/parallel/test-http2-autoselect-protocol.js
@@ -1,0 +1,72 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const net = require('net');
+const http = require('http');
+const http2 = require('http2');
+
+// Example test for HTTP/1 vs HTTP/2 protocol autoselection.
+// Refs: https://github.com/nodejs/node/issues/34532
+
+const h1Server = http.createServer(common.mustCall((req, res) => {
+  res.end('HTTP/1 Response');
+}));
+
+const h2Server = http2.createServer(common.mustCall((req, res) => {
+  res.end('HTTP/2 Response');
+}));
+
+const rawServer = net.createServer(common.mustCall(function listener(socket) {
+  const data = socket.read(3);
+
+  if (!data) { // Repeat until data is available
+    socket.once('readable', () => listener(socket));
+    return;
+  }
+
+  // Put the data back, so the real server can handle it:
+  socket.unshift(data);
+
+  if (data.toString('ascii') === 'PRI') { // Very dumb preface check
+    h2Server.emit('connection', socket);
+  } else {
+    h1Server.emit('connection', socket);
+  }
+}, 2));
+
+rawServer.listen(common.mustCall(() => {
+  const { port } = rawServer.address();
+
+  let done = 0;
+  {
+    // HTTP/2 Request
+    const client = http2.connect(`http://localhost:${port}`);
+    const req = client.request({ ':path': '/' });
+    req.end();
+
+    let content = '';
+    req.setEncoding('utf8');
+    req.on('data', (chunk) => content += chunk);
+    req.on('end', common.mustCall(() => {
+      assert.strictEqual(content, 'HTTP/2 Response');
+      if (++done === 2) rawServer.close();
+      client.close();
+    }));
+  }
+
+  {
+    // HTTP/1 Request
+    http.get(`http://localhost:${port}`, common.mustCall((res) => {
+      let content = '';
+      res.setEncoding('utf8');
+      res.on('data', (chunk) => content += chunk);
+      res.on('end', common.mustCall(() => {
+        assert.strictEqual(content, 'HTTP/1 Response');
+        if (++done === 2) rawServer.close();
+      }));
+    }));
+  }
+}));

--- a/test/parallel/test-tls-generic-stream-unshift.js
+++ b/test/parallel/test-tls-generic-stream-unshift.js
@@ -1,0 +1,43 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const fixtures = require('../common/fixtures');
+const makeDuplexPair = require('../common/duplexpair');
+const assert = require('assert');
+const { TLSSocket, connect } = require('tls');
+
+const key = fixtures.readKey('agent1-key.pem');
+const cert = fixtures.readKey('agent1-cert.pem');
+const ca = fixtures.readKey('ca1-cert.pem');
+
+const { clientSide, serverSide } = makeDuplexPair();
+
+const clientTLS = connect({
+  socket: clientSide,
+  ca,
+  host: 'agent1'  // Hostname from certificate
+});
+
+let serverTLS;
+serverSide.once('data', common.mustCall((chunk) => {
+  serverSide.unshift(chunk);
+  serverTLS = new TLSSocket(serverSide, {
+    isServer: true,
+    key,
+    cert,
+    ca
+  });
+}));
+
+assert.strictEqual(clientTLS.connecting, false);
+
+clientTLS.on('secureConnect', common.mustCall(() => {
+  clientTLS.write('foobar', common.mustCall(() => {
+    assert(serverTLS);
+    assert.strictEqual(serverTLS.read().toString(), 'foobar');
+    assert.strictEqual(clientTLS._handle.writeQueueSize, 0);
+  }));
+  assert.ok(clientTLS._handle.writeQueueSize > 0);
+}));


### PR DESCRIPTION
##### ~~stream: allow using `.push()`/`.unshift()` during `once('data')`~~

~~See #34957 (which this PR is blocked on)~~

##### tls: account for buffered data before creating TLSSocket wrap

If there is data stored in the socket, create a `JSStreamSocket`
wrapper so that no data is lost when passing the socket to the
C++ layer (which is unaware of data buffered in JS land).

Refs: https://github.com/nodejs/node/issues/34532

##### http2: account for buffered data before creating HTTP2 socket wrap

If there is data stored in the socket, create a `JSStreamSocket`
wrapper so that no data is lost when passing the socket to the
C++ layer (which is unaware of data buffered in JS land).

Fixes: https://github.com/nodejs/node/issues/34532


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
