### PR TITLE
TLS: improve compliance with shutdown standard, remove hacks

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -390,11 +390,6 @@ function socketCloseListener() {
   const req = socket._httpMessage;
   debug('HTTP socket close');
 
-  // Pull through final chunk, if anything is buffered.
-  // the ondata function will handle it properly, and this
-  // is a no-op if no final chunk remains.
-  socket.read();
-
   // NOTE: It's important to get parser here, because it could be freed by
   // the `socketOnData`.
   const parser = socket.parser;

--- a/lib/internal/stream_base_commons.js
+++ b/lib/internal/stream_base_commons.js
@@ -205,6 +205,9 @@ function onStreamRead(arrayBuffer) {
     return;
   }
 
+  // note: handle should never deliver any more read events after this point.
+  // (equivalently, it should have called readStop on itself alread).
+
   if (nread !== UV_EOF) {
     // CallJSOnreadMethod expects the return value to be a buffer.
     // Ref: https://github.com/nodejs/node/pull/34375
@@ -219,20 +222,6 @@ function onStreamRead(arrayBuffer) {
   } else {
     if (stream[kMaybeDestroy])
       stream.on('end', stream[kMaybeDestroy]);
-
-    // TODO(ronag): Without this `readStop`, `onStreamRead`
-    // will be called once more (i.e. after Readable.ended)
-    // on Windows causing a ECONNRESET, failing the
-    // test-https-truncate test.
-    if (handle.readStop) {
-      const err = handle.readStop();
-      if (err) {
-        // CallJSOnreadMethod expects the return value to be a buffer.
-        // Ref: https://github.com/nodejs/node/pull/34375
-        stream.destroy(errnoException(err, 'read'));
-        return;
-      }
-    }
 
     // Push a null to signal the end of data.
     // Do it before `maybeDestroy` for correct order of events:

--- a/lib/internal/stream_base_commons.js
+++ b/lib/internal/stream_base_commons.js
@@ -205,8 +205,11 @@ function onStreamRead(arrayBuffer) {
     return;
   }
 
-  // note: handle should never deliver any more read events after this point.
-  // (equivalently, it should have called readStop on itself alread).
+  // After seeing EOF, most streams will be closed permanently,
+  // and will not deliver any more read events after this point.
+  // (equivalently, it should have called readStop on itself already).
+  // Some streams may be reset and explicitly started again with a call
+  // to readStart, such as TTY.
 
   if (nread !== UV_EOF) {
     // CallJSOnreadMethod expects the return value to be a buffer.

--- a/src/crypto/crypto_tls.cc
+++ b/src/crypto/crypto_tls.cc
@@ -886,7 +886,7 @@ bool TLSWrap::IsClosing() {
 
 int TLSWrap::ReadStart() {
   Debug(this, "ReadStart()");
-  if (underlying_stream() != nullptr)
+  if (underlying_stream() != nullptr && !eof_)
     return underlying_stream()->ReadStart();
   return 0;
 }
@@ -1049,14 +1049,18 @@ uv_buf_t TLSWrap::OnStreamAlloc(size_t suggested_size) {
 
 void TLSWrap::OnStreamRead(ssize_t nread, const uv_buf_t& buf) {
   Debug(this, "Read %zd bytes from underlying stream", nread);
+
+  // Ignore everything after close_notify (rfc5246#section-7.2.1)
+  // TODO: unregister our interest in read events
+  if (eof_)
+    return;
+
   if (nread < 0)  {
     // Error should be emitted only after all data was read
     ClearOut();
 
-    // Ignore EOF if received close_notify
     if (nread == UV_EOF) {
-      if (eof_)
-        return;
+      // underlying stream already should have also called ReadStop on itself
       eof_ = true;
     }
 

--- a/src/crypto/crypto_tls.cc
+++ b/src/crypto/crypto_tls.cc
@@ -1051,7 +1051,6 @@ void TLSWrap::OnStreamRead(ssize_t nread, const uv_buf_t& buf) {
   Debug(this, "Read %zd bytes from underlying stream", nread);
 
   // Ignore everything after close_notify (rfc5246#section-7.2.1)
-  // TODO: unregister our interest in read events
   if (eof_)
     return;
 


### PR DESCRIPTION
RFC 5246 section-7.2.1 requires that the implementation must immediately
stop using the stream, as it is no longer TLS-encrypted. The stream is
permitted to still pump events (and errors) to other users, but those
are now unencrypted, so we should not process them here. But therefore,
we do not want to stop the underlying stream, as there could be another
user of it, but we do remove ourselves as a listener.

~~The section also states that the application must destroy the stream
immediately (discarding any pending writes, and sending a close_notify
response back), but we leave that to the upper layer of the application
here, as it should be sufficient to permit standards compliant usage
just to be ignoring read events.~~

EDIT: In August 2018, TLS v1.3 changed that requirement, per https://tools.ietf.org/html/rfc8446#section-6.1

Does not address new feature https://github.com/nodejs/node/issues/35904
Closes: https://github.com/nodejs/node/pull/35946
Co-authored-by: Momtchil Momtchev <momtchil@momtchev.com> @mmomtchev
CI with https://github.com/libuv/libuv/pull/3036: https://ci.nodejs.org/view/libuv/job/libuv-in-node/171/ (the libuv PR shouldn't be needed to pass CI, but instead should make it even harder to pass tests)