### PR TITLE
tls: handle ECONNRESET on the underlying socket

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -1047,17 +1047,21 @@ function onSocketKeylog(line) {
   this._tlsOptions.server.emit('keylog', line, this);
 }
 
-function onSocketClose(err) {
-  // Closed because of error - no need to emit it twice
-  if (err)
-    return;
-
+function onSocketError() {
   // Emit ECONNRESET
   if (!this._controlReleased && !this[kErrorEmitted]) {
     this[kErrorEmitted] = true;
     const connReset = connResetException('socket hang up');
     this._tlsOptions.server.emit('tlsClientError', connReset, this);
   }
+}
+
+function onSocketClose(err) {
+  // Closed because of error - no need to emit it twice
+  if (err)
+    return;
+
+  onSocketError.call(this);
 }
 
 function tlsConnectionListener(rawSocket) {
@@ -1084,6 +1088,8 @@ function tlsConnectionListener(rawSocket) {
 
   socket[kErrorEmitted] = false;
   socket.on('close', onSocketClose);
+  // Handle ECONNRESET
+  socket.on('error', onSocketError);
   socket.on('_tlsError', onSocketTLSError);
 }
 


### PR DESCRIPTION
Add an error handler to the underlying TLSWrap socket
mostly for the occasional ECONNRESET that a Linux
kernel might throw under heavy load
Send a tlsClientError event in this case instead of an
uncatcheable socket error

Fixes: https://github.com/nodejs/node/issues/35824

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

Triggering this bug requires continuous heavy networking load, I am not sure if I should include a unit test

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
