### PR TITLE
repl: standardize Control key indications

### DIFF
--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -34,8 +34,8 @@ feature set.
 
 The following special commands are supported by all REPL instances:
 
-* `.break`: When in the process of inputting a multi-line expression, entering
-  the `.break` command (or pressing the `<ctrl>-C` key combination) will abort
+* `.break`: When in the process of inputting a multi-line expression, enter
+  the `.break` command (or press **Ctrl+C**) to abort
   further input or processing of that expression.
 * `.clear`: Resets the REPL `context` to an empty object and clears any
   multi-line expression being input.
@@ -45,7 +45,7 @@ The following special commands are supported by all REPL instances:
   `> .save ./file/to/save.js`
 * `.load`: Load a file into the current REPL session.
   `> .load ./file/to/load.js`
-* `.editor`: Enter editor mode (`<ctrl>-D` to finish, `<ctrl>-C` to cancel).
+* `.editor`: Enter editor mode (**Ctrl+D** to finish, **Ctrl+C** to cancel).
 
 ```console
 > .editor
@@ -63,10 +63,10 @@ welcome('Node.js User');
 
 The following key combinations in the REPL have these special effects:
 
-* `<ctrl>-C`: When pressed once, has the same effect as the `.break` command.
+* **Ctrl+C**: When pressed once, has the same effect as the `.break` command.
   When pressed twice on a blank line, has the same effect as the `.exit`
   command.
-* `<ctrl>-D`: Has the same effect as the `.exit` command.
+* **Ctrl+D**: Has the same effect as the `.exit` command.
 * `<tab>`: When pressed on a blank line, displays global and local (scope)
   variables. When pressed while entering other input, displays relevant
   autocompletion options.
@@ -248,14 +248,14 @@ added:
 -->
 
 The REPL supports bi-directional reverse-i-search similar to [ZSH][]. It is
-triggered with `<ctrl> + R` to search backward and `<ctrl> + S` to search
-forward.
+triggered with **Ctrl+R** to search backward and **Ctrl+S** to search
+forwards.
 
 Duplicated history entires will be skipped.
 
 Entries are accepted as soon as any button is pressed that doesn't correspond
-with the reverse search. Cancelling is possible by pressing `escape` or
-`<ctrl> + C`.
+with the reverse search. Cancelling is possible by pressing **Esc** or
+**Ctrl+C**.
 
 Changing the direction immediately searches for the next entry in the expected
 direction from the current position on.
@@ -284,7 +284,7 @@ repl.start({ prompt: '> ', eval: myEval });
 
 #### Recoverable errors
 
-As a user is typing input into the REPL prompt, pressing the `<enter>` key will
+As a user is typing input into the REPL prompt, pressing **Enter** will
 send the current line of input to the `eval` function. In order to support
 multi-line input, the eval function can return an instance of `repl.Recoverable`
 to the provided callback function:
@@ -381,8 +381,8 @@ added: v0.7.7
 -->
 
 The `'exit'` event is emitted when the REPL is exited either by receiving the
-`.exit` command as input, the user pressing `<ctrl>-C` twice to signal `SIGINT`,
-or by pressing `<ctrl>-D` to signal `'end'` on the input stream. The listener
+`.exit` command as input, the user pressing **Ctrl+C** twice to signal `SIGINT`,
+or by pressing **Ctrl+D** to signal `'end'` on the input stream. The listener
 callback is invoked without any arguments.
 
 ```js

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -726,7 +726,9 @@ function REPLServer(prompt,
         sawSIGINT = false;
         return;
       }
