### PR TITLE
doc: clarify non-URL nature of request.url in http2

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -3127,7 +3127,7 @@ added: v8.4.0
 
 * {string}
 
-Request URL string. This contains only the URL that is present in the actual
+Request target resource string. This contains the string from the actual
 HTTP request. If the request is:
 
 ```http
@@ -3135,15 +3135,10 @@ GET /status?name=ryan HTTP/1.1
 Accept: text/plain
 ```
 
-Then `request.url` will be:
+Then `request.url` will be `'/status?name=ryan'`.
 
-<!-- eslint-disable semi -->
-```js
-'/status?name=ryan'
-```
-
-To parse the url into its parts, `require('url').parse(request.url)`
-can be used:
+To parse the target resource string into its parts,
+`require('url').parse(request.url)` can be used:
 
 ```console
 $ node


### PR DESCRIPTION
Unfrotunately, `request.url` is not necessarily a URL. Denote it as
"target resource string" instead.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
