### PR TITLE
tools: use using-declaration consistently

### DIFF
--- a/tools/snapshot/snapshot_builder.cc
+++ b/tools/snapshot/snapshot_builder.cc
@@ -25,7 +25,7 @@ void WriteVector(std::stringstream* ss, const T* vec, size_t size) {
   }
 }
 
-std::string FormatBlob(v8::StartupData* blob,
+std::string FormatBlob(StartupData* blob,
                        const std::vector<size_t>& isolate_data_indexes,
                        const EnvSerializeInfo& env_info) {
   std::stringstream ss;
@@ -75,7 +75,7 @@ const EnvSerializeInfo* NodeMainInstance::GetEnvSerializeInfo() {
   return ss.str();
 }
 
-static v8::StartupData SerializeNodeContextInternalFields(Local<Object> holder,
+static StartupData SerializeNodeContextInternalFields(Local<Object> holder,
                                                           int index,
                                                           void* env) {
   void* ptr = holder->GetAlignedPointerFromInternalField(index);

--- a/tools/snapshot/snapshot_builder.cc
+++ b/tools/snapshot/snapshot_builder.cc
@@ -76,8 +76,8 @@ const EnvSerializeInfo* NodeMainInstance::GetEnvSerializeInfo() {
 }
 
 static StartupData SerializeNodeContextInternalFields(Local<Object> holder,
-                                                          int index,
-                                                          void* env) {
+                                                      int index,
+                                                      void* env) {
   void* ptr = holder->GetAlignedPointerFromInternalField(index);
   if (ptr == nullptr || ptr == env) {
     return StartupData{nullptr, 0};


### PR DESCRIPTION

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
