### PR TITLE
fs: rimraf should not recurse on failure

### DIFF
--- a/lib/internal/fs/rimraf.js
+++ b/lib/internal/fs/rimraf.js
@@ -249,7 +249,7 @@ function _rmdirSync(path, options, originalErr) {
 
       for (let i = 1; i <= tries; i++) {
         try {
-          return rmdirSync(path, {...options, recursive: false});
+          return rmdirSync(path, { ...options, recursive: false });
         } catch (err) {
           // Only sleep if this is not the last try, and the delay is greater
           // than zero, and an error was encountered that warrants a retry.

--- a/lib/internal/fs/rimraf.js
+++ b/lib/internal/fs/rimraf.js
@@ -12,6 +12,7 @@ const {
 } = primordials;
 
 const { Buffer } = require('buffer');
+const fs = require('fs');
 const {
   chmod,
   chmodSync,
@@ -25,7 +26,7 @@ const {
   statSync,
   unlink,
   unlinkSync
-} = require('fs');
+} = fs;
 const { sep } = require('path');
 const { setTimeout } = require('timers');
 const { sleep } = require('internal/util');
@@ -249,7 +250,7 @@ function _rmdirSync(path, options, originalErr) {
 
       for (let i = 1; i <= tries; i++) {
         try {
-          return rmdirSync(path);
+          return fs.rmdirSync(path);
         } catch (err) {
           // Only sleep if this is not the last try, and the delay is greater
           // than zero, and an error was encountered that warrants a retry.

--- a/lib/internal/fs/rimraf.js
+++ b/lib/internal/fs/rimraf.js
@@ -249,7 +249,7 @@ function _rmdirSync(path, options, originalErr) {
 
       for (let i = 1; i <= tries; i++) {
         try {
-          return rmdirSync(path, options);
+          return rmdirSync(path, {...options, recursive: false});
         } catch (err) {
           // Only sleep if this is not the last try, and the delay is greater
           // than zero, and an error was encountered that warrants a retry.

--- a/lib/internal/fs/rimraf.js
+++ b/lib/internal/fs/rimraf.js
@@ -249,7 +249,7 @@ function _rmdirSync(path, options, originalErr) {
 
       for (let i = 1; i <= tries; i++) {
         try {
-          return rmdirSync(path, { ...options, recursive: false });
+          return rmdirSync(path);
         } catch (err) {
           // Only sleep if this is not the last try, and the delay is greater
           // than zero, and an error was encountered that warrants a retry.

--- a/test/known_issues/known_issues.status
+++ b/test/known_issues/known_issues.status
@@ -1,3 +1,4 @@
+
 prefix known_issues
 
 # If a known issue does not apply to a platform, list the test name in the
@@ -27,5 +28,3 @@ test-vm-timeout-escape-queuemicrotask: SKIP
 # The Raspberry Pis are too slow to run this test.
 # See https://github.com/nodejs/build/issues/2227#issuecomment-608334574
 test-crypto-authenticated-stream: SKIP
-# The bug being checked is that the test never exits.
-test-fs-open-no-close: TIMEOUT

--- a/test/parallel/test-fs-open-no-close.js
+++ b/test/parallel/test-fs-open-no-close.js
@@ -4,14 +4,7 @@
 // Failing to close a file should not keep the event loop open.
 
 const common = require('../common');
-
-// This issue only shows up on Raspberry Pi devices in our CI. When this test is
-// moved out of known_issues, this check can be removed, as the test should pass
-// on all platforms at that point.
 const assert = require('assert');
-if (process.arch !== 'arm' || process.config.variables.arm_version > 7) {
-  assert.fail('This test is for Raspberry Pi devices in CI');
-}
 
 const fs = require('fs');
 

--- a/test/parallel/test-fs-rmdir-recursive.js
+++ b/test/parallel/test-fs-rmdir-recursive.js
@@ -211,3 +211,28 @@ function removeAsync(dir) {
     message: /^The value of "options\.maxRetries" is out of range\./
   });
 }
+
+// It should not pass recursive option to rmdirSync, when called from
+// rimraf (see: #35566)
+{
+  // Make a non-empty directory:
+  const original = fs.rmdirSync;
+  const dir = `${nextDirPath()}/foo/bar`;
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(`${dir}/foo.txt`, 'hello world', 'utf8');
+
+  // When called the second time from rimraf, the recursive option should
+  // not be set for rmdirSync:
+  let callCount = 0;
+  let rmdirSyncOptionsFromRimraf;
+  fs.rmdirSync = (path, options) => {
+    if (callCount > 0) {
+      rmdirSyncOptionsFromRimraf = { ...options };
+    }
+    callCount++;
+    return original(path, options);
+  };
+  fs.rmdirSync(dir, { recursive: true });
+  fs.rmdirSync = original;
+  assert.strictEqual(rmdirSyncOptionsFromRimraf.recursive, undefined);
+}


### PR DESCRIPTION
When an error occurs while running `rimrafSync`, we pass the original options through to the call to `rmdirSync`, this in turn spawns another call to `rimraf`, rather than simply removing the file.

Fixes #34266

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
