### PR TITLE
n-api: create N-API version 7

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -3538,9 +3538,8 @@ added:
  - v13.0.0
  - v12.16.0
  - v10.22.0
+napiVersion: 7
 -->
-
-> Stability: 1 - Experimental
 
 ```c
 napi_status napi_detach_arraybuffer(napi_env env,
@@ -3567,9 +3566,8 @@ added:
  - v13.3.0
  - v12.16.0
  - v10.22.0
+napiVersion: 7
 -->
-
-> Stability: 1 - Experimental
 
 ```c
 napi_status napi_is_detached_arraybuffer(napi_env env,

--- a/src/js_native_api.h
+++ b/src/js_native_api.h
@@ -17,7 +17,7 @@
 // functions available in a new version of N-API that is not yet ported in all
 // LTS versions, they can set NAPI_VERSION knowing that they have specifically
 // depended on that version.
-#define NAPI_VERSION 6
+#define NAPI_VERSION 7
 #endif
 #endif
 

--- a/src/js_native_api.h
+++ b/src/js_native_api.h
@@ -529,7 +529,7 @@ NAPI_EXTERN napi_status napi_get_instance_data(napi_env env,
                                                void** data);
 #endif  // NAPI_VERSION >= 6
 
-#ifdef NAPI_EXPERIMENTAL
+#if NAPI_VERSION >= 7
 // ArrayBuffer detaching
 NAPI_EXTERN napi_status napi_detach_arraybuffer(napi_env env,
                                                 napi_value arraybuffer);
@@ -537,6 +537,9 @@ NAPI_EXTERN napi_status napi_detach_arraybuffer(napi_env env,
 NAPI_EXTERN napi_status napi_is_detached_arraybuffer(napi_env env,
                                                      napi_value value,
                                                      bool* result);
+#endif  // NAPI_VERSION >= 7
+
+#ifdef NAPI_EXPERIMENTAL
 // Type tagging
 NAPI_EXTERN napi_status napi_type_tag_object(napi_env env,
                                              napi_value value,

--- a/src/node_version.h
+++ b/src/node_version.h
@@ -93,6 +93,6 @@
 
 // The NAPI_VERSION provided by this version of the runtime. This is the version
 // which the Node binary being built supports.
-#define NAPI_VERSION  6
+#define NAPI_VERSION  7
 
 #endif  // SRC_NODE_VERSION_H_

--- a/test/js-native-api/test_general/test.js
+++ b/test/js-native-api/test_general/test.js
@@ -33,7 +33,7 @@ assert.notStrictEqual(test_general.testGetPrototype(baseObject),
                       test_general.testGetPrototype(extendedObject));
 
 // Test version management functions
-assert.strictEqual(test_general.testGetVersion(), 6);
+assert.strictEqual(test_general.testGetVersion(), 7);
 
 [
   123,

--- a/test/js-native-api/test_typedarray/test_typedarray.c
+++ b/test/js-native-api/test_typedarray/test_typedarray.c
@@ -1,4 +1,3 @@
-#define NAPI_EXPERIMENTAL
 #include <js_native_api.h>
 #include <string.h>
 #include <stdlib.h>


### PR DESCRIPTION
Mark `napi_detach_arraybuffer` and `napi_is_detached_arraybuffer` as
stable.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
