### PR TITLE
esm: better package.json parser errors

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1124,7 +1124,7 @@ E('ERR_INVALID_OPT_VALUE', (name, value, reason = '') => {
 E('ERR_INVALID_OPT_VALUE_ENCODING',
   'The value "%s" is invalid for option "encoding"', TypeError);
 E('ERR_INVALID_PACKAGE_CONFIG', (path, base, message) => {
-  return `Invalid package config ${path}${base ? ` imported from ${base}` :
+  return `Invalid package config ${path}${base ? ` while importing ${base}` :
     ''}${message ? `. ${message}` : ''}`;
 }, Error);
 E('ERR_INVALID_PACKAGE_TARGET',

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -82,7 +82,7 @@ function tryStatSync(path) {
   }
 }
 
-function getPackageConfig(path) {
+function getPackageConfig(path, specifier, base) {
   const existing = packageJSONCache.get(path);
   if (existing !== undefined) {
     return existing;
@@ -106,7 +106,11 @@ function getPackageConfig(path) {
   try {
     packageJSON = JSONParse(source);
   } catch (error) {
-    throw new ERR_INVALID_PACKAGE_CONFIG(path, null, error.message);
+    throw new ERR_INVALID_PACKAGE_CONFIG(
+      path,
+      (base ? `"${specifier}" from ` : '') + fileURLToPath(base || specifier),
+      error.message
+    );
   }
 
   let { imports, main, name, type } = packageJSON;
@@ -130,13 +134,14 @@ function getPackageConfig(path) {
   return packageConfig;
 }
 
-function getPackageScopeConfig(resolved, base) {
+function getPackageScopeConfig(resolved) {
   let packageJSONUrl = new URL('./package.json', resolved);
   while (true) {
     const packageJSONPath = packageJSONUrl.pathname;
     if (StringPrototypeEndsWith(packageJSONPath, 'node_modules/package.json'))
       break;
-    const packageConfig = getPackageConfig(fileURLToPath(packageJSONUrl), base);
+    const packageConfig = getPackageConfig(fileURLToPath(packageJSONUrl),
+                                           resolved);
     if (packageConfig.exists) return packageConfig;
 
     const lastPackageJSONUrl = packageJSONUrl;
@@ -497,7 +502,7 @@ function packageImportsResolve(name, base, conditions) {
     throw new ERR_INVALID_MODULE_SPECIFIER(name, reason, fileURLToPath(base));
   }
   let packageJSONUrl;
-  const packageConfig = getPackageScopeConfig(base, base);
+  const packageConfig = getPackageScopeConfig(base);
   if (packageConfig.exists) {
     packageJSONUrl = pathToFileURL(packageConfig.pjsonPath);
     const imports = packageConfig.imports;
@@ -535,7 +540,7 @@ function packageImportsResolve(name, base, conditions) {
 }
 
 function getPackageType(url) {
-  const packageConfig = getPackageScopeConfig(url, url);
+  const packageConfig = getPackageScopeConfig(url);
   return packageConfig.type;
 }
 
@@ -580,7 +585,7 @@ function packageResolve(specifier, base, conditions) {
     StringPrototypeSlice(specifier, separatorIndex));
 
   // ResolveSelf
-  const packageConfig = getPackageScopeConfig(base, base);
+  const packageConfig = getPackageScopeConfig(base);
   if (packageConfig.exists) {
     const packageJSONUrl = pathToFileURL(packageConfig.pjsonPath);
     if (packageConfig.name === packageName &&
@@ -608,7 +613,7 @@ function packageResolve(specifier, base, conditions) {
     }
 
     // Package match.
-    const packageConfig = getPackageConfig(packageJSONPath, base);
+    const packageConfig = getPackageConfig(packageJSONPath, specifier, base);
     if (packageConfig.exports !== undefined && packageConfig.exports !== null)
       return packageExportsResolve(
         packageJSONUrl, packageSubpath, packageConfig, base, conditions

--- a/test/es-module/test-esm-invalid-pjson.js
+++ b/test/es-module/test-esm-invalid-pjson.js
@@ -19,11 +19,9 @@ child.on('close', mustCall((code, signal) => {
   strictEqual(signal, null);
   ok(
     stderr.includes(
-      [
-        '[ERR_INVALID_PACKAGE_CONFIG]: ',
-        `Invalid package config ${invalidJson}. `,
-        `Unexpected token } in JSON at position ${isWindows ? 16 : 14}`
-      ].join(''),
+      `[ERR_INVALID_PACKAGE_CONFIG]: Invalid package config ${invalidJson} ` +
+      `while importing "invalid-pjson" from ${entry}. ` +
+      `Unexpected token } in JSON at position ${isWindows ? 16 : 14}`
     ),
     stderr);
 }));

--- a/test/fixtures/es-modules/pjson-invalid/package.json
+++ b/test/fixtures/es-modules/pjson-invalid/package.json
@@ -1,0 +1,1 @@
+syntax error


### PR DESCRIPTION
This is a follow-up to https://github.com/nodejs/node/pull/35072 to add more context to package.json parse errors.

Specifically the package / module being imported or imported from when the package.json parser error was encountered.

These kinds of cases make up for the fact that ESM, unlike require, does not have a require stack to see what was the import in the first case that caused the issue.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
