### PR TITLE
util: add util.parseArgs()

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -956,10 +956,14 @@ added: REPLACEME
   and this parameter is considered to be the `options` parameter.
 * `options` {Object} (Optional) The `options` parameter, if present, is an
   object supporting the following property:
-  * `expectsValue` {Array<string>|string} (Optional) One or more argument
+  * `optionsWithValue` {Array<string>|string} (Optional) One or more argument
     strings which _expect a value_ when present
-* Returns: {Object} An object having properties corresponding to parsed Options
-  and Flags, and a property `_` containing Positionals
+  * `multiOptions` {Array<string>|string} (Optional) One or more argument
+    strings which can be appear multiple times in `argv` and will be
+    concatenated into an array
+* Returns: {Object} An object having properties:
+  * `options`, an Object with properties and values corresponding to parsed Options and Flags
+  * `positionals`, an Array containing containing Positionals
 
 The `util.parseArgs` function parses command-line arguments from an array of
 strings and returns an object representation.
@@ -973,22 +977,33 @@ const argv = util.parseArgs();
 
 // argv.foo === true
 if (argv.foo) {
-  console.log(argv._); // prints [ 'bar', 'baz' ]
+  console.log(argv.positionals); // prints [ 'bar', 'baz' ]
 }
 ```
 
-Example using a custom `argv` and the `expectsValue` option:
+Example using a custom `argv` and the `optionsWithValue` option:
 
 ```js
 const argv = util.parseArgs(
   ['--foo', 'bar', 'baz'],
-  { expectsValue: ['foo'] }
+  { optionsWithValue: ['foo'] }
 );
 
 // argv.foo === 'bar'
 if (argv.foo === 'bar') {
-  console.log(argv._); // prints [ 'baz' ]
+  console.log(argv.positionals); // prints [ 'baz' ]
 }
