### PR TITLE
child_process: add an API to escape shell argument

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -707,6 +707,9 @@ see [V8 issue 7381](https://bugs.chromium.org/p/v8/issues/detail?id=7381).
 See also: [`child_process.exec()`][] and [`child_process.fork()`][].
 
 ### `child_process.escapeArgument(arg)`
+<!-- YAML
+added: REPLACEME
+-->
 
 * `arg` {string} a command line argument to escape.
 * Returns: {string} The escaped argument

--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -65,6 +65,8 @@ top of [`child_process.spawn()`][] or [`child_process.spawnSync()`][].
 * [`child_process.fork()`][]: spawns a new Node.js process and invokes a
   specified module with an IPC communication channel established that allows
   sending messages between parent and child.
+* [`child_process.escapeArgument()`][]: escapes an argument into a string
+  argument for a shell command.
 * [`child_process.execSync()`][]: a synchronous version of
   [`child_process.exec()`][] that will block the Node.js event loop.
 * [`child_process.execFileSync()`][]: a synchronous version of
@@ -703,6 +705,22 @@ from the child. Applications with a large memory footprint may find frequent
 see [V8 issue 7381](https://bugs.chromium.org/p/v8/issues/detail?id=7381).
 
 See also: [`child_process.exec()`][] and [`child_process.fork()`][].
+
+### `child_process.escapeArgument(args)`
+
+* `args` {string[]} list of string arguments.
+* Returns: {ChildProcess}
+
+The `child_process.escapeArgument()` accept the user input and safely
+pass it to another command. It is about providing a way to escape a
+string for shell usage.
+
+```js
+const { escapeArgument, child_process } = require('child_process');
+const value = 'Users & Permissions Management';
+escapeValue = child_process.escapeArgument(value);
+child_process.spawn('somescript', escapeValue);
+```
 
 ## Synchronous process creation
 
@@ -1612,6 +1630,7 @@ or [`child_process.fork()`][].
 [`ChildProcess`]: #child_process_child_process
 [`Error`]: errors.md#errors_class_error
 [`EventEmitter`]: events.md#events_class_eventemitter
+[`child_process.escapeArgument()`]: #child_process_child_process_escapeargument_args
 [`child_process.exec()`]: #child_process_child_process_exec_command_options_callback
 [`child_process.execFile()`]: #child_process_child_process_execfile_file_args_options_callback
 [`child_process.execFileSync()`]: #child_process_child_process_execfilesync_file_args_options

--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -706,20 +706,20 @@ see [V8 issue 7381](https://bugs.chromium.org/p/v8/issues/detail?id=7381).
 
 See also: [`child_process.exec()`][] and [`child_process.fork()`][].
 
-### `child_process.escapeArgument(args)`
+### `child_process.escapeArgument(arg)`
 
-* `args` {string[]} list of string arguments.
-* Returns: {ChildProcess}
+* `arg` {string} a command line argument to escape.
+* Returns: {string} The escaped argument
 
 The `child_process.escapeArgument()` accept the user input and safely
-pass it to another command. It is about providing a way to escape a
-string for shell usage.
+escapes user input for usage on a command line. It is about providing
+a way to escape a string for shell usage.
 
 ```js
-const { escapeArgument, child_process } = require('child_process');
+const { escapeArgument } = require('child_process');
 const value = 'Users & Permissions Management';
-escapeValue = child_process.escapeArgument(value);
-child_process.spawn('somescript', escapeValue);
+const escapedValue = escapeArgument(value);
+child_process.spawn('somescript', [escapedValue]);
 ```
 
 ## Synchronous process creation
@@ -1630,7 +1630,7 @@ or [`child_process.fork()`][].
 [`ChildProcess`]: #child_process_child_process
 [`Error`]: errors.md#errors_class_error
 [`EventEmitter`]: events.md#events_class_eventemitter
-[`child_process.escapeArgument()`]: #child_process_child_process_escapeargument_args
+[`child_process.escapeArgument()`]: #child_process_child_process_escapeargument_arg
 [`child_process.exec()`]: #child_process_child_process_exec_command_options_callback
 [`child_process.execFile()`]: #child_process_child_process_execfile_file_args_options_callback
 [`child_process.execFileSync()`]: #child_process_child_process_execfilesync_file_args_options

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -29,9 +29,9 @@ const {
   ObjectDefineProperty,
   ObjectPrototypeHasOwnProperty,
   Promise,
+  RegExpPrototypeTest,
   Set,
   StringPrototypeReplace,
-  RegExpPrototypeTest
 } = primordials;
 
 const {

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -30,6 +30,8 @@ const {
   ObjectPrototypeHasOwnProperty,
   Promise,
   Set,
+  StringPrototypeReplace,
+  RegExpPrototypeTest
 } = primordials;
 
 const {
@@ -567,8 +569,8 @@ function normalizeSpawnArguments(file, args, options) {
 
 function escapeArgument(str) {
   if (str === '') return '\'\'';
-  if (!/[^%+,-./:=@_0-9A-Za-z]/.test(str)) return str;
-  return '\'' + str.replace(/'/g, '\'"\'') + '\'';
+  if (!RegExpPrototypeTest(/[^%+,-./:=@_0-9A-Za-z]/, str)) return str;
+  return '\'' + StringPrototypeReplace(str, /'/g, '\'"\'') + '\'';
 }
 
 function spawn(file, args, options) {

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -565,6 +565,12 @@ function normalizeSpawnArguments(file, args, options) {
 }
 
 
+function escapeArgument(str) {
+  if (str === '') return '\'\'';
+  if (!/[^%+,-./:=@_0-9A-Za-z]/.test(str)) return str;
+  return '\'' + str.replace(/'/g, '\'"\'') + '\'';
+}
+
 function spawn(file, args, options) {
   const child = new ChildProcess();
 
@@ -707,6 +713,7 @@ function sanitizeKillSignal(killSignal) {
 module.exports = {
   _forkChild,
   ChildProcess,
+  escapeArgument,
   exec,
   execFile,
   execFileSync,

--- a/test/parallel/test-child-process-escape-argument.js
+++ b/test/parallel/test-child-process-escape-argument.js
@@ -1,0 +1,9 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const { escapeArgument } = require('child_process');
+assert.strictEqual(escapeArgument('foo'), 'foo');
+assert.strictEqual(escapeArgument('foo bar'), "'foo bar'");
+assert.strictEqual(escapeArgument('foo & bar'), "'foo & bar'");
+assert.strictEqual(escapeArgument('foo & bar$'), "'foo & bar$'");
+assert.strictEqual(escapeArgument('foo%bar'), 'foo%bar');


### PR DESCRIPTION
child_process.escapeArgument() escapes shell
arguments so that those can be passed to spawned
scripts, which expect arguments as escaped strings

Fixes: https://github.com/nodejs/node/issues/34840

Co-Authored-By: Ben Noordhuis <info@bnoordhuis.n>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
