### PR TITLE
build: increase API requests allowed when auto closing stalled issues

### DIFF
--- a/.github/workflows/close-stalled.yml
+++ b/.github/workflows/close-stalled.yml
@@ -17,6 +17,8 @@ jobs:
         close-pr-message: Closing this because it has stalled. Feel free to reopen if this PR is still relevant, or to ping the collaborator who labelled it stalled if you have any questions.
         # used to filter issues to check whether or not should be closed, avoids hitting maximum operations allowed if needing to paginate through all open issues
         only-labels: stalled
+        # max requests it will send per run to the GitHub API before it deliberately exits to avoid hitting API rate limits
+        operations-per-run: 500
         # deactivates automatic removal of stalled label if issue gets any activity
         remove-stale-when-updated: false
         # deactivates automatic stale labelling as we prefer to do that manually


### PR DESCRIPTION
The second attempt at getting the auto closing of issues & PRs to work as expected without hitting a maximum operations allowed error we've been seeing.

Recently discovered that the mentioned error is actually self imposed by the stale action itself. It keeps track of how many outgoing GitHub API requests it performs, and if that count exceeds the configured [`operations-per-run`](https://github.com/actions/stale/blob/13b324e4b28a2708236aadb11361fa65af60d201/action.yml#L41-L43) option, it exits to avoid hitting API rate limits.

Default `operations-per-run` value is set to `30`.

That's a very low limit and we're not at all concerned hitting that rate limit as of now, so we're bumping `operations-per-run` to `500`.

Refs https://github.com/nodejs/node/issues/35144

/cc @mmarchini @targos 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)