### PR TITLE
doc: revise AbortSignal text and example using events.once()

### DIFF
--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -1010,8 +1010,7 @@ added:
 * `emitter` {EventEmitter}
 * `eventName` {string|symbol} The name of the event being listened for
 * `options` {Object}
-  * `signal` {AbortSignal} An {AbortSignal} that can be used to cancel awaiting
-    events.
+  * `signal` {AbortSignal} Can be used to cancel awaiting events.
 * Returns: {AsyncIterator} that iterates `eventName` events emitted by the `emitter`
 
 ```js
@@ -1041,7 +1040,7 @@ if the `EventEmitter` emits `'error'`. It removes all listeners when
 exiting the loop. The `value` returned by each iteration is an array
 composed of the emitted event arguments.
 
-An {AbortSignal} may be used to cancel waiting on events:
+An {AbortSignal} can be used to cancel waiting on events:
 
 ```js
 const { on, EventEmitter } = require('events');

--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -835,8 +835,7 @@ added:
 * `emitter` {EventEmitter}
 * `name` {string}
 * `options` {Object}
-  * `signal` {AbortSignal} An {AbortSignal} that may be used to cancel waiting
-    for the event.
+  * `signal` {AbortSignal} Can be used to cancel waiting for the event.
 * Returns: {Promise}
 
 Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
@@ -895,7 +894,7 @@ ee.emit('error', new Error('boom'));
 // Prints: ok boom
 ```
 
-An {AbortSignal} may be used to cancel waiting for the event early:
+An {AbortSignal} can be used to cancel waiting for the event:
 
 ```js
 const { EventEmitter, once } = require('events');
@@ -918,6 +917,7 @@ async function foo(emitter, event, signal) {
 
 foo(ee, 'foo', ac.signal);
 ac.abort(); // Abort waiting for the event
+ee.emit('foo'); // Prints: Waiting for the event was canceled!
 ```
 
 ### Awaiting multiple events emitted on `process.nextTick()`


### PR DESCRIPTION
Add a line to the example code to clarify what happens if an event is
emitted after listening is canceled. Make minor revisions to surrounding
text.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
