### PR TITLE
crypto: rename check to createJob

### DIFF
--- a/lib/internal/crypto/keygen.js
+++ b/lib/internal/crypto/keygen.js
@@ -71,7 +71,7 @@ function generateKeyPair(type, options, callback) {
   if (typeof callback !== 'function')
     throw new ERR_INVALID_CALLBACK(callback);
 
-  const job = check(kCryptoJobAsync, type, options);
+  const job = createJob(kCryptoJobAsync, type, options);
 
   job.ondone = (error, result) => {
     if (error) return FunctionPrototypeCall(callback, job, error);
@@ -91,7 +91,7 @@ ObjectDefineProperty(generateKeyPair, customPromisifyArgs, {
 });
 
 function generateKeyPairSync(type, options) {
-  return handleError(check(kCryptoJobSync, type, options).run());
+  return handleError(createJob(kCryptoJobSync, type, options).run());
 }
 
 function handleError(ret) {
@@ -152,7 +152,7 @@ function parseKeyEncoding(keyType, options = {}) {
   ];
 }
 
-function check(mode, type, options) {
+function createJob(mode, type, options) {
   validateString(type, 'type');
 
   const encoding = parseKeyEncoding(type, options);


### PR DESCRIPTION
This commit renames the check function to createJob which seems to be
more descriptive of what this function does.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
