### PR TITLE
build: filter issues & PRs to auto close by matching on stalled label

### DIFF
--- a/.github/workflows/close-stalled.yml
+++ b/.github/workflows/close-stalled.yml
@@ -15,6 +15,8 @@ jobs:
         stale-issue-label: stalled
         close-issue-message: Closing this because it has stalled. Feel free to reopen if this issue is still relevant, or to ping the collaborator who labelled it stalled if you have any questions.
         close-pr-message: Closing this because it has stalled. Feel free to reopen if this PR is still relevant, or to ping the collaborator who labelled it stalled if you have any questions.
+        # used to filter issues to check whether or not should be closed, avoids hitting maximum operations allowed if needing to paginate through all open issues
+        only-labels: stalled
         # deactivates automatic removal of stalled label if issue gets any activity
         remove-stale-when-updated: false
         # deactivates automatic stale labelling as we prefer to do that manually


### PR DESCRIPTION
The auto closing of issues & PRs labelled with `stalled` doesn't seem to be working as expected. The GitHub Action UI gives the impression the stale action tries to execute more operations than it is allowed to do.

Previously there was no filtering on issues & PRs. So when it tries to fetch all the currently open issues, checking whether or not they should be get closed, it would have to perform quite a few requests pagination requests to get the information needed.

Knowing that we only care about issues & PRs already labelled `stalled`, we can provide the [`only-labels`](https://github.com/actions/stale/blob/13b324e4b28a2708236aadb11361fa65af60d201/action.yml#L38) option to make sure we only fetch relevant issues.

Refs https://github.com/nodejs/node/issues/35144

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

/cc @mmarchini 