### PR TITLE
doc: fix --experimental-wasm-modules text location

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -300,14 +300,14 @@ Enable experimental WebAssembly System Interface (WASI) support.
 added: v12.3.0
 -->
 
+Enable experimental WebAssembly module support.
+
 ### `--force-context-aware`
 <!-- YAML
 added: v12.12.0
 -->
 
 Disable loading native addons that are not [context-aware][].
-
-Enable experimental WebAssembly module support.
 
 ### `--force-fips`
 <!-- YAML


### PR DESCRIPTION
The text for `--experimental-wasm-modules` had drifted to under the `--force-context-aware` text. This commit moves it back to the proper location.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)