### PR TITLE
tools: fix doc build targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -738,7 +738,7 @@ out/doc/api/assets:
 	if [ -d doc/api/assets ]; then cp -r doc/api/assets out/doc/api; fi;
 
 # If it's not a source tarball, we need to copy assets from doc/api_assets
-out/doc/api/assets/%: doc/api_assets/% out/doc/api/assets
+out/doc/api/assets/%: doc/api_assets/% | out/doc/api/assets
 	@cp $< $@ ; $(RM) out/doc/api/assets/README.md
 
 
@@ -751,7 +751,7 @@ gen-api = tools/doc/generate.js --node-version=$(FULLVERSION) \
 		--versions-file=$(VERSIONS_DATA)
 gen-apilink = tools/doc/apilinks.js $(LINK_DATA) $(wildcard lib/*.js)
 
-$(LINK_DATA): $(wildcard lib/*.js) tools/doc/apilinks.js
+$(LINK_DATA): $(wildcard lib/*.js) tools/doc/apilinks.js | out/doc
 	$(call available-node, $(gen-apilink))
 
 # Regenerate previous versions data if the current version changes
@@ -760,14 +760,14 @@ $(VERSIONS_DATA): CHANGELOG.md src/node_version.h tools/doc/versions.js
 
 out/doc/api/%.json out/doc/api/%.html: doc/api/%.md tools/doc/generate.js \
 	tools/doc/markdown.js tools/doc/html.js tools/doc/json.js \
-	tools/doc/apilinks.js $(VERSIONS_DATA) | $(LINK_DATA)
+	tools/doc/apilinks.js $(VERSIONS_DATA) | $(LINK_DATA) out/doc/api
 	$(call available-node, $(gen-api))
 
 out/doc/api/all.html: $(apidocs_html) tools/doc/allhtml.js \
-	tools/doc/apilinks.js
+	tools/doc/apilinks.js | out/doc/api
 	$(call available-node, tools/doc/allhtml.js)
 
-out/doc/api/all.json: $(apidocs_json) tools/doc/alljson.js
+out/doc/api/all.json: $(apidocs_json) tools/doc/alljson.js | out/doc/api
 	$(call available-node, tools/doc/alljson.js)
 
 .PHONY: docopen


### PR DESCRIPTION
Adds doc output directory as order-only prerequisite for build target.

Currently, here is the issue:

```console
$ make docclean > /dev/null
$ make out/doc/api/addons.html > /dev/null
internal/fs/utils.js:298
    throw err;
    ^

Error: ENOENT: no such file or directory, open 'out/doc/apilinks.json'
    at Object.openSync (fs.js:465:3)
    at Object.writeFileSync (fs.js:1416:35)
    at Object.<anonymous> (…/tools/doc/apilinks.js:211:4)
    at Module._compile (internal/modules/cjs/loader.js:1090:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1111:10)
    at Module.load (internal/modules/cjs/loader.js:955:32)
    at Function.Module._load (internal/modules/cjs/loader.js:796:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:72:12)
    at internal/main/run_main_module.js:17:47 {
  errno: -2,
  syscall: 'open',
  code: 'ENOENT',
  path: 'out/doc/apilinks.json'
}
make: *** [out/doc/apilinks.json] Error 1
$ mkdir out/doc
$ make out/doc/api/addons.html > /dev/null
[Error: ENOENT: no such file or directory, open 'out/doc/api/addons.html'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: 'out/doc/api/addons.html'
}
[Error: ENOENT: no such file or directory, open 'out/doc/api/addons.json'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: 'out/doc/api/addons.json'
}
make: *** [out/doc/api/addons.html] Error 1
```

The problem is that the `out/doc/api` directory is not created before trying to generate the files, which fails. This PR adds the directories as prerequisites to ensure the files can be generated.

Repported by @DerekNonGeneric in https://github.com/nodejs/node/pull/34986#issuecomment-687427703.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
