### PR TITLE
test: add additional deprecation warning tests for rmdir recursive

### DIFF
--- a/test/parallel/test-fs-rmdir-recursive-sync-warns-not-found.js
+++ b/test/parallel/test-fs-rmdir-recursive-sync-warns-not-found.js
@@ -7,7 +7,7 @@ const path = require('path');
 tmpdir.refresh();
 
 {
-  // Should warn when trying to delete a file
+  // Should warn when trying to delete a nonexistent path
   common.expectWarning(
     'DeprecationWarning',
     'In future versions of Node.js, fs.rmdir(path, { recursive: true }) ' +
@@ -15,7 +15,5 @@ tmpdir.refresh();
     '{ recursive: true, force: true }) instead',
     'DEP0147'
   );
-  const filePath = path.join(tmpdir.path, 'rmdir-recursive.txt');
-  fs.writeFileSync(filePath, '');
-  fs.rmdir(filePath, { recursive: true }, common.mustCall());
+  fs.rmdirSync(path.join(tmpdir.path, 'noexist.txt'), { recursive: true });
 }

--- a/test/parallel/test-fs-rmdir-recursive-sync-warns-on-file.js
+++ b/test/parallel/test-fs-rmdir-recursive-sync-warns-on-file.js
@@ -17,5 +17,5 @@ tmpdir.refresh();
   );
   const filePath = path.join(tmpdir.path, 'rmdir-recursive.txt');
   fs.writeFileSync(filePath, '');
-  fs.rmdir(filePath, { recursive: true }, common.mustCall());
+  fs.rmdirSync(filePath, { recursive: true });
 }

--- a/test/parallel/test-fs-rmdir-recursive-warns-not-found.js
+++ b/test/parallel/test-fs-rmdir-recursive-warns-not-found.js
@@ -6,7 +6,6 @@ const path = require('path');
 
 tmpdir.refresh();
 
-
 {
   // Should warn when trying to delete a nonexistent path
   common.expectWarning(

--- a/test/parallel/test-fs-rmdir-recursive-warns-on-file.js
+++ b/test/parallel/test-fs-rmdir-recursive-warns-on-file.js
@@ -17,5 +17,5 @@ tmpdir.refresh();
   );
   const filePath = path.join(tmpdir.path, 'rmdir-recursive.txt');
   fs.writeFileSync(filePath, '');
-  fs.rmdir(filePath, { recursive: true }, common.mustCall());
+  fs.rmdir(filePath, { recursive: true }, common.mustSucceed());
 }


### PR DESCRIPTION
The recently added code coverage in #35653 highlighted an uncovered case of the rmdir recursive deprecation warning. This PR adds two new tests to ensure we cover all the places where the deprecation warning can be shown in both the sync and async versions.

cc @bcoe @nodejs/tooling 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
