### PR TITLE
Retain async context when notifying PerformanceObservers

### DIFF
--- a/lib/perf_hooks.js
+++ b/lib/perf_hooks.js
@@ -52,7 +52,6 @@ const {
   NODE_PERFORMANCE_MILESTONE_ENVIRONMENT
 } = constants;
 
-const { AsyncResource } = require('async_hooks');
 const L = require('internal/linkedlist');
 const kInspect = require('internal/util').customInspectSymbol;
 
@@ -340,12 +339,11 @@ class PerformanceObserverEntryList {
   }
 }
 
-class PerformanceObserver extends AsyncResource {
+class PerformanceObserver {
   constructor(callback) {
     if (typeof callback !== 'function') {
       throw new ERR_INVALID_CALLBACK(callback);
     }
-    super('PerformanceObserver');
     ObjectDefineProperties(this, {
       [kTypes]: {
         enumerable: false,
@@ -553,10 +551,7 @@ function getObserversList(type) {
 
 function doNotify(observer) {
   observer[kQueued] = false;
-  observer.runInAsyncScope(observer[kCallback],
-                           observer,
-                           observer[kBuffer],
-                           observer);
+  observer[kCallback](observer[kBuffer], observer);
   observer[kBuffer][kEntries] = [];
   L.init(observer[kBuffer][kEntries]);
 }

--- a/src/api/callback.cc
+++ b/src/api/callback.cc
@@ -266,6 +266,34 @@ MaybeLocal<Value> MakeCallback(Isolate* isolate,
   return ret;
 }
 
+// Use this if you just want to safely invoke some JS callback and
+// would like to retain the currently active async_context, if any.
+// In case none is available, a fixed default context will be
+// installed otherwise.
+MaybeLocal<Value> MakeSyncCallback(Isolate* isolate,
+                                   Local<Object> recv,
+                                   Local<Function> callback,
+                                   int argc,
+                                   Local<Value> argv[]) {
+  Environment* env = Environment::GetCurrent(callback->CreationContext());
+  CHECK_NOT_NULL(env);
+  if (!env->can_call_into_js()) return Local<Value>();
+
+  Context::Scope context_scope(env->context());
+  if (env->async_callback_scope_depth()) {
+    // There's another MakeCallback() on the stack, piggy back on it.
+    // In particular, retain the current async_context.
+    return callback->Call(env->context(), recv, argc, argv);
+  }
+
+  // This is a toplevel invocation and the caller (intentionally)
+  // didn't provide any async_context to run in. Install a default context.
+  MaybeLocal<Value> ret =
+    InternalMakeCallback(env, env->process_object(), recv, callback, argc, argv,
+                         async_context{0, 0});
+  return ret;
+}
+
 // Legacy MakeCallback()s
 
 Local<Value> MakeCallback(Isolate* isolate,

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -200,6 +200,12 @@ v8::MaybeLocal<v8::Value> InternalMakeCallback(
     v8::Local<v8::Value> argv[],
     async_context asyncContext);
 
+v8::MaybeLocal<v8::Value> MakeSyncCallback(v8::Isolate* isolate,
+                                           v8::Local<v8::Object> recv,
+                                           v8::Local<v8::Function> callback,
+                                           int argc,
+                                           v8::Local<v8::Value> argv[]);
+
 class InternalCallbackScope {
  public:
   enum Flags {

--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -159,11 +159,10 @@ void PerformanceEntry::Notify(Environment* env,
   AliasedUint32Array& observers = env->performance_state()->observers;
   if (!env->performance_entry_callback().IsEmpty() &&
       type != NODE_PERFORMANCE_ENTRY_TYPE_INVALID && observers[type]) {
-    node::MakeCallback(env->isolate(),
-                       object.As<Object>(),
-                       env->performance_entry_callback(),
-                       1, &object,
-                       node::async_context{0, 0});
+    node::MakeSyncCallback(env->isolate(),
+                           object.As<Object>(),
+                           env->performance_entry_callback(),
+                           1, &object);
   }
 }
 

--- a/test/parallel/test-performanceobserver-asynccontext.js
+++ b/test/parallel/test-performanceobserver-asynccontext.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const {
+  performance,
+  PerformanceObserver,
+} = require('perf_hooks');
+const {
+  executionAsyncId,
+  triggerAsyncId,
+  executionAsyncResource,
+} = require('async_hooks');
+
+// Test Non-Buffered PerformanceObserver retains async context
+{
+  const observer =
+    new PerformanceObserver(common.mustCall(callback));
+
+  const initialAsyncId = executionAsyncId();
+  let asyncIdInTimeout;
+  let asyncResourceInTimeout;
+
+  function callback(list) {
+    assert.strictEqual(triggerAsyncId(), initialAsyncId);
+    assert.strictEqual(executionAsyncId(), asyncIdInTimeout);
+    assert.strictEqual(executionAsyncResource(), asyncResourceInTimeout);
+    observer.disconnect();
+  }
+  observer.observe({ entryTypes: ['mark'] });
+
+  setTimeout(() => {
+    asyncIdInTimeout = executionAsyncId();
+    asyncResourceInTimeout = executionAsyncResource();
+    performance.mark('test1');
+  }, 0);
+}


### PR DESCRIPTION
**Problem description:**
Using the `perf_hooks` module (specifically the *User Timing API*), to collect timings in an async context (i.e. to collect metrics during the lifetime of an HTTP request), it is not possible to correlate the `PerformanceEntry`s with a single request (except for using workarounds, such as prefixing all mark names with a unique id).
This is required, when implementing e.g. tracing solutions, where one wants to have timings per requests.

**Solution:**
With the changes in this PR we are able to retain async contexts when calling the `PerformanceObserver`, which enables us to, for example, access an `AsyncLocalStorage` in the observer callback to store the collected metrics per request.

**Additional notes:**
* The above mentioned solution won't work when the `PerformanceObserver` is buffered.

**Questions:**
* What, if anything, should go into the documentation? I suppose we should mention that buffered observers do not retain the async context?
* Would this change get back-ported to the v12 release?

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
