### PR TITLE
doc: put release script specifics in details

### DIFF
--- a/doc/guides/releases.md
+++ b/doc/guides/releases.md
@@ -599,6 +599,7 @@ $ ./tools/release.sh -i ~/.ssh/node_id_rsa
 `tools/release.sh` will perform the following actions when run:
 
 <details>
+
 **a.** Select a GPG key from your private keys. It will use a command similar
 to: `gpg --list-secret-keys` to list your keys. If you don't have any keys, it
 will bail. If you have only one key, it will use that. If you have more than

--- a/doc/guides/releases.md
+++ b/doc/guides/releases.md
@@ -598,6 +598,7 @@ $ ./tools/release.sh -i ~/.ssh/node_id_rsa
 
 `tools/release.sh` will perform the following actions when run:
 
+<details>
 **a.** Select a GPG key from your private keys. It will use a command similar
 to: `gpg --list-secret-keys` to list your keys. If you don't have any keys, it
 will bail. If you have only one key, it will use that. If you have more than
@@ -631,6 +632,7 @@ SHASUMS256.txt.sig.
 
 **g.** Upload the `SHASUMS256.txt` files back to the server into the release
 directory.
+</details>
 
 If you didn't wait for ARM builds in the previous step before promoting the
 release, you should re-run `tools/release.sh` after the ARM builds have


### PR DESCRIPTION
Listing all the steps can be confusing an make it seem like
the releaser is meant to run each of these steps manually. In fact
I personally did that my first release.

Let's put those steps in a details block to make it more obvious
that it is informational and not steps to follow
