### PR TITLE
modules: runtime deprecate subpath folder mappings

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2677,6 +2677,45 @@ In future versions of Node.js, `fs.rmdir(path, { recursive: true })` will throw
 if `path` does not exist or is a file.
 Use `fs.rm(path, { recursive: true, force: true })` instead.
 
+### DEP0148: Folder mappings in `"exports"` (trailing `"/"`)
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/35746
+    description: Runtime deprecation.
+  - version: v14.13.0
+    pr-url: https://github.com/nodejs/node/pull/34718
+    description: Documentation-only deprecation.
+-->
+
+Type: Runtime (supports [`--pending-deprecation`][])
+
+Prior to [subpath patterns][] support, it was possible to define folder mappings
+in the [subpath exports][] or [subpath imports][] fields using a trailing `"/"`:
+
+```json
+{
+  "exports": {
+    "./features/": "./features/"
+  }
+}
+```
+
+This usage is deprecated for using direct [subpath patterns][]:
+
+```json
+{
+  "exports": {
+    "./features/*": "./features/*.js"
+  }
+}
+```
+
+Without `--pending-deprecation`, runtime warnings occur only for exports
+resolutions not in `node_modules`. This means there will not be deprecation
+warnings for `"exports"` in dependencies. With `--pending-deprecation`, a
+runtime warning results no matter where the `"exports"` usage occurs.
+
 [Legacy URL API]: url.md#url_legacy_url_api
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
 [RFC 6066]: https://tools.ietf.org/html/rfc6066#section-3
@@ -2801,3 +2840,6 @@ Use `fs.rm(path, { recursive: true, force: true })` instead.
 [from_string_encoding]: buffer.md#buffer_static_method_buffer_from_string_encoding
 [legacy `urlObject`]: url.md#url_legacy_urlobject
 [static methods of `crypto.Certificate()`]: crypto.md#crypto_class_certificate
+[subpath exports]: #packages_subpath_exports
+[subpath imports]: #packages_subpath_imports
+[subpath patterns]: #packages_subpath_patterns

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2690,26 +2690,9 @@ changes:
 
 Type: Runtime (supports [`--pending-deprecation`][])
 
-Prior to [subpath patterns][] support, it was possible to define folder mappings
-in the [subpath exports][] or [subpath imports][] fields using a trailing `"/"`:
-
-```json
-{
-  "exports": {
-    "./features/": "./features/"
-  }
-}
-```
-
-This usage is deprecated for using direct [subpath patterns][]:
-
-```json
-{
-  "exports": {
-    "./features/*": "./features/*.js"
-  }
-}
-```
+Prior to [subpath patterns][] support, it was possible to define
+[folder mappings][] in the [subpath exports][] or [subpath imports][] fields
+using a trailing `"/"`.
 
 Without `--pending-deprecation`, runtime warnings occur only for exports
 resolutions not in `node_modules`. This means there will not be deprecation

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2691,8 +2691,8 @@ changes:
 Type: Runtime (supports [`--pending-deprecation`][])
 
 Prior to [subpath patterns][] support, it was possible to define
-[folder mappings][] in the [subpath exports][] or [subpath imports][] fields
-using a trailing `"/"`.
+[subpath folder mappings][] in the [subpath exports][] or
+[subpath imports][] fields using a trailing `"/"`.
 
 Without `--pending-deprecation`, runtime warnings occur only for exports
 resolutions not in `node_modules`. This means there will not be deprecation
@@ -2824,5 +2824,6 @@ runtime warning results no matter where the `"exports"` usage occurs.
 [legacy `urlObject`]: url.md#url_legacy_urlobject
 [static methods of `crypto.Certificate()`]: crypto.md#crypto_class_certificate
 [subpath exports]: #packages_subpath_exports
+[subpath folder mappings]: #packages_subpath_folder_mappings
 [subpath imports]: #packages_subpath_imports
 [subpath patterns]: #packages_subpath_patterns

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -369,6 +369,45 @@ treating the right hand side target pattern as a `**` glob against the list of
 files within the package. Because `node_modules` paths are forbidden in exports
 targets, this expansion is dependent on only the files of the package itself.
 
+### Subpath folder mappings
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/35746
+    description: Runtime deprecation.
+  - version: v14.13.0
+    pr-url: https://github.com/nodejs/node/pull/34718
+    description: Documentation-only deprecation.
+-->
+
+> Stability: 0 - Deprecated: Use subpath patterns instead.
+
+Before subpath patterns were supported, a trailing `"/"` suffix was used to
+support folder mappings:
+
+```json
+{
+  "exports": {
+    "./features/": "./features/"
+  }
+}
+```
+
+_This feature will be removed in a future release._
+
+Instead, use direct [subpath patterns][]:
+
+```json
+{
+  "exports": {
+    "./features/*": "./features/*.js"
+  }
+}
+```
+
+The benefit of patterns over folder exports is that packages can always be
+imported by consumers without subpath file extensions being necessary.
+
 ### Exports sugar
 
 > Stability: 1 - Experimental

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -1079,5 +1079,6 @@ This field defines [subpath imports][] for the current package.
 [self-reference]: #packages_self_referencing_a_package_using_its_name
 [subpath exports]: #packages_subpath_exports
 [subpath imports]: #packages_subpath_imports
