### PR TITLE
tools: add pythonenv to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@
 /*.msi
 /*.wixpdb
 /*.qlog
+# For GitHub Codespaces
+/pythonenv*
 
 # === Rules for artifacts of `./configure` ===
 /icu_config.gypi


### PR DESCRIPTION
GitHub Codespaces installs a copy of Python 3.8 in the repository.

![image](https://user-images.githubusercontent.com/2352663/94399256-54bf1400-0167-11eb-957a-4cff56605e83.png)
