### PR TITLE
lib: fix duplicate logic in stream destroy

### DIFF
--- a/lib/internal/streams/destroy.js
+++ b/lib/internal/streams/destroy.js
@@ -8,6 +8,20 @@ const { Symbol } = primordials;
 const kDestroy = Symbol('kDestroy');
 const kConstruct = Symbol('kConstruct');
 
+function checkError(err, w, r) {
+  if (err) {
+    // Avoid V8 leak, https://github.com/nodejs/node/pull/34103#issuecomment-652002364
+    err.stack;
+
+    if (w && !w.errored) {
+      w.errored = err;
+    }
+    if (r && !r.errored) {
+      r.errored = err;
+    }
+  }
+}
+
 // Backwards compat. cb() is undocumented and unused in core but
 // unfortunately might be used by modules.
 function destroy(err, cb) {
@@ -24,20 +38,10 @@ function destroy(err, cb) {
     return this;
   }
 
-  if (err) {
-    // Avoid V8 leak, https://github.com/nodejs/node/pull/34103#issuecomment-652002364
-    err.stack;
-
-    if (w && !w.errored) {
-      w.errored = err;
-    }
-    if (r && !r.errored) {
-      r.errored = err;
-    }
-  }
 
   // We set destroyed to true before firing error callbacks in order
   // to make it re-entrance safe in case destroy() is called within callbacks
+  checkError(err, w, r);
 
   if (w) {
     w.destroyed = true;
@@ -66,17 +70,7 @@ function _destroy(self, err, cb) {
 
     called = true;
 
-    if (err) {
-      // Avoid V8 leak, https://github.com/nodejs/node/pull/34103#issuecomment-652002364
-      err.stack;
-
-      if (w && !w.errored) {
-        w.errored = err;
-      }
-      if (r && !r.errored) {
-        r.errored = err;
-      }
-    }
+    checkError(err, w, r);
 
     if (w) {
       w.closed = true;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Fix duplicate logic in stream destroy as the same logic is being shared
across methods and thus can be encapsulated into a single method.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->