### PR TITLE
fs:(feature) add openSafe and closeSafe

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -37,8 +37,13 @@ const {
   ObjectDefineProperties,
   ObjectDefineProperty,
   Promise,
+  Set,
   String,
 } = primordials;
+
+const {
+  objectWeakCallBack: internalObjectWeakCallBack,
+} = internalBinding('util');
 
 const { fs: constants } = internalBinding('constants');
 const {
@@ -65,6 +70,7 @@ const {
     ERR_INVALID_ARG_VALUE,
     ERR_INVALID_ARG_TYPE,
     ERR_INVALID_CALLBACK,
+    ERR_INVALID_SAFE_FILE_HANDLE,
     ERR_FEATURE_UNAVAILABLE_ON_PLATFORM
   },
   uvException
@@ -414,6 +420,50 @@ function readFileSync(path, options) {
   return buffer;
 }
 
+class SafeFileHandle {
+  constructor(fd) {
+    this._fd = fd;
+    SafeFileHandle.fdSet.add(fd);
+    internalObjectWeakCallBack(this, () => {
+      SafeFileHandle.closeSafeFileHandle(fd);
+    });
+  }
+  static closeSafeFileHandle(fd) {
+    if (SafeFileHandle.fdSet.has(fd)) {
+      fs.closeSync(fd);
+      SafeFileHandle.deleteSafeFileHandle(fd);
+    }
+  }
+  static deleteSafeFileHandle(fd) {
+    SafeFileHandle.fdSet.delete(fd);
+  }
+}
+SafeFileHandle.fdSet = new Set();
+
+function closeSafe(safeFileHandle, callback) {
+  if (!(safeFileHandle instanceof SafeFileHandle)) {
+    throw new ERR_INVALID_SAFE_FILE_HANDLE(safeFileHandle);
+  }
+  if (typeof callback !== 'function') {
+    throw new ERR_INVALID_CALLBACK(callback);
+  }
+  fs.close(safeFileHandle._fd, (err) => {
+    if (!err) {
+      SafeFileHandle.deleteSafeFileHandle(safeFileHandle._fd);
+    }
+    callback(err);
+  });
+}
+
+function closeSyncSafe(safeFileHandle) {
+  if (!(safeFileHandle instanceof SafeFileHandle)) {
+    throw new ERR_INVALID_SAFE_FILE_HANDLE(safeFileHandle);
+  }
+  const reesult = fs.closeSync(safeFileHandle._fd);
+  SafeFileHandle.deleteSafeFileHandle(safeFileHandle._fd);
+  return reesult;
+}
+
 function close(fd, callback) {
   validateInt32(fd, 'fd', 0);
   const req = new FSReqCallback();
@@ -429,7 +479,7 @@ function closeSync(fd) {
   handleErrorFromBinding(ctx);
 }
 
-function open(path, flags, mode, callback) {
+function getOpenParams(path, flags, mode, callback) {
   path = getValidatedPath(path);
   if (arguments.length < 3) {
     callback = flags;
@@ -441,6 +491,33 @@ function open(path, flags, mode, callback) {
   } else {
     mode = parseFileMode(mode, 'mode', 0o666);
   }
+  return { path, flags, mode, callback };
+}
+
+function openSafe(path, flags, mode, callback) {
+  const params = getOpenParams(...arguments);
+  path = params.path;
+  flags = params.flags;
+  mode = params.mode;
+  callback = params.callback;
+  if (typeof callback !== 'function') {
+    throw new ERR_INVALID_CALLBACK(callback);
+  }
+  fs.open(path, flags, mode, (err, fd) => {
+    callback(err, new SafeFileHandle(fd));
+  });
+}
+
+function openSyncSafe(path, flags, mode) {
+  return new SafeFileHandle(fs.openSync(path, flags, mode));
+}
+
+function open(path, flags, mode, callback) {
+  const params = getOpenParams(...arguments);
+  path = params.path;
+  flags = params.flags;
+  mode = params.mode;
+  callback = params.callback;
   const flagsNumber = stringToFlags(flags);
   callback = makeCallback(callback);
 
@@ -1969,7 +2046,9 @@ module.exports = fs = {
   chmod,
   chmodSync,
   close,
+  closeSafe,
   closeSync,
+  closeSyncSafe,
   copyFile,
   copyFileSync,
   createReadStream,
@@ -2005,7 +2084,9 @@ module.exports = fs = {
   mkdtemp,
   mkdtempSync,
   open,
+  openSafe,
   openSync,
+  openSyncSafe,
   opendir,
   opendirSync,
   readdir,

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1168,6 +1168,8 @@ E('ERR_INVALID_RETURN_VALUE', (input, name, value) => {
   return `Expected ${input} to be returned from the "${name}"` +
          ` function but got ${type}.`;
 }, TypeError);
+E('ERR_INVALID_SAFE_FILE_HANDLE',
+  'must be a SafeFileHandle type. Received %O', TypeError);
 E('ERR_INVALID_STATE', 'Invalid state: %s', Error);
 E('ERR_INVALID_SYNC_FORK_INPUT',
   'Asynchronous forks do not support ' +

--- a/test/parallel/test-fs-close-safe.js
+++ b/test/parallel/test-fs-close-safe.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const common = require('../common');
+
+const assert = require('assert');
+const fs = require('fs');
+
+const fdObj = fs.openSyncSafe(__filename, 'r');
+
+fs.closeSafe(fdObj, common.mustCall(function(...args) {
+  assert.deepStrictEqual(args, [null]);
+}));

--- a/test/parallel/test-fs-open-safe.js
+++ b/test/parallel/test-fs-open-safe.js
@@ -1,0 +1,16 @@
+'use strict';
+// Flags: --expose-gc
+
+require('../common');
+
+const assert = require('assert');
+const fs = require('fs');
+
+const max = 8192;
+let now = 1;
+for (let i = 0; i < max; i++) {
+  fs.openSyncSafe(__filename, 'r');
+  now++;
+}
+global.gc();
+assert.strictEqual(now, max);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

I heard about a problem the other day, but I think it's a design flaw.

The problem is when someone used a file descriptor but forgets to release it, causing it to leak.But that's not the point.

The point is that when we used the memory snapshot check, the file descriptor info was not in the snapshot.And there will be IO blocking.

I think we should at least show the use of file descriptors in the snapshot.A better way is to release the file description object when it is no longer referenced.This allows the memory snapshot to be stored in the file descriptor information that is referenced but not released, making it easier to diagnose the node.js problem!


Example:
```js
const max = 8192;
for (let i = 0; i < max; i++) {
  const fd = fs.openSync(__filename, 'r');
}
// Now IO is blocked!!!
```
but use `openSyncSafe` instead of `openSync`:
```js
const max = 8192;
for (let i = 0; i < max; i++) {
  const fdObj = fs.openSyncSafe(__filename, 'r');
}
global.gc(); // when GC,fdObj not be referenced,so file descriptor is released
// Now IO not blocked!
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
