### PR TITLE
idna: use url module instead of punycode

### DIFF
--- a/doc/api/intl.md
+++ b/doc/api/intl.md
@@ -51,6 +51,7 @@ option:
 | `String.prototype.toLocale*Case()`      | partial (not locale-aware)        | full                         | full                   | full       |
 | [`Number.prototype.toLocaleString()`][] | partial (not locale-aware)        | partial/full (depends on OS) | partial (English-only) | full       |
 | `Date.prototype.toLocale*String()`      | partial (not locale-aware)        | partial/full (depends on OS) | partial (English-only) | full       |
+| [Legacy URL Parser][]                   | partial (no IDN support)          | full                         | full                   | full       |
 | [WHATWG URL Parser][]                   | partial (no IDN support)          | full                         | full                   | full       |
 | [`require('buffer').transcode()`][]     | none (function does not exist)    | full                         | full                   | full       |
 | [REPL][]                                | partial (inaccurate line editing) | full                         | full                   | full       |
@@ -193,6 +194,7 @@ to be helpful:
 [ECMA-262]: https://tc39.github.io/ecma262/
 [ECMA-402]: https://tc39.github.io/ecma402/
 [ICU]: http://site.icu-project.org/
+[Legacy URL parser]: url.md#url_legacy_url_api
 [REPL]: repl.md#repl_repl
 [Test262]: https://github.com/tc39/test262/tree/HEAD/test/intl402
 [WHATWG URL parser]: url.md#url_the_whatwg_url_api

--- a/lib/internal/idna.js
+++ b/lib/internal/idna.js
@@ -4,6 +4,6 @@ if (internalBinding('config').hasIntl) {
   const { toASCII, toUnicode } = internalBinding('icu');
   module.exports = { toASCII, toUnicode };
 } else {
-  const { toASCII, toUnicode } = require('punycode');
-  module.exports = { toASCII, toUnicode };
+  const { domainToASCII, domainToUnicode } = require('internal/url');
+  module.exports = { toASCII: domainToASCII, toUnicode: domainToUnicode };
 }

--- a/test/parallel/test-bootstrap-modules.js
+++ b/test/parallel/test-bootstrap-modules.js
@@ -151,7 +151,7 @@ if (!common.isMainThread) {
 if (common.hasIntl) {
   expectedModules.add('Internal Binding icu');
 } else {
-  expectedModules.add('NativeModule punycode');
+  expectedModules.add('NativeModule url');
 }
 
 if (process.features.inspector) {

--- a/test/parallel/test-url-format.js
+++ b/test/parallel/test-url-format.js
@@ -1,7 +1,10 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const url = require('url');
+
+if (!common.hasIntl)
+  common.skip('missing Intl');
 
 // Formatting tests to verify that it'll format slightly wonky content to a
 // valid URL.

--- a/test/parallel/test-url-parse-format.js
+++ b/test/parallel/test-url-parse-format.js
@@ -1,5 +1,9 @@
 'use strict';
-require('../common');
+const common = require('../common');
+
+if (!common.hasIntl)
+  common.skip('missing Intl');
+
 const assert = require('assert');
 const inspect = require('util').inspect;
 


### PR DESCRIPTION
Remove IDN support for legacy URL API on node compiled with the `--without-intl` flag (same as WHATWG URL API).
Remove the dependency on `punycode` core module, which is already deprecated.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
