### PR TITLE
deps: V8: cherry-pick 3176bfd447a9

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.16',
+    'v8_embedder_string': '-node.17',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/api/api.cc
+++ b/deps/v8/src/api/api.cc
@@ -10716,7 +10716,8 @@ static i::HeapSnapshot* ToInternal(const HeapSnapshot* snapshot) {
 
 void HeapSnapshot::Delete() {
   i::Isolate* isolate = ToInternal(this)->profiler()->isolate();
-  if (isolate->heap_profiler()->GetSnapshotsCount() > 1) {
+  if (isolate->heap_profiler()->GetSnapshotsCount() > 1 ||
+      isolate->heap_profiler()->IsTakingSnapshot()) {
     ToInternal(this)->Delete();
   } else {
     // If this is the last snapshot, clean up all accessory data as well.

--- a/deps/v8/src/profiler/heap-profiler.h
+++ b/deps/v8/src/profiler/heap-profiler.h
@@ -49,7 +49,8 @@ class HeapProfiler : public HeapObjectAllocationTracker {
 
   SnapshotObjectId PushHeapObjectsStats(OutputStream* stream,
                                         int64_t* timestamp_us);
-  int GetSnapshotsCount();
+  int GetSnapshotsCount() const;
+  bool IsTakingSnapshot() const;
   HeapSnapshot* GetSnapshot(int index);
   SnapshotObjectId GetSnapshotObjectId(Handle<Object> obj);
   SnapshotObjectId GetSnapshotObjectId(NativeObject obj);
@@ -93,6 +94,7 @@ class HeapProfiler : public HeapObjectAllocationTracker {
   std::unique_ptr<StringsStorage> names_;
   std::unique_ptr<AllocationTracker> allocation_tracker_;
   bool is_tracking_object_moves_;
+  bool is_taking_snapshot_;
   base::Mutex profiler_mutex_;
   std::unique_ptr<SamplingHeapProfiler> sampling_heap_profiler_;
   std::vector<std::pair<v8::HeapProfiler::BuildEmbedderGraphCallback, void*>>

--- a/deps/v8/test/cctest/test-heap-profiler.cc
+++ b/deps/v8/test/cctest/test-heap-profiler.cc
@@ -4126,3 +4126,40 @@ TEST(Bug8373_2) {
 
   heap_profiler->StopTrackingHeapObjects();
 }
+
+TEST(HeapSnapshotDeleteDuringTakeSnapshot) {
+  // Check that a heap snapshot can be deleted during GC while another one
+  // is being taken.
+
+  LocalContext env;
+  v8::HandleScope scope(env->GetIsolate());
+  v8::HeapProfiler* heap_profiler = env->GetIsolate()->GetHeapProfiler();
+  int gc_calls = 0;
+  v8::Global<v8::Object> handle;
+
+  {
+    struct WeakData {
+      const v8::HeapSnapshot* snapshot;
+      int* gc_calls;
+      v8::Global<v8::Object>* handle;
+    };
+    WeakData* data =
+        new WeakData{heap_profiler->TakeHeapSnapshot(), &gc_calls, &handle};
+
+    v8::HandleScope scope(env->GetIsolate());
+    handle.Reset(env->GetIsolate(), v8::Object::New(env->GetIsolate()));
+    handle.SetWeak(
+        data,
+        [](const v8::WeakCallbackInfo<WeakData>& data) {
+          std::unique_ptr<WeakData> weakdata{data.GetParameter()};
+          const_cast<v8::HeapSnapshot*>(weakdata->snapshot)->Delete();
+          ++*weakdata->gc_calls;
+          weakdata->handle->Reset();
+        },
+        v8::WeakCallbackType::kParameter);
+  }
+  CHECK_EQ(gc_calls, 0);
+
+  CHECK(ValidateSnapshot(heap_profiler->TakeHeapSnapshot()));
+  CHECK_EQ(gc_calls, 1);
+}

--- a/test/parallel/test-v8-getheapsnapshot-twice.js
+++ b/test/parallel/test-v8-getheapsnapshot-twice.js
@@ -1,0 +1,9 @@
+'use strict';
+require('../common');
+const v8 = require('v8');
+
+// Regression test for https://github.com/nodejs/node/issues/35559
+// It is important that the return value of the first call is not used, i.e.
+// that the first snapshot is GC-able while the second one is being created.
+v8.getHeapSnapshot();
+v8.getHeapSnapshot();


### PR DESCRIPTION
##### deps: V8: cherry-pick 3176bfd447a9

Original commit message:

    [heap-profiler] Fix crash when a snapshot deleted while taking one

    Fix a crash/hang that occurred when deleting a snapshot during the
    GC that is part of taking another one.

    Specifically, when deleting the only other snapshot in such
    a situation, the `v8::HeapSnapshot::Delete()` method sees that there
    is only one (complete) snapshot at that point, and decides that it is
    okay to perform “delete all snapshots” instead of just deleting
    the requested one. That resets the internal string lookup table
    of the heap profiler, but the new snapshot that is currently in
    progress still holds references to the old string lookup table,
    leading to a use-after-free segfault or infinite loop.

    Fix this by guarding against resetting the string table while
    another heap snapshot is being taken, and add a test that would
    crash before this fix.

    This can be triggered in Node.js by repeatedly calling
    `v8.getHeapSnapshot()`, which provides heap snapshots as weakly
    held host objects.

    Change-Id: If9ac3728bf79114000982f1e7bb05e8034299e3c
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2464823
    Reviewed-by: Ulan Degenbaev <ulan@chromium.org>
    Commit-Queue: Ulan Degenbaev <ulan@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#70445}

Refs: https://github.com/v8/v8/commit/3176bfd447a909fa9608687fe3eabcf62ec7b2eb

##### test: add regression test for v8.getHeapSnapshot() crash

Fixes: https://github.com/nodejs/node/issues/35559

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
