### PR TITLE
benchmark: add startup benchmark for loading public modules

### DIFF
--- a/benchmark/fixtures/require-builtins.js
+++ b/benchmark/fixtures/require-builtins.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const list = [
+  'async_hooks',
+  'assert',
+  'buffer',
+  'child_process',
+  'console',
+  'constants',
+  'crypto',
+  'cluster',
+  'dgram',
+  'dns',
+  'domain',
+  'events',
+  'fs',
+  'http',
+  'http2',
+  'https',
+  'inspector',
+  'module',
+  'net',
+  'os',
+  'path',
+  'perf_hooks',
+  'process',
+  'punycode',
+  'querystring',
+  'readline',
+  'repl',
+  'stream',
+  'string_decoder',
+  'timers',
+  'tls',
+  'trace_events',
+  'tty',
+  'url',
+  'util',
+  'vm',
+  'zlib',
+];
+
+for (let i = 0; i < list.length; ++i) {
+  const item = list[i];
+  require(item);
+}

--- a/benchmark/misc/startup.js
+++ b/benchmark/misc/startup.js
@@ -7,7 +7,11 @@ let Worker;  // Lazy loaded in main
 
 const bench = common.createBenchmark(main, {
   dur: [1],
-  script: ['benchmark/fixtures/require-cachable', 'test/fixtures/semicolon'],
+  script: [
+    'benchmark/fixtures/require-builtins',
+    'benchmark/fixtures/require-cachable',
+    'test/fixtures/semicolon',
+  ],
   mode: ['process', 'worker']
 }, {
   flags: ['--expose-internals']


### PR DESCRIPTION
Adding a new benchmark for testing the performance of loading
available public modules.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
