### PR TITLE
tools: enable no-unused-expressions lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -227,6 +227,7 @@ module.exports = {
     'no-unreachable': 'error',
     'no-unsafe-finally': 'error',
     'no-unsafe-negation': 'error',
+    'no-unused-expressions': ['error', { allowShortCircuit: true }],
     'no-unused-labels': 'error',
     'no-unused-vars': ['error', { args: 'none', caughtErrors: 'all' }],
     'no-use-before-define': ['error', {

--- a/benchmark/_benchmark_progress.js
+++ b/benchmark/_benchmark_progress.js
@@ -39,7 +39,6 @@ class BenchmarkProgress {
     this.completedConfig = 0;
     // Total number of configurations for the current file
     this.scheduledConfig = 0;
-    this.interval;  // Updates the elapsed time.
   }
 
   startQueue(index) {

--- a/benchmark/es/destructuring-bench.js
+++ b/benchmark/es/destructuring-bench.js
@@ -12,7 +12,8 @@ function runSwapManual(n) {
   let x, y, r;
   bench.start();
   for (let i = 0; i < n; i++) {
-    x = 1, y = 2;
+    x = 1;
+    y = 2;
     r = x;
     x = y;
     y = r;
@@ -26,7 +27,8 @@ function runSwapDestructured(n) {
   let x, y;
   bench.start();
   for (let i = 0; i < n; i++) {
-    x = 1, y = 2;
+    x = 1;
+    y = 2;
     [x, y] = [y, x];
     assert.strictEqual(x, 2);
     assert.strictEqual(y, 1);

--- a/benchmark/perf_hooks/bench-eventlooputil.js
+++ b/benchmark/perf_hooks/bench-eventlooputil.js
@@ -33,7 +33,7 @@ function main({ method, n }) {
 function benchIdleTime(n) {
   bench.start();
   for (let i = 0; i < n; i++)
-    nodeTiming.idleTime;
+    nodeTiming.idleTime; // eslint-disable-line no-unused-expressions
   bench.end(n);
 }
 

--- a/benchmark/process/bench-env.js
+++ b/benchmark/process/bench-env.js
@@ -13,7 +13,7 @@ function main({ n, operation }) {
     case 'get':
       bench.start();
       for (let i = 0; i < n; i++) {
-        process.env.PATH;
+        process.env.PATH; // eslint-disable-line no-unused-expressions
       }
       bench.end(n);
       break;
@@ -42,7 +42,7 @@ function main({ n, operation }) {
     case 'query':
       bench.start();
       for (let i = 0; i < n; i++) {
-        'PATH' in process.env;
+        'PATH' in process.env; // eslint-disable-line no-unused-expressions
       }
       bench.end(n);
       break;

--- a/benchmark/string_decoder/string-decoder-create.js
+++ b/benchmark/string_decoder/string-decoder-create.js
@@ -12,8 +12,7 @@ const bench = common.createBenchmark(main, {
 function main({ encoding, n }) {
   bench.start();
   for (let i = 0; i < n; ++i) {
-    const sd = new StringDecoder(encoding);
-    !!sd.encoding;
+    new StringDecoder(encoding);
   }
   bench.end(n);
 }

--- a/doc/.eslintrc.yaml
+++ b/doc/.eslintrc.yaml
@@ -4,6 +4,7 @@ rules:
   # ease some restrictions in doc examples
   no-restricted-properties: off
   no-undef: off
+  no-unused-expressions: off
   no-unused-vars: off
   symbol-description: off
 

--- a/lib/internal/assert/assertion_error.js
+++ b/lib/internal/assert/assertion_error.js
@@ -455,7 +455,7 @@ class AssertionError extends Error {
     }
     ErrorCaptureStackTrace(this, stackStartFn || stackStartFunction);
     // Create error message including the error code in the name.
-    this.stack;
+    this.stack; // eslint-disable-line no-unused-expressions
     // Reset the name.
     this.name = 'AssertionError';
   }

--- a/lib/internal/buffer.js
+++ b/lib/internal/buffer.js
@@ -952,18 +952,18 @@ function writeFloatBackwards(val, offset = 0) {
 class FastBuffer extends Uint8Array {}
 
 function addBufferPrototypeMethods(proto) {
-  proto.readBigUInt64LE = readBigUInt64LE,
-  proto.readBigUInt64BE = readBigUInt64BE,
-  proto.readBigUint64LE = readBigUInt64LE,
-  proto.readBigUint64BE = readBigUInt64BE,
-  proto.readBigInt64LE = readBigInt64LE,
-  proto.readBigInt64BE = readBigInt64BE,
-  proto.writeBigUInt64LE = writeBigUInt64LE,
-  proto.writeBigUInt64BE = writeBigUInt64BE,
-  proto.writeBigUint64LE = writeBigUInt64LE,
-  proto.writeBigUint64BE = writeBigUInt64BE,
-  proto.writeBigInt64LE = writeBigInt64LE,
-  proto.writeBigInt64BE = writeBigInt64BE,
+  proto.readBigUInt64LE = readBigUInt64LE;
+  proto.readBigUInt64BE = readBigUInt64BE;
+  proto.readBigUint64LE = readBigUInt64LE;
+  proto.readBigUint64BE = readBigUInt64BE;
+  proto.readBigInt64LE = readBigInt64LE;
+  proto.readBigInt64BE = readBigInt64BE;
+  proto.writeBigUInt64LE = writeBigUInt64LE;
+  proto.writeBigUInt64BE = writeBigUInt64BE;
+  proto.writeBigUint64LE = writeBigUInt64LE;
+  proto.writeBigUint64BE = writeBigUInt64BE;
+  proto.writeBigInt64LE = writeBigInt64LE;
+  proto.writeBigInt64BE = writeBigInt64BE;
 
   proto.readUIntLE = readUIntLE;
   proto.readUInt32LE = readUInt32LE;

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -332,7 +332,7 @@ function addCodeToName(err, name, code) {
   err.name = `${name} [${code}]`;
   // Access the stack to generate the error message including the error code
   // from the name.
-  err.stack;
+  err.stack; // eslint-disable-line no-unused-expressions
   // Reset the name to the actual name.
   if (name === 'SystemError') {
     ObjectDefineProperty(err, 'name', {
@@ -1411,11 +1411,11 @@ E('ERR_TLS_CERT_ALTNAME_INVALID', function(reason, host, cert) {
 }, Error);
 E('ERR_TLS_DH_PARAM_SIZE', 'DH parameter size %s is less than 2048', Error);
 E('ERR_TLS_HANDSHAKE_TIMEOUT', 'TLS handshake timeout', Error);
-E('ERR_TLS_INVALID_CONTEXT', '%s must be a SecureContext', TypeError),
-E('ERR_TLS_INVALID_STATE', 'TLS socket connection must be securely established',
-  Error),
+E('ERR_TLS_INVALID_CONTEXT', '%s must be a SecureContext', TypeError);
 E('ERR_TLS_INVALID_PROTOCOL_VERSION',
   '%j is not a valid %s TLS protocol version', TypeError);
+E('ERR_TLS_INVALID_STATE', 'TLS socket connection must be securely established',
+  Error);
 E('ERR_TLS_PROTOCOL_VERSION_CONFLICT',
   'TLS protocol version %j conflicts with secureProtocol %j', TypeError);
 E('ERR_TLS_RENEGOTIATION_DISABLED',

--- a/lib/internal/streams/destroy.js
+++ b/lib/internal/streams/destroy.js
@@ -11,7 +11,7 @@ const kConstruct = Symbol('kConstruct');
 function checkError(err, w, r) {
   if (err) {
     // Avoid V8 leak, https://github.com/nodejs/node/pull/34103#issuecomment-652002364
-    err.stack;
+    err.stack; // eslint-disable-line no-unused-expressions
 
     if (w && !w.errored) {
       w.errored = err;
@@ -118,7 +118,7 @@ function _destroy(self, err, cb) {
           function(err) {
             const r = self._readableState;
             const w = self._writableState;
-            err.stack;
+            err.stack; // eslint-disable-line no-unused-expressions
 
             called = true;
 
@@ -237,7 +237,7 @@ function errorOrDestroy(stream, err, sync) {
     stream.destroy(err);
   else if (err) {
     // Avoid V8 leak, https://github.com/nodejs/node/pull/34103#issuecomment-652002364
-    err.stack;
+    err.stack; // eslint-disable-line no-unused-expressions
 
     if (w && !w.errored) {
       w.errored = err;

--- a/lib/internal/streams/writable.js
+++ b/lib/internal/streams/writable.js
@@ -438,7 +438,7 @@ function onwrite(stream, er) {
 
   if (er) {
     // Avoid V8 leak, https://github.com/nodejs/node/pull/34103#issuecomment-652002364
-    er.stack;
+    er.stack; // eslint-disable-line no-unused-expressions
 
     if (!state.errored) {
       state.errored = er;

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -424,7 +424,7 @@ function getCallSite(top) {
   const err = new Error();
   Error.captureStackTrace(err, top);
   // With the V8 Error API, the stack is not formatted until it is accessed
-  err.stack;
+  err.stack; // eslint-disable-line no-unused-expressions
   Error.prepareStackTrace = originalStackFormatter;
   return err.stack;
 }

--- a/test/js-native-api/test_general/testEnvCleanup.js
+++ b/test/js-native-api/test_general/testEnvCleanup.js
@@ -30,7 +30,7 @@ if (process.argv[2] === 'child') {
   // Make sure that only the latest attached version of a re-wrapped item's
   // finalizer gets called at env cleanup.
   module.exports['first wrap'] =
-    test_general.envCleanupWrap({}, finalizerMessages['first wrap']),
+    test_general.envCleanupWrap({}, finalizerMessages['first wrap']);
   test_general.removeWrap(module.exports['first wrap']);
   test_general.envCleanupWrap(module.exports['first wrap'],
                               finalizerMessages['second wrap']);

--- a/test/message/nexttick_throw.js
+++ b/test/message/nexttick_throw.js
@@ -26,7 +26,7 @@ process.nextTick(function() {
   process.nextTick(function() {
     process.nextTick(function() {
       process.nextTick(function() {
-        // eslint-disable-next-line no-undef
+        // eslint-disable-next-line no-undef,no-unused-expressions
         undefined_reference_error_maker;
       });
     });

--- a/test/message/timeout_throw.js
+++ b/test/message/timeout_throw.js
@@ -23,6 +23,6 @@
 require('../common');
 
 setTimeout(function() {
-  // eslint-disable-next-line no-undef
+  // eslint-disable-next-line no-undef,no-unused-expressions
   undefined_reference_error_maker;
 }, 1);

--- a/test/parallel/test-accessor-properties.js
+++ b/test/parallel/test-accessor-properties.js
@@ -17,7 +17,7 @@ const UDP = internalBinding('udp_wrap').UDP;
 {
   // Should throw instead of raise assertions
   assert.throws(() => {
-    UDP.prototype.fd;
+    UDP.prototype.fd; // eslint-disable-line no-unused-expressions
   }, TypeError);
 
   const StreamWrapProto = Object.getPrototypeOf(TTY.prototype);
@@ -26,7 +26,7 @@ const UDP = internalBinding('udp_wrap').UDP;
   properties.forEach((property) => {
     // Should throw instead of raise assertions
     assert.throws(() => {
-      TTY.prototype[property];
+      TTY.prototype[property]; // eslint-disable-line no-unused-expressions
     }, TypeError, `Missing expected TypeError for TTY.prototype.${property}`);
 
     // Should not throw for Object.getOwnPropertyDescriptor
@@ -42,6 +42,7 @@ const UDP = internalBinding('udp_wrap').UDP;
     const crypto = internalBinding('crypto');
 
     assert.throws(() => {
+      // eslint-disable-next-line no-unused-expressions
       crypto.SecureContext.prototype._external;
     }, TypeError);
 

--- a/test/parallel/test-buffer-backing-arraybuffer.js
+++ b/test/parallel/test-buffer-backing-arraybuffer.js
@@ -31,7 +31,7 @@ for (const { length, expectOnHeap } of tests) {
                        `for ${array.constructor.name}, length = ${length}`);
 
     // Consistency check: Accessing .buffer should create it.
-    array.buffer;
+    array.buffer; // eslint-disable-line no-unused-expressions
     assert(arrayBufferViewHasBuffer(array));
   }
 }

--- a/test/parallel/test-buffer-constructor-deprecation-error.js
+++ b/test/parallel/test-buffer-constructor-deprecation-error.js
@@ -14,4 +14,4 @@ process.on('warning', common.mustCall());
 
 Error.prepareStackTrace = (err, trace) => new Buffer(10);
 
-new Error().stack;
+new Error().stack; // eslint-disable-line no-unused-expressions

--- a/test/parallel/test-buffer-fakes.js
+++ b/test/parallel/test-buffer-fakes.js
@@ -14,7 +14,7 @@ assert.throws(function() {
 }, TypeError);
 
 assert.throws(function() {
-  +Buffer.prototype;
+  +Buffer.prototype; // eslint-disable-line no-unused-expressions
 }, TypeError);
 
 assert.throws(function() {

--- a/test/parallel/test-child-process-stdin-ipc.js
+++ b/test/parallel/test-child-process-stdin-ipc.js
@@ -27,7 +27,7 @@ const spawn = require('child_process').spawn;
 
 if (process.argv[2] === 'child') {
   // Just reference stdin, it should start it
-  process.stdin;
+  process.stdin; // eslint-disable-line no-unused-expressions
   return;
 }
 

--- a/test/parallel/test-dgram-deprecation-error.js
+++ b/test/parallel/test-dgram-deprecation-error.js
@@ -31,7 +31,7 @@ const propertyCases = propertiesToTest.map((propName) => {
         `Socket.prototype.${propName} is deprecated`,
         'DEP0112'
       );
-      sock[propName];
+      sock[propName]; // eslint-disable-line no-unused-expressions
     },
     () => {
       // Test property setter

--- a/test/parallel/test-disable-proto-throw.js
+++ b/test/parallel/test-disable-proto-throw.js
@@ -10,7 +10,7 @@ const { Worker, isMainThread } = require('worker_threads');
 assert(Object.prototype.hasOwnProperty('__proto__'));
 
 assert.throws(() => {
-  // eslint-disable-next-line no-proto
+  // eslint-disable-next-line no-proto,no-unused-expressions
   ({}).__proto__;
 }, {
   code: 'ERR_PROTO_ACCESS'

--- a/test/parallel/test-error-prepare-stack-trace.js
+++ b/test/parallel/test-error-prepare-stack-trace.js
@@ -13,7 +13,7 @@ const assert = require('assert');
   try {
     throw new Error('foo');
   } catch (err) {
-    err.stack;
+    err.stack; // eslint-disable-line no-unused-expressions
   }
   assert(prepareCalled);
 }

--- a/test/parallel/test-fs-readv-promises.js
+++ b/test/parallel/test-fs-readv-promises.js
@@ -18,7 +18,7 @@ function getFileName() {
 const allocateEmptyBuffers = (combinedLength) => {
   const bufferArr = [];
   // Allocate two buffers, each half the size of exptectedBuff
-  bufferArr[0] = Buffer.alloc(Math.floor(combinedLength / 2)),
+  bufferArr[0] = Buffer.alloc(Math.floor(combinedLength / 2));
   bufferArr[1] = Buffer.alloc(combinedLength - bufferArr[0].length);
 
   return bufferArr;

--- a/test/parallel/test-fs-readv-sync.js
+++ b/test/parallel/test-fs-readv-sync.js
@@ -19,7 +19,7 @@ fs.writeFileSync(filename, exptectedBuff);
 const allocateEmptyBuffers = (combinedLength) => {
   const bufferArr = [];
   // Allocate two buffers, each half the size of exptectedBuff
-  bufferArr[0] = Buffer.alloc(Math.floor(combinedLength / 2)),
+  bufferArr[0] = Buffer.alloc(Math.floor(combinedLength / 2));
   bufferArr[1] = Buffer.alloc(combinedLength - bufferArr[0].length);
 
   return bufferArr;

--- a/test/parallel/test-fs-readv.js
+++ b/test/parallel/test-fs-readv.js
@@ -17,7 +17,7 @@ const exptectedBuff = Buffer.from(expected);
 const allocateEmptyBuffers = (combinedLength) => {
   const bufferArr = [];
   // Allocate two buffers, each half the size of exptectedBuff
-  bufferArr[0] = Buffer.alloc(Math.floor(combinedLength / 2)),
+  bufferArr[0] = Buffer.alloc(Math.floor(combinedLength / 2));
   bufferArr[1] = Buffer.alloc(combinedLength - bufferArr[0].length);
 
   return bufferArr;

--- a/test/parallel/test-http-outgoing-internal-headernames-getter.js
+++ b/test/parallel/test-http-outgoing-internal-headernames-getter.js
@@ -9,5 +9,5 @@ common.expectWarning('DeprecationWarning', warn, 'DEP0066');
 {
   // Tests for _headerNames get method
   const outgoingMessage = new OutgoingMessage();
-  outgoingMessage._headerNames;
+  outgoingMessage._headerNames; // eslint-disable-line no-unused-expressions
 }

--- a/test/parallel/test-http-outgoing-internal-headers.js
+++ b/test/parallel/test-http-outgoing-internal-headers.js
@@ -13,7 +13,7 @@ common.expectWarning('DeprecationWarning', warn, 'DEP0066');
   // Tests for _headers get method
   const outgoingMessage = new OutgoingMessage();
   outgoingMessage.getHeaders = common.mustCall();
-  outgoingMessage._headers;
+  outgoingMessage._headers; // eslint-disable-line no-unused-expressions
 }
 
 {

--- a/test/parallel/test-http-same-map.js
+++ b/test/parallel/test-http-same-map.js
@@ -39,9 +39,10 @@ onresponse.responses = [];
 
 function allSame(list) {
   assert(list.length >= 2);
-  // Use |elt| in no-op position to pacify eslint.
-  for (const elt of list) elt, eval('%DebugPrint(elt)');
-  for (const elt of list) elt, assert(eval('%HaveSameMap(list[0], elt)'));
+  // eslint-disable-next-line no-unused-vars
+  for (const elt of list) eval('%DebugPrint(elt)');
+  // eslint-disable-next-line no-unused-vars
+  for (const elt of list) assert(eval('%HaveSameMap(list[0], elt)'));
 }
 
 process.on('exit', () => {

--- a/test/parallel/test-http2-unbound-socket-proxy.js
+++ b/test/parallel/test-http2-unbound-socket-proxy.js
@@ -26,7 +26,7 @@ server.listen(0, common.mustCall(() => {
     // informative error.
     setImmediate(common.mustCall(() => {
       assert.throws(() => {
-        socket.example;
+        socket.example; // eslint-disable-line no-unused-expressions
       }, {
         code: 'ERR_HTTP2_SOCKET_UNBOUND'
       });
@@ -36,6 +36,7 @@ server.listen(0, common.mustCall(() => {
         code: 'ERR_HTTP2_SOCKET_UNBOUND'
       });
       assert.throws(() => {
+        // eslint-disable-next-line no-unused-expressions
         socket instanceof net.Socket;
       }, {
         code: 'ERR_HTTP2_SOCKET_UNBOUND'

--- a/test/parallel/test-inspector-tracing-domain.js
+++ b/test/parallel/test-inspector-tracing-domain.js
@@ -30,7 +30,7 @@ function post(message, data) {
 function generateTrace() {
   return new Promise((resolve) => setTimeout(() => {
     for (let i = 0; i < 1000000; i++) {
-      'test' + i;
+      'test' + i; // eslint-disable-line no-unused-expressions
     }
     resolve();
   }, 1));

--- a/test/parallel/test-inspector-vm-global-accessors-sideeffects.js
+++ b/test/parallel/test-inspector-vm-global-accessors-sideeffects.js
@@ -19,8 +19,7 @@ session.post('Runtime.evaluate', {
   expression: 'a',
   throwOnSideEffect: true,
   contextId: 2 // context's id
-}, common.mustCall((error, res) => {
-  assert.ifError(error),
+}, common.mustSucceed((res) => {
   assert.deepStrictEqual(res, {
     result: {
       type: 'number',

--- a/test/parallel/test-internal-iterable-weak-map.js
+++ b/test/parallel/test-internal-iterable-weak-map.js
@@ -18,7 +18,7 @@ const { IterableWeakMap } = require('internal/util/iterable_weak_map');
   wm.set(_cache.moduleC, 'goodbye');
   delete _cache.moduleB;
   setImmediate(() => {
-    _cache;
+    _cache; // eslint-disable-line no-unused-expressions
     globalThis.gc();
     const values = [...wm];
     deepStrictEqual(values, ['hello', 'goodbye']);

--- a/test/parallel/test-net-after-close.js
+++ b/test/parallel/test-net-after-close.js
@@ -32,6 +32,7 @@ const server = net.createServer(common.mustCall((s) => {
 server.listen(0, common.mustCall(() => {
   const c = net.createConnection(server.address().port);
   c.on('close', common.mustCall(() => {
+    /* eslint-disable no-unused-expressions */
     console.error('connection closed');
     assert.strictEqual(c._handle, null);
     // Calling functions / accessing properties of a closed socket should not
@@ -45,5 +46,6 @@ server.listen(0, common.mustCall(() => {
     c.remoteAddress;
     c.remotePort;
     server.close();
+    /* eslint-enable no-unused-expressions */
   }));
 }));

--- a/test/parallel/test-net-during-close.js
+++ b/test/parallel/test-net-during-close.js
@@ -28,6 +28,7 @@ const server = net.createServer(function(socket) {
 });
 
 server.listen(0, common.mustCall(function() {
+  /* eslint-disable no-unused-expressions */
   const client = net.createConnection(this.address().port);
   server.close();
   // Server connection event has not yet fired client is still attempting to
@@ -37,4 +38,5 @@ server.listen(0, common.mustCall(function() {
   client.remotePort;
   // Exit now, do not wait for the client error event.
   process.exit(0);
+  /* eslint-enable no-unused-expressions */
 }));

--- a/test/parallel/test-process-env-windows-error-reset.js
+++ b/test/parallel/test-process-env-windows-error-reset.js
@@ -7,7 +7,7 @@ const assert = require('assert');
 
 {
   process.env.FOO = '';
-  process.env.NONEXISTENT_ENV_VAR;
+  process.env.NONEXISTENT_ENV_VAR; // eslint-disable-line no-unused-expressions
   const foo = process.env.FOO;
 
   assert.strictEqual(foo, '');
@@ -15,7 +15,7 @@ const assert = require('assert');
 
 {
   process.env.FOO = '';
-  process.env.NONEXISTENT_ENV_VAR;
+  process.env.NONEXISTENT_ENV_VAR; // eslint-disable-line no-unused-expressions
   const hasFoo = 'FOO' in process.env;
 
   assert.strictEqual(hasFoo, true);

--- a/test/parallel/test-repl-options.js
+++ b/test/parallel/test-repl-options.js
@@ -29,7 +29,7 @@ const repl = require('repl');
 const cp = require('child_process');
 
 assert.strictEqual(repl.repl, undefined);
-repl._builtinLibs;
+repl._builtinLibs; // eslint-disable-line no-unused-expressions
 
 common.expectWarning({
   DeprecationWarning: {

--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -532,7 +532,7 @@ testMe.complete('obj.', common.mustCall((error, data) => {
 
 // check Buffer.prototype.length not crashing.
 // Refs: https://github.com/nodejs/node/pull/11961
-putIn.run['.clear'];
+putIn.run(['.clear']);
 testMe.complete('Buffer.prototype.', common.mustCall());
 
 const testNonGlobal = repl.start({

--- a/test/parallel/test-source-map-api.js
+++ b/test/parallel/test-source-map-api.js
@@ -54,6 +54,7 @@ const { readFileSync } = require('fs');
     // Require a file that throws an exception, and has a source map.
     require('../fixtures/source-map/typescript-throw.js');
   } catch (err) {
+    // eslint-disable-next-line no-unused-expressions
     err.stack; // Force prepareStackTrace() to be called.
   }
   assert(callSite);

--- a/test/parallel/test-stdin-hang.js
+++ b/test/parallel/test-stdin-hang.js
@@ -27,6 +27,6 @@ require('../common');
 // If it does, then the test-runner will nuke it.
 
 // invoke the getter.
-process.stdin;
+process.stdin; // eslint-disable-line no-unused-expressions
 
 console.error('Should exit normally now.');

--- a/test/parallel/test-stdio-closed.js
+++ b/test/parallel/test-stdio-closed.js
@@ -7,10 +7,12 @@ const fixtures = require('../common/fixtures');
 
 if (common.isWindows) {
   if (process.argv[2] === 'child') {
+    /* eslint-disable no-unused-expressions */
     process.stdin;
     process.stdout;
     process.stderr;
     return;
+    /* eslint-enable no-unused-expressions */
   }
   const python = process.env.PYTHON || 'python';
   const script = fixtures.path('spawn_closed_stdio.py');

--- a/test/parallel/test-stdio-pipe-access.js
+++ b/test/parallel/test-stdio-pipe-access.js
@@ -32,6 +32,6 @@ switch (who) {
                        process.stderr ] });
     break;
   case 'bottom':
-    process.stdin;
+    process.stdin; // eslint-disable-line no-unused-expressions
     break;
 }

--- a/test/parallel/test-stream-pipeline-uncaught.js
+++ b/test/parallel/test-stream-pipeline-uncaught.js
@@ -16,9 +16,7 @@ process.on('uncaughtException', common.mustCall((err) => {
 const s = new PassThrough();
 s.end('data');
 pipeline(s, async function(source) {
-  for await (const chunk of source) {
-    chunk;
-  }
+  for await (const chunk of source) {} // eslint-disable-line no-unused-vars
 }, common.mustSucceed(() => {
   throw new Error('error');
 }));

--- a/test/parallel/test-stream-pipeline.js
+++ b/test/parallel/test-stream-pipeline.js
@@ -627,9 +627,7 @@ const net = require('net');
     await Promise.resolve();
     yield 'hello';
   }, async function*(source) {
-    for await (const chunk of source) {
-      chunk;
-    }
+    for await (const chunk of source) {}
   }, common.mustCall((err) => {
     assert.strictEqual(err, undefined);
   }));
@@ -645,9 +643,7 @@ const net = require('net');
     await Promise.resolve();
     throw new Error('kaboom');
   }, async function*(source) {
-    for await (const chunk of source) {
-      chunk;
-    }
+    for await (const chunk of source) {}
   }, common.mustCall((err) => {
     assert.strictEqual(err.message, 'kaboom');
   }));
@@ -703,7 +699,6 @@ const net = require('net');
     yield 'world';
   }, s, async function(source) {
     for await (const chunk of source) {
-      chunk;
       throw new Error('kaboom');
     }
   }, common.mustCall((err, val) => {
@@ -718,7 +713,6 @@ const net = require('net');
     return ['hello', 'world'];
   }, s, async function*(source) {
     for await (const chunk of source) {
-      chunk;
       throw new Error('kaboom');
     }
   }, common.mustCall((err) => {

--- a/test/parallel/test-stream-readable-async-iterators.js
+++ b/test/parallel/test-stream-readable-async-iterators.js
@@ -62,8 +62,7 @@ async function tests() {
     });
 
     await (async () => {
-      for await (const d of readable) {
-        d;
+      for await (const d of readable) { // eslint-disable-line no-unused-vars
         return;
       }
     })();
@@ -595,9 +594,7 @@ async function tests() {
       }
     });
 
-    for await (const chunk of r) {
-      chunk;
-    }
+    for await (const chunk of r) {} // eslint-disable-line no-unused-vars
     assert.strictEqual(r.destroyed, false);
   }
 
@@ -612,8 +609,7 @@ async function tests() {
       }
     });
 
-    for await (const chunk of r) {
-      chunk;
+    for await (const chunk of r) { // eslint-disable-line no-unused-vars
       break;
     }
     assert.strictEqual(r.destroyed, true);
@@ -631,9 +627,7 @@ async function tests() {
       assert.strictEqual(r.destroyed, false);
     });
 
-    for await (const chunk of r) {
-      chunk;
-    }
+    for await (const chunk of r) {} // eslint-disable-line no-unused-vars
 
     assert.strictEqual(r.destroyed, true);
   }
@@ -717,9 +711,8 @@ async function tests() {
 
         let _err;
         try {
-          for await (const chunk of res) {
-            chunk;
-          }
+          // eslint-disable-next-line no-unused-vars
+          for await (const chunk of res) {}
         } catch (err) {
           _err = err;
         }

--- a/test/parallel/test-tls-external-accessor.js
+++ b/test/parallel/test-tls-external-accessor.js
@@ -12,11 +12,11 @@ const tls = require('tls');
   const pctx = tls.createSecureContext().context;
   const cctx = Object.create(pctx);
   assert.throws(() => cctx._external, TypeError);
-  pctx._external;
+  pctx._external; // eslint-disable-line no-unused-expressions
 }
 {
   const pctx = tls.createSecurePair().credentials.context;
   const cctx = Object.create(pctx);
   assert.throws(() => cctx._external, TypeError);
-  pctx._external;
+  pctx._external; // eslint-disable-line no-unused-expressions
 }

--- a/test/parallel/test-trace-events-bootstrap.js
+++ b/test/parallel/test-trace-events-bootstrap.js
@@ -16,7 +16,7 @@ const names = [
 ];
 
 if (process.argv[2] === 'child') {
-  1 + 1;
+  1 + 1; // eslint-disable-line no-unused-expressions
 } else {
   tmpdir.refresh();
 

--- a/test/parallel/test-trace-events-environment.js
+++ b/test/parallel/test-trace-events-environment.js
@@ -21,12 +21,14 @@ const names = new Set([
 ]);
 
 if (process.argv[2] === 'child') {
+  /* eslint-disable no-unused-expressions */
   // This is just so that the child has something to do.
   1 + 1;
   // These ensure that the RunTimers, CheckImmediate, and
   // RunAndClearNativeImmediates appear in the list.
   setImmediate(() => { 1 + 1; });
   setTimeout(() => { 1 + 1; }, 1);
+  /* eslint-enable no-unused-expressions */
 } else {
   tmpdir.refresh();
 

--- a/test/parallel/test-vm-module-errors.js
+++ b/test/parallel/test-vm-module-errors.js
@@ -86,7 +86,7 @@ async function checkModuleState() {
 
   assert.throws(() => {
     const m = new SourceTextModule('');
-    m.error;
+    m.error; // eslint-disable-line no-unused-expressions
   }, {
     code: 'ERR_VM_MODULE_STATUS',
     message: 'Module status must be errored'
@@ -95,7 +95,7 @@ async function checkModuleState() {
   await assert.rejects(async () => {
     const m = await createEmptyLinkedModule();
     await m.evaluate();
-    m.error;
+    m.error; // eslint-disable-line no-unused-expressions
   }, {
     code: 'ERR_VM_MODULE_STATUS',
     message: 'Module status must be errored'
@@ -103,7 +103,7 @@ async function checkModuleState() {
 
   assert.throws(() => {
     const m = new SourceTextModule('');
-    m.namespace;
+    m.namespace; // eslint-disable-line no-unused-expressions
   }, {
     code: 'ERR_VM_MODULE_STATUS',
     message: 'Module status must not be unlinked or linking'

--- a/test/parallel/test-worker-unsupported-things.js
+++ b/test/parallel/test-worker-unsupported-things.js
@@ -40,7 +40,7 @@ if (!process.env.HAS_STARTED_WORKER) {
 
   ['channel', 'connected'].forEach((fn) => {
     assert.throws(() => {
-      process[fn];
+      process[fn]; // eslint-disable-line no-unused-expressions
     }, { code: 'ERR_WORKER_UNSUPPORTED_OPERATION' });
   });
 


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/36246

There are many places where I needed to disable the rule but I think it's still worth to have it. A few real mistakes are fixed thanks to it.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
