### PR TITLE
[v10.x] src: allows escaping NODE_OPTIONS with backslashes

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -642,6 +642,13 @@ if they had been specified on the command line before the actual command line
 (so they can be overridden). Node.js will exit with an error if an option
 that is not allowed in the environment is used, such as `-p` or a script file.
 
+In case an option value happens to contain a space (for example a path listed in
+`--require`), it must be escaped using double quotes. For example:
+
+```bash
+--require "./my path/file.js"
+```
+
 Node.js options that are allowed are:
 - `--enable-fips`
 - `--experimental-modules`

--- a/src/node.cc
+++ b/src/node.cc
@@ -2611,7 +2611,7 @@ void Init(std::vector<std::string>* argv,
 #if !defined(NODE_WITHOUT_NODE_OPTIONS)
   std::string node_options;
 
-  if (credentials::SafeGetenv("NODE_OPTIONS", &node_options)) {
+  if (SafeGetenv("NODE_OPTIONS", &node_options)) {
     std::vector<std::string> env_argv;
     // [0] is expected to be the program name, fill it in from the real argv.
     env_argv.push_back(argv->at(0));
@@ -2626,9 +2626,9 @@ void Init(std::vector<std::string>* argv,
       // Backslashes escape the following character
       if (c == '\\' && is_in_string) {
         if (index + 1 == node_options.size()) {
-          errors->push_back("invalid value for NODE_OPTIONS "
-                            "(invalid escape)\n");
-          return 9;
+          fprintf(stderr, "invalid value for NODE_OPTIONS "
+                          "(invalid escape)\n");
+          exit(9);
         } else {
           c = node_options.at(++index);
         }
@@ -2649,9 +2649,9 @@ void Init(std::vector<std::string>* argv,
     }
 
     if (is_in_string) {
-      errors->push_back("invalid value for NODE_OPTIONS "
-                        "(unterminated string)\n");
-      return 9;
+      fprintf(stderr, "invalid value for NODE_OPTIONS "
+                      "(unterminated string)\n");
+      exit(9);
     }
 
 

--- a/test/fixtures/print A.js
+++ b/test/fixtures/print A.js
@@ -1,0 +1,1 @@
+console.log('A')

--- a/test/parallel/test-cli-node-options.js
+++ b/test/parallel/test-cli-node-options.js
@@ -15,7 +15,12 @@ tmpdir.refresh();
 process.chdir(tmpdir.path);
 
 const printA = require.resolve('../fixtures/printA.js');
+const printSpaceA = require.resolve('../fixtures/print A.js');
+
+expect(` -r ${printA} `, 'A\nB\n');
 expect(`-r ${printA}`, 'A\nB\n');
+expect(`-r ${JSON.stringify(printA)}`, 'A\nB\n');
+expect(`-r ${JSON.stringify(printSpaceA)}`, 'A\nB\n');
 expect(`-r ${printA} -r ${printA}`, 'A\nB\n');
 expect('--no-deprecation', 'B\n');
 expect('--no-warnings', 'B\n');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

The characters specified within NODE_OPTIONS can now be escaped, which
is handy especially in conjunction with `--require` (where the file path
might happen to contain spaces that shouldn't cause the option to be
split into two).

This PR adds v10.x-compatible commits in addition to backport of #24065.

Fixes: nodejs#12971
Refs: https://github.com/microsoft/vscode-js-debug/issues/769
PR-URL: nodejs#24065
Reviewed-By: @addaleax 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
