### PR TITLE
doc: move v8.getHeapCodeStatistics()

### DIFF
--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -32,6 +32,28 @@ v8.setFlagsFromString('--allow_natives_syntax');
 console.log(v8.cachedDataVersionTag()); // 183726201
 ```
 
+## `v8.getHeapCodeStatistics()`
+<!-- YAML
+added: v12.8.0
+-->
+
+* Returns: {Object}
+
+Returns an object with the following properties:
+
+* `code_and_metadata_size` {number}
+* `bytecode_and_metadata_size` {number}
+* `external_script_source_size` {number}
+
+<!-- eslint-skip -->
+```js
+{
+  code_and_metadata_size: 212208,
+  bytecode_and_metadata_size: 161368,
+  external_script_source_size: 1410794
+}
+```
+
 ## `v8.getHeapSnapshot()`
 <!-- YAML
 added: v11.13.0
@@ -174,28 +196,6 @@ being non-zero indicates a potential memory leak.
   does_zap_garbage: 0,
   number_of_native_contexts: 1,
   number_of_detached_contexts: 0
-}
-```
-
-## `v8.getHeapCodeStatistics()`
-<!-- YAML
-added: v12.8.0
--->
-
-* Returns: {Object}
-
-Returns an object with the following properties:
-
-* `code_and_metadata_size` {number}
-* `bytecode_and_metadata_size` {number}
-* `external_script_source_size` {number}
-
-<!-- eslint-skip -->
-```js
-{
-  code_and_metadata_size: 212208,
-  bytecode_and_metadata_size: 161368,
-  external_script_source_size: 1410794
 }
 ```
 


### PR DESCRIPTION
Move v8.getHeapCodeStatistics() to its alphabetic location in the docs.
An effort to alphabetize all the entries met some resistance on the
grounds that it put some things in an order that wasn't logical, but
this one should be uncontroversial, I think.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
