### PR TITLE
stdio: implement manual start for ReadStream

### DIFF
--- a/lib/internal/bootstrap/switches/is_main_thread.js
+++ b/lib/internal/bootstrap/switches/is_main_thread.js
@@ -157,7 +157,11 @@ function getStdin() {
 
     case 'FILE':
       const fs = require('fs');
-      stdin = new fs.ReadStream(null, { fd: fd, autoClose: false });
+      stdin = new fs.ReadStream(null, {
+        fd: fd,
+        autoClose: false,
+        manualStart: true
+      });
       break;
 
     case 'PIPE':

--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -203,7 +203,8 @@ function Readable(options) {
   Stream.call(this, options);
 
   destroyImpl.construct(this, () => {
-    maybeReadMore(this, this._readableState);
+    if (!options || !options.manualStart)
+      maybeReadMore(this, this._readableState);
   });
 }
 

--- a/test/parallel/test-stdin-from-file-spawn.js
+++ b/test/parallel/test-stdin-from-file-spawn.js
@@ -1,0 +1,34 @@
+'use strict';
+const common = require('../common');
+const process = require('process');
+if (process.platform !== 'linux' && process.platform !== 'darwin')
+  common.skip('This is an UNIX-only test');
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const tmpdir = require('../common/tmpdir');
+
+const tmpDir = tmpdir.path;
+tmpdir.refresh();
+const tmpCmdFile = path.join(tmpDir, 'test-stdin-from-file-spawn-cmd');
+const tmpJsFile = path.join(tmpDir, 'test-stdin-from-file-spawn.js');
+fs.writeFileSync(tmpCmdFile, 'echo hello');
+fs.writeFileSync(tmpJsFile, `
+'use strict';
+const { spawn } = require('child_process');
+// Reference the object to invoke the getter
+process.stdin;
+setTimeout(() => {
+  let ok = false;
+  const child = spawn(process.env.SHELL, [], { stdio: ['inherit', 'pipe'] });
+  child.stdout.on('data', () => {
+    ok = true;
+  });
+  child.on('close', () => {
+    process.exit(ok ? 0 : -1);
+  });
+}, 100);
+`);
+
+execSync(`${process.argv[0]} ${tmpJsFile} < ${tmpCmdFile}`);

--- a/test/parallel/test-stdin-from-file-spawn.js
+++ b/test/parallel/test-stdin-from-file-spawn.js
@@ -1,8 +1,15 @@
 'use strict';
 const common = require('../common');
 const process = require('process');
-if (process.platform !== 'linux' && process.platform !== 'darwin')
-  common.skip('This is an UNIX-only test');
+
+let defaultShell;
+if (process.platform === 'linux' || process.platform === 'darwin') {
+  defaultShell = '/bin/sh';
+} else if (process.platform === 'win32') {
+  defaultShell = 'cmd.exe';
+} else {
+  common.skip('This is test exists only on Linux/Win32/OSX');
+}
 
 const { execSync } = require('child_process');
 const fs = require('fs');
@@ -21,7 +28,8 @@ const { spawn } = require('child_process');
 process.stdin;
 setTimeout(() => {
   let ok = false;
-  const child = spawn(process.env.SHELL, [], { stdio: ['inherit', 'pipe'] });
+  const child = spawn(process.env.SHELL || '${defaultShell}',
+    [], { stdio: ['inherit', 'pipe'] });
   child.stdout.on('data', () => {
     ok = true;
   });

--- a/test/parallel/test-stream-manualstart.js
+++ b/test/parallel/test-stream-manualstart.js
@@ -1,0 +1,20 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const fs = require('fs');
+
+fs.promises.open(__filename).then(common.mustCall((fd) => {
+  const rs = new fs.ReadStream(null, {
+    fd: fd,
+    manualStart: false
+  });
+  setTimeout(() => assert(rs.bytesRead > 0), common.platformTimeout(10));
+}));
+
+fs.promises.open(__filename).then(common.mustCall((fd) => {
+  const rs = new fs.ReadStream(null, {
+    fd: fd,
+    manualStart: true
+  });
+  setTimeout(() => assert(rs.bytesRead === 0), common.platformTimeout(10));
+}));


### PR DESCRIPTION
All stdio ReadStream's use manual start to avoid
consuming data for example when a process
execs/spawns

Refs: https://github.com/nodejs/node/issues/36251

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
