### PR TITLE
timers: introduce setInterval async iterator

### DIFF
--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -363,6 +363,19 @@ added: v15.0.0
   * `signal` {AbortSignal} An optional `AbortSignal` that can be used to
     cancel the scheduled `Immediate`.
 
+### `timersPromises.setInterval([delay[, value[, options]]])`
+
+* `delay` {number} The number of milliseconds to wait between iterations.
+   **Default**: `1`.
+* `value` {any} A value with which the iterator returns.
+* `options` {Object}
+  * `ref` {boolean} Set to `false` to indicate that the scheduled `Timeout`
+    between iterations should not require the Node.js event loop to
+    remain active.
+    **Default**: `true`.
+  * `signal` {AbortSignal} An optional `AbortSignal` that can be used to
+    cancel the scheduled `Timeout` between operations.
+
 [Event Loop]: https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick/#setimmediate-vs-settimeout
 [`AbortController`]: globals.md#globals_class_abortcontroller
 [`TypeError`]: errors.md#errors_class_typeerror

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -215,15 +215,6 @@ function setInterval(callback, repeat, arg1, arg2, arg3) {
   return timeout;
 }
 
-ObjectDefineProperty(setInterval, customPromisify, {
-  enumerable: true,
-  get() {
-    if (!timersPromises)
-      timersPromises = require('timers/promises');
-    return timersPromises.setInterval;
-  }
-});
-
 function clearInterval(timer) {
   // clearTimeout and clearInterval can be used to clear timers created from
   // both setTimeout and setInterval, as specified by HTML Living Standard:

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -215,6 +215,15 @@ function setInterval(callback, repeat, arg1, arg2, arg3) {
   return timeout;
 }
 
+ObjectDefineProperty(setInterval, customPromisify, {
+  enumerable: true,
+  get() {
+    if (!timersPromises)
+      timersPromises = require('timers/promises');
+    return timersPromises.setInterval;
+  }
+});
+
 function clearInterval(timer) {
   // clearTimeout and clearInterval can be used to clear timers created from
   // both setTimeout and setInterval, as specified by HTML Living Standard:

--- a/lib/timers/promises.js
+++ b/lib/timers/promises.js
@@ -17,7 +17,7 @@ const {
 
 const {
   AbortError,
-  codes: { ERR_INVALID_ARG_TYPE }
+  codes: { ERR_INVALID_ARG_TYPE, ERR_INVALID_ARG_VALUE }
 } = require('internal/errors');
 
 function cancelListenerHandler(clear, reject) {
@@ -135,7 +135,17 @@ function setInterval(after, value, options = {}) {
       'Object',
       options);
   }
-  const { signal, ref = true } = options;
+  const {
+    signal,
+    ref = true,
+    // Defers start of timers until the first iteration
+    wait = false,
+    // This has each invocation of iterator.next set up a new timeout
+    timeout: asTimeout = false,
+    // Skips intervals that are missed
+    skip = false
+    // Clears entire queue of callbacks when skip = true and the callbacks well missed the timeout
+  } = options;
   if (signal !== undefined &&
     (signal === null ||
       typeof signal !== 'object' ||
@@ -153,78 +163,128 @@ function setInterval(after, value, options = {}) {
   }
   return {
     [Symbol.asyncIterator]() {
+      // asTimeout can't skip as they always have intervals between each iteration
+      const resolveEarlyEnabled = !asTimeout && skip;
       let timeout,
-        deferred;
-      let active = true;
+        callbacks = [],
+        active = true,
+        missed = 0;
+
+      setIntervalCycle();
+
       const iterator = {
-        next() {
+        async next() {
           if (!active) {
-            return PromiseResolve({
+            return {
               done: true,
               value: undefined
-            });
+            };
           }
-          // TODO(@jasnell): If a decision is made that this cannot
-          // be backported to 12.x, then this can be converted to
-          // use optional chaining to simplify the check.
+          // TODO(@jasnell): If a decision is made that this cannot be backported
+          // to 12.x, then this can be converted to use optional chaining to
+          // simplify the check.
           if (signal && signal.aborted) {
-            return PromiseReject(
-              lazyDOMException('The operation was aborted', 'AbortError')
-            );
+            return PromiseReject(new AbortError());
           }
-          const promise = new Promise(
+          return new Promise(
             (resolve, reject) => {
-              deferred = { resolve, reject };
+              callbacks.push({ resolve, reject });
+              if (missed > 0) {
+                resolveNext();
+              }
+              setIntervalCycle();
             }
           );
-          timeout = new Timeout((value) => {
-            if (deferred) {
-              deferred.resolve({
-                done: false,
-                value
-              });
-              deferred = undefined;
-            }
-          }, after, args, false, true);
-          if (!ref) timeout.unref();
-          insert(timeout, timeout._idleTimeout);
-          return promise;
         },
-        return() {
+        async return() {
           active = false;
-          if (timeout) {
-            // eslint-disable-next-line no-undef
-            clearTimeout(timeout);
-          }
-          if (deferred) {
-            deferred.resolve({
-              done: true,
-              value: undefined
-            });
-            deferred = undefined;
-          }
-          if (signal) {
-            signal.removeEventListener('abort', onAbort);
-          }
-          return PromiseResolve({
+          clear();
+          resolveAll({
             done: true,
             value: undefined
           });
+          if (signal) {
+            signal.removeEventListener('abort', oncancel);
+          }
+          return {
+            done: true,
+            value: undefined
+          };
         }
       };
       if (signal) {
-        signal.addEventListener('abort', onAbort, { once: true });
+        signal.addEventListener('abort', oncancel, { once: true });
       }
       return iterator;
 
-      function onAbort() {
+      function setIntervalCycle() {
+        if (!active) {
+          return;
+        }
+        if (timeout) {
+          return;
+        }
+        // Wait and asTimeout both imply a callback is required before setting up a timeout
+        if (!callbacks.length && (wait || asTimeout)) {
+          return;
+        }
+        missed = 0;
+        const currentTimeout = timeout = new Timeout(() => {
+          if (asTimeout && currentTimeout === timeout) {
+            // No need to clear here as we set to not repeat for asTimeout
+            timeout = undefined;
+          }
+          resolveNext();
+        }, after, undefined, !asTimeout, true);
+        if (!ref) timeout.unref();
+        insert(timeout, timeout._idleTimeout);
+      }
+
+      function resolveNext() {
+        if (!callbacks.length) {
+          if (resolveEarlyEnabled) {
+            missed += 1;
+          }
+          return;
+        }
+        const deferred = callbacks.shift();
         if (deferred) {
-          deferred.reject(
-            lazyDOMException('The operation was aborted', 'AbortError')
-          );
-          deferred = undefined;
+          const { resolve } = deferred;
+          resolve({
+            done: false,
+            value
+          });
+          missed -= 1;
+        }
+        if (missed > 0 && callbacks.length) {
+          // Loop till we have completed each missed interval that we have a callback for
+          resolveNext();
         }
       }
+
+      function resolveAll(value) {
+        callbacks.forEach(({ resolve }) => resolve(value));
+        callbacks = [];
+      }
+
+      function rejectAll(error) {
+        callbacks.forEach(({ reject }) => reject(error));
+        callbacks = [];
+      }
+
+      function clear() {
+        if (timeout) {
+          // eslint-disable-next-line no-undef
+          clearTimeout(timeout);
+          timeout = undefined;
+        }
+      }
+
+      function oncancel() {
+        clear();
+        rejectAll(new AbortError());
+      }
+
     }
   };
 }

--- a/lib/timers/promises.js
+++ b/lib/timers/promises.js
@@ -1,9 +1,11 @@
 'use strict';
 
 const {
+  Symbol,
   FunctionPrototypeBind,
   Promise,
   PromisePrototypeFinally,
+  PromiseResolve,
   PromiseReject,
 } = primordials;
 
@@ -125,7 +127,110 @@ function setImmediate(value, options = {}) {
       () => signal.removeEventListener('abort', oncancel)) : ret;
 }
 
+function setInterval(after, value, options = {}) {
+  const args = value !== undefined ? [value] : value;
+  if (options == null || typeof options !== 'object') {
+    throw new ERR_INVALID_ARG_TYPE(
+      'options',
+      'Object',
+      options);
+  }
+  const { signal, ref = true } = options;
+  if (signal !== undefined &&
+    (signal === null ||
+      typeof signal !== 'object' ||
+      !('aborted' in signal))) {
+    throw new ERR_INVALID_ARG_TYPE(
+      'options.signal',
+      'AbortSignal',
+      signal);
+  }
+  if (typeof ref !== 'boolean') {
+    throw new ERR_INVALID_ARG_TYPE(
+      'options.ref',
+      'boolean',
+      ref);
+  }
+  return {
+    [Symbol.asyncIterator]() {
+      let timeout,
+        deferred;
+      let active = true;
+      const iterator = {
+        next() {
+          if (!active) {
+            return PromiseResolve({
+              done: true,
+              value: undefined
+            });
+          }
+          // TODO(@jasnell): If a decision is made that this cannot
+          // be backported to 12.x, then this can be converted to
+          // use optional chaining to simplify the check.
+          if (signal && signal.aborted) {
+            return PromiseReject(
+              lazyDOMException('The operation was aborted', 'AbortError')
+            );
+          }
+          const promise = new Promise(
+            (resolve, reject) => {
+              deferred = { resolve, reject };
+            }
+          );
+          timeout = new Timeout((value) => {
+            if (deferred) {
+              deferred.resolve({
+                done: false,
+                value
+              });
+              deferred = undefined;
+            }
+          }, after, args, false, true);
+          if (!ref) timeout.unref();
+          insert(timeout, timeout._idleTimeout);
+          return promise;
+        },
+        return() {
+          active = false;
+          if (timeout) {
+            // eslint-disable-next-line no-undef
+            clearTimeout(timeout);
+          }
+          if (deferred) {
+            deferred.resolve({
+              done: true,
+              value: undefined
+            });
+            deferred = undefined;
+          }
+          if (signal) {
+            signal.removeEventListener('abort', onAbort);
+          }
+          return PromiseResolve({
+            done: true,
+            value: undefined
+          });
+        }
+      };
+      if (signal) {
+        signal.addEventListener('abort', onAbort, { once: true });
+      }
+      return iterator;
+
+      function onAbort() {
+        if (deferred) {
+          deferred.reject(
+            lazyDOMException('The operation was aborted', 'AbortError')
+          );
+          deferred = undefined;
+        }
+      }
+    }
+  };
+}
+
 module.exports = {
   setTimeout,
   setImmediate,
+  setInterval,
 };

--- a/test/parallel/test-timers-promisified.js
+++ b/test/parallel/test-timers-promisified.js
@@ -261,7 +261,7 @@ process.on('multipleResolves', common.mustNotCall());
   const mainInterval = 5;
   const loopInterval = mainInterval * 1.5;
 
-  const interval = setInterval(mainInterval, input, { signal });
+  const interval = setInterval(mainInterval, input, { signal, timeout: true });
 
   async function runInterval(fn) {
     const times = [];
@@ -278,7 +278,7 @@ process.on('multipleResolves', common.mustNotCall());
   const timeoutLoop = runInterval(() => setTimeout(loopInterval));
 
   // Let it loop 5 times, then abort before the next
-  setTimeout(Math.floor(loopInterval * 5.5)).then(common.mustCall(() => {
+  setTimeout(Math.floor(loopInterval * 5.5), undefined, { timeout: true }).then(common.mustCall(() => {
     ac.abort();
   }));
 


### PR DESCRIPTION
Utilises Symbol.asyncIterator to provide an iterator compatible with `for await`

```
const {
  setInterval
} = require('timers/promises');

const ac = new AbortController()
const signal = ac.signal

setTimeout(() => ac.abort(), 500)

for await (const value of setInterval(interval, null, { ref: false, signal })) {

}
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
