### PR TITLE
tools,test: enable multiline-comment-style rule in tests

### DIFF
--- a/test/.eslintrc.yaml
+++ b/test/.eslintrc.yaml
@@ -5,11 +5,10 @@ env:
   es6: true
 
 rules:
-  # ECMAScript 6
-  # http://eslint.org/docs/rules/#ecmascript-6
   no-var: error
   prefer-const: error
   symbol-description: off
+  multiline-comment-style: ["error", "separate-lines"] 
 
   no-restricted-syntax:
     # Config copied from .eslintrc.js

--- a/test/async-hooks/test-enable-disable.js
+++ b/test/async-hooks/test-enable-disable.js
@@ -1,85 +1,84 @@
-/*
- *  Test Steps Explained
- *  ====================
- *
- *  Initializing hooks:
- *
- *  We initialize 3 hooks. For hook2 and hook3 we register a callback for the
- *  "before" and in case of hook3 also for the "after" invocations.
- *
- *  Enabling hooks initially:
- *
- *  We only enable hook1 and hook3 initially.
- *
- *  Enabling hook2:
- *
- *  When hook3's "before" invocation occurs we enable hook2.  Since this
- *  happens right before calling `onfirstImmediate` hook2 will miss all hook
- *  invocations until then, including the "init" and "before" of the first
- *  Immediate.
- *  However afterwards it collects all invocations that follow on the first
- *  Immediate as well as all invocations on the second Immediate.
- *
- *  This shows that a hook can enable another hook inside a life time event
- *  callback.
- *
- *
- *  Disabling hook1
- *
- *  Since we registered the "before" callback for hook2 it will execute it
- *  right before `onsecondImmediate` is called.
- *  At that point we disable hook1 which is why it will miss all invocations
- *  afterwards and thus won't include the second "after" as well as the
- *  "destroy" invocations
- *
- *  This shows that a hook can disable another hook inside a life time event
- *  callback.
- *
- *  Disabling hook3
- *
- *  When the second "after" invocation occurs (after onsecondImmediate), hook3
- *  disables itself.
- *  As a result it will not receive the "destroy" invocation.
- *
- *  This shows that a hook can disable itself inside a life time event callback.
- *
- *  Sample Test Log
- *  ===============
- *
- *  - setting up first Immediate
- *  hook1.init.uid-5
- *  hook3.init.uid-5
- *  - finished setting first Immediate
+//  Test Steps Explained
+//  ====================
+//
+//  Initializing hooks:
+//
+//  We initialize 3 hooks. For hook2 and hook3 we register a callback for the
+//  "before" and in case of hook3 also for the "after" invocations.
+//
+//  Enabling hooks initially:
+//
+//  We only enable hook1 and hook3 initially.
+//
+//  Enabling hook2:
+//
+//  When hook3's "before" invocation occurs we enable hook2.  Since this
+//  happens right before calling `onfirstImmediate` hook2 will miss all hook
+//  invocations until then, including the "init" and "before" of the first
+//  Immediate.
+//  However afterwards it collects all invocations that follow on the first
+//  Immediate as well as all invocations on the second Immediate.
+//
+//  This shows that a hook can enable another hook inside a life time event
+//  callback.
+//
+//
+//  Disabling hook1
+//
+//  Since we registered the "before" callback for hook2 it will execute it
+//  right before `onsecondImmediate` is called.
+//  At that point we disable hook1 which is why it will miss all invocations
+//  afterwards and thus won't include the second "after" as well as the
+//  "destroy" invocations
+//
+//  This shows that a hook can disable another hook inside a life time event
+//  callback.
+//
+//  Disabling hook3
+//
+//  When the second "after" invocation occurs (after onsecondImmediate), hook3
+//  disables itself.
+//  As a result it will not receive the "destroy" invocation.
+//
+//  This shows that a hook can disable itself inside a life time event callback.
+//
+//  Sample Test Log
+//  ===============
+//
+//  - setting up first Immediate
+//  hook1.init.uid-5
+//  hook3.init.uid-5
+//  - finished setting first Immediate
+//
+//  hook1.before.uid-5
+//  hook3.before.uid-5
+//  - enabled hook2
+//  - entering onfirstImmediate
+//
+//  - setting up second Immediate
+//  hook1.init.uid-6
+//  hook3.init.uid-6
+//  hook2.init.uid-6
+//  - finished setting second Immediate
+//
+//  - exiting onfirstImmediate
+//  hook1.after.uid-5
+//  hook3.after.uid-5
+//  hook2.after.uid-5
+//  hook1.destroy.uid-5
+//  hook3.destroy.uid-5
+//  hook2.destroy.uid-5
+//  hook1.before.uid-6
+//  hook3.before.uid-6
+//  hook2.before.uid-6
+//  - disabled hook1
+//  - entering onsecondImmediate
+//  - exiting onsecondImmediate
+//  hook3.after.uid-6
+//  - disabled hook3
+//  hook2.after.uid-6
+//  hook2.destroy.uid-6
 
- *  hook1.before.uid-5
- *  hook3.before.uid-5
- *  - enabled hook2
- *  - entering onfirstImmediate
-
- *  - setting up second Immediate
- *  hook1.init.uid-6
- *  hook3.init.uid-6
- *  hook2.init.uid-6
- *  - finished setting second Immediate
-
- *  - exiting onfirstImmediate
- *  hook1.after.uid-5
- *  hook3.after.uid-5
- *  hook2.after.uid-5
- *  hook1.destroy.uid-5
- *  hook3.destroy.uid-5
- *  hook2.destroy.uid-5
- *  hook1.before.uid-6
- *  hook3.before.uid-6
- *  hook2.before.uid-6
- *  - disabled hook1
- *  - entering onsecondImmediate
- *  - exiting onsecondImmediate
- *  hook3.after.uid-6
- *  - disabled hook3
- *  hook2.after.uid-6
- *  hook2.destroy.uid-6
- */
 
 'use strict';
 

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -195,11 +195,9 @@ const PIPE = (() => {
   return path.join(pipePrefix, pipeName);
 })();
 
