### PR TITLE
deps: V8: cherry-pick 86991d0587a1

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.19',
+    'v8_embedder_string': '-node.20',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/builtins/builtins-callsite.cc
+++ b/deps/v8/src/builtins/builtins-callsite.cc
@@ -53,6 +53,22 @@ BUILTIN(CallSitePrototypeGetColumnNumber) {
   return PositiveNumberOrNull(it.Frame()->GetColumnNumber(), isolate);
 }
 
+BUILTIN(CallSitePrototypeGetEnclosingColumnNumber) {
+  HandleScope scope(isolate);
+  CHECK_CALLSITE(recv, "getEnclosingColumnNumber");
+  FrameArrayIterator it(isolate, GetFrameArray(isolate, recv),
+                        GetFrameIndex(isolate, recv));
+  return PositiveNumberOrNull(it.Frame()->GetEnclosingColumnNumber(), isolate);
+}
+
+BUILTIN(CallSitePrototypeGetEnclosingLineNumber) {
+  HandleScope scope(isolate);
+  CHECK_CALLSITE(recv, "getEnclosingLineNumber");
+  FrameArrayIterator it(isolate, GetFrameArray(isolate, recv),
+                        GetFrameIndex(isolate, recv));
+  return PositiveNumberOrNull(it.Frame()->GetEnclosingLineNumber(), isolate);
+}
+
 BUILTIN(CallSitePrototypeGetEvalOrigin) {
   HandleScope scope(isolate);
   CHECK_CALLSITE(recv, "getEvalOrigin");

--- a/deps/v8/src/builtins/builtins-definitions.h
+++ b/deps/v8/src/builtins/builtins-definitions.h
@@ -364,6 +364,8 @@ namespace internal {
                                                                                \
   /* CallSite */                                                               \
   CPP(CallSitePrototypeGetColumnNumber)                                        \
+  CPP(CallSitePrototypeGetEnclosingColumnNumber)                               \
+  CPP(CallSitePrototypeGetEnclosingLineNumber)                                 \
   CPP(CallSitePrototypeGetEvalOrigin)                                          \
   CPP(CallSitePrototypeGetFileName)                                            \
   CPP(CallSitePrototypeGetFunction)                                            \

--- a/deps/v8/src/execution/messages.h
+++ b/deps/v8/src/execution/messages.h
@@ -87,6 +87,9 @@ class StackFrameBase {
   // Return 0-based Wasm function index. Returns -1 for non-Wasm frames.
   virtual int GetWasmFunctionIndex();
 
+  virtual int GetEnclosingColumnNumber() = 0;
+  virtual int GetEnclosingLineNumber() = 0;
+
   // Returns the index of the rejected promise in the Promise combinator input,
   // or -1 if this frame is not a Promise combinator frame.
   virtual int GetPromiseIndex() const = 0;
@@ -132,6 +135,9 @@ class JSStackFrame : public StackFrameBase {
   int GetPosition() const override;
   int GetLineNumber() override;
   int GetColumnNumber() override;
+
+  int GetEnclosingColumnNumber() override;
+  int GetEnclosingLineNumber() override;
 
   int GetPromiseIndex() const override;
 
@@ -183,6 +189,8 @@ class WasmStackFrame : public StackFrameBase {
   int GetPosition() const override;
   int GetLineNumber() override { return 0; }
   int GetColumnNumber() override;
+  int GetEnclosingColumnNumber() override;
+  int GetEnclosingLineNumber() override { return 0; }
   int GetWasmFunctionIndex() override { return wasm_func_index_; }
 
   int GetPromiseIndex() const override { return GetPosition(); }
@@ -230,6 +238,9 @@ class AsmJsWasmStackFrame : public WasmStackFrame {
   int GetPosition() const override;
   int GetLineNumber() override;
   int GetColumnNumber() override;
+
+  int GetEnclosingColumnNumber() override;
+  int GetEnclosingLineNumber() override;
 
  private:
   friend class FrameArrayIterator;

--- a/deps/v8/src/init/bootstrapper.cc
+++ b/deps/v8/src/init/bootstrapper.cc
@@ -4090,6 +4090,10 @@ void Genesis::InitializeCallSiteBuiltins() {
 
   FunctionInfo infos[] = {
       {"getColumnNumber", Builtins::kCallSitePrototypeGetColumnNumber},
+      {"getEnclosingColumnNumber",
+        Builtins::kCallSitePrototypeGetEnclosingColumnNumber},
+      {"getEnclosingLineNumber",
+        Builtins::kCallSitePrototypeGetEnclosingLineNumber},
       {"getEvalOrigin", Builtins::kCallSitePrototypeGetEvalOrigin},
       {"getFileName", Builtins::kCallSitePrototypeGetFileName},
       {"getFunction", Builtins::kCallSitePrototypeGetFunction},

--- a/deps/v8/test/mjsunit/stack-traces.js
+++ b/deps/v8/test/mjsunit/stack-traces.js
@@ -439,3 +439,23 @@ var constructor = new Error().stack[0].constructor;
 assertThrows(() => constructor.call());
 assertThrows(() => constructor.call(
     null, {}, () => undefined, {valueOf() { return 0 }}, false));
+
+// Test stack frames populated with line/column information for both call site
+// and enclosing function:
+Error.prepareStackTrace = function(e, frames) {
+  assertMatches(/stack-traces\.js/, frames[0].getFileName());
+  assertEquals(3, frames[0].getEnclosingColumnNumber());
+  assertEquals(11, frames[0].getColumnNumber());
+  assertTrue(frames[0].getEnclosingLineNumber() < frames[0].getLineNumber());
+}
+try {
+  function a() {
+    b();
+  }
+  function b() {
+    throw Error('hello world');
+  }
+  a();
+} catch (err) {
+  err.stack;
+}

--- a/deps/v8/test/mjsunit/wasm/asm-wasm-stack.js
+++ b/deps/v8/test/mjsunit/wasm/asm-wasm-stack.js
@@ -154,3 +154,18 @@ function generateOverflowWasmFromAsmJs() {
     ['f', 135, 12]   // --
   ]);
 })();
+
+(function EnclosingFunctionOffsets() {
+  const fun = generateWasmFromAsmJs(this, {throwFunc: throwException});
+  assertTrue(%IsWasmCode(fun));
+  let e = null;
+  try {
+    fun(0);
+  } catch (ex) {
+    e = ex;
+  }
+  assertEquals(68, e.stack[2].getLineNumber());
+  assertEquals(15, e.stack[2].getColumnNumber());
+  assertEquals(65, e.stack[2].getEnclosingLineNumber());
+  assertEquals(3, e.stack[2].getEnclosingColumnNumber());
+})();


### PR DESCRIPTION
Adds methods for fetching stack trace information about enclosing function.

Refs #36042

CC: @sokra

Original commit message:

    Reland "stack-trace-api: implement getEnclosingLine/Column"

    This reverts commit 5557a63beb5a53c93e9b590eaf2933e21bcb3768.

    Reason for revert: Sheriff's mistake, failing test was previously flaking.

    Original change's description:
    > Revert "stack-trace-api: implement getEnclosingLine/Column"
    >
    > This reverts commit c48ae2d96cbfdc2216706a5e9a79ae1dce5a638b.
    >
    > Reason for revert: Breaks a profiling test:
    > https://ci.chromium.org/p/v8/builders/ci/V8%20Win32/30010
    >
    > Original change's description:
    > > stack-trace-api: implement getEnclosingLine/Column
    > >
    > > Introduces getEnclosingColumn and getEnclosingLine on CallSite
    > > so that the position can be used to lookup the original symbol
    > > for function when source maps are used.
    > >
    > > BUG=v8:11157
    > >
    > > Change-Id: I06c4c374d172d206579abb170c7b7a2bd3bb159f
    > > Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2547218
    > > Reviewed-by: Jakob Kummerow <jkummerow@chromium.org>
    > > Commit-Queue: Benjamin Coe <bencoe@google.com>
    > > Cr-Commit-Position: refs/heads/master@{#71343}
    >
    > TBR=jkummerow@chromium.org,yangguo@chromium.org,bencoe@google.com
    >
    > Change-Id: Iab5c250c1c4fbdab86971f4a7e40abc8f87cf79c
    > No-Presubmit: true
    > No-Tree-Checks: true
    > No-Try: true
    > Bug: v8:11157
    > Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2555384
    > Reviewed-by: Bill Budge <bbudge@chromium.org>
    > Commit-Queue: Bill Budge <bbudge@chromium.org>
    > Cr-Commit-Position: refs/heads/master@{#71345}

    TBR=bbudge@chromium.org,jkummerow@chromium.org,yangguo@chromium.org,bencoe@google.com

    # Not skipping CQ checks because this is a reland.

    Bug: v8:11157
    Change-Id: I8dba19ceb29a24594469d2cf79626f741dc4cad3
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2555499
    Reviewed-by: Bill Budge <bbudge@chromium.org>
    Commit-Queue: Bill Budge <bbudge@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#71348}

Refs: https://github.com/v8/v8/commit/86991d0587a1f05b973eef8420c0cf48fdaaf915

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
