### PR TITLE
timers: correct explanation in comment

### DIFF
--- a/lib/internal/timers.js
+++ b/lib/internal/timers.js
@@ -261,7 +261,7 @@ function ImmediateList() {
 }
 
 // Appends an item to the end of the linked list, adjusting the current tail's
-// previous and next pointers where applicable
+// next pointer and the item's previous pointer where applicable
 ImmediateList.prototype.append = function(item) {
   if (this.tail !== null) {
     this.tail._idleNext = item;


### PR DESCRIPTION

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines]