### PR TITLE
Improve performance of checkIsHttpToken by removing regex

### DIFF
--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -224,15 +224,16 @@ function checkIsHttpToken(val) {
   for (let i = 0; i < val.length; i++) {
     const cc = val.charCodeAt(i);
     if (
+      (cc >= 97 && cc <= 122) || // a-z
+      (cc >= 65 && cc <= 90) || // A-z
+      cc === 45 || // -
       cc === 33 || // !
       (cc >= 35 && cc <= 39) || // # $ % & '
       cc === 42 || // *
       cc === 43 || // +
-      cc === 45 || // -
       cc === 46 || // .
       (cc >= 48 && cc <= 57) || // 0-9
-      (cc >= 65 && cc <= 90) || // A-z
-      (cc >= 94 && cc <= 122) || // ^ _ ` a-z
+      (cc >= 94 && cc <= 96) || // ^ _ `
       cc === 124 || // |
       cc === 126 // ~
     ) {

--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -210,14 +210,38 @@ function freeParser(parser, req, socket) {
   }
 }
 
-const tokenRegExp = /^[\^_`a-zA-Z\-0-9!#$%&'*+.|~]+$/;
 /**
  * Verifies that the given val is a valid HTTP token
  * per the rules defined in RFC 7230
  * See https://tools.ietf.org/html/rfc7230#section-3.2.6
  */
 function checkIsHttpToken(val) {
-  return tokenRegExp.test(val);
+  if (val.length === 0) {
+    return false;
+  }
+  // Character check based off of previous regex:
+  // /^[\^_`a-zA-Z\-0-9!#$%&'*+.|~]+$/
+  for (let i = 0; i < val.length; i++) {
+    const cc = val.charCodeAt(i);
+    if (
+      cc === 33 || // !
+      (cc >= 35 && cc <= 39) || // # $ % & '
+      cc === 42 || // *
+      cc === 43 || // +
+      cc === 45 || // -
+      cc === 46 || // .
+      (cc >= 48 && cc <= 57) || // 0-9
+      (cc >= 65 && cc <= 90) || // A-z
+      (cc >= 94 && cc <= 122) || // ^ _ ` a-z
+      cc === 124 || // |
+      cc === 126 // ~
+    ) {
+      continue;
+    } else {
+      return false;
+    }
+  }
+  return true;
 }
 
 const headerCharRegex = /[^\t\x20-\x7e\x80-\xff]/;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

I replaced the regex pattern with a for loop and some charCode comparisons. These appeared faster in some of my local benchmarks.