### PR TITLE
doc: run license builder

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1059,6 +1059,7 @@ The externally maintained libraries used by Node.js are:
 
 - GYP, located at tools/gyp, is licensed as follows:
   """
+    Copyright (c) 2020 Node.js contributors. All rights reserved.
     Copyright (c) 2009 Google Inc. All rights reserved.
 
     Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
License is out of date

Created by running `./tools/license-builder.sh`