### PR TITLE
doc: change requirements for objection dismissal

### DIFF
--- a/doc/guides/collaborator-guide.md
+++ b/doc/guides/collaborator-guide.md
@@ -134,8 +134,10 @@ actionable steps alongside the objection is recommended.
 If the objection is not clear to others, another collaborator can ask an
 objecting collaborator to explain their objection or to provide actionable
 steps to resolve the objection. **If the objector is unresponsive for seven
-days after a collaborator asks for clarification, another collaborator can
-dismiss the objection**.
+days after a collaborator asks for clarification or proposes a
+solution or compromise for the objection, another collaborator can dismiss
+the objection**. Be mindful of holidays and vacations before dismissing an
+objection.
 
 **Pull requests with outstanding objections must remain open until all
 objections are satisfied**. If reaching consensus is not possible, a


### PR DESCRIPTION
Previous version would allow dismissal only if the objector is
unresponsive to clarifications, but not if they are unresponsive while
other collaborators are trying to reach consensus with them. In the
spirit of collaboration the objector needs to be open to discuss
possible alternatives or should be willing to convince the PR author to
drop it. Only if reaching consensus is not possible (either to close the
PR or to make changes to it) the issue should be escalated to TSC.

Therefore the guideline is changed to allow dismissal if the objector is
unresponsive in the face of "a collaborator proposing a solution or a
compromise for the objection". Also adds a note for collaborators to be
mindful of holidays and vacations before dismissing an objection.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
