### PR TITLE
src: add loop idle time in diagnostic report

### DIFF
--- a/doc/api/report.md
+++ b/doc/api/report.md
@@ -292,7 +292,8 @@ is provided below for reference.
     {
       "type": "loop",
       "is_active": true,
-      "address": "0x000055fc7b2cb180"
+      "address": "0x000055fc7b2cb180",
+      "loopIdleTimeSeconds": 22644.8
     }
   ],
   "workers": [],

--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -294,6 +294,10 @@ static void WriteNodeReport(Isolate* isolate,
         static_cast<bool>(uv_loop_alive(env->event_loop())));
     writer.json_keyvalue("address",
         ValueToHexString(reinterpret_cast<int64_t>(env->event_loop())));
+
+    // Report Event loop idle time
+    uint64_t idle_time = uv_metrics_idle_time(env->event_loop());
+    writer.json_keyvalue("loopIdleTimeSeconds", 1.0 * idle_time / 1e9);
     writer.json_end();
   }
 

--- a/test/report/test-report-uv-handles.js
+++ b/test/report/test-report-uv-handles.js
@@ -128,6 +128,9 @@ if (process.argv[2] === 'child') {
         assert.strictEqual(handle.filename, expected_filename);
         assert(handle.is_referenced);
       }),
+      loop: common.mustCall(function loop_validator(handle) {
+        assert.strictEqual(typeof handle.loopIdleTimeSeconds, 'number');
+      }),
       pipe: common.mustCallAtLeast(function pipe_validator(handle) {
         assert(handle.is_referenced);
       }),


### PR DESCRIPTION
Add libuv's cumulative idle time in the diagnostic report.
Modify the structure of libuv section to cater to this change

Refs: https://github.com/nodejs/node/pull/34938

before
```js
  "libuv": [
    {
      "type": "async",
      "is_active": true,
      "is_referenced": false,
      "address": "0x0000000105a0bd70"
    }
  ]
```

after 

```js
  "libuv": {
    "loop_idle_time": 22644.8,
    "handles": [
      {
      "type": "async",
      "is_active": true,
      "is_referenced": false,
      "address": "0x0000000105a0bd70"
      }
    ]
  }
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
