### PR TITLE
[v10.x] n-api: create N-API version 7

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -2951,9 +2951,8 @@ of the ECMAScript Language Specification.
 ### napi_detach_arraybuffer
 <!-- YAML
 added: v10.22.0
+napiVersion: 7
 -->
-
-> Stability: 1 - Experimental
 
 ```C
 napi_status napi_detach_arraybuffer(napi_env env,
@@ -2977,9 +2976,8 @@ defined in [Section 24.1.1.3][] of the ECMAScript Language Specification.
 ### napi_is_detached_arraybuffer
 <!-- YAML
 added: v10.22.0
+napiVersion: 7
 -->
-
-> Stability: 1 - Experimental
 
 ```C
 napi_status napi_is_detached_arraybuffer(napi_env env,

--- a/src/node_api.h
+++ b/src/node_api.h
@@ -10,7 +10,7 @@
 #define NAPI_VERSION 2147483647
 #else
 // The baseline version for N-API
-#define NAPI_VERSION 6
+#define NAPI_VERSION 7
 #endif
 #endif
 
@@ -747,7 +747,7 @@ napi_get_all_property_names(napi_env env,
 
 #endif  // NAPI_VERSION >= 6
 
-#ifdef NAPI_EXPERIMENTAL
+#if NAPI_VERSION >= 7
 // ArrayBuffer detaching
 NAPI_EXTERN napi_status
 napi_detach_arraybuffer(napi_env env,
@@ -757,7 +757,7 @@ NAPI_EXTERN napi_status
 napi_is_detached_arraybuffer(napi_env env,
                              napi_value value,
                              bool* result);
-#endif  // NAPI_EXPERIMENTAL
+#endif  // NAPI_VERSION >= 7
 
 EXTERN_C_END
 

--- a/src/node_version.h
+++ b/src/node_version.h
@@ -115,6 +115,6 @@
 
 // The NAPI_VERSION provided by this version of the runtime. This is the version
 // which the Node binary being built supports.
-#define NAPI_VERSION  6
+#define NAPI_VERSION  7
 
 #endif  // SRC_NODE_VERSION_H_

--- a/test/addons-napi/test_general/test.js
+++ b/test/addons-napi/test_general/test.js
@@ -34,7 +34,7 @@ assert.notStrictEqual(test_general.testGetPrototype(baseObject),
 
 // test version management functions
 // expected version is currently 4
-assert.strictEqual(test_general.testGetVersion(), 6);
+assert.strictEqual(test_general.testGetVersion(), 7);
 
 const [ major, minor, patch, release ] = test_general.testGetNodeVersion();
 assert.strictEqual(process.version.split('-')[0],

--- a/test/addons-napi/test_typedarray/test_typedarray.c
+++ b/test/addons-napi/test_typedarray/test_typedarray.c
@@ -1,4 +1,3 @@
-#define NAPI_EXPERIMENTAL
 #include <node_api.h>
 #include <string.h>
 #include "../common.h"


### PR DESCRIPTION
Mark `napi_detach_arraybuffer` and `napi_is_detached_arraybuffer` as
stable.

Signed-off-by: @gabrielschulhof
PR-URL: https://github.com/nodejs/node/pull/35199
Reviewed-By: @cjihrig
Reviewed-By: @gengjiawen
Reviewed-By: @legendecas
Reviewed-By: @mhdawson

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
