### PR TITLE
doc: harmonize version pattern in YAML comments

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -2795,7 +2795,7 @@ added: v0.5.5
 changes:
   - version:
     - v14.9.0
-    - 12.19.0
+    - v12.19.0
     pr-url: https://github.com/nodejs/node/pull/34729
     description: This function is also available as `buf.writeUint16LE()`.
   - version: v10.0.0

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -729,7 +729,7 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/10116
     description: A deprecation code has been assigned.
   - version: v1.0.0
-    pr-url: https://github.com/iojs/io.js/pull/166
+    pr-url: https://github.com/nodejs/node/pull/166
     description: Documentation-only deprecation.
 -->
 
@@ -2143,6 +2143,9 @@ The `crypto._toBuf()` function was not designed to be used by modules outside
 of Node.js core and was removed.
 
 ### DEP0115: `crypto.prng()`, `crypto.pseudoRandomBytes()`, `crypto.rng()`
+
+<!--lint disable nodejs-yaml-comments -->
+
 <!-- YAML
 changes:
   - version: v11.0.0
@@ -2152,6 +2155,8 @@ changes:
     description: Added documentation-only deprecation
                  with `--pending-deprecation` support.
 -->
+
+<!--lint enable nodejs-yaml-comments -->
 
 Type: Documentation-only (supports [`--pending-deprecation`][])
 
@@ -2531,8 +2536,8 @@ purpose and is only available on CommonJS environment.
 <!-- YAML
 changes:
   - version:
-    - v12.19.0
     - v14.0.0
+    - v12.19.0
     pr-url: https://github.com/nodejs/node/pull/32499
     description: Documentation-only deprecation.
 -->
@@ -2658,7 +2663,7 @@ The [`crypto.Certificate()` constructor][] is deprecated. Use
 ### DEP0XXX: `fs.rmdir(path, { recursive: true })`
 <!-- YAML
 changes:
-  - version: REPLACME
+  - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/35579
     description: Documentation-only deprecation.
 -->

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -2396,7 +2396,8 @@ changes:
   - version:
      - v11.4.0
      - v10.15.0
-    pr-url: https://github.com/nodejs/node/commit/186035243fad247e3955f
+    commit: 186035243fad247e3955f
+    pr-url: https://github.com/nodejs-private/node-private/pull/143
     description: Max header size in `http_parser` was set to 8KB.
 -->
 

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1193,7 +1193,7 @@ per connection (in the case of HTTP Keep-Alive connections).
 added: v0.1.94
 changes:
   - version: v10.0.0
-    pr-url: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/19981
     description: Not listening to this event no longer causes the socket
                  to be destroyed if a client sends an Upgrade header.
 -->

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -2066,6 +2066,7 @@ changes:
      - v14.4.0
      - v12.18.0
      - v10.21.0
+    commit: 3948830ce6408be620b09a70bf66158623022af0
     pr-url: https://github.com/nodejs-private/node-private/pull/204
     description: Added `maxSettings` option with a default of 32.
   - version:
@@ -2207,6 +2208,7 @@ changes:
      - v14.4.0
      - v12.18.0
      - v10.21.0
+    commit: 3948830ce6408be620b09a70bf66158623022af0
     pr-url: https://github.com/nodejs-private/node-private/pull/204
     description: Added `maxSettings` option with a default of 32.
   - version:
@@ -2335,6 +2337,7 @@ changes:
      - v14.4.0
      - v12.18.0
      - v10.21.0
+    commit: 3948830ce6408be620b09a70bf66158623022af0
     pr-url: https://github.com/nodejs-private/node-private/pull/204
     description: Added `maxSettings` option with a default of 32.
   - version: v13.0.0

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1180,7 +1180,7 @@ is not supported.
 added: v8.3.0
 changes:
   - version: v11.0.0
-    pr-url: v11.0.0
+    pr-url: https://github.com/nodejs/node/pull/22281
     description: The class is now available on the global object.
 -->
 
@@ -1241,7 +1241,7 @@ mark.
 added: v8.3.0
 changes:
   - version: v11.0.0
-    pr-url: v11.0.0
+    pr-url: https://github.com/nodejs/node/pull/22281
     description: The class is now available on the global object.
 -->
 


### PR DESCRIPTION
I've let two linter errors slipped through in #35454.

Refs: https://github.com/nodejs/remark-preset-lint-node/pull/139

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
