### PR TITLE
Revert "src: ignore GCC -Wcast-function-type for v8.h"

### DIFF
--- a/src/string_bytes.h
+++ b/src/string_bytes.h
@@ -26,14 +26,7 @@
 
 // Decodes a v8::Local<v8::String> or Buffer to a raw char*
 
-#if (__GNUC__ >= 8) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wcast-function-type"
-#endif
 #include "v8.h"
-#if (__GNUC__ >= 8) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
 #include "env-inl.h"
 
 #include <string>

--- a/test/cctest/test_aliased_buffer.cc
+++ b/test/cctest/test_aliased_buffer.cc
@@ -1,11 +1,4 @@
-#if (__GNUC__ >= 8) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wcast-function-type"
-#endif
 #include "v8.h"
-#if (__GNUC__ >= 8) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
 #include "aliased_buffer.h"
 #include "node_test_fixture.h"
 


### PR DESCRIPTION
This reverts commit f21cf456bf36bd73d8cb6715c745e23efc22a29f as this has
now been included in the V8 version being used.

Refs:
https://github.com/v8/v8/commit/f08cbfdc4051266e4200b6e26775d35307b1259b



##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
