### PR TITLE
http: allow passing array of key/val into writeHead

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1819,7 +1819,7 @@ argument.
 `headers` may be an `Array` where the keys and values are in the same list.
 It is *not* a list of tuples. So, the even-numbered offsets are key values,
 and the odd-numbered offsets are the associated values. The array is in the same
-as as format `request.rawHeaders`.
+format as `request.rawHeaders`.
 
 Returns a reference to the `ServerResponse`, so that calls can be chained.
 

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1791,6 +1791,9 @@ the request body should be sent. See the [`'checkContinue'`][] event on
 <!-- YAML
 added: v0.1.30
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/35274
+    description: Allow passing headers as an array.
   - version:
      - v11.10.0
      - v10.17.0

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1805,13 +1805,17 @@ changes:
 
 * `statusCode` {number}
 * `statusMessage` {string}
-* `headers` {Object}
+* `headers` {Object|Array}
 * Returns: {http.ServerResponse}
 
 Sends a response header to the request. The status code is a 3-digit HTTP
 status code, like `404`. The last argument, `headers`, are the response headers.
 Optionally one can give a human-readable `statusMessage` as the second
 argument.
+
+`headers` may be an `Array` where the keys and values are in the same list.
+It is *not* a list of tuples. So, the even-numbered offsets are key values,
+and the odd-numbered offsets are the associated values.
 
 Returns a reference to the `ServerResponse`, so that calls can be chained.
 

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1818,7 +1818,8 @@ argument.
 
 `headers` may be an `Array` where the keys and values are in the same list.
 It is *not* a list of tuples. So, the even-numbered offsets are key values,
