### PR TITLE
tools,lib: recommend using safe primordials

### DIFF
--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -57,6 +57,7 @@ rules:
       into: Number
     - name: JSON
     - name: Map
+      into: Safe
     - name: Math
     - name: Number
     - name: Object
@@ -70,6 +71,7 @@ rules:
     - name: Reflect
     - name: RegExp
     - name: Set
+      into: Safe
     - name: String
     - name: Symbol
     - name: SyntaxError
@@ -80,7 +82,9 @@ rules:
     - name: Uint8ClampedArray
     - name: URIError
     - name: WeakMap
+      into: Safe
     - name: WeakSet
+      into: Safe
 globals:
   Intl: false
   # Parameters passed to internal modules

--- a/test/parallel/test-eslint-prefer-primordials.js
+++ b/test/parallel/test-eslint-prefer-primordials.js
@@ -77,6 +77,10 @@ new RuleTester({
         `,
         options: [{ name: 'Reflect' }],
       },
+      {
+        code: 'const { Map } = primordials; new Map()',
+        options: [{ name: 'Map', into: 'Safe' }],
+      },
     ],
     invalid: [
       {
@@ -153,6 +157,11 @@ new RuleTester({
         `,
         options: [{ name: 'Reflect' }],
         errors: [{ message: /const { ReflectOwnKeys } = primordials/ }]
+      },
+      {
+        code: 'new Map()',
+        options: [{ name: 'Map', into: 'Safe' }],
+        errors: [{ message: /const { SafeMap } = primordials/ }]
       },
     ]
   });


### PR DESCRIPTION
Make the linter recommend replacing `globalThis.Map` by `primordials.SafeMap`, and similar for `Set`, `WeakMap` and `WeakSet`.

Note that the use of `primordials.Map` is still allowed (same for `primordials.Set` and weak classes).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
