### PR TITLE
module: improve named cjs import errors

### DIFF
--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -23,7 +23,7 @@ const {
 const { ModuleWrap } = internalBinding('module_wrap');
 
 const { decorateErrorStack } = require('internal/util');
-const { fileURLToPath } = require('url');
+const { fileURLToPath } = require('internal/url');
 const assert = require('internal/assert');
 const resolvedPromise = PromiseResolve();
 
@@ -85,7 +85,7 @@ function extractExample(file, lineNumber) {
         ArrayPrototypeMap(imports, (i) => `  ${i}`),
         ',\n',
       )}\n` :
-      ` ${imports.join(joinString)} `;
+      ` ${ArrayPrototypeJoin(imports, joinString)} `;
 
     return `\n\nimport ${defaultImport} from '${node.node.source.value}';\n` +
       `const {${destructuringAssignment}} = ${defaultImport};\n`;

--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -68,7 +68,7 @@ function extractExample(file, lineNumber) {
     const imports = ArrayPrototypeMap(
       ArrayPrototypeFilter(
         node.node.specifiers,
-        (specifier) => specifier.type === 'ImportSpecifier')
+        (specifier) => (specifier.type === 'ImportSpecifier'),
       ),
       (specifier) => {
         const statement =
@@ -81,7 +81,10 @@ function extractExample(file, lineNumber) {
 
     const boilerplate = `const {  } = ${defaultImport};`;
     const destructuringAssignment = totalLength > 80 - boilerplate.length ?
-      `\n${ArrayPrototypeJoin(ArrayPrototypeMap(imports, (i) => `  ${i}`), ',\n')}\n` :
+      `\n${ArrayPrototypeJoin(
+        ArrayPrototypeMap(imports, (i) => `  ${i}`),
+        ',\n',
+      )}\n` :
       ` ${imports.join(joinString)} `;
 
     return `\n\nimport ${defaultImport} from '${node.node.source.value}';\n` +

--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const {
+  ArrayPrototypeFilter,
+  ArrayPrototypeFind,
   ArrayPrototypeJoin,
   ArrayPrototypeMap,
   ArrayPrototypePush,

--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -156,11 +156,8 @@ class ModuleJob {
       }
       jobsInGraph.add(moduleJob);
       const dependencyJobs = await moduleJob.linked;
-      return PromiseAll(
-        new SafeArrayIterator(
-          ArrayPrototypeMap(dependencyJobs, addJobsToDependencyGraph)
-        )
-      );
+      return PromiseAll(new SafeArrayIterator(
+        ArrayPrototypeMap(dependencyJobs, addJobsToDependencyGraph)));
     };
     await addJobsToDependencyGraph(this);
 
@@ -174,19 +171,15 @@ class ModuleJob {
       }
     } catch (e) {
       decorateErrorStack(e);
-      if (
-        StringPrototypeIncludes(e.message, ' does not provide an export named')
-      ) {
+      if (StringPrototypeIncludes(e.message,
+                                  ' does not provide an export named')) {
         const splitStack = StringPrototypeSplit(e.stack, '\n');
         const parentFileUrl = splitStack[0];
         const { 1: childSpecifier, 2: name } = StringPrototypeMatch(
           e.message,
-          /module '(.*)' does not provide an export named '(.+)'/
-        );
-        const childFileURL = await this.loader.resolve(
-          childSpecifier,
-          parentFileUrl
-        );
+          /module '(.*)' does not provide an export named '(.+)'/);
+        const childFileURL =
+            await this.loader.resolve(childSpecifier, parentFileUrl);
         const format = await this.loader.getFormat(childFileURL);
         if (format === 'commonjs') {
           const [, fileUrl, lineNumber] = StringPrototypeMatch(
@@ -197,8 +190,7 @@ class ModuleJob {
             fileURLToPath(fileUrl),
             Number(lineNumber)
           );
-          e.message =
-            `Named export '${name}' not found. The requested module` +
+          e.message = `Named export '${name}' not found. The requested module` +
             ` '${childSpecifier}' is a CommonJS module, which may not support` +
             ' all module.exports as named exports.\nCommonJS modules can ' +
             'always be imported via the default export, for example using:' +

--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -90,7 +90,7 @@ function extractExample(file, lineNumber) {
     return `\n\nimport ${defaultImport} from '${node.node.source.value}';\n` +
       `const {${destructuringAssignment}} = ${defaultImport};\n`;
   } while (node === undefined || node.node.loc.start.line <= lineNumber);
-  return '';
+  assert.fail('Could not find erroneous import statement');
 }
 
 /* A ModuleJob tracks the loading of a single Module, and the ModuleJobs of

--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -59,9 +59,9 @@ function extractExample(file, lineNumber) {
       node.node.specifiers,
       (specifier) => specifier.type === 'ImportDefaultSpecifier'
     );
-    const defaultImport = defaultSpecifier
-      ? defaultSpecifier.local.name
-      : 'pkg';
+    const defaultImport = defaultSpecifier ?
+      defaultSpecifier.local.name :
+      'pkg';
 
     const joinString = ', ';
     let totalLength = 0;
@@ -72,9 +72,9 @@ function extractExample(file, lineNumber) {
       ),
       (specifier) => {
         const statement =
-          specifier.local.name === specifier.imported.name
-            ? `${specifier.imported.name}`
-            : `${specifier.imported.name}: ${specifier.local.name}`;
+          specifier.local.name === specifier.imported.name ?
+            `${specifier.imported.name}` :
+            `${specifier.imported.name}: ${specifier.local.name}`;
         totalLength += statement.length + joinString.length;
         return statement;
       });

--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -55,7 +55,8 @@ function extractExample(file, lineNumber) {
       continue;
     }
 
-    const defaultSpecifier = node.node.specifiers.find(
+    const defaultSpecifier = ArrayPrototypeFind(
+      node.node.specifiers,
       (specifier) => specifier.type === 'ImportDefaultSpecifier'
     );
     const defaultImport = defaultSpecifier

--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -65,9 +65,12 @@ function extractExample(file, lineNumber) {
 
     const joinString = ', ';
     let totalLength = 0;
-    const imports = node.node.specifiers
-      .filter((specifier) => specifier.type === 'ImportSpecifier')
-      .map((specifier) => {
+    const imports = ArrayPrototypeMap(
+      ArrayPrototypeFilter(
+        node.node.specifiers,
+        (specifier) => specifier.type === 'ImportSpecifier')
+      ),
+      (specifier) => {
         const statement =
           specifier.local.name === specifier.imported.name
             ? `${specifier.imported.name}`
@@ -77,15 +80,12 @@ function extractExample(file, lineNumber) {
       });
 
     const boilerplate = `const {  } = ${defaultImport};`;
-    const destructuringAssignment =
-      totalLength > 80 - boilerplate.length
-        ? `\n${imports.map((i) => `  ${i}`).join(',\n')}\n`
-        : ` ${imports.join(joinString)} `;
+    const destructuringAssignment = totalLength > 80 - boilerplate.length ?
+      `\n${ArrayPrototypeJoin(ArrayPrototypeMap(imports, (i) => `  ${i}`), ',\n')}\n` :
+      ` ${imports.join(joinString)} `;
 
-    return (
-      `\n\nimport ${defaultImport} from '${node.node.source.value}';\n` +
-      `const {${destructuringAssignment}} = ${defaultImport};\n`
-    );
+    return `\n\nimport ${defaultImport} from '${node.node.source.value}';\n` +
+      `const {${destructuringAssignment}} = ${defaultImport};\n`;
   } while (node === undefined || node.node.loc.start.line <= lineNumber);
   return '';
 }

--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -5,6 +5,7 @@ const {
   ArrayPrototypeMap,
   ArrayPrototypePush,
   FunctionPrototype,
+  Number,
   ObjectSetPrototypeOf,
   PromiseAll,
   PromiseResolve,
@@ -14,19 +15,77 @@ const {
   SafeSet,
   StringPrototypeIncludes,
   StringPrototypeMatch,
-  StringPrototypeReplace,
   StringPrototypeSplit,
 } = primordials;
 
 const { ModuleWrap } = internalBinding('module_wrap');
 
 const { decorateErrorStack } = require('internal/util');
+const { fileURLToPath } = require('url');
 const assert = require('internal/assert');
 const resolvedPromise = PromiseResolve();
 
 const noop = FunctionPrototype;
 
 let hasPausedEntry = false;
+
+function extractExample(file, lineNumber) {
+  const { readFileSync } = require('fs');
+  const { parse } = require('internal/deps/acorn/acorn/dist/acorn');
+  const { findNodeAt } = require('internal/deps/acorn/acorn-walk/dist/walk');
+
+  const code = readFileSync(file, { encoding: 'utf8' });
+  const parsed = parse(code, {
+    sourceType: 'module',
+    locations: true,
+  });
+  let start = 0;
+  let node;
+  do {
+    node = findNodeAt(parsed, start);
+    start = node.node.end + 1;
+
+    if (node.node.loc.end.line < lineNumber) {
+      continue;
+    }
+
+    if (node.node.type !== 'ImportDeclaration') {
+      continue;
+    }
+
+    const defaultSpecifier = node.node.specifiers.find(
+      (specifier) => specifier.type === 'ImportDefaultSpecifier'
+    );
+    const defaultImport = defaultSpecifier
+      ? defaultSpecifier.local.name
+      : 'pkg';
+
+    const joinString = ', ';
+    let totalLength = 0;
+    const imports = node.node.specifiers
+      .filter((specifier) => specifier.type === 'ImportSpecifier')
+      .map((specifier) => {
+        const statement =
+          specifier.local.name === specifier.imported.name
+            ? `${specifier.imported.name}`
+            : `${specifier.imported.name}: ${specifier.local.name}`;
+        totalLength += statement.length + joinString.length;
+        return statement;
+      });
+
+    const boilerplate = `const {  } = ${defaultImport};`;
+    const destructuringAssignment =
+      totalLength > 80 - boilerplate.length
+        ? `\n${imports.map((i) => `  ${i}`).join(',\n')}\n`
+        : ` ${imports.join(joinString)} `;
+
+    return (
+      `\n\nimport ${defaultImport} from '${node.node.source.value}';\n` +
+      `const {${destructuringAssignment}} = ${defaultImport};\n`
+    );
+  } while (node === undefined || node.node.loc.start.line <= lineNumber);
+  return '';
+}
 
 /* A ModuleJob tracks the loading of a single Module, and the ModuleJobs of
  * its dependencies, over time. */
@@ -91,8 +150,11 @@ class ModuleJob {
       }
       jobsInGraph.add(moduleJob);
       const dependencyJobs = await moduleJob.linked;
-      return PromiseAll(new SafeArrayIterator(
-        ArrayPrototypeMap(dependencyJobs, addJobsToDependencyGraph)));
+      return PromiseAll(
+        new SafeArrayIterator(
+          ArrayPrototypeMap(dependencyJobs, addJobsToDependencyGraph)
+        )
+      );
     };
     await addJobsToDependencyGraph(this);
 
@@ -106,32 +168,35 @@ class ModuleJob {
       }
     } catch (e) {
       decorateErrorStack(e);
-      if (StringPrototypeIncludes(e.message,
-                                  ' does not provide an export named')) {
+      if (
+        StringPrototypeIncludes(e.message, ' does not provide an export named')
+      ) {
         const splitStack = StringPrototypeSplit(e.stack, '\n');
         const parentFileUrl = splitStack[0];
         const { 1: childSpecifier, 2: name } = StringPrototypeMatch(
           e.message,
-          /module '(.*)' does not provide an export named '(.+)'/);
-        const childFileURL =
-            await this.loader.resolve(childSpecifier, parentFileUrl);
+          /module '(.*)' does not provide an export named '(.+)'/
+        );
+        const childFileURL = await this.loader.resolve(
+          childSpecifier,
+          parentFileUrl
+        );
         const format = await this.loader.getFormat(childFileURL);
         if (format === 'commonjs') {
-          const importStatement = splitStack[1];
-          // TODO(@ctavan): The original error stack only provides the single
-          // line which causes the error. For multi-line import statements we
-          // cannot generate an equivalent object descructuring assignment by
-          // just parsing the error stack.
-          const oneLineNamedImports = StringPrototypeMatch(importStatement, /{.*}/);
-          const destructuringAssignment = oneLineNamedImports &&
-              StringPrototypeReplace(oneLineNamedImports, /\s+as\s+/g, ': ');
-          e.message = `Named export '${name}' not found. The requested module` +
+          const [, fileUrl, lineNumber] = StringPrototypeMatch(
+            parentFileUrl,
+            /^(.*):([0-9]+)$/
+          );
+          const example = extractExample(
+            fileURLToPath(fileUrl),
+            Number(lineNumber)
+          );
+          e.message =
+            `Named export '${name}' not found. The requested module` +
             ` '${childSpecifier}' is a CommonJS module, which may not support` +
             ' all module.exports as named exports.\nCommonJS modules can ' +
             'always be imported via the default export, for example using:' +
-            `\n\nimport pkg from '${childSpecifier}';\n${
-              destructuringAssignment ?
-                `const ${destructuringAssignment} = pkg;\n` : ''}`;
+            example;
           const newStack = StringPrototypeSplit(e.stack, '\n');
           newStack[3] = `SyntaxError: ${e.message}`;
           e.stack = ArrayPrototypeJoin(newStack, '\n');

--- a/test/es-module/test-esm-cjs-named-error.mjs
+++ b/test/es-module/test-esm-cjs-named-error.mjs
@@ -14,6 +14,21 @@ const errTemplate = (specifier, name, namedImports, defaultName) =>
 const expectedMultiLine = errTemplate('./fail.cjs', 'comeOn',
                                       '{ comeOn, everybody }');
 
+const expectedLongMultiLine = errTemplate('./fail.cjs', 'comeOn',
+                                          '{\n' +
+                                          '  comeOn,\n' +
+                                          '  one,\n' +
+                                          '  two,\n' +
+                                          '  three,\n' +
+                                          '  four,\n' +
+                                          '  five,\n' +
+                                          '  six,\n' +
+                                          '  seven,\n' +
+                                          '  eight,\n' +
+                                          '  nine,\n' +
+                                          '  ten\n' +
+                                          '}');
+
 const expectedRelative = errTemplate('./fail.cjs', 'comeOn', '{ comeOn }');
 
 const expectedRenamed = errTemplate('./fail.cjs', 'comeOn',
@@ -61,7 +76,14 @@ rejects(async () => {
 }, {
   name: 'SyntaxError',
   message: expectedMultiLine,
-}, 'should correctly format named imports across multiple lines');
+}, 'should correctly format named multi-line imports');
+
+rejects(async () => {
+  await import(`${fixtureBase}/long-multi-line.mjs`);
+}, {
+  name: 'SyntaxError',
+  message: expectedLongMultiLine,
+}, 'should correctly format named very long multi-line imports');
 
 rejects(async () => {
   await import(`${fixtureBase}/json-hack.mjs`);

--- a/test/es-module/test-esm-cjs-named-error.mjs
+++ b/test/es-module/test-esm-cjs-named-error.mjs
@@ -14,7 +14,7 @@ const errTemplate = (specifier, name, namedImports, defaultName) =>
 const expectedMultiLine = errTemplate('./fail.cjs', 'comeOn',
                                       '{ comeOn, everybody }');
 
-const expectedLongMultiLine = errTemplate('./fail.cjs', 'comeOn',
+const expectedLongMultiLine = errTemplate('./fail.cjs', 'one',
                                           '{\n' +
                                           '  comeOn,\n' +
                                           '  one,\n' +

--- a/test/fixtures/es-modules/package-cjs-named-error/default-and-renamed-import.mjs
+++ b/test/fixtures/es-modules/package-cjs-named-error/default-and-renamed-import.mjs
@@ -1,0 +1,4 @@
+import abc, {
+  comeOn as comeOnRenamed,
+  everybody,
+} from './fail.cjs';

--- a/test/fixtures/es-modules/package-cjs-named-error/fail.cjs
+++ b/test/fixtures/es-modules/package-cjs-named-error/fail.cjs
@@ -1,4 +1,14 @@
 module.exports = {
   comeOn: 'fhqwhgads',
   everybody: 'to the limit',
+  one: 1,
+  two: 2,
+  three: 3,
+  four: 4,
+  five: 5,
+  six: 6,
+  seven: 7,
+  eight: 8,
+  nine: 9,
+  ten: 10,
 };

--- a/test/fixtures/es-modules/package-cjs-named-error/long-multi-line.mjs
+++ b/test/fixtures/es-modules/package-cjs-named-error/long-multi-line.mjs
@@ -1,0 +1,14 @@
+import {
+  comeOn,
+  // everybody,
+  one,
+  two,
+  three,
+  four,
+  five,
+  six,
+  seven,
+  eight,
+  nine,
+  ten,
+} from "./fail.cjs";


### PR DESCRIPTION
When trying to import named exports from a CommonJS module an error is
thrown. Unfortunately the V8 error only contains the single line that
causes the error, it is therefore impossible to construct an equivalent
code consisting of default import + object descructuring assignment.

This was the reason why the example code was removed for multi line
import statements in https://github.com/nodejs/node/pull/35275

To generate a helpful error messages for any case we can parse the file
where the error happens using acorn and construct a valid example code
from the parsed ImportDeclaration. This will work for _any_ valid import
statement.

Since this code is only executed shortly before the node process crashes
anyways performance should not be a concern here.

Fixes: https://github.com/nodejs/node/issues/35259
Refs: https://github.com/nodejs/node/pull/35275

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
