### PR TITLE
doc,tools: remove malfunctioning Linux manpage linker

### DIFF
--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -291,7 +291,7 @@ added: v0.3.3
 Returns the operating system as a string.
 
 On POSIX systems, the operating system release is determined by calling
-[uname(3)][]. On Windows, `GetVersionExW()` is used. See
+[`uname(3)`][]. On Windows, `GetVersionExW()` is used. See
 <https://en.wikipedia.org/wiki/Uname#Examples> for more information.
 
 ## `os.setPriority([pid, ]priority)`
@@ -348,11 +348,11 @@ added: v0.3.3
 
 * Returns: {string}
 
-Returns the operating system name as returned by [uname(3)][]. For example, it
+Returns the operating system name as returned by [`uname(3)`][]. For example, it
 returns `'Linux'` on Linux, `'Darwin'` on macOS, and `'Windows_NT'` on Windows.
 
 See <https://en.wikipedia.org/wiki/Uname#Examples> for additional information
-about the output of running [uname(3)][] on various operating systems.
+about the output of running [`uname(3)`][] on various operating systems.
 
 ## `os.uptime()`
 <!-- YAML
@@ -403,8 +403,8 @@ added:
 Returns a string identifying the kernel version.
 
 On POSIX systems, the operating system release is determined by calling
-[uname(3)][]. On Windows, `RtlGetVersion()` is used, and if it is not available,
-`GetVersionExW()` will be used. See
+[`uname(3)`][]. On Windows, `RtlGetVersion()` is used, and if it is not
+available, `GetVersionExW()` will be used. See
 <https://en.wikipedia.org/wiki/Uname#Examples> for more information.
 
 ## OS constants
@@ -1272,6 +1272,6 @@ The following process scheduling constants are exported by
 [`SystemError`]: errors.html#errors_class_systemerror
 [`process.arch`]: process.html#process_process_arch
 [`process.platform`]: process.html#process_process_platform
+[`uname(3)`]: https://linux.die.net/man/3/uname
 [Android building]: https://github.com/nodejs/node/blob/master/BUILDING.md#androidandroid-based-devices-eg-firefox-os
 [EUID]: https://en.wikipedia.org/wiki/User_identifier#Effective_user_ID
-[uname(3)]: https://linux.die.net/man/3/uname

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -124,7 +124,6 @@ function preprocessText({ nodeVersion }) {
 
 // Syscalls which appear in the docs, but which only exist in BSD / macOS.
 const BSD_ONLY_SYSCALLS = new Set(['lchmod']);
-const LINUX_DIE_ONLY_SYSCALLS = new Set(['uname']);
 const HAXX_ONLY_SYSCALLS = new Set(['curl']);
 const MAN_PAGE = /(^|\s)([a-z.]+)\((\d)([a-z]?)\)/gm;
 
@@ -141,10 +140,6 @@ function linkManPages(text) {
       if (BSD_ONLY_SYSCALLS.has(name)) {
         return `${beginning}<a href="https://www.freebsd.org/cgi/man.cgi` +
           `?query=${name}&sektion=${number}">${displayAs}</a>`;
-      }
-      if (LINUX_DIE_ONLY_SYSCALLS.has(name)) {
-        return `${beginning}<a href="https://linux.die.net/man/` +
-                `${number}/${name}">${displayAs}</a>`;
       }
       if (HAXX_ONLY_SYSCALLS.has(name)) {
         return `${beginning}<a href="https://${name}.haxx.se/docs/manpage.html">${displayAs}</a>`;


### PR DESCRIPTION
The Linux manpage auto-linking is resulting in extraneous
links with empty text in the docs. Remove it as the only thing it
affects is linked explicitly in the one document that uses it.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
