### PR TITLE
stream: fix pipe unhandled error

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -729,33 +729,37 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
 
   src.on('data', ondata);
   function ondata(chunk) {
-    debug('ondata');
-    const ret = dest.write(chunk);
-    debug('dest.write', ret);
-    if (ret === false) {
-      // If the user unpiped during `dest.write()`, it is possible
-      // to get stuck in a permanently paused state if that write
-      // also returned false.
-      // => Check whether `dest` is still a piping destination.
-      if (!cleanedUp) {
-        if (state.pipes.length === 1 && state.pipes[0] === dest) {
-          debug('false write response, pause', 0);
-          state.awaitDrainWriters = dest;
-          state.multiAwaitDrain = false;
-        } else if (state.pipes.length > 1 && state.pipes.includes(dest)) {
-          debug('false write response, pause', state.awaitDrainWriters.size);
-          state.awaitDrainWriters.add(dest);
+    try {
+      debug('ondata');
+      const ret = dest.write(chunk);
+      debug('dest.write', ret);
+      if (ret === false) {
+        // If the user unpiped during `dest.write()`, it is possible
+        // to get stuck in a permanently paused state if that write
+        // also returned false.
+        // => Check whether `dest` is still a piping destination.
+        if (!cleanedUp) {
+          if (state.pipes.length === 1 && state.pipes[0] === dest) {
+            debug('false write response, pause', 0);
+            state.awaitDrainWriters = dest;
+            state.multiAwaitDrain = false;
+          } else if (state.pipes.length > 1 && state.pipes.includes(dest)) {
+            debug('false write response, pause', state.awaitDrainWriters.size);
+            state.awaitDrainWriters.add(dest);
+          }
+          src.pause();
         }
-        src.pause();
+        if (!ondrain) {
+          // When the dest drains, it reduces the awaitDrain counter
+          // on the source.  This would be more elegant with a .once()
+          // handler in flow(), but adding and removing repeatedly is
+          // too slow.
+          ondrain = pipeOnDrain(src, dest);
+          dest.on('drain', ondrain);
+        }
       }
-      if (!ondrain) {
-        // When the dest drains, it reduces the awaitDrain counter
-        // on the source.  This would be more elegant with a .once()
-        // handler in flow(), but adding and removing repeatedly is
-        // too slow.
-        ondrain = pipeOnDrain(src, dest);
-        dest.on('drain', ondrain);
-      }
+    } catch (err) {
+      destroyImpl.destroyer(dest, err);
     }
   }
 

--- a/lib/internal/streams/legacy.js
+++ b/lib/internal/streams/legacy.js
@@ -5,6 +5,7 @@ const {
 } = primordials;
 
 const EE = require('events');
+const destroyImpl = require('internal/streams/destroy');
 
 function Stream(opts) {
   EE.call(this, opts);
@@ -16,8 +17,12 @@ Stream.prototype.pipe = function(dest, options) {
   const source = this;
 
   function ondata(chunk) {
-    if (dest.writable && dest.write(chunk) === false && source.pause) {
-      source.pause();
+    try {
+      if (dest.writable && dest.write(chunk) === false && source.pause) {
+        source.pause();
+      }
+    } catch (err) {
+      destroyImpl.destroyer(dest, err);
     }
   }
 

--- a/test/parallel/test-stream-pipe-error-handling.js
+++ b/test/parallel/test-stream-pipe-error-handling.js
@@ -22,7 +22,7 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const Stream = require('stream').Stream;
+const { Stream, PassThrough } = require('stream');
 
 {
   const source = new Stream();
@@ -107,4 +107,26 @@ const Stream = require('stream').Stream;
   // Removing some OTHER random listener should not do anything
   w.removeListener('error', () => {});
   removed = true;
+}
+
+{
+  const src = new PassThrough({ objectMode: true });
+  const dst = new PassThrough();
+
+  src.pipe(dst).on('error', common.mustCall((err) => {
+    assert.strictEqual(err.code, 'ERR_INVALID_ARG_TYPE');
+  }));
+
+  src.write({});
+}
+
+{
+  const src = new Stream();
+  const dst = new PassThrough();
+
+  src.pipe(dst).on('error', common.mustCall((err) => {
+    assert.strictEqual(err.code, 'ERR_INVALID_ARG_TYPE');
+  }));
+
+  src.emit('data', {});
 }


### PR DESCRIPTION
Before this PR `pipe` could cause an unhandled exception when e.g. piping an object mode stream to a non-object mode stream. This can particularly happen when stream types are dynamically chosen.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
