### PR TITLE
src: shutdown libuv before exit()

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -705,6 +705,7 @@ void DefaultProcessExitHandler(Environment* env, int exit_code) {
   env->set_can_call_into_js(false);
   env->stop_sub_worker_contexts();
   DisposePlatform();
+  uv_library_shutdown();
   exit(exit_code);
 }
 

--- a/test/parallel/test-crypto-op-during-process-exit.js
+++ b/test/parallel/test-crypto-op-during-process-exit.js
@@ -1,0 +1,28 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto) { common.skip('missing crypto'); }
+const assert = require('assert');
+const { generateKeyPair } = require('crypto');
+
+if (common.isWindows) {
+  // Remove this conditional once the libuv change is in Node.js.
+  common.skip('crashing due to https://github.com/libuv/libuv/pull/2983');
+}
+
+// Regression test for a race condition: process.exit() might lead to OpenSSL
+// cleaning up state from the exit() call via calling its destructor, but
+// running OpenSSL operations on another thread might lead to them attempting
+// to initialize OpenSSL, leading to a crash.
+// This test crashed consistently on x64 Linux on Node v14.9.0.
+
+generateKeyPair('rsa', {
+  modulusLength: 2048,
+  privateKeyEncoding: {
+    type: 'pkcs1',
+    format: 'pem'
+  }
+}, (err/* , publicKey, privateKey */) => {
+  assert.ifError(err);
+});
+
+setTimeout(() => process.exit(), common.platformTimeout(10));


### PR DESCRIPTION
This ensures that no operations will be running on the libuv
threadpool, which is important because they may run into race
conditions with the global destructors being triggered from
`exit()`, such as in the added test example here.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
