### PR TITLE
lib: set abort-controller toStringTag

### DIFF
--- a/lib/internal/abort_controller.js
+++ b/lib/internal/abort_controller.js
@@ -7,7 +7,9 @@ const {
   ObjectAssign,
   ObjectDefineProperties,
   ObjectSetPrototypeOf,
+  ObjectDefineProperty,
   Symbol,
+  SymbolToStringTag,
   TypeError,
 } = primordials;
 
@@ -55,6 +57,13 @@ ObjectDefineProperties(AbortSignal.prototype, {
   aborted: { enumerable: true }
 });
 
+ObjectDefineProperty(AbortSignal.prototype, SymbolToStringTag, {
+  writable: false,
+  enumerable: false,
+  configurable: true,
+  value: 'AbortSignal',
+});
+
 defineEventHandler(AbortSignal.prototype, 'abort');
 
 function createAbortSignal() {
@@ -96,6 +105,13 @@ class AbortController {
 ObjectDefineProperties(AbortController.prototype, {
   signal: { enumerable: true },
   abort: { enumerable: true }
+});
+
+ObjectDefineProperty(AbortController.prototype, SymbolToStringTag, {
+  writable: false,
+  enumerable: false,
+  configurable: true,
+  value: 'AbortController',
 });
 
 module.exports = {

--- a/test/parallel/test-abortcontroller.js
+++ b/test/parallel/test-abortcontroller.js
@@ -60,3 +60,10 @@ const { ok, strictEqual, throws } = require('assert');
     /^TypeError: Illegal constructor$/
   );
 }
+{
+  // Symbol.toStringTag
+  const toString = (o) => Object.prototype.toString.call(o);
+  const ac = new AbortController();
+  strictEqual(toString(ac), '[object AbortController]');
+  strictEqual(toString(ac.signal), '[object AbortSignal]');
+}

--- a/test/parallel/test-eventtarget-memoryleakwarning.js
+++ b/test/parallel/test-eventtarget-memoryleakwarning.js
@@ -21,7 +21,7 @@ common.expectWarning({
      'Use events.setMaxListeners() to increase ' +
      'limit'],
     ['Possible EventTarget memory leak detected. 3 foo listeners added to ' +
-     '[AbortSignal [EventTarget]]. ' +
+     '[AbortSignal]. ' +
      'Use events.setMaxListeners() to increase ' +
      'limit'],
   ],


### PR DESCRIPTION
Pretty small fix for AbortController/AbortSignal defining `Symbol.toStringTag` like we're supposed to. This already works on EventTarget, isn't a big deal and I think was probably just missed before :] 

I am... not sure what to label PRs that touch only AbortController 🤷   
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
