### PR TITLE
events: remove listener after timer is finished

### DIFF
--- a/lib/timers/promises.js
+++ b/lib/timers/promises.js
@@ -59,17 +59,24 @@ function setTimeout(after, value, options = {}) {
       lazyDOMException('The operation was aborted', 'AbortError'));
   }
   return new Promise((resolve, reject) => {
-    const timeout = new Timeout(resolve, after, args, false, true);
+    let signalHandler = null;
+    function cleanupSignalHandlerThenResolve(arg) {
+      signal.removeEventListener('abort', signalHandler, { once: true });
+      resolve(arg);
+    }
+    const onDone = signal ? cleanupSignalHandlerThenResolve : resolve;
+    const timeout = new Timeout(onDone, after, args, false, true);
     if (!ref) timeout.unref();
     insert(timeout, timeout._idleTimeout);
     if (signal) {
-      signal.addEventListener('abort', () => {
+      signalHandler = () => {
         if (!timeout._destroyed) {
           // eslint-disable-next-line no-undef
           clearTimeout(timeout);
           reject(lazyDOMException('The operation was aborted', 'AbortError'));
         }
-      }, { once: true });
+      };
+      signal.addEventListener('abort', signalHandler, { once: true });
     }
   });
 }

--- a/test/parallel/test-timers-promisified.js
+++ b/test/parallel/test-timers-promisified.js
@@ -1,10 +1,13 @@
-// Flags: --no-warnings
+// Flags: --no-warnings --expose-internals
 'use strict';
 const common = require('../common');
 const assert = require('assert');
 const timers = require('timers');
 const { promisify } = require('util');
 const child_process = require('child_process');
+
+// TODO(benjamingr) - refactor to use getEventListeners when #35991 lands
+const { NodeEventTarget } = require('internal/event_target');
 
 const timerPromises = require('timers/promises');
 
@@ -90,6 +93,14 @@ process.on('multipleResolves', common.mustNotCall());
   setImmediate(10, { signal }).then(() => {
     ac.abort();
   });
+}
+{
+  // Check that timer adding signals does not leak handlers
+  const abortEmitter = new NodeEventTarget();
+  abortEmitter.aborted = false;
+  setTimeout(0, null, { signal: abortEmitter }).then(common.mustCall(() => {
+    assert.strictEqual(abortEmitter.listenerCount('abort'), 0);
+  }));
 }
 
 {


### PR DESCRIPTION
Fixes the memory leak bug described in https://github.com/nodejs/node/issues/35990#issuecomment-722977913

It is very important to me to make the point that I believe we need to do https://github.com/nodejs/node/issues/35990#issue-737609854 if we want users not to run into this footfun.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
