### PR TITLE
http: https requestTimeout 0

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1805,7 +1805,7 @@ changes:
 
 * `statusCode` {number}
 * `statusMessage` {string}
-* `headers` {Object|Array}
+* `headers` {Object}
 * Returns: {http.ServerResponse}
 
 Sends a response header to the request. The status code is a 3-digit HTTP

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1805,7 +1805,7 @@ changes:
 
 * `statusCode` {number}
 * `statusMessage` {string}
-* `headers` {Object}
+* `headers` {Object|Array}
 * Returns: {http.ServerResponse}
 
 Sends a response header to the request. The status code is a 3-digit HTTP

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -373,7 +373,7 @@ function Server(options, requestListener) {
   this.keepAliveTimeout = 5000;
   this.maxHeadersCount = null;
   this.headersTimeout = 60 * 1000; // 60 seconds
-  this.requestTimeout = 0; // 120 seconds
+  this.requestTimeout = 0;
 }
 ObjectSetPrototypeOf(Server.prototype, net.Server.prototype);
 ObjectSetPrototypeOf(Server, net.Server);

--- a/lib/https.js
+++ b/lib/https.js
@@ -80,7 +80,7 @@ function Server(opts, requestListener) {
   this.keepAliveTimeout = 5000;
   this.maxHeadersCount = null;
   this.headersTimeout = 60 * 1000; // 60 seconds
-  this.requestTimeout = 120 * 1000; // 120 seconds
+  this.requestTimeout = 0;
 }
 ObjectSetPrototypeOf(Server.prototype, tls.Server.prototype);
 ObjectSetPrototypeOf(Server, tls.Server);

--- a/test/parallel/test-https-server-request-timeout.js
+++ b/test/parallel/test-https-server-request-timeout.js
@@ -19,5 +19,3 @@ assert.strictEqual(server.requestTimeout, 0);
 const requestTimeout = common.platformTimeout(1000);
 server.requestTimeout = requestTimeout;
 assert.strictEqual(server.requestTimeout, requestTimeout);
-
-server.close();

--- a/test/parallel/test-https-server-request-timeout.js
+++ b/test/parallel/test-https-server-request-timeout.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const { createServer } = require('https');
+const { connect } = require('tls');
+const fixtures = require('../common/fixtures');
+
+const options = {
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem')
+};
+
+// This test validates that the server returns 408
+// after server.requestTimeout if the client
+// pauses before start sending the body.
+
+const server = createServer(options, common.mustCall((req, res) => {
+  let body = '';
+  req.setEncoding('utf-8');
+
+  req.on('data', (chunk) => {
+    body += chunk;
+  });
+
+  req.on('end', () => {
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.write(body);
+    res.end();
+  });
+}));
+
+// 0 seconds is the default
+assert.strictEqual(server.requestTimeout, 0);
+const requestTimeout = common.platformTimeout(1000);
+server.requestTimeout = requestTimeout;
+assert.strictEqual(server.requestTimeout, requestTimeout);
+
+server.listen(0, common.mustCall(() => {
+  const client = connect({
+    host: '127.0.0.1',
+    port: server.address().port,
+    rejectUnauthorized: false
+  });
+  let response = '';
+
+  client.on('data', common.mustCall((chunk) => {
+    response += chunk.toString('utf-8');
+  }));
+
+  client.resume();
+  client.write('POST / HTTP/1.1\r\n');
+  client.write('Content-Length: 20\r\n');
+  client.write('Connection: close\r\n');
+  client.write('\r\n');
+
+  setTimeout(() => {
+    client.write('12345678901234567890\r\n\r\n');
+  }, common.platformTimeout(2000)).unref();
+
+  const errOrEnd = common.mustCall(function(err) {
+    assert.strictEqual(
+      response,
+      'HTTP/1.1 408 Request Timeout\r\nConnection: close\r\n\r\n'
+    );
+    server.close();
+  });
+
+  client.on('end', errOrEnd);
+  client.on('error', errOrEnd);
+}));

--- a/test/parallel/test-https-server-request-timeout.js
+++ b/test/parallel/test-https-server-request-timeout.js
@@ -5,7 +5,6 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 const assert = require('assert');
 const { createServer } = require('https');
-const { connect } = require('tls');
 const fixtures = require('../common/fixtures');
 
 const options = {
@@ -13,24 +12,7 @@ const options = {
   cert: fixtures.readKey('agent1-cert.pem')
 };
 
-// This test validates that the server returns 408
-// after server.requestTimeout if the client
-// pauses before start sending the body.
-
-const server = createServer(options, common.mustCall((req, res) => {
-  let body = '';
-  req.setEncoding('utf-8');
-
-  req.on('data', (chunk) => {
-    body += chunk;
-  });
-
-  req.on('end', () => {
-    res.writeHead(200, { 'Content-Type': 'text/plain' });
-    res.write(body);
-    res.end();
-  });
-}));
+const server = createServer(options);
 
 // 0 seconds is the default
 assert.strictEqual(server.requestTimeout, 0);
@@ -38,36 +20,4 @@ const requestTimeout = common.platformTimeout(1000);
 server.requestTimeout = requestTimeout;
 assert.strictEqual(server.requestTimeout, requestTimeout);
 
-server.listen(0, common.mustCall(() => {
-  const client = connect({
-    host: '127.0.0.1',
-    port: server.address().port,
-    rejectUnauthorized: false
-  });
-  let response = '';
-
-  client.on('data', common.mustCall((chunk) => {
-    response += chunk.toString('utf-8');
-  }));
-
-  client.resume();
-  client.write('POST / HTTP/1.1\r\n');
-  client.write('Content-Length: 20\r\n');
-  client.write('Connection: close\r\n');
-  client.write('\r\n');
-
-  setTimeout(() => {
-    client.write('12345678901234567890\r\n\r\n');
-  }, common.platformTimeout(2000)).unref();
-
-  const errOrEnd = common.mustCall(function(err) {
-    assert.strictEqual(
-      response,
-      'HTTP/1.1 408 Request Timeout\r\nConnection: close\r\n\r\n'
-    );
-    server.close();
-  });
-
-  client.on('end', errOrEnd);
-  client.on('error', errOrEnd);
-}));
+server.close();


### PR DESCRIPTION
`requestTimeout` should be `0` by default for `https` just like `http`. The current default may cause breaking regressions in user code.

Fixes: https://github.com/nodejs/node/issues/35261

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
