### PR TITLE
src: limit GetProcessTitle() result to 1MB

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -144,6 +144,9 @@ std::string GetProcessTitle(const char* default_title) {
     if (rc == 0)
       break;
 
+    // If uv_setup_args() was not called, `uv_get_process_title()` will always
+    // return `UV_ENOBUFS`, no matter the input size. Guard against a possible
+    // infinite loop by limiting the buffer size.
     if (rc != UV_ENOBUFS || buf.size() >= 1024 * 1024)
       return default_title;
 

--- a/src/util.cc
+++ b/src/util.cc
@@ -144,7 +144,7 @@ std::string GetProcessTitle(const char* default_title) {
     if (rc == 0)
       break;
 
-    if (rc != UV_ENOBUFS)
+    if (rc != UV_ENOBUFS || buf.size() >= 1024 * 1024)
       return default_title;
 
     buf.resize(2 * buf.size());


### PR DESCRIPTION
`GetProcessTitle()` otherwise runs an infinite loop when
`uv_setup_argv()` has not been called (yet). This is a problem
e.g. in assertions from static constructors, which run before
`main()` and thus before `argc` and `argv` become available.

To solve that, do not allocate more than 1MB of storage for the
title and bail out if we reach that point.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
