### PR TITLE
doc: change type of child_process.signalCode to string

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -1389,9 +1389,9 @@ connection to the child.
 
 ### `subprocess.signalCode`
 
-* {integer}
+* {string|null}
 
-The `subprocess.signalCode` property indicates the signal number received by
+The `subprocess.signalCode` property indicates the signal received by
 the child process if any, else `null`.
 
 ### `subprocess.spawnargs`


### PR DESCRIPTION
During testing, and interfacing with child_processes, I found that the child_proccess.signalCode property to be the string representation of the signal, not number.

Tested on node v14.6.0 (Windows)
Tested on node v14.9.0 (Linux)

Sample code:

```js
const child_process = require('child_process');
const cp = child_process.spawn('sleep', ['10']);
cp.kill();
setTimeout(() => console.log(cp.signalCode, typeof cp.signalCode), 100);
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
