### PR TITLE
report: honor setUncaughtExceptionCaptureCallback

### DIFF
--- a/lib/internal/process/execution.js
+++ b/lib/internal/process/execution.js
@@ -92,12 +92,16 @@ function evalScript(name, body, breakFirstLine, print) {
     globalThis.module = origModule;
 }
 
-const exceptionHandlerState = { captureFn: null };
+const exceptionHandlerState = {
+  captureFn: null,
+  reportFlag: false
+};
 
 function setUncaughtExceptionCaptureCallback(fn) {
   if (fn === null) {
     exceptionHandlerState.captureFn = fn;
     shouldAbortOnUncaughtToggle[0] = 1;
+    process.report.reportOnUncaughtException = exceptionHandlerState.reportFlag;
     return;
   }
   if (typeof fn !== 'function') {
@@ -108,6 +112,9 @@ function setUncaughtExceptionCaptureCallback(fn) {
   }
   exceptionHandlerState.captureFn = fn;
   shouldAbortOnUncaughtToggle[0] = 0;
+  exceptionHandlerState.reportFlag =
+    process.report.reportOnUncaughtException === true;
+  process.report.reportOnUncaughtException = false;
 }
 
 function hasUncaughtExceptionCaptureCallback() {

--- a/test/report/test-report-uncaught-exception-override.js
+++ b/test/report/test-report-uncaught-exception-override.js
@@ -1,0 +1,26 @@
+// Flags: --report-uncaught-exception
+'use strict';
+// Test report is suppressed on uncaught exception hook.
+const common = require('../common');
+const assert = require('assert');
+const helper = require('../common/report');
+const tmpdir = require('../common/tmpdir');
+const error = new Error('test error');
+
+tmpdir.refresh();
+process.report.directory = tmpdir.path;
+
+// First, install an uncaught exception hook.
+process.setUncaughtExceptionCaptureCallback(common.mustCall());
+
+// Make sure this is ignored due to the above override.
+process.on('uncaughtException', common.mustNotCall());
+
+process.on('exit', (code) => {
+  assert.strictEqual(code, 0);
+  // Make sure no reports are generated.
+  const reports = helper.findReports(process.pid, tmpdir.path);
+  assert.strictEqual(reports.length, 0);
+});
+
+throw error;


### PR DESCRIPTION
This api does not alter the behavior of diagnostic
report configured to on uncaught exceptions.
This is deemed as a bug. Honor this API.

Refs: https://github.com/nodejs/node/pull/35588

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

/cc @addaleax 