### PR TITLE
src: mark/pop OpenSSL errors in NewRootCertStore

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -1361,6 +1361,9 @@
           'defines': [
             'HAVE_OPENSSL=1',
           ],
+          'sources': [
+            'test/cctest/test_node_crypto.cc',
+          ]
         }],
         [ 'node_use_openssl=="true" and experimental_quic==1', {
           'defines': [
@@ -1385,7 +1388,10 @@
            ]
         }],
         ['OS=="solaris"', {
-          'ldflags': [ '-I<(SHARED_INTERMEDIATE_DIR)' ]
+          'ldflags': [ '-I<(SHARED_INTERMEDIATE_DIR)' ],
+          'sources!': [
+            'test/cctest/test_node_crypto.cc',
+          ]
         }],
         # Skip cctest while building shared lib node for Windows
         [ 'OS=="win" and node_shared=="true"', {

--- a/node.gyp
+++ b/node.gyp
@@ -1389,9 +1389,6 @@
         }],
         ['OS=="solaris"', {
           'ldflags': [ '-I<(SHARED_INTERMEDIATE_DIR)' ],
-          'sources!': [
-            'test/cctest/test_node_crypto.cc',
-          ]
         }],
         # Skip cctest while building shared lib node for Windows
         [ 'OS=="win" and node_shared=="true"', {

--- a/src/crypto/crypto_context.cc
+++ b/src/crypto/crypto_context.cc
@@ -187,7 +187,9 @@ int SSL_CTX_use_certificate_chain(SSL_CTX* ctx,
                                        issuer);
 }
 
-static X509_STORE* NewRootCertStore() {
+}  // namespace
+
+X509_STORE* NewRootCertStore() {
   static std::vector<X509*> root_certs_vector;
   static Mutex root_certs_vector_mutex;
   Mutex::ScopedLock lock(root_certs_vector_mutex);
@@ -228,7 +230,6 @@ static X509_STORE* NewRootCertStore() {
 
   return store;
 }
-}  // namespace
 
 void GetRootCertificates(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);

--- a/src/crypto/crypto_context.h
+++ b/src/crypto/crypto_context.h
@@ -21,6 +21,8 @@ void GetRootCertificates(
 void IsExtraRootCertsFileLoaded(
     const v8::FunctionCallbackInfo<v8::Value>& args);
 
+X509_STORE* NewRootCertStore();
+
 class SecureContext final : public BaseObject {
  public:
   ~SecureContext() override;

--- a/test/cctest/test_node_crypto.cc
+++ b/test/cctest/test_node_crypto.cc
@@ -1,0 +1,23 @@
+// This simulates specifying the configuration option --openssl-system-ca-path
+// and settting it to a file that does not exist.
+#define NODE_OPENSSL_SYSTEM_CERT_PATH "/missing/ca.pem"
+
+#include "../../src/crypto/crypto_context.cc"  // NOLINT(build/include)
+#include "node_options.h"
+#include "openssl/err.h"
+#include "gtest/gtest.h"
+
+/*
+ * This test verifies that a call to NewRootCertDir with the build time
+ * configuration option --openssl-system-ca-path set to an missing file, will
+ * not leave any OpenSSL errors on the OpenSSL error stack.
+ * See https://github.com/nodejs/node/issues/35456 for details.
+ */
+TEST(NodeCrypto, NewRootCertStore) {
+  node::per_process::cli_options->ssl_openssl_cert_store = true;
+  X509_STORE* store = node::crypto::NewRootCertStore();
+  ASSERT_TRUE(store);
+  ASSERT_EQ(ERR_peek_error(), 0UL) << "NewRootCertStore should not have left "
+                                      "any errors on the OpenSSL error stack\n";
+  X509_STORE_free(store);
+}

--- a/test/cctest/test_node_crypto.cc
+++ b/test/cctest/test_node_crypto.cc
@@ -2,7 +2,7 @@
 // and settting it to a file that does not exist.
 #define NODE_OPENSSL_SYSTEM_CERT_PATH "/missing/ca.pem"
 
-#include "../../src/crypto/crypto_context.cc"  // NOLINT(build/include)
+#include "crypto/crypto_context.h"
 #include "node_options.h"
 #include "openssl/err.h"
 #include "gtest/gtest.h"


### PR DESCRIPTION
This commit sets the OpenSSL error mark before calling
`X509_STORE_load_locations` and pops the error mark afterwards.

The motivation for this is that it is possible that
`X509_STORE_load_locations` can produce errors if the configuration
option `--openssl-system-ca-path` file does not exist. Later if a
different function is called which calls an OpenSSL function it could
fail because these errors might still be on the OpenSSL error queue.

Currently, all functions that call `NewRootCertStore` clear the
OpenSSL error queue upon returning, but this was not the case for
example in v12.18.0.

Fixes: https://github.com/nodejs/node/issues/35456


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
