### PR TITLE
Don't 'exit' a script meant to be "source"d

### DIFF
--- a/android-configure
+++ b/android-configure
@@ -10,7 +10,7 @@
 
 if [ $# -ne 3 ]; then
   echo "$0 should have 3 parameters: ndk_path, target_arch and sdk_version"
-  exit 1
+  return 1
 fi
 
 NDK_PATH=$1
@@ -44,7 +44,7 @@ case $ARCH in
         ;;
     *)
         echo "Unsupported architecture provided: $ARCH"
-        exit 1
+        return 1
         ;;
 esac
 
@@ -58,7 +58,7 @@ major=$(echo $host_gcc_version | awk -F . '{print $1}')
 minor=$(echo $host_gcc_version | awk -F . '{print $2}')
 if [ -z $major ] || [ -z $minor ] || [ $major -lt 6 ] || [ $major -eq 6 -a $minor -lt 3 ]; then
   echo "host gcc $host_gcc_version is too old, need gcc 6.3.0"
-  exit 1
+  return 1
 fi
 
 SUFFIX="$TOOLCHAIN_NAME$ANDROID_SDK_VERSION"


### PR DESCRIPTION
Running exit in a script meant to be sourced means the user shell will
exit, which prevents seeing the error message, and is generally very
annoying.

Fixes: https://github.com/nodejs/node/issues/35519

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
