### PR TITLE
win,build,tools: support VS prerelease

### DIFF
--- a/tools/msvs/vswhere_usability_wrapper.cmd
+++ b/tools/msvs/vswhere_usability_wrapper.cmd
@@ -5,7 +5,7 @@
 
 @if not defined DEBUG_HELPER @ECHO OFF
 setlocal
-if "%~1"=="prerelease" set VSWHERE_WITH_PRERELEASE=1
+if "%~2"=="prerelease" set VSWHERE_WITH_PRERELEASE=1
 set "InstallerPath=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer"
 if not exist "%InstallerPath%" set "InstallerPath=%ProgramFiles%\Microsoft Visual Studio\Installer"
 if not exist "%InstallerPath%" goto :no-vswhere

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -250,7 +250,7 @@ echo Looking for Visual Studio 2019
 @rem cleared first as vswhere_usability_wrapper.cmd doesn't when it fails to
 @rem detect the version searched for
 if not defined target_env set "VCINSTALLDIR="
-call tools\msvs\vswhere_usability_wrapper.cmd "[16.0,17.0)"
+call tools\msvs\vswhere_usability_wrapper.cmd "[16.0,17.0)" "prerelease"
 if "_%VCINSTALLDIR%_" == "__" goto msbuild-not-found
 set "WIXSDKDIR=%WIX%\SDK\VS2017"
 if defined msi (


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

I don't know if we supporting `prerelease` (Preview) versions, but I see there is a flow for that, so I just adjust it.

Without my change, I have both *Visual Studio 19 Preview* and *Visual Studio 17 Enterprise*, but I getting the next error:

```cmd
❯ .\vcbuild.bat
Looking for Python
Python found in C:\Users\BaruchR\AppData\Local\Programs\Python\Python37\\python.exe
Looking for NASM
Looking for Visual Studio 2019
Failed to find a suitable Visual Studio installation.
Try to run in a "Developer Command Prompt" or consult
https://github.com/nodejs/node/blob/master/BUILDING.md#windows
```
<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
