### PR TITLE
crypto: add buffering to randomInt

### DIFF
--- a/benchmark/crypto/randomInt.js
+++ b/benchmark/crypto/randomInt.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const common = require('../common.js');
+const { randomInt } = require('crypto');
+
+const bench = common.createBenchmark(main, {
+  mode: ['sync', 'async-sequential', 'async-parallel'],
+  min: [-(2 ** 47) + 1, -10_000, -100],
+  max: [100, 10_000, 2 ** 47],
+  n: [1e3, 1e5]
+});
+
+function main({ mode, min, max, n }) {
+  if (mode === 'sync') {
+    bench.start();
+    for (let i = 0; i < n; i++)
+      randomInt(min, max);
+    bench.end(n);
+  } else if (mode === 'async-sequential') {
+    bench.start();
+    (function next(i) {
+      if (i === n)
+        return bench.end(n);
+      randomInt(min, max, () => {
+        next(i + 1);
+      });
+    })(0);
+  } else {
+    bench.start();
+    let done = 0;
+    for (let i = 0; i < n; i++) {
+      randomInt(min, max, () => {
+        if (++done === n)
+          bench.end(n);
+      });
+    }
+  }
+}

--- a/lib/internal/crypto/random.js
+++ b/lib/internal/crypto/random.js
@@ -2,6 +2,10 @@
 
 const {
   Array,
+  ArrayPrototypeForEach,
+  ArrayPrototypePush,
+  ArrayPrototypeShift,
+  ArrayPrototypeSplice,
   BigInt,
   FunctionPrototypeBind,
   FunctionPrototypeCall,
@@ -186,6 +190,13 @@ function randomFill(buf, offset, size, callback) {
 // e.g.: Buffer.from("ff".repeat(6), "hex").readUIntBE(0, 6);
 const RAND_MAX = 0xFFFF_FFFF_FFFF;
 
+// Cache random data to use in randomInt. The cache size must be evenly
+// divisible by 6 because each attempt to obtain a random int uses 6 bytes.
+const randomCache = new FastBuffer(6 * 1024);
+let randomCacheOffset = randomCache.length;
+let asyncCacheFillInProgress = false;
+const asyncCachePendingTasks = [];
+
 // Generates an integer in [min, max) range where min is inclusive and max is
 // exclusive.
 function randomInt(min, max, callback) {
@@ -230,33 +241,59 @@ function randomInt(min, max, callback) {
   // than or equal to 0 and less than randLimit.
   const randLimit = RAND_MAX - (RAND_MAX % range);
 
-  if (isSync) {
-    // Sync API
-    while (true) {
-      const x = randomBytes(6).readUIntBE(0, 6);
-      if (x >= randLimit) {
-        // Try again.
-        continue;
-      }
-      return (x % range) + min;
+  // If we don't have a callback, or if there is still data in the cache, we can
+  // do this synchronously, which is super fast.
+  while (isSync || (randomCacheOffset < randomCache.length)) {
+    if (randomCacheOffset === randomCache.length) {
+      // This might block the thread for a bit, but we are in sync mode.
+      randomFillSync(randomCache);
+      randomCacheOffset = 0;
     }
-  } else {
-    // Async API
-    const pickAttempt = () => {
-      randomBytes(6, (err, bytes) => {
-        if (err) return callback(err);
-        const x = bytes.readUIntBE(0, 6);
-        if (x >= randLimit) {
-          // Try again.
-          return pickAttempt();
-        }
-        const n = (x % range) + min;
-        callback(null, n);
-      });
-    };
 
-    pickAttempt();
+    const x = randomCache.readUIntBE(randomCacheOffset, 6);
+    randomCacheOffset += 6;
+
+    if (x < randLimit) {
+      const n = (x % range) + min;
+      if (isSync) return n;
+      process.nextTick(callback, undefined, n);
+      return;
+    }
   }
+
+  // At this point, we are in async mode with no data in the cache. We cannot
+  // simply refill the cache, because another async call to randomInt might
+  // already be doing that. Instead, queue this call for when the cache has
+  // been refilled.
+  ArrayPrototypePush(asyncCachePendingTasks, { min, max, callback });
+  asyncRefillRandomIntCache();
+}
+
+function asyncRefillRandomIntCache() {
+  if (asyncCacheFillInProgress)
+    return;
+
+  asyncCacheFillInProgress = true;
+  randomFill(randomCache, (err) => {
+    asyncCacheFillInProgress = false;
+
+    const tasks = asyncCachePendingTasks;
+    const errorReceiver = err && ArrayPrototypeShift(tasks);
+    if (!err)
+      randomCacheOffset = 0;
+
+    // Restart all pending tasks. If an error occurred, we only notify a single
+    // callback (errorReceiver) about it. This way, every async call to
+    // randomInt has a chance of being successful, and it avoids complex
+    // exception handling here.
+    ArrayPrototypeForEach(ArrayPrototypeSplice(tasks, 0), (task) => {
+      randomInt(task.min, task.max, task.callback);
+    });
+
+    // This is the only call that might throw, and is therefore done at the end.
+    if (errorReceiver)
+      errorReceiver.callback(err);
+  });
 }
 
 


### PR DESCRIPTION
This adds a buffer to `randomInt` to prevent calling `randomBytes` on each invocation. It also simplifies the actual calculation to always be synchronous, and doesn't duplicate the logic for asynchronous behavior. However, this change does include additional code to manage the cache.

Performance is improved significantly, by large factors, for synchronous calls and sequential asynchronous calls. For parallel calls, performance is about the same when requesting a few hundred random integers at a time.

Performance is significantly worse when requesting a large number of random integers asynchronously and in parallel. The reason is that this implementation delays all requests until the buffer has been refilled with random data, then serves as many requests as it can, then delays the remaining requests until the buffer has been refilled again, and so on. With a buffer size of 3KiB, 500 random integers can be provided without having to call `randomBytes`. When the benchmark requests 100,000 random integers asynchronously and in parallel, instead of processing 100,000 calls to `randomBytes` in parallel, the buffered implementation provides 200 batches of 500 numbers each sequentially.

- We could add additional code to handle such cases and avoid this performance penalty, but I decided to leave the additional complexity out for now. I assume that most use cases will require a sequence of random numbers, and not necessarily a large amount of random numbers at once.
- We could also change the buffer size, but that would require more memory, and could lead to slightly longer delays when refilling the buffer.
- We could also disable buffering for async in general, and only use it for sync calls. That would make any single call to `randomInt` with a callback slow, but would make generating huge amounts of random integers at the same time faster.

Benchmark results based on 30 runs (3988798fa4bdbd3ade4cb23289ec0ae05621d438 compared to the master branch at b5a47ca2d1f3b8e885164c5f1a6b3db0cdffa1c2):

```
                                                                                               confidence improvement accuracy (*)     (**)    (***)
 crypto/randomInt.js n=1000 max=100 min=-100 mode='async-parallel'                                             7.61 %       ±8.19%  ±10.90%  ±14.19%
 crypto/randomInt.js n=1000 max=100 min=-100 mode='async-sequential'                                  ***    113.40 %       ±9.73%  ±12.98%  ±16.98%
 crypto/randomInt.js n=1000 max=100 min=-100 mode='sync'                                              ***    151.27 %       ±4.81%   ±6.41%   ±8.36%
 crypto/randomInt.js n=1000 max=100 min=-10000 mode='async-parallel'                                           1.72 %       ±8.22%  ±10.97%  ±14.35%
 crypto/randomInt.js n=1000 max=100 min=-10000 mode='async-sequential'                                ***    110.33 %       ±9.82%  ±13.12%  ±17.17%
 crypto/randomInt.js n=1000 max=100 min=-10000 mode='sync'                                            ***    138.80 %       ±7.85%  ±10.54%  ±13.92%
 crypto/randomInt.js n=1000 max=100 min=-140737488355327 mode='async-parallel'                        ***     39.70 %       ±9.72%  ±12.99%  ±17.03%
 crypto/randomInt.js n=1000 max=100 min=-140737488355327 mode='async-sequential'                      ***    277.28 %      ±12.17%  ±16.35%  ±21.61%
 crypto/randomInt.js n=1000 max=100 min=-140737488355327 mode='sync'                                  ***    264.60 %       ±9.85%  ±13.13%  ±17.16%
 crypto/randomInt.js n=1000 max=10000 min=-100 mode='async-parallel'                                    *      6.06 %       ±5.92%   ±7.88%  ±10.26%
 crypto/randomInt.js n=1000 max=10000 min=-100 mode='async-sequential'                                ***     97.52 %      ±10.61%  ±14.20%  ±18.65%
 crypto/randomInt.js n=1000 max=10000 min=-100 mode='sync'                                            ***    138.26 %       ±8.36%  ±11.26%  ±14.94%
 crypto/randomInt.js n=1000 max=10000 min=-10000 mode='async-parallel'                                        -4.46 %       ±8.33%  ±11.16%  ±14.69%
 crypto/randomInt.js n=1000 max=10000 min=-10000 mode='async-sequential'                              ***    103.98 %      ±10.82%  ±14.46%  ±18.96%
 crypto/randomInt.js n=1000 max=10000 min=-10000 mode='sync'                                          ***    141.13 %       ±3.42%   ±4.56%   ±5.95%
 crypto/randomInt.js n=1000 max=10000 min=-140737488355327 mode='async-parallel'                      ***     40.64 %       ±4.59%   ±6.11%   ±7.95%
 crypto/randomInt.js n=1000 max=10000 min=-140737488355327 mode='async-sequential'                    ***    263.09 %      ±23.93%  ±32.22%  ±42.72%
 crypto/randomInt.js n=1000 max=10000 min=-140737488355327 mode='sync'                                ***    246.81 %       ±4.33%   ±5.83%   ±7.72%
 crypto/randomInt.js n=1000 max=140737488355328 min=-100 mode='async-parallel'                        ***     37.40 %       ±7.18%   ±9.59%  ±12.55%
 crypto/randomInt.js n=1000 max=140737488355328 min=-100 mode='async-sequential'                      ***    275.54 %      ±11.41%  ±15.31%  ±20.20%
 crypto/randomInt.js n=1000 max=140737488355328 min=-100 mode='sync'                                  ***    247.66 %       ±3.52%   ±4.71%   ±6.17%
 crypto/randomInt.js n=1000 max=140737488355328 min=-10000 mode='async-parallel'                      ***     36.03 %       ±7.56%  ±10.11%  ±13.27%
 crypto/randomInt.js n=1000 max=140737488355328 min=-10000 mode='async-sequential'                    ***    254.88 %      ±18.48%  ±24.85%  ±32.86%
 crypto/randomInt.js n=1000 max=140737488355328 min=-10000 mode='sync'                                ***    251.64 %       ±3.86%   ±5.16%   ±6.76%
 crypto/randomInt.js n=1000 max=140737488355328 min=-140737488355327 mode='async-parallel'                    -0.22 %       ±7.35%   ±9.80%  ±12.78%
 crypto/randomInt.js n=1000 max=140737488355328 min=-140737488355327 mode='async-sequential'          ***    104.97 %      ±12.95%  ±17.36%  ±22.87%
 crypto/randomInt.js n=1000 max=140737488355328 min=-140737488355327 mode='sync'                      ***    138.63 %       ±4.24%   ±5.71%   ±7.56%
 crypto/randomInt.js n=100000 max=100 min=-100 mode='async-parallel'                                  ***    -41.12 %       ±1.21%   ±1.62%   ±2.13%
 crypto/randomInt.js n=100000 max=100 min=-100 mode='async-sequential'                                ***    691.82 %       ±7.30%   ±9.81%  ±12.97%
 crypto/randomInt.js n=100000 max=100 min=-100 mode='sync'                                            ***   1310.10 %      ±36.17%  ±48.74%  ±64.70%
 crypto/randomInt.js n=100000 max=100 min=-10000 mode='async-parallel'                                ***    -40.20 %       ±1.28%   ±1.72%   ±2.26%
 crypto/randomInt.js n=100000 max=100 min=-10000 mode='async-sequential'                              ***    691.30 %       ±8.86%  ±11.91%  ±15.77%
 crypto/randomInt.js n=100000 max=100 min=-10000 mode='sync'                                          ***   1290.11 %      ±55.81%  ±75.21%  ±99.85%
 crypto/randomInt.js n=100000 max=100 min=-140737488355327 mode='async-parallel'                      ***    -38.02 %       ±0.83%   ±1.11%   ±1.47%
 crypto/randomInt.js n=100000 max=100 min=-140737488355327 mode='async-sequential'                    ***   1434.15 %      ±22.58%  ±30.43%  ±40.39%
 crypto/randomInt.js n=100000 max=100 min=-140737488355327 mode='sync'                                ***   2233.63 %      ±61.72%  ±83.18% ±110.43%
 crypto/randomInt.js n=100000 max=10000 min=-100 mode='async-parallel'                                ***    -40.04 %       ±1.48%   ±1.99%   ±2.64%
 crypto/randomInt.js n=100000 max=10000 min=-100 mode='async-sequential'                              ***    694.65 %       ±7.53%  ±10.12%  ±13.38%
 crypto/randomInt.js n=100000 max=10000 min=-100 mode='sync'                                          ***   1338.29 %      ±31.28%  ±42.15%  ±55.95%
 crypto/randomInt.js n=100000 max=10000 min=-10000 mode='async-parallel'                              ***    -39.62 %       ±1.15%   ±1.54%   ±2.04%
 crypto/randomInt.js n=100000 max=10000 min=-10000 mode='async-sequential'                            ***    685.36 %       ±8.82%  ±11.87%  ±15.71%
 crypto/randomInt.js n=100000 max=10000 min=-10000 mode='sync'                                        ***   1286.39 %      ±43.29%  ±58.33%  ±77.43%
 crypto/randomInt.js n=100000 max=10000 min=-140737488355327 mode='async-parallel'                    ***    -38.56 %       ±1.02%   ±1.37%   ±1.80%
 crypto/randomInt.js n=100000 max=10000 min=-140737488355327 mode='async-sequential'                  ***   1450.61 %      ±18.13%  ±24.43%  ±32.43%
 crypto/randomInt.js n=100000 max=10000 min=-140737488355327 mode='sync'                              ***   2137.98 %      ±87.00% ±117.25% ±155.67%
 crypto/randomInt.js n=100000 max=140737488355328 min=-100 mode='async-parallel'                      ***    -39.14 %       ±0.82%   ±1.09%   ±1.43%
 crypto/randomInt.js n=100000 max=140737488355328 min=-100 mode='async-sequential'                    ***   1453.44 %      ±16.70%  ±22.50%  ±29.87%
 crypto/randomInt.js n=100000 max=140737488355328 min=-100 mode='sync'                                ***   2161.60 %      ±72.54%  ±97.76% ±129.79%
 crypto/randomInt.js n=100000 max=140737488355328 min=-10000 mode='async-parallel'                    ***    -38.39 %       ±1.10%   ±1.47%   ±1.93%
 crypto/randomInt.js n=100000 max=140737488355328 min=-10000 mode='async-sequential'                  ***   1449.92 %      ±13.92%  ±18.74%  ±24.86%
 crypto/randomInt.js n=100000 max=140737488355328 min=-10000 mode='sync'                              ***   2169.74 %      ±67.67%  ±91.20% ±121.08%
 crypto/randomInt.js n=100000 max=140737488355328 min=-140737488355327 mode='async-parallel'          ***    -51.28 %       ±1.46%   ±1.96%   ±2.57%
 crypto/randomInt.js n=100000 max=140737488355328 min=-140737488355327 mode='async-sequential'        ***    695.29 %       ±8.29%  ±11.15%  ±14.75%
 crypto/randomInt.js n=100000 max=140737488355328 min=-140737488355327 mode='sync'                    ***   1271.56 %      ±36.90%  ±49.73%  ±66.01%

Be aware that when doing many comparisons the risk of a false-positive
result increases. In this case there are 54 comparisons, you can thus
expect the following amount of false-positive results:
  2.70 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.54 false positives, when considering a   1% risk acceptance (**, ***),
  0.05 false positives, when considering a 0.1% risk acceptance (***)
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
