### PR TITLE
Bug fixes for PowerPC targets

### DIFF
--- a/deps/v8/src/base/build_config.h
+++ b/deps/v8/src/base/build_config.h
@@ -203,11 +203,7 @@ constexpr int kReturnAddressStackSlotCount =
     V8_TARGET_ARCH_STORES_RETURN_ADDRESS_ON_STACK ? 1 : 0;
 
 // Number of bits to represent the page size for paged spaces.
-#if defined(V8_TARGET_ARCH_PPC) || defined(V8_TARGET_ARCH_PPC64)
-// PPC has large (64KB) physical pages.
-const int kPageSizeBits = 19;
-#else
+// Use 4KB for all targets. Not all PPC Linux kernels use 64KB pages.
 const int kPageSizeBits = 18;
-#endif
 
 #endif  // V8_BASE_BUILD_CONFIG_H_

--- a/deps/v8/src/base/cpu.h
+++ b/deps/v8/src/base/cpu.h
@@ -66,10 +66,12 @@ class V8_BASE_EXPORT CPU final {
   // PPC-specific part codes
   enum {
     PPC_POWER5,
+    PPC_POWER5_PLUS,
     PPC_POWER6,
     PPC_POWER7,
     PPC_POWER8,
     PPC_POWER9,
+    PPC_G3,
     PPC_G4,
     PPC_G5,
     PPC_PA6T

--- a/deps/v8/src/codegen/cpu-features.h
+++ b/deps/v8/src/codegen/cpu-features.h
@@ -51,11 +51,12 @@ enum CpuFeature {
   MIPS_SIMD,  // MSA instructions
 
 #elif V8_TARGET_ARCH_PPC || V8_TARGET_ARCH_PPC64
-  FPU,
+  FP_ROUND_TO_INT,
   FPR_GPR_MOV,
   LWSYNC,
   ISELECT,
   VSX,
+  VMX,
   MODULO,
 
 #elif V8_TARGET_ARCH_S390X

--- a/deps/v8/src/codegen/ppc/assembler-ppc.h
+++ b/deps/v8/src/codegen/ppc/assembler-ppc.h
@@ -1008,6 +1008,8 @@ class Assembler : public AssemblerBase {
              RCBit rc = LeaveRC);
   void fabs(const DoubleRegister frt, const DoubleRegister frb,
             RCBit rc = LeaveRC);
+  void fnabs(const DoubleRegister frt, const DoubleRegister frb,
+            RCBit rc = LeaveRC);
   void fmadd(const DoubleRegister frt, const DoubleRegister fra,
              const DoubleRegister frc, const DoubleRegister frb,
              RCBit rc = LeaveRC);

--- a/deps/v8/src/common/globals.h
+++ b/deps/v8/src/common/globals.h
@@ -203,7 +203,7 @@ constexpr bool kPlatformRequiresCodeRange = true;
 #if (V8_HOST_ARCH_PPC || V8_HOST_ARCH_PPC64) && \
     (V8_TARGET_ARCH_PPC || V8_TARGET_ARCH_PPC64) && V8_OS_LINUX
 constexpr size_t kMaximalCodeRangeSize = 512 * MB;
-constexpr size_t kMinExpectedOSPageSize = 64 * KB;  // OS page on PPC Linux
+constexpr size_t kMinExpectedOSPageSize = 4 * KB;  // min OS page size
 #elif V8_TARGET_ARCH_ARM64
 constexpr size_t kMaximalCodeRangeSize = 128 * MB;
 constexpr size_t kMinExpectedOSPageSize = 4 * KB;  // OS page.
@@ -226,7 +226,7 @@ constexpr intptr_t kIntptrSignBit = 0x80000000;
 constexpr bool kPlatformRequiresCodeRange = false;
 constexpr size_t kMaximalCodeRangeSize = 0 * MB;
 constexpr size_t kMinimumCodeRangeSize = 0 * MB;
-constexpr size_t kMinExpectedOSPageSize = 64 * KB;  // OS page on PPC Linux
+constexpr size_t kMinExpectedOSPageSize = 4 * KB;  // min OS page size
 #elif V8_TARGET_ARCH_MIPS
 constexpr bool kPlatformRequiresCodeRange = false;
 constexpr size_t kMaximalCodeRangeSize = 2048LL * MB;

--- a/deps/v8/src/compiler/backend/ppc/code-generator-ppc.cc
+++ b/deps/v8/src/compiler/backend/ppc/code-generator-ppc.cc
@@ -295,6 +295,50 @@ void EmitWordLoadPoisoningIfNeeded(CodeGenerator* codegen, Instruction* instr,
     }                                                                \
   } while (0)
 
+#define ASSEMBLE_FLOAT_ROUNDOP_RC(rounding_mode, round)              \
+  do {                                                               \
+    DoubleRegister input_reg = i.InputDoubleRegister(0);             \
+    DoubleRegister result_reg = i.OutputDoubleRegister();            \
+    Label positive, negative, done;                                  \
+    __ fcmpu(input_reg, kDoubleRegZero);                             \
+    __ bgt(&positive);                                               \
+    __ blt(&negative);                                               \
+    /* if input is 0.0 or NaN, we're done */                         \
+    __ b(&done);                                                     \
+    __ bind(&negative);                                              \
+    __ LoadDoubleLiteral(kScratchDoubleReg, Double(-0x1p+52), kScratchReg);\
+    /* if the magnitude is too big, we're already rounded */         \
+    __ fcmpu(input_reg, kScratchDoubleReg);                          \
+    __ blt(&done);                                                   \
+    __ SetRoundingMode(rounding_mode);                               \
+    /* add a -1 to the left of the mantissa, then subtract it */     \
+    __ fadd(input_reg, input_reg, kScratchDoubleReg);                \
+    __ fsub(input_reg, input_reg, kScratchDoubleReg);                \
+    /* make sure result sign is negative and set RC */               \
+    __ fnabs(input_reg, input_reg, i.OutputRCBit());                 \
+    __ ResetRoundingMode();                                          \
+    __ b(&done);                                                     \
+    __ bind(&positive);                                              \
+    __ LoadDoubleLiteral(kScratchDoubleReg, Double(0x1p+52), kScratchReg);\
+    /* if the magnitude is too big, we're already rounded */         \
+    __ fcmpu(input_reg, kScratchDoubleReg);                          \
+    __ bgt(&done);                                                   \
+    __ SetRoundingMode(rounding_mode);                               \
+    /* add a +1 to the left of the mantissa, then subtract it */     \
+    __ fadd(input_reg, input_reg, kScratchDoubleReg);                \
+    __ fsub(input_reg, input_reg, kScratchDoubleReg);                \
+    /* make sure result sign is positive and set RC */               \
+    __ fabs(input_reg, input_reg, i.OutputRCBit());                  \
+    __ ResetRoundingMode();                                          \
+    __ bind(&done);                                                  \
+    if (input_reg != result_reg) {                                   \
+      __ fmr(result_reg, input_reg);                                 \
+    }                                                                \
+    if (round) {                                                     \
+      __ frsp(result_reg, result_reg);                               \
+    }                                                                \
+  } while (0)
+
 #define ASSEMBLE_FLOAT_BINOP_RC(asm_instr, round)                    \
   do {                                                               \
     __ asm_instr(i.OutputDoubleRegister(), i.InputDoubleRegister(0), \
@@ -1669,16 +1713,32 @@ CodeGenerator::CodeGenResult CodeGenerator::AssembleArchInstruction(
       ASSEMBLE_FLOAT_UNOP_RC(fsqrt, MiscField::decode(instr->opcode()));
       break;
     case kPPC_FloorDouble:
-      ASSEMBLE_FLOAT_UNOP_RC(frim, MiscField::decode(instr->opcode()));
+      if (CpuFeatures::IsSupported(FP_ROUND_TO_INT)) {
+        ASSEMBLE_FLOAT_UNOP_RC(frim, MiscField::decode(instr->opcode()));
+      } else {
+        ASSEMBLE_FLOAT_ROUNDOP_RC(kRoundToMinusInf, MiscField::decode(instr->opcode()));
+      }
       break;
     case kPPC_CeilDouble:
-      ASSEMBLE_FLOAT_UNOP_RC(frip, MiscField::decode(instr->opcode()));
+      if (CpuFeatures::IsSupported(FP_ROUND_TO_INT)) {
+        ASSEMBLE_FLOAT_UNOP_RC(frip, MiscField::decode(instr->opcode()));
+      } else {
+        ASSEMBLE_FLOAT_ROUNDOP_RC(kRoundToPlusInf, MiscField::decode(instr->opcode()));
+      }
       break;
     case kPPC_TruncateDouble:
-      ASSEMBLE_FLOAT_UNOP_RC(friz, MiscField::decode(instr->opcode()));
+      if (CpuFeatures::IsSupported(FP_ROUND_TO_INT)) {
+        ASSEMBLE_FLOAT_UNOP_RC(friz, MiscField::decode(instr->opcode()));
+      } else {
+        ASSEMBLE_FLOAT_ROUNDOP_RC(kRoundToZero, MiscField::decode(instr->opcode()));
+      }
       break;
     case kPPC_RoundDouble:
-      ASSEMBLE_FLOAT_UNOP_RC(frin, MiscField::decode(instr->opcode()));
+      if (CpuFeatures::IsSupported(FP_ROUND_TO_INT)) {
+        ASSEMBLE_FLOAT_UNOP_RC(frin, MiscField::decode(instr->opcode()));
+      } else {
+        ASSEMBLE_FLOAT_ROUNDOP_RC(kRoundToNearest, MiscField::decode(instr->opcode()));
+      }
       break;
     case kPPC_NegDouble:
       ASSEMBLE_FLOAT_UNOP_RC(fneg, 0);

--- a/deps/v8/src/compiler/backend/ppc/instruction-selector-ppc.cc
+++ b/deps/v8/src/compiler/backend/ppc/instruction-selector-ppc.cc
@@ -2444,16 +2444,21 @@ void InstructionSelector::VisitLoadTransform(Node* node) { UNIMPLEMENTED(); }
 // static
 MachineOperatorBuilder::Flags
 InstructionSelector::SupportedMachineOperatorFlags() {
-  return MachineOperatorBuilder::kFloat32RoundDown |
-         MachineOperatorBuilder::kFloat64RoundDown |
-         MachineOperatorBuilder::kFloat32RoundUp |
-         MachineOperatorBuilder::kFloat64RoundUp |
-         MachineOperatorBuilder::kFloat32RoundTruncate |
-         MachineOperatorBuilder::kFloat64RoundTruncate |
-         MachineOperatorBuilder::kFloat64RoundTiesAway |
-         MachineOperatorBuilder::kWord32Popcnt |
-         MachineOperatorBuilder::kWord64Popcnt;
+  MachineOperatorBuilder::Flags flags = MachineOperatorBuilder::kWord32Popcnt;
+#if V8_TARGET_ARCH_PPC64
+  flags |= MachineOperatorBuilder::kWord64Popcnt;
+#endif
+  if (CpuFeatures::IsSupported(FP_ROUND_TO_INT)) {
+    flags |= MachineOperatorBuilder::kFloat32RoundDown |
+             MachineOperatorBuilder::kFloat64RoundDown |
+             MachineOperatorBuilder::kFloat32RoundUp |
+             MachineOperatorBuilder::kFloat64RoundUp |
+             MachineOperatorBuilder::kFloat32RoundTruncate |
+             MachineOperatorBuilder::kFloat64RoundTruncate |
+             MachineOperatorBuilder::kFloat64RoundTiesAway;
+  }
   // We omit kWord32ShiftIsSafe as s[rl]w use 0x3F as a mask rather than 0x1F.
+  return flags;
 }
 
 // static

--- a/deps/v8/src/heap/base/asm/ppc/push_registers_asm.cc
+++ b/deps/v8/src/heap/base/asm/ppc/push_registers_asm.cc
@@ -33,7 +33,7 @@ asm(
     // At anytime, SP (r1) needs to be multiple of 16 (i.e. 16-aligned).
     "  mflr 0                                          \n"
     "  std 0, 16(1)                                    \n"
-#if defined(_AIX)
+#if ABI_USES_FUNCTION_DESCRIPTORS
     "  std 2, 40(1)                                    \n"
 #else
     "  std 2, 24(1)                                    \n"
@@ -61,10 +61,10 @@ asm(
     // Pass 2nd parameter (r4) unchanged (StackVisitor*).
     // Save 3rd parameter (r5; IterateStackCallback).
     "  mr 6, 5                                         \n"
-#if defined(_AIX)
+#if ABI_USES_FUNCTION_DESCRIPTORS
     // Set up TOC for callee.
     "  ld 2,8(5)                                       \n"
-    // AIX uses function decorators, which means that
+    // AIX/PPC64BE (ELFv1) uses function descriptors, which means that
     // pointers to functions do not point to code, but
     //  instead point to metadata about them, hence
     // need to deterrence.
@@ -72,7 +72,7 @@ asm(
 #endif
     // Pass 3rd parameter as sp (stack pointer).
     "  mr 5, 1                                         \n"
-#if !defined(_AIX)
+#if !ABI_USES_FUNCTION_DESCRIPTORS
     // Set up r12 to be equal to the callee address (in order for TOC
     // relocation). Only needed on LE Linux.
     "  mr 12, 6                                        \n"
@@ -85,7 +85,7 @@ asm(
     // Restore lr.
     "  ld 0, 16(1)                                     \n"
     "  mtlr  0                                         \n"
-#if defined(_AIX)
+#if ABI_USES_FUNCTION_DESCRIPTORS
     // Restore TOC pointer.
     "  ld 2, 40(1)                                     \n"
 #else


### PR DESCRIPTION
Fixes for Node.js (V8) for older PowerPC targets. I'm testing with
Gentoo Linux on ppc64 (big-endian) on a PowerMac Quad G5, so this
code needs testing on other systems, especially POWER9, which I believe
should have some CPU flags enabled that aren't currently being enabled.
Currently, POWER9 is setting MODULO but not the other feature flags, so
I refactored the code to a switch statement with fallthrough assuming that
the newer POWER CPUs have all the feature flags of the earlier ones.
Please let me know if that assumption is incorrect. Other changes:

* PPC64 big-endian ELFv1 ABI uses function descriptors, like AIX.
    
* Tell the code generator when we don't have the FP to int rounding
  instructions (added in Power ISA v2.03) by not enabling them in the
  MachineOperatorBuilder::Flags if we don't have a new enough CPU.
  My first patch tried to emit the equivalent rounding behavior inline,
  but then I realized I could set the flags to not emit frim/frin/friz/frip
  if the CPU doesn't support those instructions.

* Change minimum page size to 4KB for PPC. 64KB physical pages are a
  newer feature that breaks some software, such as the nouveau driver.

* Change PPC CPU detection to use getauxval() for glibc 2.16 and newer,
  and to correctly recognize all known Linux PowerPC platform types.
  Cell BE is identified as PPC_G5; other CPUs with AltiVec as PPC_G4.
  The new PPC_G3 type is used for all other CPUs without VMX/AltiVec.

* Add VMX feature for future VMX/AltiVec code generation. VMX is a
  subset of VSX that's available on POWER6, G5, Cell, G4, and PA6T.
  The newer VSX feature is only available on POWER7 and newer CPUs.

I need to continue testing, as I'm seeing one strange failure in cctest now,
only with a release build. But I think the patches I have so far are basically
correct and ready for review and feedback. Thanks!

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
