### PR TITLE
build: use make functions instead of echo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ $(NODE_G_EXE): config.gypi out/Debug/build.ninja
 	if [ ! -r $@ -o ! -L $@ ]; then ln -fs out/Debug/$(NODE_EXE) $@; fi
 else
 $(NODE_EXE) $(NODE_G_EXE):
-	echo This Makefile currently only supports building with 'make' or 'ninja'
+	$(warning This Makefile currently only supports building with 'make' or 'ninja')
 endif
 endif
 
@@ -133,12 +133,9 @@ CONFIG_FLAGS += --debug
 endif
 
 .PHONY: with-code-cache
-with-code-cache:
-	echo "'with-code-cache' target is a noop"
-
 .PHONY: test-code-cache
-test-code-cache: with-code-cache
-	echo "'test-code-cache' target is a noop"
+with-code-cache test-code-cache:
+	$(warning '$@' target is a noop)
 
 out/Makefile: config.gypi common.gypi node.gyp \
 	deps/uv/uv.gyp deps/llhttp/llhttp.gyp deps/zlib/zlib.gyp \
@@ -468,7 +465,7 @@ benchmark/napi/.buildstamp: $(ADDONS_PREREQS) \
 
 .PHONY: clear-stalled
 clear-stalled:
-	@echo "Clean up any leftover processes but don't error if found."
+	$(info Clean up any leftover processes but don't error if found.)
 	ps awwx | grep Release/node | grep -v grep | cat
 	@PS_OUT=`ps awwx | grep Release/node | grep -v grep | awk '{print $$1}'`; \
 	if [ "$${PS_OUT}" ]; then \
@@ -519,7 +516,7 @@ test-ci-js: | clear-stalled
 	$(PYTHON) tools/test.py $(PARALLEL_ARGS) -p tap --logfile test.tap \
 		--mode=$(BUILDTYPE_LOWER) --flaky-tests=$(FLAKY_TESTS) \
 		$(TEST_CI_ARGS) $(CI_JS_SUITES)
-	@echo "Clean up any leftover processes, error if found."
+	$(info Clean up any leftover processes, error if found.)
 	ps awwx | grep Release/node | grep -v grep | cat
 	@PS_OUT=`ps awwx | grep Release/node | grep -v grep | awk '{print $$1}'`; \
 	if [ "$${PS_OUT}" ]; then \
@@ -535,7 +532,7 @@ test-ci: | clear-stalled bench-addons-build build-addons build-js-native-api-tes
 		--mode=$(BUILDTYPE_LOWER) --flaky-tests=$(FLAKY_TESTS) \
 		$(TEST_CI_ARGS) $(CI_JS_SUITES) $(CI_NATIVE_SUITES) $(CI_DOC)
 	out/Release/embedtest 'require("./test/embedding/test-embedding.js")'
-	@echo "Clean up any leftover processes, error if found."
+	$(info Clean up any leftover processes, error if found.)
 	ps awwx | grep Release/node | grep -v grep | cat
 	@PS_OUT=`ps awwx | grep Release/node | grep -v grep | awk '{print $$1}'`; \
 	if [ "$${PS_OUT}" ]; then \
@@ -671,7 +668,7 @@ test-v8: v8  ## Runs the V8 test suite on deps/v8.
 	deps/v8/tools/run-tests.py --gn --arch=$(V8_ARCH) $(V8_TEST_OPTIONS) \
 				mjsunit cctest debugger inspector message preparser \
 				$(TAP_V8)
-	@echo Testing hash seed
+	$(info Testing hash seed)
 	$(MAKE) test-hash-seed
 
 test-v8-intl: v8
@@ -691,9 +688,8 @@ test-v8-all: test-v8 test-v8-intl test-v8-benchmarks test-v8-updates
 # runs all v8 tests
 else
 test-v8 test-v8-intl test-v8-benchmarks test-v8-all:
-	@echo "Testing v8 is not available through the source tarball."
-	@echo "Use the git repo instead:" \
-		"$ git clone https://github.com/nodejs/node.git"
+	$(warning Testing V8 is not available through the source tarball.)
+	$(warning Use the git repo instead: $$ git clone https://github.com/nodejs/node.git)
 endif
 
 apidoc_dirs = out/doc out/doc/api out/doc/api/assets
@@ -928,14 +924,13 @@ MACOSOUTDIR=out/macos
 
 ifeq ($(SKIP_XZ), 1)
 check-xz:
-	@echo "SKIP_XZ=1 supplied, skipping .tar.xz creation"
+	$(info SKIP_XZ=1 supplied, skipping .tar.xz creation)
 else
 ifeq ($(HAS_XZ), 1)
 check-xz:
 else
 check-xz:
-	@echo "No xz command, cannot continue"
-	@exit 1
+	$(error No xz command, cannot continue)
 endif
 endif
 
@@ -1168,12 +1163,9 @@ ifeq ($(XZ), 1)
 endif
 
 .PHONY: bench-all
-bench-all: bench-addons-build
-	@echo "Please use benchmark/run.js or benchmark/compare.js to run the benchmarks."
-
 .PHONY: bench
-bench: bench-addons-build
-	@echo "Please use benchmark/run.js or benchmark/compare.js to run the benchmarks."
+bench bench-all: bench-addons-build
+	$(warning Please use benchmark/run.js or benchmark/compare.js to run the benchmarks.)
 
 # Build required addons for benchmark before running it.
 .PHONY: bench-addons-build
@@ -1197,7 +1189,7 @@ lint-md-clean:
 
 .PHONY: lint-md-build
 lint-md-build:
-	$(warning "Deprecated no-op target 'lint-md-build'")
+	$(warning Deprecated no-op target 'lint-md-build')
 
 ifeq ("$(wildcard tools/.mdlintstamp)","")
 LINT_MD_NEWER =
@@ -1212,7 +1204,7 @@ LINT_MD_FILES = $(shell $(FIND) $(LINT_MD_TARGETS) -type f \
 run-lint-md = tools/lint-md.js -q -f --no-stdout $(LINT_MD_FILES)
 # Lint all changed markdown files maintained by us
 tools/.mdlintstamp: $(LINT_MD_FILES)
-	@echo "Running Markdown linter..."
+	$(info Running Markdown linter...)
 	@$(call available-node,$(run-lint-md))
 	@touch $@
 
@@ -1243,7 +1235,7 @@ lint-js:
 	fi
 
 jslint: lint-js
-	@echo "Please use lint-js instead of jslint"
+	$(warning Please use lint-js instead of jslint)
 
 run-lint-js-ci = tools/node_modules/eslint/bin/eslint.js \
   --report-unused-disable-directives --ext=.js,.mjs,.md -f tap \
@@ -1252,11 +1244,11 @@ run-lint-js-ci = tools/node_modules/eslint/bin/eslint.js \
 .PHONY: lint-js-ci
 # On the CI the output is emitted in the TAP format.
 lint-js-ci:
-	@echo "Running JS linter..."
+	$(info Running JS linter...)
 	@$(call available-node,$(run-lint-js-ci))
 
 jslint-ci: lint-js-ci
-	@echo "Please use lint-js-ci instead of jslint-ci"
+	$(warning Please use lint-js-ci instead of jslint-ci)
 
 LINT_CPP_ADDON_DOC_FILES_GLOB = test/addons/??_*/*.cc test/addons/??_*/*.h
 LINT_CPP_ADDON_DOC_FILES = $(wildcard $(LINT_CPP_ADDON_DOC_FILES_GLOB))
@@ -1313,15 +1305,15 @@ CLANG_FORMAT_START ?= HEAD
 #  $ CLANG_FORMAT_START=master make format-cpp
 format-cpp: ## Format C++ diff from $CLANG_FORMAT_START to current changes
 ifneq ("","$(wildcard tools/clang-format/node_modules/)")
-	@echo "Formatting C++ diff from $(CLANG_FORMAT_START).."
+	$(info Formatting C++ diff from $(CLANG_FORMAT_START)..)
 	@$(PYTHON) tools/clang-format/node_modules/.bin/git-clang-format \
 		--binary=tools/clang-format/node_modules/.bin/clang-format \
 		--style=file \
 		$(CLANG_FORMAT_START) -- \
 		$(LINT_CPP_FILES)
 else
-	@echo "clang-format is not installed."
-	@echo "To install (requires internet access) run: $ make format-cpp-build"
+	$(info clang-format is not installed.)
+	$(info To install (requires internet access) run: $$ make format-cpp-build)
 endif
 
 ifeq ($(V),1)
@@ -1334,7 +1326,7 @@ endif
 lint-cpp: tools/.cpplintstamp
 
 tools/.cpplintstamp: $(LINT_CPP_FILES)
-	@echo "Running C++ linter..."
+	$(info Running C++ linter...)
 	@$(PYTHON) tools/cpplint.py $(CPPLINT_QUIET) $?
 	@$(PYTHON) tools/checkimports.py $?
 	@touch $@
@@ -1343,19 +1335,19 @@ tools/.cpplintstamp: $(LINT_CPP_FILES)
 lint-addon-docs: tools/.doclintstamp
 
 tools/.doclintstamp: test/addons/.docbuildstamp
-	@echo "Running C++ linter on addon docs..."
+	$(info Running C++ linter on addon docs...)
 	@$(PYTHON) tools/cpplint.py $(CPPLINT_QUIET) --filter=$(ADDON_DOC_LINT_FLAGS) \
 		$(LINT_CPP_ADDON_DOC_FILES_GLOB)
 	@touch $@
 
 cpplint: lint-cpp
-	@echo "Please use lint-cpp instead of cpplint"
+	$(warning Please use lint-cpp instead of cpplint)
 
 .PHONY: lint-py-build
 # python -m pip install flake8
 # Try with '--system' is to overcome systems that blindly set '--user'
 lint-py-build:
-	@echo "Pip installing flake8 linter on $(shell $(PYTHON) --version)..."
+	$(info Pip installing flake8 linter on $(shell $(PYTHON) --version)...)
 	$(PYTHON) -m pip install --upgrade -t tools/pip/site-packages flake8 || \
 		$(PYTHON) -m pip install --upgrade --system -t tools/pip/site-packages flake8
 
@@ -1367,8 +1359,8 @@ lint-py:
 	PYTHONPATH=tools/pip $(PYTHON) -m flake8 --count --show-source --statistics .
 else
 lint-py:
-	@echo "Python linting with flake8 is not avalible"
-	@echo "Run 'make lint-py-build'"
+	$(warning Python linting with flake8 is not avalible)
+	$(warning Run 'make lint-py-build')
 endif
 
 .PHONY: lint
@@ -1394,12 +1386,9 @@ lint-ci: lint-js-ci lint-cpp lint-py lint-md lint-addon-docs
 		exit 1 ; \
 	fi
 else
-lint:
-	@echo "Linting is not available through the source tarball."
-	@echo "Use the git repo instead:" \
-		"$ git clone https://github.com/nodejs/node.git"
-
-lint-ci: lint
+lint lint-ci:
+	$(info Linting is not available through the source tarball.)
+	$(info Use the git repo instead: $$ git clone https://github.com/nodejs/node.git)
 endif
 
 .PHONY: lint-clean
@@ -1419,6 +1408,5 @@ gen-openssl: ## Generate platform dependent openssl files (requires docker)
 	$(DOCKER_COMMAND) node-openssl-builder make -C deps/openssl/config
 else
 gen-openssl:
-	@echo "No docker command, cannot continue"
-	@exit 1
+	$(error No docker command, cannot continue)
 endif


### PR DESCRIPTION
This PR replaces `echo` calls by [built-in Make functions](https://www.gnu.org/software/make/manual/make.html#Make-Control-Functions). I can see several advantages for doing that:

* It states more clearly what is the intent (is it a warning? is it just an info?).
* It outputs warnings and error messages to stderr instead of stdout.
* It prints line number for warnings and errors, which may help collaborator to understand what's happening.
* We have several deprecated build targets that are effectively aliases to other targets. It eases the process of deprecation if we were to deprecate them by changing `warning` to `error`.


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
