### PR TITLE
stream: add FileHandle support to Read/WriteStream

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1763,6 +1763,7 @@ added: v0.1.31
 changes:
   - version:
      - v15.0.2
+    pr-url: https://github.com/nodejs/node/pull/35922
     description: The `fd` option accepts FileHandle arguments.
   - version:
      - v13.6.0
@@ -1873,6 +1874,7 @@ added: v0.1.31
 changes:
   - version:
      - v15.0.2
+    pr-url: https://github.com/nodejs/node/pull/35922
     description: The `fd` option accepts FileHandle arguments.
   - version:
      - v13.6.0

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -4720,7 +4720,7 @@ rejected.
 added: REPLACEME
 -->
 
-The `'close'` event is emitted when the FileHandle and any of its underlying
+The `'close'` event is emitted when the `FileHandle` and any of its underlying
 resources (a file descriptor, for example) have been closed.
 
 #### `filehandle.appendFile(data, options)`

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1762,6 +1762,9 @@ fs.copyFileSync('source.txt', 'destination.txt', COPYFILE_EXCL);
 added: v0.1.31
 changes:
   - version:
+     - v15.0.2
+    description: The `fd` option accepts FileHandle arguments.
+  - version:
      - v13.6.0
      - v12.17.0
     pr-url: https://github.com/nodejs/node/pull/29083
@@ -1792,7 +1795,7 @@ changes:
   * `flags` {string} See [support of file system `flags`][]. **Default:**
     `'r'`.
   * `encoding` {string} **Default:** `null`
-  * `fd` {integer} **Default:** `null`
+  * `fd` {integer|FileHandle} **Default:** `null`
   * `mode` {integer} **Default:** `0o666`
   * `autoClose` {boolean} **Default:** `true`
   * `emitClose` {boolean} **Default:** `false`
@@ -1869,6 +1872,9 @@ If `options` is a string, then it specifies the encoding.
 added: v0.1.31
 changes:
   - version:
+     - v15.0.2
+    description: The `fd` option accepts FileHandle arguments.
+  - version:
      - v13.6.0
      - v12.17.0
     pr-url: https://github.com/nodejs/node/pull/29083
@@ -1897,7 +1903,7 @@ changes:
   * `flags` {string} See [support of file system `flags`][]. **Default:**
     `'w'`.
   * `encoding` {string} **Default:** `'utf8'`
-  * `fd` {integer} **Default:** `null`
+  * `fd` {integer|FileHandle} **Default:** `null`
   * `mode` {integer} **Default:** `0o666`
   * `autoClose` {boolean} **Default:** `true`
   * `emitClose` {boolean} **Default:** `false`
@@ -4706,6 +4712,14 @@ so on), a numeric file descriptor is not used by the promise-based API. Instead,
 the promise-based API uses the `FileHandle` class in order to help avoid
 accidental leaking of unclosed file descriptors after a `Promise` is resolved or
 rejected.
+
+#### Event: `'close'`
+<!-- YAML
+added: v15.0.2
+-->
+
+The `'close'` event is emitted when the FileHandle and any of its underlying
+resources (a file descriptor, for example) have been closed.
 
 #### `filehandle.appendFile(data, options)`
 <!-- YAML

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1762,7 +1762,7 @@ fs.copyFileSync('source.txt', 'destination.txt', COPYFILE_EXCL);
 added: v0.1.31
 changes:
   - version:
-     - v15.0.2
+     - REPLACEME
     pr-url: https://github.com/nodejs/node/pull/35922
     description: The `fd` option accepts FileHandle arguments.
   - version:
@@ -1873,7 +1873,7 @@ If `options` is a string, then it specifies the encoding.
 added: v0.1.31
 changes:
   - version:
-     - v15.0.2
+     - REPLACEME
     pr-url: https://github.com/nodejs/node/pull/35922
     description: The `fd` option accepts FileHandle arguments.
   - version:
@@ -4717,7 +4717,7 @@ rejected.
 
 #### Event: `'close'`
 <!-- YAML
-added: v15.0.2
+added: REPLACEME
 -->
 
 The `'close'` event is emitted when the FileHandle and any of its underlying

--- a/lib/events.js
+++ b/lib/events.js
@@ -28,6 +28,7 @@ const {
   ErrorCaptureStackTrace,
   MathMin,
   NumberIsNaN,
+  Object,
   ObjectCreate,
   ObjectDefineProperty,
   ObjectDefineProperties,
@@ -896,3 +897,17 @@ function on(emitter, event, options) {
     iterator.return();
   }
 }
+
+const EventEmitterMixin = (Superclass) => {
+  class MixedEventEmitter extends Superclass {
+    constructor(...args) {
+      super(...args);
+      EventEmitter.call(this);
+    }
+  }
+  const protoProps = Object.getOwnPropertyDescriptors(EventEmitter.prototype);
+  delete protoProps.constructor;
+  Object.defineProperties(MixedEventEmitter.prototype, protoProps);
+  return MixedEventEmitter;
+};
+module.exports.EventEmitterMixin = EventEmitterMixin;

--- a/lib/events.js
+++ b/lib/events.js
@@ -28,7 +28,6 @@ const {
   ErrorCaptureStackTrace,
   MathMin,
   NumberIsNaN,
-  Object,
   ObjectCreate,
   ObjectDefineProperty,
   ObjectDefineProperties,
@@ -42,7 +41,7 @@ const {
   String,
   Symbol,
   SymbolFor,
-  SymbolAsyncIterator
+  SymbolAsyncIterator,
 } = primordials;
 const kRejection = SymbolFor('nodejs.rejection');
 
@@ -897,17 +896,3 @@ function on(emitter, event, options) {
     iterator.return();
   }
 }
