### PR TITLE
events: support emit on nodeeventtarget

### DIFF
--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -172,6 +172,14 @@ ObjectDefineProperty(Event.prototype, SymbolToStringTag, {
   value: 'Event',
 });
 
+class NodeCustomEvent extends Event {
+  constructor(type, options) {
+    super(type, options);
+    if (options && options.detail) {
+      this.detail = options.detail;
+    }
+  }
+}
 // The listeners for an EventTarget are maintained as a linked list.
 // Unfortunately, the way EventTarget is defined, listeners are accounted
 // using the tuple [handler,capture], and even if we don't actually make
@@ -377,6 +385,9 @@ class EventTarget {
       event[kTarget] = undefined;
   }
 
+  [kCreateEvent](nodeValue, type) {
+    return new NodeCustomEvent(type, { detail: nodeValue });
+  }
   [customInspectSymbol](depth, options) {
     const name = this.constructor.name;
     if (depth < 0)
@@ -474,6 +485,14 @@ class NodeEventTarget extends EventTarget {
     this.addEventListener(type, listener, { [kIsNodeStyleListener]: true });
     return this;
   }
+  emit(type, arg) {
+    if (typeof type !== 'string') {
+      throw new ERR_INVALID_ARG_TYPE('type', 'string', type);
+    }
+    const hadListeners = this.listenerCount(type) > 0;
+    this[kHybridDispatch](arg, type);
+    return hadListeners;
+  }
 
   once(type, listener) {
     this.addEventListener(type, listener,
@@ -502,6 +521,7 @@ ObjectDefineProperties(NodeEventTarget.prototype, {
   on: { enumerable: true },
   addListener: { enumerable: true },
   once: { enumerable: true },
+  emit: { enumerable: true },
   removeAllListeners: { enumerable: true },
 });
 

--- a/lib/internal/worker/io.js
+++ b/lib/internal/worker/io.js
@@ -127,11 +127,15 @@ ObjectDefineProperties(MessageEvent.prototype, {
   },
 });
 
+const originalCreateEvent = EventTarget.prototype[kCreateEvent];
 ObjectDefineProperty(
   MessagePort.prototype,
   kCreateEvent,
   {
     value: function(data, type) {
+      if (type !== 'message' && type !== 'messageerror') {
+        return originalCreateEvent.call(this, data, type);
+      }
       return new MessageEvent(type, { data });
     },
     configurable: false,

--- a/test/parallel/test-nodeeventtarget.js
+++ b/test/parallel/test-nodeeventtarget.js
@@ -11,6 +11,7 @@ const {
   deepStrictEqual,
   ok,
   strictEqual,
+  throws,
 } = require('assert');
 
 const { on } = require('events');
@@ -144,6 +145,27 @@ const { on } = require('events');
   target.setMaxListeners(1);
   target.on('foo', () => {});
   target.on('foo', () => {});
+}
+{
+  // Test NodeEventTarget emit
+  const emitter = new NodeEventTarget();
+  emitter.addEventListener('foo', common.mustCall((e) => {
+    strictEqual(e.type, 'foo');
+    strictEqual(e.detail, 'bar');
+    ok(e instanceof Event);
+  }), { once: true });
+  emitter.once('foo', common.mustCall((e, droppedAdditionalArgument) => {
+    strictEqual(e, 'bar');
+    strictEqual(droppedAdditionalArgument, undefined);
+  }));
+  emitter.emit('foo', 'bar', 'baz');
+}
+{
+  // Test NodeEventTarget emit unsupported usage
+  const emitter = new NodeEventTarget();
+  throws(() => {
+    emitter.emit();
+  }, /ERR_INVALID_ARG_TYPE/);
 }
 
 (async () => {

--- a/test/parallel/test-worker-message-port.js
+++ b/test/parallel/test-worker-message-port.js
@@ -16,7 +16,18 @@ const { MessageChannel, MessagePort } = require('worker_threads');
     port2.close(common.mustCall());
   }));
 }
-
+{
+  // Test emitting non-message events on a port
+  const { port2 } = new MessageChannel();
+  port2.addEventListener('foo', common.mustCall((received) => {
+    assert.strictEqual(received.type, 'foo');
+    assert.strictEqual(received.detail, 'bar');
+  }));
+  port2.on('foo', common.mustCall((received) => {
+    assert.strictEqual(received, 'bar');
+  }));
+  port2.emit('foo', 'bar');
+}
 {
   const { port1, port2 } = new MessageChannel();
 


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

