### PR TITLE
src: minor error cleanups

### DIFF
--- a/src/node_wasi.cc
+++ b/src/node_wasi.cc
@@ -104,9 +104,9 @@ static MaybeLocal<Value> WASIException(Local<Context> context,
   js_msg =
       String::Concat(isolate, js_msg, FIXED_ONE_BYTE_STRING(isolate, ", "));
   js_msg = String::Concat(isolate, js_msg, js_syscall);
-  Local<Object> e =
-    Exception::Error(js_msg)->ToObject(context)
-      .ToLocalChecked();
+  Local<Object> e;
+  if (!Exception::Error(js_msg)->ToObject(context).ToLocal(&e))
+    return MaybeLocal<Value>();
 
   if (e->Set(context,
              env->errno_string(),
@@ -128,13 +128,11 @@ WASI::WASI(Environment* env,
   options->allocator = &alloc_info_;
   int err = uvwasi_init(&uvw_, options);
   if (err != UVWASI_ESUCCESS) {
-    Local<Context> context = env->context();
-    MaybeLocal<Value> exception = WASIException(context, err, "uvwasi_init");
-
-    if (exception.IsEmpty())
+    Local<Value> exception;
+    if (!WASIException(env->context(), err, "uvwasi_init").ToLocal(&exception))
       return;
 
-    context->GetIsolate()->ThrowException(exception.ToLocalChecked());
+    env->isolate()->ThrowException(exception);
   }
 }
 

--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -40,7 +40,6 @@ using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
 using v8::Int32;
-using v8::Isolate;
 using v8::Local;
 using v8::MaybeLocal;
 using v8::Object;
@@ -216,9 +215,8 @@ void PipeWrap::Open(const FunctionCallbackInfo<Value>& args) {
   int err = uv_pipe_open(&wrap->handle_, fd);
   wrap->set_fd(fd);
 
-  Isolate* isolate = env->isolate();
   if (err != 0)
-    isolate->ThrowException(UVException(isolate, err, "uv_pipe_open"));
+    env->ThrowUVException(err, "uv_pipe_open");
 }
 
 


### PR DESCRIPTION
Just a couple of minor idiomatic error cleanups in src

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
