### PR TITLE
doc: update crypto.createSecretKey accepted types

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -2062,7 +2062,7 @@ and it will be impossible to extract the private key from the returned object.
 added: v11.6.0
 -->
 
-* `key` {Buffer}
+* `key` {Buffer | TypedArray | DataView}
 * Returns: {KeyObject}
 
 Creates and returns a new key object containing a secret key for symmetric


### PR DESCRIPTION
This updates the `crypto.createSecretKey` accepted types.

cc @tniessen 

```js
const encoder = new TextEncoder()
crypto.createSecretKey(Buffer.from('foo'))
crypto.createSecretKey(encoder.encode('foo'))
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
