### PR TITLE
doc: alphabetize v8 module entries

### DIFF
--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -223,6 +223,17 @@ v8.setFlagsFromString('--trace_gc');
 setTimeout(() => { v8.setFlagsFromString('--notrace_gc'); }, 60e3);
 ```
 
+## `v8.stopCoverage()`
+
+<!-- YAML
+added: v15.1.0
+-->
+
+The `v8.stopCoverage()` method allows the user to stop the coverage collection
+started by [`NODE_V8_COVERAGE`][] so that V8 can release the execution count
+records and optimize code. This can be used in conjunction with
+[`v8.takeCoverage()`][] if the user wants to collect the coverage on demand.
+
 ## `v8.takeCoverage()`
 
 <!-- YAML
@@ -237,17 +248,6 @@ by [`NODE_V8_COVERAGE`][].
 
 When the process is about to exit, one last coverage will still be written to
 disk unless [`v8.stopCoverage()`][] is invoked before the process exits.
-
-## `v8.stopCoverage()`
-
-<!-- YAML
-added: v15.1.0
--->
-
-The `v8.stopCoverage()` method allows the user to stop the coverage collection
-started by [`NODE_V8_COVERAGE`][], so that V8 can release the execution count
-records and optimize code. This can be used in conjunction with
-[`v8.takeCoverage()`][] if the user wants to collect the coverage on demand.
 
 ## `v8.writeHeapSnapshot([filename])`
 <!-- YAML
@@ -309,16 +309,6 @@ that is compatible with the [HTML structured clone algorithm][].
 The format is backward-compatible (i.e. safe to store to disk).
 Equal JavaScript values may result in different serialized output.
 
-### `v8.serialize(value)`
-<!-- YAML
-added: v8.0.0
--->
-
-* `value` {any}
-* Returns: {Buffer}
-
-Uses a [`DefaultSerializer`][] to serialize `value` into a buffer.
-
 ### `v8.deserialize(buffer)`
 <!-- YAML
 added: v8.0.0
@@ -329,6 +319,114 @@ added: v8.0.0
 Uses a [`DefaultDeserializer`][] with default options to read a JS value
 from a buffer.
 
+### `v8.serialize(value)`
+<!-- YAML
+added: v8.0.0
+-->
+
+* `value` {any}
+* Returns: {Buffer}
+
+Uses a [`DefaultSerializer`][] to serialize `value` into a buffer.
+
+### Class: `v8.DefaultDeserializer`
+<!-- YAML
+added: v8.0.0
+-->
+
+A subclass of [`Deserializer`][] corresponding to the format written by
+[`DefaultSerializer`][].
+
+### Class: `v8.DefaultSerializer`
+<!-- YAML
+added: v8.0.0
+-->
+
+A subclass of [`Serializer`][] that serializes `TypedArray`
+(in particular [`Buffer`][]) and `DataView` objects as host objects, and only
+stores the part of their underlying `ArrayBuffer`s that they are referring to.
+
+### Class: `v8.Deserializer`
+<!-- YAML
+added: v8.0.0
+-->
+
+#### `new Deserializer(buffer)`
+
+* `buffer` {Buffer|TypedArray|DataView} A buffer returned by
+  [`serializer.releaseBuffer()`][].
+
+Creates a new `Deserializer` object.
+
+#### `deserializer.getWireFormatVersion()`
+
+* Returns: {integer}
+
+Reads the underlying wire format version. Likely mostly to be useful to
+legacy code reading old wire format versions. May not be called before
+`.readHeader()`.
+
+#### `deserializer.readDouble()`
+
+* Returns: {number}
+
+Read a JS `number` value.
+For use inside of a custom [`deserializer._readHostObject()`][].
+
+#### `deserializer.readHeader()`
+
+Reads and validates a header (including the format version).
+May, for example, reject an invalid or unsupported wire format. In that case,
+an `Error` is thrown.
+
+#### `deserializer.readRawBytes(length)`
+
+* `length` {integer}
+* Returns: {Buffer}
+
+Read raw bytes from the deserializer’s internal buffer. The `length` parameter
+must correspond to the length of the buffer that was passed to
+[`serializer.writeRawBytes()`][].
+For use inside of a custom [`deserializer._readHostObject()`][].
+
+#### `deserializer.readUint32()`
+
+* Returns: {integer}
+
+Read a raw 32-bit unsigned integer and return it.
+For use inside of a custom [`deserializer._readHostObject()`][].
+
+#### `deserializer.readUint64()`
+
+* Returns: {integer[]}
+
+Read a raw 64-bit unsigned integer and return it as an array `[hi, lo]`
+with two 32-bit unsigned integer entries.
+For use inside of a custom [`deserializer._readHostObject()`][].
+
+#### `deserializer.readValue()`
+
+Deserializes a JavaScript value from the buffer and returns it.
+
+#### `deserializer.transferArrayBuffer(id, arrayBuffer)`
+
+* `id` {integer} A 32-bit unsigned integer.
+* `arrayBuffer` {ArrayBuffer|SharedArrayBuffer} An `ArrayBuffer` instance.
+
+Marks an `ArrayBuffer` as having its contents transferred out of band.
+Pass the corresponding `ArrayBuffer` in the serializing context to
+[`serializer.transferArrayBuffer()`][] (or return the `id` from
+[`serializer._getSharedArrayBufferId()`][] in the case of `SharedArrayBuffer`s).
+
+#### `deserializer._readHostObject()`
+
+This method is called to read some kind of host object, i.e. an object that is
+created by native C++ bindings. If it is not possible to deserialize the data,
+a suitable exception should be thrown.
+
+This method is not present on the `Deserializer` class itself but can be
+provided by subclasses.
+
 ### Class: `v8.Serializer`
 <!-- YAML
 added: v8.0.0
@@ -336,19 +434,6 @@ added: v8.0.0
 
 #### `new Serializer()`
 Creates a new `Serializer` object.
-
-#### `serializer.writeHeader()`
-
-Writes out a header, which includes the serialization format version.
-
-#### `serializer.writeValue(value)`
-
-* `value` {any}
-
-Serializes a JavaScript value and adds the serialized representation to the
-internal buffer.
-
-This throws an error if `value` cannot be serialized.
 
 #### `serializer.releaseBuffer()`
 
@@ -367,6 +452,25 @@ Marks an `ArrayBuffer` as having its contents transferred out of band.
 Pass the corresponding `ArrayBuffer` in the deserializing context to
 [`deserializer.transferArrayBuffer()`][].
 
+#### `serializer.writeDouble(value)`
+
+* `value` {number}
+
+Write a JS `number` value.
+For use inside of a custom [`serializer._writeHostObject()`][].
+
+#### `serializer.writeHeader()`
+
+Writes out a header, which includes the serialization format version.
+
+#### `serializer.writeRawBytes(buffer)`
+
+* `buffer` {Buffer|TypedArray|DataView}
+
+Write raw bytes into the serializer’s internal buffer. The deserializer
+will require a way to compute the length of the buffer.
+For use inside of a custom [`serializer._writeHostObject()`][].
+
 #### `serializer.writeUint32(value)`
 
 * `value` {integer}
@@ -382,31 +486,14 @@ For use inside of a custom [`serializer._writeHostObject()`][].
 Write a raw 64-bit unsigned integer, split into high and low 32-bit parts.
 For use inside of a custom [`serializer._writeHostObject()`][].
 
-#### `serializer.writeDouble(value)`
+#### `serializer.writeValue(value)`
 
-* `value` {number}
+* `value` {any}
 
-Write a JS `number` value.
-For use inside of a custom [`serializer._writeHostObject()`][].
+Serializes a JavaScript value and adds the serialized representation to the
+internal buffer.
 
-#### `serializer.writeRawBytes(buffer)`
-
-* `buffer` {Buffer|TypedArray|DataView}
-
-Write raw bytes into the serializer’s internal buffer. The deserializer
-will require a way to compute the length of the buffer.
-For use inside of a custom [`serializer._writeHostObject()`][].
-
-#### `serializer._writeHostObject(object)`
-
-* `object` {Object}
-
-This method is called to write some kind of host object, i.e. an object created
-by native C++ bindings. If it is not possible to serialize `object`, a suitable
-exception should be thrown.
-
-This method is not present on the `Serializer` class itself but can be provided
-by subclasses.
+This throws an error if `value` cannot be serialized.
 
 #### `serializer._getDataCloneError(message)`
 
@@ -440,103 +527,16 @@ by subclasses.
 Indicate whether to treat `TypedArray` and `DataView` objects as
 host objects, i.e. pass them to [`serializer._writeHostObject()`][].
 
-### Class: `v8.Deserializer`
-<!-- YAML
-added: v8.0.0
--->
+#### `serializer._writeHostObject(object)`
 
-#### `new Deserializer(buffer)`
+* `object` {Object}
 
-* `buffer` {Buffer|TypedArray|DataView} A buffer returned by
-  [`serializer.releaseBuffer()`][].
+This method is called to write some kind of host object, i.e. an object created
+by native C++ bindings. If it is not possible to serialize `object`, a suitable
+exception should be thrown.
 
-Creates a new `Deserializer` object.
-
-#### `deserializer.readHeader()`
-
-Reads and validates a header (including the format version).
-May, for example, reject an invalid or unsupported wire format. In that case,
-an `Error` is thrown.
-
-#### `deserializer.readValue()`
-
-Deserializes a JavaScript value from the buffer and returns it.
-
-#### `deserializer.transferArrayBuffer(id, arrayBuffer)`
-
-* `id` {integer} A 32-bit unsigned integer.
-* `arrayBuffer` {ArrayBuffer|SharedArrayBuffer} An `ArrayBuffer` instance.
-
-Marks an `ArrayBuffer` as having its contents transferred out of band.
-Pass the corresponding `ArrayBuffer` in the serializing context to
-[`serializer.transferArrayBuffer()`][] (or return the `id` from
-[`serializer._getSharedArrayBufferId()`][] in the case of `SharedArrayBuffer`s).
-
-#### `deserializer.getWireFormatVersion()`
-
-* Returns: {integer}
-
-Reads the underlying wire format version. Likely mostly to be useful to
-legacy code reading old wire format versions. May not be called before
-`.readHeader()`.
-
-#### `deserializer.readUint32()`
-
-* Returns: {integer}
-
-Read a raw 32-bit unsigned integer and return it.
-For use inside of a custom [`deserializer._readHostObject()`][].
-
-#### `deserializer.readUint64()`
-
-* Returns: {integer[]}
-
-Read a raw 64-bit unsigned integer and return it as an array `[hi, lo]`
-with two 32-bit unsigned integer entries.
-For use inside of a custom [`deserializer._readHostObject()`][].
-
-#### `deserializer.readDouble()`
-
-* Returns: {number}
-
-Read a JS `number` value.
-For use inside of a custom [`deserializer._readHostObject()`][].
-
-#### `deserializer.readRawBytes(length)`
-
-* `length` {integer}
-* Returns: {Buffer}
-
-Read raw bytes from the deserializer’s internal buffer. The `length` parameter
-must correspond to the length of the buffer that was passed to
-[`serializer.writeRawBytes()`][].
-For use inside of a custom [`deserializer._readHostObject()`][].
-
-#### `deserializer._readHostObject()`
-
-This method is called to read some kind of host object, i.e. an object that is
-created by native C++ bindings. If it is not possible to deserialize the data,
-a suitable exception should be thrown.
-
-This method is not present on the `Deserializer` class itself but can be
-provided by subclasses.
-
-### Class: `v8.DefaultSerializer`
-<!-- YAML
-added: v8.0.0
--->
-
-A subclass of [`Serializer`][] that serializes `TypedArray`
-(in particular [`Buffer`][]) and `DataView` objects as host objects, and only
-stores the part of their underlying `ArrayBuffer`s that they are referring to.
-
-### Class: `v8.DefaultDeserializer`
-<!-- YAML
-added: v8.0.0
--->
-
-A subclass of [`Deserializer`][] corresponding to the format written by
-[`DefaultSerializer`][].
+This method is not present on the `Serializer` class itself but can be provided
+by subclasses.
 
 [HTML structured clone algorithm]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm
 [V8]: https://developers.google.com/v8/


### PR DESCRIPTION
Alphabetize the entries in the v8 module documentation. I also made some
minor punctuation changes in two lines of text (removed a comma, and
changed a comma to a semicolon).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
