### PR TITLE
src: remove ERR prefix in crypto status enums

### DIFF
--- a/src/crypto/crypto_aes.cc
+++ b/src/crypto/crypto_aes.cc
@@ -31,7 +31,7 @@ namespace {
 // Implements general AES encryption and decryption for CBC
 // The key_data must be a secret key.
 // On success, this function sets out to a new AllocatedBuffer
-// instance containing the results and returns WebCryptoCipherStatus::ERR_OK.
+// instance containing the results and returns WebCryptoCipherStatus::OK.
 WebCryptoCipherStatus AES_Cipher(
     Environment* env,
     KeyObjectData* key_data,
@@ -59,7 +59,7 @@ WebCryptoCipherStatus AES_Cipher(
           nullptr,
           encrypt)) {
     // Cipher init failed
-    return WebCryptoCipherStatus::ERR_FAILED;
+    return WebCryptoCipherStatus::FAILED;
   }
 
   if (mode == EVP_CIPH_GCM_MODE && !EVP_CIPHER_CTX_ctrl(
@@ -67,7 +67,7 @@ WebCryptoCipherStatus AES_Cipher(
         EVP_CTRL_AEAD_SET_IVLEN,
         params.iv.size(),
         nullptr)) {
-    return WebCryptoCipherStatus::ERR_FAILED;
+    return WebCryptoCipherStatus::FAILED;
   }
 
   if (!EVP_CIPHER_CTX_set_key_length(
@@ -80,7 +80,7 @@ WebCryptoCipherStatus AES_Cipher(
           reinterpret_cast<const unsigned char*>(key_data->GetSymmetricKey()),
           params.iv.data<unsigned char>(),
           encrypt)) {
-    return WebCryptoCipherStatus::ERR_FAILED;
+    return WebCryptoCipherStatus::FAILED;
   }
 
   size_t tag_len = 0;
@@ -95,7 +95,7 @@ WebCryptoCipherStatus AES_Cipher(
                 EVP_CTRL_AEAD_SET_TAG,
                 params.tag.size(),
                 const_cast<char*>(params.tag.get()))) {
-          return WebCryptoCipherStatus::ERR_FAILED;
+          return WebCryptoCipherStatus::FAILED;
         }
         break;
       case kWebCryptoCipherEncrypt:
@@ -123,7 +123,7 @@ WebCryptoCipherStatus AES_Cipher(
             &out_len,
             params.additional_data.data<unsigned char>(),
             params.additional_data.size())) {
-    return WebCryptoCipherStatus::ERR_FAILED;
+    return WebCryptoCipherStatus::FAILED;
   }
 
   char* data = MallocOpenSSL<char>(buf_len);
@@ -136,7 +136,7 @@ WebCryptoCipherStatus AES_Cipher(
           &out_len,
           in.data<unsigned char>(),
           in.size())) {
-    return WebCryptoCipherStatus::ERR_FAILED;
+    return WebCryptoCipherStatus::FAILED;
   }
 
   total += out_len;
@@ -144,7 +144,7 @@ WebCryptoCipherStatus AES_Cipher(
   ptr += out_len;
   out_len = EVP_CIPHER_CTX_block_size(ctx.get());
   if (!EVP_CipherFinal_ex(ctx.get(), ptr, &out_len)) {
-    return WebCryptoCipherStatus::ERR_FAILED;
+    return WebCryptoCipherStatus::FAILED;
   }
   total += out_len;
 
@@ -153,7 +153,7 @@ WebCryptoCipherStatus AES_Cipher(
   if (cipher_mode == kWebCryptoCipherEncrypt && mode == EVP_CIPH_GCM_MODE) {
     data += out_len;
     if (!EVP_CIPHER_CTX_ctrl(ctx.get(), EVP_CTRL_AEAD_GET_TAG, tag_len, ptr))
-      return WebCryptoCipherStatus::ERR_FAILED;
+      return WebCryptoCipherStatus::FAILED;
     total += tag_len;
   }
 
@@ -161,7 +161,7 @@ WebCryptoCipherStatus AES_Cipher(
   buf.Resize(total);
   *out = std::move(buf);
 
-  return WebCryptoCipherStatus::ERR_OK;
+  return WebCryptoCipherStatus::OK;
 }
 
 // The AES_CTR implementation here takes it's inspiration from the chromium
@@ -232,7 +232,7 @@ WebCryptoCipherStatus AES_CTR_Cipher2(
           counter,
           encrypt)) {
     // Cipher init failed
-    return WebCryptoCipherStatus::ERR_FAILED;
+    return WebCryptoCipherStatus::FAILED;
   }
 
   int out_len = 0;
@@ -243,17 +243,17 @@ WebCryptoCipherStatus AES_CTR_Cipher2(
           &out_len,
           in.data<unsigned char>(),
           in.size())) {
-    return WebCryptoCipherStatus::ERR_FAILED;
+    return WebCryptoCipherStatus::FAILED;
   }
 
   if (!EVP_CipherFinal_ex(ctx.get(), out + out_len, &final_len))
