### PR TITLE
assert,repl: enable ecmaVersion 2021 in acorn parser

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -240,7 +240,7 @@ function parseCode(code, offset) {
   // Parse the read code until the correct expression is found.
   do {
     try {
-      node = parseExpressionAt(code, start, { ecmaVersion: 11 });
+      node = parseExpressionAt(code, start, { ecmaVersion: 2021 });
       start = node.end + 1 || start;
       // Find the CallExpression in the tree.
       node = findNodeAround(node, offset, 'CallExpression');

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -240,7 +240,7 @@ function parseCode(code, offset) {
   // Parse the read code until the correct expression is found.
   do {
     try {
-      node = parseExpressionAt(code, start, { ecmaVersion: 2021 });
+      node = parseExpressionAt(code, start, { ecmaVersion: 'latest' });
       start = node.end + 1 || start;
       // Find the CallExpression in the tree.
       node = findNodeAround(node, offset, 'CallExpression');

--- a/lib/internal/repl/await.js
+++ b/lib/internal/repl/await.js
@@ -90,7 +90,7 @@ function processTopLevelAwait(src) {
   const wrappedArray = wrapped.split('');
   let root;
   try {
-    root = parser.parse(wrapped, { ecmaVersion: 2021 });
+    root = parser.parse(wrapped, { ecmaVersion: 'latest' });
   } catch {
     return null;
   }

--- a/lib/internal/repl/await.js
+++ b/lib/internal/repl/await.js
@@ -90,7 +90,7 @@ function processTopLevelAwait(src) {
   const wrappedArray = wrapped.split('');
   let root;
   try {
-    root = parser.parse(wrapped, { ecmaVersion: 11 });
+    root = parser.parse(wrapped, { ecmaVersion: 2021 });
   } catch {
     return null;
   }

--- a/lib/internal/repl/utils.js
+++ b/lib/internal/repl/utils.js
@@ -114,7 +114,7 @@ function isRecoverableError(e, code) {
   // Try to parse the code with acorn.  If the parse fails, ignore the acorn
   // error and return the recoverable status.
   try {
-    RecoverableParser.parse(code, { ecmaVersion: 2021 });
+    RecoverableParser.parse(code, { ecmaVersion: 'latest' });
 
     // Odd case: the underlying JS engine (V8, Chakra) rejected this input
     // but Acorn detected no issue.  Presume that additional text won't

--- a/lib/internal/repl/utils.js
+++ b/lib/internal/repl/utils.js
@@ -114,7 +114,7 @@ function isRecoverableError(e, code) {
   // Try to parse the code with acorn.  If the parse fails, ignore the acorn
   // error and return the recoverable status.
   try {
-    RecoverableParser.parse(code, { ecmaVersion: 11 });
+    RecoverableParser.parse(code, { ecmaVersion: 2021 });
 
     // Odd case: the underlying JS engine (V8, Chakra) rejected this input
     // but Acorn detected no issue.  Presume that additional text won't


### PR DESCRIPTION
This adds support for the new logical assignment operators.
