### PR TITLE
doc: debugger, updated instructions.

### DIFF
--- a/doc/api/debugger.md
+++ b/doc/api/debugger.md
@@ -189,7 +189,7 @@ Debugger listening on ws://127.0.0.1:9229/dc9010dd-f8b8-4ac5-a510-c1a114ec7d29
 For help, see: https://nodejs.org/en/docs/inspector
 ```
 
-In Chrome, open [chrome://inspect][],  find "index" under "Remote Target", 
+In Chrome, open [chrome://inspect][],  find "index" under "Remote Target",
 and click "inspect".
 
 (In the example above, the UUID dc9010dd-f8b8-4ac5-a510-c1a114ec7d29

--- a/doc/api/debugger.md
+++ b/doc/api/debugger.md
@@ -189,12 +189,12 @@ Debugger listening on ws://127.0.0.1:9229/dc9010dd-f8b8-4ac5-a510-c1a114ec7d29
 For help, see: https://nodejs.org/en/docs/inspector
 ```
 
+In Chrome, open [chrome://inspect][],  find "index" under "Remote Target", 
+and click "inspect".
+
 (In the example above, the UUID dc9010dd-f8b8-4ac5-a510-c1a114ec7d29
 at the end of the URL is generated on the fly, it varies in different
 debugging sessions.)
-
-If the Chrome browser is older than 66.0.3345.0,
-use `inspector.html` instead of `js_app.html` in the above URL.
 
 Chrome DevTools doesn't support debugging [worker threads][] yet.
 [ndb][] can be used to debug them.
@@ -203,3 +203,4 @@ Chrome DevTools doesn't support debugging [worker threads][] yet.
 [V8 Inspector]: #debugger_v8_inspector_integration_for_node_js
 [worker threads]: worker_threads.html
 [ndb]: https://github.com/GoogleChromeLabs/ndb/
+[chrome://inspect]: chrome://inspect


### PR DESCRIPTION
The output for the CLI output when using the --inspect flag at one point gave a URL to open the inspector in Chrome. This was updated in the doc in commit: fd7e40854c447234a05dc3ef0ee717cad138c681
The new URL displayed by the CLI is `https://nodejs.org/en/docs/inspector`, a different doc that isn't helpful for accessing the inspector.
I feel that the instructions for launching the inspector should be added to the CLI output, but that also involves updating the tests, and several other places where the output for that flag are referenced. Barring that, CLI output should either reference this document, or this instruction should be added to the inspector doc. I'm happy to make these changes, but I thought I should submit the minimal change first to correct this doc.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
