### PR TITLE
test: fix child-process-pipe-dataflow

### DIFF
--- a/test/parallel/test-child-process-pipe-dataflow.js
+++ b/test/parallel/test-child-process-pipe-dataflow.js
@@ -61,8 +61,13 @@ const MB = KB * KB;
     }));
   });
 
+  let wcBuf = '';
   wc.stdout.on('data', common.mustCall((data) => {
+    wcBuf += data;
+  }));
+
+  wc.on('close', common.mustCall(() => {
     // Grep always adds one extra byte at the end.
-    assert.strictEqual(data.toString().trim(), (MB + 1).toString());
+    assert.strictEqual(wcBuf.trim(), (MB + 1).toString());
   }));
 }


### PR DESCRIPTION
Make sure all the `wc` process stdout data is received before checking
its validity.

Fixes: https://github.com/nodejs/node/issues/25988