+[subpath patterns]: #packages_subpath_patterns
 [the full specifier path]: esm.md#esm_mandatory_file_extensions
 [the dual CommonJS/ES module packages section]: #packages_dual_commonjs_es_module_packages

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -16,6 +16,7 @@ const {
   String,
   StringPrototypeEndsWith,
   StringPrototypeIndexOf,
+  StringPrototypeLastIndexOf,
   StringPrototypeReplace,
   StringPrototypeSlice,
   StringPrototypeSplit,

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -64,9 +64,9 @@ const emittedPackageWarnings = new SafeSet();
 function emitFolderMapDeprecation(match, pjsonUrl, isExports, base) {
   const pjsonPath = fileURLToPath(pjsonUrl);
   if (!pendingDeprecation) {
-    const nodeModulesIndex = pjsonPath.lastIndexOf('/node_modules/');
+    const nodeModulesIndex = StringPrototypeLastIndexOf(pjsonPath, '/node_modules/');
     if (nodeModulesIndex !== -1) {
-      const afterNodeModulesPath = pjsonPath.slice(nodeModulesIndex + 14, -13);
+      const afterNodeModulesPath = StringPrototypeSlice(pjsonPath, nodeModulesIndex + 14, -13);
       try {
         const { packageSubpath } = parsePackageName(afterNodeModulesPath);
         if (packageSubpath === '.')

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -59,6 +59,33 @@ const userConditions = getOptionValue('--conditions');
 const DEFAULT_CONDITIONS = ObjectFreeze(['node', 'import', ...userConditions]);
 const DEFAULT_CONDITIONS_SET = new SafeSet(DEFAULT_CONDITIONS);
 
+const pendingDeprecation = getOptionValue('--pending-deprecation');
+const emittedPackageWarnings = new SafeSet();
+function emitFolderMapDeprecation(match, pjsonUrl, isExports, base) {
+  const pjsonPath = fileURLToPath(pjsonUrl);
+  if (!pendingDeprecation) {
+    const nodeModulesIndex = pjsonPath.lastIndexOf('/node_modules/');
+    if (nodeModulesIndex !== -1) {
+      const afterNodeModulesPath = pjsonPath.slice(nodeModulesIndex + 14, -13);
+      try {
+        const { packageSubpath } = parsePackageName(afterNodeModulesPath);
+        if (packageSubpath === '.')
+          return;
+      } catch {}
+    }
+  }
+  if (emittedPackageWarnings.has(pjsonPath + '|' + match))
+    return;
+  emittedPackageWarnings.add(pjsonPath + '|' + match);
+  process.emitWarning(
+    `Use of deprecated folder mapping "${match}" in the ${isExports ?
+      '"exports"' : '"imports"'} field module resolution of the package at ${
+      pjsonPath}${base ? ` imported from ${fileURLToPath(base)}` : ''}.\n` +
+      `Update this package.json to use a subpath pattern like "${match}*".`,
+    'DeprecationWarning',
+    'DEP0148'
+  );
+}
 
 function getConditionsSet(conditions) {
   if (conditions !== undefined && conditions !== DEFAULT_CONDITIONS) {
@@ -507,6 +534,8 @@ function packageExportsResolve(
                                           conditions);
     if (resolved === null || resolved === undefined)
       throwExportsNotFound(packageSubpath, packageJSONUrl, base);
+    if (!pattern)
+      emitFolderMapDeprecation(bestMatch, packageJSONUrl, true, base);
     return { resolved, exact: pattern };
   }
 
@@ -556,8 +585,11 @@ function packageImportsResolve(name, base, conditions) {
           const resolved = resolvePackageTarget(
             packageJSONUrl, target, subpath, bestMatch, base, pattern, true,
             conditions);
-          if (resolved !== null)
+          if (resolved !== null) {
+            if (!pattern)
+              emitFolderMapDeprecation(bestMatch, packageJSONUrl, false, base);
             return { resolved, exact: pattern };
+          }
         }
       }
     }
@@ -570,13 +602,7 @@ function getPackageType(url) {
   return packageConfig.type;
 }
 
-/**
- * @param {string} specifier
- * @param {URL} base
- * @param {Set<string>} conditions
- * @returns {URL}
- */
-function packageResolve(specifier, base, conditions) {
+function parsePackageName(specifier, base) {
   let separatorIndex = StringPrototypeIndexOf(specifier, '/');
   let validPackageName = true;
   let isScoped = false;
@@ -609,6 +635,19 @@ function packageResolve(specifier, base, conditions) {
 
   const packageSubpath = '.' + (separatorIndex === -1 ? '' :
     StringPrototypeSlice(specifier, separatorIndex));
+
+  return { packageName, packageSubpath, isScoped };
+}
+
+/**
+ * @param {string} specifier
+ * @param {URL} base
+ * @param {Set<string>} conditions
+ * @returns {URL}
+ */
+function packageResolve(specifier, base, conditions) {
+  const { packageName, packageSubpath, isScoped } =
+    parsePackageName(specifier, base);
 
   // ResolveSelf
   const packageConfig = getPackageScopeConfig(base);

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -68,7 +68,8 @@ function emitFolderMapDeprecation(match, pjsonUrl, isExports, base) {
                                                         '/node_modules/');
     if (nodeModulesIndex !== -1) {
       const afterNodeModulesPath = StringPrototypeSlice(pjsonPath,
-                                                        nodeModulesIndex + 14, -13);
+                                                        nodeModulesIndex + 14,
+                                                        -13);
       try {
         const { packageSubpath } = parsePackageName(afterNodeModulesPath);
         if (packageSubpath === '.')

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -64,9 +64,11 @@ const emittedPackageWarnings = new SafeSet();
 function emitFolderMapDeprecation(match, pjsonUrl, isExports, base) {
   const pjsonPath = fileURLToPath(pjsonUrl);
   if (!pendingDeprecation) {
-    const nodeModulesIndex = StringPrototypeLastIndexOf(pjsonPath, '/node_modules/');
+    const nodeModulesIndex = StringPrototypeLastIndexOf(pjsonPath,
+                                                        '/node_modules/');
     if (nodeModulesIndex !== -1) {
-      const afterNodeModulesPath = StringPrototypeSlice(pjsonPath, nodeModulesIndex + 14, -13);
+      const afterNodeModulesPath = StringPrototypeSlice(pjsonPath,
+                                                        nodeModulesIndex + 14, -13);
       try {
         const { packageSubpath } = parsePackageName(afterNodeModulesPath);
         if (packageSubpath === '.')

--- a/test/es-module/test-esm-exports-pending-deprecations.mjs
+++ b/test/es-module/test-esm-exports-pending-deprecations.mjs
@@ -1,0 +1,19 @@
+// Flags: --pending-deprecation
+import { mustCall } from '../common/index.mjs';
+import assert from 'assert';
+
+let curWarning = 0;
+const expectedWarnings = [
+  '"./sub/"',
+  '"./fallbackdir/"',
+  '"./subpath/"'
+];
+
+process.addListener('warning', mustCall((warning) => {
+  assert(warning.stack.includes(expectedWarnings[curWarning++]), warning.stack);
+}, expectedWarnings.length));
+
+(async () => {
+  await import('./test-esm-exports.mjs');
+})()
+.catch((err) => console.error(err));

--- a/test/es-module/test-esm-local-deprecations.mjs
+++ b/test/es-module/test-esm-local-deprecations.mjs
@@ -1,0 +1,22 @@
+import { mustCall } from '../common/index.mjs';
+import assert from 'assert';
+import fixtures from '../common/fixtures.js';
+import { pathToFileURL } from 'url';
+
+const selfDeprecatedFolders =
+    fixtures.path('/es-modules/self-deprecated-folders/main.js');
+
+let curWarning = 0;
+const expectedWarnings = [
+  '"./" in the "exports" field',
+  '"#self/" in the "imports" field'
+];
+
+process.addListener('warning', mustCall((warning) => {
+  assert(warning.stack.includes(expectedWarnings[curWarning++]), warning.stack);
+}, expectedWarnings.length));
+
+(async () => {
+  await import(pathToFileURL(selfDeprecatedFolders));
+})()
+.catch((err) => console.error(err));

--- a/test/fixtures/es-modules/self-deprecated-folders/main.js
+++ b/test/fixtures/es-modules/self-deprecated-folders/main.js
@@ -1,0 +1,2 @@
+import 'self/main.js';
+import '#self/main.js';

--- a/test/fixtures/es-modules/self-deprecated-folders/package.json
+++ b/test/fixtures/es-modules/self-deprecated-folders/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "self",
+  "type": "module",
+  "exports": {
+    ".": "./main.js",
+    "./": "./"
+  },
+  "imports": {
+    "#self/": "./"
+  }
+}


### PR DESCRIPTION
This creates an explicit runtime deprecation warning when using the folder mappings in `"exports"` or `"imports"`.

The implicit documentation deprecation was already made when the exports patterns PR was landed in https://github.com/nodejs/node/pull/34718 and fully replaced all documentation references to this.

The warning is carefully scoped to **not** apply to external packages in node_modules, unless explicitly using the `--pending-deprecation` flag.

Tests are included for local and external, require and import, imports and exports and self-resolution cases.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
- [x] documentation is changed or added

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
