### PR TITLE
doc: put landing specifics in details tag

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -6,7 +6,7 @@
 
 <!-- source_link=lib/child_process.js -->
 
-The `child_process` module provides the ability to spawn child processes in
+The `child_process` module provides the ability to spawn subprocesses in
 a manner that is similar, but not identical, to popen(3). This capability
 is primarily provided by the [`child_process.spawn()`][] function:
 
@@ -28,24 +28,23 @@ ls.on('close', (code) => {
 ```
 
 By default, pipes for `stdin`, `stdout`, and `stderr` are established between
-the parent Node.js process and the spawned child. These pipes have
-limited (and platform-specific) capacity. If the child process writes to
-stdout in excess of that limit without the output being captured, the child
-process will block waiting for the pipe buffer to accept more data. This is
+the parent Node.js process and the spawned subprocess. These pipes have
+limited (and platform-specific) capacity. If the subprocess writes to
+stdout in excess of that limit without the output being captured, the
+subprocess blocks waiting for the pipe buffer to accept more data. This is
 identical to the behavior of pipes in the shell. Use the `{ stdio: 'ignore' }`
 option if the output will not be consumed.
 
-The command lookup will be performed using `options.env.PATH` environment
-variable if passed in `options` object, otherwise `process.env.PATH` will be
-used. To account for the fact that Windows environment variables are
-case-insensitive Node.js will lexicographically sort all `env` keys and choose
-the first one case-insensitively matching `PATH` to perform command lookup.
-This may lead to issues on Windows when passing objects to `env` option that
-have multiple variants of `PATH` variable.
+The command lookup is performed using the `options.env.PATH` environment
+variable if it is in the `options` object. Otherwise, `process.env.PATH` is
+used.
 
-On Windows Node.js will sanitize the `env` by removing case-insensitive
-duplicates. Only first (in lexicographic order) entry will be passed to the
-child process.
+On Windows, environment variables are case-insensitive. Node.js
+lexicographically sorts the `env` keys and uses the first one that
+case-insensitively matches. Only first (in lexicographic order) entry will be
+passed to the subprocess. This may lead to issues on Windows when passing
+objects to `env` option that have multiple variants of the same key, such as
+`PATH` and `Path`.
 
 The [`child_process.spawn()`][] method spawns the child process asynchronously,
 without blocking the Node.js event loop. The [`child_process.spawnSync()`][]

--- a/doc/guides/collaborator-guide.md
+++ b/doc/guides/collaborator-guide.md
@@ -469,6 +469,12 @@ code. If you wish to create the token yourself in advance, see
 
 ### Technical HOWTO
 
+Infrequently, it is necessary to manually perform the steps required to land a
+pull request rather than rely on `git-node`.
+
+<details>
+<summary>Manual landing steps</summary>
+
 Clear any `am`/`rebase` that might already be underway:
 
 ```text
@@ -625,6 +631,8 @@ Close the pull request with a "Landed in `<commit hash>`" comment. Even if
 your pull request shows the purple merged status,
 add the "Landed in \<commit hash>..\<commit hash>" comment if you added
 more than one commit.
+
+</details>
 
 ### Troubleshooting
 


### PR DESCRIPTION
Showing all the steps isn't usually useful and in makes it seem like the
collaborator is meant to follow the manual steps. I've seen this happen
during at least one onboarding. The section is also a bit long to
comfortably scroll over quickly to find the next section.

Let's put those steps in a details block to make it more obvious that it
is there for unusual situations only.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
