### PR TITLE
test: ignore asan new_delete_type_mismatch

### DIFF
--- a/test/cctest/test_environment.cc
+++ b/test/cctest/test_environment.cc
@@ -344,6 +344,17 @@ TEST_F(EnvironmentTest, SetImmediateCleanup) {
   EXPECT_EQ(called_unref, 0);
 }
 
+/*
+ * When Address Sanitizer (asan) is enabled (--enable-asan) and gcc is used as
+ * the compiler, asan will generate an error about a type/size mismatch of
+ * v8::BackingStore and v8::internal::BackingStore when deleting. The following
+ * function is used to ignore this error.
+ * Ref: https://github.com/nodejs/node/issues/35669
+ */
+extern "C" const char* __asan_default_options() {
+  return "new_delete_type_mismatch=0";
+}
+
 static char hello[] = "hello";
 
 TEST_F(EnvironmentTest, BufferWithFreeCallbackIsDetached) {


### PR DESCRIPTION
This commit adds ignore for new_delete_type_mismatch in EnvironmentTest
as this is currently generating an error when address sanitizer is
enabled and gcc is used as the compiler.

This might be a little risky as we run the risk of missing other errors
of this same type but I'm still looking into if this could be solved in
some other way in V8 and perhaps this could be a short term fix.

Fixes: https://github.com/nodejs/node/issues/35669

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
