### PR TITLE
test: throw when using public methods instead of primordials

### DIFF
--- a/lib/internal/per_context/callunsafe.js
+++ b/lib/internal/per_context/callunsafe.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const {
+  ReflectApply,
+} = primordials;
+
+class CallUnsafe {
+  #method;
+  #object;
+  constructor(object, methodName) {
+    this.#object = object;
+    this.#method = object[methodName];
+  }
+  get is_callable() {
+    return typeof this.#method === 'function';
+  }
+  call(...args) {
+    return ReflectApply(this.#method, this.#object, args);
+  }
+}
+
+function callUnsafe(object, methodName, ...args) {
+  const u = new CallUnsafe(object, methodName);
+  if (u.is_callable) {
+    return u.call(...args);
+  }
+}
+
+module.exports = {
+  CallUnsafe,
+  callUnsafe,
+};

--- a/node.gyp
+++ b/node.gyp
@@ -39,6 +39,7 @@
       'lib/internal/bootstrap/switches/does_not_own_process_state.js',
       'lib/internal/bootstrap/switches/is_main_thread.js',
       'lib/internal/bootstrap/switches/is_not_main_thread.js',
+      'lib/internal/per_context/callunsafe.js',
       'lib/internal/per_context/primordials.js',
       'lib/internal/per_context/domexception.js',
       'lib/internal/per_context/messageport.js',

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -864,3 +864,5 @@ module.exports = new Proxy(common, {
     return obj[prop];
   }
 });
+
+require('./remove-primordials.js');

--- a/test/common/remove-primordials.js
+++ b/test/common/remove-primordials.js
@@ -1,0 +1,116 @@
+/* eslint-disable node-core/require-common-first, node-core/required-modules */
+'use strict';
+
+const internal_percontext_length = 'internal/per_context/'.length;
+const isInternalUnsafeCall = (error) => {
+  // This function is equivalent to
+  // /\(node:(?!.{21}callunsafe)/.test(error.stack?.split('\n')[2] || '')
+  let i, n;
+  const stack = error.stack || '';
+  const { length } = stack;
+  for (i = 0, n = 0; i < length && !(n === 2 && stack[i] === '('); i++) {
+    // Iterate over string until we find an open parenthesis on line #2.
+    if (stack[i] === '\n' && n++ === 2)
+      // Shortcut if there is no parenthesis on line #2.
+      return false;
+  }
+  return i !== length &&
+         i + 5 < length &&
+         stack[++i] === 'n' &&
+         stack[++i] === 'o' &&
+         stack[++i] === 'd' &&
+         stack[++i] === 'e' &&
+         stack[++i] === ':' &&
+         (i + internal_percontext_length + 10 > length || (
+           stack[internal_percontext_length + ++i] !== 'c' &&
+           stack[internal_percontext_length + ++i] !== 'a' &&
+           stack[internal_percontext_length + ++i] !== 'l' &&
+           stack[internal_percontext_length + ++i] !== 'l' &&
+           stack[internal_percontext_length + ++i] !== 'u' &&
+           stack[internal_percontext_length + ++i] !== 'n' &&
+           stack[internal_percontext_length + ++i] !== 's' &&
+           stack[internal_percontext_length + ++i] !== 'a' &&
+           stack[internal_percontext_length + ++i] !== 'f' &&
+           stack[internal_percontext_length + ++i] !== 'e'));
+};
+
+
+const toDelete = [];
+function getMethodsFromPrototype(src, name) {
+  for (const key of Reflect.ownKeys(src)) {
+    if (key === 'toString') continue;
+    if (typeof key === 'string') {
+      const desc = Reflect.getOwnPropertyDescriptor(src, key);
+      if (typeof desc.value === 'function') {
+        const primordialName =
+          name === 'Function' && (key === 'apply' || key === 'call') ?
+            'ReflectApply' :
+            `${name}Prototype${key[0].toUpperCase()}${key.slice(1)}`;
+        toDelete.push([src, key, primordialName]);
+      }
+    }
+  }
+}
+
+[
+  'Array',
+  'ArrayBuffer',
+  'BigInt',
+  'BigInt64Array',
+  'BigUint64Array',
+  'Boolean',
+  'DataView',
+  'Date',
+  'Error',
+  'EvalError',
+  'Float32Array',
+  'Float64Array',
+  'Function',
+  'Int16Array',
+  'Int32Array',
+  'Int8Array',
+  'Map',
+  'Number',
+  'Object',
+  'Promise',
+  'RangeError',
+  'ReferenceError',
+  'RegExp',
+  'Set',
+  'String',
+  'Symbol',
+  'SyntaxError',
+  'TypeError',
+  'URIError',
+  'Uint16Array',
+  'Uint32Array',
+  'Uint8Array',
+  'Uint8ClampedArray',
+  'WeakMap',
+  'WeakSet',
+].forEach((name) => {
+  getMethodsFromPrototype(globalThis[name].prototype, name);
+});
+
+[
+  { name: 'TypedArray', original: Reflect.getPrototypeOf(Uint8Array) },
+].forEach(({ name, original }) => {
+  getMethodsFromPrototype(original.prototype, name);
+});
+
+for (const [proto, methodName, primordial] of toDelete) {
+  const errorMessage =
+    `Unsafe use of \`<object>.${methodName}(...<arguments>)\`.` +
+    ` Use \`primordials.${primordial}(<object>, ...<arguments>)\` instead,` +
+    ` or \`callUnsafe(<object>, '${methodName}', ...<arguments>)\`.`;
+  const original = proto[methodName];
+  proto[methodName] =
+    function() {
+      const error = new Error(errorMessage);
+      if (isInternalUnsafeCall(error)) {
+        throw error;
+      } else {
+        return Reflect.apply(original, this, arguments);
+      }
+    };
+}


