### PR TITLE
fs: support abortsignal in writeFile

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -4385,6 +4385,10 @@ details.
 <!-- YAML
 added: v0.1.29
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/35993
+    description: The options argument may include an AbortSignal to abort an
+                 ongoing writeFile request.
   - version: v14.12.0
     pr-url: https://github.com/nodejs/node/pull/34993
     description: The `data` parameter will stringify an object with an
@@ -4419,6 +4423,7 @@ changes:
   * `encoding` {string|null} **Default:** `'utf8'`
   * `mode` {integer} **Default:** `0o666`
   * `flag` {string} See [support of file system `flags`][]. **Default:** `'w'`.
+  * `signal` {AbortSignal} allows aborting an in-progress writeFile
 * `callback` {Function}
   * `err` {Error}
 
@@ -4449,6 +4454,28 @@ fs.writeFile('message.txt', 'Hello Node.js', 'utf8', callback);
 It is unsafe to use `fs.writeFile()` multiple times on the same file without
 waiting for the callback. For this scenario, [`fs.createWriteStream()`][] is
 recommended.
+
+Similarly to `fs.readFile` - `fs.writeFile` is a convenience method that
+performs multiple `write` calls internally to write the buffer passed to it.
+For performance sensitive code consider using [`fs.createWriteStream()`][].
+
+It is possible to use an {AbortSignal} to cancel an `fs.writeFile()`.
+Cancelation is "best effort", and some amount of data is likely still
+to be written.
+
+```js
+const controller = new AbortController();
+const { signal } = controller;
+const data = new Uint8Array(Buffer.from('Hello Node.js'));
+fs.writeFile('message.txt', data, { signal }, (err) => {
+  // When a request is aborted - the callback is called with an AbortError
+});
+// When the request should be aborted
+controller.abort();
+```
+
+Aborting an ongoing request does not abort individual operating
+system requests but rather the internal buffering `fs.writeFile` performs.
 
 ### Using `fs.writeFile()` with file descriptors
 
@@ -5717,6 +5744,10 @@ The `atime` and `mtime` arguments follow these rules:
 <!-- YAML
 added: v10.0.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/35993
+    description: The options argument may include an AbortSignal to abort an
+                 ongoing writeFile request.
   - version: v14.12.0
     pr-url: https://github.com/nodejs/node/pull/34993
     description: The `data` parameter will stringify an object with an
@@ -5733,6 +5764,7 @@ changes:
   * `encoding` {string|null} **Default:** `'utf8'`
   * `mode` {integer} **Default:** `0o666`
   * `flag` {string} See [support of file system `flags`][]. **Default:** `'w'`.
+  * `signal` {AbortSignal} allows aborting an in-progress writeFile
 * Returns: {Promise}
 
 Asynchronously writes data to a file, replacing the file if it already exists.
@@ -5746,7 +5778,34 @@ If `options` is a string, then it specifies the encoding.
 Any specified `FileHandle` has to support writing.
 
 It is unsafe to use `fsPromises.writeFile()` multiple times on the same file
-without waiting for the `Promise` to be resolved (or rejected).
+without waiting for the `Promise` to be fulfilled (or rejected).
+
+Similarly to `fsPromises.readFile` - `fsPromises.writeFile` is a convenience
+method that performs multiple `write` calls internally to write the buffer
+passed to it. For performance sensitive code consider using
+[`fs.createWriteStream()`][].
+
+It is possible to use an {AbortSignal} to cancel an `fsPromises.writeFile()`.
+Cancelation is "best effort", and some amount of data is likely still
+to be written.
+
+```js
+const controller = new AbortController();
+const { signal } = controller;
+const data = new Uint8Array(Buffer.from('Hello Node.js'));
+(async () => {
+  try {
+    await fs.writeFile('message.txt', data, { signal });
+  } catch (err) {
+  // When a request is aborted - err is an AbortError
+  }
+})();
+// When the request should be aborted
+controller.abort();
+```
+
+Aborting an ongoing request does not abort individual operating
+system requests but rather the internal buffering `fs.writeFile` performs.
 
 ## FS constants
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -71,6 +71,7 @@ const {
     ERR_INVALID_CALLBACK,
     ERR_FEATURE_UNAVAILABLE_ON_PLATFORM
   },
+  hideStackFrames,
   uvException
 } = require('internal/errors');
 
@@ -133,6 +134,13 @@ let ReadStream;
 let WriteStream;
 let rimraf;
 let rimrafSync;
+let DOMException;
+
+const lazyDOMException = hideStackFrames((message, name) => {
+  if (DOMException === undefined)
+    DOMException = internalBinding('messaging').DOMException;
+  return new DOMException(message, name);
+});
 
 // These have to be separate because of how graceful-fs happens to do it's
 // monkeypatching.
@@ -1409,7 +1417,11 @@ function lutimesSync(path, atime, mtime) {
   handleErrorFromBinding(ctx);
 }
 
