### PR TITLE
test: mark test-worker-eventlooputil flaky

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -6,6 +6,7 @@ prefix parallel
 
 [true] # This section applies to all platforms
 test-http2-respond-file-error-pipe-offset: PASS,FLAKY
+test-worker-eventlooputil: PASS,FLAKY
 
 [$system==win32]
 # https://github.com/nodejs/node/issues/20750


### PR DESCRIPTION
This is consistently failing in CI right now. Lets mark it flaky
while we figure out what is going on.

Refs: https://github.com/nodejs/node/issues/35844
