### PR TITLE
module: Improves Top-Level await error in cjs

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,6 +3,7 @@ lib/internal/v8_prof_polyfill.js
 lib/punycode.js
 test/addons/??_*
 test/fixtures
+test/message/cjs_top_await_error.js
 test/message/esm_display_syntax_error.mjs
 tools/icu
 tools/lint-md.js

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -1203,6 +1203,11 @@ function wrapSafe(filename, content, cjsModuleInstance) {
   } catch (err) {
     if (process.mainModule === cjsModuleInstance)
       enrichCJSError(err);
+    if (err.message.includes('await is only valid in async function')) {
+      err.message = 'Top-Level await is only supported in ESM.';
+      err.stack = err.stack.replace(/SyntaxError:.*\n/,
+                                    `SyntaxError: ${err.message}\n`);
+    }
     throw err;
   }
 

--- a/test/message/cjs_top_await_error.js
+++ b/test/message/cjs_top_await_error.js
@@ -1,0 +1,4 @@
+'use strict';
+
+await Promise.resolve();
+

--- a/test/message/cjs_top_await_error.out
+++ b/test/message/cjs_top_await_error.out
@@ -1,0 +1,13 @@
+/*/test/message/cjs_top_await_error.js:3
+await Promise.resolve();
+^^^^^
+
+SyntaxError: Top-Level await is only supported in ESM.
+    at wrapSafe (internal/modules/cjs/loader.js:**:**)
+    at Module._compile (internal/modules/cjs/loader.js:**:**)
+    at Object.Module._extensions..js (internal/modules/cjs/loader.js:**:**)
+    at Module.load (internal/modules/cjs/loader.js:**:**)
+    at Function.Module._load (internal/modules/cjs/loader.js:**:**)
+    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:**:**)
+    at internal/main/run_main_module.js:**:**
+


### PR DESCRIPTION
Top-Level await is supported in ESM and not in cjs. The default error
the message is confusing. I provided a clearer one and opened this PR with a lot of help from @MylesBorins.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
