### PR TITLE
lib: change http client path assignment

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -145,9 +145,8 @@ function ClientRequest(input, options, cb) {
   if (this.agent && this.agent.protocol)
     expectedProtocol = this.agent.protocol;
 
-  let path;
   if (options.path) {
-    path = String(options.path);
+    const path = String(options.path);
     if (INVALID_PATH_REGEX.test(path))
       throw new ERR_UNESCAPED_CHARACTERS('Request path');
   }


### PR DESCRIPTION
changed path assignment in http client lib from `let` to `const` (it's more appropriate in this case).
I addition to that, since the inner condition is the only referencing the variable, moved the assignment to the inner condition

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
