### PR TITLE
http2,tls: store WriteWrap using BaseObjectPtr

### DIFF
--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -1525,12 +1525,12 @@ void Http2Session::ClearOutgoing(int status) {
     std::vector<NgHttp2StreamWrite> current_outgoing_buffers_;
     current_outgoing_buffers_.swap(outgoing_buffers_);
     for (const NgHttp2StreamWrite& wr : current_outgoing_buffers_) {
-      WriteWrap* wrap = wr.req_wrap;
-      if (wrap != nullptr) {
+      BaseObjectPtr<AsyncWrap> wrap = std::move(wr.req_wrap);
+      if (wrap) {
         // TODO(addaleax): Pass `status` instead of 0, so that we actually error
         // out with the error from the write to the underlying protocol,
         // if one occurred.
-        wrap->Done(0);
+        WriteWrap::FromObject(wrap)->Done(0);
       }
     }
   }
@@ -1813,7 +1813,7 @@ void Http2Session::OnStreamRead(ssize_t nread, const uv_buf_t& buf_) {
 
 bool Http2Session::HasWritesOnSocketForStream(Http2Stream* stream) {
   for (const NgHttp2StreamWrite& wr : outgoing_buffers_) {
-    if (wr.req_wrap != nullptr && wr.req_wrap->stream() == stream)
+    if (wr.req_wrap && WriteWrap::FromObject(wr.req_wrap)->stream() == stream)
       return true;
   }
   return false;
@@ -1966,8 +1966,8 @@ void Http2Stream::Destroy() {
       // we still have queued outbound writes.
       while (!queue_.empty()) {
         NgHttp2StreamWrite& head = queue_.front();
-        if (head.req_wrap != nullptr)
-          head.req_wrap->Done(UV_ECANCELED);
+        if (head.req_wrap)
+          WriteWrap::FromObject(head.req_wrap)->Done(UV_ECANCELED);
         queue_.pop();
       }
 
@@ -2196,7 +2196,8 @@ int Http2Stream::DoWrite(WriteWrap* req_wrap,
     // Store the req_wrap on the last write info in the queue, so that it is
     // only marked as finished once all buffers associated with it are finished.
     queue_.emplace(NgHttp2StreamWrite {
-      i == nbufs - 1 ? req_wrap : nullptr,
+      BaseObjectPtr<AsyncWrap>(
+          i == nbufs - 1 ? req_wrap->GetAsyncWrap() : nullptr),
       bufs[i]
     });
     IncrementAvailableOutboundLength(bufs[i].len);
@@ -2290,10 +2291,11 @@ ssize_t Http2Stream::Provider::Stream::OnRead(nghttp2_session* handle,
   // find out when the HTTP2 stream wants to consume data, and because the
   // StreamBase API allows empty input chunks.
   while (!stream->queue_.empty() && stream->queue_.front().buf.len == 0) {
-    WriteWrap* finished = stream->queue_.front().req_wrap;
+    BaseObjectPtr<AsyncWrap> finished =
+        std::move(stream->queue_.front().req_wrap);
     stream->queue_.pop();
-    if (finished != nullptr)
-      finished->Done(0);
+    if (finished)
+      WriteWrap::FromObject(finished)->Done(0);
   }
 
   if (!stream->queue_.empty()) {
@@ -2919,8 +2921,8 @@ void Http2Ping::DetachFromSession() {
 }
 
 void NgHttp2StreamWrite::MemoryInfo(MemoryTracker* tracker) const {
-  if (req_wrap != nullptr)
-    tracker->TrackField("req_wrap", req_wrap->GetAsyncWrap());
+  if (req_wrap)
+    tracker->TrackField("req_wrap", req_wrap);
   tracker->TrackField("buf", buf);
 }
 

--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -144,12 +144,12 @@ using Http2Headers = NgHeaders<Http2HeadersTraits>;
 using Http2RcBufferPointer = NgRcBufPointer<Http2RcBufferPointerTraits>;
 
 struct NgHttp2StreamWrite : public MemoryRetainer {
-  WriteWrap* req_wrap = nullptr;
+  BaseObjectPtr<AsyncWrap> req_wrap;
   uv_buf_t buf;
 
   inline explicit NgHttp2StreamWrite(uv_buf_t buf_) : buf(buf_) {}
-  inline NgHttp2StreamWrite(WriteWrap* req, uv_buf_t buf_) :
-      req_wrap(req), buf(buf_) {}
+  inline NgHttp2StreamWrite(BaseObjectPtr<AsyncWrap> req_wrap, uv_buf_t buf_) :
+      req_wrap(std::move(req_wrap)), buf(buf_) {}
 
   void MemoryInfo(MemoryTracker* tracker) const override;
   SET_MEMORY_INFO_NAME(NgHttp2StreamWrite)

--- a/src/stream_base-inl.h
+++ b/src/stream_base-inl.h
@@ -243,6 +243,28 @@ StreamBase* StreamBase::FromObject(v8::Local<v8::Object> obj) {
           StreamBase::kStreamBaseField));
 }
 
+WriteWrap* WriteWrap::FromObject(v8::Local<v8::Object> req_wrap_obj) {
+  return static_cast<WriteWrap*>(StreamReq::FromObject(req_wrap_obj));
+}
+
+template <typename T, bool kIsWeak>
+WriteWrap* WriteWrap::FromObject(
+    const BaseObjectPtrImpl<T, kIsWeak>& base_obj) {
+  if (!base_obj) return nullptr;
+  return FromObject(base_obj->object());
+}
+
+ShutdownWrap* ShutdownWrap::FromObject(v8::Local<v8::Object> req_wrap_obj) {
+  return static_cast<ShutdownWrap*>(StreamReq::FromObject(req_wrap_obj));
+}
+
+template <typename T, bool kIsWeak>
+ShutdownWrap* ShutdownWrap::FromObject(
+    const BaseObjectPtrImpl<T, kIsWeak>& base_obj) {
+  if (!base_obj) return nullptr;
+  return FromObject(base_obj->object());
+}
+
 void WriteWrap::SetAllocatedStorage(AllocatedBuffer&& storage) {
   CHECK_NULL(storage_.data());
   storage_ = std::move(storage);

--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -621,12 +621,16 @@ StreamResource::~StreamResource() {
 
 ShutdownWrap* StreamBase::CreateShutdownWrap(
     Local<Object> object) {
-  return new SimpleShutdownWrap<AsyncWrap>(this, object);
+  auto* wrap = new SimpleShutdownWrap<AsyncWrap>(this, object);
+  wrap->MakeWeak();
+  return wrap;
 }
 
 WriteWrap* StreamBase::CreateWriteWrap(
     Local<Object> object) {
-  return new SimpleWriteWrap<AsyncWrap>(this, object);
+  auto* wrap = new SimpleWriteWrap<AsyncWrap>(this, object);
+  wrap->MakeWeak();
+  return wrap;
 }
 
 }  // namespace node

--- a/src/stream_base.h
+++ b/src/stream_base.h
@@ -77,6 +77,11 @@ class ShutdownWrap : public StreamReq {
       StreamBase* stream,
       v8::Local<v8::Object> req_wrap_obj);
 
+  static inline ShutdownWrap* FromObject(v8::Local<v8::Object> req_wrap_obj);
+  template <typename T, bool kIsWeak>
+  static inline ShutdownWrap* FromObject(
+      const BaseObjectPtrImpl<T, kIsWeak>& base_obj);
+
   // Call stream()->EmitAfterShutdown() and dispose of this request wrap.
   void OnDone(int status) override;
 };
@@ -88,6 +93,11 @@ class WriteWrap : public StreamReq {
   inline WriteWrap(
       StreamBase* stream,
       v8::Local<v8::Object> req_wrap_obj);
+
+  static inline WriteWrap* FromObject(v8::Local<v8::Object> req_wrap_obj);
+  template <typename T, bool kIsWeak>
+  static inline WriteWrap* FromObject(
+      const BaseObjectPtrImpl<T, kIsWeak>& base_obj);
 
   // Call stream()->EmitAfterWrite() and dispose of this request wrap.
   void OnDone(int status) override;

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -95,9 +95,9 @@ bool TLSWrap::InvokeQueued(int status, const char* error_str) {
   if (!write_callback_scheduled_)
     return false;
 
-  if (current_write_ != nullptr) {
-    WriteWrap* w = current_write_;
-    current_write_ = nullptr;
+  if (current_write_) {
+    WriteWrap* w = WriteWrap::FromObject(current_write_);
+    current_write_.reset();
     w->Done(status, error_str);
   }
 
@@ -301,7 +301,7 @@ void TLSWrap::EncOut() {
   }
 
   // Split-off queue
-  if (established_ && current_write_ != nullptr) {
+  if (established_ && current_write_) {
     Debug(this, "EncOut() setting write_callback_scheduled_");
     write_callback_scheduled_ = true;
   }
@@ -372,10 +372,10 @@ void TLSWrap::EncOut() {
 
 void TLSWrap::OnStreamAfterWrite(WriteWrap* req_wrap, int status) {
   Debug(this, "OnStreamAfterWrite(status = %d)", status);
-  if (current_empty_write_ != nullptr) {
+  if (current_empty_write_) {
     Debug(this, "Had empty write");
-    WriteWrap* finishing = current_empty_write_;
-    current_empty_write_ = nullptr;
+    WriteWrap* finishing = WriteWrap::FromObject(current_empty_write_);
+    current_empty_write_.reset();
     finishing->Done(status);
     return;
   }
@@ -735,14 +735,14 @@ int TLSWrap::DoWrite(WriteWrap* w,
     ClearOut();
     if (BIO_pending(enc_out_) == 0) {
       Debug(this, "No pending encrypted output, writing to underlying stream");
-      CHECK_NULL(current_empty_write_);
-      current_empty_write_ = w;
+      CHECK(!current_empty_write_);
+      current_empty_write_.reset(w->GetAsyncWrap());
       StreamWriteResult res =
           underlying_stream()->Write(bufs, count, send_handle);
       if (!res.async) {
         BaseObjectPtr<TLSWrap> strong_ref{this};
         env()->SetImmediate([this, strong_ref](Environment* env) {
-          OnStreamAfterWrite(current_empty_write_, 0);
+          OnStreamAfterWrite(WriteWrap::FromObject(current_empty_write_), 0);
         });
       }
       return 0;
@@ -750,8 +750,8 @@ int TLSWrap::DoWrite(WriteWrap* w,
   }
 
   // Store the current write wrap
-  CHECK_NULL(current_write_);
-  current_write_ = w;
+  CHECK(!current_write_);
+  current_write_.reset(w->GetAsyncWrap());
 
   // Write encrypted data to underlying stream and call Done().
   if (length == 0) {
@@ -804,7 +804,7 @@ int TLSWrap::DoWrite(WriteWrap* w,
     // If we stopped writing because of an error, it's fatal, discard the data.
     if (!arg.IsEmpty()) {
       Debug(this, "Got SSL error (%d), returning UV_EPROTO", err);
-      current_write_ = nullptr;
+      current_write_.reset();
       return UV_EPROTO;
     }
 

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -96,8 +96,9 @@ bool TLSWrap::InvokeQueued(int status, const char* error_str) {
     return false;
 
   if (current_write_) {
-    WriteWrap* w = WriteWrap::FromObject(current_write_);
+    BaseObjectPtr<AsyncWrap> current_write = std::move(current_write_);
     current_write_.reset();
+    WriteWrap* w = WriteWrap::FromObject(current_write);
     w->Done(status, error_str);
   }
 
@@ -374,8 +375,10 @@ void TLSWrap::OnStreamAfterWrite(WriteWrap* req_wrap, int status) {
   Debug(this, "OnStreamAfterWrite(status = %d)", status);
   if (current_empty_write_) {
     Debug(this, "Had empty write");
-    WriteWrap* finishing = WriteWrap::FromObject(current_empty_write_);
+    BaseObjectPtr<AsyncWrap> current_empty_write =
+        std::move(current_empty_write_);
     current_empty_write_.reset();
+    WriteWrap* finishing = WriteWrap::FromObject(current_empty_write);
     finishing->Done(status);
     return;
   }

--- a/src/tls_wrap.h
+++ b/src/tls_wrap.h
@@ -194,9 +194,9 @@ class TLSWrap : public AsyncWrap,
   // Waiting for ClearIn() to pass to SSL_write().
   AllocatedBuffer pending_cleartext_input_;
   size_t write_size_ = 0;
-  WriteWrap* current_write_ = nullptr;
+  BaseObjectPtr<AsyncWrap> current_write_;
   bool in_dowrite_ = false;
-  WriteWrap* current_empty_write_ = nullptr;
+  BaseObjectPtr<AsyncWrap> current_empty_write_;
   bool write_callback_scheduled_ = false;
   bool started_ = false;
   bool established_ = false;


### PR DESCRIPTION
Create weak `WriteWrap` and `ShutdownWrap` objects, and when
referencing them in C++ is necessary, use `BaseObjectPtr<>`
instead of plain pointers to keep these objects from being
garbage-collected.

This solves issues that arise when the underlying `StreamBase`
instance is weak, but the `WriteWrap` or `ShutdownWrap` instances
are not; in that case, they would otherwise potentially stick
around in memory after the stream that they originally belong
to is long gone.

It probably makes sense to use `BaseObjectptr<>` more extensively
in `StreamBase` in the long run as well.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
