### PR TITLE
doc,crypto: added sign/verify method changes about dsaEncoding

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1458,6 +1458,11 @@ changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/35093
     description: The privateKey can also be an ArrayBuffer and CryptoKey.
+  - version:
+     - v12.16.0
+     - v13.2.0
+    pr-url: https://github.com/nodejs/node/pull/29292
+    description: This function now supports IEEE-P1363 DSA and ECDSA signatures.
   - version: v12.0.0
     pr-url: https://github.com/nodejs/node/pull/26960
     description: This function now supports RSA-PSS keys.
@@ -1576,6 +1581,11 @@ changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/35093
     description: The object can also be an ArrayBuffer and CryptoKey.
+  - version:
+     - v12.16.0
+     - v13.2.0
+    pr-url: https://github.com/nodejs/node/pull/29292
+    description: This function now supports IEEE-P1363 DSA and ECDSA signatures.
   - version: v12.0.0
     pr-url: https://github.com/nodejs/node/pull/26960
     description: This function now supports RSA-PSS keys.
@@ -3284,6 +3294,12 @@ Throws an error if FIPS mode is not available.
 ### `crypto.sign(algorithm, data, key)`
 <!-- YAML
 added: v12.0.0
+changes:
+  - version:
+     - v12.16.0
+     - v13.2.0
+    pr-url: https://github.com/nodejs/node/pull/29292
+    description: This function now supports IEEE-P1363 DSA and ECDSA signatures.
 -->
 
 <!--lint disable maximum-line-length remark-lint-->
@@ -3350,6 +3366,11 @@ changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/35093
     description: The data, key, and signature arguments can also be ArrayBuffer.
+  - version:
+     - v12.16.0
+     - v13.2.0
+    pr-url: https://github.com/nodejs/node/pull/29292
+    description: This function now supports IEEE-P1363 DSA and ECDSA signatures.
 -->
 
 <!--lint disable maximum-line-length remark-lint-->


### PR DESCRIPTION
This adds the sign/verify method addition of `dsaEncoding` from #29292 to the docs.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
