### PR TITLE
lib: return boolean result of `assert.match` method

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -886,7 +886,7 @@ assert.ifError = function ifError(err) {
   }
 };
 
-function internalMatch(string, regexp, message, fn, shouldThrows = true) {
+function internalMatch(string, regexp, message, fn, shouldThrow = true) {
   if (!isRegExp(regexp)) {
     throw new ERR_INVALID_ARG_TYPE(
       'regexp', 'RegExp', regexp
@@ -896,11 +896,11 @@ function internalMatch(string, regexp, message, fn, shouldThrows = true) {
   if (typeof string !== 'string' ||
       RegExpPrototypeTest(regexp, string) !== match) {
     if (message instanceof Error) {
-      if (!shouldThrows) return false;
+      if (!shouldThrow) return false;
       throw message;
     }
 
-    if (!shouldThrows) return false;
+    if (!shouldThrow) return false;
     const generatedMessage = !message;
 
     // 'The input was expected to not match the regular expression ' +
@@ -921,14 +921,14 @@ function internalMatch(string, regexp, message, fn, shouldThrows = true) {
     err.generatedMessage = generatedMessage;
     throw err;
   }
-  if (!shouldThrows) return true;
+  if (!shouldThrow) return true;
 }
 
-assert.match = function match(string, regexp, message, shouldThrows) {
-  // Undefined shouldThrows and message as boolean
-  // means message is shouldThrows.
-  if (!shouldThrows && typeof message === 'boolean') shouldThrows = message;
-  return internalMatch(string, regexp, message, match, shouldThrows);
+assert.match = function match(string, regexp, message, shouldThrow) {
+  // Undefined shouldThrow and message as boolean
+  // means message is shouldThrow.
+  if (!shouldThrow && typeof message === 'boolean') shouldThrow = message;
+  return internalMatch(string, regexp, message, match, shouldThrow);
 };
 
 assert.doesNotMatch = function doesNotMatch(string, regexp, message) {

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -886,7 +886,7 @@ assert.ifError = function ifError(err) {
   }
 };
 
-function internalMatch(string, regexp, message, fn) {
+function internalMatch(string, regexp, message, fn, shouldThrows = true) {
   if (!isRegExp(regexp)) {
     throw new ERR_INVALID_ARG_TYPE(
       'regexp', 'RegExp', regexp
@@ -896,9 +896,11 @@ function internalMatch(string, regexp, message, fn) {
   if (typeof string !== 'string' ||
       RegExpPrototypeTest(regexp, string) !== match) {
     if (message instanceof Error) {
+      if (!shouldThrows) return false;
       throw message;
     }
 
+    if (!shouldThrows) return false;
     const generatedMessage = !message;
 
     // 'The input was expected to not match the regular expression ' +
@@ -919,10 +921,14 @@ function internalMatch(string, regexp, message, fn) {
     err.generatedMessage = generatedMessage;
     throw err;
   }
+  if (!shouldThrows) return true;
 }
 
-assert.match = function match(string, regexp, message) {
-  internalMatch(string, regexp, message, match);
+assert.match = function match(string, regexp, message, shouldThrows) {
+  // Undefined shouldThrows and message as boolean
+  // means message is shouldThrows.
+  if (!shouldThrows && typeof message === 'boolean') shouldThrows = message;
+  return internalMatch(string, regexp, message, match, shouldThrows);
 };
 
 assert.doesNotMatch = function doesNotMatch(string, regexp, message) {

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -1418,6 +1418,12 @@ assert.throws(
   assert.match('I will pass', /pass$/);
 }
 
+// Use the assert.match boolean result.
+{
+  assert(assert.match('meow', /meow$/, false));
+  assert(!assert.match('meow', /woof$/, false));
+}
+
 // Multiple assert.doesNotMatch() tests.
 {
   assert.throws(


### PR DESCRIPTION
The `assert.match` method by default will throws if there is no match,
this change can add the function of instead of throwing or not, returns
the boolean result of match.

Fixes: https://github.com/nodejs/node/issues/33869

**Note:** I'm going to leave the documentation as a TODO :)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
