### PR TITLE
crypto: set env values in Deserialize method by calling CreateNativeK…

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3265,8 +3265,11 @@ size_t KeyObjectData::GetSymmetricKeySize() const {
   return symmetric_key_len_;
 }
 
-Local<Function> KeyObjectHandle::Initialize(Environment* env,
-                                            Local<Object> target) {
+Local<Function> KeyObjectHandle::Initialize(Environment* env) {
+  Local<Function> templ = env->crypto_key_object_handle_constructor();
+  if (!templ.IsEmpty()) {
+    return templ;
+  }
   Local<FunctionTemplate> t = env->NewFunctionTemplate(New);
   t->InstanceTemplate()->SetInternalFieldCount(
       KeyObjectHandle::kInternalFieldCount);
@@ -3280,20 +3283,16 @@ Local<Function> KeyObjectHandle::Initialize(Environment* env,
   env->SetProtoMethod(t, "export", Export);
 
   auto function = t->GetFunction(env->context()).ToLocalChecked();
-  target->Set(env->context(),
-              FIXED_ONE_BYTE_STRING(env->isolate(), "KeyObjectHandle"),
-              function).Check();
-
-  return function;
+  env->set_crypto_key_object_handle_constructor(function);
+  return KeyObjectHandle::Initialize(env);
 }
 
 MaybeLocal<Object> KeyObjectHandle::Create(
     Environment* env,
     std::shared_ptr<KeyObjectData> data) {
   Local<Object> obj;
-  if (!env->crypto_key_object_handle_constructor()
-           ->NewInstance(env->context(), 0, nullptr)
-           .ToLocal(&obj)) {
+  Local<Function> fctun = KeyObjectHandle::Initialize(env);
+  if (!fctun->NewInstance(env->context(), 0, nullptr).ToLocal(&obj)) {
     return MaybeLocal<Object>();
   }
 
@@ -3466,6 +3465,9 @@ BaseObjectPtr<BaseObject> NativeKeyObject::KeyObjectTransferData::Deserialize(
 
   Local<Value> handle = KeyObjectHandle::Create(env, data_).ToLocalChecked();
   Local<Function> key_ctor;
+  Local<Value> arg = FIXED_ONE_BYTE_STRING(env->isolate(),
+                                              "internal/crypto/keys");
+  env->native_module_require()->Call(context, Null(env->isolate()), 1, &arg);
   switch (data_->GetKeyType()) {
     case kKeyTypeSecret:
       key_ctor = env->crypto_key_object_secret_constructor();
@@ -6950,8 +6952,9 @@ void Initialize(Local<Object> target,
 
   Environment* env = Environment::GetCurrent(context);
   SecureContext::Initialize(env, target);
-  env->set_crypto_key_object_handle_constructor(
-      KeyObjectHandle::Initialize(env, target));
+  target->Set(env->context(),
+            FIXED_ONE_BYTE_STRING(env->isolate(), "KeyObjectHandle"),
+            KeyObjectHandle::Initialize(env)).Check();
   env->SetMethod(target, "createNativeKeyObjectClass",
                  CreateNativeKeyObjectClass);
   CipherBase::Initialize(env, target);

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3467,7 +3467,9 @@ BaseObjectPtr<BaseObject> NativeKeyObject::KeyObjectTransferData::Deserialize(
   Local<Function> key_ctor;
   Local<Value> arg = FIXED_ONE_BYTE_STRING(env->isolate(),
                                               "internal/crypto/keys");
-  env->native_module_require()->Call(context, Null(env->isolate()), 1, &arg);
+  if (env->native_module_require()->
+      Call(context, Null(env->isolate()), 1, &arg).IsEmpty())
+    return {};
   switch (data_->GetKeyType()) {
     case kKeyTypeSecret:
       key_ctor = env->crypto_key_object_secret_constructor();

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -447,8 +447,7 @@ class KeyObjectData {
 
 class KeyObjectHandle : public BaseObject {
  public:
-  static v8::Local<v8::Function> Initialize(Environment* env,
-                                            v8::Local<v8::Object> target);
+  static v8::Local<v8::Function> Initialize(Environment* env);
 
   static v8::MaybeLocal<v8::Object> Create(Environment* env,
                                            std::shared_ptr<KeyObjectData> data);

--- a/test/parallel/test-crypto-worker-thread.js
+++ b/test/parallel/test-crypto-worker-thread.js
@@ -1,0 +1,18 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+// Issue https://github.com/nodejs/node/issues/35263
+/* Description: test for checking keyobject passed to worker thread
+ does not crash */
+const { createSecretKey } = require('crypto');
+
+const { Worker, isMainThread, workerData } = require('worker_threads');
+
+if (isMainThread) {
+  const key = createSecretKey(Buffer.from('hello'));
+  new Worker(__filename, { workerData: key });
+} else {
+  console.log(workerData);
+}


### PR DESCRIPTION
Hi @addaleax @jasnell I added some changes for the issue, I verified in my system the example jasnell has posted earlier, it is not throwing any segmentation fault. Please review the changes.Thanks !

Fixes: https://github.com/nodejs/node/issues/35263

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
