### PR TITLE
src: make MakeCallback() check can_call_into_js before getting method

### DIFF
--- a/src/api/callback.cc
+++ b/src/api/callback.cc
@@ -226,7 +226,7 @@ MaybeLocal<Value> MakeCallback(Isolate* isolate,
   // Check can_call_into_js() first because calling Get() might do so.
   Environment* env = Environment::GetCurrent(recv->CreationContext());
   CHECK_NOT_NULL(env);
-  if (!env->can_call_into_js()) Local<Value>();
+  if (!env->can_call_into_js()) return Local<Value>();
 
   Local<Value> callback_v;
   if (!recv->Get(isolate->GetCurrentContext(), symbol).To(&callback_v))

--- a/src/api/callback.cc
+++ b/src/api/callback.cc
@@ -223,10 +223,19 @@ MaybeLocal<Value> MakeCallback(Isolate* isolate,
                                int argc,
                                Local<Value> argv[],
                                async_context asyncContext) {
-  Local<Value> callback_v =
-      recv->Get(isolate->GetCurrentContext(), symbol).ToLocalChecked();
-  if (callback_v.IsEmpty()) return Local<Value>();
-  if (!callback_v->IsFunction()) return Local<Value>();
+  // Check can_call_into_js() first because calling Get() might do so.
+  Environment* env = Environment::GetCurrent(recv->CreationContext());
+  CHECK_NOT_NULL(env);
+  if (!env->can_call_into_js()) Local<Value>();
+
+  Local<Value> callback_v;
+  if (!recv->Get(isolate->GetCurrentContext(), symbol).To(&callback_v))
+    return Local<Value>();
+  if (!callback_v->IsFunction()) {
+    // This used to return an empty value, but Undefined() makes more sense
+    // since no exception is pending here.
+    return Undefined(isolate);
+  }
   Local<Function> callback = callback_v.As<Function>();
   return MakeCallback(isolate, recv, callback, argc, argv, asyncContext);
 }

--- a/src/api/callback.cc
+++ b/src/api/callback.cc
@@ -229,7 +229,7 @@ MaybeLocal<Value> MakeCallback(Isolate* isolate,
   if (!env->can_call_into_js()) return Local<Value>();
 
   Local<Value> callback_v;
-  if (!recv->Get(isolate->GetCurrentContext(), symbol).To(&callback_v))
+  if (!recv->Get(isolate->GetCurrentContext(), symbol).ToLocal(&callback_v))
     return Local<Value>();
   if (!callback_v->IsFunction()) {
     // This used to return an empty value, but Undefined() makes more sense


### PR DESCRIPTION
There is a check for this in the inner `MakeCallback()` function
called by it, but since the `Get()` call here can also result in a
call into JS, we should ideally check the flag before that.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
