### PR TITLE
test: simplify test-fs-watch.js

### DIFF
--- a/test/parallel/test-fs-watch.js
+++ b/test/parallel/test-fs-watch.js
@@ -10,12 +10,14 @@ const fs = require('fs');
 const assert = require('assert');
 const { join } = require('path');
 
+const expectFilename =
+  common.isLinux || common.isOSX || common.isWindows || common.isAIX;
+
 class WatchTestCase {
-  constructor(shouldInclude, dirName, fileName, field) {
+  constructor(dirName, fileName, field) {
     this.dirName = dirName;
     this.fileName = fileName;
     this.field = field;
-    this.shouldSkip = !shouldInclude;
   }
   get dirPath() { return join(tmpdir.path, this.dirName); }
   get filePath() { return join(this.dirPath, this.fileName); }
@@ -24,14 +26,12 @@ class WatchTestCase {
 const cases = [
   // Watch on a directory should callback with a filename on supported systems
   new WatchTestCase(
-    common.isLinux || common.isOSX || common.isWindows || common.isAIX,
     'watch1',
     'foo',
     'filePath'
   ),
   // Watch on a file should callback with a filename on supported systems
   new WatchTestCase(
-    common.isLinux || common.isOSX || common.isWindows,
     'watch2',
     'bar',
     'dirPath'
@@ -41,50 +41,51 @@ const cases = [
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 
-for (const testCase of cases) {
-  if (testCase.shouldSkip) continue;
-  fs.mkdirSync(testCase.dirPath);
-  // Long content so it's actually flushed.
-  const content1 = Date.now() + testCase.fileName.toLowerCase().repeat(1e4);
-  fs.writeFileSync(testCase.filePath, content1);
+if (expectFilename) {
+  for (const testCase of cases) {
+    fs.mkdirSync(testCase.dirPath);
+    // Long content so it's actually flushed.
+    const content1 = Date.now() + testCase.fileName.toLowerCase().repeat(1e4);
+    fs.writeFileSync(testCase.filePath, content1);
 
-  let interval;
-  const pathToWatch = testCase[testCase.field];
-  const watcher = fs.watch(pathToWatch);
-  watcher.on('error', (err) => {
-    if (interval) {
-      clearInterval(interval);
-      interval = null;
-    }
-    assert.fail(err);
-  });
-  watcher.on('close', common.mustCall(() => {
-    watcher.close(); // Closing a closed watcher should be a noop
-  }));
-  watcher.on('change', common.mustCall(function(eventType, argFilename) {
-    if (interval) {
-      clearInterval(interval);
-      interval = null;
-    }
-    if (common.isOSX)
-      assert.strictEqual(['rename', 'change'].includes(eventType), true);
-    else
-      assert.strictEqual(eventType, 'change');
-    assert.strictEqual(argFilename, testCase.fileName);
+    let interval;
+    const pathToWatch = testCase[testCase.field];
+    const watcher = fs.watch(pathToWatch);
+    watcher.on('error', (err) => {
+      if (interval) {
+        clearInterval(interval);
+        interval = null;
+      }
+      assert.fail(err);
+    });
+    watcher.on('close', common.mustCall(() => {
+      watcher.close(); // Closing a closed watcher should be a noop
+    }));
+    watcher.on('change', common.mustCall(function(eventType, argFilename) {
+      if (interval) {
+        clearInterval(interval);
+        interval = null;
+      }
+      if (common.isOSX)
+        assert.strictEqual(['rename', 'change'].includes(eventType), true);
+      else
+        assert.strictEqual(eventType, 'change');
+      assert.strictEqual(argFilename, testCase.fileName);
 
-    watcher.close();
+      watcher.close();
 
-    // We document that watchers cannot be used anymore when it's closed,
-    // here we turn the methods into noops instead of throwing
-    watcher.close(); // Closing a closed watcher should be a noop
-  }));
+      // We document that watchers cannot be used anymore when it's closed,
+      // here we turn the methods into noops instead of throwing
+      watcher.close(); // Closing a closed watcher should be a noop
+    }));
 
-  // Long content so it's actually flushed. toUpperCase so there's real change.
-  const content2 = Date.now() + testCase.fileName.toUpperCase().repeat(1e4);
-  interval = setInterval(() => {
-    fs.writeFileSync(testCase.filePath, '');
-    fs.writeFileSync(testCase.filePath, content2);
-  }, 100);
+    // Long content so it's flushed. toUpperCase so there's real change.
+    const content2 = Date.now() + testCase.fileName.toUpperCase().repeat(1e4);
+    interval = setInterval(() => {
+      fs.writeFileSync(testCase.filePath, '');
+      fs.writeFileSync(testCase.filePath, content2);
+    }, 100);
+  }
 }
 
 [false, 1, {}, [], null, undefined].forEach((input) => {


### PR DESCRIPTION
AIX supports returning file names on watched directories (judging from
the similar test in sequential). Simplify logic of test-fs-watch in
parallel.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
