### PR TITLE
docs: update crypto.createSecretKey history

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -2147,8 +2147,9 @@ added: v11.6.0
 changes:
   - version: v15.0.0
     pr-url: https://github.com/nodejs/node/pull/35093
-    description: The key can also be an ArrayBuffer. The encoding argument was
-                 added. The key cannot contain more than 2 ** 32 - 1 bytes.
+    description: The key can also be an ArrayBuffer or string. The encoding
+                 argument was added. The key cannot contain more than
+                 2 ** 32 - 1 bytes.
 -->
 
 * `key` {string|ArrayBuffer|Buffer|TypedArray|DataView}


### PR DESCRIPTION
Passing strings to `crypto.createSecretKey` was not added until v15.0.0
(specifically with commit dae283d). The existing documentation implies its
availability in prior versions which may cause confusion.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
