### PR TITLE
src: allow N-API addon in `AddLinkedBinding()`

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -677,6 +677,10 @@ void AddLinkedBinding(Environment* env, const node_module& mod) {
     prev_head->nm_link = &env->extra_linked_bindings()->back();
 }
 
+void AddLinkedBinding(Environment* env, const napi_module& mod) {
+  AddLinkedBinding(env, napi_module_to_node_module(&mod));
+}
+
 void AddLinkedBinding(Environment* env,
                       const char* name,
                       addon_context_register_func fn,

--- a/src/node.h
+++ b/src/node.h
@@ -117,6 +117,8 @@
 // Forward-declare libuv loop
 struct uv_loop_s;
 
+struct napi_module;
+
 // Forward-declare these functions now to stop MSVS from becoming
 // terminally confused when it's done in node_internals.h
 namespace node {
@@ -819,6 +821,8 @@ extern "C" NODE_EXTERN void node_module_register(void* mod);
 // In each variant, the registration function needs to be usable at least for
 // the time during which the Environment exists.
 NODE_EXTERN void AddLinkedBinding(Environment* env, const node_module& mod);
+NODE_EXTERN void AddLinkedBinding(Environment* env,
+                                  const struct napi_module& mod);
 NODE_EXTERN void AddLinkedBinding(Environment* env,
                                   const char* name,
                                   addon_context_register_func fn,

--- a/src/node_api.h
+++ b/src/node_api.h
@@ -31,7 +31,7 @@ struct uv_loop_s;  // Forward declaration.
 typedef napi_value (*napi_addon_register_func)(napi_env env,
                                                napi_value exports);
 
-typedef struct {
+typedef struct napi_module {
   int nm_version;
   unsigned int nm_flags;
   const char* nm_filename;

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -398,6 +398,8 @@ namespace fs {
 std::string Basename(const std::string& str, const std::string& extension);
 }  // namespace fs
 
+node_module napi_module_to_node_module(const napi_module* mod);
+
 }  // namespace node
 
 #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS

--- a/test/cctest/test_linked_binding.cc
+++ b/test/cctest/test_linked_binding.cc
@@ -1,5 +1,5 @@
 #include "node_test_fixture.h"
-#include "node_internals.h"  // RunBootstrapping()
+#include "node_api.h"
 
 void InitializeBinding(v8::Local<v8::Object> exports,
                        v8::Local<v8::Value> module,
@@ -82,4 +82,111 @@ TEST_F(LinkedBindingTest, LocallyDefinedLinkedBindingTest) {
   CHECK_NOT_NULL(*utf8val);
   CHECK_EQ(strcmp(*utf8val, "value"), 0);
   CHECK_EQ(calls, 1);
+}
+
+napi_value InitializeLocalNapiBinding(napi_env env, napi_value exports) {
+  napi_value key, value;
+  CHECK_EQ(
+      napi_create_string_utf8(env, "hello", NAPI_AUTO_LENGTH, &key), napi_ok);
+  CHECK_EQ(
+      napi_create_string_utf8(env, "world", NAPI_AUTO_LENGTH, &value), napi_ok);
+  CHECK_EQ(napi_set_property(env, exports, key, value), napi_ok);
+  return nullptr;
+}
+
+static napi_module local_linked_napi = {
+  NAPI_MODULE_VERSION,
+  node::ModuleFlags::kLinked,
+  nullptr,
+  InitializeLocalNapiBinding,
+  "local_linked_napi",
+  nullptr,
+  {0},
+};
+
+TEST_F(LinkedBindingTest, LocallyDefinedLinkedBindingNapiTest) {
+  const v8::HandleScope handle_scope(isolate_);
+  const Argv argv;
+  Env test_env {handle_scope, argv};
+
+  AddLinkedBinding(*test_env, local_linked_napi);
+
+  v8::Local<v8::Context> context = isolate_->GetCurrentContext();
+
+  const char* run_script =
+      "process._linkedBinding('local_linked_napi').hello";
+  v8::Local<v8::Script> script = v8::Script::Compile(
+      context,
+      v8::String::NewFromOneByte(isolate_,
+                                 reinterpret_cast<const uint8_t*>(run_script))
+                                 .ToLocalChecked())
+      .ToLocalChecked();
+  v8::Local<v8::Value> completion_value = script->Run(context).ToLocalChecked();
+  v8::String::Utf8Value utf8val(isolate_, completion_value);
+  CHECK_NOT_NULL(*utf8val);
+  CHECK_EQ(strcmp(*utf8val, "world"), 0);
+}
+
+napi_value NapiLinkedWithInstanceData(napi_env env, napi_value exports) {
+  int* instance_data = new int(0);
+  CHECK_EQ(
+      napi_set_instance_data(
+          env,
+          instance_data,
+          [](napi_env env, void* data, void* hint) {
+            ++*static_cast<int*>(data);
+          }, nullptr),
+      napi_ok);
+
+  napi_value key, value;
+  CHECK_EQ(
+      napi_create_string_utf8(env, "hello", NAPI_AUTO_LENGTH, &key), napi_ok);
+  CHECK_EQ(
+      napi_create_external(env, instance_data, nullptr, nullptr, &value),
+      napi_ok);
+  CHECK_EQ(napi_set_property(env, exports, key, value), napi_ok);
+  return nullptr;
+}
+
+static napi_module local_linked_napi_id = {
+  NAPI_MODULE_VERSION,
+  node::ModuleFlags::kLinked,
+  nullptr,
+  NapiLinkedWithInstanceData,
+  "local_linked_napi_id",
+  nullptr,
+  {0},
+};
+
+TEST_F(LinkedBindingTest, LocallyDefinedLinkedBindingNapiInstanceDataTest) {
+  const v8::HandleScope handle_scope(isolate_);
+  int* instance_data = nullptr;
+
+  {
+    const Argv argv;
+    Env test_env {handle_scope, argv};
+
+    AddLinkedBinding(*test_env, local_linked_napi_id);
+
+    v8::Local<v8::Context> context = isolate_->GetCurrentContext();
+
+    const char* run_script =
+        "process._linkedBinding('local_linked_napi_id').hello";
+    v8::Local<v8::Script> script = v8::Script::Compile(
+        context,
+        v8::String::NewFromOneByte(isolate_,
+                                   reinterpret_cast<const uint8_t*>(run_script))
+                                   .ToLocalChecked())
+        .ToLocalChecked();
+    v8::Local<v8::Value> completion_value =
+        script->Run(context).ToLocalChecked();
+    CHECK(completion_value->IsExternal());
+    instance_data = static_cast<int*>(
+        completion_value.As<v8::External>()->Value());
+    CHECK_NE(instance_data, nullptr);
+    CHECK_EQ(*instance_data, 0);
+  }
+
+  CHECK_EQ(*instance_data, 1);
+  delete instance_data;
 }


### PR DESCRIPTION
`AddLinkedBinding()` can be used to load old-style Node.js addons, but
currently not N-API addons. There’s no good reason not to support
N-API addons as well, so add that.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
