### PR TITLE
Revert "src: runtime deprecate process.umask()"

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2527,10 +2527,10 @@ purpose and is only available on CommonJS environment.
 changes:
   - version: v14.0.0
     pr-url: https://github.com/nodejs/node/pull/32499
-    description: Runtime deprecation.
+    description: Documentation-only deprecation.
 -->
 
-Type: Runtime
+Type: Documentation-only
 
 Calling `process.umask()` with no argument causes the process-wide umask to be
 written twice. This introduces a race condition between threads, and is a

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -808,14 +808,6 @@ void Environment::set_filehandle_close_warning(bool on) {
   emit_filehandle_warning_ = on;
 }
 
-bool Environment::emit_insecure_umask_warning() const {
-  return emit_insecure_umask_warning_;
-}
-
-void Environment::set_emit_insecure_umask_warning(bool on) {
-  emit_insecure_umask_warning_ = on;
-}
-
 void Environment::set_source_maps_enabled(bool on) {
   source_maps_enabled_ = on;
 }

--- a/src/env.h
+++ b/src/env.h
@@ -1160,8 +1160,6 @@ class Environment : public MemoryRetainer {
 
   inline bool filehandle_close_warning() const;
   inline void set_filehandle_close_warning(bool on);
-  inline bool emit_insecure_umask_warning() const;
-  inline void set_emit_insecure_umask_warning(bool on);
 
   inline void set_source_maps_enabled(bool on);
   inline bool source_maps_enabled() const;
@@ -1386,7 +1384,6 @@ class Environment : public MemoryRetainer {
   bool emit_env_nonstring_warning_ = true;
   bool emit_err_name_warning_ = true;
   bool emit_filehandle_warning_ = true;
-  bool emit_insecure_umask_warning_ = true;
   bool source_maps_enabled_ = false;
 
   size_t async_callback_scope_depth_ = 0;

--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -206,17 +206,6 @@ static void Umask(const FunctionCallbackInfo<Value>& args) {
 
   uint32_t old;
   if (args[0]->IsUndefined()) {
-    if (env->emit_insecure_umask_warning()) {
-      env->set_emit_insecure_umask_warning(false);
-      if (ProcessEmitDeprecationWarning(
-              env,
-              "Calling process.umask() with no arguments is prone to race "
-              "conditions and is a potential security vulnerability.",
-              "DEP0139").IsNothing()) {
-        return;
-      }
-    }
-
     old = umask(0);
     umask(static_cast<mode_t>(old));
   } else {

--- a/test/parallel/test-process-umask.js
+++ b/test/parallel/test-process-umask.js
@@ -40,13 +40,6 @@ if (common.isWindows) {
   mask = '0664';
 }
 
-common.expectWarning(
-  'DeprecationWarning',
-  'Calling process.umask() with no arguments is prone to race conditions ' +
-  'and is a potential security vulnerability.',
-  'DEP0139'
-);
-
 const old = process.umask(mask);
 
 assert.strictEqual(process.umask(old), parseInt(mask, 8));


### PR DESCRIPTION
This reverts commit 60c4c2b6c557efbb2f8f3a3de147baf987931d41.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

---

Only the documentation deprecation was released in v14.x. We pushed the runtime deprecation to v15.x, but it looks like it will cause too much ecosystem disruption.

Refs: https://github.com/nodejs/node/pull/35014#issuecomment-692382677

Opening this PR to start the discussion on reverting the runtime deprecation.