-    return WebCryptoCipherStatus::ERR_FAILED;
+    return WebCryptoCipherStatus::FAILED;
 
   out_len += final_len;
   if (static_cast<unsigned>(out_len) != in.size())
-    return WebCryptoCipherStatus::ERR_FAILED;
+    return WebCryptoCipherStatus::FAILED;
 
-  return WebCryptoCipherStatus::ERR_OK;
+  return WebCryptoCipherStatus::OK;
 }
 
 WebCryptoCipherStatus AES_CTR_Cipher(
@@ -265,25 +265,25 @@ WebCryptoCipherStatus AES_CTR_Cipher(
     ByteSource* out) {
   BignumPointer num_counters(BN_new());
   if (!BN_lshift(num_counters.get(), BN_value_one(), params.length))
-    return WebCryptoCipherStatus::ERR_FAILED;
+    return WebCryptoCipherStatus::FAILED;
 
   BignumPointer current_counter = GetCounter(params);
 
   BignumPointer num_output(BN_new());
 
   if (!BN_set_word(num_output.get(), CeilDiv(in.size(), kAesBlockSize)))
-    return WebCryptoCipherStatus::ERR_FAILED;
+    return WebCryptoCipherStatus::FAILED;
 
   // Just like in chromium's implementation, if the counter will
   // be incremented more than there are counter values, we fail.
   if (BN_cmp(num_output.get(), num_counters.get()) > 0)
-    return WebCryptoCipherStatus::ERR_FAILED;
+    return WebCryptoCipherStatus::FAILED;
 
   BignumPointer remaining_until_reset(BN_new());
   if (!BN_sub(remaining_until_reset.get(),
               num_counters.get(),
               current_counter.get())) {
-    return WebCryptoCipherStatus::ERR_FAILED;
+    return WebCryptoCipherStatus::FAILED;
   }
 
   // Output size is identical to the input size
@@ -302,7 +302,7 @@ WebCryptoCipherStatus AES_CTR_Cipher(
         in,
         params.iv.data<unsigned char>(),
         ptr);
-    if (status == WebCryptoCipherStatus::ERR_OK)
+    if (status == WebCryptoCipherStatus::OK)
       *out = std::move(buf);
     return status;
   }
@@ -319,7 +319,7 @@ WebCryptoCipherStatus AES_CTR_Cipher(
       params.iv.data<unsigned char>(),
       ptr);
 
-  if (status != WebCryptoCipherStatus::ERR_OK)
+  if (status != WebCryptoCipherStatus::OK)
     return status;
 
   // Wrap the counter around to zero
@@ -336,7 +336,7 @@ WebCryptoCipherStatus AES_CTR_Cipher(
       new_counter_block.data(),
       ptr + input_size_part1);
 
-  if (status == WebCryptoCipherStatus::ERR_OK)
+  if (status == WebCryptoCipherStatus::OK)
     *out = std::move(buf);
 
   return status;

--- a/src/crypto/crypto_cipher.h
+++ b/src/crypto/crypto_cipher.h
@@ -128,9 +128,9 @@ enum WebCryptoCipherMode {
 };
 
 enum class WebCryptoCipherStatus {
-  ERR_OK,
-  ERR_INVALID_KEY_TYPE,
-  ERR_FAILED
+  OK,
+  INVALID_KEY_TYPE,
+  FAILED
 };
 
 // CipherJob is a base implementation class for implementations of
@@ -222,13 +222,13 @@ class CipherJob final : public CryptoJob<CipherTraits> {
                 *CryptoJob<CipherTraits>::params(),
                 in_,
                 &out_)) {
-      case WebCryptoCipherStatus::ERR_OK:
+      case WebCryptoCipherStatus::OK:
         // Success!
         break;
-      case WebCryptoCipherStatus::ERR_INVALID_KEY_TYPE:
+      case WebCryptoCipherStatus::INVALID_KEY_TYPE:
         // Fall through
         // TODO(@jasnell): Separate error for this
-      case WebCryptoCipherStatus::ERR_FAILED: {
+      case WebCryptoCipherStatus::FAILED: {
         CryptoErrorVector* errors = CryptoJob<CipherTraits>::errors();
         errors->Capture();
         if (errors->empty())

--- a/src/crypto/crypto_keygen.cc
+++ b/src/crypto/crypto_keygen.cc
@@ -84,7 +84,7 @@ KeyGenJobStatus SecretKeyGenTraits::DoKeyGen(
   CHECK_LE(params->length, INT_MAX);
   params->out = MallocOpenSSL<char>(params->length);
   EntropySource(reinterpret_cast<unsigned char*>(params->out), params->length);
-  return KeyGenJobStatus::ERR_OK;
+  return KeyGenJobStatus::OK;
 }
 
 Maybe<bool> SecretKeyGenTraits::EncodeKey(

--- a/src/crypto/crypto_rsa.cc
+++ b/src/crypto/crypto_rsa.cc
@@ -196,16 +196,16 @@ WebCryptoCipherStatus RSA_Cipher(
       EVP_PKEY_CTX_new(key_data->GetAsymmetricKey().get(), nullptr));
 
   if (!ctx || init(ctx.get()) <= 0)
-    return WebCryptoCipherStatus::ERR_FAILED;
+    return WebCryptoCipherStatus::FAILED;
 
   if (EVP_PKEY_CTX_set_rsa_padding(ctx.get(), params.padding) <= 0) {
-    return WebCryptoCipherStatus::ERR_FAILED;
+    return WebCryptoCipherStatus::FAILED;
   }
 
   if (params.digest != nullptr &&
       (EVP_PKEY_CTX_set_rsa_oaep_md(ctx.get(), params.digest) <= 0 ||
        EVP_PKEY_CTX_set_rsa_mgf1_md(ctx.get(), params.digest) <= 0)) {
-    return WebCryptoCipherStatus::ERR_FAILED;
+    return WebCryptoCipherStatus::FAILED;
   }
 
   size_t label_len = params.label.size();
@@ -214,7 +214,7 @@ WebCryptoCipherStatus RSA_Cipher(
     CHECK_NOT_NULL(label);
     if (EVP_PKEY_CTX_set0_rsa_oaep_label(ctx.get(), label, label_len) <= 0) {
       OPENSSL_free(label);
-      return WebCryptoCipherStatus::ERR_FAILED;
+      return WebCryptoCipherStatus::FAILED;
     }
   }
 
@@ -225,7 +225,7 @@ WebCryptoCipherStatus RSA_Cipher(
           &out_len,
           in.data<unsigned char>(),
           in.size()) <= 0) {
-    return WebCryptoCipherStatus::ERR_FAILED;
+    return WebCryptoCipherStatus::FAILED;
   }
 
   char* data = MallocOpenSSL<char>(out_len);
@@ -238,13 +238,13 @@ WebCryptoCipherStatus RSA_Cipher(
           &out_len,
           in.data<unsigned char>(),
           in.size()) <= 0) {
-    return WebCryptoCipherStatus::ERR_FAILED;
+    return WebCryptoCipherStatus::FAILED;
   }
 
   buf.Resize(out_len);
 
   *out = std::move(buf);
-  return WebCryptoCipherStatus::ERR_OK;
+  return WebCryptoCipherStatus::OK;
 }
 }  // namespace
 
@@ -356,7 +356,7 @@ WebCryptoCipherStatus RSACipherTraits::DoCipher(
       return RSA_Cipher<EVP_PKEY_decrypt_init, EVP_PKEY_decrypt>(
           env, key_data.get(), params, in, out);
   }
-  return WebCryptoCipherStatus::ERR_FAILED;
+  return WebCryptoCipherStatus::FAILED;
 }
 
 Maybe<bool> ExportJWKRsaKey(


### PR DESCRIPTION
This commit removes the ERR prefix of the remaining status enums in
crypto so they are consistent with Commit 923f76d5231256e69985e1bd897fd490ea0cbe9c
("src: remove ERR prefix in WebCryptoKeyExportStatus").



##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
