### PR TITLE
src: rename AliasedBufferInfo->AliasedBufferIndex

### DIFF
--- a/src/aliased_buffer.h
+++ b/src/aliased_buffer.h
@@ -10,7 +10,7 @@
 
 namespace node {
 
-typedef size_t AliasedBufferInfo;
+typedef size_t AliasedBufferIndex;
 
 /**
  * Do not use this class directly when creating instances of it - use the
@@ -37,10 +37,10 @@ class AliasedBufferBase {
  public:
   AliasedBufferBase(v8::Isolate* isolate,
                     const size_t count,
-                    const AliasedBufferInfo* info = nullptr)
-      : isolate_(isolate), count_(count), byte_offset_(0), info_(info) {
+                    const AliasedBufferIndex* index = nullptr)
+      : isolate_(isolate), count_(count), byte_offset_(0), index_(index) {
     CHECK_GT(count, 0);
-    if (info != nullptr) {
+    if (index != nullptr) {
       // Will be deserialized later.
       return;
     }
@@ -72,12 +72,12 @@ class AliasedBufferBase {
       const size_t byte_offset,
       const size_t count,
       const AliasedBufferBase<uint8_t, v8::Uint8Array>& backing_buffer,
-      const AliasedBufferInfo* info = nullptr)
+      const AliasedBufferIndex* index = nullptr)
       : isolate_(isolate),
         count_(count),
         byte_offset_(byte_offset),
-        info_(info) {
-    if (info != nullptr) {
+        index_(index) {
+    if (index != nullptr) {
       // Will be deserialized later.
       return;
     }
@@ -102,20 +102,20 @@ class AliasedBufferBase {
         count_(that.count_),
         byte_offset_(that.byte_offset_),
         buffer_(that.buffer_) {
-    DCHECK_NULL(info_);
+    DCHECK_NULL(index_);
     js_array_ = v8::Global<V8T>(that.isolate_, that.GetJSArray());
   }
 
-  AliasedBufferInfo Serialize(v8::Local<v8::Context> context,
+  AliasedBufferIndex Serialize(v8::Local<v8::Context> context,
                               v8::SnapshotCreator* creator) {
-    DCHECK_NULL(info_);
+    DCHECK_NULL(index_);
     return creator->AddData(context, GetJSArray());
   }
 
   inline void Deserialize(v8::Local<v8::Context> context) {
-    DCHECK_NOT_NULL(info_);
+    DCHECK_NOT_NULL(index_);
     v8::Local<V8T> arr =
-        context->GetDataFromSnapshotOnce<V8T>(*info_).ToLocalChecked();
+        context->GetDataFromSnapshotOnce<V8T>(*index_).ToLocalChecked();
     // These may not hold true for AliasedBuffers that have grown, so should
     // be removed when we expand the snapshot support.
     DCHECK_EQ(count_, arr->Length());
@@ -124,11 +124,11 @@ class AliasedBufferBase {
         static_cast<uint8_t*>(arr->Buffer()->GetBackingStore()->Data());
     buffer_ = reinterpret_cast<NativeT*>(raw + byte_offset_);
     js_array_.Reset(isolate_, arr);
-    info_ = nullptr;
+    index_ = nullptr;
   }
 
   AliasedBufferBase& operator=(AliasedBufferBase&& that) noexcept {
-    DCHECK_NULL(info_);
+    DCHECK_NULL(index_);
     this->~AliasedBufferBase();
     isolate_ = that.isolate_;
     count_ = that.count_;
@@ -194,7 +194,7 @@ class AliasedBufferBase {
    *  Get the underlying v8 TypedArray overlayed on top of the native buffer
    */
   v8::Local<V8T> GetJSArray() const {
-    DCHECK_NULL(info_);
+    DCHECK_NULL(index_);
     return js_array_.Get(isolate_);
   }
 
@@ -211,7 +211,7 @@ class AliasedBufferBase {
    *  through the GetValue/SetValue/operator[] methods
    */
   inline const NativeT* GetNativeBuffer() const {
-    DCHECK_NULL(info_);
+    DCHECK_NULL(index_);
     return buffer_;
   }
 
@@ -227,7 +227,7 @@ class AliasedBufferBase {
    */
   inline void SetValue(const size_t index, NativeT value) {
     DCHECK_LT(index, count_);
-    DCHECK_NULL(info_);
+    DCHECK_NULL(index_);
     buffer_[index] = value;
   }
 
@@ -235,7 +235,7 @@ class AliasedBufferBase {
    *  Get value at position index
    */
   inline const NativeT GetValue(const size_t index) const {
-    DCHECK_NULL(info_);
+    DCHECK_NULL(index_);
     DCHECK_LT(index, count_);
     return buffer_[index];
   }
@@ -244,7 +244,7 @@ class AliasedBufferBase {
    *  Effectively, a synonym for GetValue/SetValue
    */
   Reference operator[](size_t index) {
-    DCHECK_NULL(info_);
+    DCHECK_NULL(index_);
     return Reference(this, index);
   }
 
@@ -260,7 +260,7 @@ class AliasedBufferBase {
   // Should only be used on an owning array, not one created as a sub array of
   // an owning `AliasedBufferBase`.
   void reserve(size_t new_capacity) {
-    DCHECK_NULL(info_);
+    DCHECK_NULL(index_);
     DCHECK_GE(new_capacity, count_);
     DCHECK_EQ(byte_offset_, 0);
     const v8::HandleScope handle_scope(isolate_);
@@ -296,7 +296,7 @@ class AliasedBufferBase {
   v8::Global<V8T> js_array_;
 
   // Deserialize data
-  const AliasedBufferInfo* info_ = nullptr;
+  const AliasedBufferIndex* index_ = nullptr;
 };
 
 typedef AliasedBufferBase<int32_t, v8::Int32Array> AliasedInt32Array;

--- a/src/env.h
+++ b/src/env.h
@@ -755,9 +755,9 @@ class AsyncHooks : public MemoryRetainer {
   };
 
   struct SerializeInfo {
-    AliasedBufferInfo async_ids_stack;
-    AliasedBufferInfo fields;
-    AliasedBufferInfo async_id_fields;
+    AliasedBufferIndex async_ids_stack;
+    AliasedBufferIndex fields;
+    AliasedBufferIndex async_id_fields;
     SnapshotIndex js_execution_async_resources;
     std::vector<SnapshotIndex> native_execution_async_resources;
   };
@@ -807,7 +807,7 @@ class ImmediateInfo : public MemoryRetainer {
   void MemoryInfo(MemoryTracker* tracker) const override;
 
   struct SerializeInfo {
-    AliasedBufferInfo fields;
+    AliasedBufferIndex fields;
   };
   SerializeInfo Serialize(v8::Local<v8::Context> context,
                           v8::SnapshotCreator* creator);
@@ -839,7 +839,7 @@ class TickInfo : public MemoryRetainer {
   ~TickInfo() = default;
 
   struct SerializeInfo {
-    AliasedBufferInfo fields;
+    AliasedBufferIndex fields;
   };
   SerializeInfo Serialize(v8::Local<v8::Context> context,
                           v8::SnapshotCreator* creator);
@@ -931,8 +931,8 @@ struct EnvSerializeInfo {
   TickInfo::SerializeInfo tick_info;
   ImmediateInfo::SerializeInfo immediate_info;
   performance::PerformanceState::SerializeInfo performance_state;
-  AliasedBufferInfo stream_base_state;
-  AliasedBufferInfo should_abort_on_uncaught_toggle;
+  AliasedBufferIndex stream_base_state;
+  AliasedBufferIndex should_abort_on_uncaught_toggle;
 
   std::vector<PropInfo> persistent_templates;
   std::vector<PropInfo> persistent_values;

--- a/src/node_perf_common.h
+++ b/src/node_perf_common.h
@@ -57,9 +57,9 @@ enum PerformanceEntryType {
 class PerformanceState {
  public:
   struct SerializeInfo {
-    AliasedBufferInfo root;
-    AliasedBufferInfo milestones;
-    AliasedBufferInfo observers;
+    AliasedBufferIndex root;
+    AliasedBufferIndex milestones;
+    AliasedBufferIndex observers;
   };
 
   explicit PerformanceState(v8::Isolate* isolate, const SerializeInfo* info);


### PR DESCRIPTION
This commit suggest renaming `AlaisedBufferInfo` to `AlaisedBufferIndex` to
make the code more readable.

The main motivation for this change is that I personally think that
the following code could be a little clearer:
```console
  context->GetDataFromSnapshotOnce<V8T>(*info_).ToLocalChecked();
```
Even knowing that `GetDataFromSnapshotOnce` takes a `size_t` I had to double
check the type of info_ to make sure.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
