### PR TITLE
test: add windows and c++ coverage

### DIFF
--- a/.github/workflows/coverage-linux.yml
+++ b/.github/workflows/coverage-linux.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Report js
         run: npx c8 report --check-coverage
       - name: Report C++
-        run: cd out && gcovr --gcov-exclude='.*\b(deps|usr|out|obj|cctest|embedding)\b' -v -r Release/obj.target --xml -o ../coverage/coverage.xml --filter='' --root=$(node -e "console.info(path.resolve(process.cwd(), '../'))")
+        run: cd out && gcovr --gcov-exclude='.*\b(deps|usr|out|obj|cctest|embedding)\b' -v -r Release/obj.target --xml -o ../coverage/coverage.xml --root=$(cd ../; pwd)
       - name: Output file count
         run: ls -l coverage/tmp/ | wc -l
       # Clean temporary output from gcov and c8, so that it's not uploaded:

--- a/.github/workflows/coverage-linux.yml
+++ b/.github/workflows/coverage-linux.yml
@@ -32,7 +32,7 @@ jobs:
       # TODO(bcoe): fix the couple tests that fail with the inspector enabled.
       # The cause is most likely coverage's use of the inspector.
       - name: Test
-        run: NODE_V8_COVERAGE=coverage/tmp make run-ci -j2 V=1 TEST_CI_ARGS="-p dots" || exit 0
+        run: NODE_V8_COVERAGE=coverage/tmp make test-cov -j2 V=1 TEST_CI_ARGS="-p dots" || exit 0
       - name: Report js
         run: npx c8 report --check-coverage
       - name: Report C++

--- a/.github/workflows/coverage-linux.yml
+++ b/.github/workflows/coverage-linux.yml
@@ -2,9 +2,19 @@ name: coverage-linux
 
 on:
   pull_request:
+    paths-ignore:
+      - 'doc/**'
+      - 'deps/**'
+      - 'benchmark/**'
+      - 'tools/**'
   push:
     branches:
       - master
+    paths-ignore:
+      - 'doc/**'
+      - 'deps/**'
+      - 'benchmark/**'
+      - 'tools/**'
 
 env:
   PYTHON_VERSION: 3.9
@@ -21,12 +31,8 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Environment Information
         run: npx envinfo
-      - name: Clone gcovr reporter
-        run: git clone -b 3.4 --depth=1 --single-branch https://github.com/gcovr/gcovr.git
-      - name: Clone patch for gcovr
-        run: git clone --depth=1 --single-branch https://github.com/nodejs/build.git
-      - name: Patch gcovr
-        run: cd gcovr && patch -N -p1 < ../build/jenkins/scripts/coverage/gcovr-patches-3.4.diff
+      - name: Install gcovr
+        run: pip install gcovr
       - name: Build
         run: make build-ci -j2 V=1 CONFIG_FLAGS="--error-on-warn --coverage"
       # TODO(bcoe): fix the couple tests that fail with the inspector enabled.
@@ -36,7 +42,7 @@ jobs:
       - name: Report js
         run: npx c8 report --check-coverage
       - name: Report C++
-        run: cd out && ../gcovr/scripts/gcovr --gcov-exclude='.*\b(deps|usr|out|cctest|embedding)\b' -v -r Release/obj.target --xml -o ../coverage/coverage.xml --gcov-executable=gcov
+        run: cd out && gcovr --gcov-exclude='.*\b(deps|usr|out|cctest|embedding)\b' -v -r Release/obj.target --xml -o ../coverage/coverage.xml --filter=''
       - name: Output file count
         run: ls -l coverage/tmp/ | wc -l
       # Clean temporary output from gcov and c8, so that it's not uploaded:

--- a/.github/workflows/coverage-linux.yml
+++ b/.github/workflows/coverage-linux.yml
@@ -39,12 +39,10 @@ jobs:
       # The cause is most likely coverage's use of the inspector.
       - name: Test
         run: NODE_V8_COVERAGE=coverage/tmp make test-cov -j2 V=1 TEST_CI_ARGS="-p dots" || exit 0
-      - name: Report js
+      - name: Report JS
         run: npx c8 report --check-coverage
       - name: Report C++
-        run: cd out && gcovr --gcov-exclude='.*\b(deps|usr|out|obj|cctest|embedding)\b' -v -r Release/obj.target --xml -o ../coverage/coverage.xml --root=$(cd ../; pwd)
-      - name: Output file count
-        run: ls -l coverage/tmp/ | wc -l
+        run: cd out && gcovr --gcov-exclude='.*\b(deps|usr|out|obj|cctest|embedding)\b' -v -r Release/obj.target --xml -o ../coverage/coverage-cxx.xml --root=$(cd ../ && pwd)
       # Clean temporary output from gcov and c8, so that it's not uploaded:
       - name: Clean tmp
         run: rm -rf coverage/tmp && rm -rf out

