### PR TITLE
doc: fix deprecation documentation inconsistencies

### DIFF
--- a/doc/api/domain.md
+++ b/doc/api/domain.md
@@ -1,5 +1,6 @@
 # Domain
 <!-- YAML
+deprecated: v1.4.2
 changes:
   - version: v8.8.0
     description: Any `Promise`s created in VM contexts no longer have a

--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -305,7 +305,7 @@ The `'removeListener'` event is emitted *after* the `listener` is removed.
 ### `EventEmitter.listenerCount(emitter, eventName)`
 <!-- YAML
 added: v0.9.12
-deprecated: v4.0.0
+deprecated: v3.2.0
 -->
 
 > Stability: 0 - Deprecated: Use [`emitter.listenerCount()`][] instead.

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2403,6 +2403,8 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/7897
     description: The `callback` parameter is no longer optional. Not passing
                  it will emit a deprecation warning with id DEP0013.
+  - version: v0.4.7
+    description: Documentation-only deprecation.
 -->
 
 * `path` {string|Buffer|URL}
@@ -2420,6 +2422,8 @@ changes:
   - version: v10.6.0
     pr-url: https://github.com/nodejs/node/pull/21498
     description: This API is no longer deprecated.
+  - version: v0.4.7
+    description: Documentation-only deprecation.
 -->
 
 * `path` {string|Buffer|URL}

--- a/doc/api/punycode.md
+++ b/doc/api/punycode.md
@@ -1,9 +1,6 @@
 # Punycode
 <!-- YAML
-changes:
-  - version: v7.0.0
-    pr-url: https://github.com/nodejs/node/pull/7941
-    description: Accessing this module will now emit a deprecation warning.
+deprecated: v7.0.0
 -->
 
 <!--introduced_in=v0.10.0-->


### PR DESCRIPTION
I've noticed a few inconsistencies between `deprecations.md` and other doc files:

* `domain.md` doesn't indicate in which version its deprecation was introduced (https://nodejs.org/docs/latest/api/deprecations.html#DEP0032).
* `EventEmitter.listenerCount` indicates a deprecation introduced in `v4.0.0` in `events.md`, but it's `v3.2.0` according to `deprecations.md` (https://nodejs.org/docs/latest/api/deprecations.html#DEP0033).
* `fs.lchown`[`Sync`] indicates when its deprecation was revoked, but not when it was assigned in `fs.md` (https://nodejs.org/docs/latest/api/deprecations.html#DEP0037 & https://nodejs.org/docs/latest/api/deprecations.html#DEP0038).
*  `punycode.md` indicates a runtime deprecation, but instead it's a documentation-only deprecation (https://nodejs.org/docs/latest/api/deprecations.html#DEP0040).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
