### PR TITLE
test: correct test-worker-eventlooputil

### DIFF
--- a/test/parallel/test-worker-eventlooputil.js
+++ b/test/parallel/test-worker-eventlooputil.js
@@ -34,9 +34,10 @@ function workerOnMetricsMsg(msg) {
   }
 
   if (msg.cmd === 'spin') {
+    const elu = eventLoopUtilization();
     const t = now();
     while (now() - t < msg.dur);
-    return this.postMessage(eventLoopUtilization());
+    return this.postMessage(eventLoopUtilization(elu));
   }
 }
 
@@ -104,8 +105,9 @@ function checkWorkerActive() {
     const w2 = workerELU(w);
 
     assert.ok(w2.active >= 50, `${w2.active} < 50`);
-    assert.ok(idleActive(wElu) > idleActive(w2),
-              `${idleActive(wElu)} <= ${idleActive(w2)}`);
+    assert.ok(wElu.active >= 50, `${wElu.active} < 50`);
+    assert.ok(idleActive(wElu) < idleActive(w2),
+              `${idleActive(wElu)} > ${idleActive(w2)}`);
 
     metricsCh.port2.postMessage({ cmd: 'close' });
   });

--- a/test/parallel/test-worker-eventlooputil.js
+++ b/test/parallel/test-worker-eventlooputil.js
@@ -69,8 +69,8 @@ let workerELU;
 
 
 function checkWorkerIdle(wElu) {
-  const tmpMainElu = eventLoopUtilization(mainElu);
   const perfWorkerElu = workerELU();
+  const tmpMainElu = eventLoopUtilization(mainElu);
   const eluDiff = eventLoopUtilization(perfWorkerElu, mainElu);
 
   assert.strictEqual(idleActive(eluDiff),
@@ -107,7 +107,7 @@ function checkWorkerActive() {
     assert.ok(w2.active >= 50, `${w2.active} < 50`);
     assert.ok(wElu.active >= 50, `${wElu.active} < 50`);
     assert.ok(idleActive(wElu) < idleActive(w2),
-              `${idleActive(wElu)} > ${idleActive(w2)}`);
+              `${idleActive(wElu)} => ${idleActive(w2)}`);
 
     metricsCh.port2.postMessage({ cmd: 'close' });
   });


### PR DESCRIPTION
The active worker check compared the time from sending message till response arrived from worker with the complete time the worker was running till it responses to the spin request.

If sending back the message is slow for some reason the test fails.

Adapt the test to compare the time seen inside the worker with the time read from main thread.

Fixes: #35844
Refs: #35886
Refs: #35664
