### PR TITLE
stream: remove isPromise utility function

### DIFF
--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -5,8 +5,9 @@
 
 const {
   ArrayIsArray,
+  ReflectApply,
   SymbolAsyncIterator,
-  SymbolIterator
+  SymbolIterator,
 } = primordials;
 
 let eos;
@@ -75,10 +76,6 @@ function popCallback(streams) {
   if (typeof streams[streams.length - 1] !== 'function')
     throw new ERR_INVALID_CALLBACK(streams[streams.length - 1]);
   return streams.pop();
-}
-
-function isPromise(obj) {
-  return !!(obj && typeof obj.then === 'function');
 }
 
 function isReadable(obj) {
@@ -222,14 +219,19 @@ function pipeline(...streams) {
         const pt = new PassThrough({
           objectMode: true
         });
-        if (isPromise(ret)) {
-          ret
-            .then((val) => {
+
+        // Handle Promises/A+ spec, `then` could be a getter that throws on
+        // second use.
+        const then = ret?.then;
+        if (typeof then === 'function') {
+          ReflectApply(then, ret, [
+            (val) => {
               value = val;
               pt.end(val);
             }, (err) => {
               pt.destroy(err);
-            });
+            }
+          ]);
         } else if (isIterable(ret, true)) {
           finishCount++;
           pump(ret, pt, finish);

--- a/test/parallel/test-stream-pipeline.js
+++ b/test/parallel/test-stream-pipeline.js
@@ -1240,3 +1240,24 @@ const net = require('net');
     }),
   );
 }
+{
+  function createThenable() {
+    let counter = 0;
+    return {
+      get then() {
+        if (counter++) {
+          throw new Error('Cannot access `then` more than once');
+        }
+        return Function.prototype;
+      },
+    };
+  }
+
+  pipeline(
+    function* () {
+      yield 0;
+    },
+    createThenable,
+    () => common.mustNotCall(),
+  );
+}


### PR DESCRIPTION
The function was not checking if the parameter was actually a Promise
instance, but if it has a `then` method. Removing the utility function
in favor of a clearer `typeof` check, handling the case when the
thenable throws if then method is accessed more than once.

The difference between a _thenable_ and a `Promise` may be important when using third party library (the parameter is provided by the user) and/or when `Promise.prototype.then` value is changed from userland. 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
