### PR TITLE
build: skip Actions tests for doc-only changes

### DIFF
--- a/.github/workflows/build-tarball.yml
+++ b/.github/workflows/build-tarball.yml
@@ -1,12 +1,17 @@
 name: Build from tarball
 
 on:
-  pull_request:
   push:
     branches:
       - master
+      - canary
       - v[0-9]+.x-staging
       - v[0-9]+.x
+    paths-ignore:
+      - 'doc/**'
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
 
 env:
   FLAKY_TESTS: dontcare

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,13 +1,17 @@
 name: build-windows
 
 on:
-  pull_request:
   push:
     branches:
       - master
       - canary
       - v[0-9]+.x-staging
       - v[0-9]+.x
+    paths-ignore:
+      - 'doc/**'
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
 
 env:
   PYTHON_VERSION: 3.8

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -1,13 +1,17 @@
 name: test-linux
 
 on:
-  pull_request:
   push:
     branches:
       - master
       - canary
       - v[0-9]+.x-staging
       - v[0-9]+.x
+    paths-ignore:
+      - 'doc/**'
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
 
 env:
   PYTHON_VERSION: 3.8

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -1,13 +1,17 @@
 name: test-macOS
 
 on:
-  pull_request:
   push:
     branches:
       - master
       - canary
       - v[0-9]+.x-staging
       - v[0-9]+.x
+    paths-ignore:
+      - 'doc/**'
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
 
 env:
   PYTHON_VERSION: 3.8


### PR DESCRIPTION
No need to run tests for doc-only changes. This doesn't cover all
doc-only changes yet, but covers enough to help reduce our Actions run
noise.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
