### PR TITLE
test: refactor test-crypto-pbkdf2

### DIFF
--- a/test/parallel/test-crypto-pbkdf2.js
+++ b/test/parallel/test-crypto-pbkdf2.js
@@ -6,19 +6,26 @@ if (!common.hasCrypto)
 const assert = require('assert');
 const crypto = require('crypto');
 
+function runPBKDF2(password, salt, iterations, keylen, hash) {
+  const syncResult =
+    crypto.pbkdf2Sync(password, salt, iterations, keylen, hash);
+
+  crypto.pbkdf2(password, salt, iterations, keylen, hash,
+                common.mustSucceed((asyncResult) => {
+                  assert.deepStrictEqual(asyncResult, syncResult);
+                }));
+
+  return syncResult;
+}
+
+function testPBKDF2(password, salt, iterations, keylen, expected, encoding) {
+  const actual = runPBKDF2(password, salt, iterations, keylen, 'sha256');
+  assert.strictEqual(actual.toString(encoding || 'latin1'), expected);
+}
+
 //
 // Test PBKDF2 with RFC 6070 test vectors (except #4)
 //
-function testPBKDF2(password, salt, iterations, keylen, expected) {
-  const actual =
-    crypto.pbkdf2Sync(password, salt, iterations, keylen, 'sha256');
-  assert.strictEqual(actual.toString('latin1'), expected);
-
-  crypto.pbkdf2(password, salt, iterations, keylen, 'sha256', (err, actual) => {
-    assert.strictEqual(actual.toString('latin1'), expected);
-  });
-}
-
 
 testPBKDF2('password', 'salt', 1, 20,
            '\x12\x0f\xb6\xcf\xfc\xf8\xb3\x2c\x43\xe7\x22\x52' +
@@ -43,15 +50,9 @@ testPBKDF2('pass\0word', 'sa\0lt', 4096, 16,
            '\x89\xb6\x9d\x05\x16\xf8\x29\x89\x3c\x69\x62\x26\x65' +
            '\x0a\x86\x87');
 
-const expected =
-    '64c486c55d30d4c5a079b8823b7d7cb37ff0556f537da8410233bcec330ed956';
-const key = crypto.pbkdf2Sync('password', 'salt', 32, 32, 'sha256');
-assert.strictEqual(key.toString('hex'), expected);
-
-crypto.pbkdf2('password', 'salt', 32, 32, 'sha256', common.mustSucceed(ondone));
-function ondone(key) {
-  assert.strictEqual(key.toString('hex'), expected);
-}
+testPBKDF2('password', 'salt', 32, 32,
+           '64c486c55d30d4c5a079b8823b7d7cb37ff0556f537da8410233bcec330ed956',
+           'hex');
 
 // Error path should not leak memory (check with valgrind).
 assert.throws(
@@ -197,38 +198,12 @@ assert.throws(
   );
 });
 
-// Any TypedArray should work for password and salt
-crypto.pbkdf2(new Uint8Array(10), 'salt', 8, 8, 'sha256', common.mustSucceed());
-crypto.pbkdf2('pass', new Uint8Array(10), 8, 8, 'sha256', common.mustSucceed());
-crypto.pbkdf2(new Uint16Array(10), 'salt', 8, 8, 'sha1', common.mustSucceed());
-crypto.pbkdf2('pass', new Uint16Array(10), 8, 8, 'sha1', common.mustSucceed());
-crypto.pbkdf2(new Uint32Array(10), 'salt', 8, 8, 'sha1', common.mustSucceed());
-crypto.pbkdf2('pass', new Uint32Array(10), 8, 8, 'sha1', common.mustSucceed());
-crypto.pbkdf2(new Float32Array(10), 'salt', 8, 8, 'sha1', common.mustSucceed());
-crypto.pbkdf2('pass', new Float32Array(10), 8, 8, 'sha1', common.mustSucceed());
-crypto.pbkdf2(new Float64Array(10), 'salt', 8, 8, 'sha1', common.mustSucceed());
-crypto.pbkdf2('pass', new Float64Array(10), 8, 8, 'sha1', common.mustSucceed());
-crypto.pbkdf2(new ArrayBuffer(10), 'salt', 8, 8, 'sha1', common.mustSucceed());
-crypto.pbkdf2('pass', new ArrayBuffer(10), 8, 8, 'sha1', common.mustSucceed());
-crypto.pbkdf2(new SharedArrayBuffer(10), 'salt', 8, 8, 'sha256',
-              common.mustSucceed());
-crypto.pbkdf2('pass', new SharedArrayBuffer(10), 8, 8, 'sha256',
-              common.mustSucceed());
-
-crypto.pbkdf2Sync(new Uint8Array(10), 'salt', 8, 8, 'sha256');
-crypto.pbkdf2Sync('pass', new Uint8Array(10), 8, 8, 'sha256');
-crypto.pbkdf2Sync(new Uint16Array(10), 'salt', 8, 8, 'sha256');
-crypto.pbkdf2Sync('pass', new Uint16Array(10), 8, 8, 'sha256');
-crypto.pbkdf2Sync(new Uint32Array(10), 'salt', 8, 8, 'sha256');
-crypto.pbkdf2Sync('pass', new Uint32Array(10), 8, 8, 'sha256');
-crypto.pbkdf2Sync(new Float32Array(10), 'salt', 8, 8, 'sha256');
-crypto.pbkdf2Sync('pass', new Float32Array(10), 8, 8, 'sha256');
-crypto.pbkdf2Sync(new Float64Array(10), 'salt', 8, 8, 'sha256');
-crypto.pbkdf2Sync('pass', new Float64Array(10), 8, 8, 'sha256');
-crypto.pbkdf2Sync(new ArrayBuffer(10), 'salt', 8, 8, 'sha256');
-crypto.pbkdf2Sync('pass', new ArrayBuffer(10), 8, 8, 'sha256');
-crypto.pbkdf2Sync(new SharedArrayBuffer(10), 'salt', 8, 8, 'sha256');
-crypto.pbkdf2Sync('pass', new SharedArrayBuffer(10), 8, 8, 'sha256');
+// Any TypedArray should work for password and salt.
+for (const SomeArray of [Uint8Array, Uint16Array, Uint32Array, Float32Array,
+                         Float64Array, ArrayBuffer, SharedArrayBuffer]) {
+  runPBKDF2(new SomeArray(10), 'salt', 8, 8, 'sha256');
+  runPBKDF2('pass', new SomeArray(10), 8, 8, 'sha256');
+}
 
 assert.throws(
   () => crypto.pbkdf2('pass', 'salt', 8, 8, 'md55', common.mustNotCall()),
@@ -252,6 +227,5 @@ const kNotPBKDF2Supported = ['shake128', 'shake256'];
 crypto.getHashes()
   .filter((hash) => !kNotPBKDF2Supported.includes(hash))
   .forEach((hash) => {
-    crypto.pbkdf2Sync(new Uint8Array(10), 'salt', 8, 8, hash);
-    crypto.pbkdf2(new Uint8Array(10), 'salt', 8, 8, hash, common.mustCall());
+    runPBKDF2(new Uint8Array(10), 'salt', 8, 8, hash);
   });


### PR DESCRIPTION
This simplifies the test case by introducing a helper function that simply verifies that the sync and async variants produce the same result.

Also, `testPBKDF2` did not use `mustCall()`/`mustSucceed()`, so it would not fail if the callback was never called.

This effectively also changes the loose `mustCall()` check at the end of the file to the stricter `mustSucceed()` function.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
