### PR TITLE
lib: make safe primordials safe to construct

### DIFF
--- a/lib/internal/per_context/primordials.js
+++ b/lib/internal/per_context/primordials.js
@@ -84,21 +84,31 @@ primordials.makeSafe = makeSafe;
 
 // Subclass the constructors because we need to use their prototype
 // methods later.
+// Defining the `constructor` is necessary here to avoid the default
+// constructor which uses the user-mutable `%ArrayIteratorPrototype%.next`.
 primordials.SafeMap = makeSafe(
   Map,
-  class SafeMap extends Map {}
+  class SafeMap extends Map {
+    constructor(i) { super(i); } // eslint-disable-line no-useless-constructor
+  }
 );
 primordials.SafeWeakMap = makeSafe(
   WeakMap,
-  class SafeWeakMap extends WeakMap {}
+  class SafeWeakMap extends WeakMap {
+    constructor(i) { super(i); } // eslint-disable-line no-useless-constructor
+  }
 );
 primordials.SafeSet = makeSafe(
   Set,
-  class SafeSet extends Set {}
+  class SafeSet extends Set {
+    constructor(i) { super(i); } // eslint-disable-line no-useless-constructor
+  }
 );
 primordials.SafeWeakSet = makeSafe(
   WeakSet,
-  class SafeWeakSet extends WeakSet {}
+  class SafeWeakSet extends WeakSet {
+    constructor(i) { super(i); } // eslint-disable-line no-useless-constructor
+  }
 );
 
 // Create copies of the namespace objects


### PR DESCRIPTION
The current constructors of `Safe(Weak)?(Map|Set)` classes are not "safe", they executes `%ArrayIteratorPrototype%.next` which may have been mutated in user-land.

That's the expected behaviour of subclasses default constructor defined the [ECMAScript spec](https://tc39.es/ecma262/#sec-runtime-semantics-classdefinitionevaluation), and I think it makes sense to disable this behaviour in this case.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
