### PR TITLE
stream: Readable.batched

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1739,6 +1739,27 @@ run().catch(console.error);
 after the `callback` has been invoked. In the case of reuse of streams after
 failure, this can cause event listener leaks and swallowed errors.
 
+### `stream.Readable.batched(stream, [options])`
+
+* `stream`
+* `options`
+
+Converts a `Readable` into an async iterator which
+returns batches with max length of `options.max`.
+
+```js
+const fs = require('fs/promises')
+
+const file = fs.open(dst)
+try {
+  for (const chunks of Readable.batched(fs.createReadStream(src))) {
+    await fs.writev(chunks)
+  }
+} finally {
+  await file.close()
+}
+```
+
 ### `stream.Readable.from(iterable, [options])`
 <!-- YAML
 added:

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1748,15 +1748,18 @@ Converts a `Readable` into an async iterator which
 returns batches with max length of `options.max`.
 
 ```js
-const fs = require('fs/promises')
+const { Readable } = require('stream');
+const fs = require('fs/promises');
 
-const file = fs.open(dst)
-try {
-  for (const chunks of Readable.batched(fs.createReadStream(src))) {
-    await fs.writev(chunks)
+async function copy(src, dst) {
+  const file = await fs.open(dst);
+  try {
+    for await (const chunks of Readable.batched(fs.createReadStream(src))) {
+      await fs.writev(chunks);
+    }
+  } finally {
+    await file.close();
   }
-} finally {
-  await file.close()
 }
 ```
 

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -1118,6 +1118,66 @@ async function* createAsyncIterator(stream) {
   }
 }
 
+async function* createBatchedAsyncIterator(stream, opts) {
+  const batchSize = opts && opts.max ? opts.max : Infinity;
+
+  let callback = nop;
+
+  function next(resolve) {
+    if (this === stream) {
+      callback();
+      callback = nop;
+    } else {
+      callback = resolve;
+    }
+  }
+
+  stream
+    .on('readable', next)
+    .on('error', next)
+    .on('end', next)
+    .on('close', next);
+
+  try {
+    const state = stream._readableState;
+    while (true) {
+      let buf = null;
+
+      do {
+        const chunk = stream.read();
+        if (chunk === null) {
+          break;
+        }
+        if (buf === null) {
+          buf = [chunk];
+        } else {
+          buf.push(chunk);
+        }
+      } while (buf.length < batchSize);
+
+      if (buf !== null) {
+        yield buf;
+      } else if (state.errored) {
+        throw state.errored;
+      } else if (state.ended) {
+        break;
+      } else if (state.closed) {
+        // TODO(ronag): ERR_PREMATURE_CLOSE?
+        break;
+      } else {
+        await new Promise(next);
+      }
+    }
+  } catch (err) {
+    destroyImpl.destroyer(stream, err);
+    throw err;
+  } finally {
+    destroyImpl.destroyer(stream, null);
+  }
+}
+
+Readable.prototype.batched = createBatchedAsyncIterator;
+
 // Making it explicit these properties are not enumerable
 // because otherwise some prototype manipulation in
 // userland will fail.


### PR DESCRIPTION
Provides a more efficient API for usage in `for await` loops. Avoids the "tick" that must occur between invocation of the loop, e.g. makes the following possible:

```js
const file = await fs.open(dst)
try {
  for await (const chunks of Readable.batched(fs.createReadStream(src))) {
    await fs.writev(chunks)
  }
} finally {
  await file.close()
}
```

vs the slower version:

```js
const file = await fs.open(dst)
try {
  for await (const chunk of fs.createReadStream(src)) {
    await fs.write(chunk)
  }
} finally {
  await file.close()
}
```

Also allows certain amount of parallelism when iterating, e.g.

```js
for await (const segments of Readable.batched(parseManifest(requestManifest(src))), { max: 4 }) {
  await Promise.all(segments.map(segment => downloadSegment(segment, dst))
}
```



##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
