### PR TITLE
async_hooks: use new v8::Context PromiseHook API

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.15',
+    'v8_embedder_string': '-node.16',
 
     ##### V8 defaults for Node.js #####
 

--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.14',
+    'v8_embedder_string': '-node.15',
 
     ##### V8 defaults for Node.js #####
 

--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.12',
+    'v8_embedder_string': '-node.13',
 
     ##### V8 defaults for Node.js #####
 

--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.13',
+    'v8_embedder_string': '-node.14',
 
     ##### V8 defaults for Node.js #####
 

--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.11',
+    'v8_embedder_string': '-node.12',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/AUTHORS
+++ b/deps/v8/AUTHORS
@@ -209,6 +209,7 @@ Seo Sanghyeon <sanxiyn@gmail.com>
 Shawn Anastasio <shawnanastasio@gmail.com>
 Shawn Presser <shawnpresser@gmail.com>
 Stefan Penner <stefan.penner@gmail.com>
+Stephen Belanger <stephen.belanger@datadoghq.com>
 Sylvestre Ledru <sledru@mozilla.com>
 Taketoshi Aono <brn@b6n.ch>
 Tao Liqiang <taolq@outlook.com>

--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -10795,6 +10795,18 @@ class V8_EXPORT Context : public Data {
   void SetContinuationPreservedEmbedderData(Local<Value> context);
 
   /**
+   * Set or clear hooks to be invoked for promise lifecycle operations.
+   * To clear a hook, set it to an empty v8::Function. Each function will
+   * receive the observed promise as the first argument. If a chaining
+   * operation is used on a promise, the init will additionally receive
+   * the parent promise as the second argument.
+   */
+  void SetPromiseHooks(Local<Function> init_hook,
+                       Local<Function> before_hook,
+                       Local<Function> after_hook,
+                       Local<Function> resolve_hook);
+
+  /**
    * Stack-allocated class which sets the execution context for all
    * operations executed within a local scope.
    */

--- a/deps/v8/src/api/api.cc
+++ b/deps/v8/src/api/api.cc
@@ -6147,6 +6147,45 @@ void Context::SetContinuationPreservedEmbedderData(Local<Value> data) {
       *i::Handle<i::HeapObject>::cast(Utils::OpenHandle(*data)));
 }
 
