### PR TITLE
test: improve error message for policy failures

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -1295,7 +1295,7 @@ function urlToOptions(url) {
   return options;
 }
 
-const forwardSlashRegEx = /\//g;
+const forwardSlashesRegEx = /\/+/g;
 
 function getPathFromURLWin32(url) {
   const hostname = url.hostname;
@@ -1311,7 +1311,7 @@ function getPathFromURLWin32(url) {
       }
     }
   }
-  pathname = pathname.replace(forwardSlashRegEx, '\\');
+  pathname = pathname.replace(forwardSlashesRegEx, '\\');
   pathname = decodeURIComponent(pathname);
   if (hostname !== '') {
     // If hostname is set, then we have a UNC path
@@ -1336,7 +1336,7 @@ function getPathFromURLPosix(url) {
   if (url.hostname !== '') {
     throw new ERR_INVALID_FILE_URL_HOST(platform);
   }
-  const pathname = url.pathname;
+  let pathname = url.pathname;
   for (let n = 0; n < pathname.length; n++) {
     if (pathname[n] === '%') {
       const third = pathname.codePointAt(n + 2) | 0x20;
@@ -1347,6 +1347,7 @@ function getPathFromURLPosix(url) {
       }
     }
   }
+  pathname = pathname.replace(forwardSlashesRegEx, '/');
   return decodeURIComponent(pathname);
 }
 

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -1295,7 +1295,7 @@ function urlToOptions(url) {
   return options;
 }
 
-const forwardSlashesRegEx = /\/+/g;
+const forwardSlashRegEx = /\//g;
 
 function getPathFromURLWin32(url) {
   const hostname = url.hostname;
@@ -1311,7 +1311,7 @@ function getPathFromURLWin32(url) {
       }
     }
   }
-  pathname = pathname.replace(forwardSlashesRegEx, '\\');
+  pathname = pathname.replace(forwardSlashRegEx, '\\');
   pathname = decodeURIComponent(pathname);
   if (hostname !== '') {
     // If hostname is set, then we have a UNC path
@@ -1336,7 +1336,7 @@ function getPathFromURLPosix(url) {
   if (url.hostname !== '') {
     throw new ERR_INVALID_FILE_URL_HOST(platform);
   }
-  let pathname = url.pathname;
+  const pathname = url.pathname;
   for (let n = 0; n < pathname.length; n++) {
     if (pathname[n] === '%') {
       const third = pathname.codePointAt(n + 2) | 0x20;
@@ -1347,7 +1347,6 @@ function getPathFromURLPosix(url) {
       }
     }
   }
-  pathname = pathname.replace(forwardSlashesRegEx, '/');
   return decodeURIComponent(pathname);
 }
 

--- a/test/common/README.md
+++ b/test/common/README.md
@@ -378,6 +378,11 @@ const { spawn } = require('child_process');
 spawn(...common.pwdCommand, { stdio: ['pipe'] });
 ```
 
+### `requireNoPackageJSONAbove()`
+
+Throws an `AssertionError` if a `package.json` file is in any ancestor
+directory. Such files may interfere with proper test functionality.
+
 ### `runWithInvalidFD(func)`
 
 * `func` [&lt;Function>][]

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -704,9 +704,7 @@ function requireNoPackageJSONAbove() {
     if (fs.existsSync(possiblePackage)) {
       throw new Error(
         'This test shouldn\'t load properties from a package.json above ' +
-        `it's file location. Found package.json at ${possiblePackage}, ` +
-        'in order to run this test properly ensure no package.json is above ' +
-        'the tests.');
+        `its file location. Found package.json at ${possiblePackage}.`);
     }
     lastPackage = possiblePackage;
     possiblePackage = path.join(possiblePackage, '..', '..', 'package.json');

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -697,6 +697,22 @@ function gcUntil(name, condition) {
   });
 }
 
