### PR TITLE
docs: error code fix in resolver spec

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -1038,7 +1038,7 @@ _conditions_)
 >       1. Otherwise, throw an _Invalid Package Target_ error.
 >    1. If _target_ split on _"/"_ or _"\\"_ contains any _"."_, _".."_ or
 >       _"node_modules"_ segments after the first segment, throw an
->       _Invalid Module Specifier_ error.
+>       _Invalid Package Target_ error.
 >    1. Let _resolvedTarget_ be the URL resolution of the concatenation of
 >       _packageURL_ and _target_.
 >    1. Assert: _resolvedTarget_ is contained in _packageURL_.


### PR DESCRIPTION
This is a minor docs correction where the error code should be `Invalid Package Target` not `Invalid Module Specifier`, which does also affect the resolution behaviour in fallbacks.

The spec change is what is already implemented in the resolver itself.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
