### PR TITLE
n-api: revert change to finalisation

### DIFF
--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -228,10 +228,9 @@ class RefBase : protected Finalizer, RefTracker {
   // from one of Unwrap or napi_delete_reference.
   //
   // When it is called from Unwrap or napi_delete_reference we only
-  // want to do the delete if there is no finalizer or the finalizer has already
-  // run or cannot have been queued to run (i.e. the reference count is > 0),
+  // want to do the delete if the finalizer has already run or
+  // cannot have been queued to run (ie the reference count is > 0),
   // otherwise we may crash when the finalizer does run.
-  //
   // If the finalizer may have been queued and has not already run
   // delay the delete until the finalizer runs by not doing the delete
   // and setting _delete_self to true so that the finalizer will
@@ -243,7 +242,6 @@ class RefBase : protected Finalizer, RefTracker {
   static inline void Delete(RefBase* reference) {
     reference->Unlink();
     if ((reference->RefCount() != 0) ||
-        (reference->_finalize_callback == nullptr) ||
         (reference->_delete_self) ||
         (reference->_finalize_ran)) {
       delete reference;

--- a/test/node-api/test_worker_terminate_finalization/test.js
+++ b/test/node-api/test_worker_terminate_finalization/test.js
@@ -1,6 +1,10 @@
 'use strict';
 const common = require('../../common');
 
+// TODO(addaleax): Run this test once it stops failing under ASAN/valgrind.
+// Refs: https://github.com/nodejs/node/issues/34731
+common.skip('Reference management in N-API leaks memory');
+
 const { Worker, isMainThread } = require('worker_threads');
 
 if (isMainThread) {

--- a/test/node-api/test_worker_terminate_finalization/test.js
+++ b/test/node-api/test_worker_terminate_finalization/test.js
@@ -3,6 +3,8 @@ const common = require('../../common');
 
 // TODO(addaleax): Run this test once it stops failing under ASAN/valgrind.
 // Refs: https://github.com/nodejs/node/issues/34731
+// Refs: https://github.com/nodejs/node/pull/35777
+// Refs: https://github.com/nodejs/node/issues/35778
 common.skip('Reference management in N-API leaks memory');
 
 const { Worker, isMainThread } = require('worker_threads');


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/35620

This reverts commit a6b655614f03e073b9c60f3d71ed884c5af32ffc which
changed finalization behavior related to N-API. We will investigate
the original issue with the test separately.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
