### PR TITLE
tools: don't print gold linker warning w/o flag

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1761,7 +1761,8 @@ def configure_section_file(o):
     proc = subprocess.Popen(['ld.gold'] + ['-v'], stdin = subprocess.PIPE,
                             stdout = subprocess.PIPE, stderr = subprocess.PIPE)
   except OSError:
-    warn('''No acceptable ld.gold linker found!''')
+    if options.node_section_ordering_info != "":
+      warn('''No acceptable ld.gold linker found!''')
     return 0
 
   match = re.match(r"^GNU gold.*([0-9]+)\.([0-9]+)$",


### PR DESCRIPTION
Currently configure_section_file is called even if the appropriate
flag has not been passed which is causing a warning to be printed
on all calls to configure without the flag.

Only call configure_section_file if `--limit-configure-section-file`
has been passed to configure.

Fixes: https://github.com/nodejs/node/issues/35872
