### PR TITLE
doc: packages docs feedback

### DIFF
--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -4,7 +4,10 @@
 
 ## Introduction
 
-A package is a folder described by a `package.json` file.
+A package is a folder tree described by a `package.json` file. The package
+consists of the folder containing the `package.json` file and all subfolders
+until the next folder containing another `package.json` file, or a folder
+named `node_modules`.
 
 This section provides guidance for package authors writing `package.json` files
 along with a reference for the [`package.json`][] fields defined by Node.js.
@@ -44,7 +47,7 @@ future-proof the package in case the default type of Node.js ever changes, and
 it will also make things easier for build tools and loaders to determine how the
 files in the package should be interpreted.
 
-### Package boundaries and file extensions
+### `package.json` and file extensions
 
 A folder containing a `package.json` file, and all subfolders below that folder
 until the next folder containing another [`package.json`][], are a
@@ -52,23 +55,23 @@ _package boundary_. Package boundaries do not carry through `node_modules`
 folders, which are effectively treated as if they contained an empty
 `package.json`.
 
-Within a package boundary, the [`package.json`][] [`"type"`][] field defines how
+Within a package, the [`package.json`][] [`"type"`][] field defines how
 Node.js should interpret `.js` files. If a `package.json` file does not have a
 `"type"` field, `.js` files are treated as [CommonJS][].
 
 A `package.json` `"type"` value of `"module"` tells Node.js to interpret `.js`
-files within that package boundary as using [ES module][] syntax.
+files within that package as using [ES module][] syntax.
 
-The package boundary applies not only to initial entry points (`node my-app.js`)
+The `"type"` field applies not only to initial entry points (`node my-app.js`)
 but also to files referenced by `import` statements and `import()` expressions.
 
 ```js
-// my-app.js, in an ES module package boundary because there is a package.json
+// my-app.js, treated as an ES module because there is a package.json
 // file in the same folder with "type": "module".
 
 import './startup/init.js';
 // Loaded as ES module since ./startup contains no package.json file,
-// and therefore inherits the ES module package boundary from one level up.
+// and therefore inherits the "type" value from one level up.
 
 import 'commonjs-package';
 // Loaded as CommonJS since ./node_modules/commonjs-package/package.json
@@ -80,9 +83,10 @@ import './node_modules/commonjs-package/index.js';
 ```
 
 Files ending with `.mjs` are always loaded as [ES modules][] regardless of
-package boundary.
+the nearest parent `package.json`.
 
-Files ending with `.cjs` are always loaded as [CommonJS][] regardless of package
+Files ending with `.cjs` are always loaded as [CommonJS][] regardless of the
+nearest parent `package.json`.
 boundary.
 
 ```js
@@ -94,17 +98,17 @@ import 'commonjs-package/src/index.mjs';
 ```
 
 The `.mjs` and `.cjs` extensions may be used to mix types within the same
-package boundary:
+package:
 
-* Within a `"type": "module"` package boundary, Node.js can be instructed to
+* Within a `"type": "module"` package, Node.js can be instructed to
   interpret a particular file as [CommonJS][] by naming it with a `.cjs`
   extension (since both `.js` and `.mjs` files are treated as ES modules within
-  a `"module"` package boundary).
+  a `"module"` package).
 
-* Within a `"type": "commonjs"` package boundary, Node.js can be instructed to
+* Within a `"type": "commonjs"` package, Node.js can be instructed to
   interpret a particular file as an [ES module][] by naming it with an `.mjs`
   extension (since both `.js` and `.cjs` files are treated as CommonJS within a
-  `"commonjs"` package boundary).
+  `"commonjs"` package).
 
 ### `--input-type` flag
 

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -49,12 +49,6 @@ files in the package should be interpreted.
 
 ### `package.json` and file extensions
 
-A folder containing a `package.json` file, and all subfolders below that folder
-until the next folder containing another [`package.json`][], are a
-_package boundary_. Package boundaries do not carry through `node_modules`
-folders, which are effectively treated as if they contained an empty
-`package.json`.
-
 Within a package, the [`package.json`][] [`"type"`][] field defines how
 Node.js should interpret `.js` files. If a `package.json` file does not have a
 `"type"` field, `.js` files are treated as [CommonJS][].
