### PR TITLE
test: add SIGTRAP to test-signal-handler

### DIFF
--- a/test/abort/test-signal-handler.js
+++ b/test/abort/test-signal-handler.js
@@ -18,6 +18,6 @@ if (process.argv[2] === 'child') {
                           ['--expose-internals', __filename, 'child'],
                           { stdio: 'inherit' });
   // FreeBSD and macOS use SIGILL for the kind of crash we're causing here.
-  assert(child.signal === 'SIGSEGV' || child.signal === 'SIGILL',
-         `child.signal = ${child.signal}`);
+  assert(child.signal === 'SIGSEGV' || child.signal === 'SIGILL' ||
+          child.signal === 'SIGTRAP', `child.signal = ${child.signal}`);
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

On apple sillicon I get test failures on `test-signal-handler` with SIGTRAP so add that to the test for expected failures.
refs: https://github.com/nodejs/build/issues/2474#issuecomment-738097545

Example build before change: https://ci.nodejs.org/job/node-test-commit-osx-arm/nodes=osx11/17/

And after: https://ci.nodejs.org/job/node-test-commit-osx-arm/nodes=osx11/18/

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
