### PR TITLE
doc: Revert refine conditions constraints PR

### DIFF
--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -364,15 +364,12 @@ For example, a package that wants to provide different ES module exports for
 Node.js supports the following conditions out of the box:
 
 * `"import"` - matched when the package is loaded via `import` or
-   `import()`, or via any top-level import or resolve operation by the
-   ECMAScript module loader. Applies regardless of the module format of the
-   target file. _Always mutually exclusive with `"require"`._
-* `"require"` - matched when the package is loaded via `require()`. The
-   referenced file should be loadable with `require()` although the condition
-   will be matched regardless of the module format of the target file. Expected
-   formats include CommonJS, JSON, and native addons but not ES modules as
-   `require()` doesn't support them. _Always mutually exclusive with
-   `"import"`._
+   `import()`. Can reference either an ES module or CommonJS file, as both
+   `import` and `import()` can load either ES module or CommonJS sources.
+   _Always matched when the `"require"` condition is not matched._
+* `"require"` - matched when the package is loaded via `require()`.
+   As `require()` only supports CommonJS, the referenced file must be CommonJS.
+   _Always matched when the `"import"` condition is not matched._
 * `"node"` - matched for any Node.js environment. Can be a CommonJS or ES
    module file. _This condition should always come after `"import"` or
    `"require"`._


### PR DESCRIPTION
This reverts the PR https://github.com/nodejs/node/pull/35311 which landed before the 7 day limit required for PRs with one approval.

This was a misinterpretation from my side of the previous relaxation of the waiting period, which I thought had also been applied to these cases.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
