### PR TITLE
modules: add setter for module.parent

### DIFF
--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -913,7 +913,7 @@ deprecated:
 
 The module that first required this one, or `null` if the current module is the
 entry point of the current process, or `undefined` if the module was loaded by
-something that is not a CommonJS module (E.G.: REPL or `import`). Read only.
+something that is not a CommonJS module (E.G.: REPL or `import`).
 
 ### `module.path`
 <!-- YAML

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -223,13 +223,24 @@ ObjectDefineProperty(Module, 'wrapper', {
 function getModuleParent() {
   return moduleParentCache.get(this);
 }
+
+function setModuleParent(value) {
+  moduleParentCache.set(this, value);
+}
+
 ObjectDefineProperty(Module.prototype, 'parent', {
   get: pendingDeprecation ? deprecate(
     getModuleParent,
     'module.parent is deprecated due to accuracy issues. Please use ' +
       'require.main to find program entry point instead.',
     'DEP0144'
-  ) : getModuleParent
+  ) : getModuleParent,
+  set: pendingDeprecation ? deprecate(
+    setModuleParent,
+    'module.parent is deprecated due to accuracy issues. Please use ' +
+      'require.main to find program entry point instead.',
+    'DEP0144'
+  ) : setModuleParent,
 });
 
 let debug = require('internal/util/debuglog').debuglog('module', (fn) => {

--- a/test/parallel/test-module-parent-setter-deprecation.js
+++ b/test/parallel/test-module-parent-setter-deprecation.js
@@ -1,0 +1,13 @@
+// Flags: --pending-deprecation
+
+'use strict';
+const common = require('../common');
+
+common.expectWarning(
+  'DeprecationWarning',
+  'module.parent is deprecated due to accuracy issues. Please use ' +
+    'require.main to find program entry point instead.',
+  'DEP0144'
+);
+
+module.parent = undefined;


### PR DESCRIPTION
`module.parent` breaks the ecosystem when read-only (see https://github.com/nodejs/node/pull/32217#issuecomment-704343589). This PR adds a setter to allow user to change its value instead of throwing.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
