### PR TITLE
fs: add validation for fd and path

### DIFF
--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -28,6 +28,8 @@ const { Buffer } = require('buffer');
 const {
   copyObject,
   getOptions,
+  getValidatedFd,
+  validatePath,
 } = require('internal/fs/utils');
 const { Readable, Writable, finished } = require('stream');
 const { toPathIfFileURL } = require('internal/url');
@@ -119,7 +121,7 @@ function close(stream, err, cb) {
 
 function importFd(stream, options) {
   stream.fd = null;
-  if (options.fd) {
+  if (options.fd != null) {
     if (typeof options.fd === 'number') {
       // When fd is a raw descriptor, we must keep our fingers crossed
       // that the descriptor won't get closed, or worse, replaced with
@@ -183,6 +185,13 @@ function ReadStream(path, options) {
     validateInteger(this.start, 'start', 0);
 
     this.pos = this.start;
+  }
+
+  // If fd has been set, validate, otherwise validate path.
+  if (this.fd != null) {
+    this.fd = getValidatedFd(this.fd);
+  } else {
+    validatePath(this.path);
   }
 
   if (this.end === undefined) {
@@ -343,6 +352,13 @@ function WriteStream(path, options) {
   this.bytesWritten = 0;
   this.closed = false;
   this[kIsPerformingIO] = false;
+
+  // If fd has been set, validate, otherwise validate path.
+  if (this.fd != null) {
+    this.fd = getValidatedFd(this.fd);
+  } else {
+    validatePath(this.path);
+  }
 
   if (this.start !== undefined) {
     validateInteger(this.start, 'start', 0);

--- a/test/parallel/test-fs-stream-options.js
+++ b/test/parallel/test-fs-stream-options.js
@@ -1,0 +1,49 @@
+'use strict';
+require('../common');
+
+const assert = require('assert');
+const fs = require('fs');
+
+{
+  const fd = 'k';
+
+  assert.throws(
+    () => {
+      fs.createReadStream(null, { fd });
+    },
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      name: 'TypeError',
+    });
+
+  assert.throws(
+    () => {
+      fs.createWriteStream(null, { fd });
+    },
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      name: 'TypeError',
+    });
+}
+
+{
+  const path = 46;
+
+  assert.throws(
+    () => {
+      fs.createReadStream(path);
+    },
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      name: 'TypeError',
+    });
+
+  assert.throws(
+    () => {
+      fs.createWriteStream(path);
+    },
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      name: 'TypeError',
+    });
+}


### PR DESCRIPTION
Adding validation to options fd & path in createWriteStream and createReadStream.

Fixes: https://github.com/nodejs/node/issues/35178

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
