### PR TITLE
http: onFinish will not be triggered again when finished

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -808,7 +808,15 @@ OutgoingMessage.prototype.end = function end(chunk, encoding, callback) {
     this.socket.cork();
   }
 
-  if (this.finished) {
+  if (chunk) {
+    if (this.finished) {
+      onError(this,
+              new ERR_STREAM_WRITE_AFTER_END(),
+              typeof callback !== 'function' ? nop : callback);
+      return this;
+    }
+    write_(this, chunk, encoding, null, true);
+  } else if (this.finished) {
     if (typeof callback === 'function') {
       if (!this.writableFinished) {
         this.on('finish', callback);
@@ -817,8 +825,6 @@ OutgoingMessage.prototype.end = function end(chunk, encoding, callback) {
       }
     }
     return this;
-  } else if (chunk) {
-    write_(this, chunk, encoding, null, true);
   } else if (!this._header) {
     this._contentLength = 0;
     this._implicitHeader();

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -685,10 +685,10 @@ function onError(msg, err, callback) {
 }
 
 function emitErrorNt(msg, err, callback) {
-  callback(err);
   if (typeof msg.emit === 'function' && !msg._closed) {
     msg.emit('error', err);
   }
+  callback(err);
 }
 
 function write_(msg, chunk, encoding, callback, fromEnd) {

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -685,10 +685,10 @@ function onError(msg, err, callback) {
 }
 
 function emitErrorNt(msg, err, callback) {
+  callback(err);
   if (typeof msg.emit === 'function' && !msg._closed) {
     msg.emit('error', err);
   }
-  callback(err);
 }
 
 function write_(msg, chunk, encoding, callback, fromEnd) {

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -808,9 +808,7 @@ OutgoingMessage.prototype.end = function end(chunk, encoding, callback) {
     this.socket.cork();
   }
 
-  if (chunk) {
-    write_(this, chunk, encoding, null, true);
-  } else if (this.finished) {
+  if (this.finished) {
     if (typeof callback === 'function') {
       if (!this.writableFinished) {
         this.on('finish', callback);
@@ -819,6 +817,8 @@ OutgoingMessage.prototype.end = function end(chunk, encoding, callback) {
       }
     }
     return this;
+  } else if (chunk) {
+    write_(this, chunk, encoding, null, true);
   } else if (!this._header) {
     this._contentLength = 0;
     this._implicitHeader();

--- a/test/parallel/test-http-outgoing-end-multiple.js
+++ b/test/parallel/test-http-outgoing-end-multiple.js
@@ -3,9 +3,17 @@ const common = require('../common');
 const assert = require('assert');
 const http = require('http');
 
+const onWriteAfterEndError = common.mustCall((err) => {
+  assert.strictEqual(err.code, 'ERR_STREAM_WRITE_AFTER_END');
+}, 2);
+
 const server = http.createServer(common.mustCall(function(req, res) {
   res.end('testing ended state', common.mustCall());
-  res.end(common.mustCall());
+  res.end(common.mustCall((err) => {
+    assert.strictEqual(err.code, 'ERR_STREAM_ALREADY_FINISHED');
+  }));
+  res.end('end', onWriteAfterEndError);
+  res.on('error', onWriteAfterEndError);
   res.on('finish', common.mustCall(() => {
     res.end(common.mustCall((err) => {
       assert.strictEqual(err.code, 'ERR_STREAM_ALREADY_FINISHED');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

When the `.end()` is called with the payload again after the end, directly return and pass the `ERR_STREAM_WRITE_AFTER_END` error to the `callback` and `error` event.

Fixes: https://github.com/nodejs/node/issues/35833

/cc @ronag @kaizhu256

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
