### PR TITLE
http: add support for abortsignal to http.request

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -2336,6 +2336,9 @@ This can be overridden for servers and client requests by passing the
 <!-- YAML
 added: v0.3.6
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/36048
+    description: It is possible to abort a request with an AbortSignal.
   - version:
      - v13.8.0
      - v12.15.0
@@ -2403,6 +2406,8 @@ changes:
      or `port` is specified, those specify a TCP Socket).
   * `timeout` {number}: A number specifying the socket timeout in milliseconds.
     This will set the timeout before the socket is connected.
+  * `signal` {AbortSignal}: An AbortSignal that may be used to abort an ongoing
+    request.
 * `callback` {Function}
 * Returns: {http.ClientRequest}
 
@@ -2595,6 +2600,10 @@ events will be emitted in the following order:
 
 Setting the `timeout` option or using the `setTimeout()` function will
 not abort the request or do anything besides add a `'timeout'` event.
+
+Passing an `AbortSignal` and then calling `abort` on the corresponding
+`AbortController` will behave the same way as calling `.destroy()` on the
+request itself.
 
 ## `http.validateHeaderName(name)`
 <!-- YAML

--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -19,7 +19,7 @@ rules:
     - selector: "ThrowStatement > CallExpression[callee.name=/Error$/]"
       message: "Use new keyword when throwing an Error."
     # Config specific to lib
-    - selector: "NewExpression[callee.name=/Error$/]:not([callee.name=/^(AssertionError|NghttpError)$/])"
+    - selector: "NewExpression[callee.name=/Error$/]:not([callee.name=/^(AssertionError|NghttpError|AbortError)$/])"
       message: "Use an error exported by the internal/errors module."
     - selector: "CallExpression[callee.object.name='Error'][callee.property.name='captureStackTrace']"
       message: "Please use `require('internal/errors').hideStackFrames()` instead."

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -51,7 +51,7 @@ const { Buffer } = require('buffer');
 const { defaultTriggerAsyncIdScope } = require('internal/async_hooks');
 const { URL, urlToOptions, searchParamsSymbol } = require('internal/url');
 const { kOutHeaders, kNeedDrain } = require('internal/http');
-const { connResetException, codes } = require('internal/errors');
+const { AbortError, connResetException, codes } = require('internal/errors');
 const {
   ERR_HTTP_HEADERS_SENT,
   ERR_INVALID_ARG_TYPE,
@@ -59,7 +59,10 @@ const {
   ERR_INVALID_PROTOCOL,
   ERR_UNESCAPED_CHARACTERS
 } = codes;
-const { validateInteger } = require('internal/validators');
+const {
+  validateInteger,
+  validateAbortSignal,
+} = require('internal/validators');
 const { getTimerDuration } = require('internal/timers');
 const {
   DTRACE_HTTP_CLIENT_REQUEST,
@@ -169,6 +172,15 @@ function ClientRequest(input, options, cb) {
   if (options.timeout !== undefined)
     this.timeout = getTimerDuration(options.timeout, 'timeout');
 
+  const signal = options.signal;
+  if (signal) {
+    validateAbortSignal(signal, 'options.signal');
+    const listener = (e) => this.destroy(new AbortError());
+    signal.addEventListener('abort', listener);
+    this.once('close', () => {
+      signal.removeEventListener('abort', listener);
+    });
+  }
   let method = options.method;
   const methodIsString = (typeof method === 'string');
   if (method !== null && method !== undefined && !methodIsString) {

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -727,6 +727,16 @@ const fatalExceptionStackEnhancers = {
   }
 };
 
+// Node uses an AbortError that isn't exactly the same as the DOMException
+// to make usage of the error in userland and readable-stream easier.
+// It is a regular error with `.code` and `.name`.
+class AbortError extends Error {
+  constructor() {
+    super('The operation was aborted');
+    this.code = 'ABORT_ERR';
+    this.name = 'AbortError';
+  }
+}
 module.exports = {
   addCodeToName, // Exported for NghttpError
   codes,
@@ -741,6 +751,7 @@ module.exports = {
   uvException,
   uvExceptionWithHostPort,
   SystemError,
+  AbortError,
   // This is exported only to facilitate testing.
   E,
   kNoOverride,


### PR DESCRIPTION
cc @mcollina @jasnell @addaleax  

This is the last one from https://github.com/nodejs/node/pull/35877#issuecomment-720071726 - if you have any more APIs you want me to add support for AbortSignal in before I go back to _that list_ I started making back then please let me know :] 

Also we should talk about streams and this probably.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
