### PR TITLE
crypto: add KeyObject.from and keyObject.export JWK format support

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1284,6 +1284,27 @@ passing keys as strings or `Buffer`s due to improved security features.
 The receiver obtains a cloned `KeyObject`, and the `KeyObject` does not need to
 be listed in the `transferList` argument.
 
+### `keyObject.asymmetricKeyDetails`
+<!-- YAML
+added: REPLACEME
+-->
+
+* {Object}
+
+This property exists only on asymmetric keys. Depending on the type of the key,
+this object contains information about the key. None of the information obtained
+through this property can be used to uniquely identify a key or to compromise
+the security of the key.
+
+For `'rsa'` and `'rsa-pss'` keys, this object has the properties `modulusLength`
+and `publicExponent`.
+
+For `'dsa'` keys, this object has the properties `modulusLength` and
+`divisorLength`.
+
+For `'ec'` keys with a known curve, this object has the string property
+`namedCurve`.
+
 ### `keyObject.asymmetricKeyType`
 <!-- YAML
 added: v11.6.0

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1290,20 +1290,15 @@ added: REPLACEME
 -->
 
 * {Object}
+  * `modulusLength`: {number} Key size in bits (RSA, DSA).
+  * `publicExponent`: {number} Public exponent (RSA).
+  * `divisorLength`: {number} Size of `q` in bits (DSA).
+  * `namedCurve`: {string} Name of the curve (EC).
 
 This property exists only on asymmetric keys. Depending on the type of the key,
 this object contains information about the key. None of the information obtained
 through this property can be used to uniquely identify a key or to compromise
 the security of the key.
-
-For `'rsa'` and `'rsa-pss'` keys, this object has the properties `modulusLength`
-and `publicExponent`.
-
-For `'dsa'` keys, this object has the properties `modulusLength` and
-`divisorLength`.
-
-For `'ec'` keys with a known curve, this object has the string property
-`namedCurve`.
 
 ### `keyObject.asymmetricKeyType`
 <!-- YAML

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1358,19 +1358,21 @@ format.
 
 For public keys, the following encoding options can be used:
 
+* `format`: {string} Must be `'pem'`, `'der'`, or `'jwk'`.
 * `type`: {string} Must be one of `'pkcs1'` (RSA only) or `'spki'`.
-* `format`: {string} Must be `'pem'` or `'der'`.
 
 For private keys, the following encoding options can be used:
 
+* `format`: {string} Must be `'pem'`, `'der'`, or `'jwk'`.
 * `type`: {string} Must be one of `'pkcs1'` (RSA only), `'pkcs8'` or
   `'sec1'` (EC only).
-* `format`: {string} Must be `'pem'` or `'der'`.
 * `cipher`: {string} If specified, the private key will be encrypted with
    the given `cipher` and `passphrase` using PKCS#5 v2.0 password based
    encryption.
 * `passphrase`: {string | Buffer} The passphrase to use for encryption, see
   `cipher`.
+
+When JWK format was selected, all other options are ignored.
 
 When PEM encoding was selected, the result will be a string, otherwise it will
 be a buffer containing the data encoded as DER.

