### PR TITLE
doc: add link describing _safe integers_ in crypto.md

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -2814,7 +2814,7 @@ Return a random integer `n` such that `min <= n < max`.  This
 implementation avoids [modulo bias][].
 
 The range (`max - min`) must be less than `2^48`. `min` and `max` must
-be safe integers.
+be [safe integers][].
 
 If the `callback` function is not provided, the random integer is
 generated synchronously.
@@ -3622,7 +3622,8 @@ See the [list of SSL OP Flags][] for details.
 [RFC 5208]: https://www.rfc-editor.org/rfc/rfc5208.txt
 [encoding]: buffer.html#buffer_buffers_and_character_encodings
 [initialization vector]: https://en.wikipedia.org/wiki/Initialization_vector
-[scrypt]: https://en.wikipedia.org/wiki/Scrypt
-[stream-writable-write]: stream.html#stream_writable_write_chunk_encoding_callback
-[stream]: stream.html
 [list of SSL OP Flags]: wiki.openssl.org/index.php/List_of_SSL_OP_Flags#Table_of_Options
+[safe integers]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isSafeInteger
+[scrypt]: https://en.wikipedia.org/wiki/Scrypt
+[stream]: stream.html
+[stream-writable-write]: stream.html#stream_writable_write_chunk_encoding_callback


### PR DESCRIPTION
Link to MDN document on `Number.isSafeInteger()` so people unfamiliar
with the concept of a _safe integer_ have a convenient resource.

While adding the link, I noticed that some of the links at the end were
not in ASCII order, so I moved them to the right place in the list.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
