### PR TITLE
doc: outline when origin is set to unhandledRejection

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -237,7 +237,8 @@ changes:
 * `origin` {string} Indicates if the exception originates from an unhandled
   rejection or from an synchronous error. Can either be `'uncaughtException'` or
   `'unhandledRejection'`. The latter is only used in conjunction with the
-  [`--unhandled-rejections`][] flag set to `strict` and an unhandled rejection.
+  [`--unhandled-rejections`][] flag set to `strict` or `throw` and
+  an unhandled rejection.
 
 The `'uncaughtException'` event is emitted when an uncaught JavaScript
 exception bubbles all the way back to the event loop. By default, Node.js
@@ -308,7 +309,9 @@ added:
 * `err` {Error} The uncaught exception.
 * `origin` {string} Indicates if the exception originates from an unhandled
   rejection or from synchronous errors. Can either be `'uncaughtException'` or
-  `'unhandledRejection'`.
+  `'unhandledRejection'`. The latter is only used in conjunction with the
+  [`--unhandled-rejections`][] flag set to `strict` or `throw` and
+  an unhandled rejection.
 
 The `'uncaughtExceptionMonitor'` event is emitted before an
 `'uncaughtException'` event is emitted or a hook installed via


### PR DESCRIPTION
##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Add a line about `unhandledRejection` in the doc for `uncaughtExceptionMonitor` to make it clear that `uncaughtExceptionMonitor` will only called for an unhandled promise rejection **if** `--unhandled-rejections` flag is set to "strict".  
This addition is a copy and paste from the doc about uncaughtException, as both have the same behaviour on the matter.
This MR was initiated because of the issue https://github.com/nodejs/node/issues/35291