### PR TITLE
src: minor cleanup and simplification of crypto::Hash

### DIFF
--- a/src/crypto/crypto_hash.h
+++ b/src/crypto/crypto_hash.h
@@ -15,8 +15,6 @@ namespace node {
 namespace crypto {
 class Hash final : public BaseObject {
  public:
-  ~Hash() override;
-
   static void Initialize(Environment* env, v8::Local<v8::Object> target);
 
   void MemoryInfo(MemoryTracker* tracker) const override;
@@ -36,10 +34,9 @@ class Hash final : public BaseObject {
   Hash(Environment* env, v8::Local<v8::Object> wrap);
 
  private:
-  EVPMDPointer mdctx_;
-  bool has_md_;
-  unsigned int md_len_;
-  unsigned char* md_value_;
+  EVPMDPointer mdctx_ {};
+  unsigned int md_len_ = 0;
+  ByteSource digest_;
 };
 
 struct HashConfig final : public MemoryRetainer {


### PR DESCRIPTION
Some minor cleanups and simplification for `crypto::Hash`

@addaleax @targos... I was working on this because `valgrind --leak-check=full` is reporting the following when `crypto.createHash()` is called but I can't seem to be able to track down the uninitialized memory...

```
==29245== Conditional jump or move depends on uninitialised value(s)
==29245==    at 0xA985F9: node::crypto::Hash::New(v8::FunctionCallbackInfo<v8::Value> const&) (in /home/james/node/node/out/Release/node)
==29245==    by 0xBB3E9A: v8::internal::MaybeHandle<v8::internal::Object> v8::internal::(anonymous namespace)::HandleApiCallHelper<true>(v8::internal::Isolate*, v8::internal::Handle<v8::internal::HeapObject>, v8::internal::Handle<v8::internal::HeapObject>, v8::internal::Handle<v8::internal::FunctionTemplateInfo>, v8::internal::Handle<v8::internal::Object>, v8::internal::BuiltinArguments) (in /home/james/node/node/out/Release/node)
==29245==    by 0xBB4D57: v8::internal::Builtin_HandleApiCall(int, unsigned long*, v8::internal::Isolate*) (in /home/james/node/node/out/Release/node)
==29245==    by 0x14B1278: Builtins_CEntry_Return1_DontSaveFPRegs_ArgvOnStack_BuiltinExit (in /home/james/node/node/out/Release/node)
==29245==    by 0x14466A0: Builtins_JSBuiltinsConstructStub (in /home/james/node/node/out/Release/node)
==29245==    by 0x152EE22: Builtins_ConstructHandler (in /home/james/node/node/out/Release/node)
==29245==    by 0x144A521: Builtins_InterpreterEntryTrampoline (in /home/james/node/node/out/Release/node)
==29245==    by 0x14465A9: Builtins_JSConstructStubGeneric (in /home/james/node/node/out/Release/node)
==29245==    by 0x152EE22: Builtins_ConstructHandler (in /home/james/node/node/out/Release/node)
==29245==    by 0x144A521: Builtins_InterpreterEntryTrampoline (in /home/james/node/node/out/Release/node)
==29245==    by 0x1444458: Builtins_ArgumentsAdaptorTrampoline (in /home/james/node/node/out/Release/node)
==29245==    by 0x144A521: Builtins_InterpreterEntryTrampoline (in /home/james/node/node/out/Release/node)
==29245==  Uninitialised value was created by a stack allocation
==29245==    at 0xA98310: node::crypto::Hash::New(v8::FunctionCallbackInfo<v8::Value> const&) (in /home/james/node/node/out/Release/node)
``` 

After digging in, I've tracked down the above warning to the HashInit call inside Hash::New ... But, here's the fun part, adding any printf inside HashInit makes the initialized jump/move disappear. 

This depends on the recent semver-major crypto refactor but can be backported.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
