### PR TITLE
module: only try to enrich CJS syntax errors

### DIFF
--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -5,6 +5,7 @@
 const {
   Boolean,
   JSONParse,
+  ObjectGetPrototypeOf,
   ObjectPrototypeHasOwnProperty,
   ObjectKeys,
   PromisePrototypeCatch,
@@ -15,6 +16,7 @@ const {
   StringPrototypeReplace,
   StringPrototypeSplit,
   StringPrototypeStartsWith,
+  SyntaxErrorPrototype,
 } = primordials;
 
 let _TYPES = null;
@@ -147,6 +149,9 @@ translators.set('module', async function moduleStrategy(url) {
 });
 
 function enrichCJSError(err) {
+  if (err == null || ObjectGetPrototypeOf(err) !== SyntaxErrorPrototype) {
+    return;
+  }
   const stack = StringPrototypeSplit(err.stack, '\n');
   /*
   * The regular expression below targets the most common import statement

--- a/test/es-module/test-esm-cjs-load-error-note.mjs
+++ b/test/es-module/test-esm-cjs-load-error-note.mjs
@@ -10,6 +10,10 @@ const Import2 = fixtures.path('/es-modules/es-note-promiserej-import-2.cjs');
 const Import3 = fixtures.path('/es-modules/es-note-unexpected-import-3.cjs');
 const Import4 = fixtures.path('/es-modules/es-note-unexpected-import-4.cjs');
 const Import5 = fixtures.path('/es-modules/es-note-unexpected-import-5.cjs');
+const Error1 = fixtures.path('/es-modules/es-note-error-1.mjs');
+const Error2 = fixtures.path('/es-modules/es-note-error-2.mjs');
+const Error3 = fixtures.path('/es-modules/es-note-error-3.mjs');
+const Error4 = fixtures.path('/es-modules/es-note-error-4.mjs');
 
 // Expect note to be included in the error output
 const expectedNote = 'To load an ES module, ' +
@@ -104,4 +108,56 @@ pImport5.on('close', mustCall((code) => {
   assert.strictEqual(code, expectedCode);
   assert.ok(!pImport5Stderr.includes(expectedNote),
             `${expectedNote} must not be included in ${pImport5Stderr}`);
+}));
+
+const pError1 = spawn(process.execPath, [Error1]);
+let pError1Stderr = '';
+pError1.stderr.setEncoding('utf8');
+pError1.stderr.on('data', (data) => {
+  pError1Stderr += data;
+});
+pError1.on('close', mustCall((code) => {
+  assert.strictEqual(code, expectedCode);
+  assert.ok(pError1Stderr.includes('Error: some error'));
+  assert.ok(!pError1Stderr.includes(expectedNote),
+            `${expectedNote} must not be included in ${pError1Stderr}`);
+}));
+
+const pError2 = spawn(process.execPath, [Error2]);
+let pError2Stderr = '';
+pError2.stderr.setEncoding('utf8');
+pError2.stderr.on('data', (data) => {
+  pError2Stderr += data;
+});
+pError2.on('close', mustCall((code) => {
+  assert.strictEqual(code, expectedCode);
+  assert.ok(pError2Stderr.includes('string'));
+  assert.ok(!pError2Stderr.includes(expectedNote),
+            `${expectedNote} must not be included in ${pError2Stderr}`);
+}));
+
+const pError3 = spawn(process.execPath, [Error3]);
+let pError3Stderr = '';
+pError3.stderr.setEncoding('utf8');
+pError3.stderr.on('data', (data) => {
+  pError3Stderr += data;
+});
+pError3.on('close', mustCall((code) => {
+  assert.strictEqual(code, expectedCode);
+  assert.ok(pError3Stderr.includes('null'));
+  assert.ok(!pError3Stderr.includes(expectedNote),
+            `${expectedNote} must not be included in ${pError3Stderr}`);
+}));
+
+const pError4 = spawn(process.execPath, [Error4]);
+let pError4Stderr = '';
+pError4.stderr.setEncoding('utf8');
+pError4.stderr.on('data', (data) => {
+  pError4Stderr += data;
+});
+pError4.on('close', mustCall((code) => {
+  assert.strictEqual(code, expectedCode);
+  assert.ok(pError4Stderr.includes('undefined'));
+  assert.ok(!pError4Stderr.includes(expectedNote),
+            `${expectedNote} must not be included in ${pError4Stderr}`);
 }));

--- a/test/fixtures/es-modules/es-note-error-1.cjs
+++ b/test/fixtures/es-modules/es-note-error-1.cjs
@@ -1,0 +1,1 @@
+throw new Error('some error');

--- a/test/fixtures/es-modules/es-note-error-1.mjs
+++ b/test/fixtures/es-modules/es-note-error-1.mjs
@@ -1,0 +1,1 @@
+import './es-note-error-1.cjs';

--- a/test/fixtures/es-modules/es-note-error-2.cjs
+++ b/test/fixtures/es-modules/es-note-error-2.cjs
@@ -1,0 +1,1 @@
+throw 'string';

--- a/test/fixtures/es-modules/es-note-error-2.mjs
+++ b/test/fixtures/es-modules/es-note-error-2.mjs
@@ -1,0 +1,1 @@
+import './es-note-error-2.cjs';

--- a/test/fixtures/es-modules/es-note-error-3.cjs
+++ b/test/fixtures/es-modules/es-note-error-3.cjs
@@ -1,0 +1,1 @@
+throw null;

--- a/test/fixtures/es-modules/es-note-error-3.mjs
+++ b/test/fixtures/es-modules/es-note-error-3.mjs
@@ -1,0 +1,1 @@
+import './es-note-error-3.cjs';

--- a/test/fixtures/es-modules/es-note-error-4.cjs
+++ b/test/fixtures/es-modules/es-note-error-4.cjs
@@ -1,0 +1,1 @@
+throw undefined;

--- a/test/fixtures/es-modules/es-note-error-4.mjs
+++ b/test/fixtures/es-modules/es-note-error-4.mjs
@@ -1,0 +1,1 @@
+import './es-note-error-4.cjs';


### PR DESCRIPTION
It is guaranteed that V8 throws a syntax error when `import` or `export`
is used outside of ESM.

Fixes: https://github.com/nodejs/node/issues/35687

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)