### PR TITLE
benchmark: make the benchmark tool work with Node 10

### DIFF
--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -4,24 +4,24 @@ const child_process = require('child_process');
 const http_benchmarkers = require('./_http-benchmarkers.js');
 
 class Benchmark {
-  // Used to make sure a benchmark only start a timer once
-  #started = false;
-
-  // Indicate that the benchmark ended
-  #ended = false;
-
-  // Holds process.hrtime value
-  #time = [0, 0];
-
-  // Use the file name as the name of the benchmark
-  name = require.main.filename.slice(__dirname.length + 1);
-
-  // Execution arguments i.e. flags used to run the jobs
-  flags = process.env.NODE_BENCHMARK_FLAGS ?
-    process.env.NODE_BENCHMARK_FLAGS.split(/\s+/) :
-    [];
-
   constructor(fn, configs, options = {}) {
+    // Used to make sure a benchmark only start a timer once
+    this._started = false;
+
+    // Indicate that the benchmark ended
+    this._ended = false;
+
+    // Holds process.hrtime value
+    this._time = [0, 0];
+
+    // Use the file name as the name of the benchmark
+    this.name = require.main.filename.slice(__dirname.length + 1);
+
+    // Execution arguments i.e. flags used to run the jobs
+    this.flags = process.env.NODE_BENCHMARK_FLAGS ?
+      process.env.NODE_BENCHMARK_FLAGS.split(/\s+/) :
+      [];
+
     // Parse job-specific configuration from the command line arguments
     const argv = process.argv.slice(2);
     const parsed_args = this._parseArgs(argv, configs, options);
@@ -214,21 +214,21 @@ class Benchmark {
   }
 
   start() {
-    if (this.#started) {
+    if (this._started) {
       throw new Error('Called start more than once in a single benchmark');
     }
-    this.#started = true;
-    this.#time = process.hrtime();
+    this._started = true;
+    this._time = process.hrtime();
   }
 
   end(operations) {
     // Get elapsed time now and do error checking later for accuracy.
-    const elapsed = process.hrtime(this.#time);
+    const elapsed = process.hrtime(this._time);
 
-    if (!this.#started) {
+    if (!this._started) {
       throw new Error('called end without start');
     }
-    if (this.#ended) {
+    if (this._ended) {
       throw new Error('called end multiple times');
     }
     if (typeof operations !== 'number') {
@@ -244,7 +244,7 @@ class Benchmark {
       elapsed[1] = 1;
     }
 
-    this.#ended = true;
+    this._ended = true;
     const time = elapsed[0] + elapsed[1] / 1e9;
     const rate = operations / time;
     this.report(rate, elapsed);


### PR DESCRIPTION
Avoid using class fields in the benchmark tools since they are
not available in Node 10. This can be reverted when Node 10
reaches EOL.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
