### PR TITLE
[v14.x] Revert "tools: add missing uv_setup_argv() calls"

### DIFF
--- a/tools/code_cache/mkcodecache.cc
+++ b/tools/code_cache/mkcodecache.cc
@@ -24,7 +24,6 @@ using v8::Local;
 int wmain(int argc, wchar_t* argv[]) {
 #else   // UNIX
 int main(int argc, char* argv[]) {
-  argv = uv_setup_args(argc, argv);
 #endif  // _WIN32
 
   v8::V8::SetFlagsFromString("--random_seed=42");

--- a/tools/snapshot/node_mksnapshot.cc
+++ b/tools/snapshot/node_mksnapshot.cc
@@ -17,7 +17,6 @@
 int wmain(int argc, wchar_t* argv[]) {
 #else   // UNIX
 int main(int argc, char* argv[]) {
-  argv = uv_setup_args(argc, argv);
 #endif  // _WIN32
 
   v8::V8::SetFlagsFromString("--random_seed=42");


### PR DESCRIPTION
`test-asan` is failing on `v14.x`. I suspect it is due to this commit - I'm raising this PR to initially just test whether this commit  is the cause of the failure (I'm having trouble running `test-asan` locally).

The original PR passed `test-asan`, so I suspect if this commit is the cause, it would be due to a related commit missing on v14.x.

This reverts commit 70e77f123164ecbdbdd4abc2e4919ce1b193421e.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
