### PR TITLE
deps: upgrade npm to 7.0.15

### DIFF
--- a/deps/npm/AUTHORS
+++ b/deps/npm/AUTHORS
@@ -735,3 +735,6 @@ Vlad GURDIGA <gurdiga@gmail.com>
 Sébastien Puech <s.puech@tricentis.com>
 Jannis Hell <Primajin@users.noreply.github.com>
 Hollow Man <hollowman@hollowman.ml>
+kai zhu <kaizhu256@gmail.com>
+Alex Woollam <alexjhwoollam@gmail.com>
+Daniel Fischer <daniel@d-fischer.dev>

--- a/deps/npm/CHANGELOG.md
+++ b/deps/npm/CHANGELOG.md
@@ -1,3 +1,38 @@
+## 7.0.15 (2020-11-27)
+
+### DEPENDENCIES
+
+* [`00e6028ef`](https://github.com/npm/cli/commit/00e6028ef83bf76eaae10241fd7ba59e39768603)
+  `@npmcli/arborist@1.0.13`
+    * do not override user-defined shorthand values when saving `package.json`
+
+### BUG FIXES
+
+* [`9c3413fbc`](https://github.com/npm/cli/commit/9c3413fbcb37e79fc0b3d980e0b5810d7961277c)
+  [#2034](https://github.com/npm/cli/issues/2034)
+  [#2245](https://github.com/npm/cli/issues/2245)
+  `npm link <pkg>` should not save `package.json`
+  ([@ruyadorno](https://github.com/ruyadorno))
+
+### DOCUMENTATION
+
+* [`1875347f9`](https://github.com/npm/cli/commit/1875347f9f4f2b50c28fe8857c5533eeebf42da2)
+  [#2196](https://github.com/npm/cli/issues/2196)
+  remove doc on obsolete `unsafe-perm` flag
+  ([@kaizhu256](https://github.com/kaizhu256))
+* [`f51e50603`](https://github.com/npm/cli/commit/f51e5060340c783a8a00dadd98e5786960caf43f)
+  [#2200](https://github.com/npm/cli/issues/2200)
+  `config.md` cleanup
+  ([@alexwoollam](https://github.com/alexwoollam))
+* [`997cbdb40`](https://github.com/npm/cli/commit/997cbdb400bcd22e457e8a06b69a7be697cfd66d)
+  [#2238](https://github.com/npm/cli/issues/2238)
+  Fix broken link to `package.json` documentation
+  ([@d-fischer](https://github.com/d-fischer))
+* [`9da972dc4`](https://github.com/npm/cli/commit/9da972dc44c21cf0e337f1c3fca44eb9df3e40d5)
+  [#2241](https://github.com/npm/cli/issues/2241)
+  `npm star` docs cleanup
+  ([@ruyadorno](https://github.com/ruyadorno))
+
 ## 7.0.14 (2020-11-23)
 
 ### DEPENDENCIES

--- a/deps/npm/docs/content/commands/npm-star.md
+++ b/deps/npm/docs/content/commands/npm-star.md
@@ -8,7 +8,6 @@ description: Mark your favorite packages
 
 ```bash
 npm star [<pkg>...]
-npm unstar [<pkg>...]
 ```
 
 ### Description
@@ -16,12 +15,26 @@ npm unstar [<pkg>...]
 "Starring" a package means that you have some interest in it.  It's
 a vaguely positive way to show that you care.
 
+It's a boolean thing. Starring repeatedly has no additional effect.
+
+### More
+
+There's also these extra commands to help you manage your favorite packages:
+
+#### Unstar
+
+You can also "unstar" a package using [`npm unstar`](/commands/npm-unstar)
+
 "Unstarring" is the same thing, but in reverse.
 
-It's a boolean thing.  Starring repeatedly has no additional effect.
+#### Listing stars
+
+You can see all your starred packages using [`npm stars`](/commands/npm-stars)
 
 ### See Also
 
+* [npm unstar](/commands/npm-unstar)
+* [npm stars](/commands/npm-stars)
 * [npm view](/commands/npm-view)
 * [npm whoami](/commands/npm-whoami)
 * [npm adduser](/commands/npm-adduser)

--- a/deps/npm/docs/content/commands/npm-stars.md
+++ b/deps/npm/docs/content/commands/npm-stars.md
@@ -20,6 +20,7 @@ you will most certainly enjoy this command.
 ### See Also
 
 * [npm star](/commands/npm-star)
+* [npm unstar](/commands/npm-unstar)
 * [npm view](/commands/npm-view)
 * [npm whoami](/commands/npm-whoami)
 * [npm adduser](/commands/npm-adduser)

--- a/deps/npm/docs/content/commands/npm-unstar.md
+++ b/deps/npm/docs/content/commands/npm-unstar.md
@@ -1,0 +1,36 @@
+---
+title: npm-unstar
+section: 1
+description: Remove an item from your favorite packages
+---
+
+### Synopsis
+
+```bash
+npm unstar [<pkg>...]
+```
+
+### Description
+
+"Unstarring" a package is the opposite of [`npm star`](/commands/npm-star),
+it removes an item from your list of favorite packages.
+
+### More
+
+There's also these extra commands to help you manage your favorite packages:
+
+#### Star
+
+You can "star" a package using [`npm star`](/commands/npm-star)
+
+#### Listing stars
+
+You can see all your starred packages using [`npm stars`](/commands/npm-stars)
+
+### See Also
+
+* [npm star](/commands/npm-star)
+* [npm stars](/commands/npm-stars)
+* [npm view](/commands/npm-view)
+* [npm whoami](/commands/npm-whoami)
+* [npm adduser](/commands/npm-adduser)

--- a/deps/npm/docs/content/using-npm/config.md
+++ b/deps/npm/docs/content/using-npm/config.md
@@ -432,7 +432,7 @@ Format `package-lock.json` or `npm-shrinkwrap.json` as a human readable file.
 * Type: Boolean
 
 When "true" displays the message at the end of each `npm install`
-aknowledging the number of dependencies looking for funding.
+acknowledging the number of dependencies looking for funding.
 See [`npm fund`](/commands/npm-fund) for details.
 
 #### fetch-retries
@@ -1096,7 +1096,7 @@ using legacy search endpoint.
 
 If true, success/failure metrics will be reported to the registry stored in
 `metrics-registry`.  These requests contain the number of successful and
-failing runs of the npm CLI and the time period overwhich those counts were
+failing runs of the npm CLI and the time period over which those counts were
 gathered. No identifying information is included in these requests.
 
 #### shell

--- a/deps/npm/docs/content/using-npm/scripts.md
+++ b/deps/npm/docs/content/using-npm/scripts.md
@@ -122,10 +122,8 @@ npm will default some script values based on package contents.
 
 ### User
 
-If npm was invoked with root privileges, then it will change the uid
-to the user account or uid specified by the `user` config, which
-defaults to `nobody`.  Set the `unsafe-perm` flag to run scripts with
-root privileges.
+When npm is run as root, scripts are always run with the effective uid
+and gid of the working directory owner.
 
 ### Environment
 

--- a/deps/npm/docs/content/using-npm/workspaces.md
+++ b/deps/npm/docs/content/using-npm/workspaces.md
@@ -18,13 +18,13 @@ order to add references to packages that should be symlinked into the current
 
 We also refer to these packages being auto-symlinked during `npm install` as a
 single **workspace**, meaning it's a nested package within the current local
-file system that is explicitly defined in the [`package.json`](/using-npm/package-json)
+file system that is explicitly defined in the [`package.json`](/configuring-npm/package-json#workspaces)
 `workspaces` configuration.
 
 ### Installing workspaces
 
 Workspaces are usually defined via the `workspaces` property of the
-[`package.json`](/using-npm/package-json) file, e.g:
+[`package.json`](/configuring-npm/package-json#workspaces) file, e.g:
 
 ```json
 {

--- a/deps/npm/docs/output/commands/npm-ls.html
+++ b/deps/npm/docs/output/commands/npm-ls.html
@@ -156,7 +156,7 @@ installed, as well as their dependencies, in a tree-structure.</p>
 limit the results to only the paths to the packages named.  Note that
 nested packages will <em>also</em> show the paths to the specified packages.
 For example, running <code>npm ls promzard</code> in npm’s source tree will show:</p>
-<pre lang="bash"><code>    npm@7.0.14 /path/to/npm
+<pre lang="bash"><code>    npm@7.0.15 /path/to/npm
     └─┬ init-package-json@0.0.4
       └── promzard@0.1.5
 </code></pre>

--- a/deps/npm/docs/output/commands/npm-stars.html
+++ b/deps/npm/docs/output/commands/npm-stars.html
@@ -155,6 +155,7 @@ you will most certainly enjoy this command.</p>
 <h3 id="see-also">See Also</h3>
 <ul>
 <li><a href="../commands/npm-star.html">npm star</a></li>
+<li><a href="../commands/npm-unstar.html">npm unstar</a></li>
 <li><a href="../commands/npm-view.html">npm view</a></li>
 <li><a href="../commands/npm-whoami.html">npm whoami</a></li>
 <li><a href="../commands/npm-adduser.html">npm adduser</a></li>

--- a/deps/npm/docs/output/commands/npm-unstar.html
+++ b/deps/npm/docs/output/commands/npm-unstar.html
@@ -1,5 +1,5 @@
 <html><head>
-<title>npm-star</title>
+<title>npm-unstar</title>
 <style>
 body {
     background-color: #ffffff;
@@ -135,32 +135,30 @@ npm command-line interface
 
 <section id="content">
 <header class="title">
-<h1 id="npm-star">npm-star</h1>
-<span class="description">Mark your favorite packages</span>
+<h1 id="npm-unstar">npm-unstar</h1>
+<span class="description">Remove an item from your favorite packages</span>
 </header>
 
 <section id="table_of_contents">
 <h2 id="table-of-contents">Table of contents</h2>
-<div id="_table_of_contents"><ul><li><a href="#synopsis">Synopsis</a></li><li><a href="#description">Description</a></li><li><a href="#more">More</a></li><ul><li><a href="#unstar">Unstar</a></li><li><a href="#listing-stars">Listing stars</a></li></ul><li><a href="#see-also">See Also</a></li></ul></div>
+<div id="_table_of_contents"><ul><li><a href="#synopsis">Synopsis</a></li><li><a href="#description">Description</a></li><li><a href="#more">More</a></li><ul><li><a href="#star">Star</a></li><li><a href="#listing-stars">Listing stars</a></li></ul><li><a href="#see-also">See Also</a></li></ul></div>
 </section>
 
 <div id="_content"><h3 id="synopsis">Synopsis</h3>
-<pre lang="bash"><code>npm star [&lt;pkg&gt;...]
+<pre lang="bash"><code>npm unstar [&lt;pkg&gt;...]
 </code></pre>
 <h3 id="description">Description</h3>
-<p>“Starring” a package means that you have some interest in it.  It’s
-a vaguely positive way to show that you care.</p>
-<p>It’s a boolean thing. Starring repeatedly has no additional effect.</p>
+<p>“Unstarring” a package is the opposite of <a href="../commands/npm-star.html"><code>npm star</code></a>,
+it removes an item from your list of favorite packages.</p>
 <h3 id="more">More</h3>
 <p>There’s also these extra commands to help you manage your favorite packages:</p>
-<h4 id="unstar">Unstar</h4>
-<p>You can also “unstar” a package using <a href="../commands/npm-unstar.html"><code>npm unstar</code></a></p>
-<p>“Unstarring” is the same thing, but in reverse.</p>
+<h4 id="star">Star</h4>
+<p>You can “star” a package using <a href="../commands/npm-star.html"><code>npm star</code></a></p>
 <h4 id="listing-stars">Listing stars</h4>
 <p>You can see all your starred packages using <a href="../commands/npm-stars.html"><code>npm stars</code></a></p>
 <h3 id="see-also">See Also</h3>
 <ul>
-<li><a href="../commands/npm-unstar.html">npm unstar</a></li>
+<li><a href="../commands/npm-star.html">npm star</a></li>
 <li><a href="../commands/npm-stars.html">npm stars</a></li>
 <li><a href="../commands/npm-view.html">npm view</a></li>
 <li><a href="../commands/npm-whoami.html">npm whoami</a></li>
@@ -169,7 +167,7 @@ a vaguely positive way to show that you care.</p>
 </div>
 
 <footer id="edit">
-<a href="https://github.com/npm/cli/edit/latest/docs/content/commands/npm-star.md">
+<a href="https://github.com/npm/cli/edit/latest/docs/content/commands/npm-unstar.md">
 <svg role="img" viewBox="0 0 16 16" width="16" height="16" fill="currentcolor" style="vertical-align: text-bottom; margin-right: 0.3em;">
 <path fill-rule="evenodd" d="M11.013 1.427a1.75 1.75 0 012.474 0l1.086 1.086a1.75 1.75 0 010 2.474l-8.61 8.61c-.21.21-.47.364-.756.445l-3.251.93a.75.75 0 01-.927-.928l.929-3.25a1.75 1.75 0 01.445-.758l8.61-8.61zm1.414 1.06a.25.25 0 00-.354 0L10.811 3.75l1.439 1.44 1.263-1.263a.25.25 0 000-.354l-1.086-1.086zM11.189 6.25L9.75 4.81l-6.286 6.287a.25.25 0 00-.064.108l-.558 1.953 1.953-.558a.249.249 0 00.108-.064l6.286-6.286z"></path>
 </svg>

--- a/deps/npm/docs/output/commands/npm.html
+++ b/deps/npm/docs/output/commands/npm.html
@@ -148,7 +148,7 @@ npm command-line interface
 <pre lang="bash"><code>npm &lt;command&gt; [args]
 </code></pre>
 <h3 id="version">Version</h3>
-<p>7.0.14</p>
+<p>7.0.15</p>
 <h3 id="description">Description</h3>
 <p>npm is the package manager for the Node JavaScript platform.  It puts
 modules in place so that node can find them, and manages dependency

--- a/deps/npm/docs/output/using-npm/config.html
+++ b/deps/npm/docs/output/using-npm/config.html
@@ -500,7 +500,7 @@ recommended that you do not use this option!</p>
 <li>Type: Boolean</li>
 </ul>
 <p>When “true” displays the message at the end of each <code>npm install</code>
-aknowledging the number of dependencies looking for funding.
+acknowledging the number of dependencies looking for funding.
 See <a href="../commands/npm-fund.html"><code>npm fund</code></a> for details.</p>
 <h4 id="fetch-retries">fetch-retries</h4>
 <ul>
@@ -1069,7 +1069,7 @@ using legacy search endpoint.</p>
 </ul>
 <p>If true, success/failure metrics will be reported to the registry stored in
 <code>metrics-registry</code>.  These requests contain the number of successful and
-failing runs of the npm CLI and the time period overwhich those counts were
+failing runs of the npm CLI and the time period over which those counts were
 gathered. No identifying information is included in these requests.</p>
 <h4 id="shell">shell</h4>
 <ul>

--- a/deps/npm/docs/output/using-npm/scripts.html
+++ b/deps/npm/docs/output/using-npm/scripts.html
@@ -254,10 +254,8 @@ default the <code>install</code> command to compile using node-gyp.</p>
 </li>
 </ul>
 <h3 id="user">User</h3>
-<p>If npm was invoked with root privileges, then it will change the uid
-to the user account or uid specified by the <code>user</code> config, which
-defaults to <code>nobody</code>.  Set the <code>unsafe-perm</code> flag to run scripts with
-root privileges.</p>
+<p>When npm is run as root, scripts are always run with the effective uid
+and gid of the working directory owner.</p>
 <h3 id="environment">Environment</h3>
 <p>Package scripts run in an environment where many pieces of information
 are made available regarding the setup of npm and the current state of

--- a/deps/npm/docs/output/using-npm/workspaces.html
+++ b/deps/npm/docs/output/using-npm/workspaces.html
@@ -155,11 +155,11 @@ order to add references to packages that should be symlinked into the current
 <code>node_modules</code> folder.</p>
 <p>We also refer to these packages being auto-symlinked during <code>npm install</code> as a
 single <strong>workspace</strong>, meaning it’s a nested package within the current local
-file system that is explicitly defined in the <a href="../using-npm/package-json.html"><code>package.json</code></a>
+file system that is explicitly defined in the <a href="../configuring-npm/package-json#workspaces.html"><code>package.json</code></a>
 <code>workspaces</code> configuration.</p>
 <h3 id="installing-workspaces">Installing workspaces</h3>
 <p>Workspaces are usually defined via the <code>workspaces</code> property of the
-<a href="../using-npm/package-json.html"><code>package.json</code></a> file, e.g:</p>
+<a href="../configuring-npm/package-json#workspaces.html"><code>package.json</code></a> file, e.g:</p>
 <pre lang="json"><code>{
   "name": "my-workspaces-powered-project",
   "workspaces": [

--- a/deps/npm/lib/link.js
+++ b/deps/npm/lib/link.js
@@ -112,14 +112,23 @@ const linkInstall = async args => {
     )
   }
 
+  // npm link should not save=true by default unless you're
+  // using any of --save-dev or other types
+  const save =
+    Boolean(npm.config.find('save') !== 'default' || npm.flatOptions.saveType)
+
   // create a new arborist instance for the local prefix and
   // reify all the pending names as symlinks there
   const localArb = new Arborist({
     ...npm.flatOptions,
     path: npm.prefix,
+    save,
   })
   await localArb.reify({
+    ...npm.flatOptions,
+    path: npm.prefix,
     add: names.map(l => `file:${resolve(globalTop, 'node_modules', l)}`),
+    save,
   })
 
   await reifyFinish(localArb)

--- a/deps/npm/lib/rebuild.js
+++ b/deps/npm/lib/rebuild.js
@@ -1,10 +1,13 @@
-const Arborist = require('@npmcli/arborist')
-const npm = require('./npm.js')
-const usageUtil = require('./utils/usage.js')
+'use strict'
+
 const { resolve } = require('path')
-const output = require('./utils/output.js')
+const Arborist = require('@npmcli/arborist')
 const npa = require('npm-package-arg')
 const semver = require('semver')
+
+const npm = require('./npm.js')
+const usageUtil = require('./utils/usage.js')
+const output = require('./utils/output.js')
 
 const cmd = (args, cb) => rebuild(args).then(() => cb()).catch(cb)
 

--- a/deps/npm/lib/stars.js
+++ b/deps/npm/lib/stars.js
@@ -1,20 +1,22 @@
 'use strict'
 
-const npm = require('./npm.js')
-const fetch = require('npm-registry-fetch')
 const log = require('npmlog')
+const fetch = require('npm-registry-fetch')
+
+const npm = require('./npm.js')
 const output = require('./utils/output.js')
 const getIdentity = require('./utils/get-identity.js')
 const usageUtil = require('./utils/usage.js')
-const usage = usageUtil('stars', 'npm stars [<user>]')
 const completion = require('./utils/completion/none.js')
+
+const usage = usageUtil('stars', 'npm stars [<user>]')
 
 const cmd = (args, cb) => stars(args).then(() => cb()).catch(cb)
 
 const stars = (args) => {
   return stars_(args).catch(er => {
     if (er.code === 'ENEEDAUTH')
-      log.warn('star', 'auth is required to look up your username')
+      log.warn('stars', 'auth is required to look up your username')
 
     throw er
   })
@@ -25,6 +27,7 @@ const stars_ = async ([user = getIdentity(npm.flatOptions)]) => {
     ...npm.flatOptions,
     query: { key: `"${await user}"` },
   })
+
   if (rows.length === 0)
     log.warn('stars', 'user has not starred any packages')
 

--- a/deps/npm/man/man1/npm-ls.1
+++ b/deps/npm/man/man1/npm-ls.1
@@ -22,7 +22,7 @@ For example, running \fBnpm ls promzard\fP in npm's source tree will show:
 .P
 .RS 2
 .nf
-    npm@7\.0\.14 /path/to/npm
+    npm@7\.0\.15 /path/to/npm
     └─┬ init\-package\-json@0\.0\.4
       └── promzard@0\.1\.5
 .fi

--- a/deps/npm/man/man1/npm-star.1
+++ b/deps/npm/man/man1/npm-star.1
@@ -6,7 +6,6 @@
 .RS 2
 .nf
 npm star [<pkg>\.\.\.]
-npm unstar [<pkg>\.\.\.]
 .fi
 .RE
 .SS Description
@@ -14,11 +13,24 @@ npm unstar [<pkg>\.\.\.]
 "Starring" a package means that you have some interest in it\.  It's
 a vaguely positive way to show that you care\.
 .P
-"Unstarring" is the same thing, but in reverse\.
+It's a boolean thing\. Starring repeatedly has no additional effect\.
+.SS More
 .P
-It's a boolean thing\.  Starring repeatedly has no additional effect\.
+There's also these extra commands to help you manage your favorite packages:
+.SS Unstar
+.P
+You can also "unstar" a package using npm help \fBunstar\fP
+.P
+"Unstarring" is the same thing, but in reverse\.
+.SS Listing stars
+.P
+You can see all your starred packages using npm help \fBstars\fP
 .SS See Also
 .RS 0
+.IP \(bu 2
+npm help unstar
+.IP \(bu 2
+npm help stars
 .IP \(bu 2
 npm help view
 .IP \(bu 2

--- a/deps/npm/man/man1/npm-stars.1
+++ b/deps/npm/man/man1/npm-stars.1
@@ -20,6 +20,8 @@ you will most certainly enjoy this command\.
 .IP \(bu 2
 npm help star
 .IP \(bu 2
+npm help unstar
+.IP \(bu 2
 npm help view
 .IP \(bu 2
 npm help whoami

--- a/deps/npm/man/man1/npm-unstar.1
+++ b/deps/npm/man/man1/npm-unstar.1
@@ -1,0 +1,37 @@
+.TH "NPM\-UNSTAR" "1" "November 2020" "" ""
+.SH "NAME"
+\fBnpm-unstar\fR \- Remove an item from your favorite packages
+.SS Synopsis
+.P
+.RS 2
+.nf
+npm unstar [<pkg>\.\.\.]
+.fi
+.RE
+.SS Description
+.P
+"Unstarring" a package is the opposite of npm help \fBstar\fP,
+it removes an item from your list of favorite packages\.
+.SS More
+.P
+There's also these extra commands to help you manage your favorite packages:
+.SS Star
+.P
+You can "star" a package using npm help \fBstar\fP
+.SS Listing stars
+.P
+You can see all your starred packages using npm help \fBstars\fP
+.SS See Also
+.RS 0
+.IP \(bu 2
+npm help star
+.IP \(bu 2
+npm help stars
+.IP \(bu 2
+npm help view
+.IP \(bu 2
+npm help whoami
+.IP \(bu 2
+npm help adduser
+
+.RE

--- a/deps/npm/man/man1/npm.1
+++ b/deps/npm/man/man1/npm.1
@@ -10,7 +10,7 @@ npm <command> [args]
 .RE
 .SS Version
 .P
-7\.0\.14
+7\.0\.15
 .SS Description
 .P
 npm is the package manager for the Node JavaScript platform\.  It puts

--- a/deps/npm/man/man7/config.7
+++ b/deps/npm/man/man7/config.7
@@ -577,7 +577,7 @@ Type: Boolean
 .RE
 .P
 When "true" displays the message at the end of each \fBnpm install\fP
-aknowledging the number of dependencies looking for funding\.
+acknowledging the number of dependencies looking for funding\.
 See npm help \fBfund\fP for details\.
 .SS fetch\-retries
 .RS 0
@@ -1473,7 +1473,7 @@ Type: Boolean
 .P
 If true, success/failure metrics will be reported to the registry stored in
 \fBmetrics\-registry\fP\|\.  These requests contain the number of successful and
-failing runs of the npm CLI and the time period overwhich those counts were
+failing runs of the npm CLI and the time period over which those counts were
 gathered\. No identifying information is included in these requests\.
 .SS shell
 .RS 0

--- a/deps/npm/man/man7/scripts.7
+++ b/deps/npm/man/man7/scripts.7
@@ -177,10 +177,8 @@ default the \fBinstall\fP command to compile using node\-gyp\.
 .RE
 .SS User
 .P
-If npm was invoked with root privileges, then it will change the uid
-to the user account or uid specified by the \fBuser\fP config, which
-defaults to \fBnobody\fP\|\.  Set the \fBunsafe\-perm\fP flag to run scripts with
-root privileges\.
+When npm is run as root, scripts are always run with the effective uid
+and gid of the working directory owner\.
 .SS Environment
 .P
 Package scripts run in an environment where many pieces of information

--- a/deps/npm/node_modules/@npmcli/arborist/lib/update-root-package-json.js
+++ b/deps/npm/node_modules/@npmcli/arborist/lib/update-root-package-json.js
@@ -1,0 +1,48 @@
+const fs = require('fs')
+const promisify = require('util').promisify
+const readFile = promisify(fs.readFile)
+const writeFile = promisify(fs.writeFile)
+const {resolve} = require('path')
+
+const parseJSON = require('json-parse-even-better-errors')
+
+const { orderDeps } = require('./dep-spec.js')
+
+const depTypes = new Set([
+  'dependencies',
+  'optionalDependencies',
+  'devDependencies',
+  'peerDependencies',
+])
+
+async function updateRootPackageJson ({ tree }) {
+  const filename = resolve(tree.path, 'package.json')
+  const originalContent = await readFile(filename, 'utf8')
+    .then(data => parseJSON(data))
+    .catch(() => null)
+
+  const depsData = orderDeps({
+    ...tree.package,
+  })
+
+  // if there's no package.json, just use internal pkg info as source of truth
+  const packageJsonContent = originalContent || depsData
+
+  // loop through all types of dependencies and update package json content
+  for (const type of depTypes)
+    packageJsonContent[type] = depsData[type]
+
+  // format content
+  const {
+    [Symbol.for('indent')]: indent,
+    [Symbol.for('newline')]: newline,
+  } = tree.package
+  const format = indent === undefined ? '  ' : indent
+  const eol = newline === undefined ? '\n' : newline
+  const content = (JSON.stringify(packageJsonContent, null, format) + '\n')
+    .replace(/\n/g, eol)
+
+  return writeFile(filename, content)
+}
+
+module.exports = updateRootPackageJson

--- a/deps/npm/node_modules/@npmcli/arborist/package.json
+++ b/deps/npm/node_modules/@npmcli/arborist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@npmcli/arborist",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Manage node_modules trees",
   "dependencies": {
     "@npmcli/installed-package-contents": "^1.0.5",

--- a/deps/npm/package.json
+++ b/deps/npm/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.0.14",
+  "version": "7.0.15",
   "name": "npm",
   "description": "a package manager for JavaScript",
   "keywords": [
@@ -42,7 +42,7 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@npmcli/arborist": "^1.0.12",
+    "@npmcli/arborist": "^1.0.13",
     "@npmcli/ci-detect": "^1.2.0",
     "@npmcli/config": "^1.2.1",
     "@npmcli/run-script": "^1.8.1",
@@ -214,6 +214,7 @@
     "Remove the 'files' below once we're done porting old tests over"
   ],
   "tap": {
+    "color": 1,
     "files": "test/{lib,bin}",
     "coverage-map": "test/coverage-map.js",
     "check-coverage": true,

--- a/deps/npm/tap-snapshots/test-lib-stars.js-TAP.test.js
+++ b/deps/npm/tap-snapshots/test-lib-stars.js-TAP.test.js
@@ -1,0 +1,15 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/lib/stars.js TAP no args > should output a list of starred packages 1`] = `
+
+@npmcli/arborist
+@npmcli/map-workspaces
+libnpmfund
+libnpmpublish
+ipt
+`

--- a/deps/npm/test/lib/link.js
+++ b/deps/npm/test/lib/link.js
@@ -23,6 +23,7 @@ const npm = {
     get () {
       return false
     },
+    find () {},
   },
 }
 const printLinks = async (opts) => {
@@ -196,7 +197,7 @@ t.test('link global linked pkg to local nm when using args', (t) => {
 })
 
 t.test('link pkg already in global space', (t) => {
-  t.plan(2)
+  t.plan(3)
 
   const testdir = t.testdir({
     'global-prefix': {
@@ -224,16 +225,25 @@ t.test('link pkg already in global space', (t) => {
   npm.globalDir = resolve(testdir, 'global-prefix', 'lib', 'node_modules')
   npm.prefix = resolve(testdir, 'my-project')
 
+  npm.config.find = () => 'default'
+
   const _cwd = process.cwd()
   process.chdir(npm.prefix)
 
   reifyOutput = async () => {
     reifyOutput = undefined
     process.chdir(_cwd)
+    npm.config.find = () => null
 
     const links = await printLinks({
       path: npm.prefix,
     })
+
+    t.equal(
+      require(resolve(testdir, 'my-project', 'package.json')).dependencies,
+      undefined,
+      'should not save to package.json upon linking'
+    )
 
     t.matchSnapshot(links, 'should create a local symlink to global pkg')
   }

--- a/deps/npm/test/lib/npm.js
+++ b/deps/npm/test/lib/npm.js
@@ -8,11 +8,16 @@ const event = process.env.npm_lifecycle_event
 for (const env of Object.keys(process.env).filter(e => /^npm_/.test(e))) {
   if (env === 'npm_command') {
     // should only be running this in the 'test' or 'run-script' command!
-    // if the lifecycle event is 'test', then it'll be 'test', otherwise
-    // it should always be run-script.  Of course, it'll be missing if this
-    // test is just run directly, which is also acceptable.
-    const cmd = event === 'test' ? 'test' : 'run-script'
-    t.match(process.env[env], cmd)
+    // if the lifecycle event is 'test', then it'll be either 'test' or 'run',
+    // otherwise it should always be run-script. Of course, it'll be missing
+    // if this test is just run directly, which is also acceptable.
+    if (event === 'test') {
+      t.ok(
+        ['test', 'run-script'].some(i => i === event),
+        'should match "npm test" or "npm run test"'
+      )
+    } else
+      t.match(process.env[env], 'run-script')
   }
   delete process.env[env]
 }

--- a/deps/npm/test/lib/rebuild.js
+++ b/deps/npm/test/lib/rebuild.js
@@ -1,0 +1,222 @@
+const fs = require('fs')
+const { resolve } = require('path')
+const t = require('tap')
+const requireInject = require('require-inject')
+
+let result = ''
+
+const npm = {
+  globalDir: '',
+  flatOptions: {
+    global: false,
+  },
+  prefix: '',
+}
+const mocks = {
+  '../../lib/npm.js': npm,
+  '../../lib/utils/output.js': (...msg) => {
+    result += msg.join('\n')
+  },
+  '../../lib/utils/usage.js': () => 'usage instructions',
+}
+
+const rebuild = requireInject('../../lib/rebuild.js', mocks)
+
+t.afterEach(cb => {
+  npm.prefix = ''
+  npm.flatOptions.global = false
+  npm.globalDir = ''
+  result = ''
+  cb()
+})
+
+t.test('no args', t => {
+  const path = t.testdir({
+    node_modules: {
+      a: {
+        'package.json': JSON.stringify({
+          name: 'a',
+          version: '1.0.0',
+          bin: 'cwd',
+          scripts: {
+            preinstall: `node -e 'require("fs").writeFileSync("cwd", "")'`,
+          },
+        }),
+      },
+      b: {
+        'package.json': JSON.stringify({
+          name: 'b',
+          version: '1.0.0',
+          bin: 'cwd',
+          scripts: {
+            preinstall: `node -e 'require("fs").writeFileSync("cwd", "")'`,
+          },
+        }),
+      },
+    },
+  })
+
+  const aBuildFile = resolve(path, 'node_modules/a/cwd')
+  const bBuildFile = resolve(path, 'node_modules/b/cwd')
+  const aBinFile = resolve(path, 'node_modules/.bin/a')
+  const bBinFile = resolve(path, 'node_modules/.bin/b')
+  t.throws(() => fs.statSync(aBuildFile))
+  t.throws(() => fs.statSync(bBuildFile))
+  t.throws(() => fs.statSync(aBinFile))
+  t.throws(() => fs.statSync(bBinFile))
+
+  npm.prefix = path
+
+  rebuild([], err => {
+    if (err)
+      throw err
+
+    t.ok(() => fs.statSync(aBuildFile))
+    t.ok(() => fs.statSync(bBuildFile))
+    t.ok(() => fs.statSync(aBinFile))
+    t.ok(() => fs.statSync(bBinFile))
+
+    t.equal(
+      result,
+      'rebuilt dependencies successfully',
+      'should output success msg'
+    )
+
+    t.end()
+  })
+})
+
+t.test('filter by pkg name', t => {
+  const path = t.testdir({
+    node_modules: {
+      a: {
+        'index.js': '',
+        'package.json': JSON.stringify({
+          name: 'a',
+          version: '1.0.0',
+          bin: 'index.js',
+        }),
+      },
+      b: {
+        'index.js': '',
+        'package.json': JSON.stringify({
+          name: 'b',
+          version: '1.0.0',
+          bin: 'index.js',
+        }),
+      },
+    },
+  })
+
+  npm.prefix = path
+
+  const aBinFile = resolve(path, 'node_modules/.bin/a')
+  const bBinFile = resolve(path, 'node_modules/.bin/b')
+  t.throws(() => fs.statSync(aBinFile))
+  t.throws(() => fs.statSync(bBinFile))
+
+  rebuild(['b'], err => {
+    if (err)
+      throw err
+
+    t.throws(() => fs.statSync(aBinFile), 'should not link a bin')
+    t.ok(() => fs.statSync(bBinFile), 'should link filtered pkg bin')
+
+    t.end()
+  })
+})
+
+t.test('filter by pkg@<range>', t => {
+  const path = t.testdir({
+    node_modules: {
+      a: {
+        'index.js': '',
+        'package.json': JSON.stringify({
+          name: 'a',
+          version: '1.0.0',
+          bin: 'index.js',
+        }),
+        node_modules: {
+          b: {
+            'index.js': '',
+            'package.json': JSON.stringify({
+              name: 'b',
+              version: '2.0.0',
+              bin: 'index.js',
+            }),
+          },
+        },
+      },
+      b: {
+        'index.js': '',
+        'package.json': JSON.stringify({
+          name: 'b',
+          version: '1.0.0',
+          bin: 'index.js',
+        }),
+      },
+    },
+  })
+
+  npm.prefix = path
+
+  const bBinFile = resolve(path, 'node_modules/.bin/b')
+  const nestedBinFile = resolve(path, 'node_modules/a/node_modules/.bin/b')
+
+  rebuild(['b@2'], err => {
+    if (err)
+      throw err
+
+    t.throws(() => fs.statSync(bBinFile), 'should not link b bin')
+    t.ok(() => fs.statSync(nestedBinFile), 'should link filtered pkg bin')
+
+    t.end()
+  })
+})
+
+t.test('filter must be a semver version/range', t => {
+  rebuild(['b:git+ssh://github.com/npm/arborist'], err => {
+    t.match(
+      err,
+      /Error: `npm rebuild` only supports SemVer version\/range specifiers/,
+      'should throw type error'
+    )
+
+    t.end()
+  })
+})
+
+t.test('global prefix', t => {
+  const globalPath = t.testdir({
+    lib: {
+      node_modules: {
+        a: {
+          'index.js': '',
+          'package.json': JSON.stringify({
+            name: 'a',
+            version: '1.0.0',
+            bin: 'index.js',
+          }),
+        },
+      },
+    },
+  })
+
+  npm.flatOptions.global = true
+  npm.globalDir = resolve(globalPath, 'lib', 'node_modules')
+
+  rebuild([], err => {
+    if (err)
+      throw err
+
+    t.ok(() => fs.statSync(resolve(globalPath, 'lib/node_modules/.bin/a')))
+
+    t.equal(
+      result,
+      'rebuilt dependencies successfully',
+      'should output success msg'
+    )
+
+    t.end()
+  })
+})

--- a/deps/npm/test/lib/stars.js
+++ b/deps/npm/test/lib/stars.js
@@ -1,0 +1,151 @@
+const requireInject = require('require-inject')
+const t = require('tap')
+
+let result = ''
+
+const noop = () => null
+const npm = { config: { get () {} }, flatOptions: {} }
+const npmFetch = { json: noop }
+const npmlog = { warn: noop }
+const mocks = {
+  npmlog,
+  'npm-registry-fetch': npmFetch,
+  '../../lib/npm.js': npm,
+  '../../lib/utils/output.js': (...msg) => {
+    result = [result, ...msg].join('\n')
+  },
+  '../../lib/utils/get-identity.js': async () => 'foo',
+  '../../lib/utils/usage.js': () => 'usage instructions',
+}
+
+const stars = requireInject('../../lib/stars.js', mocks)
+
+t.afterEach(cb => {
+  npm.config = { get () {} }
+  npmlog.warn = noop
+  result = ''
+  cb()
+})
+
+t.test('no args', t => {
+  npmFetch.json = async (uri, opts) => {
+    t.equal(uri, '/-/_view/starredByUser', 'should fetch from expected uri')
+    t.equal(opts.query.key, '"foo"', 'should match logged in username')
+
+    return {
+      rows: [
+        { value: '@npmcli/arborist' },
+        { value: '@npmcli/map-workspaces' },
+        { value: 'libnpmfund' },
+        { value: 'libnpmpublish' },
+        { value: 'ipt' },
+      ],
+    }
+  }
+
+  stars([], err => {
+    if (err)
+      throw err
+
+    t.matchSnapshot(
+      result,
+      'should output a list of starred packages'
+    )
+
+    t.end()
+  })
+})
+
+t.test('npm star <user>', t => {
+  t.plan(3)
+  npmFetch.json = async (uri, opts) => {
+    t.equal(uri, '/-/_view/starredByUser', 'should fetch from expected uri')
+    t.equal(opts.query.key, '"ruyadorno"', 'should match username')
+
+    return {
+      rows: [{ value: '@npmcli/arborist' }],
+    }
+  }
+
+  stars(['ruyadorno'], err => {
+    if (err)
+      throw err
+
+    t.match(
+      result,
+      '@npmcli/arborist',
+      'should output expected list of starred packages'
+    )
+  })
+})
+
+t.test('unauthorized request', t => {
+  t.plan(4)
+  npmFetch.json = async () => {
+    throw Object.assign(
+      new Error('Not logged in'),
+      { code: 'ENEEDAUTH' }
+    )
+  }
+
+  npmlog.warn = (title, msg) => {
+    t.equal(title, 'stars', 'should use expected title')
+    t.equal(
+      msg,
+      'auth is required to look up your username',
+      'should warn auth required msg'
+    )
+  }
+
+  stars([], err => {
+    t.match(
+      err,
+      /Not logged in/,
+      'should throw unauthorized request msg'
+    )
+
+    t.equal(
+      result,
+      '',
+      'should have empty output'
+    )
+  })
+})
+
+t.test('unexpected error', t => {
+  npmFetch.json = async () => {
+    throw new Error('ERROR')
+  }
+
+  npmlog.warn = (title, msg) => {
+    throw new Error('Should not output extra warning msgs')
+  }
+
+  stars([], err => {
+    t.match(
+      err,
+      /ERROR/,
+      'should throw unexpected error message'
+    )
+    t.end()
+  })
+})
+
+t.test('no pkg starred', t => {
+  t.plan(2)
+  npmFetch.json = async (uri, opts) => ({ rows: [] })
+
+  npmlog.warn = (title, msg) => {
+    t.equal(title, 'stars', 'should use expected title')
+    t.equal(
+      msg,
+      'user has not starred any packages',
+      'should warn no starred packages msg'
+    )
+  }
+
+  stars([], err => {
+    if (err)
+      throw err
+  })
+})


### PR DESCRIPTION
## 7.0.15 (2020-11-27)

### DEPENDENCIES

* [`00e6028ef`](https://github.com/npm/cli/commit/00e6028ef83bf76eaae10241fd7ba59e39768603) `@npmcli/arborist@1.0.13`
    * do not override user-defined shorthand values when saving `package.json`

### BUG FIXES

* [`9c3413fbc`](https://github.com/npm/cli/commit/9c3413fbcb37e79fc0b3d980e0b5810d7961277c) [#2034](https://github.com/npm/cli/issues/2034) [#2245](https://github.com/npm/cli/issues/2245) `npm link <pkg>` should not save `package.json` ([@ruyadorno](https://github.com/ruyadorno))

### DOCUMENTATION

* [`1875347f9`](https://github.com/npm/cli/commit/1875347f9f4f2b50c28fe8857c5533eeebf42da2) [#2196](https://github.com/npm/cli/issues/2196) remove doc on obsolete `unsafe-perm` flag ([@kaizhu256](https://github.com/kaizhu256))
* [`f51e50603`](https://github.com/npm/cli/commit/f51e5060340c783a8a00dadd98e5786960caf43f) [#2200](https://github.com/npm/cli/issues/2200) `config.md` cleanup ([@alexwoollam](https://github.com/alexwoollam))
* [`997cbdb40`](https://github.com/npm/cli/commit/997cbdb400bcd22e457e8a06b69a7be697cfd66d) [#2238](https://github.com/npm/cli/issues/2238) Fix broken link to `package.json` documentation ([@d-fischer](https://github.com/d-fischer))
* [`9da972dc4`](https://github.com/npm/cli/commit/9da972dc44c21cf0e337f1c3fca44eb9df3e40d5) [#2241](https://github.com/npm/cli/issues/2241) `npm star` docs cleanup ([@ruyadorno](https://github.com/ruyadorno))
