### PR TITLE
src: remove ERR prefix in WebCryptoKeyExportStatus

### DIFF
--- a/src/crypto/crypto_dh.cc
+++ b/src/crypto/crypto_dh.cc
@@ -524,11 +524,11 @@ WebCryptoKeyExportStatus DHKeyExportTraits::DoExport(
   switch (format) {
     case kWebCryptoKeyFormatPKCS8:
       if (key_data->GetKeyType() != kKeyTypePrivate)
-        return WebCryptoKeyExportStatus::ERR_INVALID_KEY_TYPE;
+        return WebCryptoKeyExportStatus::INVALID_KEY_TYPE;
       return PKEY_PKCS8_Export(key_data.get(), out);
     case kWebCryptoKeyFormatSPKI:
       if (key_data->GetKeyType() != kKeyTypePublic)
-        return WebCryptoKeyExportStatus::ERR_INVALID_KEY_TYPE;
+        return WebCryptoKeyExportStatus::INVALID_KEY_TYPE;
       return PKEY_SPKI_Export(key_data.get(), out);
     default:
       UNREACHABLE();

--- a/src/crypto/crypto_dsa.cc
+++ b/src/crypto/crypto_dsa.cc
@@ -113,14 +113,14 @@ WebCryptoKeyExportStatus DSAKeyExportTraits::DoExport(
   switch (format) {
     case kWebCryptoKeyFormatRaw:
       // Not supported for RSA keys of either type
-      return WebCryptoKeyExportStatus::ERR_FAILED;
+      return WebCryptoKeyExportStatus::FAILED;
     case kWebCryptoKeyFormatPKCS8:
       if (key_data->GetKeyType() != kKeyTypePrivate)
-        return WebCryptoKeyExportStatus::ERR_INVALID_KEY_TYPE;
+        return WebCryptoKeyExportStatus::INVALID_KEY_TYPE;
       return PKEY_PKCS8_Export(key_data.get(), out);
     case kWebCryptoKeyFormatSPKI:
       if (key_data->GetKeyType() != kKeyTypePublic)
-        return WebCryptoKeyExportStatus::ERR_INVALID_KEY_TYPE;
+        return WebCryptoKeyExportStatus::INVALID_KEY_TYPE;
       return PKEY_SPKI_Export(key_data.get(), out);
     default:
       UNREACHABLE();

--- a/src/crypto/crypto_ecdh.cc
+++ b/src/crypto/crypto_ecdh.cc
@@ -549,18 +549,18 @@ WebCryptoKeyExportStatus EC_Raw_Export(
   // Get the allocated data size...
   size_t len = EC_POINT_point2oct(group, point, form, nullptr, 0, nullptr);
   if (len == 0)
-    return WebCryptoKeyExportStatus::ERR_FAILED;
+    return WebCryptoKeyExportStatus::FAILED;
 
   unsigned char* data = MallocOpenSSL<unsigned char>(len);
   size_t check_len = EC_POINT_point2oct(group, point, form, data, len, nullptr);
   if (check_len == 0)
-    return WebCryptoKeyExportStatus::ERR_FAILED;
+    return WebCryptoKeyExportStatus::FAILED;
 
   CHECK_EQ(len, check_len);
 
   *out = ByteSource::Allocated(reinterpret_cast<char*>(data), len);
 
-  return WebCryptoKeyExportStatus::ERR_OK;
+  return WebCryptoKeyExportStatus::OK;
 }
 }  // namespace
 
@@ -581,15 +581,15 @@ WebCryptoKeyExportStatus ECKeyExportTraits::DoExport(
   switch (format) {
     case kWebCryptoKeyFormatRaw:
       if (key_data->GetKeyType() != kKeyTypePublic)
-        return WebCryptoKeyExportStatus::ERR_INVALID_KEY_TYPE;
+        return WebCryptoKeyExportStatus::INVALID_KEY_TYPE;
       return EC_Raw_Export(key_data.get(), params, out);
     case kWebCryptoKeyFormatPKCS8:
       if (key_data->GetKeyType() != kKeyTypePrivate)
-        return WebCryptoKeyExportStatus::ERR_INVALID_KEY_TYPE;
+        return WebCryptoKeyExportStatus::INVALID_KEY_TYPE;
       return PKEY_PKCS8_Export(key_data.get(), out);
     case kWebCryptoKeyFormatSPKI:
       if (key_data->GetKeyType() != kKeyTypePublic)
-        return WebCryptoKeyExportStatus::ERR_INVALID_KEY_TYPE;
+        return WebCryptoKeyExportStatus::INVALID_KEY_TYPE;
       return PKEY_SPKI_Export(key_data.get(), out);
     default:
       UNREACHABLE();

--- a/src/crypto/crypto_keys.cc
+++ b/src/crypto/crypto_keys.cc
@@ -1261,10 +1261,10 @@ WebCryptoKeyExportStatus PKEY_SPKI_Export(
   CHECK_EQ(key_data->GetKeyType(), kKeyTypePublic);
   BIOPointer bio(BIO_new(BIO_s_mem()));
   if (!i2d_PUBKEY_bio(bio.get(), key_data->GetAsymmetricKey().get()))
-    return WebCryptoKeyExportStatus::ERR_FAILED;
+    return WebCryptoKeyExportStatus::FAILED;
 
   *out = ByteSource::FromBIO(bio);
-  return WebCryptoKeyExportStatus::ERR_OK;
+  return WebCryptoKeyExportStatus::OK;
 }
 
 WebCryptoKeyExportStatus PKEY_PKCS8_Export(
@@ -1274,10 +1274,10 @@ WebCryptoKeyExportStatus PKEY_PKCS8_Export(
   BIOPointer bio(BIO_new(BIO_s_mem()));
   PKCS8Pointer p8inf(EVP_PKEY2PKCS8(key_data->GetAsymmetricKey().get()));
   if (!i2d_PKCS8_PRIV_KEY_INFO_bio(bio.get(), p8inf.get()))
-    return WebCryptoKeyExportStatus::ERR_FAILED;
+    return WebCryptoKeyExportStatus::FAILED;
 
   *out = ByteSource::FromBIO(bio);
-  return WebCryptoKeyExportStatus::ERR_OK;
+  return WebCryptoKeyExportStatus::OK;
 }
 
 namespace Keys {

--- a/src/crypto/crypto_keys.h
+++ b/src/crypto/crypto_keys.h
@@ -262,9 +262,9 @@ enum WebCryptoKeyFormat {
 };
 
 enum class WebCryptoKeyExportStatus {
-  ERR_OK,
-  ERR_INVALID_KEY_TYPE,
-  ERR_FAILED
+  OK,
+  INVALID_KEY_TYPE,
+  FAILED
 };
 
 template <typename KeyExportTraits>
@@ -336,13 +336,13 @@ class KeyExportJob final : public CryptoJob<KeyExportTraits> {
                 format_,
                 *CryptoJob<KeyExportTraits>::params(),
                 &out_)) {
-      case WebCryptoKeyExportStatus::ERR_OK:
+      case WebCryptoKeyExportStatus::OK:
         // Success!
         break;
-      case WebCryptoKeyExportStatus::ERR_INVALID_KEY_TYPE:
+      case WebCryptoKeyExportStatus::INVALID_KEY_TYPE:
         // Fall through
         // TODO(@jasnell): Separate error for this
-      case WebCryptoKeyExportStatus::ERR_FAILED: {
+      case WebCryptoKeyExportStatus::FAILED: {
         CryptoErrorVector* errors = CryptoJob<KeyExportTraits>::errors();
         errors->Capture();
         if (errors->empty())

--- a/src/crypto/crypto_rsa.cc
+++ b/src/crypto/crypto_rsa.cc
@@ -179,7 +179,7 @@ WebCryptoKeyExportStatus RSA_JWK_Export(
     KeyObjectData* key_data,
     const RSAKeyExportConfig& params,
     ByteSource* out) {
-  return WebCryptoKeyExportStatus::ERR_FAILED;
+  return WebCryptoKeyExportStatus::FAILED;
 }
 
 template <PublicKeyCipher::EVP_PKEY_cipher_init_t init,
@@ -268,16 +268,16 @@ WebCryptoKeyExportStatus RSAKeyExportTraits::DoExport(
   switch (format) {
     case kWebCryptoKeyFormatRaw:
       // Not supported for RSA keys of either type
-      return WebCryptoKeyExportStatus::ERR_FAILED;
+      return WebCryptoKeyExportStatus::FAILED;
     case kWebCryptoKeyFormatJWK:
       return RSA_JWK_Export(key_data.get(), params, out);
     case kWebCryptoKeyFormatPKCS8:
       if (key_data->GetKeyType() != kKeyTypePrivate)
-        return WebCryptoKeyExportStatus::ERR_INVALID_KEY_TYPE;
+        return WebCryptoKeyExportStatus::INVALID_KEY_TYPE;
       return PKEY_PKCS8_Export(key_data.get(), out);
     case kWebCryptoKeyFormatSPKI:
       if (key_data->GetKeyType() != kKeyTypePublic)
-        return WebCryptoKeyExportStatus::ERR_INVALID_KEY_TYPE;
+        return WebCryptoKeyExportStatus::INVALID_KEY_TYPE;
       return PKEY_SPKI_Export(key_data.get(), out);
     default:
       UNREACHABLE();


### PR DESCRIPTION
This commit suggests removing the `ERR` prefix in the
`WebCryptoKeyExportStatus` enum.

The motivation for this is that I think it improves the readability of
the code. For example, the following line had me look twice to see what
was going on:
```c++
  case WebCryptoKeyExportStatus::ERR_OK:
  // Success!
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
