### PR TITLE
Documenting OutgoingMessage

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1370,7 +1370,7 @@ emitted when the last segment of the response headers and body have been
 handed off to the operating system for transmission over the network. It
 does not imply that the client has received anything yet.
 
-### `message.addTrailers(headers)`
+### `outMessage.addTrailers(headers)`
 <!-- YAML
 added: v0.3.0
 -->
@@ -1384,33 +1384,22 @@ Trailers will **only** be emitted if chunked encoding is used for the
 response; if it is not (e.g. if the request was HTTP/1.0), they will
 be silently discarded.
 
-HTTP requires the `Trailer` header to be sent in order to
-emit trailers, with a list of the header fields in its value. E.g.,
-
-```js
-message.writeHead(200, { 'Content-Type': 'text/plain',
-                          'Trailer': 'Content-MD5' });
-message.write(fileData);
-message.addTrailers({ 'Content-MD5': '7895bf4b8828b55ceaf47747b4bca667' });
-message.end();
-```
-
 Attempting to set a header field name or value that contains invalid characters
 will result in a [`TypeError`][] being thrown.
 
-### `response.connection`
+### `outMessage.connection`
 <!-- YAML
 added: v0.3.0
 deprecated: v13.0.0
 -->
 
-> Stability: 0 - Deprecated. Use [`response.socket`][].
+> Stability: 0 - Deprecated. Use [`outMessage.socket`][].
 
 * {stream.Duplex}
 
-See [`response.socket`][].
+See [`outMessage.socket`][].
 
-### `response.cork()`
+### `outMessage.cork()`
 <!-- YAML
 added:
  - v13.2.0
@@ -1419,7 +1408,7 @@ added:
 
 See [`writable.cork()`][].
 
-### `response.end([data[, encoding]][, callback])`
+### `outMessage.end([data[, encoding]][, callback])`
 <!-- YAML
 added: v0.1.90
 changes:
@@ -1435,15 +1424,20 @@ changes:
 
 This method signals to the server that all of the response headers and body
 have been sent; that server should consider this message complete.
-The method, `response.end()`, MUST be called on each response.
+The method, `outMessage.end()`, MUST be called on each response.
 
 If `data` is specified, it is similar in effect to calling
-[`response.write(data, encoding)`][] followed by `response.end(callback)`.
+[`outMessage.write(data, encoding)`][] followed by `outMessage.end(callback)`.
 
 If `callback` is specified, it will be called when the response stream
 is finished.
 
-### `response.finished`
+### `outMessage.writableCorked`
+* Returns: {integer}
+
+Returns `0` if the socket buffer is corked, and a positive number otherwise.
+
+### `outMessage.finished`
 <!-- YAML
 added: v0.0.2
 deprecated:
@@ -1451,21 +1445,21 @@ deprecated:
  - v12.16.0
 -->
 
-> Stability: 0 - Deprecated. Use [`response.writableEnded`][].
+> Stability: 0 - Deprecated. Use [`outMessage.writableEnded`][].
 
 * {boolean}
 
-The `response.finished` property will be `true` if [`response.end()`][]
+The `outMessage.finished` property will be `true` if [`outMessage.end()`][]
 has been called.
 
-### `response.flushHeaders()`
+### `outMessage.flushHeaders()`
 <!-- YAML
 added: v1.6.0
 -->
 
-Flushes the response headers. See also: [`request.flushHeaders()`][].
+Flushes the response headers. See also: [`outMessage.flushHeaders()`][].
 
-### `response.getHeader(name)`
+### `outMessage.getHeader(name)`
 <!-- YAML
 added: v0.4.0
 -->
@@ -1478,9 +1472,9 @@ The name is case-insensitive. The type of the return value depends
 on the arguments provided to [`response.setHeader()`][].
 
 ```js
-response.setHeader('Content-Type', 'text/html');
-response.setHeader('Content-Length', Buffer.byteLength(body));
-response.setHeader('Set-Cookie', ['type=ninja', 'language=javascript']);
+outMessage.setHeader('Content-Type', 'text/html');
+outMessage.setHeader('Content-Length', Buffer.byteLength(body));
+outMessage.setHeader('Set-Cookie', ['type=ninja', 'language=javascript']);
 const contentType = response.getHeader('content-type');
 // contentType is 'text/html'
 const contentLength = response.getHeader('Content-Length');
@@ -1489,7 +1483,7 @@ const setCookie = response.getHeader('set-cookie');
 // setCookie is of type string[]
 ```
 
-### `response.getHeaderNames()`
+### `outMessage.getHeaderNames()`
 <!-- YAML
 added: v7.7.0
 -->
