### PR TITLE
[v10.x] build: expose napi_build_version variable

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -34,6 +34,7 @@ import nodedownload
 # imports in tools/
 sys.path.insert(0, 'tools')
 import getmoduleversion
+import getnapibuildversion
 from gyp_node import run_gyp
 
 # imports in deps/v8/tools/node
@@ -1131,6 +1132,10 @@ def configure_node(o):
   else:
     o['variables']['node_target_type'] = 'executable'
 
+def configure_napi(output):
+  version = getnapibuildversion.get_napi_version()
+  output['variables']['napi_build_version'] = version
+
 def configure_library(lib, output):
   shared_lib = 'shared_' + lib
   output['variables']['node_' + shared_lib] = b(getattr(options, shared_lib))
@@ -1603,6 +1608,7 @@ if (options.dest_os):
 flavor = GetFlavor(flavor_params)
 
 configure_node(output)
+configure_napi(output)
 configure_library('zlib', output)
 configure_library('http_parser', output)
 configure_library('libuv', output)

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -661,6 +661,7 @@ An example of the possible output looks like:
   variables:
    {
      host_arch: 'x64',
+     napi_build_version: 4,
      node_install_npm: 'true',
      node_prefix: '',
      node_shared_cares: 'false',

--- a/src/node_api.h
+++ b/src/node_api.h
@@ -9,7 +9,12 @@
 // Use INT_MAX, this should only be consumed by the pre-processor anyway.
 #define NAPI_VERSION 2147483647
 #else
-// The baseline version for N-API
+// The baseline version for N-API.
+// The NAPI_VERSION controls which version will be used by default when
+// compilling a native addon. If the addon developer specifically wants to use
+// functions available in a new version of N-API that is not yet ported in all
+// LTS versions, they can set NAPI_VERSION knowing that they have specifically
+// depended on that version.
 #define NAPI_VERSION 6
 #endif
 #endif

--- a/test/parallel/test-process-versions.js
+++ b/test/parallel/test-process-versions.js
@@ -43,3 +43,6 @@ for (let i = 0; i < expected_keys.length; i++) {
   const descriptor = Object.getOwnPropertyDescriptor(process.versions, key);
   assert.strictEqual(descriptor.writable, false);
 }
+
+assert.strictEqual(process.config.variables.napi_build_version,
+                   process.versions.napi);

--- a/tools/getnapibuildversion.py
+++ b/tools/getnapibuildversion.py
@@ -1,0 +1,26 @@
+from __future__ import print_function
+import os
+import re
+
+
+def get_napi_version():
+  napi_version_h = os.path.join(
+    os.path.dirname(__file__),
+    '..',
+    'src',
+    'node_version.h')
+
+  f = open(napi_version_h)
+
+  regex = '^#define NAPI_VERSION'
+
+  for line in f:
+    if re.match(regex, line):
+      napi_version = line.split()[2]
+      return napi_version
+
+  raise Exception('Could not find pattern matching %s' % regex)
+
+
+if __name__ == '__main__':
+  print(get_napi_version())


### PR DESCRIPTION
Expose `napi_build_version` to allow `node-gyp` to make it
available for building native addons.

Fixes: https://github.com/nodejs/node-gyp/issues/1745
Refs: https://github.com/nodejs/abi-stable-node/issues/371
PR-URL: https://github.com/nodejs/node/pull/27835
Reviewed-By: @bnoordhuis
Reviewed-By: @addaleax
Reviewed-By: @gabrielschulhof
Reviewed-By: @lpinca
Reviewed-By: @richardlau
Reviewed-By: @mhdawson

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
