### PR TITLE
Make recursive rmdir more strict

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -928,6 +928,11 @@ added: v14.0.0
 Used when a feature that is not available
 to the current platform which is running Node.js is used.
 
+<a id="ERR_FS_ENOTDIR"></a>
+### `ERR_FS_ENOTDIR`
+
+Path is not a directory.
+
 <a id="ERR_FS_FILE_TOO_LARGE"></a>
 ### `ERR_FS_FILE_TOO_LARGE`
 

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -3518,8 +3518,7 @@ changes:
     the number of retries. This option is ignored if the `recursive` option is
     not `true`. **Default:** `0`.
   * `recursive` {boolean} If `true`, perform a recursive directory removal. In
-    recursive mode, errors are not reported if `path` does not exist, and
-    operations are retried on failure. **Default:** `false`.
+    recursive mode operations are retried on failure. **Default:** `false`.
   * `retryDelay` {integer} The amount of time in milliseconds to wait between
     retries. This option is ignored if the `recursive` option is not `true`.
     **Default:** `100`.
@@ -3565,8 +3564,7 @@ changes:
     the number of retries. This option is ignored if the `recursive` option is
     not `true`. **Default:** `0`.
   * `recursive` {boolean} If `true`, perform a recursive directory removal. In
-    recursive mode, errors are not reported if `path` does not exist, and
-    operations are retried on failure. **Default:** `false`.
+    recursive mode operations are retried on failure. **Default:** `false`.
   * `retryDelay` {integer} The amount of time in milliseconds to wait between
     retries. This option is ignored if the `recursive` option is not `true`.
     **Default:** `100`.

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -838,6 +838,7 @@ E('ERR_FEATURE_UNAVAILABLE_ON_PLATFORM',
   'The feature %s is unavailable on the current platform' +
   ', which is being used to run Node.js',
   TypeError);