--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -5,6 +5,7 @@ const {
   ObjectDefineProperty,
   ObjectSetPrototypeOf,
   Symbol,
+  Uint8Array,
 } = primordials;
 
 const {
@@ -36,6 +37,7 @@ const {
   kHandle,
   kKeyObject,
   getArrayBufferOrView,
+  bigIntArrayToUnsignedInt,
 } = require('internal/crypto/util');
 
 const {
@@ -128,11 +130,32 @@ const [
   }
 
   const kAsymmetricKeyType = Symbol('kAsymmetricKeyType');
+  const kAsymmetricKeyDetails = Symbol('kAsymmetricKeyDetails');
+
+  // TODO: should the returne details object be frozen or otherwise protected
+  // from manipulation?
+  function normalizeKeyDetails(details = {}) {
+    if ('publicExponent' in details) {
+      return {
+        ...details,
+        publicExponent:
+          bigIntArrayToUnsignedInt(new Uint8Array(details.publicExponent))
+      };
+    }
+    return details;
+  }
 
   class AsymmetricKeyObject extends KeyObject {
     get asymmetricKeyType() {
       return this[kAsymmetricKeyType] ||
              (this[kAsymmetricKeyType] = this[kHandle].getAsymmetricKeyType());
+    }
+
+    get asymmetricKeyDetails() {
+      return this[kAsymmetricKeyDetails] ||
+             (this[kAsymmetricKeyDetails] = normalizeKeyDetails(
+               this[kHandle].keyDetail({})
+             ));
     }
   }
 

--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -132,10 +132,8 @@ const [
   const kAsymmetricKeyType = Symbol('kAsymmetricKeyType');
   const kAsymmetricKeyDetails = Symbol('kAsymmetricKeyDetails');
 
-  // TODO: should the returne details object be frozen or otherwise protected
-  // from manipulation?
   function normalizeKeyDetails(details = {}) {
-    if ('publicExponent' in details) {
+    if (details.publicExponent !== undefined) {
       return {
         ...details,
         publicExponent:

--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -113,6 +113,27 @@ const [
         throw new ERR_INVALID_ARG_TYPE('key', 'CryptoKey', key);
       return key[kKeyObject];
     }
+
+    // TODO: Can we repurpose KeyObject.from? I don't see it neither
+    // used or documented.
+    static fromJwk(jwk) {
+      // TODO: validate jwk?.kty && typeof jwk.kty === 'string'
+      if (typeof jwk?.kty !== 'string') {
+        throw new TypeError('TODO')
+      }
+
+      const handle = new KeyObjectHandle();
+      const type = handle.initJwk(jwk);
+
+      switch (type) {
+        case kKeyTypeSecret:
+          return new SecretKeyObject(handle)
+        case kKeyTypePublic:
+          return new PublicKeyObject(handle)
+        case kKeyTypePrivate:
+          return new PrivateKeyObject(handle)
+      }
+    }
   }
 
   class SecretKeyObject extends KeyObject {
@@ -143,6 +164,38 @@ const [
     return details;
   }
 
+  function mapEcCrv(keyObject) {
+    switch (keyObject.asymmetricKeyDetails.namedCurve) {
+      case 'prime256v1':
+        return 'P-256'
+      case 'secp256k1':
+        return 'secp256k1'
+      case 'secp384r1':
+        return 'P-384'
+      case 'secp521r1':
+        return 'P-521'
+      default:
+        throw new TypeError('Unsupported JWK EC curve value');
+    }
+  }
+
+  function mapOkpCrv(keyObject) {
+    switch (keyObject.asymmetricKeyType) {
+      case 'ed25519':
+        return 'Ed25519'
+      case 'ed448':
+        return 'Ed448'
+      case 'x25519':
+        return 'X25519'
+      case 'x448':
+        return 'X448'
+      default:
+        throw new TypeError('Unsupported JWK OKP sub type value');
+    }
+  }
+
+  const jwkExport = Symbol('jwkExport');
+
   class AsymmetricKeyObject extends KeyObject {
     get asymmetricKeyType() {
       return this[kAsymmetricKeyType] ||
@@ -154,6 +207,16 @@ const [
              (this[kAsymmetricKeyDetails] = normalizeKeyDetails(
                this[kHandle].keyDetail({})
              ));
+    }
+
+    [jwkExport]() {
+      const jwk = this[kHandle].exportJwk({});
+      if (jwk.kty === 'EC') {
+        jwk.crv = mapEcCrv(this)
+      } else if (jwk.kty === 'OKP') {
+        jwk.crv = mapOkpCrv(this)
+      }
+      return jwk;
     }
   }
 
@@ -167,6 +230,8 @@ const [
         format,
         type
       } = parsePublicKeyEncoding(encoding, this.asymmetricKeyType);
+      if (format === 'jwk')
+        return this[jwkExport]();
       return this[kHandle].export(format, type);
     }
   }
@@ -183,6 +248,8 @@ const [
         cipher,
         passphrase
       } = parsePrivateKeyEncoding(encoding, this.asymmetricKeyType);
+      if (format === 'jwk')
+        return this[jwkExport]();
       return this[kHandle].export(format, type, cipher, passphrase);
     }
   }
@@ -197,6 +264,8 @@ function parseKeyFormat(formatStr, defaultFormat, optionName) {
     return kKeyFormatPEM;
   else if (formatStr === 'der')
     return kKeyFormatDER;
+  else if (formatStr === 'jwk')
+    return 'jwk';
   throw new ERR_INVALID_ARG_VALUE(optionName, formatStr);
 }
 
@@ -236,6 +305,10 @@ function parseKeyFormatAndType(enc, keyType, isPublic, objName) {
   const format = parseKeyFormat(formatStr,
                                 isInput ? kKeyFormatPEM : undefined,
                                 option('format', objName));
+
+  if (format === 'jwk') {
+    return { format }
+  }
 
   const type = parseKeyType(typeStr,
                             !isInput || format === kKeyFormatDER,

--- a/src/crypto/crypto_dsa.cc
+++ b/src/crypto/crypto_dsa.cc
@@ -192,7 +192,7 @@ std::shared_ptr<KeyObjectData> ImportJWKDsaKey(
       !q_value->IsString() ||
       !q_value->IsString() ||
       (!x_value->IsUndefined() && !x_value->IsString())) {
-    THROW_ERR_CRYPTO_INVALID_JWK(env, "Invalid JSK DSA key");
+    THROW_ERR_CRYPTO_INVALID_JWK(env, "Invalid JWK DSA key");
     return std::shared_ptr<KeyObjectData>();
   }
 
@@ -210,14 +210,14 @@ std::shared_ptr<KeyObjectData> ImportJWKDsaKey(
                     p.ToBN().release(),
                     q.ToBN().release(),
                     g.ToBN().release())) {
-    THROW_ERR_CRYPTO_INVALID_JWK(env, "Invalid JSK DSA key");
+    THROW_ERR_CRYPTO_INVALID_JWK(env, "Invalid JWK DSA key");
     return std::shared_ptr<KeyObjectData>();
   }
 
   if (type == kKeyTypePrivate) {
     ByteSource x = ByteSource::FromEncodedString(env, x_value.As<String>());
     if (!DSA_set0_key(dsa.get(), nullptr, x.ToBN().release())) {
-      THROW_ERR_CRYPTO_INVALID_JWK(env, "Invalid JSK DSA key");
+      THROW_ERR_CRYPTO_INVALID_JWK(env, "Invalid JWK DSA key");
       return std::shared_ptr<KeyObjectData>();
     }
   }

--- a/src/crypto/crypto_ecdh.h
+++ b/src/crypto/crypto_ecdh.h
@@ -139,6 +139,11 @@ struct ECKeyExportTraits final {
 
 using ECKeyExportJob = KeyExportJob<ECKeyExportTraits>;
 
+v8::Maybe<bool> ExportJWKOkpKey(
+    Environment* env,
+    std::shared_ptr<KeyObjectData> key,
+    v8::Local<v8::Object> target);
+
 v8::Maybe<bool> ExportJWKEcKey(
     Environment* env,
     std::shared_ptr<KeyObjectData> key,

--- a/src/crypto/crypto_keys.cc
+++ b/src/crypto/crypto_keys.cc
@@ -543,8 +543,7 @@ Maybe<bool> GetAsymmetricKeyDetail(
     case EVP_PKEY_EC: return GetEcKeyDetail(env, key, target);
     case EVP_PKEY_DH: return GetDhKeyDetail(env, key, target);
   }
-  THROW_ERR_CRYPTO_INVALID_KEYTYPE(env);
-  return Nothing<bool>();
+  return Just(false);
 }
 }  // namespace
 

--- a/src/crypto/crypto_keys.cc
+++ b/src/crypto/crypto_keys.cc
@@ -492,6 +492,13 @@ Maybe<bool> ExportJWKAsymmetricKey(
     case EVP_PKEY_RSA_PSS: return ExportJWKRsaKey(env, key, target);
     case EVP_PKEY_DSA: return ExportJWKDsaKey(env, key, target);
     case EVP_PKEY_EC: return ExportJWKEcKey(env, key, target);
+    case EVP_PKEY_X448:
+      // Fall through
+    case EVP_PKEY_ED448:
+      // Fall through
+    case EVP_PKEY_X25519:
+      // Fall through
+    case EVP_PKEY_ED25519: return ExportJWKOkpKey(env, key, target);
   }
   THROW_ERR_CRYPTO_INVALID_KEYTYPE(env);
   return Just(false);

--- a/src/crypto/crypto_rsa.cc
+++ b/src/crypto/crypto_rsa.cc
@@ -422,12 +422,12 @@ std::shared_ptr<KeyObjectData> ImportJWKRsaKey(
       !jwk->Get(env->context(), env->jwk_d_string()).ToLocal(&d_value) ||
       !n_value->IsString() ||
       !e_value->IsString()) {
-    THROW_ERR_CRYPTO_INVALID_JWK(env, "Invalid JSK RSA key");
+    THROW_ERR_CRYPTO_INVALID_JWK(env, "Invalid JWK RSA key");
     return std::shared_ptr<KeyObjectData>();
   }
 
   if (!d_value->IsUndefined() && !d_value->IsString()) {
-    THROW_ERR_CRYPTO_INVALID_JWK(env, "Invalid JSK RSA key");
+    THROW_ERR_CRYPTO_INVALID_JWK(env, "Invalid JWK RSA key");
     return std::shared_ptr<KeyObjectData>();
   }
 
@@ -443,7 +443,7 @@ std::shared_ptr<KeyObjectData> ImportJWKRsaKey(
           n.ToBN().release(),
           e.ToBN().release(),
           nullptr)) {
-    THROW_ERR_CRYPTO_INVALID_JWK(env, "Invalid JSK RSA key");
+    THROW_ERR_CRYPTO_INVALID_JWK(env, "Invalid JWK RSA key");
     return std::shared_ptr<KeyObjectData>();
   }
 
@@ -459,7 +459,7 @@ std::shared_ptr<KeyObjectData> ImportJWKRsaKey(
         !jwk->Get(env->context(), env->jwk_dp_string()).ToLocal(&dp_value) ||
         !jwk->Get(env->context(), env->jwk_dq_string()).ToLocal(&dq_value) ||
         !jwk->Get(env->context(), env->jwk_qi_string()).ToLocal(&qi_value)) {
-      THROW_ERR_CRYPTO_INVALID_JWK(env, "Invalid JSK RSA key");
+      THROW_ERR_CRYPTO_INVALID_JWK(env, "Invalid JWK RSA key");
       return std::shared_ptr<KeyObjectData>();
     }
 
@@ -468,7 +468,7 @@ std::shared_ptr<KeyObjectData> ImportJWKRsaKey(
         !dp_value->IsString() ||
         !dq_value->IsString() ||
         !qi_value->IsString()) {
-      THROW_ERR_CRYPTO_INVALID_JWK(env, "Invalid JSK RSA key");
+      THROW_ERR_CRYPTO_INVALID_JWK(env, "Invalid JWK RSA key");
       return std::shared_ptr<KeyObjectData>();
     }
 
@@ -486,7 +486,7 @@ std::shared_ptr<KeyObjectData> ImportJWKRsaKey(
             dp.ToBN().release(),
             dq.ToBN().release(),
             qi.ToBN().release())) {
-      THROW_ERR_CRYPTO_INVALID_JWK(env, "Invalid JSK RSA key");
+      THROW_ERR_CRYPTO_INVALID_JWK(env, "Invalid JWK RSA key");
       return std::shared_ptr<KeyObjectData>();
     }
   }
@@ -547,4 +547,3 @@ void Initialize(Environment* env, Local<Object> target) {
 }  // namespace RSAAlg
 }  // namespace crypto
 }  // namespace node
