### PR TITLE
test: turn off coverage comments

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,8 +1,11 @@
-comment:
-  # Only show diff and files changed:
-  layout: "diff, files"
-  # Don't post if no changes in coverage:
-  require_changes: true
+# TODO(bcoe): re-enable coverage report comments, once we can figure out
+# how to make them more accurate for the Node.js project,
+# See: https://github.com/nodejs/node/issues/35759
+comment: false
+#  # Only show diff and files changed:
+#  layout: "diff, files"
+#  # Don't post if no changes in coverage:
+#  require_changes: true
 
 codecov:
   notify:


### PR DESCRIPTION
Turns off coverage comments for the time being, until we can sort out #35759

Refs https://github.com/nodejs/node/issues/35759, https://github.com/nodejs/node/pull/35779, https://github.com/nodejs/node/pull/35753

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
