### PR TITLE
test: read error now throws 'read' instead of 'written'

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -537,7 +537,7 @@ function read(fd, buffer, offset, length, position, callback) {
 
   if (buffer.byteLength === 0) {
     throw new ERR_INVALID_ARG_VALUE('buffer', buffer,
-                                    'is empty and cannot be written');
+                                    'is empty and cannot be read');
   }
 
   validateOffsetLengthRead(offset, length, buffer.byteLength);
@@ -589,7 +589,7 @@ function readSync(fd, buffer, offset, length, position) {
 
   if (buffer.byteLength === 0) {
     throw new ERR_INVALID_ARG_VALUE('buffer', buffer,
-                                    'is empty and cannot be written');
+                                    'is empty and cannot be read');
   }
 
   validateOffsetLengthRead(offset, length, buffer.byteLength);

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -362,7 +362,7 @@ async function read(handle, buffer, offset, length, position) {
 
   if (buffer.length === 0) {
     throw new ERR_INVALID_ARG_VALUE('buffer', buffer,
-                                    'is empty and cannot be written');
+                                    'is empty and cannot be read');
   }
 
   validateOffsetLengthRead(offset, length, buffer.length);

--- a/test/parallel/test-fs-read-empty-buffer.js
+++ b/test/parallel/test-fs-read-empty-buffer.js
@@ -14,7 +14,7 @@ assert.throws(
   () => fs.readSync(fd, buffer, 0, 10, 0),
   {
     code: 'ERR_INVALID_ARG_VALUE',
-    message: 'The argument \'buffer\' is empty and cannot be written. ' +
+    message: 'The argument \'buffer\' is empty and cannot be read. ' +
     'Received Uint8Array(0) []'
   }
 );
@@ -23,7 +23,7 @@ assert.throws(
   () => fs.read(fd, buffer, 0, 1, 0, common.mustNotCall()),
   {
     code: 'ERR_INVALID_ARG_VALUE',
-    message: 'The argument \'buffer\' is empty and cannot be written. ' +
+    message: 'The argument \'buffer\' is empty and cannot be read. ' +
     'Received Uint8Array(0) []'
   }
 );
@@ -34,7 +34,7 @@ assert.throws(
     () => filehandle.read(buffer, 0, 1, 0),
     {
       code: 'ERR_INVALID_ARG_VALUE',
-      message: 'The argument \'buffer\' is empty and cannot be written. ' +
+      message: 'The argument \'buffer\' is empty and cannot be read. ' +
                'Received Uint8Array(0) []'
     }
   );


### PR DESCRIPTION
Yesterday when I saw this I was smitten,
fs empty read error shouldn't say
`buffer is empty and cannot be written`.

So in this context,
some other words could be said,
like `buffer is empty and cannot be read`.

Fixes: https://github.com/nodejs/node/issues/36114
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
