### PR TITLE
test: update comments in test-fs-read-offset-null

### DIFF
--- a/test/parallel/test-fs-read-offset-null.js
+++ b/test/parallel/test-fs-read-offset-null.js
@@ -12,17 +12,16 @@ const fixtures = require('../common/fixtures');
 const filepath = fixtures.path('x.txt');
 
 const buf = Buffer.alloc(1);
-// Reading only one character, hence buffer of one byte is enough
+// Reading only one character, hence buffer of one byte is enough.
 
-// Test for callback api
+// Test for callback API.
 fs.open(filepath, 'r', common.mustSucceed((fd) => {
   fs.read(fd, { offset: null, buffer: buf },
           common.mustSucceed((bytesRead, buffer) => {
-            assert.strictEqual(buffer[0], 120);
             // Test is done by making sure the first letter in buffer is
             // same as first letter in file.
-            // 66 is the hex for ascii code of letter B
-
+            // 120 is the hex for ascii code of letter x.
+            assert.strictEqual(buffer[0], 120);
             fs.close(fd, common.mustSucceed(() => {}));
           }));
 }));


### PR DESCRIPTION
Update comment to refer to the correct ASCII code (120 rather than 66).
All other changes are cosmetic.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
