### PR TITLE
console: add Symbol.toStringTag property

### DIFF
--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -19,6 +19,7 @@ const {
   ReflectOwnKeys,
   Symbol,
   SymbolHasInstance,
+  SymbolToStringTag,
   WeakMap,
 } = primordials;
 
@@ -233,6 +234,12 @@ ObjectDefineProperties(Console.prototype, {
           ...consolePropAttributes,
           value: groupIndentation
         },
+        [SymbolToStringTag]: {
+          writable: false,
+          enumerable: false,
+          configurable: true,
+          value: 'console'
+        }
       });
     }
   },

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -757,7 +757,7 @@ const errorTests = [
   {
     send: 'console',
     expect: [
-      '{',
+      'Object [console] {',
       '  log: [Function: log],',
       '  warn: [Function: warn],',
       '  dir: [Function: dir],',

--- a/test/wpt/status/console.json
+++ b/test/wpt/status/console.json
@@ -1,8 +1,5 @@
 {
   "idlharness.any.js": {
     "fail": ".table, .dir and .timeLog parameter lengths are wrong"
-  },
-  "console-namespace-object-class-string.any.js": {
-    "fail": "TODO: https://github.com/web-platform-tests/wpt/pull/24717"
   }
 }


### PR DESCRIPTION
Add Symbol.toStringTag property to the console object to follow the WPT spec changes.
Update the console WPT status and the repl test case.

Refs: https://github.com/web-platform-tests/wpt/pull/24717

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
