### PR TITLE
doc: improve text for breakOnSigint

### DIFF
--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -146,11 +146,11 @@ changes:
   * `timeout` {integer} Specifies the number of milliseconds to execute `code`
     before terminating execution. If execution is terminated, an [`Error`][]
     will be thrown. This value must be a strictly positive integer.
-  * `breakOnSigint` {boolean} If `true`, the execution will be terminated when
-    `SIGINT` (Ctrl+C) is received. Existing handlers for the
-    event that have been attached via `process.on('SIGINT')` will be disabled
-    during script execution, but will continue to work after that. If execution
-    is terminated, an [`Error`][] will be thrown. **Default:** `false`.
+  * `breakOnSigint` {boolean} If `true`, execution is terminated when `SIGINT`
+    (<kbd>Ctrl</kbd>+<kbd>C</kbd>) is received. Existing handlers for the
+    event that have been attached via `process.on('SIGINT')` are disabled
+    during script execution, but continue to work after that. If execution
+    is terminated, an [`Error`][] is thrown. **Default:** `false`.
 * Returns: {any} the result of the very last statement executed in the script.
 
 Runs the compiled code contained by the `vm.Script` object within the given
@@ -208,11 +208,11 @@ changes:
   * `timeout` {integer} Specifies the number of milliseconds to execute `code`
     before terminating execution. If execution is terminated, an [`Error`][]
     will be thrown. This value must be a strictly positive integer.
-  * `breakOnSigint` {boolean} If `true`, the execution will be terminated when
-    `SIGINT` (Ctrl+C) is received. Existing handlers for the
-    event that have been attached via `process.on('SIGINT')` will be disabled
-    during script execution, but will continue to work after that. If execution
-    is terminated, an [`Error`][] will be thrown. **Default:** `false`.
+  * `breakOnSigint` {boolean} If `true`, execution is terminated when `SIGINT`
+    (<kbd>Ctrl</kbd>+<kbd>C</kbd>) is received. Existing handlers for the
+    event that have been attached via `process.on('SIGINT')` are disabled
+    during script execution, but continue to work after that. If execution
+    is terminated, an [`Error`][] is thrown. **Default:** `false`.
   * `contextName` {string} Human-readable name of the newly created context.
     **Default:** `'VM Context i'`, where `i` is an ascending numerical index of
     the created context.
@@ -272,11 +272,11 @@ changes:
   * `timeout` {integer} Specifies the number of milliseconds to execute `code`
     before terminating execution. If execution is terminated, an [`Error`][]
     will be thrown. This value must be a strictly positive integer.
-  * `breakOnSigint` {boolean} If `true`, the execution will be terminated when
-    `SIGINT` (Ctrl+C) is received. Existing handlers for the
-    event that have been attached via `process.on('SIGINT')` will be disabled
-    during script execution, but will continue to work after that. If execution
-    is terminated, an [`Error`][] will be thrown. **Default:** `false`.
+  * `breakOnSigint` {boolean} If `true`, execution is terminated when `SIGINT`
+    (<kbd>Ctrl</kbd>+<kbd>C</kbd>) is received. Existing handlers for the
+    event that have been attached via `process.on('SIGINT')` are disabled
+    during script execution, but continue to work after that. If execution
+    is terminated, an [`Error`][] is thrown. **Default:** `false`.
 * Returns: {any} the result of the very last statement executed in the script.
 
 Runs the compiled code contained by the `vm.Script` within the context of the
@@ -511,11 +511,11 @@ in the ECMAScript specification.
   * `timeout` {integer} Specifies the number of milliseconds to evaluate
     before terminating execution. If execution is interrupted, an [`Error`][]
     will be thrown. This value must be a strictly positive integer.
-  * `breakOnSigint` {boolean} If `true`, the execution will be terminated when
-    `SIGINT` (Ctrl+C) is received. Existing handlers for the event that have
-    been attached via `process.on('SIGINT')` will be disabled during script
-    execution, but will continue to work after that. If execution is
-    interrupted, an [`Error`][] will be thrown. **Default:** `false`.
+  * `breakOnSigint` {boolean} If `true`, execution is terminated when `SIGINT`
+    (<kbd>Ctrl</kbd>+<kbd>C</kbd>) is received. Existing handlers for the
+    event that have been attached via `process.on('SIGINT')` are disabled
+    during script execution, but continue to work after that. If execution
+    is interrupted, an [`Error`][] is thrown. **Default:** `false`.
 * Returns: {Promise}
 
 Evaluate the module.
