### PR TITLE
test: add common.mustSucceed

### DIFF
--- a/doc/guides/writing-tests.md
+++ b/doc/guides/writing-tests.md
@@ -209,6 +209,11 @@ const server = http.createServer(common.mustCall((req, res) => {
 
 ```
 
+**Note:** Many functions invoke their callback with an `err` value as the first
+argument. It is not a good idea to simply pass `common.mustCall()` to those
+because `common.mustCall()` will ignore the error. Use `common.mustSucceed()`
+instead.
+
 #### Countdown Module
 
 The common [Countdown module](https://github.com/nodejs/node/tree/master/test/common#countdown-module)

--- a/test/.eslintrc.yaml
+++ b/test/.eslintrc.yaml
@@ -50,6 +50,7 @@ rules:
   node-core/prefer-assert-iferror: error
   node-core/prefer-assert-methods: error
   node-core/prefer-common-mustnotcall: error
+  node-core/prefer-common-mustsucceed: error
   node-core/crypto-check: error
   node-core/eslint-check: error
   node-core/async-iife-no-unused-result: error

--- a/test/common/README.md
+++ b/test/common/README.md
@@ -314,6 +314,15 @@ If `fn` is not provided, an empty function will be used.
 Returns a function that triggers an `AssertionError` if it is invoked. `msg` is
 used as the error message for the `AssertionError`.
 
+### `mustSucceed([fn])`
+
+* `fn` [&lt;Function>][] default = () => {}
+* return [&lt;Function>][]
+
+Returns a function that accepts arguments `(err, ...args)`. If `err` is not
+`undefined` or `null`, it triggers an `AssertionError`. Otherwise, it calls
+`fn(...args)`.
+
 ### `nodeProcessAborted(exitCode, signal)`
 
 * `exitCode` [&lt;number>][]

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -327,6 +327,14 @@ function mustCall(fn, exact) {
   return _mustCallInner(fn, exact, 'exact');
 }
 
+function mustSucceed(fn, exact) {
+  return mustCall(function(err, ...args) {
+    assert.ifError(err);
+    if (typeof fn === 'function')
+      return fn.apply(this, args);
+  }, exact);
+}
+
 function mustCallAtLeast(fn, minimum) {
   return _mustCallInner(fn, minimum, 'minimum');
 }
@@ -714,6 +722,7 @@ const common = {
   mustCall,
   mustCallAtLeast,
   mustNotCall,
+  mustSucceed,
   nodeProcessAborted,
   PIPE,
   platformTimeout,

--- a/test/doctool/test-doctool-json.js
+++ b/test/doctool/test-doctool-json.js
@@ -229,10 +229,8 @@ const testData = [
 ];
 
 testData.forEach((item) => {
-  fs.readFile(item.file, 'utf8', common.mustCall((err, input) => {
-    assert.ifError(err);
-    toJSON(input, 'foo', common.mustCall((err, output) => {
-      assert.ifError(err);
+  fs.readFile(item.file, 'utf8', common.mustSucceed((input) => {
+    toJSON(input, 'foo', common.mustSucceed((output) => {
       assert.deepStrictEqual(output.json, item.json);
     }));
   }));

--- a/test/internet/test-dns-any.js
+++ b/test/internet/test-dns-any.js
@@ -127,7 +127,7 @@ TEST(async function test_sip2sip_for_naptr(done) {
   const req = dns.resolve(
     'sip2sip.info',
     'ANY',
-    common.mustSucceed(function(ret) {
+    common.mustSucceed((ret) => {
       validateResult(ret);
       done();
     }));
@@ -146,7 +146,7 @@ TEST(async function test_google_for_cname_and_srv(done) {
   const req = dns.resolve(
     '_jabber._tcp.google.com',
     'ANY',
-    common.mustSucceed(function(ret) {
+    common.mustSucceed((ret) => {
       validateResult(ret);
       done();
     }));
@@ -165,7 +165,7 @@ TEST(async function test_ptr(done) {
   const req = dns.resolve(
     '8.8.8.8.in-addr.arpa',
     'ANY',
-    common.mustSucceed(function(ret) {
+    common.mustSucceed((ret) => {
       validateResult(ret);
       done();
     }));

--- a/test/internet/test-dns-any.js
+++ b/test/internet/test-dns-any.js
@@ -127,8 +127,7 @@ TEST(async function test_sip2sip_for_naptr(done) {
   const req = dns.resolve(
     'sip2sip.info',
     'ANY',
-    common.mustCall(function(err, ret) {
-      assert.ifError(err);
+    common.mustSucceed(function(ret) {
       validateResult(ret);
       done();
     }));
@@ -147,8 +146,7 @@ TEST(async function test_google_for_cname_and_srv(done) {
   const req = dns.resolve(
     '_jabber._tcp.google.com',
     'ANY',
-    common.mustCall(function(err, ret) {
-      assert.ifError(err);
+    common.mustSucceed(function(ret) {
       validateResult(ret);
       done();
     }));
@@ -167,8 +165,7 @@ TEST(async function test_ptr(done) {
   const req = dns.resolve(
     '8.8.8.8.in-addr.arpa',
     'ANY',
-    common.mustCall(function(err, ret) {
-      assert.ifError(err);
+    common.mustSucceed(function(ret) {
       validateResult(ret);
       done();
     }));

--- a/test/internet/test-dns-ipv4.js
+++ b/test/internet/test-dns-ipv4.js
@@ -50,8 +50,7 @@ TEST(async function test_resolve4(done) {
 
   const req = dns.resolve4(
     addresses.INET4_HOST,
-    common.mustCall((err, ips) => {
-      assert.ifError(err);
+    common.mustSucceed((ips) => {
       validateResult(ips);
       done();
     }));
@@ -73,8 +72,7 @@ TEST(async function test_reverse_ipv4(done) {
 
   const req = dns.reverse(
     addresses.INET4_IP,
-    common.mustCall((err, domains) => {
-      assert.ifError(err);
+    common.mustSucceed((domains) => {
       validateResult(domains);
       done();
     }));
@@ -92,8 +90,7 @@ TEST(async function test_lookup_ipv4_explicit(done) {
 
   const req = dns.lookup(
     addresses.INET4_HOST, 4,
-    common.mustCall((err, ip, family) => {
-      assert.ifError(err);
+    common.mustSucceed((ip, family) => {
       validateResult({ address: ip, family });
       done();
     }));
@@ -111,8 +108,7 @@ TEST(async function test_lookup_ipv4_implicit(done) {
 
   const req = dns.lookup(
     addresses.INET4_HOST,
-    common.mustCall((err, ip, family) => {
-      assert.ifError(err);
+    common.mustSucceed((ip, family) => {
       validateResult({ address: ip, family });
       done();
     }));
@@ -130,8 +126,7 @@ TEST(async function test_lookup_ipv4_explicit_object(done) {
 
   const req = dns.lookup(addresses.INET4_HOST, {
     family: 4
-  }, common.mustCall((err, ip, family) => {
-    assert.ifError(err);
+  }, common.mustSucceed((ip, family) => {
     validateResult({ address: ip, family });
     done();
   }));
@@ -151,8 +146,7 @@ TEST(async function test_lookup_ipv4_hint_addrconfig(done) {
 
   const req = dns.lookup(addresses.INET4_HOST, {
     hints: dns.ADDRCONFIG
-  }, common.mustCall((err, ip, family) => {
-    assert.ifError(err);
+  }, common.mustSucceed((ip, family) => {
     validateResult({ address: ip, family });
     done();
   }));
@@ -169,8 +163,7 @@ TEST(async function test_lookup_ip_ipv4(done) {
   validateResult(await dnsPromises.lookup('127.0.0.1'));
 
   const req = dns.lookup('127.0.0.1',
-                         common.mustCall((err, ip, family) => {
-                           assert.ifError(err);
+                         common.mustSucceed((ip, family) => {
                            validateResult({ address: ip, family });
                            done();
                          }));
@@ -187,8 +180,7 @@ TEST(async function test_lookup_localhost_ipv4(done) {
   validateResult(await dnsPromises.lookup('localhost', 4));
 
   const req = dns.lookup('localhost', 4,
-                         common.mustCall((err, ip, family) => {
-                           assert.ifError(err);
+                         common.mustSucceed((ip, family) => {
                            validateResult({ address: ip, family });
                            done();
                          }));
@@ -215,8 +207,7 @@ TEST(async function test_lookup_all_ipv4(done) {
   const req = dns.lookup(
     addresses.INET4_HOST,
     { all: true, family: 4 },
-    common.mustCall((err, ips) => {
-      assert.ifError(err);
+    common.mustSucceed((ips) => {
       validateResult(ips);
       done();
     })
@@ -236,8 +227,7 @@ TEST(async function test_lookupservice_ip_ipv4(done) {
 
   const req = dns.lookupService(
     '127.0.0.1', 80,
-    common.mustCall((err, hostname, service) => {
-      assert.ifError(err);
+    common.mustSucceed((hostname, service) => {
       validateResult({ hostname, service });
       done();
     })

--- a/test/internet/test-dns-ipv6.js
+++ b/test/internet/test-dns-ipv6.js
@@ -52,8 +52,7 @@ TEST(async function test_resolve6(done) {
 
   const req = dns.resolve6(
     addresses.INET6_HOST,
-    common.mustCall((err, ips) => {
-      assert.ifError(err);
+    common.mustSucceed((ips) => {
       validateResult(ips);
       done();
     }));
@@ -74,8 +73,7 @@ TEST(async function test_reverse_ipv6(done) {
 
   const req = dns.reverse(
     addresses.INET6_IP,
-    common.mustCall((err, domains) => {
-      assert.ifError(err);
+    common.mustSucceed((domains) => {
       validateResult(domains);
       done();
     }));
@@ -94,8 +92,7 @@ TEST(async function test_lookup_ipv6_explicit(done) {
   const req = dns.lookup(
     addresses.INET6_HOST,
     6,
-    common.mustCall((err, ip, family) => {
-      assert.ifError(err);
+    common.mustSucceed((ip, family) => {
       validateResult({ address: ip, family });
       done();
     }));
@@ -126,8 +123,7 @@ TEST(async function test_lookup_ipv6_explicit_object(done) {
 
   const req = dns.lookup(addresses.INET6_HOST, {
     family: 6
-  }, common.mustCall((err, ip, family) => {
-    assert.ifError(err);
+  }, common.mustSucceed((ip, family) => {
     validateResult({ address: ip, family });
     done();
   }));
@@ -173,8 +169,7 @@ TEST(async function test_lookup_ip_ipv6(done) {
 
   const req = dns.lookup(
     '::1',
-    common.mustCall((err, ip, family) => {
-      assert.ifError(err);
+    common.mustSucceed((ip, family) => {
       validateResult({ address: ip, family });
       done();
     }));
@@ -202,8 +197,7 @@ TEST(async function test_lookup_all_ipv6(done) {
   const req = dns.lookup(
     addresses.INET6_HOST,
     { all: true, family: 6 },
-    common.mustCall((err, ips) => {
-      assert.ifError(err);
+    common.mustSucceed((ips) => {
       validateResult(ips);
       done();
     })

--- a/test/internet/test-http2-issue-32922.js
+++ b/test/internet/test-http2-issue-32922.js
@@ -1,6 +1,5 @@
 'use strict';
 const common = require('../common');
-const assert = require('assert');
 
 if (!common.hasCrypto)
   common.skip('missing crypto');
@@ -29,9 +28,7 @@ function normalSession(cb) {
     });
   });
 }
-normalSession(common.mustCall(function(err) {
-  assert.ifError(err);
-}));
+normalSession(common.mustSucceed());
 
 // Create a session using a socket that has not yet finished connecting
 function socketNotFinished(done) {
@@ -52,9 +49,7 @@ function socketNotFinished(done) {
     });
   });
 }
-socketNotFinished(common.mustCall(function(err) {
-  assert.ifError(err);
-}));
+socketNotFinished(common.mustSucceed());
 
 // Create a session using a socket that has finished connecting
 function socketFinished(done) {
@@ -75,6 +70,4 @@ function socketFinished(done) {
     });
   });
 }
-socketFinished(common.mustCall(function(err) {
-  assert.ifError(err);
-}));
+socketFinished(common.mustSucceed());

--- a/test/parallel/test-c-ares.js
+++ b/test/parallel/test-c-ares.js
@@ -43,20 +43,17 @@ const dnsPromises = dns.promises;
 })().then(common.mustCall());
 
 // Try resolution without hostname.
-dns.lookup(null, common.mustCall((error, result, addressType) => {
-  assert.ifError(error);
+dns.lookup(null, common.mustSucceed((result, addressType) => {
   assert.strictEqual(result, null);
   assert.strictEqual(addressType, 4);
 }));
 
-dns.lookup('127.0.0.1', common.mustCall((error, result, addressType) => {
-  assert.ifError(error);
+dns.lookup('127.0.0.1', common.mustSucceed((result, addressType) => {
   assert.strictEqual(result, '127.0.0.1');
   assert.strictEqual(addressType, 4);
 }));
 
-dns.lookup('::1', common.mustCall((error, result, addressType) => {
-  assert.ifError(error);
+dns.lookup('::1', common.mustSucceed((result, addressType) => {
   assert.strictEqual(result, '::1');
   assert.strictEqual(addressType, 6);
 }));

--- a/test/parallel/test-c-ares.js
+++ b/test/parallel/test-c-ares.js
@@ -83,7 +83,7 @@ dns.lookup('::1', common.mustSucceed((result, addressType) => {
 // so we disable this test on Windows.
 // IBMi reports `ENOTFOUND` when get hostname by address 127.0.0.1
 if (!common.isWindows && !common.isIBMi) {
-  dns.reverse('127.0.0.1', common.mustSucceed(function(domains) {
+  dns.reverse('127.0.0.1', common.mustSucceed((domains) => {
     assert.ok(Array.isArray(domains));
   }));
 

--- a/test/parallel/test-c-ares.js
+++ b/test/parallel/test-c-ares.js
@@ -83,8 +83,7 @@ dns.lookup('::1', common.mustSucceed((result, addressType) => {
 // so we disable this test on Windows.
 // IBMi reports `ENOTFOUND` when get hostname by address 127.0.0.1
 if (!common.isWindows && !common.isIBMi) {
-  dns.reverse('127.0.0.1', common.mustCall(function(error, domains) {
-    assert.ifError(error);
+  dns.reverse('127.0.0.1', common.mustSucceed(function(domains) {
     assert.ok(Array.isArray(domains));
   }));
 

--- a/test/parallel/test-child-process-exec-any-shells-windows.js
+++ b/test/parallel/test-child-process-exec-any-shells-windows.js
@@ -17,8 +17,8 @@ fs.mkdirSync(tmpPath);
 
 const test = (shell) => {
   cp.exec('echo foo bar', { shell: shell },
-          common.mustCall((error, stdout, stderror) => {
-            assert.ok(!error && !stderror);
+          common.mustSucceed((stdout, stderror) => {
+            assert.ok(!stderror);
             assert.ok(stdout.includes('foo') && stdout.includes('bar'));
           }));
 };
@@ -46,8 +46,8 @@ testCopy('powershell.exe',
 fs.writeFile(`${tmpPath}\\test file`, 'Test', common.mustSucceed(() => {
   cp.exec(`Get-ChildItem "${tmpPath}" | Select-Object -Property Name`,
           { shell: 'PowerShell' },
-          common.mustCall((error, stdout, stderror) => {
-            assert.ok(!error && !stderror);
+          common.mustSucceed((stdout, stderror) => {
+            assert.ok(!stderror);
             assert.ok(stdout.includes(
               'test file'));
           }));

--- a/test/parallel/test-child-process-exec-any-shells-windows.js
+++ b/test/parallel/test-child-process-exec-any-shells-windows.js
@@ -43,8 +43,7 @@ test('CMD');
 test('powershell');
 testCopy('powershell.exe',
          `${system32}\\WindowsPowerShell\\v1.0\\powershell.exe`);
-fs.writeFile(`${tmpPath}\\test file`, 'Test', common.mustCall((err) => {
-  assert.ifError(err);
+fs.writeFile(`${tmpPath}\\test file`, 'Test', common.mustSucceed(() => {
   cp.exec(`Get-ChildItem "${tmpPath}" | Select-Object -Property Name`,
           { shell: 'PowerShell' },
           common.mustCall((error, stdout, stderror) => {

--- a/test/parallel/test-child-process-exec-cwd.js
+++ b/test/parallel/test-child-process-exec-cwd.js
@@ -34,6 +34,6 @@ if (common.isWindows) {
   dir = '/dev';
 }
 
-exec(pwdcommand, { cwd: dir }, common.mustSucceed(function(stdout, stderr) {
+exec(pwdcommand, { cwd: dir }, common.mustSucceed((stdout, stderr) => {
   assert(stdout.startsWith(dir));
 }));

--- a/test/parallel/test-child-process-exec-cwd.js
+++ b/test/parallel/test-child-process-exec-cwd.js
@@ -34,7 +34,6 @@ if (common.isWindows) {
   dir = '/dev';
 }
 
-exec(pwdcommand, { cwd: dir }, common.mustCall(function(err, stdout, stderr) {
-  assert.ifError(err);
+exec(pwdcommand, { cwd: dir }, common.mustSucceed(function(stdout, stderr) {
   assert(stdout.startsWith(dir));
 }));

--- a/test/parallel/test-child-process-exec-encoding.js
+++ b/test/parallel/test-child-process-exec-encoding.js
@@ -15,8 +15,7 @@ if (process.argv[2] === 'child') {
   function run(options, callback) {
     const cmd = `"${process.execPath}" "${__filename}" child`;
 
-    cp.exec(cmd, options, common.mustCall((err, stdout, stderr) => {
-      assert.ifError(err);
+    cp.exec(cmd, options, common.mustSucceed((stdout, stderr) => {
       callback(stdout, stderr);
     }));
   }

--- a/test/parallel/test-child-process-exec-maxbuf.js
+++ b/test/parallel/test-child-process-exec-maxbuf.js
@@ -27,8 +27,7 @@ function runChecks(err, stdio, streamName, expected) {
   const cmd =
     `${process.execPath} -e "console.log('a'.repeat(1024 * 1024 - 1))"`;
 
-  cp.exec(cmd, common.mustCall((err, stdout, stderr) => {
-    assert.ifError(err);
+  cp.exec(cmd, common.mustSucceed((stdout, stderr) => {
     assert.strictEqual(stdout.trim(), 'a'.repeat(1024 * 1024 - 1));
     assert.strictEqual(stderr, '');
   }));
@@ -38,8 +37,7 @@ function runChecks(err, stdio, streamName, expected) {
   const cmd = `"${process.execPath}" -e "console.log('hello world');"`;
   const options = { maxBuffer: Infinity };
 
-  cp.exec(cmd, options, common.mustCall((err, stdout, stderr) => {
-    assert.ifError(err);
+  cp.exec(cmd, options, common.mustSucceed((stdout, stderr) => {
     assert.strictEqual(stdout.trim(), 'hello world');
     assert.strictEqual(stderr, '');
   }));
@@ -80,8 +78,7 @@ function runChecks(err, stdio, streamName, expected) {
   const cmd =
     `"${process.execPath}" -e "console.log('a'.repeat(1024 * 1024 - 1))"`;
 
-  cp.exec(cmd, common.mustCall((err, stdout, stderr) => {
-    assert.ifError(err);
+  cp.exec(cmd, common.mustSucceed((stdout, stderr) => {
     assert.strictEqual(stdout.trim(), 'a'.repeat(1024 * 1024 - 1));
     assert.strictEqual(stderr, '');
   }));

--- a/test/parallel/test-child-process-exec-std-encoding.js
+++ b/test/parallel/test-child-process-exec-std-encoding.js
@@ -13,8 +13,7 @@ if (process.argv[2] === 'child') {
   console.error(stderrData);
 } else {
   const cmd = `"${process.execPath}" "${__filename}" child`;
-  const child = cp.exec(cmd, common.mustCall((err, stdout, stderr) => {
-    assert.ifError(err);
+  const child = cp.exec(cmd, common.mustSucceed((stdout, stderr) => {
     assert.strictEqual(stdout, expectedStdout);
     assert.strictEqual(stderr, expectedStderr);
   }));

--- a/test/parallel/test-child-process-exec-timeout.js
+++ b/test/parallel/test-child-process-exec-timeout.js
@@ -51,8 +51,7 @@ cp.exec(cmd, {
 }));
 
 // Test the case where a timeout is set, but not expired.
-cp.exec(cmd, { timeout: 2 ** 30 }, common.mustCall((err, stdout, stderr) => {
-  assert.ifError(err);
+cp.exec(cmd, { timeout: 2 ** 30 }, common.mustSucceed((stdout, stderr) => {
   assert.strictEqual(stdout.trim(), 'child stdout');
   assert.strictEqual(stderr.trim(), 'child stderr');
 }));

--- a/test/parallel/test-child-process-execfile-maxbuf.js
+++ b/test/parallel/test-child-process-execfile-maxbuf.js
@@ -25,8 +25,7 @@ function checkFactory(streamName) {
   execFile(
     process.execPath,
     ['-e', 'console.log("a".repeat(1024 * 1024 - 1))'],
-    common.mustCall((err, stdout, stderr) => {
-      assert.ifError(err);
+    common.mustSucceed((stdout, stderr) => {
       assert.strictEqual(stdout.trim(), 'a'.repeat(1024 * 1024 - 1));
       assert.strictEqual(stderr, '');
     })
@@ -40,8 +39,7 @@ function checkFactory(streamName) {
     process.execPath,
     ['-e', 'console.log("hello world");'],
     options,
-    common.mustCall((err, stdout, stderr) => {
-      assert.ifError(err);
+    common.mustSucceed((stdout, stderr) => {
       assert.strictEqual(stdout.trim(), 'hello world');
       assert.strictEqual(stderr, '');
     })

--- a/test/parallel/test-child-process-execfile.js
+++ b/test/parallel/test-child-process-execfile.js
@@ -43,7 +43,5 @@ const execOpts = { encoding: 'utf8', shell: true };
 
 {
   // Verify the shell option works properly
-  execFile(process.execPath, [fixture, 0], execOpts, common.mustCall((err) => {
-    assert.ifError(err);
-  }));
+  execFile(process.execPath, [fixture, 0], execOpts, common.mustSucceed());
 }

--- a/test/parallel/test-child-process-fork-getconnections.js
+++ b/test/parallel/test-child-process-fork-getconnections.js
@@ -97,8 +97,7 @@ if (process.argv[2] === 'child') {
 
     child.once('message', common.mustCall((m) => {
       assert.strictEqual(m.status, 'closed');
-      server.getConnections(common.mustCall((err, num) => {
-        assert.ifError(err);
+      server.getConnections(common.mustSucceed((num) => {
         assert.strictEqual(num, count - (i + 1));
         closeSockets(i + 1);
       }));

--- a/test/parallel/test-child-process-send-keep-open.js
+++ b/test/parallel/test-child-process-send-keep-open.js
@@ -32,9 +32,7 @@ if (process.argv[2] !== 'child') {
       });
     }));
 
-    child.send('socket', socket, { keepOpen: true }, common.mustCall((err) => {
-      assert.ifError(err);
-    }));
+    child.send('socket', socket, { keepOpen: true }, common.mustSucceed());
   });
 
   server.listen(0, () => {

--- a/test/parallel/test-child-process-windows-hide.js
+++ b/test/parallel/test-child-process-windows-hide.js
@@ -42,8 +42,7 @@ internalCp.spawnSync = common.mustCall(function(options) {
 }
 
 {
-  const callback = common.mustCall((err, stdout, stderr) => {
-    assert.ifError(err);
+  const callback = common.mustSucceed((stdout, stderr) => {
     assert.strictEqual(stdout.trim(), '42');
     assert.strictEqual(stderr.trim(), '');
   });

--- a/test/parallel/test-cli-eval.js
+++ b/test/parallel/test-cli-eval.js
@@ -40,16 +40,14 @@ if (process.argv.length > 2) {
 }
 
 // Assert that nothing is written to stdout.
-child.exec(`${nodejs} --eval 42`, common.mustCall((err, stdout, stderr) => {
-  assert.ifError(err);
+child.exec(`${nodejs} --eval 42`, common.mustSucceed((stdout, stderr) => {
   assert.strictEqual(stdout, '');
   assert.strictEqual(stderr, '');
 }));
 
 // Assert that "42\n" is written to stderr.
 child.exec(`${nodejs} --eval "console.error(42)"`,
-           common.mustCall((err, stdout, stderr) => {
-             assert.ifError(err);
+           common.mustSucceed((stdout, stderr) => {
              assert.strictEqual(stdout, '');
              assert.strictEqual(stderr, '42\n');
            }));
@@ -58,14 +56,12 @@ child.exec(`${nodejs} --eval "console.error(42)"`,
 ['--print', '-p -e', '-pe', '-p'].forEach((s) => {
   const cmd = `${nodejs} ${s} `;
 
-  child.exec(`${cmd}42`, common.mustCall((err, stdout, stderr) => {
-    assert.ifError(err);
+  child.exec(`${cmd}42`, common.mustSucceed((stdout, stderr) => {
     assert.strictEqual(stdout, '42\n');
     assert.strictEqual(stderr, '');
   }));
 
-  child.exec(`${cmd} '[]'`, common.mustCall((err, stdout, stderr) => {
-    assert.ifError(err);
+  child.exec(`${cmd} '[]'`, common.mustSucceed((stdout, stderr) => {
     assert.strictEqual(stdout, '[]\n');
     assert.strictEqual(stderr, '');
   }));
@@ -88,8 +84,7 @@ child.exec(`${nodejs} --eval "console.error(42)"`,
 
 // Check that builtin modules are pre-defined.
 child.exec(`${nodejs} --print "os.platform()"`,
-           common.mustCall((err, stdout, stderr) => {
-             assert.ifError(err);
+           common.mustSucceed((stdout, stderr) => {
              assert.strictEqual(stderr, '');
              assert.strictEqual(stdout.trim(), require('os').platform());
            }));
@@ -113,22 +108,19 @@ child.exec(`${nodejs} -e`, common.mustCall((err, stdout, stderr) => {
 }));
 
 // Empty program should do nothing.
-child.exec(`${nodejs} -e ""`, common.mustCall((err, stdout, stderr) => {
-  assert.ifError(err);
+child.exec(`${nodejs} -e ""`, common.mustSucceed((stdout, stderr) => {
   assert.strictEqual(stdout, '');
   assert.strictEqual(stderr, '');
 }));
 
 // "\\-42" should be interpreted as an escaped expression, not a switch.
-child.exec(`${nodejs} -p "\\-42"`, common.mustCall((err, stdout, stderr) => {
-  assert.ifError(err);
+child.exec(`${nodejs} -p "\\-42"`, common.mustSucceed((stdout, stderr) => {
   assert.strictEqual(stdout, '-42\n');
   assert.strictEqual(stderr, '');
 }));
 
 child.exec(`${nodejs} --use-strict -p process.execArgv`,
-           common.mustCall((err, stdout, stderr) => {
-             assert.ifError(err);
+           common.mustSucceed((stdout, stderr) => {
              assert.strictEqual(
                stdout, "[ '--use-strict', '-p', 'process.execArgv' ]\n"
              );
@@ -143,8 +135,7 @@ child.exec(`${nodejs} --use-strict -p process.execArgv`,
   }
 
   child.exec(`${nodejs} -e 'require("child_process").fork("${emptyFile}")'`,
-             common.mustCall((err, stdout, stderr) => {
-               assert.ifError(err);
+             common.mustSucceed((stdout, stderr) => {
                assert.strictEqual(stdout, '');
                assert.strictEqual(stderr, '');
              }));
@@ -154,8 +145,7 @@ child.exec(`${nodejs} --use-strict -p process.execArgv`,
   child.exec(
     `${nodejs} -e "process.execArgv = ['-e', 'console.log(42)', 'thirdArg'];` +
                   `require('child_process').fork('${emptyFile}')"`,
-    common.mustCall((err, stdout, stderr) => {
-      assert.ifError(err);
+    common.mustSucceed((stdout, stderr) => {
       assert.strictEqual(stdout, '42\n');
       assert.strictEqual(stderr, '');
     }));
@@ -237,8 +227,7 @@ child.exec(`${nodejs} --use-strict -p process.execArgv`,
 const execOptions = '--input-type module';
 child.exec(
   `${nodejs} ${execOptions} --eval "console.log(42)"`,
-  common.mustCall((err, stdout) => {
-    assert.ifError(err);
+  common.mustSucceed((stdout) => {
     assert.strictEqual(stdout, '42\n');
   }));
 
@@ -263,16 +252,14 @@ child.exec(
 // Assert that require is undefined in ESM support
 child.exec(
   `${nodejs} ${execOptions} --eval "console.log(typeof require);"`,
-  common.mustCall((err, stdout) => {
-    assert.ifError(err);
+  common.mustSucceed((stdout) => {
     assert.strictEqual(stdout, 'undefined\n');
   }));
 
 // Assert that import.meta is defined in ESM
 child.exec(
   `${nodejs} ${execOptions} --eval "console.log(typeof import.meta);"`,
-  common.mustCall((err, stdout) => {
-    assert.ifError(err);
+  common.mustSucceed((stdout) => {
     assert.strictEqual(stdout, 'object\n');
   }));
 
@@ -280,8 +267,7 @@ child.exec(
 child.exec(
   `${nodejs} ${execOptions} ` +
   '--eval "import \'./test/fixtures/es-modules/mjs-file.mjs\'"',
-  common.mustCall((err, stdout) => {
-    assert.ifError(err);
+  common.mustSucceed((stdout) => {
     assert.strictEqual(stdout, '.mjs file\n');
   }));
 
@@ -291,8 +277,7 @@ child.exec(
   `${nodejs} ${execOptions} ` +
   '--eval "process.chdir(\'..\');' +
           'import(\'./test/fixtures/es-modules/mjs-file.mjs\')"',
-  common.mustCall((err, stdout) => {
-    assert.ifError(err);
+  common.mustSucceed((stdout) => {
     assert.strictEqual(stdout, '.mjs file\n');
   }));
 
@@ -300,7 +285,6 @@ child.exec(
   `${nodejs} ` +
   '--eval "process.chdir(\'..\');' +
           'import(\'./test/fixtures/es-modules/mjs-file.mjs\')"',
-  common.mustCall((err, stdout) => {
-    assert.ifError(err);
+  common.mustSucceed((stdout) => {
     assert.strictEqual(stdout, '.mjs file\n');
   }));

--- a/test/parallel/test-cli-node-print-help.js
+++ b/test/parallel/test-cli-node-print-help.js
@@ -14,8 +14,7 @@ let stdOut;
 
 
 function startPrintHelpTest() {
-  exec(`${process.execPath} --help`, common.mustCall((err, stdout, stderr) => {
-    assert.ifError(err);
+  exec(`${process.execPath} --help`, common.mustSucceed((stdout, stderr) => {
     stdOut = stdout;
     validateNodePrintHelp();
   }));

--- a/test/parallel/test-cluster-http-pipe.js
+++ b/test/parallel/test-cluster-http-pipe.js
@@ -51,8 +51,7 @@ http.createServer(common.mustCall((req, res) => {
 })).listen(common.PIPE, common.mustCall(() => {
   http.get({ socketPath: common.PIPE, path: '/' }, common.mustCall((res) => {
     res.resume();
-    res.on('end', common.mustCall((err) => {
-      assert.ifError(err);
+    res.on('end', common.mustSucceed(() => {
       process.send('DONE');
       process.exit();
     }));

--- a/test/parallel/test-cluster-worker-disconnect-on-error.js
+++ b/test/parallel/test-cluster-worker-disconnect-on-error.js
@@ -10,8 +10,7 @@ const server = http.createServer();
 if (cluster.isMaster) {
   let worker;
 
-  server.listen(0, common.mustCall((error) => {
-    assert.ifError(error);
+  server.listen(0, common.mustSucceed(() => {
     assert(worker);
 
     worker.send({ port: server.address().port });

--- a/test/parallel/test-crypto-hkdf.js
+++ b/test/parallel/test-crypto-hkdf.js
@@ -123,8 +123,7 @@ const {
     assert(syncResult instanceof ArrayBuffer);
     let is_async = false;
     hkdf(hash, secret, salt, info, length,
-         common.mustCall((err, asyncResult) => {
-           assert.ifError(err);
+         common.mustSucceed((asyncResult) => {
            assert(is_async);
            assert(asyncResult instanceof ArrayBuffer);
            assert.deepStrictEqual(syncResult, asyncResult);
@@ -141,8 +140,7 @@ const {
 
     const syncResult = hkdfSync(hash, buf_secret, buf_salt, buf_info, length);
     hkdf(hash, buf_secret, buf_salt, buf_info, length,
-         common.mustCall((err, asyncResult) => {
-           assert.ifError(err);
+         common.mustSucceed((asyncResult) => {
            assert.deepStrictEqual(syncResult, asyncResult);
          }));
   }
@@ -154,8 +152,7 @@ const {
 
     const syncResult = hkdfSync(hash, key_secret, buf_salt, buf_info, length);
     hkdf(hash, key_secret, buf_salt, buf_info, length,
-         common.mustCall((err, asyncResult) => {
-           assert.ifError(err);
+         common.mustSucceed((asyncResult) => {
            assert.deepStrictEqual(syncResult, asyncResult);
          }));
   }
@@ -167,8 +164,7 @@ const {
 
     const syncResult = hkdfSync(hash, ta_secret, ta_salt, ta_info, length);
     hkdf(hash, ta_secret, ta_salt, ta_info, length,
-         common.mustCall((err, asyncResult) => {
-           assert.ifError(err);
+         common.mustSucceed((asyncResult) => {
            assert.deepStrictEqual(syncResult, asyncResult);
          }));
   }
@@ -185,8 +181,7 @@ const {
       ta_info.buffer,
       length);
     hkdf(hash, ta_secret, ta_salt, ta_info, length,
-         common.mustCall((err, asyncResult) => {
-           assert.ifError(err);
+         common.mustSucceed((asyncResult) => {
            assert.deepStrictEqual(syncResult, asyncResult);
          }));
   }
@@ -203,8 +198,7 @@ const {
       sa_info,
       length);
     hkdf(hash, ta_secret, sa_salt, sa_info, length,
-         common.mustCall((err, asyncResult) => {
-           assert.ifError(err);
+         common.mustSucceed((asyncResult) => {
            assert.deepStrictEqual(syncResult, asyncResult);
          }));
   }

--- a/test/parallel/test-crypto-keygen.js
+++ b/test/parallel/test-crypto-keygen.js
@@ -143,8 +143,7 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
       type: 'pkcs1',
       format: 'pem'
     }
-  }, common.mustCall((err, publicKeyDER, privateKey) => {
-    assert.ifError(err);
+  }, common.mustSucceed((publicKeyDER, privateKey) => {
 
     assert(Buffer.isBuffer(publicKeyDER));
     assertApproximateSize(publicKeyDER, 74);
@@ -169,8 +168,7 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
       cipher: 'aes-256-cbc',
       passphrase: 'secret'
     }
-  }, common.mustCall((err, publicKeyDER, privateKey) => {
-    assert.ifError(err);
+  }, common.mustSucceed((publicKeyDER, privateKey) => {
 
     assert(Buffer.isBuffer(publicKeyDER));
     assertApproximateSize(publicKeyDER, 74);
@@ -202,8 +200,7 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
       cipher: 'aes-256-cbc',
       passphrase: 'secret'
     }
-  }, common.mustCall((err, publicKeyDER, privateKeyDER) => {
-    assert.ifError(err);
+  }, common.mustSucceed((publicKeyDER, privateKeyDER) => {
 
     assert(Buffer.isBuffer(publicKeyDER));
     assertApproximateSize(publicKeyDER, 74);
@@ -245,8 +242,7 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
       type: 'pkcs8',
       format: 'der'
     }
-  }, common.mustCall((err, publicKeyDER, privateKeyDER) => {
-    assert.ifError(err);
+  }, common.mustSucceed((publicKeyDER, privateKeyDER) => {
 
     assert(Buffer.isBuffer(publicKeyDER));
     assertApproximateSize(publicKeyDER, 74);
@@ -272,8 +268,7 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     saltLength: 16,
     hash: 'sha256',
     mgf1Hash: 'sha256'
-  }, common.mustCall((err, publicKey, privateKey) => {
-    assert.ifError(err);
+  }, common.mustSucceed((publicKey, privateKey) => {
 
     assert.strictEqual(publicKey.type, 'public');
     assert.strictEqual(publicKey.asymmetricKeyType, 'rsa-pss');
@@ -321,8 +316,7 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
       passphrase: 'secret',
       ...privateKeyEncoding
     }
-  }, common.mustCall((err, publicKey, privateKeyDER) => {
-    assert.ifError(err);
+  }, common.mustSucceed((publicKey, privateKeyDER) => {
 
     assert.strictEqual(typeof publicKey, 'string');
     assert(spkiExp.test(publicKey));
@@ -367,8 +361,7 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
       type: 'sec1',
       format: 'pem'
     }
-  }, common.mustCall((err, publicKey, privateKey) => {
-    assert.ifError(err);
+  }, common.mustSucceed((publicKey, privateKey) => {
 
     assert.strictEqual(typeof publicKey, 'string');
     assert(spkiExp.test(publicKey));
@@ -391,8 +384,7 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
       type: 'sec1',
       format: 'pem'
     }
-  }, common.mustCall((err, publicKey, privateKey) => {
-    assert.ifError(err);
+  }, common.mustSucceed((publicKey, privateKey) => {
 
     assert.strictEqual(typeof publicKey, 'string');
     assert(spkiExp.test(publicKey));
@@ -416,8 +408,7 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
       cipher: 'aes-128-cbc',
       passphrase: 'secret'
     }
-  }, common.mustCall((err, publicKey, privateKey) => {
-    assert.ifError(err);
+  }, common.mustSucceed((publicKey, privateKey) => {
 
     assert.strictEqual(typeof publicKey, 'string');
     assert(spkiExp.test(publicKey));
@@ -448,8 +439,7 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
       cipher: 'aes-128-cbc',
       passphrase: 'secret'
     }
-  }, common.mustCall((err, publicKey, privateKey) => {
-    assert.ifError(err);
+  }, common.mustSucceed((publicKey, privateKey) => {
 
     assert.strictEqual(typeof publicKey, 'string');
     assert(spkiExp.test(publicKey));
@@ -483,8 +473,7 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
       cipher: 'aes-128-cbc',
       passphrase: 'top secret'
     }
-  }, common.mustCall((err, publicKey, privateKey) => {
-    assert.ifError(err);
+  }, common.mustSucceed((publicKey, privateKey) => {
 
     assert.strictEqual(typeof publicKey, 'string');
     assert(spkiExp.test(publicKey));
@@ -519,8 +508,7 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
       cipher: 'aes-128-cbc',
       passphrase: 'top secret'
     }
-  }, common.mustCall((err, publicKey, privateKey) => {
-    assert.ifError(err);
+  }, common.mustSucceed((publicKey, privateKey) => {
 
     assert.strictEqual(typeof publicKey, 'string');
     assert(spkiExp.test(publicKey));
@@ -637,8 +625,7 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
       type: 'pkcs1',
       format: 'pem'
     }
-  }, common.mustCall((err, publicKey, privateKey) => {
-    assert.ifError(err);
+  }, common.mustSucceed((publicKey, privateKey) => {
 
     assert.strictEqual(typeof publicKey, 'object');
     assert.strictEqual(publicKey.type, 'public');
@@ -658,8 +645,7 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
       type: 'pkcs1',
       format: 'pem'
     }
-  }, common.mustCall((err, publicKey, privateKey) => {
-    assert.ifError(err);
+  }, common.mustSucceed((publicKey, privateKey) => {
 
     // The public key should still be a string.
     assert.strictEqual(typeof publicKey, 'string');
@@ -954,16 +940,14 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     namedCurve: 'P-256',
     publicKeyEncoding: { type: 'spki', format: 'pem' },
     privateKeyEncoding: { type: 'pkcs8', format: 'pem' }
-  }, common.mustCall((err, publicKey, privateKey) => {
-    assert.ifError(err);
+  }, common.mustSucceed((publicKey, privateKey) => {
   }));
 
   generateKeyPair('ec', {
     namedCurve: 'secp256k1',
     publicKeyEncoding: { type: 'spki', format: 'pem' },
     privateKeyEncoding: { type: 'pkcs8', format: 'pem' }
-  }, common.mustCall((err, publicKey, privateKey) => {
-    assert.ifError(err);
+  }, common.mustSucceed((publicKey, privateKey) => {
   }));
 }
 
@@ -971,8 +955,7 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
 {
   if (!/^1\.1\.0/.test(process.versions.openssl)) {
     ['ed25519', 'ed448', 'x25519', 'x448'].forEach((keyType) => {
-      generateKeyPair(keyType, common.mustCall((err, publicKey, privateKey) => {
-        assert.ifError(err);
+      generateKeyPair(keyType, common.mustSucceed((publicKey, privateKey) => {
 
         assert.strictEqual(publicKey.type, 'public');
         assert.strictEqual(publicKey.asymmetricKeyType, keyType);
@@ -988,8 +971,7 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
 {
   generateKeyPair('dh', {
     primeLength: 1024
-  }, common.mustCall((err, publicKey, privateKey) => {
-    assert.ifError(err);
+  }, common.mustSucceed((publicKey, privateKey) => {
 
     assert.strictEqual(publicKey.type, 'public');
     assert.strictEqual(publicKey.asymmetricKeyType, 'dh');

--- a/test/parallel/test-crypto-keygen.js
+++ b/test/parallel/test-crypto-keygen.js
@@ -144,7 +144,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
       format: 'pem'
     }
   }, common.mustSucceed((publicKeyDER, privateKey) => {
-
     assert(Buffer.isBuffer(publicKeyDER));
     assertApproximateSize(publicKeyDER, 74);
 
@@ -169,7 +168,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
       passphrase: 'secret'
     }
   }, common.mustSucceed((publicKeyDER, privateKey) => {
-
     assert(Buffer.isBuffer(publicKeyDER));
     assertApproximateSize(publicKeyDER, 74);
 
@@ -201,7 +199,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
       passphrase: 'secret'
     }
   }, common.mustSucceed((publicKeyDER, privateKeyDER) => {
-
     assert(Buffer.isBuffer(publicKeyDER));
     assertApproximateSize(publicKeyDER, 74);
 
@@ -243,7 +240,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
       format: 'der'
     }
   }, common.mustSucceed((publicKeyDER, privateKeyDER) => {
-
     assert(Buffer.isBuffer(publicKeyDER));
     assertApproximateSize(publicKeyDER, 74);
 
@@ -269,7 +265,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     hash: 'sha256',
     mgf1Hash: 'sha256'
   }, common.mustSucceed((publicKey, privateKey) => {
-
     assert.strictEqual(publicKey.type, 'public');
     assert.strictEqual(publicKey.asymmetricKeyType, 'rsa-pss');
 
@@ -317,7 +312,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
       ...privateKeyEncoding
     }
   }, common.mustSucceed((publicKey, privateKeyDER) => {
-
     assert.strictEqual(typeof publicKey, 'string');
     assert(spkiExp.test(publicKey));
     // The private key is DER-encoded.
@@ -362,7 +356,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
       format: 'pem'
     }
   }, common.mustSucceed((publicKey, privateKey) => {
-
     assert.strictEqual(typeof publicKey, 'string');
     assert(spkiExp.test(publicKey));
     assert.strictEqual(typeof privateKey, 'string');
@@ -385,7 +378,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
       format: 'pem'
     }
   }, common.mustSucceed((publicKey, privateKey) => {
-
     assert.strictEqual(typeof publicKey, 'string');
     assert(spkiExp.test(publicKey));
     assert.strictEqual(typeof privateKey, 'string');
@@ -409,7 +401,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
       passphrase: 'secret'
     }
   }, common.mustSucceed((publicKey, privateKey) => {
-
     assert.strictEqual(typeof publicKey, 'string');
     assert(spkiExp.test(publicKey));
     assert.strictEqual(typeof privateKey, 'string');
@@ -440,7 +431,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
       passphrase: 'secret'
     }
   }, common.mustSucceed((publicKey, privateKey) => {
-
     assert.strictEqual(typeof publicKey, 'string');
     assert(spkiExp.test(publicKey));
     assert.strictEqual(typeof privateKey, 'string');
@@ -474,7 +464,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
       passphrase: 'top secret'
     }
   }, common.mustSucceed((publicKey, privateKey) => {
-
     assert.strictEqual(typeof publicKey, 'string');
     assert(spkiExp.test(publicKey));
     assert.strictEqual(typeof privateKey, 'string');
@@ -509,7 +498,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
       passphrase: 'top secret'
     }
   }, common.mustSucceed((publicKey, privateKey) => {
-
     assert.strictEqual(typeof publicKey, 'string');
     assert(spkiExp.test(publicKey));
     assert.strictEqual(typeof privateKey, 'string');
@@ -626,7 +614,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
       format: 'pem'
     }
   }, common.mustSucceed((publicKey, privateKey) => {
-
     assert.strictEqual(typeof publicKey, 'object');
     assert.strictEqual(publicKey.type, 'public');
     assert.strictEqual(publicKey.asymmetricKeyType, 'rsa');
@@ -646,7 +633,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
       format: 'pem'
     }
   }, common.mustSucceed((publicKey, privateKey) => {
-
     // The public key should still be a string.
     assert.strictEqual(typeof publicKey, 'string');
 
@@ -956,7 +942,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
   if (!/^1\.1\.0/.test(process.versions.openssl)) {
     ['ed25519', 'ed448', 'x25519', 'x448'].forEach((keyType) => {
       generateKeyPair(keyType, common.mustSucceed((publicKey, privateKey) => {
-
         assert.strictEqual(publicKey.type, 'public');
         assert.strictEqual(publicKey.asymmetricKeyType, keyType);
 
@@ -972,7 +957,6 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
   generateKeyPair('dh', {
     primeLength: 1024
   }, common.mustSucceed((publicKey, privateKey) => {
-
     assert.strictEqual(publicKey.type, 'public');
     assert.strictEqual(publicKey.asymmetricKeyType, 'dh');
 

--- a/test/parallel/test-crypto-pbkdf2.js
+++ b/test/parallel/test-crypto-pbkdf2.js
@@ -115,7 +115,7 @@ for (const iterations of [-1, 0]) {
 
 // Should not get FATAL ERROR with empty password and salt
 // https://github.com/nodejs/node/issues/8571
-crypto.pbkdf2('', '', 1, 32, 'sha256', common.mustCall(assert.ifError));
+crypto.pbkdf2('', '', 1, 32, 'sha256', common.mustSucceed());
 
 assert.throws(
   () => crypto.pbkdf2('password', 'salt', 8, 8, common.mustNotCall()),

--- a/test/parallel/test-crypto-pbkdf2.js
+++ b/test/parallel/test-crypto-pbkdf2.js
@@ -48,9 +48,8 @@ const expected =
 const key = crypto.pbkdf2Sync('password', 'salt', 32, 32, 'sha256');
 assert.strictEqual(key.toString('hex'), expected);
 
-crypto.pbkdf2('password', 'salt', 32, 32, 'sha256', common.mustCall(ondone));
-function ondone(err, key) {
-  assert.ifError(err);
+crypto.pbkdf2('password', 'salt', 32, 32, 'sha256', common.mustSucceed(ondone));
+function ondone(key) {
   assert.strictEqual(key.toString('hex'), expected);
 }
 
@@ -199,22 +198,22 @@ assert.throws(
 });
 
 // Any TypedArray should work for password and salt
-crypto.pbkdf2(new Uint8Array(10), 'salt', 8, 8, 'sha256', common.mustCall());
-crypto.pbkdf2('pass', new Uint8Array(10), 8, 8, 'sha256', common.mustCall());
-crypto.pbkdf2(new Uint16Array(10), 'salt', 8, 8, 'sha256', common.mustCall());
-crypto.pbkdf2('pass', new Uint16Array(10), 8, 8, 'sha256', common.mustCall());
-crypto.pbkdf2(new Uint32Array(10), 'salt', 8, 8, 'sha256', common.mustCall());
-crypto.pbkdf2('pass', new Uint32Array(10), 8, 8, 'sha256', common.mustCall());
-crypto.pbkdf2(new Float32Array(10), 'salt', 8, 8, 'sha256', common.mustCall());
-crypto.pbkdf2('pass', new Float32Array(10), 8, 8, 'sha256', common.mustCall());
-crypto.pbkdf2(new Float64Array(10), 'salt', 8, 8, 'sha256', common.mustCall());
-crypto.pbkdf2('pass', new Float64Array(10), 8, 8, 'sha256', common.mustCall());
-crypto.pbkdf2(new ArrayBuffer(10), 'salt', 8, 8, 'sha256', common.mustCall());
-crypto.pbkdf2('pass', new ArrayBuffer(10), 8, 8, 'sha256', common.mustCall());
+crypto.pbkdf2(new Uint8Array(10), 'salt', 8, 8, 'sha256', common.mustSucceed());
+crypto.pbkdf2('pass', new Uint8Array(10), 8, 8, 'sha256', common.mustSucceed());
+crypto.pbkdf2(new Uint16Array(10), 'salt', 8, 8, 'sha1', common.mustSucceed());
+crypto.pbkdf2('pass', new Uint16Array(10), 8, 8, 'sha1', common.mustSucceed());
+crypto.pbkdf2(new Uint32Array(10), 'salt', 8, 8, 'sha1', common.mustSucceed());
+crypto.pbkdf2('pass', new Uint32Array(10), 8, 8, 'sha1', common.mustSucceed());
+crypto.pbkdf2(new Float32Array(10), 'salt', 8, 8, 'sha1', common.mustSucceed());
+crypto.pbkdf2('pass', new Float32Array(10), 8, 8, 'sha1', common.mustSucceed());
+crypto.pbkdf2(new Float64Array(10), 'salt', 8, 8, 'sha1', common.mustSucceed());
+crypto.pbkdf2('pass', new Float64Array(10), 8, 8, 'sha1', common.mustSucceed());
+crypto.pbkdf2(new ArrayBuffer(10), 'salt', 8, 8, 'sha1', common.mustSucceed());
+crypto.pbkdf2('pass', new ArrayBuffer(10), 8, 8, 'sha1', common.mustSucceed());
 crypto.pbkdf2(new SharedArrayBuffer(10), 'salt', 8, 8, 'sha256',
-              common.mustCall());
+              common.mustSucceed());
 crypto.pbkdf2('pass', new SharedArrayBuffer(10), 8, 8, 'sha256',
-              common.mustCall());
+              common.mustSucceed());
 
 crypto.pbkdf2Sync(new Uint8Array(10), 'salt', 8, 8, 'sha256');
 crypto.pbkdf2Sync('pass', new Uint8Array(10), 8, 8, 'sha256');

--- a/test/parallel/test-crypto-random.js
+++ b/test/parallel/test-crypto-random.js
@@ -129,8 +129,7 @@ common.expectWarning('DeprecationWarning',
 {
   const buf = Buffer.alloc(10);
   const before = buf.toString('hex');
-  crypto.randomFill(buf, common.mustCall((err, buf) => {
-    assert.ifError(err);
+  crypto.randomFill(buf, common.mustSucceed((buf) => {
     const after = buf.toString('hex');
     assert.notStrictEqual(before, after);
   }));
@@ -139,8 +138,7 @@ common.expectWarning('DeprecationWarning',
 {
   const buf = new Uint8Array(new Array(10).fill(0));
   const before = Buffer.from(buf).toString('hex');
-  crypto.randomFill(buf, common.mustCall((err, buf) => {
-    assert.ifError(err);
+  crypto.randomFill(buf, common.mustSucceed((buf) => {
     const after = Buffer.from(buf).toString('hex');
     assert.notStrictEqual(before, after);
   }));
@@ -155,8 +153,7 @@ common.expectWarning('DeprecationWarning',
     new DataView(new ArrayBuffer(10))
   ].forEach((buf) => {
     const before = Buffer.from(buf.buffer).toString('hex');
-    crypto.randomFill(buf, common.mustCall((err, buf) => {
-      assert.ifError(err);
+    crypto.randomFill(buf, common.mustSucceed((buf) => {
       const after = Buffer.from(buf.buffer).toString('hex');
       assert.notStrictEqual(before, after);
     }));
@@ -207,8 +204,7 @@ common.expectWarning('DeprecationWarning',
 {
   const buf = Buffer.alloc(10);
   const before = buf.toString('hex');
-  crypto.randomFill(buf, 5, 5, common.mustCall((err, buf) => {
-    assert.ifError(err);
+  crypto.randomFill(buf, 5, 5, common.mustSucceed((buf) => {
     const after = buf.toString('hex');
     assert.notStrictEqual(before, after);
     assert.deepStrictEqual(before.slice(0, 5), after.slice(0, 5));
@@ -218,8 +214,7 @@ common.expectWarning('DeprecationWarning',
 {
   const buf = new Uint8Array(new Array(10).fill(0));
   const before = Buffer.from(buf).toString('hex');
-  crypto.randomFill(buf, 5, 5, common.mustCall((err, buf) => {
-    assert.ifError(err);
+  crypto.randomFill(buf, 5, 5, common.mustSucceed((buf) => {
     const after = Buffer.from(buf).toString('hex');
     assert.notStrictEqual(before, after);
     assert.deepStrictEqual(before.slice(0, 5), after.slice(0, 5));
@@ -356,8 +351,7 @@ assert.throws(
   // Asynchronous API
   const randomInts = [];
   for (let i = 0; i < 100; i++) {
-    crypto.randomInt(3, common.mustCall((err, n) => {
-      assert.ifError(err);
+    crypto.randomInt(3, common.mustSucceed((n) => {
       assert.ok(n >= 0);
       assert.ok(n < 3);
       randomInts.push(n);
@@ -391,8 +385,7 @@ assert.throws(
   // Positive range
   const randomInts = [];
   for (let i = 0; i < 100; i++) {
-    crypto.randomInt(1, 3, common.mustCall((err, n) => {
-      assert.ifError(err);
+    crypto.randomInt(1, 3, common.mustSucceed((n) => {
       assert.ok(n >= 1);
       assert.ok(n < 3);
       randomInts.push(n);
@@ -409,8 +402,7 @@ assert.throws(
   // Negative range
   const randomInts = [];
   for (let i = 0; i < 100; i++) {
-    crypto.randomInt(-10, -8, common.mustCall((err, n) => {
-      assert.ifError(err);
+    crypto.randomInt(-10, -8, common.mustSucceed((n) => {
       assert.ok(n >= -10);
       assert.ok(n < -8);
       randomInts.push(n);

--- a/test/parallel/test-crypto-random.js
+++ b/test/parallel/test-crypto-random.js
@@ -166,8 +166,7 @@ common.expectWarning('DeprecationWarning',
     new SharedArrayBuffer(10)
   ].forEach((buf) => {
     const before = Buffer.from(buf).toString('hex');
-    crypto.randomFill(buf, common.mustCall((err, buf) => {
-      assert.ifError(err);
+    crypto.randomFill(buf, common.mustSucceed((buf) => {
       const after = Buffer.from(buf).toString('hex');
       assert.notStrictEqual(before, after);
     }));

--- a/test/parallel/test-crypto-random.js
+++ b/test/parallel/test-crypto-random.js
@@ -460,8 +460,8 @@ assert.throws(
   const maxInt = Number.MAX_SAFE_INTEGER;
   const minInt = Number.MIN_SAFE_INTEGER;
 
-  crypto.randomInt(minInt, minInt + 5, common.mustCall());
-  crypto.randomInt(maxInt - 5, maxInt, common.mustCall());
+  crypto.randomInt(minInt, minInt + 5, common.mustSucceed());
+  crypto.randomInt(maxInt - 5, maxInt, common.mustSucceed());
 
   assert.throws(
     () => crypto.randomInt(minInt - 1, minInt + 5, common.mustNotCall()),
@@ -483,8 +483,8 @@ assert.throws(
     }
   );
 
-  crypto.randomInt(1, common.mustCall());
-  crypto.randomInt(0, 1, common.mustCall());
+  crypto.randomInt(1, common.mustSucceed());
+  crypto.randomInt(0, 1, common.mustSucceed());
   for (const arg of [[0], [1, 1], [3, 2], [-5, -5], [11, -10]]) {
     assert.throws(() => crypto.randomInt(...arg, common.mustNotCall()), {
       code: 'ERR_OUT_OF_RANGE',
@@ -496,8 +496,8 @@ assert.throws(
   }
 
   const MAX_RANGE = 0xFFFF_FFFF_FFFF;
-  crypto.randomInt(MAX_RANGE, common.mustCall());
-  crypto.randomInt(1, MAX_RANGE + 1, common.mustCall());
+  crypto.randomInt(MAX_RANGE, common.mustSucceed());
+  crypto.randomInt(1, MAX_RANGE + 1, common.mustSucceed());
   assert.throws(
     () => crypto.randomInt(1, MAX_RANGE + 2, common.mustNotCall()),
     {

--- a/test/parallel/test-crypto-scrypt.js
+++ b/test/parallel/test-crypto-scrypt.js
@@ -149,8 +149,7 @@ for (const options of good) {
   const { pass, salt, keylen, expected } = options;
   const actual = crypto.scryptSync(pass, salt, keylen, options);
   assert.strictEqual(actual.toString('hex'), expected);
-  crypto.scrypt(pass, salt, keylen, options, common.mustCall((err, actual) => {
-    assert.ifError(err);
+  crypto.scrypt(pass, salt, keylen, options, common.mustSucceed((actual) => {
     assert.strictEqual(actual.toString('hex'), expected);
   }));
 }
@@ -184,8 +183,7 @@ for (const options of toobig) {
   const expected = crypto.scryptSync('pass', 'salt', 1, defaults);
   const actual = crypto.scryptSync('pass', 'salt', 1);
   assert.deepStrictEqual(actual.toString('hex'), expected.toString('hex'));
-  crypto.scrypt('pass', 'salt', 1, common.mustCall((err, actual) => {
-    assert.ifError(err);
+  crypto.scrypt('pass', 'salt', 1, common.mustSucceed((actual) => {
     assert.deepStrictEqual(actual.toString('hex'), expected.toString('hex'));
   }));
 }
@@ -200,8 +198,7 @@ for (const options of toobig) {
   const actual = crypto.scryptSync('pass', 'salt', 1);
   assert.deepStrictEqual(actual, expected.toString(testEncoding));
 
-  crypto.scrypt('pass', 'salt', 1, common.mustCall((err, actual) => {
-    assert.ifError(err);
+  crypto.scrypt('pass', 'salt', 1, common.mustSucceed((actual) => {
     assert.deepStrictEqual(actual, expected.toString(testEncoding));
   }));
 
@@ -225,8 +222,7 @@ for (const { args, expected } of badargs) {
   // Values for maxmem that do not fit in 32 bits but that are still safe
   // integers should be allowed.
   crypto.scrypt('', '', 4, { maxmem: 2 ** 52 },
-                common.mustCall((err, actual) => {
-                  assert.ifError(err);
+                common.mustSucceed((actual) => {
                   assert.strictEqual(actual.toString('hex'), 'd72c87d0');
                 }));
 

--- a/test/parallel/test-crypto-secret-keygen.js
+++ b/test/parallel/test-crypto-secret-keygen.js
@@ -76,8 +76,7 @@ assert.throws(() => generateKeySync('aes', { length: 123 }), {
   const keybuf = key.export();
   assert.strictEqual(keybuf.byteLength, 128 / 8);
 
-  generateKey('aes', { length: 128 }, common.mustCall((err, key) => {
-    assert.ifError(err);
+  generateKey('aes', { length: 128 }, common.mustSucceed((key) => {
     assert(key);
     const keybuf = key.export();
     assert.strictEqual(keybuf.byteLength, 128 / 8);
@@ -90,8 +89,7 @@ assert.throws(() => generateKeySync('aes', { length: 123 }), {
   const keybuf = key.export();
   assert.strictEqual(keybuf.byteLength, 256 / 8);
 
-  generateKey('aes', { length: 256 }, common.mustCall((err, key) => {
-    assert.ifError(err);
+  generateKey('aes', { length: 256 }, common.mustSucceed((key) => {
     assert(key);
     const keybuf = key.export();
     assert.strictEqual(keybuf.byteLength, 256 / 8);
@@ -104,8 +102,7 @@ assert.throws(() => generateKeySync('aes', { length: 123 }), {
   const keybuf = key.export();
   assert.strictEqual(keybuf.byteLength, Math.floor(123 / 8));
 
-  generateKey('hmac', { length: 123 }, common.mustCall((err, key) => {
-    assert.ifError(err);
+  generateKey('hmac', { length: 123 }, common.mustSucceed((key) => {
     assert(key);
     const keybuf = key.export();
     assert.strictEqual(keybuf.byteLength, Math.floor(123 / 8));

--- a/test/parallel/test-dgram-connect-send-callback-buffer-length.js
+++ b/test/parallel/test-dgram-connect-send-callback-buffer-length.js
@@ -10,8 +10,7 @@ const buf = Buffer.allocUnsafe(256);
 const offset = 20;
 const len = buf.length - offset;
 
-const messageSent = common.mustCall(function messageSent(err, bytes) {
-  assert.ifError(err);
+const messageSent = common.mustSucceed(function messageSent(bytes) {
   assert.notStrictEqual(bytes, buf.length);
   assert.strictEqual(bytes, buf.length - offset);
   client.close();

--- a/test/parallel/test-dgram-connect-send-callback-buffer.js
+++ b/test/parallel/test-dgram-connect-send-callback-buffer.js
@@ -8,7 +8,7 @@ const client = dgram.createSocket('udp4');
 
 const buf = Buffer.allocUnsafe(256);
 
-const onMessage = common.mustSucceed(function(bytes) {
+const onMessage = common.mustSucceed((bytes) => {
   assert.strictEqual(bytes, buf.length);
   client.close();
 });

--- a/test/parallel/test-dgram-connect-send-callback-buffer.js
+++ b/test/parallel/test-dgram-connect-send-callback-buffer.js
@@ -8,8 +8,7 @@ const client = dgram.createSocket('udp4');
 
 const buf = Buffer.allocUnsafe(256);
 
-const onMessage = common.mustCall(function(err, bytes) {
-  assert.ifError(err);
+const onMessage = common.mustSucceed(function(bytes) {
   assert.strictEqual(bytes, buf.length);
   client.close();
 });

--- a/test/parallel/test-dgram-connect-send-empty-buffer.js
+++ b/test/parallel/test-dgram-connect-send-empty-buffer.js
@@ -10,7 +10,7 @@ client.bind(0, common.mustCall(function() {
   const port = this.address().port;
   client.connect(port, common.mustCall(() => {
     const buf = Buffer.alloc(0);
-    client.send(buf, 0, 0, common.mustCall());
+    client.send(buf, 0, 0, common.mustSucceed());
   }));
 
   client.on('message', common.mustCall((buffer) => {

--- a/test/parallel/test-dgram-connect-send-multi-buffer-copy.js
+++ b/test/parallel/test-dgram-connect-send-multi-buffer-copy.js
@@ -6,8 +6,7 @@ const dgram = require('dgram');
 
 const client = dgram.createSocket('udp4');
 
-const onMessage = common.mustCall(common.mustCall((err, bytes) => {
-  assert.ifError(err);
+const onMessage = common.mustCall(common.mustSucceed((bytes) => {
   assert.strictEqual(bytes, buf1.length + buf2.length);
 }));
 

--- a/test/parallel/test-dgram-send-address-types.js
+++ b/test/parallel/test-dgram-send-address-types.js
@@ -5,8 +5,7 @@ const dgram = require('dgram');
 
 const buf = Buffer.from('test');
 
-const onMessage = common.mustCall((err, bytes) => {
-  assert.ifError(err);
+const onMessage = common.mustSucceed((bytes) => {
   assert.strictEqual(bytes, buf.length);
 }, 6);
 

--- a/test/parallel/test-dgram-send-callback-buffer-empty-address.js
+++ b/test/parallel/test-dgram-send-callback-buffer-empty-address.js
@@ -8,8 +8,7 @@ const client = dgram.createSocket('udp4');
 
 const buf = Buffer.alloc(256, 'x');
 
-const onMessage = common.mustCall(function(err, bytes) {
-  assert.ifError(err);
+const onMessage = common.mustSucceed(function(bytes) {
   assert.strictEqual(bytes, buf.length);
   client.close();
 });

--- a/test/parallel/test-dgram-send-callback-buffer-empty-address.js
+++ b/test/parallel/test-dgram-send-callback-buffer-empty-address.js
@@ -8,7 +8,7 @@ const client = dgram.createSocket('udp4');
 
 const buf = Buffer.alloc(256, 'x');
 
-const onMessage = common.mustSucceed(function(bytes) {
+const onMessage = common.mustSucceed((bytes) => {
   assert.strictEqual(bytes, buf.length);
   client.close();
 });

--- a/test/parallel/test-dgram-send-callback-buffer-length-empty-address.js
+++ b/test/parallel/test-dgram-send-callback-buffer-length-empty-address.js
@@ -10,8 +10,7 @@ const buf = Buffer.alloc(256, 'x');
 const offset = 20;
 const len = buf.length - offset;
 
-const onMessage = common.mustCall(function messageSent(err, bytes) {
-  assert.ifError(err);
+const onMessage = common.mustSucceed(function messageSent(bytes) {
   assert.notStrictEqual(bytes, buf.length);
   assert.strictEqual(bytes, buf.length - offset);
   client.close();

--- a/test/parallel/test-dgram-send-callback-buffer-length.js
+++ b/test/parallel/test-dgram-send-callback-buffer-length.js
@@ -31,8 +31,7 @@ const buf = Buffer.allocUnsafe(256);
 const offset = 20;
 const len = buf.length - offset;
 
-const messageSent = common.mustCall(function messageSent(err, bytes) {
-  assert.ifError(err);
+const messageSent = common.mustSucceed(function messageSent(bytes) {
   assert.notStrictEqual(bytes, buf.length);
   assert.strictEqual(bytes, buf.length - offset);
   client.close();

--- a/test/parallel/test-dgram-send-callback-buffer.js
+++ b/test/parallel/test-dgram-send-callback-buffer.js
@@ -8,7 +8,7 @@ const client = dgram.createSocket('udp4');
 
 const buf = Buffer.allocUnsafe(256);
 
-const onMessage = common.mustSucceed(function(bytes) {
+const onMessage = common.mustSucceed((bytes) => {
   assert.strictEqual(bytes, buf.length);
   client.close();
 });

--- a/test/parallel/test-dgram-send-callback-buffer.js
+++ b/test/parallel/test-dgram-send-callback-buffer.js
@@ -8,8 +8,7 @@ const client = dgram.createSocket('udp4');
 
 const buf = Buffer.allocUnsafe(256);
 
-const onMessage = common.mustCall(function(err, bytes) {
-  assert.ifError(err);
+const onMessage = common.mustSucceed(function(bytes) {
   assert.strictEqual(bytes, buf.length);
   client.close();
 });

--- a/test/parallel/test-dgram-send-callback-multi-buffer-empty-address.js
+++ b/test/parallel/test-dgram-send-callback-multi-buffer-empty-address.js
@@ -6,8 +6,7 @@ const dgram = require('dgram');
 
 const client = dgram.createSocket('udp4');
 
-const messageSent = common.mustCall(function messageSent(err, bytes) {
-  assert.ifError(err);
+const messageSent = common.mustSucceed(function messageSent(bytes) {
   assert.strictEqual(bytes, buf1.length + buf2.length);
 });
 

--- a/test/parallel/test-dns-lookup.js
+++ b/test/parallel/test-dns-lookup.js
@@ -115,8 +115,7 @@ dns.lookup(false, {
   hints: 0,
   family: 0,
   all: true
-}, common.mustCall((error, result, addressType) => {
-  assert.ifError(error);
+}, common.mustSucceed((result, addressType) => {
   assert.deepStrictEqual(result, []);
   assert.strictEqual(addressType, undefined);
 }));
@@ -125,8 +124,7 @@ dns.lookup('127.0.0.1', {
   hints: 0,
   family: 4,
   all: true
-}, common.mustCall((error, result, addressType) => {
-  assert.ifError(error);
+}, common.mustSucceed((result, addressType) => {
   assert.deepStrictEqual(result, [{
     address: '127.0.0.1',
     family: 4
@@ -138,8 +136,7 @@ dns.lookup('127.0.0.1', {
   hints: 0,
   family: 4,
   all: false
-}, common.mustCall((error, result, addressType) => {
-  assert.ifError(error);
+}, common.mustSucceed((result, addressType) => {
   assert.deepStrictEqual(result, '127.0.0.1');
   assert.strictEqual(addressType, 4);
 }));

--- a/test/parallel/test-dns-multi-channel.js
+++ b/test/parallel/test-dns-multi-channel.js
@@ -44,8 +44,7 @@ function ready() {
 
   for (const { server: { socket, reply }, resolver } of resolvers) {
     resolver.setServers([`127.0.0.1:${socket.address().port}`]);
-    resolver.resolve4('example.org', common.mustCall((err, res) => {
-      assert.ifError(err);
+    resolver.resolve4('example.org', common.mustSucceed((res) => {
       assert.deepStrictEqual(res, [reply.address]);
       socket.close();
     }));

--- a/test/parallel/test-dns-resolveany.js
+++ b/test/parallel/test-dns-resolveany.js
@@ -45,8 +45,7 @@ server.bind(0, common.mustCall(async () => {
 
   validateResults(await dnsPromises.resolveAny('example.org'));
 
-  dns.resolveAny('example.org', common.mustCall((err, res) => {
-    assert.ifError(err);
+  dns.resolveAny('example.org', common.mustSucceed((res) => {
     validateResults(res);
     server.close();
   }));

--- a/test/parallel/test-dns.js
+++ b/test/parallel/test-dns.js
@@ -442,8 +442,7 @@ assert.throws(() => {
 
       validateResults(await dnsPromises[method]('example.org', options));
 
-      dns[method]('example.org', options, common.mustCall((err, res) => {
-        assert.ifError(err);
+      dns[method]('example.org', options, common.mustSucceed((res) => {
         validateResults(res);
         cases.shift();
         nextCase();

--- a/test/parallel/test-domain-crypto.js
+++ b/test/parallel/test-domain-crypto.js
@@ -35,9 +35,9 @@ global.domain = require('domain');
 
 // Should not throw a 'TypeError: undefined is not a function' exception
 crypto.randomBytes(8);
-crypto.randomBytes(8, common.mustCall());
+crypto.randomBytes(8, common.mustSucceed());
 const buf = Buffer.alloc(8);
 crypto.randomFillSync(buf);
 crypto.pseudoRandomBytes(8);
-crypto.pseudoRandomBytes(8, common.mustCall());
-crypto.pbkdf2('password', 'salt', 8, 8, 'sha1', common.mustCall());
+crypto.pseudoRandomBytes(8, common.mustSucceed());
+crypto.pbkdf2('password', 'salt', 8, 8, 'sha1', common.mustSucceed());

--- a/test/parallel/test-eslint-prefer-common-mustsucceed.js
+++ b/test/parallel/test-eslint-prefer-common-mustsucceed.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+common.skipIfEslintMissing();
+
+const RuleTester = require('../../tools/node_modules/eslint').RuleTester;
+const rule = require('../../tools/eslint-rules/prefer-common-mustsucceed');
+
+const msg1 = 'Please use common.mustSucceed instead of ' +
+             'common.mustCall(assert.ifError).';
+const msg2 = 'Please use common.mustSucceed instead of ' +
+             'common.mustCall with assert.ifError.';
+
+new RuleTester({
+  parserOptions: { ecmaVersion: 2015 }
+}).run('prefer-common-mustsucceed', rule, {
+  valid: [
+    'foo((err) => assert.ifError(err))',
+    'foo(function(err) { assert.ifError(err) })',
+    'foo(assert.ifError)',
+    'common.mustCall((err) => err)'
+  ],
+  invalid: [
+    {
+      code: 'common.mustCall(assert.ifError)',
+      errors: [{ message: msg1 }]
+    },
+    {
+      code: 'common.mustCall((err) => assert.ifError(err))',
+      errors: [{ message: msg2 }]
+    },
+    {
+      code: 'common.mustCall((e) => assert.ifError(e))',
+      errors: [{ message: msg2 }]
+    },
+    {
+      code: 'common.mustCall(function(e) { assert.ifError(e); })',
+      errors: [{ message: msg2 }]
+    },
+    {
+      code: 'common.mustCall(function(e) { return assert.ifError(e); })',
+      errors: [{ message: msg2 }]
+    },
+    {
+      code: 'common.mustCall(function(e) {{ assert.ifError(e); }})',
+      errors: [{ message: msg2 }]
+    }
+  ]
+});

--- a/test/parallel/test-fs-append-file.js
+++ b/test/parallel/test-fs-append-file.js
@@ -45,11 +45,8 @@ const throwNextTick = (e) => { process.nextTick(() => { throw e; }); };
 {
   const filename = join(tmpdir.path, 'append.txt');
 
-  fs.appendFile(filename, s, common.mustCall(function(e) {
-    assert.ifError(e);
-
-    fs.readFile(filename, common.mustCall(function(e, buffer) {
-      assert.ifError(e);
+  fs.appendFile(filename, s, common.mustSucceed(() => {
+    fs.readFile(filename, common.mustSucceed((buffer) => {
       assert.strictEqual(Buffer.byteLength(s), buffer.length);
     }));
   }));
@@ -72,11 +69,8 @@ const throwNextTick = (e) => { process.nextTick(() => { throw e; }); };
   const filename = join(tmpdir.path, 'append-non-empty.txt');
   fs.writeFileSync(filename, currentFileData);
 
-  fs.appendFile(filename, s, common.mustCall(function(e) {
-    assert.ifError(e);
-
-    fs.readFile(filename, common.mustCall(function(e, buffer) {
-      assert.ifError(e);
+  fs.appendFile(filename, s, common.mustSucceed(() => {
+    fs.readFile(filename, common.mustSucceed((buffer) => {
       assert.strictEqual(Buffer.byteLength(s) + currentFileData.length,
                          buffer.length);
     }));
@@ -104,11 +98,8 @@ const throwNextTick = (e) => { process.nextTick(() => { throw e; }); };
 
   const buf = Buffer.from(s, 'utf8');
 
-  fs.appendFile(filename, buf, common.mustCall((e) => {
-    assert.ifError(e);
-
-    fs.readFile(filename, common.mustCall((e, buffer) => {
-      assert.ifError(e);
+  fs.appendFile(filename, buf, common.mustSucceed(() => {
+    fs.readFile(filename, common.mustSucceed((buffer) => {
       assert.strictEqual(buf.length + currentFileData.length, buffer.length);
     }));
   }));
@@ -166,17 +157,10 @@ const throwNextTick = (e) => { process.nextTick(() => { throw e; }); };
   const filename = join(tmpdir.path, 'append-descriptors.txt');
   fs.writeFileSync(filename, currentFileData);
 
-  fs.open(filename, 'a+', common.mustCall((e, fd) => {
-    assert.ifError(e);
-
-    fs.appendFile(fd, s, common.mustCall((e) => {
-      assert.ifError(e);
-
-      fs.close(fd, common.mustCall((e) => {
-        assert.ifError(e);
-
-        fs.readFile(filename, common.mustCall((e, buffer) => {
-          assert.ifError(e);
+  fs.open(filename, 'a+', common.mustSucceed((fd) => {
+    fs.appendFile(fd, s, common.mustSucceed(() => {
+      fs.close(fd, common.mustSucceed(() => {
+        fs.readFile(filename, common.mustSucceed((buffer) => {
           assert.strictEqual(Buffer.byteLength(s) + currentFileData.length,
                              buffer.length);
         }));

--- a/test/parallel/test-fs-buffer.js
+++ b/test/parallel/test-fs-buffer.js
@@ -12,8 +12,7 @@ tmpdir.refresh();
 fs.access(Buffer.from(tmpdir.path), common.mustSucceed());
 
 const buf = Buffer.from(path.join(tmpdir.path, 'a.txt'));
-fs.open(buf, 'w+', common.mustCall((err, fd) => {
-  assert.ifError(err);
+fs.open(buf, 'w+', common.mustSucceed((fd) => {
   assert(fd);
   fs.close(fd, common.mustSucceed());
 }));
@@ -31,10 +30,8 @@ assert.throws(
 );
 
 const dir = Buffer.from(fixtures.fixturesDir);
-fs.readdir(dir, 'hex', common.mustCall((err, hexList) => {
-  assert.ifError(err);
-  fs.readdir(dir, common.mustCall((err, stringList) => {
-    assert.ifError(err);
+fs.readdir(dir, 'hex', common.mustSucceed((hexList) => {
+  fs.readdir(dir, common.mustSucceed((stringList) => {
     stringList.forEach((val, idx) => {
       const fromHexList = Buffer.from(hexList[idx], 'hex').toString();
       assert.strictEqual(

--- a/test/parallel/test-fs-buffer.js
+++ b/test/parallel/test-fs-buffer.js
@@ -9,13 +9,13 @@ const path = require('path');
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 
-fs.access(Buffer.from(tmpdir.path), common.mustCall(assert.ifError));
+fs.access(Buffer.from(tmpdir.path), common.mustSucceed());
 
 const buf = Buffer.from(path.join(tmpdir.path, 'a.txt'));
 fs.open(buf, 'w+', common.mustCall((err, fd) => {
   assert.ifError(err);
   assert(fd);
-  fs.close(fd, common.mustCall(assert.ifError));
+  fs.close(fd, common.mustSucceed());
 }));
 
 assert.throws(

--- a/test/parallel/test-fs-chmod-mask.js
+++ b/test/parallel/test-fs-chmod-mask.js
@@ -46,7 +46,6 @@ function test(mode, asString) {
     const file = path.join(tmpdir.path, `fchmod-async-${suffix}.txt`);
     fs.writeFileSync(file, 'test', 'utf-8');
     fs.open(file, 'w', common.mustSucceed((fd) => {
-
       fs.fchmod(fd, input, common.mustSucceed(() => {
         assert.strictEqual(fs.fstatSync(fd).mode & 0o777, mode);
         fs.close(fd, assert.ifError);

--- a/test/parallel/test-fs-chmod-mask.js
+++ b/test/parallel/test-fs-chmod-mask.js
@@ -29,8 +29,7 @@ function test(mode, asString) {
     const file = path.join(tmpdir.path, `chmod-async-${suffix}.txt`);
     fs.writeFileSync(file, 'test', 'utf-8');
 
-    fs.chmod(file, input, common.mustCall((err) => {
-      assert.ifError(err);
+    fs.chmod(file, input, common.mustSucceed(() => {
       assert.strictEqual(fs.statSync(file).mode & 0o777, mode);
     }));
   }
@@ -46,11 +45,9 @@ function test(mode, asString) {
   {
     const file = path.join(tmpdir.path, `fchmod-async-${suffix}.txt`);
     fs.writeFileSync(file, 'test', 'utf-8');
-    fs.open(file, 'w', common.mustCall((err, fd) => {
-      assert.ifError(err);
+    fs.open(file, 'w', common.mustSucceed((fd) => {
 
-      fs.fchmod(fd, input, common.mustCall((err) => {
-        assert.ifError(err);
+      fs.fchmod(fd, input, common.mustSucceed(() => {
         assert.strictEqual(fs.fstatSync(fd).mode & 0o777, mode);
         fs.close(fd, assert.ifError);
       }));
@@ -74,8 +71,7 @@ function test(mode, asString) {
     fs.writeFileSync(file, 'test', 'utf-8');
     fs.symlinkSync(file, link);
 
-    fs.lchmod(link, input, common.mustCall((err) => {
-      assert.ifError(err);
+    fs.lchmod(link, input, common.mustSucceed(() => {
       assert.strictEqual(fs.lstatSync(link).mode & 0o777, mode);
     }));
   }

--- a/test/parallel/test-fs-chmod.js
+++ b/test/parallel/test-fs-chmod.js
@@ -80,8 +80,7 @@ const file2 = path.join(tmpdir.path, 'a1.js');
 // Create file1.
 fs.closeSync(fs.openSync(file1, 'w'));
 
-fs.chmod(file1, mode_async.toString(8), common.mustCall((err) => {
-  assert.ifError(err);
+fs.chmod(file1, mode_async.toString(8), common.mustSucceed(() => {
 
   if (common.isWindows) {
     assert.ok((fs.statSync(file1).mode & 0o777) & mode_async);
@@ -97,11 +96,9 @@ fs.chmod(file1, mode_async.toString(8), common.mustCall((err) => {
   }
 }));
 
-fs.open(file2, 'w', common.mustCall((err, fd) => {
-  assert.ifError(err);
+fs.open(file2, 'w', common.mustSucceed((fd) => {
 
-  fs.fchmod(fd, mode_async.toString(8), common.mustCall((err) => {
-    assert.ifError(err);
+  fs.fchmod(fd, mode_async.toString(8), common.mustSucceed(() => {
 
     if (common.isWindows) {
       assert.ok((fs.fstatSync(fd).mode & 0o777) & mode_async);
@@ -136,8 +133,7 @@ if (fs.lchmod) {
 
   fs.symlinkSync(file2, link);
 
-  fs.lchmod(link, mode_async, common.mustCall((err) => {
-    assert.ifError(err);
+  fs.lchmod(link, mode_async, common.mustSucceed(() => {
 
     assert.strictEqual(fs.lstatSync(link).mode & 0o777, mode_async);
 

--- a/test/parallel/test-fs-chmod.js
+++ b/test/parallel/test-fs-chmod.js
@@ -81,7 +81,6 @@ const file2 = path.join(tmpdir.path, 'a1.js');
 fs.closeSync(fs.openSync(file1, 'w'));
 
 fs.chmod(file1, mode_async.toString(8), common.mustSucceed(() => {
-
   if (common.isWindows) {
     assert.ok((fs.statSync(file1).mode & 0o777) & mode_async);
   } else {
@@ -97,9 +96,7 @@ fs.chmod(file1, mode_async.toString(8), common.mustSucceed(() => {
 }));
 
 fs.open(file2, 'w', common.mustSucceed((fd) => {
-
   fs.fchmod(fd, mode_async.toString(8), common.mustSucceed(() => {
-
     if (common.isWindows) {
       assert.ok((fs.fstatSync(fd).mode & 0o777) & mode_async);
     } else {
@@ -134,7 +131,6 @@ if (fs.lchmod) {
   fs.symlinkSync(file2, link);
 
   fs.lchmod(link, mode_async, common.mustSucceed(() => {
-
     assert.strictEqual(fs.lstatSync(link).mode & 0o777, mode_async);
 
     fs.lchmodSync(link, mode_sync);

--- a/test/parallel/test-fs-copyfile.js
+++ b/test/parallel/test-fs-copyfile.js
@@ -76,8 +76,7 @@ try {
 
 // Copies asynchronously.
 tmpdir.refresh(); // Don't use unlinkSync() since the last test may fail.
-fs.copyFile(src, dest, common.mustCall((err) => {
-  assert.ifError(err);
+fs.copyFile(src, dest, common.mustSucceed(() => {
   verify(src, dest);
 
   // Copy asynchronously with flags.

--- a/test/parallel/test-fs-empty-readStream.js
+++ b/test/parallel/test-fs-empty-readStream.js
@@ -28,7 +28,6 @@ const fixtures = require('../common/fixtures');
 const emptyFile = fixtures.path('empty.txt');
 
 fs.open(emptyFile, 'r', common.mustSucceed((fd) => {
-
   const read = fs.createReadStream(emptyFile, { fd });
 
   read.once('data', common.mustNotCall('data event should not emit'));
@@ -37,7 +36,6 @@ fs.open(emptyFile, 'r', common.mustSucceed((fd) => {
 }));
 
 fs.open(emptyFile, 'r', common.mustSucceed((fd) => {
-
   const read = fs.createReadStream(emptyFile, { fd });
 
   read.pause();

--- a/test/parallel/test-fs-empty-readStream.js
+++ b/test/parallel/test-fs-empty-readStream.js
@@ -27,9 +27,7 @@ const fixtures = require('../common/fixtures');
 
 const emptyFile = fixtures.path('empty.txt');
 
-fs.open(emptyFile, 'r', common.mustCall((error, fd) => {
-
-  assert.ifError(error);
+fs.open(emptyFile, 'r', common.mustSucceed((fd) => {
 
   const read = fs.createReadStream(emptyFile, { fd });
 
@@ -38,9 +36,7 @@ fs.open(emptyFile, 'r', common.mustCall((error, fd) => {
   read.once('end', common.mustCall());
 }));
 
-fs.open(emptyFile, 'r', common.mustCall((error, fd) => {
-
-  assert.ifError(error);
+fs.open(emptyFile, 'r', common.mustSucceed((fd) => {
 
   const read = fs.createReadStream(emptyFile, { fd });
 

--- a/test/parallel/test-fs-existssync-false.js
+++ b/test/parallel/test-fs-existssync-false.js
@@ -31,6 +31,4 @@ for (let i = 0; i < 50; i++) {
 assert(fs.existsSync(dir), 'Directory is not accessible');
 
 // Test if file exists asynchronously
-fs.access(dir, common.mustCall((err) => {
-  assert.ifError(err);
-}));
+fs.access(dir, common.mustSucceed());

--- a/test/parallel/test-fs-fsync.js
+++ b/test/parallel/test-fs-fsync.js
@@ -35,17 +35,14 @@ const fileTemp = path.join(tmpdir.path, 'a.js');
 tmpdir.refresh();
 fs.copyFileSync(fileFixture, fileTemp);
 
-fs.open(fileTemp, 'a', 0o777, common.mustCall(function(err, fd) {
-  assert.ifError(err);
+fs.open(fileTemp, 'a', 0o777, common.mustSucceed(function(fd) {
 
   fs.fdatasyncSync(fd);
 
   fs.fsyncSync(fd);
 
-  fs.fdatasync(fd, common.mustCall(function(err) {
-    assert.ifError(err);
-    fs.fsync(fd, common.mustCall(function(err) {
-      assert.ifError(err);
+  fs.fdatasync(fd, common.mustSucceed(function() {
+    fs.fsync(fd, common.mustSucceed(function() {
       fs.closeSync(fd);
     }));
   }));

--- a/test/parallel/test-fs-fsync.js
+++ b/test/parallel/test-fs-fsync.js
@@ -35,14 +35,13 @@ const fileTemp = path.join(tmpdir.path, 'a.js');
 tmpdir.refresh();
 fs.copyFileSync(fileFixture, fileTemp);
 
-fs.open(fileTemp, 'a', 0o777, common.mustSucceed(function(fd) {
-
+fs.open(fileTemp, 'a', 0o777, common.mustSucceed((fd) => {
   fs.fdatasyncSync(fd);
 
   fs.fsyncSync(fd);
 
-  fs.fdatasync(fd, common.mustSucceed(function() {
-    fs.fsync(fd, common.mustSucceed(function() {
+  fs.fdatasync(fd, common.mustSucceed(() => {
+    fs.fsync(fd, common.mustSucceed(() => {
       fs.closeSync(fd);
     }));
   }));

--- a/test/parallel/test-fs-lchown.js
+++ b/test/parallel/test-fs-lchown.js
@@ -58,8 +58,7 @@ if (!common.isWindows) {
   tmpdir.refresh();
   fs.copyFileSync(__filename, testFile);
   fs.lchownSync(testFile, uid, gid);
-  fs.lchown(testFile, uid, gid, common.mustCall(async (err) => {
-    assert.ifError(err);
+  fs.lchown(testFile, uid, gid, common.mustSucceed(async (err) => {
     await promises.lchown(testFile, uid, gid);
   }));
 }

--- a/test/parallel/test-fs-long-path.js
+++ b/test/parallel/test-fs-long-path.js
@@ -26,7 +26,6 @@ if (!common.isWindows)
 
 const fs = require('fs');
 const path = require('path');
-const assert = require('assert');
 
 const tmpdir = require('../common/tmpdir');
 
@@ -42,10 +41,8 @@ console.log({
   fullPathLength: fullPath.length
 });
 
-fs.writeFile(fullPath, 'ok', common.mustCall(function(err) {
-  assert.ifError(err);
+fs.writeFile(fullPath, 'ok', common.mustSucceed(function() {
 
-  fs.stat(fullPath, common.mustCall(function(err, stats) {
-    assert.ifError(err);
+  fs.stat(fullPath, common.mustSucceed(function(stats) {
   }));
 }));

--- a/test/parallel/test-fs-long-path.js
+++ b/test/parallel/test-fs-long-path.js
@@ -41,8 +41,6 @@ console.log({
   fullPathLength: fullPath.length
 });
 
-fs.writeFile(fullPath, 'ok', common.mustSucceed(function() {
-
-  fs.stat(fullPath, common.mustSucceed(function(stats) {
-  }));
+fs.writeFile(fullPath, 'ok', common.mustSucceed(() => {
+  fs.stat(fullPath, common.mustSucceed());
 }));

--- a/test/parallel/test-fs-mkdir-mode-mask.js
+++ b/test/parallel/test-fs-mkdir-mode-mask.js
@@ -31,8 +31,7 @@ function test(mode, asString) {
 
   {
     const dir = path.join(tmpdir.path, `mkdir-${suffix}`);
-    fs.mkdir(dir, input, common.mustCall((err) => {
-      assert.ifError(err);
+    fs.mkdir(dir, input, common.mustSucceed(() => {
       assert.strictEqual(fs.statSync(dir).mode & 0o777, mode);
     }));
   }

--- a/test/parallel/test-fs-mkdir-rmdir.js
+++ b/test/parallel/test-fs-mkdir-rmdir.js
@@ -25,8 +25,7 @@ fs.rmdirSync(d);
 assert(!fs.existsSync(d));
 
 // Similarly test the Async version
-fs.mkdir(d, 0o666, common.mustCall(function(err) {
-  assert.ifError(err);
+fs.mkdir(d, 0o666, common.mustSucceed(function() {
 
   fs.mkdir(d, 0o666, common.mustCall(function(err) {
     assert.strictEqual(this, undefined);

--- a/test/parallel/test-fs-mkdir-rmdir.js
+++ b/test/parallel/test-fs-mkdir-rmdir.js
@@ -25,8 +25,7 @@ fs.rmdirSync(d);
 assert(!fs.existsSync(d));
 
 // Similarly test the Async version
-fs.mkdir(d, 0o666, common.mustSucceed(function() {
-
+fs.mkdir(d, 0o666, common.mustSucceed(() => {
   fs.mkdir(d, 0o666, common.mustCall(function(err) {
     assert.strictEqual(this, undefined);
     assert.ok(err, 'got no error');

--- a/test/parallel/test-fs-open-flags.js
+++ b/test/parallel/test-fs-open-flags.js
@@ -89,8 +89,7 @@ if (common.isLinux || common.isOSX) {
   tmpdir.refresh();
   const file = path.join(tmpdir.path, 'a.js');
   fs.copyFileSync(fixtures.path('a.js'), file);
-  fs.open(file, O_DSYNC, common.mustCall((err, fd) => {
-    assert.ifError(err);
+  fs.open(file, O_DSYNC, common.mustSucceed((fd) => {
     fs.closeSync(fd);
   }));
 }

--- a/test/parallel/test-fs-open-mode-mask.js
+++ b/test/parallel/test-fs-open-mode-mask.js
@@ -29,8 +29,7 @@ function test(mode, asString) {
 
   {
     const file = path.join(tmpdir.path, `open-${suffix}.txt`);
-    fs.open(file, 'w+', input, common.mustCall((err, fd) => {
-      assert.ifError(err);
+    fs.open(file, 'w+', input, common.mustSucceed((fd) => {
       assert.strictEqual(fs.fstatSync(fd).mode & 0o777, mode);
       fs.closeSync(fd);
       assert.strictEqual(fs.statSync(file).mode & 0o777, mode);

--- a/test/parallel/test-fs-open.js
+++ b/test/parallel/test-fs-open.js
@@ -38,25 +38,15 @@ assert.strictEqual(caughtException, true);
 
 fs.openSync(__filename);
 
-fs.open(__filename, common.mustCall((err) => {
-  assert.ifError(err);
-}));
+fs.open(__filename, common.mustSucceed());
 
-fs.open(__filename, 'r', common.mustCall((err) => {
-  assert.ifError(err);
-}));
+fs.open(__filename, 'r', common.mustSucceed());
 
-fs.open(__filename, 'rs', common.mustCall((err) => {
-  assert.ifError(err);
-}));
+fs.open(__filename, 'rs', common.mustSucceed());
 
-fs.open(__filename, 'r', 0, common.mustCall((err) => {
-  assert.ifError(err);
-}));
+fs.open(__filename, 'r', 0, common.mustSucceed());
 
-fs.open(__filename, 'r', null, common.mustCall((err) => {
-  assert.ifError(err);
-}));
+fs.open(__filename, 'r', null, common.mustSucceed());
 
 async function promise() {
   await fs.promises.open(__filename);

--- a/test/parallel/test-fs-opendir.js
+++ b/test/parallel/test-fs-opendir.js
@@ -81,9 +81,7 @@ fs.opendir(testDir, common.mustCall(function(err, dir) {
       assert(!syncInner);
       assert.ifError(err);
 
-      dir.close(common.mustCall(function(err) {
-        assert.ifError(err);
-      }));
+      dir.close(common.mustSucceed());
     }));
     syncInner = false;
   }));

--- a/test/parallel/test-fs-opendir.js
+++ b/test/parallel/test-fs-opendir.js
@@ -65,7 +65,7 @@ const invalidCallbackObj = {
 }
 
 // Check the opendir async version
-fs.opendir(testDir, common.mustSucceed(function(dir) {
+fs.opendir(testDir, common.mustSucceed((dir) => {
   let sync = true;
   dir.read(common.mustCall((err, dirent) => {
     assert(!sync);

--- a/test/parallel/test-fs-opendir.js
+++ b/test/parallel/test-fs-opendir.js
@@ -65,8 +65,7 @@ const invalidCallbackObj = {
 }
 
 // Check the opendir async version
-fs.opendir(testDir, common.mustCall(function(err, dir) {
-  assert.ifError(err);
+fs.opendir(testDir, common.mustSucceed(function(dir) {
   let sync = true;
   dir.read(common.mustCall((err, dirent) => {
     assert(!sync);

--- a/test/parallel/test-fs-read.js
+++ b/test/parallel/test-fs-read.js
@@ -35,8 +35,7 @@ function test(bufferAsync, bufferSync, expected) {
           0,
           expected.length,
           0,
-          common.mustCall((err, bytesRead) => {
-            assert.ifError(err);
+          common.mustSucceed((bytesRead) => {
             assert.strictEqual(bytesRead, expected.length);
             assert.deepStrictEqual(bufferAsync, expected);
           }));
@@ -62,8 +61,7 @@ test(new Uint8Array(expected.length),
   const nRead = fs.readSync(fd, Buffer.alloc(1), 0, 1, pos);
   assert.strictEqual(nRead, 0);
 
-  fs.read(fd, Buffer.alloc(1), 0, 1, pos, common.mustCall((err, nRead) => {
-    assert.ifError(err);
+  fs.read(fd, Buffer.alloc(1), 0, 1, pos, common.mustSucceed((nRead) => {
     assert.strictEqual(nRead, 0);
   }));
 }

--- a/test/parallel/test-fs-readdir-types.js
+++ b/test/parallel/test-fs-readdir-types.js
@@ -67,8 +67,7 @@ fs.readdir(__filename, {
 // Check the readdir async version
 fs.readdir(readdirDir, {
   withFileTypes: true
-}, common.mustCall((err, dirents) => {
-  assert.ifError(err);
+}, common.mustSucceed((dirents) => {
   assertDirents(dirents);
 }));
 
@@ -104,8 +103,7 @@ binding.readdir = common.mustCall((path, encoding, types, req, ctx) => {
 assertDirents(fs.readdirSync(readdirDir, { withFileTypes: true }));
 fs.readdir(readdirDir, {
   withFileTypes: true
-}, common.mustCall((err, dirents) => {
-  assert.ifError(err);
+}, common.mustSucceed((dirents) => {
   assertDirents(dirents);
 }));
 

--- a/test/parallel/test-fs-readdir-ucs2.js
+++ b/test/parallel/test-fs-readdir-ucs2.js
@@ -23,8 +23,7 @@ try {
   throw e;
 }
 
-fs.readdir(tmpdir.path, 'ucs2', common.mustCall((err, list) => {
-  assert.ifError(err);
+fs.readdir(tmpdir.path, 'ucs2', common.mustSucceed((list) => {
   assert.strictEqual(list.length, 1);
   const fn = list[0];
   assert.deepStrictEqual(Buffer.from(fn, 'ucs2'), filebuff);

--- a/test/parallel/test-fs-readdir.js
+++ b/test/parallel/test-fs-readdir.js
@@ -21,7 +21,7 @@ files.forEach(function(currentFile) {
 assert.deepStrictEqual(files, fs.readdirSync(readdirDir).sort());
 
 // Check the readdir async version
-fs.readdir(readdirDir, common.mustSucceed(function(f) {
+fs.readdir(readdirDir, common.mustSucceed((f) => {
   assert.deepStrictEqual(files, f.sort());
 }));
 

--- a/test/parallel/test-fs-readdir.js
+++ b/test/parallel/test-fs-readdir.js
@@ -21,8 +21,7 @@ files.forEach(function(currentFile) {
 assert.deepStrictEqual(files, fs.readdirSync(readdirDir).sort());
 
 // Check the readdir async version
-fs.readdir(readdirDir, common.mustCall(function(err, f) {
-  assert.ifError(err);
+fs.readdir(readdirDir, common.mustSucceed(function(f) {
   assert.deepStrictEqual(files, f.sort());
 }));
 

--- a/test/parallel/test-fs-readfile-fd.js
+++ b/test/parallel/test-fs-readfile-fd.js
@@ -75,18 +75,15 @@ function tempFdSync(callback) {
 
   {
     // Tests the fs.readFile().
-    fs.open(filename, 'r', common.mustCall((err, fd) => {
-      assert.ifError(err);
+    fs.open(filename, 'r', common.mustSucceed((fd) => {
       const buf = Buffer.alloc(5);
 
       // Read only five bytes, so that the position moves to five.
-      fs.read(fd, buf, 0, 5, null, common.mustCall((err, bytes) => {
-        assert.ifError(err);
+      fs.read(fd, buf, 0, 5, null, common.mustSucceed((bytes) => {
         assert.strictEqual(bytes, 5);
         assert.deepStrictEqual(buf.toString(), 'Hello');
 
-        fs.readFile(fd, common.mustCall((err, data) => {
-          assert.ifError(err);
+        fs.readFile(fd, common.mustSucceed((data) => {
           // readFile() should read from position five, instead of zero.
           assert.deepStrictEqual(data.toString(), ' World');
 

--- a/test/parallel/test-fs-readfile-pipe-large.js
+++ b/test/parallel/test-fs-readfile-pipe-large.js
@@ -29,8 +29,7 @@ const exec = require('child_process').exec;
 const f = JSON.stringify(__filename);
 const node = JSON.stringify(process.execPath);
 const cmd = `cat ${filename} | ${node} ${f} child`;
-exec(cmd, { maxBuffer: 1000000 }, common.mustCall((err, stdout, stderr) => {
-  assert.ifError(err);
+exec(cmd, { maxBuffer: 1000000 }, common.mustSucceed((stdout, stderr) => {
   assert.strictEqual(
     stdout,
     dataExpected,

--- a/test/parallel/test-fs-readfile-pipe.js
+++ b/test/parallel/test-fs-readfile-pipe.js
@@ -31,8 +31,7 @@ const assert = require('assert');
 const fs = require('fs');
 
 if (process.argv[2] === 'child') {
-  fs.readFile('/dev/stdin', common.mustCall(function(er, data) {
-    assert.ifError(er);
+  fs.readFile('/dev/stdin', common.mustSucceed((data) => {
     process.stdout.write(data);
   }));
   return;

--- a/test/parallel/test-fs-readfile-pipe.js
+++ b/test/parallel/test-fs-readfile-pipe.js
@@ -47,7 +47,7 @@ const exec = require('child_process').exec;
 const f = JSON.stringify(__filename);
 const node = JSON.stringify(process.execPath);
 const cmd = `cat ${filename} | ${node} ${f} child`;
-exec(cmd, common.mustSucceed(function(stdout, stderr) {
+exec(cmd, common.mustSucceed((stdout, stderr) => {
   assert.strictEqual(
     stdout,
     dataExpected,

--- a/test/parallel/test-fs-readfile-pipe.js
+++ b/test/parallel/test-fs-readfile-pipe.js
@@ -47,8 +47,7 @@ const exec = require('child_process').exec;
 const f = JSON.stringify(__filename);
 const node = JSON.stringify(process.execPath);
 const cmd = `cat ${filename} | ${node} ${f} child`;
-exec(cmd, common.mustCall(function(err, stdout, stderr) {
-  assert.ifError(err);
+exec(cmd, common.mustSucceed(function(stdout, stderr) {
   assert.strictEqual(
     stdout,
     dataExpected,

--- a/test/parallel/test-fs-readfile-unlink.js
+++ b/test/parallel/test-fs-readfile-unlink.js
@@ -37,8 +37,7 @@ tmpdir.refresh();
 
 fs.writeFileSync(fileName, buf);
 
-fs.readFile(fileName, common.mustCall((err, data) => {
-  assert.ifError(err);
+fs.readFile(fileName, common.mustSucceed((data) => {
   assert.strictEqual(data.length, buf.length);
   assert.strictEqual(buf[0], 42);
 

--- a/test/parallel/test-fs-readfilesync-enoent.js
+++ b/test/parallel/test-fs-readfilesync-enoent.js
@@ -18,7 +18,7 @@ function test(p) {
   const result = fs.realpathSync(p);
   assert.strictEqual(result.toLowerCase(), path.resolve(p).toLowerCase());
 
-  fs.realpath(p, common.mustSucceed(function(result) {
+  fs.realpath(p, common.mustSucceed((result) => {
     assert.strictEqual(result.toLowerCase(), path.resolve(p).toLowerCase());
   }));
 }

--- a/test/parallel/test-fs-readfilesync-enoent.js
+++ b/test/parallel/test-fs-readfilesync-enoent.js
@@ -18,8 +18,7 @@ function test(p) {
   const result = fs.realpathSync(p);
   assert.strictEqual(result.toLowerCase(), path.resolve(p).toLowerCase());
 
-  fs.realpath(p, common.mustCall(function(err, result) {
-    assert.ok(!err);
+  fs.realpath(p, common.mustSucceed(function(result) {
     assert.strictEqual(result.toLowerCase(), path.resolve(p).toLowerCase());
   }));
 }

--- a/test/parallel/test-fs-readfilesync-pipe-large.js
+++ b/test/parallel/test-fs-readfilesync-pipe-large.js
@@ -29,7 +29,7 @@ const cmd = `cat ${filename} | ${node} ${f} child`;
 exec(
   cmd,
   { maxBuffer: 1000000 },
-  common.mustSucceed(function(stdout, stderr) {
+  common.mustSucceed((stdout, stderr) => {
     assert.strictEqual(stdout, dataExpected);
     assert.strictEqual(stderr, '');
     console.log('ok');

--- a/test/parallel/test-fs-readfilesync-pipe-large.js
+++ b/test/parallel/test-fs-readfilesync-pipe-large.js
@@ -29,8 +29,7 @@ const cmd = `cat ${filename} | ${node} ${f} child`;
 exec(
   cmd,
   { maxBuffer: 1000000 },
-  common.mustCall(function(err, stdout, stderr) {
-    assert.ifError(err);
+  common.mustSucceed(function(stdout, stderr) {
     assert.strictEqual(stdout, dataExpected);
     assert.strictEqual(stderr, '');
     console.log('ok');

--- a/test/parallel/test-fs-readv.js
+++ b/test/parallel/test-fs-readv.js
@@ -24,8 +24,7 @@ const allocateEmptyBuffers = (combinedLength) => {
 };
 
 const getCallback = (fd, bufferArr) => {
-  return common.mustCall((err, bytesRead, buffers) => {
-    assert.ifError(err);
+  return common.mustSucceed((bytesRead, buffers) => {
 
     assert.deepStrictEqual(bufferArr, buffers);
     const expectedLength = exptectedBuff.length;

--- a/test/parallel/test-fs-readv.js
+++ b/test/parallel/test-fs-readv.js
@@ -25,7 +25,6 @@ const allocateEmptyBuffers = (combinedLength) => {
 
 const getCallback = (fd, bufferArr) => {
   return common.mustSucceed((bytesRead, buffers) => {
-
     assert.deepStrictEqual(bufferArr, buffers);
     const expectedLength = exptectedBuff.length;
     assert.deepStrictEqual(bytesRead, expectedLength);

--- a/test/parallel/test-fs-realpath-buffer-encoding.js
+++ b/test/parallel/test-fs-realpath-buffer-encoding.js
@@ -54,45 +54,37 @@ for (encoding in expected) {
   fs.realpath(
     string_dir,
     { encoding },
-    common.mustCall((err, res) => {
-      assert.ifError(err);
+    common.mustSucceed((res) => {
       assert.strictEqual(res, expected_value);
     })
   );
-  fs.realpath(string_dir, encoding, common.mustCall((err, res) => {
-    assert.ifError(err);
+  fs.realpath(string_dir, encoding, common.mustSucceed((res) => {
     assert.strictEqual(res, expected_value);
   }));
   fs.realpath(
     buffer_dir,
     { encoding },
-    common.mustCall((err, res) => {
-      assert.ifError(err);
+    common.mustSucceed((res) => {
       assert.strictEqual(res, expected_value);
     })
   );
-  fs.realpath(buffer_dir, encoding, common.mustCall((err, res) => {
-    assert.ifError(err);
+  fs.realpath(buffer_dir, encoding, common.mustSucceed((res) => {
     assert.strictEqual(res, expected_value);
   }));
 }
 
-fs.realpath(string_dir, { encoding: 'buffer' }, common.mustCall((err, res) => {
-  assert.ifError(err);
+fs.realpath(string_dir, { encoding: 'buffer' }, common.mustSucceed((res) => {
   assert.deepStrictEqual(res, buffer_dir);
 }));
 
-fs.realpath(string_dir, 'buffer', common.mustCall((err, res) => {
-  assert.ifError(err);
+fs.realpath(string_dir, 'buffer', common.mustSucceed((res) => {
   assert.deepStrictEqual(res, buffer_dir);
 }));
 
-fs.realpath(buffer_dir, { encoding: 'buffer' }, common.mustCall((err, res) => {
-  assert.ifError(err);
+fs.realpath(buffer_dir, { encoding: 'buffer' }, common.mustSucceed((res) => {
   assert.deepStrictEqual(res, buffer_dir);
 }));
 
-fs.realpath(buffer_dir, 'buffer', common.mustCall((err, res) => {
-  assert.ifError(err);
+fs.realpath(buffer_dir, 'buffer', common.mustSucceed((res) => {
   assert.deepStrictEqual(res, buffer_dir);
 }));

--- a/test/parallel/test-fs-realpath-native.js
+++ b/test/parallel/test-fs-realpath-native.js
@@ -12,8 +12,7 @@ assert.strictEqual(
 
 fs.realpath.native(
   './test/parallel/test-fs-realpath-native.js',
-  common.mustCall(function(err, res) {
-    assert.ifError(err);
+  common.mustSucceed(function(res) {
     assert.strictEqual(res.toLowerCase(), filename);
     assert.strictEqual(this, undefined);
   }));

--- a/test/parallel/test-fs-realpath-on-substed-drive.js
+++ b/test/parallel/test-fs-realpath-on-substed-drive.js
@@ -41,13 +41,11 @@ result = fs.realpathSync(filename, 'buffer');
 assert(Buffer.isBuffer(result));
 assert(result.equals(filenameBuffer));
 
-fs.realpath(filename, common.mustCall(function(err, result) {
-  assert.ifError(err);
+fs.realpath(filename, common.mustSucceed(function(result) {
   assert.strictEqual(result, filename);
 }));
 
-fs.realpath(filename, 'buffer', common.mustCall(function(err, result) {
-  assert.ifError(err);
+fs.realpath(filename, 'buffer', common.mustSucceed(function(result) {
   assert(Buffer.isBuffer(result));
   assert(result.equals(filenameBuffer));
 }));

--- a/test/parallel/test-fs-realpath-on-substed-drive.js
+++ b/test/parallel/test-fs-realpath-on-substed-drive.js
@@ -41,11 +41,11 @@ result = fs.realpathSync(filename, 'buffer');
 assert(Buffer.isBuffer(result));
 assert(result.equals(filenameBuffer));
 
-fs.realpath(filename, common.mustSucceed(function(result) {
+fs.realpath(filename, common.mustSucceed((result) => {
   assert.strictEqual(result, filename);
 }));
 
-fs.realpath(filename, 'buffer', common.mustSucceed(function(result) {
+fs.realpath(filename, 'buffer', common.mustSucceed((result) => {
   assert(Buffer.isBuffer(result));
   assert(result.equals(filenameBuffer));
 }));

--- a/test/parallel/test-fs-realpath.js
+++ b/test/parallel/test-fs-realpath.js
@@ -564,8 +564,7 @@ function runNextTest(err) {
     return console.log(`${numtests} subtests completed OK for fs.realpath`);
   }
   testsRun++;
-  test(fs.realpath, fs.realpathSync, common.mustCall((err) => {
-    assert.ifError(err);
+  test(fs.realpath, fs.realpathSync, common.mustSucceed(() => {
     testsRun++;
     test(fs.realpath.native,
          fs.realpathSync.native,

--- a/test/parallel/test-fs-rm.js
+++ b/test/parallel/test-fs-rm.js
@@ -72,8 +72,7 @@ function removeAsync(dir) {
       assert.strictEqual(err.syscall, 'rm');
 
       // Recursive removal should succeed.
-      fs.rm(dir, { recursive: true }, common.mustCall((err) => {
-        assert.ifError(err);
+      fs.rm(dir, { recursive: true }, common.mustSucceed(() => {
 
         // Attempted removal should fail now because the directory is gone.
         fs.rm(dir, common.mustCall((err) => {

--- a/test/parallel/test-fs-rmdir-recursive.js
+++ b/test/parallel/test-fs-rmdir-recursive.js
@@ -73,10 +73,8 @@ function removeAsync(dir) {
 
       // Recursive removal should succeed.
       fs.rmdir(dir, { recursive: true }, common.mustSucceed(() => {
-
         // No error should occur if recursive and the directory does not exist.
         fs.rmdir(dir, { recursive: true }, common.mustSucceed(() => {
-
           // Attempted removal should fail now because the directory is gone.
           fs.rmdir(dir, common.mustCall((err) => {
             assert.strictEqual(err.syscall, 'rmdir');

--- a/test/parallel/test-fs-rmdir-recursive.js
+++ b/test/parallel/test-fs-rmdir-recursive.js
@@ -72,12 +72,10 @@ function removeAsync(dir) {
       assert.strictEqual(err.syscall, 'rmdir');
 
       // Recursive removal should succeed.
-      fs.rmdir(dir, { recursive: true }, common.mustCall((err) => {
-        assert.ifError(err);
+      fs.rmdir(dir, { recursive: true }, common.mustSucceed(() => {
 
         // No error should occur if recursive and the directory does not exist.
-        fs.rmdir(dir, { recursive: true }, common.mustCall((err) => {
-          assert.ifError(err);
+        fs.rmdir(dir, { recursive: true }, common.mustSucceed(() => {
 
           // Attempted removal should fail now because the directory is gone.
           fs.rmdir(dir, common.mustCall((err) => {

--- a/test/parallel/test-fs-stat.js
+++ b/test/parallel/test-fs-stat.js
@@ -69,7 +69,7 @@ fs.open('.', 'r', undefined, common.mustCall(function(err, fd) {
   fs.close(fd, common.mustSucceed());
 }));
 
-fs.stat(__filename, common.mustSucceed(function(s) {
+fs.stat(__filename, common.mustSucceed((s) => {
   assert.strictEqual(s.isDirectory(), false);
   assert.strictEqual(s.isFile(), true);
   assert.strictEqual(s.isSocket(), false);

--- a/test/parallel/test-fs-stat.js
+++ b/test/parallel/test-fs-stat.js
@@ -25,8 +25,7 @@ const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 
-fs.stat('.', common.mustCall(function(err, stats) {
-  assert.ifError(err);
+fs.stat('.', common.mustSucceed(function(stats) {
   assert.ok(stats.mtime instanceof Date);
   assert.ok(stats.hasOwnProperty('blksize'));
   assert.ok(stats.hasOwnProperty('blocks'));
@@ -36,8 +35,7 @@ fs.stat('.', common.mustCall(function(err, stats) {
   assert.strictEqual(this, undefined);
 }));
 
-fs.lstat('.', common.mustCall(function(err, stats) {
-  assert.ifError(err);
+fs.lstat('.', common.mustSucceed(function(stats) {
   assert.ok(stats.mtime instanceof Date);
   // Confirm that we are not running in the context of the internal binding
   // layer.
@@ -46,12 +44,10 @@ fs.lstat('.', common.mustCall(function(err, stats) {
 }));
 
 // fstat
-fs.open('.', 'r', undefined, common.mustCall(function(err, fd) {
-  assert.ifError(err);
+fs.open('.', 'r', undefined, common.mustSucceed(function(fd) {
   assert.ok(fd);
 
-  fs.fstat(fd, common.mustCall(function(err, stats) {
-    assert.ifError(err);
+  fs.fstat(fd, common.mustSucceed(function(stats) {
     assert.ok(stats.mtime instanceof Date);
     fs.close(fd, assert.ifError);
     // Confirm that we are not running in the context of the internal binding
@@ -73,8 +69,7 @@ fs.open('.', 'r', undefined, common.mustCall(function(err, fd) {
   fs.close(fd, common.mustSucceed());
 }));
 
-fs.stat(__filename, common.mustCall(function(err, s) {
-  assert.ifError(err);
+fs.stat(__filename, common.mustSucceed(function(s) {
   assert.strictEqual(s.isDirectory(), false);
   assert.strictEqual(s.isFile(), true);
   assert.strictEqual(s.isSocket(), false);

--- a/test/parallel/test-fs-stat.js
+++ b/test/parallel/test-fs-stat.js
@@ -70,7 +70,7 @@ fs.open('.', 'r', undefined, common.mustCall(function(err, fd) {
 fs.open('.', 'r', undefined, common.mustCall(function(err, fd) {
   const stats = fs.fstatSync(fd);
   assert.ok(stats.mtime instanceof Date);
-  fs.close(fd, common.mustCall(assert.ifError));
+  fs.close(fd, common.mustSucceed());
 }));
 
 fs.stat(__filename, common.mustCall(function(err, s) {

--- a/test/parallel/test-fs-symlink-buffer-path.js
+++ b/test/parallel/test-fs-symlink-buffer-path.js
@@ -43,15 +43,15 @@ let fileTime;
 // Refs: https://github.com/nodejs/node/issues/34514
 fs.symlinkSync(Buffer.from(linkData), linkPath);
 
-fs.lstat(linkPath, common.mustSucceed(function(stats) {
+fs.lstat(linkPath, common.mustSucceed((stats) => {
   linkTime = stats.mtime.getTime();
 }));
 
-fs.stat(linkPath, common.mustSucceed(function(stats) {
+fs.stat(linkPath, common.mustSucceed((stats) => {
   fileTime = stats.mtime.getTime();
 }));
 
-fs.readlink(linkPath, common.mustSucceed(function(destination) {
+fs.readlink(linkPath, common.mustSucceed((destination) => {
   assert.strictEqual(destination, linkData);
 }));
 

--- a/test/parallel/test-fs-symlink-buffer-path.js
+++ b/test/parallel/test-fs-symlink-buffer-path.js
@@ -43,18 +43,15 @@ let fileTime;
 // Refs: https://github.com/nodejs/node/issues/34514
 fs.symlinkSync(Buffer.from(linkData), linkPath);
 
-fs.lstat(linkPath, common.mustCall(function(err, stats) {
-  assert.ifError(err);
+fs.lstat(linkPath, common.mustSucceed(function(stats) {
   linkTime = stats.mtime.getTime();
 }));
 
-fs.stat(linkPath, common.mustCall(function(err, stats) {
-  assert.ifError(err);
+fs.stat(linkPath, common.mustSucceed(function(stats) {
   fileTime = stats.mtime.getTime();
 }));
 
-fs.readlink(linkPath, common.mustCall(function(err, destination) {
-  assert.ifError(err);
+fs.readlink(linkPath, common.mustSucceed(function(destination) {
   assert.strictEqual(destination, linkData);
 }));
 

--- a/test/parallel/test-fs-symlink-dir-junction-relative.js
+++ b/test/parallel/test-fs-symlink-dir-junction-relative.js
@@ -38,8 +38,7 @@ const linkData = fixtures.fixturesDir;
 tmpdir.refresh();
 
 // Test fs.symlink()
-fs.symlink(linkData, linkPath1, 'junction', common.mustCall(function(err) {
-  assert.ifError(err);
+fs.symlink(linkData, linkPath1, 'junction', common.mustSucceed(function() {
   verifyLink(linkPath1);
 }));
 

--- a/test/parallel/test-fs-symlink-dir-junction-relative.js
+++ b/test/parallel/test-fs-symlink-dir-junction-relative.js
@@ -38,7 +38,7 @@ const linkData = fixtures.fixturesDir;
 tmpdir.refresh();
 
 // Test fs.symlink()
-fs.symlink(linkData, linkPath1, 'junction', common.mustSucceed(function() {
+fs.symlink(linkData, linkPath1, 'junction', common.mustSucceed(() => {
   verifyLink(linkPath1);
 }));
 

--- a/test/parallel/test-fs-symlink-dir-junction.js
+++ b/test/parallel/test-fs-symlink-dir-junction.js
@@ -34,19 +34,15 @@ const linkPath = path.join(tmpdir.path, 'cycles_link');
 
 tmpdir.refresh();
 
-fs.symlink(linkData, linkPath, 'junction', common.mustCall(function(err) {
-  assert.ifError(err);
+fs.symlink(linkData, linkPath, 'junction', common.mustSucceed(function() {
 
-  fs.lstat(linkPath, common.mustCall(function(err, stats) {
-    assert.ifError(err);
+  fs.lstat(linkPath, common.mustSucceed(function(stats) {
     assert.ok(stats.isSymbolicLink());
 
-    fs.readlink(linkPath, common.mustCall(function(err, destination) {
-      assert.ifError(err);
+    fs.readlink(linkPath, common.mustSucceed(function(destination) {
       assert.strictEqual(destination, linkData);
 
-      fs.unlink(linkPath, common.mustCall(function(err) {
-        assert.ifError(err);
+      fs.unlink(linkPath, common.mustSucceed(function() {
         assert(!fs.existsSync(linkPath));
         assert(fs.existsSync(linkData));
       }));
@@ -59,13 +55,11 @@ fs.symlink(linkData, linkPath, 'junction', common.mustCall(function(err) {
   const linkData = fixtures.path('/not/exists/dir');
   const linkPath = path.join(tmpdir.path, 'invalid_junction_link');
 
-  fs.symlink(linkData, linkPath, 'junction', common.mustCall(function(err) {
-    assert.ifError(err);
+  fs.symlink(linkData, linkPath, 'junction', common.mustSucceed(function() {
 
     assert(!fs.existsSync(linkPath));
 
-    fs.unlink(linkPath, common.mustCall(function(err) {
-      assert.ifError(err);
+    fs.unlink(linkPath, common.mustSucceed(function() {
       assert(!fs.existsSync(linkPath));
     }));
   }));

--- a/test/parallel/test-fs-symlink-dir-junction.js
+++ b/test/parallel/test-fs-symlink-dir-junction.js
@@ -34,15 +34,14 @@ const linkPath = path.join(tmpdir.path, 'cycles_link');
 
 tmpdir.refresh();
 
-fs.symlink(linkData, linkPath, 'junction', common.mustSucceed(function() {
-
-  fs.lstat(linkPath, common.mustSucceed(function(stats) {
+fs.symlink(linkData, linkPath, 'junction', common.mustSucceed(() => {
+  fs.lstat(linkPath, common.mustSucceed((stats) => {
     assert.ok(stats.isSymbolicLink());
 
-    fs.readlink(linkPath, common.mustSucceed(function(destination) {
+    fs.readlink(linkPath, common.mustSucceed((destination) => {
       assert.strictEqual(destination, linkData);
 
-      fs.unlink(linkPath, common.mustSucceed(function() {
+      fs.unlink(linkPath, common.mustSucceed(() => {
         assert(!fs.existsSync(linkPath));
         assert(fs.existsSync(linkData));
       }));
@@ -55,11 +54,10 @@ fs.symlink(linkData, linkPath, 'junction', common.mustSucceed(function() {
   const linkData = fixtures.path('/not/exists/dir');
   const linkPath = path.join(tmpdir.path, 'invalid_junction_link');
 
-  fs.symlink(linkData, linkPath, 'junction', common.mustSucceed(function() {
-
+  fs.symlink(linkData, linkPath, 'junction', common.mustSucceed(() => {
     assert(!fs.existsSync(linkPath));
 
-    fs.unlink(linkPath, common.mustSucceed(function() {
+    fs.unlink(linkPath, common.mustSucceed(() => {
       assert(!fs.existsSync(linkPath));
     }));
   }));

--- a/test/parallel/test-fs-symlink-dir.js
+++ b/test/parallel/test-fs-symlink-dir.js
@@ -31,8 +31,7 @@ function testSync(target, path) {
 }
 
 function testAsync(target, path) {
-  fs.symlink(target, path, common.mustCall((err) => {
-    assert.ifError(err);
+  fs.symlink(target, path, common.mustSucceed(() => {
     fs.readdirSync(path);
   }));
 }
@@ -53,8 +52,7 @@ for (const linkTarget of linkTargets) {
   }
 
   function testAsync(target, path) {
-    fs.symlink(target, path, common.mustCall((err) => {
-      assert.ifError(err);
+    fs.symlink(target, path, common.mustSucceed(() => {
       assert(!fs.existsSync(path));
     }));
   }

--- a/test/parallel/test-fs-symlink-longpath.js
+++ b/test/parallel/test-fs-symlink-longpath.js
@@ -15,15 +15,13 @@ fs.mkdirSync(longPath, { recursive: true });
 const targetDirtectory = path.join(longPath, 'target-directory');
 fs.mkdirSync(targetDirtectory);
 const pathDirectory = path.join(tmpDir, 'new-directory');
-fs.symlink(targetDirtectory, pathDirectory, 'dir', common.mustCall((err) => {
-  assert.ifError(err);
+fs.symlink(targetDirtectory, pathDirectory, 'dir', common.mustSucceed(() => {
   assert(fs.existsSync(pathDirectory));
 }));
 
 const targetFile = path.join(longPath, 'target-file');
 fs.writeFileSync(targetFile, 'data');
 const pathFile = path.join(tmpDir, 'new-file');
-fs.symlink(targetFile, pathFile, common.mustCall((err) => {
-  assert.ifError(err);
+fs.symlink(targetFile, pathFile, common.mustSucceed(() => {
   assert(fs.existsSync(pathFile));
 }));

--- a/test/parallel/test-fs-symlink.js
+++ b/test/parallel/test-fs-symlink.js
@@ -39,21 +39,17 @@ tmpdir.refresh();
 const linkData = fixtures.path('/cycles/root.js');
 const linkPath = path.join(tmpdir.path, 'symlink1.js');
 
-fs.symlink(linkData, linkPath, common.mustCall(function(err) {
-  assert.ifError(err);
+fs.symlink(linkData, linkPath, common.mustSucceed(function() {
 
-  fs.lstat(linkPath, common.mustCall(function(err, stats) {
-    assert.ifError(err);
+  fs.lstat(linkPath, common.mustSucceed(function(stats) {
     linkTime = stats.mtime.getTime();
   }));
 
-  fs.stat(linkPath, common.mustCall(function(err, stats) {
-    assert.ifError(err);
+  fs.stat(linkPath, common.mustSucceed(function(stats) {
     fileTime = stats.mtime.getTime();
   }));
 
-  fs.readlink(linkPath, common.mustCall(function(err, destination) {
-    assert.ifError(err);
+  fs.readlink(linkPath, common.mustSucceed(function(destination) {
     assert.strictEqual(destination, linkData);
   }));
 }));
@@ -63,8 +59,7 @@ fs.symlink(linkData, linkPath, common.mustCall(function(err) {
   const linkData = fixtures.path('/not/exists/file');
   const linkPath = path.join(tmpdir.path, 'symlink2.js');
 
-  fs.symlink(linkData, linkPath, common.mustCall(function(err) {
-    assert.ifError(err);
+  fs.symlink(linkData, linkPath, common.mustSucceed(function() {
 
     assert(!fs.existsSync(linkPath));
   }));

--- a/test/parallel/test-fs-symlink.js
+++ b/test/parallel/test-fs-symlink.js
@@ -39,17 +39,16 @@ tmpdir.refresh();
 const linkData = fixtures.path('/cycles/root.js');
 const linkPath = path.join(tmpdir.path, 'symlink1.js');
 
-fs.symlink(linkData, linkPath, common.mustSucceed(function() {
-
-  fs.lstat(linkPath, common.mustSucceed(function(stats) {
+fs.symlink(linkData, linkPath, common.mustSucceed(() => {
+  fs.lstat(linkPath, common.mustSucceed((stats) => {
     linkTime = stats.mtime.getTime();
   }));
 
-  fs.stat(linkPath, common.mustSucceed(function(stats) {
+  fs.stat(linkPath, common.mustSucceed((stats) => {
     fileTime = stats.mtime.getTime();
   }));
 
-  fs.readlink(linkPath, common.mustSucceed(function(destination) {
+  fs.readlink(linkPath, common.mustSucceed((destination) => {
     assert.strictEqual(destination, linkData);
   }));
 }));
@@ -59,8 +58,7 @@ fs.symlink(linkData, linkPath, common.mustSucceed(function() {
   const linkData = fixtures.path('/not/exists/file');
   const linkPath = path.join(tmpdir.path, 'symlink2.js');
 
-  fs.symlink(linkData, linkPath, common.mustSucceed(function() {
-
+  fs.symlink(linkData, linkPath, common.mustSucceed(() => {
     assert(!fs.existsSync(linkPath));
   }));
 }

--- a/test/parallel/test-fs-truncate-clear-file-zero.js
+++ b/test/parallel/test-fs-truncate-clear-file-zero.js
@@ -49,7 +49,7 @@ tmpdir.refresh();
   fs.truncate(
     filename,
     5,
-    common.mustSucceed(function() {
+    common.mustSucceed(() => {
       assert.strictEqual(fs.readFileSync(filename).toString(), '01234');
     })
   );

--- a/test/parallel/test-fs-truncate-clear-file-zero.js
+++ b/test/parallel/test-fs-truncate-clear-file-zero.js
@@ -49,8 +49,7 @@ tmpdir.refresh();
   fs.truncate(
     filename,
     5,
-    common.mustCall(function(err) {
-      assert.ifError(err);
+    common.mustSucceed(function() {
       assert.strictEqual(fs.readFileSync(filename).toString(), '01234');
     })
   );

--- a/test/parallel/test-fs-truncate-fd.js
+++ b/test/parallel/test-fs-truncate-fd.js
@@ -16,8 +16,7 @@ const msg = 'Using fs.truncate with a file descriptor is deprecated.' +
 
 
 common.expectWarning('DeprecationWarning', msg, 'DEP0081');
-fs.truncate(fd, 5, common.mustCall((err) => {
-  assert.ok(!err);
+fs.truncate(fd, 5, common.mustSucceed(() => {
   assert.strictEqual(fs.readFileSync(filename, 'utf8'), 'hello');
 }));
 

--- a/test/parallel/test-fs-truncate.js
+++ b/test/parallel/test-fs-truncate.js
@@ -155,7 +155,7 @@ function testFtruncate(cb) {
 {
   const file3 = path.resolve(tmp, 'truncate-file-3.txt');
   fs.writeFileSync(file3, 'Hi');
-  fs.truncate(file3, 4, common.mustSucceed(function() {
+  fs.truncate(file3, 4, common.mustSucceed(() => {
     assert(fs.readFileSync(file3).equals(Buffer.from('Hi\u0000\u0000')));
   }));
 }
@@ -165,7 +165,7 @@ function testFtruncate(cb) {
   fs.writeFileSync(file4, 'Hi');
   const fd = fs.openSync(file4, 'r+');
   process.on('beforeExit', () => fs.closeSync(fd));
-  fs.ftruncate(fd, 4, common.mustSucceed(function() {
+  fs.ftruncate(fd, 4, common.mustSucceed(() => {
     assert(fs.readFileSync(file4).equals(Buffer.from('Hi\u0000\u0000')));
   }));
 }
@@ -219,7 +219,7 @@ function testFtruncate(cb) {
     );
   });
 
-  fs.ftruncate(fd, undefined, common.mustSucceed(function() {
+  fs.ftruncate(fd, undefined, common.mustSucceed(() => {
     assert(fs.readFileSync(file5).equals(Buffer.from('')));
   }));
 }
@@ -229,7 +229,7 @@ function testFtruncate(cb) {
   fs.writeFileSync(file6, 'Hi');
   const fd = fs.openSync(file6, 'r+');
   process.on('beforeExit', () => fs.closeSync(fd));
-  fs.ftruncate(fd, -1, common.mustSucceed(function() {
+  fs.ftruncate(fd, -1, common.mustSucceed(() => {
     assert(fs.readFileSync(file6).equals(Buffer.from('')));
   }));
 }
@@ -237,7 +237,7 @@ function testFtruncate(cb) {
 {
   const file7 = path.resolve(tmp, 'truncate-file-7.txt');
   fs.writeFileSync(file7, 'Hi');
-  fs.truncate(file7, undefined, common.mustSucceed(function() {
+  fs.truncate(file7, undefined, common.mustSucceed(() => {
     assert(fs.readFileSync(file7).equals(Buffer.from('')));
   }));
 }

--- a/test/parallel/test-fs-truncate.js
+++ b/test/parallel/test-fs-truncate.js
@@ -155,8 +155,7 @@ function testFtruncate(cb) {
 {
   const file3 = path.resolve(tmp, 'truncate-file-3.txt');
   fs.writeFileSync(file3, 'Hi');
-  fs.truncate(file3, 4, common.mustCall(function(err) {
-    assert.ifError(err);
+  fs.truncate(file3, 4, common.mustSucceed(function() {
     assert(fs.readFileSync(file3).equals(Buffer.from('Hi\u0000\u0000')));
   }));
 }
@@ -166,8 +165,7 @@ function testFtruncate(cb) {
   fs.writeFileSync(file4, 'Hi');
   const fd = fs.openSync(file4, 'r+');
   process.on('beforeExit', () => fs.closeSync(fd));
-  fs.ftruncate(fd, 4, common.mustCall(function(err) {
-    assert.ifError(err);
+  fs.ftruncate(fd, 4, common.mustSucceed(function() {
     assert(fs.readFileSync(file4).equals(Buffer.from('Hi\u0000\u0000')));
   }));
 }
@@ -221,8 +219,7 @@ function testFtruncate(cb) {
     );
   });
 
-  fs.ftruncate(fd, undefined, common.mustCall(function(err) {
-    assert.ifError(err);
+  fs.ftruncate(fd, undefined, common.mustSucceed(function() {
     assert(fs.readFileSync(file5).equals(Buffer.from('')));
   }));
 }
@@ -232,8 +229,7 @@ function testFtruncate(cb) {
   fs.writeFileSync(file6, 'Hi');
   const fd = fs.openSync(file6, 'r+');
   process.on('beforeExit', () => fs.closeSync(fd));
-  fs.ftruncate(fd, -1, common.mustCall(function(err) {
-    assert.ifError(err);
+  fs.ftruncate(fd, -1, common.mustSucceed(function() {
     assert(fs.readFileSync(file6).equals(Buffer.from('')));
   }));
 }
@@ -241,8 +237,7 @@ function testFtruncate(cb) {
 {
   const file7 = path.resolve(tmp, 'truncate-file-7.txt');
   fs.writeFileSync(file7, 'Hi');
-  fs.truncate(file7, undefined, common.mustCall(function(err) {
-    assert.ifError(err);
+  fs.truncate(file7, undefined, common.mustSucceed(function() {
     assert(fs.readFileSync(file7).equals(Buffer.from('')));
   }));
 }

--- a/test/parallel/test-fs-truncate.js
+++ b/test/parallel/test-fs-truncate.js
@@ -71,8 +71,7 @@ fs.truncateSync(fd);
 fs.closeSync(fd);
 
 // Async tests
-testTruncate(common.mustCall(function(er) {
-  assert.ifError(er);
+testTruncate(common.mustSucceed(() => {
   testFtruncate(common.mustSucceed());
 }));
 

--- a/test/parallel/test-fs-truncate.js
+++ b/test/parallel/test-fs-truncate.js
@@ -73,7 +73,7 @@ fs.closeSync(fd);
 // Async tests
 testTruncate(common.mustCall(function(er) {
   assert.ifError(er);
-  testFtruncate(common.mustCall(assert.ifError));
+  testFtruncate(common.mustSucceed());
 }));
 
 function testTruncate(cb) {

--- a/test/parallel/test-fs-whatwg-url.js
+++ b/test/parallel/test-fs-whatwg-url.js
@@ -22,8 +22,7 @@ const url = pathToFileURL(p);
 assert(url instanceof URL);
 
 // Check that we can pass in a URL object successfully
-fs.readFile(url, common.mustCall((err, data) => {
-  assert.ifError(err);
+fs.readFile(url, common.mustSucceed((data) => {
   assert(Buffer.isBuffer(data));
 }));
 

--- a/test/parallel/test-fs-write-buffer.js
+++ b/test/parallel/test-fs-write-buffer.js
@@ -33,9 +33,7 @@ tmpdir.refresh();
 {
   const filename = path.join(tmpdir.path, 'write1.txt');
   fs.open(filename, 'w', 0o644, common.mustSucceed((fd) => {
-
     const cb = common.mustSucceed((written) => {
-
       assert.strictEqual(written, expected.length);
       fs.closeSync(fd);
 
@@ -51,9 +49,7 @@ tmpdir.refresh();
 {
   const filename = path.join(tmpdir.path, 'write2.txt');
   fs.open(filename, 'w', 0o644, common.mustSucceed((fd) => {
-
     const cb = common.mustSucceed((written) => {
-
       assert.strictEqual(written, 2);
       fs.closeSync(fd);
 
@@ -68,10 +64,8 @@ tmpdir.refresh();
 // fs.write with a buffer, without the offset and length parameters:
 {
   const filename = path.join(tmpdir.path, 'write3.txt');
-  fs.open(filename, 'w', 0o644, common.mustSucceed(function(fd) {
-
-    const cb = common.mustSucceed(function(written) {
-
+  fs.open(filename, 'w', 0o644, common.mustSucceed((fd) => {
+    const cb = common.mustSucceed((written) => {
       assert.strictEqual(written, expected.length);
       fs.closeSync(fd);
 
@@ -86,10 +80,8 @@ tmpdir.refresh();
 // fs.write with the offset passed as undefined followed by the callback:
 {
   const filename = path.join(tmpdir.path, 'write4.txt');
-  fs.open(filename, 'w', 0o644, common.mustSucceed(function(fd) {
-
-    const cb = common.mustSucceed(function(written) {
-
+  fs.open(filename, 'w', 0o644, common.mustSucceed((fd) => {
+    const cb = common.mustSucceed((written) => {
       assert.strictEqual(written, expected.length);
       fs.closeSync(fd);
 
@@ -105,9 +97,7 @@ tmpdir.refresh();
 {
   const filename = path.join(tmpdir.path, 'write5.txt');
   fs.open(filename, 'w', 0o644, common.mustSucceed((fd) => {
-
     const cb = common.mustSucceed((written) => {
-
       assert.strictEqual(written, expected.length);
       fs.closeSync(fd);
 
@@ -123,9 +113,7 @@ tmpdir.refresh();
 {
   const filename = path.join(tmpdir.path, 'write6.txt');
   fs.open(filename, 'w', 0o644, common.mustSucceed((fd) => {
-
     const cb = common.mustSucceed((written) => {
-
       assert.strictEqual(written, expected.length);
       fs.closeSync(fd);
 
@@ -141,7 +129,6 @@ tmpdir.refresh();
 {
   const filename = path.join(tmpdir.path, 'write7.txt');
   fs.open(filename, 'w', 0o644, common.mustSucceed((fd) => {
-
     assert.throws(() => {
       fs.write(fd,
                Buffer.from('abcd'),

--- a/test/parallel/test-fs-write-buffer.js
+++ b/test/parallel/test-fs-write-buffer.js
@@ -32,11 +32,9 @@ tmpdir.refresh();
 // fs.write with all parameters provided:
 {
   const filename = path.join(tmpdir.path, 'write1.txt');
-  fs.open(filename, 'w', 0o644, common.mustCall((err, fd) => {
-    assert.ifError(err);
+  fs.open(filename, 'w', 0o644, common.mustSucceed((fd) => {
 
-    const cb = common.mustCall((err, written) => {
-      assert.ifError(err);
+    const cb = common.mustSucceed((written) => {
 
       assert.strictEqual(written, expected.length);
       fs.closeSync(fd);
@@ -52,11 +50,9 @@ tmpdir.refresh();
 // fs.write with a buffer, without the length parameter:
 {
   const filename = path.join(tmpdir.path, 'write2.txt');
-  fs.open(filename, 'w', 0o644, common.mustCall((err, fd) => {
-    assert.ifError(err);
+  fs.open(filename, 'w', 0o644, common.mustSucceed((fd) => {
 
-    const cb = common.mustCall((err, written) => {
-      assert.ifError(err);
+    const cb = common.mustSucceed((written) => {
 
       assert.strictEqual(written, 2);
       fs.closeSync(fd);
@@ -112,11 +108,9 @@ tmpdir.refresh();
 // fs.write with offset and length passed as undefined followed by the callback:
 {
   const filename = path.join(tmpdir.path, 'write5.txt');
-  fs.open(filename, 'w', 0o644, common.mustCall((err, fd) => {
-    assert.ifError(err);
+  fs.open(filename, 'w', 0o644, common.mustSucceed((fd) => {
 
-    const cb = common.mustCall((err, written) => {
-      assert.ifError(err);
+    const cb = common.mustSucceed((written) => {
 
       assert.strictEqual(written, expected.length);
       fs.closeSync(fd);
@@ -132,11 +126,9 @@ tmpdir.refresh();
 // fs.write with a Uint8Array, without the offset and length parameters:
 {
   const filename = path.join(tmpdir.path, 'write6.txt');
-  fs.open(filename, 'w', 0o644, common.mustCall((err, fd) => {
-    assert.ifError(err);
+  fs.open(filename, 'w', 0o644, common.mustSucceed((fd) => {
 
-    const cb = common.mustCall((err, written) => {
-      assert.ifError(err);
+    const cb = common.mustSucceed((written) => {
 
       assert.strictEqual(written, expected.length);
       fs.closeSync(fd);
@@ -152,8 +144,7 @@ tmpdir.refresh();
 // fs.write with invalid offset type
 {
   const filename = path.join(tmpdir.path, 'write7.txt');
-  fs.open(filename, 'w', 0o644, common.mustCall((err, fd) => {
-    assert.ifError(err);
+  fs.open(filename, 'w', 0o644, common.mustSucceed((fd) => {
 
     assert.throws(() => {
       fs.write(fd,

--- a/test/parallel/test-fs-write-buffer.js
+++ b/test/parallel/test-fs-write-buffer.js
@@ -68,11 +68,9 @@ tmpdir.refresh();
 // fs.write with a buffer, without the offset and length parameters:
 {
   const filename = path.join(tmpdir.path, 'write3.txt');
-  fs.open(filename, 'w', 0o644, common.mustCall(function(err, fd) {
-    assert.ifError(err);
+  fs.open(filename, 'w', 0o644, common.mustSucceed(function(fd) {
 
-    const cb = common.mustCall(function(err, written) {
-      assert.ifError(err);
+    const cb = common.mustSucceed(function(written) {
 
       assert.strictEqual(written, expected.length);
       fs.closeSync(fd);
@@ -88,11 +86,9 @@ tmpdir.refresh();
 // fs.write with the offset passed as undefined followed by the callback:
 {
   const filename = path.join(tmpdir.path, 'write4.txt');
-  fs.open(filename, 'w', 0o644, common.mustCall(function(err, fd) {
-    assert.ifError(err);
+  fs.open(filename, 'w', 0o644, common.mustSucceed(function(fd) {
 
-    const cb = common.mustCall(function(err, written) {
-      assert.ifError(err);
+    const cb = common.mustSucceed(function(written) {
 
       assert.strictEqual(written, expected.length);
       fs.closeSync(fd);

--- a/test/parallel/test-fs-write-file-typedarrays.js
+++ b/test/parallel/test-fs-write-file-typedarrays.js
@@ -33,9 +33,7 @@ for (const expectView of common.getArrayBufferViews(inputBuffer)) {
 for (const expectView of common.getArrayBufferViews(inputBuffer)) {
   console.log('Async test for ', expectView[Symbol.toStringTag]);
   const file = `${filename}-${expectView[Symbol.toStringTag]}`;
-  fs.writeFile(file, expectView, common.mustCall((e) => {
-    assert.ifError(e);
-
+  fs.writeFile(file, expectView, common.mustSucceed(() => {
     fs.readFile(file, 'utf8', common.mustSucceed((data) => {
       assert.strictEqual(data, inputBuffer.toString('utf8'));
     }));

--- a/test/parallel/test-fs-write-file-typedarrays.js
+++ b/test/parallel/test-fs-write-file-typedarrays.js
@@ -36,8 +36,7 @@ for (const expectView of common.getArrayBufferViews(inputBuffer)) {
   fs.writeFile(file, expectView, common.mustCall((e) => {
     assert.ifError(e);
 
-    fs.readFile(file, 'utf8', common.mustCall((err, data) => {
-      assert.ifError(err);
+    fs.readFile(file, 'utf8', common.mustSucceed((data) => {
       assert.strictEqual(data, inputBuffer.toString('utf8'));
     }));
   }));

--- a/test/parallel/test-fs-write-file.js
+++ b/test/parallel/test-fs-write-file.js
@@ -38,11 +38,8 @@ const s = '南越国是前203年至前111年存在于岭南地区的一个国家
           '历经五代君主。南越国是岭南地区的第一个有记载的政权国家，采用封建制和郡县制并存的制度，' +
           '它的建立保证了秦末乱世岭南地区社会秩序的稳定，有效的改善了岭南地区落后的政治、##济现状。\n';
 
-fs.writeFile(filename, s, common.mustCall(function(e) {
-  assert.ifError(e);
-
-  fs.readFile(filename, common.mustCall(function(e, buffer) {
-    assert.ifError(e);
+fs.writeFile(filename, s, common.mustSucceed(() => {
+  fs.readFile(filename, common.mustSucceed((buffer) => {
     assert.strictEqual(Buffer.byteLength(s), buffer.length);
   }));
 }));
@@ -51,12 +48,8 @@ fs.writeFile(filename, s, common.mustCall(function(e) {
 const filename2 = join(tmpdir.path, 'test2.txt');
 const buf = Buffer.from(s, 'utf8');
 
-fs.writeFile(filename2, buf, common.mustCall(function(e) {
-  assert.ifError(e);
-
-  fs.readFile(filename2, common.mustCall(function(e, buffer) {
-    assert.ifError(e);
-
+fs.writeFile(filename2, buf, common.mustSucceed(() => {
+  fs.readFile(filename2, common.mustSucceed((buffer) => {
     assert.strictEqual(buf.length, buffer.length);
   }));
 }));
@@ -64,18 +57,10 @@ fs.writeFile(filename2, buf, common.mustCall(function(e) {
 // Test that writeFile accepts file descriptors.
 const filename4 = join(tmpdir.path, 'test4.txt');
 
-fs.open(filename4, 'w+', common.mustCall(function(e, fd) {
-  assert.ifError(e);
-
-  fs.writeFile(fd, s, common.mustCall(function(e) {
-    assert.ifError(e);
-
-    fs.close(fd, common.mustCall(function(e) {
-      assert.ifError(e);
-
-      fs.readFile(filename4, common.mustCall(function(e, buffer) {
-        assert.ifError(e);
-
+fs.open(filename4, 'w+', common.mustSucceed((fd) => {
+  fs.writeFile(fd, s, common.mustSucceed(() => {
+    fs.close(fd, common.mustSucceed(() => {
+      fs.readFile(filename4, common.mustSucceed((buffer) => {
         assert.strictEqual(Buffer.byteLength(s), buffer.length);
       }));
     }));

--- a/test/parallel/test-fs-write-reuse-callback.js
+++ b/test/parallel/test-fs-write-reuse-callback.js
@@ -19,8 +19,7 @@ const size = 16 * 1024;
 const writes = 1000;
 let done = 0;
 
-const ondone = common.mustCall((err) => {
-  assert.ifError(err);
+const ondone = common.mustSucceed(() => {
   if (++done < writes) {
     if (done % 25 === 0) global.gc();
     setImmediate(write);

--- a/test/parallel/test-fs-write.js
+++ b/test/parallel/test-fs-write.js
@@ -80,11 +80,9 @@ common.allowGlobals(externalizeString, isOneByteString, x);
 }
 /* eslint-enable no-undef */
 
-fs.open(fn, 'w', 0o644, common.mustCall((err, fd) => {
-  assert.ifError(err);
+fs.open(fn, 'w', 0o644, common.mustSucceed((fd) => {
 
-  const done = common.mustCall((err, written) => {
-    assert.ifError(err);
+  const done = common.mustSucceed((written) => {
     assert.strictEqual(written, Buffer.byteLength(expected));
     fs.closeSync(fd);
     const found = fs.readFileSync(fn, 'utf8');
@@ -92,8 +90,7 @@ fs.open(fn, 'w', 0o644, common.mustCall((err, fd) => {
     assert.strictEqual(found, expected);
   });
 
-  const written = common.mustCall((err, written) => {
-    assert.ifError(err);
+  const written = common.mustSucceed((written) => {
     assert.strictEqual(written, 0);
     fs.write(fd, expected, 0, 'utf8', done);
   });
@@ -102,11 +99,9 @@ fs.open(fn, 'w', 0o644, common.mustCall((err, fd) => {
 }));
 
 const args = constants.O_CREAT | constants.O_WRONLY | constants.O_TRUNC;
-fs.open(fn2, args, 0o644, common.mustCall((err, fd) => {
-  assert.ifError(err);
+fs.open(fn2, args, 0o644, common.mustSucceed((fd) => {
 
-  const done = common.mustCall((err, written) => {
-    assert.ifError(err);
+  const done = common.mustSucceed((written) => {
     assert.strictEqual(written, Buffer.byteLength(expected));
     fs.closeSync(fd);
     const found = fs.readFileSync(fn2, 'utf8');
@@ -114,8 +109,7 @@ fs.open(fn2, args, 0o644, common.mustCall((err, fd) => {
     assert.strictEqual(found, expected);
   });
 
-  const written = common.mustCall((err, written) => {
-    assert.ifError(err);
+  const written = common.mustSucceed((written) => {
     assert.strictEqual(written, 0);
     fs.write(fd, expected, 0, 'utf8', done);
   });
@@ -123,11 +117,9 @@ fs.open(fn2, args, 0o644, common.mustCall((err, fd) => {
   fs.write(fd, '', 0, 'utf8', written);
 }));
 
-fs.open(fn3, 'w', 0o644, common.mustCall((err, fd) => {
-  assert.ifError(err);
+fs.open(fn3, 'w', 0o644, common.mustSucceed((fd) => {
 
-  const done = common.mustCall((err, written) => {
-    assert.ifError(err);
+  const done = common.mustSucceed((written) => {
     assert.strictEqual(written, Buffer.byteLength(expected));
     fs.closeSync(fd);
   });

--- a/test/parallel/test-fs-write.js
+++ b/test/parallel/test-fs-write.js
@@ -81,7 +81,6 @@ common.allowGlobals(externalizeString, isOneByteString, x);
 /* eslint-enable no-undef */
 
 fs.open(fn, 'w', 0o644, common.mustSucceed((fd) => {
-
   const done = common.mustSucceed((written) => {
     assert.strictEqual(written, Buffer.byteLength(expected));
     fs.closeSync(fd);
@@ -100,7 +99,6 @@ fs.open(fn, 'w', 0o644, common.mustSucceed((fd) => {
 
 const args = constants.O_CREAT | constants.O_WRONLY | constants.O_TRUNC;
 fs.open(fn2, args, 0o644, common.mustSucceed((fd) => {
-
   const done = common.mustSucceed((written) => {
     assert.strictEqual(written, Buffer.byteLength(expected));
     fs.closeSync(fd);
@@ -118,7 +116,6 @@ fs.open(fn2, args, 0o644, common.mustSucceed((fd) => {
 }));
 
 fs.open(fn3, 'w', 0o644, common.mustSucceed((fd) => {
-
   const done = common.mustSucceed((written) => {
     assert.strictEqual(written, Buffer.byteLength(expected));
     fs.closeSync(fd);

--- a/test/parallel/test-fs-write.js
+++ b/test/parallel/test-fs-write.js
@@ -124,11 +124,8 @@ fs.open(fn3, 'w', 0o644, common.mustSucceed((fd) => {
   fs.write(fd, expected, done);
 }));
 
-fs.open(fn4, 'w', 0o644, common.mustCall((err, fd) => {
-  assert.ifError(err);
-
-  const done = common.mustCall((err, written) => {
-    assert.ifError(err);
+fs.open(fn4, 'w', 0o644, common.mustSucceed((fd) => {
+  const done = common.mustSucceed((written) => {
     assert.strictEqual(written, Buffer.byteLength(expected));
     fs.closeSync(fd);
   });

--- a/test/parallel/test-fs-writefile-with-fd.js
+++ b/test/parallel/test-fs-writefile-with-fd.js
@@ -38,18 +38,15 @@ tmpdir.refresh();
   const file = join(tmpdir.path, 'test1.txt');
 
   /* Open the file descriptor. */
-  fs.open(file, 'w', common.mustCall((err, fd) => {
-    assert.ifError(err);
+  fs.open(file, 'w', common.mustSucceed((fd) => {
 
     /* Write only five characters, so that the position moves to five. */
-    fs.write(fd, 'Hello', common.mustCall((err, bytes) => {
-      assert.ifError(err);
+    fs.write(fd, 'Hello', common.mustSucceed((bytes) => {
       assert.strictEqual(bytes, 5);
       assert.deepStrictEqual(fs.readFileSync(file).toString(), 'Hello');
 
       /* Write some more with writeFile(). */
-      fs.writeFile(fd, 'World', common.mustCall((err) => {
-        assert.ifError(err);
+      fs.writeFile(fd, 'World', common.mustSucceed(() => {
 
         /* New content should be written at position five, instead of zero. */
         assert.deepStrictEqual(fs.readFileSync(file).toString(), 'HelloWorld');

--- a/test/parallel/test-fs-writefile-with-fd.js
+++ b/test/parallel/test-fs-writefile-with-fd.js
@@ -39,7 +39,6 @@ tmpdir.refresh();
 
   /* Open the file descriptor. */
   fs.open(file, 'w', common.mustSucceed((fd) => {
-
     /* Write only five characters, so that the position moves to five. */
     fs.write(fd, 'Hello', common.mustSucceed((bytes) => {
       assert.strictEqual(bytes, 5);
@@ -47,7 +46,6 @@ tmpdir.refresh();
 
       /* Write some more with writeFile(). */
       fs.writeFile(fd, 'World', common.mustSucceed(() => {
-
         /* New content should be written at position five, instead of zero. */
         assert.deepStrictEqual(fs.readFileSync(file).toString(), 'HelloWorld');
 

--- a/test/parallel/test-fs-writev.js
+++ b/test/parallel/test-fs-writev.js
@@ -25,7 +25,6 @@ const getFileName = (i) => path.join(tmpdir.path, `writev_${i}.txt`);
   const bufferArr = [buffer, buffer];
 
   const done = common.mustSucceed((written, buffers) => {
-
     assert.deepStrictEqual(bufferArr, buffers);
     const expectedLength = bufferArr.length * buffer.byteLength;
     assert.deepStrictEqual(written, expectedLength);
@@ -46,7 +45,6 @@ const getFileName = (i) => path.join(tmpdir.path, `writev_${i}.txt`);
   const bufferArr = [buffer, buffer];
 
   const done = common.mustSucceed((written, buffers) => {
-
     assert.deepStrictEqual(bufferArr, buffers);
 
     const expectedLength = bufferArr.length * buffer.byteLength;

--- a/test/parallel/test-fs-writev.js
+++ b/test/parallel/test-fs-writev.js
@@ -24,8 +24,7 @@ const getFileName = (i) => path.join(tmpdir.path, `writev_${i}.txt`);
   const buffer = Buffer.from(expected);
   const bufferArr = [buffer, buffer];
 
-  const done = common.mustCall((err, written, buffers) => {
-    assert.ifError(err);
+  const done = common.mustSucceed((written, buffers) => {
 
     assert.deepStrictEqual(bufferArr, buffers);
     const expectedLength = bufferArr.length * buffer.byteLength;
@@ -46,8 +45,7 @@ const getFileName = (i) => path.join(tmpdir.path, `writev_${i}.txt`);
   const buffer = Buffer.from(expected);
   const bufferArr = [buffer, buffer];
 
-  const done = common.mustCall((err, written, buffers) => {
-    assert.ifError(err);
+  const done = common.mustSucceed((written, buffers) => {
 
     assert.deepStrictEqual(bufferArr, buffers);
 

--- a/test/parallel/test-http-outgoing-finish.js
+++ b/test/parallel/test-http-outgoing-finish.js
@@ -49,7 +49,7 @@ function write(out) {
   let endCb = false;
 
   // First, write until it gets some backpressure
-  while (out.write(buf, common.mustCall())) {}
+  while (out.write(buf, common.mustSucceed())) {}
 
   // Now end, and make sure that we don't get the 'finish' event
   // before the tick where the cb gets called.  We give it until

--- a/test/parallel/test-http-unix-socket-keep-alive.js
+++ b/test/parallel/test-http-unix-socket-keep-alive.js
@@ -10,8 +10,7 @@ tmpdir.refresh();
 
 server.listen(common.PIPE, common.mustCall(() =>
   asyncLoop(makeKeepAliveRequest, 10, common.mustCall(() =>
-    server.getConnections(common.mustCall((err, conns) => {
-      assert.ifError(err);
+    server.getConnections(common.mustSucceed((conns) => {
       assert.strictEqual(conns, 1);
       server.close();
     }))

--- a/test/parallel/test-http2-buffersize.js
+++ b/test/parallel/test-http2-buffersize.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { mustCall, hasCrypto, skip } = require('../common');
+const { mustCall, mustSucceed, hasCrypto, skip } = require('../common');
 if (!hasCrypto)
   skip('missing crypto');
 const assert = require('assert');
@@ -42,7 +42,7 @@ const { once } = require('events');
       stream.on('data', () => {});
 
       for (let i = 0; i < kTimes; i += 1) {
-        stream.write(Buffer.allocUnsafe(kBufferSize), mustCall());
+        stream.write(Buffer.allocUnsafe(kBufferSize), mustSucceed());
         const expectedSocketBufferSize = kBufferSize * (i + 1);
         assert.strictEqual(stream.bufferSize, expectedSocketBufferSize);
       }

--- a/test/parallel/test-http2-client-upload-reject.js
+++ b/test/parallel/test-http2-client-upload-reject.js
@@ -14,8 +14,7 @@ const loc = fixtures.path('person-large.jpg');
 
 assert(fs.existsSync(loc));
 
-fs.readFile(loc, common.mustCall((err, data) => {
-  assert.ifError(err);
+fs.readFile(loc, common.mustSucceed((data) => {
 
   const server = http2.createServer();
 

--- a/test/parallel/test-http2-client-upload-reject.js
+++ b/test/parallel/test-http2-client-upload-reject.js
@@ -15,7 +15,6 @@ const loc = fixtures.path('person-large.jpg');
 assert(fs.existsSync(loc));
 
 fs.readFile(loc, common.mustSucceed((data) => {
-
   const server = http2.createServer();
 
   server.on('stream', common.mustCall((stream) => {

--- a/test/parallel/test-http2-client-upload.js
+++ b/test/parallel/test-http2-client-upload.js
@@ -16,8 +16,7 @@ let fileData;
 
 assert(fs.existsSync(loc));
 
-fs.readFile(loc, common.mustCall((err, data) => {
-  assert.ifError(err);
+fs.readFile(loc, common.mustSucceed((data) => {
   fileData = data;
 
   const server = http2.createServer();

--- a/test/parallel/test-http2-compat-client-upload-reject.js
+++ b/test/parallel/test-http2-compat-client-upload-reject.js
@@ -15,7 +15,6 @@ const loc = fixtures.path('person-large.jpg');
 assert(fs.existsSync(loc));
 
 fs.readFile(loc, common.mustSucceed((data) => {
-
   const server = http2.createServer(common.mustCall((req, res) => {
     setImmediate(() => {
       res.writeHead(400);

--- a/test/parallel/test-http2-compat-client-upload-reject.js
+++ b/test/parallel/test-http2-compat-client-upload-reject.js
@@ -14,8 +14,7 @@ const loc = fixtures.path('person-large.jpg');
 
 assert(fs.existsSync(loc));
 
-fs.readFile(loc, common.mustCall((err, data) => {
-  assert.ifError(err);
+fs.readFile(loc, common.mustSucceed((data) => {
 
   const server = http2.createServer(common.mustCall((req, res) => {
     setImmediate(() => {

--- a/test/parallel/test-http2-compat-serverresponse-createpushresponse.js
+++ b/test/parallel/test-http2-compat-serverresponse-createpushresponse.js
@@ -40,8 +40,7 @@ const server = h2.createServer((request, response) => {
   response.createPushResponse({
     ':path': '/pushed',
     ':method': 'GET'
-  }, common.mustCall((error, push) => {
-    assert.ifError(error);
+  }, common.mustSucceed((push) => {
     assert.strictEqual(push.stream.id % 2, 0);
     push.end(pushExpect);
     response.end();

--- a/test/parallel/test-http2-create-client-secure-session.js
+++ b/test/parallel/test-http2-create-client-secure-session.js
@@ -73,7 +73,7 @@ function verifySecureSession(key, cert, ca, opts) {
       assert.strictEqual(jsonData.servername,
                          opts.servername || 'localhost');
       assert.strictEqual(jsonData.alpnProtocol, 'h2');
-      server.close(common.mustCall());
+      server.close(common.mustSucceed());
       client[kSocket].destroy();
     }));
   }));

--- a/test/parallel/test-http2-dont-lose-data.js
+++ b/test/parallel/test-http2-dont-lose-data.js
@@ -11,8 +11,7 @@ const server = http2.createServer();
 server.on('stream', (s) => {
   assert(s.pushAllowed);
 
-  s.pushStream({ ':path': '/file' }, common.mustCall((err, pushStream) => {
-    assert.ifError(err);
+  s.pushStream({ ':path': '/file' }, common.mustSucceed((pushStream) => {
     pushStream.respond();
     pushStream.end('a push stream');
   }));

--- a/test/parallel/test-http2-options-max-reserved-streams.js
+++ b/test/parallel/test-http2-options-max-reserved-streams.js
@@ -20,8 +20,7 @@ server.on('stream', common.mustCall((stream) => {
   // The first pushStream will complete as normal
   stream.pushStream({
     ':path': '/foobar',
-  }, common.mustCall((err, pushedStream) => {
-    assert.ifError(err);
+  }, common.mustSucceed((pushedStream) => {
     pushedStream.respond();
     pushedStream.end();
     pushedStream.on('aborted', common.mustNotCall());
@@ -32,8 +31,7 @@ server.on('stream', common.mustCall((stream) => {
   // being set to only 1
   stream.pushStream({
     ':path': '/foobar',
-  }, common.mustCall((err, pushedStream) => {
-    assert.ifError(err);
+  }, common.mustSucceed((pushedStream) => {
     pushedStream.respond();
     pushedStream.on('aborted', common.mustCall());
     pushedStream.on('error', common.mustNotCall());

--- a/test/parallel/test-http2-respond-file-error-pipe-offset.js
+++ b/test/parallel/test-http2-respond-file-error-pipe-offset.js
@@ -56,4 +56,4 @@ server.listen(0, () => {
   req.end();
 });
 
-fs.writeFile(pipeName, 'Hello, world!\n', common.mustCall());
+fs.writeFile(pipeName, 'Hello, world!\n', common.mustSucceed());

--- a/test/parallel/test-http2-respond-file-with-pipe.js
+++ b/test/parallel/test-http2-respond-file-with-pipe.js
@@ -49,8 +49,7 @@ server.listen(0, () => {
   req.end();
 });
 
-fs.open(pipeName, 'w', common.mustCall((err, fd) => {
-  assert.ifError(err);
+fs.open(pipeName, 'w', common.mustSucceed((fd) => {
   fs.writeSync(fd, 'Hello, world!\n');
   fs.closeSync(fd);
 }));

--- a/test/parallel/test-http2-server-close-callback.js
+++ b/test/parallel/test-http2-server-close-callback.js
@@ -12,7 +12,7 @@ const server = http2.createServer();
 let session;
 
 const countdown = new Countdown(2, () => {
-  server.close(common.mustCall());
+  server.close(common.mustSucceed());
   session.destroy();
 });
 

--- a/test/parallel/test-http2-server-push-stream.js
+++ b/test/parallel/test-http2-server-push-stream.js
@@ -14,8 +14,7 @@ server.on('stream', common.mustCall((stream, headers) => {
       ':scheme': 'http',
       ':path': '/foobar',
       ':authority': `localhost:${port}`,
-    }, common.mustCall((err, push, headers) => {
-      assert.ifError(err);
+    }, common.mustSucceed((push, headers) => {
       push.respond({
         'content-type': 'text/html',
         ':status': 200,

--- a/test/parallel/test-https-close.js
+++ b/test/parallel/test-https-close.js
@@ -29,7 +29,7 @@ server.on('connection', (connection) => {
 });
 
 function shutdown() {
-  server.close(common.mustCall());
+  server.close(common.mustSucceed());
 
   for (const key in connections) {
     connections[key].destroy();

--- a/test/parallel/test-inspector-heapdump.js
+++ b/test/parallel/test-inspector-heapdump.js
@@ -18,8 +18,7 @@ session.on('HeapProfiler.addHeapSnapshotChunk', (m) => {
   chunks.push(m.params.chunk);
 });
 
-session.post('HeapProfiler.takeHeapSnapshot', null, common.mustCall((e, r) => {
-  assert.ifError(e);
+session.post('HeapProfiler.takeHeapSnapshot', null, common.mustSucceed((r) => {
   assert.deepStrictEqual(r, {});
   session.disconnect();
 

--- a/test/parallel/test-intl.js
+++ b/test/parallel/test-intl.js
@@ -133,7 +133,7 @@ if (!common.hasIntl) {
     execFile(
       process.execPath, ['-p', 'new Date().toLocaleString()'],
       { env },
-      common.mustCall((e) => assert.ifError(e))
+      common.mustSucceed()
     );
   }
 
@@ -144,7 +144,7 @@ if (!common.hasIntl) {
       process.execPath,
       ['-p', 'new Intl.NumberFormat().resolvedOptions().locale'],
       { env },
-      common.mustCall((e) => assert.ifError(e))
+      common.mustSucceed()
     );
   }
 }

--- a/test/parallel/test-net-pingpong.js
+++ b/test/parallel/test-net-pingpong.js
@@ -39,7 +39,7 @@ function pingPongTest(port, host) {
     assert.strictEqual(socket.server, server);
     assert.strictEqual(
       server,
-      server.getConnections(common.mustSucceed(function(connections) {
+      server.getConnections(common.mustSucceed((connections) => {
         assert.strictEqual(connections, 1);
       }))
     );

--- a/test/parallel/test-net-pingpong.js
+++ b/test/parallel/test-net-pingpong.js
@@ -39,8 +39,7 @@ function pingPongTest(port, host) {
     assert.strictEqual(socket.server, server);
     assert.strictEqual(
       server,
-      server.getConnections(common.mustCall(function(err, connections) {
-        assert.ifError(err);
+      server.getConnections(common.mustSucceed(function(connections) {
         assert.strictEqual(connections, 1);
       }))
     );

--- a/test/parallel/test-pipe-file-to-http.js
+++ b/test/parallel/test-pipe-file-to-http.js
@@ -69,9 +69,7 @@ function makeRequest() {
 
   const s = fs.ReadStream(filename);
   s.pipe(req);
-  s.on('close', common.mustCall((err) => {
-    assert.ifError(err);
-  }));
+  s.on('close', common.mustSucceed());
 
   req.on('response', (res) => {
     res.resume();

--- a/test/parallel/test-pipe-head.js
+++ b/test/parallel/test-pipe-head.js
@@ -10,8 +10,7 @@ const script = fixtures.path('print-10-lines.js');
 
 const cmd = `"${nodePath}" "${script}" | head -2`;
 
-exec(cmd, common.mustCall(function(err, stdout, stderr) {
-  assert.ifError(err);
+exec(cmd, common.mustSucceed(function(stdout, stderr) {
   const lines = stdout.split('\n');
   assert.strictEqual(lines.length, 3);
 }));

--- a/test/parallel/test-pipe-head.js
+++ b/test/parallel/test-pipe-head.js
@@ -10,7 +10,7 @@ const script = fixtures.path('print-10-lines.js');
 
 const cmd = `"${nodePath}" "${script}" | head -2`;
 
-exec(cmd, common.mustSucceed(function(stdout, stderr) {
+exec(cmd, common.mustSucceed((stdout, stderr) => {
   const lines = stdout.split('\n');
   assert.strictEqual(lines.length, 3);
 }));

--- a/test/parallel/test-preload.js
+++ b/test/parallel/test-preload.js
@@ -142,7 +142,7 @@ childProcess.exec(
 // Test that preload works with -i
 const interactive = childProcess.exec(
   `"${nodeBinary}" ${preloadOption([fixtureD])}-i`,
-  common.mustSucceed(function(stdout, stderr) {
+  common.mustSucceed((stdout, stderr) => {
     assert.ok(stdout.endsWith("> 'test'\n> "));
   })
 );
@@ -163,7 +163,7 @@ childProcess.exec(
 childProcess.exec(
   `"${nodeBinary}" ${preloadOption(['./printA.js'])} "${fixtureB}"`,
   { cwd: fixtures.fixturesDir },
-  common.mustSucceed(function(stdout, stderr) {
+  common.mustSucceed((stdout, stderr) => {
     assert.strictEqual(stdout, 'A\nB\n');
   })
 );
@@ -172,7 +172,7 @@ if (common.isWindows) {
   childProcess.exec(
     `"${nodeBinary}" ${preloadOption(['.\\printA.js'])} "${fixtureB}"`,
     { cwd: fixtures.fixturesDir },
-    common.mustSucceed(function(stdout, stderr) {
+    common.mustSucceed((stdout, stderr) => {
       assert.strictEqual(stdout, 'A\nB\n');
     })
   );

--- a/test/parallel/test-preload.js
+++ b/test/parallel/test-preload.js
@@ -142,8 +142,7 @@ childProcess.exec(
 // Test that preload works with -i
 const interactive = childProcess.exec(
   `"${nodeBinary}" ${preloadOption([fixtureD])}-i`,
-  common.mustCall(function(err, stdout, stderr) {
-    assert.ifError(err);
+  common.mustSucceed(function(stdout, stderr) {
     assert.ok(stdout.endsWith("> 'test'\n> "));
   })
 );
@@ -164,8 +163,7 @@ childProcess.exec(
 childProcess.exec(
   `"${nodeBinary}" ${preloadOption(['./printA.js'])} "${fixtureB}"`,
   { cwd: fixtures.fixturesDir },
-  common.mustCall(function(err, stdout, stderr) {
-    assert.ifError(err);
+  common.mustSucceed(function(stdout, stderr) {
     assert.strictEqual(stdout, 'A\nB\n');
   })
 );
@@ -174,8 +172,7 @@ if (common.isWindows) {
   childProcess.exec(
     `"${nodeBinary}" ${preloadOption(['.\\printA.js'])} "${fixtureB}"`,
     { cwd: fixtures.fixturesDir },
-    common.mustCall(function(err, stdout, stderr) {
-      assert.ifError(err);
+    common.mustSucceed(function(stdout, stderr) {
       assert.strictEqual(stdout, 'A\nB\n');
     })
   );

--- a/test/parallel/test-process-redirect-warnings-env.js
+++ b/test/parallel/test-process-redirect-warnings-env.js
@@ -20,8 +20,7 @@ const warnpath = path.join(tmpdir.path, 'warnings.txt');
 
 fork(warnmod, { env: { ...process.env, NODE_REDIRECT_WARNINGS: warnpath } })
   .on('exit', common.mustCall(() => {
-    fs.readFile(warnpath, 'utf8', common.mustCall((err, data) => {
-      assert.ifError(err);
+    fs.readFile(warnpath, 'utf8', common.mustSucceed((data) => {
       assert(/\(node:\d+\) Warning: a bad practice warning/.test(data));
     }));
   }));

--- a/test/parallel/test-process-redirect-warnings.js
+++ b/test/parallel/test-process-redirect-warnings.js
@@ -20,8 +20,7 @@ const warnpath = path.join(tmpdir.path, 'warnings.txt');
 
 fork(warnmod, { execArgv: [`--redirect-warnings=${warnpath}`] })
   .on('exit', common.mustCall(() => {
-    fs.readFile(warnpath, 'utf8', common.mustCall((err, data) => {
-      assert.ifError(err);
+    fs.readFile(warnpath, 'utf8', common.mustSucceed((data) => {
       assert(/\(node:\d+\) Warning: a bad practice warning/.test(data));
     }));
   }));

--- a/test/parallel/test-quic-client-server.js
+++ b/test/parallel/test-quic-client-server.js
@@ -184,9 +184,7 @@ client.on('close', common.mustCall(onSocketClose.bind(client)));
       assert(!stream.serverInitiated);
 
       let data = '';
-      pipeline(createReadStream(__filename), stream, common.mustCall((err) => {
-        assert.ifError(err);
-      }));
+      pipeline(createReadStream(__filename), stream, common.mustSucceed());
 
       stream.setEncoding('utf8');
       stream.on('blocked', common.mustNotCall());
@@ -346,9 +344,7 @@ client.on('close', common.mustCall(onSocketClose.bind(client)));
   }
 
   const stream = await req.openStream();
-  pipeline(createReadStream(__filename), stream, common.mustCall((err) => {
-    assert.ifError(err);
-  }));
+  pipeline(createReadStream(__filename), stream, common.mustSucceed());
   let data = '';
   stream.resume();
   stream.setEncoding('utf8');

--- a/test/parallel/test-quic-quicsocket-packetloss-stream-rx.js
+++ b/test/parallel/test-quic-quicsocket-packetloss-stream-rx.js
@@ -49,9 +49,7 @@ const countdown = new Countdown(1, () => {
     debug('QuicServerSession Created');
     session.on('stream', common.mustCall((stream) => {
       debug('Bidirectional, Client-initiated stream %d received', stream.id);
-      pipeline(stream, stream, common.mustCall((err) => {
-        assert(!err);
-      }));
+      pipeline(stream, stream, common.mustSucceed());
     }));
   }));
 

--- a/test/parallel/test-quic-quicsocket-packetloss-stream-tx.js
+++ b/test/parallel/test-quic-quicsocket-packetloss-stream-tx.js
@@ -49,9 +49,7 @@ const countdown = new Countdown(1, () => {
     debug('QuicServerSession Created');
     session.on('stream', common.mustCall((stream) => {
       debug('Bidirectional, Client-initiated stream %d received', stream.id);
-      pipeline(stream, stream, common.mustCall((err) => {
-        assert(!err);
-      }));
+      pipeline(stream, stream, common.mustSucceed());
     }));
   }));
 

--- a/test/parallel/test-quic-quicstream-close-early.js
+++ b/test/parallel/test-quic-quicstream-close-early.js
@@ -28,7 +28,7 @@ const countdown = new Countdown(2, () => {
   server.on('session', common.mustCall(async (session) => {
     if (qlog) session.qlog.pipe(createWriteStream('server.qlog'));
     const uni = await session.openStream({ halfOpen: true });
-    uni.write('hi', common.mustCall((err) => assert(!err)));
+    uni.write('hi', common.mustSucceed());
     uni.on('error', common.mustNotCall());
     uni.on('data', common.mustNotCall());
     uni.on('close', common.mustCall());
@@ -67,8 +67,8 @@ const countdown = new Countdown(2, () => {
   }));
 
   const stream = await req.openStream();
-  stream.write('hello', common.mustCall((err) => assert(!err)));
-  stream.write('there', common.mustCall((err) => assert(!err)));
+  stream.write('hello', common.mustSucceed());
+  stream.write('there', common.mustSucceed());
   stream.resume();
   stream.on('error', common.mustNotCall());
   stream.on('end', common.mustCall());

--- a/test/parallel/test-quic-simple-client-migrate.js
+++ b/test/parallel/test-quic-simple-client-migrate.js
@@ -22,7 +22,7 @@ const server = createQuicSocket({ server: options });
 (async function() {
   server.on('session', common.mustCall((session) => {
     session.on('stream', common.mustCall(async (stream) => {
-      pipeline(stream, stream, common.mustCall());
+      pipeline(stream, stream, common.mustSucceed());
       (await session.openStream({ halfOpen: true }))
         .end('Hello from the server');
     }));

--- a/test/parallel/test-repl-history-perm.js
+++ b/test/parallel/test-repl-history-perm.js
@@ -35,8 +35,7 @@ const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 const replHistoryPath = path.join(tmpdir.path, '.node_repl_history');
 
-const checkResults = common.mustSucceed(function(r) {
-
+const checkResults = common.mustSucceed((r) => {
   const stat = fs.statSync(replHistoryPath);
   const fileMode = stat.mode & 0o777;
   assert.strictEqual(

--- a/test/parallel/test-repl-history-perm.js
+++ b/test/parallel/test-repl-history-perm.js
@@ -35,8 +35,7 @@ const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 const replHistoryPath = path.join(tmpdir.path, '.node_repl_history');
 
-const checkResults = common.mustCall(function(err, r) {
-  assert.ifError(err);
+const checkResults = common.mustSucceed(function(r) {
 
   const stat = fs.statSync(replHistoryPath);
   const fileMode = stat.mode & 0o777;

--- a/test/parallel/test-repl-save-load.js
+++ b/test/parallel/test-repl-save-load.js
@@ -61,8 +61,7 @@ assert.strictEqual(fs.readFileSync(saveFileName, 'utf8'),
                    testFile.join('\n'));
 
 // Make sure that the REPL data is "correct".
-testMe.complete('inner.o', common.mustCall(function(error, data) {
-  assert.ifError(error);
+testMe.complete('inner.o', common.mustSucceed(function(data) {
   assert.deepStrictEqual(data, works);
 }));
 
@@ -73,8 +72,7 @@ putIn.run(['.clear']);
 putIn.run([`.load ${saveFileName}`]);
 
 // Make sure that the REPL data is "correct".
-testMe.complete('inner.o', common.mustCall(function(error, data) {
-  assert.ifError(error);
+testMe.complete('inner.o', common.mustSucceed(function(data) {
   assert.deepStrictEqual(data, works);
 }));
 

--- a/test/parallel/test-repl-save-load.js
+++ b/test/parallel/test-repl-save-load.js
@@ -61,7 +61,7 @@ assert.strictEqual(fs.readFileSync(saveFileName, 'utf8'),
                    testFile.join('\n'));
 
 // Make sure that the REPL data is "correct".
-testMe.complete('inner.o', common.mustSucceed(function(data) {
+testMe.complete('inner.o', common.mustSucceed((data) => {
   assert.deepStrictEqual(data, works);
 }));
 
@@ -72,7 +72,7 @@ putIn.run(['.clear']);
 putIn.run([`.load ${saveFileName}`]);
 
 // Make sure that the REPL data is "correct".
-testMe.complete('inner.o', common.mustSucceed(function(data) {
+testMe.complete('inner.o', common.mustSucceed((data) => {
   assert.deepStrictEqual(data, works);
 }));
 

--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -44,8 +44,7 @@ process.chdir(fixtures.fixturesDir);
 const repl = require('repl');
 
 function getNoResultsFunction() {
-  return common.mustCall((err, data) => {
-    assert.ifError(err);
+  return common.mustSucceed((data) => {
     assert.deepStrictEqual(data[0], []);
   });
 }
@@ -343,8 +342,7 @@ testMe.complete("require\t( 'n", common.mustCall(function(error, data) {
 
   {
     const path = '../fixtures/repl-folder-extensions/f';
-    testMe.complete(`require('${path}`, common.mustCall((err, data) => {
-      assert.ifError(err);
+    testMe.complete(`require('${path}`, common.mustSucceed((data) => {
       assert.strictEqual(data.length, 2);
       assert.strictEqual(data[1], path);
       assert.ok(data[0].includes('../fixtures/repl-folder-extensions/foo.js'));

--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -203,8 +203,7 @@ const spaceTimeout = setTimeout(function() {
   throw new Error('timeout');
 }, 1000);
 
-testMe.complete(' ', common.mustCall(function(error, data) {
-  assert.ifError(error);
+testMe.complete(' ', common.mustSucceed(function(data) {
   assert.strictEqual(data[1], '');
   assert.ok(data[0].includes('globalThis'));
   clearTimeout(spaceTimeout);

--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -203,7 +203,7 @@ const spaceTimeout = setTimeout(function() {
   throw new Error('timeout');
 }, 1000);
 
-testMe.complete(' ', common.mustSucceed(function(data) {
+testMe.complete(' ', common.mustSucceed((data) => {
   assert.strictEqual(data[1], '');
   assert.ok(data[0].includes('globalThis'));
   clearTimeout(spaceTimeout);

--- a/test/parallel/test-repl-use-global.js
+++ b/test/parallel/test-repl-use-global.js
@@ -29,8 +29,7 @@ const globalTest = (useGlobal, cb, output) => (err, repl) => {
 
 // Test how the global object behaves in each state for useGlobal
 for (const [option, expected] of globalTestCases) {
-  runRepl(option, globalTest, common.mustCall((err, output) => {
-    assert.ifError(err);
+  runRepl(option, globalTest, common.mustSucceed((output) => {
     assert.strictEqual(output, expected);
   }));
 }
@@ -58,8 +57,7 @@ const processTest = (useGlobal, cb, output) => (err, repl) => {
 };
 
 for (const option of processTestCases) {
-  runRepl(option, processTest, common.mustCall((err, output) => {
-    assert.ifError(err);
+  runRepl(option, processTest, common.mustSucceed((output) => {
     assert.strictEqual(output, 'undefined\n42');
   }));
 }

--- a/test/parallel/test-setproctitle.js
+++ b/test/parallel/test-setproctitle.js
@@ -34,8 +34,7 @@ const cmd = common.isLinux ?
   `ps -o pid,args | grep '${process.pid} ${title}' | grep -v grep` :
   `ps -p ${process.pid} -o args=`;
 
-exec(cmd, common.mustCall((error, stdout, stderr) => {
-  assert.ifError(error);
+exec(cmd, common.mustSucceed((stdout, stderr) => {
   assert.strictEqual(stderr, '');
 
   // Freebsd always add ' (procname)' to the process title

--- a/test/parallel/test-stdout-to-file.js
+++ b/test/parallel/test-stdout-to-file.js
@@ -23,8 +23,7 @@ function test(size, useBuffer, cb) {
 
   console.log(`${size} chars to ${tmpFile}...`);
 
-  childProcess.exec(cmd, common.mustCall(function(err) {
-    assert.ifError(err);
+  childProcess.exec(cmd, common.mustSucceed(function() {
     console.log('done!');
 
     const stat = fs.statSync(tmpFile);

--- a/test/parallel/test-stdout-to-file.js
+++ b/test/parallel/test-stdout-to-file.js
@@ -23,7 +23,7 @@ function test(size, useBuffer, cb) {
 
   console.log(`${size} chars to ${tmpFile}...`);
 
-  childProcess.exec(cmd, common.mustSucceed(function() {
+  childProcess.exec(cmd, common.mustSucceed(() => {
     console.log('done!');
 
     const stat = fs.statSync(tmpFile);

--- a/test/parallel/test-stream-finished.js
+++ b/test/parallel/test-stream-finished.js
@@ -20,9 +20,7 @@ const http = require('http');
     read() {}
   });
 
-  finished(rs, common.mustCall((err) => {
-    assert(!err, 'no error');
-  }));
+  finished(rs, common.mustSucceed());
 
   rs.push(null);
   rs.resume();
@@ -35,9 +33,7 @@ const http = require('http');
     }
   });
 
-  finished(ws, common.mustCall((err) => {
-    assert(!err, 'no error');
-  }));
+  finished(ws, common.mustSucceed());
 
   ws.end();
 }
@@ -60,8 +56,7 @@ const http = require('http');
     finish = true;
   });
 
-  finished(tr, common.mustCall((err) => {
-    assert(!err, 'no error');
+  finished(tr, common.mustSucceed(() => {
     assert(finish);
     assert(ended);
   }));
@@ -108,9 +103,7 @@ const http = require('http');
 {
   const rs = new Readable();
 
-  finished(rs, common.mustCall((err) => {
-    assert(!err, 'no error');
-  }));
+  finished(rs, common.mustSucceed());
 
   rs.push(null);
   rs.emit('close'); // Should not trigger an error

--- a/test/parallel/test-stream-pipeline-process.js
+++ b/test/parallel/test-stream-pipeline-process.js
@@ -9,9 +9,7 @@ if (process.argv[2] === 'child') {
   pipeline(
     process.stdin,
     process.stdout,
-    common.mustCall((err) => {
-      assert.ifError(err);
-    })
+    common.mustSucceed()
   );
 } else {
   const cp = require('child_process');

--- a/test/parallel/test-stream-pipeline-process.js
+++ b/test/parallel/test-stream-pipeline-process.js
@@ -20,8 +20,7 @@ if (process.argv[2] === 'child') {
     `"${process.execPath}"`,
     `"${__filename}"`,
     'child'
-  ].join(' '), common.mustCall((err, stdout) => {
-    assert.ifError(err);
+  ].join(' '), common.mustSucceed((stdout) => {
     assert.strictEqual(stdout.split(os.EOL).shift().trim(), 'hello');
   }));
 }

--- a/test/parallel/test-stream-pipeline-uncaught.js
+++ b/test/parallel/test-stream-pipeline-uncaught.js
@@ -19,7 +19,6 @@ pipeline(s, async function(source) {
   for await (const chunk of source) {
     chunk;
   }
-}, common.mustCall((err) => {
-  assert.ifError(err);
+}, common.mustSucceed(() => {
   throw new Error('error');
 }));

--- a/test/parallel/test-stream-pipeline.js
+++ b/test/parallel/test-stream-pipeline.js
@@ -254,7 +254,7 @@ const net = require('net');
 
 {
   const server = http.createServer((req, res) => {
-    pipeline(req, res, common.mustCall());
+    pipeline(req, res, common.mustSucceed());
   });
 
   server.listen(0, () => {
@@ -1109,7 +1109,7 @@ const net = require('net');
 {
   const server = net.createServer(common.mustCall((socket) => {
     // echo server
-    pipeline(socket, socket, common.mustCall());
+    pipeline(socket, socket, common.mustSucceed());
     // 13 force destroys the socket before it has a chance to emit finish
     socket.on('finish', common.mustCall(() => {
       server.close();
@@ -1145,7 +1145,7 @@ const net = require('net');
     })
   });
 
-  pipeline(d, sink, common.mustCall());
+  pipeline(d, sink, common.mustSucceed());
 
   d.write('test');
   d.end();
@@ -1154,7 +1154,7 @@ const net = require('net');
 {
   const server = net.createServer(common.mustCall((socket) => {
     // echo server
-    pipeline(socket, socket, common.mustCall());
+    pipeline(socket, socket, common.mustSucceed());
     socket.on('finish', common.mustCall(() => {
       server.close();
     }));
@@ -1192,7 +1192,7 @@ const net = require('net');
     })
   });
 
-  pipeline(d, sink, common.mustCall());
+  pipeline(d, sink, common.mustSucceed());
 
   d.write('test');
   d.end();

--- a/test/parallel/test-stream-pipeline.js
+++ b/test/parallel/test-stream-pipeline.js
@@ -44,8 +44,7 @@ const net = require('net');
   }
   read.push(null);
 
-  pipeline(read, write, common.mustCall((err) => {
-    assert.ok(!err, 'no error');
+  pipeline(read, write, common.mustSucceed(() => {
     assert.ok(finished);
     assert.deepStrictEqual(processed, expected);
   }));
@@ -376,8 +375,7 @@ const net = require('net');
     rs,
     oldStream,
     ws,
-    common.mustCall((err) => {
-      assert(!err, 'no error');
+    common.mustSucceed(() => {
       assert(finished, 'last stream finished');
     })
   );
@@ -528,8 +526,7 @@ const net = require('net');
   pipeline(function*() {
     yield 'hello';
     yield 'world';
-  }(), w, common.mustCall((err) => {
-    assert.ok(!err);
+  }(), w, common.mustSucceed(() => {
     assert.strictEqual(res, 'helloworld');
   }));
 }
@@ -546,8 +543,7 @@ const net = require('net');
     await Promise.resolve();
     yield 'hello';
     yield 'world';
-  }(), w, common.mustCall((err) => {
-    assert.ok(!err);
+  }(), w, common.mustSucceed(() => {
     assert.strictEqual(res, 'helloworld');
   }));
 }
@@ -563,8 +559,7 @@ const net = require('net');
   pipeline(function*() {
     yield 'hello';
     yield 'world';
-  }, w, common.mustCall((err) => {
-    assert.ok(!err);
+  }, w, common.mustSucceed(() => {
     assert.strictEqual(res, 'helloworld');
   }));
 }
@@ -581,8 +576,7 @@ const net = require('net');
     await Promise.resolve();
     yield 'hello';
     yield 'world';
-  }, w, common.mustCall((err) => {
-    assert.ok(!err);
+  }, w, common.mustSucceed(() => {
     assert.strictEqual(res, 'helloworld');
   }));
 }
@@ -601,8 +595,7 @@ const net = require('net');
     for await (const chunk of source) {
       res += chunk;
     }
-  }, common.mustCall((err) => {
-    assert.ok(!err);
+  }, common.mustSucceed(() => {
     assert.strictEqual(res, 'HELLOWORLD');
   }));
 }
@@ -622,8 +615,7 @@ const net = require('net');
       ret += chunk;
     }
     return ret;
-  }, common.mustCall((err, val) => {
-    assert.ok(!err);
+  }, common.mustSucceed((val) => {
     assert.strictEqual(val, 'HELLOWORLD');
   }));
 }
@@ -895,8 +887,7 @@ const net = require('net');
     for await (const chunk of source) {
       res += chunk;
     }
-  }, common.mustCall((err) => {
-    assert.ok(!err);
+  }, common.mustSucceed(() => {
     assert.strictEqual(res, 'HELLOWORLD');
   }));
 }
@@ -954,8 +945,7 @@ const net = require('net');
     pipeline(
       body,
       req,
-      common.mustCall((err) => {
-        assert(!err);
+      common.mustSucceed(() => {
         assert(!req.res);
         assert(!req.aborted);
         req.abort();
@@ -969,8 +959,7 @@ const net = require('net');
 {
   const src = new PassThrough();
   const dst = new PassThrough();
-  pipeline(src, dst, common.mustCall((err) => {
-    assert(!err);
+  pipeline(src, dst, common.mustSucceed(() => {
     assert.strictEqual(dst.destroyed, false);
   }));
   src.end();
@@ -980,8 +969,7 @@ const net = require('net');
   const src = new PassThrough();
   const dst = new PassThrough();
   dst.readable = false;
-  pipeline(src, dst, common.mustCall((err) => {
-    assert(!err);
+  pipeline(src, dst, common.mustSucceed(() => {
     assert.strictEqual(dst.destroyed, false);
   }));
   src.end();
@@ -1224,8 +1212,7 @@ const net = require('net');
       callback();
     }
   });
-  pipeline([r, w], common.mustCall((err) => {
-    assert.ok(!err);
+  pipeline([r, w], common.mustSucceed(() => {
     assert.strictEqual(res, 'helloworld');
   }));
 }

--- a/test/parallel/test-stream-pipeline.js
+++ b/test/parallel/test-stream-pipeline.js
@@ -1075,9 +1075,7 @@ const net = require('net');
     for await (const chunk of source) {
       yield { chunk };
     }
-  }, common.mustCall((err) => {
-    assert.ifError(err);
-  }));
+  }, common.mustSucceed());
 }
 
 {

--- a/test/parallel/test-tls-addca.js
+++ b/test/parallel/test-tls-addca.js
@@ -43,8 +43,7 @@ connect({
   connect({
     client: clientOptions,
     server: serverOptions,
-  }, common.mustCall((err, pair, cleanup) => {
-    assert.ifError(err);
+  }, common.mustSucceed((pair, cleanup) => {
     cleanup();
   }));
 }));

--- a/test/parallel/test-tls-ca-concat.js
+++ b/test/parallel/test-tls-ca-concat.js
@@ -6,7 +6,7 @@ const fixtures = require('../common/fixtures');
 // non-CA cert and showing that agent6's CA root is still found.
 
 const {
-  assert, connect, keys
+  connect, keys
 } = require(fixtures.path('tls-connect'));
 
 connect({
@@ -18,7 +18,6 @@ connect({
     cert: keys.agent6.cert,
     key: keys.agent6.key,
   },
-}, common.mustCall((err, pair, cleanup) => {
-  assert.ifError(err);
+}, common.mustSucceed((pair, cleanup) => {
   return cleanup();
 }));

--- a/test/parallel/test-tls-cert-chains-concat.js
+++ b/test/parallel/test-tls-cert-chains-concat.js
@@ -20,7 +20,6 @@ connect({
     key: keys.agent6.key,
   },
 }, common.mustSucceed((pair, cleanup) => {
-
   const peer = pair.client.conn.getPeerCertificate();
   debug('peer:\n', peer);
   assert.strictEqual(peer.subject.emailAddress, 'adam.lippai@tresorit.com');

--- a/test/parallel/test-tls-cert-chains-concat.js
+++ b/test/parallel/test-tls-cert-chains-concat.js
@@ -19,8 +19,7 @@ connect({
     cert: keys.agent6.cert,
     key: keys.agent6.key,
   },
-}, common.mustCall((err, pair, cleanup) => {
-  assert.ifError(err);
+}, common.mustSucceed((pair, cleanup) => {
 
   const peer = pair.client.conn.getPeerCertificate();
   debug('peer:\n', peer);

--- a/test/parallel/test-tls-client-getephemeralkeyinfo.js
+++ b/test/parallel/test-tls-client-getephemeralkeyinfo.js
@@ -35,9 +35,7 @@ function test(size, type, name, cipher) {
     conn.end();
   }));
 
-  server.on('close', common.mustCall((err) => {
-    assert.ifError(err);
-  }));
+  server.on('close', common.mustSucceed());
 
   server.listen(0, '127.0.0.1', common.mustCall(() => {
     const client = tls.connect({

--- a/test/parallel/test-tls-disable-renegotiation.js
+++ b/test/parallel/test-tls-disable-renegotiation.js
@@ -73,8 +73,7 @@ server.listen(0, common.mustCall(() => {
 
     // Negotiation is still permitted for this first
     // attempt. This should succeed.
-    let ok = client.renegotiate(options, common.mustCall((err) => {
-      assert.ifError(err);
+    let ok = client.renegotiate(options, common.mustSucceed(() => {
       // Once renegotiation completes, we write some
       // data to the socket, which triggers the on
       // data event on the server. After that data

--- a/test/parallel/test-tls-ecdh.js
+++ b/test/parallel/test-tls-ecdh.js
@@ -51,7 +51,7 @@ server.listen(0, '127.0.0.1', common.mustCall(function() {
   const cmd = `"${common.opensslCli}" s_client -cipher ${
     options.ciphers} -connect 127.0.0.1:${this.address().port}`;
 
-  exec(cmd, common.mustSucceed(function(stdout, stderr) {
+  exec(cmd, common.mustSucceed((stdout, stderr) => {
     assert(stdout.includes(reply));
     server.close();
   }));

--- a/test/parallel/test-tls-ecdh.js
+++ b/test/parallel/test-tls-ecdh.js
@@ -51,8 +51,7 @@ server.listen(0, '127.0.0.1', common.mustCall(function() {
   const cmd = `"${common.opensslCli}" s_client -cipher ${
     options.ciphers} -connect 127.0.0.1:${this.address().port}`;
 
-  exec(cmd, common.mustCall(function(err, stdout, stderr) {
-    assert.ifError(err);
+  exec(cmd, common.mustSucceed(function(stdout, stderr) {
     assert(stdout.includes(reply));
     server.close();
   }));

--- a/test/parallel/test-trace-events-api.js
+++ b/test/parallel/test-trace-events-api.js
@@ -149,8 +149,7 @@ function testApiInChildProcess(execArgs, cb) {
     const file = path.join(tmpdir.path, 'node_trace.1.log');
 
     assert(fs.existsSync(file));
-    fs.readFile(file, common.mustCall((err, data) => {
-      assert.ifError(err);
+    fs.readFile(file, common.mustSucceed((data) => {
       const traces = JSON.parse(data.toString()).traceEvents
         .filter((trace) => trace.cat !== '__metadata');
       assert.strictEqual(traces.length,

--- a/test/parallel/test-util-callbackify.js
+++ b/test/parallel/test-util-callbackify.js
@@ -32,8 +32,7 @@ const values = [
     }
 
     const cbAsyncFn = callbackify(asyncFn);
-    cbAsyncFn(common.mustCall((err, ret) => {
-      assert.ifError(err);
+    cbAsyncFn(common.mustSucceed((ret) => {
       assert.strictEqual(ret, value);
     }));
 
@@ -43,8 +42,7 @@ const values = [
     }
 
     const cbPromiseFn = callbackify(promiseFn);
-    cbPromiseFn(common.mustCall((err, ret) => {
-      assert.ifError(err);
+    cbPromiseFn(common.mustSucceed((ret) => {
       assert.strictEqual(ret, value);
     }));
 
@@ -58,8 +56,7 @@ const values = [
     }
 
     const cbThenableFn = callbackify(thenableFn);
-    cbThenableFn(common.mustCall((err, ret) => {
-      assert.ifError(err);
+    cbThenableFn(common.mustSucceed((ret) => {
       assert.strictEqual(ret, value);
     }));
   }
@@ -162,8 +159,7 @@ const values = [
       Object.getPrototypeOf(asyncFn)
     );
     assert.strictEqual(Object.getPrototypeOf(cbAsyncFn), Function.prototype);
-    cbAsyncFn(value, common.mustCall((err, ret) => {
-      assert.ifError(err);
+    cbAsyncFn(value, common.mustSucceed((ret) => {
       assert.strictEqual(ret, value);
     }));
 
@@ -181,8 +177,7 @@ const values = [
 
     const cbPromiseFn = callbackify(promiseFn);
     assert.strictEqual(promiseFn.length, obj);
-    cbPromiseFn(value, common.mustCall((err, ret) => {
-      assert.ifError(err);
+    cbPromiseFn(value, common.mustSucceed((ret) => {
       assert.strictEqual(ret, value);
     }));
   }
@@ -242,8 +237,7 @@ const values = [
   execFile(
     process.execPath,
     [fixture],
-    common.mustCall((err, stdout, stderr) => {
-      assert.ifError(err);
+    common.mustSucceed((stdout, stderr) => {
       assert.strictEqual(
         stdout.trim(),
         `ifError got unwanted exception: ${fixture}`);

--- a/test/parallel/test-util-callbackify.js
+++ b/test/parallel/test-util-callbackify.js
@@ -193,8 +193,7 @@ const values = [
       },
     };
     iAmThis.cbFn = callbackify(iAmThis.fn);
-    iAmThis.cbFn(value, common.mustCall(function(err, ret) {
-      assert.ifError(err);
+    iAmThis.cbFn(value, common.mustSucceed(function(ret) {
       assert.strictEqual(ret, value);
       assert.strictEqual(this, iAmThis);
     }));
@@ -206,8 +205,7 @@ const values = [
       },
     };
     iAmThat.cbFn = callbackify(iAmThat.fn);
-    iAmThat.cbFn(value, common.mustCall(function(err, ret) {
-      assert.ifError(err);
+    iAmThat.cbFn(value, common.mustSucceed(function(ret) {
       assert.strictEqual(ret, value);
       assert.strictEqual(this, iAmThat);
     }));

--- a/test/parallel/test-worker-no-stdin-stdout-interaction.js
+++ b/test/parallel/test-worker-no-stdin-stdout-interaction.js
@@ -15,6 +15,6 @@ if (isMainThread) {
   process.stdin.on('data', () => {});
 
   for (let i = 0; i < 10; ++i) {
-    process.stdout.write(`processing(${i})\n`, common.mustCall());
+    process.stdout.write(`processing(${i})\n`, common.mustSucceed());
   }
 }

--- a/test/parallel/test-zlib-from-concatenated-gzip.js
+++ b/test/parallel/test-zlib-from-concatenated-gzip.js
@@ -20,13 +20,11 @@ const data = Buffer.concat([
 
 assert.strictEqual(zlib.gunzipSync(data).toString(), (abc + def));
 
-zlib.gunzip(data, common.mustCall((err, result) => {
-  assert.ifError(err);
+zlib.gunzip(data, common.mustSucceed((result) => {
   assert.strictEqual(result.toString(), (abc + def));
 }));
 
-zlib.unzip(data, common.mustCall((err, result) => {
-  assert.ifError(err);
+zlib.unzip(data, common.mustSucceed((result) => {
   assert.strictEqual(result.toString(), (abc + def));
 }));
 
@@ -34,8 +32,7 @@ zlib.unzip(data, common.mustCall((err, result) => {
 zlib.unzip(Buffer.concat([
   zlib.deflateSync('abc'),
   zlib.deflateSync('def')
-]), common.mustCall((err, result) => {
-  assert.ifError(err);
+]), common.mustSucceed((result) => {
   assert.strictEqual(result.toString(), abc);
 }));
 

--- a/test/parallel/test-zlib-from-gzip-with-trailing-garbage.js
+++ b/test/parallel/test-zlib-from-gzip-with-trailing-garbage.js
@@ -14,8 +14,7 @@ let data = Buffer.concat([
 
 assert.strictEqual(zlib.gunzipSync(data).toString(), 'abcdef');
 
-zlib.gunzip(data, common.mustCall((err, result) => {
-  assert.ifError(err);
+zlib.gunzip(data, common.mustSucceed((result) => {
   assert.strictEqual(
     result.toString(),
     'abcdef',

--- a/test/sequential/test-init.js
+++ b/test/sequential/test-init.js
@@ -36,8 +36,7 @@ process.env.TEST_INIT = 1;
 
 function test(file, expected) {
   const path = `"${process.execPath}" ${file}`;
-  child.exec(path, { env: process.env }, common.mustCall((err, out) => {
-    assert.ifError(err);
+  child.exec(path, { env: process.env }, common.mustSucceed((out) => {
     assert.strictEqual(out, expected, `'node ${file}' failed!`);
   }));
 }

--- a/tools/eslint-rules/prefer-common-mustsucceed.js
+++ b/tools/eslint-rules/prefer-common-mustsucceed.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const mustCall = 'CallExpression[callee.object.name="common"]' +
+                 '[callee.property.name="mustCall"]';
+
+module.exports = (context) => {
+  function isAssertIfError(node) {
+    return node.type === 'MemberExpression' &&
+           node.object.type === 'Identifier' &&
+           node.object.name === 'assert' &&
+           node.property.type === 'Identifier' &&
+           node.property.name === 'ifError';
+  }
+
+  function isCallToIfError(node, errName) {
+    return node.type === 'CallExpression' &&
+           isAssertIfError(node.callee) &&
+           node.arguments.length > 0 &&
+           node.arguments[0].type === 'Identifier' &&
+           node.arguments[0].name === errName;
+  }
+
+  function bodyStartsWithCallToIfError(body, errName) {
+    while (body.type === 'BlockStatement' && body.body.length > 0)
+      body = body.body[0];
+
+    let expr;
+    switch (body.type) {
+      case 'ReturnStatement':
+        expr = body.argument;
+        break;
+      case 'ExpressionStatement':
+        expr = body.expression;
+        break;
+      default:
+        expr = body;
+    }
+
+    return isCallToIfError(expr, errName);
+  }
+
+  return {
+    [`${mustCall}:exit`]: (mustCall) => {
+      if (mustCall.arguments.length > 0) {
+        const callback = mustCall.arguments[0];
+        if (isAssertIfError(callback)) {
+          context.report(mustCall, 'Please use common.mustSucceed instead of ' +
+                                   'common.mustCall(assert.ifError).');
+        }
+
+        if (callback.type === 'ArrowFunctionExpression' ||
+            callback.type === 'FunctionExpression') {
+          if (callback.params.length > 0 &&
+              callback.params[0].type === 'Identifier') {
+            const errName = callback.params[0].name;
+            if (bodyStartsWithCallToIfError(callback.body, errName)) {
+              context.report(mustCall, 'Please use common.mustSucceed instead' +
+                                       ' of common.mustCall with' +
+                                       ' assert.ifError.');
+            }
+          }
+        }
+      }
+    }
+  };
+};


### PR DESCRIPTION
Our increasingly large collection of tests makes frequent use of this pattern:

```javascript
someFunction(/* some args */, common.mustCall((err, /* some results */) => {
  assert.ifError(err);
  // Something else
});
```

This PR changes those to this pattern:

```javascript
someFunction(/* some args */, common.mustSucceed((/* some results */) => {
  // Something else
});
```

This simple change allows us to remove more than 300 lines of code from tests. Another aspect is that many tests really should be using `mustSucceed()` instead of `mustCall()`, because `mustCall()` silently ignores errors passed to it. I changed the crypto tests manually where I found such cases, and a few other test files, but there's probably dozens or hundreds of such cases in other test files.

---

To make this easier to review, I separated the changes into multiple commits.

1. The first commit introduces the new API.
2. The next three commits apply regular expressions for automatic conversions from `mustCall` to `mustSucceed`.
   1. The first replaces all occurrences of `mustCall\([ \n]*(\(erro?r?\)[ \n]*=>[ \n]*\{?|function[ \n]*\(erro?r?\)[ \n]*\{)?[ \n]*assert\.ifError(\(erro?r?\))?;?[ \n]*\}?[ \n]*\)` with `mustSucceed()`. These are trivial cases, e.g, `mustCall(assert.ifError)`, `mustCall((err) => assert.ifError(err))`, `mustCall(function(err) { assert.ifError(err); })` etc.
   2. The second replaces all occurrences of `mustCall\([\n ]*\(erro?r?(,[\n ]*([^\)]*))?\)([\n ]*)=>([\n ]*)\{[\n ]+assert\.ifError\(erro?r?\);\n` with `mustSucceed(($2)$3=>$4{\n`. These are arrow functions that take an error argument and begin with `assert.ifError`.
   3. The third replaces all occurrences of `mustCall\([\n ]*function[ \n]*\(erro?r?(, *([^\)]*))?\)([ \t\n]*)\{[\n ]+assert\.ifError\(erro?r?\);\n` with `mustSucceed(function($2)$3{\n`. These are regular functions that take an error argument and begin with `assert.ifError`.
3. The fifth commit converts functions containing statements such as `assert.ok(!err)` to `mustSucceed`, where possible.
4. The sixth commit improves formatting. While all previous commits pass tests and linter, the regular expressions leave some unnecessary empty lines. While at it, I also converted some functions to arrow functions (only in lines that I changed anyway).
5. The seventh commit replaces the weaker `mustCall` with `mustSucceed` where it seems to make sense.

---

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
