### PR TITLE
lib: add span API to diagnostics_channel

### DIFF
--- a/lib/diagnostics_channel.js
+++ b/lib/diagnostics_channel.js
@@ -4,6 +4,10 @@ const {
   ArrayPrototypeIndexOf,
   ArrayPrototypePush,
   ArrayPrototypeSplice,
+  Map,
+  MapPrototypeDelete,
+  MapPrototypeGet,
+  MapPrototypeSet,
   ObjectCreate,
   ObjectGetPrototypeOf,
   ObjectSetPrototypeOf,
@@ -20,6 +24,103 @@ const {
 const { triggerUncaughtException } = internalBinding('errors');
 
 const { WeakReference } = internalBinding('util');
+
+function identity(v) {
+  return v;
+}
+
+class SpanMessage {
+  constructor(action, id, data) {
+    this.action = action;
+    this.id = id;
+    this.data = data;
+  }
+
+  // Augment with type: span to identify over the wire through JSON
+  toJSON() {
+    return {
+      ...this,
+      type: 'span'
+    };
+  }
+}
+
+let spanId = 0;
+
+class InactiveSpan {
+  annotate() {}
+  end() {}
+}
+
+class Span {
+  constructor(channel, data) {
+    this._channel = channel;
+    this.id = ++spanId;
+    this._ended = false;
+
+    this._message('start', data);
+  }
+
+  _message(action, data) {
+    if (this._ended) return;
+
+    if (action === 'end') {
+      this._ended = true;
+    }
+
+    this._channel.publish(new SpanMessage(action, this.id, data));
+  }
+
+  annotate(data) {
+    this._message('annotation', data);
+  }
+
+  end(data) {
+    this._message('end', data);
+  }
+
+  static aggregate(channel, map = identity, onComplete) {
+    const spans = new Map();
+
+    if (typeof onComplete !== 'function') {
+      onComplete = map;
+      map = identity;
+    }
+
+    // eslint-disable-next-line no-use-before-define
+    if (!(channel instanceof Channel)) {
+      throw new ERR_INVALID_ARG_TYPE('channel', ['Channel'], channel);
+    }
+    if (typeof onComplete !== 'function') {
+      throw new ERR_INVALID_ARG_TYPE('onComplete', ['function'], onComplete);
+    }
+
+    function onMessage(message) {
+      // A span message may be pre or post serialization so identify either
+      if (message instanceof SpanMessage || message.type === 'span') {
+        let messages = MapPrototypeGet(spans, message.id);
+        if (!messages) {
+          messages = [];
+          MapPrototypeSet(spans, message.id, messages);
+        }
+
+        ArrayPrototypePush(messages, map(message));
+
+        if (message.action === 'end') {
+          onComplete(messages);
+          MapPrototypeDelete(spans, message.id);
+        }
+      }
+    }
+
+    channel.subscribe(onMessage);
+
+    return () => {
+      spans.clear();
+      channel.unsubscribe(onMessage);
+    };
+  }
+}
 
 // TODO(qard): should there be a C++ channel interface?
 class ActiveChannel {
@@ -60,6 +161,10 @@ class ActiveChannel {
       }
     }
   }
+
+  span(data) {
+    return new Span(this, data);
+  }
 }
 
 class Channel {
@@ -85,6 +190,10 @@ class Channel {
   }
 
   publish() {}
+
+  span() {
+    return new InactiveSpan();
+  }
 }
 
 const channels = ObjectCreate(null);
