### PR TITLE
src: move node_process to modern THROW_ERR*

### DIFF
--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -137,8 +137,9 @@ static void Kill(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   Local<Context> context = env->context();
 
-  if (args.Length() != 2)
-    return env->ThrowError("Bad argument.");
+  if (args.Length() < 2) {
+    THROW_ERR_MISSING_ARGS(env, "Bad argument.");
+  }
 
   int pid;
   if (!args[0]->Int32Value(context).To(&pid)) return;
@@ -292,8 +293,8 @@ static void ResourceUsage(const FunctionCallbackInfo<Value>& args) {
 static void DebugProcess(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
-  if (args.Length() != 1) {
-    return env->ThrowError("Invalid number of arguments.");
+  if (args.Length() < 1) {
+    return THROW_ERR_MISSING_ARGS(env, "Invalid number of arguments.");
   }
 
   CHECK(args[0]->IsNumber());
@@ -317,9 +318,8 @@ static void DebugProcess(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   Isolate* isolate = args.GetIsolate();
 
-  if (args.Length() != 1) {
-    env->ThrowError("Invalid number of arguments.");
-    return;
+  if (args.Length() < 1) {
+    return THROW_ERR_MISSING_ARGS(env, "Invalid number of arguments.");
   }
 
   HANDLE process = nullptr;


### PR DESCRIPTION
Semver-minor because it adds a code. Not semver-major because the error messages do not change. There is one changed detail tho: previously a couple of these functions would throw if *too many* arguments were passed in. I've relaxed that here given that it's not a check we consistently apply throughout.

Signed-off-by: James M Snell <jasnell@gmail.com>

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
