### PR TITLE
build: require "allow edits" to be checked

### DIFF
--- a/.github/workflows/require-allow-edits.yml
+++ b/.github/workflows/require-allow-edits.yml
@@ -1,0 +1,14 @@
+name: Require “Allow Edits”
+
+on: [pull_request]
+
+jobs:
+  _:
+    name: "Require “Allow Edits”"
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: ljharb/require-allow-edits@main
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This github action will fail if "allow edits" is not checked - this allows all PRs to be landed purple.

Open to any feedback for tweaking error messages, and if there's concern with depending on `main`, i'm happy to use tags, or make an explicit `node` branch, so node's usage of the action can be more precisely targeted.

See also, #35001