### PR TITLE
tools: hide commit queue action link

### DIFF
--- a/tools/actions/commit-queue.sh
+++ b/tools/actions/commit-queue.sh
@@ -67,10 +67,8 @@ for pr in "$@"; do
   if ! tail -n 10 output | grep '. Post "Landed in .*/pull/'"${pr}"; then
     gitHubCurl "$(labelsUrl "$pr")" POST --data '{"labels": ["'"${COMMIT_QUEUE_FAILED_LABEL}"'"]}'
 
-    # Use printf to properly escape newline symbols for jq.
-    printf -v cqurl "\n\nCommit Queue action: %s/%s/%s/actions/runs/%s" \
-      "$GITHUB_SERVER_URL" "${OWNER}" "${REPOSITORY}" "$GITHUB_RUN_ID"
-    jq -n --arg content "<details><summary>Commit Queue failed</summary><pre>$(cat output)</pre></details>$cqurl" '{body: $content}' > output.json
+    cqurl="${GITHUB_SERVER_URL}/${OWNER}/${REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+    jq -n --arg content "<details><summary>Commit Queue failed</summary><pre>$(cat output)</pre><a href='$cqurl'>$cqurl</a></details>" '{body: $content}' > output.json
     cat output.json
 
     gitHubCurl "$(commentsUrl "$pr")" POST --data @output.json


### PR DESCRIPTION
I don't think it's useful to have it outside of the `<details>` element – folks who are likely to click on it are also likely to open the `<details>` first, and it takes place for folks who are not interested.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
