### PR TITLE
zlib: test BrotliCompress throws invalid arg value

### DIFF
--- a/test/parallel/test-zlib-invalid-arg-value-brotli-compress.js
+++ b/test/parallel/test-zlib-invalid-arg-value-brotli-compress.js
@@ -1,0 +1,20 @@
+'use strict';
+
+require('../common');
+
+// This test ensures that the BrotliCompress function throws
+// ERR_INVALID_ARG_TYPE when the values of the `params` key-value object are
+// neither numbers nor booleans.
+
+const assert = require('assert');
+const { BrotliCompress, constants } = require('zlib');
+
+const opts = {
+  params: {
+    [constants.BROTLI_PARAM_MODE]: 'lol'
+  }
+};
+
+assert.throws(() => BrotliCompress(opts), {
+  code: 'ERR_INVALID_ARG_TYPE'
+});


### PR DESCRIPTION
Improving the coverage for this:
https://github.com/nodejs/node/blob/0ca861745ad47f1b02dbb4ea30b0d7d4328f0719/lib/zlib.js#L807-L809
First time I'm writing a test! :smiley:
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
