### PR TITLE
child_process: add AbortSignal support

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -250,6 +250,9 @@ lsExample();
 <!-- YAML
 added: v0.1.91
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/36308
+    description: AbortSignal support was added.
   - version: v8.8.0
     pr-url: https://github.com/nodejs/node/pull/15380
     description: The `windowsHide` option is supported now.
@@ -277,6 +280,7 @@ changes:
     `'/bin/sh'` on Unix, and `process.env.ComSpec` on Windows. A different
     shell can be specified as a string. See [Shell requirements][] and
     [Default Windows shell][]. **Default:** `false` (no shell).
+  * `signal` {AbortSignal} allows aborting the execFile using an AbortSignal
 * `callback` {Function} Called with the output when process terminates.
   * `error` {Error}
   * `stdout` {string|Buffer}
@@ -329,6 +333,19 @@ getVersion();
 **If the `shell` option is enabled, do not pass unsanitized user input to this
 function. Any input containing shell metacharacters may be used to trigger
 arbitrary command execution.**
+
+If the `signal` option is enabled, calling `.abort()` on the corresponding
+`AbortController` is similar to calling `.kill()` on the child process except
+the error passed to the callback will be an `AbortError`:
+
+```js
+const controller = new AbortController();
+const { signal } = controller;
+const child = execFile('node', ['--version'], { signal }, (error) => {
+  console.log(error); // an AbortError
+});
+signal.abort();
+```
 
 ### `child_process.fork(modulePath[, args][, options])`
 <!-- YAML

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -58,15 +58,24 @@ let debug = require('internal/util/debuglog').debuglog(
 );
 const { Buffer } = require('buffer');
 const { Pipe, constants: PipeConstants } = internalBinding('pipe_wrap');
+
+const {
+  AbortError,
+  codes: errorCodes,
+} = require('internal/errors');
 const {
   ERR_INVALID_ARG_VALUE,
   ERR_CHILD_PROCESS_IPC_REQUIRED,
   ERR_CHILD_PROCESS_STDIO_MAXBUFFER,
   ERR_INVALID_ARG_TYPE,
-  ERR_OUT_OF_RANGE
-} = require('internal/errors').codes;
+  ERR_OUT_OF_RANGE,
+} = errorCodes;
 const { clearTimeout, setTimeout } = require('timers');
-const { validateString, isInt32 } = require('internal/validators');
+const {
+  validateString,
+  isInt32,
+  validateAbortSignal,
+} = require('internal/validators');
 const child_process = require('internal/child_process');
 const {
   getValidStdio,
@@ -245,6 +254,9 @@ function execFile(file /* , args, options, callback */) {
   // Validate maxBuffer, if present.
   validateMaxBuffer(options.maxBuffer);
 
+  // Validate signal, if present
+  validateAbortSignal(options.signal, 'options.signal');
+
   options.killSignal = sanitizeKillSignal(options.killSignal);
 
   const child = spawn(file, args, {
@@ -361,6 +373,20 @@ function execFile(file /* , args, options, callback */) {
       kill();
       timeoutId = null;
     }, options.timeout);
+  }
+  if (options.signal) {
+    if (options.signal.aborted) {
+      process.nextTick(() => kill());
+    } else {
+      options.signal.addEventListener('abort', () => {
+        if (!ex) {
+          ex = new AbortError();
+        }
+        kill();
+      });
+      const remove = () => options.signal.removeEventListener('abort', kill);
+      child.once('close', remove);
+    }
   }
 
   if (child.stdout) {

--- a/test/parallel/test-bootstrap-modules.js
+++ b/test/parallel/test-bootstrap-modules.js
@@ -114,6 +114,7 @@ if (!common.isMainThread) {
     'Internal Binding performance',
     'Internal Binding symbols',
     'Internal Binding worker',
+    'NativeModule internal/streams/add-abort-signal',
     'NativeModule internal/streams/duplex',
     'NativeModule internal/streams/passthrough',
     'NativeModule internal/streams/readable',

--- a/test/parallel/test-child-process-execfile.js
+++ b/test/parallel/test-child-process-execfile.js
@@ -7,6 +7,7 @@ const { getSystemErrorName } = require('util');
 const fixtures = require('../common/fixtures');
 
 const fixture = fixtures.path('exit.js');
+const echoFixture = fixtures.path('echo.js');
 const execOpts = { encoding: 'utf8', shell: true };
 
 {
@@ -44,4 +45,17 @@ const execOpts = { encoding: 'utf8', shell: true };
 {
   // Verify the shell option works properly
   execFile(process.execPath, [fixture, 0], execOpts, common.mustSucceed());
+}
+
+{
+  // Verify that the signal option works properly
+  const ac = new AbortController();
+  const { signal } = ac;
+
+  const callback = common.mustCall((err) => {
+    assert.strictEqual(err.code, 'ABORT_ERR');
+    assert.strictEqual(err.name, 'AbortError');
+  });
+  execFile(process.execPath, [echoFixture, 0], { signal }, callback);
+  ac.abort();
 }


### PR DESCRIPTION
Support `AbortSignal` in `child_process.execFile`.

Bikeshedding:
 - I know everywhere else it's called `signal` and that it's the web platform guidance - but I think we might want to deviate here and call the parameter `abortSignal` to prevent confusion with OS signals and `killSignal`. WDYT?

I will follow up with support in the other child_process APIs like fork and spawn.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