@@ -87,7 +81,6 @@ the nearest parent `package.json`.
 
 Files ending with `.cjs` are always loaded as [CommonJS][] regardless of the
 nearest parent `package.json`.
-boundary.
 
 ```js
 import './legacy-file.cjs';
@@ -761,8 +754,7 @@ This section describes the fields used by the Node.js runtime. Other tools (such
 as [npm](https://docs.npmjs.com/creating-a-package-json-file)) may use
 additional fields which are ignored by Node.js and not documented here.
 
-The following fields in `package.json` files are relevant to the Node.js module
-loading system, and are described in detail below.
+The following fields in `package.json` files are used in Node.js:
 
 * [`"name"`][] - Relevant when using named imports within a package. Also used
   by package managers as the name of the package.
@@ -817,7 +809,7 @@ changes:
 * Type: {string}
 
 The `"type"` field defines the module format that Node.js will use for all
-`.js` files that have that `package.json` file as their [package boundary][].
+`.js` files that have that `package.json` file as their nearest parent.
 
 Files ending with `.js` will be loaded as ES modules when the nearest parent
 `package.json` file contains a top-level field `"type"` with a value of
@@ -979,7 +971,7 @@ analogous to the exports field.
 [`"type"`]: #packages_type
 [entry points]: #packages_package_entry_points
 [`package.json`]: #packages_node_js_package_json_field_definitions
-[package boundary]: #packages_package_boundaries_and_file_extensions
+[`package.json` and file extensions]: #packages_package_json_and_file_extensions
 [self-reference]: #packages_self_referencing_a_package_using_its_name
 [subpath exports]: #packages_subpath_exports
 [the full specifier path]: modules_esm.html#modules_esm_mandatory_file_extensions

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -16,7 +16,7 @@ initial input, or when referenced by `import` statements within ES module code:
 
 * Files ending in `.mjs`.
 
-* Files ending in `.js` when the package boundary `package.json` file contains a
+* Files ending in `.js` when the nearest parent `package.json` file contains a
   top-level [`"type"`][] field with a value of `"module"`.
 
 * Strings passed in as an argument to `--eval`, or piped to `node` via `STDIN`,
@@ -32,8 +32,8 @@ or when referenced by `import` statements within ES module code:
 
 * Files ending in `.cjs`.
 
-* Files ending in `.js` when the package boundary `package.json` file contains a
-  top-level [`"type"`][] field with a value of `"commonjs"`.
+* Files ending in `.js` when the nearest parent `package.json` file contains a
+  top-level field [`"type"`][] with a value of `"commonjs"`.
 
 * Strings passed in as an argument to `--eval` or `--print`, or piped to `node`
   via `STDIN`, with the flag `--input-type=commonjs`.
@@ -815,11 +815,11 @@ changes:
 The `"type"` field defines the module format that Node.js will use for all
 `.js` files that have that `package.json` file as their [package boundary][].
 
-Files ending with `.js` will be loaded as ES modules when the package boundary
+Files ending with `.js` will be loaded as ES modules when the nearest parent
 `package.json` file contains a top-level field `"type"` with a value of
 `"module"`.
 
-The package boundary `package.json` is defined as the first `package.json` found
+The nearest parent `package.json` is defined as the first `package.json` found
 when searching in the current folder, that folder’s parent, and so on up
 until a node_modules folder or the volume root is reached.
 
@@ -835,12 +835,12 @@ until a node_modules folder or the volume root is reached.
 node my-app.js # Runs as ES module
 ```
 
-If no `package.json` is found once the volume root is reached, or if the package
-boundary `package.json` lacks a `"type"` field, or contains
-`"type": "commonjs"`, `.js` files are treated as [CommonJS][].
+If no `package.json` is found once the volume root is reached, or if the nearest
+parent `package.json` lacks a `"type"` field, or contains `"type": "commonjs"`,
+`.js` files are treated as [CommonJS][].
 
