### PR TITLE
[12.x] doc: update fs promise-based examples

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -60,7 +60,7 @@ Promise-based operations return a `Promise` that is resolved when the
 asynchronous operation is complete.
 
 ```js
-const fs = require('fs/promises');
+const fs = require('fs').promises;
 
 (async function(path) {
   try {
@@ -106,7 +106,7 @@ fs.rename('/tmp/hello', '/tmp/world', (err) => {
 Or, use the promise-based API:
 
 ```js
-const fs = require('fs/promises');
+const fs = require('fs').promises;
 
 (async function(from, to) {
   try {


### PR DESCRIPTION
https://github.com/nodejs/node/pull/34843 was cherry-picked onto
`v12.x-staging` in 961844d25b but the `fs/promises` API, as used
in the examples, is only available from Node.js 14. Change the
added examples to use `require(fs).promises` instead.

Fixes: https://github.com/nodejs/node/issues/35740
Refs: https://github.com/nodejs/node/pull/34843

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
