### PR TITLE
[v12.x backport] repl: support --loader option in builtin REPL

### DIFF
--- a/lib/internal/main/repl.js
+++ b/lib/internal/main/repl.js
@@ -7,6 +7,7 @@ const {
   prepareMainThreadExecution
 } = require('internal/bootstrap/pre_execution');
 
+const esmLoader = require('internal/process/esm_loader');
 const {
   evalScript
 } = require('internal/process/execution');
@@ -32,31 +33,33 @@ if (process.env.NODE_REPL_EXTERNAL_MODULE) {
     process.exit(1);
   }
 
-  console.log(`Welcome to Node.js ${process.version}.\n` +
-    'Type ".help" for more information.');
+  esmLoader.loadESM(() => {
+    console.log(`Welcome to Node.js ${process.version}.\n` +
+      'Type ".help" for more information.');
 
-  const cliRepl = require('internal/repl');
-  cliRepl.createInternalRepl(process.env, (err, repl) => {
-    if (err) {
-      throw err;
-    }
-    repl.on('exit', () => {
-      if (repl._flushing) {
-        repl.pause();
-        return repl.once('flushHistory', () => {
-          process.exit();
-        });
+    const cliRepl = require('internal/repl');
+    cliRepl.createInternalRepl(process.env, (err, repl) => {
+      if (err) {
+        throw err;
       }
-      process.exit();
+      repl.on('exit', () => {
+        if (repl._flushing) {
+          repl.pause();
+          return repl.once('flushHistory', () => {
+            process.exit();
+          });
+        }
+        process.exit();
+      });
     });
-  });
 
-  // If user passed '-e' or '--eval' along with `-i` or `--interactive`,
-  // evaluate the code in the current context.
-  if (getOptionValue('[has_eval_string]')) {
-    evalScript('[eval]',
-               getOptionValue('--eval'),
-               getOptionValue('--inspect-brk'),
-               getOptionValue('--print'));
-  }
+    // If user passed '-e' or '--eval' along with `-i` or `--interactive`,
+    // evaluate the code in the current context.
+    if (getOptionValue('[has_eval_string]')) {
+      evalScript('[eval]',
+                 getOptionValue('--eval'),
+                 getOptionValue('--inspect-brk'),
+                 getOptionValue('--print'));
+    }
+  });
 }

--- a/lib/internal/main/repl.js
+++ b/lib/internal/main/repl.js
@@ -61,5 +61,5 @@ if (process.env.NODE_REPL_EXTERNAL_MODULE) {
                  getOptionValue('--inspect-brk'),
                  getOptionValue('--print'));
     }
-  });
+  }, false);
 }