-

--- a/src/env.h
+++ b/src/env.h
@@ -286,6 +286,7 @@ constexpr size_t kFsStatsBufferLength =
   V(jwk_dsa_string, "DSA")                                                     \
   V(jwk_e_string, "e")                                                         \
   V(jwk_ec_string, "EC")                                                       \
+  V(jwk_okp_string, "OKP")                                                     \
   V(jwk_g_string, "g")                                                         \
   V(jwk_k_string, "k")                                                         \
   V(jwk_p_string, "p")                                                         \

--- a/test/parallel/test-crypto-key-objects.js
+++ b/test/parallel/test-crypto-key-objects.js
@@ -70,6 +70,7 @@ const privateDsa = fixtures.readKey('dsa_private_encrypted_1025.pem',
   assert.strictEqual(key.type, 'secret');
   assert.strictEqual(key.symmetricKeySize, 32);
   assert.strictEqual(key.asymmetricKeyType, undefined);
+  assert.strictEqual(key.asymmetricKeyDetails, undefined);
 
   const exportedKey = key.export();
   assert(keybuf.equals(exportedKey));

--- a/test/parallel/test-crypto-keygen.js
+++ b/test/parallel/test-crypto-keygen.js
@@ -123,10 +123,18 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
   assert.strictEqual(typeof publicKey, 'object');
   assert.strictEqual(publicKey.type, 'public');
   assert.strictEqual(publicKey.asymmetricKeyType, 'rsa');
+  assert.deepStrictEqual(publicKey.asymmetricKeyDetails, {
+    modulusLength: 512,
+    publicExponent: 65537
+  });
 
   assert.strictEqual(typeof privateKey, 'object');
   assert.strictEqual(privateKey.type, 'private');
   assert.strictEqual(privateKey.asymmetricKeyType, 'rsa');
+  assert.deepStrictEqual(privateKey.asymmetricKeyDetails, {
+    modulusLength: 512,
+    publicExponent: 65537
+  });
 }
 
 {
@@ -268,9 +276,17 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
   }, common.mustSucceed((publicKey, privateKey) => {
     assert.strictEqual(publicKey.type, 'public');
     assert.strictEqual(publicKey.asymmetricKeyType, 'rsa-pss');
+    assert.deepStrictEqual(publicKey.asymmetricKeyDetails, {
+      modulusLength: 512,
+      publicExponent: 65537
+    });
 
     assert.strictEqual(privateKey.type, 'private');
     assert.strictEqual(privateKey.asymmetricKeyType, 'rsa-pss');
+    assert.deepStrictEqual(privateKey.asymmetricKeyDetails, {
+      modulusLength: 512,
+      publicExponent: 65537
+    });
 
     // Unlike RSA, RSA-PSS does not allow encryption.
     assert.throws(() => {
@@ -338,6 +354,28 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
       key: privateKeyDER,
       ...privateKeyEncoding,
       passphrase: 'secret'
+    });
+  }));
+}
+
+{
+  // Test async DSA key object generation.
+  generateKeyPair('dsa', {
+    modulusLength: 512,
+    divisorLength: 256
+  }, common.mustSucceed((publicKey, privateKey) => {
+    assert.strictEqual(publicKey.type, 'public');
+    assert.strictEqual(publicKey.asymmetricKeyType, 'dsa');
+    assert.deepStrictEqual(publicKey.asymmetricKeyDetails, {
+      modulusLength: 512,
+      divisorLength: 256
+    });
+
+    assert.strictEqual(privateKey.type, 'private');
+    assert.strictEqual(privateKey.asymmetricKeyType, 'dsa');
+    assert.deepStrictEqual(privateKey.asymmetricKeyDetails, {
+      modulusLength: 512,
+      divisorLength: 256
     });
   }));
 }