### PR DESCRIPTION
This PR adds a check on our tests to unsure core doesn't use any built-in methods from the global object which could be mitigated by users.

#### Simple example

```js
' '.repeat(4)
```

If that line of code is inside an internal module, it would raise the following error:

```
Error: Unsafe use of `<object>.repeat(...<arguments>)`. Use `primordials.StringPrototypeRepeat(<object>, ...<arguments>)` instead, or `callUnsafe(<object>, 'repeat', ...<arguments>)`.
```

#### When we meant to use the global builtins

Sometimes, we really want to call the user-mitigated methods. A typical example are `Thenable`s, where we usually want to support third-party libraries, and not always call `Promise.prototype.then`. It's usually done like this:

```js
const then = promise.then;
if (typeof then === 'function') then.call(promise, onSuccess, onError);
```

That would raise two errors:

```
Error: Unsafe use of `<object>.call(...<arguments>)`. Use `primordials.ReflectApply(<object>, ...<arguments>)` instead, or `callUnsafe(<object>, 'call', ...<arguments>)`.
Error: Unsafe use of `<object>.then(...<arguments>)`. Use `primordials.PromisePrototypeThen(<object>, ...<arguments>)` instead, or `callUnsafe(<object>, 'then', ...<arguments>)`.
```

The correct™️ way of doing that would indeed be to use `callUnsafe`:

```js
callUnsafe(promise, 'then', onSuccess, onError);
```
or
```js
const then = new CallUnsafe(promise, 'then');
if(then.is_callable) then.call(onSuccess, onError);
else { /* Do something else */ }
```

#### Limitations

- Unlike a linter check, there is no guarantee this tool can check all unsafe uses of JS builtins. That limitation would go away with a test coverage of 100%.
- I'm using `Error#stack` to test if the call was made by an internal or by the test files. It's detecting `node:` prefix, which was introduced in Node.js 15. I don't think this can be backported to earlier release lines.
- There are SO MANY failing tests currently. Changing all internal calls to primordials is an enormous work, however I'm confident it's feasible, maybe by encouraging first-time contributors to pick up certain files. It's a great way of diving into Node.js internals, which helps to better understand how it's working and help gain confidence to contribute further on the code base.

#### Next steps

We might want to land a modified version without waiting for all the tests to pass: 

- Make the `remove-primordials` module opt-in.
- Emit warnings instead of throwing errors.
- Have a tool that counts the number of warning to make sure the number is getting down (I.E. we are not introducing more _unsafe_ calls to internals).

Fixes: https://github.com/nodejs/node/issues/30697

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
