### PR TITLE
crypto: fix regression in randomFill/randomBytes

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -2631,7 +2631,7 @@ changes:
                  `ERR_INVALID_CALLBACK`.
 -->
 
-* `size` {number} The `size` must not be larger than `2**31 - 1`.
+* `size` {number} The `size` must be less or equal to `2**31 - 1`.
 * `callback` {Function}
   * `err` {Error}
   * `buf` {Buffer}

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -2631,7 +2631,7 @@ changes:
                  `ERR_INVALID_CALLBACK`.
 -->
 
-* `size` {number}
+* `size` {number} The `size` must not be larger than `2**31 - 1`.
 * `callback` {Function}
   * `err` {Error}
   * `buf` {Buffer}
@@ -2691,9 +2691,11 @@ changes:
     description: The `buffer` argument may be any `TypedArray` or `DataView`.
 -->
 
-* `buffer` {Buffer|TypedArray|DataView} Must be supplied.
+* `buffer` {Buffer|TypedArray|DataView} Must be supplied. The
+  size of the provided `buffer` must not be larger than `2**31 - 1`.
 * `offset` {number} **Default:** `0`
-* `size` {number} **Default:** `buffer.length - offset`
+* `size` {number} **Default:** `buffer.length - offset`. The `size`
+  must not be larger than `2**31 - 1`.
 * Returns: {Buffer|TypedArray|DataView} The object passed as `buffer` argument.
 
 Synchronous version of [`crypto.randomFill()`][].
@@ -2737,9 +2739,11 @@ changes:
     description: The `buffer` argument may be any `TypedArray` or `DataView`.
 -->
 
-* `buffer` {Buffer|TypedArray|DataView} Must be supplied.
+* `buffer` {Buffer|TypedArray|DataView} Must be supplied. The size
+  of the provided `buffer` must not be larger than `2**31 - 1`.
 * `offset` {number} **Default:** `0`
-* `size` {number} **Default:** `buffer.length - offset`
+* `size` {number} **Default:** `buffer.length - offset`.  The `size`
+  must not be larger than `2**31 - 1`.
 * `callback` {Function} `function(err, buf) {}`.
 
 This function is similar to [`crypto.randomBytes()`][] but requires the first

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5855,6 +5855,7 @@ struct RandomBytesJob : public CryptoJob {
 
 
 void RandomBytes(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
   CHECK(args[0]->IsArrayBufferView());  // buffer; wrap object retains ref.
   CHECK(args[1]->IsUint32());  // offset
   CHECK(args[2]->IsUint32());  // size
@@ -5863,7 +5864,10 @@ void RandomBytes(const FunctionCallbackInfo<Value>& args) {
   const uint32_t size = args[2].As<Uint32>()->Value();
   CHECK_GE(offset + size, offset);  // Overflow check.
   CHECK_LE(offset + size, Buffer::Length(args[0]));  // Bounds check.
-  Environment* env = Environment::GetCurrent(args);
+
+  if (size > INT_MAX)
+    return THROW_ERR_OUT_OF_RANGE(env, "buffer is too large");
+
   std::unique_ptr<RandomBytesJob> job(new RandomBytesJob(env));
   job->data = reinterpret_cast<unsigned char*>(Buffer::Data(args[0])) + offset;
   job->size = size;

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -255,7 +255,7 @@ function platformTimeout(ms) {
 }
 
 let knownGlobals = [
-//  AbortController,
+  AbortController,
   clearImmediate,
   clearInterval,
   clearTimeout,

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -255,7 +255,7 @@ function platformTimeout(ms) {
 }
 
 let knownGlobals = [
-  AbortController,
+//  AbortController,
   clearImmediate,
   clearInterval,
   clearTimeout,

--- a/test/parallel/test-crypto-random-regression.js
+++ b/test/parallel/test-crypto-random-regression.js
@@ -1,0 +1,32 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const { Buffer } = require('buffer');
+const assert = require('assert');
+
+const {
+  randomFill,
+  randomFillSync,
+  randomBytes
+} = require('crypto');
+
+let kData;
+try {
+  kData = Buffer.alloc(2 ** 31 + 1);
+} catch {
+  common.skip('not enough memory');
+}
+
+assert.throws(() => randomFill(kData, common.mustNotCall()), {
+  code: 'ERR_OUT_OF_RANGE'
+});
+
+assert.throws(() => randomFillSync(kData), {
+  code: 'ERR_OUT_OF_RANGE'
+});
+
+assert.throws(() => randomBytes(2 ** 31 + 1), {
+  code: 'ERR_OUT_OF_RANGE'
+});


### PR DESCRIPTION
Fixes a segfault when a buffer larger than `2**31-1` is passed in to randomFill/randomFillSync or when a size larger than `2**31-1` is passed in to randomBytes.

I opened this one separate because we should decide if this is the way we want to handle this. This PR adds a throw if the size is larger than `2**31-1`. Alternatively, we could allow larger values by splitting it into multiple calls to `RAND_bytes`. That said, I'd like to believe that asking for random values larger than `2**31-1` is going to be exceedingly rare (I'd really hope), so I think the throw is sufficient here.

Related to: https://github.com/nodejs/node/pull/35132

Signed-off-by: James M Snell <jasnell@gmail.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