-`import` statements of `.js` files are treated as ES modules if the package
-boundary `package.json` contains `"type": "module"`.
+`import` statements of `.js` files are treated as ES modules if the nearest
+parent `package.json` contains `"type": "module"`.
 
 ```js
 // my-app.js, part of the same example as above

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -212,8 +212,8 @@ To set the main entry point for a package, it is advisable to define both
 }
 ```
 
-When defining the the [`"exports"`][] field all subpaths of the package will
-be encapsulated and no longer available to importers. For example,
+When defining the [`"exports"`][] field all subpaths of the package will be
+encapsulated and no longer available to importers. For example,
 `require('pkg/subpath.js')` would throw a new "Package Path Not Exported" error.
 
 This encapsulation of exports provides more reliable guarantees
@@ -763,17 +763,17 @@ loading system, and are described in detail below.
   by package managers as the name of the package.
 * [`"type"`][] - The package type determining whether to load `.js` files as
   CommonJS or ES modules.
-* [`"main"`][] - The default module when loading the package, if exports is not
-  specified, and in versions of Node.js prior to the introduction of exports.
 * [`"exports"`][] - Package exports and conditional exports. When present,
   limits which submodules may be loaded from within the package.
+* [`"main"`][] - The default module when loading the package, if exports is not
+  specified, and in versions of Node.js prior to the introduction of exports.
 * [`"imports"`][] - Package imports, for use by modules within the package
   itself.
 
 ### `"name"`
 <!-- YAML
 added:
-  - v12.16.0p
+  - v12.16.0
   - v13.1.0
 changes:
   - version:
@@ -849,30 +849,6 @@ import './startup.js'; // Loaded as ES module because of package.json
 Regardless of the value of the `"type"` field, `.mjs` files are always treated
 as ES modules and `.cjs` files are always treated as CommonJS.
 
