### PR TITLE
fs: use errno constant with ERR_FS_EISDIR

### DIFF
--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -44,40 +44,47 @@ const kStats = Symbol('stats');
 const assert = require('internal/assert');
 
 const {
-  F_OK = 0,
-  W_OK = 0,
-  R_OK = 0,
-  X_OK = 0,
-  COPYFILE_EXCL,
-  COPYFILE_FICLONE,
-  COPYFILE_FICLONE_FORCE,
-  O_APPEND,
-  O_CREAT,
-  O_EXCL,
-  O_RDONLY,
-  O_RDWR,
-  O_SYNC,
-  O_TRUNC,
-  O_WRONLY,
-  S_IFBLK,
-  S_IFCHR,
-  S_IFDIR,
-  S_IFIFO,
-  S_IFLNK,
-  S_IFMT,
-  S_IFREG,
-  S_IFSOCK,
-  UV_FS_SYMLINK_DIR,
-  UV_FS_SYMLINK_JUNCTION,
-  UV_DIRENT_UNKNOWN,
-  UV_DIRENT_FILE,
-  UV_DIRENT_DIR,
-  UV_DIRENT_LINK,
-  UV_DIRENT_FIFO,
-  UV_DIRENT_SOCKET,
-  UV_DIRENT_CHAR,
-  UV_DIRENT_BLOCK
-} = internalBinding('constants').fs;
+  fs: {
+    F_OK = 0,
+    W_OK = 0,
+    R_OK = 0,
+    X_OK = 0,
+    COPYFILE_EXCL,
+    COPYFILE_FICLONE,
+    COPYFILE_FICLONE_FORCE,
+    O_APPEND,
+    O_CREAT,
+    O_EXCL,
+    O_RDONLY,
+    O_RDWR,
+    O_SYNC,
+    O_TRUNC,
+    O_WRONLY,
+    S_IFBLK,
+    S_IFCHR,
+    S_IFDIR,
+    S_IFIFO,
+    S_IFLNK,
+    S_IFMT,
+    S_IFREG,
+    S_IFSOCK,
+    UV_FS_SYMLINK_DIR,
+    UV_FS_SYMLINK_JUNCTION,
+    UV_DIRENT_UNKNOWN,
+    UV_DIRENT_FILE,
+    UV_DIRENT_DIR,
+    UV_DIRENT_LINK,
+    UV_DIRENT_FIFO,
+    UV_DIRENT_SOCKET,
+    UV_DIRENT_CHAR,
+    UV_DIRENT_BLOCK
+  },
+  os: {
+    errno: {
+      EISDIR
+    }
+  }
+} = internalBinding('constants');
 
 // The access modes can be any of F_OK, R_OK, W_OK or X_OK. Some might not be
 // available on specific systems. They can be used in combination as well
@@ -694,7 +701,7 @@ const validateRmOptions = hideStackFrames((path, options, callback) => {
         message: 'is a directory',
         path,
         syscall: 'rm',
-        errno: -21
+        errno: EISDIR
       }));
     }
     return callback(null, options);
@@ -716,7 +723,7 @@ const validateRmOptionsSync = hideStackFrames((path, options) => {
         message: 'is a directory',
         path,
         syscall: 'rm',
-        errno: -21
+        errno: EISDIR
       });
     }
   } catch (err) {


### PR DESCRIPTION
This commit updates `rm()` to use the `EISDIR` constant with `ERR_FS_EISDIR` instead of hard coding -21.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)