### PR TITLE
crypto: simplify KeyObject constructor

### DIFF
--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -43,13 +43,6 @@ for (const m of [[kKeyEncodingPKCS1, 'pkcs1'], [kKeyEncodingPKCS8, 'pkcs8'],
                  [kKeyEncodingSPKI, 'spki'], [kKeyEncodingSEC1, 'sec1']])
   encodingNames[m[0]] = m[1];
 
-function checkKeyTypeAndHandle(type, handle) {
-  if (type !== 'secret' && type !== 'public' && type !== 'private')
-    throw new ERR_INVALID_ARG_VALUE('type', type);
-  if (typeof handle !== 'object' || !(handle instanceof KeyObjectHandle))
-    throw new ERR_INVALID_ARG_TYPE('handle', 'object', handle);
-}
-
 // Creating the KeyObject class is a little complicated due to inheritance
 // and that fact that KeyObjects should be transferrable between threads,
 // which requires the KeyObject base class to be implemented in C++.
@@ -64,7 +57,12 @@ const [
   // Publicly visible KeyObject class.
   class KeyObject extends NativeKeyObject {
     constructor(type, handle) {
-      super(checkKeyTypeAndHandle(type, handle) || handle);
+      if (type !== 'secret' && type !== 'public' && type !== 'private')
+        throw new ERR_INVALID_ARG_VALUE('type', type);
+      if (typeof handle !== 'object' || !(handle instanceof KeyObjectHandle))
+        throw new ERR_INVALID_ARG_TYPE('handle', 'object', handle);
+
+      super(handle);
 
       this[kKeyType] = type;
 


### PR DESCRIPTION
Inline a function that only gets called in the constructor. Make call to
`super()` more straightforward in the process by removing conditional
involving the function as it only ever returns `undefined` or else
throws. That made the code a little hard to understand, as without
looking at the function, one would likely expect it to return `true`
on success rather than `undefined`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
