### PR TITLE
doc: remove http2 non-link anchor tags

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -2428,7 +2428,6 @@ added: v8.4.0
 -->
 
 #### Error codes for `RST_STREAM` and `GOAWAY`
-<a id="error_codes"></a>
 
 | Value  | Name                | Constant                                      |
 |--------|---------------------|-----------------------------------------------|
@@ -2552,7 +2551,6 @@ server.on('stream', (stream, headers) => {
 });
 ```
 
-<a id="http2-sensitive-headers"></a>
 #### Sensitive headers
 
 HTTP2 headers can be marked as sensitive, which means that the HTTP/2
@@ -3761,5 +3759,5 @@ you need to implement any fall-back behaviour yourself.
 [`tls.connect()`]: tls.html#tls_tls_connect_options_callback
 [`tls.createServer()`]: tls.html#tls_tls_createserver_options_secureconnectionlistener
 [`writable.writableFinished`]: stream.html#stream_writable_writablefinished
-[error code]: #error_codes
-[Sensitive headers]: #http2-sensitive-headers
+[error code]: #http2_error_codes_for_rst_stream_and_goaway
+[Sensitive headers]: #http2_sensitive_headers


### PR DESCRIPTION
Headers have ids automatically assigned. Removed ad hoc ids using anchor
tags that aren't links.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
