### PR TITLE
tools: ignore build folder when checking links

### DIFF
--- a/tools/doc/checkLinks.js
+++ b/tools/doc/checkLinks.js
@@ -27,6 +27,7 @@ function findMarkdownFilesRecursively(dirPath) {
     if (
       entry.isDirectory() &&
       entry.name !== 'api' &&
+      entry.name !== 'build' &&
       entry.name !== 'changelogs' &&
       entry.name !== 'deps' &&
       entry.name !== 'fixtures' &&


### PR DESCRIPTION
We checkout build as a subdirectory as part of CI and
if you run `make test` instead of `make test-ci` you get
loads of errors about markdown link breaks. Ignore this
directory as we don't need to examine another repo


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
