### PR TITLE
doc: added version 7 to N-API version matrix

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -256,12 +256,14 @@ listed as supporting a later version.
     <th scope="col">4</th>
     <th scope="col">5</th>
     <th scope="col">6</th>
+    <th scope="col">7</th>
   </tr>
   <tr>
     <th scope="row">v6.x</th>
     <td></td>
     <td></td>
     <td>v6.14.2*</td>
+    <td></td>
     <td></td>
     <td></td>
     <td></td>
@@ -274,12 +276,14 @@ listed as supporting a later version.
     <td>v8.16.0</td>
     <td></td>
     <td></td>
+    <td></td>
   </tr>
   <tr>
     <th scope="row">v9.x</th>
     <td>v9.0.0*</td>
     <td>v9.3.0*</td>
     <td>v9.11.0*</td>
+    <td></td>
     <td></td>
     <td></td>
     <td></td>
@@ -292,6 +296,7 @@ listed as supporting a later version.
     <td>v10.16.0</td>
     <td>v10.17.0</td>
     <td>v10.20.0</td>
+    <td></td>
   </tr>
   <tr>
     <th scope="row">v11.x</th>
@@ -299,6 +304,7 @@ listed as supporting a later version.
     <td>v11.0.0</td>
     <td>v11.0.0</td>
     <td>v11.8.0</td>
+    <td></td>
     <td></td>
     <td></td>
   </tr>
@@ -310,6 +316,7 @@ listed as supporting a later version.
     <td>v12.0.0</td>
     <td>v12.11.0</td>
     <td>v12.17.0</td>
+    <td></td>
   </tr>
   <tr>
     <th scope="row">v13.x</th>
@@ -318,6 +325,7 @@ listed as supporting a later version.
     <td>v13.0.0</td>
     <td>v13.0.0</td>
     <td>v13.0.0</td>
+    <td></td>
     <td></td>
   </tr>
   <tr>
@@ -328,6 +336,7 @@ listed as supporting a later version.
     <td>v14.0.0</td>
     <td>v14.0.0</td>
     <td>v14.0.0</td>
+    <td>v14.12.0</td>
   </tr>
 </table>
 


### PR DESCRIPTION
Node.js version 14.12.0 released the N-API version 7, but it's not present on the N-API version matrix.
This change  should fix the problem in the documentation.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
