### PR TITLE
build: Use GITHUB_ENV instead of set-env

### DIFF
--- a/.github/workflows/auto-start-ci.yml
+++ b/.github/workflows/auto-start-ci.yml
@@ -28,8 +28,8 @@ jobs:
 
       - name: Set variables
         run: |
-          echo "::set-env name=REPOSITORY::$(echo ${{ github.repository }} | cut -d/ -f2)"
-          echo "::set-env name=OWNER::${{ github.repository_owner }}"
+          echo "REPOSITORY=$(echo ${{ github.repository }} | cut -d/ -f2)" >> ${GITHUB_ENV}
+          echo "OWNER=${{ github.repository_owner }}" >> ${GITHUB_ENV}
 
       # Get Pull Requests
       - name: Get Pull Requests

--- a/.github/workflows/build-tarball.yml
+++ b/.github/workflows/build-tarball.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Extract tarball
         run: |
           tar xzf tarballs/*.tar.gz
-          echo "::set-env name=TAR_DIR::`basename tarballs/*.tar.gz .tar.gz`"
+          echo "TAR_DIR=`basename tarballs/*.tar.gz .tar.gz`" >> ${GITHUB_ENV}
       - name: Copy directories needed for testing
         run: |
           cp -r tools/node_modules $TAR_DIR/tools

--- a/.github/workflows/commit-queue.yml
+++ b/.github/workflows/commit-queue.yml
@@ -42,8 +42,8 @@ jobs:
 
       - name: Set variables
         run: |
-          echo "::set-env name=REPOSITORY::$(echo ${{ github.repository }} | cut -d/ -f2)"
-          echo "::set-env name=OWNER::${{ github.repository_owner }}"
+          echo "REPOSITORY=$(echo ${{ github.repository }} | cut -d/ -f2)" >> ${GITHUB_ENV}
+          echo "OWNER=${{ github.repository_owner }}" >> ${GITHUB_ENV}
 
       - name: Get Pull Requests
         uses: octokit/graphql-action@v2.x


### PR DESCRIPTION
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

> Action and workflow authors who are setting environment variables via stdout should update any usage of the set-env and add-path workflow commands to use the new environment files.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
