### PR TITLE
doc: upgrade stability status of report API

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1913,9 +1913,11 @@ Additional documentation is available in the [report documentation][].
 ### `process.report.reportOnFatalError`
 <!-- YAML
 added: v11.12.0
+changes:
+  - version:
+     - REPLACEME
+    description: This API is no longer experimental.
 -->
-
-> Stability: 1 - Experimental
 
 * {boolean}
 


### PR DESCRIPTION
The property `process.report.reportOnFatalError`
was deemed experimental, as it was not honored
under certain scenarios (for example out of memory
conditions). The report configuration were previously
stored on the `environment` structure which was not
available on these types of fatal error cases.

The referenced PR has addressed this case (sometime
back), and the property is working as intended.

Refs: https://github.com/nodejs/node/pull/32207

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
