### PR TITLE
Always available FIPS options

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -607,7 +607,7 @@ added: v6.9.0
 
 Load an OpenSSL configuration file on startup. Among other uses, this can be
 used to enable FIPS-compliant crypto if Node.js is built
-with against FIPS-enabled OpenSSL.
+against FIPS-enabled OpenSSL.
 
 ### `--pending-deprecation`
 <!-- YAML

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -186,8 +186,8 @@ code from strings throw an exception instead. This does not affect the Node.js
 added: v6.0.0
 -->
 
-Enable FIPS-compliant crypto at startup. (Requires Node.js to be built with
-`./configure --openssl-fips`.)
+Enable FIPS-compliant crypto at startup. (Requires Node.js to be built
+against FIPS-compatible OpenSSL.)
 
 ### `--enable-source-maps`
 <!-- YAML
@@ -606,8 +606,8 @@ added: v6.9.0
 -->
 
 Load an OpenSSL configuration file on startup. Among other uses, this can be
-used to enable FIPS-compliant crypto if Node.js is built with
-`./configure --openssl-fips`.
+used to enable FIPS-compliant crypto if Node.js is built
+with against FIPS-enabled OpenSSL.
 
 ### `--pending-deprecation`
 <!-- YAML

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -37,12 +37,10 @@ assertCrypto();
 
 const {
   ERR_CRYPTO_FIPS_FORCED,
-  ERR_CRYPTO_FIPS_UNAVAILABLE
 } = require('internal/errors').codes;
 const constants = internalBinding('constants').crypto;
 const { getOptionValue } = require('internal/options');
 const pendingDeprecation = getOptionValue('--pending-deprecation');