@@ -925,16 +963,24 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
   // It should recognize both NIST and standard curve names.
   generateKeyPair('ec', {
     namedCurve: 'P-256',
-    publicKeyEncoding: { type: 'spki', format: 'pem' },
-    privateKeyEncoding: { type: 'pkcs8', format: 'pem' }
   }, common.mustSucceed((publicKey, privateKey) => {
+    assert.deepStrictEqual(publicKey.asymmetricKeyDetails, {
+      namedCurve: 'prime256v1'
+    });
+    assert.deepStrictEqual(privateKey.asymmetricKeyDetails, {
+      namedCurve: 'prime256v1'
+    });
   }));
 
   generateKeyPair('ec', {
     namedCurve: 'secp256k1',
-    publicKeyEncoding: { type: 'spki', format: 'pem' },
-    privateKeyEncoding: { type: 'pkcs8', format: 'pem' }
   }, common.mustSucceed((publicKey, privateKey) => {
+    assert.deepStrictEqual(publicKey.asymmetricKeyDetails, {
+      namedCurve: 'secp256k1'
+    });
+    assert.deepStrictEqual(privateKey.asymmetricKeyDetails, {
+      namedCurve: 'secp256k1'
+    });
   }));
 }
 
@@ -945,9 +991,11 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
       generateKeyPair(keyType, common.mustSucceed((publicKey, privateKey) => {
         assert.strictEqual(publicKey.type, 'public');
         assert.strictEqual(publicKey.asymmetricKeyType, keyType);
+        assert.deepStrictEqual(publicKey.asymmetricKeyDetails, {});
 
         assert.strictEqual(privateKey.type, 'private');
         assert.strictEqual(privateKey.asymmetricKeyType, keyType);
+        assert.deepStrictEqual(privateKey.asymmetricKeyDetails, {});
       }));
     });
   }


### PR DESCRIPTION
**I'm opening this Draft PR to see/probe if there's interest in taking it further (cleaning up and getting it ready to land, which i'm all willing to do). It builds on top of #36188**

This adds the `'jwk'` format option value for `keyObject.export`. It also adds a `KeyObject.fromJwk` static method (its functionality should probably be added to `KeyObject.from` but I don't think that one was meant to ship in the first place so maybe this could completely replace it, see the question in code.)

WDYT? Is it worth spending further time on in hopes of being accepted?

refs #24471
refs #26854

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
