### PR TITLE
workers: experimental BroadcastChannel

### DIFF
--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -274,6 +274,98 @@ if (isMainThread) {
 }
 ```
 
+## Class: `BroadcastChannel extends EventTarget`
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+Instances of `BroadcastChannel` allow asynchronous one-to-many communication
+with all other `BroadcastChannel` instances bound to the same channel name.
+
+```js
+'use strict';
+
+const {
+  isMainThread,
+  BroadcastChannel,
+  Worker
+} = require('worker_threads');
+
+const bc = new BroadcastChannel('hello');
+
+if (isMainThread) {
+  let c = 0;
+  bc.onmessage = (event) => {
+    console.log(event.data);
+    if (++c === 10) bc.close();
+  };
+  for (let n = 0; n < 10; n++)
+    new Worker(__filename);
+} else {
+  bc.postMessage('hello from every worker');
+  bc.close();
+}
+```
+
+### `new BroadcastChannel(name)`
+<!-- YAML
+added: REPLACEME
+-->
+
+* `name` {any} The name of the channel to connect to. Any JavaScript value
+  that can be converted to a string using ``${name}`` is permitted.
+
+### `broadcastChannel.close()`
+<!-- YAML
+added: REPLACEME
+-->
+
+Closes the `BroadcastChannel` connection.
+
+### `broadcastChannel.onmessage`
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {Function} Invoked with a single `MessageEvent` argument
+  when a message is received.
+
+### `broadcastChannel.onmessageerror`
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {Function} Invoked with a received message cannot be
+  deserialized.
+
+### `broadcastChannel.postMessage(message)`
+<!-- YAML
+added: REPLACEME
+-->
+
+* `message` {any} Any cloneable JavaScript value.
+
+### `broadcastChannel.ref()`
+<!-- YAML
+added: REPLACEME
+-->
+
+Opposite of `unref()`. Calling `ref()` on a previously `unref()`ed
+BroadcastChannel will *not* let the program exit if it's the only active handle
+left (the default behavior). If the port is `ref()`ed, calling `ref()` again
+will have no effect.
+
+### `broadcastChannel.unref()`
+<!-- YAML
+added: REPLACEME
+-->
+
+Calling `unref()` on a BroadcastChannel will allow the thread to exit if this
+is the only active handle in the event system. If the BroadcastChannel is
+already `unref()`ed calling `unref()` again will have no effect.
+
 ## Class: `MessageChannel`
 <!-- YAML
 added: v10.5.0

--- a/lib/internal/worker/io.js
+++ b/lib/internal/worker/io.js
@@ -19,11 +19,13 @@ const {
 const {
   MessagePort,
   MessageChannel,
+  broadcastChannel,
   drainMessagePort,
   moveMessagePortToContext,
   receiveMessageOnPort: receiveMessageOnPort_,
   stopMessagePort,
-  checkMessagePort
+  checkMessagePort,
+  DOMException,
 } = internalBinding('messaging');
 const {
   getEnvMessagePort
@@ -41,14 +43,20 @@ const {
 } = require('internal/event_target');
 const { inspect } = require('internal/util/inspect');
 const {
-  ERR_INVALID_ARG_TYPE
-} = require('internal/errors').codes;
+  codes: {
+    ERR_INVALID_ARG_TYPE,
+    ERR_MISSING_ARGS,
+  }
+} = require('internal/errors');
 
 const kData = Symbol('kData');
+const kHandle = Symbol('kHandle');
 const kIncrementsPortRef = Symbol('kIncrementsPortRef');
 const kLastEventId = Symbol('kLastEventId');
 const kName = Symbol('kName');
 const kOrigin = Symbol('kOrigin');
+const kOnMessage = Symbol('kOnMessage');
+const kOnMessageError = Symbol('kOnMessageError');
 const kPort = Symbol('kPort');
 const kPorts = Symbol('kPorts');
 const kWaitingStreams = Symbol('kWaitingStreams');
@@ -324,6 +332,76 @@ function receiveMessageOnPort(port) {
   return { message };
 }
 
+function onMessageEvent(type, data) {
+  this.dispatchEvent(new MessageEvent(type, { data }));
+}
+
+class BroadcastChannel extends EventTarget {
+  constructor(name) {
+    if (arguments.length === 0)
+      throw new ERR_MISSING_ARGS('name');
+    super();
+    this[kName] = `${name}`;
+    this[kHandle] = broadcastChannel(this[kName]);
+    this[kOnMessage] = onMessageEvent.bind(this, 'message');
+    this[kOnMessageError] = onMessageEvent.bind(this, 'messageerror');
+    this[kHandle].on('message', this[kOnMessage]);
+    this[kHandle].on('messageerror', this[kOnMessageError]);
+  }
+
+  [inspect.custom](depth, options) {
+    if (depth < 0)
+      return 'BroadcastChannel';
+
+    const opts = {
+      ...options,
+      depth: options.depth == null ? null : options.depth - 1
+    };
+
+    return `BroadcastChannel ${inspect({
+      name: this[kName],
+      active: this[kHandle] !== undefined,
+    }, opts)}`;
+  }
+
+  get name() { return this[kName]; }
+
+  close() {
+    if (this[kHandle] === undefined)
+      return;
+    this[kHandle].off('message', this[kOnMessage]);
+    this[kHandle].off('messageerror', this[kOnMessageError]);
+    this[kOnMessage] = undefined;
+    this[kOnMessageError] = undefined;
+    this[kHandle].close();
+    this[kHandle] = undefined;
+  }
+
+  postMessage(message) {
+    if (arguments.length === 0)
+      throw new ERR_MISSING_ARGS('message');
+    if (this[kHandle] === undefined)
+      throw new DOMException('BroadcastChannel is closed.');
+    if (this[kHandle].postMessage(message) === undefined)
+      throw new DOMException('Message could not be posted.');
+  }
+
+  ref() {
+    if (this[kHandle])
+      this[kHandle].ref();
+    return this;
+  }
+
+  unref() {
+    if (this[kHandle])
+      this[kHandle].unref();
+    return this;
+  }
+}
+
+defineEventHandler(BroadcastChannel.prototype, 'message');
+defineEventHandler(BroadcastChannel.prototype, 'messageerror');
+
 module.exports = {
   drainMessagePort,
   messageTypes,
@@ -339,5 +417,6 @@ module.exports = {
   setupPortReferencing,
   ReadableWorkerStdio,
   WritableWorkerStdio,
-  createWorkerStdio
+  createWorkerStdio,
+  BroadcastChannel,
 };

--- a/lib/worker_threads.js
+++ b/lib/worker_threads.js
@@ -13,6 +13,7 @@ const {
   MessageChannel,
   moveMessagePortToContext,
   receiveMessageOnPort,
+  BroadcastChannel,
 } = require('internal/worker/io');
 
 const {
@@ -32,4 +33,5 @@ module.exports = {
   Worker,
   parentPort: null,
   workerData: null,
+  BroadcastChannel,
 };

--- a/test/parallel/test-worker-broadcastchannel-wpt.js
+++ b/test/parallel/test-worker-broadcastchannel-wpt.js
@@ -1,0 +1,148 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const {
+  BroadcastChannel,
+} = require('worker_threads');
+
+{
+  const c1 = new BroadcastChannel('eventType').unref();
+  const c2 = new BroadcastChannel('eventType');
+
+  c2.onmessage = common.mustCall((e) => {
+    assert(e instanceof MessageEvent);
+    assert.strictEqual(e.target, c2);
+    assert.strictEqual(e.type, 'message');
+    assert.strictEqual(e.data, 'hello world');
+    c2.close();
+  });
+  c1.postMessage('hello world');
+}
+
+{
+  // Messages are delivered in port creation order.
+  // TODO(@jasnell): The ordering here is different than
+  // what the browsers would implement due to the different
+  // dispatching algorithm under the covers. What's not
+  // immediately clear is whether the ordering is spec
+  // mandated. In this test, c1 should receive events
+  // first, then c2, then c3. In the Node.js dispatching
+  // algorithm this means the ordering is:
+  //    from c3    (c1 from c3)
+  //    done       (c1 from c2)
+  //    from c1    (c2 from c1)
+  //    from c3    (c2 from c3)
+  //    from c1    (c3 from c1)
+  //    done       (c3 from c2)
+  //
+  // Whereas in the browser-ordering (as illustrated in the
+  // Web Platform Tests) it would be:
+  //    from c1    (c2 from c1)
+  //    from c1    (c3 from c1)
+  //    from c3    (c1 from c3)
+  //    from c3    (c2 from c3)
+  //    done       (c1 from c2)
+  //    done       (c3 from c2)
+  const c1 = new BroadcastChannel('order');
+  const c2 = new BroadcastChannel('order');
+  const c3 = new BroadcastChannel('order');
+
+  const events = [];
+  let doneCount = 0;
+  const handler = common.mustCall((e) => {
+    events.push(e);
+    if (e.data === 'done') {
+      doneCount++;
+      if (doneCount === 2) {
+        assert.strictEqual(events.length, 6);
+        assert.strictEqual(events[0].data, 'from c3');
+        assert.strictEqual(events[1].data, 'done');
+        assert.strictEqual(events[2].data, 'from c1');
+        assert.strictEqual(events[3].data, 'from c3');
+        assert.strictEqual(events[4].data, 'from c1');
+        assert.strictEqual(events[5].data, 'done');
+        c1.close();
+        c2.close();
+        c3.close();
+      }
+    }
+  }, 6);
+  c1.onmessage = handler;
+  c2.onmessage = handler;
+  c3.onmessage = handler;
+
+  c1.postMessage('from c1');
+  c3.postMessage('from c3');
+  c2.postMessage('done');
+}
+
+{
+  // Messages aren't delivered to a closed port
+  const c1 = new BroadcastChannel('closed1').unref();
+  const c2 = new BroadcastChannel('closed1');
+  const c3 = new BroadcastChannel('closed1');
+
+  c2.onmessage = common.mustNotCall();
+  c2.close();
+  c3.onmessage = common.mustCall(() => c3.close());
+  c1.postMessage('test');
+}
+
+{
+  // Messages aren't delivered to a port closed after calling postMessage.
+  const c1 = new BroadcastChannel('closed2').unref();
+  const c2 = new BroadcastChannel('closed2');
+  const c3 = new BroadcastChannel('closed2');
+
+  c2.onmessage = common.mustNotCall();
+  c3.onmessage = common.mustCall(() => c3.close());
+  c1.postMessage('test');
+  c2.close();
+}
+
+{
+  // Closing and creating channels during message delivery works correctly
+  const c1 = new BroadcastChannel('create-in-onmessage').unref();
+  const c2 = new BroadcastChannel('create-in-onmessage');
+
+  c2.onmessage = common.mustCall((e) => {
+    assert.strictEqual(e.data, 'first');
+    c2.close();
+    const c3 = new BroadcastChannel('create-in-onmessage');
+    c3.onmessage = common.mustCall((event) => {
+      assert.strictEqual(event.data, 'done');
+      c3.close();
+    });
+    c1.postMessage('done');
+  });
+  c1.postMessage('first');
+  c2.postMessage('second');
+}
+
+{
+  // Closing a channel in onmessage prevents already queued tasks
+  // from firing onmessage events
+  const c1 = new BroadcastChannel('close-in-onmessage2').unref();
+  const c2 = new BroadcastChannel('close-in-onmessage2');
+  const c3 = new BroadcastChannel('close-in-onmessage2');
+  const events = [];
+  c1.onmessage = (e) => events.push('c1: ' + e.data);
+  c2.onmessage = (e) => events.push('c2: ' + e.data);
+  c3.onmessage = (e) => events.push('c3: ' + e.data);
+
+  // c2 closes itself when it receives the first message
+  c2.addEventListener('message', common.mustCall(() => c2.close()));
+
+  c3.addEventListener('message', common.mustCall((e) => {
+    if (e.data === 'done') {
+      assert.deepStrictEqual(events, [
+        'c2: first',
+        'c3: first',
+        'c3: done']);
+      c3.close();
+    }
+  }, 2));
+  c1.postMessage('first');
+  c1.postMessage('done');
+}

--- a/test/parallel/test-worker-broadcastchannel.js
+++ b/test/parallel/test-worker-broadcastchannel.js
@@ -1,0 +1,135 @@
+'use strict';
+
+const common = require('../common');
+const {
+  BroadcastChannel,
+  Worker,
+} = require('worker_threads');
+const assert = require('assert');
+
+assert.throws(() => new BroadcastChannel(Symbol('test')), {
+  message: /Cannot convert a Symbol value to a string/
+});
+
+assert.throws(() => new BroadcastChannel(), {
+  message: /The "name" argument must be specified/
+});
+
+// These should all just work
+[undefined, 1, null, 'test', 1n, false, Infinity].forEach((i) => {
+  const bc = new BroadcastChannel(i);
+  assert.strictEqual(bc.name, `${i}`);
+  bc.close();
+});
+
+{
+  // Empty postMessage throws
+  const bc = new BroadcastChannel('whatever');
+  assert.throws(() => bc.postMessage(), {
+    message: /The "message" argument must be specified/
+  });
+  bc.close();
+  // Calling close multiple times should not throw
+  bc.close();
+
+  // Calling postMessage after close should throw
+  assert.throws(() => bc.postMessage(null), {
+    message: /BroadcastChannel is closed/
+  });
+}
+
+{
+  const bc1 = new BroadcastChannel('channel1');
+  const bc2 = new BroadcastChannel('channel1');
+  const bc3 = new BroadcastChannel('channel1');
+  const bc4 = new BroadcastChannel('channel2');
+  assert.strictEqual(bc1.name, 'channel1');
+  assert.strictEqual(bc2.name, 'channel1');
+  assert.strictEqual(bc3.name, 'channel1');
+  assert.strictEqual(bc4.name, 'channel2');
+  bc1.addEventListener('message', common.mustCall((event) => {
+    assert.strictEqual(event.data, 'hello');
+    bc1.close();
+    bc2.close();
+    bc4.close();
+  }));
+  bc3.addEventListener('message', common.mustCall((event) => {
+    assert.strictEqual(event.data, 'hello');
+    bc3.close();
+  }));
+  bc2.addEventListener('message', common.mustNotCall());
+  bc4.addEventListener('message', common.mustNotCall());
+  bc2.postMessage('hello');
+}
+
+{
+  const bc1 = new BroadcastChannel('onmessage-channel1');
+  const bc2 = new BroadcastChannel('onmessage-channel1');
+  const bc3 = new BroadcastChannel('onmessage-channel1');
+  const bc4 = new BroadcastChannel('onmessage-channel2');
+  assert.strictEqual(bc1.name, 'onmessage-channel1');
+  assert.strictEqual(bc2.name, 'onmessage-channel1');
+  assert.strictEqual(bc3.name, 'onmessage-channel1');
+  assert.strictEqual(bc4.name, 'onmessage-channel2');
+  bc1.onmessage = common.mustCall((event) => {
+    assert.strictEqual(event.data, 'hello');
+    bc1.close();
+    bc2.close();
+    bc4.close();
+  });
+  bc3.onmessage = common.mustCall((event) => {
+    assert.strictEqual(event.data, 'hello');
+    bc3.close();
+  });
+  bc2.onmessage = common.mustNotCall();
+  bc4.onmessage = common.mustNotCall();
+  bc2.postMessage('hello');
+}
+
+{
+  const bc = new BroadcastChannel('worker1');
+  new Worker(`
+    const assert = require('assert');
+    const { BroadcastChannel } = require('worker_threads');
+    const bc = new BroadcastChannel('worker1');
+    bc.addEventListener('message', (event) => {
+      assert.strictEqual(event.data, 123);
+      // If this close() is not executed, the test should hang and timeout.
+      // If the test does hang and timeout in CI, then the first step should
+      // be to check that the two bc.close() calls are being made.
+      bc.close();
+    });
+    bc.postMessage(321);
+  `, { eval: true });
+  bc.addEventListener('message', common.mustCall(({ data }) => {
+    assert.strictEqual(data, 321);
+    bc.postMessage(123);
+    bc.close();
+  }));
+}
+
+{
+  const bc1 = new BroadcastChannel('channel3');
+  const bc2 = new BroadcastChannel('channel3');
+  bc2.postMessage(new SharedArrayBuffer(10));
+  bc1.addEventListener('message', common.mustCall(({ data }) => {
+    assert(data instanceof SharedArrayBuffer);
+    bc1.close();
+    bc2.close();
+  }));
+}
+
+{
+  const bc1 = new BroadcastChannel('channel3');
+  const mc = new MessageChannel();
+  assert.throws(() => bc1.postMessage(mc), {
+    message: /Object that needs transfer was found/
+  });
+  assert.throws(() => bc1.postMessage(Symbol()), {
+    message: /Symbol\(\) could not be cloned/
+  });
+  bc1.close();
+  assert.throws(() => bc1.postMessage(Symbol()), {
+    message: /BroadcastChannel is closed/
+  });
+}

--- a/tools/doc/type-parser.js
+++ b/tools/doc/type-parser.js
@@ -40,6 +40,10 @@ const customTypesMap = {
   'WebAssembly.Instance':
     `${jsDocPrefix}Reference/Global_Objects/WebAssembly/Instance`,
 
+  'BroadcastChannel':
+    'worker_threads.html#worker_threads_class_broadcastchannel_' +
+    'extends_eventtarget',
+
   'Iterable':
     `${jsDocPrefix}Reference/Iteration_protocols#The_iterable_protocol`,
   'Iterator':


