### PR TITLE
test: make .out checks embedder-friendly

### DIFF
--- a/test/message/esm_loader_not_found.out
+++ b/test/message/esm_loader_not_found.out
@@ -1,5 +1,5 @@
 (node:*) ExperimentalWarning: --experimental-loader is an experimental feature. This feature could change at any time
-(Use `node --trace-warnings ...` to show where the warning was created)
+(Use `* --trace-warnings ...` to show where the warning was created)
 internal/process/esm_loader.js:*
     internalBinding('errors').triggerUncaughtException(
                               ^

--- a/test/message/esm_loader_not_found_cjs_hint_relative.out
+++ b/test/message/esm_loader_not_found_cjs_hint_relative.out
@@ -1,5 +1,5 @@
 (node:*) ExperimentalWarning: --experimental-loader is an experimental feature. This feature could change at any time
-(Use `node --trace-warnings ...` to show where the warning was created)
+(Use `* --trace-warnings ...` to show where the warning was created)
 internal/process/esm_loader.js:*
     internalBinding('errors').triggerUncaughtException(
                               ^

--- a/test/message/esm_loader_syntax_error.out
+++ b/test/message/esm_loader_syntax_error.out
@@ -1,5 +1,5 @@
 (node:*) ExperimentalWarning: --experimental-loader is an experimental feature. This feature could change at any time
-(Use `node --trace-warnings ...` to show where the warning was created)
+(Use `* --trace-warnings ...` to show where the warning was created)
 file://*/test/fixtures/es-module-loaders/syntax-error.mjs:2
 await async () => 0;
 ^^^^^^^^^^^^^

--- a/test/message/promise_unhandled_warn_with_error.out
+++ b/test/message/promise_unhandled_warn_with_error.out
@@ -6,5 +6,5 @@
     at *
     at *
     at *
-(Use `node --trace-warnings ...` to show where the warning was created)
+(Use `* --trace-warnings ...` to show where the warning was created)
 *UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)

--- a/test/pseudo-tty/test-tty-color-support-warning-2.out
+++ b/test/pseudo-tty/test-tty-color-support-warning-2.out
@@ -1,3 +1,3 @@
 
 (node:*) Warning: The 'NODE_DISABLE_COLORS' env is ignored due to the 'FORCE_COLOR' env being set.
-(Use `node --trace-warnings ...` to show where the warning was created)
+(Use `* --trace-warnings ...` to show where the warning was created)

--- a/test/pseudo-tty/test-tty-color-support-warning.out
+++ b/test/pseudo-tty/test-tty-color-support-warning.out
@@ -1,3 +1,3 @@
 
 (node:*) Warning: The 'NODE_DISABLE_COLORS' and 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
-(Use `node --trace-warnings ...` to show where the warning was created)
+(Use `* --trace-warnings ...` to show where the warning was created)

--- a/test/pseudo-tty/test-tty-color-support.out
+++ b/test/pseudo-tty/test-tty-color-support.out
@@ -1,2 +1,2 @@
 (node:*) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
-(Use `node --trace-warnings ...` to show where the warning was created)
+(Use `* --trace-warnings ...` to show where the warning was created)


### PR DESCRIPTION
Some of the color support tests in `pseudo-tty` and some esm tests in `message` were hardcoded to check the output messages against `node` - this causes failures in Electron's smoke tests against Node.js, since they'll output e.g:

```sh
(Use `electron --trace-warnings ...` to show where the warning was created)
```

in our case.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
