### PR TITLE
tools: fix undeclared identifier FALSE

### DIFF
--- a/tools/icu/iculslocs.cc
+++ b/tools/icu/iculslocs.cc
@@ -150,7 +150,7 @@ int localeExists(const char* loc, UBool* exists) {
   }
   icu::LocalUResourceBundlePointer aResource(
       ures_openDirect(packageName.data(), loc, &status));
-  *exists = FALSE;
+  *exists = false;
   if (U_SUCCESS(status)) {
     *exists = true;
     if (VERBOSE > 1) {


### PR DESCRIPTION
I'm getting an error when trying to compile `master` with small ICU:

```
../tools/icu/iculslocs.cc:153:13: error: use of undeclared identifier 'FALSE'
  *exists = FALSE;
            ^
1 error generated.
```

The rest of the file is using `false` instead of `FALSE`, this seems to be an error so here's the fix.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
