### PR TITLE
vm: add `SafeForTerminationScope`s for SIGINT interruptions

### DIFF
--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -350,6 +350,7 @@ void ModuleWrap::Evaluate(const FunctionCallbackInfo<Value>& args) {
 
   ShouldNotAbortOnUncaughtScope no_abort_scope(env);
   TryCatchScope try_catch(env);
+  Isolate::SafeForTerminationScope safe_for_termination(env->isolate());
 
   bool timed_out = false;
   bool received_signal = false;

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -933,6 +933,7 @@ bool ContextifyScript::EvalMachine(Environment* env,
     return false;
   }
   TryCatchScope try_catch(env);
+  Isolate::SafeForTerminationScope safe_for_termination(env->isolate());
   ContextifyScript* wrapped_script;
   ASSIGN_OR_RETURN_UNWRAP(&wrapped_script, args.Holder(), false);
   Local<UnboundScript> unbound_script =

--- a/test/cctest/test_environment.cc
+++ b/test/cctest/test_environment.cc
@@ -549,3 +549,62 @@ TEST_F(EnvironmentTest, SetImmediateMicrotasks) {
 
   EXPECT_EQ(called, 1);
 }
+
+#ifndef _WIN32  // No SIGINT on Windows.
+TEST_F(NodeZeroIsolateTestFixture, CtrlCWithOnlySafeTerminationTest) {
+  // We need to go through the whole setup dance here because we want to
+  // set only_terminate_in_safe_scope.
+  // Allocate and initialize isolate
+  v8::Isolate::CreateParams create_params;
+  create_params.array_buffer_allocator = allocator.get();
+  create_params.only_terminate_in_safe_scope = true;
+  v8::Isolate* isolate = v8::Isolate::Allocate();
+  CHECK_NOT_NULL(isolate);
+  platform->RegisterIsolate(isolate, &current_loop);
+  v8::Isolate::Initialize(isolate, create_params);
+
+  // Try creating Context + IsolateData + Environment
+  {
+    v8::Isolate::Scope isolate_scope(isolate);
+    v8::HandleScope handle_scope(isolate);
+
+    auto context = node::NewContext(isolate);
+    CHECK(!context.IsEmpty());
+    v8::Context::Scope context_scope(context);
+
+    std::unique_ptr<node::IsolateData, decltype(&node::FreeIsolateData)>
+      isolate_data{node::CreateIsolateData(isolate,
+                                           &current_loop,
+                                           platform.get()),
+                   node::FreeIsolateData};
+    CHECK(isolate_data);
+
+    std::unique_ptr<node::Environment, decltype(&node::FreeEnvironment)>
+      environment{node::CreateEnvironment(isolate_data.get(),
+                                          context,
+                                          {},
+                                          {}),
+                  node::FreeEnvironment};
+    CHECK(environment);
+
+    v8::Local<v8::Value> main_ret =
+        node::LoadEnvironment(environment.get(),
+            "'use strict';\n"
+            "const { runInThisContext } = require('vm');\n"
+            "try {\n"
+            "  runInThisContext("
+            "    `process.kill(process.pid, 'SIGINT'); while(true){}`, "
+            "    { breakOnSigint: true });\n"
+            "  return 'unreachable';\n"
+            "} catch (err) {\n"
+            "  return err.code;\n"
+            "}").ToLocalChecked();
+    node::Utf8Value main_ret_str(isolate, main_ret);
+    EXPECT_EQ(std::string(*main_ret_str), "ERR_SCRIPT_EXECUTION_INTERRUPTED");
+  }
+
+  // Cleanup
+  platform->UnregisterIsolate(isolate);
+  isolate->Dispose();
+}
+#endif  // _WIN32

--- a/test/cctest/test_environment.cc
+++ b/test/cctest/test_environment.cc
@@ -554,7 +554,7 @@ TEST_F(EnvironmentTest, SetImmediateMicrotasks) {
 TEST_F(NodeZeroIsolateTestFixture, CtrlCWithOnlySafeTerminationTest) {
   // We need to go through the whole setup dance here because we want to
   // set only_terminate_in_safe_scope.
-  // Allocate and initialize isolate
+  // Allocate and initialize Isolate.
   v8::Isolate::CreateParams create_params;
   create_params.array_buffer_allocator = allocator.get();
   create_params.only_terminate_in_safe_scope = true;
@@ -563,7 +563,7 @@ TEST_F(NodeZeroIsolateTestFixture, CtrlCWithOnlySafeTerminationTest) {
   platform->RegisterIsolate(isolate, &current_loop);
   v8::Isolate::Initialize(isolate, create_params);
 
-  // Try creating Context + IsolateData + Environment
+  // Try creating Context + IsolateData + Environment.
   {
     v8::Isolate::Scope isolate_scope(isolate);
     v8::HandleScope handle_scope(isolate);
@@ -603,7 +603,7 @@ TEST_F(NodeZeroIsolateTestFixture, CtrlCWithOnlySafeTerminationTest) {
     EXPECT_EQ(std::string(*main_ret_str), "ERR_SCRIPT_EXECUTION_INTERRUPTED");
   }
 
-  // Cleanup
+  // Cleanup.
   platform->UnregisterIsolate(isolate);
   isolate->Dispose();
 }


### PR DESCRIPTION
Some embedders, like Electron, choose to start Node.js with
`only_terminate_in_safe_scope` set to `true`. In those cases, parts
of the API that expect execution termination to happen need to
be marked as able to receive those events. In our case, this is
the Ctrl+C support of the `vm` module (and Workers, but since
we’re in control of creating the `Isolate` for them, that’s a
non-concern there).

Add those scopes and add a regression test.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
