### PR TITLE
test: add http agent to executionAsyncResource

### DIFF
--- a/test/async-hooks/test-async-exec-resource-http-agent.js
+++ b/test/async-hooks/test-async-exec-resource-http-agent.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const common = require('../common');
+
+const assert = require('node:assert');
+const {
+  executionAsyncResource,
+  executionAsyncId,
+  createHook,
+} = require('node:async_hooks');
+const http = require('node:http');
+
+const hooked = {};
+createHook({
+  init(asyncId, type, triggerAsyncId, resource) {
+    hooked[asyncId] = resource;
+  },
+}).enable();
+
+const agent = new http.Agent({
+  maxSockets: 1,
+});
+
+const server = http.createServer((req, res) => {
+  res.end('ok');
+});
+
+server.listen(0, common.mustCall(() => {
+  assert.strictEqual(executionAsyncResource(), hooked[executionAsyncId()]);
+
+  http.get({ agent, port: server.address().port }, common.mustCall(() => {
+    assert.strictEqual(executionAsyncResource(), hooked[executionAsyncId()]);
+    server.close();
+    agent.destroy();
+  }));
+}));


### PR DESCRIPTION
I added a testcase about executionAsyncResource with Http Agent.

Refs: https://github.com/nodejs/node/blob/master/test/async-hooks/test-async-exec-resource-http.js
Signed-off-by: psj-tar-gz <lyricalllmagical@gmail.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
