### PR TITLE
Cares vulnerability

### DIFF
--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -1246,6 +1246,9 @@ class QueryAnyWrap: public QueryWrap {
                                ret,
                                addrttls,
                                &naddrttls);
+    if (naddrttls > static_cast<int>(arraysize(addrttls))) {
+      naddrttls = arraysize(addrttls);
+    }
     uint32_t a_count = ret->Length();
     if (status != ARES_SUCCESS && status != ARES_ENODATA) {
       ParseError(status);
@@ -1293,6 +1296,9 @@ class QueryAnyWrap: public QueryWrap {
                                ret,
                                addr6ttls,
                                &naddr6ttls);
+    if (naddr6ttls > static_cast<int>(arraysize(addr6ttls))) {
+      naddr6ttls = arraysize(addr6ttls);
+    }
     uint32_t aaaa_count = ret->Length() - a_count;
     if (status != ARES_SUCCESS && status != ARES_ENODATA) {
       ParseError(status);
@@ -1431,6 +1437,9 @@ class QueryAWrap: public QueryWrap {
                                ret,
                                addrttls,
                                &naddrttls);
+    if (naddrttls > static_cast<int>(arraysize(addrttls))) {
+      naddrttls = arraysize(addrttls);
+    }
     if (status != ARES_SUCCESS) {
       ParseError(status);
       return;
@@ -1477,6 +1486,9 @@ class QueryAaaaWrap: public QueryWrap {
                                ret,
                                addrttls,
                                &naddrttls);
+    if (naddrttls > static_cast<int>(arraysize(addrttls))) {
+      naddrttls = arraysize(addrttls);
+    }
     if (status != ARES_SUCCESS) {
       ParseError(status);
       return;

--- a/test/internet/test-dns-stackoverflow.js
+++ b/test/internet/test-dns-stackoverflow.js
@@ -1,0 +1,10 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const dns = require('dns');
+
+dns.resolve4('ticbrasil.com.br', function(err, addresses, family) {
+  assert.strictEqual(typeof addresses.length[addresses.length - 1],
+                     'undefined');
+});


### PR DESCRIPTION
Due to a recent c-ares bug, Node was exposed to
a security vulnerability due to reading beyond the
end of the array of DNS responses when they were
more than 256
c-ares team will fix this bug, but in the meantime,
this will plug the security hole

Fixes: https://github.com/nodejs/node/issues/36063
Refs: https://github.com/c-ares/c-ares/issues/371
Refs: https://github.com/c-ares/c-ares/commit/0d252eb3b2147179296a3bdb4ef97883c97c54d3

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] unit tests
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