-
-const EventEmitterMixin = (Superclass) => {
-  class MixedEventEmitter extends Superclass {
-    constructor(...args) {
-      super(...args);
-      EventEmitter.call(this);
-    }
-  }
-  const protoProps = Object.getOwnPropertyDescriptors(EventEmitter.prototype);
-  delete protoProps.constructor;
-  Object.defineProperties(MixedEventEmitter.prototype, protoProps);
-  return MixedEventEmitter;
-};
-module.exports.EventEmitterMixin = EventEmitterMixin;

--- a/lib/events.js
+++ b/lib/events.js
@@ -41,7 +41,7 @@ const {
   String,
   Symbol,
   SymbolFor,
-  SymbolAsyncIterator,
+  SymbolAsyncIterator
 } = primordials;
 const kRejection = SymbolFor('nodejs.rejection');
 

--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -32,7 +32,6 @@ const { validateObject } = require('internal/validators');
 
 const { customInspectSymbol } = require('internal/util');
 const { inspect } = require('util');
-const EventEmitter = require('events');
 
 const kIsEventTarget = SymbolFor('nodejs.event_target');
 

--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -9,6 +9,7 @@ const {
   ObjectDefineProperties,
   ObjectDefineProperty,
   ObjectGetOwnPropertyDescriptor,
+  ObjectGetOwnPropertyDescriptors,
   ReflectApply,
   SafeMap,
   String,
@@ -30,6 +31,7 @@ const { validateObject } = require('internal/validators');
 
 const { customInspectSymbol } = require('internal/util');
 const { inspect } = require('util');
+const EventEmitter = require('events');
 
 const kIsEventTarget = SymbolFor('nodejs.event_target');
 
@@ -646,8 +648,23 @@ function defineEventHandler(emitter, name) {
     enumerable: true
   });
 }
