### PR TITLE
module: fix crash on multiline named cjs imports

### DIFF
--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -108,16 +108,23 @@ class ModuleJob {
               await this.loader.resolve(childSpecifier, parentFileUrl);
         const format = await this.loader.getFormat(childFileURL);
         if (format === 'commonjs') {
-          const importStatement = splitStack[1];
-          const namedImports = StringPrototypeMatch(importStatement, /{.*}/)[0];
-          const destructuringAssignment = StringPrototypeReplace(namedImports, /\s+as\s+/g, ': ');
           e.message = `The requested module '${childSpecifier}' is expected ` +
             'to be of type CommonJS, which does not support named exports. ' +
             'CommonJS modules can be imported by importing the default ' +
-            'export.\n' +
-            'For example:\n' +
-            `import pkg from '${childSpecifier}';\n` +
-            `const ${destructuringAssignment} = pkg;`;
+            'export.';
+          // TODO(@ctavan): The original error stack only provides the single
+          // line which causes the error. For multi-line import statements we
+          // cannot generate an equivalent object descructuring assignment by
+          // just parsing the error stack.
+          const importStatement = splitStack[1];
+          const oneLineNamedImports = StringPrototypeMatch(importStatement, /{.*}/);
+          if (oneLineNamedImports) {
+            const destructuringAssignment =
+              StringPrototypeReplace(oneLineNamedImports[0], /\s+as\s+/g, ': ');
+            e.message += '\nFor example:\n' +
+              `import pkg from '${childSpecifier}';\n` +
+              `const ${destructuringAssignment} = pkg;`;
+          }
           const newStack = StringPrototypeSplit(e.stack, '\n');
           newStack[3] = `SyntaxError: ${e.message}`;
           e.stack = ArrayPrototypeJoin(newStack, '\n');

--- a/test/es-module/test-esm-cjs-named-error.mjs
+++ b/test/es-module/test-esm-cjs-named-error.mjs
@@ -10,6 +10,10 @@ const expectedRelative = 'The requested module \'./fail.cjs\' is expected to ' +
   'import pkg from \'./fail.cjs\';\n' +
   'const { comeOn } = pkg;';
 
+const expectedWithoutExample = 'The requested module \'./fail.cjs\' is ' +
+  'expected to be of type CommonJS, which does not support named exports. ' +
+  'CommonJS modules can be imported by importing the default export.';
+
 const expectedRenamed = 'The requested module \'./fail.cjs\' is expected to ' +
   'be of type CommonJS, which does not support named exports. CommonJS ' +
   'modules can be imported by importing the default export.\n' +
@@ -51,6 +55,13 @@ rejects(async () => {
   name: 'SyntaxError',
   message: expectedRenamed
 }, 'should correctly format named imports with renames');
+
+rejects(async () => {
+  await import(`${fixtureBase}/multi-line.mjs`);
+}, {
+  name: 'SyntaxError',
+  message: expectedWithoutExample,
+}, 'should correctly format named imports across multiple lines');
 
 rejects(async () => {
   await import(`${fixtureBase}/json-hack.mjs`);

--- a/test/fixtures/es-modules/package-cjs-named-error/fail.cjs
+++ b/test/fixtures/es-modules/package-cjs-named-error/fail.cjs
@@ -1,3 +1,4 @@
 module.exports = {
-  comeOn: 'fhqwhgads'
+  comeOn: 'fhqwhgads',
+  rightNow: 'abcde',
 };

--- a/test/fixtures/es-modules/package-cjs-named-error/fail.cjs
+++ b/test/fixtures/es-modules/package-cjs-named-error/fail.cjs
@@ -1,4 +1,4 @@
 module.exports = {
   comeOn: 'fhqwhgads',
-  rightNow: 'abcde',
+  everybody: 'to the limit',
 };

--- a/test/fixtures/es-modules/package-cjs-named-error/multi-line.mjs
+++ b/test/fixtures/es-modules/package-cjs-named-error/multi-line.mjs
@@ -1,0 +1,4 @@
+import {
+  comeOn,
+  rightNow,
+} from './fail.cjs';

--- a/test/fixtures/es-modules/package-cjs-named-error/multi-line.mjs
+++ b/test/fixtures/es-modules/package-cjs-named-error/multi-line.mjs
@@ -1,4 +1,4 @@
 import {
   comeOn,
-  rightNow,
+  everybody,
 } from './fail.cjs';


### PR DESCRIPTION
The node process crashes when trying to parse a multiline import
statement for named exports of a CommonJS module:

    TypeError: Cannot read property '0' of null
          at ModuleJob._instantiate (internal/modules/esm/module_job.js:112:77)
          at async ModuleJob.run (internal/modules/esm/module_job.js:137:5)
          at async Loader.import (internal/modules/esm/loader.js:165:24)
          at async rejects.name (file:///***/node/test/es-module/test-esm-cjs-named-error.mjs:56:3)
          at async waitForActual (assert.js:721:5)
          at async rejects (assert.js:830:25),

The reason is that the regexp that is currently used to decorate the
original error fails for multi line import statements.

Unfortunately the undecorated error stack only contains the single line
which causes the import to fail:

    file:///***/node/test/fixtures/es-modules/package-cjs-named-error/multi-line.mjs:2
      comeOn,
      ^^^^^^
    SyntaxError: The requested module './fail.cjs' does not provide an export named 'comeOn'
        at ModuleJob._instantiate (internal/modules/esm/module_job.js:98:21)
        at async ModuleJob.run (internal/modules/esm/module_job.js:141:5)
        at async Loader.import (internal/modules/esm/loader.js:165:24)
        at async rejects.name (file:///***/node/test/es-module/test-esm-cjs-named-error.mjs:56:3)
        at async waitForActual (assert.js:721:5)
        at async rejects (assert.js:830:25)

Hence, for multiline import statements we cannot create an equivalent
piece of code that uses default import followed by an object
destructuring assignment.

In any case the node process should definitely not crash. So until we
have a more sophisticated way of extracting the entire problematic
multiline import statement, show the code example only for single-line
imports where the current regexp approach works well.

Refs: https://github.com/nodejs/node/issues/35259

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