### PR DESCRIPTION
Currently very experimental and definitely not finished implementation of [`BroadcastChannel`](https://developer.mozilla.org/en-US/docs/Web/API/Broadcast_Channel_API) for Node.js.

The intent for this is for it to be completely compatible with the browser API. It's not there yet.

For folks who are not familiar with `BroadcastChannel`, it is essentially a one-to-many alternative to `MessageChannel`.

```js
'use strict';

const {
  isMainThread,
  BroadcastChannel,
  Worker
} = require('worker_threads');

const bc = new BroadcastChannel('hello');

if (isMainThread) {
  let c = 0;
  bc.onmessage = (event) => {
    console.log(event.data);
    if (++c === 10) bc.close();
  };
  for (let n = 0; n < 10; n++)
    new Worker(__filename);
} else {
  bc.postMessage('hello from every worker');
  bc.close();
}
```

All `BroadcastChannel` instances that share the same channel name, created in the main thread or worker threads, will receive a copy of the posted message.

Message delivery is at-most once, with no retention. When a message is posted, it is synchronously copied and queued into each of the other instances. Those other instances will deliver the message copy asynchronously.

Transferables are not supported with `BroadcastChannel`, so only messages that can be cloned are supported.

One use case of `BroadcastChannel` is to signal a group of worker threads that a process is shutting down, without having to send individual signals to each worker:

Worker:
```js
const bc = new BroadcastChannel('pool-controller');
bc.onmessage = (({data}) => {
  if (data.shutdown)
    console.log('Shutting down!');
  bc.postMessage({done:true});
};

// Do worker stuff...
```

Main:
```js
const bc = new BroadcastChannel('pool-controller');
bc.onmessage = ({data}) => console.log(data.done);
new Worker('worker.js');
setTimeout(() => bc.postMessage({shutdown:true}), 1000);
```

@addaleax: I'd be interested in your opinions on how to improve the C++ part of the implementation.
@benjamingr: I'd be interested in your thoughts on the JavaScript side of the implementation.

This is definitely a work in progress still, motivated by some needs around [Piscina](https://github.com/piscinajs/piscina).



##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