--- a/.github/workflows/coverage-linux.yml
+++ b/.github/workflows/coverage-linux.yml
@@ -11,7 +11,6 @@ env:
   FLAKY_TESTS: dontcare
 
 jobs:
-  # TODO(bcoe): add support for C++ coverage.
   coverage-linux:
     runs-on: ubuntu-latest
     steps:
@@ -23,13 +22,18 @@ jobs:
       - name: Environment Information
         run: npx envinfo
       - name: Build
-        run: make build-ci -j2 V=1 CONFIG_FLAGS="--error-on-warn"
+        run: make build-ci -j2 V=1 CONFIG_FLAGS="--error-on-warn --coverage"
       # TODO(bcoe): fix the couple tests that fail with the inspector enabled.
       # The cause is most likely coverage's use of the inspector.
       - name: Test
         run: NODE_V8_COVERAGE=coverage/tmp make run-ci -j2 V=1 TEST_CI_ARGS="-p dots" || exit 0
-      - name: Report
+      - name: Report js
         run: npx c8 report --check-coverage
+      - name: Report gcov
+        run: cd out && ../gcovr/scripts/gcovr \
+          --gcov-exclude='.*\b(deps|usr|out|cctest|embedding)\b' -v \
+          -r Release/obj.target --xml -o ../coverage/coverage.xml \
+          --gcov-executable=gcov
       - name: Output file count
         run: ls -l coverage/tmp/ | wc -l
       - name: Clean tmp

--- a/.github/workflows/coverage-linux.yml
+++ b/.github/workflows/coverage-linux.yml
@@ -21,6 +21,12 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Environment Information
         run: npx envinfo
+      - name: Clone gcovr
+        run: git clone -b 3.4 --depth=1 --single-branch https://github.com/gcovr/gcovr.git
+      - name: Clone patch for gcovr
+        run: git clone --depth=1 --single-branch https://github.com/nodejs/build.git
+      - name: Patch gcovr
+        run: cd gcovr && patch -N -p1 < ../build/jenkins/scripts/coverage/gcovr-patches-3.4.diff
       - name: Build
         run: make build-ci -j2 V=1 CONFIG_FLAGS="--error-on-warn --coverage"
       # TODO(bcoe): fix the couple tests that fail with the inspector enabled.

--- a/.github/workflows/coverage-linux.yml
+++ b/.github/workflows/coverage-linux.yml
@@ -21,7 +21,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Environment Information
         run: npx envinfo
-      - name: Clone gcovr
+      - name: Clone gcovr reporter
         run: git clone -b 3.4 --depth=1 --single-branch https://github.com/gcovr/gcovr.git
       - name: Clone patch for gcovr
         run: git clone --depth=1 --single-branch https://github.com/nodejs/build.git
@@ -35,11 +35,8 @@ jobs:
         run: NODE_V8_COVERAGE=coverage/tmp make run-ci -j2 V=1 TEST_CI_ARGS="-p dots" || exit 0
       - name: Report js
         run: npx c8 report --check-coverage
-      - name: Report gcov
-        run: cd out && ../gcovr/scripts/gcovr \
-          --gcov-exclude='.*\b(deps|usr|out|cctest|embedding)\b' -v \
-          -r Release/obj.target --xml -o ../coverage/coverage.xml \
-          --gcov-executable=gcov
+      - name: Report C++
+        run: cd out && ../gcovr/scripts/gcovr --gcov-exclude='.*\b(deps|usr|out|cctest|embedding)\b' -v -r Release/obj.target --xml -o ../coverage/coverage.xml --gcov-executable=gcov
       - name: Output file count
         run: ls -l coverage/tmp/ | wc -l
       - name: Clean tmp

--- a/.github/workflows/coverage-linux.yml
+++ b/.github/workflows/coverage-linux.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Environment Information
         run: npx envinfo
       - name: Install gcovr
-        run: pip install gcovr
+        run: pip install gcovr==4.2
       - name: Build
         run: make build-ci -j2 V=1 CONFIG_FLAGS="--error-on-warn --coverage"
       # TODO(bcoe): fix the couple tests that fail with the inspector enabled.
@@ -42,7 +42,7 @@ jobs:
       - name: Report js
         run: npx c8 report --check-coverage
       - name: Report C++
-        run: cd out && gcovr --gcov-exclude='.*\b(deps|usr|out|cctest|embedding)\b' -v -r Release/obj.target --xml -o ../coverage/coverage.xml --filter=''
+        run: cd out && gcovr --gcov-exclude='.*\b(deps|usr|out|obj|cctest|embedding)\b' -v -r Release/obj.target --xml -o ../coverage/coverage.xml --filter='' --root=$(node -e "console.info(path.resolve(process.cwd(), '../'))")
       - name: Output file count
         run: ls -l coverage/tmp/ | wc -l
       # Clean temporary output from gcov and c8, so that it's not uploaded:

