### PR TITLE
build: add arm64 windows build to node-v8 repo

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -28,3 +28,19 @@ jobs:
         run: npx envinfo
       - name: Build
         run: ./vcbuild.bat experimental-quic
+
+  build-windows-arm64:
+    if: github.repository == 'nodejs/node-v8'
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install deps
+        run: choco install nasm
+      - name: Environment Information
+        run: npx envinfo
+      - name: Build
+        run: ./vcbuild.bat arm64


### PR DESCRIPTION
Fix: https://github.com/nodejs/node/issues/35677

## Why we need such a thing ?
V8 doesn't have an arm64 CI on windows, make it very hard to find issues on windows arm64. Like V8 8.6, fixing arm issue take quite some time since we don't know which commit start failing.
node-v8 sync v8 daily, so it will be easy for us notice arm64 failure and debug.

## Why not enable this on main repo,
Jenkins already has arm64 setup and running on windows. And cross compile is drastically slow on windows (near 2x slow IIRC). 
