### PR TITLE
path: add `path/posix` and `path/win32` alias modules

### DIFF
--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -437,7 +437,7 @@ added: v0.11.15
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/34962
-    description: Exposed as `require('path/posix')`
+    description: Exposed as `require('path/posix')`.
 -->
 
 * {Object}

--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -434,12 +434,18 @@ A [`TypeError`][] is thrown if `path` is not a string.
 ## `path.posix`
 <!-- YAML
 added: v0.11.15
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/34962
+    description: Exposed as `require('path/posix')`
 -->
 
 * {Object}
 
 The `path.posix` property provides access to POSIX specific implementations
 of the `path` methods.
+
+The API is accessible via `require('path').posix` or `require('path/posix')`.
 
 ## `path.relative(from, to)`
 <!-- YAML
@@ -568,12 +574,18 @@ method is non-operational and always returns `path` without modifications.
 ## `path.win32`
 <!-- YAML
 added: v0.11.15
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/34962
+    description: Exposed as `require('path/win32')`
 -->
 
 * {Object}
 
 The `path.win32` property provides access to Windows-specific implementations
 of the `path` methods.
+
+The API is accessible via `require('path').win32` or `require('path/win32')`.
 
 [MSDN-Rel-Path]: https://docs.microsoft.com/en-us/windows/desktop/FileIO/naming-a-file#fully-qualified-vs-relative-paths
 [`TypeError`]: errors.md#errors_class_typeerror

--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -577,7 +577,7 @@ added: v0.11.15
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/34962
-    description: Exposed as `require('path/win32')`
+    description: Exposed as `require('path/win32')`.
 -->
 
 * {Object}

--- a/lib/path/posix.js
+++ b/lib/path/posix.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('path').posix;

--- a/lib/path/win32.js
+++ b/lib/path/win32.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('path').win32;

--- a/node.gyp
+++ b/node.gyp
@@ -72,6 +72,8 @@
       'lib/net.js',
       'lib/os.js',
       'lib/path.js',
+      'lib/path/posix.js',
+      'lib/path/win32.js',
       'lib/perf_hooks.js',
       'lib/process.js',
       'lib/punycode.js',

--- a/test/es-module/test-esm-path-posix.mjs
+++ b/test/es-module/test-esm-path-posix.mjs
@@ -1,0 +1,6 @@
+import '../common/index.mjs';
+import assert from 'assert';
+import { posix } from 'path';
+import pathPosix from 'path/posix';
+
+assert.strictEqual(pathPosix, posix);

--- a/test/es-module/test-esm-path-win32.mjs
+++ b/test/es-module/test-esm-path-win32.mjs
@@ -1,0 +1,6 @@
+import '../common/index.mjs';
+import assert from 'assert';
+import { win32 } from 'path';
+import pathWin32 from 'path/win32';
+
+assert.strictEqual(pathWin32, win32);

--- a/test/parallel/test-path-posix-exists.js
+++ b/test/parallel/test-path-posix-exists.js
@@ -1,0 +1,6 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+
+assert.strictEqual(require('path/posix'), require('path').posix);

--- a/test/parallel/test-path-win32-exists.js
+++ b/test/parallel/test-path-win32-exists.js
@@ -1,0 +1,6 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+
+assert.strictEqual(require('path/win32'), require('path').win32);


### PR DESCRIPTION
Turns out, <https://github.com/nodejs/node/pull/34055> is not the last alias module, because I forgot about `path.posix` and `path.win32`.

---

**Refs:** <https://github.com/nodejs/node/pull/31553>
**Refs:** <https://github.com/nodejs/node/pull/32953>
**Refs:** <https://github.com/nodejs/node/pull/33950>
**Refs:** <https://github.com/nodejs/node/pull/34001>
**Refs:** <https://github.com/nodejs/node/pull/34002>
**Refs:** <https://github.com/nodejs/node/pull/34055>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
