### PR TITLE
lib: fix inspector links for stack traces

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -65,6 +65,7 @@ const { isPromise, isRegExp } = require('internal/util/types');
 const { EOL } = require('internal/constants');
 const { NativeModule } = require('internal/bootstrap/loaders');
 const { isError } = require('internal/util');
+const { fileURLToPath } = require('internal/url');
 
 const errorCache = new SafeMap();
 const CallTracker = require('internal/assert/calltracker');
@@ -291,11 +292,17 @@ function getErrMessage(message, fn) {
   overrideStackTrace.set(err, (_, stack) => stack);
   const call = err.stack[0];
 
-  const filename = call.getFileName();
+  let filename = call.getFileName();
   const line = call.getLineNumber() - 1;
   let column = call.getColumnNumber() - 1;
   let identifier;
   let code;
+
+  if (filename && StringPrototypeStartsWith(filename, 'file:')) {
+    try {
+      filename = fileURLToPath(filename);
+    } catch {}
+  }
 
   if (filename) {
     identifier = `${filename}${line}${column}`;

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -1005,12 +1005,18 @@ Module.prototype.require = function(id) {
 // (needed for setting breakpoint when called with --inspect-brk)
 let resolvedArgv;
 let hasPausedEntry = false;
+const absolutePathToUrlConverter = new URL('file://');
 
 function wrapSafe(filename, content, cjsModuleInstance) {
+  let filenameUrl = filename;
+  if(path.isAbsolute(filename)) {
+    absolutePathToUrlConverter.pathname = filename;
+    filenameUrl = absolutePathToUrlConverter.href;
+  }
   if (patched) {
     const wrapper = Module.wrap(content);
     return vm.runInThisContext(wrapper, {
-      filename,
+      filename: filenameUrl,
       lineOffset: 0,
       displayErrors: true,
       importModuleDynamically: async (specifier) => {
@@ -1020,10 +1026,6 @@ function wrapSafe(filename, content, cjsModuleInstance) {
     });
   }
   let compiled;
-  let filenameUrl = filename;
-  try {
-    filenameUrl = normalizeReferrerURL(filename);
-  } catch {}
   try {
     compiled = compileFunction(
       content,

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -1020,10 +1020,14 @@ function wrapSafe(filename, content, cjsModuleInstance) {
     });
   }
   let compiled;
+  let filenameUrl = filename;
+  try {
+    filenameUrl = normalizeReferrerURL(filename);
+  } catch {}
   try {
     compiled = compileFunction(
       content,
-      filename,
+      filenameUrl,
       0,
       0,
       undefined,

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -76,7 +76,12 @@ const {
   maybeCacheSourceMap,
   rekeySourceMap
 } = require('internal/source_map/source_map_cache');
-const { pathToFileURL, fileURLToPath, isURLInstance } = require('internal/url');
+const {
+  pathToFileURL,
+  fileURLToPath,
+  isURLInstance,
+  URL
+} = require('internal/url');
 const { deprecate } = require('internal/util');
 const vm = require('vm');
 const assert = require('internal/assert');
@@ -1009,7 +1014,7 @@ const absolutePathToUrlConverter = new URL('file://');
 
 function wrapSafe(filename, content, cjsModuleInstance) {
   let filenameUrl = filename;
-  if(path.isAbsolute(filename)) {
+  if (path.isAbsolute(filename)) {
     absolutePathToUrlConverter.pathname = filename;
     filenameUrl = absolutePathToUrlConverter.href;
   }

--- a/lib/internal/source_map/prepare_stack_trace.js
+++ b/lib/internal/source_map/prepare_stack_trace.js
@@ -85,10 +85,7 @@ const prepareStackTrace = (globalThis, error, trace) => {
           const prefix = (name && name !== t.getFunctionName()) ?
             `\n        -> at ${name}` :
             '\n        ->';
-          const originalSourceNoScheme =
-            StringPrototypeStartsWith(originalSource, 'file://') ?
-              fileURLToPath(originalSource) : originalSource;
-          str += `${prefix} (${originalSourceNoScheme}:${originalLine + 1}:` +
+          str += `${prefix} (${originalSource}:${originalLine + 1}:` +
             `${originalColumn + 1})`;
         }
       }

--- a/test/parallel/test-common-must-not-call.js
+++ b/test/parallel/test-common-must-not-call.js
@@ -4,6 +4,7 @@ const common = require('../common');
 const assert = require('assert');
 const path = require('path');
 const util = require('util');
+const { fileURLToPath } = require('url');
 
 const message = 'message';
 const testFunction1 = common.mustNotCall(message);
@@ -13,10 +14,15 @@ const testFunction2 = common.mustNotCall(message);
 const createValidate = (line, args = []) => common.mustCall((e) => {
   const prefix = `${message} at `;
   assert.ok(e.message.startsWith(prefix));
+  e.message = e.message.substring(prefix.length);
+  if (e.message.startsWith('file:')) {
+    const url = /.*/.exec(e.message)[0];
+    e.message = fileURLToPath(url) + e.message.substring(url.length);
+  }
   if (process.platform === 'win32') {
     e.message = e.message.substring(2); // remove 'C:'
   }
-  const msg = e.message.substring(prefix.length);
+  const msg = e.message;
   const firstColon = msg.indexOf(':');
   const fileName = msg.substring(0, firstColon);
   const rest = msg.substring(firstColon + 1);
@@ -26,14 +32,14 @@ const createValidate = (line, args = []) => common.mustCall((e) => {
   assert.strictEqual(rest, line + argsInfo);
 });
 
-const validate1 = createValidate('9');
+const validate1 = createValidate('10');
 try {
   testFunction1();
 } catch (e) {
   validate1(e);
 }
 
-const validate2 = createValidate('11', ['hello', 42]);
+const validate2 = createValidate('12', ['hello', 42]);
 try {
   testFunction2('hello', 42);
 } catch (e) {

--- a/test/parallel/test-domain-set-uncaught-exception-capture-after-load.js
+++ b/test/parallel/test-domain-set-uncaught-exception-capture-after-load.js
@@ -1,6 +1,7 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
+const { pathToFileURL } = require('url');
 
 (function foobar() {
   require('domain');
@@ -20,7 +21,7 @@ assert.throws(
     assert(err.stack.includes('-'.repeat(40)),
            `expected ${err.stack} to contain dashes`);
 
-    const location = `at foobar (${__filename}:`;
+    const location = `at foobar (${pathToFileURL(__filename)}:`;
     assert(err.stack.includes(location),
            `expected ${err.stack} to contain ${location}`);
     return true;

--- a/test/parallel/test-http-timeout-client-warning.js
+++ b/test/parallel/test-http-timeout-client-warning.js
@@ -2,12 +2,13 @@
 const common = require('../common');
 const http = require('http');
 const assert = require('assert');
+const { pathToFileURL } = require('url');
 
 // Checks that the setTimeout duration overflow warning is emitted
 // synchronously and therefore contains a meaningful stacktrace.
 
 process.on('warning', common.mustCall((warning) => {
-  assert(warning.stack.includes(__filename));
+  assert(warning.stack.includes(pathToFileURL(__filename)));
 }));
 
 const server = http.createServer((req, resp) => resp.end());

--- a/test/sequential/test-cli-syntax-bad.js
+++ b/test/sequential/test-cli-syntax-bad.js
@@ -44,7 +44,7 @@ const syntaxErrorRE = /^SyntaxError: \b/m;
 
       // stderr should include the filename
       assert(stderr.startsWith(pathToFileURL(file)),
-             `${stderr} starts with ${file}`);
+             `${stderr} starts with ${pathToFileURL(file)}`);
     }));
   });
 });

--- a/test/sequential/test-cli-syntax-bad.js
+++ b/test/sequential/test-cli-syntax-bad.js
@@ -3,6 +3,7 @@
 const common = require('../common');
 const assert = require('assert');
 const { exec } = require('child_process');
+const { pathToFileURL } = require('url');
 const fixtures = require('../common/fixtures');
 
 const node = process.execPath;
@@ -42,7 +43,8 @@ const syntaxErrorRE = /^SyntaxError: \b/m;
       assert(syntaxErrorRE.test(stderr), `${syntaxErrorRE} === ${stderr}`);
 
       // stderr should include the filename
-      assert(stderr.startsWith(file), `${stderr} starts with ${file}`);
+      assert(stderr.startsWith(pathToFileURL(file)),
+             `${stderr} starts with ${file}`);
     }));
   });
 });

