### PR TITLE
doc: ESM documentation consolidation and reordering

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -234,7 +234,7 @@ Enable experimental JSON support for the ES Module loader.
 added: v9.0.0
 -->
 
-Specify the `module` of a custom [experimental ECMAScript Module loader][].
+Specify the `module` of a custom experimental [ECMAScript Module loader][].
 `module` may be either a path to a file, or an ECMAScript Module name.
 
 ### `--experimental-modules`
@@ -1642,6 +1642,7 @@ $ node --max-old-space-size=1536 index.js
 ```
 
 [Chrome DevTools Protocol]: https://chromedevtools.github.io/devtools-protocol/
+[ECMAScript Module loader]: esm.md#esm_loaders
 [REPL]: repl.md
 [ScriptCoverage]: https://chromedevtools.github.io/devtools-protocol/tot/Profiler#type-ScriptCoverage
 [Source Map]: https://sourcemaps.info/spec.html
@@ -1662,7 +1663,6 @@ $ node --max-old-space-size=1536 index.js
 [debugger]: debugger.md
 [debugging security implications]: https://nodejs.org/en/docs/guides/debugging-getting-started/#security-implications
 [emit_warning]: process.md#process_process_emitwarning_warning_type_code_ctor
-[experimental ECMAScript Module loader]: esm.md#esm_experimental_loaders
 [jitless]: https://v8.dev/blog/jitless
 [libuv threadpool documentation]: https://docs.libuv.org/en/latest/threadpool.html
 [remote code execution]: https://www.owasp.org/index.php/Code_Injection

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -114,7 +114,7 @@ The _specifier_ of an `import` statement is the string after the `from` keyword,
 e.g. `'path'` in `import { sep } from 'path'`. Specifiers are also used in
 `export from` statements, and as the argument to an `import()` expression.
 
-There are four types of specifiers:
+There are three types of specifiers:
 
 * _Relative specifiers_ like `'./startup.js'` or `'../config.mjs'`. They refer
   to a path relative to the location of the importing file. _The file extension
@@ -130,7 +130,7 @@ There are four types of specifiers:
 
 Bare specifier resolutions are handled by the [Node.js module resolution
 algorithm][]. All other specifier resolutions are always only resolved with
-the standard relative [URL](https://url.spec.whatwg.org/) resolution semantics.
+the standard relative [URL][] resolution semantics.
 
 Like in CommonJS, module files within packages can be accessed by appending a
 path to the package name; unless the package’s [`package.json`][] contains an
@@ -169,7 +169,7 @@ import './foo.mjs?query=2'; // loads ./foo.mjs with query of "?query=2"
 ```
 
 The volume root may be referenced via `/`, `//` or `file:///`. Given the
-differences between URL and path resolution (such as percent encoding details),
+differences between [URL][] and path resolution (such as percent encoding details),
 it is recommended to use [url.pathToFileURL][] when importing a path.
 
 #### `data:` Imports

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -439,17 +439,7 @@ Alterantively `module.createRequire()` can be used.
 
 Native modules are not currently supported with ES module imports.
 
-They can be loaded directly with `process.dlopen`:
-
-```js
-import process from 'process';
-import { fileURLToPath } from 'url';
-
-const module = { exports: {} };
-process.dlopen(module, fileURLToPath(new URL('./local.node', import.meta.url)));
-```
-
-Alternatively `module.createRequire()` can be used.
+The can instead be loaded with `module.createRequire()` or `process.dlopen`.
 
 #### No `require.resolve`
 

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -71,9 +71,9 @@ Expect major changes in the implementation including interoperability support,
 specifier resolution, and default behavior.
 
 <!-- Anchors to make sure old links find a target -->
-<i id="#esm_package_json_type_field"></i>
-<i id="#esm_package_scope_and_file_extensions"></i>
-<i id="#esm_input_type_flag"></i>
+<i id="esm_package_json_type_field"></i>
+<i id="esm_package_scope_and_file_extensions"></i>
+<i id="esm_input_type_flag"></i>
 
 ## Enabling
 
