### PR TITLE
fs: refactor to use private fields

### DIFF
--- a/lib/internal/fs/dir.js
+++ b/lib/internal/fs/dir.js
@@ -7,7 +7,6 @@ const {
   FunctionPrototypeBind,
   ObjectDefineProperty,
   PromiseReject,
-  Symbol,
   SymbolAsyncIterator,
 } = primordials;
 
@@ -35,84 +34,78 @@ const {
   validateUint32
 } = require('internal/validators');
 
-const kDirHandle = Symbol('kDirHandle');
-const kDirPath = Symbol('kDirPath');
-const kDirBufferedEntries = Symbol('kDirBufferedEntries');
-const kDirClosed = Symbol('kDirClosed');
-const kDirOptions = Symbol('kDirOptions');
-const kDirReadImpl = Symbol('kDirReadImpl');
-const kDirReadPromisified = Symbol('kDirReadPromisified');
-const kDirClosePromisified = Symbol('kDirClosePromisified');
-const kDirOperationQueue = Symbol('kDirOperationQueue');
-
 class Dir {
+  #handle = undefined;
+  #path = undefined;
+  #options = undefined;
+  #bufferedEntries = [];
+  #dirClosed = false;
+  // Either `null` or an Array of pending operations (= functions to be called
+  // once the current operation is done).
+  #operationQueue = null;
+  #readPromisified = undefined;
+  #closePromisified = undefined;
+
   constructor(handle, path, options) {
     if (handle == null) throw new ERR_MISSING_ARGS('handle');
-    this[kDirHandle] = handle;
-    this[kDirBufferedEntries] = [];
-    this[kDirPath] = path;
-    this[kDirClosed] = false;
-
-    // Either `null` or an Array of pending operations (= functions to be called
-    // once the current operation is done).
-    this[kDirOperationQueue] = null;
-
-    this[kDirOptions] = {
+    this.#handle = handle;
+    this.#path = path;
+    this.#options = {
       bufferSize: 32,
       ...getOptions(options, {
         encoding: 'utf8'
       })
     };
 
-    validateUint32(this[kDirOptions].bufferSize, 'options.bufferSize', true);
-
-    this[kDirReadPromisified] = FunctionPrototypeBind(
-      internalUtil.promisify(this[kDirReadImpl]), this, false);
-    this[kDirClosePromisified] = FunctionPrototypeBind(
+    this.#readPromisified = FunctionPrototypeBind(
+      internalUtil.promisify(this.#readImpl), this, false);
+    this.#closePromisified = this.#closePromisified = FunctionPrototypeBind(
       internalUtil.promisify(this.close), this);
+
+    validateUint32(this.#options.bufferSize, 'options.bufferSize', true);
   }
 
   get path() {
-    return this[kDirPath];
+    return this.#path;
   }
 
   read(callback) {
-    return this[kDirReadImpl](true, callback);
+    return this.#readImpl(true, callback);
   }
 
-  [kDirReadImpl](maybeSync, callback) {
-    if (this[kDirClosed] === true) {
+  #readImpl(maybeSync, callback) {
+    if (this.#dirClosed === true) {
       throw new ERR_DIR_CLOSED();
     }
 
     if (callback === undefined) {
-      return this[kDirReadPromisified]();
+      return this.#readPromisified();
     } else if (typeof callback !== 'function') {
       throw new ERR_INVALID_CALLBACK(callback);
     }
 
-    if (this[kDirOperationQueue] !== null) {
-      ArrayPrototypePush(this[kDirOperationQueue], () => {
-        this[kDirReadImpl](maybeSync, callback);
+    if (this.#operationQueue !== null) {
+      ArrayPrototypePush(this.#operationQueue, () => {
+        this.#readImpl(maybeSync, callback);
       });
       return;
     }
 
-    if (this[kDirBufferedEntries].length > 0) {
+    if (this.#bufferedEntries.length > 0) {
       const [ name, type ] =
-        ArrayPrototypeSplice(this[kDirBufferedEntries], 0, 2);
+        ArrayPrototypeSplice(this.#bufferedEntries, 0, 2);
       if (maybeSync)
-        process.nextTick(getDirent, this[kDirPath], name, type, callback);
+        process.nextTick(getDirent, this.#path, name, type, callback);
       else
-        getDirent(this[kDirPath], name, type, callback);
+        getDirent(this.#path, name, type, callback);
       return;
     }
 
     const req = new FSReqCallback();
     req.oncomplete = (err, result) => {
       process.nextTick(() => {
-        const queue = this[kDirOperationQueue];
-        this[kDirOperationQueue] = null;
+        const queue = this.#operationQueue;
+        this.#operationQueue = null;
         for (const op of queue) op();
       });
 
@@ -120,37 +113,37 @@ class Dir {
         return callback(err, result);
       }
 
-      this[kDirBufferedEntries] = ArrayPrototypeSlice(result, 2);
-      getDirent(this[kDirPath], result[0], result[1], callback);
+      this.#bufferedEntries = ArrayPrototypeSlice(result, 2);
+      getDirent(this.#path, result[0], result[1], callback);
     };
 
-    this[kDirOperationQueue] = [];
-    this[kDirHandle].read(
-      this[kDirOptions].encoding,
-      this[kDirOptions].bufferSize,
+    this.#operationQueue = [];
+    this.#handle.read(
+      this.#options.encoding,
+      this.#options.bufferSize,
       req
     );
   }
 
   readSync() {
-    if (this[kDirClosed] === true) {
+    if (this.#dirClosed === true) {
       throw new ERR_DIR_CLOSED();
     }
 
-    if (this[kDirOperationQueue] !== null) {
+    if (this.#operationQueue !== null) {
       throw new ERR_DIR_CONCURRENT_OPERATION();
     }
 
-    if (this[kDirBufferedEntries].length > 0) {
+    if (this.#bufferedEntries.length > 0) {
       const [ name, type ] =
-          ArrayPrototypeSplice(this[kDirBufferedEntries], 0, 2);
-      return getDirent(this[kDirPath], name, type);
+          ArrayPrototypeSplice(this.#bufferedEntries, 0, 2);
+      return getDirent(this.#path, name, type);
     }
 
-    const ctx = { path: this[kDirPath] };
-    const result = this[kDirHandle].read(
-      this[kDirOptions].encoding,
-      this[kDirOptions].bufferSize,
+    const ctx = { path: this.#path };
+    const result = this.#handle.read(
+      this.#options.encoding,
+      this.#options.bufferSize,
       undefined,
       ctx
     );
@@ -160,17 +153,17 @@ class Dir {
       return result;
     }
 
-    this[kDirBufferedEntries] = ArrayPrototypeSlice(result, 2);
-    return getDirent(this[kDirPath], result[0], result[1]);
+    this.#bufferedEntries = ArrayPrototypeSlice(result, 2);
+    return getDirent(this.#path, result[0], result[1]);
   }
 
   close(callback) {
     // Promise
     if (callback === undefined) {
-      if (this[kDirClosed] === true) {
+      if (this.#dirClosed === true) {
         return PromiseReject(new ERR_DIR_CLOSED());
       }
-      return this[kDirClosePromisified]();
+      return this.#closePromisified();
     }
 
     // callback
@@ -178,36 +171,36 @@ class Dir {
       throw new ERR_INVALID_CALLBACK(callback);
     }
 
-    if (this[kDirClosed] === true) {
+    if (this.#dirClosed === true) {
       process.nextTick(callback, new ERR_DIR_CLOSED());
       return;
     }
 
-    if (this[kDirOperationQueue] !== null) {
-      this[kDirOperationQueue].push(() => {
+    if (this.#operationQueue !== null) {
+      this.#operationQueue.push(() => {
         this.close(callback);
       });
       return;
     }
 
-    this[kDirClosed] = true;
+    this.#dirClosed = true;
     const req = new FSReqCallback();
     req.oncomplete = callback;
-    this[kDirHandle].close(req);
+    this.#handle.close(req);
   }
 
   closeSync() {
-    if (this[kDirClosed] === true) {
+    if (this.#dirClosed === true) {
       throw new ERR_DIR_CLOSED();
     }
 
-    if (this[kDirOperationQueue] !== null) {
+    if (this.#operationQueue !== null) {
       throw new ERR_DIR_CONCURRENT_OPERATION();
     }
 
-    this[kDirClosed] = true;
-    const ctx = { path: this[kDirPath] };
-    const result = this[kDirHandle].close(undefined, ctx);
+    this.#dirClosed = true;
+    const ctx = { path: this.#path };
+    const result = this.#handle.close(undefined, ctx);
     handleErrorFromBinding(ctx);
     return result;
   }
@@ -215,14 +208,14 @@ class Dir {
   async* entries() {
     try {
       while (true) {
-        const result = await this[kDirReadPromisified]();
+        const result = await this.#readPromisified();
         if (result === null) {
           break;
         }
         yield result;
       }
     } finally {
-      await this[kDirClosePromisified]();
+      await this.#closePromisified();
     }
   }
 }

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -50,7 +50,6 @@ const {
   validateUint32
 } = require('internal/validators');
 const pathModule = require('path');
-const kType = Symbol('type');
 const kStats = Symbol('stats');
 const assert = require('internal/assert');
 
@@ -135,37 +134,38 @@ function assertEncoding(encoding) {
 }
 
 class Dirent {
+  #type = undefined;
   constructor(name, type) {
     this.name = name;
-    this[kType] = type;
+    this.#type = type;
   }
 
   isDirectory() {
-    return this[kType] === UV_DIRENT_DIR;
+    return this.#type === UV_DIRENT_DIR;
   }
 
   isFile() {
-    return this[kType] === UV_DIRENT_FILE;
+    return this.#type === UV_DIRENT_FILE;
   }
 
   isBlockDevice() {
-    return this[kType] === UV_DIRENT_BLOCK;
+    return this.#type === UV_DIRENT_BLOCK;
   }
 
   isCharacterDevice() {
-    return this[kType] === UV_DIRENT_CHAR;
+    return this.#type === UV_DIRENT_CHAR;
   }
 
   isSymbolicLink() {
-    return this[kType] === UV_DIRENT_LINK;
+    return this.#type === UV_DIRENT_LINK;
   }
 
   isFIFO() {
-    return this[kType] === UV_DIRENT_FIFO;
+    return this.#type === UV_DIRENT_FIFO;
   }
 
   isSocket() {
-    return this[kType] === UV_DIRENT_SOCKET;
+    return this.#type === UV_DIRENT_SOCKET;
   }
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Current thoughts are personal, feel free to point out problems if inappropriate!

Refactor lib/internal/fs/dir.js and lib/internal/fs/util.js to use private fields instead of symbols.

Reason:
- Symbol used to emulate Private Fields ([Using global symbols](https://github.com/nodejs/node/blob/master/doc/guides/using-symbols.md#symbolstring)), but now Private Fields are available ([proposal-class-fields#Private fields](https://github.com/tc39/proposal-class-fields#private-fields)).
- Symbol makes the code not easy to understand. We need to jump around between uses and definitions.
- Symbols are used in Node.js in two ways.
	1. to implement private variables only. 
	2. for variables that may be used by internal code, but do not want to be modified externally.

When I see a Symbol, I need to look at the context to determine if the variable is just private or shared by internal. I think Symbol only do option 2 in the project, which will make the code easier to read.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
