### PR TITLE
doc: clarify use of NAPI_EXPERIMENTAL

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -262,7 +262,7 @@ version 1 but continued to evolve until Node.js 8.6.0. The API is different in
 versions prior to Node.js 8.6.0. We recommend N-API version 3 or later.
 
 Each API documented for N-API will have a header named `added in:`, and APIs
-which are stable, `N-API version:`. APIs are directly usable when using
+which are stable will have the additional header `N-API version:`. APIs are directly usable when using
 a Node.js version which supports the N-API version shown in `N-API version:`
 or higher. When using a Node.js version that does not support the
 `N-API version:` listed or if there is no `N-API version:` listed,

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -261,7 +261,7 @@ listed as supporting a later version.
 version 1 but continued to evolve until Node.js 8.6.0. The API is different in
 versions prior to Node.js 8.6.0. We recommend N-API version 3 or later.
 
-For each API documented for N-API, there will be `added in:`, and for APIs
+Each API documented for N-API will have a header named `added in:`, and APIs
 which are stable, `N-API version:`. APIs are directly usable when using
 a Node.js version which supports the N-API version shown in `N-API version:`
 or higher. When using a Node.js version that does not support the

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -261,6 +261,16 @@ listed as supporting a later version.
 version 1 but continued to evolve until Node.js 8.6.0. The API is different in
 versions prior to Node.js 8.6.0. We recommend N-API version 3 or later.
 
+For each API documented for N-API, there will be `added in:`, and for APIs
+which are stable, `N-API version:`. APIs are directly usable when using
+a Node.js version which supports the N-API version shown in `N-API version:`
+or higher. When using a Node.js version that does not support the
+`N-API version:` listed or if there is no `N-API version:` listed,
+then the API will only be available if you include
+`#define NAPI_EXPERIMENTAL`. If an API is not available and you are
+using a version of Node.js which is later than `added in:`
+this is most likely the reason.
+
 The N-APIs associated strictly with accessing ECMAScript features from native
 code can be found separately in `js_native_api.h` and `js_native_api_types.h`.
 The APIs defined in these headers are included in `node_api.h` and

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -268,7 +268,7 @@ or higher. When using a Node.js version that does not support the
 `N-API version:` listed or if there is no `N-API version:` listed,
 then the API will only be available if
 `#define NAPI_EXPERIMENTAL` precedes the inclusion of `node_api.h` or `js_native_api.h`. If an API appears not to be available on
-using a version of Node.js which is later than `added in:`
+a version of Node.js which is later than the one shown in `added in:` then
 this is most likely the reason for the apparent absence.
 
 The N-APIs associated strictly with accessing ECMAScript features from native

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -267,7 +267,7 @@ a Node.js version which supports the N-API version shown in `N-API version:`
 or higher. When using a Node.js version that does not support the
 `N-API version:` listed or if there is no `N-API version:` listed,
 then the API will only be available if
-`#define NAPI_EXPERIMENTAL`. If an API is not available and you are
+`#define NAPI_EXPERIMENTAL` precedes the inclusion of `node_api.h` or `js_native_api.h`. If an API appears not to be available on
 using a version of Node.js which is later than `added in:`
 this is most likely the reason for the apparent absence.
 

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -262,9 +262,10 @@ version 1 but continued to evolve until Node.js 8.6.0. The API is different in
 versions prior to Node.js 8.6.0. We recommend N-API version 3 or later.
 
 Each API documented for N-API will have a header named `added in:`, and APIs
-which are stable will have the additional header `N-API version:`. APIs are directly usable when using
-a Node.js version which supports the N-API version shown in `N-API version:`
-or higher. When using a Node.js version that does not support the
+which are stable will have the additional header `N-API version:`.
+APIs are directly usable when using a Node.js version which supports
+the N-API version shown in `N-API version:` or higher.
+When using a Node.js version that does not support the
 `N-API version:` listed or if there is no `N-API version:` listed,
 then the API will only be available if
 `#define NAPI_EXPERIMENTAL` precedes the inclusion of `node_api.h`

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -267,7 +267,8 @@ a Node.js version which supports the N-API version shown in `N-API version:`
 or higher. When using a Node.js version that does not support the
 `N-API version:` listed or if there is no `N-API version:` listed,
 then the API will only be available if
-`#define NAPI_EXPERIMENTAL` precedes the inclusion of `node_api.h` or `js_native_api.h`. If an API appears not to be available on
+`#define NAPI_EXPERIMENTAL` precedes the inclusion of `node_api.h`
+or `js_native_api.h`. If an API appears not to be available on
 a version of Node.js which is later than the one shown in `added in:` then
 this is most likely the reason for the apparent absence.
 

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -269,7 +269,7 @@ or higher. When using a Node.js version that does not support the
 then the API will only be available if you include
 `#define NAPI_EXPERIMENTAL`. If an API is not available and you are
 using a version of Node.js which is later than `added in:`
-this is most likely the reason.
+this is most likely the reason for the apparent absence.
 
 The N-APIs associated strictly with accessing ECMAScript features from native
 code can be found separately in `js_native_api.h` and `js_native_api_types.h`.

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -266,7 +266,7 @@ which are stable, `N-API version:`. APIs are directly usable when using
 a Node.js version which supports the N-API version shown in `N-API version:`
 or higher. When using a Node.js version that does not support the
 `N-API version:` listed or if there is no `N-API version:` listed,
-then the API will only be available if you include
+then the API will only be available if
 `#define NAPI_EXPERIMENTAL`. If an API is not available and you are
 using a version of Node.js which is later than `added in:`
 this is most likely the reason for the apparent absence.


### PR DESCRIPTION
We've had a few questions about APIs not being available which
were related to not having specified `NAPI_EXPERIMENTAL`.

Add some additional documentation to explain this common
issue:

Refs: https://github.com/nodejs/node-addon-api/issues/810

Signed-off-by: Michael Dawson <mdawson@devrus.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
