### PR TITLE
src: store EventTarget and Event constructors on env

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -146,6 +146,10 @@ if (!config.noBrowserGlobals) {
     Event,
   } = require('internal/event_target');
   exposeInterface(global, 'EventTarget', EventTarget);
+  internalBinding('util').storeEventTargetConstructors(
+    EventTarget,
+    Event);
+
   exposeInterface(global, 'Event', Event);
   const {
     MessageChannel,

--- a/src/env.h
+++ b/src/env.h
@@ -520,6 +520,8 @@ constexpr size_t kFsStatsBufferLength =
   V(domexception_function, v8::Function)                                       \
   V(enhance_fatal_stack_after_inspector, v8::Function)                         \
   V(enhance_fatal_stack_before_inspector, v8::Function)                        \
+  V(event_constructor, v8::Function)                                           \
+  V(eventtarget_constructor, v8::Function)                                     \
   V(fs_use_promises_symbol, v8::Symbol)                                        \
   V(host_import_module_dynamically_callback, v8::Function)                     \
   V(host_initialize_import_meta_object_callback, v8::Function)                 \

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -195,6 +195,16 @@ void ArrayBufferViewHasBuffer(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(args[0].As<ArrayBufferView>()->HasBuffer());
 }
 
+void StoreEventTargetConstructors(const FunctionCallbackInfo<Value>& args) {
+  CHECK(args[0]->IsFunction());  // EventTarget
+  CHECK(args[1]->IsFunction());  // Event
+  Environment* env = Environment::GetCurrent(args);
+  CHECK(env->eventtarget_constructor().IsEmpty());
+  CHECK(env->event_constructor().IsEmpty());
+  env->set_eventtarget_constructor(args[0].As<v8::Function>());
+  env->set_event_constructor(args[1].As<v8::Function>());
+}
+
 class WeakReference : public BaseObject {
  public:
   WeakReference(Environment* env, Local<Object> object, Local<Object> target)
@@ -293,6 +303,7 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(WeakReference::IncRef);
   registry->Register(WeakReference::DecRef);
   registry->Register(GuessHandleType);
+  registry->Register(StoreEventTargetConstructors);
 }
 
 void Initialize(Local<Object> target,
@@ -367,6 +378,9 @@ void Initialize(Local<Object> target,
               weak_ref->GetFunction(context).ToLocalChecked()).Check();
 
   env->SetMethod(target, "guessHandleType", GuessHandleType);
+
+  env->SetMethod(target, "storeEventTargetConstructors",
+                 StoreEventTargetConstructors);
 }
 
 }  // namespace util


### PR DESCRIPTION
Start to an answer for https://github.com/nodejs/node/discussions/35870

Allows creating instances of EventTarget and Event at the native layer. With additional work, can be used to create classes that inherit from EventTarget and Event.

Signed-off-by: James M Snell <jasnell@gmail.com>

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