-function writeAll(fd, isUserFd, buffer, offset, length, callback) {
+function writeAll(fd, isUserFd, buffer, offset, length, signal, callback) {
+  if (signal?.aborted) {
+    callback(lazyDOMException('The operation was aborted', 'AbortError'));
+    return;
+  }
   // write(fd, buffer, offset, length, position, callback)
   fs.write(fd, buffer, offset, length, null, (writeErr, written) => {
     if (writeErr) {
@@ -1429,7 +1441,7 @@ function writeAll(fd, isUserFd, buffer, offset, length, callback) {
     } else {
       offset += written;
       length -= written;
-      writeAll(fd, isUserFd, buffer, offset, length, callback);
+      writeAll(fd, isUserFd, buffer, offset, length, signal, callback);
     }
   });
 }
@@ -1446,16 +1458,22 @@ function writeFile(path, data, options, callback) {
 
   if (isFd(path)) {
     const isUserFd = true;
-    writeAll(path, isUserFd, data, 0, data.byteLength, callback);
+    const signal = options.signal;
+    writeAll(path, isUserFd, data, 0, data.byteLength, signal, callback);
     return;
   }
 
+  if (options.signal?.aborted) {
+    callback(lazyDOMException('The operation was aborted', 'AbortError'));
+    return;
+  }
   fs.open(path, flag, options.mode, (openErr, fd) => {
     if (openErr) {
       callback(openErr);
     } else {
       const isUserFd = false;
-      writeAll(fd, isUserFd, data, 0, data.byteLength, callback);
+      const signal = options.signal;
+      writeAll(fd, isUserFd, data, 0, data.byteLength, signal, callback);
     }
   });
 }

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -250,12 +250,15 @@ async function fsCall(fn, handle, ...args) {
   }
 }
 
-async function writeFileHandle(filehandle, data) {
+async function writeFileHandle(filehandle, data, signal) {
   // `data` could be any kind of typed array.
   data = new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
   let remaining = data.length;
   if (remaining === 0) return;
   do {
+    if (signal?.aborted) {
+      throw new lazyDOMException('The operation was aborted', 'AbortError');
+    }
     const { bytesWritten } =
       await write(filehandle, data, 0,
                   MathMin(kWriteFileMaxChunkSize, data.length));
@@ -633,9 +636,12 @@ async function writeFile(path, data, options) {
   }
 
   if (path instanceof FileHandle)
-    return writeFileHandle(path, data);
+    return writeFileHandle(path, data, options.signal);
 
   const fd = await open(path, flag, options.mode);
+  if (options.signal?.aborted) {
+    throw new lazyDOMException('The operation was aborted', 'AbortError');
+  }
   return PromisePrototypeFinally(writeFileHandle(fd, data), fd.close);
 }
 

--- a/test/parallel/test-fs-write-file.js
+++ b/test/parallel/test-fs-write-file.js
@@ -66,3 +66,32 @@ fs.open(filename4, 'w+', common.mustSucceed((fd) => {
     }));
   }));
 }));
+
+
+{
+  // Test that writeFile is cancellable with an AbortSignal.
+  // Before the operation has started
+  const controller = new AbortController();
+  const signal = controller.signal;
+  const filename3 = join(tmpdir.path, 'test3.txt');
+
+  fs.writeFile(filename3, s, { signal }, common.mustCall((err) => {
+    assert.strictEqual(err.name, 'AbortError');
+  }));
+
+  controller.abort();
+}
+
+{
+  // Test that writeFile is cancellable with an AbortSignal.
+  // After the operation has started
+  const controller = new AbortController();
+  const signal = controller.signal;
+  const filename4 = join(tmpdir.path, 'test4.txt');
+
+  fs.writeFile(filename4, s, { signal }, common.mustCall((err) => {
+    assert.strictEqual(err.name, 'AbortError');
+  }));
+
+  process.nextTick(() => controller.abort());
+}


### PR DESCRIPTION
Now that https://github.com/nodejs/node/pull/35911 is landed the next suggestion in https://github.com/nodejs/node/pull/35877 by @mcollina was fs.writeFile (here https://github.com/nodejs/node/pull/35877#issuecomment-720071726 ) - so I am going over the suggestions one by one and adding AbortSignal support.

This PR lets you abort an ongoing `writeFile` request.

```js
const controller = new AbortController();
const { signal } = controller;
const data = new Uint8Array(Buffer.from('Hello Node.js'));
(async () => {
  try {
    await fs.writeFile('message.txt', data, { signal });
  } catch (err) {
  // When a request is aborted - err is an AbortError
  }
})();
// When the request should be aborted
controller.abort();
```

Note that unlike `readFile` this is very stateful - so _some_ of the data will be written to the file (this is expected IMO). I vaguely recall in the summit @addaleax has something smart to say regarding the error but I don't remember the conclusion. I am happy to tack the offset (how many bytes were written) on the AbortError if that would help.
