### PR TITLE
doc: standardize on _backward_

### DIFF
--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -436,7 +436,7 @@ If the graceful disconnect behavior is not needed, use `worker.process.kill()`.
 
 Causes `.exitedAfterDisconnect` to be set.
 
-This method is aliased as `worker.destroy()` for backwards compatibility.
+This method is aliased as `worker.destroy()` for backward compatibility.
 
 In a worker, `process.kill()` exists, but it is not this function;
 it is [`kill()`][].

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1604,7 +1604,7 @@ The default encoding to use for functions that can take either strings
 or [buffers][`Buffer`]. The default value is `'buffer'`, which makes methods
 default to [`Buffer`][] objects.
 
-The `crypto.DEFAULT_ENCODING` mechanism is provided for backwards compatibility
+The `crypto.DEFAULT_ENCODING` mechanism is provided for backward compatibility
 with legacy programs that expect `'latin1'` to be the default encoding.
 
 New applications should expect the default to be `'buffer'`.

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -2342,7 +2342,7 @@ important ways:
    * Pipes (and sockets): *synchronous* on Windows, *asynchronous* on POSIX
 
 These behaviors are partly for historical reasons, as changing them would
-create backwards incompatibility, but they are also expected by some users.
+create backward incompatibility, but they are also expected by some users.
 
 Synchronous writes avoid problems such as output written with `console.log()` or
 `console.error()` being unexpectedly interleaved, or not written at all if

--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -828,7 +828,7 @@ const { createInterface } = require('readline');
   <tr>
     <td><code>ctrl</code> + <code>w</code> or <code>ctrl</code>
     + <code>backspace</code></td>
-    <td>Delete backwards to a word boundary</td>
+    <td>Delete backward to a word boundary</td>
     <td><code>ctrl</code> + <code>backspace</code> Doesn't
     work on Linux, Mac and Windows</td>
   </tr>

--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -248,8 +248,8 @@ added:
 -->
 
 The REPL supports bi-directional reverse-i-search similar to [ZSH][]. It is
-triggered with `<ctrl> + R` to search backwards and `<ctrl> + S` to search
-forwards.
+triggered with `<ctrl> + R` to search backward and `<ctrl> + S` to search
+forward.
 
 Duplicated history entires will be skipped.
 

--- a/doc/guides/technical-values.md
+++ b/doc/guides/technical-values.md
@@ -26,7 +26,7 @@ with Node.js. Some key elements of this include:
 Whenever possible, we seek to ensure that working code continues to work. To
 keep the trust of developers and users, we value stability.
 Some key elements of this include:
-* Backwards compatibility
+* Backward compatibility
 * Stable releases on a predictable schedule
 * A strong safety net, including testing how changes
   in Node.js affect popular packages


### PR DESCRIPTION
We use _backward incompatible_ and _backwards incompatible_ with no
discernible pattern in the docs. Follow Chicago Manual of Style and also
our standardization on US English and favor _backward_.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
