### PR TITLE
cli: add --node-memory-debug option

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -546,6 +546,14 @@ added: v6.0.0
 
 Silence all process warnings (including deprecations).
 
+### `--node-memory-debug`
+<!-- YAML
+added: REPLACEME
+-->
+
+Enable extra debug checks for memory leaks in Node.js internals. This is
+usually only useful for developers debugging Node.js itself.
+
 ### `--openssl-config=file`
 <!-- YAML
 added: v6.9.0
@@ -1282,6 +1290,7 @@ Node.js options that are allowed are:
 * `--no-deprecation`
 * `--no-force-async-hooks-checks`
 * `--no-warnings`
+* `--node-memory-debug`
 * `--openssl-config`
 * `--pending-deprecation`
 * `--policy-integrity`

--- a/doc/node.1
+++ b/doc/node.1
@@ -278,6 +278,10 @@ These will still be enabled dynamically when `async_hooks` is enabled.
 .It Fl -no-warnings
 Silence all process warnings (including deprecations).
 .
+.It Fl -node-memory-debug
+Enable extra debug checks for memory leaks in Node.js internals. This is
+usually only useful for developers debugging Node.js itself.
+.
 .It Fl -openssl-config Ns = Ns Ar file
 Load an OpenSSL configuration file on startup.
 Among other uses, this can be used to enable FIPS-compliant crypto if Node.js is built with

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -762,6 +762,12 @@ PerProcessOptionsParser::PerProcessOptionsParser(
             kAllowedInEnvironment);
 
   Insert(iop, &PerProcessOptions::get_per_isolate_options);
+
+  AddOption("--node-memory-debug",
+            "Run with extra debug checks for memory leaks in Node.js itself",
+            NoOp{}, kAllowedInEnvironment);
+  Implies("--node-memory-debug", "--debug-arraybuffer-allocations");
+  Implies("--node-memory-debug", "--verify-base-objects");
 }
 
 inline std::string RemoveBrackets(const std::string& host) {


### PR DESCRIPTION
Add a public switch that turns on features for debugging memory
leaks inside of Node.js core.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