+E('ERR_FS_ENOTDIR', 'not a directory', SystemError);
 E('ERR_FS_FILE_TOO_LARGE', 'File size (%s) is greater than 2 GB', RangeError);
 E('ERR_FS_INVALID_SYMLINK_TYPE',
   'Symlink type must be one of "dir", "file", or "junction". Received "%s"',

--- a/lib/internal/fs/rimraf.js
+++ b/lib/internal/fs/rimraf.js
@@ -31,7 +31,7 @@ const { setTimeout } = require('timers');
 const { sleep } = require('internal/util');
 const {
   codes: {
-    ERR_INVALID_ARG_VALUE
+    ERR_FS_ENOTDIR
   },
 } = require('internal/errors');
 const notEmptyErrorCodes = new Set(['ENOTEMPTY', 'EEXIST', 'EPERM']);
@@ -49,9 +49,13 @@ function rimraf(path, options, callback) {
     if (err && err.code === 'ENOENT') {
       callback(err);
     } else if (stats && !stats.isDirectory()) {
-      callback(new ERR_INVALID_ARG_VALUE(
-        'path', path, 'is not a directory'
-      ));
+      callback(new ERR_FS_ENOTDIR({
+        code: 'ENOTDIR',
+        message: 'not a directory',
+        path,
+        syscall: 'rmdir',
+        errno: -20
+      }));
     } else {
       _rimraf(path, options, callback);
     }
@@ -202,7 +206,13 @@ function rimrafSync(path, options) {
   }
 
   if (stats && !stats.isDirectory()) {
-    throw new ERR_INVALID_ARG_VALUE('path', path, 'is not a directory');
+    throw new ERR_FS_ENOTDIR({
+      code: 'ENOTDIR',
+      message: 'not a directory',
+      path,
+      syscall: 'rmdir',
+      errno: -20
+    });
   }
 
   _rimrafSync(path, options);

--- a/lib/internal/fs/rimraf.js
+++ b/lib/internal/fs/rimraf.js
@@ -29,6 +29,11 @@ const {
 const { sep } = require('path');
 const { setTimeout } = require('timers');
 const { sleep } = require('internal/util');
+const {
+  codes: {
+    ERR_INVALID_ARG_VALUE
+  },
+} = require('internal/errors');
 const notEmptyErrorCodes = new Set(['ENOTEMPTY', 'EEXIST', 'EPERM']);
 const retryErrorCodes = new Set(
   ['EBUSY', 'EMFILE', 'ENFILE', 'ENOTEMPTY', 'EPERM']);
@@ -40,14 +45,29 @@ const separator = Buffer.from(sep);
 
 
 function rimraf(path, options, callback) {
+  stat(path, (err, stats) => {
+    if (err && err.code === 'ENOENT') {
+      callback(err);
+    } else if (stats && !stats.isDirectory()) {
+      callback(new ERR_INVALID_ARG_VALUE(
+        'path', path, 'is not a directory'
+      ));
+    } else {
+      _rimraf(path, options, callback);
+    }
+  });
+}
+
+
+function _rimraf(path, options, callback) {
   let retries = 0;
 
-  _rimraf(path, options, function CB(err) {
+  __rimraf(path, options, function CB(err) {
     if (err) {
       if (retryErrorCodes.has(err.code) && retries < options.maxRetries) {
         retries++;
         const delay = retries * options.retryDelay;
-        return setTimeout(_rimraf, delay, path, options, CB);
+        return setTimeout(__rimraf, delay, path, options, CB);
       }
 
       // The file is already gone.
@@ -60,7 +80,7 @@ function rimraf(path, options, callback) {
 }
 
 
-function _rimraf(path, options, callback) {
+function __rimraf(path, options, callback) {
   // SunOS lets the root user unlink directories. Use lstat here to make sure
   // it's not a directory.
   lstat(path, (err, stats) => {
@@ -141,7 +161,7 @@ function _rmchildren(path, options, callback) {
     files.forEach((child) => {
       const childPath = Buffer.concat([pathBuf, separator, child]);
 
-      rimraf(childPath, options, (err) => {
+      _rimraf(childPath, options, (err) => {
         if (done)
           return;
 
@@ -172,6 +192,24 @@ function rimrafPromises(path, options) {
 
 
 function rimrafSync(path, options) {
+  let stats;
+
+  try {
+    stats = statSync(path);
+  } catch (err) {
+    if (err.code === 'ENOENT')
+      throw err;
+  }
+
+  if (!stats.isDirectory()) {
+    throw new ERR_INVALID_ARG_VALUE('path', path, 'is not a directory');
+  }
+
+  _rimrafSync(path, options);
+}
+
+
+function _rimrafSync(path, options) {
   let stats;
 
   try {
@@ -242,7 +280,7 @@ function _rmdirSync(path, options, originalErr) {
       readdirSync(pathBuf, readdirEncoding).forEach((child) => {
         const childPath = Buffer.concat([pathBuf, separator, child]);
 
-        rimrafSync(childPath, options);
+        _rimrafSync(childPath, options);
       });
 
       const tries = options.maxRetries + 1;

--- a/lib/internal/fs/rimraf.js
+++ b/lib/internal/fs/rimraf.js
@@ -201,7 +201,7 @@ function rimrafSync(path, options) {
       throw err;
   }
 
-  if (!stats.isDirectory()) {
+  if (stats && !stats.isDirectory()) {
     throw new ERR_INVALID_ARG_VALUE('path', path, 'is not a directory');
   }
 

--- a/test/common/tmpdir.js
+++ b/test/common/tmpdir.js
@@ -6,7 +6,11 @@ const path = require('path');
 const { isMainThread } = require('worker_threads');
 
 function rimrafSync(pathname) {
-  fs.rmdirSync(pathname, { maxRetries: 3, recursive: true });
+  try {
+    fs.rmdirSync(pathname, { maxRetries: 3, recursive: true });
+  } catch {
+    // do nothing
+  }
 }
 
 const testRoot = process.env.NODE_TEST_DIR ?

--- a/test/parallel/test-fs-rmdir-recursive.js
+++ b/test/parallel/test-fs-rmdir-recursive.js
@@ -117,8 +117,8 @@ function removeAsync(dir) {
     assert.strictEqual(err.code, 'ERR_INVALID_ARG_VALUE');
     assert.strictEqual(err.name, 'TypeError');
     assert.match(err.message, /^The argument 'path' is not a directory\./);
+    fs.unlinkSync(filePath);
   }));
-  fs.unlinkSync(filePath);
 }
 
 // Test the synchronous version.
@@ -147,15 +147,18 @@ function removeAsync(dir) {
   const filePath = path.join(tmpdir.path, 'rmdir-sync-file.txt');
   fs.writeFileSync(filePath, '');
 
-  assert.throws(() => {
-    fs.rmdirSync(filePath, { recursive: true });
-  }, {
-    code: 'ERR_INVALID_ARG_VALUE',
-    name: 'TypeError',
-    message: /^The argument 'path' is not a directory\./
-  });
+  try {
+    assert.throws(() => {
+      fs.rmdirSync(filePath, { recursive: true });
+    }, {
+      code: 'ERR_INVALID_ARG_VALUE',
+      name: 'TypeError',
+      message: /^The argument 'path' is not a directory\./
+    });
+  } finally {
+    fs.unlinkSync(filePath);
+  }
 
-  fs.unlinkSync(filePath);
 
   // Recursive removal should succeed.
   fs.rmdirSync(dir, { recursive: true });
@@ -189,17 +192,21 @@ function removeAsync(dir) {
   });
 
   // Should fail if target is a file
-  const filePath = path.join(tmpdir.path, 'rmdir-sync-file.txt');
+  const filePath = path.join(tmpdir.path, 'rmdir-promises-file.txt');
   fs.writeFileSync(filePath, '');
 
-  assert.rejects(fs.promises.rmdir(
-    filePath,
-    { recursive: true }
-  ), {
-    code: 'ERR_INVALID_ARG_VALUE',
-    name: 'TypeError',
-    message: /^The argument 'path' is not a directory\./
-  });
+  try {
+    assert.rejects(fs.promises.rmdir(
+      filePath,
+      { recursive: true }
+    ), {
+      code: 'ERR_INVALID_ARG_VALUE',
+      name: 'TypeError',
+      message: /^The argument 'path' is not a directory\./
+    });
+  } finally {
+    fs.unlinkSync(filePath);
+  }
 
   // Attempted removal should fail now because the directory is gone.
   assert.rejects(fs.promises.rmdir(dir), { syscall: 'rmdir' });

--- a/test/parallel/test-fs-rmdir-recursive.js
+++ b/test/parallel/test-fs-rmdir-recursive.js
@@ -114,10 +114,13 @@ function removeAsync(dir) {
   const filePath = path.join(tmpdir.path, 'rmdir-async-file.txt');
   fs.writeFileSync(filePath, '');
   fs.rmdir(filePath, { recursive: true }, common.mustCall((err) => {
-    assert.strictEqual(err.code, 'ERR_INVALID_ARG_VALUE');
-    assert.strictEqual(err.name, 'TypeError');
-    assert.match(err.message, /^The argument 'path' is not a directory\./);
-    fs.unlinkSync(filePath);
+    try {
+      assert.strictEqual(err.code, 'ERR_INVALID_ARG_VALUE');
+      assert.strictEqual(err.name, 'TypeError');
+      assert.match(err.message, /^The argument 'path' is not a directory\./);
+    } finally {
+      fs.unlinkSync(filePath);
+    }
   }));
 }
 
@@ -196,7 +199,7 @@ function removeAsync(dir) {
   fs.writeFileSync(filePath, '');
 
   try {
-    assert.rejects(fs.promises.rmdir(
+    await assert.rejects(fs.promises.rmdir(
       filePath,
       { recursive: true }
     ), {

--- a/test/parallel/test-fs-rmdir-recursive.js
+++ b/test/parallel/test-fs-rmdir-recursive.js
@@ -115,9 +115,14 @@ function removeAsync(dir) {
   fs.writeFileSync(filePath, '');
   fs.rmdir(filePath, { recursive: true }, common.mustCall((err) => {
     try {
-      assert.strictEqual(err.code, 'ERR_INVALID_ARG_VALUE');
-      assert.strictEqual(err.name, 'TypeError');
-      assert.match(err.message, /^The argument 'path' is not a directory\./);
+      assert.strictEqual(err.code, 'ERR_FS_ENOTDIR');
+      assert.strictEqual(err.name, 'SystemError');
+      assert.match(err.message, /^not a directory/);
+      assert.strictEqual(err.info.code, 'ENOTDIR');
+      assert.strictEqual(err.info.message, 'not a directory');
+      assert.strictEqual(err.info.path, filePath);
+      assert.strictEqual(err.info.syscall, 'rmdir');
+      assert.strictEqual(err.info.errno, -20);
     } finally {
       fs.unlinkSync(filePath);
     }
@@ -154,9 +159,16 @@ function removeAsync(dir) {
     assert.throws(() => {
       fs.rmdirSync(filePath, { recursive: true });
     }, {
-      code: 'ERR_INVALID_ARG_VALUE',
-      name: 'TypeError',
-      message: /^The argument 'path' is not a directory\./
+      code: 'ERR_FS_ENOTDIR',
+      name: 'SystemError',
+      message: /^not a directory/,
+      info: {
+        code: 'ENOTDIR',
+        message: 'not a directory',
+        path: filePath,
+        syscall: 'rmdir',
+        errno: -20
+      }
     });
   } finally {
     fs.unlinkSync(filePath);
@@ -203,9 +215,16 @@ function removeAsync(dir) {
       filePath,
       { recursive: true }
     ), {
-      code: 'ERR_INVALID_ARG_VALUE',
-      name: 'TypeError',
-      message: /^The argument 'path' is not a directory\./
+      code: 'ERR_FS_ENOTDIR',
+      name: 'SystemError',
+      message: /^not a directory/,
+      info: {
+        code: 'ENOTDIR',
+        message: 'not a directory',
+        path: filePath,
+        syscall: 'rmdir',
+        errno: -20
+      }
     });
   } finally {
     fs.unlinkSync(filePath);

--- a/test/parallel/test-policy-parse-integrity.js
+++ b/test/parallel/test-policy-parse-integrity.js
@@ -20,7 +20,13 @@ function hash(algo, body) {
 }
 
 const tmpdirPath = path.join(tmpdir.path, 'test-policy-parse-integrity');
-fs.rmdirSync(tmpdirPath, { maxRetries: 3, recursive: true });
+
+try {
+  fs.rmdirSync(tmpdirPath, { maxRetries: 3, recursive: true });
+} catch {
+  // do nothing
+}
+
 fs.mkdirSync(tmpdirPath, { recursive: true });
 
 const policyFilepath = path.join(tmpdirPath, 'policy');


### PR DESCRIPTION
This PR changes the behaviour of recursive rmdir (rimraf) in the following ways:

1. Throws an exception when the path to remove does not exist
1. Throws an exception when the path to remove points to a file instead of a directory

These changes are based on the discussion in #35171 

cc @nodejs/tooling 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
