### PR TITLE
build: add support for section ordering

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -172,6 +172,16 @@
         },
         'cflags': [ '-O3' ],
         'conditions': [
+          ['node_section_ordering_file!="-"', {
+            'cflags': [
+              '-fuse-ld=gold',
+              '-ffunction-sections',
+            ],
+            'ldflags': [
+              '-fuse-ld=gold',
+              '-Wl,--section-ordering-file=<(node_section_ordering_file)',
+            ]
+          }],
           ['OS=="solaris"', {
             # pull in V8's postmortem metadata
             'ldflags': [ '-Wl,-z,allextract' ]

--- a/common.gypi
+++ b/common.gypi
@@ -111,6 +111,9 @@
       ['target_arch in "ppc64 s390x"', {
         'v8_enable_backtrace': 1,
       }],
+      ['OS=="linux"', {
+        'node_section_ordering_info%': ''
+      }]
     ],
   },
 
@@ -172,15 +175,19 @@
         },
         'cflags': [ '-O3' ],
         'conditions': [
-          ['node_section_ordering_file!="-"', {
-            'cflags': [
-              '-fuse-ld=gold',
-              '-ffunction-sections',
+          ['OS=="linux"', {
+            'conditions': [
+              ['node_section_ordering_info!=""', {
+                'cflags': [
+                  '-fuse-ld=gold',
+                  '-ffunction-sections',
+                ],
+                'ldflags': [
+                  '-fuse-ld=gold',
+                  '-Wl,--section-ordering-file=<(node_section_ordering_info)',
+                ],
+              }],
             ],
-            'ldflags': [
-              '-fuse-ld=gold',
-              '-Wl,--section-ordering-file=<(node_section_ordering_file)',
-            ]
           }],
           ['OS=="solaris"', {
             # pull in V8's postmortem metadata

--- a/configure.py
+++ b/configure.py
@@ -504,7 +504,7 @@ parser.add_option('--use-largepages-script-lld',
 
 parser.add_option('--use-section-ordering-file',
     action='store',
-    dest='node_section_ordering_file',
+    dest='node_section_ordering_info',
     default='',
     help='Pass a section ordering file to the linker. This requires that ' +
          'Node.js be linked using the gold linker. The gold linker must have ' +
@@ -1779,6 +1779,7 @@ def configure_section_file(o):
     proc = subprocess.Popen(['ld.gold'] + ['-v'], stdin = subprocess.PIPE,
                             stdout = subprocess.PIPE, stderr = subprocess.PIPE)
   except OSError:
+    warn('''No acceptable ld.gold linker found!''')
     return 0
 
   match = re.match(r"^GNU gold.*([0-9]+)\.([0-9]+)$",
@@ -1791,12 +1792,11 @@ def configure_section_file(o):
       error('''GNU gold version must be greater than 1.2 in order to use section
             reordering''')
 
-  if options.node_section_ordering_file != "":
-    o['variables']['node_section_ordering_file'] = os.path.realpath(
-      str(options.node_section_ordering_file))
+  if options.node_section_ordering_info != "":
+    o['variables']['node_section_ordering_info'] = os.path.realpath(
+      str(options.node_section_ordering_info))
   else:
-    # An empty string here will cause gyp to fail.
-    o['variables']['node_section_ordering_file'] = "-"
+    o['variables']['node_section_ordering_info'] = ""
 
 def make_bin_override():
   if sys.platform == 'win32':

--- a/configure.py
+++ b/configure.py
@@ -502,6 +502,14 @@ parser.add_option('--use-largepages-script-lld',
     dest='node_use_large_pages_script_lld',
     help='This option has no effect. --use-largepages is now a runtime option.')
 
+parser.add_option('--use-section-ordering-file',
+    action='store',
+    dest='node_section_ordering_file',
+    default='',
+    help='Pass a section ordering file to the linker. This requires that ' +
+         'Node.js be linked using the gold linker. The gold linker must have ' +
+         'version 1.2 or greater.')
+
 intl_optgroup.add_option('--with-intl',
     action='store',
     dest='with_intl',
@@ -1766,6 +1774,29 @@ def configure_inspector(o):
                        options.without_ssl)
   o['variables']['v8_enable_inspector'] = 0 if disable_inspector else 1
 
+def configure_section_file(o):
+  try:
+    proc = subprocess.Popen(['ld.gold'] + ['-v'], stdin = subprocess.PIPE,
+                            stdout = subprocess.PIPE, stderr = subprocess.PIPE)
+  except OSError:
+    return 0
+
+  match = re.match(r"^GNU gold.*([0-9]+)\.([0-9]+)$",
+                   proc.communicate()[0].decode("utf-8"))
+
+  if match:
+    gold_major_version = match.group(1)
+    gold_minor_version = match.group(2)
+    if int(gold_major_version) == 1 and int(gold_minor_version) <= 1:
+      error('''GNU gold version must be greater than 1.2 in order to use section
+            reordering''')
+
+  if options.node_section_ordering_file != "":
+    o['variables']['node_section_ordering_file'] = os.path.realpath(
+      str(options.node_section_ordering_file))
+  else:
+    # An empty string here will cause gyp to fail.
+    o['variables']['node_section_ordering_file'] = "-"
 
 def make_bin_override():
   if sys.platform == 'win32':
@@ -1831,6 +1862,7 @@ configure_openssl(output)
 configure_intl(output)
 configure_static(output)
 configure_inspector(output)
+configure_section_file(output)
 
 # Forward OSS-Fuzz settings
 output['variables']['ossfuzz'] = b(options.ossfuzz)


### PR DESCRIPTION
Adds support for using a section ordering file with the gold linker.
This makes it possible to reorder functions in a build to optimize for
a specific workload.

`hfsort` is a tool that can be used to generate such a file from perf-
recorded LBR data by running Node.js as `node --perf-basic-prof`.

Refs: https://github.com/facebook/hhvm/tree/9966d482c19c6120c621c6f3896525fb19fb3842/hphp/tools/hfsort
Refs: https://software.intel.com/content/www/us/en/develop/articles/runtime-optimization-blueprint-IA-optimization-with-last-branch-record.html
Refs: https://github.com/nodejs/node/pull/16891/
Signed-off-by: @gabrielschulhof

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
