### PR TITLE
Update fs.md (minor indentation issue in /doc)

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -5565,7 +5565,7 @@ that represent files will be deleted. The permissive behavior of the
 `recursive` option is deprecated, `ENOTDIR` and `ENOENT` will be thrown in
 the future.
 
-## `fsPromises.rm(path[, options])`
+### `fsPromises.rm(path[, options])`
 <!-- YAML
 added: v14.14.0
 -->


### PR DESCRIPTION
Indentation in https://nodejs.org/docs/latest/api/fs.html#fs_fs_promises_api is not correct (level 2 and it should be to level 3).
