### PR TITLE
crypto: fix randomInt range check

### DIFF
--- a/lib/internal/crypto/random.js
+++ b/lib/internal/crypto/random.js
@@ -149,8 +149,8 @@ function randomInt(min, max, cb) {
   if (!NumberIsSafeInteger(max)) {
     throw new ERR_INVALID_ARG_TYPE('max', 'safe integer', max);
   }
-  if (!(max >= min)) {
-    throw new ERR_OUT_OF_RANGE('max', `>= ${min}`, max);
+  if (max <= min) {
+    throw new ERR_OUT_OF_RANGE('max', `> ${min}`, max);
   }
 
   // First we generate a random int between [0..range)

--- a/test/parallel/test-crypto-random.js
+++ b/test/parallel/test-crypto-random.js
@@ -458,11 +458,14 @@ assert.throws(
 
   crypto.randomInt(1, common.mustCall());
   crypto.randomInt(0, 1, common.mustCall());
-  assert.throws(() => crypto.randomInt(0, common.mustNotCall()), {
-    code: 'ERR_OUT_OF_RANGE',
-    name: 'RangeError',
-    message: 'The value of "max" is out of range. It must be > 0. Received 0'
-  });
+  for (const arg of [[0], [1, 1], [3, 2], [-5, -5], [11, -10]]) {
+    assert.throws(() => crypto.randomInt(...arg, common.mustNotCall()), {
+      code: 'ERR_OUT_OF_RANGE',
+      name: 'RangeError',
+      message: 'The value of "max" is out of range. It must be > ' +
+               `${arg[arg.length - 2] || 0}. Received ${arg[arg.length - 1]}`
+    });
+  }
 
   const MAX_RANGE = 0xFFFF_FFFF_FFFF;
   crypto.randomInt(MAX_RANGE, common.mustCall());

--- a/test/parallel/test-crypto-random.js
+++ b/test/parallel/test-crypto-random.js
@@ -456,12 +456,12 @@ assert.throws(
     }
   );
 
-  crypto.randomInt(0, common.mustCall());
-  crypto.randomInt(0, 0, common.mustCall());
-  assert.throws(() => crypto.randomInt(-1, common.mustNotCall()), {
+  crypto.randomInt(1, common.mustCall());
+  crypto.randomInt(0, 1, common.mustCall());
+  assert.throws(() => crypto.randomInt(0, common.mustNotCall()), {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
-    message: 'The value of "max" is out of range. It must be >= 0. Received -1'
+    message: 'The value of "max" is out of range. It must be > 0. Received 0'
   });
 
   const MAX_RANGE = 0xFFFF_FFFF_FFFF;


### PR DESCRIPTION
The current implementation allows `crypto.randomInt(0)` and returns `NaN`.

Refs: https://github.com/nodejs/node/pull/34600

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