+
+const EventEmitterMixin = (Superclass) => {
+  class MixedEventEmitter extends Superclass {
+    constructor(...args) {
+      super(...args);
+      EventEmitter.call(this);
+    }
+  }
+  const protoProps = ObjectGetOwnPropertyDescriptors(EventEmitter.prototype);
+  delete protoProps.constructor;
+  ObjectDefineProperties(MixedEventEmitter.prototype, protoProps);
+  return MixedEventEmitter;
+};
+
 module.exports = {
   Event,
+  EventEmitterMixin,
   EventTarget,
   NodeEventTarget,
   defineEventHandler,

--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -4,6 +4,7 @@ const {
   ArrayFrom,
   Boolean,
   Error,
+  FunctionPrototypeCall,
   NumberIsInteger,
   ObjectAssign,
   ObjectDefineProperties,

--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -653,7 +653,7 @@ const EventEmitterMixin = (Superclass) => {
   class MixedEventEmitter extends Superclass {
     constructor(...args) {
       super(...args);
-      EventEmitter.call(this);
+      FunctionPrototypeCall(EventEmitter, this);
     }
   }
   const protoProps = ObjectGetOwnPropertyDescriptors(EventEmitter.prototype);

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -20,7 +20,7 @@ const {
   PromisePrototypeThen,
   PromiseResolve,
   Symbol,
-  Uint8Array
+  Uint8Array,
 } = primordials;
 
 const {
@@ -71,7 +71,7 @@ const {
 } = require('internal/validators');
 const pathModule = require('path');
 const { promisify } = require('internal/util');
-const EventEmitter = require('events');
+const { EventEmitterMixin } = require('internal/event_target');
 
 const kHandle = Symbol('kHandle');
 const kFd = Symbol('kFd');
@@ -97,7 +97,7 @@ const lazyDOMException = hideStackFrames((message, name) => {
   return new DOMException(message, name);
 });
 
-class FileHandle extends EventEmitter.EventEmitterMixin(JSTransferable) {
+class FileHandle extends EventEmitterMixin(JSTransferable) {
   constructor(filehandle) {
     super();
     this[kHandle] = filehandle;
@@ -229,7 +229,6 @@ class FileHandle extends EventEmitter.EventEmitterMixin(JSTransferable) {
   [kDeserialize]({ handle }) {
     this[kHandle] = handle;
     this[kFd] = handle.fd;
-    EventEmitter.call(this);
   }
 
   [kRef]() {
@@ -727,5 +726,5 @@ module.exports = {
 
   FileHandle,
   kRef,
-  kUnref
+  kUnref,
 };

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -257,7 +257,7 @@ for (const op of ['on', 'emit', 'once', 'off', 'addListener',
                   'prependListener', 'removeListener', 'removeAllListeners',
                   'listeners', 'rawListeners'])
   FileHandle.prototype[op] = function(...args) {
-    this[kEmitter][op].apply(this[kEmitter], args);
+    ReflectApply(this[kEmitter][op], this[kEmitter], args);
   };
 
 async function fsCall(fn, handle, ...args) {

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -71,13 +71,17 @@ const {
 } = require('internal/validators');
 const pathModule = require('path');
 const { promisify } = require('internal/util');
+const EventEmitter = require('events');
 
 const kHandle = Symbol('kHandle');
 const kFd = Symbol('kFd');
 const kRefs = Symbol('kRefs');
+const kEmitter = Symbol('kEmitter');
 const kClosePromise = Symbol('kClosePromise');
 const kCloseResolve = Symbol('kCloseResolve');
 const kCloseReject = Symbol('kCloseReject');
+const kRef = Symbol('kRef');
+const kUnref = Symbol('kUnref');
 
 const { kUsePromises } = binding;
 const {
@@ -97,6 +101,7 @@ const lazyDOMException = hideStackFrames((message, name) => {
 class FileHandle extends JSTransferable {
   constructor(filehandle) {
     super();
+    this[kEmitter] = new EventEmitter();
     this[kHandle] = filehandle;
     this[kFd] = filehandle ? filehandle.fd : -1;
 
@@ -177,6 +182,8 @@ class FileHandle extends JSTransferable {
       return this[kClosePromise];
     }
 
+    this[kEmitter].emit('close');
+
     this[kRefs]--;
     if (this[kRefs] === 0) {
       this[kFd] = -1;
@@ -211,6 +218,7 @@ class FileHandle extends JSTransferable {
     this[kFd] = -1;
     this[kHandle] = null;
     this[kRefs] = 0;
+    this[kEmitter] = null;
 
     return {
       data: { handle },
@@ -225,8 +233,32 @@ class FileHandle extends JSTransferable {
   [kDeserialize]({ handle }) {
     this[kHandle] = handle;
     this[kFd] = handle.fd;
+    this[kEmitter] = new EventEmitter();
+  }
+
+  [kRef]() {
+    this[kRefs]++;
+  }
+
+  [kUnref]() {
+    this[kRefs]--;
+    if (this[kRefs] === 0) {
+      this[kFd] = -1;
+      PromisePrototypeThen(
+        this[kHandle].close(),
+        this[kCloseResolve],
+        this[kCloseReject]
+      );
+    }
   }
 }
+
+for (const op of ['on', 'emit', 'once', 'off', 'addListener',
+                  'prependListener', 'removeListener', 'removeAllListeners',
+                  'listeners', 'rawListeners'])
+  FileHandle.prototype[op] = function(...args) {
+    this[kEmitter][op].apply(this[kEmitter], args);
+  };
 
 async function fsCall(fn, handle, ...args) {
   if (handle[kRefs] === undefined) {
@@ -242,18 +274,10 @@ async function fsCall(fn, handle, ...args) {
   }
 
   try {
-    handle[kRefs]++;
+    handle[kRef]();
     return await fn(handle, ...args);
   } finally {
-    handle[kRefs]--;
-    if (handle[kRefs] === 0) {
-      handle[kFd] = -1;
-      PromisePrototypeThen(
-        handle[kHandle].close(),
-        handle[kCloseResolve],
-        handle[kCloseReject]
-      );
-    }
+    handle[kUnref]();
   }
 }
 
@@ -712,5 +736,7 @@ module.exports = {
     readFile,
   },
 
-  FileHandle
+  FileHandle,
+  kRef,
+  kUnref
 };

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -20,9 +20,7 @@ const {
   PromisePrototypeThen,
   PromiseResolve,
   Symbol,
-  Uint8Array,
-  PromisePrototypeThen,
-  ReflectApply
+  Uint8Array
 } = primordials;
 
 const {
@@ -78,7 +76,6 @@ const EventEmitter = require('events');
 const kHandle = Symbol('kHandle');
 const kFd = Symbol('kFd');
 const kRefs = Symbol('kRefs');
-const kEmitter = Symbol('kEmitter');
 const kClosePromise = Symbol('kClosePromise');
 const kCloseResolve = Symbol('kCloseResolve');
 const kCloseReject = Symbol('kCloseReject');
@@ -100,10 +97,9 @@ const lazyDOMException = hideStackFrames((message, name) => {
   return new DOMException(message, name);
 });
 
-class FileHandle extends JSTransferable {
+class FileHandle extends EventEmitter.EventEmitterMixin(JSTransferable) {
   constructor(filehandle) {
     super();
-    this[kEmitter] = new EventEmitter();
     this[kHandle] = filehandle;
     this[kFd] = filehandle ? filehandle.fd : -1;
 
@@ -184,8 +180,6 @@ class FileHandle extends JSTransferable {
       return this[kClosePromise];
     }
 
-    this[kEmitter].emit('close');
-
     this[kRefs]--;
     if (this[kRefs] === 0) {
       this[kFd] = -1;
@@ -206,6 +200,7 @@ class FileHandle extends JSTransferable {
       );
     }
 
+    this.emit('close');
     return this[kClosePromise];
   }
 
@@ -220,7 +215,6 @@ class FileHandle extends JSTransferable {
     this[kFd] = -1;
     this[kHandle] = null;
     this[kRefs] = 0;
-    this[kEmitter] = null;
 
     return {
       data: { handle },
@@ -235,7 +229,7 @@ class FileHandle extends JSTransferable {
   [kDeserialize]({ handle }) {
     this[kHandle] = handle;
     this[kFd] = handle.fd;
-    this[kEmitter] = new EventEmitter();
+    EventEmitter.call(this);
   }
 
   [kRef]() {
@@ -254,13 +248,6 @@ class FileHandle extends JSTransferable {
     }
   }
 }
-
-for (const op of ['on', 'emit', 'once', 'off', 'addListener',
-                  'prependListener', 'removeListener', 'removeAllListeners',
-                  'listeners', 'rawListeners'])
-  FileHandle.prototype[op] = function(...args) {
-    ReflectApply(this[kEmitter][op], this[kEmitter], args);
-  };
 
 async function fsCall(fn, handle, ...args) {
   if (handle[kRefs] === undefined) {

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -21,6 +21,8 @@ const {
   PromiseResolve,
   Symbol,
   Uint8Array,
+  PromisePrototypeThen,
+  ReflectApply
 } = primordials;
 
 const {

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -2,13 +2,13 @@
 
 const {
   Array,
+  FunctionPrototypeBind,
   MathMin,
   ObjectDefineProperty,
   ObjectSetPrototypeOf,
+  PromisePrototypeThen,
   ReflectApply,
   Symbol,
-  PromisePrototypeThen,
-  FunctionPrototypeBind
 } = primordials;
 
 const {

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -20,14 +20,13 @@ const { deprecate } = require('internal/util');
 const { validateInteger } = require('internal/validators');
 const { errorOrDestroy } = require('internal/streams/destroy');
 const fs = require('fs');
-const { kRef, kUnref } = require('internal/fs/promises');
+const { kRef, kUnref, FileHandle } = require('internal/fs/promises');
 const { Buffer } = require('buffer');
 const {
   copyObject,
   getOptions,
 } = require('internal/fs/utils');
 const { Readable, Writable, finished } = require('stream');
-const { FileHandle } = require('internal/fs/promises');
 const { toPathIfFileURL } = require('internal/url');
 const kIoDone = Symbol('kIoDone');
 const kIsPerformingIO = Symbol('kIsPerformingIO');
@@ -124,7 +123,8 @@ function importFd(stream, options) {
       // another one
       // https://github.com/nodejs/node/issues/35862
       stream.fd = options.fd;
-    } else if (typeof options.fd === 'object' && options.fd instanceof FileHandle) {
+    } else if (typeof options.fd === 'object' &&
+      options.fd instanceof FileHandle) {
       // When fd is a FileHandle we can listen for 'close' events
       if (options.fs)
         // FileHandle is not supported with custom fs operations
@@ -135,7 +135,8 @@ function importFd(stream, options) {
       stream[kHandle][kRef]();
       options.fd.on('close', FunctionPrototypeBind(stream.close, stream));
     } else
-      throw ERR_INVALID_ARG_TYPE('options.fd', ['number', 'FileHandle'], options.fd);
+      throw ERR_INVALID_ARG_TYPE('options.fd',
+                                 ['number', 'FileHandle'], options.fd);
   }
 }
 

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -77,24 +77,23 @@ const FileHandleOperations = (handle) => {
     },
     close: (fd, cb) => {
       handle[kUnref]();
-      handle.close()
-        .then(() => cb())
-        .catch((err) => cb(err));
+      PromisePrototypeThen(handle.close(),
+                           () => cb(), cb);
     },
     read: (fd, buf, offset, length, pos, cb) => {
-      handle.read(buf, offset, length, pos)
-        .then((r) => cb(null, r.bytesRead, r.buffer))
-        .catch((err) => cb(err, 0, buf));
+      PromisePrototypeThen(handle.read(buf, offset, length, pos),
+                           (r) => cb(null, r.bytesRead, r.buffer), 
+                           (err) => cb(err, 0, buf));
     },
     write: (fd, buf, offset, length, pos, cb) => {
-      handle.read(buf, offset, length, pos)
-        .then((r) => cb(null, r.bytesWritten, r.buffer))
-        .catch((err) => cb(err, 0, buf));
+      PromisePrototypeThen(handle.write(buf, offset, length, pos),
+                           (r) => cb(null, r.bytesWritten, r.buffer), 
+                           (err) => cb(err, 0, buf));
     },
     writev: (fd, buffers, pos, cb) => {
-      handle.writev(buffers, pos)
-        .then((r) => cb(null, r.bytesWritten, r.buffers))
-        .catch((err) => cb(err, 0, buffers));
+      PromisePrototypeThen(handle.writev(buffers, pos),
+                           (r) => cb(null, r.bytesWritten, r.buffers), 
+                           (err) => cb(err, 0, buffers));
     }
   };
 };
@@ -125,7 +124,7 @@ function importFd(stream, options) {
       stream.fd = options.fd.fd;
       stream[kFs] = FileHandleOperations(stream[kHandle]);
       stream[kHandle][kRef]();
-      options.fd.on('close', stream.close.bind(stream));
+      options.fd.on('close', FunctionPrototypeBind(stream.close, stream));
     }
     // When fd is a raw descriptor, we must keep our fingers crossed
     // that the descriptor won't get closed, or worse, replaced with

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -14,7 +14,7 @@ const {
 const {
   ERR_INVALID_ARG_TYPE,
   ERR_OUT_OF_RANGE,
-  ERR_METHOD_NOT_IMPLEMENTED
+  ERR_METHOD_NOT_IMPLEMENTED,
 } = require('internal/errors').codes;
 const { deprecate } = require('internal/util');
 const { validateInteger } = require('internal/validators');

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -27,6 +27,7 @@ const {
   getOptions,
 } = require('internal/fs/utils');
 const { Readable, Writable, finished } = require('stream');
+const { FileHandle } = require('internal/fs/promises');
 const { toPathIfFileURL } = require('internal/url');
 const kIoDone = Symbol('kIoDone');
 const kIsPerformingIO = Symbol('kIsPerformingIO');
@@ -123,7 +124,7 @@ function importFd(stream, options) {
       // another one
       // https://github.com/nodejs/node/issues/35862
       stream.fd = options.fd;
-    } else {
+    } else if (typeof options.fd === 'object' && options.fd instanceof FileHandle) {
       // When fd is a FileHandle we can listen for 'close' events
       if (options.fs)
         // FileHandle is not supported with custom fs operations
@@ -133,7 +134,8 @@ function importFd(stream, options) {
       stream[kFs] = FileHandleOperations(stream[kHandle]);
       stream[kHandle][kRef]();
       options.fd.on('close', FunctionPrototypeBind(stream.close, stream));
-    }
+    } else
+      throw ERR_INVALID_ARG_TYPE('options.fd', ['number', 'FileHandle'], options.fd);
   }
 }
 

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -20,7 +20,7 @@ const { deprecate } = require('internal/util');
 const { validateInteger } = require('internal/validators');
 const { errorOrDestroy } = require('internal/streams/destroy');
 const fs = require('fs');
-const { FileHandle, kRef, kUnref } = require('internal/fs/promises');
+const { kRef, kUnref } = require('internal/fs/promises');
 const { Buffer } = require('buffer');
 const {
   copyObject,
@@ -117,23 +117,22 @@ function close(stream, err, cb) {
 function importFd(stream, options) {
   stream.fd = null;
   if (options.fd) {
-    // When fd is a FileHandle we can listen for 'close' events
-    if (options.fd instanceof FileHandle) {
-      // FileHandle is not supported with custom fs operations
+    if (typeof options.fd === 'number') {
+      // When fd is a raw descriptor, we must keep our fingers crossed
+      // that the descriptor won't get closed, or worse, replaced with
+      // another one
+      // https://github.com/nodejs/node/issues/35862
+      stream.fd = options.fd;
+    } else {
+      // When fd is a FileHandle we can listen for 'close' events
       if (options.fs)
+        // FileHandle is not supported with custom fs operations
         throw new ERR_METHOD_NOT_IMPLEMENTED('FileHandle with fs');
       stream[kHandle] = options.fd;
       stream.fd = options.fd.fd;
       stream[kFs] = FileHandleOperations(stream[kHandle]);
       stream[kHandle][kRef]();
       options.fd.on('close', FunctionPrototypeBind(stream.close, stream));
-    }
-    // When fd is a raw descriptor, we must keep our fingers crossed
-    // that the descriptor won't get closed, or worse, replaced with
-    // another one
-    // https://github.com/nodejs/node/issues/35862
-    if (typeof options.fd === 'number') {
-      stream.fd = options.fd;
     }
   }
 }

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -11,12 +11,14 @@ const {
 
 const {
   ERR_INVALID_ARG_TYPE,
-  ERR_OUT_OF_RANGE
+  ERR_OUT_OF_RANGE,
+  ERR_METHOD_NOT_IMPLEMENTED
 } = require('internal/errors').codes;
 const { deprecate } = require('internal/util');
 const { validateInteger } = require('internal/validators');
 const { errorOrDestroy } = require('internal/streams/destroy');
 const fs = require('fs');
+const { FileHandle, kRef, kUnref } = require('internal/fs/promises');
 const { Buffer } = require('buffer');
 const {
   copyObject,
@@ -28,6 +30,7 @@ const kIoDone = Symbol('kIoDone');
 const kIsPerformingIO = Symbol('kIsPerformingIO');
 
 const kFs = Symbol('kFs');
+const kHandle = Symbol('kHandle');
 
 function _construct(callback) {
   const stream = this;
@@ -66,6 +69,36 @@ function _construct(callback) {
   }
 }
 
+// This generates an fs operations structure for a FileHandle
+const FileHandleOperations = (handle) => {
+  return {
+    open: (path, flags, mode, cb) => {
+      throw new ERR_METHOD_NOT_IMPLEMENTED('open()');
+    },
+    close: (fd, cb) => {
+      handle[kUnref]();
+      handle.close()
+        .then(() => cb())
+        .catch((err) => cb(err));
+    },
+    read: (fd, buf, offset, length, pos, cb) => {
+      handle.read(buf, offset, length, pos)
+        .then((r) => cb(null, r.bytesRead, r.buffer))
+        .catch((err) => cb(err, 0, buf));
+    },
+    write: (fd, buf, offset, length, pos, cb) => {
+      handle.read(buf, offset, length, pos)
+        .then((r) => cb(null, r.bytesWritten, r.buffer))
+        .catch((err) => cb(err, 0, buf));
+    },
+    writev: (fd, buffers, pos, cb) => {
+      handle.writev(buffers, pos)
+        .then((r) => cb(null, r.bytesWritten, r.buffers))
+        .catch((err) => cb(err, 0, buffers));
+    }
+  };
+};
+
 function close(stream, err, cb) {
   if (!stream.fd) {
     // TODO(ronag)
@@ -77,6 +110,30 @@ function close(stream, err, cb) {
       cb(er || err);
     });
     stream.fd = null;
+  }
+}
+
+function importFd(stream, options) {
+  stream.fd = null;
+  if (options.fd) {
+    // When fd is a FileHandle we can listen for 'close' events
+    if (options.fd instanceof FileHandle) {
+      // FileHandle is not supported with custom fs operations
+      if (options.fs)
+        throw new ERR_METHOD_NOT_IMPLEMENTED('FileHandle with fs');
+      stream[kHandle] = options.fd;
+      stream.fd = options.fd.fd;
+      stream[kFs] = FileHandleOperations(stream[kHandle]);
+      stream[kHandle][kRef]();
+      options.fd.on('close', stream.close.bind(stream));
+    }
+    // When fd is a raw descriptor, we must keep our fingers crossed
+    // that the descriptor won't get closed, or worse, replaced with
+    // another one
+    // https://github.com/nodejs/node/issues/35862
+    if (typeof options.fd === 'number') {
+      stream.fd = options.fd;
+    }
   }
 }
 
@@ -118,6 +175,8 @@ function ReadStream(path, options) {
   this.fd = options.fd === undefined ? null : options.fd;
   this.flags = options.flags === undefined ? 'r' : options.flags;
   this.mode = options.mode === undefined ? 0o666 : options.mode;
+
+  importFd(this, options);
 
   this.start = options.start;
   this.end = options.end;
@@ -287,9 +346,10 @@ function WriteStream(path, options) {
 
   // Path will be ignored when fd is specified, so it can be falsy
   this.path = toPathIfFileURL(path);
-  this.fd = options.fd === undefined ? null : options.fd;
   this.flags = options.flags === undefined ? 'w' : options.flags;
   this.mode = options.mode === undefined ? 0o666 : options.mode;
+
+  importFd(this, options);
 
   this.start = options.start;
   this.pos = undefined;

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -7,6 +7,8 @@ const {
   ObjectSetPrototypeOf,
   ReflectApply,
   Symbol,
+  PromisePrototypeThen,
+  FunctionPrototypeBind
 } = primordials;
 
 const {
@@ -82,17 +84,17 @@ const FileHandleOperations = (handle) => {
     },
     read: (fd, buf, offset, length, pos, cb) => {
       PromisePrototypeThen(handle.read(buf, offset, length, pos),
-                           (r) => cb(null, r.bytesRead, r.buffer), 
+                           (r) => cb(null, r.bytesRead, r.buffer),
                            (err) => cb(err, 0, buf));
     },
     write: (fd, buf, offset, length, pos, cb) => {
       PromisePrototypeThen(handle.write(buf, offset, length, pos),
-                           (r) => cb(null, r.bytesWritten, r.buffer), 
+                           (r) => cb(null, r.bytesWritten, r.buffer),
                            (err) => cb(err, 0, buf));
     },
     writev: (fd, buffers, pos, cb) => {
       PromisePrototypeThen(handle.writev(buffers, pos),
-                           (r) => cb(null, r.bytesWritten, r.buffers), 
+                           (r) => cb(null, r.bytesWritten, r.buffers),
                            (err) => cb(err, 0, buffers));
     }
   };

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -175,7 +175,6 @@ function ReadStream(path, options) {
 
   // Path will be ignored when fd is specified, so it can be falsy
   this.path = toPathIfFileURL(path);
-  this.fd = options.fd === undefined ? null : options.fd;
   this.flags = options.flags === undefined ? 'r' : options.flags;
   this.mode = options.mode === undefined ? 0o666 : options.mode;
 

--- a/test/parallel/test-fs-promises-file-handle-read-worker.js
+++ b/test/parallel/test-fs-promises-file-handle-read-worker.js
@@ -21,7 +21,6 @@ if (isMainThread) {
     });
   });
   fs.promises.open(file, 'r').then((handle) => {
-    handle.on('close', common.mustNotCall());
     fs.createReadStream(null, { fd: handle });
     assert.throws(() => {
       new Worker(__filename, {
@@ -34,6 +33,7 @@ if (isMainThread) {
   });
 } else {
   const handle = workerData.handle;
+  handle.on('close', common.mustCall());
   const stream = fs.createReadStream(null, { fd: handle });
 
   stream.on('data', common.mustCallAtLeast((data) => {
@@ -41,6 +41,7 @@ if (isMainThread) {
   }));
 
   stream.on('end', common.mustCall(() => {
+    handle.close();
     assert.strictEqual(output, input);
   }));
 

--- a/test/parallel/test-fs-promises-file-handle-read-worker.js
+++ b/test/parallel/test-fs-promises-file-handle-read-worker.js
@@ -9,10 +9,11 @@ const input = 'hello world';
 const { Worker, isMainThread, workerData } = require('worker_threads');
 
 let output = '';
-tmpdir.refresh();
-fs.writeFileSync(file, input);
 
 if (isMainThread) {
+  tmpdir.refresh();
+  fs.writeFileSync(file, input);
+
   fs.promises.open(file, 'r').then((handle) => {
     handle.on('close', common.mustNotCall());
     new Worker(__filename, {

--- a/test/parallel/test-fs-promises-file-handle-read-worker.js
+++ b/test/parallel/test-fs-promises-file-handle-read-worker.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const assert = require('assert');
 const path = require('path');
 const tmpdir = require('../common/tmpdir');
-const file = path.join(tmpdir.path, '/read_stream_filehandle_worker.txt');
+const file = path.join(tmpdir.path, 'read_stream_filehandle_worker.txt');
 const input = 'hello world';
 const { Worker, isMainThread, workerData } = require('worker_threads');
 

--- a/test/parallel/test-fs-promises-file-handle-read-worker.js
+++ b/test/parallel/test-fs-promises-file-handle-read-worker.js
@@ -1,0 +1,48 @@
+'use strict';
+const common = require('../common');
+const fs = require('fs');
+const assert = require('assert');
+const path = require('path');
+const tmpdir = require('../common/tmpdir');
+const file = path.join(tmpdir.path, '/read_stream_filehandle_worker.txt');
+const input = 'hello world';
+const { Worker, isMainThread, workerData } = require('worker_threads');
+
+let output = '';
+tmpdir.refresh();
+fs.writeFileSync(file, input);
+
+if (isMainThread) {
+  fs.promises.open(file, 'r').then((handle) => {
+    handle.on('close', common.mustNotCall());
+    new Worker(__filename, {
+      workerData: { handle },
+      transferList: [handle]
+    });
+  });
+  fs.promises.open(file, 'r').then((handle) => {
+    handle.on('close', common.mustNotCall());
+    fs.createReadStream(null, { fd: handle });
+    assert.throws(() => {
+      new Worker(__filename, {
+        workerData: { handle },
+        transferList: [handle]
+      });
+    }, {
+      code: 25,
+    });
+  });
+} else {
+  const handle = workerData.handle;
+  const stream = fs.createReadStream(null, { fd: handle });
+
+  stream.on('data', common.mustCallAtLeast((data) => {
+    output += data;
+  }));
+
+  stream.on('end', common.mustCall(() => {
+    assert.strictEqual(output, input);
+  }));
+
+  stream.on('close', common.mustCall());
+}

--- a/test/parallel/test-fs-promises-file-handle-read-worker.js
+++ b/test/parallel/test-fs-promises-file-handle-read-worker.js
@@ -8,9 +8,7 @@ const file = path.join(tmpdir.path, 'read_stream_filehandle_worker.txt');
 const input = 'hello world';
 const { Worker, isMainThread, workerData } = require('worker_threads');
 
-let output = '';
-
-if (isMainThread) {
+if (isMainThread || !workerData) {
   tmpdir.refresh();
   fs.writeFileSync(file, input);
 
@@ -33,6 +31,8 @@ if (isMainThread) {
     });
   });
 } else {
+  let output = '';
+
   const handle = workerData.handle;
   handle.on('close', common.mustCall());
   const stream = fs.createReadStream(null, { fd: handle });

--- a/test/parallel/test-fs-promises-file-handle-read.js
+++ b/test/parallel/test-fs-promises-file-handle-read.js
@@ -71,4 +71,4 @@ let useConf = false;
       .then(validateLargeRead)
       .then(common.mustCall());
   }
-})();
+})().then(common.mustCall());

--- a/test/parallel/test-fs-promises-file-handle-read.js
+++ b/test/parallel/test-fs-promises-file-handle-read.js
@@ -19,33 +19,32 @@ async function read(fileHandle, buffer, offset, length, position) {
     fileHandle.read(buffer, offset, length, position);
 }
 
-async function validateRead() {
-  const filePath = path.resolve(tmpDir, 'tmp-read-file.txt');
-  const fileHandle = await open(filePath, 'w+');
-  const buffer = Buffer.from('Hello world', 'utf8');
+async function validateRead(data, file) {
+  const filePath = path.resolve(tmpDir, file);
+  const buffer = Buffer.from(data, 'utf8');
 
   const fd = fs.openSync(filePath, 'w+');
-  fs.writeSync(fd, buffer, 0, buffer.length);
-  fs.closeSync(fd);
-  const readAsyncHandle = await read(fileHandle, Buffer.alloc(11), 0, 11, 0);
-  assert.deepStrictEqual(buffer.length, readAsyncHandle.bytesRead);
-  assert.deepStrictEqual(buffer, readAsyncHandle.buffer);
-
-  await fileHandle.close();
-}
-
-async function validateEmptyRead() {
-  const filePath = path.resolve(tmpDir, 'tmp-read-empty-file.txt');
   const fileHandle = await open(filePath, 'w+');
-  const buffer = Buffer.from('', 'utf8');
+  const streamFileHandle = await open(filePath, 'w+');
 
-  const fd = fs.openSync(filePath, 'w+');
   fs.writeSync(fd, buffer, 0, buffer.length);
   fs.closeSync(fd);
-  const readAsyncHandle = await read(fileHandle, Buffer.alloc(11), 0, 11, 0);
-  assert.deepStrictEqual(buffer.length, readAsyncHandle.bytesRead);
 
+  fileHandle.on('close', common.mustCall());
+  const readAsyncHandle = await read(fileHandle, Buffer.alloc(11), 0, 11, 0);
+  assert.deepStrictEqual(data.length, readAsyncHandle.bytesRead);
+  if (data.length)
+    assert.deepStrictEqual(buffer, readAsyncHandle.buffer);
   await fileHandle.close();
+
+  const stream = fs.createReadStream(null, { fd: streamFileHandle });
+  let streamData = Buffer.alloc(0);
+  for await (const chunk of stream)
+    streamData = Buffer.from(chunk);
+  assert.deepStrictEqual(buffer, streamData);
+  if (data.length)
+    assert.deepStrictEqual(streamData, readAsyncHandle.buffer);
+  await streamFileHandle.close();
 }
 
 async function validateLargeRead() {
@@ -67,9 +66,9 @@ let useConf = false;
     tmpdir.refresh();
     useConf = value;
 
-    await validateRead()
-          .then(validateEmptyRead)
-          .then(validateLargeRead)
-          .then(common.mustCall());
+    await validateRead('Hello world', 'tmp-read-file.txt')
+      .then(validateRead('', 'tmp-read-empty-file.txt'))
+      .then(validateLargeRead)
+      .then(common.mustCall());
   }
 });

--- a/test/parallel/test-fs-promises-file-handle-read.js
+++ b/test/parallel/test-fs-promises-file-handle-read.js
@@ -71,4 +71,4 @@ let useConf = false;
       .then(validateLargeRead)
       .then(common.mustCall());
   }
-});
+})();

--- a/test/parallel/test-fs-read-stream-file-handle.js
+++ b/test/parallel/test-fs-read-stream-file-handle.js
@@ -61,4 +61,5 @@ fs.promises.open(file, 'r').then((handle) => {
     name: 'Error',
     message: 'The FileHandle with fs method is not implemented'
   });
+  handle.close();
 });

--- a/test/parallel/test-fs-read-stream-file-handle.js
+++ b/test/parallel/test-fs-read-stream-file-handle.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const assert = require('assert');
 const path = require('path');
 const tmpdir = require('../common/tmpdir');
-const file = path.join(tmpdir.path, '/read_stream_filehandle_test.txt');
+const file = path.join(tmpdir.path, 'read_stream_filehandle_test.txt');
 const input = 'hello world';
 
 let output = '';

--- a/test/parallel/test-fs-read-stream-file-handle.js
+++ b/test/parallel/test-fs-read-stream-file-handle.js
@@ -1,0 +1,46 @@
+'use strict';
+const common = require('../common');
+const fs = require('fs');
+const assert = require('assert');
+const path = require('path');
+const tmpdir = require('../common/tmpdir');
+const file = path.join(tmpdir.path, '/read_stream_filehandle_test.txt');
+const input = 'hello world';
+
+let output = '';
+tmpdir.refresh();
+fs.writeFileSync(file, input);
+
+fs.promises.open(file, 'r').then((handle) => {
+  handle.on('close', common.mustCall());
+  const stream = fs.createReadStream(null, { fd: handle });
+
+  stream.on('data', common.mustCallAtLeast((data) => {
+    output += data;
+  }));
+
+  stream.on('end', common.mustCall(() => {
+    assert.strictEqual(output, input);
+  }));
+
+  stream.on('close', common.mustCall());
+});
+
+fs.promises.open(file, 'r').then((handle) => {
+  handle.on('close', common.mustCall());
+  const stream = fs.createReadStream(null, { fd: handle });
+  stream.on('data', common.mustNotCall());
+  stream.on('close', common.mustCall());
+
+  handle.close();
+});
+
+fs.promises.open(file, 'r').then((handle) => {
+  assert.throws(() => {
+    fs.createReadStream(null, { fd: handle, fs });
+  }, {
+    code: 'ERR_METHOD_NOT_IMPLEMENTED',
+    name: 'Error',
+    message: 'The FileHandle with fs method is not implemented'
+  });
+});

--- a/test/parallel/test-fs-read-stream-file-handle.js
+++ b/test/parallel/test-fs-read-stream-file-handle.js
@@ -36,6 +36,24 @@ fs.promises.open(file, 'r').then((handle) => {
 });
 
 fs.promises.open(file, 'r').then((handle) => {
+  handle.on('close', common.mustCall());
+  const stream = fs.createReadStream(null, { fd: handle });
+  stream.on('close', common.mustCall());
+
+  stream.on('data', common.mustCall(() => {
+    handle.close();
+  }));
+});
+
+fs.promises.open(file, 'r').then((handle) => {
+  handle.on('close', common.mustCall());
+  const stream = fs.createReadStream(null, { fd: handle });
+  stream.on('close', common.mustCall());
+
+  stream.close();
+});
+
+fs.promises.open(file, 'r').then((handle) => {
   assert.throws(() => {
     fs.createReadStream(null, { fd: handle, fs });
   }, {

--- a/test/parallel/test-fs-read-stream-file-handle.js
+++ b/test/parallel/test-fs-read-stream-file-handle.js
@@ -11,7 +11,7 @@ let output = '';
 tmpdir.refresh();
 fs.writeFileSync(file, input);
 
-fs.promises.open(file, 'r').then((handle) => {
+fs.promises.open(file, 'r').then(common.mustCall((handle) => {
   handle.on('close', common.mustCall());
   const stream = fs.createReadStream(null, { fd: handle });
 
@@ -24,18 +24,18 @@ fs.promises.open(file, 'r').then((handle) => {
   }));
 
   stream.on('close', common.mustCall());
-});
+}));
 
-fs.promises.open(file, 'r').then((handle) => {
+fs.promises.open(file, 'r').then(common.mustCall((handle) => {
   handle.on('close', common.mustCall());
   const stream = fs.createReadStream(null, { fd: handle });
   stream.on('data', common.mustNotCall());
   stream.on('close', common.mustCall());
 
   handle.close();
-});
+}));
 
-fs.promises.open(file, 'r').then((handle) => {
+fs.promises.open(file, 'r').then(common.mustCall((handle) => {
   handle.on('close', common.mustCall());
   const stream = fs.createReadStream(null, { fd: handle });
   stream.on('close', common.mustCall());
@@ -43,17 +43,17 @@ fs.promises.open(file, 'r').then((handle) => {
   stream.on('data', common.mustCall(() => {
     handle.close();
   }));
-});
+}));
 
-fs.promises.open(file, 'r').then((handle) => {
+fs.promises.open(file, 'r').then(common.mustCall((handle) => {
   handle.on('close', common.mustCall());
   const stream = fs.createReadStream(null, { fd: handle });
   stream.on('close', common.mustCall());
 
   stream.close();
-});
+}));
 
-fs.promises.open(file, 'r').then((handle) => {
+fs.promises.open(file, 'r').then(common.mustCall((handle) => {
   assert.throws(() => {
     fs.createReadStream(null, { fd: handle, fs });
   }, {
@@ -62,4 +62,4 @@ fs.promises.open(file, 'r').then((handle) => {
     message: 'The FileHandle with fs method is not implemented'
   });
   handle.close();
-});
+}));

--- a/test/parallel/test-fs-write-stream-file-handle.js
+++ b/test/parallel/test-fs-write-stream-file-handle.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const assert = require('assert');
 const tmpdir = require('../common/tmpdir');
-const file = path.join(tmpdir.path, '/write_stream_filehandle_test.txt');
+const file = path.join(tmpdir.path, 'write_stream_filehandle_test.txt');
 const input = 'hello world';
 
 tmpdir.refresh();

--- a/test/parallel/test-fs-write-stream-file-handle.js
+++ b/test/parallel/test-fs-write-stream-file-handle.js
@@ -1,0 +1,17 @@
+'use strict';
+const common = require('../common');
+const fs = require('fs');
+const path = require('path');
+const tmpdir = require('../common/tmpdir');
+const file = path.join(tmpdir.path, '/write_stream_filehandle_test.txt');
+const input = 'hello world';
+
+tmpdir.refresh();
+
+fs.promises.open(file, 'w+').then((handle) => {
+  handle.on('close', common.mustCall());
+  const stream = fs.createWriteStream(null, { fd: handle });
+
+  stream.end(input);
+  stream.on('close', common.mustCall());
+});

--- a/test/parallel/test-fs-write-stream-file-handle.js
+++ b/test/parallel/test-fs-write-stream-file-handle.js
@@ -2,6 +2,7 @@
 const common = require('../common');
 const fs = require('fs');
 const path = require('path');
+const assert = require('assert');
 const tmpdir = require('../common/tmpdir');
 const file = path.join(tmpdir.path, '/write_stream_filehandle_test.txt');
 const input = 'hello world';
@@ -13,5 +14,8 @@ fs.promises.open(file, 'w+').then((handle) => {
   const stream = fs.createWriteStream(null, { fd: handle });
 
   stream.end(input);
-  stream.on('close', common.mustCall());
+  stream.on('close', common.mustCall(() => {
+    const output = fs.readFileSync(file, 'utf-8');
+    assert.strictEqual(output, input);
+  }));
 });

--- a/test/parallel/test-fs-write-stream-file-handle.js
+++ b/test/parallel/test-fs-write-stream-file-handle.js
@@ -9,7 +9,7 @@ const input = 'hello world';
 
 tmpdir.refresh();
 
-fs.promises.open(file, 'w+').then((handle) => {
+fs.promises.open(file, 'w+').then(common.mustCall((handle) => {
   handle.on('close', common.mustCall());
   const stream = fs.createWriteStream(null, { fd: handle });
 
@@ -18,4 +18,4 @@ fs.promises.open(file, 'w+').then((handle) => {
     const output = fs.readFileSync(file, 'utf-8');
     assert.strictEqual(output, input);
   }));
-});
+}));


### PR DESCRIPTION
Support creating a Read/WriteStream from a
FileHandle instead of a raw file descriptor
Add an EventEmitter to FileHandle with a single
'close' event

Refs: https://github.com/nodejs/node/issues/35240

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
