### PR TITLE
doc: remove "Synchronously" for fsPromises.rm()

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -5567,7 +5567,7 @@ added: REPLACEME
     retries. This option is ignored if the `recursive` option is not `true`.
     **Default:** `100`.
 
-Synchronously removes files and directories (modeled on the standard POSIX `rm`
+Removes files and directories (modeled on the standard POSIX `rm`
 utility). Resolves the `Promise` with no arguments on success.
 
 ### `fsPromises.stat(path[, options])`


### PR DESCRIPTION
Because it's a promise, fsPromises.rm() is asynchronous. That is
implicit in every other fsPromises entry, so this removes
"Synchronously" rather than replacing it with "Asynchronously".

@iansu @bcoe 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
