### PR TITLE
crypto: fix regression on randomFillSync

### DIFF
--- a/lib/internal/crypto/random.js
+++ b/lib/internal/crypto/random.js
@@ -113,7 +113,7 @@ function randomFillSync(buf, offset = 0, size) {
 
   const job = new RandomBytesJob(
     kCryptoJobSync,
-    buf.buffer || buf,
+    buf,
     offset,
     size);
 

--- a/test/parallel/test-crypto-randomfillsync-regression.js
+++ b/test/parallel/test-crypto-randomfillsync-regression.js
@@ -1,0 +1,18 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const { randomFillSync } = require('crypto');
+const { notStrictEqual } = require('assert');
+
+const ab = new ArrayBuffer(20);
+const buf = Buffer.from(ab, 10);
+
+const before = buf.toString('hex');
+
+randomFillSync(buf);
+
+const after = buf.toString('hex');
+
+notStrictEqual(before, after);


### PR DESCRIPTION
Node.js 15.0.0 included a regression on crypto.randomFillSync that needs a quick patch. We should do a quick 15.0.1 once this lands. This should be fast-tracked.

Signed-off-by: James M Snell <jasnell@gmail.com>

@panva @nodejs/releasers 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
