### PR TITLE
fs: remove experimental language from rmdir recursive

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -3522,8 +3522,6 @@ changes:
                  it will emit a deprecation warning with id DEP0013.
 -->
 
-> Stability: 1 - Recursive removal is experimental.
-
 * `path` {string|Buffer|URL}
 * `options` {Object}
   * `maxRetries` {integer} If an `EBUSY`, `EMFILE`, `ENFILE`, `ENOTEMPTY`, or
@@ -3545,6 +3543,12 @@ to the completion callback.
 
 Using `fs.rmdir()` on a file (not a directory) results in an `ENOENT` error on
 Windows and an `ENOTDIR` error on POSIX.
+
+Setting `recursive` to `true` results in behavior similar to the Unix command
+`rm -rf`: an error will not be raised for paths that do not exist, and paths
+that represent files will be deleted. The permissive behavior of the
+`recursive` option is deprecated, `ENOTDIR` and `ENOENT` will be thrown in
+the future.
 
 ## `fs.rmdirSync(path[, options])`
 <!-- YAML
@@ -3569,8 +3573,6 @@ changes:
                  `file:` protocol. Support is currently still *experimental*.
 -->
 
-> Stability: 1 - Recursive removal is experimental.
-
 * `path` {string|Buffer|URL}
 * `options` {Object}
   * `maxRetries` {integer} If an `EBUSY`, `EMFILE`, `ENFILE`, `ENOTEMPTY`, or
@@ -3589,6 +3591,12 @@ Synchronous rmdir(2). Returns `undefined`.
 
 Using `fs.rmdirSync()` on a file (not a directory) results in an `ENOENT` error
 on Windows and an `ENOTDIR` error on POSIX.
+
+Setting `recursive` to `true` results in behavior similar to the Unix command
+`rm -rf`: an error will not be raised for paths that do not exist, and paths
+that represent files will be deleted. The permissive behavior of the
+`recursive` option is deprecated, `ENOTDIR` and `ENOENT` will be thrown in
+the future.
 
 ## `fs.stat(path[, options], callback)`
 <!-- YAML
@@ -5474,6 +5482,12 @@ no arguments upon success.
 Using `fsPromises.rmdir()` on a file (not a directory) results in the
 `Promise` being rejected with an `ENOENT` error on Windows and an `ENOTDIR`
 error on POSIX.
+
+Setting `recursive` to `true` results in behavior similar to the Unix command
+`rm -rf`: an error will not be raised for paths that do not exist, and paths
+that represent files will be deleted. The permissive behavior of the
+`recursive` option is deprecated, `ENOTDIR` and `ENOENT` will be thrown in
+the future.
 
 ### `fsPromises.stat(path[, options])`
 <!-- YAML


### PR DESCRIPTION
I would like to make a case for removing the experimental flag from `rmdir`'s `recursive` option:

1. the feature [landed over a year ago](https://github.com/nodejs/node/pull/29168).
2. the functionality is quite useful to tooling authors (_we use it in Node.js' own test suite, see: #30849_), 
3. users are [hesitant to use the `recursive` option](https://github.com/nginx/njs/issues/279#issuecomment-663852875), due to it being experimental.
4. I feel that this feature aligns closely with the value of "[Developer Experience](https://github.com/nodejs/node/pull/35145)", described in the technical values document @mhdawson's is working on.

### Regarding #34278, "Rethink `recursive` flag".

As a compromise, I initially looked at raising an `ENOENT` exception, if the initial `path` provided to `rmdir` did not exist ... I was thinking perhaps we could get away with deviating a bit from `rimraf`'s behavior, in the name of reaching consensus.

This immediately broke our test test suite, because we rely on the current `recursive` behavior in our [`tmpdir.js` helper](https://github.com/nodejs/node/blob/master/test/common/tmpdir.js#L8) ... It also drilled home for me that deviating from `rimraf` might not be a great idea...

> The current implementation of `rmdir` + `recursive` provides behavior the community is accustomed to, due to its similarity to `rimraf`.

## An alternative compromise

What if we explicitly call out in documentation the fact that setting `recursive` to `true` gives you behavior that matches the community module `rimraf`?

It might be the case that, _due to some of the oddities in this API surface_, a module like `fs-extra` avoids setting the `recursive` option. But, as our own use case in `tmdir.js` demonstrates, the `recursive` option, as it exists today, is great for a variety of tooling needs.

CC: @CxRes, @nodejs/tooling, @RyanZim, @iansu 

Refs: https://github.com/nodejs/node/issues/34278

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
