### PR TITLE
doc: list the stability status of each module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -749,6 +749,7 @@ out/doc/api/all.html: $(apidocs_html) tools/doc/allhtml.js \
 out/doc/api/all.json: $(apidocs_json) tools/doc/alljson.js | out/doc/api
 	$(call available-node, tools/doc/alljson.js)
 
+.PHONY: out/doc/api/stability
 out/doc/api/stability: out/doc/api/all.json tools/doc/stability.js | out/doc/api
 	$(call available-node, tools/doc/stability.js)
 

--- a/Makefile
+++ b/Makefile
@@ -696,7 +696,7 @@ doc-only: tools/doc/node_modules \
 	@if [ "$(shell $(node_use_openssl))" != "true" ]; then \
 		echo "Skipping doc-only (no crypto)"; \
 	else \
-		$(MAKE) out/doc/api/all.html out/doc/api/all.json; \
+		$(MAKE) out/doc/api/all.html out/doc/api/all.json out/doc/api/stability; \
 	fi
 
 .PHONY: doc
@@ -748,6 +748,9 @@ out/doc/api/all.html: $(apidocs_html) tools/doc/allhtml.js \
 
 out/doc/api/all.json: $(apidocs_json) tools/doc/alljson.js | out/doc/api
 	$(call available-node, tools/doc/alljson.js)
+
+out/doc/api/stability: out/doc/api/all.json tools/doc/stability.js | out/doc/api
+	$(call available-node, tools/doc/stability.js)
 
 .PHONY: docopen
 docopen: out/doc/api/all.html

--- a/doc/api/documentation.md
+++ b/doc/api/documentation.md
@@ -43,6 +43,9 @@ Bugs or behavior changes may surprise users when Experimental API
 modifications occur. To avoid surprises, use of an Experimental feature may need
 a command-line flag. Experimental features may also emit a [warning][].
 
+## Stability overview
+<!-- STABILITY_OVERVIEW_SLOT -->
+
 ## JSON output
 <!-- YAML
 added: v0.6.12

--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -263,6 +263,10 @@ ol.version-picker li:last-child a {
   background-color: var(--green2);
 }
 
