### PR TITLE
lib: add %TypedArray% abstract constructor to primordials

### DIFF
--- a/lib/internal/freeze_intrinsics.js
+++ b/lib/internal/freeze_intrinsics.js
@@ -65,6 +65,8 @@ const {
   SymbolIterator,
   SyntaxError,
   TypeError,
+  TypedArray,
+  TypedArrayPrototype,
   Uint16Array,
   Uint32Array,
   Uint8Array,
@@ -105,7 +107,7 @@ module.exports = function() {
     // AsyncGeneratorFunction
     ObjectGetPrototypeOf(async function* () {}),
     // TypedArray
-    ObjectGetPrototypeOf(Uint8Array),
+    TypedArrayPrototype,
 
     // 19 Fundamental Objects
     Object.prototype, // 19.1
@@ -189,7 +191,7 @@ module.exports = function() {
     // AsyncGeneratorFunction
     ObjectGetPrototypeOf(async function* () {}),
     // TypedArray
-    ObjectGetPrototypeOf(Uint8Array),
+    TypedArray,
 
     // 18 The Global Object
     eval,

--- a/lib/internal/per_context/primordials.js
+++ b/lib/internal/per_context/primordials.js
@@ -175,5 +175,18 @@ primordials.SafePromise = makeSafe(
   copyPrototype(original.prototype, primordials, `${name}Prototype`);
 });
 
+// Create copies of abstract intrinsic objects that are not directly exposed
+// on the global object.
+// Refs: https://tc39.es/ecma262/#sec-%typedarray%-intrinsic-object
+[
+  { name: 'TypedArray', original: Reflect.getPrototypeOf(Uint8Array) },
+].forEach(({ name, original }) => {
+  primordials[name] = original;
+  // The static %TypedArray% methods require a valid `this`, but can't be bound,
+  // as they need a subclass constructor as the receiver:
+  copyPrototype(original, primordials, name);
+  copyPrototype(original.prototype, primordials, `${name}Prototype`);
+});
+
 Object.setPrototypeOf(primordials, null);
 Object.freeze(primordials);

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -57,10 +57,10 @@ const {
   SymbolPrototypeValueOf,
   SymbolIterator,
   SymbolToStringTag,
+  TypedArrayPrototype,
   Uint16Array,
   Uint32Array,
   Uint8Array,
-  Uint8ArrayPrototype,
   Uint8ClampedArray,
   uncurryThis,
 } = primordials;
@@ -141,8 +141,7 @@ const setSizeGetter = uncurryThis(
 const mapSizeGetter = uncurryThis(
   ObjectGetOwnPropertyDescriptor(MapPrototype, 'size').get);
 const typedArraySizeGetter = uncurryThis(
-  ObjectGetOwnPropertyDescriptor(
-    ObjectGetPrototypeOf(Uint8ArrayPrototype), 'length').get);
+  ObjectGetOwnPropertyDescriptor(TypedArrayPrototype, 'length').get);
 
 let hexSlice;
 

--- a/lib/internal/util/types.js
+++ b/lib/internal/util/types.js
@@ -3,13 +3,10 @@
 const {
   ArrayBufferIsView,
   ObjectGetOwnPropertyDescriptor,
-  ObjectGetPrototypeOf,
   SymbolToStringTag,
-  Uint8ArrayPrototype,
+  TypedArrayPrototype,
   uncurryThis,
 } = primordials;
-
-const TypedArrayPrototype = ObjectGetPrototypeOf(Uint8ArrayPrototype);
 
 const TypedArrayProto_toStringTag =
     uncurryThis(


### PR DESCRIPTION
**Refs:** <https://github.com/nodejs/node/pull/35448>
**Refs:** <https://github.com/nodejs/node/pull/36003>
**Refs:** https://tc39.es/ecma262/#sec-%typedarray%-intrinsic-object

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

---

Supersedes and closes <https://github.com/nodejs/node/pull/32127>

review?(@aduh95, @targos)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
