### PR TITLE
[deps] V8: cherry-pick 71736859756b2bd0444bdb0a87a

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -34,7 +34,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.40',
+    'v8_embedder_string': '-node.41',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/heap/heap.h
+++ b/deps/v8/src/heap/heap.h
@@ -1262,8 +1262,10 @@ class Heap {
   // Heap object allocation tracking. ==========================================
   // ===========================================================================
 
-  void AddHeapObjectAllocationTracker(HeapObjectAllocationTracker* tracker);
-  void RemoveHeapObjectAllocationTracker(HeapObjectAllocationTracker* tracker);
+  V8_EXPORT_PRIVATE void AddHeapObjectAllocationTracker(
+      HeapObjectAllocationTracker* tracker);
+  V8_EXPORT_PRIVATE void RemoveHeapObjectAllocationTracker(
+      HeapObjectAllocationTracker* tracker);
   bool has_heap_object_allocation_tracker() const {
     return !allocation_trackers_.empty();
   }

--- a/deps/v8/test/cctest/heap/heap-tester.h
+++ b/deps/v8/test/cctest/heap/heap-tester.h
@@ -11,6 +11,7 @@
 // Tests that should have access to private methods of {v8::internal::Heap}.
 // Those tests need to be defined using HEAP_TEST(Name) { ... }.
 #define HEAP_TEST_METHODS(V)                              \
+  V(CodeLargeObjectSpace)                                 \
   V(CompactionFullAbortedPage)                            \
   V(CompactionPartiallyAbortedPage)                       \
   V(CompactionPartiallyAbortedPageIntraAbortedPointers)   \

--- a/deps/v8/test/cctest/heap/test-heap.cc
+++ b/deps/v8/test/cctest/heap/test-heap.cc
@@ -6781,8 +6781,8 @@ HEAP_TEST(CodeLargeObjectSpace) {
       AllocationAlignment::kCodeAligned);
 
   CHECK(allocation.ToObjectChecked().address() == allocation_tracker.address());
-  heap->CreateFillerObjectAt(allocation.ToAddress(), size_in_bytes,
-                             ClearRecordedSlots::kNo);
+  heap->CreateFillerObjectAt(allocation.ToObjectChecked().address(),
+                             size_in_bytes, ClearRecordedSlots::kNo);
   heap->RemoveHeapObjectAllocationTracker(&allocation_tracker);
 }
 

--- a/deps/v8/test/cctest/heap/test-heap.cc
+++ b/deps/v8/test/cctest/heap/test-heap.cc
@@ -6754,6 +6754,38 @@ TEST(CodeObjectRegistry) {
   CHECK(MemoryChunk::FromAddress(code2_address)->Contains(code2_address));
 }
 
+class TestAllocationTracker : public HeapObjectAllocationTracker {
+ public:
+  explicit TestAllocationTracker(int expected_size) : expected_size_(expected_size) {}
+
+  void AllocationEvent(Address addr, int size) {
+    CHECK(expected_size_ == size);
+    address_ = addr;
+  }
+
+  Address address() { return address_; }
+
+ private:
+  int expected_size_;
+  Address address_;
+};
+
+HEAP_TEST(CodeLargeObjectSpace) {
+  Heap* heap = CcTest::heap();
+  int size_in_bytes = kMaxRegularHeapObjectSize + kSystemPointerSize;
+  TestAllocationTracker allocation_tracker{size_in_bytes};
+  heap->AddHeapObjectAllocationTracker(&allocation_tracker);
+
+  AllocationResult allocation = heap->AllocateRaw(
+      size_in_bytes, AllocationType::kCode, AllocationOrigin::kGeneratedCode,
+      AllocationAlignment::kCodeAligned);
+
+  CHECK(allocation.ToAddress() == allocation_tracker.address());
+  heap->CreateFillerObjectAt(allocation.ToAddress(), size_in_bytes,
+                             ClearRecordedSlots::kNo);
+  heap->RemoveHeapObjectAllocationTracker(&allocation_tracker);
+}
+
 }  // namespace heap
 }  // namespace internal
 }  // namespace v8

--- a/deps/v8/test/cctest/heap/test-heap.cc
+++ b/deps/v8/test/cctest/heap/test-heap.cc
@@ -6780,7 +6780,7 @@ HEAP_TEST(CodeLargeObjectSpace) {
       size_in_bytes, AllocationType::kCode, AllocationOrigin::kGeneratedCode,
       AllocationAlignment::kCodeAligned);
 
-  CHECK(allocation.ToAddress() == allocation_tracker.address());
+  CHECK(allocation.ToObjectChecked().address() == allocation_tracker.address());
   heap->CreateFillerObjectAt(allocation.ToAddress(), size_in_bytes,
                              ClearRecordedSlots::kNo);
   heap->RemoveHeapObjectAllocationTracker(&allocation_tracker);

--- a/deps/v8/test/cctest/heap/test-heap.cc
+++ b/deps/v8/test/cctest/heap/test-heap.cc
@@ -6778,7 +6778,7 @@ HEAP_TEST(CodeLargeObjectSpace) {
 
   AllocationResult allocation = heap->AllocateRaw(
       size_in_bytes, AllocationType::kCode, AllocationOrigin::kGeneratedCode,
-      AllocationAlignment::kCodeAligned);
+      AllocationAlignment::kWordAligned);
 
   CHECK(allocation.ToObjectChecked().address() == allocation_tracker.address());
   heap->CreateFillerObjectAt(allocation.ToObjectChecked().address(),


### PR DESCRIPTION
Original commit message:

   [heap] Add large_object_threshold to AllocateRaw

   This commit adds a check in Heap::AllocateRaw when setting the
   large_object variable, when the AllocationType is of type kCode, to
   take into account the size of the CodeSpace's area size.

   The motivation for this change is that without this check it is
   possible that size_in_bytes is less than 128, and hence not considered
   a large object, but it might be larger than the available space
   in code_space->AreaSize(), which will cause the object to be created
   in the CodeLargeObjectSpace. This will later cause a segmentation fault
   when calling the following chain of functions:

      if (!large_object) {
         MemoryChunk::FromHeapObject(heap_object)
             ->GetCodeObjectRegistry()
             ->RegisterNewlyAllocatedCodeObject(heap_object.address());
      }

   We (Red Hat) ran into this issue when running Node.js v12.16.1 in
   combination with yarn on aarch64 (this was the only architecture that
   this happed on).

   Bug: v8:10808
   Change-Id: I0c396b0eb64bc4cc91d9a3be521254f3130eac7b
   Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2390665
   Commit-Queue: Ulan Degenbaev <ulan@chromium.org>
   Reviewed-by: Ulan Degenbaev <ulan@chromium.org>
   Cr-Commit-Position: refs/heads/master@{#69876}

Refs: https://github.com/v8/v8/commit/71736859756b2bd0444bdb0a87a61a0b090cbba2

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
