### PR TITLE
tools: fix config serialization w/ long strings

### DIFF
--- a/tools/js2c.py
+++ b/tools/js2c.py
@@ -163,9 +163,11 @@ def handle_config_gypi(config_filename):
 def jsonify(config):
   # 1. string comments
   config = re.sub(r'#.*?\n', '', config)
+  # 2. join multiline strings
+  config = re.sub(r"'$\s+'", '', config, flags=re.M)
   # 3. normalize string literals from ' into "
   config = re.sub('\'', '"', config)
-  # 2. turn pseudo-booleans strings into Booleans
+  # 4. turn pseudo-booleans strings into Booleans
   config = re.sub('"true"', 'true', config)
   config = re.sub('"false"', 'false', config)
   return config


### PR DESCRIPTION
So that “config.gypi” gets serialized correctly in cases such as:

    ./configure --v8-options='--write-protect-code-memory --wasm-write-protect-code-memory'

Where “v8_options” gets prettyprinted into a multiline string.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)