### PR TITLE
http2: Fix error stream write followed by destroy

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -176,7 +176,9 @@ function debugStream(id, sessionType, message, ...args) {
 }
 
 function debugStreamObj(stream, message, ...args) {
-  debugStream(stream[kID], stream[kSession][kType], message, ...args);
+  const session = stream[kSession];
+  const type = session ? session[kType] : undefined;
+  debugStream(stream[kID], type, message, ...args);
 }
 
 function debugSession(sessionType, message, ...args) {

--- a/test/parallel/test-http2-destroy-after-write.js
+++ b/test/parallel/test-http2-destroy-after-write.js
@@ -1,0 +1,37 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+}
+
+const http2 = require('http2');
+const assert = require('assert');
+
+const server = http2.createServer();
+
+server.on('session', common.mustCall(function(session) {
+  session.on('stream', common.mustCall(function(stream) {
+    stream.on('end', common.mustCall(function() {
+      this.respond({
+        ':status': 200
+      });
+      this.write('foo');
+      this.destroy();
+    }));
+    stream.resume();
+  }));
+}));
+
+server.listen(0, function() {
+  const client = http2.connect(`http://localhost:${server.address().port}`);
+  const stream = client.request({ ':method': 'POST' });
+  stream.on('response', common.mustCall(function(headers) {
+    assert.strictEqual(headers[':status'], 200);
+  }));
+  stream.on('close', common.mustCall(() => {
+    client.close();
+    server.close();
+  }));
+  stream.resume();
+  stream.end();
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Without the fix, the test fails with:

```
node:internal/http2/core:179
  debugStream(stream[kID], stream[kSession][kType], message, ...args);
                                           ^

TypeError: Cannot read property 'Symbol(type)' of undefined
    at debugStreamObj (node:internal/http2/core:179:44)
    at node:internal/http2/core:2041:7
    at processTicksAndRejections (node:internal/process/task_queues:75:11)
```
