### PR TITLE
crypto: fix size_t/int regression node_crypto

### DIFF
--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -571,7 +571,7 @@ class CipherBase : public BaseObject {
   bool InitAuthenticated(const char* cipher_type, int iv_len,
                          unsigned int auth_tag_len);
   bool CheckCCMMessageLength(int message_len);
-  UpdateResult Update(const char* data, int len, AllocatedBuffer* out);
+  UpdateResult Update(const char* data, size_t len, AllocatedBuffer* out);
   bool Final(AllocatedBuffer* out);
   bool SetAutoPadding(bool auto_padding);
 
@@ -613,7 +613,7 @@ class Hmac : public BaseObject {
 
  protected:
   void HmacInit(const char* hash_type, const char* key, int key_len);
-  bool HmacUpdate(const char* data, int len);
+  bool HmacUpdate(const char* data, size_t len);
 
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void HmacInit(const v8::FunctionCallbackInfo<v8::Value>& args);
@@ -638,7 +638,7 @@ class Hash final : public BaseObject {
   SET_SELF_SIZE(Hash)
 
   bool HashInit(const EVP_MD* md, v8::Maybe<unsigned int> xof_md_len);
-  bool HashUpdate(const char* data, int len);
+  bool HashUpdate(const char* data, size_t len);
 
  protected:
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
@@ -670,7 +670,7 @@ class SignBase : public BaseObject {
   SignBase(Environment* env, v8::Local<v8::Object> wrap);
 
   Error Init(const char* sign_type);
-  Error Update(const char* data, int len);
+  Error Update(const char* data, size_t len);
 
   // TODO(joyeecheung): track the memory used by OpenSSL types
   SET_NO_MEMORY_INFO()
@@ -757,7 +757,7 @@ class PublicKeyCipher {
                      const void* oaep_label,
                      size_t oaep_label_size,
                      const unsigned char* data,
-                     int len,
+                     size_t len,
                      AllocatedBuffer* out);
 
   template <Operation operation,

--- a/test/parallel/test-crypto-hash-hmac-regression.js
+++ b/test/parallel/test-crypto-hash-hmac-regression.js
@@ -1,0 +1,72 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+if (!common.enoughTestMem)
+  common.skip('skip on low memory machines');
+
+const assert = require('assert');
+
+const {
+  Buffer
+} = require('buffer');
+
+const {
+  createHash,
+  createHmac,
+  createSign,
+  createCipheriv,
+  randomBytes,
+  generateKeyPairSync,
+  publicEncrypt,
+  publicDecrypt,
+} = require('crypto');
+
+let kData;
+try {
+  kData = Buffer.alloc(2 ** 31 + 1);
+} catch {
+  // If the Buffer could not be allocated for some reason,
+  // just skip the test. There are some systems in CI that
+  // simply cannot allocated a large enough buffer.
+  common.skip('skip on low memory machines');
+}
+
+// https://github.com/nodejs/node/pull/31406 changed the maximum value
+// of buffer.kMaxLength but Hash, Hmac, and SignBase, CipherBase update
+// expected int for the size, causing both of the following to segfault.
+// Both update operations have been updated to expected size size_t.
+
+// Closely related is the fact that publicEncrypt max input size is
+// 2**31-1 due to limitations in OpenSSL.
+
+createHash('sha512').update(kData);
+
+createHmac('sha512', 'a secret').update(kData);
+
+createSign('sha512').update(kData);
+
+const { publicKey, privateKey } = generateKeyPairSync('rsa', {
+  modulusLength: 1024,
+  publicExponent: 3
+});
+
+assert.throws(() => publicEncrypt(publicKey, kData), {
+  code: 'ERR_OUT_OF_RANGE'
+});
+
+assert.throws(() => publicDecrypt(privateKey, kData), {
+  code: 'ERR_OUT_OF_RANGE'
+});
+
+{
+  const cipher = createCipheriv(
+    'aes-192-cbc',
+    'key'.repeat(8),
+    randomBytes(16));
+
+  assert.throws(() => cipher.update(kData), {
+    code: 'ERR_OUT_OF_RANGE'
+  });
+}


### PR DESCRIPTION
https://github.com/nodejs/node/pull/31406 introduced a regression in `Hash` and `Hmac` update operations.

~~Haven't looked yet, but it's possible that this also affects other Stream-based crypto operations (e.g. sig, verify, etc)~~ Definitely impacted... adding those to the changeset here.

/cc @addaleax @bnoordhuis 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
