### PR TITLE
Refine "require" / "import" conditions constraints

### DIFF
--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -364,12 +364,15 @@ For example, a package that wants to provide different ES module exports for
 Node.js supports the following conditions out of the box:
 
 * `"import"` - matched when the package is loaded via `import` or
-   `import()`. Can reference either an ES module or CommonJS file, as both
-   `import` and `import()` can load either ES module or CommonJS sources.
-   _Always matched when the `"require"` condition is not matched._
-* `"require"` - matched when the package is loaded via `require()`.
-   As `require()` only supports CommonJS, the referenced file must be CommonJS.
-   _Always matched when the `"import"` condition is not matched._
+   `import()`, or via any top-level import or resolve operation by the
+   ECMAScript module loader. Applies regardless of the module format of the
+   target file. _Always mutually exclusive with `"require"`._
+* `"require"` - matched when the package is loaded via `require()`. The
+   referenced file should be loadable with `require()` although the condition
+   will be matched regardless of the module format of the target file. Expected
+   formats include CommonJS, JSON, and native addons but not ES modules as
+   `require()` doesn't support them. _Always mutually exclusive with
+   `"import"`._
 * `"node"` - matched for any Node.js environment. Can be a CommonJS or ES
    module file. _This condition should always come after `"import"` or
    `"require"`._


### PR DESCRIPTION
This PR follows up from the discussion in https://github.com/nodejs/modules/issues/556 in relaxing the constraint that `"require"` and `"import"` should be exhaustive and permitting other tools to decide to match neither of these conditions effectively.

The important property of mutual exclusivity remains though.

I also took the opportunity to clarify that `"import"` applies for any top-level resolve or load operation in the ES module loader and that `"require"` is able to resolve non-CommonJS formats, to try and make the fundamental definitions of these conditions clearer for tools etc.

It's a fine line between clarify and understandability here, another reason to work towards separating "guide" information from "api" information into two halves of this section ideally over time.

Feedback welcome.

//cc @nodejs/modules-active-members @lukastaegert @sokra.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
