### PR TITLE
test: improve test-stream-duplex-readable-end

### DIFF
--- a/test/parallel/test-stream-duplex-readable-end.js
+++ b/test/parallel/test-stream-duplex-readable-end.js
@@ -1,6 +1,6 @@
 'use strict';
 // https://github.com/nodejs/node/issues/35926
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const stream = require('stream');
 
@@ -22,11 +22,8 @@ const dst = new stream.Transform({
 
 src.pipe(dst);
 
-function parser_end() {
-  assert.ok(loops > 0);
-  dst.removeAllListeners();
-}
-
 dst.on('data', () => { });
-dst.on('end', parser_end);
-dst.on('error', parser_end);
+dst.on('end', common.mustCall(() => {
+  assert.strictEqual(loops, 3);
+  assert.ok(src.isPaused());
+}));


### PR DESCRIPTION
- Remove unneeded listener for the `'error'` event.
- Use `common.mustCall()`.
- Verify that the `src` stream gets paused.

Refs: https://github.com/nodejs/node/pull/35941

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
