### PR TITLE
lib: use primordials when calling methods of Error global object

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -22,6 +22,7 @@
 
 const {
   Error,
+  ErrorCaptureStackTrace,
   ObjectAssign,
   ObjectIs,
   ObjectKeys,
@@ -271,8 +272,7 @@ function getErrMessage(message, fn) {
   // We only need the stack trace. To minimize the overhead use an object
   // instead of an error.
   const err = {};
-  // eslint-disable-next-line no-restricted-syntax
-  Error.captureStackTrace(err, fn);
+  ErrorCaptureStackTrace(err, fn);
   Error.stackTraceLimit = tmpLimit;
 
   overrideStackTrace.set(err, (_, stack) => stack);
@@ -791,7 +791,7 @@ function hasMatchingError(actual, expected) {
   if (expected.prototype !== undefined && actual instanceof expected) {
     return true;
   }
-  if (Error.isPrototypeOf(expected)) {
+  if (ObjectPrototypeIsPrototypeOf(Error, expected)) {
     return false;
   }
   return expected.call({}, actual) === true;

--- a/lib/events.js
+++ b/lib/events.js
@@ -24,6 +24,7 @@
 const {
   Boolean,
   Error,
+  ErrorCaptureStackTrace,
   MathMin,
   NumberIsNaN,
   ObjectCreate,
@@ -291,8 +292,7 @@ EventEmitter.prototype.emit = function emit(type, ...args) {
     if (er instanceof Error) {
       try {
         const capture = {};
-        // eslint-disable-next-line no-restricted-syntax
-        Error.captureStackTrace(capture, EventEmitter.prototype.emit);
+        ErrorCaptureStackTrace(capture, EventEmitter.prototype.emit);
         ObjectDefineProperty(er, kEnhanceStackBeforeInspector, {
           value: enhanceStackTrace.bind(this, er, capture),
           configurable: true

--- a/lib/internal/assert/assertion_error.js
+++ b/lib/internal/assert/assertion_error.js
@@ -2,6 +2,7 @@
 
 const {
   Error,
+  ErrorCaptureStackTrace,
   MathMax,
   ObjectCreate,
   ObjectDefineProperty,
@@ -444,8 +445,7 @@ class AssertionError extends Error {
       this.expected = expected;
       this.operator = operator;
     }
-    // eslint-disable-next-line no-restricted-syntax
-    Error.captureStackTrace(this, stackStartFn || stackStartFunction);
+    ErrorCaptureStackTrace(this, stackStartFn || stackStartFunction);
     // Create error message including the error code in the name.
     this.stack;
     // Reset the name.

--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -2,7 +2,6 @@
 
 const {
   ArrayPrototypeUnshift,
-  Error,
   ErrorCaptureStackTrace,
   FunctionPrototypeBind,
   ObjectPrototypeHasOwnProperty,

--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -3,6 +3,7 @@
 const {
   ArrayPrototypeUnshift,
   Error,
+  ErrorCaptureStackTrace,
   FunctionPrototypeBind,
   ObjectPrototypeHasOwnProperty,
   ObjectDefineProperty,
@@ -159,8 +160,7 @@ function fatalError(e) {
     process._rawDebug(e.stack);
   } else {
     const o = { message: e };
-    // eslint-disable-next-line no-restricted-syntax
-    Error.captureStackTrace(o, fatalError);
+    ErrorCaptureStackTrace(o, fatalError);
     process._rawDebug(o.stack);
   }
 

--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -7,7 +7,6 @@ const {
   ArrayFrom,
   ArrayIsArray,
   Boolean,
-  Error,
   ErrorCaptureStackTrace,
   Map,
   MathFloor,

--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -8,6 +8,7 @@ const {
   ArrayIsArray,
   Boolean,
   Error,
+  ErrorCaptureStackTrace,
   Map,
   MathFloor,
   Number,
@@ -395,8 +396,7 @@ const consoleMethods = {
       name: 'Trace',
       message: this[kFormatForStderr](args)
     };
-    // eslint-disable-next-line no-restricted-syntax
-    Error.captureStackTrace(err, trace);
+    ErrorCaptureStackTrace(err, trace);
     this.error(err.stack);
   },
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -13,6 +13,7 @@
 const {
   ArrayIsArray,
   Error,
+  ErrorCaptureStackTrace,
   ErrorPrototypeToString,
   JSONStringify,
   Map,
@@ -306,8 +307,7 @@ function hideStackFrames(fn) {
 function addCodeToName(err, name, code) {
   // Set the stack
   if (excludedStackFn !== undefined) {
-    // eslint-disable-next-line no-restricted-syntax
-    Error.captureStackTrace(err, excludedStackFn);
+    ErrorCaptureStackTrace(err, excludedStackFn);
   }
   // Add the error code to the name to include it in the stack trace.
   err.name = `${name} [${code}]`;
@@ -443,9 +443,7 @@ function uvException(ctx) {
   if (dest) {
     err.dest = dest;
   }
-
-  // eslint-disable-next-line no-restricted-syntax
-  Error.captureStackTrace(err, excludedStackFn || uvException);
+  ErrorCaptureStackTrace(err, excludedStackFn || uvException);
   return err;
 }
 
@@ -486,9 +484,7 @@ function uvExceptionWithHostPort(err, syscall, address, port) {
   if (port) {
     ex.port = port;
   }
-
-  // eslint-disable-next-line no-restricted-syntax
-  Error.captureStackTrace(ex, excludedStackFn || uvExceptionWithHostPort);
+  ErrorCaptureStackTrace(ex, excludedStackFn || uvExceptionWithHostPort);
   return ex;
 }
 
@@ -515,9 +511,7 @@ function errnoException(err, syscall, original) {
   ex.errno = err;
   ex.code = code;
   ex.syscall = syscall;
-
-  // eslint-disable-next-line no-restricted-syntax
-  Error.captureStackTrace(ex, excludedStackFn || errnoException);
+  ErrorCaptureStackTrace(ex, excludedStackFn || errnoException);
   return ex;
 }
 
@@ -564,9 +558,7 @@ function exceptionWithHostPort(err, syscall, address, port, additional) {
   if (port) {
     ex.port = port;
   }
-
-  // eslint-disable-next-line no-restricted-syntax
-  Error.captureStackTrace(ex, excludedStackFn || exceptionWithHostPort);
+  ErrorCaptureStackTrace(ex, excludedStackFn || exceptionWithHostPort);
   return ex;
 }
 
@@ -610,9 +602,7 @@ function dnsException(code, syscall, hostname) {
   if (hostname) {
     ex.hostname = hostname;
   }
-
-  // eslint-disable-next-line no-restricted-syntax
-  Error.captureStackTrace(ex, excludedStackFn || dnsException);
+  ErrorCaptureStackTrace(ex, excludedStackFn || dnsException);
   return ex;
 }
 

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -5,6 +5,7 @@ const {
   BigInt,
   DateNow,
   Error,
+  ErrorCaptureStackTrace,
   ObjectPrototypeHasOwnProperty,
   Number,
   NumberIsFinite,
@@ -302,16 +303,14 @@ function getOptions(options, defaultOptions) {
 function handleErrorFromBinding(ctx) {
   if (ctx.errno !== undefined) {  // libuv error numbers
     const err = uvException(ctx);
-    // eslint-disable-next-line no-restricted-syntax
-    Error.captureStackTrace(err, handleErrorFromBinding);
+    ErrorCaptureStackTrace(err, handleErrorFromBinding);
     throw err;
   }
   if (ctx.error !== undefined) {  // Errors created in C++ land.
     // TODO(joyeecheung): currently, ctx.error are encoding errors
     // usually caused by memory problems. We need to figure out proper error
     // code(s) for this.
-    // eslint-disable-next-line no-restricted-syntax
-    Error.captureStackTrace(ctx.error, handleErrorFromBinding);
+    ErrorCaptureStackTrace(ctx.error, handleErrorFromBinding);
     throw ctx.error;
   }
 }

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -4,7 +4,6 @@ const {
   ArrayIsArray,
   BigInt,
   DateNow,
-  Error,
   ErrorCaptureStackTrace,
   ObjectPrototypeHasOwnProperty,
   Number,

--- a/lib/internal/process/warning.js
+++ b/lib/internal/process/warning.js
@@ -3,6 +3,7 @@
 const {
   ArrayIsArray,
   Error,
+  ErrorCaptureStackTrace,
   String,
 } = primordials;
 
@@ -162,8 +163,7 @@ function createWarningObject(warning, type, code, ctor, detail) {
   warning.name = String(type || 'Warning');
   if (code !== undefined) warning.code = code;
   if (detail !== undefined) warning.detail = detail;
-  // eslint-disable-next-line no-restricted-syntax
-  Error.captureStackTrace(warning, ctor || process.emitWarning);
+  ErrorCaptureStackTrace(warning, ctor || process.emitWarning);
   return warning;
 }
 


### PR DESCRIPTION
This is to unsure that code using those methods won't crash if the
methods are deleted in userland.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
