### PR TITLE
module: fix builtin reexport tracing

### DIFF
--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -24,7 +24,7 @@ function lazyTypes() {
 }
 
 const { readFileSync } = require('fs');
-const { extname } = require('path');
+const { extname, isAbsolute } = require('path');
 const {
   stripBOM,
   loadNativeModule
@@ -244,7 +244,8 @@ function cjsPreparseModuleExports(filename) {
       continue;
     }
     const ext = extname(resolved);
-    if (ext === '.js' || ext === '.cjs' || !CJSModule._extensions[ext]) {
+    if ((ext === '.js' || ext === '.cjs' || !CJSModule._extensions[ext]) &&
+        isAbsolute(resolved)) {
       const { exportNames: reexportNames } = cjsPreparseModuleExports(resolved);
       for (const name of reexportNames)
         exportNames.add(name);

--- a/test/es-module/test-esm-cjs-builtins.js
+++ b/test/es-module/test-esm-cjs-builtins.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const common = require('../common');
+const fixtures = require('../common/fixtures');
+const { spawn } = require('child_process');
+const assert = require('assert');
+
+const entry = fixtures.path('/es-modules/builtin-imports-case.mjs');
+
+const child = spawn(process.execPath, [entry]);
+child.stderr.setEncoding('utf8');
+let stdout = '';
+child.stdout.setEncoding('utf8');
+child.stdout.on('data', (data) => {
+  stdout += data;
+});
+child.on('close', common.mustCall((code, signal) => {
+  assert.strictEqual(code, 0);
+  assert.strictEqual(signal, null);
+  assert.strictEqual(stdout, 'ok\n');
+}));

--- a/test/fixtures/es-modules/builtin-imports-case.mjs
+++ b/test/fixtures/es-modules/builtin-imports-case.mjs
@@ -1,0 +1,5 @@
+import { strictEqual } from 'assert';
+import './dep1.js';
+import { assert as depAssert } from './dep2.js';
+strictEqual(depAssert.strictEqual, strictEqual);
+console.log('ok');

--- a/test/fixtures/es-modules/dep1.js
+++ b/test/fixtures/es-modules/dep1.js
@@ -1,0 +1,1 @@
+module.exports = require('assert');

--- a/test/fixtures/es-modules/dep2.js
+++ b/test/fixtures/es-modules/dep2.js
@@ -1,0 +1,1 @@
+exports.assert = require('assert');


### PR DESCRIPTION
This fixes https://github.com/nodejs/node/issues/35483 by ensuring that reexport tracing in the named exports extraction does not attempt to operate on builtin modules.

Since this is a regression it would be good to fast track this fix.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
