### PR TITLE
async_hooks: fix leak in AsyncLocalStorage exit

### DIFF
--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -271,6 +271,14 @@ class AsyncLocalStorage {
     }
   }
 
+  _enable() {
+    if (!this.enabled) {
+      this.enabled = true;
+      storageList.push(this);
+      storageHook.enable();
+    }
+  }
+
   // Propagate the context from a parent resource to a child one
   _propagate(resource, triggerResource) {
     const store = triggerResource[this.kResourceStore];
@@ -280,11 +288,7 @@ class AsyncLocalStorage {
   }
 
   enterWith(store) {
-    if (!this.enabled) {
-      this.enabled = true;
-      storageList.push(this);
-      storageHook.enable();
-    }
+    this._enable();
     const resource = executionAsyncResource();
     resource[this.kResourceStore] = store;
   }
@@ -308,11 +312,11 @@ class AsyncLocalStorage {
     if (!this.enabled) {
       return callback(...args);
     }
-    this.enabled = false;
+    this.disable();
     try {
       return callback(...args);
     } finally {
-      this.enabled = true;
+      this._enable();
     }
   }
 

--- a/test/parallel/test-async-local-storage-exit-does-not-leak.js
+++ b/test/parallel/test-async-local-storage-exit-does-not-leak.js
@@ -1,0 +1,25 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { AsyncLocalStorage } = require('async_hooks');
+
+const als = new AsyncLocalStorage();
+
+// Make sure _propagate function exists.
+assert.ok(typeof als._propagate === 'function');
+
+// The als instance should be getting removed from the storageList in
+// lib/async_hooks.js when exit(...) is called, therefore when the nested runs
+// are called there should be no copy of the als in the storageList to run the
+// _propagate method on.
+als._propagate = common.mustNotCall('_propagate() should not be called');
+
+const done = common.mustCall();
+
+function run(count) {
+  if (count === 0) return done();
+  als.run({}, () => {
+    als.exit(run, --count);
+  });
+}
+run(100);


### PR DESCRIPTION
If `exit` is called and then `run` or `enterWith` are called within the `exit` function, the als instance should not be added to the `storageList` additional times. The correct behaviour is to remove the instance from the `storageList` before executing the `exit` handler and then to restore it after.

This PR fixes a memory leak wherein an `AsyncLocalStorage` instance could be repeatedly inserted to the `storageList` array which keeps track of active instances to call `als._propagate(...)` on in the shared async_hooks instance.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)