### PR TITLE
[v14.x] doc: remove documentation for stream._construct()

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1953,56 +1953,6 @@ const myWritable = new Writable({
 });
 ```
 
-#### `writable._construct(callback)`
-<!-- YAML
-added: v14.13.1
--->
-
-* `callback` {Function} Call this function (optionally with an error
-  argument) when the stream has finished initializing.
-
-The `_construct()` method MUST NOT be called directly. It may be implemented
-by child classes, and if so, will be called by the internal `Writable`
-class methods only.
-
-This optional function will be called in a tick after the stream constructor
-has returned, delaying any `_write()`, `_final()` and `_destroy()` calls until
-`callback` is called. This is useful to initialize state or asynchronously
-initialize resources before the stream can be used.
-
-```js
-const { Writable } = require('stream');
-const fs = require('fs');
-
-class WriteStream extends Writable {
-  constructor(filename) {
-    super();
-    this.filename = filename;
-    this.fd = fd;
-  }
-  _construct(callback) {
-    fs.open(this.filename, (fd, err) => {
-      if (err) {
-        callback(err);
-      } else {
-        this.fd = fd;
-        callback();
-      }
-    });
-  }
-  _write(chunk, encoding, callback) {
-    fs.write(this.fd, chunk, callback);
-  }
-  _destroy(err, callback) {
-    if (this.fd) {
-      fs.close(this.fd, (er) => callback(er || err));
-    } else {
-      callback(err);
-    }
-  }
-}
-```
-
 #### `writable._write(chunk, encoding, callback)`
 <!-- YAML
 changes:
@@ -2267,63 +2217,6 @@ const myReadable = new Readable({
     // ...
   }
 });
-```
-
-#### `readable._construct(callback)`
-<!-- YAML
-added: v14.13.1
--->
-
-* `callback` {Function} Call this function (optionally with an error
-  argument) when the stream has finished initializing.
-
-The `_construct()` method MUST NOT be called directly. It may be implemented
-by child classes, and if so, will be called by the internal `Readable`
-class methods only.
-
-This optional function will be scheduled in the next tick by the stream
-constructor, delaying any `_read()` and `_destroy()` calls until `callback` is
-called. This is useful to initialize state or asynchronously initialize
-resources before the stream can be used.
-
-```js
-const { Readable } = require('stream');
-const fs = require('fs');
-
-class ReadStream extends Readable {
-  constructor(filename) {
-    super();
-    this.filename = filename;
-    this.fd = null;
-  }
-  _construct(callback) {
-    fs.open(this.filename, (fd, err) => {
-      if (err) {
-        callback(err);
-      } else {
-        this.fd = fd;
-        callback();
-      }
-    });
-  }
-  _read(n) {
-    const buf = Buffer.alloc(n);
-    fs.read(this.fd, buf, 0, n, null, (err, bytesRead) => {
-      if (err) {
-        this.destroy(err);
-      } else {
-        this.push(bytesRead > 0 ? buf.slice(0, bytesRead) : null);
-      }
-    });
-  }
-  _destroy(err, callback) {
-    if (this.fd) {
-      fs.close(this.fd, (er) => callback(er || err));
-    } else {
-      callback(err);
-    }
-  }
-}
 ```
 
 #### `readable._read(size)`


### PR DESCRIPTION
The feature was added in Node.js v15.0.0.

Fixes: https://github.com/nodejs/node/issues/36058
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
