### PR TITLE
test: add more valid results to test-trace-atomics-wait

### DIFF
--- a/test/parallel/test-trace-atomics-wait.js
+++ b/test/parallel/test-trace-atomics-wait.js
@@ -56,6 +56,11 @@ const expectedTimelines = [
 [Thread 0] Atomics.wait(<address> + 4, 0, inf) was woken up by another thread
 [Thread 1] Atomics.wait(<address> + 4, -1, inf) was woken up by another thread`,
   `${begin}
+[Thread 1] Atomics.wait(<address> + 4, 0, inf) started
+[Thread 0] Atomics.wait(<address> + 4, -1, inf) started
+[Thread 0] Atomics.wait(<address> + 4, 0, inf) was woken up by another thread
+[Thread 1] Atomics.wait(<address> + 4, -1, inf) was woken up by another thread`,
+  `${begin}
 [Thread 0] Atomics.wait(<address> + 4, 0, inf) started
 [Thread 0] Atomics.wait(<address> + 4, 0, inf) was woken up by another thread
 [Thread 1] Atomics.wait(<address> + 4, -1, inf) started
@@ -73,12 +78,18 @@ values mismatched`,
 [Thread 1] Atomics.wait(<address> + 4, -1, inf) did not wait because the \
 values mismatched`,
   `${begin}
+[Thread 1] Atomics.wait(<address> + 4, 0, inf) started
+[Thread 0] Atomics.wait(<address> + 4, -1, inf) started
+[Thread 0] Atomics.wait(<address> + 4, 0, inf) was woken up by another thread
+[Thread 1] Atomics.wait(<address> + 4, -1, inf) did not wait because the \
+values mismatched`,
+  `${begin}
 [Thread 0] Atomics.wait(<address> + 4, 0, inf) started
 [Thread 0] Atomics.wait(<address> + 4, 0, inf) did not wait because the \
 values mismatched
 [Thread 1] Atomics.wait(<address> + 4, -1, inf) started
 [Thread 1] Atomics.wait(<address> + 4, -1, inf) did not wait because the \
-values mismatched`
+values mismatched`,
 ];
 
 assert(expectedTimelines.includes(actualTimeline));


### PR DESCRIPTION
The two starting `Atomics.wait()` operations are not ordered,
but the test assumed a specific ordering because of the latency
that comes with spinning up a Worker thread.

Add variants of the existing potential valid results that account
for the reverse ordering.

Fixes: https://github.com/nodejs/node/issues/35059

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
