### PR TITLE
gyp,build: consistent shared library location

### DIFF
--- a/test/common/shared-lib-util.js
+++ b/test/common/shared-lib-util.js
@@ -17,11 +17,11 @@ function addLibraryPath(env) {
 
   env.LD_LIBRARY_PATH =
     (env.LD_LIBRARY_PATH ? env.LD_LIBRARY_PATH + path.delimiter : '') +
-    path.join(kExecPath, 'lib.target');
+    kExecPath;
   // For AIX.
   env.LIBPATH =
     (env.LIBPATH ? env.LIBPATH + path.delimiter : '') +
-    path.join(kExecPath, 'lib.target');
+    kExecPath;
   // For Mac OSX.
   env.DYLD_LIBRARY_PATH =
     (env.DYLD_LIBRARY_PATH ? env.DYLD_LIBRARY_PATH + path.delimiter : '') +
@@ -34,10 +34,8 @@ function addLibraryPath(env) {
 function getSharedLibPath() {
   if (common.isWindows) {
     return path.join(kExecPath, 'node.dll');
-  } else if (common.isOSX) {
-    return path.join(kExecPath, `libnode.${kShlibSuffix}`);
   }
-  return path.join(kExecPath, 'lib.target', `libnode.${kShlibSuffix}`);
+  return path.join(kExecPath, `libnode.${kShlibSuffix}`);
 }
 
 // Get the binary path of stack frames.

--- a/tools/gyp/pylib/gyp/generator/make.py
+++ b/tools/gyp/pylib/gyp/generator/make.py
@@ -1621,10 +1621,8 @@ $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj)/%%%s FORCE_DO_CMD
                     if any(dep.endswith(".so") or ".so." in dep for dep in deps):
                         # We want to get the literal string "$ORIGIN"
                         # into the link command, so we need lots of escaping.
-                        ldflags.append(r"-Wl,-rpath=\$$ORIGIN/lib.%s/" % self.toolset)
-                        ldflags.append(
-                            r"-Wl,-rpath-link=\$(builddir)/lib.%s/" % self.toolset
-                        )
+                        ldflags.append(r"-Wl,-rpath=\$$ORIGIN/")
+                        ldflags.append(r"-Wl,-rpath-link=\$(builddir)/")
                 library_dirs = config.get("library_dirs", [])
                 ldflags += [("-L%s" % library_dir) for library_dir in library_dirs]
                 self.WriteList(ldflags, "LDFLAGS_%s" % configname)
@@ -2172,14 +2170,16 @@ $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj)/%%%s FORCE_DO_CMD
 
     def _InstallableTargetInstallPath(self):
         """Returns the location of the final output for an installable target."""
+        # Functionality removed for all platforms to match Xcode and hoist
+        # shared libraries into PRODUCT_DIR for users:
         # Xcode puts shared_library results into PRODUCT_DIR, and some gyp files
         # rely on this. Emulate this behavior for mac.
-        if self.type == "shared_library" and (
-            self.flavor != "mac" or self.toolset != "target"
-        ):
-            # Install all shared libs into a common directory (per toolset) for
-            # convenient access with LD_LIBRARY_PATH.
-            return "$(builddir)/lib.%s/%s" % (self.toolset, self.alias)
+        # if self.type == "shared_library" and (
+        #     self.flavor != "mac" or self.toolset != "target"
+        # ):
+        #    # Install all shared libs into a common directory (per toolset) for
+        #    # convenient access with LD_LIBRARY_PATH.
+        #    return "$(builddir)/lib.%s/%s" % (self.toolset, self.alias)
         return "$(builddir)/" + self.alias
 
 

--- a/tools/install.py
+++ b/tools/install.py
@@ -132,10 +132,6 @@ def files(action):
       output_file += '.dll'
     else:
       output_file = 'lib' + output_file + '.' + variables.get('shlib_suffix')
-      # GYP will output to lib.target except on OS X, this is hardcoded
-      # in its source - see the _InstallableTargetInstallPath function.
-      if sys.platform != 'darwin':
-        output_prefix += 'lib.target/'
 
   if 'false' == variables.get('node_shared'):
     action([output_prefix + output_file], 'bin/' + output_file)


### PR DESCRIPTION
Ref: https://github.com/nodejs/node-gyp/issues/2233
Ref: https://github.com/nodejs/gyp-next/pull/69

Pending agreement on https://github.com/nodejs/gyp-next/pull/69. Perhaps this could be argued to be a breaking change here? But I'm making the case that it's a bugfix for GYP as far as node-gyp and npm is concerned. Doing this here makes it consistent across all (and matches the behaviour node-gyp has had for many years now). This really should go out with npm 7 and node 15, but I have no idea on timing on either of those things.

@nodejs/build 
@nodejs/gyp 
@nodejs/node-gyp 