### PR TITLE
[v14.x backport] http2: check write not scheduled in scope destructor

### DIFF
--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -88,7 +88,8 @@ Http2Scope::Http2Scope(Http2Session* session) : session_(session) {
 Http2Scope::~Http2Scope() {
   if (!session_) return;
   session_->set_in_scope(false);
-  session_->MaybeScheduleWrite();
+  if (!session_->is_write_scheduled())
+    session_->MaybeScheduleWrite();
 }
 
 // The Http2Options object is used during the construction of Http2Session

--- a/test/parallel/test-http2-close-while-writing.js
+++ b/test/parallel/test-http2-close-while-writing.js
@@ -1,0 +1,46 @@
+'use strict';
+// https://github.com/nodejs/node/issues/33156
+const common = require('../common');
+const fixtures = require('../common/fixtures');
+
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+}
+
+const http2 = require('http2');
+
+const key = fixtures.readKey('agent8-key.pem', 'binary');
+const cert = fixtures.readKey('agent8-cert.pem', 'binary');
+const ca = fixtures.readKey('fake-startcom-root-cert.pem', 'binary');
+
+const server = http2.createSecureServer({
+  key,
+  cert,
+  maxSessionMemory: 1000
+});
+
+let client_stream;
+
+server.on('session', common.mustCall(function(session) {
+  session.on('stream', common.mustCall(function(stream) {
+    stream.resume();
+    stream.on('data', function() {
+      this.write(Buffer.alloc(1));
+      process.nextTick(() => client_stream.destroy());
+    });
+  }));
+}));
+
+server.listen(0, function() {
+  const client = http2.connect(`https://localhost:${server.address().port}`, {
+    ca,
+    maxSessionMemory: 1000
+  });
+  client_stream = client.request({ ':method': 'POST' });
+  client_stream.on('close', common.mustCall(() => {
+    client.close();
+    server.close();
+  }));
+  client_stream.resume();
+  client_stream.write(Buffer.alloc(64 * 1024));
+});


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/33156

PR-URL: https://github.com/nodejs/node/pull/36241
Reviewed-By: Matteo Collina <matteo.collina@gmail.com>
Reviewed-By: Rich Trott <rtrott@gmail.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