--- a/.github/workflows/coverage-linux.yml
+++ b/.github/workflows/coverage-linux.yml
@@ -39,8 +39,9 @@ jobs:
         run: cd out && ../gcovr/scripts/gcovr --gcov-exclude='.*\b(deps|usr|out|cctest|embedding)\b' -v -r Release/obj.target --xml -o ../coverage/coverage.xml --gcov-executable=gcov
       - name: Output file count
         run: ls -l coverage/tmp/ | wc -l
+      # Clean temporary output from gcov and c8, so that it's not uploaded:
       - name: Clean tmp
-        run: rm -rf coverage/tmp
+        run: rm -rf coverage/tmp && rm -rf out
       - name: Upload
         uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/coverage-windows.yml
+++ b/.github/workflows/coverage-windows.yml
@@ -1,4 +1,4 @@
-name: coverage-linux
+name: coverage-windows
 
 on:
   pull_request:
@@ -11,30 +11,32 @@ env:
   FLAKY_TESTS: dontcare
 
 jobs:
-  # TODO(bcoe): add support for C++ coverage.
-  coverage-linux:
-    runs-on: ubuntu-latest
+  coverage-windows:
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v2
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install deps
+        run: choco install nasm
       - name: Environment Information
         run: npx envinfo
       - name: Build
-        run: make build-ci -j2 V=1 CONFIG_FLAGS="--error-on-warn"
-      # TODO(bcoe): fix the couple tests that fail with the inspector enabled.
-      # The cause is most likely coverage's use of the inspector.
+        run: ./vcbuild.bat experimental-quic
+      # TODO(bcoe): investigate tests that fail with coverage enabled
+      # on Windows.
       - name: Test
-        run: NODE_V8_COVERAGE=coverage/tmp make run-ci -j2 V=1 TEST_CI_ARGS="-p dots" || exit 0
+        run: ./vcbuild.bat test-ci-js; node -e 'process.exit(0)'
+        env:
+          NODE_V8_COVERAGE: ./coverage/tmp
       - name: Report
-        run: npx c8 report --check-coverage
-      - name: Output file count
-        run: ls -l coverage/tmp/ | wc -l
+        run: npx c8 report
       - name: Clean tmp
-        run: rm -rf coverage/tmp
+        run: npx rimraf ./coverage/tmp
       - name: Upload
         uses: codecov/codecov-action@v1
         with:
           directory: ./coverage
+

--- a/.github/workflows/coverage-windows.yml
+++ b/.github/workflows/coverage-windows.yml
@@ -39,4 +39,3 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           directory: ./coverage
-

--- a/.github/workflows/coverage-windows.yml
+++ b/.github/workflows/coverage-windows.yml
@@ -2,9 +2,19 @@ name: coverage-windows
 
 on:
   pull_request:
+    paths-ignore:
+      - 'doc/**'
+      - 'deps/**'
+      - 'benchmark/**'
+      - 'tools/**'
   push:
     branches:
       - master
+    paths-ignore:
+      - 'doc/**'
+      - 'deps/**'
+      - 'benchmark/**'
+      - 'tools/**'
 
 env:
   PYTHON_VERSION: 3.9
@@ -24,7 +34,7 @@ jobs:
       - name: Environment Information
         run: npx envinfo
       - name: Build
-        run: ./vcbuild.bat experimental-quic
+        run: ./vcbuild.bat
       # TODO(bcoe): investigate tests that fail with coverage enabled
       # on Windows.
       - name: Test

--- a/.nycrc
+++ b/.nycrc
@@ -9,7 +9,7 @@
   "reporter": [
     "html",
     "text",
-    "lcov"
+    "cobertura"
   ],
   "lines": 95,
   "branches": "93",

--- a/Makefile
+++ b/Makefile
@@ -297,6 +297,7 @@ v8:
 .PHONY: jstest
 jstest: build-addons build-js-native-api-tests build-node-api-tests ## Runs addon tests and JS tests
 	$(PYTHON) tools/test.py $(PARALLEL_ARGS) --mode=$(BUILDTYPE_LOWER) \
+		$(TEST_CI_ARGS) \
 		--skip-tests=$(CI_SKIP_TESTS) \
 		$(JS_SUITES) \
 		$(NATIVE_SUITES)

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,6 +3,8 @@ comment:
   layout: "diff, files"
   # Don't post if no changes in coverage:
   require_changes: true
-notify:
-  # Wait for all coverage builds:
-  after_n_builds: 2
+
+codecov:
+  notify:
+    # Wait for all coverage builds:
+    after_n_builds: 2

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+comment:
+  # Only show diff and files changed:
+  layout: "diff, files"
+  # Don't post if no changes in coverage:
+  require_changes: true
+notify:
+  # Wait for all coverage builds:
+  after_n_builds: 2


### PR DESCRIPTION
Experiment to see if collecting coverage for Windows will "just work".

Refs: https://github.com/nodejs/node/pull/35653
Refs: https://github.com/nodejs/node/issues/35646
Fixes: https://github.com/nodejs/node/issues/35696

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
