### PR TITLE
quic: remove undefined variable

### DIFF
--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -2389,7 +2389,6 @@ class QuicClientSession extends QuicSession {
 
     // If handle is a number, creating the session failed.
     if (typeof handle === 'number') {
-      let reason;
       switch (handle) {
         case ERR_FAILED_TO_CREATE_SESSION:
           throw new ERR_QUIC_FAILED_TO_CREATE_SESSION();
@@ -2398,7 +2397,7 @@ class QuicClientSession extends QuicSession {
         case ERR_INVALID_TLS_SESSION_TICKET:
           throw new ERR_QUIC_INVALID_TLS_SESSION_TICKET();
         default:
-          throw new ERR_OPERATION_FAILED(`Unspecified reason [${reason}]`);
+          throw new ERR_OPERATION_FAILED(`Unspecified reason [${handle}]`);
       }
     }
 


### PR DESCRIPTION
The `reason` variable never gets defined. It's use in a template string
will always end up as the string `'undefined'`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