-/*
- * Check that when running a test with
- * `$node --abort-on-uncaught-exception $file child`
- * the process aborts.
- */
+// Check that when running a test with
+// `$node --abort-on-uncaught-exception $file child`
+// the process aborts.
 function childShouldThrowAndAbort() {
   let testCmd = '';
   if (!isWindows) {

--- a/test/internet/test-dns-ipv6.js
+++ b/test/internet/test-dns-ipv6.js
@@ -103,19 +103,18 @@ TEST(async function test_lookup_ipv6_explicit(done) {
   checkWrap(req);
 });
 
-/* This ends up just being too problematic to test
-TEST(function test_lookup_ipv6_implicit(done) {
-  var req = dns.lookup(addresses.INET6_HOST, function(err, ip, family) {
-    assert.ifError(err);
-    assert.ok(net.isIPv6(ip));
-    assert.strictEqual(family, 6);
+// This ends up just being too problematic to test
+// TEST(function test_lookup_ipv6_implicit(done) {
+//   var req = dns.lookup(addresses.INET6_HOST, function(err, ip, family) {
+//     assert.ifError(err);
+//     assert.ok(net.isIPv6(ip));
+//     assert.strictEqual(family, 6);
 
-    done();
-  });
+//     done();
+//   });
 
-  checkWrap(req);
-});
-*/
+//   checkWrap(req);
+// });
 
 TEST(async function test_lookup_ipv6_explicit_object(done) {
   function validateResult(res) {
@@ -233,15 +232,15 @@ TEST(function test_lookupservice_ip_ipv6(done) {
   checkWrap(req);
 });
 
-/* Disabled because it appears to be not working on linux. */
-/* TEST(function test_lookup_localhost_ipv6(done) {
-  var req = dns.lookup('localhost', 6, function(err, ip, family) {
-    assert.ifError(err);
-    assert.ok(net.isIPv6(ip));
-    assert.strictEqual(family, 6);
-
-    done();
-  });
-
-  checkWrap(req);
-}); */
+// Disabled because it appears to be not working on Linux.
+// TEST(function test_lookup_localhost_ipv6(done) {
+//   var req = dns.lookup('localhost', 6, function(err, ip, family) {
+//     assert.ifError(err);
+//     assert.ok(net.isIPv6(ip));
+//     assert.strictEqual(family, 6);
+//
+//     done();
+//   });
+//
+//   checkWrap(req);
+// });

--- a/test/internet/test-http-dns-fail.js
+++ b/test/internet/test-http-dns-fail.js
@@ -20,10 +20,9 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-/*
- * Repeated requests for a domain that fails to resolve
- * should trigger the error event after each attempt.
- */
+
+// Repeated requests for a domain that fails to resolve
+// should trigger the error event after each attempt.
 
 const common = require('../common');
 const assert = require('assert');

--- a/test/node-api/test_make_callback/test.js
+++ b/test/node-api/test_make_callback/test.js
@@ -31,28 +31,28 @@ assert.strictEqual(makeCallback(this,
 
 // TODO(node-api): napi_make_callback needs to support
 // strings passed for the func argument
-/*
-const recv = {
-  one: common.mustCall(function() {
-    assert.strictEqual(0, arguments.length);
-    assert.strictEqual(this, recv);
-    return 42;
-  }),
-  two: common.mustCall(function(x) {
-    assert.strictEqual(1, arguments.length);
-    assert.strictEqual(this, recv);
-    assert.strictEqual(x, 1337);
-    return 42;
-  }),
-};
+//
+// const recv = {
+//   one: common.mustCall(function() {
+//     assert.strictEqual(0, arguments.length);
+//     assert.strictEqual(this, recv);
+//     return 42;
+//   }),
+//   two: common.mustCall(function(x) {
+//     assert.strictEqual(1, arguments.length);
+//     assert.strictEqual(this, recv);
+//     assert.strictEqual(x, 1337);
+//     return 42;
+//   }),
+// };
+//
+// assert.strictEqual(makeCallback(recv, 'one'), 42);
+// assert.strictEqual(makeCallback(recv, 'two', 1337), 42);
+//
+// // Check that callbacks on a receiver from a different context works.
+// const foreignObject = vm.runInNewContext('({ fortytwo() { return 42; } })');
+// assert.strictEqual(makeCallback(foreignObject, 'fortytwo'), 42);
 
-assert.strictEqual(makeCallback(recv, 'one'), 42);
-assert.strictEqual(makeCallback(recv, 'two', 1337), 42);
-
-// Check that callbacks on a receiver from a different context works.
-const foreignObject = vm.runInNewContext('({ fortytwo() { return 42; } })');
-assert.strictEqual(makeCallback(foreignObject, 'fortytwo'), 42);
-*/
 
 // Check that the callback is made in the context of the receiver.
 const target = vm.runInNewContext(`

--- a/test/parallel/test-buffer-parent-property.js
+++ b/test/parallel/test-buffer-parent-property.js
@@ -1,11 +1,9 @@
 'use strict';
 
-/*
- * Fix for https://github.com/nodejs/node/issues/8266
- *
- * Zero length Buffer objects should expose the `buffer` property of the
- * TypedArrays, via the `parent` property.
- */
+// Fix for https://github.com/nodejs/node/issues/8266
+//
+// Zero length Buffer objects should expose the `buffer` property of the
+// TypedArrays, via the `parent` property.
 require('../common');
 const assert = require('assert');
 

--- a/test/parallel/test-buffer-writeuint.js
+++ b/test/parallel/test-buffer-writeuint.js
@@ -3,13 +3,11 @@
 require('../common');
 const assert = require('assert');
 
-/*
- * We need to check the following things:
- *  - We are correctly resolving big endian (doesn't mean anything for 8 bit)
- *  - Correctly resolving little endian (doesn't mean anything for 8 bit)
- *  - Correctly using the offsets
- *  - Correctly interpreting values that are beyond the signed range as unsigned
- */
+// We need to check the following things:
+//  - We are correctly resolving big endian (doesn't mean anything for 8 bit)
+//  - Correctly resolving little endian (doesn't mean anything for 8 bit)
+//  - Correctly using the offsets
+//  - Correctly interpreting values that are beyond the signed range as unsigned
 
 { // OOB
   const data = Buffer.alloc(8);

--- a/test/parallel/test-child-process-cwd.js
+++ b/test/parallel/test-child-process-cwd.js
@@ -27,11 +27,9 @@ tmpdir.refresh();
 const assert = require('assert');
 const { spawn } = require('child_process');
 
-/*
-  Spawns 'pwd' with given options, then test
-  - whether the exit code equals expectCode,
-  - optionally whether the trimmed stdout result matches expectData
-*/
+// Spawns 'pwd' with given options, then test
+// - whether the exit code equals expectCode,
+// - optionally whether the trimmed stdout result matches expectData
 function testCwd(options, expectCode = 0, expectData) {
   const child = spawn(...common.pwdCommand, options);
 

--- a/test/parallel/test-child-process-double-pipe.js
+++ b/test/parallel/test-child-process-double-pipe.js
@@ -47,15 +47,13 @@ if (isWindows) {
   echo = spawn('echo', ['hello\nnode\nand\nworld\n']);
 }
 
-/*
- * grep and sed hang if the spawn function leaks file descriptors to child
- * processes.
- * This happens when calling pipe(2) and then forgetting to set the
- * FD_CLOEXEC flag on the resulting file descriptors.
- *
- * This test checks child processes exit, meaning they don't hang like
- * explained above.
- */
+// If the spawn function leaks file descriptors to subprocesses, grep and sed
+// hang.
+// This happens when calling pipe(2) and then forgetting to set the
+// FD_CLOEXEC flag on the resulting file descriptors.
+//
+// This test checks child processes exit, meaning they don't hang like
+// explained above.
 
 
 // pipe echo | grep

--- a/test/parallel/test-child-process-fork-dgram.js
+++ b/test/parallel/test-child-process-fork-dgram.js
@@ -20,12 +20,12 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-/*
- * The purpose of this test is to make sure that when forking a process,
- * sending a fd representing a UDP socket to the child and sending messages
- * to this endpoint, these messages are distributed to the parent and the
- * child process.
- */
+
+// The purpose of this test is to make sure that when forking a process,
+// sending a fd representing a UDP socket to the child and sending messages
+// to this endpoint, these messages are distributed to the parent and the
+// child process.
+
 
 const common = require('../common');
 if (common.isWindows)
@@ -80,10 +80,8 @@ if (process.argv[2] === 'child') {
     const serverPort = parentServer.address().port;
 
     const timer = setInterval(() => {
-      /*
-       * Both the parent and the child got at least one message,
-       * test passed, clean up everything.
-       */
+      // Both the parent and the child got at least one message,
+      // test passed, clean up everything.
       if (parentGotMessage && childGotMessage) {
         clearInterval(timer);
         client.close();

--- a/test/parallel/test-cluster-fork-windowsHide.js
+++ b/test/parallel/test-cluster-fork-windowsHide.js
@@ -5,16 +5,15 @@ const child_process = require('child_process');
 const cluster = require('cluster');
 
 if (!process.argv[2]) {
-  /* It seems Windows only allocate new console window for
-   * attaching processes spawned by detached processes. i.e.
-   * - If process D is spawned by process C with `detached: true`,
-   *   and process W is spawned by process D with `detached: false`,
-   *   W will get a new black console window popped up.
-   * - If D is spawned by C with `detached: false` or W is spawned
-   *   by D with `detached: true`, no console window will pop up for W.
-   *
-   * So, we have to spawn a detached process first to run the actual test.
-   */
+  // It seems Windows only allocate new console window for
+  // attaching processes spawned by detached processes. i.e.
+  // - If process D is spawned by process C with `detached: true`,
+  //   and process W is spawned by process D with `detached: false`,
+  //   W will get a new black console window popped up.
+  // - If D is spawned by C with `detached: false` or W is spawned
+  //   by D with `detached: true`, no console window will pop up for W.
+  //
+  // So, we have to spawn a detached process first to run the actual test.
   const master = child_process.spawn(
     process.argv[0],
     [process.argv[1], '--cluster'],

--- a/test/parallel/test-cluster-worker-destroy.js
+++ b/test/parallel/test-cluster-worker-destroy.js
@@ -20,13 +20,12 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-/*
- * The goal of this test is to cover the Workers' implementation of
- * Worker.prototype.destroy. Worker.prototype.destroy is called within
- * the worker's context: once when the worker is still connected to the
- * master, and another time when it's not connected to it, so that we cover
- * both code paths.
- */
+
+// The goal of this test is to cover the Workers' implementation of
+// Worker.prototype.destroy. Worker.prototype.destroy is called within
+// the worker's context: once when the worker is still connected to the
+// master, and another time when it's not connected to it, so that we cover
+// both code paths.
 
 const common = require('../common');
 const assert = require('assert');

--- a/test/parallel/test-crypto-dh-padding.js
+++ b/test/parallel/test-crypto-dh-padding.js
@@ -28,41 +28,40 @@ if (!common.hasCrypto)
 const assert = require('assert');
 const crypto = require('crypto');
 
-/* This test verifies padding with leading zeroes for shared
- * secrets that are strictly smaller than the modulus (prime).
- * See:
- *  RFC 4346: https://www.ietf.org/rfc/rfc4346.txt
- *  https://github.com/nodejs/node-v0.x-archive/issues/7906
- *  https://github.com/nodejs/node-v0.x-archive/issues/5239
- *
- * In FIPS mode OPENSSL_DH_FIPS_MIN_MODULUS_BITS = 1024, meaning we need
- * a FIPS-friendly >= 1024 bit prime, we can use MODP 14 from RFC 3526:
- * https://www.ietf.org/rfc/rfc3526.txt
- *
- * We can generate appropriate values with this code:
- *
- * crypto = require('crypto');
- *
- * for (;;) {
- *   var a = crypto.getDiffieHellman('modp14'),
- *   var b = crypto.getDiffieHellman('modp14');
- *
- *   a.generateKeys();
- *   b.generateKeys();
- *
- *   var aSecret = a.computeSecret(b.getPublicKey()).toString('hex');
- *   console.log("A public: " + a.getPublicKey().toString('hex'));
- *   console.log("A private: " + a.getPrivateKey().toString('hex'));
- *   console.log("B public: " + b.getPublicKey().toString('hex'));
- *   console.log("B private: " + b.getPrivateKey().toString('hex'));
- *   console.log("A secret: " + aSecret);
- *   console.log('-------------------------------------------------');
- *   if(aSecret.substring(0,2) === "00") {
- *     console.log("found short key!");
- *     return;
- *   }
- * }
- */
+// This test verifies padding with leading zeroes for shared
+// secrets that are strictly smaller than the modulus (prime).
+// See:
+//  RFC 4346: https://www.ietf.org/rfc/rfc4346.txt
+//  https://github.com/nodejs/node-v0.x-archive/issues/7906
+//  https://github.com/nodejs/node-v0.x-archive/issues/5239
+//
+// In FIPS mode OPENSSL_DH_FIPS_MIN_MODULUS_BITS = 1024, meaning we need
+// a FIPS-friendly >= 1024 bit prime, we can use MODP 14 from RFC 3526:
+// https://www.ietf.org/rfc/rfc3526.txt
+//
+// We can generate appropriate values with this code:
+//
+// crypto = require('crypto');
+//
+// for (;;) {
+//   var a = crypto.getDiffieHellman('modp14'),
+//   var b = crypto.getDiffieHellman('modp14');
+//
+//   a.generateKeys();
+//   b.generateKeys();
+//
+//   var aSecret = a.computeSecret(b.getPublicKey()).toString('hex');
+//   console.log("A public: " + a.getPublicKey().toString('hex'));
+//   console.log("A private: " + a.getPrivateKey().toString('hex'));
+//   console.log("B public: " + b.getPublicKey().toString('hex'));
+//   console.log("B private: " + b.getPrivateKey().toString('hex'));
+//   console.log("A secret: " + aSecret);
+//   console.log('-------------------------------------------------');
+//   if(aSecret.substring(0,2) === "00") {
+//     console.log("found short key!");
+//     return;
+//   }
+// }
 
 const apub =
 '5484455905d3eff34c70980e871f27f05448e66f5a6efbb97cbcba4e927196c2bd9ea272cded91\

--- a/test/parallel/test-crypto-dh.js
+++ b/test/parallel/test-crypto-dh.js
@@ -182,9 +182,9 @@ const aSecret = alice.computeSecret(bob.getPublicKey()).toString('hex');
 const bSecret = bob.computeSecret(alice.getPublicKey()).toString('hex');
 assert.strictEqual(aSecret, bSecret);
 
-/* Ensure specific generator (buffer) works as expected.
- * The values below (modp2/modp2buf) are for a 1024 bits long prime from
- * RFC 2412 E.2, see https://tools.ietf.org/html/rfc2412. */
+// Ensure specific generator (buffer) works as expected.
+// The values below (modp2/modp2buf) are for a 1024 bits long prime from
+// RFC 2412 E.2, see https://tools.ietf.org/html/rfc2412. */
 const modp2 = crypto.createDiffieHellmanGroup('modp2');
 const modp2buf = Buffer.from([
   0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xc9, 0x0f,

--- a/test/parallel/test-crypto-worker-thread.js
+++ b/test/parallel/test-crypto-worker-thread.js
@@ -4,8 +4,7 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 // Issue https://github.com/nodejs/node/issues/35263
-/* Description: test for checking keyobject passed to worker thread
- does not crash */
+// Description: Test that passing keyobject to worker thread does not crash.
 const { createSecretKey } = require('crypto');
 
 const { Worker, isMainThread, workerData } = require('worker_threads');

--- a/test/parallel/test-dns.js
+++ b/test/parallel/test-dns.js
@@ -207,15 +207,13 @@ assert.deepStrictEqual(dns.getServers(), []);
 }
 
 {
-  /*
-  * Make sure that dns.lookup throws if hints does not represent a valid flag.
-  * (dns.V4MAPPED | dns.ADDRCONFIG | dns.ALL) + 1 is invalid because:
-  * - it's different from dns.V4MAPPED and dns.ADDRCONFIG and dns.ALL.
-  * - it's different from any subset of them bitwise ored.
-  * - it's different from 0.
-  * - it's an odd number different than 1, and thus is invalid, because
-  * flags are either === 1 or even.
-  */
+  // Make sure that dns.lookup throws if hints does not represent a valid flag.
+  // (dns.V4MAPPED | dns.ADDRCONFIG | dns.ALL) + 1 is invalid because:
+  // - it's different from dns.V4MAPPED and dns.ADDRCONFIG and dns.ALL.
+  // - it's different from any subset of them bitwise ored.
+  // - it's different from 0.
+  // - it's an odd number different than 1, and thus is invalid, because
+  // flags are either === 1 or even.
   const hints = (dns.V4MAPPED | dns.ADDRCONFIG | dns.ALL) + 1;
   const err = {
     code: 'ERR_INVALID_ARG_VALUE',

--- a/test/parallel/test-domain-emit-error-handler-stack.js
+++ b/test/parallel/test-domain-emit-error-handler-stack.js
@@ -5,17 +5,15 @@ const assert = require('assert');
 const domain = require('domain');
 const EventEmitter = require('events');
 
-/*
- * Make sure that the domains stack and the active domain is setup properly when
- * a domain's error handler is called due to an error event being emitted.
- * More specifically, we want to test that:
- * - the active domain in the domain's error handler is *not* that domain, *but*
- *   the active domain is a any direct parent domain at the time the error was
- *   emitted.
- * - the domains stack in the domain's error handler does *not* include that
- *   domain, *but* it includes all parents of that domain when the error was
- *   emitted.
- */
+// Make sure that the domains stack and the active domain is setup properly when
+// a domain's error handler is called due to an error event being emitted.
+// More specifically, we want to test that:
+// - the active domain in the domain's error handler is//not* that domain,//but*
+//   the active domain is a any direct parent domain at the time the error was
+//   emitted.
+// - the domains stack in the domain's error handler does//not* include that
+//   domain, *but* it includes all parents of that domain when the error was
+//   emitted.
 const d1 = domain.create();
 const d2 = domain.create();
 const d3 = domain.create();

--- a/test/parallel/test-domain-thrown-error-handler-stack.js
+++ b/test/parallel/test-domain-thrown-error-handler-stack.js
@@ -3,11 +3,9 @@
 const common = require('../common');
 const domain = require('domain');
 
-/*
- * Make sure that when an erorr is thrown from a nested domain, its error
- * handler runs outside of that domain, but within the context of any parent
- * domain.
- */
+// Make sure that when an erorr is thrown from a nested domain, its error
+// handler runs outside of that domain, but within the context of any parent
+// domain.
 
 const d = domain.create();
 const d2 = domain.create();

--- a/test/parallel/test-domain-top-level-error-handler-clears-stack.js
+++ b/test/parallel/test-domain-top-level-error-handler-clears-stack.js
@@ -3,10 +3,8 @@
 const common = require('../common');
 const domain = require('domain');
 
-/*
- * Make sure that the domains stack is cleared after a top-level domain
- * error handler exited gracefully.
- */
+// Make sure that the domains stack is cleared after a top-level domain
+// error handler exited gracefully.
 const d = domain.create();
 
 d.on('error', common.mustCall(() => {

--- a/test/parallel/test-domain-top-level-error-handler-throw.js
+++ b/test/parallel/test-domain-top-level-error-handler-throw.js
@@ -1,11 +1,9 @@
 'use strict';
 
-/*
- * The goal of this test is to make sure that when a top-level error
- * handler throws an error following the handling of a previous error,
- * the process reports the error message from the error thrown in the
- * top-level error handler, not the one from the previous error.
- */
+// The goal of this test is to make sure that when a top-level error
+// handler throws an error following the handling of a previous error,
+// the process reports the error message from the error thrown in the
+// top-level error handler, not the one from the previous error.
 
 require('../common');
 

--- a/test/parallel/test-domain-uncaught-exception.js
+++ b/test/parallel/test-domain-uncaught-exception.js
@@ -1,12 +1,10 @@
 'use strict';
 
-/*
- * The goal of this test is to make sure that errors thrown within domains
- * are handled correctly. It checks that the process' 'uncaughtException' event
- * is emitted when appropriate, and not emitted when it shouldn't. It also
- * checks that the proper domain error handlers are called when they should
- * be called, and not called when they shouldn't.
- */
+// The goal of this test is to make sure that errors thrown within domains
+// are handled correctly. It checks that the process' 'uncaughtException' event
+// is emitted when appropriate, and not emitted when it shouldn't. It also
+// checks that the proper domain error handlers are called when they should
+// be called, and not called when they shouldn't.
 
 const common = require('../common');
 const assert = require('assert');
@@ -16,11 +14,9 @@ const child_process = require('child_process');
 const tests = [];
 
 function test1() {
-  /*
-   * Throwing from an async callback from within a domain that doesn't have
-   * an error handler must result in emitting the process' uncaughtException
-   * event.
-   */
+  // Throwing from an async callback from within a domain that doesn't have
+  // an error handler must result in emitting the process' uncaughtException
+  // event.
   const d = domain.create();
   d.run(function() {
     setTimeout(function onTimeout() {
@@ -35,10 +31,8 @@ tests.push({
 });
 
 function test2() {
-  /*
-   * Throwing from from within a domain that doesn't have an error handler must
-   * result in emitting the process' uncaughtException event.
-   */
+  // Throwing from from within a domain that doesn't have an error handler must
+  // result in emitting the process' uncaughtException event.
   const d2 = domain.create();
   d2.run(function() {
     throw new Error('boom!');
@@ -51,11 +45,9 @@ tests.push({
 });
 
 function test3() {
-  /*
-   * This test creates two nested domains: d3 and d4. d4 doesn't register an
-   * error handler, but d3 does. The error is handled by the d3 domain and thus
-   * an 'uncaughtException' event should _not_ be emitted.
-   */
+  // This test creates two nested domains: d3 and d4. d4 doesn't register an
+  // error handler, but d3 does. The error is handled by the d3 domain and thus
+  // an 'uncaughtException' event should _not_ be emitted.
   const d3 = domain.create();
   const d4 = domain.create();
 
@@ -76,15 +68,13 @@ tests.push({
 });
 
 function test4() {
-  /*
-   * This test creates two nested domains: d5 and d6. d6 doesn't register an
-   * error handler. When the timer's callback is called, because async
-   * operations like timer callbacks are bound to the domain that was active
-   * at the time of their creation, and because both d5 and d6 domains have
-   * exited by the time the timer's callback is called, its callback runs with
-   * only d6 on the domains stack. Since d6 doesn't register an error handler,
-   * the process' uncaughtException event should be emitted.
-   */
+  // This test creates two nested domains: d5 and d6. d6 doesn't register an
+  // error handler. When the timer's callback is called, because async
+  // operations like timer callbacks are bound to the domain that was active
+  // at the time of their creation, and because both d5 and d6 domains have
+  // exited by the time the timer's callback is called, its callback runs with
+  // only d6 on the domains stack. Since d6 doesn't register an error handler,
+  // the process' uncaughtException event should be emitted.
   const d5 = domain.create();
   const d6 = domain.create();
 
@@ -107,11 +97,9 @@ tests.push({
 });
 
 function test5() {
-  /*
-   * This test creates two nested domains: d7 and d8. d8 _does_ register an
-   * error handler, so throwing within that domain should not emit an uncaught
-   * exception.
-   */
+  // This test creates two nested domains: d7 and d8. d8 _does_ register an
+  // error handler, so throwing within that domain should not emit an uncaught
+  // exception.
   const d7 = domain.create();
   const d8 = domain.create();
 
@@ -131,11 +119,10 @@ tests.push({
 });
 
 function test6() {
-  /*
-   * This test creates two nested domains: d9 and d10. d10 _does_ register an
-   * error handler, so throwing within that domain in an async callback should
-   * _not_ emit an uncaught exception.
-   */
+  // This test creates two nested domains: d9 and d10. d10 _does_ register an
+  // error handler, so throwing within that domain in an async callback should
+  // _not_ emit an uncaught exception.
+  //
   const d9 = domain.create();
   const d10 = domain.create();
 

--- a/test/parallel/test-domain-with-abort-on-uncaught-exception.js
+++ b/test/parallel/test-domain-with-abort-on-uncaught-exception.js
@@ -4,27 +4,25 @@ const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 
-/*
- * The goal of this test is to make sure that:
- *
- * - Even if --abort_on_uncaught_exception is passed on the command line,
- * setting up a top-level domain error handler and throwing an error
- * within this domain does *not* make the process abort. The process exits
- * gracefully.
- *
- * - When passing --abort_on_uncaught_exception on the command line and
- * setting up a top-level domain error handler, an error thrown
- * within this domain's error handler *does* make the process abort.
- *
- * - When *not* passing --abort_on_uncaught_exception on the command line and
- * setting up a top-level domain error handler, an error thrown within this
- * domain's error handler does *not* make the process abort, but makes it exit
- * with the proper failure exit code.
- *
- * - When throwing an error within the top-level domain's error handler
- * within a try/catch block, the process should exit gracefully, whether or
- * not --abort_on_uncaught_exception is passed on the command line.
- */
+// The goal of this test is to make sure that:
+//
+// - Even if --abort_on_uncaught_exception is passed on the command line,
+// setting up a top-level domain error handler and throwing an error
+// within this domain does *not* make the process abort. The process exits
+// gracefully.
+//
+// - When passing --abort_on_uncaught_exception on the command line and
+// setting up a top-level domain error handler, an error thrown
+// within this domain's error handler *does* make the process abort.
+//
+// - When *not* passing --abort_on_uncaught_exception on the command line and
+// setting up a top-level domain error handler, an error thrown within this
+// domain's error handler does *not* make the process abort, but makes it exit
+// with the proper failure exit code.
+//
+// - When throwing an error within the top-level domain's error handler
+// within a try/catch block, the process should exit gracefully, whether or
+// not --abort_on_uncaught_exception is passed on the command line.
 
 const domainErrHandlerExMessage = 'exception from domain error handler';
 

--- a/test/parallel/test-fs-access.js
+++ b/test/parallel/test-fs-access.js
@@ -32,29 +32,27 @@ tmpdir.refresh();
 createFileWithPerms(readOnlyFile, 0o444);
 createFileWithPerms(readWriteFile, 0o666);
 
-/*
- * On non-Windows supported platforms, fs.access(readOnlyFile, W_OK, ...)
- * always succeeds if node runs as the super user, which is sometimes the
- * case for tests running on our continuous testing platform agents.
- *
- * In this case, this test tries to change its process user id to a
- * non-superuser user so that the test that checks for write access to a
- * read-only file can be more meaningful.
- *
- * The change of user id is done after creating the fixtures files for the same
- * reason: the test may be run as the superuser within a directory in which
- * only the superuser can create files, and thus it may need superuser
- * privileges to create them.
- *
- * There's not really any point in resetting the process' user id to 0 after
- * changing it to 'nobody', since in the case that the test runs without
- * superuser privilege, it is not possible to change its process user id to
- * superuser.
- *
- * It can prevent the test from removing files created before the change of user
- * id, but that's fine. In this case, it is the responsibility of the
- * continuous integration platform to take care of that.
- */
+// On non-Windows supported platforms, fs.access(readOnlyFile, W_OK, ...)
+// always succeeds if node runs as the super user, which is sometimes the
+// case for tests running on our continuous testing platform agents.
+//
+// In this case, this test tries to change its process user id to a
+// non-superuser user so that the test that checks for write access to a
+// read-only file can be more meaningful.
+//
+// The change of user id is done after creating the fixtures files for the same
+// reason: the test may be run as the superuser within a directory in which
+// only the superuser can create files, and thus it may need superuser
+// privileges to create them.
+//
+// There's not really any point in resetting the process' user id to 0 after
+// changing it to 'nobody', since in the case that the test runs without
+// superuser privilege, it is not possible to change its process user id to
+// superuser.
+//
+// It can prevent the test from removing files created before the change of user
+// id, but that's fine. In this case, it is the responsibility of the
+// continuous integration platform to take care of that.
 let hasWriteAccessForReadonlyFile = false;
 if (!common.isWindows && process.getuid() === 0) {
   hasWriteAccessForReadonlyFile = true;

--- a/test/parallel/test-fs-options-immutable.js
+++ b/test/parallel/test-fs-options-immutable.js
@@ -1,12 +1,10 @@
 'use strict';
 const common = require('../common');
 
-/*
- * These tests make sure that the `options` object passed to these functions are
- * never altered.
- *
- * Refer: https://github.com/nodejs/node/issues/7655
- */
+// These tests make sure that the `options` object passed to these functions are
+// never altered.
+//
+// Refer: https://github.com/nodejs/node/issues/7655
 
 const assert = require('assert');
 const fs = require('fs');

--- a/test/parallel/test-fs-promises-readfile-with-fd.js
+++ b/test/parallel/test-fs-promises-readfile-with-fd.js
@@ -1,9 +1,7 @@
 'use strict';
 
-/*
- * This test makes sure that `readFile()` always reads from the current
- * position of the file, instead of reading from the beginning of the file.
- */
+// This test makes sure that `readFile()` always reads from the current
+// position of the file, instead of reading from the beginning of the file.
 
 const common = require('../common');
 const assert = require('assert');

--- a/test/parallel/test-fs-promises-writefile-with-fd.js
+++ b/test/parallel/test-fs-promises-writefile-with-fd.js
@@ -1,9 +1,7 @@
 'use strict';
 
-/*
- * This test makes sure that `writeFile()` always writes from the current
- * position of the file, instead of truncating the file.
- */
+// This test makes sure that `writeFile()` always writes from the current
+// position of the file, instead of truncating the file.
 
 const common = require('../common');
 const assert = require('assert');

--- a/test/parallel/test-fs-readfile-fd.js
+++ b/test/parallel/test-fs-readfile-fd.js
@@ -51,37 +51,35 @@ function tempFdSync(callback) {
 }
 
 {
-  /*
-   * This test makes sure that `readFile()` always reads from the current
-   * position of the file, instead of reading from the beginning of the file,
-   * when used with file descriptors.
-   */
+  // This test makes sure that `readFile()` always reads from the current
+  // position of the file, instead of reading from the beginning of the file,
+  // when used with file descriptors.
 
   const filename = join(tmpdir.path, 'test.txt');
   fs.writeFileSync(filename, 'Hello World');
 
   {
-    /* Tests the fs.readFileSync(). */
+    // Tests the fs.readFileSync().
     const fd = fs.openSync(filename, 'r');
 
-    /* Read only five bytes, so that the position moves to five. */
+    // Read only five bytes, so that the position moves to five.
     const buf = Buffer.alloc(5);
     assert.deepStrictEqual(fs.readSync(fd, buf, 0, 5), 5);
     assert.deepStrictEqual(buf.toString(), 'Hello');
 
-    /* readFileSync() should read from position five, instead of zero. */
+    // readFileSync() should read from position five, instead of zero.
     assert.deepStrictEqual(fs.readFileSync(fd).toString(), ' World');
 
     fs.closeSync(fd);
   }
 
   {
-    /* Tests the fs.readFile(). */
+    // Tests the fs.readFile().
     fs.open(filename, 'r', common.mustCall((err, fd) => {
       assert.ifError(err);
       const buf = Buffer.alloc(5);
 
-      /* Read only five bytes, so that the position moves to five. */
+      // Read only five bytes, so that the position moves to five.
       fs.read(fd, buf, 0, 5, null, common.mustCall((err, bytes) => {
         assert.ifError(err);
         assert.strictEqual(bytes, 5);
@@ -89,7 +87,7 @@ function tempFdSync(callback) {
 
         fs.readFile(fd, common.mustCall((err, data) => {
           assert.ifError(err);
-          /* readFile() should read from position five, instead of zero. */
+          // readFile() should read from position five, instead of zero.
           assert.deepStrictEqual(data.toString(), ' World');
 
           fs.closeSync(fd);

--- a/test/parallel/test-fs-realpath.js
+++ b/test/parallel/test-fs-realpath.js
@@ -298,17 +298,16 @@ function test_deep_symlink_mix(realpath, realpathSync, callback) {
     return callback();
   }
 
-  /*
-  /tmp/node-test-realpath-f1 -> $tmpDir/node-test-realpath-d1/foo
-  /tmp/node-test-realpath-d1 -> $tmpDir/node-test-realpath-d2
-  /tmp/node-test-realpath-d2/foo -> $tmpDir/node-test-realpath-f2
-  /tmp/node-test-realpath-f2
-    -> $tmpDir/targets/nested-index/one/realpath-c
-  $tmpDir/targets/nested-index/one/realpath-c
-    -> $tmpDir/targets/nested-index/two/realpath-c
-  $tmpDir/targets/nested-index/two/realpath-c -> $tmpDir/cycles/root.js
-  $tmpDir/targets/cycles/root.js (hard)
-  */
+  // /tmp/node-test-realpath-f1 -> $tmpDir/node-test-realpath-d1/foo
+  // /tmp/node-test-realpath-d1 -> $tmpDir/node-test-realpath-d2
+  // /tmp/node-test-realpath-d2/foo -> $tmpDir/node-test-realpath-f2
+  // /tmp/node-test-realpath-f2
+  //   -> $tmpDir/targets/nested-index/one/realpath-c
+  // $tmpDir/targets/nested-index/one/realpath-c
+  //   -> $tmpDir/targets/nested-index/two/realpath-c
+  // $tmpDir/targets/nested-index/two/realpath-c -> $tmpDir/cycles/root.js
+  // $tmpDir/targets/cycles/root.js (hard)
+
   const entry = tmp('node-test-realpath-f1');
   try { fs.unlinkSync(tmp('node-test-realpath-d2/foo')); } catch {}
   try { fs.rmdirSync(tmp('node-test-realpath-d2')); } catch {}

--- a/test/parallel/test-fs-writefile-with-fd.js
+++ b/test/parallel/test-fs-writefile-with-fd.js
@@ -1,10 +1,8 @@
 'use strict';
 
-/*
- * This test makes sure that `writeFile()` always writes from the current
- * position of the file, instead of truncating the file, when used with file
- * descriptors.
- */
+// This test makes sure that `writeFile()` always writes from the current
+// position of the file, instead of truncating the file, when used with file
+// descriptors.
 
 const common = require('../common');
 const assert = require('assert');

--- a/test/parallel/test-http-client-keep-alive-release-before-finish.js
+++ b/test/parallel/test-http-client-keep-alive-release-before-finish.js
@@ -20,10 +20,9 @@ const server = http.createServer((req, res) => {
     res.resume();
   }));
 
-  /* What happens here is that the server `end`s the response before we send
-   * `something`, and the client thought that this is a green light for sending
-   * next GET request
-   */
+  // What happens here is that the server `end`s the response before we send
+  // `something`, and the client thought that this is a green light for sending
+  // next GET request
   post.write(Buffer.alloc(16 * 1024, 'X'));
   setTimeout(() => {
     post.end('something');

--- a/test/parallel/test-http-host-header-ipv6-fail.js
+++ b/test/parallel/test-http-host-header-ipv6-fail.js
@@ -1,13 +1,12 @@
 'use strict';
-/*
- * When using the object form of http.request and using an IPv6 address
- * as a hostname, and using a non-standard port, the Host header
- * is improperly formatted.
- * Issue: https://github.com/nodejs/node/issues/5308
- * As per https://tools.ietf.org/html/rfc7230#section-5.4 and
- * https://tools.ietf.org/html/rfc3986#section-3.2.2
- * the IPv6 address should be enclosed in square brackets
- */
+
+// When using the object form of http.request and using an IPv6 address
+// as a hostname, and using a non-standard port, the Host header
+// is improperly formatted.
+// Issue: https://github.com/nodejs/node/issues/5308
+// As per https://tools.ietf.org/html/rfc7230#section-5.4 and
+// https://tools.ietf.org/html/rfc3986#section-3.2.2
+// the IPv6 address should be enclosed in square brackets
 
 const common = require('../common');
 const assert = require('assert');

--- a/test/parallel/test-http-no-read-no-dump.js
+++ b/test/parallel/test-http-no-read-no-dump.js
@@ -40,10 +40,9 @@ const server = http.createServer((req, res) => {
     };
   }));
 
-  /* What happens here is that the server `end`s the response before we send
-   * `something`, and the client thought that this is a green light for sending
-   * next GET request
-   */
+  // What happens here is that the server `end`s the response before we send
+  // `something`, and the client thought that this is a green light for sending
+  // next GET request
   post.write('initial');
 
   http.request({

--- a/test/parallel/test-http-upgrade-server.js
+++ b/test/parallel/test-http-upgrade-server.js
@@ -78,9 +78,7 @@ function writeReq(socket, data, encoding) {
 }
 
 
-/*-----------------------------------------------
-  connection: Upgrade with listener
------------------------------------------------*/
+// connection: Upgrade with listener
 function test_upgrade_with_listener() {
   const conn = net.createConnection(server.address().port);
   conn.setEncoding('utf8');
@@ -118,9 +116,7 @@ function test_upgrade_with_listener() {
   });
 }
 
-/*-----------------------------------------------
-  connection: Upgrade, no listener
------------------------------------------------*/
+// connection: Upgrade, no listener
 function test_upgrade_no_listener() {
   const conn = net.createConnection(server.address().port);
   conn.setEncoding('utf8');
@@ -144,9 +140,7 @@ function test_upgrade_no_listener() {
   });
 }
 
-/*-----------------------------------------------
-  connection: normal
------------------------------------------------*/
+// connection: normal
 function test_standard_http() {
   const conn = net.createConnection(server.address().port);
   conn.setEncoding('utf8');
@@ -175,9 +169,7 @@ server.listen(0, function() {
 });
 
 
-/*-----------------------------------------------
-  Fin.
------------------------------------------------*/
+// Fin.
 process.on('exit', function() {
   assert.strictEqual(requests_recv, 3);
   assert.strictEqual(requests_sent, 3);

--- a/test/parallel/test-next-tick-doesnt-hang.js
+++ b/test/parallel/test-next-tick-doesnt-hang.js
@@ -20,10 +20,9 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-/*
- * This test verifies that having a single nextTick statement and nothing else
- * does not hang the event loop. If this test times out it has failed.
- */
+
+// This test verifies that having a single nextTick statement and nothing else
+// does not hang the event loop. If this test times out it has failed.
 
 require('../common');
 process.nextTick(function() {

--- a/test/parallel/test-next-tick-ordering.js
+++ b/test/parallel/test-next-tick-ordering.js
@@ -48,9 +48,8 @@ console.log('Running from main.');
 
 process.on('exit', function() {
   assert.strictEqual(done[0], 'nextTick');
-  /* Disabling this test. I don't think we can ensure the order
-  for (i = 0; i < N; i += 1) {
-    assert.strictEqual(i, done[i + 1]);
-  }
-  */
+  // Disabling this test. I don't think we can ensure the order
+  // for (i = 0; i < N; i += 1) {
+  //  assert.strictEqual(i, done[i + 1]);
+  // }
 });

--- a/test/parallel/test-process-env.js
+++ b/test/parallel/test-process-env.js
@@ -70,22 +70,21 @@ if (process.argv[2] === 'you-are-the-child') {
 delete process.env.NON_EXISTING_VARIABLE;
 assert(delete process.env.NON_EXISTING_VARIABLE);
 
-/* For the moment we are not going to support setting the timezone via the
- * environment variables. The problem is that various V8 platform backends
- * deal with timezone in different ways. The windows platform backend caches
- * the timezone value while the Linux one hits libc for every query.
-
-https://github.com/joyent/node/blob/08782931205bc4f6d28102ebc29fd806e8ccdf1f/deps/v8/src/platform-linux.cc#L339-345
-https://github.com/joyent/node/blob/08782931205bc4f6d28102ebc29fd806e8ccdf1f/deps/v8/src/platform-win32.cc#L590-596
-
-// set the timezone; see tzset(3)
-process.env.TZ = 'Europe/Amsterdam';
-
-// time difference between Greenwich and Amsterdam is +2 hours in the summer
-date = new Date('Fri, 10 Sep 1982 03:15:00 GMT');
-assert.strictEqual(3, date.getUTCHours());
-assert.strictEqual(5, date.getHours());
-*/
+// For the moment we are not going to support setting the timezone via the
+// environment variables. The problem is that various V8 platform backends
+// deal with timezone in different ways. The Windows platform backend caches
+// the timezone value while the Linux one hits libc for every query.
+//
+// https://github.com/joyent/node/blob/08782931205bc4f6d28102ebc29fd806e8ccdf1f/deps/v8/src/platform-linux.cc#L339-345
+// https://github.com/joyent/node/blob/08782931205bc4f6d28102ebc29fd806e8ccdf1f/deps/v8/src/platform-win32.cc#L590-596
+//
+// // set the timezone; see tzset(3)
+// process.env.TZ = 'Europe/Amsterdam';
+//
+// // time difference between Greenwich and Amsterdam is +2 hours in the summer
+// date = new Date('Fri, 10 Sep 1982 03:15:00 GMT');
+// assert.strictEqual(3, date.getUTCHours());
+// assert.strictEqual(5, date.getHours());
 
 // Environment variables should be case-insensitive on Windows, and
 // case-sensitive on other platforms.

--- a/test/parallel/test-querystring-maxKeys-non-finite.js
+++ b/test/parallel/test-querystring-maxKeys-non-finite.js
@@ -7,11 +7,8 @@ require('../common');
 const assert = require('assert');
 const parse = require('querystring').parse;
 
-/*
-taken from express-js/body-parser
-https://github.com/expressjs/body-parser/
-blob/ed25264fb494cf0c8bc992b8257092cd4f694d5e/test/urlencoded.js#L636-L651
-*/
+// Taken from express-js/body-parser
+// https://github.com/expressjs/body-parser/blob/ed25264fb494cf0c8bc992b8257092cd4f694d5e/test/urlencoded.js#L636-L651
 function createManyParams(count) {
   let str = '';
 

--- a/test/parallel/test-repl-unexpected-token-recoverable.js
+++ b/test/parallel/test-repl-unexpected-token-recoverable.js
@@ -1,7 +1,7 @@
 'use strict';
-/*
- * This is a regression test for https://github.com/joyent/node/issues/8874.
- */
+
+// This is a regression test for https://github.com/joyent/node/issues/8874.
+
 require('../common');
 const assert = require('assert');
 

--- a/test/parallel/test-stream-transform-final-sync.js
+++ b/test/parallel/test-stream-transform-final-sync.js
@@ -5,56 +5,56 @@ const assert = require('assert');
 const stream = require('stream');
 let state = 0;
 
-/*
-What you do
-const stream = new stream.Transform({
-  transform: function transformCallback(chunk, _, next) {
-    // part 1
-    this.push(chunk);
-    //part 2
-    next();
-  },
-  final: function endCallback(done) {
-    // part 1
-    process.nextTick(function () {
-      // part 2
-      done();
-    });
-  },
-  flush: function flushCallback(done) {
-    // part 1
-    process.nextTick(function () {
-      // part 2
-      done();
-    });
-  }
-});
-t.on('data', dataListener);
-t.on('end', endListener);
-t.on('finish', finishListener);
-t.write(1);
-t.write(4);
-t.end(7, endMethodCallback);
 
-The order things are called
-
-1. transformCallback part 1
-2. dataListener
-3. transformCallback part 2
-4. transformCallback part 1
-5. dataListener
-6. transformCallback part 2
-7. transformCallback part 1
-8. dataListener
-9. transformCallback part 2
-10. finalCallback part 1
-11. finalCallback part 2
-12. flushCallback part 1
-13. finishListener
-14. endMethodCallback
-15. flushCallback part 2
-16. endListener
-*/
+// What you do
+//
+// const stream = new stream.Transform({
+//   transform: function transformCallback(chunk, _, next) {
+//     // part 1
+//     this.push(chunk);
+//     //part 2
+//     next();
+//   },
+//   final: function endCallback(done) {
+//     // part 1
+//     process.nextTick(function () {
+//       // part 2
+//       done();
+//     });
+//   },
+//   flush: function flushCallback(done) {
+//     // part 1
+//     process.nextTick(function () {
+//       // part 2
+//       done();
+//     });
+//   }
+// });
+// t.on('data', dataListener);
+// t.on('end', endListener);
+// t.on('finish', finishListener);
+// t.write(1);
+// t.write(4);
+// t.end(7, endMethodCallback);
+//
+// The order things are called
+//
+// 1. transformCallback part 1
+// 2. dataListener
+// 3. transformCallback part 2
+// 4. transformCallback part 1
+// 5. dataListener
+// 6. transformCallback part 2
+// 7. transformCallback part 1
+// 8. dataListener
+// 9. transformCallback part 2
+// 10. finalCallback part 1
+// 11. finalCallback part 2
+// 12. flushCallback part 1
+// 13. finishListener
+// 14. endMethodCallback
+// 15. flushCallback part 2
+// 16. endListener
 
 const t = new stream.Transform({
   objectMode: true,

--- a/test/parallel/test-stream-transform-final.js
+++ b/test/parallel/test-stream-transform-final.js
@@ -5,56 +5,56 @@ const assert = require('assert');
 const stream = require('stream');
 let state = 0;
 
-/*
-What you do
-const stream = new stream.Transform({
-  transform: function transformCallback(chunk, _, next) {
-    // part 1
-    this.push(chunk);
-    //part 2
-    next();
-  },
-  final: function endCallback(done) {
-    // part 1
-    process.nextTick(function () {
-      // part 2
-      done();
-    });
-  },
-  flush: function flushCallback(done) {
-    // part 1
-    process.nextTick(function () {
-      // part 2
-      done();
-    });
-  }
-});
-t.on('data', dataListener);
-t.on('end', endListener);
-t.on('finish', finishListener);
-t.write(1);
-t.write(4);
-t.end(7, endMethodCallback);
 
-The order things are called
+// What you do:
+//
+// const stream = new stream.Transform({
+//   transform: function transformCallback(chunk, _, next) {
+//     // part 1
+//     this.push(chunk);
+//     //part 2
+//     next();
+//   },
+//   final: function endCallback(done) {
+//     // part 1
+//     process.nextTick(function () {
+//       // part 2
+//       done();
+//     });
+//   },
+//   flush: function flushCallback(done) {
+//     // part 1
+//     process.nextTick(function () {
+//       // part 2
+//       done();
+//     });
+//   }
+// });
+// t.on('data', dataListener);
+// t.on('end', endListener);
+// t.on('finish', finishListener);
+// t.write(1);
+// t.write(4);
+// t.end(7, endMethodCallback);
+//
+// The order things are called
 
-1. transformCallback part 1
-2. dataListener
-3. transformCallback part 2
-4. transformCallback part 1
-5. dataListener
-6. transformCallback part 2
-7. transformCallback part 1
-8. dataListener
-9. transformCallback part 2
-10. finalCallback part 1
-11. finalCallback part 2
-12. flushCallback part 1
-13. finishListener
-14. endMethodCallback
-15. flushCallback part 2
-16. endListener
-*/
+// 1. transformCallback part 1
+// 2. dataListener
+// 3. transformCallback part 2
+// 4. transformCallback part 1
+// 5. dataListener
+// 6. transformCallback part 2
+// 7. transformCallback part 1
+// 8. dataListener
+// 9. transformCallback part 2
+// 10. finalCallback part 1
+// 11. finalCallback part 2
+// 12. flushCallback part 1
+// 13. finishListener
+// 14. endMethodCallback
+// 15. flushCallback part 2
+// 16. endListener
 
 const t = new stream.Transform({
   objectMode: true,

--- a/test/parallel/test-timers-non-integer-delay.js
+++ b/test/parallel/test-timers-non-integer-delay.js
@@ -23,21 +23,19 @@
 const common = require('../common');
 const assert = require('assert');
 
-/*
- * This test makes sure that non-integer timer delays do not make the process
- * hang. See https://github.com/joyent/node/issues/8065 and
- * https://github.com/joyent/node/issues/8068 which have been fixed by
- * https://github.com/joyent/node/pull/8073.
- *
- * If the process hangs, this test will make the tests suite timeout,
- * otherwise it will exit very quickly (after 50 timers with a short delay
- * fire).
- *
- * We have to set at least several timers with a non-integer delay to
- * reproduce the issue. Sometimes, a timer with a non-integer delay will
- * expire correctly. 50 timers has always been more than enough to reproduce
- * it 100%.
- */
+// This test makes sure that non-integer timer delays do not make the process
+// hang. See https://github.com/joyent/node/issues/8065 and
+// https://github.com/joyent/node/issues/8068 which have been fixed by
+// https://github.com/joyent/node/pull/8073.
+//
+// If the process hangs, this test will make the tests suite timeout,
+// otherwise it will exit very quickly (after 50 timers with a short delay
+// fire).
+//
+// We have to set at least several timers with a non-integer delay to
+// reproduce the issue. Sometimes, a timer with a non-integer delay will
+// expire correctly. 50 timers has always been more than enough to reproduce
+// it 100%.
 
 const TIMEOUT_DELAY = 1.1;
 let N = 50;

--- a/test/parallel/test-timers-same-timeout-wrong-list-deleted.js
+++ b/test/parallel/test-timers-same-timeout-wrong-list-deleted.js
@@ -1,15 +1,13 @@
 'use strict';
 
-/*
- * This is a regression test for https://github.com/nodejs/node/issues/7722.
- *
- * When nested timers have the same timeout, calling clearTimeout on the
- * older timer after it has fired causes the list the newer timer is in
- * to be deleted. Since the newer timer was not cleared, it still blocks
- * the event loop completing for the duration of its timeout, however, since
- * no reference exists to it in its list, it cannot be canceled and its
- * callback is not called when the timeout elapses.
- */
+// This is a regression test for https://github.com/nodejs/node/issues/7722.
+//
+// When nested timers have the same timeout, calling clearTimeout on the
+// older timer after it has fired causes the list the newer timer is in
+// to be deleted. Since the newer timer was not cleared, it still blocks
+// the event loop completing for the duration of its timeout, however, since
+// no reference exists to it in its list, it cannot be canceled and its
+// callback is not called when the timeout elapses.
 
 const common = require('../common');
 

--- a/test/parallel/test-timers-socket-timeout-removes-other-socket-unref-timer.js
+++ b/test/parallel/test-timers-socket-timeout-removes-other-socket-unref-timer.js
@@ -1,8 +1,6 @@
 'use strict';
 
-/*
- * This test is a regression test for joyent/node#8897.
- */
+// Regression test for https://github.com/nodejs/node-v0.x-archive/issues/8897.
 
 const common = require('../common');
 const net = require('net');
@@ -14,12 +12,10 @@ const server = net.createServer(function onClient(client) {
   clients.push(client);
 
   if (clients.length === 2) {
-    /*
-     * Enroll two timers, and make the one supposed to fire first
-     * unenroll the other one supposed to fire later. This mutates
-     * the list of unref timers when traversing it, and exposes the
-     * original issue in joyent/node#8897.
-     */
+    // Enroll two timers, and make the one supposed to fire first
+    // unenroll the other one supposed to fire later. This mutates
+    // the list of unref timers when traversing it, and exposes the
+    // original issue in joyent/node#8897.
     clients[0].setTimeout(1, () => {
       clients[1].setTimeout(0);
       clients[0].end();

--- a/test/parallel/test-timers-unref-active.js
+++ b/test/parallel/test-timers-unref-active.js
@@ -1,19 +1,17 @@
 'use strict';
 
-/*
- * This test is aimed at making sure that unref timers queued with
- * timers._unrefActive work correctly.
- *
- * Basically, it queues one timer in the unref queue, and then queues
- * it again each time its timeout callback is fired until the callback
- * has been called ten times.
- *
- * At that point, it unenrolls the unref timer so that its timeout callback
- * is not fired ever again.
- *
- * Finally, a ref timeout is used with a delay large enough to make sure that
- * all 10 timeouts had the time to expire.
- */
+// This test is aimed at making sure that unref timers queued with
+// timers._unrefActive work correctly.
+//
+// Basically, it queues one timer in the unref queue, and then queues
+// it again each time its timeout callback is fired until the callback
+// has been called ten times.
+//
+// At that point, it unenrolls the unref timer so that its timeout callback
+// is not fired ever again.
+//
+// Finally, a ref timeout is used with a delay large enough to make sure that
+// all 10 timeouts had the time to expire.
 
 require('../common');
 const timers = require('timers');
@@ -22,14 +20,12 @@ const assert = require('assert');
 const someObject = {};
 let nbTimeouts = 0;
 
-/*
- * libuv 0.10.x uses GetTickCount on Windows to implement timers, which uses
- * system's timers whose resolution is between 10 and 16ms. See
- * http://msdn.microsoft.com/en-us/library/windows/desktop/ms724408.aspx
- * for more information. That's the lowest resolution for timers across all
- * supported platforms. We're using it as the lowest common denominator,
- * and thus expect 5 timers to be able to fire in under 100 ms.
- */
+// libuv 0.10.x uses GetTickCount on Windows to implement timers, which uses
+// system's timers whose resolution is between 10 and 16ms. See
+// http://msdn.microsoft.com/en-us/library/windows/desktop/ms724408.aspx
+// for more information. That's the lowest resolution for timers across all
+// supported platforms. We're using it as the lowest common denominator,
+// and thus expect 5 timers to be able to fire in under 100 ms.
 const N = 5;
 const TEST_DURATION = 1000;
 

--- a/test/parallel/test-timers-unref-remove-other-unref-timers-only-one-fires.js
+++ b/test/parallel/test-timers-unref-remove-other-unref-timers-only-one-fires.js
@@ -1,15 +1,15 @@
 'use strict';
 
-/*
- * The goal of this test is to make sure that, after the regression introduced
- * by 934bfe23a16556d05bfb1844ef4d53e8c9887c3d, the fix preserves the following
- * behavior of unref timers: if two timers are scheduled to fire at the same
- * time, if one unenrolls the other one in its _onTimeout callback, the other
- * one will *not* fire.
- *
- * This behavior is a private implementation detail and should not be
- * considered public interface.
- */
+
+// The goal of this test is to make sure that, after the regression introduced
+// by 934bfe23a16556d05bfb1844ef4d53e8c9887c3d, the fix preserves the following
+// behavior of unref timers: if two timers are scheduled to fire at the same
+// time, if one unenrolls the other one in its _onTimeout callback, the other
+// one will *not* fire.
+
+// This behavior is a private implementation detail and should not be
+// considered public interface.
+
 require('../common');
 const timers = require('timers');
 const assert = require('assert');

--- a/test/parallel/test-timers-unref-remove-other-unref-timers.js
+++ b/test/parallel/test-timers-unref-remove-other-unref-timers.js
@@ -1,11 +1,9 @@
 'use strict';
 
-/*
- * This test is a regression test for joyent/node#8897.
- *
- * It tests some private implementation details that should not be
- * considered public interface.
- */
+// Regression test for https://github.com/nodejs/node-v0.x-archive/issues/8897.
+
+// Test some private implementation details that should not be
+// considered public interface.
 const common = require('../common');
 const timers = require('timers');
 

--- a/test/parallel/test-timers-unrefd-interval-still-fires.js
+++ b/test/parallel/test-timers-unrefd-interval-still-fires.js
@@ -1,7 +1,5 @@
 'use strict';
-/*
- * This test is a regression test for joyent/node#8900.
- */
+// Regression test for https://github.com/nodejs/node-v0.x-archive/issues/8900.
 const common = require('../common');
 
 const TEST_DURATION = common.platformTimeout(1000);

--- a/test/parallel/test-tls-server-verify.js
+++ b/test/parallel/test-tls-server-verify.js
@@ -265,10 +265,8 @@ function runTest(port, testIndex) {
     rejectUnauthorized: tcase.rejectUnauthorized
   };
 
-  /*
-   * If renegotiating - session might be resumed and openssl won't request
-   * client's certificate (probably because of bug in the openssl)
-   */
+  // If renegotiating - session might be resumed and openssl won't request
+  // client's certificate (probably because of bug in the openssl)
   if (tcase.renegotiate) {
     serverOptions.secureOptions =
         SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION;

--- a/test/parallel/test-tls-wrap-event-emmiter.js
+++ b/test/parallel/test-tls-wrap-event-emmiter.js
@@ -1,9 +1,7 @@
 'use strict';
 
-/*
- * Issue: https://github.com/nodejs/node/issues/3655
- * Test checks if we get exception instead of runtime error
- */
+// Issue: https://github.com/nodejs/node/issues/3655
+// Test checks if we get exception instead of runtime error
 
 const common = require('../common');
 if (!common.hasCrypto)

--- a/test/parallel/test-url-relative.js
+++ b/test/parallel/test-url-relative.js
@@ -7,9 +7,7 @@ const url = require('url');
 // When source is false
 assert.strictEqual(url.resolveObject('', 'foo'), 'foo');
 
-/*
- [from, path, expected]
-*/
+// [from, path, expected]
 const relativeTests = [
   ['/foo/bar/baz', 'quux', '/foo/bar/quux'],
   ['/foo/bar/baz', 'quux/asdf', '/foo/bar/quux/asdf'],

--- a/test/parallel/test-whatwg-url-constructor.js
+++ b/test/parallel/test-whatwg-url-constructor.js
@@ -16,11 +16,11 @@ const request = {
   )
 };
 
-/* The following tests are copied from WPT. Modifications to them should be
-   upstreamed first. Refs:
-   https://github.com/w3c/web-platform-tests/blob/8791bed/url/url-constructor.html
-   License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
-*/
+// The following tests are copied from WPT. Modifications to them should be
+// upstreamed first.
+// Refs: https://github.com/w3c/web-platform-tests/blob/8791bed/url/url-constructor.html
+// License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
+
 /* eslint-disable */
 function runURLConstructorTests() {
   // var setup = async_test("Loading data…")

--- a/test/parallel/test-whatwg-url-origin.js
+++ b/test/parallel/test-whatwg-url-origin.js
@@ -15,11 +15,11 @@ const request = {
   )
 };
 
-/* The following tests are copied from WPT. Modifications to them should be
-   upstreamed first. Refs:
-   https://github.com/w3c/web-platform-tests/blob/8791bed/url/url-origin.html
-   License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
-*/
+// The following tests are copied from WPT. Modifications to them should be
+// upstreamed first.
+// Refs: https://github.com/w3c/web-platform-tests/blob/8791bed/url/url-origin.html
+// License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
+
 /* eslint-disable */
 function runURLOriginTests() {
   // var setup = async_test("Loading data…")

--- a/test/parallel/test-whatwg-url-setters.js
+++ b/test/parallel/test-whatwg-url-setters.js
@@ -16,11 +16,11 @@ const request = {
   ))
 };
 
-/* The following tests are copied from WPT. Modifications to them should be
-   upstreamed first. Refs:
-   https://github.com/w3c/web-platform-tests/blob/8791bed/url/url-setters.html
-   License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
-*/
+// The following tests are copied from WPT. Modifications to them should be
+// upstreamed first.
+// Refs: https://github.com/w3c/web-platform-tests/blob/8791bed/url/url-setters.html
+// License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
+
 /* eslint-disable */
 function startURLSettersTests() {
 //   var setup = async_test("Loading data…")

--- a/test/parallel/test-whatwg-url-toascii.js
+++ b/test/parallel/test-whatwg-url-toascii.js
@@ -15,11 +15,11 @@ const request = {
   )
 };
 
-/* The following tests are copied from WPT. Modifications to them should be
-   upstreamed first. Refs:
-   https://github.com/w3c/web-platform-tests/blob/4839a0a804/url/toascii.window.js
-   License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
-*/
+// The following tests are copied from WPT. Modifications to them should be
+// upstreamed first.
+// Refs: https://github.com/w3c/web-platform-tests/blob/4839a0a804/url/toascii.window.js
+// License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
+
 /* eslint-disable */
 // async_test(t => {
 //   const request = new XMLHttpRequest()

--- a/test/parallel/test-worker-debug.js
+++ b/test/parallel/test-worker-debug.js
@@ -128,14 +128,12 @@ class WorkerSession extends EventEmitter {
 }
 
 async function testBasicWorkerDebug(session, post) {
-  /*
-    1. Do 'enable' with waitForDebuggerOnStart = true
-    2. Run worker. It should break on start.
-    3. Enable Runtime (to get console message) and Debugger. Resume.
-    4. Breaks on the 'debugger' statement. Resume.
-    5. Console message received, worker runs to a completion.
-    6. contextCreated/contextDestroyed had been properly dispatched
-  */
+  // 1. Do 'enable' with waitForDebuggerOnStart = true
+  // 2. Run worker. It should break on start.
+  // 3. Enable Runtime (to get console message) and Debugger. Resume.
+  // 4. Breaks on the 'debugger' statement. Resume.
+  // 5. Console message received, worker runs to a completion.
+  // 6. contextCreated/contextDestroyed had been properly dispatched
   console.log('Test basic debug scenario');
   await post('NodeWorker.enable', { waitForDebuggerOnStart: true });
   const attached = waitForWorkerAttach(session);

--- a/test/sequential/test-child-process-exit.js
+++ b/test/sequential/test-child-process-exit.js
@@ -48,12 +48,6 @@ assert.ok(!child.stderr);
 
 console.error('gen=%d, pid=%d', gen, process.pid);
 
-/*
-var timer = setTimeout(function() {
-  throw new Error('timeout! gen='+gen);
-}, 1000);
-*/
-
 child.on('exit', function(code) {
   console.error('exit %d from gen %d', code, gen + 1);
 });

--- a/test/sequential/test-inspector-port-cluster.js
+++ b/test/sequential/test-inspector-port-cluster.js
@@ -14,10 +14,8 @@ const childProcess = require('child_process');
 
 let offset = 0;
 
-/*
- * This test suite checks that inspector port in cluster is incremented
- * for different execArgv combinations
- */
+// This test suite checks that inspector port in cluster is incremented
+// for different execArgv combinations
 
 function testRunnerMain() {
   let defaultPortCase = spawnMaster({

--- a/test/sequential/test-pipe.js
+++ b/test/sequential/test-pipe.js
@@ -34,9 +34,7 @@ let gotThanks = false;
 let tcpLengthSeen = 0;
 
 
-/*
- * 5MB of random buffer.
- */
+// 5MB of random buffer.
 const buffer = Buffer.allocUnsafe(bufferSize);
 for (let i = 0; i < buffer.length; i++) {
   buffer[i] = parseInt(Math.random() * 10000) % 256;


### PR DESCRIPTION
Use `//` for multline comments. Some tests mixed and matched, and at least one did so in a (to me) surprising way.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
