### PR TITLE
benchmark: fix build warnings

### DIFF
--- a/benchmark/napi/function_args/binding.cc
+++ b/benchmark/napi/function_args/binding.cc
@@ -123,7 +123,9 @@ void CallWithArguments(const FunctionCallbackInfo<Value>& args) {
   }
 }
 
-void Initialize(Local<Object> target) {
+void Initialize(Local<Object> target,
+                Local<Value> module,
+                void* data) {
   NODE_SET_METHOD(target, "callWithString", CallWithString);
   NODE_SET_METHOD(target, "callWithLongString", CallWithString);
 

--- a/benchmark/napi/function_call/binding.cc
+++ b/benchmark/napi/function_call/binding.cc
@@ -7,7 +7,9 @@ void Hello(const v8::FunctionCallbackInfo<v8::Value>& args) {
   args.GetReturnValue().Set(c++);
 }
 
-void Initialize(v8::Local<v8::Object> target) {
+void Initialize(v8::Local<v8::Object> target,
+                v8::Local<v8::Value> module,
+                void* data) {
   NODE_SET_METHOD(target, "hello", Hello);
 }
 


### PR DESCRIPTION
The napi/* benchmarks were using an incorrect signature for the V8
add-on init function. This was causing a warning.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
