### PR TITLE
errors: simplify ERR_REQUIRE_ESM message generation

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1317,7 +1317,7 @@ E('ERR_REQUIRE_ESM',
         filename : path.basename(filename);
       msg +=
         '\nrequire() of ES modules is not supported.\nrequire() of ' +
-        `${filename} ${parentPath ? `from ${parentPath} ` : ''}` +
+        `${filename} from ${parentPath} ` +
         'is an ES module file as it is a .js file whose nearest parent ' +
         'package.json contains "type": "module" which defines all .js ' +
         'files in that package scope as ES modules.\nInstead rename ' +


### PR DESCRIPTION
Because of the condition that starts the `if` block, we know that
`parentPath` must be truthy. So there is no need to check for that in
the template string that generates the error message.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
