### PR TITLE
n-api: unlink reference during its destructor

### DIFF
--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -220,7 +220,7 @@ class RefBase : protected Finalizer, RefTracker {
                        finalize_hint);
   }
 
-  ~RefBase() { Unlink(); }
+  virtual ~RefBase() { Unlink(); }
 
   inline void* Data() {
     return _finalize_data;

--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -220,6 +220,8 @@ class RefBase : protected Finalizer, RefTracker {
                        finalize_hint);
   }
 
+  ~RefBase() { Unlink(); }
+
   inline void* Data() {
     return _finalize_data;
   }
@@ -240,7 +242,6 @@ class RefBase : protected Finalizer, RefTracker {
   // the finalizer and _delete_self is set. In this case we
   // know we need to do the deletion so just do it.
   static inline void Delete(RefBase* reference) {
-    reference->Unlink();
     if ((reference->RefCount() != 0) ||
         (reference->_delete_self) ||
         (reference->_finalize_ran)) {

--- a/test/node-api/test_worker_terminate_finalization/test.js
+++ b/test/node-api/test_worker_terminate_finalization/test.js
@@ -1,11 +1,9 @@
 'use strict';
 const common = require('../../common');
 
-// TODO(addaleax): Run this test once it stops failing under ASAN/valgrind.
 // Refs: https://github.com/nodejs/node/issues/34731
 // Refs: https://github.com/nodejs/node/pull/35777
 // Refs: https://github.com/nodejs/node/issues/35778
-common.skip('Reference management in N-API leaks memory');
 
 const { Worker, isMainThread } = require('worker_threads');
 


### PR DESCRIPTION
Currently, a reference is being unlinked from the list of references
tracked by the environment when `v8impl::Reference::Delete` is called.
This causes a leak when deletion must be deferred because the finalizer
hasn't yet run, but the finalizer does not run because environment
teardown is in progress, and so no more gc runs will happen, and the
`FinalizeAll` run that happens during environment teardown does not
catch the reference because it's no longer in the list. The test below
will fail when running with ASAN:
```
./node ./test/node-api/test_worker_terminate_finalization/test.js
```

OTOH if, to address the above leak, we make a special case to not
unlink a reference during environment teardown, we run into a
situation where the reference gets deleted by
`v8impl::Reference::Delete` but does not get unlinked because it's
environment teardown time. This leaves a stale pointer in the linked
list which will result in a use-after-free in `FinalizeAll` during
environment teardown. The test below will fail if we make the above
change:
```
./node -e "require('./test/node-api/test_instance_data/build/Release/test_ref_then_set.node');"
```

Thus, we unlink a reference precisely when we destroy it – in its
destructor.

Refs: https://github.com/nodejs/node/issues/34731
Refs: https://github.com/nodejs/node/pull/34839
Refs: https://github.com/nodejs/node/issues/35620
Refs: https://github.com/nodejs/node/issues/35777
Fixes: https://github.com/nodejs/node/issues/35778
Signed-off-by: @gabrielschulhof 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
