### PR TITLE
perf_hooks: make nodeTiming a first-class object

### DIFF
--- a/lib/perf_hooks.js
+++ b/lib/perf_hooks.js
@@ -165,70 +165,74 @@ function getMilestoneTimestamp(milestoneIdx) {
   return ns / 1e6 - timeOrigin;
 }
 
+const PerformanceNodeTimingProps = {
+  enumerable: true,
+  configurable: true
+};
 class PerformanceNodeTiming extends PerformanceEntry {
   constructor() {
     super();
 
     ObjectDefineProperties(this, {
       name: {
-        enumerable: true,
+        ...PerformanceNodeTimingProps,
         value: 'node'
       },
 
       entryType: {
-        enumerable: true,
+        ...PerformanceNodeTimingProps,
         value: 'node'
       },
 
       startTime: {
-        enumerable: true,
+        ...PerformanceNodeTimingProps,
         value: 0
       },
 
       duration: {
-        enumerable: true,
+        ...PerformanceNodeTimingProps,
         get() {
           return now() - timeOrigin;
         }
       },
 
       nodeStart: {
-        enumerable: true,
+        ...PerformanceNodeTimingProps,
         get() {
           return getMilestoneTimestamp(NODE_PERFORMANCE_MILESTONE_NODE_START);
         }
       },
 
       v8Start: {
-        enumerable: true,
+        ...PerformanceNodeTimingProps,
         get() {
           return getMilestoneTimestamp(NODE_PERFORMANCE_MILESTONE_V8_START);
         }
       },
 
       environment: {
-        enumerable: true,
+        ...PerformanceNodeTimingProps,
         get() {
           return getMilestoneTimestamp(NODE_PERFORMANCE_MILESTONE_ENVIRONMENT);
         }
       },
 
       loopStart: {
-        enumerable: true,
+        ...PerformanceNodeTimingProps,
         get() {
           return getMilestoneTimestamp(NODE_PERFORMANCE_MILESTONE_LOOP_START);
         }
       },
 
       loopExit: {
-        enumerable: true,
+        ...PerformanceNodeTimingProps,
         get() {
           return getMilestoneTimestamp(NODE_PERFORMANCE_MILESTONE_LOOP_EXIT);
         }
       },
 
       bootstrapComplete: {
-        enumerable: true,
+        ...PerformanceNodeTimingProps,
         get() {
           return getMilestoneTimestamp(
             NODE_PERFORMANCE_MILESTONE_BOOTSTRAP_COMPLETE);
@@ -236,7 +240,7 @@ class PerformanceNodeTiming extends PerformanceEntry {
       },
 
       idleTime: {
-        enumerable: true,
+        ...PerformanceNodeTimingProps,
         get() {
           return loopIdleTime();
         }

--- a/lib/perf_hooks.js
+++ b/lib/perf_hooks.js
@@ -165,74 +165,80 @@ function getMilestoneTimestamp(milestoneIdx) {
   return ns / 1e6 - timeOrigin;
 }
 
-const PerformanceNodeTimingProps = {
-  enumerable: true,
-  configurable: true
-};
 class PerformanceNodeTiming extends PerformanceEntry {
   constructor() {
     super();
 
     ObjectDefineProperties(this, {
       name: {
-        ...PerformanceNodeTimingProps,
+        enumerable: true,
+        configurable: true,
         value: 'node'
       },
 
       entryType: {
-        ...PerformanceNodeTimingProps,
+        enumerable: true,
+        configurable: true,
         value: 'node'
       },
 
       startTime: {
-        ...PerformanceNodeTimingProps,
+        enumerable: true,
+        configurable: true,
         value: 0
       },
 
       duration: {
-        ...PerformanceNodeTimingProps,
+        enumerable: true,
+        configurable: true,
         get() {
           return now() - timeOrigin;
         }
       },
 
       nodeStart: {
-        ...PerformanceNodeTimingProps,
+        enumerable: true,
+        configurable: true,
         get() {
           return getMilestoneTimestamp(NODE_PERFORMANCE_MILESTONE_NODE_START);
         }
       },
 
       v8Start: {
-        ...PerformanceNodeTimingProps,
+        enumerable: true,
+        configurable: true,
         get() {
           return getMilestoneTimestamp(NODE_PERFORMANCE_MILESTONE_V8_START);
         }
       },
 
       environment: {
-        ...PerformanceNodeTimingProps,
+        enumerable: true,
+        configurable: true,
         get() {
           return getMilestoneTimestamp(NODE_PERFORMANCE_MILESTONE_ENVIRONMENT);
         }
       },
 
       loopStart: {
-        ...PerformanceNodeTimingProps,
+        enumerable: true,
+        configurable: true,
         get() {
           return getMilestoneTimestamp(NODE_PERFORMANCE_MILESTONE_LOOP_START);
         }
       },
 
       loopExit: {
-        ...PerformanceNodeTimingProps,
+        enumerable: true,
+        configurable: true,
         get() {
           return getMilestoneTimestamp(NODE_PERFORMANCE_MILESTONE_LOOP_EXIT);
         }
       },
 
       bootstrapComplete: {
-        ...PerformanceNodeTimingProps,
+        enumerable: true,
+        configurable: true,
         get() {
           return getMilestoneTimestamp(
             NODE_PERFORMANCE_MILESTONE_BOOTSTRAP_COMPLETE);
@@ -240,7 +246,8 @@ class PerformanceNodeTiming extends PerformanceEntry {
       },
 
       idleTime: {
-        ...PerformanceNodeTimingProps,
+        enumerable: true,
+        configurable: true,
         get() {
           return loopIdleTime();
         }

--- a/lib/perf_hooks.js
+++ b/lib/perf_hooks.js
@@ -172,23 +172,17 @@ class PerformanceNodeTiming extends PerformanceEntry {
     ObjectDefineProperties(this, {
       name: {
         enumerable: true,
-        get() {
-          return 'node';
-        }
+        value: 'node'
       },
 
       entryType: {
         enumerable: true,
-        get() {
-          return 'node';
-        }
+        value: 'node'
       },
 
       startTime: {
         enumerable: true,
-        get() {
-          return 0;
-        }
+        value: 0
       },
 
       duration: {

--- a/lib/perf_hooks.js
+++ b/lib/perf_hooks.js
@@ -166,50 +166,89 @@ function getMilestoneTimestamp(milestoneIdx) {
 }
 
 class PerformanceNodeTiming extends PerformanceEntry {
-  get name() {
-    return 'node';
-  }
+  constructor() {
+    super();
 
-  get entryType() {
-    return 'node';
-  }
+    ObjectDefineProperties(this, {
+      name: {
+        enumerable: true,
+        get() {
+          return 'node';
+        }
+      },
 
-  get startTime() {
-    return 0;
-  }
+      entryType: {
+        enumerable: true,
+        get() {
+          return 'node';
+        }
+      },
 
-  get duration() {
-    return now() - timeOrigin;
-  }
+      startTime: {
+        enumerable: true,
+        get() {
+          return 0;
+        }
+      },
 
-  get nodeStart() {
-    return getMilestoneTimestamp(NODE_PERFORMANCE_MILESTONE_NODE_START);
-  }
+      duration: {
+        enumerable: true,
+        get() {
+          return now() - timeOrigin;
+        }
+      },
 
-  get v8Start() {
-    return getMilestoneTimestamp(NODE_PERFORMANCE_MILESTONE_V8_START);
-  }
+      nodeStart: {
+        enumerable: true,
+        get() {
+          return getMilestoneTimestamp(NODE_PERFORMANCE_MILESTONE_NODE_START);
+        }
+      },
 
-  get environment() {
-    return getMilestoneTimestamp(NODE_PERFORMANCE_MILESTONE_ENVIRONMENT);
-  }
+      v8Start: {
+        enumerable: true,
+        get() {
+          return getMilestoneTimestamp(NODE_PERFORMANCE_MILESTONE_V8_START);
+        }
+      },
 
-  get loopStart() {
-    return getMilestoneTimestamp(NODE_PERFORMANCE_MILESTONE_LOOP_START);
-  }
+      environment: {
+        enumerable: true,
+        get() {
+          return getMilestoneTimestamp(NODE_PERFORMANCE_MILESTONE_ENVIRONMENT);
+        }
+      },
 
-  get loopExit() {
-    return getMilestoneTimestamp(NODE_PERFORMANCE_MILESTONE_LOOP_EXIT);
-  }
+      loopStart: {
+        enumerable: true,
+        get() {
+          return getMilestoneTimestamp(NODE_PERFORMANCE_MILESTONE_LOOP_START);
+        }
+      },
 
-  get bootstrapComplete() {
-    return getMilestoneTimestamp(NODE_PERFORMANCE_MILESTONE_BOOTSTRAP_COMPLETE);
-  }
+      loopExit: {
+        enumerable: true,
+        get() {
+          return getMilestoneTimestamp(NODE_PERFORMANCE_MILESTONE_LOOP_EXIT);
+        }
+      },
 
-  get idleTime() {
-    return loopIdleTime();
-  }
+      bootstrapComplete: {
+        enumerable: true,
+        get() {
+          return getMilestoneTimestamp(
+            NODE_PERFORMANCE_MILESTONE_BOOTSTRAP_COMPLETE);
+        }
+      },
 
+      idleTime: {
+        enumerable: true,
+        get() {
+          return loopIdleTime();
+        }
+      }
+    });
+  }
   [kInspect]() {
     return {
       name: 'node',

--- a/test/parallel/test-performance-eventlooputil.js
+++ b/test/parallel/test-performance-eventlooputil.js
@@ -22,6 +22,12 @@ if (nodeTiming.loopStart === -1) {
                          { idle: 0, active: 0, utilization: 0 });
 }
 
+for (const p of ['name', 'entryType', 'startTime', 'duration',
+                 'nodeStart', 'v8Start', 'environment', 'loopStart', 'loopExit',
+                 'bootstrapComplete', 'idleTime'])
+  assert.ok(typeof JSON.parse(JSON.stringify(nodeTiming))[p] ===
+    typeof nodeTiming[p]);
+
 setTimeout(mustCall(function r() {
   const t = Date.now();
   const elu1 = eventLoopUtilization();

--- a/test/parallel/test-performance-eventlooputil.js
+++ b/test/parallel/test-performance-eventlooputil.js
@@ -22,9 +22,10 @@ if (nodeTiming.loopStart === -1) {
                          { idle: 0, active: 0, utilization: 0 });
 }
 
-for (const p of ['name', 'entryType', 'startTime', 'duration',
-                 'nodeStart', 'v8Start', 'environment', 'loopStart', 'loopExit',
-                 'bootstrapComplete', 'idleTime'])
+const nodeTimingProps = ['name', 'entryType', 'startTime', 'duration',
+                         'nodeStart', 'v8Start', 'environment', 'loopStart',
+                         'loopExit', 'bootstrapComplete', 'idleTime'];
+for (const p of nodeTimingProps)
   assert.ok(typeof JSON.parse(JSON.stringify(nodeTiming))[p] ===
     typeof nodeTiming[p]);
 


### PR DESCRIPTION
Render all properties of nodeTiming enumerable
so JSON.stringify and Object.keys can access them

Fixes: https://github.com/nodejs/node/issues/35936

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
