### PR TITLE
child_process: clean event listener correctly

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -378,14 +378,13 @@ function execFile(file /* , args, options, callback */) {
     if (options.signal.aborted) {
       process.nextTick(() => kill());
     } else {
+      const childController = new AbortController();
       options.signal.addEventListener('abort', () => {
-        if (!ex) {
+        if (!ex)
           ex = new AbortError();
-        }
         kill();
-      });
-      const remove = () => options.signal.removeEventListener('abort', kill);
-      child.once('close', remove);
+      }, { signal: childController.signal });
+      child.once('close', () => childController.abort());
     }
   }
 

--- a/test/parallel/test-child-process-execfile.js
+++ b/test/parallel/test-child-process-execfile.js
@@ -3,6 +3,7 @@
 const common = require('../common');
 const assert = require('assert');
 const execFile = require('child_process').execFile;
+const { getEventListeners } = require('events');
 const { getSystemErrorName } = require('util');
 const fixtures = require('../common/fixtures');
 
@@ -68,5 +69,15 @@ const execOpts = { encoding: 'utf8', shell: true };
 
     execFile(process.execPath, [echoFixture, 0], { signal: 'hello' }, callback);
   }, { code: 'ERR_INVALID_ARG_TYPE', name: 'TypeError' });
+}
+{
+  // Verify that the process completing removes the abort listener
+  const ac = new AbortController();
+  const { signal } = ac;
 
+  const callback = common.mustCall((err) => {
+    assert.strictEqual(getEventListeners(ac.signal).length, 0);
+    assert.strictEqual(err, null);
+  });
+  execFile(process.execPath, [fixture, 0], { signal }, callback);
 }


### PR DESCRIPTION
I was working on AbortSignal for spawn and noticed there is a leak in
the current code for AbortSignal support in child_process since it
removes the wrong listener. I used the new signal as argument feature
to make removing the listener easier and added a test.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
