### PR TITLE
tls: forward new SecureContext options

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -1330,6 +1330,9 @@ Server.prototype.setSecureContext = function(options) {
   if (options.ticketKeys)
     this.ticketKeys = options.ticketKeys;
 
+  this.privateKeyIdentifier = options.privateKeyIdentifier;
+  this.privateKeyEngine = options.privateKeyEngine;
+
   this._sharedCreds = tls.createSecureContext({
     pfx: this.pfx,
     key: this.key,
@@ -1349,7 +1352,9 @@ Server.prototype.setSecureContext = function(options) {
     crl: this.crl,
     sessionIdContext: this.sessionIdContext,
     ticketKeys: this.ticketKeys,
-    sessionTimeout: this.sessionTimeout
+    sessionTimeout: this.sessionTimeout,
+    privateKeyIdentifier: this.privateKeyIdentifier,
+    privateKeyEngine: this.privateKeyEngine,
   });
 };
 
@@ -1415,6 +1420,11 @@ Server.prototype.setOptions = deprecate(function(options) {
   }
   if (options.pskCallback) this[kPskCallback] = options.pskCallback;
   if (options.pskIdentityHint) this[kPskIdentityHint] = options.pskIdentityHint;
+  if (options.sigalgs) this.sigalgs = options.sigalgs;
+  if (options.privateKeyIdentifier !== undefined)
+    this.privateKeyIdentifier = options.privateKeyIdentifier;
+  if (options.privateKeyEngine !== undefined)
+    this.privateKeyEngine = options.privateKeyEngine;
 }, 'Server.prototype.setOptions() is deprecated', 'DEP0122');
 
 // SNI Contexts High-Level API

--- a/lib/https.js
+++ b/lib/https.js
@@ -24,6 +24,7 @@
 const {
   ObjectAssign,
   ObjectSetPrototypeOf,
+  JSONStringify,
 } = primordials;
 
 require('internal/util').assertCrypto();
@@ -235,6 +236,18 @@ Agent.prototype.getName = function getName(options) {
   name += ':';
   if (options.sessionIdContext)
     name += options.sessionIdContext;
+
+  name += ':';
+  if (options.sigalgs)
+    name += JSONStringify(options.sigalgs);
+
+  name += ':';
+  if (options.privateKeyIdentifier)
+    name += options.privateKeyIdentifier;
+
+  name += ':';
+  if (options.privateKeyEngine)
+    name += options.privateKeyEngine;
 
   return name;
 };

--- a/test/parallel/test-https-agent-getname.js
+++ b/test/parallel/test-https-agent-getname.js
@@ -12,7 +12,7 @@ const agent = new https.Agent();
 // empty options
 assert.strictEqual(
   agent.getName({}),
-  'localhost:::::::::::::::::::'
+  'localhost::::::::::::::::::::::'
 );
 
 // Pass all options arguments
@@ -34,11 +34,15 @@ const options = {
   secureOptions: 0,
   secureProtocol: 'secureProtocol',
   servername: 'localhost',
-  sessionIdContext: 'sessionIdContext'
+  sessionIdContext: 'sessionIdContext',
+  sigalgs: 'sigalgs',
+  privateKeyIdentifier: 'privateKeyIdentifier',
+  privateKeyEngine: 'privateKeyEngine',
 };
 
 assert.strictEqual(
   agent.getName(options),
   '0.0.0.0:443:192.168.1.1:ca:cert:dynamic:ciphers:key:pfx:false:localhost:' +
-    '::secureProtocol:c,r,l:false:ecdhCurve:dhparam:0:sessionIdContext'
+    '::secureProtocol:c,r,l:false:ecdhCurve:dhparam:0:sessionIdContext:' +
+    '"sigalgs":privateKeyIdentifier:privateKeyEngine'
 );


### PR DESCRIPTION
We have a few places where we individually forward each parameter to tls.createSecureContext(). In #28973 and others, we added new SecureContext options but forgot to keep these places up to date. As for https.Agent#getName, I understand that at least `privateKeyIdentifier` and `privateKeyEngine` should be added too, since they're a substitute for `key`. I've also added `sigalgs`.

Properties which are still not included in https.Agent#getName: password, sessionTimeout, ticketKeys. Tell me if you think some of these should be included too.

Fixes: https://github.com/nodejs/node/issues/36322
Refs: https://github.com/nodejs/node/pull/28973