@@ -456,7 +456,7 @@ hooks can provide this workflow in the future.
 
 `require.cache` is not used by `import`. It has a separate cache.
 
-<i id="#esm_experimental_json_modules"></i>
+<i id="esm_experimental_json_modules"></i>
 
 ## JSON modules
 
@@ -490,7 +490,7 @@ node index.mjs # fails
 node --experimental-json-modules index.mjs # works
 ```
 
-<i id="#esm_experimental_wasm_modules"></i>
+<i id="esm_experimental_wasm_modules"></i>
 
 ## Wasm modules
 
@@ -518,7 +518,7 @@ node --experimental-wasm-modules index.mjs
 
 would provide the exports interface for the instantiation of `module.wasm`.
 
-<i id="#esm_experimental_top_level_await"></i>
+<i id="esm_experimental_top_level_await"></i>
 
 ## Top-level `await`
 
@@ -546,7 +546,7 @@ console.log(five); // Logs `5`
 node b.mjs # works
 ```
 
-<i id="#esm_experimental_loaders"></i>
+<i id="esm_experimental_loaders"></i>
 
 ## Loaders
 

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -1287,6 +1287,7 @@ success!
 [Node.js EP for ES Modules]: https://github.com/nodejs/node-eps/blob/master/002-es-modules.md
 [Node.js Module Resolution Algorithm]: #esm_resolver_algorithm_specification
 [Terminology]: #esm_terminology
+[URL]: https://url.spec.whatwg.org/
 [WHATWG JSON modules specification]: https://html.spec.whatwg.org/#creating-a-json-module-script
 [`"exports"`]: packages.md#packages_exports
 [`"type"`]: packages.md#packages_type

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -134,7 +134,7 @@ algorithm][]. All other specifier resolutions are always only resolved with
 the standard relative [URL][] resolution semantics.
 
 Like in CommonJS, module files within packages can be accessed by appending a
-path to the package name; unless the package’s [`package.json`][] contains an
+path to the package name unless the package’s [`package.json`][] contains an
 [`"exports"`][] field, in which case files within packages can only be accessed
 via the paths defined in [`"exports"`][].
 

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -169,8 +169,8 @@ import './foo.mjs?query=2'; // loads ./foo.mjs with query of "?query=2"
 ```
 
 The volume root may be referenced via `/`, `//` or `file:///`. Given the
-differences between [URL][] and path resolution (such as percent encoding details),
-it is recommended to use [url.pathToFileURL][] when importing a path.
+differences between [URL][] and path resolution (such as percent encoding
+details), it is recommended to use [url.pathToFileURL][] when importing a path.
 
 #### `data:` Imports
 

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -116,41 +116,61 @@ e.g. `'path'` in `import { sep } from 'path'`. Specifiers are also used in
 
 There are four types of specifiers:
 
-* _Bare specifiers_ like `'some-package'`. They refer to an entry point of a
-  package by the package name.
-
-* _Deep import specifiers_ like `'some-package/lib/shuffle.mjs'`. They refer to
-  a path within a package prefixed by the package name.
-
 * _Relative specifiers_ like `'./startup.js'` or `'../config.mjs'`. They refer
-  to a path relative to the location of the importing file.
+  to a path relative to the location of the importing file. _The file extension
+  is always mandatory for these._
+
+* _Bare specifiers_ like `'some-package'` or `'some-package/shuffle'`. They can
+  refer to the main entry point of a package by the package name, or a
+  specific feature module within a package prefixed by the package name as per
+  the examples respectively. _The file extension is optional for these._
 
 * _Absolute specifiers_ like `'file:///opt/nodejs/config.js'`. They refer
   directly and explicitly to a full path.
 
