### PR TITLE
test: fix bootstrap test

### DIFF
--- a/test/parallel/test-bootstrap-modules.js
+++ b/test/parallel/test-bootstrap-modules.js
@@ -114,7 +114,6 @@ if (!common.isMainThread) {
     'Internal Binding performance',
     'Internal Binding symbols',
     'Internal Binding worker',
-    'NativeModule internal/streams/add-abort-signal',
     'NativeModule internal/streams/duplex',
     'NativeModule internal/streams/passthrough',
     'NativeModule internal/streams/readable',


### PR DESCRIPTION
I landed PR https://github.com/nodejs/node/commit/20de5f7efce655d435cfb5ae0811577314fbdeb9 through NCU and somehow this [change](
https://github.com/nodejs/node/commit/20de5f7efce655d435cfb5ae0811577314fbdeb9#diff-eeda4d549f43051fb9ffbc8286e838ebfd607bae681dfc55a76679e6705124f9R117) related to another PR landed in.

I'm investigating how that happened since NCU is supposed to validate a green CI of the code on GH

This PR removes the change. I'm investigating how that happened and am utterly confused.

Edit: https://github.com/nodejs/node/pull/36308#issuecomment-739570404
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
