### PR TITLE
stream: remove kludge masking RST on Windows

### DIFF
--- a/deps/uv/src/win/tcp.c
+++ b/deps/uv/src/win/tcp.c
@@ -1429,11 +1429,7 @@ void uv_tcp_close(uv_loop_t* loop, uv_tcp_t* tcp) {
   if (tcp->flags & UV_HANDLE_READ_PENDING) {
     /* In order for winsock to do a graceful close there must not be any any
      * pending reads, or the socket must be shut down for writing */
-    if (!(tcp->flags & UV_HANDLE_SHARED_TCP_SOCKET)) {
-      /* Just do shutdown on non-shared sockets, which ensures graceful close. */
-      shutdown(tcp->socket, SD_SEND);
-
-    } else if (uv_tcp_try_cancel_io(tcp) == 0) {
+    if (uv_tcp_try_cancel_io(tcp) == 0) {
       /* In case of a shared socket, we try to cancel all outstanding I/O,. If
        * that works, don't close the socket yet - wait for the read req to
        * return and close the socket in uv_tcp_endgame. */

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -815,7 +815,10 @@ function resOnFinish(req, res, socket, state, server) {
 
   if (res._last) {
     if (typeof socket.destroySoon === 'function') {
-      socket.destroySoon();
+      if (socket.readableEnded)
+        socket.destroySoon();
+      else
+        socket.on('end', socket.destroySoon);
     } else {
       socket.end();
     }

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -815,10 +815,7 @@ function resOnFinish(req, res, socket, state, server) {
 
   if (res._last) {
     if (typeof socket.destroySoon === 'function') {
-      if (socket.readableEnded)
-        socket.destroySoon();
-      else
-        socket.on('end', socket.destroySoon);
+      socket.destroySoon();
     } else {
       socket.end();
     }

--- a/lib/internal/stream_base_commons.js
+++ b/lib/internal/stream_base_commons.js
@@ -222,20 +222,6 @@ function onStreamRead(arrayBuffer) {
     if (stream[kMaybeDestroy])
       stream.on('end', stream[kMaybeDestroy]);
 
-    // TODO(ronag): Without this `readStop`, `onStreamRead`
-    // will be called once more (i.e. after Readable.ended)
-    // on Windows causing a ECONNRESET, failing the
-    // test-https-truncate test.
-    if (handle.readStop) {
-      const err = handle.readStop();
-      if (err) {
-        // CallJSOnreadMethod expects the return value to be a buffer.
-        // Ref: https://github.com/nodejs/node/pull/34375
-        stream.destroy(errnoException(err, 'read'));
-        return;
-      }
-    }
-
     // Push a null to signal the end of data.
     // Do it before `maybeDestroy` for correct order of events:
     // `end` -> `close`

--- a/test/parallel/test-https-agent-jssocket-close.js
+++ b/test/parallel/test-https-agent-jssocket-close.js
@@ -1,0 +1,55 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const tls = require('tls');
+const fixtures = require('../common/fixtures');
+const https = require('https');
+const key = fixtures.readKey('agent1-key.pem');
+const cert = fixtures.readKey('agent1-cert.pem');
+const net = require('net');
+const { Duplex } = require('stream');
+
+class CustomAgent extends https.Agent {
+  createConnection(options, cb) {
+    const realSocket = net.createConnection(options);
+    const stream = new Duplex({
+      emitClose: false,
+      read(n) {
+        (function retry() {
+          const data = realSocket.read();
+          if (data === null)
+            return realSocket.once('readable', retry);
+          stream.push(data);
+        })();
+      },
+      write(chunk, enc, callback) {
+        realSocket.write(chunk, enc, callback);
+      },
+    });
+    realSocket.on('end', () => stream.push(null));
+
+    stream.on('end', common.mustCall());
+    return tls.connect({ ...options, socket: stream });
+  }
+}
+
+const httpsServer = https.createServer({
+  key,
+  cert,
+}, (req, res) => {
+  httpsServer.close();
+  res.end('hello world!');
+});
+httpsServer.listen(0, 'localhost', () => {
+  const agent = new CustomAgent();
+  https.get({
+    host: 'localhost',
+    port: httpsServer.address().port,
+    agent,
+    headers: { Connection: 'close' },
+    rejectUnauthorized: false
+  }, (res) => {
+    res.resume();
+  });
+});

--- a/test/parallel/test-https-truncate.js
+++ b/test/parallel/test-https-truncate.js
@@ -48,7 +48,7 @@ function httpsTest() {
 
   server.listen(0, function() {
     const opts = { port: this.address().port, rejectUnauthorized: false };
-    https.get(opts).on('response', function (res) {
+    https.get(opts).on('response', function(res) {
       test(res);
     });
   });

--- a/test/parallel/test-https-truncate.js
+++ b/test/parallel/test-https-truncate.js
@@ -50,10 +50,12 @@ function httpsTest() {
     const opts = { port: this.address().port, rejectUnauthorized: false };
     https.get(opts).on('response', function(res) {
       test(res);
+    }).on('error', () => {
+      // TODO: investigate why the server closes with a TCP RST on Windows
+      // https://github.com/nodejs/node/issues/35904
     });
   });
 }
-
 
 const test = common.mustCall(function(res) {
   res.on('end', common.mustCall(function() {

--- a/test/parallel/test-https-truncate.js
+++ b/test/parallel/test-https-truncate.js
@@ -48,11 +48,8 @@ function httpsTest() {
 
   server.listen(0, function() {
     const opts = { port: this.address().port, rejectUnauthorized: false };
-    https.get(opts).on('response', function(res) {
+    https.get(opts).on('response', function (res) {
       test(res);
-    }).on('error', () => {
-      // TODO: investigate why the server closes with a TCP RST on Windows
-      // https://github.com/nodejs/node/issues/35904
     });
   });
 }


### PR DESCRIPTION
Remove the kludge that masks the TCP RST on
Windows on test-https-truncate
That RST is very real, originates from the server
and should be investigated

Fixes: https://github.com/nodejs/node/issues/35904

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
