### PR TITLE
http2: move events to the JSStreamSocket

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1129,6 +1129,8 @@ class Http2Session extends EventEmitter {
     if (!socket._handle || !socket._handle.isStreamBase) {
       socket = new JSStreamSocket(socket);
     }
+    socket.on('error', socketOnError);
+    socket.on('close', socketOnClose);
 
     // No validation is performed on the input parameters because this
     // constructor is not exported directly for users.
@@ -2909,9 +2911,6 @@ function connectionListener(socket) {
     return;
   }
 
-  socket.on('error', socketOnError);
-  socket.on('close', socketOnClose);
-
   // Set up the Session
   const session = new ServerHttp2Session(options, socket, this);
 
@@ -3133,12 +3132,6 @@ function connect(authority, options, listener) {
   }
 
   const session = new ClientHttp2Session(options, socket);
-
-  // ClientHttp2Session may create a new socket object
-  // when socket is a JSSocket (socket != kSocket)
-  // https://github.com/nodejs/node/issues/35695
-  session[kSocket].on('error', socketOnError);
-  session[kSocket].on('close', socketOnClose);
 
   session[kAuthority] = `${options.servername || host}:${port}`;
   session[kProtocol] = protocol;

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -3132,10 +3132,13 @@ function connect(authority, options, listener) {
     }
   }
 
-  socket.on('error', socketOnError);
-  socket.on('close', socketOnClose);
-
   const session = new ClientHttp2Session(options, socket);
+
+  // ClientHttp2Session may create a new socket object
+  // when socket is a JSSocket (socket != kSocket)
+  // https://github.com/nodejs/node/issues/35695
+  session[kSocket].on('error', socketOnError);
+  session[kSocket].on('close', socketOnClose);
 
   session[kAuthority] = `${options.servername || host}:${port}`;
   session[kProtocol] = protocol;

--- a/test/parallel/test-http2-client-jsstream-destroy.js
+++ b/test/parallel/test-http2-client-jsstream-destroy.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const h2 = require('http2');
+const tls = require('tls');
+const fixtures = require('../common/fixtures');
+const { Duplex } = require('stream');
+
+const server = h2.createSecureServer({
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem')
+});
+
+class JSSocket extends Duplex {
+  constructor(socket) {
+    super({ emitClose: true });
+    socket.on('close', () => this.destroy());
+    socket.on('data', (data) => this.push(data));
+    this.socket = socket;
+  }
+
+  _write(data, encoding, callback) {
+    this.socket.write(data, encoding, callback);
+  }
+
+  _read(size) {
+  }
+
+  _final(cb) {
+    cb();
+  }
+}
+
+server.listen(0, common.mustCall(function() {
+  const socket = tls.connect({
+    rejectUnauthorized: false,
+    host: 'localhost',
+    port: this.address().port,
+    ALPNProtocols: ['h2']
+  }, () => {
+    const proxy = new JSSocket(socket);
+    const client = h2.connect(`https://localhost:${this.address().port}`, {
+      createConnection: () => proxy
+    });
+    const req = client.request();
+
+    setTimeout(() => socket.destroy(), 200);
+    setTimeout(() => client.close(), 400);
+    setTimeout(() => server.close(), 600);
+
+    req.on('close', common.mustCall(() => { }));
+  });
+}));

--- a/test/parallel/test-http2-client-jsstream-destroy.js
+++ b/test/parallel/test-http2-client-jsstream-destroy.js
@@ -46,9 +46,9 @@ server.listen(0, common.mustCall(function() {
     });
     const req = client.request();
 
-    setTimeout(() => socket.destroy(), 200);
-    setTimeout(() => client.close(), 400);
-    setTimeout(() => server.close(), 600);
+    setTimeout(() => socket.destroy(), common.platformTimeout(100));
+    setTimeout(() => client.close(), common.platformTimeout(200));
+    setTimeout(() => server.close(), common.platformTimeout(300));
 
     req.on('close', common.mustCall(() => { }));
   });


### PR DESCRIPTION
When using a JSStreamSocket, the
HTTP2Session constructor will replace
the socket object
http2 events should be attached to the
JSStreamSocket object because the http2
session handle lives there

Fixes: https://github.com/nodejs/node/issues/35695

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
