### PR TITLE
ci(automation): automatically update licenses weekly / on-demand

### DIFF
--- a/.github/workflows/license-builder.yml
+++ b/.github/workflows/license-builder.yml
@@ -1,0 +1,22 @@
+name: license update
+on:
+  schedule:
+    # 00:00:00 every Monday
+    # https://crontab.guru/#0_0_*_*_1
+    - cron: "0 0 * * 1"
+  workflow_dispatch:
+
+jobs:
+  update_routes:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: "./tools/license-builder.sh" # run the license builder tool
+      - uses: gr2m/create-or-update-pull-request-action@v1.x # create a PR or update the Action's existing PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          title: "doc: run license-builder"
+          body: "License is likely out of date. This is an automatically generated PR by the `license-builder.yml` GitHub Action, which runs `license-builder.sh` and submits a new PR or updates an existing PR."
+          commit-message: 'doc: run license-builder'
+          labels: meta


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

In https://github.com/nodejs/node/pull/35577, I brought up that the license updating could be automated with relative ease using @gr2m's [create-or-update-pull-request-action](https://github.com/gr2m/create-or-update-pull-request-action). I spent some time today between work getting this working. You can find an example in https://github.com/bnb/node/pull/2 of how it works - specifically, note that the first commit (my commit!) removes the line that #335577 added, and then the action adds it back once it's done.

The action currently is set to allow for two triggers:
- 00:00:00 on Monday, every week (I assume this is GMT?)
- Manually from the GitHub Actions UI by anyone with permissions via the `workflow_dispatch` trigger. This is for the case where someone from the TSC or core knows there's an update and would prefer to not wait.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
