### PR TITLE
build: update github workflows

### DIFF
--- a/.github/workflows/auto-start-ci.yml
+++ b/.github/workflows/auto-start-ci.yml
@@ -26,8 +26,8 @@ jobs:
 
       - name: Set variables
         run: |
-          echo "::set-env name=REPOSITORY::$(echo ${{ github.repository }} | cut -d/ -f2)"
-          echo "::set-env name=OWNER::${{ github.repository_owner }}"
+          echo "REPOSITORY=$(echo ${{ github.repository }} | cut -d/ -f2)" >> $GITHUB_ENV
+          echo "OWNER=${{ github.repository_owner }}" >> $GITHUB_ENV
 
       # Get Pull Requests
       - name: Get Pull Requests

--- a/.github/workflows/auto-start-ci.yml
+++ b/.github/workflows/auto-start-ci.yml
@@ -17,8 +17,6 @@ jobs:
       - uses: actions/checkout@v2
 
       # Install dependencies
-      - name: Install jq
-        run: sudo apt-get install jq -y
       - name: Install Node.js
         uses: actions/setup-node@v2-beta
         with:

--- a/.github/workflows/build-tarball.yml
+++ b/.github/workflows/build-tarball.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Extract tarball
         run: |
           tar xzf tarballs/*.tar.gz
-          echo "::set-env name=TAR_DIR::`basename tarballs/*.tar.gz .tar.gz`"
+          echo "TAR_DIR=`basename tarballs/*.tar.gz .tar.gz`" >> $GITHUB_ENV
       - name: Copy directories needed for testing
         run: |
           cp -r tools/node_modules $TAR_DIR/tools

--- a/.github/workflows/commit-queue.yml
+++ b/.github/workflows/commit-queue.yml
@@ -35,10 +35,8 @@ jobs:
         uses: actions/setup-node@v2-beta
         with:
           node-version: '12'
-      - name: Install dependencies
-        run: |
-          sudo apt-get install jq -y
-          npm install -g node-core-utils@latest
+      - name: Install node-core-utils
+        run: npm install -g node-core-utils@latest
 
       - name: Set variables
         run: |

--- a/.github/workflows/commit-queue.yml
+++ b/.github/workflows/commit-queue.yml
@@ -40,8 +40,8 @@ jobs:
 
       - name: Set variables
         run: |
-          echo "::set-env name=REPOSITORY::$(echo ${{ github.repository }} | cut -d/ -f2)"
-          echo "::set-env name=OWNER::${{ github.repository_owner }}"
+          echo "REPOSITORY=$(echo ${{ github.repository }} | cut -d/ -f2)" >> $GITHUB_ENV
+          echo "OWNER=${{ github.repository_owner }}" >> $GITHUB_ENV
 
       - name: Get Pull Requests
         uses: octokit/graphql-action@v2.x


### PR DESCRIPTION
See https://github.com/nodejs/node/actions/runs/306130006 for an example with the `set-env` deprecation message.

commit 8a7ee81286aabda6d20fcffced770f61999cd230

    build: use GITHUB_ENV file to set env variables

    The other way is deprecated.

commit b3e69720d7acdd3784d9481f586580fbe6aa5023

    build: do not install jq in workflows

    It is already installed in the GitHub runners.