### PR TITLE
esm: use "node:" internal namespace for builtins

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -925,7 +925,7 @@ The resolver can throw the following errors:
 > 1. If _selfUrl_ is not **undefined**, return _selfUrl_.
 > 1. If _packageSubpath_ is _"."_ and _packageName_ is a Node.js builtin
 >    module, then
->    1. Return the string _"nodejs:"_ concatenated with _packageSpecifier_.
+>    1. Return the string _"node:"_ concatenated with _packageSpecifier_.
 > 1. While _parentURL_ is not the file system root,
 >    1. Let _packageURL_ be the URL resolution of _"node_modules/"_
 >       concatenated with _packageSpecifier_, relative to _parentURL_.

--- a/lib/internal/modules/esm/get_format.js
+++ b/lib/internal/modules/esm/get_format.js
@@ -34,7 +34,7 @@ if (experimentalJsonModules)
   extensionFormatMap['.json'] = legacyExtensionFormatMap['.json'] = 'json';
 
 function defaultGetFormat(url, context, defaultGetFormatUnused) {
-  if (StringPrototypeStartsWith(url, 'nodejs:')) {
+  if (StringPrototypeStartsWith(url, 'node:')) {
     return { format: 'builtin' };
   }
   const parsed = new URL(url);

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -776,13 +776,13 @@ function defaultResolve(specifier, context = {}, defaultResolveUnused) {
       };
     }
   } catch {}