-      self.output.write('(To exit, press ^C again or ^D or type .exit)\n');
+      self.output.write(
+        '(To exit, press Ctrl+C again or Ctrl+D or type .exit)\n'
+      );
       sawSIGINT = true;
     } else {
       sawSIGINT = false;
@@ -791,7 +793,7 @@ function REPLServer(prompt,
       if (e && !self[kBufferedCommandSymbol] && cmd.trim().startsWith('npm ')) {
         self.output.write('npm should be run outside of the ' +
                                 'Node.js REPL, in your normal shell.\n' +
-                                '(Press Control-D to exit.)\n');
+                                '(Press Ctrl+D to exit.)\n');
         self.displayPrompt();
         return;
       }
@@ -836,7 +838,7 @@ function REPLServer(prompt,
     if (self.editorMode) {
       self.output.write(`${self._initialPrompt}.editor\n`);
       self.output.write(
-        '// Entering editor mode (^D to finish, ^C to cancel)\n');
+        '// Entering editor mode (Ctrl+D to finish, Ctrl+C to cancel)\n');
       self.output.write(`${self[kBufferedCommandSymbol]}\n`);
       self.prompt(true);
     } else {
@@ -1508,8 +1510,8 @@ function defineDefaultCommands(repl) {
         const line = `.${name}${cmd.help ? spaces + cmd.help : ''}\n`;
         this.output.write(line);
       }
-      this.output.write('\nPress ^C to abort current expression, ' +
-        '^D to exit the REPL\n');
+      this.output.write('\nPress Ctrl+C to abort current expression, ' +
+        'Ctrl+D to exit the REPL\n');
       this.displayPrompt();
     }
   });
@@ -1555,7 +1557,7 @@ function defineDefaultCommands(repl) {
       action() {
         _turnOnEditorMode(this);
         this.output.write(
-          '// Entering editor mode (^D to finish, ^C to cancel)\n');
+          '// Entering editor mode (Ctrl+D to finish, Ctrl+C to cancel)\n');
       }
     });
   }

--- a/test/parallel/test-repl-editor.js
+++ b/test/parallel/test-repl-editor.js
@@ -19,9 +19,10 @@ function run({ input, output, event, checkTerminalCodes = true }) {
 
   stream.write = (msg) => found += msg.replace('\r', '');
 
-  let expected = `${terminalCode}.editor\n` +
-                 '// Entering editor mode (^D to finish, ^C to cancel)\n' +
-                 `${input}${output}\n${terminalCode}`;
+  let expected =
+    `${terminalCode}.editor\n` +
+    '// Entering editor mode (Ctrl+D to finish, Ctrl+C to cancel)\n' +
+    `${input}${output}\n${terminalCode}`;
 
   const replServer = repl.start({
     prompt: '> ',
@@ -47,7 +48,7 @@ function run({ input, output, event, checkTerminalCodes = true }) {
 const tests = [
   {
     input: '',
-    output: '\n(To exit, press ^C again or ^D or type .exit)',
+    output: '\n(To exit, press Ctrl+C again or Ctrl+D or type .exit)',
     event: { ctrl: true, name: 'c' }
   },
   {

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -373,7 +373,7 @@ const errorTests = [
     send: 'npm install foobar',
     expect: [
       'npm should be run outside of the Node.js REPL, in your normal shell.',
-      '(Press Control-D to exit.)'
+      '(Press Ctrl+D to exit.)'
     ]
   },
   {
@@ -453,7 +453,7 @@ const errorTests = [
       /\.load/,
       /\.save/,
       '',
-      'Press ^C to abort current expression, ^D to exit the REPL',
+      'Press Ctrl+C to abort current expression, Ctrl+D to exit the REPL',
       /'thefourtheye'/
     ]
   },


### PR DESCRIPTION
Throughout our messages and docs, we refer to the Control key in a
surprisingly varied number of ways:

* Control
* Ctrl
* Cntl
* varied capitalization on the above (e.g., ctrl vs. Ctrl)

Then, in key combinations:

* One of the items from the previous list followed by `-`
* ... or followed by `+`
* ... surrounded or not by `<` and `>`
* ... and inside backticks or not
* ... or just `^`

This is the start of standardization on the formulation recommended by
the Microsoft Style Guide (e.g., **Ctrl+C**).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
