### PR TITLE
quic: delay destroying the readable until 'end'

### DIFF
--- a/lib/internal/quic/core.js
+++ b/lib/internal/quic/core.js
@@ -2673,7 +2673,14 @@ class QuicStream extends Duplex {
 
     // Put the QuicStream into detached mode before calling destroy
     this[kSetHandle]();
-    this.destroy();
+    if (this._readableState.endEmitted)
+      this.destroy();
+    else {
+      // Delay destroying the Readable until the end has been received
+      this.once('end', () => {
+        this.destroy();
+      });
+    }
   }
 
   [kHeaders](headers, kind, push_id) {


### PR DESCRIPTION
Delay destroying the readable until the end has been
received. This fixes the existing unit test that uses
an async iterator which won't read the last chunk
if the Readable has been destroyed.

Refs: https://github.com/nodejs/node/commit/1d8ecd8cfec2a5340028ac8be9f24024c4f9a810
Fixes: https://github.com/nodejs/node/issues/35789

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
