### PR TITLE
module: refine module type mismatch error cases

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -71,7 +71,6 @@ const fs = require('fs');
 const internalFS = require('internal/fs/utils');
 const path = require('path');
 const { sep } = path;
-const { emitWarningSync } = require('internal/process/warning');
 const { internalModuleStat } = internalBinding('fs');
 const packageJsonReader = require('internal/modules/package_json_reader');
 const { safeGetenv } = internalBinding('credentials');
@@ -114,6 +113,7 @@ const {
 } = require('internal/util/types');
 
 const asyncESM = require('internal/process/esm_loader');
+const { enrichCJSError } = require('internal/modules/esm/translators');
 const { kEvaluated } = internalBinding('module_wrap');
 const {
   encodedSepRegEx,
@@ -127,28 +127,6 @@ const relativeResolveCache = ObjectCreate(null);
 
 let requireDepth = 0;
 let statCache = null;
-
-function enrichCJSError(err) {
-  const stack = err.stack.split('\n');
-
-  const lineWithErr = stack[1];
-
-  /*
-    The regular expression below targets the most common import statement
-    usage. However, some cases are not matching, cases like import statement
-    after a comment block and/or after a variable definition.
-  */
-  if (err.message.startsWith('Unexpected token \'export\'') ||
-    (RegExpPrototypeTest(/^\s*import(?=[ {'"*])\s*(?![ (])/, lineWithErr))) {
-    // Emit the warning synchronously because we are in the middle of handling
-    // a SyntaxError that will throw and likely terminate the process before an
-    // asynchronous warning would be emitted.
-    emitWarningSync(
-      'To load an ES module, set "type": "module" in the package.json or use ' +
-      'the .mjs extension.'
-    );
-  }
-}
 
 function stat(filename) {
   filename = path.toNamespacedPath(filename);

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -9,9 +9,12 @@ const {
   ObjectKeys,
   PromisePrototypeCatch,
   PromiseReject,
+  RegExpPrototypeTest,
   SafeMap,
   SafeSet,
   StringPrototypeReplace,
+  StringPrototypeSplit,
+  StringPrototypeStartsWith,
 } = primordials;
 
 let _TYPES = null;
@@ -54,9 +57,11 @@ const experimentalImportMetaResolve =
     getOptionValue('--experimental-import-meta-resolve');
 const asyncESM = require('internal/process/esm_loader');
 const cjsParse = require('internal/deps/cjs-module-lexer/lexer');
+const { emitWarningSync } = require('internal/process/warning');
 
 const translators = new SafeMap();
 exports.translators = translators;
+exports.enrichCJSError = enrichCJSError;
 
 let DECODER = null;
 function assertBufferSource(body, allowString, hookName) {
@@ -130,6 +135,25 @@ translators.set('module', async function moduleStrategy(url) {
   return module;
 });
 
+function enrichCJSError(err) {
+  const stack = StringPrototypeSplit(err.stack, '\n');
+  /*
+  * The regular expression below targets the most common import statement
+  * usage. However, some cases are not matching, cases like import statement
+  * after a comment block and/or after a variable definition.
+  */
+  if (StringPrototypeStartsWith(err.message, 'Unexpected token \'export\'') ||
+    RegExpPrototypeTest(/^\s*import(?=[ {'"*])\s*(?![ (])/, stack[1])) {
+    // Emit the warning synchronously because we are in the middle of handling
+    // a SyntaxError that will throw and likely terminate the process before an
+    // asynchronous warning would be emitted.
+    emitWarningSync(
+      'To load an ES module, set "type": "module" in the package.json or use ' +
+      'the .mjs extension.'
+    );
+  }
+}
+
 // Strategy for loading a node-style CommonJS module
 const isWindows = process.platform === 'win32';
 const winSepRegEx = /\//g;
@@ -152,7 +176,12 @@ translators.set('commonjs', async function commonjsStrategy(url, isMain) {
       exports = asyncESM.ESMLoader.cjsCache.get(module);
       asyncESM.ESMLoader.cjsCache.delete(module);
     } else {
-      exports = CJSModule._load(filename, undefined, isMain);
+      try {
+        exports = CJSModule._load(filename, undefined, isMain);
+      } catch (err) {
+        enrichCJSError(err);
+        throw err;
+      }
     }
 
     for (const exportName of exportNames) {
@@ -190,7 +219,13 @@ function cjsPreparseModuleExports(filename) {
     source = readFileSync(filename, 'utf8');
   } catch {}
 
-  const { exports, reexports } = cjsParse(source || '');
+  let exports, reexports;
+  try {
+    ({ exports, reexports } = cjsParse(source || ''));
+  } catch {
+    exports = [];
+    reexports = [];
+  }
 
   const exportNames = new SafeSet(exports);
 

--- a/test/es-module/test-esm-cjs-exports.js
+++ b/test/es-module/test-esm-cjs-exports.js
@@ -7,7 +7,7 @@ const assert = require('assert');
 
 const entry = fixtures.path('/es-modules/cjs-exports.mjs');
 
-const child = spawn(process.execPath, [entry]);
+let child = spawn(process.execPath, [entry]);
 child.stderr.setEncoding('utf8');
 let stdout = '';
 child.stdout.setEncoding('utf8');
@@ -18,4 +18,18 @@ child.on('close', common.mustCall((code, signal) => {
   assert.strictEqual(code, 0);
   assert.strictEqual(signal, null);
   assert.strictEqual(stdout, 'ok\n');
+}));
+
+const entryInvalid = fixtures.path('/es-modules/cjs-exports-invalid.mjs');
+child = spawn(process.execPath, [entryInvalid]);
+let stderr = '';
+child.stderr.setEncoding('utf8');
+child.stderr.on('data', (data) => {
+  stderr += data;
+});
+child.on('close', common.mustCall((code, signal) => {
+  assert.strictEqual(code, 1);
+  assert.strictEqual(signal, null);
+  assert.ok(stderr.includes('Warning: To load an ES module'));
+  assert.ok(stderr.includes('Unexpected token \'export\''));
 }));

--- a/test/fixtures/es-modules/cjs-exports-invalid.mjs
+++ b/test/fixtures/es-modules/cjs-exports-invalid.mjs
@@ -1,0 +1,1 @@
+import cjs from './invalid-cjs.js';

--- a/test/fixtures/es-modules/invalid-cjs.js
+++ b/test/fixtures/es-modules/invalid-cjs.js
@@ -1,0 +1,1 @@
+export var name = 5;


### PR DESCRIPTION
This fixes up the error message in the case when importing a CJS module that contains ES module syntax.

Specifically, hiding the cjs-module-lexer parse failure message, and also then surfacing the warning context that informs the user about the "type" and ".mjs" format indicators to be able to correct the underlying issue.

Before this change:

```js
import { name } from './module.cjs';
```

where `module.cjs` contains `export` / `import` syntax so is not valid CommonJS, would output as per the error in https://github.com/nodejs/node/issues/35425.

With this change, we now get an error like:

```
(node:7249) Warning: To load an ES module, set "type": "module" in the package.json or use the .mjs extension.
(Use `node --trace-warnings ...` to show where the warning was created)
/home/guybedford/Projects/node/test/fixtures/es-modules/invalid-cjs.js:1
export var name = 5;
^^^^^^

SyntaxError: Unexpected token 'export'
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
