### PR TITLE
deps: update to uvwasi 0.0.11

### DIFF
--- a/deps/uvwasi/include/uvwasi.h
+++ b/deps/uvwasi/include/uvwasi.h
@@ -10,7 +10,7 @@ extern "C" {
 
 #define UVWASI_VERSION_MAJOR 0
 #define UVWASI_VERSION_MINOR 0
-#define UVWASI_VERSION_PATCH 10
+#define UVWASI_VERSION_PATCH 11
 #define UVWASI_VERSION_HEX ((UVWASI_VERSION_MAJOR << 16) | \
                             (UVWASI_VERSION_MINOR <<  8) | \
                             (UVWASI_VERSION_PATCH))

--- a/deps/uvwasi/include/wasi_serdes.h
+++ b/deps/uvwasi/include/wasi_serdes.h
@@ -103,6 +103,9 @@ IOVS_STRUCT(ciovec_t)
 #define UVWASI_SERDES_SIZE_iovec_t 8
 IOVS_STRUCT(iovec_t)
 
+#define UVWASI_SERDES_SIZE_dirent_t 24
+STRUCT(dirent_t)
+
 #define UVWASI_SERDES_SIZE_fdstat_t 24
 STRUCT(fdstat_t)
 

--- a/deps/uvwasi/src/wasi_serdes.c
+++ b/deps/uvwasi/src/wasi_serdes.c
@@ -84,6 +84,13 @@ uint8_t uvwasi_serdes_read_uint8_t(const void* ptr,  size_t offset) {
   ALIAS(userdata_t,      uint64_t)                                            \
   ALIAS(whence_t,        uint8_t)                                             \
                                                                               \
+  STRUCT(dirent_t) {                                                          \
+    FIELD( 0, dircookie_t, d_next);                                           \
+    FIELD( 8, inode_t,     d_ino);                                            \
+    FIELD(16, uint32_t,    d_namlen);                                         \
+    FIELD(20, filetype_t,  d_type);                                           \
+  }                                                                           \
+                                                                              \
   STRUCT(fdstat_t) {                                                          \
     FIELD( 0, filetype_t, fs_filetype);                                       \
     FIELD( 2, fdflags_t,  fs_flags);                                          \


### PR DESCRIPTION
Notable changes:

- Several issues have been addressed in `uvwasi_fd_readdir()`.
  A bug in the copying of the directory entry's name has been fixed.
  The function now returns `UVWASI_ENOSYS` on Windows and Android.
  Serdes support has been added for `uvwasi_dirent_t`'s.
- The libuv dependency has been updated to v1.39.0 (not relevant for the Node.js integration).

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)