### PR TITLE
punycode: runtime deprecation

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -831,12 +831,15 @@ The [`require.extensions`][] property is deprecated.
 ### DEP0040: `punycode` module
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/35092
+    description: Added support for `--pending-deprecation`.
   - version: v7.0.0
     pr-url: https://github.com/nodejs/node/pull/7941
     description: Documentation-only deprecation.
 -->
 
-Type: Documentation-only
+Type: Documentation-only (supports [`--pending-deprecation`][])
 
 The [`punycode`][] module is deprecated. Please use a userland alternative
 instead.

--- a/lib/punycode.js
+++ b/lib/punycode.js
@@ -1,5 +1,15 @@
 'use strict';
 
+const { getOptionValue } = require('internal/options');
+if (getOptionValue('--pending-deprecation')){
+	process.emitWarning(
+		'The `punycode` module is deprecated. Please use a userland ' +
+		'alternative instead.',
+		'DeprecationWarning',
+		'DEP0040',
+	);
+}
+
 /** Highest positive signed 32-bit float value */
 const maxInt = 2147483647; // aka. 0x7FFFFFFF or 2^31-1
 

--- a/test/message/core_line_numbers.js
+++ b/test/message/core_line_numbers.js
@@ -1,11 +1,11 @@
 'use strict';
 require('../common');
-const punycode = require('punycode');
+const path = require('path');
 
 // This test verifies that line numbers in core modules are reported correctly.
-// The punycode module was chosen for testing because it changes infrequently.
-// If this test begins failing, it is likely due to a punycode update, and the
+// The path module was chosen for testing because it changes infrequently.
+// If this test begins failing, it is likely due to a path update, and the
 // test's assertions simply need to be updated to reflect the changes. If a
-// punycode update was not made, and this test begins failing, then line numbers
+// path update was not made, and this test begins failing, then line numbers
 // are probably actually broken.
-punycode.decode('x');
+path.dirname(0);

--- a/test/message/core_line_numbers.out
+++ b/test/message/core_line_numbers.out
@@ -1,14 +1,17 @@
-punycode.js:42
-	throw new RangeError(errors[type]);
-	^
+internal/validators.js:*
+    throw new ERR_INVALID_ARG_TYPE(name, 'string', value);
+    ^
 
-RangeError: Invalid input
-    at error (punycode.js:42:8)
-    at Object.decode (punycode.js:*:*)
+TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received type number (0)
+    at new NodeError (internal/errors.js:*:*)
+    at validateString (internal/validators.js:*:*)
+    at Object.dirname (path.js:1128:5)
     at Object.<anonymous> (*test*message*core_line_numbers.js:*:*)
     at Module._compile (internal/modules/cjs/loader.js:*:*)
     at Object.Module._extensions..js (internal/modules/cjs/loader.js:*:*)
     at Module.load (internal/modules/cjs/loader.js:*:*)
     at Function.Module._load (internal/modules/cjs/loader.js:*:*)
     at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:*:*)
-    at internal/main/run_main_module.js:*:*
+    at internal/main/run_main_module.js:*:* {
+  code: 'ERR_INVALID_ARG_TYPE'
+}

--- a/test/parallel/test-punycode.js
+++ b/test/parallel/test-punycode.js
@@ -1,3 +1,5 @@
+// Flags: --pending-deprecation
+
 // Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -20,7 +22,13 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+const common = require('../common');
+
+const punycodeWarning =
+  'The `punycode` module is deprecated. Please use a userland alternative ' +
+  'instead.';
+common.expectWarning('DeprecationWarning', punycodeWarning, 'DEP0040');
+
 const punycode = require('punycode');
 const assert = require('assert');
 


### PR DESCRIPTION
`punycode` is doc deprecated since v7 and the npm package is downloaded 40M per week, I think it's time to move its deprecation forward.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
