### PR TITLE
fs: allow `position` parameter to be a `BigInt` in read and readSync

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2931,7 +2931,7 @@ changes:
 * `buffer` {Buffer|TypedArray|DataView}
 * `offset` {integer}
 * `length` {integer}
-* `position` {integer}
+* `position` {integer|bigint}
 * `callback` {Function}
   * `err` {Error}
   * `bytesRead` {integer}
@@ -2976,7 +2976,7 @@ changes:
   * `buffer` {Buffer|TypedArray|DataView} **Default:** `Buffer.alloc(16384)`
   * `offset` {integer} **Default:** `0`
   * `length` {integer} **Default:** `buffer.length`
-  * `position` {integer} **Default:** `null`
+  * `position` {integer|bigint} **Default:** `null`
 * `callback` {Function}
   * `err` {Error}
   * `bytesRead` {integer}
@@ -3273,7 +3273,7 @@ changes:
 * `buffer` {Buffer|TypedArray|DataView}
 * `offset` {integer}
 * `length` {integer}
-* `position` {integer}
+* `position` {integer|bigint}
 * Returns: {number}
 
 Returns the number of `bytesRead`.
@@ -3300,7 +3300,7 @@ changes:
 * `options` {Object}
   * `offset` {integer} **Default:** `0`
   * `length` {integer} **Default:** `buffer.length`
-  * `position` {integer} **Default:** `null`
+  * `position` {integer|bigint} **Default:** `null`
 * Returns: {number}
 
 Returns the number of `bytesRead`.

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -37,7 +37,6 @@ const {
   BigIntPrototypeToString,
   MathMax,
   Number,
-  NumberIsSafeInteger,
   ObjectCreate,
   ObjectDefineProperties,
   ObjectDefineProperty,
@@ -75,7 +74,8 @@ const {
     ERR_FS_FILE_TOO_LARGE,
     ERR_INVALID_ARG_VALUE,
     ERR_INVALID_ARG_TYPE,
-    ERR_FEATURE_UNAVAILABLE_ON_PLATFORM
+    ERR_FEATURE_UNAVAILABLE_ON_PLATFORM,
+    ERR_OUT_OF_RANGE,
   },
   hideStackFrames,
   uvErrmapGet,
@@ -545,8 +545,22 @@ function read(fd, buffer, offset, length, position, callback) {
 
   validateOffsetLengthRead(offset, length, buffer.byteLength);
 
-  if (!NumberIsSafeInteger(position))
+  if (position == null)
     position = -1;
+
+  if (typeof position === 'number') {
+    validateInteger(position, 'position');
+  } else if (typeof position === 'bigint') {
+    if (!(position >= -(2n ** 63n) && position <= 2n ** 63n - 1n)) {
+      throw new ERR_OUT_OF_RANGE('position',
+                                 `>= ${-(2n ** 63n)} && <= ${2n ** 63n - 1n}`,
+                                 position);
+    }
+  } else {
+    throw new ERR_INVALID_ARG_TYPE('position',
+                                   ['integer', 'bigint'],
+                                   position);
+  }
 
   function wrapper(err, bytesRead) {
     // Retain a reference to buffer so that it can't be GC'ed too soon.
@@ -597,8 +611,22 @@ function readSync(fd, buffer, offset, length, position) {
 
   validateOffsetLengthRead(offset, length, buffer.byteLength);
 
-  if (!NumberIsSafeInteger(position))
+  if (position == null)
     position = -1;
+
+  if (typeof position === 'number') {
+    validateInteger(position, 'position');
+  } else if (typeof position === 'bigint') {
+    if (!(position >= -(2n ** 63n) && position <= 2n ** 63n - 1n)) {
+      throw new ERR_OUT_OF_RANGE('position',
+                                 `>= ${-(2n ** 63n)} && <= ${2n ** 63n - 1n}`,
+                                 position);
+    }
+  } else {
+    throw new ERR_INVALID_ARG_TYPE('position',
+                                   ['integer', 'bigint'],
+                                   position);
+  }
 
   const ctx = {};
   const result = binding.read(fd, buffer, offset, length, position,

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -51,6 +51,7 @@ namespace node {
 namespace fs {
 
 using v8::Array;
+using v8::BigInt;
 using v8::Boolean;
 using v8::Context;
 using v8::EscapableHandleScope;
@@ -2038,8 +2039,10 @@ static void Read(const FunctionCallbackInfo<Value>& args) {
   const size_t len = static_cast<size_t>(args[3].As<Int32>()->Value());
   CHECK(Buffer::IsWithinBounds(off, len, buffer_length));
 
-  CHECK(IsSafeJsInt(args[4]));
-  const int64_t pos = args[4].As<Integer>()->Value();
+  CHECK(IsSafeJsInt(args[4]) || args[4]->IsBigInt());
+  const int64_t pos = args[4]->IsNumber() ?
+                      args[4].As<Integer>()->Value() :
+                      args[4].As<BigInt>()->Int64Value();
 
   char* buf = buffer_data + off;
   uv_buf_t uvbuf = uv_buf_init(buf, len);


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/36185

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
