### PR TITLE
http2: add support for TypedArray to getUnpackedSettings

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -2544,7 +2544,7 @@ console.log(packed.toString('base64'));
 added: v8.4.0
 -->
 
-* `buf` {Buffer|Uint8Array} The packed settings.
+* `buf` {Buffer|TypedArray} The packed settings.
 * Returns: {HTTP/2 Settings Object}
 
 Returns a [HTTP/2 Settings Object][] containing the deserialized settings from

--- a/lib/internal/buffer.js
+++ b/lib/internal/buffer.js
@@ -1067,5 +1067,7 @@ module.exports = {
   addBufferPrototypeMethods,
   markAsUntransferable,
   createUnsafeBuffer,
+  readUInt16BE,
+  readUInt32BE,
   reconnectZeroFillToggle
 };

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -13,6 +13,7 @@ const {
   ObjectDefineProperty,
   ObjectPrototypeHasOwnProperty,
   Promise,
+  ReflectApply,
   ReflectGetPrototypeOf,
   Set,
   Symbol,
@@ -32,6 +33,7 @@ const assert = require('assert');
 const EventEmitter = require('events');
 const fs = require('fs');
 const http = require('http');
+const { readUInt16BE, readUInt32BE } = require('internal/buffer');
 const net = require('net');
 const { Duplex } = require('stream');
 const tls = require('tls');
@@ -3208,18 +3210,18 @@ function getPackedSettings(settings) {
 }
 
 function getUnpackedSettings(buf, options = {}) {
-  if (!isArrayBufferView(buf)) {
+  if (!isArrayBufferView(buf) || buf.length === undefined) {
     throw new ERR_INVALID_ARG_TYPE('buf',
-                                   ['Buffer', 'TypedArray', 'DataView'], buf);
+                                   ['Buffer', 'TypedArray'], buf);
   }
   if (buf.length % 6 !== 0)
     throw new ERR_HTTP2_INVALID_PACKED_SETTINGS_LENGTH();
   const settings = {};
   let offset = 0;
   while (offset < buf.length) {
-    const id = buf.readUInt16BE(offset);
+    const id = ReflectApply(readUInt16BE, buf, [offset]);
     offset += 2;
-    const value = buf.readUInt32BE(offset);
+    const value = ReflectApply(readUInt32BE, buf, [offset]);
     switch (id) {
       case NGHTTP2_SETTINGS_HEADER_TABLE_SIZE:
         settings.headerTableSize = value;

--- a/test/parallel/test-http2-getpackedsettings.js
+++ b/test/parallel/test-http2-getpackedsettings.js
@@ -200,15 +200,15 @@ http2.getPackedSettings({ enablePush: false });
     0x00, 0x02, 0x00, 0x00, 0x00, 0x01,
     0x00, 0x08, 0x00, 0x00, 0x00, 0x00]).buffer);
 
-    assert.throws(() => {
-      http2.getUnpackedSettings(packed);
-    }, {
-      code: 'ERR_INVALID_ARG_TYPE',
-      name: 'TypeError',
-      message:
+  assert.throws(() => {
+    http2.getUnpackedSettings(packed);
+  }, {
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError',
+    message:
         'The "buf" argument must be an instance of Buffer or TypedArray.' +
         common.invalidArgTypeHelper(packed)
-    });
+  });
 }
 
 {

--- a/test/parallel/test-http2-getpackedsettings.js
+++ b/test/parallel/test-http2-getpackedsettings.js
@@ -133,8 +133,8 @@ http2.getPackedSettings({ enablePush: false });
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
       message:
-        'The "buf" argument must be an instance of Buffer, TypedArray, or ' +
-        `DataView.${common.invalidArgTypeHelper(input)}`
+        'The "buf" argument must be an instance of Buffer or TypedArray.' +
+        common.invalidArgTypeHelper(input)
     });
   });
 
@@ -157,6 +157,58 @@ http2.getPackedSettings({ enablePush: false });
   assert.strictEqual(settings.maxHeaderSize, 100);
   assert.strictEqual(settings.enablePush, true);
   assert.strictEqual(settings.enableConnectProtocol, false);
