### PR TITLE
http2: fix destroy() to send and handle remote NGHTTP2_CANCEL

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -2182,9 +2182,10 @@ class Http2Stream extends Duplex {
     );
     const hasHandle = handle !== undefined;
 
-    if (!this.closed)
-      closeStream(this, code, hasHandle ? kForceRstStream : kNoRstStream);
-    this.push(null);
+    if (!this.closed) {
+      const rstStreamStatus = hasHandle ? kForceRstStream : kNoRstStream;
+      closeStream(this, code || NGHTTP2_CANCEL, rstStreamStatus);
+    }
 
     if (hasHandle) {
       handle.destroy();
@@ -2200,8 +2201,13 @@ class Http2Stream extends Duplex {
     // RST code 8 not emitted as an error as its used by clients to signify
     // abort and is already covered by aborted event, also allows more
     // seamless compatibility with http1
-    if (err == null && code !== NGHTTP2_NO_ERROR && code !== NGHTTP2_CANCEL)
+    if (err == null &&
+        code !== NGHTTP2_NO_ERROR &&
+        (code !== NGHTTP2_CANCEL || !this.aborted))
       err = new ERR_HTTP2_STREAM_ERROR(nameForErrorCode[code] || code);
+
+    if (!err)
+      this.push(null);
 
     this[kSession] = undefined;
     this[kHandle] = undefined;

--- a/test/parallel/test-http2-client-destroy.js
+++ b/test/parallel/test-http2-client-destroy.js
@@ -116,7 +116,7 @@ const Countdown = require('../common/countdown');
       client.destroy();
     });
 
-    client.request();
+    client.request().on('error', common.expectsError());
   }));
 }
 
@@ -161,7 +161,7 @@ const Countdown = require('../common/countdown');
 
     client.close();
     req.resume();
-    req.on('end', common.mustCall());
+    req.on('end', common.mustNotCall());
     req.on('close', common.mustCall(() => server.close()));
   }));
 }

--- a/test/parallel/test-http2-client-onconnect-errors.js
+++ b/test/parallel/test-http2-client-onconnect-errors.js
@@ -102,7 +102,7 @@ function runTest(test) {
     });
   }
 
