### PR TITLE
n-api: add more property defaults

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -1778,7 +1778,7 @@ provided by the addon:
 napi_value Init(napi_env env, napi_value exports) {
   napi_status status;
   napi_property_descriptor desc =
-    {"hello", NULL, Method, NULL, NULL, NULL, napi_default, NULL};
+    {"hello", NULL, Method, NULL, NULL, NULL, napi_default_property, NULL};
   status = napi_define_properties(env, exports, 1, &desc);
   if (status != napi_ok) return NULL;
   return exports;
@@ -1805,7 +1805,7 @@ To define a class so that new instances can be created (often used with
 napi_value Init(napi_env env, napi_value exports) {
   napi_status status;
   napi_property_descriptor properties[] = {
-    { "value", NULL, NULL, GetValue, SetValue, NULL, napi_default, NULL },
+    { "value", NULL, NULL, GetValue, SetValue, NULL, napi_default_method, NULL },
     DECLARE_NAPI_METHOD("plusOne", PlusOne),
     DECLARE_NAPI_METHOD("multiply", Multiply),
   };
@@ -3719,8 +3719,8 @@ if (status != napi_ok) return status;
 
 // Set the properties
 napi_property_descriptor descriptors[] = {
-  { "foo", NULL, NULL, NULL, NULL, fooValue, napi_default, NULL },
-  { "bar", NULL, NULL, NULL, NULL, barValue, napi_default, NULL }
+  { "foo", NULL, NULL, NULL, NULL, fooValue, napi_default_method, NULL },
+  { "bar", NULL, NULL, NULL, NULL, barValue, napi_default_method, NULL }
 }
 status = napi_define_properties(env,
                                 obj,
@@ -3742,6 +3742,14 @@ typedef enum {
   // Used with napi_define_class to distinguish static properties
   // from instance properties. Ignored by napi_define_properties.
   napi_static = 1 << 10,
+
+  // Default for class methods.
+  napi_default_method = napi_writable | napi_configurable,
+
+  // Default for object properties, like in JS obj[prop].
+  napi_default_property = napi_writable |
+                          napi_enumerable |
+                          napi_configurable,
 } napi_property_attributes;
 ```
 
@@ -3760,6 +3768,10 @@ They can be one or more of the following bitflags:
 * `napi_static`: The property will be defined as a static property on a class as
   opposed to an instance property, which is the default. This is used only by
   [`napi_define_class`][]. It is ignored by `napi_define_properties`.
+* `napi_default_method`: The property is configureable, writeable but not
+  enumerable like a method in a JS class.
+* `napi_default_property`: The property is writable, enumerable and configurable
+  like a property set via JS code `obj.key = value`.
 
 #### napi_property_descriptor
 

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -1778,7 +1778,7 @@ provided by the addon:
 napi_value Init(napi_env env, napi_value exports) {
   napi_status status;
   napi_property_descriptor desc =
-    {"hello", NULL, Method, NULL, NULL, NULL, napi_default_property, NULL};
+    {"hello", NULL, Method, NULL, NULL, NULL, napi_default, NULL};
   status = napi_define_properties(env, exports, 1, &desc);
   if (status != napi_ok) return NULL;
   return exports;
@@ -1805,7 +1805,7 @@ To define a class so that new instances can be created (often used with
 napi_value Init(napi_env env, napi_value exports) {
   napi_status status;
   napi_property_descriptor properties[] = {
-    { "value", NULL, NULL, GetValue, SetValue, NULL, napi_default_method, NULL },
+    { "value", NULL, NULL, GetValue, SetValue, NULL, napi_default, NULL },
     DECLARE_NAPI_METHOD("plusOne", PlusOne),
     DECLARE_NAPI_METHOD("multiply", Multiply),
   };
@@ -3719,8 +3719,8 @@ if (status != napi_ok) return status;
 
 // Set the properties
 napi_property_descriptor descriptors[] = {
-  { "foo", NULL, NULL, NULL, NULL, fooValue, napi_default_method, NULL },
-  { "bar", NULL, NULL, NULL, NULL, barValue, napi_default_method, NULL }
+  { "foo", NULL, NULL, NULL, NULL, fooValue, napi_default, NULL },
+  { "bar", NULL, NULL, NULL, NULL, barValue, napi_default, NULL }
 }
 status = napi_define_properties(env,
                                 obj,

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -3731,6 +3731,12 @@ if (status != napi_ok) return status;
 
 ### Structures
 #### napi_property_attributes
+<!-- YAML
+changes:
+ - version: REPLACEME
+   pr-url: https://github.com/nodejs/node/pull/35214
+   description: added `napi_default_method` and `napi_default_property`
+-->
 
 ```c
 typedef enum {

--- a/src/js_native_api_types.h
+++ b/src/js_native_api_types.h
@@ -30,6 +30,14 @@ typedef enum {
   // Used with napi_define_class to distinguish static properties
   // from instance properties. Ignored by napi_define_properties.
   napi_static = 1 << 10,
+
+  // Default for class methods.
+  napi_default_method = napi_writable | napi_configurable,
+
+  // Default for object properties, like in JS obj[prop].
+  napi_default_jsproperty = napi_writable |
+                            napi_enumerable |
+                            napi_configurable,
 } napi_property_attributes;
 
 typedef enum {

--- a/src/js_native_api_types.h
+++ b/src/js_native_api_types.h
@@ -31,6 +31,7 @@ typedef enum {
   // from instance properties. Ignored by napi_define_properties.
   napi_static = 1 << 10,
 
+#ifdef NAPI_EXPERIMENTAL
   // Default for class methods.
   napi_default_method = napi_writable | napi_configurable,
 
@@ -38,6 +39,7 @@ typedef enum {
   napi_default_jsproperty = napi_writable |
                             napi_enumerable |
                             napi_configurable,
+#endif
 } napi_property_attributes;
 
 typedef enum {

--- a/src/js_native_api_types.h
+++ b/src/js_native_api_types.h
@@ -39,7 +39,7 @@ typedef enum {
   napi_default_jsproperty = napi_writable |
                             napi_enumerable |
                             napi_configurable,
-#endif
+#endif  // NAPI_EXPERIMENTAL
 } napi_property_attributes;
 
 typedef enum {


### PR DESCRIPTION
Add a default value for class method and js like property in `enum napi_property_attributes`.

n-api currently offers only one default which is non configurable, non writable, non enumerable - like `Object.defineProperty()`. While this is formal correct the usual way to create properties in JS is either by defining a class or use `obj.prop = value`.

The defaults from these variants are now backed into enum values.

Refs: https://github.com/nodejs/node-addon-api/issues/811

