### PR TITLE
events: getEventListeners static

### DIFF
--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -829,6 +829,40 @@ class MyClass extends EventEmitter {
 }
 ```
 
+## `events.getEventListeners(emitterOrTarget, eventName)`
+<!-- YAML
+added:
+ - REPLACEME
+-->
+* `emitterOrTarget` {EventEmitter|EventTarget}
+* `eventName` {string|symbol}
+* Returns: {Function[]}
+
+Returns a copy of the array of listeners for the event named `eventName`.
+
+For `EventEmitter`s this behaves exactly the same as calling `.listeners` on
+the emitter.
+
+For `EventTarget`s this is the only way to get the event listeners for the
+event target. This is useful for debugging and diagnostic purposes.
+
+```js
+const { getEventListeners, EventEmitter } = require('events');
+
+{
+  const ee = new EventEmitter();
+  const listener = () => console.log('Events are fun');
+  ee.on('foo', listener);
+  getEventListeners(ee, 'foo'); // [listener]
+}
+{
+  const et = new EventTarget();
+  const listener = () => console.log('Events are fun');
+  ee.addEventListener('foo', listener);
+  getEventListeners(ee, 'foo'); // [listener]
+}
+```
+
 ## `events.once(emitter, name[, options])`
 <!-- YAML
 added:

--- a/lib/events.js
+++ b/lib/events.js
@@ -22,6 +22,7 @@
 'use strict';
 
 const {
+  ArrayPrototypePush,
   Boolean,
   Error,
   ErrorCaptureStackTrace,
@@ -74,13 +75,14 @@ const lazyDOMException = hideStackFrames((message, name) => {
   return new DOMException(message, name);
 });
 
+
 function EventEmitter(opts) {
   EventEmitter.init.call(this, opts);
 }
 module.exports = EventEmitter;
 module.exports.once = once;
 module.exports.on = on;
-
+module.exports.getEventListeners = getEventListeners;
 // Backwards-compat with node 0.10.x
 EventEmitter.EventEmitter = EventEmitter;
 
@@ -632,6 +634,28 @@ function unwrapListeners(arr) {
       ret[i] = orig;
   }
   return ret;
+}
+
+function getEventListeners(emitterOrTarget, type) {
+  // First check if EventEmitter
+  if (typeof emitterOrTarget.listeners === 'function') {
+    return emitterOrTarget.listeners(type);
+  }
+  // Require event target lazily to avoid always loading it
+  const { isEventTarget, kEvents } = require('internal/event_target');
+  if (isEventTarget(emitterOrTarget)) {
+    const root = emitterOrTarget[kEvents].get(type);
+    const listeners = [];
+    let handler = root?.next;
+    while (handler?.listener !== undefined) {
+      ArrayPrototypePush(listeners, handler.listener);
+      handler = handler.next;
+    }
+    return listeners;
+  }
+  throw new ERR_INVALID_ARG_TYPE('emitter',
+                                 ['EventEmitter', 'EventTarget'],
+                                 emitterOrTarget);
 }
 
 async function once(emitter, name, options = {}) {

--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -636,4 +636,6 @@ module.exports = {
   kNewListener,
   kTrustEvent,
   kRemoveListener,
+  kEvents,
+  isEventTarget,
 };

--- a/test/parallel/test-events-static-geteventlisteners.js
+++ b/test/parallel/test-events-static-geteventlisteners.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const common = require('../common');
+
+const {
+  deepStrictEqual,
+} = require('assert');
+
+const { getEventListeners, EventEmitter } = require('events');
+
+// Test getEventListeners on EventEmitter
+{
+  const fn1 = common.mustNotCall();
+  const fn2 = common.mustNotCall();
+  const emitter = new EventEmitter();
+  emitter.on('foo', fn1);
+  emitter.on('foo', fn2);
+  emitter.on('baz', fn1);
+  emitter.on('baz', fn1);
+  deepStrictEqual(getEventListeners(emitter, 'foo'), [fn1, fn2]);
+  deepStrictEqual(getEventListeners(emitter, 'bar'), []);
+  deepStrictEqual(getEventListeners(emitter, 'baz'), [fn1, fn1]);
+}
+// Test getEventListeners on EventTarget
+{
+  const fn1 = common.mustNotCall();
+  const fn2 = common.mustNotCall();
+  const target = new EventTarget();
+  target.addEventListener('foo', fn1);
+  target.addEventListener('foo', fn2);
+  target.addEventListener('baz', fn1);
+  target.addEventListener('baz', fn1);
+  deepStrictEqual(getEventListeners(target, 'foo'), [fn1, fn2]);
+  deepStrictEqual(getEventListeners(target, 'bar'), []);
+  deepStrictEqual(getEventListeners(target, 'baz'), [fn1]);
+}


### PR DESCRIPTION
This adds a static `getEventListeners` to `events`. The major difference between it and `.listeners` is that it works with `EventTarget`s and not just EventEmitters.

This is useful after talking to users of `EventTarget` and `AbortController` for two main reasons:
 - For diagnostics and digging into why EventTargets are behaving and trying to isolate possible memory leaks.
 - For creating linked `AbortSignal`s potentially.

cc @bterlson 

This has to be a static because we are not allowed to add this method on `EventTarget.prototype`. I checked with WHATWG and the only way I could come up with that is both spec compliant and addresses the use case.

The web platform itself does not have a way to do this (due to encapsulation) but I double checked we are allowed to expose this functionality as long as it's not on `EventTarget` itself (from the public #whatwg IRC channel):

<img width="1471" alt="Screen Shot 2020-11-05 at 21 02 17" src="https://user-images.githubusercontent.com/1315533/98354199-0edc5200-2029-11eb-9083-c6e426612cb0.png">


##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
