### PR TITLE
fs: deprecation warning on recursive rmdir

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2664,6 +2664,9 @@ The [`crypto.Certificate()` constructor][] is deprecated. Use
 <!-- YAML
 changes:
   - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/35579
+    description: Documentation-only deprecation.
+  - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/35562
     description: Runtime deprecation.
 -->

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2671,11 +2671,11 @@ changes:
     description: Runtime deprecation.
 -->
 
-Type: Documentation-only
+Type: Runtime
 
 In future versions of Node.js, `fs.rmdir(path, { recursive: true })` will throw
-on nonexistent paths, or when given a file as a target, use
-`fs.rm(path, {recursive: true, force: true })` instead.
+if `path` does not exist or is a file.
+Use `fs.rm(path, { recursive: true, force: true })` instead.
 
 [Legacy URL API]: url.md#url_legacy_url_api
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2664,15 +2664,15 @@ The [`crypto.Certificate()` constructor][] is deprecated. Use
 <!-- YAML
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/35579
-    description: Documentation-only deprecation.
+    pr-url: https://github.com/nodejs/node/pull/35562
+    description: Runtime deprecation.
 -->
 
 Type: Documentation-only
 
 In future versions of Node.js, `fs.rmdir(path, { recursive: true })` will throw
-on nonexistent paths, or when given a file as a target.
-Use `fs.rm(path, { recursive: true, force: true })` instead.
+on nonexistent paths, or when given a file as a target, use
+`fs.rm(path, {recursive: true, force: true })` instead.
 
 [Legacy URL API]: url.md#url_legacy_url_api
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -859,14 +859,18 @@ function rmdir(path, options, callback) {
   path = pathModule.toNamespacedPath(getValidatedPath(path));
 
   if (options && options.recursive) {
-    validateRmOptions(path, { ...options, force: true }, (err, options) => {
-      if (err) {
-        return callback(err);
-      }
+    options = validateRmOptions(
+      path,
+      { ...options, force: true },
+      true,
+      (err, options) => {
+        if (err) {
+          return callback(err);
+        }
 
-      lazyLoadRimraf();
-      return rimraf(path, options, callback);
-    });
+        lazyLoadRimraf();
+        return rimraf(path, options, callback);
+      });
   } else {
     validateRmdirOptions(options);
     const req = new FSReqCallback();
@@ -879,7 +883,7 @@ function rmdirSync(path, options) {
   path = getValidatedPath(path);
 
   if (options && options.recursive) {
-    options = validateRmOptionsSync(path, { ...options, force: true });
+    options = validateRmOptionsSync(path, { ...options, force: true }, true);
     lazyLoadRimraf();
     return rimrafSync(pathModule.toNamespacedPath(path), options);
   }

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -900,7 +900,7 @@ function rm(path, options, callback) {
     options = undefined;
   }
 
-  validateRmOptions(path, options, (err, options) => {
+  validateRmOptions(path, options, false, (err, options) => {
     if (err) {
       return callback(err);
     }
@@ -910,7 +910,7 @@ function rm(path, options, callback) {
 }
 
 function rmSync(path, options) {
-  options = validateRmOptionsSync(path, options);
+  options = validateRmOptionsSync(path, options, false);
 
   lazyLoadRimraf();
   return rimrafSync(pathModule.toNamespacedPath(path), options);

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -421,7 +421,7 @@ async function ftruncate(handle, len = 0) {
 
 async function rm(path, options) {
   path = pathModule.toNamespacedPath(getValidatedPath(path));
-  options = await validateRmOptionsPromise(path, options);
+  options = await validateRmOptionsPromise(path, options, false);
   return rimrafPromises(path, options);
 }
 

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -672,7 +672,7 @@ const defaultRmdirOptions = {
   recursive: false,
 };
 
-const validateRmOptions = hideStackFrames((path, options, callback) => {
+const validateRmOptions = hideStackFrames((path, options, warn, callback) => {
   options = validateRmdirOptions(options, defaultRmOptions);
   validateBoolean(options.force, 'options.force');
 

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -677,11 +677,22 @@ const validateRmOptions = hideStackFrames((path, options, callback) => {
   validateBoolean(options.force, 'options.force');
 
   lazyLoadFs().stat(path, (err, stats) => {
-    if (err) {
-      if (options.force && err.code === 'ENOENT') {
+    if (err && err.code === 'ENOENT') {
+      if (options.force) {
+        if (warn) {
+          emitPermissiveRmdirWarning();
+        }
         return callback(null, options);
       }
       return callback(err, options);
+    }
+
+    if (err) {
+      return callback(err);
+    }
+
+    if (warn && !stats.isDirectory()) {
+      emitPermissiveRmdirWarning();
     }
 
     if (stats.isDirectory() && !options.recursive) {
@@ -697,12 +708,16 @@ const validateRmOptions = hideStackFrames((path, options, callback) => {
   });
 });
 
-const validateRmOptionsSync = hideStackFrames((path, options) => {
+const validateRmOptionsSync = hideStackFrames((path, options, warn) => {
   options = validateRmdirOptions(options, defaultRmOptions);
   validateBoolean(options.force, 'options.force');
 
   try {
     const stats = lazyLoadFs().statSync(path);
+
+    if (warn && !stats.isDirectory()) {
+      emitPermissiveRmdirWarning();
+    }
 
     if (stats.isDirectory() && !options.recursive) {
       throw new ERR_FS_EISDIR({
@@ -718,11 +733,26 @@ const validateRmOptionsSync = hideStackFrames((path, options) => {
       throw err;
     } else if (err.code === 'ENOENT' && !options.force) {
       throw err;
+    } else if (warn && err.code === 'ENOENT') {
+      emitPermissiveRmdirWarning();
     }
   }
 
   return options;
 });
+
+let permissiveRmdirWarned = false;
+
+function emitPermissiveRmdirWarning() {
+  if (!permissiveRmdirWarned) {
+    process.emitWarning(
+      'Permissive rmdir recursive is deprecated, use rm recursive instead',
+      'DeprecationWarning',
+      'DEP0147'
+    );
+    permissiveRmdirWarned = true;
+  }
+}
 
 const validateRmdirOptions = hideStackFrames(
   (options, defaults = defaultRmdirOptions) => {

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -742,8 +742,9 @@ let permissiveRmdirWarned = false;
 function emitPermissiveRmdirWarning() {
   if (!permissiveRmdirWarned) {
     process.emitWarning(
-      'Permissive rmdir recursive is deprecated, use rm recursive and force \
-instead',
+      'In future versions of Node.js, fs.rmdir(path, { recursive: true }) ' +
+      'will throw if path does not exist or is a file. Use fs.rm(path, ' +
+      '{ recursive: true, force: true }) instead',
       'DeprecationWarning',
       'DEP0147'
     );

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -746,7 +746,7 @@ let permissiveRmdirWarned = false;
 function emitPermissiveRmdirWarning() {
   if (!permissiveRmdirWarned) {
     process.emitWarning(
-      'Permissive rmdir recursive is deprecated, use rm recursive and force\
+      'Permissive rmdir recursive is deprecated, use rm recursive and force \
 instead',
       'DeprecationWarning',
       'DEP0147'

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -677,18 +677,14 @@ const validateRmOptions = hideStackFrames((path, options, callback) => {
   validateBoolean(options.force, 'options.force');
 
   lazyLoadFs().stat(path, (err, stats) => {
-    if (err && err.code === 'ENOENT') {
-      if (options.force) {
+    if (err) {
+      if (options.force && err.code === 'ENOENT') {
         if (warn) {
           emitPermissiveRmdirWarning();
         }
         return callback(null, options);
       }
       return callback(err, options);
-    }
-
-    if (err) {
-      return callback(err);
     }
 
     if (warn && !stats.isDirectory()) {

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -746,7 +746,8 @@ let permissiveRmdirWarned = false;
 function emitPermissiveRmdirWarning() {
   if (!permissiveRmdirWarned) {
     process.emitWarning(
-      'Permissive rmdir recursive is deprecated, use rm recursive instead',
+      'Permissive rmdir recursive is deprecated, use rm recursive and force\
+instead',
       'DeprecationWarning',
       'DEP0147'
     );

--- a/test/parallel/test-fs-rmdir-recursive-warns-not-found.js
+++ b/test/parallel/test-fs-rmdir-recursive-warns-not-found.js
@@ -1,0 +1,24 @@
+// Flags: --expose-internals
+'use strict';
+const common = require('../common');
+const tmpdir = require('../common/tmpdir');
+const fs = require('fs');
+const path = require('path');
+
+tmpdir.refresh();
+
+common.expectWarning(
+  'DeprecationWarning',
+  'Permissive rmdir recursive is deprecated, use rm recursive and force \
+instead',
+  'DEP0147'
+);
+
+{
+  // Should warn when trying to delete a nonexistent path
+  fs.rmdir(
+    path.join(tmpdir.path, 'noexist.txt'),
+    { recursive: true },
+    common.mustCall()
+  );
+}

--- a/test/parallel/test-fs-rmdir-recursive-warns-not-found.js
+++ b/test/parallel/test-fs-rmdir-recursive-warns-not-found.js
@@ -1,4 +1,3 @@
-// Flags: --expose-internals
 'use strict';
 const common = require('../common');
 const tmpdir = require('../common/tmpdir');
@@ -7,15 +6,14 @@ const path = require('path');
 
 tmpdir.refresh();
 
-common.expectWarning(
-  'DeprecationWarning',
-  'Permissive rmdir recursive is deprecated, use rm recursive and force \
-instead',
-  'DEP0147'
-);
-
+// Should warn when trying to delete a nonexistent path
 {
-  // Should warn when trying to delete a nonexistent path
+  common.expectWarning(
+    'DeprecationWarning',
+    'Permissive rmdir recursive is deprecated, use rm recursive and force \
+instead',
+    'DEP0147'
+  );
   fs.rmdir(
     path.join(tmpdir.path, 'noexist.txt'),
     { recursive: true },

--- a/test/parallel/test-fs-rmdir-recursive-warns-not-found.js
+++ b/test/parallel/test-fs-rmdir-recursive-warns-not-found.js
@@ -6,12 +6,14 @@ const path = require('path');
 
 tmpdir.refresh();
 
-// Should warn when trying to delete a nonexistent path
+
 {
+  // Should warn when trying to delete a nonexistent path
   common.expectWarning(
     'DeprecationWarning',
-    'Permissive rmdir recursive is deprecated, use rm recursive and force \
-instead',
+    'In future versions of Node.js, fs.rmdir(path, { recursive: true }) ' +
+    'will throw if path does not exist or is a file. Use fs.rm(path, ' +
+    '{ recursive: true, force: true }) instead',
     'DEP0147'
   );
   fs.rmdir(

--- a/test/parallel/test-fs-rmdir-recursive-warns-on-file.js
+++ b/test/parallel/test-fs-rmdir-recursive-warns-on-file.js
@@ -1,0 +1,23 @@
+// Flags: --expose-internals
+'use strict';
+const common = require('../common');
+const tmpdir = require('../common/tmpdir');
+const fs = require('fs');
+const path = require('path');
+
+tmpdir.refresh();
+
+common.expectWarning(
+  'DeprecationWarning',
+  'Permissive rmdir recursive is deprecated, use rm recursive and force \
+instead',
+  'DEP0147'
+);
+
+{
+  const filePath = path.join(tmpdir.path, 'rmdir-recursive.txt');
+  fs.writeFileSync(filePath, '');
+
+  // Should warn when trying to delete a file
+  fs.rmdirSync(filePath, { recursive: true });
+}

--- a/test/parallel/test-fs-rmdir-recursive-warns-on-file.js
+++ b/test/parallel/test-fs-rmdir-recursive-warns-on-file.js
@@ -1,4 +1,3 @@
-// Flags: --expose-internals
 'use strict';
 const common = require('../common');
 const tmpdir = require('../common/tmpdir');
@@ -7,17 +6,15 @@ const path = require('path');
 
 tmpdir.refresh();
 
-common.expectWarning(
-  'DeprecationWarning',
-  'Permissive rmdir recursive is deprecated, use rm recursive and force \
-instead',
-  'DEP0147'
-);
-
+// Should warn when trying to delete a file
 {
+  common.expectWarning(
+    'DeprecationWarning',
+    'Permissive rmdir recursive is deprecated, use rm recursive and force \
+instead',
+    'DEP0147'
+  );
   const filePath = path.join(tmpdir.path, 'rmdir-recursive.txt');
   fs.writeFileSync(filePath, '');
-
-  // Should warn when trying to delete a file
   fs.rmdirSync(filePath, { recursive: true });
 }

--- a/test/parallel/test-fs-rmdir-recursive-warns-on-file.js
+++ b/test/parallel/test-fs-rmdir-recursive-warns-on-file.js
@@ -6,12 +6,13 @@ const path = require('path');
 
 tmpdir.refresh();
 
-// Should warn when trying to delete a file
 {
+  // Should warn when trying to delete a file
   common.expectWarning(
     'DeprecationWarning',
-    'Permissive rmdir recursive is deprecated, use rm recursive and force \
-instead',
+    'In future versions of Node.js, fs.rmdir(path, { recursive: true }) ' +
+    'will throw if path does not exist or is a file. Use fs.rm(path, ' +
+    '{ recursive: true, force: true }) instead',
     'DEP0147'
   );
   const filePath = path.join(tmpdir.path, 'rmdir-recursive.txt');

--- a/test/parallel/test-fs-rmdir-recursive.js
+++ b/test/parallel/test-fs-rmdir-recursive.js
@@ -11,7 +11,8 @@ tmpdir.refresh();
 
 common.expectWarning(
   'DeprecationWarning',
-  'Permissive rmdir recursive is deprecated, use rm recursive instead',
+  'Permissive rmdir recursive is deprecated, use rm recursive and force \
+instead',
   'DEP0147'
 );
 

--- a/test/parallel/test-fs-rmdir-recursive.js
+++ b/test/parallel/test-fs-rmdir-recursive.js
@@ -7,15 +7,13 @@ const fs = require('fs');
 const path = require('path');
 const { validateRmdirOptions } = require('internal/fs/utils');
 
-const realEmitWarning = process.emitWarning;
-process.emitWarning = () => {
-  // Reset back to default after the test.
-  process.emitWarning = realEmitWarning;
-
-  throw new Error('deprecated');
-};
-
 tmpdir.refresh();
+
+common.expectWarning(
+  'DeprecationWarning',
+  'Permissive rmdir recursive is deprecated, use rm recursive instead',
+  'DEP0147'
+);
 
 let count = 0;
 const nextDirPath = (name = 'rmdir-recursive') =>
@@ -83,8 +81,8 @@ function removeAsync(dir) {
       fs.rmdir(dir, { recursive: true }, common.mustCall((err) => {
         assert.ifError(err);
 
-        // No deprecation warning should occur if recursive and the directory
-        // does not exist because the warning has already been output once.
+        // Should print deprecation warning if recursive and directory does not
+        // exist.
         fs.rmdir(dir, { recursive: true }, common.mustCall((err) => {
           assert.ifError(err);
 
@@ -132,11 +130,8 @@ function removeAsync(dir) {
   // Recursive removal should succeed.
   fs.rmdirSync(dir, { recursive: true });
 
-  // Should print deprecation warning if recursive and the directory does not
-  // exist.
-  assert.throws(() => {
-    fs.rmdirSync(dir, { recursive: true });
-  }, { message: 'deprecated' });
+  // Should print deprecation warning if recursive and directory does not exist.
+  fs.rmdirSync(dir, { recursive: true });
 
   // Attempted removal should fail now because the directory is gone.
   assert.throws(() => fs.rmdirSync(dir), { syscall: 'rmdir' });
@@ -156,8 +151,7 @@ function removeAsync(dir) {
   // Recursive removal should succeed.
   await fs.promises.rmdir(dir, { recursive: true });
 
-  // No deprecation warning should occur if recursive and the directory does not
-  // exist because the warning has already been output once.
+  // Should print deprecation warning if recursive and directory does not exist.
   fs.promises.rmdir(dir, { recursive: true });
 
   // Attempted removal should fail now because the directory is gone.

--- a/test/parallel/test-fs-rmdir-recursive.js
+++ b/test/parallel/test-fs-rmdir-recursive.js
@@ -75,7 +75,7 @@ function removeAsync(dir) {
       fs.rmdir(dir, { recursive: true }, common.mustCall((err) => {
         assert.ifError(err);
 
-        // Succeeds if recursive and directory (but will warn).
+        // No error should occur if recursive and the directory does not exist.
         fs.rmdir(dir, { recursive: true }, common.mustCall((err) => {
           assert.ifError(err);
 
@@ -145,7 +145,7 @@ function removeAsync(dir) {
   await fs.promises.rmdir(dir, { recursive: true });
 
   // No error should occur if recursive and the directory does not exist.
-  fs.promises.rmdir(dir, { recursive: true });
+  await fs.promises.rmdir(dir, { recursive: true });
 
   // Attempted removal should fail now because the directory is gone.
   assert.rejects(fs.promises.rmdir(dir), { syscall: 'rmdir' });

--- a/test/parallel/test-fs-rmdir-recursive.js
+++ b/test/parallel/test-fs-rmdir-recursive.js
@@ -9,13 +9,6 @@ const { validateRmdirOptions } = require('internal/fs/utils');
 
 tmpdir.refresh();
 
-common.expectWarning(
-  'DeprecationWarning',
-  'Permissive rmdir recursive is deprecated, use rm recursive and force \
-instead',
-  'DEP0147'
-);
-
 let count = 0;
 const nextDirPath = (name = 'rmdir-recursive') =>
   path.join(tmpdir.path, `${name}-${count++}`);
@@ -82,8 +75,7 @@ function removeAsync(dir) {
       fs.rmdir(dir, { recursive: true }, common.mustCall((err) => {
         assert.ifError(err);
 
-        // Should print deprecation warning if recursive and directory does not
-        // exist.
+        // Succeeds if recursive and directory (but will warn).
         fs.rmdir(dir, { recursive: true }, common.mustCall((err) => {
           assert.ifError(err);
 
@@ -131,7 +123,7 @@ function removeAsync(dir) {
   // Recursive removal should succeed.
   fs.rmdirSync(dir, { recursive: true });
 
-  // Should print deprecation warning if recursive and directory does not exist.
+  // No error should occur if recursive and the directory does not exist.
   fs.rmdirSync(dir, { recursive: true });
 
   // Attempted removal should fail now because the directory is gone.
@@ -152,7 +144,7 @@ function removeAsync(dir) {
   // Recursive removal should succeed.
   await fs.promises.rmdir(dir, { recursive: true });
 
-  // Should print deprecation warning if recursive and directory does not exist.
+  // No error should occur if recursive and the directory does not exist.
   fs.promises.rmdir(dir, { recursive: true });
 
   // Attempted removal should fail now because the directory is gone.


### PR DESCRIPTION
This is a follow up to #35494 to add a deprecation warning when using recursive rmdir. This only warns if you are attempting to remove a file or a nonexistent path.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