-### `"main"`
-<!-- YAML
-added: v0.4.0
--->
-
-* Type: {string}
-
-```json
-{
-  "main": "./main.js"
-}
-```
-
-The `"main"` field defines the script that is used when the [package directory
-is loaded via `require()`](modules.html#modules_folders_as_modules). Its value
-is interpreted as a path.
-
-```js
-require('./path/to/directory'); // This resolves to ./path/to/directory/main.js.
-```
-
-When a package has an [`"exports"`][] field, this will take precedence over the
-`"main"` field when importing the package by name.
-
 ### `"exports"`
 <!-- YAML
 added: v12.7.0
@@ -914,6 +890,30 @@ referenced via `require` or via `import`.
 
 All paths defined in the `"exports"` must be relative file URLs starting with
 `./`.
+
+### `"main"`
+<!-- YAML
+added: v0.4.0
+-->
+
+* Type: {string}
+
+```json
+{
+  "main": "./main.js"
+}
+```
+
+The `"main"` field defines the script that is used when the [package directory
+is loaded via `require()`](modules.html#modules_folders_as_modules). Its value
+is interpreted as a path.
+
+```js
+require('./path/to/directory'); // This resolves to ./path/to/directory/main.js.
+```
+
+When a package has an [`"exports"`][] field, this will take precedence over the
+`"main"` field when importing the package by name.
 
 ### `"imports"`
 <!-- YAML

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -212,9 +212,10 @@ To set the main entry point for a package, it is advisable to define both
 }
 ```
 
-When defining the [`"exports"`][] field all subpaths of the package will be
+When defining the [`"exports"`][] field, all subpaths of the package will be
 encapsulated and no longer available to importers. For example,
-`require('pkg/subpath.js')` would throw a new "Package Path Not Exported" error.
+`require('pkg/subpath.js')` would throw an [`ERR_PACKAGE_PATH_NOT_EXPORTED`][]
+error.
 
 This encapsulation of exports provides more reliable guarantees
 about package interfaces for tools and when handling semver upgrades for a
@@ -812,13 +813,13 @@ changes:
 * Type: {string}
 
 The `"type"` field defines the module format that Node.js will use for all
-`.js` files within a particular `package.json` file’s [package boundary][].
+`.js` files that have that `package.json` file as their [package boundary][].
 
-Files ending with `.js` will be loaded as ES modules when the nearest parent
+Files ending with `.js` will be loaded as ES modules when the package boundary
 `package.json` file contains a top-level field `"type"` with a value of
 `"module"`.
 
-The nearest parent `package.json` is defined as the first `package.json` found
+The package boundary `package.json` is defined as the first `package.json` found
 when searching in the current folder, that folder’s parent, and so on up
 until a node_modules folder or the volume root is reached.
 
@@ -834,9 +835,9 @@ until a node_modules folder or the volume root is reached.
 node my-app.js # Runs as ES module
 ```
 
-If no `package.json` is found once the volume root is reached, or if the nearest
-parent `package.json` lacks a `"type"` field, or contains `"type": "commonjs"`,
-`.js` files are treated as [CommonJS][].
+If no `package.json` is found once the volume root is reached, or if the package
+boundary `package.json` lacks a `"type"` field, or contains
+`"type": "commonjs"`, `.js` files are treated as [CommonJS][].
 
 `import` statements of `.js` files are treated as ES modules if the package
 boundary `package.json` contains `"type": "module"`.
@@ -962,6 +963,7 @@ analogous to the exports field.
 [Babel]: https://babeljs.io/
 [Conditional exports]: #packages_conditional_exports
 [CommonJS]: modules.html
+[`ERR_PACKAGE_PATH_NOT_EXPORTED`]: errors.html#errors_err_package_path_not_exported
 [ES modules]: esm.html
 [ES module]: esm.html
 [`esm`]: https://github.com/standard-things/esm#readme

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -9,7 +9,7 @@ consists of the folder containing the `package.json` file and all subfolders
 until the next folder containing another `package.json` file, or a folder
 named `node_modules`.
 
-This section provides guidance for package authors writing `package.json` files
+This page provides guidance for package authors writing `package.json` files
 along with a reference for the [`package.json`][] fields defined by Node.js.
 
 ## Determining module system

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -839,9 +839,10 @@ until a node_modules folder or the volume root is reached.
 node my-app.js # Runs as ES module
 ```
 
-If no `package.json` is found once the volume root is reached, or if the nearest
-parent `package.json` lacks a `"type"` field, or contains `"type": "commonjs"`,
-`.js` files are treated as [CommonJS][].
+If the nearest parent `package.json` lacks a `"type"` field, or contains
+`"type": "commonjs"`, `.js` files are treated as [CommonJS][]. If the volume
+root is reached and no `package.json` is found, `.js` files are treated as
+[CommonJS][].
 
 `import` statements of `.js` files are treated as ES modules if the nearest
 parent `package.json` contains `"type": "module"`.
@@ -958,7 +959,7 @@ where `import '#dep'` would now get the resolution of the external package
 `dep-node-native` (including its exports in turn), and instead get the local
 file `./dep-polyfill.js` relative to the package in other environments.
 
-Unlike the exports field, import maps permit mapping to external packages,
+Unlike the `"exports"` field, import maps permit mapping to external packages,
 providing an important use case for conditional loading scenarios.
 
 Apart from the above, the resolution rules for the imports field are otherwise

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -971,7 +971,6 @@ analogous to the exports field.
 [`"type"`]: #packages_type
 [entry points]: #packages_package_entry_points
 [`package.json`]: #packages_node_js_package_json_field_definitions
-[`package.json` and file extensions]: #packages_package_json_and_file_extensions
 [self-reference]: #packages_self_referencing_a_package_using_its_name
 [subpath exports]: #packages_subpath_exports
 [the full specifier path]: modules_esm.html#modules_esm_mandatory_file_extensions


### PR DESCRIPTION
This PR brings through the deferred feedback from https://github.com/nodejs/node/pull/34748 from myself and @isaacs.

I carefully ensured to mention all items brought up there in this PR including renaming "package scope" to "package boundary" and adding a summary section to the list of fields.

Further review suggestions very welcome. This should then unblock https://github.com/nodejs/node/pull/34970 and subsequent PRs from release.

@nodejs/modules-active-members @nodejs/documentation @aduh95 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