+void v8::Context::SetPromiseHooks(Local<Function> init_hook,
+                                  Local<Function> before_hook,
+                                  Local<Function> after_hook,
+                                  Local<Function> resolve_hook) {
+  i::Handle<i::Context> context = Utils::OpenHandle(this);
+  i::Isolate* isolate = context->GetIsolate();
+
+  i::Handle<i::Object> init = isolate->factory()->undefined_value();
+  i::Handle<i::Object> before = isolate->factory()->undefined_value();
+  i::Handle<i::Object> after = isolate->factory()->undefined_value();
+  i::Handle<i::Object> resolve = isolate->factory()->undefined_value();
+
+  bool has_hook = false;
+
+  if (!init_hook.IsEmpty()) {
+    init = Utils::OpenHandle(*init_hook);
+    has_hook = true;
+  }
+  if (!before_hook.IsEmpty()) {
+    before = Utils::OpenHandle(*before_hook);
+    has_hook = true;
+  }
+  if (!after_hook.IsEmpty()) {
+    after = Utils::OpenHandle(*after_hook);
+    has_hook = true;
+  }
+  if (!resolve_hook.IsEmpty()) {
+    resolve = Utils::OpenHandle(*resolve_hook);
+    has_hook = true;
+  }
+
+  isolate->SetHasContextPromiseHooks(has_hook);
+
+  context->native_context().set_promise_hook_init_function(*init);
+  context->native_context().set_promise_hook_before_function(*before);
+  context->native_context().set_promise_hook_after_function(*after);
+  context->native_context().set_promise_hook_resolve_function(*resolve);
+}
+
 MaybeLocal<Context> metrics::Recorder::GetContext(
     Isolate* isolate, metrics::Recorder::ContextId id) {
   i::Isolate* i_isolate = reinterpret_cast<i::Isolate*>(isolate);

--- a/deps/v8/src/builtins/builtins-async-function-gen.cc
+++ b/deps/v8/src/builtins/builtins-async-function-gen.cc
@@ -157,12 +157,14 @@ TF_BUILTIN(AsyncFunctionEnter, AsyncFunctionBuiltinsAssembler) {
   StoreObjectFieldNoWriteBarrier(
       async_function_object, JSAsyncFunctionObject::kPromiseOffset, promise);
 
+  RunContextPromiseHookInit(context, promise, UndefinedConstant());
+
   // Fire promise hooks if enabled and push the Promise under construction
   // in an async function on the catch prediction stack to handle exceptions
   // thrown before the first await.
   Label if_instrumentation(this, Label::kDeferred),
       if_instrumentation_done(this);
-  Branch(IsPromiseHookEnabledOrDebugIsActiveOrHasAsyncEventDelegate(),
+  Branch(IsIsolatePromiseHookEnabledOrDebugIsActiveOrHasAsyncEventDelegate(),
          &if_instrumentation, &if_instrumentation_done);
   BIND(&if_instrumentation);
   {

--- a/deps/v8/src/builtins/builtins-async-gen.cc
+++ b/deps/v8/src/builtins/builtins-async-gen.cc
@@ -99,18 +99,11 @@ TNode<Object> AsyncBuiltinsAssembler::AwaitOld(
 
   TVARIABLE(HeapObject, var_throwaway, UndefinedConstant());
 
-  // Deal with PromiseHooks and debug support in the runtime. This
-  // also allocates the throwaway promise, which is only needed in
-  // case of PromiseHooks or debugging.
-  Label if_debugging(this, Label::kDeferred), do_resolve_promise(this);
-  Branch(IsPromiseHookEnabledOrDebugIsActiveOrHasAsyncEventDelegate(),
-         &if_debugging, &do_resolve_promise);
-  BIND(&if_debugging);
-  var_throwaway =
-      CAST(CallRuntime(Runtime::kAwaitPromisesInitOld, context, value, promise,
-                       outer_promise, on_reject, is_predicted_as_caught));
-  Goto(&do_resolve_promise);
-  BIND(&do_resolve_promise);
+  RunContextPromiseHookInit(context, promise, outer_promise);
+
+  InitAwaitPromise(Runtime::kAwaitPromisesInitOld, context, value, promise,
+                   outer_promise, on_reject, is_predicted_as_caught,
+                   &var_throwaway);
 
   // Perform ! Call(promiseCapability.[[Resolve]], undefined, « promise »).
   CallBuiltin(Builtins::kResolvePromise, context, promise, value);
@@ -170,21 +163,46 @@ TNode<Object> AsyncBuiltinsAssembler::AwaitOptimized(
 
   TVARIABLE(HeapObject, var_throwaway, UndefinedConstant());
 
-  // Deal with PromiseHooks and debug support in the runtime. This
-  // also allocates the throwaway promise, which is only needed in
-  // case of PromiseHooks or debugging.
-  Label if_debugging(this, Label::kDeferred), do_perform_promise_then(this);
-  Branch(IsPromiseHookEnabledOrDebugIsActiveOrHasAsyncEventDelegate(),
-         &if_debugging, &do_perform_promise_then);
-  BIND(&if_debugging);
-  var_throwaway =
-      CAST(CallRuntime(Runtime::kAwaitPromisesInit, context, promise, promise,
-                       outer_promise, on_reject, is_predicted_as_caught));
-  Goto(&do_perform_promise_then);
-  BIND(&do_perform_promise_then);
+  InitAwaitPromise(Runtime::kAwaitPromisesInit, context, promise, promise,
+                   outer_promise, on_reject, is_predicted_as_caught,
+                   &var_throwaway);
 
   return CallBuiltin(Builtins::kPerformPromiseThen, native_context, promise,
                      on_resolve, on_reject, var_throwaway.value());
+}
+
+void AsyncBuiltinsAssembler::InitAwaitPromise(
+    Runtime::FunctionId id, TNode<Context> context, TNode<Object> value,
+    TNode<Object> promise, TNode<Object> outer_promise,
+    TNode<HeapObject> on_reject, TNode<Oddball> is_predicted_as_caught,
+    TVariable<HeapObject>* var_throwaway) {
+  // Deal with PromiseHooks and debug support in the runtime. This
+  // also allocates the throwaway promise, which is only needed in
+  // case of PromiseHooks or debugging.
+  Label if_debugging(this, Label::kDeferred),
+      if_promise_hook(this, Label::kDeferred),
+      not_debugging(this),
+      do_nothing(this);
+  TNode<Uint32T> promiseHookFlags = PromiseHookFlags();
+  Branch(IsIsolatePromiseHookEnabledOrDebugIsActiveOrHasAsyncEventDelegate(
+      promiseHookFlags), &if_debugging, &not_debugging);
+  BIND(&if_debugging);
+  *var_throwaway =
+      CAST(CallRuntime(id, context, value, promise,
+                       outer_promise, on_reject, is_predicted_as_caught));
+  Goto(&do_nothing);
+  BIND(&not_debugging);
+
+  // This call to NewJSPromise is to keep behaviour parity with what happens
+  // in Runtime::kAwaitPromisesInit above if native hooks are set. It will
+  // create a throwaway promise that will trigger an init event and will get
+  // passed into Builtins::kPerformPromiseThen below.
+  Branch(IsContextPromiseHookEnabled(promiseHookFlags), &if_promise_hook,
+         &do_nothing);
+  BIND(&if_promise_hook);
+  *var_throwaway = NewJSPromise(context, promise);
+  Goto(&do_nothing);
+  BIND(&do_nothing);
 }
 
 TNode<Object> AsyncBuiltinsAssembler::Await(

--- a/deps/v8/src/builtins/builtins-async-gen.h
+++ b/deps/v8/src/builtins/builtins-async-gen.h
@@ -62,6 +62,12 @@ class AsyncBuiltinsAssembler : public PromiseBuiltinsAssembler {
                                TNode<SharedFunctionInfo> on_resolve_sfi,
                                TNode<SharedFunctionInfo> on_reject_sfi,
                                TNode<Oddball> is_predicted_as_caught);
+
+  void InitAwaitPromise(
+      Runtime::FunctionId id, TNode<Context> context, TNode<Object> value,
+      TNode<Object> promise, TNode<Object> outer_promise,
+      TNode<HeapObject> on_reject, TNode<Oddball> is_predicted_as_caught,
+      TVariable<HeapObject>* var_throwaway);
 };
 
 }  // namespace internal

--- a/deps/v8/src/builtins/builtins-async-generator-gen.cc
+++ b/deps/v8/src/builtins/builtins-async-generator-gen.cc
@@ -520,7 +520,7 @@ TF_BUILTIN(AsyncGeneratorResolve, AsyncGeneratorBuiltinsAssembler) {
   // the "promiseResolve" hook would not be fired otherwise.
   Label if_fast(this), if_slow(this, Label::kDeferred), return_promise(this);
   GotoIfForceSlowPath(&if_slow);
-  GotoIf(IsPromiseHookEnabled(), &if_slow);
+  GotoIf(IsIsolatePromiseHookEnabledOrHasAsyncEventDelegate(), &if_slow);
   Branch(IsPromiseThenProtectorCellInvalid(), &if_slow, &if_fast);
 
   BIND(&if_fast);

--- a/deps/v8/src/builtins/cast.tq
+++ b/deps/v8/src/builtins/cast.tq
@@ -386,6 +386,12 @@ Cast<Undefined|Callable>(o: HeapObject): Undefined|Callable
   return HeapObjectToCallable(o) otherwise CastError;
 }
 
+Cast<Undefined|JSFunction>(o: HeapObject): Undefined|JSFunction
+    labels CastError {
+  if (o == Undefined) return Undefined;
+  return Cast<JSFunction>(o) otherwise CastError;
+}
+
 macro Cast<T : type extends Symbol>(o: Symbol): T labels CastError;
 Cast<PublicSymbol>(s: Symbol): PublicSymbol labels CastError {
   if (s.flags.is_private) goto CastError;

--- a/deps/v8/src/builtins/promise-abstract-operations.tq
+++ b/deps/v8/src/builtins/promise-abstract-operations.tq
@@ -196,6 +196,8 @@ FulfillPromise(implicit context: Context)(
   // Assert: The value of promise.[[PromiseState]] is "pending".
   assert(promise.Status() == PromiseState::kPending);
 
+  RunContextPromiseHookResolve(promise);
+
   // 2. Let reactions be promise.[[PromiseFulfillReactions]].
   const reactions =
       UnsafeCast<(Zero | PromiseReaction)>(promise.reactions_or_result);
@@ -214,17 +216,24 @@ FulfillPromise(implicit context: Context)(
 }
 
 extern macro PromiseBuiltinsAssembler::
-    IsPromiseHookEnabledOrDebugIsActiveOrHasAsyncEventDelegate(): bool;
+    IsIsolatePromiseHookEnabledOrDebugIsActiveOrHasAsyncEventDelegate(): bool;
+
+extern macro PromiseBuiltinsAssembler::
+    IsIsolatePromiseHookEnabledOrDebugIsActiveOrHasAsyncEventDelegate(uint32):
+        bool;
 
 // https://tc39.es/ecma262/#sec-rejectpromise
 transitioning builtin
 RejectPromise(implicit context: Context)(
     promise: JSPromise, reason: JSAny, debugEvent: Boolean): JSAny {
+  const promiseHookFlags = PromiseHookFlags();
+
   // If promise hook is enabled or the debugger is active, let
   // the runtime handle this operation, which greatly reduces
   // the complexity here and also avoids a couple of back and
   // forth between JavaScript and C++ land.
-  if (IsPromiseHookEnabledOrDebugIsActiveOrHasAsyncEventDelegate() ||
+  if (IsIsolatePromiseHookEnabledOrDebugIsActiveOrHasAsyncEventDelegate(
+          promiseHookFlags) ||
       !promise.HasHandler()) {
     // 7. If promise.[[PromiseIsHandled]] is false, perform
     //    HostPromiseRejectionTracker(promise, "reject").
@@ -232,6 +241,8 @@ RejectPromise(implicit context: Context)(
     // here, but we let the C++ code take care of this completely.
     return runtime::RejectPromise(promise, reason, debugEvent);
   }
+
+  RunContextPromiseHookResolve(promise, promiseHookFlags);
 
   // 2. Let reactions be promise.[[PromiseRejectReactions]].
   const reactions =

--- a/deps/v8/src/builtins/promise-all.tq
+++ b/deps/v8/src/builtins/promise-all.tq
@@ -232,7 +232,7 @@ Reject(Object) {
       // PerformPromiseThen), since this is only necessary for DevTools and
       // PromiseHooks.
       if (promiseResolveFunction != Undefined ||
-          IsPromiseHookEnabledOrDebugIsActiveOrHasAsyncEventDelegate() ||
+          IsIsolatePromiseHookEnabledOrDebugIsActiveOrHasAsyncEventDelegate() ||
           IsPromiseSpeciesProtectorCellInvalid() || Is<Smi>(nextValue) ||
           !IsPromiseThenLookupChainIntact(
               nativeContext, UnsafeCast<HeapObject>(nextValue).map)) {

--- a/deps/v8/src/builtins/promise-all.tq
+++ b/deps/v8/src/builtins/promise-all.tq
@@ -231,8 +231,7 @@ Reject(Object) {
       // the PromiseReaction (aka we can pass undefined to
       // PerformPromiseThen), since this is only necessary for DevTools and
       // PromiseHooks.
-      if (promiseResolveFunction != Undefined ||
-          IsIsolatePromiseHookEnabledOrDebugIsActiveOrHasAsyncEventDelegate() ||
+      if (promiseResolveFunction != Undefined || NeedsAnyPromiseHooks() ||
           IsPromiseSpeciesProtectorCellInvalid() || Is<Smi>(nextValue) ||
           !IsPromiseThenLookupChainIntact(
               nativeContext, UnsafeCast<HeapObject>(nextValue).map)) {

--- a/deps/v8/src/builtins/promise-constructor.tq
+++ b/deps/v8/src/builtins/promise-constructor.tq
@@ -40,7 +40,8 @@ extern macro ConstructorBuiltinsAssembler::FastNewObject(
     Context, JSFunction, JSReceiver): JSObject;
 
 extern macro
-PromiseBuiltinsAssembler::IsPromiseHookEnabledOrHasAsyncEventDelegate(): bool;
+PromiseBuiltinsAssembler::IsIsolatePromiseHookEnabledOrHasAsyncEventDelegate(
+    uint32): bool;
 
 // https://tc39.es/ecma262/#sec-promise-executor
 transitioning javascript builtin
@@ -73,9 +74,7 @@ PromiseConstructor(
     result = UnsafeCast<JSPromise>(
         FastNewObject(context, promiseFun, UnsafeCast<JSReceiver>(newTarget)));
     PromiseInit(result);
-    if (IsPromiseHookEnabledOrHasAsyncEventDelegate()) {
-      runtime::PromiseHookInit(result, Undefined);
-    }
+    RunAnyPromiseHookInit(result, Undefined);
   }
 
   const isDebugActive = IsDebugActive();

--- a/deps/v8/src/builtins/promise-jobs.tq
+++ b/deps/v8/src/builtins/promise-jobs.tq
@@ -25,7 +25,7 @@ PromiseResolveThenableJob(implicit context: Context)(
   const promiseThen = *NativeContextSlot(ContextSlot::PROMISE_THEN_INDEX);
   const thenableMap = thenable.map;
   if (TaggedEqual(then, promiseThen) && IsJSPromiseMap(thenableMap) &&
-      !IsPromiseHookEnabledOrDebugIsActiveOrHasAsyncEventDelegate() &&
+      !IsIsolatePromiseHookEnabledOrDebugIsActiveOrHasAsyncEventDelegate() &&
       IsPromiseSpeciesLookupChainIntact(nativeContext, thenableMap)) {
     // We know that the {thenable} is a JSPromise, which doesn't require
     // any special treatment and that {then} corresponds to the initial

--- a/deps/v8/src/builtins/promise-jobs.tq
+++ b/deps/v8/src/builtins/promise-jobs.tq
@@ -7,6 +7,7 @@
 // https://tc39.es/ecma262/#sec-promise-jobs
 namespace promise {
 extern macro IsJSPromiseMap(Map): bool;
+extern macro NeedsAnyPromiseHooks(): bool;
 
 // https://tc39.es/ecma262/#sec-promiseresolvethenablejob
 transitioning builtin
@@ -25,7 +26,7 @@ PromiseResolveThenableJob(implicit context: Context)(
   const promiseThen = *NativeContextSlot(ContextSlot::PROMISE_THEN_INDEX);
   const thenableMap = thenable.map;
   if (TaggedEqual(then, promiseThen) && IsJSPromiseMap(thenableMap) &&
-      !IsIsolatePromiseHookEnabledOrDebugIsActiveOrHasAsyncEventDelegate() &&
+      !NeedsAnyPromiseHooks() &&
       IsPromiseSpeciesLookupChainIntact(nativeContext, thenableMap)) {
     // We know that the {thenable} is a JSPromise, which doesn't require
     // any special treatment and that {then} corresponds to the initial

--- a/deps/v8/src/builtins/promise-misc.tq
+++ b/deps/v8/src/builtins/promise-misc.tq
@@ -104,9 +104,7 @@ transitioning macro RunContextPromiseHookInit(implicit context: Context)(
     promise: JSPromise, parent: Object) {
   const maybeHook = *NativeContextSlot(
       ContextSlot::PROMISE_HOOK_INIT_FUNCTION_INDEX);
-  if (IsUndefined(maybeHook)) return;
-
-  const hook = Cast<JSFunction>(maybeHook) otherwise unreachable;
+  const hook = Cast<Callable>(maybeHook) otherwise return;
   const parentObject = Is<JSPromise>(parent) ? Cast<JSPromise>(parent)
       otherwise unreachable: Undefined;
 
@@ -165,13 +163,11 @@ transitioning macro RunContextPromiseHookAfter(implicit context: Context)(
 }
 
 transitioning macro RunContextPromiseHook(implicit context: Context)(
-    slot: Slot<NativeContext, Undefined|JSFunction>,
+    slot: Slot<NativeContext, Undefined|Callable>,
     promiseOrCapability: JSPromise|PromiseCapability|Undefined, flags: uint32) {
   if (!IsContextPromiseHookEnabled(flags)) return;
   const maybeHook = *NativeContextSlot(slot);
-  if (IsUndefined(maybeHook)) return;
-
-  const hook = Cast<JSFunction>(maybeHook) otherwise unreachable;
+  const hook = Cast<Callable>(maybeHook) otherwise return;
 
   let promise: JSPromise;
   typeswitch (promiseOrCapability) {

--- a/deps/v8/src/builtins/promise-misc.tq
+++ b/deps/v8/src/builtins/promise-misc.tq
@@ -8,6 +8,9 @@
 namespace runtime {
 extern transitioning runtime
 AllowDynamicFunction(implicit context: Context)(JSAny): JSAny;
+
+extern transitioning runtime
+ReportMessageFromMicrotask(implicit context: Context)(JSAny): JSAny;
 }
 
 // Unsafe functions that should be used very carefully.
@@ -16,6 +19,12 @@ extern macro PromiseBuiltinsAssembler::ZeroOutEmbedderOffsets(JSPromise): void;
 
 extern macro PromiseBuiltinsAssembler::AllocateJSPromise(Context): HeapObject;
 }
+
+extern macro
+PromiseBuiltinsAssembler::IsContextPromiseHookEnabled(uint32): bool;
+
+extern macro
+PromiseBuiltinsAssembler::PromiseHookFlags(): uint32;
 
 namespace promise {
 extern macro IsFunctionWithPrototypeSlotMap(Map): bool;
@@ -90,6 +99,110 @@ macro NewPromiseRejectReactionJobTask(implicit context: Context)(
   };
 }
 
+@export
+transitioning macro RunContextPromiseHookInit(implicit context: Context)(
+    promise: JSPromise, parent: Object) {
+  const maybeHook = *NativeContextSlot(
+      ContextSlot::PROMISE_HOOK_INIT_FUNCTION_INDEX);
+  if (IsUndefined(maybeHook)) return;
+
+  const hook = Cast<JSFunction>(maybeHook) otherwise unreachable;
+  const parentObject = Is<JSPromise>(parent) ? Cast<JSPromise>(parent)
+      otherwise unreachable: Undefined;
+
+  try {
+    Call(context, hook, Undefined, promise, parentObject);
+  } catch (e) {
+    runtime::ReportMessageFromMicrotask(e);
+  }
+}
+
+@export
+transitioning macro RunContextPromiseHookResolve(implicit context: Context)(
+    promise: JSPromise) {
+  RunContextPromiseHook(
+      ContextSlot::PROMISE_HOOK_RESOLVE_FUNCTION_INDEX, promise,
+      PromiseHookFlags());
+}
+
+@export
+transitioning macro RunContextPromiseHookResolve(implicit context: Context)(
+    promise: JSPromise, flags: uint32) {
+  RunContextPromiseHook(
+      ContextSlot::PROMISE_HOOK_RESOLVE_FUNCTION_INDEX, promise, flags);
+}
+
+@export
+transitioning macro RunContextPromiseHookBefore(implicit context: Context)(
+    promiseOrCapability: JSPromise|PromiseCapability) {
+  RunContextPromiseHook(
+      ContextSlot::PROMISE_HOOK_BEFORE_FUNCTION_INDEX, promiseOrCapability,
+      PromiseHookFlags());
+}
+
+@export
+transitioning macro RunContextPromiseHookBefore(implicit context: Context)(
+    promiseOrCapability: JSPromise|PromiseCapability, flags: uint32) {
+  RunContextPromiseHook(
+      ContextSlot::PROMISE_HOOK_BEFORE_FUNCTION_INDEX, promiseOrCapability,
+      flags);
+}
+
+@export
+transitioning macro RunContextPromiseHookAfter(implicit context: Context)(
+    promiseOrCapability: JSPromise|PromiseCapability) {
+  RunContextPromiseHook(
+      ContextSlot::PROMISE_HOOK_AFTER_FUNCTION_INDEX, promiseOrCapability,
+      PromiseHookFlags());
+}
+
+@export
+transitioning macro RunContextPromiseHookAfter(implicit context: Context)(
+    promiseOrCapability: JSPromise|PromiseCapability, flags: uint32) {
+  RunContextPromiseHook(
+      ContextSlot::PROMISE_HOOK_AFTER_FUNCTION_INDEX, promiseOrCapability,
+      flags);
+}
+
+transitioning macro RunContextPromiseHook(implicit context: Context)(
+    slot: Slot<NativeContext, Undefined|JSFunction>,
+    promiseOrCapability: JSPromise|PromiseCapability, flags: uint32) {
+  if (!IsContextPromiseHookEnabled(flags)) return;
+  const maybeHook = *NativeContextSlot(slot);
+  if (IsUndefined(maybeHook)) return;
+
+  const hook = Cast<JSFunction>(maybeHook) otherwise unreachable;
+
+  let promise: JSPromise;
+  typeswitch (promiseOrCapability) {
+    case (jspromise: JSPromise): {
+      promise = jspromise;
+    }
+    case (capability: PromiseCapability): {
+      promise = Cast<JSPromise>(capability.promise) otherwise return;
+    }
+  }
+
+  try {
+    Call(context, hook, Undefined, promise);
+  } catch (e) {
+    runtime::ReportMessageFromMicrotask(e);
+  }
+}
+
+transitioning macro RunAnyPromiseHookInit(implicit context: Context)(
+    promise: JSPromise, parent: Object) {
+  const promiseHookFlags = PromiseHookFlags();
+  // Fast return if no hooks are set.
+  if (promiseHookFlags == 0) return;
+  if (IsContextPromiseHookEnabled(promiseHookFlags)) {
+    RunContextPromiseHookInit(promise, parent);
+  }
+  if (IsIsolatePromiseHookEnabledOrHasAsyncEventDelegate(promiseHookFlags)) {
+    runtime::PromiseHookInit(promise, parent);
+  }
+}
+
 // These allocate and initialize a promise with pending state and
 // undefined fields.
 //
@@ -100,9 +213,7 @@ transitioning macro NewJSPromise(implicit context: Context)(parent: Object):
     JSPromise {
   const instance = InnerNewJSPromise();
   PromiseInit(instance);
-  if (IsPromiseHookEnabledOrHasAsyncEventDelegate()) {
-    runtime::PromiseHookInit(instance, parent);
-  }
+  RunAnyPromiseHookInit(instance, parent);
   return instance;
 }
 
@@ -124,10 +235,7 @@ transitioning macro NewJSPromise(implicit context: Context)(
   instance.reactions_or_result = result;
   instance.SetStatus(status);
   promise_internal::ZeroOutEmbedderOffsets(instance);
-
-  if (IsPromiseHookEnabledOrHasAsyncEventDelegate()) {
-    runtime::PromiseHookInit(instance, Undefined);
-  }
+  RunAnyPromiseHookInit(instance, Undefined);
   return instance;
 }
 

--- a/deps/v8/src/builtins/promise-misc.tq
+++ b/deps/v8/src/builtins/promise-misc.tq
@@ -134,7 +134,7 @@ transitioning macro RunContextPromiseHookResolve(implicit context: Context)(
 
 @export
 transitioning macro RunContextPromiseHookBefore(implicit context: Context)(
-    promiseOrCapability: JSPromise|PromiseCapability) {
+    promiseOrCapability: JSPromise|PromiseCapability|Undefined) {
   RunContextPromiseHook(
       ContextSlot::PROMISE_HOOK_BEFORE_FUNCTION_INDEX, promiseOrCapability,
       PromiseHookFlags());
@@ -142,7 +142,7 @@ transitioning macro RunContextPromiseHookBefore(implicit context: Context)(
 
 @export
 transitioning macro RunContextPromiseHookBefore(implicit context: Context)(
-    promiseOrCapability: JSPromise|PromiseCapability, flags: uint32) {
+    promiseOrCapability: JSPromise|PromiseCapability|Undefined, flags: uint32) {
   RunContextPromiseHook(
       ContextSlot::PROMISE_HOOK_BEFORE_FUNCTION_INDEX, promiseOrCapability,
       flags);
@@ -150,7 +150,7 @@ transitioning macro RunContextPromiseHookBefore(implicit context: Context)(
 
 @export
 transitioning macro RunContextPromiseHookAfter(implicit context: Context)(
-    promiseOrCapability: JSPromise|PromiseCapability) {
+    promiseOrCapability: JSPromise|PromiseCapability|Undefined) {
   RunContextPromiseHook(
       ContextSlot::PROMISE_HOOK_AFTER_FUNCTION_INDEX, promiseOrCapability,
       PromiseHookFlags());
@@ -158,7 +158,7 @@ transitioning macro RunContextPromiseHookAfter(implicit context: Context)(
 
 @export
 transitioning macro RunContextPromiseHookAfter(implicit context: Context)(
-    promiseOrCapability: JSPromise|PromiseCapability, flags: uint32) {
+    promiseOrCapability: JSPromise|PromiseCapability|Undefined, flags: uint32) {
   RunContextPromiseHook(
       ContextSlot::PROMISE_HOOK_AFTER_FUNCTION_INDEX, promiseOrCapability,
       flags);
@@ -166,7 +166,7 @@ transitioning macro RunContextPromiseHookAfter(implicit context: Context)(
 
 transitioning macro RunContextPromiseHook(implicit context: Context)(
     slot: Slot<NativeContext, Undefined|JSFunction>,
-    promiseOrCapability: JSPromise|PromiseCapability, flags: uint32) {
+    promiseOrCapability: JSPromise|PromiseCapability|Undefined, flags: uint32) {
   if (!IsContextPromiseHookEnabled(flags)) return;
   const maybeHook = *NativeContextSlot(slot);
   if (IsUndefined(maybeHook)) return;
@@ -180,6 +180,9 @@ transitioning macro RunContextPromiseHook(implicit context: Context)(
     }
     case (capability: PromiseCapability): {
       promise = Cast<JSPromise>(capability.promise) otherwise return;
+    }
+    case (Undefined): {
+      return;
     }
   }
 

--- a/deps/v8/src/builtins/promise-resolve.tq
+++ b/deps/v8/src/builtins/promise-resolve.tq
@@ -97,7 +97,7 @@ ResolvePromise(implicit context: Context)(
   // We also let the runtime handle it if promise == resolution.
   // We can use pointer comparison here, since the {promise} is guaranteed
   // to be a JSPromise inside this function and thus is reference comparable.
-  if (IsPromiseHookEnabledOrDebugIsActiveOrHasAsyncEventDelegate() ||
+  if (IsIsolatePromiseHookEnabledOrDebugIsActiveOrHasAsyncEventDelegate() ||
       TaggedEqual(promise, resolution))
     deferred {
       return runtime::ResolvePromise(promise, resolution);

--- a/deps/v8/src/builtins/promise-resolve.tq
+++ b/deps/v8/src/builtins/promise-resolve.tq
@@ -30,7 +30,8 @@ transitioning builtin
 PromiseResolve(implicit context: Context)(
     constructor: JSReceiver, value: JSAny): JSAny {
   const nativeContext = LoadNativeContext(context);
-  const promiseFun = *NativeContextSlot(ContextSlot::PROMISE_FUNCTION_INDEX);
+  const promiseFun = *NativeContextSlot(
+      nativeContext, ContextSlot::PROMISE_FUNCTION_INDEX);
   try {
     // Check if {value} is a JSPromise.
     const value = Cast<JSPromise>(value) otherwise NeedToAllocate;
@@ -40,7 +41,8 @@ PromiseResolve(implicit context: Context)(
     // intact, as that guards the lookup path for "constructor" on
     // JSPromise instances which have the (initial) Promise.prototype.
     const promisePrototype =
-        *NativeContextSlot(ContextSlot::PROMISE_PROTOTYPE_INDEX);
+        *NativeContextSlot(
+        nativeContext, ContextSlot::PROMISE_PROTOTYPE_INDEX);
     // Check that Torque load elimination works.
     static_assert(nativeContext == LoadNativeContext(context));
     if (value.map.prototype != promisePrototype) {
@@ -139,7 +141,8 @@ ResolvePromise(implicit context: Context)(
       assert(IsJSReceiverMap(resolutionMap));
       assert(!IsPromiseThenProtectorCellInvalid());
       if (resolutionMap ==
-          *NativeContextSlot(ContextSlot::ITERATOR_RESULT_MAP_INDEX)) {
+          *NativeContextSlot(
+              nativeContext, ContextSlot::ITERATOR_RESULT_MAP_INDEX)) {
         return FulfillPromise(promise, resolution);
       } else {
         goto Slow;
@@ -147,10 +150,11 @@ ResolvePromise(implicit context: Context)(
     }
 
     const promisePrototype =
-        *NativeContextSlot(ContextSlot::PROMISE_PROTOTYPE_INDEX);
+        *NativeContextSlot(
+        nativeContext, ContextSlot::PROMISE_PROTOTYPE_INDEX);
     if (resolutionMap.prototype == promisePrototype) {
       // The {resolution} is a native Promise in this case.
-      then = *NativeContextSlot(ContextSlot::PROMISE_THEN_INDEX);
+      then = *NativeContextSlot(nativeContext, ContextSlot::PROMISE_THEN_INDEX);
       // Check that Torque load elimination works.
       static_assert(nativeContext == LoadNativeContext(context));
       goto Enqueue;

--- a/deps/v8/src/codegen/code-stub-assembler.cc
+++ b/deps/v8/src/codegen/code-stub-assembler.cc
@@ -13435,11 +13435,11 @@ TNode<BoolT> CodeStubAssembler::
   return Word32NotEqual(flags, Int32Constant(0));
 }
 
-TNode<BoolT> CodeStubAssembler::
-    IsAnyPromiseHookEnabledOrHasAsyncEventDelegate(TNode<Uint32T> flags) {
+TNode<BoolT> CodeStubAssembler::NeedsAnyPromiseHooks(TNode<Uint32T> flags) {
   uint32_t mask = Isolate::PromiseHookFields::HasContextPromiseHook::kMask |
                   Isolate::PromiseHookFields::HasIsolatePromiseHook::kMask |
-                  Isolate::PromiseHookFields::HasAsyncEventDelegate::kMask;
+                  Isolate::PromiseHookFields::HasAsyncEventDelegate::kMask |
+                  Isolate::PromiseHookFields::IsDebugActive::kMask;
   return IsSetWord32(flags, mask);
 }
 

--- a/deps/v8/src/codegen/code-stub-assembler.cc
+++ b/deps/v8/src/codegen/code-stub-assembler.cc
@@ -13391,35 +13391,56 @@ TNode<BoolT> CodeStubAssembler::IsDebugActive() {
   return Word32NotEqual(is_debug_active, Int32Constant(0));
 }
 
-TNode<BoolT> CodeStubAssembler::IsPromiseHookEnabled() {
-  const TNode<RawPtrT> promise_hook = Load<RawPtrT>(
-      ExternalConstant(ExternalReference::promise_hook_address(isolate())));
-  return WordNotEqual(promise_hook, IntPtrConstant(0));
-}
-
 TNode<BoolT> CodeStubAssembler::HasAsyncEventDelegate() {
   const TNode<RawPtrT> async_event_delegate = Load<RawPtrT>(ExternalConstant(
       ExternalReference::async_event_delegate_address(isolate())));
   return WordNotEqual(async_event_delegate, IntPtrConstant(0));
 }
 
-TNode<BoolT> CodeStubAssembler::IsPromiseHookEnabledOrHasAsyncEventDelegate() {
-  const TNode<Uint8T> promise_hook_or_async_event_delegate =
-      Load<Uint8T>(ExternalConstant(
-          ExternalReference::promise_hook_or_async_event_delegate_address(
-              isolate())));
-  return Word32NotEqual(promise_hook_or_async_event_delegate, Int32Constant(0));
+TNode<Uint32T> CodeStubAssembler::PromiseHookFlags() {
+  return Load<Uint32T>(ExternalConstant(
+    ExternalReference::promise_hook_flags_address(isolate())));
+}
+
+TNode<BoolT> CodeStubAssembler::IsAnyPromiseHookEnabled(TNode<Uint32T> flags) {
+  uint32_t mask = Isolate::PromiseHookFields::HasContextPromiseHook::kMask |
+                  Isolate::PromiseHookFields::HasIsolatePromiseHook::kMask;
+  return IsSetWord32(flags, mask);
+}
+
+TNode<BoolT> CodeStubAssembler::IsContextPromiseHookEnabled(
+    TNode<Uint32T> flags) {
+  return IsSetWord32<Isolate::PromiseHookFields::HasContextPromiseHook>(flags);
 }
 
 TNode<BoolT> CodeStubAssembler::
-    IsPromiseHookEnabledOrDebugIsActiveOrHasAsyncEventDelegate() {
-  const TNode<Uint8T> promise_hook_or_debug_is_active_or_async_event_delegate =
-      Load<Uint8T>(ExternalConstant(
-          ExternalReference::
-              promise_hook_or_debug_is_active_or_async_event_delegate_address(
-                  isolate())));
-  return Word32NotEqual(promise_hook_or_debug_is_active_or_async_event_delegate,
-                        Int32Constant(0));
+    IsIsolatePromiseHookEnabledOrHasAsyncEventDelegate(TNode<Uint32T> flags) {
+  uint32_t mask = Isolate::PromiseHookFields::HasIsolatePromiseHook::kMask |
+                  Isolate::PromiseHookFields::HasAsyncEventDelegate::kMask;
+  return IsSetWord32(flags, mask);
+}
+
+TNode<BoolT> CodeStubAssembler::
+    IsIsolatePromiseHookEnabledOrDebugIsActiveOrHasAsyncEventDelegate(
+        TNode<Uint32T> flags) {
+  uint32_t mask = Isolate::PromiseHookFields::HasIsolatePromiseHook::kMask |
+                  Isolate::PromiseHookFields::HasAsyncEventDelegate::kMask |
+                  Isolate::PromiseHookFields::IsDebugActive::kMask;
+  return IsSetWord32(flags, mask);
+}
+
+TNode<BoolT> CodeStubAssembler::
+    IsAnyPromiseHookEnabledOrDebugIsActiveOrHasAsyncEventDelegate(
+        TNode<Uint32T> flags) {
+  return Word32NotEqual(flags, Int32Constant(0));
+}
+
+TNode<BoolT> CodeStubAssembler::
+    IsAnyPromiseHookEnabledOrHasAsyncEventDelegate(TNode<Uint32T> flags) {
+  uint32_t mask = Isolate::PromiseHookFields::HasContextPromiseHook::kMask |
+                  Isolate::PromiseHookFields::HasIsolatePromiseHook::kMask |
+                  Isolate::PromiseHookFields::HasAsyncEventDelegate::kMask;
+  return IsSetWord32(flags, mask);
 }
 
 TNode<Code> CodeStubAssembler::LoadBuiltin(TNode<Smi> builtin_id) {

--- a/deps/v8/src/codegen/code-stub-assembler.h
+++ b/deps/v8/src/codegen/code-stub-assembler.h
@@ -3497,10 +3497,44 @@ class V8_EXPORT_PRIVATE CodeStubAssembler
       TNode<Context> context);
 
   // Promise helpers
-  TNode<BoolT> IsPromiseHookEnabled();
+  TNode<Uint32T> PromiseHookFlags();
   TNode<BoolT> HasAsyncEventDelegate();
-  TNode<BoolT> IsPromiseHookEnabledOrHasAsyncEventDelegate();
-  TNode<BoolT> IsPromiseHookEnabledOrDebugIsActiveOrHasAsyncEventDelegate();
+  TNode<BoolT> IsContextPromiseHookEnabled(TNode<Uint32T> flags);
+  TNode<BoolT> IsContextPromiseHookEnabled() {
+    return IsContextPromiseHookEnabled(PromiseHookFlags());
+  }
+  TNode<BoolT> IsAnyPromiseHookEnabled(TNode<Uint32T> flags);
+  TNode<BoolT> IsAnyPromiseHookEnabled() {
+    return IsAnyPromiseHookEnabled(PromiseHookFlags());
+  }
+  TNode<BoolT> IsIsolatePromiseHookEnabledOrHasAsyncEventDelegate(
+      TNode<Uint32T> flags);
+  TNode<BoolT> IsIsolatePromiseHookEnabledOrHasAsyncEventDelegate() {
+    return IsIsolatePromiseHookEnabledOrHasAsyncEventDelegate(
+        PromiseHookFlags());
+  }
+  TNode<BoolT>
+  IsIsolatePromiseHookEnabledOrDebugIsActiveOrHasAsyncEventDelegate(
+      TNode<Uint32T> flags);
+  TNode<BoolT>
+  IsIsolatePromiseHookEnabledOrDebugIsActiveOrHasAsyncEventDelegate() {
+    return IsIsolatePromiseHookEnabledOrDebugIsActiveOrHasAsyncEventDelegate(
+        PromiseHookFlags());
+  }
+  TNode<BoolT> IsAnyPromiseHookEnabledOrDebugIsActiveOrHasAsyncEventDelegate(
+      TNode<Uint32T> flags);
+  TNode<BoolT>
+  IsAnyPromiseHookEnabledOrDebugIsActiveOrHasAsyncEventDelegate() {
+    return IsAnyPromiseHookEnabledOrDebugIsActiveOrHasAsyncEventDelegate(
+        PromiseHookFlags());
+  }
+  TNode<BoolT> IsAnyPromiseHookEnabledOrHasAsyncEventDelegate(
+      TNode<Uint32T> flags);
+  TNode<BoolT>
+  IsAnyPromiseHookEnabledOrHasAsyncEventDelegate() {
+    return IsAnyPromiseHookEnabledOrHasAsyncEventDelegate(
+        PromiseHookFlags());
+  }
 
   // for..in helpers
   void CheckPrototypeEnumCache(TNode<JSReceiver> receiver,

--- a/deps/v8/src/codegen/code-stub-assembler.h
+++ b/deps/v8/src/codegen/code-stub-assembler.h
@@ -3528,12 +3528,10 @@ class V8_EXPORT_PRIVATE CodeStubAssembler
     return IsAnyPromiseHookEnabledOrDebugIsActiveOrHasAsyncEventDelegate(
         PromiseHookFlags());
   }
-  TNode<BoolT> IsAnyPromiseHookEnabledOrHasAsyncEventDelegate(
-      TNode<Uint32T> flags);
-  TNode<BoolT>
-  IsAnyPromiseHookEnabledOrHasAsyncEventDelegate() {
-    return IsAnyPromiseHookEnabledOrHasAsyncEventDelegate(
-        PromiseHookFlags());
+
+  TNode<BoolT> NeedsAnyPromiseHooks(TNode<Uint32T> flags);
+  TNode<BoolT> NeedsAnyPromiseHooks() {
+    return NeedsAnyPromiseHooks(PromiseHookFlags());
   }
 
   // for..in helpers

--- a/deps/v8/src/codegen/external-reference.cc
+++ b/deps/v8/src/codegen/external-reference.cc
@@ -925,6 +925,11 @@ ExternalReference ExternalReference::cpu_features() {
   return ExternalReference(&CpuFeatures::supported_);
 }
 
+ExternalReference ExternalReference::promise_hook_flags_address(
+    Isolate* isolate) {
+  return ExternalReference(isolate->promise_hook_flags_address());
+}
+
 ExternalReference ExternalReference::promise_hook_address(Isolate* isolate) {
   return ExternalReference(isolate->promise_hook_address());
 }
@@ -932,21 +937,6 @@ ExternalReference ExternalReference::promise_hook_address(Isolate* isolate) {
 ExternalReference ExternalReference::async_event_delegate_address(
     Isolate* isolate) {
   return ExternalReference(isolate->async_event_delegate_address());
-}
-
-ExternalReference
-ExternalReference::promise_hook_or_async_event_delegate_address(
-    Isolate* isolate) {
-  return ExternalReference(
-      isolate->promise_hook_or_async_event_delegate_address());
-}
-
-ExternalReference ExternalReference::
-    promise_hook_or_debug_is_active_or_async_event_delegate_address(
-        Isolate* isolate) {
-  return ExternalReference(
-      isolate
-          ->promise_hook_or_debug_is_active_or_async_event_delegate_address());
 }
 
 ExternalReference ExternalReference::debug_execution_mode_address(

--- a/deps/v8/src/codegen/external-reference.h
+++ b/deps/v8/src/codegen/external-reference.h
@@ -50,13 +50,9 @@ class StatsCounter;
   V(handle_scope_limit_address, "HandleScope::limit")                          \
   V(scheduled_exception_address, "Isolate::scheduled_exception")               \
   V(address_of_pending_message_obj, "address_of_pending_message_obj")          \
+  V(promise_hook_flags_address, "Isolate::promise_hook_flags_address()")       \
   V(promise_hook_address, "Isolate::promise_hook_address()")                   \
   V(async_event_delegate_address, "Isolate::async_event_delegate_address()")   \
-  V(promise_hook_or_async_event_delegate_address,                              \
-    "Isolate::promise_hook_or_async_event_delegate_address()")                 \
-  V(promise_hook_or_debug_is_active_or_async_event_delegate_address,           \
-    "Isolate::promise_hook_or_debug_is_active_or_async_event_delegate_"        \
-    "address()")                                                               \
   V(debug_execution_mode_address, "Isolate::debug_execution_mode_address()")   \
   V(debug_is_active_address, "Debug::is_active_address()")                     \
   V(debug_hook_on_function_call_address,                                       \

--- a/deps/v8/src/d8/d8.cc
+++ b/deps/v8/src/d8/d8.cc
@@ -1792,6 +1792,20 @@ void Shell::AsyncHooksTriggerAsyncId(
       PerIsolateData::Get(isolate)->GetAsyncHooks()->GetTriggerAsyncId()));
 }
 
+void Shell::SetPromiseHooks(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  Isolate* isolate = args.GetIsolate();
+  Local<Context> context = isolate->GetCurrentContext();
+  HandleScope handle_scope(isolate);
+
+  context->SetPromiseHooks(
+    args[0]->IsFunction() ? args[0].As<Function>() : Local<Function>(),
+    args[1]->IsFunction() ? args[1].As<Function>() : Local<Function>(),
+    args[2]->IsFunction() ? args[2].As<Function>() : Local<Function>(),
+    args[3]->IsFunction() ? args[3].As<Function>() : Local<Function>());
+
+  args.GetReturnValue().Set(v8::Undefined(isolate));
+}
+
 void WriteToFile(FILE* file, const v8::FunctionCallbackInfo<v8::Value>& args) {
   for (int i = 0; i < args.Length(); i++) {
     HandleScope handle_scope(args.GetIsolate());
@@ -2581,6 +2595,14 @@ Local<ObjectTemplate> Shell::CreateD8Template(Isolate* isolate) {
                       FunctionTemplate::New(isolate, LogGetAndStop));
 
     d8_template->Set(isolate, "log", log_template);
+  }
+  {
+    Local<ObjectTemplate> promise_template = ObjectTemplate::New(isolate);
+    promise_template->Set(
+        isolate, "setHooks",
+        FunctionTemplate::New(isolate, SetPromiseHooks, Local<Value>(),
+                              Local<Signature>(), 4));
+    d8_template->Set(isolate, "promise", promise_template);
   }
   return d8_template;
 }

--- a/deps/v8/src/d8/d8.h
+++ b/deps/v8/src/d8/d8.h
@@ -478,6 +478,8 @@ class Shell : public i::AllStatic {
   static void AsyncHooksTriggerAsyncId(
       const v8::FunctionCallbackInfo<v8::Value>& args);
 
+  static void SetPromiseHooks(const v8::FunctionCallbackInfo<v8::Value>& args);
+
   static void Print(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void PrintErr(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Write(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/deps/v8/src/execution/isolate.h
+++ b/deps/v8/src/execution/isolate.h
@@ -1428,21 +1428,27 @@ class V8_EXPORT_PRIVATE Isolate final : private HiddenFactory {
   }
 #endif
 
+  void SetHasContextPromiseHooks(bool context_promise_hook) {
+    promise_hook_flags_ = PromiseHookFields::HasContextPromiseHook::update(
+        promise_hook_flags_, context_promise_hook);
+    PromiseHookStateUpdated();
+  }
+
+  bool HasContextPromiseHooks() const {
+    return PromiseHookFields::HasContextPromiseHook::decode(
+        promise_hook_flags_);
+  }
+
+  Address promise_hook_flags_address() {
+    return reinterpret_cast<Address>(&promise_hook_flags_);
+  }
+
   Address promise_hook_address() {
     return reinterpret_cast<Address>(&promise_hook_);
   }
 
   Address async_event_delegate_address() {
     return reinterpret_cast<Address>(&async_event_delegate_);
-  }
-
-  Address promise_hook_or_async_event_delegate_address() {
-    return reinterpret_cast<Address>(&promise_hook_or_async_event_delegate_);
-  }
-
-  Address promise_hook_or_debug_is_active_or_async_event_delegate_address() {
-    return reinterpret_cast<Address>(
-        &promise_hook_or_debug_is_active_or_async_event_delegate_);
   }
 
   Address handle_scope_implementer_address() {
@@ -1460,6 +1466,9 @@ class V8_EXPORT_PRIVATE Isolate final : private HiddenFactory {
   void SetPromiseHook(PromiseHook hook);
   void RunPromiseHook(PromiseHookType type, Handle<JSPromise> promise,
                       Handle<Object> parent);
+  void RunAllPromiseHooks(PromiseHookType type, Handle<JSPromise> promise,
+                          Handle<Object> parent);
+  void UpdatePromiseHookProtector();
   void PromiseHookStateUpdated();
 
   void AddDetachedContext(Handle<Context> context);
@@ -1697,6 +1706,13 @@ class V8_EXPORT_PRIVATE Isolate final : private HiddenFactory {
   }
 #endif
 
+  struct PromiseHookFields {
+    using HasContextPromiseHook = base::BitField<bool, 0, 1>;
+    using HasIsolatePromiseHook = HasContextPromiseHook::Next<bool, 1>;
+    using HasAsyncEventDelegate = HasIsolatePromiseHook::Next<bool, 1>;
+    using IsDebugActive = HasAsyncEventDelegate::Next<bool, 1>;
+  };
+
  private:
   explicit Isolate(std::unique_ptr<IsolateAllocator> isolate_allocator);
   ~Isolate();
@@ -1779,6 +1795,16 @@ class V8_EXPORT_PRIVATE Isolate final : private HiddenFactory {
 
   void RunPromiseHookForAsyncEventDelegate(PromiseHookType type,
                                            Handle<JSPromise> promise);
+
+  bool HasIsolatePromiseHooks() const {
+    return PromiseHookFields::HasIsolatePromiseHook::decode(
+        promise_hook_flags_);
+  }
+
+  bool HasAsyncEventDelegate() const {
+    return PromiseHookFields::HasAsyncEventDelegate::decode(
+        promise_hook_flags_);
+  }
 
   const char* RAILModeName(RAILMode rail_mode) const {
     switch (rail_mode) {
@@ -2032,8 +2058,7 @@ class V8_EXPORT_PRIVATE Isolate final : private HiddenFactory {
   debug::ConsoleDelegate* console_delegate_ = nullptr;
 
   debug::AsyncEventDelegate* async_event_delegate_ = nullptr;
-  bool promise_hook_or_async_event_delegate_ = false;
-  bool promise_hook_or_debug_is_active_or_async_event_delegate_ = false;
+  uint32_t promise_hook_flags_ = 0;
   int async_task_count_ = 0;
 
   std::unique_ptr<LocalIsolate> main_thread_local_isolate_;

--- a/deps/v8/src/heap/factory.cc
+++ b/deps/v8/src/heap/factory.cc
@@ -3377,7 +3377,8 @@ Handle<JSPromise> Factory::NewJSPromiseWithoutHook() {
 
 Handle<JSPromise> Factory::NewJSPromise() {
   Handle<JSPromise> promise = NewJSPromiseWithoutHook();
-  isolate()->RunPromiseHook(PromiseHookType::kInit, promise, undefined_value());
+  isolate()->RunAllPromiseHooks(PromiseHookType::kInit, promise,
+                                undefined_value());
   return promise;
 }
 

--- a/deps/v8/src/objects/contexts.cc
+++ b/deps/v8/src/objects/contexts.cc
@@ -511,5 +511,53 @@ STATIC_ASSERT(NativeContext::kSize ==
               (Context::SizeFor(NativeContext::NATIVE_CONTEXT_SLOTS) +
                kSystemPointerSize));
 
+void NativeContext::RunPromiseHook(PromiseHookType type,
+                                   Handle<JSPromise> promise,
+                                   Handle<Object> parent) {
+  Isolate* isolate = promise->GetIsolate();
+  DCHECK(isolate->HasContextPromiseHooks());
+  int contextSlot;
+
+  switch (type) {
+    case PromiseHookType::kInit:
+      contextSlot = PROMISE_HOOK_INIT_FUNCTION_INDEX;
+      break;
+    case PromiseHookType::kResolve:
+      contextSlot = PROMISE_HOOK_RESOLVE_FUNCTION_INDEX;
+      break;
+    case PromiseHookType::kBefore:
+      contextSlot = PROMISE_HOOK_BEFORE_FUNCTION_INDEX;
+      break;
+    case PromiseHookType::kAfter:
+      contextSlot = PROMISE_HOOK_AFTER_FUNCTION_INDEX;
+      break;
+    default:
+      UNREACHABLE();
+  }
+
+  Handle<Object> hook(isolate->native_context()->get(contextSlot), isolate);
+  if (hook->IsUndefined()) return;
+
+  int argc = type == PromiseHookType::kInit ? 2 : 1;
+  Handle<Object> argv[2] = {
+    Handle<Object>::cast(promise),
+    parent
+  };
+
+  Handle<Object> receiver = isolate->global_proxy();
+
+  if (Execution::Call(isolate, hook, receiver, argc, argv).is_null()) {
+    DCHECK(isolate->has_pending_exception());
+    Handle<Object> exception(isolate->pending_exception(), isolate);
+
+    MessageLocation* no_location = nullptr;
+    Handle<JSMessageObject> message =
+        isolate->CreateMessageOrAbort(exception, no_location);
+    MessageHandler::ReportMessage(isolate, no_location, message);
+
+    isolate->clear_pending_exception();
+  }
+}
+
 }  // namespace internal
 }  // namespace v8

--- a/deps/v8/src/objects/contexts.h
+++ b/deps/v8/src/objects/contexts.h
@@ -198,6 +198,11 @@ enum ContextLookupFlags {
   V(NUMBER_FUNCTION_INDEX, JSFunction, number_function)                        \
   V(OBJECT_FUNCTION_INDEX, JSFunction, object_function)                        \
   V(OBJECT_FUNCTION_PROTOTYPE_MAP_INDEX, Map, object_function_prototype_map)   \
+  V(PROMISE_HOOK_INIT_FUNCTION_INDEX, Object, promise_hook_init_function)      \
+  V(PROMISE_HOOK_BEFORE_FUNCTION_INDEX, Object, promise_hook_before_function)  \
+  V(PROMISE_HOOK_AFTER_FUNCTION_INDEX, Object, promise_hook_after_function)    \
+  V(PROMISE_HOOK_RESOLVE_FUNCTION_INDEX, Object,                               \
+    promise_hook_resolve_function)                                             \
   V(PROXY_CALLABLE_MAP_INDEX, Map, proxy_callable_map)                         \
   V(PROXY_CONSTRUCTOR_MAP_INDEX, Map, proxy_constructor_map)                   \
   V(PROXY_FUNCTION_INDEX, JSFunction, proxy_function)                          \
@@ -691,6 +696,9 @@ class NativeContext : public Context {
   void ResetErrorsThrown();
   void IncrementErrorsThrown();
   int GetErrorsThrown();
+
+  void RunPromiseHook(PromiseHookType type, Handle<JSPromise> promise,
+                      Handle<Object> parent);
 
  private:
   STATIC_ASSERT(OffsetOfElementAt(EMBEDDER_DATA_INDEX) ==

--- a/deps/v8/src/objects/contexts.tq
+++ b/deps/v8/src/objects/contexts.tq
@@ -124,6 +124,12 @@ extern enum ContextSlot extends intptr constexpr 'Context::Field' {
   PROMISE_PROTOTYPE_INDEX: Slot<NativeContext, JSObject>,
   STRICT_FUNCTION_WITHOUT_PROTOTYPE_MAP_INDEX: Slot<NativeContext, Map>,
 
+  PROMISE_HOOK_INIT_FUNCTION_INDEX: Slot<NativeContext, Undefined|JSFunction>,
+  PROMISE_HOOK_BEFORE_FUNCTION_INDEX: Slot<NativeContext, Undefined|JSFunction>,
+  PROMISE_HOOK_AFTER_FUNCTION_INDEX: Slot<NativeContext, Undefined|JSFunction>,
+  PROMISE_HOOK_RESOLVE_FUNCTION_INDEX:
+      Slot<NativeContext, Undefined|JSFunction>,
+
   CONTINUATION_PRESERVED_EMBEDDER_DATA_INDEX: Slot<NativeContext, HeapObject>,
 
   BOUND_FUNCTION_WITH_CONSTRUCTOR_MAP_INDEX: Slot<NativeContext, Map>,

--- a/deps/v8/src/objects/contexts.tq
+++ b/deps/v8/src/objects/contexts.tq
@@ -124,11 +124,10 @@ extern enum ContextSlot extends intptr constexpr 'Context::Field' {
   PROMISE_PROTOTYPE_INDEX: Slot<NativeContext, JSObject>,
   STRICT_FUNCTION_WITHOUT_PROTOTYPE_MAP_INDEX: Slot<NativeContext, Map>,
 
-  PROMISE_HOOK_INIT_FUNCTION_INDEX: Slot<NativeContext, Undefined|JSFunction>,
-  PROMISE_HOOK_BEFORE_FUNCTION_INDEX: Slot<NativeContext, Undefined|JSFunction>,
-  PROMISE_HOOK_AFTER_FUNCTION_INDEX: Slot<NativeContext, Undefined|JSFunction>,
-  PROMISE_HOOK_RESOLVE_FUNCTION_INDEX:
-      Slot<NativeContext, Undefined|JSFunction>,
+  PROMISE_HOOK_INIT_FUNCTION_INDEX: Slot<NativeContext, Undefined|Callable>,
+  PROMISE_HOOK_BEFORE_FUNCTION_INDEX: Slot<NativeContext, Undefined|Callable>,
+  PROMISE_HOOK_AFTER_FUNCTION_INDEX: Slot<NativeContext, Undefined|Callable>,
+  PROMISE_HOOK_RESOLVE_FUNCTION_INDEX: Slot<NativeContext, Undefined|Callable>,
 
   CONTINUATION_PRESERVED_EMBEDDER_DATA_INDEX: Slot<NativeContext, HeapObject>,
 

--- a/deps/v8/src/objects/objects.cc
+++ b/deps/v8/src/objects/objects.cc
@@ -5254,8 +5254,8 @@ Handle<Object> JSPromise::Reject(Handle<JSPromise> promise,
   if (isolate->debug()->is_active()) MoveMessageToPromise(isolate, promise);
 
   if (debug_event) isolate->debug()->OnPromiseReject(promise, reason);
-  isolate->RunPromiseHook(PromiseHookType::kResolve, promise,
-                          isolate->factory()->undefined_value());
+  isolate->RunAllPromiseHooks(PromiseHookType::kResolve, promise,
+                              isolate->factory()->undefined_value());
 
   // 1. Assert: The value of promise.[[PromiseState]] is "pending".
   CHECK_EQ(Promise::kPending, promise->status());
@@ -5290,8 +5290,8 @@ MaybeHandle<Object> JSPromise::Resolve(Handle<JSPromise> promise,
   DCHECK(
       !reinterpret_cast<v8::Isolate*>(isolate)->GetCurrentContext().IsEmpty());
 
-  isolate->RunPromiseHook(PromiseHookType::kResolve, promise,
-                          isolate->factory()->undefined_value());
+  isolate->RunAllPromiseHooks(PromiseHookType::kResolve, promise,
+                              isolate->factory()->undefined_value());
 
   // 7. If SameValue(resolution, promise) is true, then
   if (promise.is_identical_to(resolution)) {

--- a/deps/v8/src/runtime/runtime-promise.cc
+++ b/deps/v8/src/runtime/runtime-promise.cc
@@ -29,8 +29,8 @@ RUNTIME_FUNCTION(Runtime_PromiseRejectEventFromStack) {
     // undefined, which we interpret as being a caught exception event.
     rejected_promise = isolate->GetPromiseOnStackOnThrow();
   }
-  isolate->RunPromiseHook(PromiseHookType::kResolve, promise,
-                          isolate->factory()->undefined_value());
+  isolate->RunAllPromiseHooks(PromiseHookType::kResolve, promise,
+                              isolate->factory()->undefined_value());
   isolate->debug()->OnPromiseReject(rejected_promise, value);
 
   // Report only if we don't actually have a handler.
@@ -142,7 +142,7 @@ Handle<JSPromise> AwaitPromisesInitCommon(Isolate* isolate,
   // hook for the throwaway promise (passing the {promise} as its
   // parent).
   Handle<JSPromise> throwaway = isolate->factory()->NewJSPromiseWithoutHook();
-  isolate->RunPromiseHook(PromiseHookType::kInit, throwaway, promise);
+  isolate->RunAllPromiseHooks(PromiseHookType::kInit, throwaway, promise);
 
   // On inspector side we capture async stack trace and store it by
   // outer_promise->async_task_id when async function is suspended first time.
@@ -204,7 +204,7 @@ RUNTIME_FUNCTION(Runtime_AwaitPromisesInitOld) {
 
   // Fire the init hook for the wrapper promise (that we created for the
   // {value} previously).
-  isolate->RunPromiseHook(PromiseHookType::kInit, promise, outer_promise);
+  isolate->RunAllPromiseHooks(PromiseHookType::kInit, promise, outer_promise);
   return *AwaitPromisesInitCommon(isolate, value, promise, outer_promise,
                                   reject_handler, is_predicted_as_caught);
 }

--- a/deps/v8/test/cctest/test-code-stub-assembler.cc
+++ b/deps/v8/test/cctest/test-code-stub-assembler.cc
@@ -2595,7 +2595,8 @@ TEST(IsPromiseHookEnabled) {
   CodeStubAssembler m(asm_tester.state());
 
   m.Return(
-      m.SelectBooleanConstant(m.IsPromiseHookEnabledOrHasAsyncEventDelegate()));
+      m.SelectBooleanConstant(
+          m.IsIsolatePromiseHookEnabledOrHasAsyncEventDelegate()));
 
   FunctionTester ft(asm_tester.GenerateCode(), kNumParams);
   Handle<Object> result =

--- a/deps/v8/test/mjsunit/promise-hooks.js
+++ b/deps/v8/test/mjsunit/promise-hooks.js
@@ -246,7 +246,7 @@ exceptions();
 (function regress1126309() {
   function __f_16(test) {
     test();
-    d8.promise.setHooks( undefined, () => {});
+    d8.promise.setHooks(undefined, () => {});
     %PerformMicrotaskCheckpoint();
     d8.promise.setHooks();
   }
@@ -260,5 +260,16 @@ exceptions();
   Promise.resolve();
   Promise.reject();
   %PerformMicrotaskCheckpoint();
+  d8.promise.setHooks();
+})();
+
+
+(function promiseAll() {
+  let initCount = 0;
+  d8.promise.setHooks(() => { initCount++});
+  Promise.all([Promise.resolve(1)]);
+  %PerformMicrotaskCheckpoint();
+  assertEquals(initCount, 3);
+
   d8.promise.setHooks();
 })();

--- a/deps/v8/test/mjsunit/promise-hooks.js
+++ b/deps/v8/test/mjsunit/promise-hooks.js
@@ -1,7 +1,7 @@
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-//
+
 // Flags: --allow-natives-syntax --opt --no-always-opt --no-stress-opt --deopt-every-n-times=0 --ignore-unhandled-promises
 
 let log = [];
@@ -242,3 +242,13 @@ optimizerBailout(async () => {
 });
 basicTest();
 exceptions();
+
+(function regress1126309() {
+  function __f_16(test) {
+    test();
+    d8.promise.setHooks( undefined, () => {});
+    %PerformMicrotaskCheckpoint();
+    d8.promise.setHooks();
+  }
+  __f_16(async () => { await Promise.resolve()});
+})();

--- a/deps/v8/test/mjsunit/promise-hooks.js
+++ b/deps/v8/test/mjsunit/promise-hooks.js
@@ -1,0 +1,244 @@
+// Copyright 2020 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+//
+// Flags: --allow-natives-syntax --opt --no-always-opt --no-stress-opt --deopt-every-n-times=0 --ignore-unhandled-promises
+
+let log = [];
+let asyncId = 0;
+
+function logEvent (type, args) {
+  const promise = args[0];
+  promise.asyncId = promise.asyncId || ++asyncId;
+  log.push({
+    type,
+    promise,
+    parent: args[1],
+    argsLength: args.length
+  })
+}
+function initHook(...args) {
+  logEvent('init', args);
+}
+function resolveHook(...args) {
+  logEvent('resolve', args);
+}
+function beforeHook(...args) {
+  logEvent('before', args);
+}
+function afterHook(...args) {
+  logEvent('after', args);
+}
+
+function printLog(message) {
+  console.log(` --- ${message} --- `)
+  for (const event of log) {
+    console.log(JSON.stringify(event))
+  }
+}
+
+function assertNextEvent(type, args) {
+  const [ promiseOrId, parentOrId ] = args;
+  const nextEvent = log.shift();
+
+  assertEquals(type, nextEvent.type);
+  assertEquals(type === 'init' ? 2 : 1, nextEvent.argsLength);
+
+  assertTrue(nextEvent.promise instanceof Promise);
+  if (promiseOrId instanceof Promise) {
+    assertEquals(promiseOrId, nextEvent.promise);
+  } else {
+    assertTrue(typeof promiseOrId === 'number');
+    assertEquals(promiseOrId, nextEvent.promise?.asyncId);
+  }
+
+  if (parentOrId instanceof Promise) {
+    assertEquals(parentOrId, nextEvent.parent);
+    assertTrue(nextEvent.parent instanceof Promise);
+  } else if (typeof parentOrId === 'number') {
+    assertEquals(parentOrId, nextEvent.parent?.asyncId);
+    assertTrue(nextEvent.parent instanceof Promise);
+  } else {
+    assertEquals(undefined, parentOrId);
+    assertEquals(undefined, nextEvent.parent);
+  }
+}
+function assertEmptyLog() {
+  assertEquals(0, log.length);
+  asyncId = 0;
+  log = [];
+}
+
+// Verify basic log structure of different promise behaviours
+function basicTest() {
+  d8.promise.setHooks(initHook, beforeHook, afterHook, resolveHook);
+
+  // `new Promise(...)` triggers init event with correct promise
+  var done, p1 = new Promise(r => done = r);
+  %PerformMicrotaskCheckpoint();
+  assertNextEvent('init', [ p1 ]);
+  assertEmptyLog();
+
+  // `promise.then(...)` triggers init event with correct promise and parent
+  var p2 = p1.then(() => { });
+  %PerformMicrotaskCheckpoint();
+  assertNextEvent('init', [ p2, p1 ]);
+  assertEmptyLog();
+
+  // `resolve(...)` triggers resolve event and any already attached continuations
+  done();
+  %PerformMicrotaskCheckpoint();
+  assertNextEvent('resolve', [ p1 ]);
+  assertNextEvent('before', [ p2 ]);
+  assertNextEvent('resolve', [ p2 ]);
+  assertNextEvent('after', [ p2 ]);
+  assertEmptyLog();
+
+  // `reject(...)` triggers the resolve event
+  var done, p3 = new Promise((_, r) => done = r);
+  done();
+  %PerformMicrotaskCheckpoint();
+  assertNextEvent('init', [ p3 ]);
+  assertNextEvent('resolve', [ p3 ]);
+  assertEmptyLog();
+
+  // `promise.catch(...)` triggers init event with correct promise and parent
+  // When the promise is already completed, the continuation should also run
+  // immediately at the next checkpoint.
+  var p4 = p3.catch(() => { });
+  %PerformMicrotaskCheckpoint();
+  assertNextEvent('init', [ p4, p3 ]);
+  assertNextEvent('before', [ p4 ]);
+  assertNextEvent('resolve', [ p4 ]);
+  assertNextEvent('after', [ p4 ]);
+  assertEmptyLog();
+
+  // Detach hooks
+  d8.promise.setHooks();
+}
+
+// Exceptions thrown in hook handlers should not raise or reject
+function exceptions() {
+  function thrower() {
+    throw new Error('unexpected!');
+  }
+
+  // Init hook
+  d8.promise.setHooks(thrower);
+  assertDoesNotThrow(() => {
+    Promise.resolve()
+      .catch(assertUnreachable);
+  });
+  %PerformMicrotaskCheckpoint();
+  d8.promise.setHooks();
+
+  // Before hook
+  d8.promise.setHooks(undefined, thrower);
+  assertDoesNotThrow(() => {
+    Promise.resolve()
+      .then(() => {})
+      .catch(assertUnreachable);
+  });
+  %PerformMicrotaskCheckpoint();
+  d8.promise.setHooks();
+
+  // After hook
+  d8.promise.setHooks(undefined, undefined, thrower);
+  assertDoesNotThrow(() => {
+    Promise.resolve()
+      .then(() => {})
+      .catch(assertUnreachable);
+  });
+  %PerformMicrotaskCheckpoint();
+  d8.promise.setHooks();
+
+  // Resolve hook
+  d8.promise.setHooks(undefined, undefined, undefined, thrower);
+  assertDoesNotThrow(() => {
+    Promise.resolve()
+      .catch(assertUnreachable);
+  });
+  %PerformMicrotaskCheckpoint();
+  d8.promise.setHooks();
+
+  // Resolve hook for a reject
+  d8.promise.setHooks(undefined, undefined, undefined, thrower);
+  assertDoesNotThrow(() => {
+    Promise.reject()
+      .then(assertUnreachable)
+      .catch();
+  });
+  %PerformMicrotaskCheckpoint();
+  d8.promise.setHooks();
+}
+
+// For now, expect the optimizer to bail out on async functions
+// when context promise hooks are attached.
+function optimizerBailout(test, verify) {
+  // Warm up test method
+  %PrepareFunctionForOptimization(test);
+  assertUnoptimized(test);
+  test();
+  test();
+  test();
+  %PerformMicrotaskCheckpoint();
+
+  // Prove transition to optimized code when no hooks are present
+  assertUnoptimized(test);
+  %OptimizeFunctionOnNextCall(test);
+  test();
+  assertOptimized(test);
+  %PerformMicrotaskCheckpoint();
+
+  // Verify that attaching hooks deopts the async function
+  d8.promise.setHooks(initHook, beforeHook, afterHook, resolveHook);
+  // assertUnoptimized(test);
+
+  // Verify log structure of deoptimized call
+  %PrepareFunctionForOptimization(test);
+  test();
+  %PerformMicrotaskCheckpoint();
+
+  verify();
+
+  // Optimize and verify log structure again
+  %OptimizeFunctionOnNextCall(test);
+  test();
+  assertOptimized(test);
+  %PerformMicrotaskCheckpoint();
+
+  verify();
+
+  d8.promise.setHooks();
+}
+
+optimizerBailout(async () => {
+  await Promise.resolve();
+}, () => {
+  assertNextEvent('init', [ 1 ]);
+  assertNextEvent('init', [ 2 ]);
+  assertNextEvent('resolve', [ 2 ]);
+  assertNextEvent('init', [ 3, 2 ]);
+  assertNextEvent('before', [ 3 ]);
+  assertNextEvent('resolve', [ 1 ]);
+  assertNextEvent('resolve', [ 3 ]);
+  assertNextEvent('after', [ 3 ]);
+  assertEmptyLog();
+});
+optimizerBailout(async () => {
+  await { then (cb) { cb() } };
+}, () => {
+  assertNextEvent('init', [ 1 ]);
+  assertNextEvent('init', [ 2, 1 ]);
+  assertNextEvent('init', [ 3, 2 ]);
+  assertNextEvent('before', [ 2 ]);
+  assertNextEvent('resolve', [ 2 ]);
+  assertNextEvent('after', [ 2 ]);
+  assertNextEvent('before', [ 3 ]);
+  assertNextEvent('resolve', [ 1 ]);
+  assertNextEvent('resolve', [ 3 ]);
+  assertNextEvent('after', [ 3 ]);
+  assertEmptyLog();
+});
+basicTest();
+exceptions();

--- a/deps/v8/test/mjsunit/promise-hooks.js
+++ b/deps/v8/test/mjsunit/promise-hooks.js
@@ -252,3 +252,13 @@ exceptions();
   }
   __f_16(async () => { await Promise.resolve()});
 })();
+
+(function boundFunction() {
+  function hook() {};
+  const bound = hook.bind(this);
+  d8.promise.setHooks(bound, bound, bound, bound);
+  Promise.resolve();
+  Promise.reject();
+  %PerformMicrotaskCheckpoint();
+  d8.promise.setHooks();
+})();

--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -5,7 +5,6 @@ const {
   ErrorCaptureStackTrace,
   ObjectPrototypeHasOwnProperty,
   ObjectDefineProperty,
-  Promise,
   Symbol,
 } = primordials;
 
@@ -53,7 +52,7 @@ const {
   clearAsyncIdStack,
 } = async_wrap;
 // For performance reasons, only track Promises when a hook is enabled.
-const { enablePromiseHook, disablePromiseHook } = async_wrap;
+const { enablePromiseHook, disablePromiseHook, setPromiseHooks } = async_wrap;
 // Properties in active_hooks are used to keep track of the set of hooks being
 // executed in case another hook is enabled/disabled. The new set of hooks is
 // then restored once the active set of hooks is finished executing.
@@ -303,53 +302,50 @@ function restoreActiveHooks() {
   active_hooks.tmp_fields = null;
 }
 
-function trackPromise(promise, parent, silent) {
-  const asyncId = getOrSetAsyncId(promise);
+function trackPromise(promise, parent) {
+  if (promise[async_id_symbol]) {
+    return;
+  }
 
+  promise[async_id_symbol] = newAsyncId();
   promise[trigger_async_id_symbol] = parent ? getOrSetAsyncId(parent) :
     getDefaultTriggerAsyncId();
+}
 
-  if (!silent && initHooksExist()) {
-    const triggerId = promise[trigger_async_id_symbol];
-    emitInitScript(asyncId, 'PROMISE', triggerId, promise);
+function promiseInitHook(promise, parent) {
+  trackPromise(promise, parent);
+  const asyncId = promise[async_id_symbol];
+  const triggerAsyncId = promise[trigger_async_id_symbol];
+  emitInitScript(asyncId, 'PROMISE', triggerAsyncId, promise);
+}
+
+function promiseBeforeHook(promise) {
+  trackPromise(promise);
+  const asyncId = promise[async_id_symbol];
+  const triggerId = promise[trigger_async_id_symbol];
+  emitBeforeScript(asyncId, triggerId, promise);
+}
+
+function promiseAfterHook(promise) {
+  trackPromise(promise);
+  const asyncId = promise[async_id_symbol];
+  if (hasHooks(kAfter)) {
+    emitAfterNative(asyncId);
+  }
+  if (asyncId === executionAsyncId()) {
+    // This condition might not be true if async_hooks was enabled during
+    // the promise callback execution.
+    // Popping it off the stack can be skipped in that case, because it is
+    // known that it would correspond to exactly one call with
+    // PromiseHookType::kBefore that was not witnessed by the PromiseHook.
+    popAsyncContext(asyncId);
   }
 }
 
-function fastPromiseHook(type, promise, parent) {
-  if (type === kInit || !promise[async_id_symbol]) {
-    const silent = type !== kInit;
-    if (parent instanceof Promise) {
-      trackPromise(promise, parent, silent);
-    } else {
-      trackPromise(promise, null, silent);
-    }
-
-    if (!silent) return;
-  }
-
+function promiseResolveHook(promise) {
+  trackPromise(promise);
   const asyncId = promise[async_id_symbol];
-  switch (type) {
-    case kBefore:
-      const triggerId = promise[trigger_async_id_symbol];
-      emitBeforeScript(asyncId, triggerId, promise);
-      break;
-    case kAfter:
-      if (hasHooks(kAfter)) {
-        emitAfterNative(asyncId);
-      }
-      if (asyncId === executionAsyncId()) {
-        // This condition might not be true if async_hooks was enabled during
-        // the promise callback execution.
-        // Popping it off the stack can be skipped in that case, because it is
-        // known that it would correspond to exactly one call with
-        // PromiseHookType::kBefore that was not witnessed by the PromiseHook.
-        popAsyncContext(asyncId);
-      }
-      break;
-    case kPromiseResolve:
-      emitPromiseResolveNative(asyncId);
-      break;
-  }
+  emitPromiseResolveNative(asyncId);
 }
 
 let wantPromiseHook = false;
@@ -357,17 +353,17 @@ function enableHooks() {
   async_hook_fields[kCheck] += 1;
 }
 
-let promiseHookMode = -1;
 function updatePromiseHookMode() {
   wantPromiseHook = true;
   if (destroyHooksExist()) {
-    if (promiseHookMode !== 1) {
-      promiseHookMode = 1;
-      enablePromiseHook();
-    }
-  } else if (promiseHookMode !== 0) {
-    promiseHookMode = 0;
-    enablePromiseHook(fastPromiseHook);
+    enablePromiseHook();
+  } else {
+    setPromiseHooks(
+      initHooksExist() ? promiseInitHook : undefined,
+      promiseBeforeHook,
+      promiseAfterHook,
+      promiseResolveHooksExist() ? promiseResolveHook : undefined,
+    );
   }
 }
 
@@ -383,8 +379,8 @@ function disableHooks() {
 
 function disablePromiseHookIfNecessary() {
   if (!wantPromiseHook) {
-    promiseHookMode = -1;
     disablePromiseHook();
+    setPromiseHooks(undefined, undefined, undefined, undefined);
   }
 }
 
@@ -456,6 +452,10 @@ function afterHooksExist() {
 
 function destroyHooksExist() {
   return hasHooks(kDestroy);
+}
+
+function promiseResolveHooksExist() {
+  return hasHooks(kPromiseResolve);
 }
 
 

--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -452,6 +452,15 @@ static void EnablePromiseHook(const FunctionCallbackInfo<Value>& args) {
   }
 }
 
+static void SetPromiseHooks(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  Local<Context> ctx = env->context();
+  ctx->SetPromiseHooks(
+    args[0]->IsFunction() ? args[0].As<Function>() : Local<Function>(),
+    args[1]->IsFunction() ? args[1].As<Function>() : Local<Function>(),
+    args[2]->IsFunction() ? args[2].As<Function>() : Local<Function>(),
+    args[3]->IsFunction() ? args[3].As<Function>() : Local<Function>());
+}
 
 static void DisablePromiseHook(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
@@ -631,6 +640,7 @@ void AsyncWrap::Initialize(Local<Object> target,
   env->SetMethod(target, "clearAsyncIdStack", ClearAsyncIdStack);
   env->SetMethod(target, "queueDestroyAsyncId", QueueDestroyAsyncId);
   env->SetMethod(target, "enablePromiseHook", EnablePromiseHook);
+  env->SetMethod(target, "setPromiseHooks", SetPromiseHooks);
   env->SetMethod(target, "disablePromiseHook", DisablePromiseHook);
   env->SetMethod(target, "registerDestroyHook", RegisterDestroyHook);
 
@@ -725,6 +735,7 @@ void AsyncWrap::RegisterExternalReferences(
   registry->Register(ClearAsyncIdStack);
   registry->Register(QueueDestroyAsyncId);
   registry->Register(EnablePromiseHook);
+  registry->Register(SetPromiseHooks);
   registry->Register(DisablePromiseHook);
   registry->Register(RegisterDestroyHook);
   registry->Register(AsyncWrap::GetAsyncId);


### PR DESCRIPTION
I've been working on an alternative to the existing PromiseHook API in V8 using split JSFunctions per event type rather than the old way which routes everything through a single C++ function even though it's just going right back to JS in the end. The old way has many, many costly boundary jumps and deopts in many cases, so we really need a better way to track promise lifecycle events. 😅 

The corresponding Chromium Review is here: ~https://chromium-review.googlesource.com/c/v8/v8/+/2466783~ https://chromium-review.googlesource.com/c/v8/v8/+/2759188

As the change has not yet landed in V8, I'm opening this as a draft PR just to show my progress and give people something to look at. I've got some nice benchmarks to share too!

Before: 

```
❯ ./node-master benchmark/async_hooks/promises.js
async_hooks/promises.js asyncHooks="enabled" n=1000000: 271,514.4761845998
async_hooks/promises.js asyncHooks="enabledWithDestroy" n=1000000: 187,109.67499761964
async_hooks/promises.js asyncHooks="enabledWithInitOnly" n=1000000: 315,364.83307747904
async_hooks/promises.js asyncHooks="disabled" n=1000000: 1,668,525.7547478643
```

After:

```
❯ ./node benchmark/async_hooks/promises.js       
async_hooks/promises.js asyncHooks="enabled" n=1000000: 1,250,448.989340235
async_hooks/promises.js asyncHooks="enabledWithDestroy" n=1000000: 194,382.33020796857
async_hooks/promises.js asyncHooks="enabledWithInitOnly" n=1000000: 1,071,082.1953050198
async_hooks/promises.js asyncHooks="disabled" n=1000000: 1,673,424.8290965108
```

It's getting about 3-4x better performance. Not quite on-par with disabled yet, but getting close. There is still much that can be done to improve those numbers though.

The current changes do not allow the optimizer to do its magic in certain cases so I'm hoping to dig a bit more into getting those cases to optimize too. For reference though, the _existing_ PromiseHook API bails out too, so this is quite a bit faster already. I'm also investigating moving the `PromiseWrap` used when there's a destroy hook to using this model and wrapping from JS instead, which I think should still be an overall performance improvement despite the hop back to native for the initial wrap.

cc @nodejs/diagnostics @nodejs/v8 

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)