--- a/lib/internal/modules/run_main.js
+++ b/lib/internal/modules/run_main.js
@@ -40,21 +40,10 @@ function shouldUseESMLoader(mainPath) {
 function runMainESM(mainPath) {
   const esmLoader = require('internal/process/esm_loader');
   const { pathToFileURL } = require('internal/url');
-  const { hasUncaughtExceptionCaptureCallback } =
-      require('internal/process/execution');
-  return esmLoader.initializeLoader().then(() => {
+  esmLoader.loadESM((ESMLoader) => {
     const main = path.isAbsolute(mainPath) ?
       pathToFileURL(mainPath).href : mainPath;
-    return esmLoader.ESMLoader.import(main);
-  }).catch((e) => {
-    if (hasUncaughtExceptionCaptureCallback()) {
-      process._fatalException(e);
-      return;
-    }
-    internalBinding('errors').triggerUncaughtException(
-      e,
-      true /* fromPromise */
-    );
+    return ESMLoader.import(main);
   });
 }
 

--- a/lib/internal/process/esm_loader.js
+++ b/lib/internal/process/esm_loader.js
@@ -48,11 +48,13 @@ let ESMLoader = new Loader();
 exports.ESMLoader = ESMLoader;
 
 let calledInitialize = false;
-async function initializeLoader() {
+async function initializeLoader(emitWarning) {
   assert(calledInitialize === false);
-  process.emitWarning(
-    'The ESM module loader is experimental.',
-    'ExperimentalWarning', undefined);
+  if (emitWarning) {
+    process.emitWarning(
+      'The ESM module loader is experimental.',
+      'ExperimentalWarning', undefined);
+  }
   calledInitialize = true;
   if (!userLoader)
     return;
@@ -76,9 +78,9 @@ async function initializeLoader() {
   })();
 }
 
-exports.loadESM = async function loadESM(callback) {
+exports.loadESM = async function loadESM(callback, emitWarning = true) {
   try {
-    await initializeLoader();
+    await initializeLoader(emitWarning);
     await callback(ESMLoader);
   } catch (err) {
     if (hasUncaughtExceptionCaptureCallback()) {

--- a/lib/internal/process/esm_loader.js
+++ b/lib/internal/process/esm_loader.js
@@ -5,6 +5,9 @@ const {
 } = require('internal/errors').codes;
 const assert = require('internal/assert');
 const { Loader } = require('internal/modules/esm/loader');
+const {
+  hasUncaughtExceptionCaptureCallback,
+} = require('internal/process/execution');
 const { pathToFileURL } = require('internal/url');
 const {
   getModuleFromWrap,
@@ -45,7 +48,6 @@ let ESMLoader = new Loader();
 exports.ESMLoader = ESMLoader;
 
 let calledInitialize = false;
-exports.initializeLoader = initializeLoader;
 async function initializeLoader() {
   assert(calledInitialize === false);
   process.emitWarning(
@@ -73,3 +75,19 @@ async function initializeLoader() {
     return exports.ESMLoader = ESMLoader;
   })();
 }
+
+exports.loadESM = async function loadESM(callback) {
+  try {
+    await initializeLoader();
+    await callback(ESMLoader);
+  } catch (err) {
+    if (hasUncaughtExceptionCaptureCallback()) {
+      process._fatalException(err);
+      return;
+    }
+    internalBinding('errors').triggerUncaughtException(
+      err,
+      true /* fromPromise */
+    );
+  }
+};

--- a/test/message/esm_display_syntax_error_import.out
+++ b/test/message/esm_display_syntax_error_import.out
@@ -6,3 +6,4 @@ SyntaxError: The requested module '../fixtures/es-module-loaders/module-named-ex
     at ModuleJob._instantiate (internal/modules/esm/module_job.js:*:*)
     at async ModuleJob.run (internal/modules/esm/module_job.js:*:*)
     at async Loader.import (internal/modules/esm/loader.js:*:*)
+    at async Object.loadESM (internal/process/esm_loader.js:*:*)

--- a/test/message/esm_display_syntax_error_import_module.out
+++ b/test/message/esm_display_syntax_error_import_module.out
@@ -6,3 +6,4 @@ SyntaxError: The requested module './module-named-exports.mjs' does not provide 
     at ModuleJob._instantiate (internal/modules/esm/module_job.js:*:*)
     at async ModuleJob.run (internal/modules/esm/module_job.js:*:*)
     at async Loader.import (internal/modules/esm/loader.js:*:*)
+    at async Object.loadESM (internal/process/esm_loader.js:*:*)

--- a/test/message/esm_loader_not_found.out
+++ b/test/message/esm_loader_not_found.out
@@ -1,6 +1,6 @@
 (node:*) ExperimentalWarning: The ESM module loader is experimental.
 (node:*) ExperimentalWarning: --experimental-loader is an experimental feature. This feature could change at any time
-internal/modules/run_main.js:*
+internal/process/esm_loader.js:*
     internalBinding('errors').triggerUncaughtException(
                               ^
 Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'i-dont-exist' imported from *
@@ -11,8 +11,8 @@ Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'i-dont-exist' imported from *
     at Loader.getModuleJob (internal/modules/esm/loader.js:*:*)
     at Loader.import (internal/modules/esm/loader.js:*:*)
     at internal/process/esm_loader.js:*:*
-    at Object.initializeLoader (internal/process/esm_loader.js:*:*)
-    at runMainESM (internal/modules/run_main.js:*:*)
-    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:*:*) {
+    at initializeLoader (internal/process/esm_loader.js:*:*)
+    at Object.loadESM (internal/process/esm_loader.js:*:*)
+    at runMainESM (internal/modules/run_main.js:*:*) {
   code: 'ERR_MODULE_NOT_FOUND'
 }

--- a/test/message/esm_loader_not_found_cjs_hint_bare.out
+++ b/test/message/esm_loader_not_found_cjs_hint_bare.out
@@ -1,5 +1,5 @@
 (node:*) ExperimentalWarning: The ESM module loader is experimental.
-internal/modules/run_main.js:*
+internal/process/esm_loader.js:*
     internalBinding('errors').triggerUncaughtException(
                               ^
 

--- a/test/message/esm_loader_not_found_cjs_hint_relative.out
+++ b/test/message/esm_loader_not_found_cjs_hint_relative.out
@@ -1,6 +1,6 @@
 (node:*) ExperimentalWarning: The ESM module loader is experimental.
 (node:*) ExperimentalWarning: --experimental-loader is an experimental feature. This feature could change at any time
-internal/modules/run_main.js:*
+internal/process/esm_loader.js:*
     internalBinding('errors').triggerUncaughtException(
                               ^
 
@@ -13,8 +13,8 @@ Did you mean to import ./test/common/fixtures.js?
     at Loader.getModuleJob (internal/modules/esm/loader.js:*:*)
     at Loader.import (internal/modules/esm/loader.js:*:*)
     at internal/process/esm_loader.js:*:*
-    at Object.initializeLoader (internal/process/esm_loader.js:*:*)
-    at runMainESM (internal/modules/run_main.js:*:*)
-    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:*:*) {
+    at initializeLoader (internal/process/esm_loader.js:*:*)
+    at Object.loadESM (internal/process/esm_loader.js:*:*)
+    at runMainESM (internal/modules/run_main.js:*:*) {
   code: 'ERR_MODULE_NOT_FOUND'
 }


### PR DESCRIPTION
Backport of https://github.com/nodejs/node/pull/33437

First commit is a cherry-pick of https://github.com/nodejs/node/commit/05539c166a331b9b37925239cb8cef1dc923387a with simple conflicts solved.
I added a fixup commit to avoid printing the experimental warning everytime the REPL is started. There is one difference with the current state of v12.x though: if we merge this, using dynamic import from within the REPL will no longer print the warning, because the ESM loader will already be initialized.

/cc @nodejs/modules 