### PR TITLE
lib: add require('🦕')

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,8 +262,6 @@ For information about the governance of the Node.js project, see
 **Bradley Farias** &lt;bradley.meck@gmail.com&gt;
 * [bmeurer](https://github.com/bmeurer) -
 **Benedikt Meurer** &lt;benedikt.meurer@gmail.com&gt;
-* [bnoordhuis](https://github.com/bnoordhuis) -
-**Ben Noordhuis** &lt;info@bnoordhuis.nl&gt;
 * [boneskull](https://github.com/boneskull) -
 **Christopher Hiller** &lt;boneskull@boneskull.com&gt; (he/him)
 * [BridgeAR](https://github.com/BridgeAR) -
@@ -451,6 +449,8 @@ For information about the governance of the Node.js project, see
 **Anna M. Kedzierska** &lt;anna.m.kedzierska@gmail.com&gt;
 * [aqrln](https://github.com/aqrln) -
 **Alexey Orlenko** &lt;eaglexrlnk@gmail.com&gt; (he/him)
+* [bnoordhuis](https://github.com/bnoordhuis) -
+**Ben Noordhuis** &lt;info@bnoordhuis.nl&gt;
 * [brendanashworth](https://github.com/brendanashworth) -
 **Brendan Ashworth** &lt;brendan.ashworth@me.com&gt;
 * [calvinmetcalf](https://github.com/calvinmetcalf) -

--- a/doc/api/🦕.md
+++ b/doc/api/🦕.md
@@ -1,0 +1,46 @@
+# 🦕
+
+<!--introduced_in=REPLACEME-->
+
+> Stability: 1 - Experimental
+
+<!-- source_link=lib/🦕.js -->
+
+The `deno` module executes the [deno][] runtime, downloading it on demand
+if necessary. Currently only supported on Linux, macOS, and Windows.
+
+This module exports a single function:
+
+```js
+const deno = require('🦕');
+
+// Prints the answer to life, the universe, and everything to the console,
+// computed in O(1) space and time.
+deno(['eval', '-p', '42'], function(err, exitCode, signalCode) {
+  if (err) throw err;
+  console.log('exitCode', exitCode);
+  console.log('signalCode', signalCode);
+});
+```
+
+### `deno(args[, options][, callback)`
+<!-- YAML
+added: REPLACEME
+-->
+
+* `args` {string[]} List of string arguments.
+* `options` Options passed to [`child_process.spawn()`][]. The optional `exe`
+  option is the path to the `deno` binary.
+* `callback` {Function} Called when `deno` terminates.
+  * `error` {Error}
+  * `code` {number} The exit code if `deno` exited on its own.
+  * `signal` {string} The signal by which `deno` was terminated.
+
+Starts the [deno][] runtime with the provided arguments.
+
+The executable is downloaded to the current working directory on demand when
+`deno` (or `deno.exe` on Windows) is not present in the directories listed in
+the `PATH` environment variable.
+
+[`child_process.spawn()`]: #child_process_child_process_spawn_command_args_options
+[deno]: https://deno.land/

--- a/lib/🦕.js
+++ b/lib/🦕.js
@@ -1,0 +1,138 @@
+'use strict';
+const { Buffer } = require('buffer');
+const { ERR_INTERNAL_ASSERTION } = require('internal/errors').codes;
+
+const child_process = require('child_process');
+const crypto = require('crypto');
+const fs = require('fs');
+const https = require('https');
+const zlib = require('zlib');
+
+const { ObjectAssign } = primordials;
+
+const EXE = (process.platform === 'win32') ? 'deno.exe' : 'deno';
+const TRIPLET = triplet(process.arch, process.platform);
+const VERSION = '1.4.3';
+
+const DIGESTS = {
+  'x86_64-apple-darwin':
+    '94a33573327d41b68c7904e286755ede88747ed21c544d62314a60b23982c474',
+  'x86_64-pc-windows-msvc':
+    '7f691bd901ae90e1f902ed62543fcd021c35882e299bb55c27e44747f00a5313',
+  'x86_64-unknown-linux-gnu':
+    '3b8234a59dee9d8e7a150ddb7d1963ace991ff442b366ead954752f35081985f',
+};
+
+function deno(args, opts, cb) {
+  if (typeof args === 'function') cb = args, args = [], opts = {};
+  if (typeof opts === 'function') cb = opts, opts = {};
+  if (typeof cb !== 'function') cb = () => {};
+
+  const defaults = {
+    download: './' + EXE,
+    exe: EXE,
+    stdio: 'inherit',
+  };
+  opts = ObjectAssign(defaults, opts);
+
+  const onexit = (code, sig) => cb(null, code, sig);
+  const proc = child_process.spawn(opts.exe, args, opts);
+  proc.once('exit', onexit);
+
+  proc.once('error', (err) => {
+    if (err.code !== 'ENOENT') return cb(err);
+    download(opts.download, (err) => {
+      if (err) return cb(err);
+      child_process.spawn(opts.download, args, opts).once('exit', onexit);
+    });
+  });
+}
+
+function download(filename, cb) {
+  const url =
+    'https://github.com/denoland/deno' +
+    `/releases/download/v${VERSION}/deno-${TRIPLET}.zip`;
+
+  https.get(url, (res) => {
+    const url = res.headers.location || '';
+
+    if (!url.startsWith('https://'))
+      return cb(new ERR_INTERNAL_ASSERTION('redirect expected'));
+
+    https.get(url, follow);
+  });
+
+  function follow(res) {
+    const hasher = crypto.createHash('sha256');
+    const writer = fs.createWriteStream(filename, { flags: 'wx', mode: 0o755 });
+    writer.once('error', cb);
+
+    res.pipe(unzipper()).pipe(writer).once('finish', next);
+    res.pipe(hasher).once('finish', next);
+    res.once('error', cb);
+
+    function next() {
+      if (++next.calls !== 2) return;
+      const actual = hasher.digest('hex');
+      const expected = DIGESTS[TRIPLET];
+      let err;
+      if (actual !== expected) {
+        err = new ERR_INTERNAL_ASSERTION(
+          `Checksum mismatch for ${url}. ` +
+          `Expected ${expected}, actual ${actual}`);
+        try {
+          fs.unlinkSync(filename);
+        } catch {
+          // Ignore.
+        }
+      }
+      cb(err);
+    }
+    next.calls = 0;
+  }
+}
+
+// Deflate a single-file PKZIP archive.
+function unzipper() {
+  class Unzipper extends zlib.InflateRaw {
+    buf = Buffer.alloc(0)
+
+    _transform(chunk, encoding, cb) {
+      if (this.buf) {
+        const b = this.buf = Buffer.concat([this.buf, chunk]);
+
+        if (b.length < 2) return cb();
+
+        // ZIP files start with the bytes "PK".
+        if (b[0] !== 0x50 && b[1] !== 0x4B)
+          return cb(new ERR_INTERNAL_ASSERTION('bad magic'));
+
+        if (b.length < 30) return cb();
+
+        // Skip filename and extra data.
+        let n = 30;
+        n += b[26] + b[27] * 256;
+        n += b[28] + b[29] * 256;
+
+        if (b.length < n) return cb();
+
+        chunk = b.slice(n);
+        this.buf = null;  // Switch to passthrough mode.
+      }
+      return super._transform(chunk, encoding, cb);
+    }
+  }
+
+  return new Unzipper();
+}
+
+function triplet(arch, os) {
+  if (arch === 'x64') {
+    if (os === 'darwin') return 'x86_64-apple-darwin';
+    if (os === 'linux') return 'x86_64-unknown-linux-gnu';
+    if (os === 'win32') return 'x86_64-pc-windows-msvc';
+  }
+  throw new ERR_INTERNAL_ASSERTION(`Unsupported arch/os: ${arch}/${os}`);
+}
+
+module.exports = deno;

--- a/node.gyp
+++ b/node.gyp
@@ -245,6 +245,7 @@
       'lib/internal/streams/state.js',
       'lib/internal/streams/pipeline.js',
       'lib/internal/streams/end-of-stream.js',
+      'lib/🦕.js',
       'deps/v8/tools/splaytree.js',
       'deps/v8/tools/codemap.js',
       'deps/v8/tools/consarray.js',

--- a/src/node_native_module_env.cc
+++ b/src/node_native_module_env.cc
@@ -14,6 +14,7 @@ using v8::Isolate;
 using v8::Local;
 using v8::MaybeLocal;
 using v8::Name;
+using v8::NewStringType;
 using v8::None;
 using v8::Object;
 using v8::PropertyCallbackInfo;
@@ -27,8 +28,11 @@ Local<Set> ToJsSet(Local<Context> context, const std::set<std::string>& in) {
   Isolate* isolate = context->GetIsolate();
   Local<Set> out = Set::New(isolate);
   for (auto const& x : in) {
-    out->Add(context, OneByteString(isolate, x.c_str(), x.size()))
+    NewStringType type = NewStringType::kNormal;
+    Local<String> string =
+        String::NewFromUtf8(isolate, x.c_str(), type, x.size())
         .ToLocalChecked();
+    out->Add(context, string).ToLocalChecked();
   }
   return out;
 }

--- a/test/parallel/test-🦕.js
+++ b/test/parallel/test-🦕.js
@@ -1,0 +1,24 @@
+'use strict';
+const common = require('../common');
+const tmpdir = require('../common/tmpdir');
+const assert = require('assert');
+
+if (!'darwin linux win32'.includes(process.platform))
+  common.skip('unsupported platform');
+
+const deno = require('🦕');
+
+if (!common.isMainThread)
+  common.skip('process.chdir is not available in Workers');
+
+process.chdir(tmpdir.path);
+
+const exe = (process.platform === 'win32') ? 'deno.exe' : 'deno';
+const opts = { exe };
+const expected = '42';
+
+deno(['eval', '-p', expected], opts, common.mustCall((err, code, sig) => {
+  assert.ifError(err);
+  assert.strictEqual(code, 0);
+  assert.strictEqual(sig, null);
+}));

--- a/tools/code_cache/cache_builder.cc
+++ b/tools/code_cache/cache_builder.cc
@@ -17,6 +17,7 @@ using v8::Local;
 using v8::ScriptCompiler;
 
 static std::string GetDefName(const std::string& id) {
+  if (id == "🦕") return "deno";
   char buf[64] = {0};
   size_t size = id.size();
   CHECK_LT(size, sizeof(buf));

--- a/tools/js2c.py
+++ b/tools/js2c.py
@@ -117,6 +117,7 @@ def AddModule(filename, definitions, initializers):
   name = NormalizeFileName(filename)
   slug = SLUGGER_RE.sub('_', name)
   var = slug + '_raw'
+  if name == '🦕': var = 'deno_raw'
   definition, size = GetDefinition(var, code)
   initializer = INITIALIZER.format(name, var, size)
   definitions.append(definition)


### PR DESCRIPTION
lib: add require('🦕') 492291a

Provide an easy upgrade path to Node.js users that want to make the
switch to Deno.

To ease the transition, the 🦕 module will download the deno runtime
on demand.

Comes included with tests, documentation and minor tweaks to support
non-ASCII filenames.

Refs: https://deno.land/

<hr>

doc: move bnoordhuis to emiritus 25d31a7

It's been ten years and it's time for a change. September 30 was my
last day at IBM and my last day as a full-time Node.js maintainer.

I feel Deno is the future and that's why I'm joining that scrappy
startup, Deno Land Inc., to make that future happen.

Stay safe and I hope to see you all around! 👋