-  req.on('end', common.mustCall());
+  req.on('end', common.mustNotCall());
   req.on('close', common.mustCall(() => {
     client.destroy();
 

--- a/test/parallel/test-http2-client-socket-destroy.js
+++ b/test/parallel/test-http2-client-socket-destroy.js
@@ -32,7 +32,12 @@ server.listen(0, common.mustCall(function() {
   }));
 
   req.resume();
-  req.on('end', common.mustCall());
+  req.on('error', common.expectsError({
+    code: 'ERR_HTTP2_STREAM_ERROR',
+    name: 'Error',
+    message: 'Stream closed with error code NGHTTP2_CANCEL'
+  }));
+  req.on('end', common.mustNotCall());
   req.on('close', common.mustCall(() => server.close()));
 
   // On the client, the close event must call

--- a/test/parallel/test-http2-compat-serverresponse-destroy.js
+++ b/test/parallel/test-http2-compat-serverresponse-destroy.js
@@ -44,10 +44,15 @@ server.listen(0, common.mustCall(() => {
   {
     const req = client.request();
     req.on('response', common.mustNotCall());
-    req.on('error', common.mustNotCall());
-    req.on('end', common.mustCall());
+    req.on('error', common.expectsError({
+      code: 'ERR_HTTP2_STREAM_ERROR',
+      name: 'Error',
+      message: 'Stream closed with error code NGHTTP2_CANCEL'
+    }));
     req.on('close', common.mustCall(() => countdown.dec()));
+
     req.resume();
+    req.on('end', common.mustNotCall());
   }
 
   {
@@ -62,7 +67,7 @@ server.listen(0, common.mustCall(() => {
     req.on('close', common.mustCall(() => countdown.dec()));
 
     req.resume();
-    req.on('end', common.mustCall());
+    req.on('end', common.mustNotCall());
   }
 
   {
@@ -77,6 +82,6 @@ server.listen(0, common.mustCall(() => {
     req.on('close', common.mustCall(() => countdown.dec()));
 
     req.resume();
-    req.on('end', common.mustCall());
+    req.on('end', common.mustNotCall());
   }
 }));

--- a/test/parallel/test-http2-compat-serverresponse-headers-after-destroy.js
+++ b/test/parallel/test-http2-compat-serverresponse-headers-after-destroy.js
@@ -38,7 +38,13 @@ server.listen(0, common.mustCall(function() {
       ':authority': `localhost:${port}`
     };
     const request = client.request(headers);
-    request.on('end', common.mustCall(function() {
+    request.on('error', common.expectsError({
+      code: 'ERR_HTTP2_STREAM_ERROR',
+      name: 'Error',
+      message: 'Stream closed with error code NGHTTP2_CANCEL'
+    }));
+    request.on('end', common.mustNotCall());
+    request.on('close', common.mustCall(function() {
       client.close();
     }));
     request.end();

--- a/test/parallel/test-http2-compat-socket-destroy-delayed.js
+++ b/test/parallel/test-http2-compat-socket-destroy-delayed.js
@@ -1,18 +1,13 @@
 'use strict';
 
 const common = require('../common');
-const { mustCall } = common;
+const { mustCall, mustNotCall } = common;
 
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const http2 = require('http2');
 const assert = require('assert');
-
-const {
-  HTTP2_HEADER_PATH,
-  HTTP2_HEADER_METHOD,
-} = http2.constants;
 
 // This tests verifies that calling `req.socket.destroy()` via
 // setImmediate does not crash.
@@ -25,18 +20,22 @@ const app = http2.createServer(mustCall((req, res) => {
 
 app.listen(0, mustCall(() => {
   const session = http2.connect(`http://localhost:${app.address().port}`);
-  const request = session.request({
-    [HTTP2_HEADER_PATH]: '/',
-    [HTTP2_HEADER_METHOD]: 'get'
-  });
+  const request = session.request();
   request.once('response', mustCall((headers, flags) => {
     let data = '';
     request.on('data', (chunk) => { data += chunk; });
-    request.on('end', mustCall(() => {
+    // This should error since the server fails to finish the stream
+    request.on('error', mustCall((err) => {
+      common.expectsError({
+        code: 'ERR_HTTP2_STREAM_ERROR',
+        name: 'Error',
+        message: 'Stream closed with error code NGHTTP2_CANCEL'
+      })(err);
       assert.strictEqual(data, 'hello');
       session.close();
       app.close();
     }));
+    request.on('end', mustNotCall());
   }));
   request.end();
 }));

--- a/test/parallel/test-http2-compat-socket-set.js
+++ b/test/parallel/test-http2-compat-socket-set.js
@@ -83,7 +83,7 @@ server.on('request', common.mustCall(function(request, response) {
       assert.strictEqual(request.stream._isProcessing, true);
     });
   }));
-  response.stream.destroy();
+  response.end();
 }));
 
 server.listen(0, common.mustCall(function() {

--- a/test/parallel/test-http2-compat-socket.js
+++ b/test/parallel/test-http2-compat-socket.js
@@ -49,7 +49,7 @@ server.on('request', common.mustCall(function(request, response) {
 
   request.on('end', common.mustCall(() => {
     assert.strictEqual(request.socket.readable, false);
-    response.socket.destroy();
+    response.end();
   }));
   response.on('finish', common.mustCall(() => {
     assert.ok(request.socket);
@@ -84,7 +84,9 @@ server.listen(0, common.mustCall(function() {
       ':authority': `localhost:${port}`
     };
     const request = client.request(headers);
-    request.on('end', common.mustCall(() => {
+    request.on('error', common.mustNotCall());
+    request.on('end', common.mustCall());
+    request.on('close', common.mustCall(() => {
       client.close();
     }));
     request.end();

--- a/test/parallel/test-http2-compat-write-head-destroyed.js
+++ b/test/parallel/test-http2-compat-write-head-destroyed.js
@@ -19,8 +19,10 @@ const server = http2.createServer(common.mustCall((req, res) => {
 server.listen(0, common.mustCall(() => {
   const client = http2.connect(`http://localhost:${server.address().port}`);
 
-  const req = client.request();
+  const req = client.request({}, { endStream: false });
   req.on('response', common.mustNotCall());
+  req.on('error', common.mustNotCall());
+  req.on('aborted', common.mustCall());
   req.on('close', common.mustCall((arg) => {
     client.close();
     server.close();

--- a/test/parallel/test-http2-large-write-destroy.js
+++ b/test/parallel/test-http2-large-write-destroy.js
@@ -32,8 +32,12 @@ server.listen(0, common.mustCall(() => {
 
   const req = client.request({ ':path': '/' });
   req.end();
-  req.resume(); // Otherwise close won't be emitted if there's pending data.
 
+  req.on('error', common.expectsError({
+    code: 'ERR_HTTP2_STREAM_ERROR',
+    name: 'Error',
+    message: 'Stream closed with error code NGHTTP2_CANCEL'
+  }));
   req.on('close', common.mustCall(() => {
     client.close();
     server.close();

--- a/test/parallel/test-http2-max-concurrent-streams.js
+++ b/test/parallel/test-http2-max-concurrent-streams.js
@@ -45,7 +45,7 @@ server.listen(0, common.mustCall(() => {
     req.on('aborted', common.mustCall());
     req.on('response', common.mustNotCall());
     req.resume();
-    req.on('end', common.mustCall());
+    req.on('end', common.mustNotCall());
     req.on('close', common.mustCall(() => countdown.dec()));
     req.on('error', common.expectsError({
       code: 'ERR_HTTP2_STREAM_ERROR',

--- a/test/parallel/test-http2-multi-content-length.js
+++ b/test/parallel/test-http2-multi-content-length.js
@@ -54,7 +54,7 @@ server.listen(0, common.mustCall(() => {
     // header to be set for non-payload bearing requests...
     const req = client.request({ 'content-length': 1 });
     req.resume();
-    req.on('end', common.mustCall());
+    req.on('end', common.mustNotCall());
     req.on('close', common.mustCall(() => countdown.dec()));
     req.on('error', common.expectsError({
       code: 'ERR_HTTP2_STREAM_ERROR',

--- a/test/parallel/test-http2-respond-errors.js
+++ b/test/parallel/test-http2-respond-errors.js
@@ -43,7 +43,13 @@ server.listen(0, common.mustCall(() => {
   const client = http2.connect(`http://localhost:${server.address().port}`);
   const req = client.request();
 
-  req.on('end', common.mustCall(() => {
+  req.on('error', common.expectsError({
+    code: 'ERR_HTTP2_STREAM_ERROR',
+    name: 'Error',
+    message: 'Stream closed with error code NGHTTP2_CANCEL'
+  }));
+  req.on('end', common.mustNotCall());
+  req.on('close', common.mustCall(() => {
     client.close();
     server.close();
   }));

--- a/test/parallel/test-http2-respond-file-errors.js
+++ b/test/parallel/test-http2-respond-file-errors.js
@@ -94,6 +94,12 @@ server.listen(0, common.mustCall(() => {
   const client = http2.connect(`http://localhost:${server.address().port}`);
   const req = client.request();
 
+  req.on('error', common.expectsError({
+    code: 'ERR_HTTP2_STREAM_ERROR',
+    name: 'Error',
+    message: 'Stream closed with error code NGHTTP2_CANCEL'
+  }));
+  req.on('end', common.mustNotCall());
   req.on('close', common.mustCall(() => {
     client.close();
     server.close();

--- a/test/parallel/test-http2-respond-file-fd-errors.js
+++ b/test/parallel/test-http2-respond-file-fd-errors.js
@@ -117,6 +117,12 @@ server.listen(0, common.mustCall(() => {
   const client = http2.connect(`http://localhost:${server.address().port}`);
   const req = client.request();
 
+  req.on('error', common.expectsError({
+    code: 'ERR_HTTP2_STREAM_ERROR',
+    name: 'Error',
+    message: 'Stream closed with error code NGHTTP2_CANCEL'
+  }));
+  req.on('end', common.mustNotCall());
   req.on('close', common.mustCall(() => {
     client.close();
     server.close();

--- a/test/parallel/test-http2-respond-file-fd-invalid.js
+++ b/test/parallel/test-http2-respond-file-fd-invalid.js
@@ -40,7 +40,8 @@ server.listen(0, () => {
   req.on('response', common.mustCall());
   req.on('error', errorCheck);
   req.on('data', common.mustNotCall());
-  req.on('end', common.mustCall(() => {
+  req.on('end', common.mustNotCall());
+  req.on('close', common.mustCall(() => {
     assert.strictEqual(req.rstCode, NGHTTP2_INTERNAL_ERROR);
     client.close();
     server.close();

--- a/test/parallel/test-http2-respond-nghttperrors.js
+++ b/test/parallel/test-http2-respond-nghttperrors.js
@@ -88,7 +88,8 @@ function runTest(test) {
   req.resume();
   req.end();
 
-  req.on('end', common.mustCall(() => {
+  req.on('end', common.mustNotCall());
+  req.on('close', common.mustCall(() => {
     client.close();
 
     if (!tests.length) {

--- a/test/parallel/test-http2-respond-with-fd-errors.js
+++ b/test/parallel/test-http2-respond-with-fd-errors.js
@@ -96,7 +96,8 @@ function runTest(test) {
   req.resume();
   req.end();
 
-  req.on('end', common.mustCall(() => {
+  req.on('end', common.mustNotCall());
+  req.on('close', common.mustCall(() => {
     client.close();
 
     if (!tests.length) {

--- a/test/parallel/test-http2-respond-with-file-connection-abort.js
+++ b/test/parallel/test-http2-respond-with-file-connection-abort.js
@@ -28,5 +28,11 @@ server.listen(0, common.mustCall(() => {
     net.Socket.prototype.destroy.call(client.socket);
     server.close();
   }));
+  req.on('error', common.expectsError({
+    code: 'ERR_HTTP2_STREAM_ERROR',
+    name: 'Error',
+    message: 'Stream closed with error code NGHTTP2_CANCEL'
+  }));
+  req.on('end', common.mustNotCall());
   req.end();
 }));

--- a/test/parallel/test-http2-server-shutdown-before-respond.js
+++ b/test/parallel/test-http2-server-shutdown-before-respond.js
@@ -32,5 +32,6 @@ server.on('listening', common.mustCall(() => {
   }));
   req.resume();
   req.on('data', common.mustNotCall());
-  req.on('end', common.mustCall(() => server.close()));
+  req.on('end', common.mustNotCall());
+  req.on('close', common.mustCall(() => server.close()));
 }));

--- a/test/parallel/test-http2-server-shutdown-options-errors.js
+++ b/test/parallel/test-http2-server-shutdown-options-errors.js
@@ -59,6 +59,12 @@ server.listen(
     const client = http2.connect(`http://localhost:${server.address().port}`);
     const req = client.request();
     req.resume();
+    req.on('error', common.expectsError({
+      code: 'ERR_HTTP2_STREAM_ERROR',
+      name: 'Error',
+      message: 'Stream closed with error code NGHTTP2_CANCEL'
+    }));
+    req.on('end', common.mustNotCall());
     req.on('close', common.mustCall(() => {
       client.close();
       server.close();

--- a/test/parallel/test-http2-server-stream-session-destroy.js
+++ b/test/parallel/test-http2-server-stream-session-destroy.js
@@ -48,6 +48,11 @@ server.listen(0, common.mustCall(() => {
   const client = h2.connect(`http://localhost:${server.address().port}`);
   const req = client.request();
   req.resume();
-  req.on('end', common.mustCall());
+  req.on('error', common.expectsError({
+    code: 'ERR_HTTP2_STREAM_ERROR',
+    name: 'Error',
+    message: 'Stream closed with error code NGHTTP2_CANCEL'
+  }));
+  req.on('end', common.mustNotCall());
   req.on('close', common.mustCall(() => server.close(common.mustCall())));
 }));

--- a/test/parallel/test-http2-zero-length-header.js
+++ b/test/parallel/test-http2-zero-length-header.js
@@ -17,10 +17,16 @@ server.on('stream', (stream, headers) => {
     '__proto__': null,
     [http2.sensitiveHeaders]: []
   });
-  stream.session.destroy();
+  stream.respond({ ':status': 200 });
+  stream.end();
   server.close();
 });
 server.listen(0, common.mustCall(() => {
   const client = http2.connect(`http://localhost:${server.address().port}/`);
-  client.request({ ':path': '/', '': 'foo', 'bar': '' }).end();
+  const req = client.request({ ':path': '/', '': 'foo', 'bar': '' });
+  req.on('error', common.mustNotCall());
+  req.on('end', common.mustCall());
+  req.on('close', common.mustCall(() => {
+    client.close();
+  }));
 }));

--- a/test/sequential/test-http2-max-session-memory.js
+++ b/test/sequential/test-http2-max-session-memory.js
@@ -38,7 +38,7 @@ server.listen(0, common.mustCall(() => {
       }));
       req.on('close', common.mustCall(() => {
         server.close();
-        client.destroy();
+        client.close();
       }));
     });
 


### PR DESCRIPTION
This patch fixes the HTTP2 stream close behaviour to be more inline with HTTP1.

Most importantly, it allows consumers to detect that the remote server/client has closed the stream prematurely with code 8 (NGHTTP2_CANCEL). Without this patch, the consumer just receives an `'end'` event, as if nothing bad happened!

Secondly, and also very important, it ensures that a `stream.destroy()` called on an active stream, will signal that the stream ended prematurely with code 8 (NGHTTP2_CANCEL), instead of code 0 (NGHTTP2_NO_ERROR).

This fixes #35302 and appears to fix #33537 as well. It also helps with #35209, since node will send the proper `RST_STREAM` code, and clients should not need to check for `'content-length'` to know something is wrong.

#### How it is done

Inside `Http2Stream._destroy()`:
1. Always call `closeStream()` with a non-zero code. This ensures that the `destroy()` is signalled when needed.
1. Emit an `'error'` if stream has been closed with code 8 by the remote, without an `'aborted'` event being triggered.
1. Avoid sending `'end'` event for streams that are going to error.

While the patch itself is somewhat simple, it requires a lot of updated test cases. At face value, it would appear that this is a bad patch, but I would like to argue that _all_ the modified tests are just inherently wrong. As such, this should not be seen as a breaking change, but a long coming bug fix.

Most of the modified tests are just about changing a wrongly expected `'end'` to an `'error'`. For some of the tests that didn't explicitly test `destroy()`, I changed it to end the stream more gracefully instead. Feel free to challenge me on any of the changes, as I have put a lot of thought into it, and believe they are all appropriate bug fixes.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