+}
+
+{
+  const packed = new Uint16Array([
+    0x00, 0x01, 0x00, 0x00, 0x00, 0x64,
+    0x00, 0x03, 0x00, 0x00, 0x00, 0xc8,
+    0x00, 0x05, 0x00, 0x00, 0x4e, 0x20,
+    0x00, 0x04, 0x00, 0x00, 0x00, 0x64,
+    0x00, 0x06, 0x00, 0x00, 0x00, 0x64,
+    0x00, 0x02, 0x00, 0x00, 0x00, 0x01,
+    0x00, 0x08, 0x00, 0x00, 0x00, 0x00]);
+
+  assert.throws(() => {
+    http2.getUnpackedSettings(packed.slice(5));
+  }, {
+    code: 'ERR_HTTP2_INVALID_PACKED_SETTINGS_LENGTH',
+    name: 'RangeError',
+    message: 'Packed settings length must be a multiple of six'
+  });
+
+  const settings = http2.getUnpackedSettings(packed);
+
+  assert(settings);
+  assert.strictEqual(settings.headerTableSize, 100);
+  assert.strictEqual(settings.initialWindowSize, 100);
+  assert.strictEqual(settings.maxFrameSize, 20000);
+  assert.strictEqual(settings.maxConcurrentStreams, 200);
+  assert.strictEqual(settings.maxHeaderListSize, 100);
+  assert.strictEqual(settings.maxHeaderSize, 100);
+  assert.strictEqual(settings.enablePush, true);
+  assert.strictEqual(settings.enableConnectProtocol, false);
+}
+
+{
+  const packed = new DataView(Buffer.from([
+    0x00, 0x01, 0x00, 0x00, 0x00, 0x64,
+    0x00, 0x03, 0x00, 0x00, 0x00, 0xc8,
+    0x00, 0x05, 0x00, 0x00, 0x4e, 0x20,
+    0x00, 0x04, 0x00, 0x00, 0x00, 0x64,
+    0x00, 0x06, 0x00, 0x00, 0x00, 0x64,
+    0x00, 0x02, 0x00, 0x00, 0x00, 0x01,
+    0x00, 0x08, 0x00, 0x00, 0x00, 0x00]).buffer);
+
+    assert.throws(() => {
+      http2.getUnpackedSettings(packed);
+    }, {
+      code: 'ERR_INVALID_ARG_TYPE',
+      name: 'TypeError',
+      message:
+        'The "buf" argument must be an instance of Buffer or TypedArray.' +
+        common.invalidArgTypeHelper(input)
+    });
 }
 
 {

--- a/test/parallel/test-http2-getpackedsettings.js
+++ b/test/parallel/test-http2-getpackedsettings.js
@@ -207,7 +207,7 @@ http2.getPackedSettings({ enablePush: false });
       name: 'TypeError',
       message:
         'The "buf" argument must be an instance of Buffer or TypedArray.' +
-        common.invalidArgTypeHelper(input)
+        common.invalidArgTypeHelper(packed)
     });
 }
 


### PR DESCRIPTION
This PR is trying to fix the behaviour of `http2.getUnpackedSettings`.

```console
$ node --version
v16.0.0-pre
$ node -e "http2.getUnpackedSettings('')"
node:internal/http2/core:3167
    throw new ERR_INVALID_ARG_TYPE('buf',
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "buf" argument must be an instance of Buffer, TypedArray, or DataView. Received type string ('')
    at new NodeError (node:internal/errors:258:15)
    at Object.getUnpackedSettings (node:internal/http2/core:3167:11)
    at [eval]:1:7
    at Script.runInThisContext (node:vm:132:18)
    at Object.runInThisContext (node:vm:309:38)
    at node:internal/process/execution:77:19
    at [eval]-wrapper:6:22
    at evalScript (node:internal/process/execution:76:60)
    at node:internal/main/eval_string:23:3 {
  code: 'ERR_INVALID_ARG_TYPE'
}
$ node -e "http2.getUnpackedSettings(new Uint8Array([0,0,0,0,0,0]))"
node:internal/http2/core:3175
    const id = buf.readUInt16BE(offset);
                   ^

TypeError: buf.readUInt16BE is not a function
    at Object.getUnpackedSettings (node:internal/http2/core:3175:20)
    at [eval]:1:7
    at Script.runInThisContext (node:vm:132:18)
    at Object.runInThisContext (node:vm:309:38)
    at node:internal/process/execution:77:19
    at [eval]-wrapper:6:22
    at evalScript (node:internal/process/execution:76:60)
    at node:internal/main/eval_string:23:3
```

The error message says we can use `TypedArray`, the documentation says we can use `Uint8Array`, but in practice only Node.js `Buffer` object are accepted.

This PR adds support for all `TypedArray` and remove `DataView`  from the error message. It also updates the documentation.


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