+```
+
+Example using custom `argv`, `optionsWithValue`, and the `multiOptions` option:
+
+```js
+const argv = util.parseArgs(
+  ['--foo', 'bar', '--foo', 'baz'],
+  { optionsWithValue: 'foo', multiOptions: 'foo' }
+);
+
+console.log(argv.options.bar); // prints [ 'bar', 'baz' ]
 ```
 
 [`ERR_INVALID_ARG_TYPE`][] will be thrown if the `argv` parameter is not an
@@ -1005,9 +1020,9 @@ Arguments fall into one of three catgories:
   * When appearing _once_ in the array, the value of the property will be `true`
   * When _repeated_ in the array, the value of the property becomes a count of
     repetitions (e.g., `['-v', '-v' '-v']` results in `{ v: 3 }`)
-* _Options_, declared by `expectsValue`, which begin with one or more dashes,
+* _Options_, declared by `optionsWithValue`, which begin with one or more dashes,
   and _do_ have an associated value (e.g., `node app.js --require script.js`)
-  * Use the `expectsValue` option to `util.parseArgs` to declare Options
+  * Use the `optionsWithValue` option to `util.parseArgs` to declare Options
   * The Option _name_ is the string following the prefix of one-or-more dashes,
     e.g., the name of `--foo` is `foo`
   * The Option _value_ is the next string following the name, e.g., the Option
@@ -1021,10 +1036,10 @@ Arguments fall into one of three catgories:
     * The array ends with the Option name (e.g., `['--foo']`)
   * When repeated, values are concatenated into an Array; unlike Flags, they _do
     not_ become a numeric count
-  * When an Option name appears in the Array (or string) of `expectsValue`, and
+  * When an Option name appears in the Array (or string) of `optionsWithValue`, and
     does _not_ appear in the `argv` array, the resulting object _will not_
     contain a property with this Option name (e.g.,
-    `util.parseArgs(['--bar'], { expectsValue: 'foo' })` will result in
+    `util.parseArgs(['--bar'], { optionsWithValue: 'foo' })` will result in
     `{bar: true, _: [] }`
 * _Positionals_ (or "positional arguments"), which _do not_ begin with one or
   more dashes (e.g., `['script.js']`), _or_ every item in the `argv` Array
@@ -1037,7 +1052,7 @@ Arguments fall into one of three catgories:
     result in an object of `{_: ['--foo']}`)
 
 A Flag or Option with having the name `_` will be ignored. If it was declared
-as an Option (via the `expectsValue` option), its value will be ignored as well.
+as an Option (via the `optionsWithValue` option), its value will be ignored as well.
 
 `util.parseArgs` does not consider "short" arguments (e.g., `-v`) to be
 different than "long" arguments (e.g., `--verbose`).  Furthermore, it does not

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1043,10 +1043,12 @@ have an associated string value (e.g., `node app.js --verbose`).
   once)
 * A Flag appearing in `multiOptions` but not in the `argv` Array will be omitted
   from the `options` property of the returned object
-* If a string value is erroneously provided in `argv` for a Flag via the `=`
-  separator, the string value will be replaced with `true`; e.g.,
-  `['--require=script.js']` becomes `{options: {require: true}}, positionals:
-  []}`
+* _Special case for negated Flags_: If a string value of `false` is provided in
+  `argv` for a Flag via the `=` separator, the value will become boolean
+  `false`, e.g., `['--verbose=false']` becomes `{options: {verbose: false}},
+  positionals: []}`; any value other than the string `false` will become `true`,
+  and if `=` is not provided, the value is interpreted as a
+  [Positional][Positionals]
 
 ### Options
 

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1043,6 +1043,10 @@ have an associated string value (e.g., `node app.js --verbose`).
   once)
 * A Flag appearing in `multiOptions` but not in the `argv` Array will be omitted
   from the `options` property of the returned object
+* If a string value is erroneously provided in `argv` for a Flag via the `=`
+  separator, the string value will be replaced with `true`; e.g.,
+  `['--require=script.js']` becomes `{options: {require: true}}, positionals:
+  []}`
 
 ### Options
 

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -951,7 +951,7 @@ equality.
 added: REPLACEME
 -->
 
-* `argv` {string[]|Object} (Optional) Array of argument strings; defaults
+* `argv` {string[]} (Optional) Array of argument strings; defaults
   to [`process.argv.slice(2)`](process_argv). If an Object, the default is used,
   and this parameter is considered to be the `options` parameter.
 * `options` {Object} (Optional) The `options` parameter is an

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1060,8 +1060,9 @@ different than "long" arguments (e.g., `--verbose`).  Furthermore, it does not
 allow concatenation of short arguments (e.g., `-v -D` cannot be expressed as
 `-vD`).
 
-Conversion to/from "camelCase" occurs; a Flag or Option name of `no-color`
-results in an object with a `no-color` property.
+_No_ conversion to/from "camelCase" occurs; a Flag or Option name of `no-color`
+results in an object with a `no-color` property.  A Flag or Option name of
+`noColor` results in an object with a `noColor` property.
 
 ## `util.promisify(original)`
 <!-- YAML

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -946,7 +946,7 @@ Otherwise, returns `false`.
 See [`assert.deepStrictEqual()`][] for more information about deep strict
 equality.
 
-## `util.parseArgs([argv[, options]])`
+## `util.parseArgs([argv][, options])`
 <!-- YAML
 added: REPLACEME
 -->
@@ -954,18 +954,18 @@ added: REPLACEME
 * `argv` {string[]|Object} (Optional) Array of argument strings; defaults
   to [`process.argv.slice(2)`](process_argv). If an Object, the default is used,
   and this parameter is considered to be the `options` parameter.
-* `options` {Object} (Optional) The `options` parameter, if present, is an
+* `options` {Object} (Optional) The `options` parameter is an
   object supporting the following properties:
   * `optionsWithValue` {string[]|string} (Optional) One or more argument
-    strings which _expect a value_ when present (see [Options][]
+    strings which _expect a value_ when present in `argv` (see [Options][]
     for details)
   * `multiOptions` {string[]|string} (Optional) One or more argument
     strings which, when appearing multiple times in `argv`, will be concatenated
     into an Array
 * Returns: {Object} An object having properties:
   * `options` {Object}, having properties and values corresponding to parsed
-    [Options][] and [Flags][], if any
-  * `positionals` {string[]}, containing [Positionals][], if any
+    [Options][] and [Flags][]
+  * `positionals` {string[]}, containing [Positionals][]
 
 The `util.parseArgs` function parses command-line arguments from an Array of
 strings and returns an object representation.

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1035,9 +1035,9 @@ have an associated string value (e.g., `node app.js --verbose`).
   object
 * By default, when appearing any number of times in the `argv` Array, the value
   of the property will be `true`. To get a "count" of the times a Flag is
-  repeated, specify the Flag name in the `multiOptions` option; this will parsed
-  to an Array of `true` values, and you can derive the "count" from the `length`
-  property of this Array
+  repeated, specify the Flag name in the `multiOptions` option; this will be
+  parsed to an Array of `true` values, and you can derive the "count" from the
+  `length` property of this Array
 * When a Flag appears in `multiOptions`, and when provided in `argv`, the value
   in the returned object will _always_ be an Array (even if it is only provided
   once)
@@ -1050,7 +1050,7 @@ have an associated string value (e.g., `node app.js --verbose`).
 
 ### Options
 
-_Options_ are arguments which begin with one or more dashes (`-`), and _do_ have
+_Options_ are arguments which begin with one or more dashes (`-`), and _expect_
 an associated value (e.g., `node app.js --require script.js`).
 
 * Use the `optionsWithValue` option to `util.parseArgs` to declare Options
@@ -1091,7 +1091,7 @@ with one or more dashes (e.g., `['script.js']`), _and/or_ all items in the
 * Positionals will _always_ be parsed verbatim (e.g., `['--', '--foo']` will
   result in an object of `{positionals: ['--foo'], options: {}}`)
 
-Please note:
+### Additional Considerations
 
 * `util.parseArgs` does not consider "short" arguments (e.g., `-v`) to be
   different than "long" arguments (e.g., `--verbose`).  Furthermore, it does not

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -962,7 +962,8 @@ added: REPLACEME
     strings which can be appear multiple times in `argv` and will be
     concatenated into an array
 * Returns: {Object} An object having properties:
-  * `options`, an Object with properties and values corresponding to parsed Options and Flags
+  * `options`, an Object with properties and values corresponding to parsed
+    Options and Flags
   * `positionals`, an Array containing containing Positionals
 
 The `util.parseArgs` function parses command-line arguments from an array of
@@ -1020,8 +1021,9 @@ Arguments fall into one of three catgories:
   * When appearing _once_ in the array, the value of the property will be `true`
   * When _repeated_ in the array, the value of the property becomes a count of
     repetitions (e.g., `['-v', '-v' '-v']` results in `{ v: 3 }`)
-* _Options_, declared by `optionsWithValue`, which begin with one or more dashes,
-  and _do_ have an associated value (e.g., `node app.js --require script.js`)
+* _Options_, declared by `optionsWithValue`, which begin with one or more
+  dashes, and _do_ have an associated value (e.g., `node app.js --require
+  script.js`)
   * Use the `optionsWithValue` option to `util.parseArgs` to declare Options
   * The Option _name_ is the string following the prefix of one-or-more dashes,
     e.g., the name of `--foo` is `foo`
@@ -1036,11 +1038,10 @@ Arguments fall into one of three catgories:
     * The array ends with the Option name (e.g., `['--foo']`)
   * When repeated, values are concatenated into an Array; unlike Flags, they _do
     not_ become a numeric count
-  * When an Option name appears in the Array (or string) of `optionsWithValue`, and
-    does _not_ appear in the `argv` array, the resulting object _will not_
-    contain a property with this Option name (e.g.,
-    `util.parseArgs(['--bar'], { optionsWithValue: 'foo' })` will result in
-    `{bar: true, _: [] }`
+  * When an Option name appears in the Array (or string) of `optionsWithValue`,
+    and does _not_ appear in the `argv` array, the resulting object _will not_
+    contain a property with this Option name (e.g., `util.parseArgs(['--bar'],
+    { optionsWithValue: 'foo' })` will result in `{bar: true, _: [] }`
 * _Positionals_ (or "positional arguments"), which _do not_ begin with one or
   more dashes (e.g., `['script.js']`), _or_ every item in the `argv` Array
   following a `--` (e.g., `['--', 'script.js']`)
@@ -1051,8 +1052,8 @@ Arguments fall into one of three catgories:
   * Positionals will _always_ be parsed verbatim (e.g., `['--', '--foo']` will
     result in an object of `{_: ['--foo']}`)
 
-A Flag or Option with having the name `_` will be ignored. If it was declared
-as an Option (via the `optionsWithValue` option), its value will be ignored as well.
+A Flag or Option having the name `_` will be ignored. If it was declared as an
+Option (via the `optionsWithValue` option), its value will be ignored as well.
 
 `util.parseArgs` does not consider "short" arguments (e.g., `-v`) to be
 different than "long" arguments (e.g., `--verbose`).  Furthermore, it does not

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1062,8 +1062,8 @@ an associated value (e.g., `node app.js --require script.js`).
   value of `['--foo' 'bar']` is `bar`
 * Option values may be provided _with or without_ a `=` separator (e.g.,
   `['--require=script.js']` is equivalent to `['--require', 'script.js']`)
-* If an Option value is not provided, the Option will be omitted from the
-  `options` property of the returned object
+* If an Option value is not found in `argv`, the associated value will be parsed
+  to an empty string (`''`)
 * An argument-like value (a value beginning with one or more dashes) immediately
   following an Option in the `argv` Array will cause the Option to be omitted
   from the `options` property of the returned object _unless_ the `=` separator

--- a/lib/internal/util/parse_args.js
+++ b/lib/internal/util/parse_args.js
@@ -118,7 +118,7 @@ const parseArgs = (
         if (optionValue === undefined) {
           optionValue = (
             argv[pos + 1] && StringPrototypeStartsWith(argv[pos + 1], '-')
-          ) || argv[++pos];
+          ) || argv[++pos] || '';
         }
       } else {
         // To get a `false` value for a Flag, use e.g., ['--flag=false']

--- a/lib/internal/util/parse_args.js
+++ b/lib/internal/util/parse_args.js
@@ -1,0 +1,121 @@
+'use strict';
+
+const {
+  ArrayIsArray,
+  ArrayPrototypePush,
+  ArrayPrototypeSlice,
+  Number,
+  SafeSet,
+  StringPrototypeReplace,
+  StringPrototypeSplit,
+  StringPrototypeStartsWith,
+} = primordials;
+const { ERR_INVALID_ARG_TYPE } = require('internal/errors').codes;
+
+/**
+ * Returns an Object representation of command-line arguments to a script.
+ *
+ * Default behavior:
+ * - All arguments are considered "boolean flags"; in the returned
+ *   object, the key is the argument (if present), and the value will be `true`.
+ * - Uses `process.argv.slice(2)`, but can accept an explicit array of strings.
+ * - Argument(s) specified in `opts.expectsValue` will have `string` values
+ *   instead of `true`; the subsequent item in the `argv` array will be consumed
+ *   if a `=` is not used.
+ * - If `=` is present, the value will be boolean if and only if the RHS of the
+ *   string is one of string `true` or `false`
+ * - "Bare" arguments are those which do not begin with a `-` or `--` and those
+ *   after a bare `--`; these will be returned as items of the `_` array
+ * - The `_` array will always be present, even if empty.
+ * - Repeated arguments are combined into an array
+ * @param {string[]} [argv=process.argv.slice(2)] - Array of script arguments as
+ * strings
+ * @param {Object} [options] - Options
+ * @param {string[]|string} [opts.expectsValue] - Argument(s) listed here expect
+ * a value
+ * @example
+ * parseArgs(['--foo', '--bar']) // {foo: true, bar: true, _: []}
+ * parseArgs(['--foo', '-b']) // {foo: true, b: true, _: []}
+ * parseArgs(['---foo']) // {foo: true, _: []}
+ * parseArgs(['--foo=bar']) // {foo: true, _: []}
+ * parseArgs(['--foo', 'bar']) // {foo: true, _: ['bar']}
+ * parseArgs(['--foo', 'bar'], {expectsValue: 'foo'}) // {foo: 'bar', _: []}
+ * parseArgs(['foo']) // {_: ['foo']}
+ * parseArgs(['--foo', '--', '--bar']) // {foo: true, _: ['--bar']}
+ * parseArgs(['--foo=bar', '--foo=baz']) // {foo: ['bar', 'baz'], _: []}
+ * parseArgs(['--foo', '--foo']) // {foo: true, _: []}
+ * pasreArgs(['--foo=true']) // {foo: true, _: []}
+ * parseArgs(['--foo=false']) // {foo: false, _: [])}
+ * parseArgs(['--foo=true', '--foo=false']) // {foo: false, _: [])}
+ * parseArgs(['--foo', 'true']) // {foo: true, _: ['true']}
+ * parseArgs(['--foo', 'true'], {expectsValue: ['foo']}) // {foo: true, _: []}
+ */
+const parseArgs = (
+  argv = ArrayPrototypeSlice(process.argv, 2),
+  options = { expectsValue: [] }
+) => {
+  if (!ArrayIsArray(argv)) {
+    options = argv;
+    argv = ArrayPrototypeSlice(process.argv, 2);
+  }
+  if (typeof options !== 'object' || options === null) {
+    throw new ERR_INVALID_ARG_TYPE(
+      'options',
+      'object',
+      options);
+  }
+  if (typeof options.expectsValue === 'string') {
+    options.expectsValue = [options.expectsValue];
+  }
+  const expectsValue = new SafeSet(options.expectsValue || []);
+  const result = { _: [] };
+
+  let pos = 0;
+  while (true) {
+    const arg = argv[pos];
+    if (arg === undefined) {
+      return result;
+    }
+    if (StringPrototypeStartsWith(arg, '-')) {
+      // Everything after a bare '--' is considered a positional argument
+      // and is returned verbatim
+      if (arg === '--') {
+        ArrayPrototypePush(result._, ...ArrayPrototypeSlice(argv, ++pos));
+        return result;
+      }
+      // Any number of leading dashes are allowed
+      const argParts = StringPrototypeSplit(StringPrototypeReplace(arg, /^-+/, ''), '=');
+      const lhs = argParts[0];
+      let rhs = argParts[1];
+
+      if (expectsValue.has(lhs)) {
+        // Consume the next item in the array if `=` was not used
+        // and the next item is not itself a flag or option
+        if (rhs === undefined) {
+          rhs = StringPrototypeStartsWith(argv[pos + 1], '-') || argv[++pos];
+        }
+
+        if (lhs !== '_') {
+          if (result[lhs] === undefined) {
+            result[lhs] = rhs;
+          } else if (ArrayIsArray(result[lhs])) {
+            ArrayPrototypePush(result[lhs], rhs);
+          } else {
+            result[lhs] = [result[lhs], rhs];
+          }
+        }
+      } else if (lhs !== '_') {
+        // In the case of args where we did not expect a value, the value is
+        // `true` unless there are multiple, at which point it becomes a count.
+        result[lhs] = result[lhs] === undefined || Number(result[lhs]) + 1;
+      }
+    } else if (arg !== '_') {
+      ArrayPrototypePush(result._, arg);
+    }
+    pos++;
+  }
+};
+
+module.exports = {
+  parseArgs
+};

--- a/lib/internal/util/parse_args.js
+++ b/lib/internal/util/parse_args.js
@@ -15,27 +15,26 @@ const { ERR_INVALID_ARG_TYPE } = require('internal/errors').codes;
  * Returns an Object representation of command-line arguments.
  *
  * Default behavior:
- * - All arguments are considered "boolean flags"; in the returned
- *   object, the key is the argument (if present), and the value will be `true`.
+ * - All arguments are considered "boolean flags"; in the `options` property of
+ *   returned object, the key is the argument (if present), and the value will
+ *   be `true`.
  * - Uses `process.argv.slice(2)`, but can accept an explicit array of strings.
  * - Argument(s) specified in `opts.optionsWithValue` will have `string` values
  *   instead of `true`; the subsequent item in the `argv` array will be consumed
- *   if a `=` is not used.
- * - If `=` is present, the value will be boolean if and only if the RHS of the
- *   string is one of string `true` or `false`
+ *   if a `=` is not used
  * - "Bare" arguments are those which do not begin with a `-` or `--` and those
- *   after a bare `--`; these will be returned as items of the `_` array
+ *   after a bare `--`; these will be returned as items of the `positionals`
+ *   array
  * - The `positionals` array will always be present, even if empty.
  * - The `options` Object will always be present, even if empty.
- * - Repeated arguments are combined into an array
  * @param {string[]} [argv=process.argv.slice(2)] - Array of script arguments as
  * strings
  * @param {Object} [options] - Options
  * @param {string[]|string} [opts.optionsWithValue] - This argument (or
  * arguments) expect a value
  * @param {string[]|string} [opts.multiOptions] - This argument (or arguments)
- * can be specified multiple times and its values will be concatenated into
- * an array
+ * can be specified multiple times and its values will be concatenated into an
+ * array
  * @example
  * parseArgs(['--foo', '--bar'])
  *   // {options: { foo: true, bar: true }, positionals: []}

--- a/lib/internal/util/parse_args.js
+++ b/lib/internal/util/parse_args.js
@@ -4,7 +4,6 @@ const {
   ArrayIsArray,
   ArrayPrototypePush,
   ArrayPrototypeSlice,
-  Number,
   SafeSet,
   StringPrototypeReplace,
   StringPrototypeSplit,

--- a/lib/internal/util/parse_args.js
+++ b/lib/internal/util/parse_args.js
@@ -22,9 +22,9 @@ const { ERR_INVALID_ARG_TYPE } = require('internal/errors').codes;
  * - Argument(s) specified in `opts.optionsWithValue` will have `string` values
  *   instead of `true`; the subsequent item in the `argv` array will be consumed
  *   if a `=` is not used
- * - "Bare" arguments are those which do not begin with a `-` or `--` and those
- *   after a bare `--`; these will be returned as items of the `positionals`
- *   array
+ * - "Bare" arguments (positionals) are those which do not begin with a `-` or
+ *   `--` and those after a bare `--`; these will be returned as items of the
+ *   `positionals` array
  * - The `positionals` array will always be present, even if empty.
  * - The `options` Object will always be present, even if empty.
  * @param {string[]} [argv=process.argv.slice(2)] - Array of script arguments as
@@ -64,6 +64,8 @@ const { ERR_INVALID_ARG_TYPE } = require('internal/errors').codes;
  *   // {options: {foo: true}, positionals: []}
  * parseArgs(['--foo', '--foo'], {multiOptions: ['foo']})
  *   // {options: {foo: [true, true]}, positionals: []}
+ * parseArgs(['--very-wordy-option'])
+ *   // {options: {'very-wordy-option': true}, positionals: []}
  */
 const parseArgs = (
   argv = ArrayPrototypeSlice(process.argv, 2),

--- a/lib/internal/util/parse_args.js
+++ b/lib/internal/util/parse_args.js
@@ -30,11 +30,11 @@ const { ERR_INVALID_ARG_TYPE } = require('internal/errors').codes;
  * @param {string[]} [argv=process.argv.slice(2)] - Array of script arguments as
  * strings
  * @param {Object} [options] - Options
- * @param {string[]|string} [opts.optionsWithValue] - This argument (or
+ * @param {string[]|string} [options.optionsWithValue] - This argument (or
  * arguments) expect a value
- * @param {string[]|string} [opts.multiOptions] - This argument (or arguments)
- * can be specified multiple times and its values will be concatenated into an
- * array
+ * @param {string[]|string} [options.multiOptions] - This argument (or
+ * arguments) can be specified multiple times and its values will be
+ * concatenated into an array
  * @returns {{options: Object, positionals: string[]}} Parsed arguments
  * @example
  * parseArgs(['--foo', '--bar'])
@@ -92,11 +92,8 @@ const parseArgs = (
   const result = { positionals: [], options: {} };
 
   let pos = 0;
-  while (true) {
+  while (pos < argv.length) {
     const arg = argv[pos];
-    if (arg === undefined) {
-      return result;
-    }
     if (StringPrototypeStartsWith(arg, '-')) {
       // Everything after a bare '--' is considered a positional argument
       // and is returned verbatim
@@ -115,8 +112,9 @@ const parseArgs = (
       // and the next item is not itself a flag or option
       if (optionsWithValue.has(optionName)) {
         if (optionValue === undefined) {
-          optionValue = StringPrototypeStartsWith(argv[pos + 1], '-') ||
-              argv[++pos];
+          optionValue = (
+            argv[pos + 1] && StringPrototypeStartsWith(argv[pos + 1], '-')
+          ) || argv[++pos];
         }
       } else {
         optionValue = true;
@@ -130,7 +128,7 @@ const parseArgs = (
         } else {
           ArrayPrototypePush(result.options[optionName], optionValue);
         }
-      } else {
+      } else if (optionValue !== undefined) {
         result.options[optionName] = optionValue;
       }
     } else {
@@ -138,6 +136,7 @@ const parseArgs = (
     }
     pos++;
   }
+  return result;
 };
 
 module.exports = {

--- a/lib/internal/util/parse_args.js
+++ b/lib/internal/util/parse_args.js
@@ -13,46 +13,62 @@ const {
 const { ERR_INVALID_ARG_TYPE } = require('internal/errors').codes;
 
 /**
- * Returns an Object representation of command-line arguments to a script.
+ * Returns an Object representation of command-line arguments.
  *
  * Default behavior:
  * - All arguments are considered "boolean flags"; in the returned
  *   object, the key is the argument (if present), and the value will be `true`.
  * - Uses `process.argv.slice(2)`, but can accept an explicit array of strings.
- * - Argument(s) specified in `opts.expectsValue` will have `string` values
+ * - Argument(s) specified in `opts.optionsWithValue` will have `string` values
  *   instead of `true`; the subsequent item in the `argv` array will be consumed
  *   if a `=` is not used.
  * - If `=` is present, the value will be boolean if and only if the RHS of the
  *   string is one of string `true` or `false`
  * - "Bare" arguments are those which do not begin with a `-` or `--` and those
  *   after a bare `--`; these will be returned as items of the `_` array
- * - The `_` array will always be present, even if empty.
+ * - The `positionals` array will always be present, even if empty.
+ * - The `options` Object will always be present, even if empty.
  * - Repeated arguments are combined into an array
  * @param {string[]} [argv=process.argv.slice(2)] - Array of script arguments as
  * strings
  * @param {Object} [options] - Options
- * @param {string[]|string} [opts.expectsValue] - Argument(s) listed here expect
- * a value
+ * @param {string[]|string} [opts.optionsWithValue] - This argument (or
+ * arguments) expect a value
+ * @param {string[]|string} [opts.multiOptions] - This argument (or arguments)
+ * can be specified multiple times and its values will be concatenated into
+ * an array
  * @example
- * parseArgs(['--foo', '--bar']) // {foo: true, bar: true, _: []}
- * parseArgs(['--foo', '-b']) // {foo: true, b: true, _: []}
- * parseArgs(['---foo']) // {foo: true, _: []}
- * parseArgs(['--foo=bar']) // {foo: true, _: []}
- * parseArgs(['--foo', 'bar']) // {foo: true, _: ['bar']}
- * parseArgs(['--foo', 'bar'], {expectsValue: 'foo'}) // {foo: 'bar', _: []}
- * parseArgs(['foo']) // {_: ['foo']}
- * parseArgs(['--foo', '--', '--bar']) // {foo: true, _: ['--bar']}
- * parseArgs(['--foo=bar', '--foo=baz']) // {foo: ['bar', 'baz'], _: []}
- * parseArgs(['--foo', '--foo']) // {foo: true, _: []}
- * pasreArgs(['--foo=true']) // {foo: true, _: []}
- * parseArgs(['--foo=false']) // {foo: false, _: [])}
- * parseArgs(['--foo=true', '--foo=false']) // {foo: false, _: [])}
- * parseArgs(['--foo', 'true']) // {foo: true, _: ['true']}
- * parseArgs(['--foo', 'true'], {expectsValue: ['foo']}) // {foo: true, _: []}
+ * parseArgs(['--foo', '--bar'])
+ *   // {options: { foo: true, bar: true }, positionals: []}
+ * parseArgs(['--foo', '-b'])
+ *   // {options: { foo: true, b: true }, positionals: []}
+ * parseArgs(['---foo'])
+ *   // {options: { foo: true }, positionals: []}
+ * parseArgs(['--foo=bar'])
+ *   // {options: { foo: true }, positionals: []}
+ * parseArgs([--foo', 'bar'])
+ *   // {options: {foo: true}, positionals: ['bar']}
+ * parseArgs(['--foo', 'bar'], {optionsWithValue: 'foo'})
+ *   // {options: {foo: 'bar'}, positionals: []}
+ * parseArgs(['foo'])
+ *   // {options: {}, positionals: ['foo']}
+ * parseArgs(['--foo', '--', '--bar'])
+ *   // {options: {foo: true}, positionals: ['--bar']}
+ * parseArgs(['--foo=bar', '--foo=baz'])
+ *   // {options: {foo: true}, positionals: []}
+ * parseArgs(['--foo=bar', '--foo=baz'], {optionsWithValue: 'foo'})
+ *   // {options: {foo: 'baz'}, positionals: []}
+ * parseArgs(['--foo=bar', '--foo=baz'], {
+ *   optionsWithValue: 'foo', multiOptions: 'foo'
+ * }) // {options: {foo: ['bar', 'baz']}, positionals: []}
+ * parseArgs(['--foo', '--foo'])
+ *   // {options: {foo: true}, positionals: []}
+ * parseArgs(['--foo', '--foo'], {multiOptions: ['foo']})
+ *   // {options: {foo: [true, true]}, positionals: []}
  */
 const parseArgs = (
   argv = ArrayPrototypeSlice(process.argv, 2),
-  options = { expectsValue: [] }
+  options = { optionsWithValue: [] }
 ) => {
   if (!ArrayIsArray(argv)) {
     options = argv;
@@ -64,11 +80,15 @@ const parseArgs = (
       'object',
       options);
   }
-  if (typeof options.expectsValue === 'string') {
-    options.expectsValue = [options.expectsValue];
+  if (typeof options.optionsWithValue === 'string') {
+    options.optionsWithValue = [options.optionsWithValue];
   }
-  const expectsValue = new SafeSet(options.expectsValue || []);
-  const result = { _: [] };
+  if (typeof options.multiOptions === 'string') {
+    options.multiOptions = [options.multiOptions];
+  }
+  const optionsWithValue = new SafeSet(options.optionsWithValue || []);
+  const multiOptions = new SafeSet(options.multiOptions || []);
+  const result = { positionals: [], options: {} };
 
   let pos = 0;
   while (true) {
@@ -80,37 +100,40 @@ const parseArgs = (
       // Everything after a bare '--' is considered a positional argument
       // and is returned verbatim
       if (arg === '--') {
-        ArrayPrototypePush(result._, ...ArrayPrototypeSlice(argv, ++pos));
+        ArrayPrototypePush(
+          result.positionals, ...ArrayPrototypeSlice(argv, ++pos)
+        );
         return result;
       }
       // Any number of leading dashes are allowed
       const argParts = StringPrototypeSplit(StringPrototypeReplace(arg, /^-+/, ''), '=');
-      const lhs = argParts[0];
-      let rhs = argParts[1];
+      const optionName = argParts[0];
+      let optionValue = argParts[1];
 
-      if (expectsValue.has(lhs)) {
+      // Consume the next item in the array if `=` was not used
+      // and the next item is not itself a flag or option
+      if (optionsWithValue.has(optionName)) {
+        if (optionValue === undefined) {
+          optionValue = StringPrototypeStartsWith(argv[pos + 1], '-') ||
+              argv[++pos];
+        }
+      } else {
+        optionValue = true;
+      }
+
+      if (multiOptions.has(optionName)) {
         // Consume the next item in the array if `=` was not used
         // and the next item is not itself a flag or option
-        if (rhs === undefined) {
-          rhs = StringPrototypeStartsWith(argv[pos + 1], '-') || argv[++pos];
+        if (result.options[optionName] === undefined) {
+          result.options[optionName] = [optionValue];
+        } else {
+          ArrayPrototypePush(result.options[optionName], optionValue);
         }
-
-        if (lhs !== '_') {
-          if (result[lhs] === undefined) {
-            result[lhs] = rhs;
-          } else if (ArrayIsArray(result[lhs])) {
-            ArrayPrototypePush(result[lhs], rhs);
-          } else {
-            result[lhs] = [result[lhs], rhs];
-          }
-        }
-      } else if (lhs !== '_') {
-        // In the case of args where we did not expect a value, the value is
-        // `true` unless there are multiple, at which point it becomes a count.
-        result[lhs] = result[lhs] === undefined || Number(result[lhs]) + 1;
+      } else {
+        result.options[optionName] = optionValue;
       }
-    } else if (arg !== '_') {
-      ArrayPrototypePush(result._, arg);
+    } else {
+      ArrayPrototypePush(result.positionals, arg);
     }
     pos++;
   }

--- a/lib/internal/util/parse_args.js
+++ b/lib/internal/util/parse_args.js
@@ -35,6 +35,7 @@ const { ERR_INVALID_ARG_TYPE } = require('internal/errors').codes;
  * @param {string[]|string} [opts.multiOptions] - This argument (or arguments)
  * can be specified multiple times and its values will be concatenated into an
  * array
+ * @returns {{options: Object, positionals: string[]}} Parsed arguments
  * @example
  * parseArgs(['--foo', '--bar'])
  *   // {options: { foo: true, bar: true }, positionals: []}

--- a/lib/internal/util/parse_args.js
+++ b/lib/internal/util/parse_args.js
@@ -66,6 +66,10 @@ const { ERR_INVALID_ARG_TYPE } = require('internal/errors').codes;
  *   // {options: {foo: [true, true]}, positionals: []}
  * parseArgs(['--very-wordy-option'])
  *   // {options: {'very-wordy-option': true}, positionals: []}
+ * parseArgs(['--verbose=false'])
+ *   // {options: {verbose: false}, positionals: []}
+ * parseArgs(['--verbose', 'false'])
+ *   // {options: {verbose: true}, positionals: ['false']}
  */
 const parseArgs = (
   argv = ArrayPrototypeSlice(process.argv, 2),
@@ -117,7 +121,8 @@ const parseArgs = (
           ) || argv[++pos];
         }
       } else {
-        optionValue = true;
+        // To get a `false` value for a Flag, use e.g., ['--flag=false']
+        optionValue = optionValue !== 'false';
       }
 
       if (multiOptions.has(optionName)) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -54,6 +54,7 @@ const { validateNumber } = require('internal/validators');
 const { TextDecoder, TextEncoder } = require('internal/encoding');
 const { isBuffer } = require('buffer').Buffer;
 const types = require('internal/util/types');
+const { parseArgs } = require('internal/util/parse_args');
 
 const {
   deprecate,
@@ -270,6 +271,7 @@ module.exports = {
   isFunction,
   isPrimitive,
   log,
+  parseArgs,
   promisify,
   TextDecoder,
   TextEncoder,

--- a/node.gyp
+++ b/node.gyp
@@ -218,6 +218,7 @@
       'lib/internal/util/debuglog.js',
       'lib/internal/util/inspect.js',
       'lib/internal/util/inspector.js',
+      'lib/internal/util/parse_args.js',
       'lib/internal/util/types.js',
       'lib/internal/http2/core.js',
       'lib/internal/http2/compat.js',

--- a/test/parallel/test-bootstrap-modules.js
+++ b/test/parallel/test-bootstrap-modules.js
@@ -80,6 +80,7 @@ const expectedModules = new Set([
   'NativeModule internal/util',
   'NativeModule internal/util/debuglog',
   'NativeModule internal/util/inspect',
+  'NativeModule internal/util/parse_args',
   'NativeModule internal/util/types',
   'NativeModule internal/validators',
   'NativeModule internal/vm/module',

--- a/test/parallel/test-util-parseargs.js
+++ b/test/parallel/test-util-parseargs.js
@@ -8,116 +8,143 @@ const { format, parseArgs } = require('util');
   const data = new Map([
     [
       { argv: ['--foo', '--bar'] },
-      { foo: true, bar: true, _: [] }
+      { options: { foo: true, bar: true }, positionals: [] }
     ],
     [
       { argv: ['--foo', '-b'] },
-      { foo: true, b: true, _: [] }
+      { options: { foo: true, b: true }, positionals: [] }
     ],
     [
       { argv: ['---foo'] },
-      { foo: true, _: [] }
+      { options: { foo: true }, positionals: [] }
     ],
     [
       { argv: ['--foo=bar'] },
-      { foo: true, _: [] }
+      { options: { foo: true }, positionals: [] }
     ],
     [
-      { argv: ['--foo=bar'], opts: { expectsValue: ['foo'] } },
-      { foo: 'bar', _: [] }
+      { argv: ['--foo=bar'], opts: { optionsWithValue: ['foo'] } },
+      { options: { foo: 'bar' }, positionals: [] }
     ],
     [
       { argv: ['--foo', 'bar'] },
-      { foo: true, _: ['bar'] }
+      { options: { foo: true }, positionals: ['bar'] }
     ],
     [
-      { argv: ['--foo', 'bar'], opts: { expectsValue: 'foo' } },
-      { foo: 'bar', _: [] }
+      { argv: ['--foo', 'bar'], opts: { optionsWithValue: 'foo' } },
+      { options: { foo: 'bar' }, positionals: [] }
     ],
     [
       { argv: ['foo'] },
-      { _: ['foo'] }
+      { options: {}, positionals: ['foo'] }
     ],
     [
       { argv: ['--foo', '--', '--bar'] },
-      { foo: true, _: ['--bar'] }
+      { options: { foo: true }, positionals: ['--bar'] }
     ],
     [
-      { argv: ['--foo=bar', '--foo=baz'], opts: { expectsValue: 'foo' } },
-      { foo: ['bar', 'baz'], _: [] }
+      { argv: ['--foo=bar', '--foo=baz'], opts: { optionsWithValue: 'foo' } },
+      { options: { foo: 'baz' }, positionals: [] }
+    ],
+    [
+      {
+        argv: ['--foo=bar', '--foo=baz'],
+        opts: { optionsWithValue: 'foo', multiOptions: 'foo' }
+      },
+      { options: { foo: ['bar', 'baz'] }, positionals: [] }
     ],
     [
       { argv: ['--foo', '--foo'] },
-      { foo: 2, _: [] }
+      { options: { foo: true }, positionals: [] }
+    ],
+    [
+      { argv: ['--foo', '--foo'], opts: { multiOptions: 'foo' } },
+      { options: { foo: [true, true] }, positionals: [] }
     ],
     [
       { argv: ['--foo=true'] },
-      { foo: true, _: [] }
+      { options: { foo: true }, positionals: [] }
     ],
     [
       { argv: ['--foo=false'] },
-      { foo: true, _: [] }
+      { options: { foo: true }, positionals: [] }
     ],
     [
       { argv: ['--foo', 'true'] },
-      { foo: true, _: ['true'] }
+      { options: { foo: true }, positionals: ['true'] }
     ],
     [
-      { argv: ['--foo', 'true'], opts: { expectsValue: ['foo'] } },
-      { foo: 'true', _: [] }
+      { argv: ['--foo', 'true'], opts: { optionsWithValue: ['foo'] } },
+      { options: { foo: 'true' }, positionals: [] }
     ],
     [
-      { argv: ['--foo', 'false', 'false'], opts: { expectsValue: ['foo'] } },
-      { foo: 'false', _: ['false'] }
+      {
+        argv: ['--foo', 'false', 'false'],
+        opts: { optionsWithValue: ['foo'] }
+      },
+      { options: { foo: 'false' }, positionals: ['false'] }
     ],
     [
       { argv: ['--foo=true', '--foo=false'] },
-      { foo: 2, _: [] }
+      { options: { foo: true }, positionals: [] }
     ],
     [
       { argv: ['--foo', 'true', '--foo', 'false'] },
-      { foo: 2, _: ['true', 'false'] }
+      { options: { foo: true }, positionals: ['true', 'false'] }
     ],
     [
       { argv: ['--foo', 'true', '--foo', 'false'],
-        opts: { expectsValue: 'foo' } },
-      { foo: ['true', 'false'], _: [] }
+        opts: { optionsWithValue: 'foo', multiOptions: ['foo'] } },
+      { options: { foo: ['true', 'false'] }, positionals: [] }
+    ],
+    [
+      { argv: ['--foo', 'true', '--foo', 'false'],
+        opts: { optionsWithValue: 'foo' } },
+      { options: { foo: 'false' }, positionals: [] }
     ],
     [
       { argv: ['--foo', 'true', '--foo=false'],
-        opts: { expectsValue: 'foo' } },
-      { foo: ['true', 'false'], _: [] }
+        opts: { optionsWithValue: 'foo', multiOptions: ['foo'] } },
+      { options: { foo: ['true', 'false'] }, positionals: [] }
     ],
     [
       { argv: ['--foo', 'true', '--foo=false'] },
-      { foo: 2, _: ['true'] }
+      { options: { foo: true }, positionals: ['true'] }
     ],
     [
       {
         argv: ['--foo', 'bar', '--foo', 'baz'],
-        opts: { expectsValue: ['foo'] }
+        opts: { optionsWithValue: ['foo'], multiOptions: 'foo' }
       },
-      { foo: ['bar', 'baz'], _: [] }
+      { options: { foo: ['bar', 'baz'] }, positionals: [] }
     ],
     [
-      { argv: ['--foo', '--bar'], opts: { expectsValue: 'foo' } },
-      { foo: true, bar: true, _: [] }
+      { argv: ['--foo', '--bar'], opts: { optionsWithValue: 'foo' } },
+      { options: { foo: true, bar: true }, positionals: [] }
     ],
     [
-      { argv: ['--foo=--bar'], opts: { expectsValue: 'foo' } },
-      { foo: '--bar', _: [] }
+      { argv: ['--foo=--bar'], opts: { optionsWithValue: 'foo' } },
+      { options: { foo: '--bar' }, positionals: [] }
     ],
     [
       { argv: ['-_'] },
-      { _: [] }
+      { options: { _: true }, positionals: [] }
     ],
     [
-      { argv: ['--_=bar'], opts: { expectsValue: '_' } },
-      { _: [] }
+      { argv: ['--_=bar'], opts: { optionsWithValue: '_' } },
+      { options: { _: 'bar' }, positionals: [] }
     ],
     [
-      { argv: ['--_', 'bar'], opts: { expectsValue: '_' } },
-      { _: [] }
+      { argv: ['--_', 'bar'], opts: { optionsWithValue: '_' } },
+      { options: { _: 'bar' }, positionals: [] }
+    ],
+    [
+      { argv: [], opts: { optionsWithValue: 'foo', multiOptions: 'foo' } },
+      { options: { }, positionals: [] }
+    ],
+    [
+      { argv: [], opts: { multiOptions: 'foo' } },
+      { options: { }, positionals: [] }
     ]
   ]);
 
@@ -136,9 +163,13 @@ const { format, parseArgs } = require('util');
   const originalArgv = process.argv;
   process.argv = [process.execPath, __filename, '--foo', 'bar'];
   try {
-    assert.deepStrictEqual(parseArgs(), { foo: true, _: ['bar'] });
     assert.deepStrictEqual(
-      parseArgs({ expectsValue: 'foo' }), { foo: 'bar', _: [] }
+      parseArgs(),
+      { options: { foo: true }, positionals: ['bar'] }
+    );
+    assert.deepStrictEqual(
+      parseArgs({ optionsWithValue: 'foo' }),
+      { options: { foo: 'bar' }, positionals: [] }
     );
   } finally {
     process.argv = originalArgv;

--- a/test/parallel/test-util-parseargs.js
+++ b/test/parallel/test-util-parseargs.js
@@ -145,6 +145,10 @@ const { format, parseArgs } = require('util');
     [
       { argv: [], opts: { multiOptions: 'foo' } },
       { options: { }, positionals: [] }
+    ],
+    [
+      { argv: ['--foo'], opts: { optionsWithValue: 'foo' } },
+      { options: {}, positionals: [] }
     ]
   ]);
 

--- a/test/parallel/test-util-parseargs.js
+++ b/test/parallel/test-util-parseargs.js
@@ -67,11 +67,19 @@ const { format, parseArgs } = require('util');
     ],
     [
       { argv: ['--foo=false'] },
+      { options: { foo: false }, positionals: [] }
+    ],
+    [
+      { argv: ['--foo=bar'] },
       { options: { foo: true }, positionals: [] }
     ],
     [
       { argv: ['--foo', 'true'] },
       { options: { foo: true }, positionals: ['true'] }
+    ],
+    [
+      { argv: ['--foo', 'false'] },
+      { options: { foo: true }, positionals: ['false'] }
     ],
     [
       { argv: ['--foo', 'true'], opts: { optionsWithValue: ['foo'] } },
@@ -86,7 +94,7 @@ const { format, parseArgs } = require('util');
     ],
     [
       { argv: ['--foo=true', '--foo=false'] },
-      { options: { foo: true }, positionals: [] }
+      { options: { foo: false }, positionals: [] }
     ],
     [
       { argv: ['--foo', 'true', '--foo', 'false'] },
@@ -109,7 +117,7 @@ const { format, parseArgs } = require('util');
     ],
     [
       { argv: ['--foo', 'true', '--foo=false'] },
-      { options: { foo: true }, positionals: ['true'] }
+      { options: { foo: false }, positionals: ['true'] }
     ],
     [
       {

--- a/test/parallel/test-util-parseargs.js
+++ b/test/parallel/test-util-parseargs.js
@@ -156,7 +156,7 @@ const { format, parseArgs } = require('util');
     ],
     [
       { argv: ['--foo'], opts: { optionsWithValue: 'foo' } },
-      { options: {}, positionals: [] }
+      { options: { foo: '' }, positionals: [] }
     ]
   ]);
 

--- a/test/parallel/test-util-parseargs.js
+++ b/test/parallel/test-util-parseargs.js
@@ -1,0 +1,160 @@
+'use strict';
+
+const { invalidArgTypeHelper } = require('../common');
+const assert = require('assert');
+const { format, parseArgs } = require('util');
+
+{
+  const data = new Map([
+    [
+      { argv: ['--foo', '--bar'] },
+      { foo: true, bar: true, _: [] }
+    ],
+    [
+      { argv: ['--foo', '-b'] },
+      { foo: true, b: true, _: [] }
+    ],
+    [
+      { argv: ['---foo'] },
+      { foo: true, _: [] }
+    ],
+    [
+      { argv: ['--foo=bar'] },
+      { foo: true, _: [] }
+    ],
+    [
+      { argv: ['--foo=bar'], opts: { expectsValue: ['foo'] } },
+      { foo: 'bar', _: [] }
+    ],
+    [
+      { argv: ['--foo', 'bar'] },
+      { foo: true, _: ['bar'] }
+    ],
+    [
+      { argv: ['--foo', 'bar'], opts: { expectsValue: 'foo' } },
+      { foo: 'bar', _: [] }
+    ],
+    [
+      { argv: ['foo'] },
+      { _: ['foo'] }
+    ],
+    [
+      { argv: ['--foo', '--', '--bar'] },
+      { foo: true, _: ['--bar'] }
+    ],
+    [
+      { argv: ['--foo=bar', '--foo=baz'], opts: { expectsValue: 'foo' } },
+      { foo: ['bar', 'baz'], _: [] }
+    ],
+    [
+      { argv: ['--foo', '--foo'] },
+      { foo: 2, _: [] }
+    ],
+    [
+      { argv: ['--foo=true'] },
+      { foo: true, _: [] }
+    ],
+    [
+      { argv: ['--foo=false'] },
+      { foo: true, _: [] }
+    ],
+    [
+      { argv: ['--foo', 'true'] },
+      { foo: true, _: ['true'] }
+    ],
+    [
+      { argv: ['--foo', 'true'], opts: { expectsValue: ['foo'] } },
+      { foo: 'true', _: [] }
+    ],
+    [
+      { argv: ['--foo', 'false', 'false'], opts: { expectsValue: ['foo'] } },
+      { foo: 'false', _: ['false'] }
+    ],
+    [
+      { argv: ['--foo=true', '--foo=false'] },
+      { foo: 2, _: [] }
+    ],
+    [
+      { argv: ['--foo', 'true', '--foo', 'false'] },
+      { foo: 2, _: ['true', 'false'] }
+    ],
+    [
+      { argv: ['--foo', 'true', '--foo', 'false'],
+        opts: { expectsValue: 'foo' } },
+      { foo: ['true', 'false'], _: [] }
+    ],
+    [
+      { argv: ['--foo', 'true', '--foo=false'],
+        opts: { expectsValue: 'foo' } },
+      { foo: ['true', 'false'], _: [] }
+    ],
+    [
+      { argv: ['--foo', 'true', '--foo=false'] },
+      { foo: 2, _: ['true'] }
+    ],
+    [
+      {
+        argv: ['--foo', 'bar', '--foo', 'baz'],
+        opts: { expectsValue: ['foo'] }
+      },
+      { foo: ['bar', 'baz'], _: [] }
+    ],
+    [
+      { argv: ['--foo', '--bar'], opts: { expectsValue: 'foo' } },
+      { foo: true, bar: true, _: [] }
+    ],
+    [
+      { argv: ['--foo=--bar'], opts: { expectsValue: 'foo' } },
+      { foo: '--bar', _: [] }
+    ],
+    [
+      { argv: ['-_'] },
+      { _: [] }
+    ],
+    [
+      { argv: ['--_=bar'], opts: { expectsValue: '_' } },
+      { _: [] }
+    ],
+    [
+      { argv: ['--_', 'bar'], opts: { expectsValue: '_' } },
+      { _: [] }
+    ]
+  ]);
+
+  data.forEach((output, input) => {
+    const { argv, opts } = input;
+    assert.deepStrictEqual(
+      parseArgs(argv, opts),
+      output,
+      format('%o does not parse to %o', input, output)
+    );
+  });
+}
+
+{
+  // Use of `process.argv.slice(2)` as default `argv` value
+  const originalArgv = process.argv;
+  process.argv = [process.execPath, __filename, '--foo', 'bar'];
+  try {
+    assert.deepStrictEqual(parseArgs(), { foo: true, _: ['bar'] });
+    assert.deepStrictEqual(
+      parseArgs({ expectsValue: 'foo' }), { foo: 'bar', _: [] }
+    );
+  } finally {
+    process.argv = originalArgv;
+  }
+}
+
+{
+  // error checking
+  const value = 'strings not allowed';
+  assert.throws(() => {
+    parseArgs(value);
+  }, {
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError',
+    message:
+      'The "options" argument must be of type object.' +
+      invalidArgTypeHelper(value)
+  });
+}


### PR DESCRIPTION
Add a function, `util.parseArgs()`, which accepts an array of
arguments and returns a parsed object representation thereof.

Ref: https://github.com/nodejs/tooling/issues/19

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

* * *

### Motivation

While this has been discussed at length in the [Node.js Tooling Group](/nodejs/tooling) and its [associated issue](https://github.com/nodejs/tooling/issues/19), let me provide a summary:

- `process.argv.slice(2)` is rather awkward boilerplate, especially for those new to Node.js
- Parsing options without the use of a userland module reliably requires, well, about as much code as this PR adds; the complexity quickly ramps up going from _one_ argument to _two_
- It's often useful to add a few command-line flags in an ad-hoc manner to, say, `app.js`
- It's often useful to parse command-line flags in example code, which would otherwise demand installation of a userland module (thus complicating things)

`process.parseArgs()` makes handling command-line arguments "natively" much easier.  Given that _so many tools_ are being written in Node.js, it makes sense to center this experience.

### Design Considerations

First, let me acknowledge that _there are many ways to parse command-line arguments_.  There is no standard, cross-platform, agreed-upon convention.  Command-line arguments look different in Windows vs. POSIX vs. GNU, and there's much variation across programs.  _And_ these are still _conventions_, not hard & fast requirements.  We can easily be paralyzed attempting to choose what "styles" to support or not.  It is certain that there will be someone who agrees that Node.js should have this feature, but should not do it _in this way_.

But to implement the feature, we have to do it in _some_ way.  This is why _the way is the way it is_:

I have researched the various features and behavior of many popular userland command-line parsing libraries, and have distilled it down to the _most commonly supported features_, while striving further to trim any features which are not strictly necessary to get the bulk of the work done.  While these do not align to, say, POSIX conventions, they _do_ align with end-user expectations of how a Node.js CLI should work.  What follows is consideration of a few specific features.

#### The Requirement of `=` for Options Expecting a Value

For example, one may argue that `--foo=bar` should be the only way to use the value `bar` for the option `foo`; but users of CLI apps built on Node.js expect `--foo bar` to work just as well.  There was not a single popular argument-parsing library that did not support this behavior.  Thus, `process.parseArgs()` supports this behavior (it cannot be _automatic_ without  introducing ambiguity, but I will discuss that later).

#### Combination of Single-Character Flags

Another one is combining (or concatenating?) "short flags"--those using a single hyphen, like `-v`--where `-vD` would be equivalent to `-v -D`.  While this is a POSIX convention, it is not universally supported by the popular command-line parsers.  Since it is inherently _sugar_ (and makes the implementation more complicated), we chose not to implement it.

#### Data Types

Like HTML attribute values (`<tag attr="1">`), command-line arguments are provided to programs _as strings_, regardless of the data type they imply.  While most of the userland arg parsers support some notion of a "data type"-i.e., this argument value is a _number_, _string_, or _boolean_--it is not strictly necessary.  It is up to the user to handle the coercion of these values.

#### Default Behavior: Boolean Flags

The default behavior is to treat anything that looks like an argument (that's mainly "arguments beginning with one or more dashes") as a _boolean flag_.  The presence of one of these arguments implies `true`.  From investigation of popular CLI apps, we found that _most_ arguments are treated as boolean flags, so it makes sense for this to be the default behavior.  This means that a developer who just wants to know whether something is "on" or "off" will not need to provide any options to `process.parseArgs()`.

#### Handling Values

Some arguments _do_ need values, (e.g., `--require my-script.js`), and in order to eliminate ambiguity, the API consumer must define which arguments _expect a value_.  This is done via the `expectsValue` option to `process.parseArgs()`, which is the _only_ option to `process.parseArgs()`.  **This is the _only_ option `process.parseArgs()` accepts.**

_Possible alternatives:_

- Rename `expectsValue` to something else

#### Repeated Arguments

It's common to need to support multiple values for a single argument, e.g., `--require a.js --require b.js`.  In this example, `require` needs to be listed in the `expectsValue` option.  The result is an object containing a `require` property whose value is an array of strings; `['b.js', 'c.js']`.  In the example of `--require c.js`, the value of the `require` property is a string, `'c.js'`.

When working with boolean flags (those _not_ declared in `expectsValue`), it was trivial to support the case in which repeated arguments result in a _count_.  One `-v` will result in an object where `{v: true}`, but `-v -v` will result in `{v: 2}`.  Either way, the value will be _truthy_.

_Possible alternatives:_

- _Every_ argument expecting a value (as declared in `expectsValue`) will parse to _Array_ of strings, even if there is only one string in the Array (e.g., `--require c.js` becomes `{require: ['c.js']}`.  That makes the API more consistent at the expense of making the common case (no repetition) slightly more awkward.
- Remove the "count" behavior.  While this is widely supported by modules, I don't often see it used in the wild in Node.js CLI apps.

#### Positional Arguments

Arguments after `--` or without a dash prefix are considered "positional".  These are placed into the Array property `_` of the returned object.  This is a convention used by many other userland argparsers in Node.js.  It is always present, even if empty.  This _also_ means that `_` is _reserved_ as a flag/option name (e.g., `--_` will be ignored).

_Possible alternatives:_

- Throw if `_` is provided in `expectsValue`

### Intended Audience

It is already possible to build great arg parsing modules on top of what Node.js provides; the prickly API is abstracted away by these modules.  Thus, `process.parseArgs()` is not necessarily intended for library authors; it is intended for developers of simple CLI tools, ad-hoc scripts, deployed Node.js applications, and learning materials.

It is exceedingly difficult to provide an API which would _both_ be friendly to these Node.js users while being extensible enough for libraries to build upon.  We chose to prioritize these use cases because these are currently not well-served by Node.js' API.

### Questions

- In particular, I'm not 100% confident in the terminology I chose for the documentation ("Flags", "Options", "Positionals").  This _does_ align with other documentation I've read on the subject of CLI arguments, I am unsure if introducing this terminology to our documentation is a Good Idea.  Perhaps it can be expressed without new terminology.

- I sorted some files around my modification in in `node.gyp`, which looked like it _wanted_ to be in order, but was not.  It did not seem to affect the build, but I can revert these changes if need be.

- Should it be `process.parseArgv()`?  While it _does_ parse `process.argv` by default, it does not necessarily need to be used with `process.argv`.

- Do I need to do more input validation, throw more exceptions, or take other defensive measures?

### Credits

While this is my implementation, the design is a product of work by myself, @bcoe, @ruyadorno, and @nodejs/tooling.