### PR TITLE
module: update to cjs-module-lexer@0.4.0

### DIFF
--- a/deps/cjs-module-lexer/package.json
+++ b/deps/cjs-module-lexer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cjs-module-lexer",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "Lexes CommonJS modules, returning their named exports metadata",
   "main": "lexer.js",
   "exports": {

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -1261,7 +1261,7 @@ success!
 [`transformSource` hook]: #esm_transformsource_source_context_defaulttransformsource
 [`string`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String
 [`util.TextDecoder`]: util.md#util_class_util_textdecoder
-[cjs-module-lexer]: https://github.com/guybedford/cjs-module-lexer/tree/0.3.1
+[cjs-module-lexer]: https://github.com/guybedford/cjs-module-lexer/tree/0.4.0
 [special scheme]: https://url.spec.whatwg.org/#special-scheme
 [the official standard format]: https://tc39.github.io/ecma262/#sec-modules
 [transpiler loader example]: #esm_transpiler_loader


### PR DESCRIPTION
This updates to cjs-module-lexer@0.4.0 containing the following two improvements:

* 20% performance improvement thanks to the PR by @JoostK (https://github.com/guybedford/cjs-module-lexer/pull/9)
* Restriction of reexport assignments to only the last `module.exports = require('external')` case, which should avoid unnecessary work for webpack bundle externals also as a minor performance improvement (https://github.com/guybedford/cjs-module-lexer/pull/11)

@nodejs/modules-active-members 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
