### PR TITLE
stream: fix thrown object reference

### DIFF
--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -269,7 +269,7 @@ function pipeline(...streams) {
     } else {
       const name = reading ? `transform[${i - 1}]` : 'destination';
       throw new ERR_INVALID_ARG_TYPE(
-        name, ['Stream', 'Function'], ret);
+        name, ['Stream', 'Function'], stream);
     }
   }
 


### PR DESCRIPTION
The thrown error incorrectly references the previous entry in the list, rather than the one that is problematic.

This makes for a very confusing error message. Eg. `The "transform[0]" argument must be of type function or an instance of Stream. Received an instance of ReadableStream`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
