### PR TITLE
option --prof documentation help added

### DIFF
--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -401,8 +401,8 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             &EnvironmentOptions::preserve_symlinks_main,
             kAllowedInEnvironment);
   AddOption("--prof",
-+            "Generate V8 profiler output.",
-+            &EnvironmentOptions::syntax_prof_only);
+            "Generate V8 profiler output.",
+            V8Option{});
   AddOption("--prof-process",
             "process V8 profiler output generated using --prof",
             &EnvironmentOptions::prof_process);

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -400,6 +400,9 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "preserve symbolic links when resolving the main module",
             &EnvironmentOptions::preserve_symlinks_main,
             kAllowedInEnvironment);
+  AddOption("--prof",
++            "Generate V8 profiler output.",
++            &EnvironmentOptions::syntax_prof_only);
   AddOption("--prof-process",
             "process V8 profiler output generated using --prof",
             &EnvironmentOptions::prof_process);


### PR DESCRIPTION
Hi, I trying to add prof documentation help on node_options.cc file, but when I test running show the following error:

../src/node_options.cc:405:35: error: no member named 'syntax_prof_only' in
      'node::EnvironmentOptions'
            &EnvironmentOptions::syntax_prof_only);

So I don't know if I have to add 'syntax_prof_only' somewhere before.

Thaks for you help

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
