### PR TITLE
doc: adopt MDN style for kbd elements

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -573,12 +573,18 @@ td > *:last-child {
 }
 
 kbd {
-  font-size: 1.2em;
-  font-weight: 700;
+  background-color: #eee;
   border-radius: 3px;
-  padding: 1px 2px 0;
-  border: 1px solid black;
-}
+  border: 1px solid #b4b4b4;
+  box-shadow: 0 1px 1px rgba(0, 0, 0, .2), 0 2px 0 0 rgba(255, 255, 255, .7) inset;
+  color: #333;
+  display: inline-block;
+  font-size: .85em;
+  font-weight: 700;
+  line-height: 1;
+  padding: 2px 4px;
+  white-space: nowrap;
+ }
 
 .changelog > summary {
   margin: .5rem 0;


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/718899/94914614-36eff880-0460-11eb-9fe3-0b7b1f9368ce.png)

After:

![image](https://user-images.githubusercontent.com/718899/94916631-e7abc700-0463-11eb-9bc7-6bf2b990d716.png)

<details>
<summary>The previous "After" version"</summary>
After:

![image](https://user-images.githubusercontent.com/718899/94914638-4111f700-0460-11eb-9ffe-a4884bb93499.png)
</details>
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
