### PR TITLE
doc: Add doc for --experimental-wasm-threads flag since v12

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -300,6 +300,13 @@ Enable experimental WebAssembly System Interface (WASI) support.
 added: v12.3.0
 -->
 
+### `--experimental-wasm-threads`
+<!-- YAML
+added: v12.0.0
+-->
+
+Enable experimental WebAssembly worker-based threads with SharedArrayBuffer.
+
 ### `--force-context-aware`
 <!-- YAML
 added: v12.12.0
@@ -1319,6 +1326,7 @@ Node.js options that are allowed are:
 * `--experimental-vm-modules`
 * `--experimental-wasi-unstable-preview1`
 * `--experimental-wasm-modules`
+* `--experimental-wasm-threads`
 * `--force-context-aware`
 * `--force-fips`
 * `--frozen-intrinsics`

--- a/doc/node.1
+++ b/doc/node.1
@@ -170,6 +170,9 @@ Enable experimental WebAssembly System Interface support.
 .It Fl -experimental-wasm-modules
 Enable experimental WebAssembly module support.
 .
+.It Fl -experimental-wasm-threads
+Enable experimental WebAssembly worker-based thread support with shared memory.
+.
 .It Fl -force-context-aware
 Disable loading native addons that are not context-aware.
 .

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -304,6 +304,10 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "experimental ES Module support for webassembly modules",
             &EnvironmentOptions::experimental_wasm_modules,
             kAllowedInEnvironment);
+  AddOption("--experimental-wasm-threads",
+            "experimental support for webassembly worker-based threads",
+            &EnvironmentOptions::experimental_wasm_threads,
+            kAllowedInEnvironment);
   AddOption("--experimental-import-meta-resolve",
             "experimental ES Module import.meta.resolve() support",
             &EnvironmentOptions::experimental_import_meta_resolve,

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -106,6 +106,7 @@ class EnvironmentOptions : public Options {
   bool experimental_modules = false;
   std::string experimental_specifier_resolution;
   bool experimental_wasm_modules = false;
+  bool experimental_wasm_threads = false;
   bool experimental_import_meta_resolve = false;
   std::string module_type;
   std::string experimental_policy;


### PR DESCRIPTION
This is a V8 flag that's required to enable WebAssembly threading which is otherwise listed as supported for NodeJS 12+ in compat-data.  There's very little documentation available on this flag w.r.t. WebAssembly in Node, just blog posts and such.

I added a note about it to the MDN browser-compat-data table for WebAssembly.Memory with the shared flag: https://github.com/mdn/browser-compat-data/pull/7420

This flag is also still required in Node 14 and 15; verified on my workstation.

##### Checklist

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)