### PR TITLE
[12.x backport] module: remove experimental modules warning

### DIFF
--- a/lib/internal/process/esm_loader.js
+++ b/lib/internal/process/esm_loader.js
@@ -3,7 +3,6 @@
 const {
   ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING,
 } = require('internal/errors').codes;
-const assert = require('internal/assert');
 const { Loader } = require('internal/modules/esm/loader');
 const {
   hasUncaughtExceptionCaptureCallback,
@@ -26,13 +25,6 @@ exports.initializeImportMetaObject = function(wrap, meta) {
 };
 
 exports.importModuleDynamicallyCallback = async function(wrap, specifier) {
-  assert(calledInitialize === true || !userLoader);
-  if (!calledInitialize) {
-    process.emitWarning(
-      'The ESM module loader is experimental.',
-      'ExperimentalWarning', undefined);
-    calledInitialize = true;
-  }
   const { callbackMap } = internalBinding('module_wrap');
   if (callbackMap.has(wrap)) {
     const { importModuleDynamically } = callbackMap.get(wrap);
@@ -47,15 +39,7 @@ exports.importModuleDynamicallyCallback = async function(wrap, specifier) {
 let ESMLoader = new Loader();
 exports.ESMLoader = ESMLoader;
 
-let calledInitialize = false;
-async function initializeLoader(emitWarning) {
-  assert(calledInitialize === false);
-  if (emitWarning) {
-    process.emitWarning(
-      'The ESM module loader is experimental.',
-      'ExperimentalWarning', undefined);
-  }
-  calledInitialize = true;
+async function initializeLoader() {
   if (!userLoader)
     return;
   let cwd;
@@ -78,9 +62,9 @@ async function initializeLoader(emitWarning) {
   })();
 }
 
-exports.loadESM = async function loadESM(callback, emitWarning = true) {
+exports.loadESM = async function loadESM(callback) {
   try {
-    await initializeLoader(emitWarning);
+    await initializeLoader();
     await callback(ESMLoader);
   } catch (err) {
     if (hasUncaughtExceptionCaptureCallback()) {

--- a/test/es-module/test-esm-dynamic-import.js
+++ b/test/es-module/test-esm-dynamic-import.js
@@ -38,9 +38,6 @@ function expectFsNamespace(result) {
 // For direct use of import expressions inside of CJS or ES modules, including
 // via eval, all kinds of specifiers should work without issue.
 (function testScriptOrModuleImport() {
-  common.expectWarning('ExperimentalWarning',
-                       'The ESM module loader is experimental.');
-
   // Importing another file, both direct & via eval
   // expectOkNamespace(import(relativePath));
   expectOkNamespace(eval(`import("${relativePath}")`));

--- a/test/es-module/test-esm-nowarn-exports.mjs
+++ b/test/es-module/test-esm-nowarn-exports.mjs
@@ -16,7 +16,7 @@ child.stderr.on('data', (data) => {
 child.on('close', (code, signal) => {
   strictEqual(code, 0);
   strictEqual(signal, null);
-  ok(stderr.toString().includes(
+  ok(!stderr.toString().includes(
     'ExperimentalWarning: The ESM module loader is experimental'
   ));
   ok(!stderr.toString().includes(

--- a/test/message/async_error_sync_esm.out
+++ b/test/message/async_error_sync_esm.out
@@ -1,4 +1,3 @@
-(node:*) ExperimentalWarning: The ESM module loader is experimental.
 Error: test
     at one (*fixtures*async-error.js:4:9)
     at two (*fixtures*async-error.js:17:9)

--- a/test/message/esm_display_syntax_error.out
+++ b/test/message/esm_display_syntax_error.out
@@ -1,4 +1,3 @@
-(node:*) ExperimentalWarning: The ESM module loader is experimental.
 file:///*/test/message/esm_display_syntax_error.mjs:2
 await async () => 0;
 ^^^^^

--- a/test/message/esm_display_syntax_error_import.out
+++ b/test/message/esm_display_syntax_error_import.out
@@ -1,4 +1,3 @@
-(node:*) ExperimentalWarning: The ESM module loader is experimental.
 file:///*/test/message/esm_display_syntax_error_import.mjs:5
   notfound
   ^^^^^^^^

--- a/test/message/esm_display_syntax_error_import_module.out
+++ b/test/message/esm_display_syntax_error_import_module.out
@@ -1,4 +1,3 @@
-(node:*) ExperimentalWarning: The ESM module loader is experimental.
 file:///*/test/fixtures/es-module-loaders/syntax-error-import.mjs:1
 import { foo, notfound } from './module-named-exports.mjs';
               ^^^^^^^^

--- a/test/message/esm_display_syntax_error_module.out
+++ b/test/message/esm_display_syntax_error_module.out
@@ -1,4 +1,3 @@
-(node:*) ExperimentalWarning: The ESM module loader is experimental.
 file:///*/test/fixtures/es-module-loaders/syntax-error.mjs:2
 await async () => 0;
 ^^^^^

--- a/test/message/esm_loader_not_found.out
+++ b/test/message/esm_loader_not_found.out
@@ -1,4 +1,3 @@
-(node:*) ExperimentalWarning: The ESM module loader is experimental.
 (node:*) ExperimentalWarning: --experimental-loader is an experimental feature. This feature could change at any time
 internal/process/esm_loader.js:*
     internalBinding('errors').triggerUncaughtException(

--- a/test/message/esm_loader_not_found_cjs_hint_bare.out
+++ b/test/message/esm_loader_not_found_cjs_hint_bare.out
@@ -1,4 +1,3 @@
-(node:*) ExperimentalWarning: The ESM module loader is experimental.
 internal/process/esm_loader.js:*
     internalBinding('errors').triggerUncaughtException(
                               ^

--- a/test/message/esm_loader_not_found_cjs_hint_relative.out
+++ b/test/message/esm_loader_not_found_cjs_hint_relative.out
@@ -1,4 +1,3 @@
-(node:*) ExperimentalWarning: The ESM module loader is experimental.
 (node:*) ExperimentalWarning: --experimental-loader is an experimental feature. This feature could change at any time
 internal/process/esm_loader.js:*
     internalBinding('errors').triggerUncaughtException(

--- a/test/message/esm_loader_syntax_error.out
+++ b/test/message/esm_loader_syntax_error.out
@@ -1,4 +1,3 @@
-(node:*) ExperimentalWarning: The ESM module loader is experimental.
 (node:*) ExperimentalWarning: --experimental-loader is an experimental feature. This feature could change at any time
 file://*/test/fixtures/es-module-loaders/syntax-error.mjs:2
 await async () => 0;


### PR DESCRIPTION
This backports the PR with the removal of the experimental warning from https://github.com/nodejs/node/pull/31974.

This seems important as many users are unaware the 12.x implementation provides the same stable base-level modules functionality.

It would be nice to get the approvals here in the mean time, but this should probably only land once the two previously left out backports from the last 12 release have landed:

- [ ] CJS exports https://github.com/nodejs/node/pull/35405
- [ ] CJS module lexer performance patch https://github.com/nodejs/node/pull/35501
- [ ] The exports pattern commit from https://github.com/nodejs/node/pull/35385 which was bumped from the last release
- [ ] Documentation backports https://github.com/nodejs/node/pull/35757

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