@@ -1500,14 +1494,14 @@ Returns an array containing the unique names of the current outgoing headers.
 All header names are lowercase.
 
 ```js
-response.setHeader('Foo', 'bar');
-response.setHeader('Set-Cookie', ['foo=bar', 'bar=baz']);
+outMessage.setHeader('Foo', 'bar');
+outMessage.setHeader('Set-Cookie', ['foo=bar', 'bar=baz']);
 
 const headerNames = response.getHeaderNames();
 // headerNames === ['foo', 'set-cookie']
 ```
 
-### `response.getHeaders()`
+### `outMessage.getHeaders()`
 <!-- YAML
 added: v7.7.0
 -->
@@ -1520,20 +1514,20 @@ header-related http module methods. The keys of the returned object are the
 header names and the values are the respective header values. All header names
 are lowercase.
 
-The object returned by the `response.getHeaders()` method _does not_
+The object returned by the `outMessage.getHeaders()` method _does not_
 prototypically inherit from the JavaScript `Object`. This means that typical
 `Object` methods such as `obj.toString()`, `obj.hasOwnProperty()`, and others
 are not defined and *will not work*.
 
 ```js
-response.setHeader('Foo', 'bar');
-response.setHeader('Set-Cookie', ['foo=bar', 'bar=baz']);
+outMessage.setHeader('Foo', 'bar');
+outMessage.setHeader('Set-Cookie', ['foo=bar', 'bar=baz']);
 
-const headers = response.getHeaders();
+const headers = outMessage.getHeaders();
 // headers === { foo: 'bar', 'set-cookie': ['foo=bar', 'bar=baz'] }
 ```
 
-### `response.hasHeader(name)`
+### `outMessage.hasHeader(name)`
 <!-- YAML
 added: v7.7.0
 -->
@@ -1545,10 +1539,10 @@ Returns `true` if the header identified by `name` is currently set in the
 outgoing headers. The header name matching is case-insensitive.
 
 ```js
-const hasContentType = response.hasHeader('content-type');
+const hasContentType = outMessage.hasHeader('content-type');
 ```
 
-### `response.headersSent`
+### `outMessage.headersSent`
 <!-- YAML
 added: v0.9.3
 -->
@@ -1557,7 +1551,7 @@ added: v0.9.3
 
 Boolean (read-only). True if headers were sent, false otherwise.
 
-### `response.removeHeader(name)`
+### `outMessage.removeHeader(name)`
 <!-- YAML
 added: v0.4.0
 -->
@@ -1567,10 +1561,10 @@ added: v0.4.0
 Removes a header that's queued for implicit sending.
 
 ```js
-response.removeHeader('Content-Encoding');
+outMessage.removeHeader('Content-Encoding');
 ```
 
-### `response.sendDate`
+### `outMessage.sendDate`
 <!-- YAML
 added: v0.7.5
 -->
@@ -1583,7 +1577,7 @@ the response if it is not already present in the headers. Defaults to true.
 This should only be disabled for testing; HTTP requires the Date header
 in responses.
 
-### `response.setHeader(name, value)`
+### `outMessage.setHeader(name, value)`
 <!-- YAML
 added: v0.4.0
 -->
@@ -1597,46 +1591,25 @@ Returns the response object.
 Sets a single header value for implicit headers. If this header already exists
 in the to-be-sent headers, its value will be replaced. Use an array of strings
 here to send multiple headers with the same name. Non-string values will be
-stored without modification. Therefore, [`response.getHeader()`][] may return
+stored without modification. Therefore, [`outMessage.getHeader()`][] may return
 non-string values. However, the non-string values will be converted to strings
 for network transmission. The same response object is returned to the caller,
 to enable call chaining.
 
 ```js
-response.setHeader('Content-Type', 'text/html');
+outMessage.setHeader('Content-Type', 'text/html');
 ```
 
 or
 
 ```js
-response.setHeader('Set-Cookie', ['type=ninja', 'language=javascript']);
+outMessage.setHeader('Set-Cookie', ['type=ninja', 'language=javascript']);
 ```
 
 Attempting to set a header field name or value that contains invalid characters
 will result in a [`TypeError`][] being thrown.
 
-When headers have been set with [`response.setHeader()`][], they will be merged
-with any headers passed to [`response.writeHead()`][], with the headers passed
-to [`response.writeHead()`][] given precedence.
-
-```js
-// Returns content-type = text/plain
-const server = http.createServer((req, res) => {
-  res.setHeader('Content-Type', 'text/html');
-  res.setHeader('X-Foo', 'bar');
-  res.writeHead(200, { 'Content-Type': 'text/plain' });
-  res.end('ok');
-});
-```
-
-If [`response.writeHead()`][] method is called and this method has not been
-called, it will directly write the supplied header values onto the network
-channel without caching internally, and the [`response.getHeader()`][] on the
-header will not yield the expected result. If progressive population of headers
-is desired with potential future retrieval and modification, use
-[`response.setHeader()`][] instead of [`response.writeHead()`][].
-
-### `response.setTimeout(msecs[, callback])`
+### `outMessage.setTimeout(msecs[, callback])`
 <!-- YAML
 added: v0.9.12
 -->
