### PR TITLE
timers: add default value to Timeout 'after' param

### DIFF
--- a/lib/internal/timers.js
+++ b/lib/internal/timers.js
@@ -160,8 +160,7 @@ function initAsyncResource(resource, type) {
 
 // Timer constructor function.
 // The entire prototype is defined in lib/timers.js
-function Timeout(callback, after, args, isRepeat, isRefed) {
-  after *= 1; // Coalesce to number or NaN
+function Timeout(callback, after = 1, args, isRepeat, isRefed) {
   if (!(after >= 1 && after <= TIMEOUT_MAX)) {
     if (after > TIMEOUT_MAX) {
       process.emitWarning(`${after} does not fit into` +


### PR DESCRIPTION
Multiplying 'after' by 1 converted the potentially
undefined value to NaN which is treated as falsy
in the subsequent boolean evaluations. The
default value of 1 should more expressively
control for undefined 'after' argument
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines]
