### PR TITLE
domain: refactor to use more primordials

### DIFF
--- a/lib/domain.js
+++ b/lib/domain.js
@@ -27,11 +27,17 @@
 // unless they address existing, critical bugs.
 
 const {
-  Array,
+  ArrayPrototypeEvery,
+  ArrayPrototypeIndexOf,
+  ArrayPrototypeLastIndexOf,
+  ArrayPrototypePush,
+  ArrayPrototypeSlice,
+  ArrayPrototypeSplice,
   Error,
-  Map,
+  FunctionPrototypeCall,
   ObjectDefineProperty,
   ReflectApply,
+  SafeMap,
   Symbol,
 } = primordials;
 
@@ -61,7 +67,7 @@ ObjectDefineProperty(process, 'domain', {
   }
 });
 
-const pairing = new Map();
+const pairing = new SafeMap();
 const asyncHook = createHook({
   init(asyncId, type, triggerAsyncId, resource) {
     if (process.domain !== null && process.domain !== undefined) {
@@ -149,7 +155,8 @@ exports._stack = stack;
 useDomainTrampoline(topLevelDomainCallback);
 
 function updateExceptionCapture() {
-  if (stack.every((domain) => domain.listenerCount('error') === 0)) {
+  if (ArrayPrototypeEvery(stack,
+                          (domain) => domain.listenerCount('error') === 0)) {
     setUncaughtExceptionCaptureCallback(null);
   } else {
     setUncaughtExceptionCaptureCallback(null);
@@ -296,18 +303,18 @@ Domain.prototype.enter = function() {
   // Note that this might be a no-op, but we still need
   // to push it onto the stack so that we can pop it later.
   exports.active = process.domain = this;
-  stack.push(this);
+  ArrayPrototypePush(stack, this);
   updateExceptionCapture();
 };
 
 
 Domain.prototype.exit = function() {
   // Don't do anything if this domain is not on the stack.
-  const index = stack.lastIndexOf(this);
+  const index = ArrayPrototypeLastIndexOf(stack, this);
   if (index === -1) return;
 
   // Exit all domains until this one.
-  stack.splice(index);
+  ArrayPrototypeSplice(stack, index);
 
   exports.active = stack[stack.length - 1];
   process.domain = exports.active;
@@ -346,33 +353,21 @@ Domain.prototype.add = function(ee) {
     value: this,
     writable: true
   });
-  this.members.push(ee);
+  ArrayPrototypePush(this.members, ee);
 };
 
 
 Domain.prototype.remove = function(ee) {
   ee.domain = null;
-  const index = this.members.indexOf(ee);
+  const index = ArrayPrototypeIndexOf(this.members, ee);
   if (index !== -1)
-    this.members.splice(index, 1);
+    ArrayPrototypeSplice(this.members, index, 1);
 };
 
 
 Domain.prototype.run = function(fn) {
-  let ret;
-
   this.enter();
-  if (arguments.length >= 2) {
-    const len = arguments.length;
-    const args = new Array(len - 1);
-
-    for (let i = 1; i < len; i++)
-      args[i - 1] = arguments[i];
-
-    ret = fn.apply(this, args);
-  } else {
-    ret = fn.call(this);
-  }
+  const ret = ReflectApply(fn, this, ArrayPrototypeSlice(arguments, 1));
   this.exit();
 
   return ret;
@@ -394,17 +389,8 @@ function intercepted(_this, self, cb, fnargs) {
     return;
   }
 
-  const args = [];
-  let ret;
-
   self.enter();
-  if (fnargs.length > 1) {
-    for (let i = 1; i < fnargs.length; i++)
-      args.push(fnargs[i]);
-    ret = cb.apply(_this, args);
-  } else {
-    ret = cb.call(_this);
-  }
+  const ret = ReflectApply(cb, _this, ArrayPrototypeSlice(fnargs, 1));
   self.exit();
 
   return ret;
@@ -423,13 +409,8 @@ Domain.prototype.intercept = function(cb) {
 
 
 function bound(_this, self, cb, fnargs) {
-  let ret;
-
   self.enter();
-  if (fnargs.length > 0)
-    ret = cb.apply(_this, fnargs);
-  else
-    ret = cb.call(_this);
+  const ret = ReflectApply(cb, _this, fnargs);
   self.exit();
 
   return ret;
@@ -468,7 +449,7 @@ EventEmitter.init = function() {
     this.domain = exports.active;
   }
 
-  return eventInit.call(this);
+  return FunctionPrototypeCall(eventInit, this);
 };
 
 const eventEmit = EventEmitter.prototype.emit;
@@ -506,7 +487,7 @@ EventEmitter.prototype.emit = function(...args) {
     // handler doesn't run in its own context. This prevents any event emitter
     // created or any exception thrown in that error handler from recursively
     // executing that error handler.
-    const origDomainsStack = stack.slice();
+    const origDomainsStack = ArrayPrototypeSlice(stack);
     const origActiveDomain = process.domain;
 
     // Travel the domains stack from top to bottom to find the first domain
@@ -521,7 +502,7 @@ EventEmitter.prototype.emit = function(...args) {
     if (idx < 0) {
       stack.length = 0;
     } else {
-      stack.splice(idx + 1);
+      ArrayPrototypeSplice(stack, idx + 1);
     }
 
     // Change the current active domain


### PR DESCRIPTION
FWIW I'm using `ReflectApply` to replace uses of `Function.prototype.apply` and `Function.prototype.call` because it has less overhead (see https://github.com/nodejs/node/pull/35838#pullrequestreview-519781441 for more info).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passe
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
