### PR TITLE
src: use transferred consistently

### DIFF
--- a/src/base_object.h
+++ b/src/base_object.h
@@ -116,13 +116,13 @@ class BaseObject : public MemoryRetainer {
   // the current object:
   // - kUntransferable:
   //     No transfer is possible, either because this type of BaseObject does
-  //     not know how to be transfered, or because it is not in a state in
+  //     not know how to be transferred, or because it is not in a state in
   //     which it is possible to do so (e.g. because it has already been
-  //     transfered).
+  //     transferred).
   // - kTransferable:
-  //     This object can be transfered in a destructive fashion, i.e. will be
+  //     This object can be transferred in a destructive fashion, i.e. will be
   //     rendered unusable on the sending side of the channel in the process
-  //     of being transfered. (In C++ this would be referred to as movable but
+  //     of being transferred. (In C++ this would be referred to as movable but
   //     not copyable.) Objects of this type need to be listed in the
   //     `transferList` argument of the relevant postMessage() call in order to
   //     make sure that they are not accidentally destroyed on the sending side.

--- a/src/node_messaging.h
+++ b/src/node_messaging.h
@@ -16,7 +16,7 @@ class MessagePort;
 typedef MaybeStackBuffer<v8::Local<v8::Value>, 8> TransferList;
 
 // Used to represent the in-flight structure of an object that is being
-// transfered or cloned using postMessage().
+// transferred or cloned using postMessage().
 class TransferData : public MemoryRetainer {
  public:
   // Deserialize this object on the receiving end after a .postMessage() call.

--- a/src/quic/node_quic_session.h
+++ b/src/quic/node_quic_session.h
@@ -735,7 +735,7 @@ class QuicApplication : public MemoryRetainer,
 
 // QUIC sessions are logical connections that exchange data
 // back and forth between peer endpoints via UDP. Every QuicSession
-// has an associated TLS context and all data transfered between
+// has an associated TLS context and all data transferred between
 // the peers is always encrypted. Unlike TLS over TCP, however,
 // The QuicSession uses a session identifier that is independent
 // of both the local *and* peer IP address, allowing a QuicSession


### PR DESCRIPTION
This commit updates usages of transfered to be transferred to make it
consist in all comments.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
