### PR TITLE
src: expose v8::Isolate setup callbacks

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -31,14 +31,14 @@ using v8::SealHandleScope;
 using v8::String;
 using v8::Value;
 
-static bool AllowWasmCodeGenerationCallback(Local<Context> context,
-                                            Local<String>) {
+bool AllowWasmCodeGenerationCallback(Local<Context> context,
+                                     Local<String>) {
   Local<Value> wasm_code_gen =
       context->GetEmbedderData(ContextEmbedderIndex::kAllowWasmCodeGeneration);
   return wasm_code_gen->IsUndefined() || wasm_code_gen->IsTrue();
 }
 
-static bool ShouldAbortOnUncaughtException(Isolate* isolate) {
+bool ShouldAbortOnUncaughtException(Isolate* isolate) {
   DebugSealHandleScope scope(isolate);
   Environment* env = Environment::GetCurrent(isolate);
   return env != nullptr &&
@@ -48,9 +48,9 @@ static bool ShouldAbortOnUncaughtException(Isolate* isolate) {
          !env->inside_should_not_abort_on_uncaught_scope();
 }
 
-static MaybeLocal<Value> PrepareStackTraceCallback(Local<Context> context,
-                                      Local<Value> exception,
-                                      Local<Array> trace) {
+MaybeLocal<Value> PrepareStackTraceCallback(Local<Context> context,
+                                            Local<Value> exception,
+                                            Local<Array> trace) {
   Environment* env = Environment::GetCurrent(context);
   if (env == nullptr) {
     return exception->ToString(context).FromMaybe(Local<Value>());
@@ -245,7 +245,7 @@ void SetIsolateMiscHandlers(v8::Isolate* isolate, const IsolateSettings& s) {
 
   if ((s.flags & SHOULD_NOT_SET_PROMISE_REJECTION_CALLBACK) == 0) {
     auto* promise_reject_cb = s.promise_reject_callback ?
-      s.promise_reject_callback : task_queue::PromiseRejectCallback;
+      s.promise_reject_callback : PromiseRejectCallback;
     isolate->SetPromiseRejectCallback(promise_reject_cb);
   }
 

--- a/src/node.h
+++ b/src/node.h
@@ -495,6 +495,16 @@ NODE_EXTERN void DefaultProcessExitHandler(Environment* env, int exit_code);
 // This may return nullptr if context is not associated with a Node instance.
 NODE_EXTERN Environment* GetCurrentEnvironment(v8::Local<v8::Context> context);
 
+NODE_EXTERN void OnFatalError(const char* location, const char* message);
+NODE_EXTERN void PromiseRejectCallback(v8::PromiseRejectMessage message);
+NODE_EXTERN bool AllowWasmCodeGenerationCallback(v8::Local<v8::Context> context,
+                                            v8::Local<v8::String>);
+NODE_EXTERN bool ShouldAbortOnUncaughtException(v8::Isolate* isolate);
+NODE_EXTERN v8::MaybeLocal<v8::Value> PrepareStackTraceCallback(
+    v8::Local<v8::Context> context,
+    v8::Local<v8::Value> exception,
+    v8::Local<v8::Array> trace);
+
 // This returns the MultiIsolatePlatform used in the main thread of Node.js.
 // If NODE_USE_V8_PLATFORM has not been defined when Node.js was built,
 // it returns nullptr.

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -100,10 +100,6 @@ std::string GetHumanReadableProcessName();
 void InitializeContextRuntime(v8::Local<v8::Context>);
 bool InitializePrimordials(v8::Local<v8::Context> context);
 
-namespace task_queue {
-void PromiseRejectCallback(v8::PromiseRejectMessage message);
-}  // namespace task_queue
-
 class NodeArrayBufferAllocator : public ArrayBufferAllocator {
  public:
   inline uint32_t* zero_fill_field() { return &zero_fill_field_; }

--- a/src/node_task_queue.cc
+++ b/src/node_task_queue.cc
@@ -29,27 +29,6 @@ using v8::PromiseRejectEvent;
 using v8::PromiseRejectMessage;
 using v8::Value;
 
-namespace task_queue {
-
-static void EnqueueMicrotask(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-  Isolate* isolate = env->isolate();
-
-  CHECK(args[0]->IsFunction());
-
-  isolate->EnqueueMicrotask(args[0].As<Function>());
-}
-
-static void RunMicrotasks(const FunctionCallbackInfo<Value>& args) {
-  MicrotasksScope::PerformCheckpoint(args.GetIsolate());
-}
-
-static void SetTickCallback(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-  CHECK(args[0]->IsFunction());
-  env->set_tick_callback_function(args[0].As<Function>());
-}
-
 void PromiseRejectCallback(PromiseRejectMessage message) {
   static std::atomic<uint64_t> unhandledRejections{0};
   static std::atomic<uint64_t> rejectionsHandledAfter{0};
@@ -108,6 +87,26 @@ void PromiseRejectCallback(PromiseRejectMessage message) {
     fprintf(stderr, "Exception in PromiseRejectCallback:\n");
     PrintCaughtException(isolate, env->context(), try_catch);
   }
+}
+namespace task_queue {
+
+static void EnqueueMicrotask(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  Isolate* isolate = env->isolate();
+
+  CHECK(args[0]->IsFunction());
+
+  isolate->EnqueueMicrotask(args[0].As<Function>());
+}
+
+static void RunMicrotasks(const FunctionCallbackInfo<Value>& args) {
+  MicrotasksScope::PerformCheckpoint(args.GetIsolate());
+}
+
+static void SetTickCallback(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  CHECK(args[0]->IsFunction());
+  env->set_tick_callback_function(args[0].As<Function>());
 }
 
 static void SetPromiseRejectCallback(


### PR DESCRIPTION
This PR makes some more of the `v8::Isolate*` setup callbacks used by Node.js to external embedders. We already possess the ability to override the callbacks used, but there are some situations in which we would still want to access Node.js' default behavior.

For example: in an Electron renderer process, the context currently in play would not have been subject to some of the `ContextEmbedderData` data set by Node.js, but the `v8::Isolate` would assume that it had and make erroneous choices as a result. As such, in this situation, we would tell the isolate to make different choices in the callback depending on the current process. We could, of course, simply copy over the code, but we then run the risk of missing future changes to this callback logic. There is also precedent for this - we can already access `task_queue::PromiseRejectCallback` for similar ends.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
