### PR TITLE
doc: fix YAML syntax errors

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1422,7 +1422,7 @@ added:
 changes:
   - version:
     - v14.10.0
-    = v12.19.0
+    - v12.19.0
     pr-url: https://github.com/nodejs/node/pull/34960
     description: This function is also available as `buf.readBigUint64LE()`.
 -->

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -901,7 +901,6 @@ loading.
 ### `module.parent`
 <!-- YAML
 added: v0.1.16
-deprecated: v14.6.0
 deprecated:
   - v12.19.0
   - v14.6.0

--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -488,7 +488,7 @@ These advanced options are available for controlling decompression:
 <!-- YAML
 added: v0.11.1
 changes:
-  - version
+  - version:
     - v14.5.0
     - v12.19.0
     pr-url: https://github.com/nodejs/node/pull/33516


### PR DESCRIPTION
It seems v12.19.0 release commit contains an unintended YAML syntax error, which causes CI to fail for every PR.

cc @codebytere 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
