### PR TITLE
test: prints error that contains undefined

### DIFF
--- a/test/message/error_with_undefined.js
+++ b/test/message/error_with_undefined.js
@@ -1,0 +1,15 @@
+'use strict';
+
+require('../common');
+
+function test() {
+	let a = 'abc ';
+	let b = 1;
+	let c = ' def';
+	let msg = a + b.value + c; //b.value is undefined value
+	console.error(msg);
+	throw new Error(msg);
+}
+Object.defineProperty(test, 'name', {value: 'fun ' + undefined + ' tion'});
+
+test();

--- a/test/message/error_with_undefined.out
+++ b/test/message/error_with_undefined.out
@@ -1,0 +1,14 @@
+abc undefined def
+*error_with_undefined.js:*
+  throw new Error(msg);
+  ^
+
+Error: abc undefined def
+    at fun undefined tion (*error_with_undefined.js:*:*)
+    at Object.<anonymous> (*error_with_undefined.js:*:*)
+    at Module._compile (internal/modules/cjs/loader.js:*:*)
+    at Object.Module._extensions..js (internal/modules/cjs/loader.js:*:*)
+    at Module.load (internal/modules/cjs/loader.js:*:*)
+    at Function.Module._load (internal/modules/cjs/loader.js:*:*)
+    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:*:*)
+    at internal/main/run_main_module.js:*:*


### PR DESCRIPTION
I added a test case that prints error messages that contains 'undefined'. 
However, I can't find out to remove error messages whenever I run this code.
I executed as it is written in Running Tests(Building.md). I'm not sure what causes an error, but I guess out file is the reason.
Below, I attached an error message when I execute the code. Please let me know if it is anything wrong with my code.

```js
jungeun@LAPTOP-HMIPBKAH:~/ddanzit/node$ python tools/test.py test/message/error_with_undefined.js
[00:00|%   0|+   0|-   0]: release error_with_undefined.jsmatch failed
line=2
expect=^\ \ throw\ new\ Error\(msg\)\;$
actual= throw new Error(msg);
=== release error_with_undefined.js ===
Path: message/error_with_undefined.js
abc undefined def
/home/jungeun/ddanzit/node/test/message/error_with_undefined.js:11
        throw new Error(msg);
        ^

Error: abc undefined def
    at fun undefined tion (/home/jungeun/ddanzit/node/test/message/error_with_undefined.js:11:8)
    at Object.<anonymous> (/home/jungeun/ddanzit/node/test/message/error_with_undefined.js:15:1)
    at Module._compile (internal/modules/cjs/loader.js:1090:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1111:10)
    at Module.load (internal/modules/cjs/loader.js:955:32)
    at Function.Module._load (internal/modules/cjs/loader.js:796:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:72:12)
    at internal/main/run_main_module.js:17:47
Command: out/Release/node /home/jungeun/ddanzit/node/test/message/error_with_undefined.js
[00:00|% 100|+   0|-   1]: Done
```