### PR TITLE
fs/promises: fix fd resource cleanup

### DIFF
--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -400,7 +400,7 @@ async function rename(oldPath, newPath) {
 
 async function truncate(path, len = 0) {
   const fd = await open(path, 'r+');
-  return ftruncate(fd, len).finally(fd.close.bind(fd));
+  return ftruncate(fd, len).finally(fd.close);
 }
 
 async function ftruncate(handle, len = 0) {


### PR DESCRIPTION
Untested, but the existing code looks just plain _wrong_ - the more so because line 403 _does_ call `fs.close.bind(fd)`.