### PR TITLE
events: support signal in EventTarget

### DIFF
--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -200,10 +200,12 @@ class Listener {
       previous.next = this;
     this.previous = previous;
     this.listener = listener;
+    // TODO(benjamingr) these 4 can be 'flags' to save 3 slots
     this.once = once;
     this.capture = capture;
     this.passive = passive;
     this.isNodeStyleListener = isNodeStyleListener;
+    this.removed = false;
 
     this.callback =
       typeof listener === 'function' ?
@@ -220,6 +222,7 @@ class Listener {
       this.previous.next = this.next;
     if (this.next !== undefined)
       this.next.previous = this.previous;
+    this.removed = true;
   }
 }
 
@@ -269,6 +272,7 @@ class EventTarget {
       once,
       capture,
       passive,
+      signal,
       isNodeStyleListener
     } = validateEventListenerOptions(options);
 
@@ -285,6 +289,17 @@ class EventTarget {
       return;
     }
     type = String(type);
+
+    if (signal) {
+      if (signal.aborted) {
+        return false;
+      }
+      // TODO(benjamingr) make this weak somehow? ideally the signal would
+      // not prevent the event target from GC.
+      signal.addEventListener('abort', () => {
+        this.removeEventListener(type, listener, options);
+      }, { once: true });
+    }
 
     let root = this[kEvents].get(type);
 
