### PR TITLE
src: add way to get IsolateData and allocator from Environment

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -436,6 +436,14 @@ Environment* GetCurrentEnvironment(Local<Context> context) {
   return Environment::GetCurrent(context);
 }
 
+IsolateData* GetEnvironmentIsolateData(Environment* env) {
+  return env->isolate_data();
+}
+
+ArrayBufferAllocator* GetArrayBufferAllocator(IsolateData* isolate_data) {
+  return isolate_data->node_allocator();
+}
+
 MultiIsolatePlatform* GetMultiIsolatePlatform(Environment* env) {
   return GetMultiIsolatePlatform(env->isolate_data());
 }

--- a/src/node.h
+++ b/src/node.h
@@ -463,6 +463,8 @@ NODE_EXTERN void DefaultProcessExitHandler(Environment* env, int exit_code);
 
 // This may return nullptr if context is not associated with a Node instance.
 NODE_EXTERN Environment* GetCurrentEnvironment(v8::Local<v8::Context> context);
+NODE_EXTERN IsolateData* GetEnvironmentIsolateData(Environment* env);
+NODE_EXTERN ArrayBufferAllocator* GetArrayBufferAllocator(IsolateData* data);
 
 NODE_EXTERN void OnFatalError(const char* location, const char* message);
 NODE_EXTERN void PromiseRejectCallback(v8::PromiseRejectMessage message);

--- a/test/cctest/test_environment.cc
+++ b/test/cctest/test_environment.cc
@@ -586,6 +586,9 @@ TEST_F(NodeZeroIsolateTestFixture, CtrlCWithOnlySafeTerminationTest) {
                                           {}),
                   node::FreeEnvironment};
     CHECK(environment);
+    EXPECT_EQ(node::GetEnvironmentIsolateData(environment.get()),
+              isolate_data.get());
+    EXPECT_EQ(node::GetArrayBufferAllocator(isolate_data.get()), nullptr);
 
     v8::Local<v8::Value> main_ret =
         node::LoadEnvironment(environment.get(),


### PR DESCRIPTION
Add a way to get the current `IsolateData*` and, from it, the current
Node.js `ArrayBufferAllocator` if there is one. This can be useful
for re-using either one of these structures as an embedder.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