+function requireNoPackageJSONAbove() {
+  let possiblePackage = path.join(__dirname, '..', 'package.json');
+  let lastPackage = null;
+  while (possiblePackage !== lastPackage) {
+    if (fs.existsSync(possiblePackage)) {
+      throw new Error(
+        'This test shouldn\'t load properties from a package.json above ' +
+        `it's file location. Found package.json at ${possiblePackage}, ` +
+        'in order to run this test properly ensure no package.json is above ' +
+        'the tests.');
+    }
+    lastPackage = possiblePackage;
+    possiblePackage = path.join(possiblePackage, '..', '..', 'package.json');
+  }
+}
+
 const common = {
   allowGlobals,
   buildType,
@@ -736,6 +752,7 @@ const common = {
   platformTimeout,
   printSkipMessage,
   pwdCommand,
+  requireNoPackageJSONAbove,
   runWithInvalidFD,
   skip,
   skipIf32Bits,

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -702,7 +702,7 @@ function requireNoPackageJSONAbove() {
   let lastPackage = null;
   while (possiblePackage !== lastPackage) {
     if (fs.existsSync(possiblePackage)) {
-      throw new Error(
+      assert.fail(
         'This test shouldn\'t load properties from a package.json above ' +
         `its file location. Found package.json at ${possiblePackage}.`);
     }

--- a/test/parallel/test-policy-dependencies.js
+++ b/test/parallel/test-policy-dependencies.js
@@ -3,6 +3,7 @@
 const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
+common.requireNoPackageJSONAbove();
 
 const fixtures = require('../common/fixtures');
 

--- a/test/parallel/test-policy-dependency-conditions.js
+++ b/test/parallel/test-policy-dependency-conditions.js
@@ -4,6 +4,7 @@
 const common = require('../common');
 
 if (!common.hasCrypto) common.skip('missing crypto');
+common.requireNoPackageJSONAbove();
 
 const Manifest = require('internal/policy/manifest').Manifest;
 

--- a/test/parallel/test-policy-integrity-flag.js
+++ b/test/parallel/test-policy-integrity-flag.js
@@ -3,6 +3,7 @@
 const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
+common.requireNoPackageJSONAbove();
 
 const fixtures = require('../common/fixtures');
 

--- a/test/parallel/test-policy-parse-integrity.js
+++ b/test/parallel/test-policy-parse-integrity.js
@@ -2,6 +2,7 @@
 
 const common = require('../common');
 if (!common.hasCrypto) common.skip('missing crypto');
+common.requireNoPackageJSONAbove();
 
 const tmpdir = require('../common/tmpdir');
 const assert = require('assert');

--- a/test/parallel/test-policy-scopes-dependencies.js
+++ b/test/parallel/test-policy-scopes-dependencies.js
@@ -4,6 +4,7 @@
 const common = require('../common');
 
 if (!common.hasCrypto) common.skip('missing crypto');
+common.requireNoPackageJSONAbove();
 
 const Manifest = require('internal/policy/manifest').Manifest;
 const assert = require('assert');

--- a/test/parallel/test-policy-scopes-integrity.js
+++ b/test/parallel/test-policy-scopes-integrity.js
@@ -4,6 +4,7 @@
 const common = require('../common');
 
 if (!common.hasCrypto) common.skip('missing crypto');
+common.requireNoPackageJSONAbove();
 
 const Manifest = require('internal/policy/manifest').Manifest;
 const assert = require('assert');

--- a/test/parallel/test-policy-scopes.js
+++ b/test/parallel/test-policy-scopes.js
@@ -3,6 +3,7 @@
 const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
+common.requireNoPackageJSONAbove();
 
 const fixtures = require('../common/fixtures');
 

--- a/test/pummel/test-policy-integrity.js
+++ b/test/pummel/test-policy-integrity.js
@@ -2,6 +2,7 @@
 
 const common = require('../common');
 if (!common.hasCrypto) common.skip('missing crypto');
+common.requireNoPackageJSONAbove();
 
 const { debuglog } = require('util');
 const debug = debuglog('test');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
fixes: #35600  

this doesn't attempt to fix this outside of running node's test suite since we cannot know when a package.json is expected or not except through the policy itself. in theory any test relying on "type" should also use this helper... but that is basically everything so it is fine to omit I think.