### PR TITLE
doc: improve table accessibility

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -244,16 +244,92 @@ from version 3 with some additions. This means that it is not necessary
 to recompile for new versions of Node.js which are
 listed as supporting a later version.
 
-|       | 1        | 2        | 3        | 4        | 5         | 6         |
-|-------|----------|----------|----------|----------|-----------|-----------|
-| v6.x  |          |          | v6.14.2* |          |           |           |
-| v8.x  | v8.6.0** | v8.10.0* | v8.11.2  | v8.16.0  |           |           |
-| v9.x  | v9.0.0*  | v9.3.0*  | v9.11.0* |          |           |           |
-| v10.x | v10.0.0  | v10.0.0  | v10.0.0  | v10.16.0 | v10.17.0  | v10.20.0  |
-| v11.x | v11.0.0  | v11.0.0  | v11.0.0  | v11.8.0  |           |           |
-| v12.x | v12.0.0  | v12.0.0  | v12.0.0  | v12.0.0  | v12.11.0  | v12.17.0  |
-| v13.x | v13.0.0  | v13.0.0  | v13.0.0  | v13.0.0  | v13.0.0   |           |
-| v14.x | v14.0.0  | v14.0.0  | v14.0.0  | v14.0.0  | v14.0.0   | v14.0.0   |
+<!-- For accessibility purposes, this table needs row headers. That means we
+     can't do it in markdown. Hence, the raw HTML. -->
+
+<table>
+  <tr>
+    <td></td>
+    <th scope="col">1</th>
+    <th scope="col">2</th>
+    <th scope="col">3</th>
+    <th scope="col">4</th>
+    <th scope="col">5</th>
+    <th scope="col">6</th>
+  </tr>
+  <tr>
+    <th scope="row">v6.x</th>
+    <td></td>
+    <td></td>
+    <td>v6.14.2*</td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <th scope="row">v8.x</th>
+    <td>v8.6.0**</td>
+    <td>v8.10.0*</td>
+    <td>v8.11.2</td>
+    <td>v8.16.0</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <th scope="row">v9.x</th>
+    <td>v9.0.0*</td>
+    <td>v9.3.0*</td>
+    <td>v9.11.0*</td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <th scope="row">v10.x</th>
+    <td>v10.0.0</td>
+    <td>v10.0.0</td>
+    <td>v10.0.0</td>
+    <td>v10.16.0</td>
+    <td>v10.17.0</td>
+    <td>v10.20.0</td>
+  </tr>
+  <tr>
+    <th scope="row">v11.x</th>
+    <td>v11.0.0</td>
+    <td>v11.0.0</td>
+    <td>v11.0.0</td>
+    <td>v11.8.0</td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <th scope="row">v12.x</th>
+    <td>v12.0.0</td>
+    <td>v12.0.0</td>
+    <td>v12.0.0</td>
+    <td>v12.0.0</td>
+    <td>v12.11.0</td>
+    <td>v12.17.0</td>
+  </tr>
+  <tr>
+    <th scope="row">v13.x</th>
+    <td>v13.0.0</td>
+    <td>v13.0.0</td>
+    <td>v13.0.0</td>
+    <td>v13.0.0</td>
+    <td>v13.0.0</td>
+    <td></td>
+  </tr>
+  <tr>
+    <th scope="row">v14.x</th>
+    <td>v14.0.0</td>
+    <td>v14.0.0</td>
+    <td>v14.0.0</td>
+    <td>v14.0.0</td>
+    <td>v14.0.0</td>
+    <td>v14.0.0</td>
+  </tr>
+</table>
 
 \* N-API was experimental.
 


### PR DESCRIPTION
The compatibility matrix in the N-API doc needs row headers for
accessibility purposes. Unfortunately, those aren't possible in markdown
without resorting to HTML markup. So this converts the table from
markdown to HTML. This is less convenient for documentation authors and
for other readers of the raw markdown docs, but I believe accessibility
for the viewers of our HTML docs outweighs that concern.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
