### PR TITLE
test: add onerror test cases to policy

### DIFF
--- a/test/parallel/test-policy-parse-integrity.js
+++ b/test/parallel/test-policy-parse-integrity.js
@@ -44,7 +44,8 @@ const packageFilepath = path.join(tmpdirPath, 'package.json');
 const packageURL = pathToFileURL(packageFilepath);
 const packageBody = '{"main": "dep.js"}';
 
-function test({ shouldFail, integrity }) {
+function test({ shouldFail, integrity, manifest = {} }) {
+  manifest.resources = {};
   const resources = {
     [packageURL]: {
       body: packageBody,
@@ -54,9 +55,6 @@ function test({ shouldFail, integrity }) {
       body: depBody,
       integrity
     }
-  };
-  const manifest = {
-    resources: {},
   };
   for (const [url, { body, integrity }] of Object.entries(resources)) {
     manifest.resources[url] = {
@@ -95,4 +93,18 @@ test({
     'sha256',
     depBody
   )}`,
+});
+test({
+  shouldFail: true,
+  integrity: `sha256-${hash('sha256', 'file:///')}`,
+  manifest: {
+    onerror: 'exit'
+  }
+});
+test({
+  shouldFail: false,
+  integrity: `sha256-${hash('sha256', 'file:///')}`,
+  manifest: {
+    onerror: 'log'
+  }
 });

--- a/test/parallel/test-policy-scopes-integrity.js
+++ b/test/parallel/test-policy-scopes-integrity.js
@@ -280,3 +280,36 @@ const assert = require('assert');
   }
 }
 // #endregion
+// #startonerror
+{
+  const manifest = new Manifest({
+    scopes: {
+      'file:///': {
+        integrity: true
+      }
+    },
+    onerror: 'throw'
+  });
+  assert.throws(
+    () => {
+      manifest.assertIntegrity('http://example.com');
+    },
+    /ERR_MANIFEST_ASSERT_INTEGRITY/
+  );
+}
+{
+  assert.throws(
+    () => {
+      new Manifest({
+        scopes: {
+          'file:///': {
+            integrity: true
+          }
+        },
+        onerror: 'unknown'
+      });
+    },
+    /ERR_MANIFEST_UNKNOWN_ONERROR/
+  );
+}
+// #endonerror


### PR DESCRIPTION
Increase test coverage of `lib/internal/policy/manifest.js`

Refs: https://coverage.nodejs.org/coverage-642f2064c06793b7/lib/internal/policy/manifest.js.html#L60
Refs: https://coverage.nodejs.org/coverage-642f2064c06793b7/lib/internal/policy/manifest.js.html#L146
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
