### PR TITLE
module: add isPreloading indicator

### DIFF
--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -76,6 +76,14 @@ const requireUtil = createRequireFromPath('../src/utils/');
 requireUtil('./some-tool');
 ```
 
+### `module.isPreloading`
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {boolean} `true` if the module is running during the Node.js preload
+  phase.
+
 ### `module.syncBuiltinESMExports()`
 <!-- YAML
 added: v12.12.0

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -139,6 +139,7 @@ const relativeResolveCache = ObjectCreate(null);
 
 let requireDepth = 0;
 let statCache = null;
+let isPreloading = false;
 
 function stat(filename) {
   filename = path.toNamespacedPath(filename);
@@ -229,6 +230,10 @@ ObjectDefineProperty(Module, 'wrapper', {
     patched = true;
     wrapperProxy = value;
   }
+});
+
+ObjectDefineProperty(Module.prototype, 'isPreloading', {
+  get() { return isPreloading; }
 });
 
 function getModuleParent() {
@@ -1243,6 +1248,8 @@ Module._preloadModules = function(requests) {
   if (!ArrayIsArray(requests))
     return;
 
+  isPreloading = true;
+
   // Preloaded modules have a dummy parent module which is deemed to exist
   // in the current working directory. This seeds the search path for
   // preloaded modules.
@@ -1251,11 +1258,13 @@ Module._preloadModules = function(requests) {
     parent.paths = Module._nodeModulePaths(process.cwd());
   } catch (e) {
     if (e.code !== 'ENOENT') {
+      isPreloading = false;
       throw e;
     }
   }
   for (let n = 0; n < requests.length; n++)
     parent.require(requests[n]);
+  isPreloading = false;
 };
 
 Module.syncBuiltinESMExports = function syncBuiltinESMExports() {

--- a/test/fixtures/ispreloading.js
+++ b/test/fixtures/ispreloading.js
@@ -1,0 +1,2 @@
+const assert = require('assert');
+assert(module.isPreloading);

--- a/test/parallel/test-preload.js
+++ b/test/parallel/test-preload.js
@@ -27,6 +27,19 @@ const fixtureE = fixtures.path('intrinsic-mutation.js');
 const fixtureF = fixtures.path('print-intrinsic-mutation-name.js');
 const fixtureG = fixtures.path('worker-from-argv.js');
 const fixtureThrows = fixtures.path('throws_error4.js');
+const fixtureIsPreloading = fixtures.path('ispreloading.js');
+
+// Assert that module.isPreloading is false here
+assert(!module.isPreloading);
+
+// Test that module.isPreloading is set in preloaded module
+// Test preloading a single module works
+childProcess.exec(
+  `"${nodeBinary}" ${preloadOption([fixtureIsPreloading])} "${fixtureB}"`,
+  function(err, stdout, stderr) {
+    assert.ifError(err);
+    assert.strictEqual(stdout, 'B\n');
+  });
 
 // Test preloading a single module works
 childProcess.exec(`"${nodeBinary}" ${preloadOption([fixtureA])} "${fixtureB}"`,


### PR DESCRIPTION
Adds a `module.isPreloading` property that is `true` only during the
preload (`-r`) phase of Node.js bootstrap. This provides modules an
easy, non-hacky way of knowing if they are being loaded during preload.

For example, `sample.js`:

```js
console.log(module.isPreloading);
```

```sh
$ node -r sample.js -pe ""
true
undefined
```

```sh
$ node sample.js
false
```

Signed-off-by: James M Snell <jasnell@gmail.com>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
