### PR TITLE
doc: remove problematic auto-linking of curl man pages

### DIFF
--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -745,7 +745,7 @@ For an example of running a "full-featured" (`terminal`) REPL over
 a `net.Server` and `net.Socket` instance, see:
 <https://gist.github.com/TooTallNate/2209310>.
 
-For an example of running a REPL instance over [curl(1)][], see:
+For an example of running a REPL instance over [`curl(1)`][], see:
 <https://gist.github.com/TooTallNate/2053342>.
 
 [ZSH]: https://en.wikipedia.org/wiki/Z_shell
@@ -761,5 +761,5 @@ For an example of running a REPL instance over [curl(1)][], see:
 [`util.inspect()`]: util.html#util_util_inspect_object_options
 [`reverse-i-search`]: #repl_reverse_i_search
 [TTY keybindings]: readline.html#readline_tty_keybindings
-[curl(1)]: https://curl.haxx.se/docs/manpage.html
+[`curl(1)`]: https://curl.haxx.se/docs/manpage.html
 [stream]: stream.html

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -126,7 +126,6 @@ function preprocessText({ nodeVersion }) {
 
 // Syscalls which appear in the docs, but which only exist in BSD / macOS.
 const BSD_ONLY_SYSCALLS = new Set(['lchmod']);
-const HAXX_ONLY_SYSCALLS = new Set(['curl']);
 const MAN_PAGE = /(^|\s)([a-z.]+)\((\d)([a-z]?)\)/gm;
 
 // Handle references to man pages, eg "open(2)" or "lchmod(2)".
@@ -142,9 +141,6 @@ function linkManPages(text) {
       if (BSD_ONLY_SYSCALLS.has(name)) {
         return `${beginning}<a href="https://www.freebsd.org/cgi/man.cgi` +
           `?query=${name}&sektion=${number}">${displayAs}</a>`;
-      }
-      if (HAXX_ONLY_SYSCALLS.has(name)) {
-        return `${beginning}<a href="https://${name}.haxx.se/docs/manpage.html">${displayAs}</a>`;
       }
 
       return `${beginning}<a href="http://man7.org/linux/man-pages/man${number}` +


### PR DESCRIPTION
The only instance of curl man page linking is in repl.md and it is
explicit. The magic autolinking in html.js creates a superfluous empty
link. Remove it.

Before, two adjacent links generated, with the first one having no text:

```html
<a href="https://curl.haxx.se/docs/manpage.html"></a>
<a href="https://curl.haxx.se/docs/manpage.html"><code>curl(1)</code></a>
```

After, just one link:

```html
<a href="https://curl.haxx.se/docs/manpage.html"><code>curl(1)</code></a>
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
