### PR TITLE
doc: update benchmark CI test indicator in README

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -18,7 +18,7 @@ For the tests to run on Windows, be sure to clone Node.js source code with the
 | `abort`          | Yes        | Tests for when the `--abort-on-uncaught-exception` flag is used. |
 | `addons`         | Yes        | Tests for [addon](https://nodejs.org/api/addons.html) functionality along with some tests that require an addon. |
 | `async-hooks`    | Yes       | Tests for [async_hooks](https://nodejs.org/api/async_hooks.html) functionality. |
-| `benchmark`      | No        | Test minimal functionality of benchmarks. |
+| `benchmark`      | Yes       | Test minimal functionality of benchmarks. |
 | `cctest`         | Yes       | C++ tests that are run as part of the build process. |
 | `code-cache`     | No        | Tests for a Node.js binary compiled with V8 code cache. |
 | `common`         |           | Common modules shared among many tests. [Documentation](./common/README.md) |


### PR DESCRIPTION
As of c7627da837af55e3a37ca0933b6a3247fc6c06bb, benchmark tests are run
in CI, but the README was not updated to indicate this.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
