### PR TITLE
crypto: fix passing TypedArray to webcrypto AES methods

### DIFF
--- a/lib/internal/crypto/aes.js
+++ b/lib/internal/crypto/aes.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const {
+  ArrayBufferIsView,
   ArrayBufferPrototypeSlice,
   ArrayFrom,
   ArrayPrototypeIncludes,
@@ -8,6 +9,7 @@ const {
   MathFloor,
   Promise,
   SafeSet,
+  TypedArrayPrototypeSlice,
 } = primordials;
 
 const {
@@ -183,8 +185,10 @@ function asyncAesGcmCipher(
   let tag;
   switch (mode) {
     case kWebCryptoCipherDecrypt:
-      tag = ArrayBufferPrototypeSlice(data, -tagByteLength);
-      data = ArrayBufferPrototypeSlice(data, 0, -tagByteLength);
+      const slice = ArrayBufferIsView(data) ?
+        TypedArrayPrototypeSlice : ArrayBufferPrototypeSlice;
+      tag = slice(data, -tagByteLength);
+      data = slice(data, 0, -tagByteLength);
       break;
     case kWebCryptoCipherEncrypt:
       tag = tagByteLength;


### PR DESCRIPTION
Refs: https://www.w3.org/TR/WebCryptoAPI/#subtlecrypto-interface
Fixes: https://github.com/nodejs/node/issues/36083

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

/cc @panva

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
