### PR TITLE
timers: reject with AbortError on cancellation

### DIFF
--- a/lib/timers/promises.js
+++ b/lib/timers/promises.js
@@ -14,22 +14,14 @@ const {
 } = require('internal/timers');
 
 const {
-  hideStackFrames,
+  AbortError,
   codes: { ERR_INVALID_ARG_TYPE }
 } = require('internal/errors');
-
-let DOMException;
-
-const lazyDOMException = hideStackFrames((message, name) => {
-  if (DOMException === undefined)
-    DOMException = internalBinding('messaging').DOMException;
-  return new DOMException(message, name);
-});
 
 function cancelListenerHandler(clear, reject) {
   if (!this._destroyed) {
     clear(this);
-    reject(lazyDOMException('The operation was aborted', 'AbortError'));
+    reject(new AbortError());
   }
 }
 
@@ -64,8 +56,7 @@ function setTimeout(after, value, options = {}) {
   // to 12.x, then this can be converted to use optional chaining to
   // simplify the check.
   if (signal && signal.aborted) {
-    return PromiseReject(
-      lazyDOMException('The operation was aborted', 'AbortError'));
+    return PromiseReject(new AbortError());
   }
   let oncancel;
   const ret = new Promise((resolve, reject) => {
@@ -115,8 +106,7 @@ function setImmediate(value, options = {}) {
   // to 12.x, then this can be converted to use optional chaining to
   // simplify the check.
   if (signal && signal.aborted) {
-    return PromiseReject(
-      lazyDOMException('The operation was aborted', 'AbortError'));
+    return PromiseReject(new AbortError());
   }
   let oncancel;
   const ret = new Promise((resolve, reject) => {


### PR DESCRIPTION
Following the consensus from the AbortSignal behaviour meeting (at https://github.com/nodejs/node/issues/36084 )

This replaces the DOMException timers/promises reject with with a Node AbortError (like HTTP/HTTP2 and streams)

From a user point of view it has the same `.name` and `.code` but is easier to shim, even the docs and tests don't need to change :]

cc @mcollina @jasnell @ronag

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
