### PR TITLE
doc: add `socket.readyState`

### DIFF
--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -1028,6 +1028,20 @@ written out, which may not be immediately.
 See `Writable` stream [`write()`][stream_writable_write] method for more
 information.
 
+### `socket.readyState`
+<!-- YAML
+added: v0.5.0
+-->
+
+* {string}
+
+This property represents the state of the connection as a string.
+
+* If the stream is connecting `socket.readyState` is `opening`.
+* If the stream is readable and writable, it is `open`.
+* If the stream is readable and not writable, it is `readOnly`.
+* If the stream is not readable and writable, it is `writeOnly`.
+
 ## `net.connect()`
 
 Aliases to


### PR DESCRIPTION

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

This PR adds description of `socket.readyState` [net documentation](https://nodejs.org/api/net.html)  

Note that the `readyState` property was added in v0.5.0: https://github.com/nodejs/node/commit/e697cfb6fc020c08afa2c794ee5802e5a4d2b97b

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is changed or added

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