@@ -1654,7 +1627,7 @@ the server, then sockets are destroyed when they time out. If a handler is
 assigned to the request, the response, or the server's `'timeout'` events,
 timed out sockets must be handled explicitly.
 
-### `response.socket`
+### `outMessage.socket`
 <!-- YAML
 added: v0.3.0
 -->
@@ -1664,14 +1637,17 @@ added: v0.3.0
 Reference to the underlying socket. Usually users will not want to access
 this property. In particular, the socket will not emit `'readable'` events
 because of how the protocol parser attaches to the socket. After
-`response.end()`, the property is nulled.
+`outMessage.end()`, the property is nulled.
 
 ```js
 const http = require('http');
 const server = http.createServer((req, res) => {
-  const ip = res.socket.remoteAddress;
-  const port = res.socket.remotePort;
-  res.end(`Your IP address is ${ip} and your source port is ${port}.`);
+  const { OutgoingMessage } = require('_http_outgoing');
+  const outMessage = new OutgoingMessage();
+  outMessage.socket = req.socket;
+  const ip = outMessage.socket.remoteAddress;
+  const port = outMessage.socket.remotePort;
+  console.log(`Your IP address is ${ip} and your source port is ${port}.`);
 }).listen(3000);
 ```
 
@@ -1679,44 +1655,7 @@ This property is guaranteed to be an instance of the {net.Socket} class,
 a subclass of {stream.Duplex}, unless the user specified a socket
 type other than {net.Socket}.
 
-### `response.statusCode`
-<!-- YAML
-added: v0.4.0
--->
-
-* {number} **Default:** `200`
-
-When using implicit headers (not calling [`response.writeHead()`][] explicitly),
-this property controls the status code that will be sent to the client when
-the headers get flushed.
-
-```js
-response.statusCode = 404;
-```
-
-After response header was sent to the client, this property indicates the
-status code which was sent out.
-
-### `response.statusMessage`
-<!-- YAML
-added: v0.11.8
--->
-
-* {string}
-
-When using implicit headers (not calling [`response.writeHead()`][] explicitly),
-this property controls the status message that will be sent to the client when
-the headers get flushed. If this is left as `undefined` then the standard
-message for the status code will be used.
-
-```js
-response.statusMessage = 'Not found';
-```
-
-After response header was sent to the client, this property indicates the
-status message which was sent out.
-
-### `response.uncork()`
+### `outMessage.uncork()`
 <!-- YAML
 added:
  - v13.2.0
@@ -1725,18 +1664,18 @@ added:
 
 See [`writable.uncork()`][].
 
-### `response.writableEnded`
+### `outMessage.writableEnded`
 <!-- YAML
 added: v12.9.0
 -->
 
 * {boolean}
 
-Is `true` after [`response.end()`][] has been called. This property
+Is `true` after [`outMessage.end()`][] has been called. This property
 does not indicate whether the data has been flushed, for this use
-[`response.writableFinished`][] instead.
+[`outMessage.writableFinished`][] instead.
 
-### `response.writableFinished`
+### `outMessage.writableFinished`
 <!-- YAML
 added: v12.7.0
 -->
@@ -1746,7 +1685,24 @@ added: v12.7.0
 Is `true` if all data has been flushed to the underlying system, immediately
 before the [`'finish'`][] event is emitted.
 
-### `response.write(chunk[, encoding][, callback])`
+### `outMessage.writableLength`
+
+* {integer}
+
+Returns the length, in bytes, of the socket buffer plus the data and headers of the OutgoingMessage.
+
+### `outMessage.writableHighWaterMark`
+
+* {number}
+
+Returns the high water mark (see [`stream.buffering`][]) for [`outMessage.socket`][]'s writable stream.
+
+### `outMessage.writableNeedDrain`
+* {boolean}
+
+Returns `true` if there is data in the writable queue that needs to be drained.
+
+### `outMessage.write(chunk[, encoding][, callback])`
 <!-- YAML
 added: v0.1.29
 -->
@@ -1756,15 +1712,8 @@ added: v0.1.29
 * `callback` {Function}
 * Returns: {boolean}
 
-If this method is called and [`response.writeHead()`][] has not been called,
-it will switch to implicit header mode and flush the implicit headers.
-
 This sends a chunk of the response body. This method may
 be called multiple times to provide successive parts of the body.
-
-In the `http` module, the response body is omitted when the
-request is a HEAD request. Similarly, the `204` and `304` responses
-_must not_ include a message body.
 
 `chunk` can be a string or a buffer. If `chunk` is a string,
 the second parameter specifies how to encode it into a byte stream.
