### PR TITLE
fs: throw rm() validation errors

### DIFF
--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -673,12 +673,8 @@ const defaultRmdirOptions = {
 };
 
 const validateRmOptions = hideStackFrames((path, options, callback) => {
-  try {
-    options = validateRmdirOptions(options, defaultRmOptions);
-    validateBoolean(options.force, 'options.force');
-  } catch (err) {
-    return callback(err);
-  }
+  options = validateRmdirOptions(options, defaultRmOptions);
+  validateBoolean(options.force, 'options.force');
 
   lazyLoadFs().stat(path, (err, stats) => {
     if (err) {


### PR DESCRIPTION
This commit updates `validateRmOptions()` to throw on input validation failures. This is consistent with how Node handles validation in most places across the codebase.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)