### PR TITLE
fs: small rmdir() and validateRmOptions() cleanup

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -859,20 +859,16 @@ function rmdir(path, options, callback) {
   path = pathModule.toNamespacedPath(getValidatedPath(path));
 
   if (options && options.recursive) {
-    options = validateRmOptions(
-      path,
-      { ...options, force: true },
-      (err, options) => {
-        if (err) {
-          return callback(err);
-        }
+    validateRmOptions(path, { ...options, force: true }, (err, options) => {
+      if (err) {
+        return callback(err);
+      }
 
-        lazyLoadRimraf();
-        return rimraf(path, options, callback);
-      });
-
+      lazyLoadRimraf();
+      return rimraf(path, options, callback);
+    });
   } else {
-    options = validateRmdirOptions(options);
+    validateRmdirOptions(options);
     const req = new FSReqCallback();
     req.oncomplete = callback;
     return binding.rmdir(path, req);

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -684,15 +684,11 @@ const validateRmOptions = hideStackFrames((path, options, callback) => {
     );
 
   lazyLoadFs().stat(path, (err, stats) => {
-    if (err && err.code === 'ENOENT') {
-      if (options.force) {
+    if (err) {
+      if (options.force && err.code === 'ENOENT') {
         return callback(null, options);
       }
       return callback(err, options);
-    }
-
-    if (err) {
-      return callback(err);
     }
 
     if (stats.isDirectory() && !options.recursive) {


### PR DESCRIPTION
The first commit simplifies some error handling in `validateRmOptions()`. The second commit removes two unnecessary assignments in `rmdir()`.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)