### PR TITLE
[14.x] doc: fix Node.js 14.x changelogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Select a Node.js version below to view the changelog history:
 
 * [Node.js 14](doc/changelogs/CHANGELOG_V14.md) **Current**
-* [Node.js 13](doc/changelogs/CHANGELOG_V13.md) **Current**
+* [Node.js 13](doc/changelogs/CHANGELOG_V13.md) End-of-Life
 * [Node.js 12](doc/changelogs/CHANGELOG_V12.md) **Long Term Support**
 * [Node.js 11](doc/changelogs/CHANGELOG_V11.md) End-of-Life
 * [Node.js 10](doc/changelogs/CHANGELOG_V10.md) Long Term Support
@@ -25,7 +25,6 @@ release.
 <table>
 <tr>
   <th title="Current"><a href="doc/changelogs/CHANGELOG_V14.md">14</a><sup>Current</sup></th>
-  <th title="Current"><a href="doc/changelogs/CHANGELOG_V13.md">13</a><sup>Current</sup></th>
   <th title="LTS Until 2022-04"><a href="doc/changelogs/CHANGELOG_V12.md">12</a><sup>LTS</sup></th>
   <th title="LTS Until 2021-04"><a href="doc/changelogs/CHANGELOG_V10.md">10</a><sup>LTS</sup></th>
 </tr>

--- a/doc/changelogs/CHANGELOG_V14.md
+++ b/doc/changelogs/CHANGELOG_V14.md
@@ -9,7 +9,7 @@
 <th>Current</th>
 </tr>
 <tr>
-<td>
+<td valign="top">
 <a href="#14.14.0">14.14.0</a><br/>
 <a href="#14.13.0">14.13.0</a><br/>
 <a href="#14.12.0">14.12.0</a><br/>


### PR DESCRIPTION
Remove the table headings for Node.js 13.x that were not removed in
631dd21709.

Vertically align the list of releases in the 14.x changelog as they
are in the changelogs for 12.x and 10.x.

---

I'd like to fast track this, if possible, so that it can land with https://github.com/nodejs/node/pull/35746.
cc @nodejs/releasers 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
