### PR TITLE
meta: notify slack when someone force pushes

### DIFF
--- a/.github/workflows/notify-force-push.yml
+++ b/.github/workflows/notify-force-push.yml
@@ -1,0 +1,25 @@
+on:
+  push:
+    branches:
+      - master
+
+name: Notify on Force Push
+jobs:
+  slackNotification:
+    name: Slack Notification
+    if: ${{ github.event.forced && github.repository == 'nodejs/node' }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Slack Notification
+      uses: rtCamp/action-slack-notify@master
+      env:
+        SLACK_COLOR: '#DE512A'
+        SLACK_ICON: https://github.com/nodejs.png?size=48
+        SLACK_TITLE: '${{ github.actor }} force-pushed to ${{ github.ref }}'
+        SLACK_MESSAGE: |
+          A commit was force-pushed to <https://github.com/${{ github.repository }}/tree/master|${{ github.repository }}@master> by <https://github.com/${{ github.actor }}|${{ github.actor }}>
+
+          Before: <https://github.com/${{ github.repository }}/commit/${{ github.event.before }}|${{ github.event.before }}>
+          After: <https://github.com/${{ github.repository }}/commit/${{ github.event.after }}|${{ github.event.after }}>
+        SLACK_USERNAME: nodejs-bot
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
**Blocked by https://github.com/nodejs/admin/issues/551**

Notify #nodejs-dev on the OpenJS Foundation slack when someone
force-pushes, removing one manual step from force-pushing.

![image](https://user-images.githubusercontent.com/4048656/92642889-bb9e8b00-f295-11ea-8d18-69b00eed449e.png)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
