### PR TITLE
child_process: add ChildProcess 'spawn' event

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -1033,6 +1033,21 @@ child process, the `message` argument can contain data that JSON is not able
 to represent.
 See [Advanced serialization][] for more details.
 
+### Event: `'spawn'`
+<!-- YAML
+added: REPLACEME
+-->
+
+The `'spawn'` event is emitted once the child process has spawned successfully.
+
+If emitted, the `'spawn'` event comes before all other events and before any
+data is received via `stdout` or `stderr`.
+
+The `'spawn'` event will fire regardless of whether an error occurs **within**
+the spawned process. For example, if `bash some-command` spawns successfully,
+the `'spawn'` event will fire, though `bash` may fail to spawn `some-command`.
+This caveat also applies when using `{ shell: true }`.
+
 ### `subprocess.channel`
 <!-- YAML
 added: v7.1.0

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -400,6 +400,8 @@ ChildProcess.prototype.spawn = function(options) {
     this._handle.close();
     this._handle = null;
     throw errnoException(err, 'spawn');
+  } else {
+    process.nextTick(onSpawnNT, this);
   }
 
   this.pid = this._handle.pid;
@@ -462,6 +464,11 @@ ChildProcess.prototype.spawn = function(options) {
 
 function onErrorNT(self, err) {
   self._handle.onexit(err);
+}
+
+
+function onSpawnNT(self) {
+  self.emit('spawn');
 }
 
 

--- a/test/parallel/test-child-process-spawn-error.js
+++ b/test/parallel/test-child-process-spawn-error.js
@@ -41,6 +41,8 @@ assert.strictEqual(enoentChild.stdio[0], enoentChild.stdin);
 assert.strictEqual(enoentChild.stdio[1], enoentChild.stdout);
 assert.strictEqual(enoentChild.stdio[2], enoentChild.stderr);
 
+enoentChild.on('spawn', common.mustNotCall());
+
 enoentChild.on('error', common.mustCall(function(err) {
   assert.strictEqual(err.code, 'ENOENT');
   assert.strictEqual(getSystemErrorName(err.errno), 'ENOENT');

--- a/test/parallel/test-child-process-spawn-event.js
+++ b/test/parallel/test-child-process-spawn-event.js
@@ -1,0 +1,27 @@
+'use strict';
+const common = require('../common');
+const spawn = require('child_process').spawn;
+const assert = require('assert');
+
+const subprocess = spawn('echo', ['ok']);
+
+let didSpawn = false;
+subprocess.on('spawn', function() {
+  didSpawn = true;
+});
+function mustCallAfterSpawn() {
+  return common.mustCall(function() {
+    assert.ok(didSpawn);
+  });
+}
+
+subprocess.on('error', common.mustNotCall());
+subprocess.on('spawn', common.mustCall());
+subprocess.stdout.on('data', mustCallAfterSpawn());
+subprocess.stdout.on('end', mustCallAfterSpawn());
+subprocess.stdout.on('close', mustCallAfterSpawn());
+subprocess.stderr.on('data', common.mustNotCall());
+subprocess.stderr.on('end', mustCallAfterSpawn());
+subprocess.stderr.on('close', mustCallAfterSpawn());
+subprocess.on('exit', mustCallAfterSpawn());
+subprocess.on('close', mustCallAfterSpawn());


### PR DESCRIPTION
The new event signals that the subprocess has spawned successfully and
no 'error' event will be emitted from failing to spawn.

Fixes: https://github.com/nodejs/node/issues/35288

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests ~~and/or benchmarks~~ are included
- [X] documentation is ~~changed or~~ added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Big thanks to @bnoordhuis for his guidance & the actual changes to `lib/`!
