### PR TITLE
[v12.x] events: assume an EventEmitter if emitter.on is a function

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -623,7 +623,10 @@ function unwrapListeners(arr) {
 
 function once(emitter, name) {
   return new Promise((resolve, reject) => {
-    if (typeof emitter.addEventListener === 'function') {
+    if (
+      typeof emitter.addEventListener === 'function' &&
+      typeof emitter.on !== 'function'
+    ) {
       // EventTarget does not have `error` event semantics like Node
       // EventEmitters, we do not listen to `error` events here.
       emitter.addEventListener(

--- a/test/parallel/test-events-once.js
+++ b/test/parallel/test-events-once.js
@@ -166,6 +166,27 @@ async function onceWithEventTargetError() {
   strictEqual(Reflect.has(et.events, 'error'), false);
 }
 
+async function assumesEventEmitterIfOnIsAFunction() {
+  const ee = new EventEmitter();
+  ee.addEventListener = () => {};
+
+  const expected = new Error('kaboom');
+  let err;
+  process.nextTick(() => {
+    ee.emit('error', expected);
+  });
+
+  try {
+    await once(ee, 'myevent');
+  } catch (_e) {
+    err = _e;
+  }
+
+  strictEqual(err, expected);
+  strictEqual(ee.listenerCount('error'), 0);
+  strictEqual(ee.listenerCount('myevent'), 0);
+}
+
 Promise.all([
   onceAnEvent(),
   onceAnEventWithTwoArgs(),
@@ -175,4 +196,5 @@ Promise.all([
   onceWithEventTarget(),
   onceWithEventTargetTwoArgs(),
   onceWithEventTargetError(),
+  assumesEventEmitterIfOnIsAFunction(),
 ]).then(common.mustCall());


### PR DESCRIPTION
Assume that the `emitter` argument of `EventEmitter.once()` is an
`EventEmitter` if `emitter.on` is a function.

Refs: https://github.com/nodejs/node/commit/4b3654e923e7c3c2
Refs: https://github.com/websockets/ws/issues/1795

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
