### PR TITLE
[v14.x backport] test: update wpt tests for encoding

### DIFF
--- a/test/fixtures/wpt/README.md
+++ b/test/fixtures/wpt/README.md
@@ -11,7 +11,7 @@ See [test/wpt](../../wpt/README.md) for information on how these tests are run.
 Last update:
 
 - console: https://github.com/web-platform-tests/wpt/tree/9786a4b131/console
-- encoding: https://github.com/web-platform-tests/wpt/tree/5059d2c777/encoding
+- encoding: https://github.com/web-platform-tests/wpt/tree/d7f9e16c9a/encoding
 - url: https://github.com/web-platform-tests/wpt/tree/418f7fabeb/url
 - resources: https://github.com/web-platform-tests/wpt/tree/e1fddfbf80/resources
 - interfaces: https://github.com/web-platform-tests/wpt/tree/8ada332aea/interfaces

--- a/test/fixtures/wpt/encoding/idlharness.any.js
+++ b/test/fixtures/wpt/encoding/idlharness.any.js
@@ -4,7 +4,7 @@
 
 idl_test(
   ['encoding'],
-  [], // No deps
+  ['streams'],
   idl_array => {
     idl_array.add_objects({
       TextEncoder: ['new TextEncoder()'],

--- a/test/fixtures/wpt/versions.json
+++ b/test/fixtures/wpt/versions.json
@@ -4,7 +4,7 @@
     "path": "console"
   },
   "encoding": {
-    "commit": "5059d2c77703d67d2f76931b44e6d2437526b6e9",
+    "commit": "d7f9e16c9a9d578a05b59787ba4de68b710de725",
     "path": "encoding"
   },
   "url": {


### PR DESCRIPTION
Refs: https://github.com/web-platform-tests/wpt/pull/25542

PR-URL: https://github.com/nodejs/node/pull/35330
Reviewed-By: Luigi Pinca <luigipinca@gmail.com>
Reviewed-By: Shingo Inoue <leko.noor@gmail.com>
Reviewed-By: Rich Trott <rtrott@gmail.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
