### PR TITLE
benchmark : changed `fstat` to `fstatSync`

### DIFF
--- a/benchmark/fs/bench-statSync.js
+++ b/benchmark/fs/bench-statSync.js
@@ -21,6 +21,6 @@ function main({ n, statSyncType }) {
   }
   bench.end(n);
 
-  if (statSyncType === 'fstat')
+  if (statSyncType === 'fstatSync')
     fs.closeSync(arg);
 }


### PR DESCRIPTION
Changed `fstat` to `fstatSync` as mentioned in the issue #36199 

Fixes: https://github.com/nodejs/node/issues/36199