--- a/test/sequential/test-cli-syntax-require.js
+++ b/test/sequential/test-cli-syntax-require.js
@@ -4,6 +4,7 @@ const common = require('../common');
 const assert = require('assert');
 const { exec } = require('child_process');
 const fixtures = require('../common/fixtures');
+const { pathToFileURL } = require('url');
 
 const node = process.execPath;
 
@@ -29,8 +30,9 @@ const syntaxErrorRE = /^SyntaxError: \b/m;
       // stderr should have a syntax error message
       assert(syntaxErrorRE.test(stderr), `${syntaxErrorRE} === ${stderr}`);
 
-      // stderr should include the filename
-      assert(stderr.startsWith(file), `${stderr} starts with ${file}`);
+      // stderr should include the file URL
+      const fileUrl = pathToFileURL(file);
+      assert(stderr.startsWith(fileUrl), `${stderr} starts with ${file}`);
     }));
   });
 });


### PR DESCRIPTION
When the chrome inspector (chrome://inspect) display stack traces, it
makes the filename clickable, and developer can easily locate the
relevant source with a single click. This only works when filenames are
valid URLs. The CJS loader seems to compile sources with absolute path
instead of URL, breaking the inspector functionality. This is especially
apparent when node_modules contain "at" symbol (@). The loader already
presents module to the inspector using file URL, the same URL should be
used for compiling the source.

For example the current stack trace looks like this:

![Current Stack Trace](https://i.imgur.com/D4cj2QJ.png)
```
TypeError: (...)
    at Object.<anonymous> (/home/dragiyski/(...)/@dragiyski/(...)/test.js:19:5)
```
and as shown the link covers only the part after the first slash after the ``@`` directory. The link leads to URL starting with slash (/), which opens an empty (about:blank) tab within the browser. This is an expected behavior, because in URLs ``@`` represents ``user@host`` delimiter and the path is not valid absolute URL as it does not have protocol. A properly fixed URL looks like this:

![Fixed Stack Trace](https://i.imgur.com/3SOLHOW.png)
```
TypeError: (...)
    at Object.<anonymous> (file:///home/dragiyski/(...)/@dragiyski/(...)/test.js:19:5)
```
and clicking on the link provided in inspector opens the actual location of the source for all call sites, including node_modules containing ``@`` symbol in their path. For the console, the path is printed with ``file://`` in front and clickable in some terminals.

Note: (...) replaces a valid path omitted for security reasons.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
