### PR TITLE
test: fix races in test-performance-eventlooputil

### DIFF
--- a/test/parallel/test-performance-eventlooputil.js
+++ b/test/parallel/test-performance-eventlooputil.js
@@ -23,28 +23,28 @@ if (nodeTiming.loopStart === -1) {
 }
 
 setTimeout(mustCall(function r() {
-  const t = Date.now();
   const elu1 = eventLoopUtilization();
 
   // Force idle time to accumulate before allowing test to continue.
   if (elu1.idle <= 0)
     return setTimeout(mustCall(r), 5);
 
+  const t = Date.now();
   while (Date.now() - t < SPIN_DUR) { }
 
-  const elu2 = eventLoopUtilization();
-  const elu3 = eventLoopUtilization(elu1);
-  const elu4 = eventLoopUtilization(elu2, elu1);
+  const elu2 = eventLoopUtilization(elu1);
+  const elu3 = eventLoopUtilization();
+  const elu4 = eventLoopUtilization(elu3, elu1);
 
-  assert.strictEqual(elu3.idle, 0);
+  assert.strictEqual(elu2.idle, 0);
   assert.strictEqual(elu4.idle, 0);
-  assert.strictEqual(elu3.utilization, 1);
+  assert.strictEqual(elu2.utilization, 1);
   assert.strictEqual(elu4.utilization, 1);
-  assert.strictEqual(elu2.active - elu1.active, elu4.active);
-  assert.ok(elu3.active > SPIN_DUR - 10, `${elu3.active} <= ${SPIN_DUR - 10}`);
+  assert.strictEqual(elu3.active - elu1.active, elu4.active);
+  assert.ok(elu2.active > SPIN_DUR - 10, `${elu2.active} <= ${SPIN_DUR - 10}`);
+  assert.ok(elu2.active < elu4.active, `${elu2.active} >= ${elu4.active}`);
+  assert.ok(elu3.active > elu2.active, `${elu3.active} <= ${elu2.active}`);
   assert.ok(elu3.active > elu4.active, `${elu3.active} <= ${elu4.active}`);
-  assert.ok(elu2.active > elu3.active, `${elu2.active} <= ${elu3.active}`);
-  assert.ok(elu2.active > elu4.active, `${elu2.active} <= ${elu4.active}`);
 
   setTimeout(mustCall(runIdleTimeTest), TIMEOUT);
 }), 5);


### PR DESCRIPTION
Fix two races in test-performance-eventlooputil resulting in a flaky test.

elu1 was capture after start time t from spin look. If OS descides to reschedule the process after capturing t but before getting elu for >=50ms the spin loop is actually a nop. elu1 doesn't show this and as a result elut3 = eventLoopUtilization(elu1) results in
elu3.active is lower then the expected spin time.
Moving capturing of t after capturing t, just before the spin look
avoids this.

Similar if OS decides to shedule a different process between getting the total elu from start and the diff elu showing the spin loop the check to verify that total active time is long then the spin loop
fails.
Exchanging these statements avoids this race.

Fixes: #35309

fyi @trevnorris 
