### PR TITLE
test: use global.EventTarget instead of internals

### DIFF
--- a/test/parallel/test-abortcontroller.js
+++ b/test/parallel/test-abortcontroller.js
@@ -1,10 +1,9 @@
-// Flags: --no-warnings --expose-internals
+// Flags: --no-warnings
 'use strict';
 
 const common = require('../common');
 
 const { ok, strictEqual } = require('assert');
-const { Event } = require('internal/event_target');
 
 {
   // Tests that abort is fired with the correct event type on AbortControllers

--- a/test/parallel/test-eventtarget-once-twice.js
+++ b/test/parallel/test-eventtarget-once-twice.js
@@ -1,10 +1,5 @@
-// Flags: --expose-internals --no-warnings
 'use strict';
 const common = require('../common');
-const {
-  Event,
-  EventTarget,
-} = require('internal/event_target');
 const { once } = require('events');
 
 const et = new EventTarget();

--- a/test/parallel/test-eventtarget-whatwg-once.js
+++ b/test/parallel/test-eventtarget-whatwg-once.js
@@ -1,12 +1,6 @@
-// Flags: --expose-internals --no-warnings
 'use strict';
 
 const common = require('../common');
-
-const {
-  Event,
-  EventTarget,
-} = require('internal/event_target');
 
 const {
   strictEqual,

--- a/test/parallel/test-eventtarget.js
+++ b/test/parallel/test-eventtarget.js
@@ -2,11 +2,7 @@
 'use strict';
 
 const common = require('../common');
-const {
-  Event,
-  EventTarget,
-  defineEventHandler
-} = require('internal/event_target');
+const { defineEventHandler } = require('internal/event_target');
 
 const {
   ok,

--- a/test/parallel/test-nodeeventtarget.js
+++ b/test/parallel/test-nodeeventtarget.js
@@ -2,10 +2,7 @@
 'use strict';
 
 const common = require('../common');
-const {
-  Event,
-  NodeEventTarget,
-} = require('internal/event_target');
+const { NodeEventTarget } = require('internal/event_target');
 
 const {
   deepStrictEqual,


### PR DESCRIPTION
`EventTarget` and `Event` are available from the global scope, there is no need to use the `--expose-internals` flag in the tests.

Refs: https://github.com/nodejs/node/pull/35496

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
