### PR TITLE
doc: adjust tables to prepare for stricter linting

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -172,7 +172,7 @@ Binaries at <https://nodejs.org/download/release/> are produced on:
 | aix-ppc64             | AIX 7.1 TL05 on PPC64BE with GCC 6                                       |
 | darwin-x64 (and .pkg) | macOS 10.15, Xcode Command Line Tools 11 with -mmacosx-version-min=10.13 |
 | linux-arm64           | CentOS 7 with devtoolset-8 / GCC 8 <sup>[8](#fn8)</sup>                  |
-| linux-armv7l          | Cross-compiled on Ubuntu 18.04 x64 with [custom GCC toolchain](https://github.com/rvagg/rpi-newer-crosstools)   |
+| linux-armv7l          | Cross-compiled on Ubuntu 18.04 x64 with [custom GCC toolchain](https://github.com/rvagg/rpi-newer-crosstools) |
 | linux-ppc64le         | CentOS 7 with devtoolset-8 / GCC 8 <sup>[8](#fn8)</sup>                  |
 | linux-s390x           | RHEL 7 with devtoolset-8 / GCC 8 <sup>[8](#fn8)</sup>                    |
 | linux-x64             | CentOS 7 with devtoolset-8 / GCC 8 <sup>[8](#fn8)</sup>                  |

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1511,16 +1511,16 @@ the permissions for the file owner. The middle digit (`6` in the example),
 specifies permissions for the group. The right-most digit (`5` in the example),
 specifies the permissions for others.
 
-| Number  |       Description        |
-| ------- | ------------------------ |
-|   `7`   | read, write, and execute |
-|   `6`   | read and write           |
-|   `5`   | read and execute         |
-|   `4`   | read only                |
-|   `3`   | write and execute        |
-|   `2`   | write only               |
-|   `1`   | execute only             |
-|   `0`   | no permission            |
+| Number |       Description        |
+| ------ | ------------------------ |
+|   `7`  | read, write, and execute |
+|   `6`  | read and write           |
+|   `5`  | read and execute         |
+|   `4`  | read only                |
+|   `3`  | write and execute        |
+|   `2`  | write only               |
+|   `1`  | execute only             |
+|   `0`  | no permission            |
 
 For example, the octal value `0o765` means:
 

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1159,18 +1159,18 @@ Different Node.js build configurations support different sets of encodings.
 
 #### Encodings supported when Node.js is built with the `small-icu` option
 
-| Encoding     | Aliases                           |
-| -----------  | --------------------------------- |
-| `'utf-8'`    | `'unicode-1-1-utf-8'`, `'utf8'`   |
-| `'utf-16le'` | `'utf-16'`                        |
-| `'utf-16be'` |                                   |
+| Encoding     | Aliases                         |
+| -----------  | --------------------------------|
+| `'utf-8'`    | `'unicode-1-1-utf-8'`, `'utf8'` |
+| `'utf-16le'` | `'utf-16'`                      |
+| `'utf-16be'` |                                 |
 
 #### Encodings supported when ICU is disabled
 
-| Encoding     | Aliases                           |
-| -----------  | --------------------------------- |
-| `'utf-8'`    | `'unicode-1-1-utf-8'`, `'utf8'`   |
-| `'utf-16le'` | `'utf-16'`                        |
+| Encoding     | Aliases                         |
+| -----------  | --------------------------------|
+| `'utf-8'`    | `'unicode-1-1-utf-8'`, `'utf8'` |
+| `'utf-16le'` | `'utf-16'`                      |
 
 The `'iso-8859-16'` encoding listed in the [WHATWG Encoding Standard][]
 is not supported.

--- a/doc/guides/diagnostic-tooling-support-tiers.md
+++ b/doc/guides/diagnostic-tooling-support-tiers.md
@@ -100,9 +100,9 @@ The tools are currently assigned to Tiers as follows:
 
 ## Tier 2
 
- | Tool Type | Tool/API Name             | Regular Testing in Node.js CI | Integrated with Node.js | Target Tier |
- |-----------|---------------------------|-------------------------------|-------------------------|-------------|
- |           |                           |                               |                         |             |
+ | Tool Type | Tool/API Name | Regular Testing in Node.js CI | Integrated with Node.js | Target Tier |
+ |-----------|---------------|-------------------------------|-------------------------|-------------|
+ |           |               |                               |                         |             |
 
 ## Tier 3
 
@@ -116,9 +116,9 @@ The tools are currently assigned to Tiers as follows:
 
 ## Tier 4
 
- | Tool Type | Tool/API Name             | Regular Testing in Node.js CI | Integrated with Node.js | Target Tier |
- |-----------|---------------------------|-------------------------------|-------------------------|-------------|
- |           |                           |                               |                         |             |
+ | Tool Type | Tool/API Name | Regular Testing in Node.js CI | Integrated with Node.js | Target Tier |
+ |-----------|---------------|-------------------------------|-------------------------|-------------|
+ |           |               |                               |                         |             |
 
 ## Not yet classified
 

--- a/doc/guides/doc-style-guide.md
+++ b/doc/guides/doc-style-guide.md
@@ -39,21 +39,21 @@ this guide.
   * Use [language][]-aware fences. (<code>```js</code>)
   * For the [info string][], use one of the following.
 
-    | Meaning       | Info string       |
-    | ------------- | ----------------- |
-    | Bash          | `bash`            |
-    | C             | `c`               |
-    | C++           | `cpp`             |
-    | CoffeeScript  | `coffee`          |
-    | Diff          | `diff`            |
-    | HTTP          | `http`            |
-    | JavaScript    | `js`              |
-    | JSON          | `json`            |
-    | Markdown      | `markdown`        |
-    | Plaintext     | `text`            |
-    | Powershell    | `powershell`      |
-    | R             | `r`               |
-    | Shell Session | `console`         |
+    | Meaning       | Info string  |
+    | ------------- | -------------|
+    | Bash          | `bash`       |
+    | C             | `c`          |
+    | C++           | `cpp`        |
+    | CoffeeScript  | `coffee`     |
+    | Diff          | `diff`       |
+    | HTTP          | `http`       |
+    | JavaScript    | `js`         |
+    | JSON          | `json`       |
+    | Markdown      | `markdown`   |
+    | Plaintext     | `text`       |
+    | Powershell    | `powershell` |
+    | R             | `r`          |
+    | Shell Session | `console`    |
 
     If one of your language-aware fences needs an info string that is not
     already on this list, you may use `text` until the grammar gets added to

--- a/test/async-hooks/coverage.md
+++ b/test/async-hooks/coverage.md
@@ -2,31 +2,31 @@
 
 Showing which kind of async resource is covered by which test:
 
-| Resource Type        | Test                                       |
-|----------------------|--------------------------------------------|
-| CONNECTION           | test-connection.ssl.js                     |
-| FSEVENTWRAP          | test-fseventwrap.js                        |
-| FSREQCALLBACK        | test-fsreqcallback-{access,readFile}.js    |
-| GETADDRINFOREQWRAP   | test-getaddrinforeqwrap.js                 |
-| GETNAMEINFOREQWRAP   | test-getnameinforeqwrap.js                 |
-| HTTPINCOMINGMESSAGE  | test-httpparser.request.js                 |
-| HTTPCLIENTREQUEST    | test-httpparser.response.js                |
-| Immediate            | test-immediate.js                          |
-| JSSTREAM             | TODO (crashes when accessing directly)     |
-| PBKDF2REQUEST        | test-crypto-pbkdf2.js                      |
-| PIPECONNECTWRAP      | test-pipeconnectwrap.js                    |
-| PIPEWRAP             | test-pipewrap.js                           |
-| PROCESSWRAP          | test-pipewrap.js                           |
-| QUERYWRAP            | test-querywrap.js                          |
-| RANDOMBYTESREQUEST   | test-crypto-randomBytes.js                 |
-| SHUTDOWNWRAP         | test-shutdownwrap.js                       |
-| SIGNALWRAP           | test-signalwrap.js                         |
-| STATWATCHER          | test-statwatcher.js                        |
-| TCPCONNECTWRAP       | test-tcpwrap.js                            |
-| TCPWRAP              | test-tcpwrap.js                            |
-| TLSWRAP              | test-tlswrap.js                            |
-| TTYWRAP              | test-ttywrap.{read,write}stream.js         |
-| UDPSENDWRAP          | test-udpsendwrap.js                        |
-| UDPWRAP              | test-udpwrap.js                            |
-| WRITEWRAP            | test-writewrap.js                          |
-| ZLIB                 | test-zlib.zlib-binding.deflate.js          |
+| Resource Type       | Test                                    |
+|---------------------|-----------------------------------------|
+| CONNECTION          | test-connection.ssl.js                  |
+| FSEVENTWRAP         | test-fseventwrap.js                     |
+| FSREQCALLBACK       | test-fsreqcallback-{access,readFile}.js |
+| GETADDRINFOREQWRAP  | test-getaddrinforeqwrap.js              |
+| GETNAMEINFOREQWRAP  | test-getnameinforeqwrap.js              |
+| HTTPINCOMINGMESSAGE | test-httpparser.request.js              |
+| HTTPCLIENTREQUEST   | test-httpparser.response.js             |
+| Immediate           | test-immediate.js                       |
+| JSSTREAM            | TODO (crashes when accessing directly)  |
+| PBKDF2REQUEST       | test-crypto-pbkdf2.js                   |
+| PIPECONNECTWRAP     | test-pipeconnectwrap.js                 |
+| PIPEWRAP            | test-pipewrap.js                        |
+| PROCESSWRAP         | test-pipewrap.js                        |
+| QUERYWRAP           | test-querywrap.js                       |
+| RANDOMBYTESREQUEST  | test-crypto-randomBytes.js              |
+| SHUTDOWNWRAP        | test-shutdownwrap.js                    |
+| SIGNALWRAP          | test-signalwrap.js                      |
+| STATWATCHER         | test-statwatcher.js                     |
+| TCPCONNECTWRAP      | test-tcpwrap.js                         |
+| TCPWRAP             | test-tcpwrap.js                         |
+| TLSWRAP             | test-tlswrap.js                         |
+| TTYWRAP             | test-ttywrap.{read,write}stream.js      |
+| UDPSENDWRAP         | test-udpsendwrap.js                     |
+| UDPWRAP             | test-udpwrap.js                         |
+| WRITEWRAP           | test-writewrap.js                       |
+| ZLIB                | test-zlib.zlib-binding.deflate.js       |


### PR DESCRIPTION
Adjust padding on tables for stricter linting coming in the next version
of remark/remark-lint.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
