### PR TITLE
doc: use kbd element in os doc

### DIFF
--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -436,7 +436,7 @@ The following signal constants are exported by `os.constants.signals`.
   <tr>
     <td><code>SIGINT</code></td>
     <td>Sent to indicate when a user wishes to interrupt a process
-    (<code>(Ctrl+C)</code>).</td>
+    (<kbd>Ctrl</kbd>+<kbd>C</kbd>).</td>
   </tr>
   <tr>
     <td><code>SIGQUIT</code></td>


### PR DESCRIPTION
Use kbd element for key strokes and remove extra parentheses.

Before:

![image](https://user-images.githubusercontent.com/718899/96114041-eafa7600-0e99-11eb-97d0-91fa548c42be.png)


After:

<img width="783" alt="Screen Shot 2020-10-15 at 3 52 00 AM" src="https://user-images.githubusercontent.com/718899/96113990-d3bb8880-0e99-11eb-8c24-4a66839a4acb.png">


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
