### PR TITLE
doc: document rmdir/recursive deprecation

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2659,7 +2659,7 @@ The [`crypto.Certificate()` constructor][] is deprecated. Use
 <!-- YAML
 changes:
   - version: REPLACME
-    pr-url: https://github.com/nodejs/node/pull/35171
+    pr-url: https://github.com/nodejs/node/pull/35579
     description: Documentation-only deprecation.
 -->
 

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2655,6 +2655,20 @@ Type: Documentation-only
 The [`crypto.Certificate()` constructor][] is deprecated. Use
 [static methods of `crypto.Certificate()`][] instead.
 
+### DEP0XXX: `fs.rmdir(path, { recursive: true })`
+<!-- YAML
+changes:
+  - version: REPLACME
+    pr-url: https://github.com/nodejs/node/pull/35562
+    description: Runtime deprecation.
+-->
+
+Type: Documentation-only
+
+`fs.rmdir(path, { recursive: true })` will throw on nonexistent paths, or when
+given a file as a target. Use `fs.rm(path, { recursive: true, force: true })`
+instead.
+
 [Legacy URL API]: url.md#url_legacy_url_api
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
 [RFC 6066]: https://tools.ietf.org/html/rfc6066#section-3

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2660,7 +2660,7 @@ The [`crypto.Certificate()` constructor][] is deprecated. Use
 changes:
   - version: REPLACME
     pr-url: https://github.com/nodejs/node/pull/35562
-    description: Runtime deprecation.
+    description: Documentation-only deprecation.
 -->
 
 Type: Documentation-only

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2659,7 +2659,7 @@ The [`crypto.Certificate()` constructor][] is deprecated. Use
 <!-- YAML
 changes:
   - version: REPLACME
-    pr-url: https://github.com/nodejs/node/pull/35562
+    pr-url: https://github.com/nodejs/node/pull/35171
     description: Documentation-only deprecation.
 -->
 

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2665,9 +2665,9 @@ changes:
 
 Type: Documentation-only
 
-`fs.rmdir(path, { recursive: true })` will throw on nonexistent paths, or when
-given a file as a target. Use `fs.rm(path, { recursive: true, force: true })`
-instead.
+In future versions of Node.js, `fs.rmdir(path, { recursive: true })` will throw
+on nonexistent paths, or when given a file as a target.
+Use `fs.rm(path, { recursive: true, force: true })` instead.
 
 [Legacy URL API]: url.md#url_legacy_url_api
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf


### PR DESCRIPTION
Document deprecation of rmdir/recursive permissive functionality.

----

As suggested by @aduh95, this adds the deprecation of the permissive behavior of `rmdir`/`recursive` as a docs only deprecation, in the `deprecations.md`.

We already updated the docs in #35171, to mention that the permissive behavior will one day be removed.

Refs: https://github.com/nodejs/node/pull/35562

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

CC: @iansu 
