### PR TITLE
doc: spruce up user journey to local docs browsing

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -439,8 +439,8 @@ If you prefer to read the full documentation in a browser, run the following.
 make docserve
 ```
 
-This will build the docs, spin up a static file server, and provide a URL to
-where you may browse the documentation locally.
+This will spin up a static file server, and provide a URL to where you may
+browse the documentation locally.
 
 If you're comfortable viewing the documentation using the program your operating
 system has associated with the default web browser, run the following.
@@ -449,8 +449,8 @@ system has associated with the default web browser, run the following.
 make docopen
 ```
 
-This will build the docs, spin up a static file server, and open a URL to a
-one-page version of all the browsable HTML documents using the default browser.
+This will open a file URL to a one-page version of all the browsable HTML
+documents using the default browser.
 
 To test if Node.js was built correctly:
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -433,23 +433,24 @@ To read the man page:
 man doc/node.1
 ```
 
-If you prefer to read the full documentation in a browser, run the following
-after `make doc` is finished:
+If you prefer to read the full documentation in a browser, run the following.
 
 ```bash
 make docserve
 ```
 
-This will provide a URL to where you may browse the documentation locally.
+This will build the docs, spin up a static file server, and provide a URL to
+where you may browse the documentation locally.
 
-If you prefer to read the documentation as a one-page version of all the
-browsable HTML documents, run the following after `make doc` is finished:
+If you're comfortable viewing the documentation using the program your operating
+system has associated with the default web browser, run the following.
 
 ```bash
 make docopen
 ```
 
-This will open a browser with the documentation.
+This will build the docs, spin up a static file server, and open a URL to a
+one-page version of all the browsable HTML documents using the default browser.
 
 To test if Node.js was built correctly:
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -439,8 +439,8 @@ If you prefer to read the full documentation in a browser, run the following.
 make docserve
 ```
 
-This will spin up a static file server, and provide a URL to where you may
-browse the documentation locally.
+This will spin up a static file server and provide a URL to where you may browse
+the documentation locally.
 
 If you're comfortable viewing the documentation using the program your operating
 system has associated with the default web browser, run the following.

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -417,41 +417,50 @@ To build the documentation:
 
 This will build Node.js first (if necessary) and then use it to build the docs:
 
-```console
-$ make doc
+```bash
+make doc
 ```
 
 If you have an existing Node.js build, you can build just the docs with:
 
-```console
-$ NODE=/path/to/node make doc-only
+```bash
+NODE=/path/to/node make doc-only
 ```
 
-To read the documentation:
+To read the man page:
 
-```console
-$ man doc/node.1
+```bash
+man doc/node.1
 ```
 
-If you prefer to read the documentation in a browser,
-run the following after `make doc` is finished:
+If you prefer to read the full documentation in a browser, run the following
+after `make doc` is finished:
 
-```console
-$ make docopen
+```bash
+make docserve
+```
+
+This will provide a URL to where you may browse the documentation locally.
+
+If you prefer to read the documentation as a one-page version of all the
+browsable HTML documents, run the following after `make doc` is finished:
+
+```bash
+make docopen
 ```
 
 This will open a browser with the documentation.
 
 To test if Node.js was built correctly:
 
-```console
-$ ./node -e "console.log('Hello from Node.js ' + process.version)"
+```bash
+./node -e "console.log('Hello from Node.js ' + process.version)"
 ```
 
 To install this version of Node.js into a system directory:
 
-```console
-$ [sudo] make install
+```bash
+[sudo] make install
 ```
 
 #### Building a debug build

--- a/Makefile
+++ b/Makefile
@@ -776,8 +776,7 @@ docopen: $(apidocs_html)
 
 .PHONY: docserve
 docserve: $(apidocs_html)
-	@$(PYTHON) -mwebbrowser http://localhost:8000/all.html
-	@$(PYTHON) -m http.server -d $(PWD)/out/doc/api
+	@$(PYTHON) -m http.server 8000 --bind 127.0.0.1 --directory out/doc/api
 
 .PHONY: docclean
 docclean:

--- a/Makefile
+++ b/Makefile
@@ -775,7 +775,7 @@ docopen: $(apidocs_html)
 	@$(PYTHON) -mwebbrowser file://$(PWD)/out/doc/api/all.html
 
 .PHONY: docserve
-docserve: $(apidocs_html)
+docserve: $(apidocs_html) $(apiassets)
 	@$(PYTHON) -m http.server 8000 --bind 127.0.0.1 --directory out/doc/api
 
 .PHONY: docclean


### PR DESCRIPTION
This patch improves the means by which the docs are viewed locally.

* Remove extraneous code in the `docserve` Makefile target
* Document the `docserve` task for all to know
* Bring all code snippets in this section up to speed
* Clarify the purpose of each documentation browsing method

Fixes: https://github.com/nodejs/node/issues/34977