### PR TITLE
win, child_process: sanitize env variables

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -43,6 +43,10 @@ the first one case-insensitively matching `PATH` to perform command lookup.
 This may lead to issues on Windows when passing objects to `env` option that
 have multiple variants of `PATH` variable.
 
+On Windows Node.js will sanitize the `env` by removing case-insensitive
+duplicates. Only first (in lexicographic order) entry will be passed to the
+child process.
+
 The [`child_process.spawn()`][] method spawns the child process asynchronously,
 without blocking the Node.js event loop. The [`child_process.spawnSync()`][]
 function provides equivalent functionality in a synchronous manner that blocks

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -29,6 +29,7 @@ const {
   ObjectDefineProperty,
   ObjectPrototypeHasOwnProperty,
   Promise,
+  Set,
 } = primordials;
 
 const {
@@ -524,8 +525,27 @@ function normalizeSpawnArguments(file, args, options) {
     env.NODE_V8_COVERAGE = process.env.NODE_V8_COVERAGE;
   }
 
+  let envKeys = [];
   // Prototype values are intentionally included.
   for (const key in env) {
+    envKeys.push(key);
+  }
+
+  if (process.platform === 'win32') {
+    // On Windows env keys are case insensitive. Filter out duplicates,
+    // keeping only the first one (in lexicographic order)
+    const sawKey = new Set();
+    envKeys = envKeys.sort().filter((key) => {
+      const uppercaseKey = key.toUpperCase();
+      if (sawKey.has(uppercaseKey)) {
+        return false;
+      }
+      sawKey.add(uppercaseKey);
+      return true;
+    });
+  }
+
+  for (const key of envKeys) {
     const value = env[key];
     if (value !== undefined) {
       envPairs.push(`${key}=${value}`);

--- a/test/parallel/test-child-process-env.js
+++ b/test/parallel/test-child-process-env.js
@@ -36,7 +36,9 @@ const env = {
   'HELLO': 'WORLD',
   'UNDEFINED': undefined,
   'NULL': null,
-  'EMPTY': ''
+  'EMPTY': '',
+  'duplicate': 'lowercase',
+  'DUPLICATE': 'uppercase',
 };
 Object.setPrototypeOf(env, {
   'FOO': 'BAR'
@@ -65,4 +67,11 @@ child.stdout.on('end', mustCall(() => {
   assert.ok(!response.includes('UNDEFINED=undefined'));
   assert.ok(response.includes('NULL=null'));
   assert.ok(response.includes(`EMPTY=${os.EOL}`));
+  if (isWindows) {
+    assert.ok(response.includes('DUPLICATE=uppercase'));
+    assert.ok(!response.includes('duplicate=lowercase'));
+  } else {
+    assert.ok(response.includes('DUPLICATE=uppercase'));
+    assert.ok(response.includes('duplicate=lowercase'));
+  }
 }));


### PR DESCRIPTION
On Windows environment variables are case-insensitive. When spawning
child process certain apps can get confused if some of the variables are
duplicated.

This adds a step on Windows to normalizeSpawnArguments that removes such
duplicates, keeping only the first (in lexicographic order) entry in the
env key of options. This is partly already done for the PATH entry.

Fixes: https://github.com/nodejs/node/issues/35129

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
