### PR TITLE
crypto: add keyObject.asymmetricKeyDetails for asymmetric keys

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1284,6 +1284,27 @@ passing keys as strings or `Buffer`s due to improved security features.
 The receiver obtains a cloned `KeyObject`, and the `KeyObject` does not need to
 be listed in the `transferList` argument.
 
+### `keyObject.asymmetricKeyDetails`
+<!-- YAML
+added: REPLACEME
+-->
+
+* {Object}
+
+This property exists only on asymmetric keys. Depending on the type of the key,
+this object contains information about the key. None of the information obtained
+through this property can be used to uniquely identify a key or to compromise
+the security of the key.
+
+For `'rsa'` and `'rsa-pss'` keys, this object has the properties `modulusLength`
+and `publicExponent`.
+
+For `'dsa'` keys, this object has the properties `modulusLength` and
+`divisorLength`.
+
+For `'ec'` keys with a known curve, this object has the string property
+`namedCurve`.
+
 ### `keyObject.asymmetricKeyType`
 <!-- YAML
 added: v11.6.0

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1290,20 +1290,15 @@ added: REPLACEME
 -->
 
 * {Object}
+  * `modulusLength`: {number} Key size in bits (RSA, DSA).
+  * `publicExponent`: {number} Public exponent (RSA).
+  * `divisorLength`: {number} Size of `q` in bits (DSA).
+  * `namedCurve`: {string} Name of the curve (EC).
 
 This property exists only on asymmetric keys. Depending on the type of the key,
 this object contains information about the key. None of the information obtained
 through this property can be used to uniquely identify a key or to compromise
 the security of the key.
-
-For `'rsa'` and `'rsa-pss'` keys, this object has the properties `modulusLength`
-and `publicExponent`.
-
-For `'dsa'` keys, this object has the properties `modulusLength` and
-`divisorLength`.
-
-For `'ec'` keys with a known curve, this object has the string property
-`namedCurve`.
 
 ### `keyObject.asymmetricKeyType`
 <!-- YAML

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1291,7 +1291,7 @@ added: REPLACEME
 
 * {Object}
   * `modulusLength`: {number} Key size in bits (RSA, DSA).
-  * `publicExponent`: {number} Public exponent (RSA).
+  * `publicExponent`: {bigint} Public exponent (RSA).
   * `divisorLength`: {number} Size of `q` in bits (DSA).
   * `namedCurve`: {string} Name of the curve (EC).
 

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1300,6 +1300,9 @@ this object contains information about the key. None of the information obtained
 through this property can be used to uniquely identify a key or to compromise
 the security of the key.
 
+RSA-PSS parameters, DH, or any future key type details might be exposed via this
+API using additional attributes.
+
 ### `keyObject.asymmetricKeyType`
 <!-- YAML
 added: v11.6.0

--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -37,7 +37,7 @@ const {
   kHandle,
   kKeyObject,
   getArrayBufferOrView,
-  bigIntArrayToBigInt,
+  bigIntArrayToUnsignedBigInt,
 } = require('internal/crypto/util');
 
 const {
@@ -137,7 +137,7 @@ const [
       return {
         ...details,
         publicExponent:
-          bigIntArrayToBigInt(new Uint8Array(details.publicExponent))
+          bigIntArrayToUnsignedBigInt(new Uint8Array(details.publicExponent))
       };
     }
     return details;
@@ -150,10 +150,18 @@ const [
     }
 
     get asymmetricKeyDetails() {
-      return this[kAsymmetricKeyDetails] ||
+      switch (this.asymmetricKeyType) {
+        case 'rsa':
+        case 'rsa-pss':
+        case 'dsa':
+        case 'ec':
+          return this[kAsymmetricKeyDetails] ||
              (this[kAsymmetricKeyDetails] = normalizeKeyDetails(
                this[kHandle].keyDetail({})
              ));
+        default:
+          return {};
+      }
     }
   }
 

