### PR TITLE
doc: remove "end user"

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -1744,7 +1744,7 @@ Type: Deprecation revoked
 
 Importing assert directly was not recommended as the exposed functions use
 loose equality checks. The deprecation was revoked because use of the `assert`
-module is not discouraged, and the deprecation caused end user confusion.
+module is not discouraged, and the deprecation caused developer confusion.
 
 ### DEP0090: Invalid GCM authentication tag lengths
 <!-- YAML

--- a/doc/api/documentation.md
+++ b/doc/api/documentation.md
@@ -38,8 +38,8 @@ The stability indices are as follows:
 > priority.
 
 Use caution when making use of Experimental features, particularly within
-modules. End users may not be aware that experimental features are being used.
-Bugs or behavior changes may surprise end users when Experimental API
+modules. Users may not be aware that experimental features are being used.
+Bugs or behavior changes may surprise users when Experimental API
 modifications occur. To avoid surprises, use of an Experimental feature may need
 a command-line flag. Experimental features may also emit a [warning][].
 

--- a/doc/api/domain.md
+++ b/doc/api/domain.md
@@ -20,7 +20,7 @@ changes:
 <!-- source_link=lib/domain.js -->
 
 **This module is pending deprecation**. Once a replacement API has been
-finalized, this module will be fully deprecated. Most end users should
+finalized, this module will be fully deprecated. Most developers should
 **not** have cause to use this module. Users who absolutely must have
 the functionality that domains provide may rely on it for the time being
 but should expect to have to migrate to a different solution

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -224,7 +224,7 @@ above `constructorOpt`, including `constructorOpt`, will be omitted from the
 generated stack trace.
 
 The `constructorOpt` argument is useful for hiding implementation
-details of error generation from an end user. For instance:
+details of error generation from the user. For instance:
 
 ```js
 function MyError() {


### PR DESCRIPTION
We use "end user" in ambiguous ways. Sometimes we mean the developer,
and sometimes we mean the application user. Use "developer" where
developer is meant.

Refs: https://docs.microsoft.com/en-us/style-guide/a-z-word-list-term-collections/u/user-end-user

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
