### PR TITLE
src: integrate URL::href() and use in inspector

### DIFF
--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -638,9 +638,7 @@ class NodeInspectorClient : public V8InspectorClient {
     if (!IsFilePath(resource_name))
       return nullptr;
     node::url::URL url = node::url::URL::FromFilePath(resource_name);
-    // TODO(ak239spb): replace this code with url.href().
-    // Refs: https://github.com/nodejs/node/issues/22610
-    return Utf8ToStringView(url.protocol() + "/" + url.path());
+    return Utf8ToStringView(url.href());
   }
 
   node::Environment* env_;

--- a/src/node_url.h
+++ b/src/node_url.h
@@ -71,6 +71,7 @@ struct url_data {
   std::string query;
   std::string fragment;
   std::vector<std::string> path;
+  std::string href;
 };
 
 class URL {
@@ -82,6 +83,8 @@ class URL {
                     bool has_url,
                     const struct url_data* base,
                     bool has_base);
+
+  static std::string SerializeURL(const struct url_data* url, bool exclude);
 
   URL(const char* input, const size_t len) {
     Parse(input, len, kUnknownState, &context_, false, nullptr, false);
@@ -158,6 +161,10 @@ class URL {
       ret += '/' + element;
     }
     return ret;
+  }
+
+  std::string href() const {
+    return SerializeURL(&context_, false);
   }
 
   // Get the path of the file: URL in a format consumable by native file system

--- a/test/cctest/test_url.cc
+++ b/test/cctest/test_url.cc
@@ -137,25 +137,31 @@ TEST_F(URLTest, FromFilePath) {
   file_url = URL::FromFilePath("C:\\Program Files\\");
   EXPECT_EQ("file:", file_url.protocol());
   EXPECT_EQ("//C:/Program%20Files/", file_url.path());
+  EXPECT_EQ("file:///C:/Program%20Files/", file_url.href());
 
   file_url = URL::FromFilePath("C:\\a\\b\\c");
   EXPECT_EQ("file:", file_url.protocol());
   EXPECT_EQ("//C:/a/b/c", file_url.path());
+  EXPECT_EQ("file:///C:/a/b/c", file_url.href());
 
   file_url = URL::FromFilePath("b:\\a\\%%.js");
   EXPECT_EQ("file:", file_url.protocol());
   EXPECT_EQ("//b:/a/%25%25.js", file_url.path());
+  EXPECT_EQ("file:///b:/a/%25%25.js", file_url.href());
 #else
   file_url = URL::FromFilePath("/");
   EXPECT_EQ("file:", file_url.protocol());
   EXPECT_EQ("//", file_url.path());
+  EXPECT_EQ("file:///", file_url.href());
 
   file_url = URL::FromFilePath("/a/b/c");
   EXPECT_EQ("file:", file_url.protocol());
   EXPECT_EQ("//a/b/c", file_url.path());
+  EXPECT_EQ("file:///a/b/c", file_url.href());
 
   file_url = URL::FromFilePath("/a/%%.js");
   EXPECT_EQ("file:", file_url.protocol());
   EXPECT_EQ("//a/%25%25.js", file_url.path());
+  EXPECT_EQ("file:///a/%25%25.js", file_url.href());
 #endif
 }


### PR DESCRIPTION
To have the same logic of URL serialization in different modules, I implemented `SerializeURL` to generate `node::url::URL::href()` which is mentioned in `inspector_agent.cc` as ToDo. Migrating lib's side href into C++ would be the next step if there is no blocker.

Refs: https://github.com/nodejs/node/issues/22610

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
