### PR TITLE
tools: exclude gyp from markdown link checker

### DIFF
--- a/tools/doc/checkLinks.js
+++ b/tools/doc/checkLinks.js
@@ -31,6 +31,7 @@ function findMarkdownFilesRecursively(dirPath) {
       entry.name !== 'changelogs' &&
       entry.name !== 'deps' &&
       entry.name !== 'fixtures' &&
+      entry.name !== 'gyp' &&
       entry.name !== 'node_modules' &&
       entry.name !== 'out' &&
       entry.name !== 'tmp'


### PR DESCRIPTION
The changelog format used in gyp-next does not comply to the rules.
