### PR TITLE
doc: unhide resolver spec

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -871,8 +871,7 @@ The resolver can throw the following errors:
 * _Package Import Not Defined_: Package imports do not define the specifier.
 * _Module Not Found_: The package or module requested does not exist.
 
-<details>
-<summary>Resolver algorithm specification</summary>
+### Resolver Algorithm Specification
 
 **ESM_RESOLVE**(_specifier_, _parentURL_)
 
@@ -1125,8 +1124,6 @@ _internal_, _conditions_)
 > 1. If the file at _packageURL_ does not parse as valid JSON, then
 >    1. Throw an _Invalid Package Configuration_ error.
 > 1. Return the parsed JSON source of the file at _pjsonURL_.
-
-</details>
 
 ### Customizing ESM specifier resolution algorithm
 


### PR DESCRIPTION
It comes up quite a bit that people ask me how to implement the Node.js resolver and they weren't necessarily aware there is a detailed specification available.

If we unhide the specification text I think this will make it clearer to more people that there is a very carefully well-defined resolution algorithm that tooling can follow.

We've moved content out of the esm.md page so that it seems like it adds less bloat too at this point.

I'm open to suggestions re moving this somewhere else, and don't feel too strongly that this should land either if anyone has any concerns about this approach as well.

//cc @nodejs/modules-active-members 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