-  if (parsed && parsed.protocol === 'nodejs:')
+  if (parsed && parsed.protocol === 'node:')
     return { url: specifier };
   if (parsed && parsed.protocol !== 'file:' && parsed.protocol !== 'data:')
     throw new ERR_UNSUPPORTED_ESM_URL_SCHEME(parsed);
   if (NativeModule.canBeRequiredByUsers(specifier)) {
     return {
-      url: 'nodejs:' + specifier
+      url: 'node:' + specifier
     };
   }
   if (parentURL && StringPrototypeStartsWith(parentURL, 'data:')) {

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -9,6 +9,7 @@ const {
   PromiseReject,
   SafeMap,
   StringPrototypeReplace,
+  StringPrototypeSlice,
   StringPrototypeStartsWith,
 } = primordials;
 

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -147,9 +147,9 @@ translators.set('commonjs', function commonjsStrategy(url, isMain) {
 translators.set('builtin', async function builtinStrategy(url) {
   debug(`Translating BuiltinModule ${url}`);
   // Slice 'node:' scheme
-  const id = url.slice(5);
+  const id = StringPrototypeSlice(url, 5);
   const module = loadNativeModule(id, url, true);
-  if (!url.startsWith('node:') || !module) {
+  if (!StringPrototypeStartsWith(url, 'node:') || !module) {
     throw new ERR_UNKNOWN_BUILTIN_MODULE(url);
   }
   debug(`Loading BuiltinModule ${url}`);

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -146,10 +146,10 @@ translators.set('commonjs', function commonjsStrategy(url, isMain) {
 // through normal resolution
 translators.set('builtin', async function builtinStrategy(url) {
   debug(`Translating BuiltinModule ${url}`);
-  // Slice 'nodejs:' scheme
-  const id = url.slice(7);
+  // Slice 'node:' scheme
+  const id = url.slice(5);
   const module = loadNativeModule(id, url, true);
-  if (!url.startsWith('nodejs:') || !module) {
+  if (!url.startsWith('node:') || !module) {
     throw new ERR_UNKNOWN_BUILTIN_MODULE(id);
   }
   debug(`Loading BuiltinModule ${url}`);

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -150,7 +150,7 @@ translators.set('builtin', async function builtinStrategy(url) {
   const id = url.slice(5);
   const module = loadNativeModule(id, url, true);
   if (!url.startsWith('node:') || !module) {
-    throw new ERR_UNKNOWN_BUILTIN_MODULE(id);
+    throw new ERR_UNKNOWN_BUILTIN_MODULE(url);
   }
   debug(`Loading BuiltinModule ${url}`);
   return module.getESMFacade();

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -9,6 +9,7 @@ const {
   PromiseReject,
   SafeMap,
   StringPrototypeReplace,
+  StringPrototypeStartsWith,
 } = primordials;
 
 let _TYPES = null;

--- a/test/es-module/test-esm-dynamic-import.js
+++ b/test/es-module/test-esm-dynamic-import.js
@@ -48,9 +48,9 @@ function expectFsNamespace(result) {
   expectFsNamespace(import('fs'));
   expectFsNamespace(eval('import("fs")'));
   expectFsNamespace(eval('import("fs")'));
-  expectFsNamespace(import('nodejs:fs'));
+  expectFsNamespace(import('node:fs'));
 
-  expectModuleError(import('nodejs:unknown'),
+  expectModuleError(import('node:unknown'),
                     'ERR_UNKNOWN_BUILTIN_MODULE');
   expectModuleError(import('./not-an-existing-module.mjs'),
                     'ERR_MODULE_NOT_FOUND');

--- a/test/fixtures/es-module-loaders/builtin-named-exports-loader.mjs
+++ b/test/fixtures/es-module-loaders/builtin-named-exports-loader.mjs
@@ -15,7 +15,7 @@ export function getGlobalPreloadCode() {
 
 export function resolve(specifier, context, defaultResolve) {
   const def = defaultResolve(specifier, context);
-  if (def.url.startsWith('nodejs:')) {
+  if (def.url.startsWith('node:')) {
     return {
       url: `custom-${def.url}`,
     };
@@ -24,7 +24,7 @@ export function resolve(specifier, context, defaultResolve) {
 }
 
 export function getSource(url, context, defaultGetSource) {
-  if (url.startsWith('custom-nodejs:')) {
+  if (url.startsWith('custom-node:')) {
     const urlObj = new URL(url);
     return {
       source: generateBuiltinModule(urlObj.pathname),
@@ -35,7 +35,7 @@ export function getSource(url, context, defaultGetSource) {
 }
 
 export function getFormat(url, context, defaultGetFormat) {
-  if (url.startsWith('custom-nodejs:')) {
+  if (url.startsWith('custom-node:')) {
     return { format: 'module' };
   }
   return defaultGetFormat(url, context, defaultGetFormat);

--- a/test/fixtures/es-module-loaders/example-loader.mjs
+++ b/test/fixtures/es-module-loaders/example-loader.mjs
@@ -11,7 +11,7 @@ baseURL.pathname = process.cwd() + '/';
 export function resolve(specifier, { parentURL = baseURL }, defaultResolve) {
   if (builtinModules.includes(specifier)) {
     return {
-      url: 'nodejs:' + specifier
+      url: 'node:' + specifier
     };
   }
   if (/^\.{1,2}[/]/.test(specifier) !== true && !specifier.startsWith('file:')) {
@@ -27,7 +27,7 @@ export function resolve(specifier, { parentURL = baseURL }, defaultResolve) {
 }
 
 export function getFormat(url, context, defaultGetFormat) {
-  if (url.startsWith('nodejs:') && builtinModules.includes(url.slice(7))) {
+  if (url.startsWith('node:') && builtinModules.includes(url.slice(5))) {
     return {
       format: 'builtin'
     };

--- a/test/fixtures/es-module-loaders/loader-unknown-builtin-module.mjs
+++ b/test/fixtures/es-module-loaders/loader-unknown-builtin-module.mjs
@@ -1,14 +1,14 @@
 export async function resolve(specifier, { parentURL }, defaultResolve) {
   if (specifier === 'unknown-builtin-module') {
     return {
-      url: 'nodejs:unknown-builtin-module'
+      url: 'node:unknown-builtin-module'
     };
   }
   return defaultResolve(specifier, {parentURL}, defaultResolve);
 }
 
 export async function getFormat(url, context, defaultGetFormat) {
-  if (url === 'nodejs:unknown-builtin-module') {
+  if (url === 'node:unknown-builtin-module') {
     return {
       format: 'builtin'
     };

--- a/test/fixtures/es-module-loaders/not-found-assert-loader.mjs
+++ b/test/fixtures/es-module-loaders/not-found-assert-loader.mjs
@@ -14,7 +14,7 @@ export async function resolve(specifier, { parentURL }, defaultResolve) {
   catch (e) {
     assert.strictEqual(e.code, 'ERR_MODULE_NOT_FOUND');
     return {
-      url: 'nodejs:fs'
+      url: 'node:fs'
     };
   }
   assert.fail(`Module resolution for ${specifier} should be throw ERR_MODULE_NOT_FOUND`);

--- a/test/parallel/test-loaders-unknown-builtin-module.mjs
+++ b/test/parallel/test-loaders-unknown-builtin-module.mjs
@@ -2,7 +2,7 @@
 import { expectsError, mustCall } from '../common/index.mjs';
 import assert from 'assert';
 
-const unknownBuiltinModule = 'unknown-builtin-module';
+const unknownBuiltinModule = 'node:unknown-builtin-module';
 
 import(unknownBuiltinModule)
 .then(assert.fail, expectsError({


### PR DESCRIPTION
This has been discussed a couple of times in the past few meetings that the internal representation for builtins should align with policies using the `node:` scheme as well as to allow this to be the scheme to make public for users in future if we ever want to expose it more explicitly in any modules APIs or interfaces.

This is strictly a minor breaking change, but should have relatively low usage in the wild and is entirely limited to the experimental modules and loader cases.

@nodejs/modules-active-members

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
