### PR TITLE
doc: update example url of ICU

### DIFF
--- a/doc/guides/maintaining-icu.md
+++ b/doc/guides/maintaining-icu.md
@@ -83,7 +83,7 @@ V8 will not compile.
 
 ```c
 // deps/v8/src/objects/intl-objects.h
-#define V8_MINIMUM_ICU_VERSION 64
+#define V8_MINIMUM_ICU_VERSION 65
 ```
 
 V8 in Node.js depends on the ICU version supplied by Node.js.
@@ -104,7 +104,7 @@ should be sufficient).
 ```bash
 ./configure \
     --with-intl=full-icu \
-    --with-icu-source=http://download.icu-project.org/files/icu4c/58.1/icu4c-58_1-src.tgz
+    --with-icu-source=https://github.com/unicode-org/icu/releases/download/release-67-1/icu4c-67_1-src.tgz
 make
 ```
 


### PR DESCRIPTION
The host page of ICU package which is written as http://download.icu-project.org/files/icu4c/58.1/icu4c-58_1-src.tgz in the guide does not seem to available and they move to GitHub's release page for downloads. Refs http://site.icu-project.org/download/67#TOC-ICU4C-Download as an example. As a minor tweak, I also updated the version number of `V8_MINIMUM_ICU_VERSION` in the doc to sync with the actual code in `deps/v8/src/objects/intl-objects.h`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
