### PR TITLE
tools: only use 2 cores for macos action

### DIFF
--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -25,6 +25,6 @@ jobs:
       - name: Environment Information
         run: npx envinfo
       - name: Build
-        run: make build-ci -j8 V=1 CONFIG_FLAGS="--error-on-warn --experimental-quic"
+        run: make build-ci -j2 V=1 CONFIG_FLAGS="--error-on-warn --experimental-quic"
       - name: Test
-        run: make run-ci -j8 V=1 TEST_CI_ARGS="-p actions"
+        run: make run-ci -j2 V=1 TEST_CI_ARGS="-p actions"


### PR DESCRIPTION
There are only 2 cores available so we shouldn't be using -j8

Refs: https://docs.github.com/en/free-pro-team@latest/actions/reference/specifications-for-github-hosted-runners#supported-runners-and-hardware-resources