### PR TITLE
src: fix compiler warning in env.cc

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -1224,7 +1224,7 @@ void Environment::VerifyNoStrongBaseObjects() {
 
   if (!options()->verify_base_objects) return;
 
-  ForEachBaseObject([this](BaseObject* obj) {
+  ForEachBaseObject([](BaseObject* obj) {
     if (obj->IsNotIndicativeOfMemoryLeakAtExit()) return;
     fprintf(stderr, "Found bad BaseObject during clean exit: %s\n",
             obj->MemoryInfoName().c_str());


### PR DESCRIPTION
     ../src/env.cc:1227:22: error: lambda capture 'this' is not used [-Werror,-Wunused-lambda-capture]
      ForEachBaseObject([this](BaseObject* obj) {
                     ^~~~

(I don’t think we need to discuss fast-tracking here, but you can feel free to :+1: this either way.)
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
