### PR TITLE
tools,doc: allow page titles to contain inline code

### DIFF
--- a/test/doctool/test-doctool-html.js
+++ b/test/doctool/test-doctool-html.js
@@ -9,7 +9,7 @@ try {
 }
 
 const assert = require('assert');
-const { readFile } = require('fs');
+const { readFile } = require('fs/promises');
 const fixtures = require('../common/fixtures');
 const { replaceLinks } = require('../../tools/doc/markdown.js');
 const html = require('../../tools/doc/html.js');
@@ -58,11 +58,6 @@ function toHTML({ input, filename, nodeVersion, versions }) {
 // This HTML will be stripped of all whitespace because we don't currently
 // have an HTML parser.
 const testData = [
-  {
-    file: fixtures.path('sample_document.md'),
-    html: '<ol><li>fish</li><li>fish</li></ol>' +
-      '<ul><li>Redfish</li><li>Bluefish</li></ul>'
-  },
   {
     file: fixtures.path('order_of_end_tags_5873.md'),
     html: '<h3>Static method: Buffer.from(array) <span> ' +
@@ -126,6 +121,10 @@ const testData = [
     'href="#foo_see_also" id="foo_see_also">#</a></span></h2><p>Check' +
     'out also<a href="https://nodejs.org/">this guide</a></p>'
   },
+  {
+    file: fixtures.path('document_with_special_heading.md'),
+    html: '<title>Sample markdown with special heading |',
+  }
 ];
 
 const spaces = /\s/g;
@@ -140,21 +139,20 @@ const versions = [
   { num: '0.12.x' },
   { num: '0.10.x' }];
 
-testData.forEach(({ file, html }) => {
+testData.forEach(async ({ file, html }) => {
   // Normalize expected data by stripping whitespace.
   const expected = html.replace(spaces, '');
 
-  readFile(file, 'utf8', common.mustCall(async (err, input) => {
-    assert.ifError(err);
-    const output = toHTML({ input: input,
-                            filename: 'foo',
-                            nodeVersion: process.version,
-                            versions: versions });
+  const input = await readFile(file, 'utf8');
 
-    const actual = output.replace(spaces, '');
-    // Assert that the input stripped of all whitespace contains the
-    // expected markup.
-    assert(actual.includes(expected),
-           `ACTUAL: ${actual}\nEXPECTED: ${expected}`);
-  }));
+  const output = toHTML({ input,
+                          filename: 'foo',
+                          nodeVersion: process.version,
+                          versions });
+
+  const actual = output.replace(spaces, '');
+  // Assert that the input stripped of all whitespace contains the
+  // expected markup.
+  assert(actual.includes(expected),
+         `ACTUAL: ${actual}\nEXPECTED: ${expected}`);
 });

--- a/test/doctool/test-doctool-html.js
+++ b/test/doctool/test-doctool-html.js
@@ -9,7 +9,7 @@ try {
 }
 
 const assert = require('assert');
-const { readFile } = require('fs/promises');
+const { readFileSync } = require('fs');
 const fixtures = require('../common/fixtures');
 const { replaceLinks } = require('../../tools/doc/markdown.js');
 const html = require('../../tools/doc/html.js');
@@ -139,11 +139,11 @@ const versions = [
   { num: '0.12.x' },
   { num: '0.10.x' }];
 
-testData.forEach(async ({ file, html }) => {
+testData.forEach(({ file, html }) => {
   // Normalize expected data by stripping whitespace.
   const expected = html.replace(spaces, '');
 
-  const input = await readFile(file, 'utf8');
+  const input = readFileSync(file, 'utf8');
 
   const output = toHTML({ input,
                           filename: 'foo',

--- a/test/fixtures/document_with_special_heading.md
+++ b/test/fixtures/document_with_special_heading.md
@@ -1,0 +1,4 @@
+# Sample `markdown` with _special_ **heading**
+
+Sometimes heading contains more than just one text child, the current file is
+there to test just that. 

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -96,7 +96,9 @@ function firstHeader() {
     const heading = find(tree, { type: 'heading' });
 
     if (heading && heading.children.length) {
-      file.section = heading.children.map(({ value }) => value).join('');
+      const recursiveTextContent = (node) =>
+        node.value || node.children.map(recursiveTextContent).join('');
+      file.section = recursiveTextContent(heading);
     } else {
       file.section = 'Index';
     }

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -93,12 +93,12 @@ function toHTML({ input, content, filename, nodeVersion, versions }) {
 // Set the section name based on the first header.  Default to 'Index'.
 function firstHeader() {
   return (tree, file) => {
-    file.section = 'Index';
-
     const heading = find(tree, { type: 'heading' });
-    if (heading) {
-      const text = find(heading, { type: 'text' });
-      if (text) file.section = text.value;
+
+    if (heading?.children.length) {
+      file.section = heading.children.map(({ value }) => value).join('');
+    } else {
+      file.section = 'Index';
     }
   };
 }

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -95,7 +95,7 @@ function firstHeader() {
   return (tree, file) => {
     const heading = find(tree, { type: 'heading' });
 
-    if (heading?.children.length) {
+    if (heading && heading.children.length) {
       file.section = heading.children.map(({ value }) => value).join('');
     } else {
       file.section = 'Index';

--- a/tools/doc/package.json
+++ b/tools/doc/package.json
@@ -4,7 +4,7 @@
   "description": "Internal tool for generating Node.js API docs",
   "version": "0.0.0",
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=12.10.0"
   },
   "dependencies": {
     "highlight.js": "^9.18.1",

--- a/tools/doc/package.json
+++ b/tools/doc/package.json
@@ -4,7 +4,7 @@
   "description": "Internal tool for generating Node.js API docs",
   "version": "0.0.0",
   "engines": {
-    "node": ">=12.10.0"
+    "node": ">=14.0.0"
   },
   "dependencies": {
     "highlight.js": "^9.18.1",


### PR DESCRIPTION
Previously the HTML title would be cut to the first text node only. This PR concats the text value of all the node children of the first heading.

This is currently visible on [Modules: `module` API](https://nodejs.org/api/module.html) page:

_Currently, on nodejs.org:_
```html
<title>Modules:  | Node.js v14.9.0 Documentation</title>
```

_With this PR:_
```html
<title>Modules: module API | Node.js v15.0.0 Documentation</title>
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
