### PR TITLE
timers: cleanup abort listener on awaitable timers

### DIFF
--- a/lib/timers/promises.js
+++ b/lib/timers/promises.js
@@ -2,6 +2,7 @@
 
 const {
   Promise,
+  PromisePrototypeFinally,
   PromiseReject,
 } = primordials;
 
@@ -23,6 +24,13 @@ const lazyDOMException = hideStackFrames((message, name) => {
     DOMException = internalBinding('messaging').DOMException;
   return new DOMException(message, name);
 });
+
+function cancelListenerHandler(clear, reject) {
+  if (!this._destroyed) {
+    clear(this);
+    reject(lazyDOMException('The operation was aborted', 'AbortError'));
+  }
+}
 
 function setTimeout(after, value, options = {}) {
   const args = value !== undefined ? [value] : value;
@@ -58,20 +66,21 @@ function setTimeout(after, value, options = {}) {
     return PromiseReject(
       lazyDOMException('The operation was aborted', 'AbortError'));
   }
-  return new Promise((resolve, reject) => {
+  let oncancel;
+  const ret = new Promise((resolve, reject) => {
     const timeout = new Timeout(resolve, after, args, false, true);
     if (!ref) timeout.unref();
     insert(timeout, timeout._idleTimeout);
     if (signal) {
-      signal.addEventListener('abort', () => {
-        if (!timeout._destroyed) {
-          // eslint-disable-next-line no-undef
-          clearTimeout(timeout);
-          reject(lazyDOMException('The operation was aborted', 'AbortError'));
-        }
-      }, { once: true });
+      // eslint-disable-next-line no-undef
+      oncancel = cancelListenerHandler.bind(timeout, clearTimeout, reject);
+      signal.addEventListener('abort', oncancel);
     }
   });
+  return oncancel !== undefined ?
+    PromisePrototypeFinally(
+      ret,
+      () => signal.removeEventListener('abort', oncancel)) : ret;
 }
 
 function setImmediate(value, options = {}) {
@@ -107,19 +116,20 @@ function setImmediate(value, options = {}) {
     return PromiseReject(
       lazyDOMException('The operation was aborted', 'AbortError'));
   }
-  return new Promise((resolve, reject) => {
+  let oncancel;
+  const ret = new Promise((resolve, reject) => {
     const immediate = new Immediate(resolve, [value]);
     if (!ref) immediate.unref();
     if (signal) {
-      signal.addEventListener('abort', () => {
-        if (!immediate._destroyed) {
-          // eslint-disable-next-line no-undef
-          clearImmediate(immediate);
-          reject(lazyDOMException('The operation was aborted', 'AbortError'));
-        }
-      }, { once: true });
+      // eslint-disable-next-line no-undef
+      oncancel = cancelListenerHandler.bind(immediate, clearImmediate, reject);
+      signal.addEventListener('abort', oncancel);
     }
   });
+  return oncancel !== undefined ?
+    PromisePrototypeFinally(
+      ret,
+      () => signal.removeEventListener('abort', oncancel)) : ret;
 }
 
 module.exports = {


### PR DESCRIPTION
Alternative to https://github.com/nodejs/node/pull/35992 ... cleanup 
abort listeners when timer successfully fires

﻿Co-authored-by: Benjamin Gruenbaum <benjamingr@gmail.com>
Signed-off-by: James M Snell <jasnell@gmail.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
