### PR TITLE
events: make abort_controller event trusted

### DIFF
--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -1282,9 +1282,10 @@ This is not used in Node.js and is provided purely for completeness.
 added: v14.5.0
 -->
 
-* Type: {boolean} Always returns `false`.
+* Type: {boolean} True for Node.js internal events, false otherwise.
 
-This is not used in Node.js and is provided purely for completeness.
+Currently only `AbortSignal`s' `"abort"` event is fired with `isTrusted`
+set to `true`.
 
 #### `event.preventDefault()`
 <!-- YAML

--- a/lib/internal/abort_controller.js
+++ b/lib/internal/abort_controller.js
@@ -11,7 +11,8 @@ const {
 
 const {
   EventTarget,
-  Event
+  Event,
+  kTrustEvent
 } = require('internal/event_target');
 const {
   customInspectSymbol,
@@ -49,7 +50,9 @@ ObjectDefineProperties(AbortSignal.prototype, {
 function abortSignal(signal) {
   if (signal[kAborted]) return;
   signal[kAborted] = true;
-  const event = new Event('abort');
+  const event = new Event('abort', {
+    [kTrustEvent]: true
+  });
   if (typeof signal.onabort === 'function') {
     signal.onabort(event);
   }

--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -9,10 +9,12 @@ const {
   ObjectAssign,
   ObjectDefineProperties,
   ObjectDefineProperty,
+  ObjectGetOwnPropertyDescriptor,
   String,
   Symbol,
   SymbolFor,
   SymbolToStringTag,
+  SafeWeakSet,
 } = primordials;
 
 const {
@@ -41,6 +43,7 @@ const kRemoveListener = Symbol('kRemoveListener');
 const kIsNodeStyleListener = Symbol('kIsNodeStyleListener');
 const kMaxListeners = Symbol('kMaxListeners');
 const kMaxListenersWarned = Symbol('kMaxListenersWarned');
+const kTrustEvent = Symbol('kTrustEvent');
 
 // Lazy load perf_hooks to avoid the additional overhead on startup
 let perf_hooks;
@@ -61,7 +64,12 @@ const kBubbles = Symbol('bubbles');
 const kComposed = Symbol('composed');
 const kPropagationStopped = Symbol('propagationStopped');
 
-const isTrusted = () => false;
+const isTrustedSet = new SafeWeakSet();
+const isTrusted = ObjectGetOwnPropertyDescriptor({
+  get isTrusted() {
+    return isTrustedSet.has(this);
+  }
+}, 'isTrusted').get;
 
 class Event {
   constructor(type, options) {
@@ -77,6 +85,10 @@ class Event {
     this[kDefaultPrevented] = false;
     this[kTimestamp] = lazyNow();
     this[kPropagationStopped] = false;
+    if (options != null && options[kTrustEvent]) {
+      isTrustedSet.add(this);
+    }
+
     // isTrusted is special (LegacyUnforgeable)
     ObjectDefineProperty(this, 'isTrusted', {
       get: isTrusted,
@@ -571,5 +583,6 @@ module.exports = {
   initNodeEventTarget,
   kCreateEvent,
   kNewListener,
+  kTrustEvent,
   kRemoveListener,
 };

--- a/lib/internal/per_context/primordials.js
+++ b/lib/internal/per_context/primordials.js
@@ -101,6 +101,10 @@ primordials.SafeSet = makeSafe(
   Set,
   class SafeSet extends Set {}
 );
+primordials.SafeWeakSet = makeSafe(
+  WeakSet,
+  class SafeWeakSet extends WeakSet {}
+);
 primordials.SafePromise = makeSafe(
   Promise,
   class SafePromise extends Promise {}

--- a/test/parallel/test-abortcontroller.js
+++ b/test/parallel/test-abortcontroller.js
@@ -1,11 +1,13 @@
-// Flags: --no-warnings
+// Flags: --no-warnings --expose-internals
 'use strict';
 
 const common = require('../common');
 
 const { ok, strictEqual } = require('assert');
+const { Event } = require('internal/event_target');
 
 {
+  // Tests that abort is fired with the correct event type on AbortControllers
   const ac = new AbortController();
   ok(ac.signal);
   ac.signal.onabort = common.mustCall((event) => {
@@ -19,4 +21,34 @@ const { ok, strictEqual } = require('assert');
   ac.abort();
   ac.abort();
   ok(ac.signal.aborted);
+}
+
+{
+  // Tests that abort events are trusted
+  const ac = new AbortController();
+  ac.signal.addEventListener('abort', common.mustCall((event) => {
+    ok(event.isTrusted);
+  }));
+  ac.abort();
+}
+
+{
+  // Tests that abort events have the same `isTrusted` reference
+  const first = new AbortController();
+  const second = new AbortController();
+  let ev1, ev2;
+  const ev3 = new Event('abort');
+  first.signal.addEventListener('abort', common.mustCall((event) => {
+    ev1 = event;
+  }));
+  second.signal.addEventListener('abort', common.mustCall((event) => {
+    ev2 = event;
+  }));
+  first.abort();
+  second.abort();
+  const firstTrusted = Reflect.getOwnPropertyDescriptor(ev1, 'isTrusted').get;
+  const secondTrusted = Reflect.getOwnPropertyDescriptor(ev2, 'isTrusted').get;
+  const untrusted = Reflect.getOwnPropertyDescriptor(ev3, 'isTrusted').get;
+  strictEqual(firstTrusted, secondTrusted);
+  strictEqual(untrusted, firstTrusted);
 }


### PR DESCRIPTION
Fire `abort` event as trusted, fixes https://github.com/nodejs/node/issues/35748 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
