### PR TITLE
n-api: add napi_define_subclass

### DIFF
--- a/benchmark/napi/function_call/index.js
+++ b/benchmark/napi/function_call/index.js
@@ -46,7 +46,8 @@ const bench = common.createBenchmark(main, {
 
 function main({ n, type }) {
   if (type.match(/napi_define/)) {
-    const instance = type == 'napi_define_class' ? class_instance : subclass_instance;
+    const instance = (type === 'napi_define_class' ? class_instance :
+      subclass_instance);
     bench.start();
     for (let i = 0; i < n; i++) {
       instance.fn();

--- a/benchmark/napi/function_call/index.js
+++ b/benchmark/napi/function_call/index.js
@@ -29,6 +29,9 @@ try {
 }
 const napi = napi_binding.hello;
 
+const class_instance = new napi_binding.Class();
+const subclass_instance = new napi_binding.Subclass();
+
 let c = 0;
 function js() {
   return c++;
@@ -37,15 +40,24 @@ function js() {
 assert(js() === cxx());
 
 const bench = common.createBenchmark(main, {
-  type: ['js', 'cxx', 'napi'],
-  n: [1e6, 1e7, 5e7]
+  type: ['js', 'cxx', 'napi', 'napi_define_class', 'napi_define_subclass'],
+  n: [1e6, 1e7, 5e7, 1e8]
 });
 
 function main({ n, type }) {
-  const fn = type === 'cxx' ? cxx : type === 'napi' ? napi : js;
-  bench.start();
-  for (let i = 0; i < n; i++) {
-    fn();
+  if (type.match(/napi_define/)) {
+    const instance = type == 'napi_define_class' ? class_instance : subclass_instance;
+    bench.start();
+    for (let i = 0; i < n; i++) {
+      instance.fn();
+    }
+    bench.end(n);
+  } else {
+    const fn = type === 'cxx' ? cxx : type === 'napi' ? napi : js;
+    bench.start();
+    for (let i = 0; i < n; i++) {
+      fn();
+    }
+    bench.end(n);
   }
-  bench.end(n);
 }

--- a/benchmark/napi/function_call/napi_binding.c
+++ b/benchmark/napi/function_call/napi_binding.c
@@ -1,4 +1,5 @@
 #include <assert.h>
+#define NAPI_EXPERIMENTAL
 #include <node_api.h>
 
 static int32_t increment = 0;
@@ -11,7 +12,9 @@ static napi_value Hello(napi_env env, napi_callback_info info) {
 }
 
 NAPI_MODULE_INIT() {
-  napi_value hello;
+  napi_value hello, klass, subklass;
+
+  // Create plain function and attach to exports.
   napi_status status =
       napi_create_function(env,
                            "hello",
@@ -22,5 +25,36 @@ NAPI_MODULE_INIT() {
   assert(status == napi_ok);
   status = napi_set_named_property(env, exports, "hello", hello);
   assert(status == napi_ok);
+
+  // Create class and attach to exports.
+  napi_property_descriptor prop =
+    { "fn", NULL, Hello, NULL, NULL, NULL, napi_enumerable, NULL };
+  status = napi_define_class(env,
+                             "Class",
+                             NAPI_AUTO_LENGTH,
+                             Hello,
+                             NULL,
+                             1,
+                             &prop,
+                             &klass);
+  assert (status == napi_ok);
+  status = napi_set_named_property(env, exports, "Class", klass);
+  assert(status == napi_ok);
+
+  // Create subclass and attach to exports.
+  status = napi_define_subclass(env,
+                                NULL,
+                                "Class",
+                                NAPI_AUTO_LENGTH,
+                                Hello,
+                                NULL,
+                                NULL,
+                                1,
+                                &prop,
+                                &subklass);
+  assert (status == napi_ok);
+  status = napi_set_named_property(env, exports, "Subclass", subklass);
+  assert(status == napi_ok);
+
   return exports;
 }

--- a/src/js_native_api.h
+++ b/src/js_native_api.h
@@ -554,6 +554,18 @@ NAPI_EXTERN napi_status napi_object_freeze(napi_env env,
                                            napi_value object);
 NAPI_EXTERN napi_status napi_object_seal(napi_env env,
                                          napi_value object);
+
+NAPI_EXTERN napi_status
+napi_define_subclass(napi_env env,
+                     napi_value parent_constructor,
+                     const char* utf8name,
+                     size_t length,
+                     napi_callback constructor,
+                     napi_callback get_super_params,
+                     void* data,
+                     size_t property_count,
+                     const napi_property_descriptor* properties,
+                     napi_value* child_ctor);
 #endif  // NAPI_EXPERIMENTAL
 
 EXTERN_C_END

--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -3410,10 +3410,13 @@ napi_status napi_define_subclass(napi_env env,
   // Assemble the formal parameter list and the class body, and init the args.
   for (size_t idx = 0; idx < property_count; idx++) {
     if ((props[idx].attributes & napi_static) == 0) {
-      key = (props[idx].name != nullptr)
-        ? "[" + gen.PushArg(props[idx].name) + "]"
-        : std::string(props[idx].utf8name);
-
+      napi_value name = props[idx].name;
+      if (name == nullptr)
+        STATUS_CALL(napi_create_string_utf8(env,
+                                            props[idx].utf8name,
+                                            NAPI_AUTO_LENGTH,
+                                            &name));
+      key = "[" + gen.PushArg(name) + "]";
       if (props[idx].value != nullptr) {
         gen.PostProcess(key, &props[idx]);
       } else if (props[idx].method != nullptr) {

--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -731,10 +731,10 @@ class JSClassGen {
     post_process += "    },\n";
   }
 
-  inline std::string PushArg(napi_value val = nullptr) {
+  inline std::string PushArg(napi_value val) {
     std::string propname = "prop" + std::to_string(param_idx++);
     formal_args += ", " + propname;
-    if (val != nullptr) args.push_back(val);
+    args.push_back(val);
     return propname;
   }
 
@@ -751,7 +751,6 @@ class JSClassGen {
                              method,
                              desc->data,
                              &fn));
-    args.push_back(fn);
 
     class_body += "    " +
         ((method == desc->method) ? key + "(...x)" :
@@ -759,7 +758,7 @@ class JSClassGen {
         "set " + key + "(x)") + " {\n"
         "      if (!(this instanceof " + classname + "))\n"
         "        throw new Error('Illegal invocation');\n"
-        "      return " + PushArg() + ".apply(this, " +
+        "      return " + PushArg(fn) + ".apply(this, " +
         ((method == desc->method) ? "x" :
         (method == desc->getter) ? "[]" : "[x]") + ");\n" +
         "    }\n";

--- a/test/js-native-api/common.h
+++ b/test/js-native-api/common.h
@@ -61,6 +61,12 @@
 #define DECLARE_NAPI_GETTER(name, func)                                  \
   { (name), NULL, NULL, (func), NULL, NULL, napi_default, NULL }
 
+#define STATUS_CALL(call)                 \
+  do {                                    \
+    napi_status status = (call);          \
+    if (status != napi_ok) return status; \
+  } while (0)
+
 void add_returned_status(napi_env env,
                          const char* key,
                          napi_value object,

--- a/test/js-native-api/test_constructor/test.js
+++ b/test/js-native-api/test_constructor/test.js
@@ -5,58 +5,71 @@ const assert = require('assert');
 const getterOnlyErrorRE =
   /^TypeError: Cannot set property .* of #<.*> which has only a getter$/;
 
+const readonlyValueErrorRE =
+  /^TypeError: Cannot assign to read only property '.*' of object '#<.*>'$/;
+
 // Testing api calls for a constructor that defines properties
-const TestConstructor = require(`./build/${common.buildType}/test_constructor`);
-const test_object = new TestConstructor();
+const { MyObject, MyObjectViaSubclass } =
+  require(`./build/${common.buildType}/test_constructor`);
 
-assert.strictEqual(test_object.echo('hello'), 'hello');
+test(MyObject);
+test(MyObjectViaSubclass);
 
-test_object.readwriteValue = 1;
-assert.strictEqual(test_object.readwriteValue, 1);
-test_object.readwriteValue = 2;
-assert.strictEqual(test_object.readwriteValue, 2);
+function test(NativeConstructor) {
+  const test_object = new NativeConstructor();
 
-assert.throws(() => { test_object.readonlyValue = 3; },
-              /^TypeError: Cannot assign to read only property 'readonlyValue' of object '#<MyObject>'$/);
+  assert.strictEqual(test_object.echo('hello'), 'hello');
 
-assert.ok(test_object.hiddenValue);
+  test_object.readwriteValue = 1;
+  assert.strictEqual(test_object.readwriteValue, 1);
+  test_object.readwriteValue = 2;
+  assert.strictEqual(test_object.readwriteValue, 2);
 
-// Properties with napi_enumerable attribute should be enumerable.
-const propertyNames = [];
-for (const name in test_object) {
-  propertyNames.push(name);
+  assert.throws(() => { test_object.readonlyValue = 3; }, readonlyValueErrorRE);
+
+  assert.ok(test_object.hiddenValue);
+
+  assert.throws(() => { test_object.echo.apply(null, []); }, /Illegal invocation/);
+
+  // Properties with napi_enumerable attribute should be enumerable.
+  const propertyNames = [];
+  for (const name in test_object) {
+    propertyNames.push(name);
+  }
+  assert.ok(propertyNames.includes('echo'));
+  assert.ok(propertyNames.includes('readwriteValue'));
+  assert.ok(propertyNames.includes('readonlyValue'));
+  assert.ok(!propertyNames.includes('hiddenValue'));
+  assert.ok(!propertyNames.includes('readwriteAccessor1'));
+  assert.ok(!propertyNames.includes('readwriteAccessor2'));
+  assert.ok(!propertyNames.includes('readonlyAccessor1'));
+  assert.ok(!propertyNames.includes('readonlyAccessor2'));
+
+  // The napi_writable attribute should be ignored for accessors.
+  test_object.readwriteAccessor1 = 1;
+  assert.strictEqual(test_object.readwriteAccessor1, 1);
+  assert.strictEqual(test_object.readonlyAccessor1, 1);
+  assert.throws(() => { test_object.readonlyAccessor1 = 3; },
+                getterOnlyErrorRE);
+  test_object.readwriteAccessor2 = 2;
+  assert.strictEqual(test_object.readwriteAccessor2, 2);
+  assert.strictEqual(test_object.readonlyAccessor2, 2);
+  assert.throws(() => { test_object.readonlyAccessor2 = 3; },
+                getterOnlyErrorRE);
+
+  // Validate that static properties are on the class as opposed
+  // to the instance
+  assert.strictEqual(NativeConstructor.staticReadonlyAccessor1, 10);
+  assert.strictEqual(test_object.staticReadonlyAccessor1, undefined);
+
+  // Verify that passing NULL to napi_define_class() results in the correct
+  // error.
+  assert.deepStrictEqual(NativeConstructor.TestDefineClass(), {
+    envIsNull: 'Invalid argument',
+    nameIsNull: 'Invalid argument',
+    cbIsNull: 'Invalid argument',
+    cbDataIsNull: 'napi_ok',
+    propertiesIsNull: 'Invalid argument',
+    resultIsNull: 'Invalid argument'
+  });
 }
-assert.ok(propertyNames.includes('echo'));
-assert.ok(propertyNames.includes('readwriteValue'));
-assert.ok(propertyNames.includes('readonlyValue'));
-assert.ok(!propertyNames.includes('hiddenValue'));
-assert.ok(!propertyNames.includes('readwriteAccessor1'));
-assert.ok(!propertyNames.includes('readwriteAccessor2'));
-assert.ok(!propertyNames.includes('readonlyAccessor1'));
-assert.ok(!propertyNames.includes('readonlyAccessor2'));
-
-// The napi_writable attribute should be ignored for accessors.
-test_object.readwriteAccessor1 = 1;
-assert.strictEqual(test_object.readwriteAccessor1, 1);
-assert.strictEqual(test_object.readonlyAccessor1, 1);
-assert.throws(() => { test_object.readonlyAccessor1 = 3; }, getterOnlyErrorRE);
-test_object.readwriteAccessor2 = 2;
-assert.strictEqual(test_object.readwriteAccessor2, 2);
-assert.strictEqual(test_object.readonlyAccessor2, 2);
-assert.throws(() => { test_object.readonlyAccessor2 = 3; }, getterOnlyErrorRE);
-
-// Validate that static properties are on the class as opposed
-// to the instance
-assert.strictEqual(TestConstructor.staticReadonlyAccessor1, 10);
-assert.strictEqual(test_object.staticReadonlyAccessor1, undefined);
-
-// Verify that passing NULL to napi_define_class() results in the correct
-// error.
-assert.deepStrictEqual(TestConstructor.TestDefineClass(), {
-  envIsNull: 'Invalid argument',
-  nameIsNull: 'Invalid argument',
-  cbIsNull: 'Invalid argument',
-  cbDataIsNull: 'napi_ok',
-  propertiesIsNull: 'Invalid argument',
-  resultIsNull: 'Invalid argument'
-});

--- a/test/js-native-api/test_constructor/test2.js
+++ b/test/js-native-api/test_constructor/test2.js
@@ -3,6 +3,6 @@ const common = require('../../common');
 const assert = require('assert');
 
 // Testing api calls for a constructor that defines properties
-const TestConstructor =
-    require(`./build/${common.buildType}/test_constructor`).constructorName;
+const TestConstructor = require(`./build/${common.buildType}/test_constructor`)
+  .MyObject.constructorName;
 assert.strictEqual(TestConstructor.name, 'MyObject');

--- a/test/js-native-api/test_constructor/test_constructor.c
+++ b/test/js-native-api/test_constructor/test_constructor.c
@@ -1,3 +1,4 @@
+#define NAPI_EXPERIMENTAL
 #include <js_native_api.h>
 #include "../common.h"
 
@@ -159,7 +160,7 @@ static napi_value NewExtra(napi_env env, napi_callback_info info) {
 
 EXTERN_C_START
 napi_value Init(napi_env env, napi_value exports) {
-  napi_value number, cons;
+  napi_value number, cons, subcons;
   NAPI_CALL(env, napi_create_double(env, value_, &number));
 
   NAPI_CALL(env, napi_define_class(
@@ -189,8 +190,21 @@ napi_value Init(napi_env env, napi_value exports) {
   };
 
   NAPI_CALL(env, napi_define_class(env, "MyObject", NAPI_AUTO_LENGTH, New,
-      NULL, sizeof(properties)/sizeof(*properties), properties, &cons));
+      NULL, sizeof(properties) / sizeof(*properties), properties, &cons));
 
-  return cons;
+  NAPI_CALL(env, napi_define_subclass(env, NULL, "MyObjectViaSubclass",
+      NAPI_AUTO_LENGTH, New, NULL, NULL,
+      sizeof(properties) / sizeof(*properties), properties, &subcons));
+
+  napi_property_descriptor export_props[] = {
+    { "MyObject", NULL, NULL, NULL, NULL, cons, napi_enumerable, NULL },
+    { "MyObjectViaSubclass", NULL, NULL, NULL, NULL, subcons, napi_enumerable,
+        NULL },
+  };
+
+  NAPI_CALL(env, napi_define_properties(env, exports,
+      sizeof(export_props) / sizeof(*export_props), export_props));
+
+  return exports;
 }
 EXTERN_C_END

--- a/test/js-native-api/test_subclass/binding.gyp
+++ b/test/js-native-api/test_subclass/binding.gyp
@@ -1,0 +1,12 @@
+{
+  "targets": [
+    {
+      "target_name": "test_subclass",
+      "sources": [
+        "../common.c",
+        "../entry_point.c",
+        "test_subclass.c"
+      ]
+    }
+  ]
+}

--- a/test/js-native-api/test_subclass/test.js
+++ b/test/js-native-api/test_subclass/test.js
@@ -44,4 +44,8 @@ function test(Superclass, Subclass) {
   assert.strictEqual(subItem.chainableMethod('something'), '1-something-1');
   assert.strictEqual(superItem.value, 5);
   assert.strictEqual(subItem.value, 5);
+  assert(superItem instanceof Superclass);
+  assert(subItem instanceof Subclass);
+  assert(subItem instanceof Superclass);
+  assert.strictEqual(Subclass.__proto__, Superclass);
 }

--- a/test/js-native-api/test_subclass/test.js
+++ b/test/js-native-api/test_subclass/test.js
@@ -1,0 +1,47 @@
+'use strict';
+const common = require('../../common');
+const assert = require('assert');
+
+const binding = require(`./build/${common.buildType}/test_subclass`);
+
+class JSClass {
+  superMethod(param) { return param + 1; }
+  chainableMethod(param) { return param + '-1'; }
+  value = 5;
+}
+
+class JSSubclassOfJSClass extends JSClass {
+  subMethod(param) { return param - 1; }
+  chainableMethod(param) { return '1-' + super.chainableMethod(param); }
+}
+
+const NativeClass = binding.NativeClass;
+
+class JSSubclassOfNativeClass extends NativeClass {
+  subMethod(param) { return param - 1; }
+  chainableMethod(param) { return '1-' + super.chainableMethod(param); }
+}
+
+const NativeSubclassOfJSClass = binding.defineSubclass(JSClass);
+
+const NativeSubClassOfNativeClass = binding.NativeSubclass;
+
+// Testing pure-JS provides an easy test-of-the-test to make sure we expect the
+// right things of the native class hierarchy.
+test(JSClass, JSSubclassOfJSClass);
+test(JSClass, NativeSubclassOfJSClass);
+test(NativeClass, JSSubclassOfNativeClass);
+test(NativeClass, NativeSubClassOfNativeClass);
+
+function test(Superclass, Subclass) {
+  const superItem = new Superclass();
+  const subItem = new Subclass();
+
+  assert.strictEqual(superItem.superMethod(42), 43);
+  assert.strictEqual(subItem.superMethod(42), 43);
+  assert.strictEqual(subItem.subMethod(42), 41);
+  assert.strictEqual(superItem.chainableMethod('something'), 'something-1');
+  assert.strictEqual(subItem.chainableMethod('something'), '1-something-1');
+  assert.strictEqual(superItem.value, 5);
+  assert.strictEqual(subItem.value, 5);
+}

--- a/test/js-native-api/test_subclass/test.js
+++ b/test/js-native-api/test_subclass/test.js
@@ -47,5 +47,5 @@ function test(Superclass, Subclass) {
   assert(superItem instanceof Superclass);
   assert(subItem instanceof Subclass);
   assert(subItem instanceof Superclass);
-  assert.strictEqual(Subclass.__proto__, Superclass);
+  assert.strictEqual(Object.getPrototypeOf(Subclass), Superclass);
 }

--- a/test/js-native-api/test_subclass/test_subclass.c
+++ b/test/js-native-api/test_subclass/test_subclass.c
@@ -1,0 +1,187 @@
+#include <stdlib.h>
+#include <string.h>
+#define NAPI_EXPERIMENTAL
+#include <js_native_api.h>
+#include "../common.h"
+
+static napi_value NativeClass(napi_env env, napi_callback_info info) {
+  return NULL;
+}
+
+static napi_value SuperMethod(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value param;
+  int32_t value;
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, &param, NULL, NULL));
+  NAPI_CALL(env, napi_get_value_int32(env, param, &value));
+  NAPI_CALL(env, napi_create_int32(env, ++value, &param));
+  return param;
+}
+
+static napi_value SuperChainableMethod(napi_env env, napi_callback_info info) {
+  size_t argc = 1, length;
+  napi_value param;
+  char* str;
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, &param, NULL, NULL));
+  NAPI_CALL(env, napi_get_value_string_utf8(env, param, NULL, 0, &length));
+  str = malloc(length + 3);
+  memset(str, 0, length + 3);
+  NAPI_CALL(env,
+            napi_get_value_string_utf8(env, param, str, length + 1, &length));
+  str[length] = '-';
+  str[length + 1] = '1';
+  NAPI_CALL(env, napi_create_string_utf8(env, str, length + 2, &param));
+  free(str);
+  return param;
+}
+
+static napi_status InitNativeClass(napi_env env, napi_value* result) {
+  napi_property_descriptor props[] = {
+    DECLARE_NAPI_PROPERTY("superMethod", SuperMethod),
+    DECLARE_NAPI_PROPERTY("chainableMethod", SuperChainableMethod),
+    { "value", NULL, NULL, NULL, NULL, NULL, napi_enumerable, NULL },
+  };
+
+  STATUS_CALL(napi_create_uint32(env, 5, &props[2].value));
+
+  return napi_define_class(env,
+                           "NativeClass",
+                           NAPI_AUTO_LENGTH,
+                           NativeClass,
+                           NULL,
+                           sizeof(props) / sizeof(*props),
+                           props,
+                           result);
+}
+
+static napi_value NativeSubclass(napi_env env, napi_callback_info info) {
+  return NULL;
+}
+
+static napi_value SubMethod(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value param;
+  int32_t value;
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, &param, NULL, NULL));
+  NAPI_CALL(env, napi_get_value_int32(env, param, &value));
+  NAPI_CALL(env, napi_create_int32(env, --value, &param));
+  return param;
+}
+
+static napi_value SubChainableMethod(napi_env env, napi_callback_info info) {
+  size_t argc = 1, length;
+  char* str;
+  napi_value param, super_fn, js_this;
+  napi_ref super_ref;
+  NAPI_CALL(env, napi_get_cb_info(env,
+                                  info,
+                                  &argc,
+                                  &param,
+                                  &js_this,
+                                  (void**)(&super_ref)));
+
+  // Chain up.
+  NAPI_CALL(env, napi_get_reference_value(env, super_ref, &super_fn));
+  NAPI_CALL(env, napi_call_function(env, js_this, super_fn, 1, &param, &param));
+
+  // Prepend "1-"
+  NAPI_CALL(env, napi_get_value_string_utf8(env, param, NULL, 0, &length));
+  str = malloc(length + 3);
+  memset(str, 0, length + 3);
+  NAPI_CALL(env, napi_get_value_string_utf8(env,
+                                            param,
+                                            &str[2],
+                                            length + 1,
+                                            &length));
+  str[0] = '1';
+  str[1] = '-';
+  NAPI_CALL(env, napi_create_string_utf8(env, str, length + 2, &param));
+  free(str);
+  return param;
+}
+
+static void DeleteSuperRef(napi_env env, void* data, void* hint) {
+  NAPI_CALL_RETURN_VOID(env, napi_delete_reference(env, (napi_ref)data));
+}
+
+static napi_value ProcessSuperParams(napi_env env, napi_callback_info info) {
+  napi_value ar;
+  NAPI_CALL(env, napi_create_array(env, &ar));
+  return ar;
+}
+
+static napi_status
+InitNativeSubclass(napi_env env, napi_value super, napi_value* result) {
+  napi_ref super_ref;
+  napi_value super_fn;
+
+  napi_property_descriptor props[] = {
+    DECLARE_NAPI_PROPERTY(NULL, SubMethod),
+    DECLARE_NAPI_PROPERTY("chainableMethod", SubChainableMethod),
+  };
+
+  // Intentionally use a string-valued `napi_value` instead of a literal string.
+  STATUS_CALL(napi_create_string_utf8(env,
+                                      "subMethod",
+                                      NAPI_AUTO_LENGTH,
+                                      &props[0].name));
+
+  // Save a reference to the chain-up method that the subclass'
+  // `chainableMethod` will use.
+  STATUS_CALL(napi_get_named_property(env, super, "prototype", &super_fn));
+  STATUS_CALL(napi_get_named_property(env,
+                                      super_fn,
+                                      "chainableMethod",
+                                      &super_fn));
+  STATUS_CALL(napi_create_reference(env, super_fn, 1, &super_ref));
+  props[1].data = super_ref;
+
+  STATUS_CALL(napi_define_subclass(env,
+                                   super,
+                                   "NativeSubclass",
+                                   NAPI_AUTO_LENGTH,
+                                   NativeSubclass,
+                                   ProcessSuperParams,
+                                   NULL,
+                                   sizeof(props) / sizeof(*props),
+                                   props,
+                                   result));
+
+  // Make sure the reference gets destroyed along with the constructor.
+  return napi_add_finalizer(env,
+                            *result,
+                            super_ref,
+                            DeleteSuperRef,
+                            NULL,
+                            NULL);
+}
+
+static napi_value DefineSubclass(napi_env env, napi_callback_info info) {
+  napi_value result;
+  size_t argc = 1;
+
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, &result, NULL, NULL));
+  NAPI_CALL(env, InitNativeSubclass(env, result, &result));
+
+  return result;
+}
+
+EXTERN_C_START
+napi_value Init(napi_env env, napi_value exports) {
+  napi_property_descriptor props[] = {
+    { "NativeClass", NULL, NULL, NULL, NULL, NULL, napi_enumerable, NULL },
+    { "NativeSubclass", NULL, NULL, NULL, NULL, NULL, napi_enumerable, NULL },
+    DECLARE_NAPI_PROPERTY("defineSubclass", DefineSubclass),
+  };
+
+  NAPI_CALL(env, InitNativeClass(env, &props[0].value));
+
+  NAPI_CALL(env, InitNativeSubclass(env, props[0].value, &props[1].value));
+
+  NAPI_CALL(env, napi_define_properties(env,
+                                        exports,
+                                        sizeof(props) / sizeof(*props),
+                                        props));
+  return exports;
+}
+EXTERN_C_END


### PR DESCRIPTION
Add the ability to define a subclass of a JS class by generating a JS
snippet that uses the `extends` syntax and calls the native bindings
which are passed in as parameters to the generated function responsible
for defining the subclass.

An example of a generated JS snippet might be:

```js
(function(parent, ctor, getSuperParams, prop0, prop1) {
  'use strict';
  class NativeSubclass extends parent {
    constructor() {
      super(...getSuperParams.apply(null, arguments));
      ctor.apply(this, arguments);
    }
    subMethod() {
      if (!(this instanceof NativeSubclass))
        throw new Error('Illegal invocation');
      return prop0.apply(this, arguments);
    }
    chainableMethod() {
      if (!(this instanceof NativeSubclass))
        throw new Error('Illegal invocation');
      return prop1.apply(this, arguments);
    }
  }

  return NativeSubclass;
})
```

where `ctor`, `getSuperParams`, `prop0`, and `prop1` are native
functions supplied to `napi_define_subclass`.

Signed-off-by: @gabrielschulhof

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
