### PR TITLE
doc: format exponents better

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -3137,8 +3137,8 @@ added: v8.2.0
 
 * {integer} The largest size allowed for a single `Buffer` instance.
 
-On 32-bit architectures, this value currently is `(2^30)-1` (~1GB).
-On 64-bit architectures, this value currently is `(2^31)-1` (~2GB).
+On 32-bit architectures, this value currently is 2<sup>30</sup> - 1 (~1GB).
+On 64-bit architectures, this value currently is 2<sup>31</sup> - 1 (~2GB).
 
 This value is also available as [`buffer.kMaxLength`][].
 

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -2813,7 +2813,7 @@ added: REPLACEME
 Return a random integer `n` such that `min <= n < max`.  This
 implementation avoids [modulo bias][].
 
-The range (`max - min`) must be less than `2^48`. `min` and `max` must
+The range (`max - min`) must be less than 2<sup>48</sup>. `min` and `max` must
 be safe integers.
 
 If the `callback` function is not provided, the random integer is

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -2385,8 +2385,8 @@ This API is used to convert from the C `int64_t` type to the JavaScript
 The JavaScript `Number` type is described in [Section 6.1.6][]
 of the ECMAScript Language Specification. Note the complete range of `int64_t`
 cannot be represented with full precision in JavaScript. Integer values
-outside the range of [`Number.MIN_SAFE_INTEGER`][] `-(2^53 - 1)` -
-[`Number.MAX_SAFE_INTEGER`][] `(2^53 - 1)` will lose precision.
+outside the range of [`Number.MIN_SAFE_INTEGER`][] `-(2**53 - 1)` -
+[`Number.MAX_SAFE_INTEGER`][] `(2**53 - 1)` will lose precision.
 
 #### napi_create_double
 <!-- YAML
@@ -2932,7 +2932,7 @@ of the given JavaScript `Number`.
 
 If the number exceeds the range of the 32 bit integer, then the result is
 truncated to the equivalent of the bottom 32 bits. This can result in a large
-positive number becoming a negative number if the value is > 2^31 -1.
+positive number becoming a negative number if the value is > 2<sup>31</sup> - 1.
 
 Non-finite number values (`NaN`, `+Infinity`, or `-Infinity`) set the
 result to zero.
@@ -2961,7 +2961,8 @@ This API returns the C `int64` primitive equivalent of the given JavaScript
 `Number`.
 
 `Number` values outside the range of [`Number.MIN_SAFE_INTEGER`][]
-`-(2^53 - 1)` - [`Number.MAX_SAFE_INTEGER`][] `(2^53 - 1)` will lose precision.
+`-(2**53 - 1)` - [`Number.MAX_SAFE_INTEGER`][] `(2**53 - 1)` will lose
+precision.
 
 Non-finite number values (`NaN`, `+Infinity`, or `-Infinity`) set the
 result to zero.


### PR DESCRIPTION
The `2^n` notation is common in mathematics, but even then it often requires parentheses or braces. In JavaScript and C++, the `^` operator stands for bitwise xor, and should be avoided in the docs. In code tags, the JavaScript operator `**` can be used. Otherwise, the `sup` tag can be used for formatting.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
