### PR TITLE
util: remove instance check on empty object

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -253,7 +253,7 @@ function getUserOptions(ctx, isCrossContext) {
     ObjectSetPrototypeOf(ret, null);
     for (const key of ObjectKeys(ret)) {
       if ((typeof ret[key] === 'object' || typeof ret[key] === 'function') &&
-          ret[key] !== null) {
+        ret[key] !== null) {
         delete ret[key];
       }
     }
@@ -261,7 +261,7 @@ function getUserOptions(ctx, isCrossContext) {
       let stylized;
       try {
         stylized = `${ctx.stylize(value, flavour)}`;
-      } catch {}
+      } catch { }
 
       if (typeof stylized !== 'string') return value;
       // `stylized` is a string as it should be, which is safe to pass along.
@@ -497,9 +497,9 @@ function strEscape(str) {
   for (let i = 0; i < lastIndex; i++) {
     const point = str.charCodeAt(i);
     if (point === singleQuote ||
-        point === 92 ||
-        point < 32 ||
-        (point > 126 && point < 160)) {
+      point === 92 ||
+      point < 32 ||
+      (point > 126 && point < 160)) {
       if (last === i) {
         result += meta[point];
       } else {
@@ -540,12 +540,11 @@ function getConstructorName(obj, ctx, recurseTimes, protoProps) {
   while (obj || isUndetectableObject(obj)) {
     const descriptor = ObjectGetOwnPropertyDescriptor(obj, 'constructor');
     if (descriptor !== undefined &&
-        typeof descriptor.value === 'function' &&
-        descriptor.value.name !== '' &&
-        tmp instanceof descriptor.value) {
+      typeof descriptor.value === 'function' &&
+      descriptor.value.name !== '') {
       if (protoProps !== undefined &&
-         (firstProto !== obj ||
-         !builtInObjects.has(descriptor.value.name))) {
+        (firstProto !== obj ||
+          !builtInObjects.has(descriptor.value.name))) {
         addPrototypeProperties(
           ctx, tmp, firstProto || tmp, recurseTimes, protoProps);
       }
@@ -599,8 +598,8 @@ function addPrototypeProperties(ctx, main, obj, recurseTimes, output) {
       // Stop as soon as a built-in object type is detected.
       const descriptor = ObjectGetOwnPropertyDescriptor(obj, 'constructor');
       if (descriptor !== undefined &&
-          typeof descriptor.value === 'function' &&
-          builtInObjects.has(descriptor.value.name)) {
+        typeof descriptor.value === 'function' &&
+        builtInObjects.has(descriptor.value.name)) {
         return;
       }
     }
@@ -619,8 +618,8 @@ function addPrototypeProperties(ctx, main, obj, recurseTimes, output) {
     for (const key of keys) {
       // Ignore the `constructor` property and keys that exist on layers above.
       if (key === 'constructor' ||
-          ObjectPrototypeHasOwnProperty(main, key) ||
-          (depth !== 0 && keySet.has(key))) {
+        ObjectPrototypeHasOwnProperty(main, key) ||
+        (depth !== 0 && keySet.has(key))) {
         continue;
       }
       const desc = ObjectGetOwnPropertyDescriptor(obj, key);
@@ -636,9 +635,9 @@ function addPrototypeProperties(ctx, main, obj, recurseTimes, output) {
         output.push(value);
       }
     }
-  // Limit the inspection to up to three prototype layers. Using `recurseTimes`
-  // is not a good choice here, because it's as if the properties are declared
-  // on the current object from the users perspective.
+    // Limit the inspection to up to three prototype layers. Using `recurseTimes`
+    // is not a good choice here, because it's as if the properties are declared
+    // on the current object from the users perspective.
   } while (++depth !== 3);
 }
 
@@ -674,7 +673,7 @@ function getKeys(value, showHidden) {
       keys = ObjectKeys(value);
     } catch (err) {
       assert(isNativeError(err) && err.name === 'ReferenceError' &&
-             isModuleNamespaceObject(value));
+        isModuleNamespaceObject(value));
       keys = ObjectGetOwnPropertyNames(value);
     }
     if (symbols.length !== 0) {
@@ -737,8 +736,8 @@ function findTypedConstructor(value) {
 function formatValue(ctx, value, recurseTimes, typedArray) {
   // Primitive types cannot have properties.
   if (typeof value !== 'object' &&
-      typeof value !== 'function' &&
-      !isUndetectableObject(value)) {
+    typeof value !== 'function' &&
+    !isUndetectableObject(value)) {
     return formatPrimitive(ctx.stylize, value, ctx);
   }
   if (value === null) {
@@ -762,10 +761,10 @@ function formatValue(ctx, value, recurseTimes, typedArray) {
   if (ctx.customInspect) {
     const maybeCustom = value[customInspectSymbol];
     if (typeof maybeCustom === 'function' &&
-        // Filter out the util module, its inspect function is special.
-        maybeCustom !== inspect &&
-        // Also filter out any prototype objects using the circular check.
-        !(value.constructor && value.constructor.prototype === value)) {
+      // Filter out the util module, its inspect function is special.
+      maybeCustom !== inspect &&
+      // Also filter out any prototype objects using the circular check.
+      !(value.constructor && value.constructor.prototype === value)) {
       // This makes sure the recurseTimes are reported as before while using
       // a counter internally.
       const depth = ctx.depth === null ? null : ctx.depth - recurseTimes;
@@ -820,12 +819,12 @@ function formatRaw(ctx, value, recurseTimes, typedArray) {
   // Only list the tag in case it's non-enumerable / not an own property.
   // Otherwise we'd print this twice.
   if (typeof tag !== 'string' ||
-      (tag !== '' &&
+    (tag !== '' &&
       (ctx.showHidden ?
         ObjectPrototypeHasOwnProperty :
         ObjectPrototypePropertyIsEnumerable)(
-        value, SymbolToStringTag
-      ))) {
+          value, SymbolToStringTag
+        ))) {
     tag = '';
   }
   let base = '';
@@ -931,7 +930,7 @@ function formatRaw(ctx, value, recurseTimes, typedArray) {
       if (prefix !== 'RegExp ')
         base = `${prefix}${base}`;
       if ((keys.length === 0 && protoProps === undefined) ||
-          (recurseTimes > ctx.depth && ctx.depth !== null)) {
+        (recurseTimes > ctx.depth && ctx.depth !== null)) {
         return ctx.stylize(base, 'regexp');
       }
     } else if (isDate(value)) {
@@ -960,7 +959,7 @@ function formatRaw(ctx, value, recurseTimes, typedArray) {
         formatter = formatArrayBuffer;
       } else if (keys.length === 0 && protoProps === undefined) {
         return prefix +
-              `{ byteLength: ${formatNumber(ctx.stylize, value.byteLength)} }`;
+          `{ byteLength: ${formatNumber(ctx.stylize, value.byteLength)} }`;
       }
       braces[0] = `${prefix}{`;
       keys.unshift('byteLength');
@@ -1141,9 +1140,9 @@ function getFunctionBase(value, constructor, tag) {
     const slice = stringified.slice(5, -1);
     const bracketIndex = slice.indexOf('{');
     if (bracketIndex !== -1 &&
-        (!slice.slice(0, bracketIndex).includes('(') ||
-          // Slow path to guarantee that it's indeed a class.
-          classRegExp.test(slice.replace(stripCommentsRegExp)))) {
+      (!slice.slice(0, bracketIndex).includes('(') ||
+        // Slow path to guarantee that it's indeed a class.
+        classRegExp.test(slice.replace(stripCommentsRegExp)))) {
       return getClassBase(value, constructor, tag);
     }
   }
@@ -1193,7 +1192,7 @@ function formatError(err, constructor, tag, ctx, keys) {
   // A stack trace may contain arbitrary data. Only manipulate the output
   // for "regular errors" (errors that "look normal") for now.
   if (constructor === null ||
-      (name.endsWith('Error') &&
+    (name.endsWith('Error') &&
       stack.startsWith(name) &&
       (stack.length === len || stack[len] === ':' || stack[len] === '\n'))) {
     let fallback = 'Error';
@@ -1286,7 +1285,7 @@ function groupArrayElements(ctx, output, value) {
   // entry is longer than 1/5 of all other entries combined). Otherwise the
   // space in-between small entries would be enormous.
   if (actualMax * 3 + ctx.indentationLvl < ctx.breakLength &&
-      (totalLength / actualMax > 5 || maxLength <= 6)) {
+    (totalLength / actualMax > 5 || maxLength <= 6)) {
 
     const approxCharHeights = 2.5;
     const averageBias = MathSqrt(actualMax - totalLength / output.length);
@@ -1350,9 +1349,9 @@ function groupArrayElements(ctx, output, value) {
       }
       if (order === 'padStart') {
         const padding = maxLineLength[j - i] +
-                        output[j].length -
-                        dataLen[j] -
-                        separatorSpace;
+          output[j].length -
+          dataLen[j] -
+          separatorSpace;
         str += output[j].padStart(padding, ' ');
       } else {
         str += output[j];
@@ -1373,7 +1372,7 @@ function handleMaxCallStackSize(ctx, err, constructorName, indentationLvl) {
     ctx.indentationLvl = indentationLvl;
     return ctx.stylize(
       `[${constructorName}: Inspection interrupted ` +
-        'prematurely. Maximum call stack size exceeded.]',
+      'prematurely. Maximum call stack size exceeded.]',
       'special'
     );
   }
@@ -1398,10 +1397,10 @@ function formatPrimitive(fn, value, ctx) {
       trailer = `... ${remaining} more character${remaining > 1 ? 's' : ''}`;
     }
     if (ctx.compact !== true &&
-        // TODO(BridgeAR): Add unicode support. Use the readline getStringWidth
-        // function.
-        value.length > kMinLineLength &&
-        value.length > ctx.breakLength - ctx.indentationLvl - 4) {
+      // TODO(BridgeAR): Add unicode support. Use the readline getStringWidth
+      // function.
+      value.length > kMinLineLength &&
+      value.length > ctx.breakLength - ctx.indentationLvl - 4) {
       return value
         .split(/(?<=\n)/)
         .map((line) => fn(strEscape(line), 'string'))
@@ -1426,7 +1425,7 @@ function formatNamespaceObject(keys, ctx, value, recurseTimes) {
   for (let i = 0; i < keys.length; i++) {
     try {
       output[i] = formatProperty(ctx, value, recurseTimes, keys[i],
-                                 kObjectType);
+        kObjectType);
     } catch (err) {
       if (!(isNativeError(err) && err.name === 'ReferenceError')) {
         throw err;
@@ -1440,7 +1439,7 @@ function formatNamespaceObject(keys, ctx, value, recurseTimes) {
       // We have to find the last whitespace and have to replace that value as
       // it will be visualized as a regular string.
       output[i] = output[i].slice(0, pos + 1) +
-                  ctx.stylize('<uninitialized>', 'special');
+        ctx.stylize('<uninitialized>', 'special');
     }
   }
   // Reset the keys to an empty array. This prevents duplicated inspection.
@@ -1569,7 +1568,7 @@ function formatMap(value, ctx, ignored, recurseTimes) {
   ctx.indentationLvl += 2;
   for (const [k, v] of value) {
     output.push(`${formatValue(ctx, k, recurseTimes)} => ` +
-                formatValue(ctx, v, recurseTimes));
+      formatValue(ctx, v, recurseTimes));
   }
   ctx.indentationLvl -= 2;
   return output;
@@ -1696,8 +1695,8 @@ function formatProperty(ctx, value, recurseTimes, key, type, desc) {
     const s = ctx.stylize;
     const sp = 'special';
     if (ctx.getters && (ctx.getters === true ||
-          (ctx.getters === 'get' && desc.set === undefined) ||
-          (ctx.getters === 'set' && desc.set !== undefined))) {
+      (ctx.getters === 'get' && desc.set === undefined) ||
+      (ctx.getters === 'set' && desc.set !== undefined))) {
       try {
         const tmp = value[key];
         ctx.indentationLvl += 2;
@@ -1789,12 +1788,12 @@ function reduceToSingleString(
       // `ctx.compact`, as long as the properties are smaller than
       // `ctx.breakLength`.
       if (ctx.currentDepth - recurseTimes < ctx.compact &&
-          entries === output.length) {
+        entries === output.length) {
         // Line up all entries on a single line in case the entries do not
         // exceed `breakLength`. Add 10 as constant to start next to all other
         // factors that may reduce `breakLength`.
         const start = output.length + ctx.indentationLvl +
-                      braces[0].length + base.length + 10;
+          braces[0].length + base.length + 10;
         if (isBelowBreakLength(ctx, output, start, base)) {
           return `${base ? `${base} ` : ''}${braces[0]} ${join(output, ', ')}` +
             ` ${braces[1]}`;
@@ -1869,7 +1868,7 @@ function tryStringify(arg) {
       }
     }
     if (err.name === 'TypeError' &&
-        firstErrorLine(err) === CIRCULAR_ERROR_MESSAGE) {
+      firstErrorLine(err) === CIRCULAR_ERROR_MESSAGE) {
       return '[Circular]';
     }
     throw err;
@@ -1913,8 +1912,8 @@ function formatWithOptionsInternal(inspectOptions, ...args) {
               } else if (typeof tempArg === 'bigint') {
                 tempStr = `${tempArg}n`;
               } else if (typeof tempArg !== 'object' ||
-                         tempArg === null ||
-                         !hasBuiltInToString(tempArg)) {
+                tempArg === null ||
+                !hasBuiltInToString(tempArg)) {
                 tempStr = String(tempArg);
               } else {
                 tempStr = inspect(tempArg, {
@@ -1957,7 +1956,7 @@ function formatWithOptionsInternal(inspectOptions, ...args) {
                 tempStr = 'NaN';
               } else {
                 tempStr = formatNumber(stylizeNoColor,
-                                       NumberParseInt(tempInteger));
+                  NumberParseInt(tempInteger));
               }
               break;
             case 102: // 'f'
@@ -1966,7 +1965,7 @@ function formatWithOptionsInternal(inspectOptions, ...args) {
                 tempStr = 'NaN';
               } else {
                 tempStr = formatNumber(stylizeNoColor,
-                                       NumberParseFloat(tempFloat));
+                  NumberParseFloat(tempFloat));
               }
               break;
             case 99: // 'c'

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -253,7 +253,7 @@ function getUserOptions(ctx, isCrossContext) {
     ObjectSetPrototypeOf(ret, null);
     for (const key of ObjectKeys(ret)) {
       if ((typeof ret[key] === 'object' || typeof ret[key] === 'function') &&
-        ret[key] !== null) {
+          ret[key] !== null) {
         delete ret[key];
       }
     }
@@ -261,7 +261,7 @@ function getUserOptions(ctx, isCrossContext) {
       let stylized;
       try {
         stylized = `${ctx.stylize(value, flavour)}`;
-      } catch { }
+      } catch {}
 
       if (typeof stylized !== 'string') return value;
       // `stylized` is a string as it should be, which is safe to pass along.
@@ -497,9 +497,9 @@ function strEscape(str) {
   for (let i = 0; i < lastIndex; i++) {
     const point = str.charCodeAt(i);
     if (point === singleQuote ||
-      point === 92 ||
-      point < 32 ||
-      (point > 126 && point < 160)) {
+        point === 92 ||
+        point < 32 ||
+        (point > 126 && point < 160)) {
       if (last === i) {
         result += meta[point];
       } else {
@@ -540,11 +540,11 @@ function getConstructorName(obj, ctx, recurseTimes, protoProps) {
   while (obj || isUndetectableObject(obj)) {
     const descriptor = ObjectGetOwnPropertyDescriptor(obj, 'constructor');
     if (descriptor !== undefined &&
-      typeof descriptor.value === 'function' &&
-      descriptor.value.name !== '') {
+        typeof descriptor.value === 'function' &&
+        descriptor.value.name !== '') {
       if (protoProps !== undefined &&
-        (firstProto !== obj ||
-          !builtInObjects.has(descriptor.value.name))) {
+         (firstProto !== obj ||
+         !builtInObjects.has(descriptor.value.name))) {
         addPrototypeProperties(
           ctx, tmp, firstProto || tmp, recurseTimes, protoProps);
       }
@@ -598,8 +598,8 @@ function addPrototypeProperties(ctx, main, obj, recurseTimes, output) {
       // Stop as soon as a built-in object type is detected.
       const descriptor = ObjectGetOwnPropertyDescriptor(obj, 'constructor');
       if (descriptor !== undefined &&
-        typeof descriptor.value === 'function' &&
-        builtInObjects.has(descriptor.value.name)) {
+          typeof descriptor.value === 'function' &&
+          builtInObjects.has(descriptor.value.name)) {
         return;
       }
     }
@@ -618,8 +618,8 @@ function addPrototypeProperties(ctx, main, obj, recurseTimes, output) {
     for (const key of keys) {
       // Ignore the `constructor` property and keys that exist on layers above.
       if (key === 'constructor' ||
-        ObjectPrototypeHasOwnProperty(main, key) ||
-        (depth !== 0 && keySet.has(key))) {
+          ObjectPrototypeHasOwnProperty(main, key) ||
+          (depth !== 0 && keySet.has(key))) {
         continue;
       }
       const desc = ObjectGetOwnPropertyDescriptor(obj, key);
@@ -635,9 +635,9 @@ function addPrototypeProperties(ctx, main, obj, recurseTimes, output) {
         output.push(value);
       }
     }
-    // Limit the inspection to up to three prototype layers. Using `recurseTimes`
-    // is not a good choice here, because it's as if the properties are declared
-    // on the current object from the users perspective.
+  // Limit the inspection to up to three prototype layers. Using `recurseTimes`
+  // is not a good choice here, because it's as if the properties are declared
+  // on the current object from the users perspective.
   } while (++depth !== 3);
 }
 
@@ -673,7 +673,7 @@ function getKeys(value, showHidden) {
       keys = ObjectKeys(value);
     } catch (err) {
       assert(isNativeError(err) && err.name === 'ReferenceError' &&
-        isModuleNamespaceObject(value));
+             isModuleNamespaceObject(value));
       keys = ObjectGetOwnPropertyNames(value);
     }
     if (symbols.length !== 0) {
@@ -736,8 +736,8 @@ function findTypedConstructor(value) {
 function formatValue(ctx, value, recurseTimes, typedArray) {
   // Primitive types cannot have properties.
   if (typeof value !== 'object' &&
-    typeof value !== 'function' &&
-    !isUndetectableObject(value)) {
+      typeof value !== 'function' &&
+      !isUndetectableObject(value)) {
     return formatPrimitive(ctx.stylize, value, ctx);
   }
   if (value === null) {
@@ -761,10 +761,10 @@ function formatValue(ctx, value, recurseTimes, typedArray) {
   if (ctx.customInspect) {
     const maybeCustom = value[customInspectSymbol];
     if (typeof maybeCustom === 'function' &&
-      // Filter out the util module, its inspect function is special.
-      maybeCustom !== inspect &&
-      // Also filter out any prototype objects using the circular check.
-      !(value.constructor && value.constructor.prototype === value)) {
+        // Filter out the util module, its inspect function is special.
+        maybeCustom !== inspect &&
+        // Also filter out any prototype objects using the circular check.
+        !(value.constructor && value.constructor.prototype === value)) {
       // This makes sure the recurseTimes are reported as before while using
       // a counter internally.
       const depth = ctx.depth === null ? null : ctx.depth - recurseTimes;
@@ -819,12 +819,12 @@ function formatRaw(ctx, value, recurseTimes, typedArray) {
   // Only list the tag in case it's non-enumerable / not an own property.
   // Otherwise we'd print this twice.
   if (typeof tag !== 'string' ||
-    (tag !== '' &&
+      (tag !== '' &&
       (ctx.showHidden ?
         ObjectPrototypeHasOwnProperty :
         ObjectPrototypePropertyIsEnumerable)(
-          value, SymbolToStringTag
-        ))) {
+        value, SymbolToStringTag
+      ))) {
     tag = '';
   }
   let base = '';
@@ -930,7 +930,7 @@ function formatRaw(ctx, value, recurseTimes, typedArray) {
       if (prefix !== 'RegExp ')
         base = `${prefix}${base}`;
       if ((keys.length === 0 && protoProps === undefined) ||
-        (recurseTimes > ctx.depth && ctx.depth !== null)) {
+          (recurseTimes > ctx.depth && ctx.depth !== null)) {
         return ctx.stylize(base, 'regexp');
       }
     } else if (isDate(value)) {
@@ -959,7 +959,7 @@ function formatRaw(ctx, value, recurseTimes, typedArray) {
         formatter = formatArrayBuffer;
       } else if (keys.length === 0 && protoProps === undefined) {
         return prefix +
-          `{ byteLength: ${formatNumber(ctx.stylize, value.byteLength)} }`;
+              `{ byteLength: ${formatNumber(ctx.stylize, value.byteLength)} }`;
       }
       braces[0] = `${prefix}{`;
       keys.unshift('byteLength');
@@ -1140,9 +1140,9 @@ function getFunctionBase(value, constructor, tag) {
     const slice = stringified.slice(5, -1);
     const bracketIndex = slice.indexOf('{');
     if (bracketIndex !== -1 &&
-      (!slice.slice(0, bracketIndex).includes('(') ||
-        // Slow path to guarantee that it's indeed a class.
-        classRegExp.test(slice.replace(stripCommentsRegExp)))) {
+        (!slice.slice(0, bracketIndex).includes('(') ||
+          // Slow path to guarantee that it's indeed a class.
+          classRegExp.test(slice.replace(stripCommentsRegExp)))) {
       return getClassBase(value, constructor, tag);
     }
   }
@@ -1192,7 +1192,7 @@ function formatError(err, constructor, tag, ctx, keys) {
   // A stack trace may contain arbitrary data. Only manipulate the output
   // for "regular errors" (errors that "look normal") for now.
   if (constructor === null ||
-    (name.endsWith('Error') &&
+      (name.endsWith('Error') &&
       stack.startsWith(name) &&
       (stack.length === len || stack[len] === ':' || stack[len] === '\n'))) {
     let fallback = 'Error';
@@ -1285,7 +1285,7 @@ function groupArrayElements(ctx, output, value) {
   // entry is longer than 1/5 of all other entries combined). Otherwise the
   // space in-between small entries would be enormous.
   if (actualMax * 3 + ctx.indentationLvl < ctx.breakLength &&
-    (totalLength / actualMax > 5 || maxLength <= 6)) {
+      (totalLength / actualMax > 5 || maxLength <= 6)) {
 
     const approxCharHeights = 2.5;
     const averageBias = MathSqrt(actualMax - totalLength / output.length);
@@ -1349,9 +1349,9 @@ function groupArrayElements(ctx, output, value) {
       }
       if (order === 'padStart') {
         const padding = maxLineLength[j - i] +
-          output[j].length -
-          dataLen[j] -
-          separatorSpace;
+                        output[j].length -
+                        dataLen[j] -
+                        separatorSpace;
         str += output[j].padStart(padding, ' ');
       } else {
         str += output[j];
@@ -1372,7 +1372,7 @@ function handleMaxCallStackSize(ctx, err, constructorName, indentationLvl) {
     ctx.indentationLvl = indentationLvl;
     return ctx.stylize(
       `[${constructorName}: Inspection interrupted ` +
-      'prematurely. Maximum call stack size exceeded.]',
+        'prematurely. Maximum call stack size exceeded.]',
       'special'
     );
   }
@@ -1397,10 +1397,10 @@ function formatPrimitive(fn, value, ctx) {
       trailer = `... ${remaining} more character${remaining > 1 ? 's' : ''}`;
     }
     if (ctx.compact !== true &&
-      // TODO(BridgeAR): Add unicode support. Use the readline getStringWidth
-      // function.
-      value.length > kMinLineLength &&
-      value.length > ctx.breakLength - ctx.indentationLvl - 4) {
+        // TODO(BridgeAR): Add unicode support. Use the readline getStringWidth
+        // function.
+        value.length > kMinLineLength &&
+        value.length > ctx.breakLength - ctx.indentationLvl - 4) {
       return value
         .split(/(?<=\n)/)
         .map((line) => fn(strEscape(line), 'string'))
@@ -1425,7 +1425,7 @@ function formatNamespaceObject(keys, ctx, value, recurseTimes) {
   for (let i = 0; i < keys.length; i++) {
     try {
       output[i] = formatProperty(ctx, value, recurseTimes, keys[i],
-        kObjectType);
+                                 kObjectType);
     } catch (err) {
       if (!(isNativeError(err) && err.name === 'ReferenceError')) {
         throw err;
@@ -1439,7 +1439,7 @@ function formatNamespaceObject(keys, ctx, value, recurseTimes) {
       // We have to find the last whitespace and have to replace that value as
       // it will be visualized as a regular string.
       output[i] = output[i].slice(0, pos + 1) +
-        ctx.stylize('<uninitialized>', 'special');
+                  ctx.stylize('<uninitialized>', 'special');
     }
   }
   // Reset the keys to an empty array. This prevents duplicated inspection.
@@ -1568,7 +1568,7 @@ function formatMap(value, ctx, ignored, recurseTimes) {
   ctx.indentationLvl += 2;
   for (const [k, v] of value) {
     output.push(`${formatValue(ctx, k, recurseTimes)} => ` +
-      formatValue(ctx, v, recurseTimes));
+                formatValue(ctx, v, recurseTimes));
   }
   ctx.indentationLvl -= 2;
   return output;
@@ -1695,8 +1695,8 @@ function formatProperty(ctx, value, recurseTimes, key, type, desc) {
     const s = ctx.stylize;
     const sp = 'special';
     if (ctx.getters && (ctx.getters === true ||
-      (ctx.getters === 'get' && desc.set === undefined) ||
-      (ctx.getters === 'set' && desc.set !== undefined))) {
+          (ctx.getters === 'get' && desc.set === undefined) ||
+          (ctx.getters === 'set' && desc.set !== undefined))) {
       try {
         const tmp = value[key];
         ctx.indentationLvl += 2;
@@ -1788,12 +1788,12 @@ function reduceToSingleString(
       // `ctx.compact`, as long as the properties are smaller than
       // `ctx.breakLength`.
       if (ctx.currentDepth - recurseTimes < ctx.compact &&
-        entries === output.length) {
+          entries === output.length) {
         // Line up all entries on a single line in case the entries do not
         // exceed `breakLength`. Add 10 as constant to start next to all other
         // factors that may reduce `breakLength`.
         const start = output.length + ctx.indentationLvl +
-          braces[0].length + base.length + 10;
+                      braces[0].length + base.length + 10;
         if (isBelowBreakLength(ctx, output, start, base)) {
           return `${base ? `${base} ` : ''}${braces[0]} ${join(output, ', ')}` +
             ` ${braces[1]}`;
@@ -1868,7 +1868,7 @@ function tryStringify(arg) {
       }
     }
     if (err.name === 'TypeError' &&
-      firstErrorLine(err) === CIRCULAR_ERROR_MESSAGE) {
+        firstErrorLine(err) === CIRCULAR_ERROR_MESSAGE) {
       return '[Circular]';
     }
     throw err;
@@ -1912,8 +1912,8 @@ function formatWithOptionsInternal(inspectOptions, ...args) {
               } else if (typeof tempArg === 'bigint') {
                 tempStr = `${tempArg}n`;
               } else if (typeof tempArg !== 'object' ||
-                tempArg === null ||
-                !hasBuiltInToString(tempArg)) {
+                         tempArg === null ||
+                         !hasBuiltInToString(tempArg)) {
                 tempStr = String(tempArg);
               } else {
                 tempStr = inspect(tempArg, {
@@ -1956,7 +1956,7 @@ function formatWithOptionsInternal(inspectOptions, ...args) {
                 tempStr = 'NaN';
               } else {
                 tempStr = formatNumber(stylizeNoColor,
-                  NumberParseInt(tempInteger));
+                                       NumberParseInt(tempInteger));
               }
               break;
             case 102: // 'f'
@@ -1965,7 +1965,7 @@ function formatWithOptionsInternal(inspectOptions, ...args) {
                 tempStr = 'NaN';
               } else {
                 tempStr = formatNumber(stylizeNoColor,
-                  NumberParseFloat(tempFloat));
+                                       NumberParseFloat(tempFloat));
               }
               break;
             case 99: // 'c'

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -623,6 +623,18 @@ assert.strictEqual(util.inspect(-5e-324), '-5e-324');
   );
 }
 
+// Test for property descriptors on null/empty object
+{
+  function prototype() {}
+  prototype.prototype = null;
+  const obj = {};
+  obj.constructor = prototype;
+  assert.strictEqual(
+    util.inspect(obj, false),
+    'prototype { constructor: [Function: prototype] }'
+  );
+}
+
 // Exceptions should print the error message, not '{}'.
 {
   [


### PR DESCRIPTION
Remove a useless check on Object descriptor. It seems like js browsers engine dont do this check.

Fixes: https://github.com/nodejs/node/issues/35730

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
