### PR TITLE
n-api: support for object freeze/seal

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -4227,6 +4227,53 @@ this API will set the properties on the object one at a time, as defined by
 `DefineOwnProperty()` (described in [Section 9.1.6][] of the ECMA-262
 specification).
 
+#### napi_object_freeze
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+```c
+napi_status napi_object_freeze(napi_env env,
+                               napi_value object);
+```
+
+* `[in] env`: The environment that the N-API call is invoked under.
+* `[in] object`: The object to freeze.
+
+Returns `napi_ok` if the API succeeded.
+
+This method freezes a given object. This prevents new properties from
+being added to it, existing properties from being removed, prevents
+changing the enumerability, configurability, or writability of existing
+properties, and prevents the values of existing properties from being changed.
+It also prevents the object's prototype from being changed. This is described
+in [Section 19.1.2.6](https://tc39.es/ecma262/#sec-object.freeze) of the
+ECMA-262 specification.
+
+#### napi_object_seal
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+```c
+napi_status napi_object_seal(napi_env env,
+                             napi_value object);
+```
+
+* `[in] env`: The environment that the N-API call is invoked under.
+* `[in] object`: The object to seal.
+
+Returns `napi_ok` if the API succeeded.
+
+This method seals a given object. This prevents new properties from being
+added to it, as well as marking all existing properties as non-configurable.
+This is described in [Section 19.1.2.20](https://tc39.es/ecma262/#sec-object.seal)
+of the ECMA-262 specification.
+
 ## Working with JavaScript functions
 
 N-API provides a set of APIs that allow JavaScript code to

--- a/src/js_native_api.h
+++ b/src/js_native_api.h
@@ -550,6 +550,10 @@ napi_check_object_type_tag(napi_env env,
                            napi_value value,
                            const napi_type_tag* type_tag,
                            bool* result);
+NAPI_EXTERN napi_status napi_object_freeze(napi_env env,
+                                           napi_value object);
+NAPI_EXTERN napi_status napi_object_seal(napi_env env,
+                                         napi_value object);
 #endif  // NAPI_EXPERIMENTAL
 
 EXTERN_C_END

--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -1362,6 +1362,42 @@ napi_status napi_define_properties(napi_env env,
   return GET_RETURN_STATUS(env);
 }
 
+napi_status napi_object_freeze(napi_env env,
+                               napi_value object) {
+  NAPI_PREAMBLE(env);
+
+  v8::Local<v8::Context> context = env->context();
+  v8::Local<v8::Object> obj;
+
+  CHECK_TO_OBJECT(env, context, obj, object);
+
+  v8::Maybe<bool> set_frozen =
+    obj->SetIntegrityLevel(context, v8::IntegrityLevel::kFrozen);
+
+  RETURN_STATUS_IF_FALSE_WITH_PREAMBLE(env,
+    set_frozen.FromMaybe(false), napi_generic_failure);
+
+  return GET_RETURN_STATUS(env);
+}
+
+napi_status napi_object_seal(napi_env env,
+                             napi_value object) {
+  NAPI_PREAMBLE(env);
+
+  v8::Local<v8::Context> context = env->context();
+  v8::Local<v8::Object> obj;
+
+  CHECK_TO_OBJECT(env, context, obj, object);
+
+  v8::Maybe<bool> set_sealed =
+    obj->SetIntegrityLevel(context, v8::IntegrityLevel::kSealed);
+
+  RETURN_STATUS_IF_FALSE_WITH_PREAMBLE(env,
+    set_sealed.FromMaybe(false), napi_generic_failure);
+
+  return GET_RETURN_STATUS(env);
+}
+
 napi_status napi_is_array(napi_env env, napi_value value, bool* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, value);

--- a/test/js-native-api/test_object/test.js
+++ b/test/js-native-api/test_object/test.js
@@ -284,15 +284,16 @@ assert.deepStrictEqual(test_object.TestGetProperty(), {
   assert.strictEqual(Object.isSealed(obj), true);
 
   assert.throws(() => {
-    obj['w'] = 'd'
+    obj.w = 'd';
   }, /Cannot add property w, object is not extensible/);
 
   assert.throws(() => {
-    delete obj['x']
+    delete obj.x;
   }, /Cannot delete property 'x' of #<Object>/);
 
-  // Sealed objects allow updating existing properties.
-  assert.doesNotThrow(() => { obj['x'] = 'd' });
+  // Sealed objects allow updating existing properties,
+  // so this should not throw.
+  obj.x = 'd';
 }
 
 {
@@ -303,14 +304,14 @@ assert.deepStrictEqual(test_object.TestGetProperty(), {
   assert.strictEqual(Object.isFrozen(obj), true);
 
   assert.throws(() => {
-    obj['x'] = 10
+    obj.x = 10;
   }, /Cannot assign to read only property 'x' of object '#<Object>/);
 
   assert.throws(() => {
-    obj['w'] = 15
+    obj.w = 15;
   }, /Cannot add property w, object is not extensible/);
 
   assert.throws(() => {
-    delete obj['x']
+    delete obj.x;
   }, /Cannot delete property 'x' of #<Object>/);
 }

--- a/test/js-native-api/test_object/test.js
+++ b/test/js-native-api/test_object/test.js
@@ -275,3 +275,42 @@ assert.deepStrictEqual(test_object.TestGetProperty(), {
   keyIsNull: 'Invalid argument',
   resultIsNull: 'Invalid argument'
 });
+
+{
+  const obj = { x: 'a', y: 'b', z: 'c' };
+
+  test_object.TestSeal(obj);
+
+  assert.strictEqual(Object.isSealed(obj), true);
+
+  assert.throws(() => {
+    obj['w'] = 'd'
+  }, /Cannot add property w, object is not extensible/);
+
+  assert.throws(() => {
+    delete obj['x']
+  }, /Cannot delete property 'x' of #<Object>/);
+
+  // Sealed objects allow updating existing properties.
+  assert.doesNotThrow(() => { obj['x'] = 'd' });
+}
+
+{
+  const obj = { x: 10, y: 10, z: 10 };
+
+  test_object.TestFreeze(obj);
+
+  assert.strictEqual(Object.isFrozen(obj), true);
+
+  assert.throws(() => {
+    obj['x'] = 10
+  }, /Cannot assign to read only property 'x' of object '#<Object>/);
+
+  assert.throws(() => {
+    obj['w'] = 15
+  }, /Cannot add property w, object is not extensible/);
+
+  assert.throws(() => {
+    delete obj['x']
+  }, /Cannot delete property 'x' of #<Object>/);
+}

--- a/test/js-native-api/test_object/test_object.c
+++ b/test/js-native-api/test_object/test_object.c
@@ -472,6 +472,30 @@ static napi_value TestGetProperty(napi_env env,
   return object;
 }
 
+static napi_value TestFreeze(napi_env env,
+                             napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args[1];
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+
+  napi_value object = args[0];
+  NAPI_CALL(env, napi_object_freeze(env, object));
+
+  return object;
+}
+
+static napi_value TestSeal(napi_env env,
+                           napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args[1];
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+
+  napi_value object = args[0];
+  NAPI_CALL(env, napi_object_seal(env, object));
+
+  return object;
+}
+
 // We create two type tags. They are basically 128-bit UUIDs.
 static const napi_type_tag type_tags[2] = {
   { 0xdaf987b3cc62481a, 0xb745b0497f299531 },
@@ -532,6 +556,8 @@ napi_value Init(napi_env env, napi_value exports) {
     DECLARE_NAPI_PROPERTY("TypeTaggedInstance", TypeTaggedInstance),
     DECLARE_NAPI_PROPERTY("CheckTypeTag", CheckTypeTag),
     DECLARE_NAPI_PROPERTY("TestGetProperty", TestGetProperty),
+    DECLARE_NAPI_PROPERTY("TestFreeze", TestFreeze),
+    DECLARE_NAPI_PROPERTY("TestSeal", TestSeal),
   };
 
   init_test_null(env, exports);


### PR DESCRIPTION
This is PR adds support for `Object.freeze()` & `Object.seal()` to n-api. 

cc @gabrielschulhof (not sure who else is best to ping here!) 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
