### PR TITLE
doc,esm: add history support info

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -2,6 +2,27 @@
 
 <!--introduced_in=v8.5.0-->
 <!-- type=misc -->
+<!-- YAML
+added: v8.5.0
+changes:
+  - version:
+    - v14.13.0
+    pr-url: https://github.com/nodejs/node/pull/35249
+    description: Support for detection of CommonJS named exports.
+  - version: v14.8.0
+    pr-url: https://github.com/nodejs/node/pull/34558
+    description: Unflag Top-Level Await.
+  - version:
+    - v13.2.0
+    - v12.17.0
+    pr-url: https://github.com/nodejs/node/pull/29866
+    description: Loading ECMAScript modules no longer requires a command-line flag.
+  - version: v12.0.0
+    pr-url: https://github.com/nodejs/node/pull/26745
+    description:
+      Add support for ES modules using `.js` file extension via `package.json`
+      `"type"` field.
+-->
 
 > Stability: 1 - Experimental
 

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -1,6 +1,36 @@
 # Modules: Packages
 
 <!-- type=misc -->
+<!-- YAML
+changes:
+  - version:
+    - v14.13.0
+    pr-url: https://github.com/nodejs/node/pull/34718
+    description: Add support for `"exports"` patterns.
+  - version: v14.6.0
+    pr-url: https://github.com/nodejs/node/pull/34117
+    description: Add package `"imports"` field.
+  - version:
+    - v13.7.0
+    - v12.16.0
+    pr-url: https://github.com/nodejs/node/pull/31001
+    description: Unflag conditional exports.
+  - version:
+    - v13.6.0
+    - v12.16.0
+    pr-url: https://github.com/nodejs/node/pull/31002
+    description: Unflag self-referencing a package using its name.
+  - version: v12.7.0
+    pr-url: https://github.com/nodejs/node/pull/28568
+    description:
+      Introduce `"exports"` `package.json` field as a more powerful alternative
+      to the classic `"main"` field.
+  - version: v12.0.0
+    pr-url: https://github.com/nodejs/node/pull/26745
+    description:
+      Add support for ES modules using `.js` file extension via `package.json`
+      `"type"` field.
+-->
 
 ## Introduction
 


### PR DESCRIPTION
Documents which versions of Node.js support which ESM-feature. This is intended to help library authors determine the minimal Node.js version that supports the features they are using.

I've tried to come up with an exhaustive list of ESM-only features that may impact the way one can write modules:
* Unflagged ESM
* Unflagged TLA
* Supports for `.js` ES modules

Am I missing something?

Refs: https://github.com/nodejs/node/pull/35370#discussion_r495542261

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
cc @guybedford 