@@ -1773,9 +1722,9 @@ the second parameter specifies how to encode it into a byte stream.
 This is the raw HTTP body and has nothing to do with higher-level multi-part
 body encodings that may be used.
 
-The first time [`response.write()`][] is called, it will send the buffered
+The first time [`outMessage.write()`][] is called, it will send the buffered
 header information and the first chunk of the body to the client. The second
-time [`response.write()`][] is called, Node.js assumes data will be streamed,
+time [`outMessage.write()`][] is called, Node.js assumes data will be streamed,
 and sends the new data separately. That is, the response is buffered up to the
 first chunk of the body.
 
@@ -1783,105 +1732,6 @@ Returns `true` if the entire data was flushed successfully to the kernel
 buffer. Returns `false` if all or part of the data was queued in user memory.
 `'drain'` will be emitted when the buffer is free again.
 
-### `response.writeContinue()`
-<!-- YAML
-added: v0.3.0
--->
-
-Sends a HTTP/1.1 100 Continue message to the client, indicating that
-the request body should be sent. See the [`'checkContinue'`][] event on
-`Server`.
-
-### `response.writeHead(statusCode[, statusMessage][, headers])`
-<!-- YAML
-added: v0.1.30
-changes:
-  - version: v14.14.0
-    pr-url: https://github.com/nodejs/node/pull/35274
-    description: Allow passing headers as an array.
-  - version:
-     - v11.10.0
-     - v10.17.0
-    pr-url: https://github.com/nodejs/node/pull/25974
-    description: Return `this` from `writeHead()` to allow chaining with
-                 `end()`.
-  - version:
-    - v5.11.0
-    - v4.4.5
-    pr-url: https://github.com/nodejs/node/pull/6291
-    description: A `RangeError` is thrown if `statusCode` is not a number in
-                 the range `[100, 999]`.
--->
-
-* `statusCode` {number}
-* `statusMessage` {string}
-* `headers` {Object|Array}
-* Returns: {http.ServerResponse}
-
-Sends a response header to the request. The status code is a 3-digit HTTP
-status code, like `404`. The last argument, `headers`, are the response headers.
-Optionally one can give a human-readable `statusMessage` as the second
-argument.
-
-`headers` may be an `Array` where the keys and values are in the same list.
-It is *not* a list of tuples. So, the even-numbered offsets are key values,
-and the odd-numbered offsets are the associated values. The array is in the same
-format as `request.rawHeaders`.
-
-Returns a reference to the `ServerResponse`, so that calls can be chained.
-
-```js
-const body = 'hello world';
-response
-  .writeHead(200, {
-    'Content-Length': Buffer.byteLength(body),
-    'Content-Type': 'text/plain'
-  })
-  .end(body);
-```
-
-This method must only be called once on a message and it must
-be called before [`response.end()`][] is called.
-
-If [`response.write()`][] or [`response.end()`][] are called before calling
-this, the implicit/mutable headers will be calculated and call this function.
-
-When headers have been set with [`response.setHeader()`][], they will be merged
-with any headers passed to [`response.writeHead()`][], with the headers passed
-to [`response.writeHead()`][] given precedence.
-
-If this method is called and [`response.setHeader()`][] has not been called,
-it will directly write the supplied header values onto the network channel
-without caching internally, and the [`response.getHeader()`][] on the header
-will not yield the expected result. If progressive population of headers is
-desired with potential future retrieval and modification, use
-[`response.setHeader()`][] instead.
-
-```js
-// Returns content-type = text/plain
-const server = http.createServer((req, res) => {
-  res.setHeader('Content-Type', 'text/html');
-  res.setHeader('X-Foo', 'bar');
-  res.writeHead(200, { 'Content-Type': 'text/plain' });
-  res.end('ok');
-});
-```
-
-`Content-Length` is given in bytes, not characters. Use
-[`Buffer.byteLength()`][] to determine the length of the body in bytes. Node.js
-does not check whether `Content-Length` and the length of the body which has
-been transmitted are equal or not.
-
-Attempting to set a header field name or value that contains invalid characters
-will result in a [`TypeError`][] being thrown.
-
-### `response.writeProcessing()`
-<!-- YAML
-added: v10.0.0
--->
-
-Sends a HTTP/1.1 102 Processing message to the client, indicating that
-the request body should be sent.
 
 ## Class: `http.ServerResponse`
 <!-- YAML


### PR DESCRIPTION
I took a crack at Documenting Outgoing Message per #33847

Repeated and cleaned up language from `http.ServerResponse`. 

I cannot figure out how to get OutgoingMessage to send on its own, however. It feels like it is intended as an abstract class for `http.ServerResponse`?

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
