### PR TITLE
test: fix comment about DNS lookup test

### DIFF
--- a/test/parallel/test-c-ares.js
+++ b/test/parallel/test-c-ares.js
@@ -42,8 +42,7 @@ const dnsPromises = dns.promises;
   assert.strictEqual(res.family, 6);
 })().then(common.mustCall());
 
-// Try resolution without callback
-
+// Try resolution without hostname.
 dns.lookup(null, common.mustCall((error, result, addressType) => {
   assert.ifError(error);
   assert.strictEqual(result, null);


### PR DESCRIPTION
This comment has been there for about 10.5 years (see f13e2f96e40ecdd6e76854508c3b0cad6bcd1a8d), but I don't think it has ever been an accurate description of the test. (Unless I am missing something, of course.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
