### PR TITLE
url: make URL cloneable for MessagePort

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -9,6 +9,7 @@ const {
   ObjectDefineProperty,
   ObjectGetOwnPropertySymbols,
   ObjectGetPrototypeOf,
+  ObjectSetPrototypeOf,
   ObjectKeys,
   ReflectGetOwnPropertyDescriptor,
   ReflectOwnKeys,
@@ -82,6 +83,12 @@ const {
   kSchemeStart
 } = internalBinding('url');
 
+const {
+  JSTransferable,
+  kClone,
+  kDeserialize,
+} = require('internal/worker/js_transferable');
+
 const context = Symbol('context');
 const cannotBeBase = Symbol('cannot-be-base');
 const cannotHaveUsernamePasswordPort =
@@ -121,8 +128,9 @@ function serializeTupleOrigin(scheme, host, port) {
 // URL Standard, with a few differences. It is also the object transported to
 // the C++ binding.
 // Refs: https://url.spec.whatwg.org/#concept-url
-class URLContext {
+class URLContext extends JSTransferable {
   constructor() {
+    super();
     this.flags = 0;
     this.scheme = ':';
     this.username = '';
@@ -133,14 +141,44 @@ class URLContext {
     this.query = null;
     this.fragment = null;
   }
+
+  [kClone]() {
+    return {
+      data: {
+        flags: this.flags,
+        scheme: this.scheme,
+        username: this.username,
+        password: this.password,
+        host: this.host,
+        port: this.port,
+        path: this.path,
+        query: this.query,
+        fragment: this.fragment,
+      },
+      deserializeInfo: 'internal/url:URLContext'
+    };
+  }
+
+  [kDeserialize](data) {
+    this.flags = data.flags;
+    this.scheme = data.scheme;
+    this.username = data.username;
+    this.password = data.password;
+    this.host = data.host;
+    this.port = data.port;
+    this.path = data.path;
+    this.query = data.query;
+    this.fragment = data.fragment;
+  }
 }
 
-class URLSearchParams {
+class URLSearchParams extends JSTransferable {
   // URL Standard says the default value is '', but as undefined and '' have
   // the same result, undefined is used to prevent unnecessary parsing.
   // Default parameter is necessary to keep URLSearchParams.length === 0 in
   // accordance with Web IDL spec.
   constructor(init = undefined) {
+    super();
     if (init === null || init === undefined) {
       this[searchParams] = [];
     } else if (typeof init === 'object' || typeof init === 'function') {
@@ -203,6 +241,21 @@ class URLSearchParams {
     this[context] = null;
   }
 
+  [kClone]() {
+    return {
+      data: {
+        searchParams: this[searchParams],
+        context: this[context],
+      },
+      deserializeInfo: 'internal/url:InternalURLSearchParams'
+    };
+  }
+
+  [kDeserialize](data) {
+    this[searchParams] = data.searchParams;
+    this[context] = data.context;
+  }
+
   [inspect.custom](recurseTimes, ctx) {
     if (!this || !this[searchParams] || this[searchParams][searchParams]) {
       throw new ERR_INVALID_THIS('URLSearchParams');
@@ -235,6 +288,20 @@ class URLSearchParams {
     return `${this.constructor.name} {}`;
   }
 }
+
+class InternalURLSearchParams extends JSTransferable {
+  constructor(_searchParams, _context) {
+    super();
+    this[searchParams] = _searchParams;
+    this[context] = _context;
+  }
+}
+
+InternalURLSearchParams.prototype.constructor = URLSearchParams;
+ObjectSetPrototypeOf(
+  InternalURLSearchParams.prototype,
+  URLSearchParams.prototype);
+
 
 function onParseComplete(flags, protocol, username, password,
                          host, port, path, query, fragment) {
@@ -323,8 +390,9 @@ function onParseHashComplete(flags, protocol, username, password,
   this[context].fragment = fragment;
 }
 
-class URL {
+class URL extends JSTransferable {
   constructor(input, base) {
+    super();
     // toUSVString is not needed.
     input = `${input}`;
     let base_context;
@@ -334,6 +402,21 @@ class URL {
     this[context] = new URLContext();
     parse(input, -1, base_context, undefined, onParseComplete.bind(this),
           onParseError);
+  }
+
+  [kClone]() {
+    return {
+      data: {
+        context: this[context],
+        searchParams: this[searchParams],
+      },
+      deserializeInfo: 'internal/url:InternalURL'
+    };
+  }
+
+  [kDeserialize](data) {
+    this[context] = data.context;
+    this[searchParams] = data.searchParams;
   }
 
   get [special]() {
@@ -386,6 +469,17 @@ class URL {
     return `${constructor.name} ${inspect(obj, opts)}`;
   }
 }
+
+class InternalURL extends JSTransferable {
+  constructor(_context, _searchParams) {
+    super();
+    this[context] = _context;
+    this[searchParams] = _searchParams;
+  }
+}
+
+InternalURL.prototype.constructor = URL;
+ObjectSetPrototypeOf(InternalURL.prototype, URL.prototype);
 
 ObjectDefineProperties(URL.prototype, {
   [kFormat]: {
@@ -1462,7 +1556,10 @@ module.exports = {
   toPathIfFileURL,
   isURLInstance,
   URL,
+  URLContext,
   URLSearchParams,
+  InternalURL,
+  InternalURLSearchParams,
   domainToASCII,
   domainToUnicode,
   urlToOptions,

--- a/test/parallel/test-worker-transferable-url.js
+++ b/test/parallel/test-worker-transferable-url.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+
+const mc = new MessageChannel();
+const source = new URL('https://abc:123@example.org:80/a/b/c?d=e#f');
+
+mc.port2.onmessage = common.mustCall(({ data }) => {
+  assert(data instanceof URL);
+  assert.strictEqual(data.href, source.href);
+  mc.port2.close();
+});
+
+mc.port1.unref();
+mc.port1.postMessage(source);


### PR DESCRIPTION
Allow URL object instances to be cloned when sent via MessagePort.

e.g.

```js
const mc = new MessageChannel();
const url = new URL('https://example.org');
mc.port1.postMessage(url);

mc.port2.on('message', ({data}) => {
  console.log(data.href);
});
```

Signed-off-by: James M Snell <jasnell@gmail.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
