### PR TITLE
test: mark test-http2-respond-file-error-pipe-offset flaky

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -5,6 +5,7 @@ prefix parallel
 # sample-test                        : PASS,FLAKY
 
 [true] # This section applies to all platforms
+test-http2-respond-file-error-pipe-offset: PASS,FLAKY
 
 [$system==win32]
 # https://github.com/nodejs/node/issues/20750


### PR DESCRIPTION
This is now failing inconsistently across many platforms. This
appears to be the result of the addition of mustSucceed being
added to the test during testing refactoring.

We should mark flaky until we have figured out what the issue
is.

Refs: https://github.com/nodejs/node/issues/35881

/cc @Trott @tniessen 