### PR TITLE
events: support defining event handlers on prototypes

### DIFF
--- a/lib/internal/abort_controller.js
+++ b/lib/internal/abort_controller.js
@@ -48,6 +48,8 @@ ObjectDefineProperties(AbortSignal.prototype, {
   aborted: { enumerable: true }
 });
 
+defineEventHandler(AbortSignal.prototype, 'abort');
+
 function abortSignal(signal) {
   if (signal[kAborted]) return;
   signal[kAborted] = true;
@@ -65,7 +67,6 @@ class AbortController {
   constructor() {
     this[kSignal] = new AbortSignal();
     emitExperimentalWarning('AbortController');
-    defineEventHandler(this[kSignal], 'abort');
   }
 
   get signal() { return this[kSignal]; }

--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -9,6 +9,7 @@ const {
   ObjectDefineProperties,
   ObjectDefineProperty,
   ObjectGetOwnPropertyDescriptor,
+  ReflectApply,
   SafeMap,
   String,
   Symbol,
@@ -578,24 +579,47 @@ function emitUnhandledRejectionOrErr(that, err, event) {
   process.emit('error', err, event);
 }
 
+function makeEventHandler(handler) {
+  // Event handlers are dispatched in the order they were first set
+  // See https://github.com/nodejs/node/pull/35949#issuecomment-722496598
+  function eventHandler(...args) {
+    if (typeof eventHandler.handler !== 'function') {
+      return;
+    }
+    return ReflectApply(eventHandler.handler, this, args);
+  }
+  eventHandler.handler = handler;
+  return eventHandler;
+}
+
 function defineEventHandler(emitter, name) {
   // 8.1.5.1 Event handlers - basically `on[eventName]` attributes
   ObjectDefineProperty(emitter, `on${name}`, {
     get() {
-      return this[kHandlers]?.get(name);
+      return this[kHandlers]?.get(name)?.handler;
     },
     set(value) {
-      const oldValue = this[kHandlers]?.get(name);
-      if (oldValue) {
-        this.removeEventListener(name, oldValue);
-      }
-      if (typeof value === 'function') {
-        this.addEventListener(name, value);
-      }
       if (!this[kHandlers]) {
         this[kHandlers] = new SafeMap();
       }
-      this[kHandlers].set(name, value);
+      let wrappedHandler = this[kHandlers]?.get(name);
+      if (wrappedHandler) {
+        if (typeof wrappedHandler.handler === 'function') {
+          this[kEvents].get(name).size--;
+          const size = this[kEvents].get(name).size;
+          this[kRemoveListener](size, name, wrappedHandler.handler, false);
+        }
+        wrappedHandler.handler = value;
+        if (typeof wrappedHandler.handler === 'function') {
+          this[kEvents].get(name).size++;
+          const size = this[kEvents].get(name).size;
+          this[kNewListener](size, name, value, false, false, false);
+        }
+      } else {
+        wrappedHandler = makeEventHandler(value);
+        this.addEventListener(name, wrappedHandler);
+      }
+      this[kHandlers].set(name, wrappedHandler);
     },
     configurable: true,
     enumerable: true

--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -592,7 +592,9 @@ function defineEventHandler(emitter, name) {
         emitter.addEventListener(name, value);
       }
       eventHandlerValue = value;
-    }
+    },
+    configurable: true,
+    enumerable: true
   });
 }
 module.exports = {

--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -14,6 +14,7 @@ const {
   Symbol,
   SymbolFor,
   SymbolToStringTag,
+  SafeWeakMap,
   SafeWeakSet,
 } = primordials;
 
@@ -577,21 +578,27 @@ function emitUnhandledRejectionOrErr(that, err, event) {
   process.emit('error', err, event);
 }
 
+// A map of emitter -> map of name -> handler
+const eventHandlerValueMap = new SafeWeakMap();
+
 function defineEventHandler(emitter, name) {
   // 8.1.5.1 Event handlers - basically `on[eventName]` attributes
-  let eventHandlerValue;
   ObjectDefineProperty(emitter, `on${name}`, {
     get() {
-      return eventHandlerValue;
+      return eventHandlerValueMap.get(this)?.get(name);
     },
     set(value) {
-      if (eventHandlerValue) {
-        emitter.removeEventListener(name, eventHandlerValue);
+      const oldValue = eventHandlerValueMap.get(this)?.get(name);
+      if (oldValue) {
+        this.removeEventListener(name, oldValue);
       }
       if (typeof value === 'function') {
-        emitter.addEventListener(name, value);
+        this.addEventListener(name, value);
       }
-      eventHandlerValue = value;
+      if (!eventHandlerValueMap.has(this)) {
+        eventHandlerValueMap.set(this, new Map());
+      }
+      eventHandlerValueMap.get(this).set(name, value);
     },
     configurable: true,
     enumerable: true

--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -4,17 +4,16 @@ const {
   ArrayFrom,
   Boolean,
   Error,
-  Map,
   NumberIsInteger,
   ObjectAssign,
   ObjectDefineProperties,
   ObjectDefineProperty,
   ObjectGetOwnPropertyDescriptor,
+  SafeMap,
   String,
   Symbol,
   SymbolFor,
   SymbolToStringTag,
-  SafeWeakMap,
   SafeWeakSet,
 } = primordials;
 
@@ -36,6 +35,7 @@ const kIsEventTarget = SymbolFor('nodejs.event_target');
 const kEvents = Symbol('kEvents');
 const kStop = Symbol('kStop');
 const kTarget = Symbol('kTarget');
+const kHandlers = Symbol('khandlers');
 
 const kHybridDispatch = Symbol.for('nodejs.internal.kHybridDispatch');
 const kCreateEvent = Symbol('kCreateEvent');
@@ -219,7 +219,7 @@ class Listener {
 }
 
 function initEventTarget(self) {
-  self[kEvents] = new Map();
+  self[kEvents] = new SafeMap();
 }
 
 class EventTarget {
@@ -578,27 +578,24 @@ function emitUnhandledRejectionOrErr(that, err, event) {
   process.emit('error', err, event);
 }
 
-// A map of emitter -> map of name -> handler
-const eventHandlerValueMap = new SafeWeakMap();
-
 function defineEventHandler(emitter, name) {
   // 8.1.5.1 Event handlers - basically `on[eventName]` attributes
   ObjectDefineProperty(emitter, `on${name}`, {
     get() {
-      return eventHandlerValueMap.get(this)?.get(name);
+      return this[kHandlers]?.get(name);
     },
     set(value) {
-      const oldValue = eventHandlerValueMap.get(this)?.get(name);
+      const oldValue = this[kHandlers]?.get(name);
       if (oldValue) {
         this.removeEventListener(name, oldValue);
       }
       if (typeof value === 'function') {
         this.addEventListener(name, value);
       }
-      if (!eventHandlerValueMap.has(this)) {
-        eventHandlerValueMap.set(this, new Map());
+      if (!this[kHandlers]) {
+        this[kHandlers] = new SafeMap();
       }
-      eventHandlerValueMap.get(this).set(name, value);
+      this[kHandlers].set(name, value);
     },
     configurable: true,
     enumerable: true

--- a/lib/internal/worker/io.js
+++ b/lib/internal/worker/io.js
@@ -146,12 +146,13 @@ ObjectDefineProperty(
 // This is called from inside the `MessagePort` constructor.
 function oninit() {
   initNodeEventTarget(this);
-  // TODO(addaleax): This should be on MessagePort.prototype, but
-  // defineEventHandler() does not support that.
   defineEventHandler(this, 'message');
   defineEventHandler(this, 'messageerror');
   setupPortReferencing(this, this, 'message');
 }
+
+defineEventHandler(MessagePort.prototype, 'message');
+defineEventHandler(MessagePort.prototype, 'messageerror');
 
 ObjectDefineProperty(MessagePort.prototype, onInitSymbol, {
   enumerable: true,

--- a/lib/internal/worker/io.js
+++ b/lib/internal/worker/io.js
@@ -146,8 +146,6 @@ ObjectDefineProperty(
 // This is called from inside the `MessagePort` constructor.
 function oninit() {
   initNodeEventTarget(this);
-  defineEventHandler(this, 'message');
-  defineEventHandler(this, 'messageerror');
   setupPortReferencing(this, this, 'message');
 }
 

--- a/test/parallel/test-eventtarget.js
+++ b/test/parallel/test-eventtarget.js
@@ -524,3 +524,15 @@ let asyncTest = Promise.resolve();
   strictEqual(descriptor.configurable, true);
   strictEqual(descriptor.enumerable, true);
 }
+{
+  const target = new EventTarget();
+  defineEventHandler(target, 'foo');
+  const output = [];
+  target.addEventListener('foo', () => output.push(1));
+  target.onfoo = common.mustNotCall();
+  target.addEventListener('foo', () => output.push(3));
+  target.onfoo = () => output.push(2);
+  target.addEventListener('foo', () => output.push(4));
+  target.dispatchEvent(new Event('foo'));
+  deepStrictEqual(output, [1, 2, 3, 4]);
+}

--- a/test/parallel/test-eventtarget.js
+++ b/test/parallel/test-eventtarget.js
@@ -517,3 +517,10 @@ let asyncTest = Promise.resolve();
   }));
   target.dispatchEvent(new Event('foo'));
 }
+{
+  const target = new EventTarget();
+  defineEventHandler(target, 'foo');
+  const descriptor = Object.getOwnPropertyDescriptor(target, 'onfoo');
+  strictEqual(descriptor.configurable, true);
+  strictEqual(descriptor.enumerable, true);
+}

--- a/test/parallel/test-worker-message-port.js
+++ b/test/parallel/test-worker-message-port.js
@@ -165,9 +165,7 @@ const { MessageChannel, MessagePort } = require('worker_threads');
   assert.deepStrictEqual(
     Object.getOwnPropertyNames(MessagePort.prototype).sort(),
     [
-      // TODO(addaleax): This should include onmessage (and eventually
-      // onmessageerror).
-      'close', 'constructor', 'postMessage', 'ref', 'start',
-      'unref'
+      'close', 'constructor', 'onmessage', 'onmessageerror', 'postMessage',
+      'ref', 'start', 'unref'
     ]);
 }


### PR DESCRIPTION
This PR allows defining event handlers on prototypes and not just on instances.

Fixes a TODO in the code

CC @addaleax 

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