@@ -961,11 +961,11 @@ changes:
   * `timeout` {integer} Specifies the number of milliseconds to execute `code`
     before terminating execution. If execution is terminated, an [`Error`][]
     will be thrown. This value must be a strictly positive integer.
-  * `breakOnSigint` {boolean} If `true`, the execution will be terminated when
-    `SIGINT` (Ctrl+C) is received. Existing handlers for the
-    event that have been attached via `process.on('SIGINT')` will be disabled
-    during script execution, but will continue to work after that. If execution
-    is terminated, an [`Error`][] will be thrown. **Default:** `false`.
+  * `breakOnSigint` {boolean} If `true`, execution is terminated when `SIGINT`
+    (<kbd>Ctrl</kbd>+<kbd>C</kbd>) is received. Existing handlers for the
+    event that have been attached via `process.on('SIGINT')` are disabled
+    during script execution, but continue to work after that. If execution
+    is terminated, an [`Error`][] is thrown. **Default:** `false`.
   * `cachedData` {Buffer|TypedArray|DataView} Provides an optional `Buffer` or
     `TypedArray`, or `DataView` with V8's code cache data for the supplied
      source. When supplied, the `cachedDataRejected` value will be set to
@@ -1044,11 +1044,11 @@ changes:
   * `timeout` {integer} Specifies the number of milliseconds to execute `code`
     before terminating execution. If execution is terminated, an [`Error`][]
     will be thrown. This value must be a strictly positive integer.
-  * `breakOnSigint` {boolean} If `true`, the execution will be terminated when
-    `SIGINT` (Ctrl+C) is received. Existing handlers for the
-    event that have been attached via `process.on('SIGINT')` will be disabled
-    during script execution, but will continue to work after that. If execution
-    is terminated, an [`Error`][] will be thrown. **Default:** `false`.
+  * `breakOnSigint` {boolean} If `true`, execution is terminated when `SIGINT`
+    (<kbd>Ctrl</kbd>+<kbd>C</kbd>) is received. Existing handlers for the
+    event that have been attached via `process.on('SIGINT')` are disabled
+    during script execution, but continue to work after that. If execution
+    is terminated, an [`Error`][] is thrown. **Default:** `false`.
   * `contextName` {string} Human-readable name of the newly created context.
     **Default:** `'VM Context i'`, where `i` is an ascending numerical index of
     the created context.
@@ -1138,11 +1138,11 @@ changes:
   * `timeout` {integer} Specifies the number of milliseconds to execute `code`
     before terminating execution. If execution is terminated, an [`Error`][]
     will be thrown. This value must be a strictly positive integer.
-  * `breakOnSigint` {boolean} If `true`, the execution will be terminated when
-    `SIGINT` (Ctrl+C) is received. Existing handlers for the
-    event that have been attached via `process.on('SIGINT')` will be disabled
-    during script execution, but will continue to work after that. If execution
-    is terminated, an [`Error`][] will be thrown. **Default:** `false`.
+  * `breakOnSigint` {boolean} If `true`, execution is terminated when `SIGINT`
+    (<kbd>Ctrl</kbd>+<kbd>C</kbd>) is received. Existing handlers for the
+    event that have been attached via `process.on('SIGINT')` are disabled
+    during script execution, but continue to work after that. If execution
+    is terminated, an [`Error`][] is thrown. **Default:** `false`.
   * `cachedData` {Buffer|TypedArray|DataView} Provides an optional `Buffer` or
     `TypedArray`, or `DataView` with V8's code cache data for the supplied
      source. When supplied, the `cachedDataRejected` value will be set to


### PR DESCRIPTION
* Make the 7 instances of breakOnSigint text blocks consistent.
* Use present tense.
* Use kbd element for keystrokes.
* Minor style edits.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