--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -5,6 +5,7 @@ const {
   ObjectDefineProperty,
   ObjectSetPrototypeOf,
   Symbol,
+  Uint8Array,
 } = primordials;
 
 const {
@@ -36,6 +37,7 @@ const {
   kHandle,
   kKeyObject,
   getArrayBufferOrView,
+  bigIntArrayToUnsignedInt,
 } = require('internal/crypto/util');
 
 const {
@@ -128,11 +130,32 @@ const [
   }
 
   const kAsymmetricKeyType = Symbol('kAsymmetricKeyType');
+  const kAsymmetricKeyDetails = Symbol('kAsymmetricKeyDetails');
+
+  // TODO: should the returne details object be frozen or otherwise protected
+  // from manipulation?
+  function normalizeKeyDetails(details = {}) {
+    if ('publicExponent' in details) {
+      return {
+        ...details,
+        publicExponent:
+          bigIntArrayToUnsignedInt(new Uint8Array(details.publicExponent))
+      };
+    }
+    return details;
+  }
 
   class AsymmetricKeyObject extends KeyObject {
     get asymmetricKeyType() {
       return this[kAsymmetricKeyType] ||
              (this[kAsymmetricKeyType] = this[kHandle].getAsymmetricKeyType());
+    }
+
+    get asymmetricKeyDetails() {
+      return this[kAsymmetricKeyDetails] ||
+             (this[kAsymmetricKeyDetails] = normalizeKeyDetails(
+               this[kHandle].keyDetail({})
+             ));
     }
   }
 

--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -37,7 +37,7 @@ const {
   kHandle,
   kKeyObject,
   getArrayBufferOrView,
-  bigIntArrayToUnsignedInt,
+  bigIntArrayToBigInt,
 } = require('internal/crypto/util');
 
 const {
@@ -137,7 +137,7 @@ const [
       return {
         ...details,
         publicExponent:
-          bigIntArrayToUnsignedInt(new Uint8Array(details.publicExponent))
+          bigIntArrayToBigInt(new Uint8Array(details.publicExponent))
       };
     }
     return details;

--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -132,10 +132,8 @@ const [
   const kAsymmetricKeyType = Symbol('kAsymmetricKeyType');
   const kAsymmetricKeyDetails = Symbol('kAsymmetricKeyDetails');
 
-  // TODO: should the returne details object be frozen or otherwise protected
-  // from manipulation?
   function normalizeKeyDetails(details = {}) {
-    if ('publicExponent' in details) {
+    if (details.publicExponent !== undefined) {
       return {
         ...details,
         publicExponent:

--- a/lib/internal/crypto/util.js
+++ b/lib/internal/crypto/util.js
@@ -3,6 +3,7 @@
 const {
   ArrayPrototypeIncludes,
   ArrayPrototypePush,
+  BigInt,
   FunctionPrototypeBind,
   Number,
   Promise,
@@ -308,6 +309,17 @@ function bigIntArrayToUnsignedInt(input) {
   return result;
 }
 
+function bigIntArrayToBigInt(input) {
+  let result = 0n;
+
+  for (let n = 0; n < input.length; ++n) {
+    const n_reversed = input.length - n - 1;
+    result |= BigInt(input[n]) << 8n * BigInt(n_reversed);
+  }
+
+  return result;
+}
+
 function getStringOption(options, key) {
   let value;
   if (options && (value = options[key]) != null)
@@ -413,6 +425,7 @@ module.exports = {
   jobPromise,
   lazyRequire,
   validateMaxBufferLength,
+  bigIntArrayToBigInt,
   bigIntArrayToUnsignedInt,
   getStringOption,
   getUsagesUnion,

--- a/lib/internal/crypto/util.js
+++ b/lib/internal/crypto/util.js
@@ -309,7 +309,7 @@ function bigIntArrayToUnsignedInt(input) {
   return result;
 }
 
-function bigIntArrayToBigInt(input) {
+function bigIntArrayToUnsignedBigInt(input) {
   let result = 0n;
 
   for (let n = 0; n < input.length; ++n) {
@@ -425,7 +425,7 @@ module.exports = {
   jobPromise,
   lazyRequire,
   validateMaxBufferLength,
-  bigIntArrayToBigInt,
+  bigIntArrayToUnsignedBigInt,
   bigIntArrayToUnsignedInt,
   getStringOption,
   getUsagesUnion,

--- a/src/crypto/crypto_keys.cc
+++ b/src/crypto/crypto_keys.cc
@@ -543,7 +543,8 @@ Maybe<bool> GetAsymmetricKeyDetail(
     case EVP_PKEY_EC: return GetEcKeyDetail(env, key, target);
     case EVP_PKEY_DH: return GetDhKeyDetail(env, key, target);
   }
-  return Just(false);
+  THROW_ERR_CRYPTO_INVALID_KEYTYPE(env);
+  return Nothing<bool>();
 }
 }  // namespace
 

--- a/src/crypto/crypto_keys.cc
+++ b/src/crypto/crypto_keys.cc
@@ -543,8 +543,7 @@ Maybe<bool> GetAsymmetricKeyDetail(
     case EVP_PKEY_EC: return GetEcKeyDetail(env, key, target);
     case EVP_PKEY_DH: return GetDhKeyDetail(env, key, target);
   }
-  THROW_ERR_CRYPTO_INVALID_KEYTYPE(env);
-  return Nothing<bool>();
+  return Just(false);
 }
 }  // namespace
 

--- a/test/parallel/test-crypto-key-objects.js
+++ b/test/parallel/test-crypto-key-objects.js
@@ -70,6 +70,7 @@ const privateDsa = fixtures.readKey('dsa_private_encrypted_1025.pem',
   assert.strictEqual(key.type, 'secret');
   assert.strictEqual(key.symmetricKeySize, 32);
   assert.strictEqual(key.asymmetricKeyType, undefined);
+  assert.strictEqual(key.asymmetricKeyDetails, undefined);
 
   const exportedKey = key.export();
   assert(keybuf.equals(exportedKey));

--- a/test/parallel/test-crypto-keygen.js
+++ b/test/parallel/test-crypto-keygen.js
@@ -115,6 +115,31 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
 }
 
 {
+  // Test sync key generation with key objects with a non-standard
+  // publicExpononent
+  const { publicKey, privateKey } = generateKeyPairSync('rsa', {
+    publicExponent: 3,
+    modulusLength: 512
+  });
+
+  assert.strictEqual(typeof publicKey, 'object');
+  assert.strictEqual(publicKey.type, 'public');
+  assert.strictEqual(publicKey.asymmetricKeyType, 'rsa');
+  assert.deepStrictEqual(publicKey.asymmetricKeyDetails, {
+    modulusLength: 512,
+    publicExponent: 3n
+  });
+
+  assert.strictEqual(typeof privateKey, 'object');
+  assert.strictEqual(privateKey.type, 'private');
+  assert.strictEqual(privateKey.asymmetricKeyType, 'rsa');
+  assert.deepStrictEqual(privateKey.asymmetricKeyDetails, {
+    modulusLength: 512,
+    publicExponent: 3n
+  });
+}
+
+{
   // Test sync key generation with key objects.
   const { publicKey, privateKey } = generateKeyPairSync('rsa', {
     modulusLength: 512
@@ -125,7 +150,7 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
   assert.strictEqual(publicKey.asymmetricKeyType, 'rsa');
   assert.deepStrictEqual(publicKey.asymmetricKeyDetails, {
     modulusLength: 512,
-    publicExponent: 65537
+    publicExponent: 65537n
   });
 
   assert.strictEqual(typeof privateKey, 'object');
@@ -133,7 +158,7 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
   assert.strictEqual(privateKey.asymmetricKeyType, 'rsa');
   assert.deepStrictEqual(privateKey.asymmetricKeyDetails, {
     modulusLength: 512,
-    publicExponent: 65537
+    publicExponent: 65537n
   });
 }
 
@@ -278,14 +303,14 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     assert.strictEqual(publicKey.asymmetricKeyType, 'rsa-pss');
     assert.deepStrictEqual(publicKey.asymmetricKeyDetails, {
       modulusLength: 512,
-      publicExponent: 65537
+      publicExponent: 65537n
     });
 
     assert.strictEqual(privateKey.type, 'private');
     assert.strictEqual(privateKey.asymmetricKeyType, 'rsa-pss');
     assert.deepStrictEqual(privateKey.asymmetricKeyDetails, {
       modulusLength: 512,
-      publicExponent: 65537
+      publicExponent: 65537n
     });
 
     // Unlike RSA, RSA-PSS does not allow encryption.

--- a/test/parallel/test-crypto-keygen.js
+++ b/test/parallel/test-crypto-keygen.js
@@ -123,10 +123,18 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
   assert.strictEqual(typeof publicKey, 'object');
   assert.strictEqual(publicKey.type, 'public');
   assert.strictEqual(publicKey.asymmetricKeyType, 'rsa');
+  assert.deepStrictEqual(publicKey.asymmetricKeyDetails, {
+    modulusLength: 512,
+    publicExponent: 65537
+  });
 
   assert.strictEqual(typeof privateKey, 'object');
   assert.strictEqual(privateKey.type, 'private');
   assert.strictEqual(privateKey.asymmetricKeyType, 'rsa');
+  assert.deepStrictEqual(privateKey.asymmetricKeyDetails, {
+    modulusLength: 512,
+    publicExponent: 65537
+  });
 }
 
 {
@@ -268,9 +276,17 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
   }, common.mustSucceed((publicKey, privateKey) => {
     assert.strictEqual(publicKey.type, 'public');
     assert.strictEqual(publicKey.asymmetricKeyType, 'rsa-pss');
+    assert.deepStrictEqual(publicKey.asymmetricKeyDetails, {
+      modulusLength: 512,
+      publicExponent: 65537
+    });
 
     assert.strictEqual(privateKey.type, 'private');
     assert.strictEqual(privateKey.asymmetricKeyType, 'rsa-pss');
+    assert.deepStrictEqual(privateKey.asymmetricKeyDetails, {
+      modulusLength: 512,
+      publicExponent: 65537
+    });
 
     // Unlike RSA, RSA-PSS does not allow encryption.
     assert.throws(() => {
@@ -338,6 +354,28 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
       key: privateKeyDER,
       ...privateKeyEncoding,
       passphrase: 'secret'
+    });
+  }));
+}
+
+{
+  // Test async DSA key object generation.
+  generateKeyPair('dsa', {
+    modulusLength: 512,
+    divisorLength: 256
+  }, common.mustSucceed((publicKey, privateKey) => {
+    assert.strictEqual(publicKey.type, 'public');
+    assert.strictEqual(publicKey.asymmetricKeyType, 'dsa');
+    assert.deepStrictEqual(publicKey.asymmetricKeyDetails, {
+      modulusLength: 512,
+      divisorLength: 256
+    });
+
+    assert.strictEqual(privateKey.type, 'private');
+    assert.strictEqual(privateKey.asymmetricKeyType, 'dsa');
+    assert.deepStrictEqual(privateKey.asymmetricKeyDetails, {
+      modulusLength: 512,
+      divisorLength: 256
     });
   }));
 }
@@ -925,16 +963,24 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
   // It should recognize both NIST and standard curve names.
   generateKeyPair('ec', {
     namedCurve: 'P-256',
-    publicKeyEncoding: { type: 'spki', format: 'pem' },
-    privateKeyEncoding: { type: 'pkcs8', format: 'pem' }
   }, common.mustSucceed((publicKey, privateKey) => {
+    assert.deepStrictEqual(publicKey.asymmetricKeyDetails, {
+      namedCurve: 'prime256v1'
+    });
+    assert.deepStrictEqual(privateKey.asymmetricKeyDetails, {
+      namedCurve: 'prime256v1'
+    });
   }));
 
   generateKeyPair('ec', {
     namedCurve: 'secp256k1',
-    publicKeyEncoding: { type: 'spki', format: 'pem' },
-    privateKeyEncoding: { type: 'pkcs8', format: 'pem' }
   }, common.mustSucceed((publicKey, privateKey) => {
+    assert.deepStrictEqual(publicKey.asymmetricKeyDetails, {
+      namedCurve: 'secp256k1'
+    });
+    assert.deepStrictEqual(privateKey.asymmetricKeyDetails, {
+      namedCurve: 'secp256k1'
+    });
   }));
 }
 
@@ -945,9 +991,11 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
       generateKeyPair(keyType, common.mustSucceed((publicKey, privateKey) => {
         assert.strictEqual(publicKey.type, 'public');
         assert.strictEqual(publicKey.asymmetricKeyType, keyType);
+        assert.deepStrictEqual(publicKey.asymmetricKeyDetails, {});
 
         assert.strictEqual(privateKey.type, 'private');
         assert.strictEqual(privateKey.asymmetricKeyType, keyType);
+        assert.deepStrictEqual(privateKey.asymmetricKeyDetails, {});
       }));
     });
   }


### PR DESCRIPTION
This API exposes key details. It is conceptually different from the
previously discussed keyObject.fields property since it does not give
access to information that could compromise the security of the key, and
the obtained information cannot be used to uniquely identify a key.

The intended purpose is to determine "security properties" of keys, e.g.
to generate a new key pair with the same parameters, or to decide
whether a key is secure enough.

This replaces and closes #30045

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