+.module_stability {
+  vertical-align: middle;
+}
+
 .api_metadata {
   font-size: .85rem;
   margin-bottom: 1rem;

--- a/tools/doc/alljson.js
+++ b/tools/doc/alljson.js
@@ -43,6 +43,9 @@ for (const link of toc.match(/<a.*?>/g)) {
 
   for (const property in data) {
     if (results.hasOwnProperty(property)) {
+      data[property].forEach((mod) => {
+        mod.source = data.source;
+      });
       results[property].push(...data[property]);
     }
   }

--- a/tools/doc/stability.js
+++ b/tools/doc/stability.js
@@ -93,7 +93,7 @@ function updateStabilityMark(file, value, mark) {
   const offset = fs.writeSync(fd, value, index, 'utf-8');
 
   // Re-write the end of the file after `value`.
-  fs.writeSync(fd, content, index + mark.length);
+  fs.writeSync(fd, content, index + mark.length, undefined, index + offset);
   fs.closeSync(fd);
 }
 

--- a/tools/doc/stability.js
+++ b/tools/doc/stability.js
@@ -90,7 +90,7 @@ function updateStabilityMark(file, value, mark) {
   const index = content.indexOf(mark);
 
   // Overwrite the mark with `value` parameter.
-  fs.writeSync(fd, value, index, 'utf-8');
+  const offset = fs.writeSync(fd, value, index, 'utf-8');
 
   // Re-write the end of the file after `value`.
   fs.writeSync(fd, content, index + mark.length);

--- a/tools/doc/stability.js
+++ b/tools/doc/stability.js
@@ -108,4 +108,4 @@ const html = createHTML(markdownTable);
 updateStabilityMark(output.docHTML, html, mark);
 
 // add json output
-updateStabilityMark(output.docJSON, JSON.stringify(html), `"${mark}"`);
+updateStabilityMark(output.docJSON, JSON.stringify(html), JSON.stringify(mark));

--- a/tools/doc/stability.js
+++ b/tools/doc/stability.js
@@ -1,0 +1,102 @@
+'use strict';
+
+// Build stability table to documentation.html/json/md by generated all.json
+
+const fs = require('fs');
+const path = require('path');
+const unified = require('unified');
+const raw = require('rehype-raw');
+const markdown = require('remark-parse');
+const htmlStringify = require('rehype-stringify');
+const gfm = require('remark-gfm');
+const remark2rehype = require('remark-rehype');
+const visit = require('unist-util-visit');
+
+const source = `${__dirname}/../../out/doc/api`;
+const data = require(path.join(source, 'all.json'));
+const mark = '<!-- STABILITY_OVERVIEW_SLOT -->';
+
+const output = {
+  json: path.join(source, 'stability.json'),
+  docHTML: path.join(source, 'documentation.html'),
+  docJSON: path.join(source, 'documentation.json'),
+  docMarkdown: path.join(source, 'documentation.md'),
+};
+
+function collectStability(data) {
+  const stability = [];
+
+  for (const mod of data.modules) {
+    if (mod.displayName && mod.stability >= 0) {
+      const link = mod.source.replace('doc/api/', '').replace('.md', '.html');
+      // const link = re.exec(toc)[1]
+      stability.push({
+        api: mod.name,
+        link: link,
+        stability: mod.stability,
+        stabilityText: `(${mod.stability}) ${mod.stabilityText}`,
+      });
+    }
+  }
+
+  stability.sort((a, b) => a.api.localeCompare(b.api));
+  return stability;
+}
+
+function createMarkdownTable(data) {
+  const md = ['| API | Stability |', '| --- | --------- |'];
+
+  for (const mod of data) {
+    md.push(`| [${mod.api}](${mod.link}) | ${mod.stabilityText} |`);
+  }
+
+  return md.join('\n');
+}
+
+function createHTML(md) {
+  const file = unified()
+    .use(markdown)
+    .use(gfm)
+    .use(remark2rehype, { allowDangerousHtml: true })
+    .use(raw)
+    .use(htmlStringify)
+    .use(processStability)
+    .processSync(md);
+
+  return file.contents.trim();
+}
+
+function processStability() {
+  return (tree) => {
+    visit(tree, { type: 'element', tagName: 'tr' }, (node) => {
+      const [api, stability] = node.children;
+      if (api.tagName !== 'td') {
+        return;
+      }
+
+      api.properties.class = 'module_stability';
+
+      const level = stability.children[0].value[1];
+      stability.properties.class = `api_stability api_stability_${level}`;
+    });
+  };
+}
+
+function updateStabilityMark(file, value, mark) {
+  const content = fs.readFileSync(file, { encoding: 'utf-8' });
+  const newContent = content.replace(mark, value);
+  fs.writeFileSync(file, newContent, { encoding: 'utf-8' });
+}
+
+const stability = collectStability(data);
+
+// add markdown
+const markdownTable = createMarkdownTable(stability);
+updateStabilityMark(output.docMarkdown, markdownTable, mark);
+
+// add html table
+const html = createHTML(markdownTable);
+updateStabilityMark(output.docHTML, html, mark);
+
+// add json output
+updateStabilityMark(output.docJSON, JSON.stringify(html), `"${mark}"`);

--- a/tools/doc/stability.js
+++ b/tools/doc/stability.js
@@ -83,9 +83,18 @@ function processStability() {
 }
 
 function updateStabilityMark(file, value, mark) {
-  const content = fs.readFileSync(file, { encoding: 'utf-8' });
-  const newContent = content.replace(mark, value);
-  fs.writeFileSync(file, newContent, { encoding: 'utf-8' });
+  const fd = fs.openSync(file, 'r+');
+  const content = fs.readFileSync(fd);
+
+  // Find the position of the `mark`.
+  const index = content.indexOf(mark);
+
+  // Overwrite the mark with `value` parameter.
+  fs.writeSync(fd, value, index, 'utf-8');
+
+  // Re-write the end of the file after `value`.
+  fs.writeSync(fd, content, index + mark.length);
+  fs.closeSync(fd);
 }
 
 const stability = collectStability(data);


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/23723

Generate a module compatibility table from out/doc/all.json and insert it into documentation.html/md/json.

Preview:
![image](https://user-images.githubusercontent.com/13161470/99900652-ea9c9880-2ceb-11eb-8c76-558ec3030428.png)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
