### PR TITLE
crypto: pass empty passphrases to OpenSSL properly

### DIFF
--- a/src/crypto/crypto_keygen.h
+++ b/src/crypto/crypto_keygen.h
@@ -251,8 +251,10 @@ struct KeyPairGenConfig final : public MemoryRetainer {
 
   void MemoryInfo(MemoryTracker* tracker) const override {
     tracker->TrackField("key", key);
-    tracker->TrackFieldWithSize("private_key_encoding.passphrase",
-                        private_key_encoding.passphrase_.size());
+    if (!private_key_encoding.passphrase_.IsEmpty()) {
+      tracker->TrackFieldWithSize("private_key_encoding.passphrase",
+                                  private_key_encoding.passphrase_->size());
+    }
     tracker->TrackField("params", params);
   }
 

--- a/src/crypto/crypto_keys.h
+++ b/src/crypto/crypto_keys.h
@@ -63,7 +63,10 @@ using PublicKeyEncodingConfig = AsymmetricKeyEncodingConfig;
 
 struct PrivateKeyEncodingConfig : public AsymmetricKeyEncodingConfig {
   const EVP_CIPHER* cipher_;
-  ByteSource passphrase_;
+  // The ByteSource alone is not enough to distinguish between "no passphrase"
+  // and a zero-length passphrase (which can be a null pointer), therefore, we
+  // use a NonCopyableMaybe.
+  NonCopyableMaybe<ByteSource> passphrase_;
 };
 
 // This uses the built-in reference counter of OpenSSL to manage an EVP_PKEY

--- a/src/crypto/crypto_util.cc
+++ b/src/crypto/crypto_util.cc
@@ -74,13 +74,13 @@ bool EntropySource(unsigned char* buffer, size_t length) {
 }
 
 int PasswordCallback(char* buf, int size, int rwflag, void* u) {
-  const char* passphrase = static_cast<char*>(u);
+  const ByteSource* passphrase = *static_cast<const ByteSource**>(u);
   if (passphrase != nullptr) {
     size_t buflen = static_cast<size_t>(size);
-    size_t len = strlen(passphrase);
+    size_t len = passphrase->size();
     if (buflen < len)
       return -1;
-    memcpy(buf, passphrase, len);
+    memcpy(buf, passphrase->get(), len);
     return len;
   }
 

--- a/src/util.h
+++ b/src/util.h
@@ -602,6 +602,15 @@ class NonCopyableMaybe {
     return empty_;
   }
 
+  const T* get() const {
+    return empty_ ? nullptr : &value_;
+  }
+
+  const T* operator->() const {
+    CHECK(!empty_);
+    return &value_;
+  }
+
   T&& Release() {
     CHECK_EQ(empty_, false);
     empty_ = true;


### PR DESCRIPTION
This solves two related problems:

1. `PrivateKeyEncodingConfig` was unable to distinguish between "no passphrase" and zero-length passphrases, since both may be stored as `ByteSource(nullptr, 0)`.
2. OpenSSL uses its default key callback when a cipher was specified, but a `nullptr` for the passphrase. However, this did happen when an empty passphrase was specified, because `malloc(0)` is allowed to return a `nullptr`.

I'm not sure why these problems don't affect older versions.

Fixes: https://github.com/nodejs/node/issues/35898

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
