### PR TITLE
src,crypto: remove redundant OpenSSLBuffer

### DIFF
--- a/src/crypto/crypto_common.cc
+++ b/src/crypto/crypto_common.cc
@@ -499,7 +499,8 @@ MaybeLocal<Value> GetSerialNumber(Environment* env, X509* cert) {
   if (ASN1_INTEGER* serial_number = X509_get_serialNumber(cert)) {
     BignumPointer bn(ASN1_INTEGER_to_BN(serial_number, nullptr));
     if (bn) {
-      OpenSSLBuffer buf(BN_bn2hex(bn.get()));
+      char* data = BN_bn2hex(bn.get());
+      ByteSource buf = ByteSource::Allocated(data, strlen(data));
       if (buf)
         return OneByteString(env->isolate(), buf.get());
     }

--- a/src/crypto/crypto_common.h
+++ b/src/crypto/crypto_common.h
@@ -13,11 +13,6 @@
 
 namespace node {
 namespace crypto {
-// OPENSSL_free is a macro, so we need a wrapper function.
-struct OpenSSLBufferDeleter {
-  void operator()(char* pointer) const { OPENSSL_free(pointer); }
-};
-using OpenSSLBuffer = std::unique_ptr<char[], OpenSSLBufferDeleter>;
 
 struct StackOfX509Deleter {
   void operator()(STACK_OF(X509)* p) const { sk_X509_pop_free(p, X509_free); }


### PR DESCRIPTION
Replace the OpenSSLBuffer utility with ByteSource and remove OpenSSLBuffer.

Signed-off-by: James M Snell <jasnell@gmail.com>

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
