### PR TITLE
crypto: improve invalid arg type message for randomInt()

### DIFF
--- a/lib/internal/crypto/random.js
+++ b/lib/internal/crypto/random.js
@@ -144,10 +144,10 @@ function randomInt(min, max, callback) {
     throw new ERR_INVALID_CALLBACK(callback);
   }
   if (!NumberIsSafeInteger(min)) {
-    throw new ERR_INVALID_ARG_TYPE('min', 'safe integer', min);
+    throw new ERR_INVALID_ARG_TYPE('min', 'a safe integer', min);
   }
   if (!NumberIsSafeInteger(max)) {
-    throw new ERR_INVALID_ARG_TYPE('max', 'safe integer', max);
+    throw new ERR_INVALID_ARG_TYPE('max', 'a safe integer', max);
   }
   if (max <= min) {
     throw new ERR_OUT_OF_RANGE(

--- a/test/parallel/test-crypto-random.js
+++ b/test/parallel/test-crypto-random.js
@@ -394,13 +394,13 @@ assert.throws(
     const invalidMinError = {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "min" argument must be safe integer.' +
+      message: 'The "min" argument must be a safe integer.' +
                `${common.invalidArgTypeHelper(i)}`,
     };
     const invalidMaxError = {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "max" argument must be safe integer.' +
+      message: 'The "max" argument must be a safe integer.' +
                `${common.invalidArgTypeHelper(i)}`,
     };
 
@@ -441,7 +441,7 @@ assert.throws(
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "min" argument must be safe integer.' +
+      message: 'The "min" argument must be a safe integer.' +
       `${common.invalidArgTypeHelper(minInt - 1)}`,
     }
   );
@@ -451,7 +451,7 @@ assert.throws(
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "max" argument must be safe integer.' +
+      message: 'The "max" argument must be a safe integer.' +
       `${common.invalidArgTypeHelper(maxInt + 1)}`,
     }
   );


### PR DESCRIPTION
Use "must be a safe integer" rather than "must be safe integer". I
believe the former is more easily understood/clear.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
