### PR TITLE
stream: fix regression on duplex end

### DIFF
--- a/lib/internal/streams/writable.js
+++ b/lib/internal/streams/writable.js
@@ -366,6 +366,12 @@ function writeOrBuffer(stream, state, chunk, encoding, callback) {
 
   state.length += len;
 
+  // stream._write resets state.length
+  const ret = state.length < state.highWaterMark;
+  // We must ensure that previous needDrain will not be reset to false.
+  if (!ret)
+    state.needDrain = true;
+
   if (state.writing || state.corked || state.errored || !state.constructed) {
     state.buffered.push({ chunk, encoding, callback });
     if (state.allBuffers && encoding !== 'buffer') {
@@ -382,12 +388,6 @@ function writeOrBuffer(stream, state, chunk, encoding, callback) {
     stream._write(chunk, encoding, state.onwrite);
     state.sync = false;
   }
-
-  const ret = state.length < state.highWaterMark;
-
-  // We must ensure that previous needDrain will not be reset to false.
-  if (!ret)
-    state.needDrain = true;
 
   // Return false if errored or destroyed in order to break
   // any synchronous while(stream.write(data)) loops.

--- a/test/parallel/test-stream-duplex-readable-end.js
+++ b/test/parallel/test-stream-duplex-readable-end.js
@@ -1,0 +1,32 @@
+'use strict';
+// https://github.com/nodejs/node/issues/35926
+require('../common');
+const assert = require('assert');
+const stream = require('stream');
+
+let loops = 5;
+
+const src = new stream.Readable({
+  read() {
+    if (loops--)
+      this.push(Buffer.alloc(20000));
+  }
+});
+
+const dst = new stream.Transform({
+  transform(chunk, output, fn) {
+    this.push(null);
+    fn();
+  }
+});
+
+src.pipe(dst);
+
+function parser_end() {
+  assert.ok(loops > 0);
+  dst.removeAllListeners();
+}
+
+dst.on('data', () => { });
+dst.on('end', parser_end);
+dst.on('error', parser_end);


### PR DESCRIPTION
Decide the return status of writeOrBuffer before
calling stream.write which can reset state.length

Fixes: https://github.com/nodejs/node/issues/35926

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
