### PR TITLE
doc: fix deprecation history

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -1739,7 +1739,7 @@ changes:
     description: Deprecation revoked.
   - version:
       - v9.9.0
-      - v10.0.0
+      - v8.13.0
     pr-url: https://github.com/nodejs/node/pull/17002
     description: Documentation-only deprecation.
 -->
@@ -2547,9 +2547,9 @@ API.
 <!-- YAML
 changes:
   - version:
-    - v12.19.0
-    - v14.6.0
-    pr-url: https://github.com/nodejs/node/pull/32217
+    - v14.1.0
+    - v13.14.0
+    pr-url: https://github.com/nodejs/node/pull/32807
     description: Documentation-only deprecation.
 -->
 
@@ -2598,7 +2598,9 @@ no longer required due to simplification of the implementation.
 ### DEP0144: `module.parent`
 <!-- YAML
 changes:
-  - version: v14.6.0
+  - version:
+    - v14.6.0
+    - v12.19.0
     pr-url: https://github.com/nodejs/node/pull/32217
     description: Documentation-only deprecation.
 -->


### PR DESCRIPTION
* DEP0089(9692df76c085ceb85e6959184bc2d26c5f6146d3) was backported to [v8.13.0](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V8.md#8.13.0). It's not in the v10.x changelog as it was already in v9.x.
* ~DEP0098(efb32592e1b78ec2559e1a409faa049e756a9501) doesn't appear anywhere in the v9.x nor v8.x changelogs, I don't think it's ever been backported.~
* DEP0140: was introduced by https://github.com/nodejs/node/pull/32807 and landed in v14.1.0 and v13.14.0
* DEP0144: just landed on v12.19.0

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