@@ -382,6 +397,12 @@ class EventTarget {
       // Cache the next item in case this iteration removes the current one
       next = handler.next;
 
+      if (handler.removed) {
+        // Deal with the case an event is removed while event handlers are
+        // Being processed (removeEventListener called from a listener)
+        handler = next;
+        continue;
+      }
       if (handler.once) {
         handler.remove();
         root.size--;
@@ -550,6 +571,7 @@ function validateEventListenerOptions(options) {
     once: Boolean(options.once),
     capture: Boolean(options.capture),
     passive: Boolean(options.passive),
+    signal: options.signal,
     isNodeStyleListener: Boolean(options[kIsNodeStyleListener])
   };
 }

--- a/test/parallel/test-eventtarget-whatwg-signal.js
+++ b/test/parallel/test-eventtarget-whatwg-signal.js
@@ -1,0 +1,155 @@
+'use strict';
+
+require('../common');
+
+const {
+  strictEqual,
+} = require('assert');
+
+// Manually ported from: wpt@dom/events/AddEventListenerOptions-signal.any.js
+
+{
+  // Passing an AbortSignal to addEventListener does not prevent
+  // removeEventListener
+  let count = 0;
+  function handler() {
+    count++;
+  }
+  const et = new EventTarget();
+  const controller = new AbortController();
+  et.addEventListener('test', handler, { signal: controller.signal });
+  et.dispatchEvent(new Event('test'));
+  strictEqual(count, 1, 'Adding a signal still adds a listener');
+  et.dispatchEvent(new Event('test'));
+  strictEqual(count, 2, 'The listener was not added with the once flag');
+  controller.abort();
+  et.dispatchEvent(new Event('test'));
+  strictEqual(count, 2, 'Aborting on the controller removes the listener');
+  et.addEventListener('test', handler, { signal: controller.signal });
+  et.dispatchEvent(new Event('test'));
+  strictEqual(count, 2, 'Passing an aborted signal never adds the handler');
+}
+
+{
+  // Passing an AbortSignal to addEventListener works with the once flag
+  let count = 0;
+  function handler() {
+    count++;
+  }
+  const et = new EventTarget();
+  const controller = new AbortController();
+  et.addEventListener('test', handler, { signal: controller.signal });
+  et.removeEventListener('test', handler);
+  et.dispatchEvent(new Event('test'));
+  strictEqual(count, 0, 'The listener was still removed');
+}
+
+{
+  // Removing a once listener works with a passed signal
+  let count = 0;
+  function handler() {
+    count++;
+  }
+  const et = new EventTarget();
+  const controller = new AbortController();
+  const options = { signal: controller.signal, once: true };
+  et.addEventListener('test', handler, options);
+  controller.abort();
+  et.dispatchEvent(new Event('test'));
+  strictEqual(count, 0, 'The listener was still removed');
+}
+
+{
+  let count = 0;
+  function handler() {
+    count++;
+  }
+  const et = new EventTarget();
+  const controller = new AbortController();
+  const options = { signal: controller.signal, once: true };
+  et.addEventListener('test', handler, options);
+  et.removeEventListener('test', handler);
+  et.dispatchEvent(new Event('test'));
+  strictEqual(count, 0, 'The listener was still removed');
+}
+
+{
+  // Passing an AbortSignal to multiple listeners
+  let count = 0;
+  function handler() {
+    count++;
+  }
+  const et = new EventTarget();
+  const controller = new AbortController();
+  const options = { signal: controller.signal, once: true };
+  et.addEventListener('first', handler, options);
+  et.addEventListener('second', handler, options);
+  controller.abort();
+  et.dispatchEvent(new Event('first'));
+  et.dispatchEvent(new Event('second'));
+  strictEqual(count, 0, 'The listener was still removed');
+}
+
+{
+  // Passing an AbortSignal to addEventListener works with the capture flag
+  let count = 0;
+  function handler() {
+    count++;
+  }
+  const et = new EventTarget();
+  const controller = new AbortController();
+  const options = { signal: controller.signal, capture: true };
+  et.addEventListener('test', handler, options);
+  controller.abort();
+  et.dispatchEvent(new Event('test'));
+  strictEqual(count, 0, 'The listener was still removed');
+}
+
+{
+  // Aborting from a listener does not call future listeners
+  let count = 0;
+  function handler() {
+    count++;
+  }
+  const et = new EventTarget();
+  const controller = new AbortController();
+  const options = { signal: controller.signal };
+  et.addEventListener('test', () => {
+    controller.abort();
+  }, options);
+  et.addEventListener('test', handler, options);
+  et.dispatchEvent(new Event('test'));
+  strictEqual(count, 0, 'The listener was still removed');
+}
+
+{
+  // Adding then aborting a listener in another listener does not call it
+  let count = 0;
+  function handler() {
+    count++;
+  }
+  const et = new EventTarget();
+  const controller = new AbortController();
+  et.addEventListener('test', () => {
+    et.addEventListener('test', handler, { signal: controller.signal });
+    controller.abort();
+  }, { signal: controller.signal });
+  et.dispatchEvent(new Event('test'));
+  strictEqual(count, 0, 'The listener was still removed');
+}
+
+{
+  // Aborting from a nested listener should remove it
+  const et = new EventTarget();
+  const ac = new AbortController();
+  let count = 0;
+  et.addEventListener('foo', () => {
+    et.addEventListener('foo', () => {
+      count++;
+      if (count > 5) ac.abort();
+      et.dispatchEvent(new Event('foo'));
+    }, { signal: ac.signal });
+    et.dispatchEvent(new Event('foo'));
+  }, { once: true });
+  et.dispatchEvent(new Event('foo'));
+}

--- a/test/parallel/test-eventtarget.js
+++ b/test/parallel/test-eventtarget.js
@@ -532,3 +532,12 @@ let asyncTest = Promise.resolve();
   target.dispatchEvent(new Event('foo'));
   deepStrictEqual(output, [1, 2, 3, 4]);
 }
+{
+  const et = new EventTarget();
+  const listener = common.mustNotCall();
+  et.addEventListener('foo', common.mustCall((e) => {
+    et.removeEventListener('foo', listener);
+  }));
+  et.addEventListener('foo', listener);
+  et.dispatchEvent(new Event('foo'));
+}


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/36073

This is this feature https://github.com/whatwg/dom/issues/911 I've implemented the spec I worked on in https://github.com/whatwg/dom/pull/919 and ported the WPTs from https://github.com/web-platform-tests/wpt/pull/26472 

This is following implementations from Chrome and Firefox and positive signals regarding the spec. I am happy to put this behind an experimental warning if you think that's a good idea.

Ping @jasnell 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