@@ -118,5 +227,6 @@ function hasSubscribers(name) {
 module.exports = {
   channel,
   hasSubscribers,
-  Channel
+  Channel,
+  Span
 };

--- a/test/parallel/test-diagnostics-channel-span-aggregate.js
+++ b/test/parallel/test-diagnostics-channel-span-aggregate.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const common = require('../common');
+const dc = require('diagnostics_channel');
+const assert = require('assert');
+
+const inputs = [
+  { test: 'start' },
+  { test: 'annotation' },
+  { test: 'end' }
+];
+
+const channel = dc.channel('test');
+
+const receivedSpans = [];
+
+const map = common.mustCall((message) => {
+  message.ts = process.hrtime.bigint();
+  return message;
+}, 7);
+
+const onComplete = common.mustCall((span) => {
+  receivedSpans.push(span);
+}, 3);
+
+dc.Span.aggregate(channel, map, onComplete);
+
+let expectedMessage = inputs.shift();
+const spanA = channel.span(expectedMessage);
+const spanB = channel.span(expectedMessage);
+const spanC = channel.span(expectedMessage);
+
+expectedMessage = inputs.shift();
+spanA.annotate(expectedMessage);
+
+expectedMessage = inputs.shift();
+spanB.end(expectedMessage);
+spanC.end(expectedMessage);
+spanA.end(expectedMessage);
+
+const [ receivedB, receivedC, receivedA ] = receivedSpans;
+
+// Spans received in order of completion
+for (const span of receivedB) {
+  assert.strictEqual(span.id, 2);
+}
+for (const span of receivedC) {
+  assert.strictEqual(span.id, 3);
+}
+for (const span of receivedA) {
+  assert.strictEqual(span.id, 1);
+}
+
+// A starts before B which starts before C
+assert.ok(receivedA[0].ts < receivedB[0].ts);
+assert.ok(receivedB[0].ts < receivedC[0].ts);
+
+// B ends before C which ends before A
+assert.ok(receivedA[2].ts > receivedC[1].ts);
+assert.ok(receivedC[1].ts > receivedB[1].ts);
+
+// Middle event of last span is an annotation
+const [, annotation] = receivedA;
+assert.strictEqual(annotation.action, 'annotation');
+
+for (const spans of receivedSpans) {
+  const [ start, ...rest ] = spans;
+  const end = rest.pop();
+
+  // First and last messages are start and end
+  assert.strictEqual(start.action, 'start');
+  assert.strictEqual(end.action, 'end');
+
+  // Annotation time occurs between all starts and ends
+  assert.ok(annotation.ts > start.ts);
+  assert.ok(annotation.ts < end.ts);
+}

--- a/test/parallel/test-diagnostics-channel-spans.js
+++ b/test/parallel/test-diagnostics-channel-spans.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const common = require('../common');
+const dc = require('diagnostics_channel');
+const assert = require('assert');
+
+const inputs = [
+  { test: 'start' },
+  { test: 'annotation' },
+  { test: 'end' }
+];
+
+const channel = dc.channel('test');
+
+// Span interface produces inactive spans when not subscribing.
+const inactiveSpan = channel.span({});
+assert.strictEqual(inactiveSpan.channel, undefined);
+
+let expectedAction;
+let expectedId = 0;
+let expectedMessage;
+
+channel.subscribe(common.mustCall((message) => {
+  assert.strictEqual(message.toJSON().type, 'span');
+  assert.strictEqual(message.action, expectedAction);
+  assert.strictEqual(message.id, 2 - (++expectedId % 2));
+  assert.deepStrictEqual(message.data, expectedMessage);
+}, inputs.length * 2));
+
+expectedAction = 'start';
+expectedMessage = inputs.shift();
+const spanA = channel.span(expectedMessage);
+const spanB = channel.span(expectedMessage);
+
+expectedAction = 'annotation';
+expectedMessage = inputs.shift();
+spanA.annotate(expectedMessage);
+spanB.annotate(expectedMessage);
+
+expectedAction = 'end';
+expectedMessage = inputs.shift();
+spanA.end(expectedMessage);
+spanB.end(expectedMessage);

--- a/tools/doc/type-parser.js
+++ b/tools/doc/type-parser.js
@@ -112,6 +112,7 @@ const customTypesMap = {
   'dgram.Socket': 'dgram.html#dgram_class_dgram_socket',
 
   'Channel': 'diagnostics_channel.html#diagnostics_channel_class_channel',
+  'Span': 'diagnostics_channel.html#diagnostics_channel_class_span',
 
   'Domain': 'domain.html#domain_class_domain',
 


### PR DESCRIPTION
I've split the span api out of #34895 as the exact design seems to still be a bit controversial, so I'd like to iterate on it here to allow the core of diagnostics_channel to land separately.

Depends on #34895

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
