### PR TITLE
lib: add `WebAssembly` to `primordials`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -359,6 +359,7 @@ module.exports = {
     MessagePort: 'readable',
     TextEncoder: 'readable',
     TextDecoder: 'readable',
+    WebAssembly: 'readonly',
     queueMicrotask: 'readable',
     globalThis: 'readable',
     btoa: 'readable',

--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -152,6 +152,7 @@ rules:
       into: Safe
     - name: WeakSet
       into: Safe
+    - name: WebAssembly
 globals:
   Intl: false
   # Parameters passed to internal modules

--- a/lib/internal/freeze_intrinsics.js
+++ b/lib/internal/freeze_intrinsics.js
@@ -118,6 +118,14 @@ const {
   WeakRefPrototype,
   WeakSet,
   WeakSetPrototype,
+  WebAssembly,
+  WebAssemblyModulePrototype,
+  WebAssemblyInstancePrototype,
+  WebAssemblyTablePrototype,
+  WebAssemblyMemoryPrototype,
+  WebAssemblyCompileErrorPrototype,
+  WebAssemblyLinkErrorPrototype,
+  WebAssemblyRuntimeErrorPrototype,
   decodeURI,
   decodeURIComponent,
   encodeURI,
@@ -129,7 +137,6 @@ const {
   Atomics,
   Intl,
   SharedArrayBuffer,
-  WebAssembly
 } = globalThis;
 
 module.exports = function() {
@@ -217,13 +224,13 @@ module.exports = function() {
 
     // Other APIs / Web Compatibility
     console.Console.prototype,
-    WebAssembly.Module.prototype,
-    WebAssembly.Instance.prototype,
-    WebAssembly.Table.prototype,
-    WebAssembly.Memory.prototype,
-    WebAssembly.CompileError.prototype,
-    WebAssembly.LinkError.prototype,
-    WebAssembly.RuntimeError.prototype,
+    WebAssemblyModulePrototype,
+    WebAssemblyInstancePrototype,
+    WebAssemblyTablePrototype,
+    WebAssemblyMemoryPrototype,
+    WebAssemblyCompileErrorPrototype,
+    WebAssemblyLinkErrorPrototype,
+    WebAssemblyRuntimeErrorPrototype,
   ];
   const intrinsics = [
     // 10.2.4.1 ThrowTypeError

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -17,7 +17,11 @@ const {
   StringPrototypeSlice,
   StringPrototypeStartsWith,
   SyntaxErrorPrototype,
-  globalThis: { WebAssembly },
+  WebAssembly,
+  WebAssemblyCompile,
+  WebAssemblyInstance,
+  WebAssemblyModuleExports,
+  WebAssemblyModuleImports,
 } = primordials;
 
 let _TYPES = null;
@@ -345,21 +349,21 @@ translators.set('wasm', async function(url, source) {
 
   let compiled;
   try {
-    compiled = await WebAssembly.compile(source);
+    compiled = await WebAssemblyCompile(source);
   } catch (err) {
     err.message = errPath(url) + ': ' + err.message;
     throw err;
   }
 
   const imports =
-      ArrayPrototypeMap(WebAssembly.Module.imports(compiled),
+      ArrayPrototypeMap(WebAssemblyModuleImports(compiled),
                         ({ module }) => module);
   const exports =
-    ArrayPrototypeMap(WebAssembly.Module.exports(compiled),
+    ArrayPrototypeMap(WebAssemblyModuleExports(compiled),
                       ({ name }) => name);
 
   return createDynamicModule(imports, exports, url, (reflect) => {
-    const { exports } = new WebAssembly.Instance(compiled, reflect.imports);
+    const { exports } = new WebAssemblyInstance(compiled, reflect.imports);
     for (const expt of ObjectKeys(exports))
       reflect.exports[expt].set(exports[expt]);
   }).module;


### PR DESCRIPTION
This is used to handle support for **WebAssembly** modules and static analysis of named exports from **CommonJS** modules.

---

Note that adding **WebAssembly** types to `/typings/primordials.d.ts` depends on <https://github.com/microsoft/TypeScript-DOM-lib-generator/pull/959> in order to avoid adding `lib: ["DOM"]` to `tsconfig.json`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