-and the odd-numbered offsets are the associated values.
+and the odd-numbered offsets are the associated values. The array is in the same
+as as format `request.rawHeaders`.
 
 Returns a reference to the `ServerResponse`, so that calls can be chained.
 

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -381,8 +381,14 @@ function _storeHeader(firstLine, headers) {
         processHeader(this, state, entry[0], entry[1], false);
       }
     } else if (ArrayIsArray(headers)) {
-      for (const entry of headers) {
-        processHeader(this, state, entry[0], entry[1], true);
+      if (headers.length && ArrayIsArray(headers[0])) {
+        for (const entry of headers) {
+          processHeader(this, state, entry[0], entry[1], true);
+        }
+      } else {
+        for (let n = 0; n < headers.length; n += 2) {
+          processHeader(this, state, headers[n + 0], headers[n + 1], true);
+        }
       }
     } else {
       for (const key in headers) {

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -53,6 +53,7 @@ const {
     ERR_HTTP_TRAILER_INVALID,
     ERR_INVALID_HTTP_TOKEN,
     ERR_INVALID_ARG_TYPE,
+    ERR_INVALID_ARG_VALUE,
     ERR_INVALID_CHAR,
     ERR_METHOD_NOT_IMPLEMENTED,
     ERR_STREAM_CANNOT_PIPE,
@@ -386,6 +387,10 @@ function _storeHeader(firstLine, headers) {
           processHeader(this, state, entry[0], entry[1], true);
         }
       } else {
+        if (headers.length % 2 !== 0) {
+          throw new ERR_INVALID_ARG_VALUE('headers', headers);
+        }
+
         for (let n = 0; n < headers.length; n += 2) {
           processHeader(this, state, headers[n + 0], headers[n + 1], true);
         }

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -276,15 +276,15 @@ function writeHead(statusCode, reason, obj) {
   }
   this.statusCode = statusCode;
 
-  if (ArrayIsArray(obj) && obj.length % 2 !== 0) {
-    throw new ERR_INVALID_ARG_VALUE('headers', obj);
-  }
-
   let headers;
   if (this[kOutHeaders]) {
     // Slow-case: when progressive API and header fields are passed.
     let k;
     if (ArrayIsArray(obj)) {
+      if (obj.length % 2 !== 0) {
+        throw new ERR_INVALID_ARG_VALUE('headers', obj);
+      }
+
       for (let n = 0; n < obj.length; n += 2) {
         k = obj[n + 0];
         if (k) this.setHeader(k, obj[n + 1]);

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -22,6 +22,7 @@
 'use strict';
 
 const {
+  ArrayIsArray,
   Error,
   ObjectKeys,
   ObjectSetPrototypeOf,
@@ -278,7 +279,12 @@ function writeHead(statusCode, reason, obj) {
   if (this[kOutHeaders]) {
     // Slow-case: when progressive API and header fields are passed.
     let k;
-    if (obj) {
+    if (ArrayIsArray(obj)) {
+      for (let n = 0; n < obj.length; n += 2) {
+        k = obj[n + 0];
+        if (k) this.setHeader(k, obj[n + 1]);
+      }
+    } else if (obj) {
       const keys = ObjectKeys(obj);
       // Retain for(;;) loop for performance reasons
       // Refs: https://github.com/nodejs/node/pull/30958

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -68,6 +68,7 @@ const {
   ERR_HTTP_INVALID_STATUS_CODE,
   ERR_HTTP_SOCKET_ENCODING,
   ERR_INVALID_ARG_TYPE,
+  ERR_INVALID_ARG_VALUE,
   ERR_INVALID_CHAR
 } = codes;
 const {
@@ -274,6 +275,10 @@ function writeHead(statusCode, reason, obj) {
     obj = reason;
   }
   this.statusCode = statusCode;
+
+  if (ArrayIsArray(obj) && obj.length % 2 !== 0) {
+    throw new ERR_INVALID_ARG_VALUE('headers', obj);
+  }
 
   let headers;
   if (this[kOutHeaders]) {

--- a/test/parallel/test-http-write-head-2.js
+++ b/test/parallel/test-http-write-head-2.js
@@ -16,9 +16,9 @@ const http = require('http');
     http.get({ port: server.address().port }, common.mustCall((res) => {
       assert.strictEqual(res.headers.test, '2');
       assert.strictEqual(res.headers.test2, '2');
-      res.resume().on('end', () => {
+      res.resume().on('end', common.mustCall(() => {
         server.close();
-      });
+      }));
     }));
   }));
 }
@@ -33,9 +33,29 @@ const http = require('http');
     http.get({ port: server.address().port }, common.mustCall((res) => {
       assert.strictEqual(res.headers.test, '1');
       assert.strictEqual(res.headers.test2, '2');
-      res.resume().on('end', () => {
+      res.resume().on('end', common.mustCall(() => {
         server.close();
-      });
+      }));
+    }));
+  }));
+}
+
+
+{
+  const server = http.createServer(common.mustCall((req, res) => {
+    try {
+      res.writeHead(200, [ 'test', '1', 'test2', '2', 'asd' ]);
+    } catch (err) {
+      assert.strictEqual(err.code, 'ERR_INVALID_ARG_VALUE');
+    }
+    res.end();
+  }));
+
+  server.listen(0, common.mustCall(function() {
+    http.get({ port: server.address().port }, common.mustCall((res) => {
+      res.resume().on('end', common.mustCall(() => {
+        server.close();
+      }));
     }));
   }));
 }

--- a/test/parallel/test-http-write-head-2.js
+++ b/test/parallel/test-http-write-head-2.js
@@ -1,0 +1,41 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+// Verify that ServerResponse.writeHead() works with arrays.
+
+{
+  const server = http.createServer(common.mustCall((req, res) => {
+    res.setHeader('test', '1');
+    res.writeHead(200, [ 'test', '2', 'test2', '2' ]);
+    res.end();
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    http.get({ port: server.address().port }, common.mustCall((res) => {
+      assert.strictEqual(res.headers.test, '2');
+      assert.strictEqual(res.headers.test2, '2');
+      res.resume().on('end', () => {
+        server.close();
+      });
+    }));
+  }));
+}
+
+{
+  const server = http.createServer(common.mustCall((req, res) => {
+    res.writeHead(200, [ 'test', '1', 'test2', '2' ]);
+    res.end();
+  }));
+
+  server.listen(0, common.mustCall(function() {
+    http.get({ port: server.address().port }, common.mustCall((res) => {
+      assert.strictEqual(res.headers.test, '1');
+      assert.strictEqual(res.headers.test2, '2');
+      res.resume().on('end', () => {
+        server.close();
+      });
+    }));
+  }));
+}


### PR DESCRIPTION
Enables an optimization when the user already has the headers
in an array form, e.g. when proxying.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
