### PR TITLE
https: add abortcontroller test

### DIFF
--- a/test/parallel/test-https-abortcontroller.js
+++ b/test/parallel/test-https-abortcontroller.js
@@ -1,0 +1,39 @@
+'use strict';
+const common = require('../common');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const fixtures = require('../common/fixtures');
+const https = require('https');
+const assert = require('assert');
+const { once } = require('events');
+
+const options = {
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem')
+};
+
+(async () => {
+  const { port, server } = await new Promise((resolve) => {
+    const server = https.createServer(options, () => {});
+    server.listen(0, () => resolve({ port: server.address().port, server }));
+  });
+  try {
+    const ac = new AbortController();
+    const req = https.request({
+      host: 'localhost',
+      port,
+      path: '/',
+      method: 'GET',
+      rejectUnauthorized: false,
+      signal: ac.signal,
+    });
+    process.nextTick(() => ac.abort());
+    const [ err ] = await once(req, 'error');
+    assert.strictEqual(err.name, 'AbortError');
+    assert.strictEqual(err.code, 'ABORT_ERR');
+  } finally {
+    server.close();
+  }
+})().then(common.mustCall());


### PR DESCRIPTION
I noticed that `AbortController` already works with HTTPs given the relationship between http and https but the functionality is not tested anywhere.

So I added a test to https AbortController functionality.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

