### PR TITLE
deps: V8: cherry-pick 6be2f6e26e8d

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.15',
+    'v8_embedder_string': '-node.16',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/debug/debug-evaluate.cc
+++ b/deps/v8/src/debug/debug-evaluate.cc
@@ -473,6 +473,7 @@ bool BytecodeHasNoSideEffect(interpreter::Bytecode bytecode) {
     case Bytecode::kToNumeric:
     case Bytecode::kToString:
     // Misc.
+    case Bytecode::kIncBlockCounter:  // Coverage counters.
     case Bytecode::kForInEnumerate:
     case Bytecode::kForInPrepare:
     case Bytecode::kForInContinue:

--- a/deps/v8/test/inspector/debugger/side-effect-free-coverage-enabled-expected.txt
+++ b/deps/v8/test/inspector/debugger/side-effect-free-coverage-enabled-expected.txt
@@ -1,0 +1,3 @@
+Tests side-effect-free evaluation with coverage enabled
+Paused on 'debugger;'
+f() returns 1

--- a/deps/v8/test/inspector/debugger/side-effect-free-coverage-enabled.js
+++ b/deps/v8/test/inspector/debugger/side-effect-free-coverage-enabled.js
@@ -1,0 +1,43 @@
+// Copyright 2020 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+let {session, contextGroup, Protocol} = InspectorTest.start('Tests side-effect-free evaluation with coverage enabled');
+
+contextGroup.addScript(`
+function testFunction()
+{
+  var o = 0;
+  function f() { return 1; }
+  function g() { o = 2; return o; }
+  f,g;
+  debugger;
+}
+//# sourceURL=foo.js`);
+
+// Side effect free call should not result in EvalError when coverage
+// is enabled:
+Protocol.Profiler.enable()
+Protocol.Profiler.startPreciseCoverage({callCount: true, detailed: true})
+
+Protocol.Debugger.enable();
+
+Protocol.Debugger.oncePaused().then(debuggerPaused);
+
+Protocol.Runtime.evaluate({ "expression": "setTimeout(testFunction, 0)" });
+
+var topFrameId;
+
+function debuggerPaused(messageObject)
+{
+  InspectorTest.log("Paused on 'debugger;'");
+
+  topFrameId = messageObject.params.callFrames[0].callFrameId;
+  Protocol.Debugger.evaluateOnCallFrame({ callFrameId: topFrameId, expression: "f()", throwOnSideEffect: true}).then(evaluatedFirst);
+}
+
+function evaluatedFirst(response)
+{
+  InspectorTest.log("f() returns " + response.result.result.value);
+  InspectorTest.completeTest();
+}

--- a/deps/v8/test/inspector/inspector.status
+++ b/deps/v8/test/inspector/inspector.status
@@ -33,6 +33,7 @@
   'debugger/eval-scopes': [PASS, FAIL],
   'debugger/scope-skip-variables-with-empty-name': [PASS, FAIL],
   'debugger/update-call-frame-scopes': [PASS, FAIL],
+  'debugger/side-effect-free-coverage-enabled': [PASS, FAIL],
   'debugger/side-effect-free-debug-evaluate': [PASS, FAIL],
   'debugger/evaluate-on-call-frame-in-module': [PASS, FAIL],
 }],  # variant != default


### PR DESCRIPTION
Original commit message:

    [coverage] IncBlockCounter should not be side-effect

    Incrementing coverage counter was triggering EvalError for
    evaluateOnCallFrame when throwOnSideEffect is true.

    R=jgruber@chromium.org, sigurds@chromium.org, yangguo@chromium.org

    Bug: v8:10856
    Change-Id: I0552e19a3a14ff61a9cb626494fb4a21979d535e
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2384011
    Commit-Queue: Benjamin Coe <bencoe@google.com>
    Reviewed-by: Jakob Gruber <jgruber@chromium.org>
    Reviewed-by: Yang Guo <yangguo@chromium.org>
    Reviewed-by: Sigurd Schneider <sigurds@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#69628}

Refs: https://github.com/v8/v8/commit/6be2f6e26e8ddfbc1a48c510672b319809674a34

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
