### PR TITLE
events: add a few tests

### DIFF
--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -72,10 +72,10 @@ const isTrusted = ObjectGetOwnPropertyDescriptor({
 }, 'isTrusted').get;
 
 class Event {
-  constructor(type, options) {
+  constructor(type, options = null) {
     if (arguments.length === 0)
       throw new ERR_MISSING_ARGS('type');
-    if (options != null)
+    if (options !== null)
       validateObject(options, 'options');
     const { cancelable, bubbles, composed } = { ...options };
     this[kCancelable] = !!cancelable;

--- a/test/parallel/test-eventtarget.js
+++ b/test/parallel/test-eventtarget.js
@@ -414,6 +414,7 @@ let asyncTest = Promise.resolve();
 }
 
 {
+  // Event Statics
   strictEqual(Event.NONE, 0);
   strictEqual(Event.CAPTURING_PHASE, 1);
   strictEqual(Event.AT_TARGET, 2);
@@ -424,6 +425,8 @@ let asyncTest = Promise.resolve();
     strictEqual(e.eventPhase, Event.AT_TARGET);
   }), { once: true });
   target.dispatchEvent(new Event('foo'));
+  // Event is a function
+  strictEqual(Event.length, 1);
 }
 
 {
@@ -484,4 +487,33 @@ let asyncTest = Promise.resolve();
   const event = new Event('foo');
   eventTarget.dispatchEvent(event);
   strictEqual(event.target, eventTarget);
+}
+{
+  // Event target exported keys
+  const eventTarget = new EventTarget();
+  deepStrictEqual(Object.keys(eventTarget), []);
+  deepStrictEqual(Object.getOwnPropertyNames(eventTarget), []);
+  const parentKeys = Object.keys(Object.getPrototypeOf(eventTarget)).sort();
+  const keys = ['addEventListener', 'dispatchEvent', 'removeEventListener'];
+  deepStrictEqual(parentKeys, keys);
+}
+{
+  // Subclassing
+  class SubTarget extends EventTarget {}
+  const target = new SubTarget();
+  target.addEventListener('foo', common.mustCall());
+  target.dispatchEvent(new Event('foo'));
+}
+{
+  // Test event order
+  const target = new EventTarget();
+  let state = 0;
+  target.addEventListener('foo', common.mustCall(() => {
+    strictEqual(state, 0);
+    state++;
+  }));
+  target.addEventListener('foo', common.mustCall(() => {
+    strictEqual(state, 1);
+  }));
+  target.dispatchEvent(new Event('foo'));
 }


### PR DESCRIPTION
Added a few EventTarget tests I've found by playing with the code and "porting" bits of the spec I've read.

Note that at the moment Chrome has different prototype keys for `Event` though I could not figure out if that bit is actually required by the spec.

```js
Object.keys(Object.getPrototypeOf(new Event('foo'))); // different between chrome and Node
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

