### PR TITLE
querystring: manage percent character at unescape

### DIFF
--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -94,13 +94,13 @@ function unescapeBuffer(s, decodeSpaces) {
       hexHigh = unhexTable[currentChar];
       if (!(hexHigh >= 0)) {
         out[outIndex++] = 37; // '%'
+        continue;
       } else {
         nextChar = s.charCodeAt(++index);
         hexLow = unhexTable[nextChar];
         if (!(hexLow >= 0)) {
           out[outIndex++] = 37; // '%'
-          out[outIndex++] = currentChar;
-          currentChar = nextChar;
+          index--;
         } else {
           hasHex = true;
           currentChar = hexHigh * 16 + hexLow;

--- a/test/parallel/test-querystring.js
+++ b/test/parallel/test-querystring.js
@@ -175,7 +175,10 @@ const qsUnescapeTestCases = [
   ['there%2Qare%0-fake%escaped values in%%%%this%9Hstring',
    'there%2Qare%0-fake%escaped values in%%%%this%9Hstring'],
   ['%20%21%22%23%24%25%26%27%28%29%2A%2B%2C%2D%2E%2F%30%31%32%33%34%35%36%37',
-   ' !"#$%&\'()*+,-./01234567']
+   ' !"#$%&\'()*+,-./01234567'],
+  ['%%2a', '%*'],
+  ['%2sf%2a', '%2sf*'],
+  ['%2%2af%2a', '%2*f*']
 ];
 
 assert.strictEqual(qs.parse('id=918854443121279438895193').id,


### PR DESCRIPTION
Related: https://github.com/nodejs/node/issues/33892
Fixes: https://github.com/nodejs/node/issues/35012

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)