-const { fipsMode } = internalBinding('config');
 const fipsForced = getOptionValue('--force-fips');
 const {
   getFipsCrypto,
@@ -218,10 +216,8 @@ module.exports = {
   sign: signOneShot,
   setEngine,
   timingSafeEqual,
-  getFips: !fipsMode ? getFipsDisabled :
-    fipsForced ? getFipsForced : getFipsCrypto,
-  setFips: !fipsMode ? setFipsDisabled :
-    fipsForced ? setFipsForced : setFipsCrypto,
+  getFips: fipsForced ? getFipsForced : getFipsCrypto,
+  setFips: fipsForced ? setFipsForced : setFipsCrypto,
   verify: verifyOneShot,
 
   // Classes
@@ -242,17 +238,9 @@ module.exports = {
   secureHeapUsed,
 };
 
-function setFipsDisabled() {
-  throw new ERR_CRYPTO_FIPS_UNAVAILABLE();
-}
-
 function setFipsForced(val) {
   if (val) return;
   throw new ERR_CRYPTO_FIPS_FORCED();
-}
-
-function getFipsDisabled() {
-  return 0;
 }
 
 function getFipsForced() {
@@ -276,10 +264,8 @@ ObjectDefineProperties(module.exports, {
   },
   // crypto.fips is deprecated. DEP0093. Use crypto.getFips()/crypto.setFips()
   fips: {
-    get: !fipsMode ? getFipsDisabled :
-      fipsForced ? getFipsForced : getFipsCrypto,
-    set: !fipsMode ? setFipsDisabled :
-      fipsForced ? setFipsForced : setFipsCrypto
+    get: fipsForced ? getFipsForced : getFipsCrypto,
+    set: fipsForced ? setFipsForced : setFipsCrypto
   },
   DEFAULT_ENCODING: {
     enumerable: false,

--- a/node.gypi
+++ b/node.gypi
@@ -319,9 +319,6 @@
     [ 'node_use_openssl=="true"', {
       'defines': [ 'HAVE_OPENSSL=1' ],
       'conditions': [
-        ['openssl_fips != "" or openssl_is_fips=="true"', {
-          'defines': [ 'NODE_FIPS_MODE' ],
-        }],
         [ 'node_shared_openssl=="false"', {
           'dependencies': [
             './deps/openssl/openssl.gyp:openssl',

--- a/src/crypto/crypto_cipher.cc
+++ b/src/crypto/crypto_cipher.cc
@@ -343,12 +343,10 @@ void CipherBase::Init(const char* cipher_type,
   HandleScope scope(env()->isolate());
   MarkPopErrorOnReturn mark_pop_error_on_return;
 
-#ifdef NODE_FIPS_MODE
   if (FIPS_mode()) {
     return THROW_ERR_CRYPTO_UNSUPPORTED_OPERATION(env(),
         "crypto.createCipher() is not supported in FIPS mode.");
   }
-#endif  // NODE_FIPS_MODE
 
   const EVP_CIPHER* const cipher = EVP_get_cipherbyname(cipher_type);
   if (cipher == nullptr)
@@ -528,14 +526,12 @@ bool CipherBase::InitAuthenticated(
       return false;
     }
 
-#ifdef NODE_FIPS_MODE
     // TODO(tniessen) Support CCM decryption in FIPS mode
     if (mode == EVP_CIPH_CCM_MODE && kind_ == kDecipher && FIPS_mode()) {
       THROW_ERR_CRYPTO_UNSUPPORTED_OPERATION(env(),
           "CCM encryption not supported in FIPS mode");
       return false;
     }
-#endif
 
     // Tell OpenSSL about the desired length.
     if (!EVP_CIPHER_CTX_ctrl(ctx_.get(), EVP_CTRL_AEAD_SET_TAG, auth_tag_len,

--- a/src/crypto/crypto_sig.cc
+++ b/src/crypto/crypto_sig.cc
@@ -27,7 +27,6 @@ using v8::Value;
 namespace crypto {
 namespace {
 bool ValidateDSAParameters(EVP_PKEY* key) {
-#ifdef NODE_FIPS_MODE
   /* Validate DSA2 parameters from FIPS 186-4 */
   if (FIPS_mode() && EVP_PKEY_DSA == EVP_PKEY_base_id(key)) {
     DSA* dsa = EVP_PKEY_get0_DSA(key);
@@ -43,7 +42,6 @@ bool ValidateDSAParameters(EVP_PKEY* key) {
            (L == 2048 && N == 256) ||
            (L == 3072 && N == 256);
   }
-#endif  // NODE_FIPS_MODE
 
   return true;
 }

--- a/src/crypto/crypto_util.cc
+++ b/src/crypto/crypto_util.cc
@@ -142,10 +142,9 @@ void InitCryptoOnce() {
     }
   }
   if (0 != err) {
-    fprintf(stderr,
-            "openssl fips failed: %s\n",
-            ERR_error_string(err, nullptr));
-    UNREACHABLE();
+    auto* isolate = Isolate::GetCurrent();
+    auto* env = Environment::GetCurrent(isolate);
+    return ThrowCryptoError(env, err);
   }
 
   // Turn off compression. Saves memory and protects against CRIME attacks.

--- a/src/crypto/crypto_util.h
+++ b/src/crypto/crypto_util.h
@@ -22,6 +22,8 @@
 #ifndef OPENSSL_NO_ENGINE
 #  include <openssl/engine.h>
 #endif  // !OPENSSL_NO_ENGINE
+// The FIPS-related functions are only available
+// when the OpenSSL itself was compiled with FIPS support.
 #ifdef  OPENSSL_FIPS
 #  include <openssl/fips.h>
 #endif  // OPENSSL_FIPS

--- a/src/crypto/crypto_util.h
+++ b/src/crypto/crypto_util.h
@@ -22,6 +22,9 @@
 #ifndef OPENSSL_NO_ENGINE
 #  include <openssl/engine.h>
 #endif  // !OPENSSL_NO_ENGINE
+#ifdef  OPENSSL_FIPS
+#  include <openssl/fips.h>
+#endif  // OPENSSL_FIPS
 
 #include <algorithm>
 #include <memory>
@@ -510,11 +513,11 @@ bool SetEngine(
 void SetEngine(const v8::FunctionCallbackInfo<v8::Value>& args);
 #endif  // !OPENSSL_NO_ENGINE
 
-#ifdef NODE_FIPS_MODE
 void GetFipsCrypto(const v8::FunctionCallbackInfo<v8::Value>& args);
 
 void SetFipsCrypto(const v8::FunctionCallbackInfo<v8::Value>& args);
-#endif /* NODE_FIPS_MODE */
+
+void TestFipsCrypto(const v8::FunctionCallbackInfo<v8::Value>& args);
 
 class CipherPushContext {
  public:

--- a/src/node.cc
+++ b/src/node.cc
@@ -1012,11 +1012,11 @@ InitializationResult InitializeOncePerProcess(int argc, char** argv) {
     if (credentials::SafeGetenv("NODE_EXTRA_CA_CERTS", &extra_ca_certs))
       crypto::UseExtraCaCerts(extra_ca_certs);
   }
-#ifdef NODE_FIPS_MODE
   // In the case of FIPS builds we should make sure
   // the random source is properly initialized first.
-  OPENSSL_init();
-#endif  // NODE_FIPS_MODE
+  if (FIPS_mode()) {
+    OPENSSL_init();
+  }
   // V8 on Windows doesn't have a good source of entropy. Seed it from
   // OpenSSL's pool.
   V8::SetEntropySource(crypto::EntropySource);

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -42,9 +42,7 @@ static void Initialize(Local<Object> target,
   READONLY_FALSE_PROPERTY(target, "hasOpenSSL");
 #endif  // HAVE_OPENSSL
 
-#ifdef NODE_FIPS_MODE
   READONLY_TRUE_PROPERTY(target, "fipsMode");
-#endif
 
 #ifdef NODE_HAVE_I18N_SUPPORT
 

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -766,7 +766,6 @@ PerProcessOptionsParser::PerProcessOptionsParser(
             &PerProcessOptions::ssl_openssl_cert_store);
   Implies("--use-openssl-ca", "[ssl_openssl_cert_store]");
   ImpliesNot("--use-bundled-ca", "[ssl_openssl_cert_store]");
-#if NODE_FIPS_MODE
   AddOption("--enable-fips",
             "enable FIPS crypto at startup",
             &PerProcessOptions::enable_fips_crypto,
@@ -775,7 +774,6 @@ PerProcessOptionsParser::PerProcessOptionsParser(
             "force FIPS crypto (cannot be disabled)",
             &PerProcessOptions::force_fips_crypto,
             kAllowedInEnvironment);
-#endif
   AddOption("--secure-heap",
             "total size of the OpenSSL secure heap",
             &PerProcessOptions::secure_heap,

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -245,10 +245,8 @@ class PerProcessOptions : public Options {
 #endif
   bool use_openssl_ca = false;
   bool use_bundled_ca = false;
-#if NODE_FIPS_MODE
   bool enable_fips_crypto = false;
   bool force_fips_crypto = false;
-#endif
 #endif
 
   // Per-process because reports can be triggered outside a known V8 context.

--- a/test/parallel/test-cli-node-print-help.js
+++ b/test/parallel/test-cli-node-print-help.js
@@ -9,7 +9,6 @@ const common = require('../common');
 const assert = require('assert');
 const { exec } = require('child_process');
 const { internalBinding } = require('internal/test/binding');
-const { fipsMode } = internalBinding('config');
 let stdOut;
 
 
@@ -28,9 +27,8 @@ function validateNodePrintHelp() {
   const cliHelpOptions = [
     { compileConstant: HAVE_OPENSSL,
       flags: [ '--openssl-config=...', '--tls-cipher-list=...',
-               '--use-bundled-ca', '--use-openssl-ca' ] },
-    { compileConstant: fipsMode,
-      flags: [ '--enable-fips', '--force-fips' ] },
+               '--use-bundled-ca', '--use-openssl-ca',
+               '--enable-fips', '--force-fips' ] },
     { compileConstant: NODE_HAVE_I18N_SUPPORT,
       flags: [ '--icu-data-dir=...', 'NODE_ICU_DATA' ] },
     { compileConstant: HAVE_INSPECTOR,

--- a/test/parallel/test-cli-node-print-help.js
+++ b/test/parallel/test-cli-node-print-help.js
@@ -8,7 +8,6 @@ const common = require('../common');
 
 const assert = require('assert');
 const { exec } = require('child_process');
-const { internalBinding } = require('internal/test/binding');
 let stdOut;
 
 

--- a/test/parallel/test-process-env-allowed-flags-are-documented.js
+++ b/test/parallel/test-process-env-allowed-flags-are-documented.js
@@ -51,6 +51,8 @@ const conditionalOpts = [
         '--use-openssl-ca',
         '--secure-heap',
         '--secure-heap-min',
+        '--enable-fips',
+        '--force-fips',
       ].includes(opt);
     }
   }, {

--- a/test/parallel/test-process-env-allowed-flags-are-documented.js
+++ b/test/parallel/test-process-env-allowed-flags-are-documented.js
@@ -54,15 +54,6 @@ const conditionalOpts = [
       ].includes(opt);
     }
   }, {
-    // We are using openssl_is_fips from the configuration because it could be
-    // the case that OpenSSL is FIPS compatible but fips has not been enabled
-    // (starting node with --enable-fips). If we use common.hasFipsCrypto
-    // that would only tells us if fips has been enabled, but in this case we
-    // want to check options which will be available regardless of whether fips
-    // is enabled at runtime or not.
-    include: process.config.variables.openssl_is_fips,
-    filter: (opt) => opt.includes('-fips')
-  }, {
     include: common.hasIntl,
     filter: (opt) => opt === '--icu-data-dir'
   }, {


### PR DESCRIPTION
This is continuation of #35019, rebased on current master. I have taken it over from @voxik.

## Additional changes

`fipsMode` constant was replaced by (hopefully) internal binding to `FIPS_selftest()` OpenSSL function.
The binding is called `testFipsCrypto()` and it simply returns 1 or 0 based on the FIPS status reported by OpenSSL.
The relevant tests were adjusted to rely on this in place of the original constant.

## Open problems

There is still the issue of reporting errors in `InitCryptoOnce()`:

```cpp
/* Override FIPS settings in cnf file, if needed. */
unsigned long err = 0;  // NOLINT(runtime/int)
if (per_process::cli_options->enable_fips_crypto ||
    per_process::cli_options->force_fips_crypto) {
  if (0 == FIPS_mode() && !FIPS_mode_set(1)) {
    err = ERR_get_error();
  }
}
if (0 != err) {
  fprintf(stderr,
          "openssl fips failed: %s\n",
          ERR_error_string(err, nullptr));
  UNREACHABLE();
}
```

The `UNREACHABLE()` section is not so unreachable anymore 😉.
Unfortunately, I was not able to figure out better way to report an error – anything similar to `return ThrowCryptoError(env, err)` requires a reference to the environment, which AFAIK is not available in the `InitCryptoOnce()`.

Any pointers?

---

Fixes #34903; obsoletes/closes #35019.
