### PR TITLE
[v14.x] deps: V8: backport 3f071e3e7e15

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.13',
+    'v8_embedder_string': '-node.14',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/compiler/backend/ppc/code-generator-ppc.cc
+++ b/deps/v8/src/compiler/backend/ppc/code-generator-ppc.cc
@@ -1515,12 +1515,14 @@ CodeGenerator::CodeGenResult CodeGenerator::AssembleArchInstruction(
       }
       break;
     case kPPC_MulHigh32:
-      __ mulhw(i.OutputRegister(), i.InputRegister(0), i.InputRegister(1),
-               i.OutputRCBit());
+      __ mulhw(r0, i.InputRegister(0), i.InputRegister(1), i.OutputRCBit());
+      // High 32 bits are undefined and need to be cleared.
+      __ clrldi(i.OutputRegister(), r0, Operand(32));
       break;
     case kPPC_MulHighU32:
-      __ mulhwu(i.OutputRegister(), i.InputRegister(0), i.InputRegister(1),
-                i.OutputRCBit());
+      __ mulhwu(r0, i.InputRegister(0), i.InputRegister(1), i.OutputRCBit());
+      // High 32 bits are undefined and need to be cleared.
+      __ clrldi(i.OutputRegister(), r0, Operand(32));
       break;
     case kPPC_MulDouble:
       ASSEMBLE_FLOAT_BINOP_RC(fmul, MiscField::decode(instr->opcode()));


### PR DESCRIPTION
Original commit message:

    PPC: Optimize clearing higher bits of mulhw/mulhwu

    Change-Id: Ie3e14a6ef4531349e81a8ae741bc7470c7e547ca
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2349468
    Reviewed-by: Junliang Yan <jyan@ca.ibm.com>
    Commit-Queue: Milad Farazmand <miladfar@ca.ibm.com>
    Cr-Commit-Position: refs/heads/master@{#69343}

Refs: https://github.com/v8/v8/commit/3f071e3e7e15af187267af6c3b369029e27c8cf5

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