-Bare specifiers, and the bare specifier portion of deep import specifiers, are
-strings; but everything else in a specifier is a URL.
+Bare specifier resolutions are handled by the [Node.js module resolution
+algorithm][]. All other specifier resolutions are always only resolved with
+the standard relative [URL](https://url.spec.whatwg.org/) resolution semantics.
 
-`file:`, `node:`, and `data:` URLs are supported. A specifier like
-`'https://example.com/app.js'` may be supported by browsers but it is not
-supported in Node.js.
+Like in CommonJS, module files within packages can be accessed by appending a
+path to the package name; unless the package’s [`package.json`][] contains an
+[`"exports"`][] field, in which case files within packages can only be accessed
+via the paths defined in [`"exports"`][].
 
-Specifiers may not begin with `/` or `//`. These are reserved for potential
-future use. The root of the current volume may be referenced via `file:///`.
+For details on these package resolution rules that apply to bare specifiers in
+the Node.js module resolution, see the [packages documentation](packages.md).
 
-#### `node:` Imports
+### Mandatory file extensions
 
-<!-- YAML
-added: v14.13.1
--->
+A file extension must be provided when using the `import` keyword to resolve
+relative or absolute specifiers. Directory indexes (e.g. `'./startup/index.js'`)
+must also be fully specified.
 
-`node:` URLs are supported as a means to load Node.js builtin modules. This
-URL scheme allows for builtin modules to be referenced by valid absolute URL
-strings.
+This behavior matches how `import` behaves in browser environments, assuming a
+typically configured server.
+
+### URLs
+
+ES modules are resolved and cached as URLs. This means that files containing
+special characters such as `#` and `?` need to be escaped.
+
+`file:`, `node:`, and `data:` URL schemes are supported. A specifier like
+`'https://example.com/app.js'` is not supported natively in Node.js unless using
+a [custom HTTPS loader][].
+
+#### `file:` URLs
+
+Modules are loaded multiple times if the `import` specifier used to resolve
+them has a different query or fragment.
 
 ```js
-import fs from 'node:fs/promises';
+import './foo.mjs?query=1'; // loads ./foo.mjs with query of "?query=1"
+import './foo.mjs?query=2'; // loads ./foo.mjs with query of "?query=2"
 ```
+
+The volume root may be referenced via `/`, `//` or `file:///`. Given the
+differences between URL and path resolution (such as percent encoding details),
+it is recommended to use [url.pathToFileURL][] when importing a path.
 
 #### `data:` Imports
 
@@ -177,107 +197,114 @@ import 'data:text/javascript,console.log("hello!");';
 import _ from 'data:application/json,"world!"';
 ```
 
+#### `node:` Imports
+
+<!-- YAML
+added: v14.13.1
+-->
+
+`node:` URLs are supported as an alternative means to load Node.js builtin
+modules. This URL scheme allows for builtin modules to be referenced by valid
+absolute URL strings.
+
+```js
+import fs from 'node:fs/promises';
+```
+
+## Builtin modules
+
+[Core modules][] provide named exports of their public API. A
+default export is also provided which is the value of the CommonJS exports.
+The default export can be used for, among other things, modifying the named
+exports. Named exports of builtin modules are updated only by calling
+[`module.syncBuiltinESMExports()`][].
+
+```js
+import EventEmitter from 'events';
+const e = new EventEmitter();
+```
+
+```js
+import { readFile } from 'fs';
+readFile('./foo.txt', (err, source) => {
+  if (err) {
+    console.error(err);
+  } else {
+    console.log(source);
+  }
+});
+```
+
+```js
+import fs, { readFileSync } from 'fs';
+import { syncBuiltinESMExports } from 'module';
+
+fs.readFileSync = () => Buffer.from('Hello, ESM');
+syncBuiltinESMExports();
+
+fs.readFileSync === readFileSync;
+```
+
 ## `import.meta`
 
 * {Object}
 
-The `import.meta` metaproperty is an `Object` that contains the following
-property:
+The `import.meta` meta property is an `Object` that contains the following
+properties.
 
-* `url` {string} The absolute `file:` URL of the module.
+### `import.meta.url`
 
-## Differences between ES modules and CommonJS
+* {string} The absolute `file:` URL of the module.
 
-### Mandatory file extensions
+This is defined exactly the same as it is in browsers providing the URL of the
+current module file.
 
-A file extension must be provided when using the `import` keyword. Directory
-indexes (e.g. `'./startup/index.js'`) must also be fully specified.
-
-This behavior matches how `import` behaves in browser environments, assuming a
-typically configured server.
-
-### No `NODE_PATH`
-
-`NODE_PATH` is not part of resolving `import` specifiers. Please use symlinks
-if this behavior is desired.
-
-### No `require`, `exports`, `module.exports`, `__filename`, `__dirname`
-
-These CommonJS variables are not available in ES modules.
-
-`require` can be imported into an ES module using [`module.createRequire()`][].
-
-Equivalents of `__filename` and `__dirname` can be created inside of each file
-via [`import.meta.url`][].
+This enables useful patterns such as relative file loading:
 
 ```js
-import { fileURLToPath } from 'url';
-import { dirname } from 'path';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+import { readFileSync } from 'fs';
+const buffer = readFileSync(new URL('./data.proto', import.meta.url));
 ```
 
-### No `require.resolve`
+### `import.meta.resolve(specifier[, parent])`
 
-Former use cases relying on `require.resolve` to determine the resolved path
-of a module can be supported via `import.meta.resolve`, which is experimental
-and supported via the `--experimental-import-meta-resolve` flag:
+> Stability: 1 - Experimental
 
+* `specifier` {string} The module specifier to resolve relative to `parent`.
+* `parent` {string|URL} The absolute parent module URL to resolve from. If none
+  is specified, the value of `import.meta.url` is used as the default.
+* Returns: {Promise}
+
+<!-- eslint-skip -->
 ```js
-(async () => {
-  const dependencyAsset = await import.meta.resolve('component-lib/asset.css');
-})();
+const dependencyAsset = await import.meta.resolve('component-lib/asset.css');
 ```
 
 `import.meta.resolve` also accepts a second argument which is the parent module
 from which to resolve from:
 
+<!-- eslint-skip -->
 ```js
-(async () => {
-  // Equivalent to import.meta.resolve('./dep')
-  await import.meta.resolve('./dep', import.meta.url);
-})();
+await import.meta.resolve('./dep', import.meta.url);
 ```
 
 This function is asynchronous because the ES module resolver in Node.js is
-asynchronous. With the introduction of [Top-Level Await][], these use cases
-will be easier as they won't require an async function wrapper.
+asynchronous.
 
-### No `require.extensions`
+## `import()` expressions
 
-`require.extensions` is not used by `import`. The expectation is that loader
-hooks can provide this workflow in the future.
-
-### No `require.cache`
-
-`require.cache` is not used by `import`. It has a separate cache.
-
-### URL-based paths
-
-ES modules are resolved and cached based upon
-[URL](https://url.spec.whatwg.org/) semantics. This means that files containing
-special characters such as `#` and `?` need to be escaped.
-
-Modules are loaded multiple times if the `import` specifier used to resolve
-them has a different query or fragment.
-
-```js
-import './foo.mjs?query=1'; // loads ./foo.mjs with query of "?query=1"
-import './foo.mjs?query=2'; // loads ./foo.mjs with query of "?query=2"
-```
-
-For now, only modules using the `file:` protocol can be loaded.
+[Dynamic `import()`][] is supported in both CommonJS and ES modules. In CommonJS
+modules it can be used to load ES modules.
 
 ## Interoperability with CommonJS
 
 ### `require`
 
-`require` always treats the files it references as CommonJS. This applies
-whether `require` is used the traditional way within a CommonJS environment, or
-in an ES module environment using [`module.createRequire()`][].
+`require` always treats the files it references as CommonJS.
 
-To include an ES module into CommonJS, use [`import()`][].
+Using `require` to load an ES module is not supported because ES modules have
+asynchronous execution. Instead, use use [`import()`][] to load an ES module
+from a CommonJS module.
 
 ### `import` statements
 
@@ -290,30 +317,7 @@ When importing [CommonJS modules](#esm_commonjs_namespaces), the
 available, provided by static analysis as a convenience for better ecosystem
 compatibility.
 
-Additional experimental flags are available for importing
-[Wasm modules](#esm_experimental_wasm_modules) or
-[JSON modules](#esm_experimental_json_modules). For importing native modules or
-JSON modules unflagged, see [`module.createRequire()`][].
-
-The _specifier_ of an `import` statement (the string after the `from` keyword)
-can either be an URL-style relative path like `'./file.mjs'` or a package name
-like `'fs'`.
-
-Like in CommonJS, files within packages can be accessed by appending a path to
-the package name; unless the package’s [`package.json`][] contains an
-[`"exports"`][] field, in which case files within packages need to be accessed
-via the path defined in [`"exports"`][].
-
-```js
-import { sin, cos } from 'geometry/trigonometry-functions.mjs';
-```
-
-### `import()` expressions
-
-[Dynamic `import()`][] is supported in both CommonJS and ES modules. It can be
-used to include ES module files from CommonJS code.
-
-## CommonJS Namespaces
+### CommonJS Namespaces
 
 CommonJS modules consist of a `module.exports` object which can be of any type.
 
@@ -396,41 +400,7 @@ Named exports detection covers many common export patterns, reexport patterns
 and build tool and transpiler outputs. See [cjs-module-lexer][] for the exact
 semantics implemented.
 
-## Builtin modules
-
-[Core modules][] provide named exports of their public API. A
-default export is also provided which is the value of the CommonJS exports.
-The default export can be used for, among other things, modifying the named
-exports. Named exports of builtin modules are updated only by calling
-[`module.syncBuiltinESMExports()`][].
-
-```js
-import EventEmitter from 'events';
-const e = new EventEmitter();
-```
-
-```js
-import { readFile } from 'fs';
-readFile('./foo.txt', (err, source) => {
-  if (err) {
-    console.error(err);
-  } else {
-    console.log(source);
-  }
-});
-```
-
-```js
-import fs, { readFileSync } from 'fs';
-import { syncBuiltinESMExports } from 'module';
-
-fs.readFileSync = () => Buffer.from('Hello, ESM');
-syncBuiltinESMExports();
-
-fs.readFileSync === readFileSync;
-```
-
-## CommonJS, JSON, and native modules
+### CommonJS, JSON, and native modules
 
 CommonJS, JSON, and native modules can be used with
 [`module.createRequire()`][].
@@ -448,7 +418,47 @@ const cjs = require('./cjs.cjs');
 cjs === 'cjs'; // true
 ```
 
-## Experimental JSON modules
+### Differences between ES modules and CommonJS
+
+#### No `NODE_PATH`
+
+`NODE_PATH` is not part of resolving `import` specifiers. Please use symlinks
+if this behavior is desired.
+
+#### No `require`, `exports`, `module.exports`, `__filename`, `__dirname`
+
+These CommonJS variables are not available in ES modules.
+
+`require` can be imported into an ES module using [`module.createRequire()`][].
+
+Equivalents of `__filename` and `__dirname` can be created inside of each file
+via [`import.meta.url`][].
+
+```js
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+```
+
+#### No `require.resolve`
+
+Former use cases relying on `require.resolve` to determine the resolved path
+of a module can be supported via [`import.meta.resolve`][].
+
+#### No `require.extensions`
+
+`require.extensions` is not used by `import`. The expectation is that loader
+hooks can provide this workflow in the future.
+
+#### No `require.cache`
+
+`require.cache` is not used by `import`. It has a separate cache.
+
+## JSON modules
+
+> Stability: 1 - Experimental
 
 Currently importing JSON modules are only supported in the `commonjs` mode
 and are loaded using the CJS loader. [WHATWG JSON modules specification][] are
@@ -478,7 +488,9 @@ node index.mjs # fails
 node --experimental-json-modules index.mjs # works
 ```
 
-## Experimental Wasm modules
+## Wasm modules
+
+> Stability: 1 - Experimental
 
 Importing Web Assembly modules is supported under the
 `--experimental-wasm-modules` flag, allowing any `.wasm` files to be
@@ -502,7 +514,9 @@ node --experimental-wasm-modules index.mjs
 
 would provide the exports interface for the instantiation of `module.wasm`.
 
-## Experimental top-level `await`
+## Top-level `await`
+
+> Stability: 1 - Experimental
 
 The `await` keyword may be used in the top level (outside of async functions)
 within modules as per the [ECMAScript Top-Level `await` proposal][].
@@ -526,7 +540,9 @@ console.log(five); // Logs `5`
 node b.mjs # works
 ```
 
-## Experimental loaders
+## Loaders
+
+> Stability: 1 - Experimental
 
 **Note: This API is currently being redesigned and will still change.**
 
@@ -1237,6 +1253,8 @@ _internal_, _conditions_)
 
 ### Customizing ESM specifier resolution algorithm
 
+> Stability: 1 - Experimental
+
 The current specifier resolution does not support all default behavior of
 the CommonJS loader. One of the behavior differences is automatic resolution
 of file extensions and the ability to import directories that have an index
@@ -1267,8 +1285,8 @@ success!
 [ECMAScript-modules implementation]: https://github.com/nodejs/modules/blob/master/doc/plan-for-new-modules-implementation.md
 [ES Module Integration Proposal for Web Assembly]: https://github.com/webassembly/esm-integration
 [Node.js EP for ES Modules]: https://github.com/nodejs/node-eps/blob/master/002-es-modules.md
+[Node.js Module Resolution Algorithm]: #esm_resolver_algorithm_specification
 [Terminology]: #esm_terminology
-[Top-Level Await]: https://github.com/tc39/proposal-top-level-await
 [WHATWG JSON modules specification]: https://html.spec.whatwg.org/#creating-a-json-module-script
 [`"exports"`]: packages.md#packages_exports
 [`"type"`]: packages.md#packages_type
@@ -1279,7 +1297,8 @@ success!
 [`data:` URLs]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs
 [`export`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export
 [`import()`]: #esm_import_expressions
-[`import.meta.url`]: #esm_import_meta
+[`import.meta.url`]: #esm_import_meta_url
+[`import.meta.resolve`]: #esm_import_meta_resolve
 [`import`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import
 [`module.createRequire()`]: module.md#module_module_createrequire_filename
 [`module.syncBuiltinESMExports()`]: module.md#module_module_syncbuiltinesmexports
@@ -1288,6 +1307,8 @@ success!
 [`string`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String
 [`util.TextDecoder`]: util.md#util_class_util_textdecoder
 [cjs-module-lexer]: https://github.com/guybedford/cjs-module-lexer/tree/1.0.0
+[custom https loader]: #esm_https_loader
 [special scheme]: https://url.spec.whatwg.org/#special-scheme
 [the official standard format]: https://tc39.github.io/ecma262/#sec-modules
 [transpiler loader example]: #esm_transpiler_loader
+[url.pathToFileURL]: url.md#url_url_pathtofileurl_path

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -429,9 +429,8 @@ Local JSON files can be loaded relative to `import.meta.url` with `fs` directly:
 
 <!-- eslint-skip -->
 ```js
-import { promises as fs } from 'fs';
-
-const json = JSON.parse(await fs.readFile('./data.json', import.meta.url));
+import { readFile } from 'fs/promises';
+const json = JSON.parse(await readFile(new URL('./dat.json', import.meta.url)));
 ```
 
 Alterantively `module.createRequire()` can be used.

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -439,7 +439,8 @@ Alterantively `module.createRequire()` can be used.
 
 Native modules are not currently supported with ES module imports.
 
-The can instead be loaded with `module.createRequire()` or `process.dlopen`.
+The can instead be loaded with [`module.createRequire()`][] or
+[`process.dlopen`][].
 
 #### No `require.resolve`
 
@@ -1321,6 +1322,7 @@ success!
 [`module.createRequire()`]: module.md#module_module_createrequire_filename
 [`module.syncBuiltinESMExports()`]: module.md#module_module_syncbuiltinesmexports
 [`package.json`]: packages.md#packages_node_js_package_json_field_definitions
+[`process.dlopen`]: process.md#process_process_dlopen_module_filename_flags
 [`transformSource` hook]: #esm_transformsource_source_context_defaulttransformsource
 [`string`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String
 [`util.TextDecoder`]: util.md#util_class_util_textdecoder

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -456,6 +456,8 @@ hooks can provide this workflow in the future.
 
 `require.cache` is not used by `import`. It has a separate cache.
 
+<i id="#esm_experimental_json_modules"></i>
+
 ## JSON modules
 
 > Stability: 1 - Experimental
@@ -488,6 +490,8 @@ node index.mjs # fails
 node --experimental-json-modules index.mjs # works
 ```
 
+<i id="#esm_experimental_wasm_modules"></i>
+
 ## Wasm modules
 
 > Stability: 1 - Experimental
@@ -514,6 +518,8 @@ node --experimental-wasm-modules index.mjs
 
 would provide the exports interface for the instantiation of `module.wasm`.
 
+<i id="#esm_experimental_top_level_await"></i>
+
 ## Top-level `await`
 
 > Stability: 1 - Experimental
@@ -539,6 +545,8 @@ console.log(five); // Logs `5`
 ```bash
 node b.mjs # works
 ```
+
+<i id="#esm_experimental_loaders"></i>
 
 ## Loaders
 

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -118,12 +118,13 @@ There are three types of specifiers:
 
 * _Relative specifiers_ like `'./startup.js'` or `'../config.mjs'`. They refer
   to a path relative to the location of the importing file. _The file extension
-  is always mandatory for these._
+  is always necessary for these._
 
 * _Bare specifiers_ like `'some-package'` or `'some-package/shuffle'`. They can
   refer to the main entry point of a package by the package name, or a
   specific feature module within a package prefixed by the package name as per
-  the examples respectively. _The file extension is optional for these._
+  the examples respectively. _Including the file extension is only necessary
+  for packages without an [`"exports"`][] field._
 
 * _Absolute specifiers_ like `'file:///opt/nodejs/config.js'`. They refer
   directly and explicitly to a full path.

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -1298,7 +1298,7 @@ success!
 [`export`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export
 [`import()`]: #esm_import_expressions
 [`import.meta.url`]: #esm_import_meta_url
-[`import.meta.resolve`]: #esm_import_meta_resolve
+[`import.meta.resolve`]: #esm_import_meta_resolve_specifier_parent
 [`import`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import
 [`module.createRequire()`]: module.md#module_module_createrequire_filename
 [`module.syncBuiltinESMExports()`]: module.md#module_module_syncbuiltinesmexports

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -895,11 +895,11 @@ The `flags` argument is an integer that allows to specify dlopen
 behavior. See the [`os.constants.dlopen`][] documentation for details.
 
 An important requirement when calling `process.dlopen()` is that the `module`
-instance must be passed. Functions exported by the C++ Addon will then be
+instance must be passed. Functions exported by the C++ Addon are then
 accessible via `module.exports`.
 
 The example below shows how to load a C++ Addon, named `local.node`,
-that exports a `foo` function. All the symbols will be loaded before
+that exports a `foo` function. All the symbols are loaded before
 the call returns, by passing the `RTLD_NOW` constant. In this example
 the constant is assumed to be available.
 

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -885,31 +885,29 @@ changes:
 * `filename` {string}
 * `flags` {os.constants.dlopen} **Default:** `os.constants.dlopen.RTLD_LAZY`
 
-The `process.dlopen()` method allows to dynamically load shared
-objects. It is primarily used by `require()` to load
-C++ Addons, and should not be used directly, except in special
-cases. In other words, [`require()`][] should be preferred over
-`process.dlopen()`, unless there are specific reasons.
+The `process.dlopen()` method allows dynamically loading shared objects. It is
+primarily used by `require()` to load C++ Addons, and should not be used
+directly, except in special cases. In other words, [`require()`][] should be
+preferred over `process.dlopen()` unless there are specific reasons such as
+custom dlopen flags or loading from ES modules.
 
 The `flags` argument is an integer that allows to specify dlopen
 behavior. See the [`os.constants.dlopen`][] documentation for details.
 
-If there are specific reasons to use `process.dlopen()` (for instance,
-to specify dlopen flags), it's often useful to use [`require.resolve()`][]
-to look up the module's path.
+An important requirement when calling `process.dlopen()` is that the `module`
+instance must be passed. Functions exported by the C++ Addon will then be
+accessible via `module.exports`.
 
-An important drawback when calling `process.dlopen()` is that the `module`
-instance must be passed. Functions exported by the C++ Addon will be accessible
-via `module.exports`.
-
-The example below shows how to load a C++ Addon, named as `binding`,
+The example below shows how to load a C++ Addon, named `local.node`,
 that exports a `foo` function. All the symbols will be loaded before
 the call returns, by passing the `RTLD_NOW` constant. In this example
 the constant is assumed to be available.
 
 ```js
 const os = require('os');
-process.dlopen(module, require.resolve('binding'),
+const path = require('path');
+const module = { exports: {} };
+process.dlopen(module, path.join(__dirname, 'local.node'),
                os.constants.dlopen.RTLD_NOW);
 module.exports.foo();
 ```
@@ -2678,7 +2676,6 @@ cases:
 [`readable.read()`]: stream.md#stream_readable_read_size
 [`require()`]: globals.md#globals_require
 [`require.main`]: modules.md#modules_accessing_the_main_module
-[`require.resolve()`]: modules.md#modules_require_resolve_request_options
 [`subprocess.kill()`]: child_process.md#child_process_subprocess_kill_signal
 [`v8.setFlagsFromString()`]: v8.md#v8_v8_setflagsfromstring_flags
 [debugger]: debugger.md


### PR DESCRIPTION
I just went through the `esm.md` docs and consolidated sections where it seemed to make sense as well as reordering the structure slightly now that the layout of this page is finally stable.

Changes include:

* Removing explicit "experimental" from headings, and instead setting the `> Stability` note.
* Removed the distinction of deep package specifiers for a single bare specifier definition. This is because with exports, imports etc deep package specifiers are in theory only one of many types of bare specifier at this point.
* Added a note that file extensions are necessary for abslute and relative specifiers
* Added a note that file extensions are optional for bare specifiers
* Moved up the "mandatory file extensions" section into the import specifiers section.
* Created a new "URLs" section as a subsection of import specifiers, and included sections on `file:`, `data:` and `node:` URLs. Brought all the file resolution considerations under the "`file:` Imports" heading here.
* Added a note about `pathToFileURL`
* Updated the note that absolute specifiers can start with `/` or `//`
* Split `import.meta` into `import.meta.url` and `import.meta.resolve` subsections. Expanded on their use cases.
* Moved up the dynamic `import()` expressions section
* Moved "Differences between CommonJS and ES modules" to the bottom of the "Interoperability with CommonJS" section.
* Simplified the "Interoperability with CommonJS" section to remove repetition / information that repeats directly what is already said above about specifier resolution, and also to get straight to the point of what is supported.
* Added a note that `require` of ES modules is not supported because ES modules are asynchronous.
* Move dynamic import before import meta
* Move import before require in interop section
* Separate "No require, exports, module.exports" from "No __dirname, __filename"
* Move CommonJS, JSON, native modules to "differences" section, with full practical examples for the replacements of each
* Update process.dlopen documentation to be slightly more ES modules use case appropriate.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
