### PR TITLE
repl: refactor to avoid unsafe array iteration

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1258,7 +1258,7 @@ function complete(line, callback) {
           }
         }
       }
-    }
+    });
     if (group.length) {
       ArrayPrototypePush(completionGroups, group);
     }

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1229,8 +1229,8 @@ function complete(line, callback) {
       paths = ArrayPrototypeConcat(module.paths, CJSModule.globalPaths);
     }
 
-    for (let dir of paths) {
-      dir = path.resolve(dir, subdir);
+    for (let i = 0; i < paths.length; i++) {
+      const dir = path.resolve(paths[i], subdir);
       const dirents = gracefulReaddir(dir, { withFileTypes: true }) || [];
       for (const dirent of dirents) {
         if (RegExpPrototypeTest(versionedFileNamesRe, dirent.name) ||

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -663,7 +663,7 @@ function REPLServer(prompt,
       let matched = false;
 
       errStack = '';
-      ArrayPrototypePush(lines, line => {
+      ArrayPrototypePush(lines, (line) => {
         if (!matched &&
             RegExpPrototypeTest(/^\[?([A-Z][a-z0-9_]*)*Error/, line)) {
           errStack += writer.options.breakLength >= line.length ?
@@ -1230,7 +1230,7 @@ function complete(line, callback) {
       paths = ArrayPrototypeConcat(module.paths, CJSModule.globalPaths);
     }
 
-    ArrayPrototypeForEach(paths, dir => {
+    ArrayPrototypeForEach(paths, (dir) => {
       dir = path.resolve(dir, subdir);
       const dirents = gracefulReaddir(dir, { withFileTypes: true }) || [];
       for (const dirent of dirents) {

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -754,7 +754,7 @@ function REPLServer(prompt,
   const prioritizedSigintQueue = new SafeSet();
   self.on('SIGINT', function onSigInt() {
     if (prioritizedSigintQueue.size > 0) {
-      ArrayPrototypeForEach(prioritizedSigintQueue, task => task());
+      ArrayPrototypeForEach(prioritizedSigintQueue, (task) => task());
       return;
     }
 

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1391,7 +1391,7 @@ function complete(line, callback) {
     ArrayPrototypeForEach(completionGroups, (group) => {
       ArrayPrototypeSort(group, (a, b) => (b > a ? 1 : -1));
       const setSize = uniqueSet.size;
-      ArrayPrototypeSort(group, (entry) => {
+      ArrayPrototypeForEach(group, (entry) => {
         if (!uniqueSet.has(entry)) {
           ArrayPrototypeUnshift(completions, entry);
           uniqueSet.add(entry);

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -46,6 +46,7 @@ const {
   ArrayPrototypeConcat,
   ArrayPrototypeFilter,
   ArrayPrototypeFindIndex,
+  ArrayPrototypeForEach,
   ArrayPrototypeIncludes,
   ArrayPrototypeJoin,
   ArrayPrototypeMap,

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -754,9 +754,7 @@ function REPLServer(prompt,
   const prioritizedSigintQueue = new SafeSet();
   self.on('SIGINT', function onSigInt() {
     if (prioritizedSigintQueue.size > 0) {
-      for (const task of prioritizedSigintQueue) {
-        task();
-      }
+      ArrayPrototypeForEach(prioritizedSigintQueue, task => task());
       return;
     }
 
@@ -1010,13 +1008,13 @@ REPLServer.prototype.createContext = function() {
     }, () => {
       context = vm.createContext();
     });
-    for (const name of ObjectGetOwnPropertyNames(global)) {
+    ArrayPrototypeForEach(ObjectGetOwnPropertyNames(global), (name) => {
       // Only set properties that do not already exist as a global builtin.
       if (!globalBuiltins.has(name)) {
         ObjectDefineProperty(context, name,
                              ObjectGetOwnPropertyDescriptor(global, name));
       }
-    }
+    });
     context.global = context;
     const _console = new Console(this.output);
     ObjectDefineProperty(context, 'console', {
@@ -1350,11 +1348,11 @@ function complete(line, callback) {
 
       if (memberGroups.length) {
         expr += chaining;
-        for (const group of memberGroups) {
+        ArrayPrototypeForEach(memberGroups, (group) => {
           ArrayPrototypePush(completionGroups,
                              ArrayPrototypeMap(group,
                                                (member) => `${expr}${member}`));
-        }
+        });
         if (filter) {
           filter = `${expr}${filter}`;
         }
@@ -1373,7 +1371,7 @@ function complete(line, callback) {
     // Filter, sort (within each group), uniq and merge the completion groups.
     if (completionGroups.length && filter) {
       const newCompletionGroups = [];
-      for (const group of completionGroups) {
+      ArrayPrototypeForEach(completionGroups, (group) => {
         const filteredGroup = ArrayPrototypeFilter(
           group,
           (str) => StringPrototypeStartsWith(str, filter)
@@ -1381,7 +1379,7 @@ function complete(line, callback) {
         if (filteredGroup.length) {
           ArrayPrototypePush(newCompletionGroups, filteredGroup);
         }
-      }
+      });
       completionGroups = newCompletionGroups;
     }
 
@@ -1390,20 +1388,20 @@ function complete(line, callback) {
     const uniqueSet = new SafeSet(['']);
     // Completion group 0 is the "closest" (least far up the inheritance
     // chain) so we put its completions last: to be closest in the REPL.
-    for (const group of completionGroups) {
+    ArrayPrototypeForEach(completionGroups, (group) => {
       ArrayPrototypeSort(group, (a, b) => (b > a ? 1 : -1));
       const setSize = uniqueSet.size;
-      for (const entry of group) {
+      ArrayPrototypeSort(group, (entry) => {
         if (!uniqueSet.has(entry)) {
           ArrayPrototypeUnshift(completions, entry);
           uniqueSet.add(entry);
         }
-      }
+      });
       // Add a separator between groups.
       if (uniqueSet.size !== setSize) {
         ArrayPrototypeUnshift(completions, '');
       }
-    }
+    });
 
     // Remove obsolete group entry, if present.
     if (completions[0] === '') {
@@ -1567,14 +1565,13 @@ function defineDefaultCommands(repl) {
       const longestNameLength = MathMax(
         ...ArrayPrototypeMap(names, (name) => name.length)
       );
-      for (let n = 0; n < names.length; n++) {
-        const name = names[n];
+      ArrayPrototypeForEach(names, (name) => {
         const cmd = this.commands[name];
         const spaces =
           StringPrototypeRepeat(' ', longestNameLength - name.length + 3);
         const line = `.${name}${cmd.help ? spaces + cmd.help : ''}\n`;
         this.output.write(line);
-      }
+      };
       this.output.write('\nPress Ctrl+C to abort current expression, ' +
         'Ctrl+D to exit the REPL\n');
       this.displayPrompt();

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -663,7 +663,7 @@ function REPLServer(prompt,
       let matched = false;
 
       errStack = '';
-      for (const line of lines) {
+      ArrayPrototypePush(lines, line => {
         if (!matched &&
             RegExpPrototypeTest(/^\[?([A-Z][a-z0-9_]*)*Error/, line)) {
           errStack += writer.options.breakLength >= line.length ?
@@ -673,7 +673,7 @@ function REPLServer(prompt,
         } else {
           errStack += line;
         }
-      }
+      });
       if (!matched) {
         const ln = lines.length === 1 ? ' ' : ':\n';
         errStack = `Uncaught${ln}${errStack}`;
@@ -1230,7 +1230,7 @@ function complete(line, callback) {
       paths = ArrayPrototypeConcat(module.paths, CJSModule.globalPaths);
     }
 
-    ArrayPrototypeForEach(paths, (dir) => {
+    ArrayPrototypeForEach(paths, dir => {
       dir = path.resolve(dir, subdir);
       const dirents = gracefulReaddir(dir, { withFileTypes: true }) || [];
       for (const dirent of dirents) {

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1229,8 +1229,8 @@ function complete(line, callback) {
       paths = ArrayPrototypeConcat(module.paths, CJSModule.globalPaths);
     }
 
-    for (let i = 0; i < paths.length; i++) {
-      const dir = path.resolve(paths[i], subdir);
+    ArrayPrototypeForEach(paths, (dir) => {
+      dir = path.resolve(dir, subdir);
       const dirents = gracefulReaddir(dir, { withFileTypes: true }) || [];
       for (const dirent of dirents) {
         if (RegExpPrototypeTest(versionedFileNamesRe, dirent.name) ||

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -663,7 +663,7 @@ function REPLServer(prompt,
       let matched = false;
 
       errStack = '';
-      ArrayPrototypePush(lines, (line) => {
+      ArrayPrototypeForEach(lines, (line) => {
         if (!matched &&
             RegExpPrototypeTest(/^\[?([A-Z][a-z0-9_]*)*Error/, line)) {
           errStack += writer.options.breakLength >= line.length ?

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1571,7 +1571,7 @@ function defineDefaultCommands(repl) {
           StringPrototypeRepeat(' ', longestNameLength - name.length + 3);
         const line = `.${name}${cmd.help ? spaces + cmd.help : ''}\n`;
         this.output.write(line);
-      };
+      });
       this.output.write('\nPress Ctrl+C to abort current expression, ' +
         'Ctrl+D to exit the REPL\n');
       this.displayPrompt();

--- a/test/parallel/test-repl-unsafe-array-iteration.js
+++ b/test/parallel/test-repl-unsafe-array-iteration.js
@@ -6,9 +6,8 @@ const { spawn } = require('child_process');
 function run(input, expectation) {
   const node = spawn(process.argv0);
 
-  node.stderr.on('data', common.mustCall((data) => {
-    assert.ok(data.includes(expectation));
-  }));
+  node.stderr.on('data', common.mustNotCall());
+  node.on('exit', common.mustCall((code) => assert.strictEqual(code, 0)));
 
   node.stdin.write(input);
   node.stdin.end();

--- a/test/parallel/test-repl-unsafe-array-iteration.js
+++ b/test/parallel/test-repl-unsafe-array-iteration.js
@@ -10,10 +10,6 @@ function run(input, expectation) {
     assert.ok(data.includes(expectation));
   }));
 
-  node.on('close', common.mustCall((code) => {
-    assert.strictEqual(code, 1);
-  }));
-
   node.stdin.write(input);
   node.stdin.end();
 }

--- a/test/parallel/test-repl-unsafe-array-iteration.js
+++ b/test/parallel/test-repl-unsafe-array-iteration.js
@@ -1,0 +1,42 @@
+'use strict';
+const common = require('../common');
+const ArrayStream = require('../common/arraystream');
+const assert = require('assert');
+const repl = require('repl');
+
+function run(input) {
+  const inputStream = new ArrayStream();
+  const outputStream = new ArrayStream();
+  let output = '';
+
+  outputStream.write = (data) => { output += data.replace('\r', ''); };
+
+  const r = repl.start({
+    input: inputStream,
+    output: outputStream,
+    terminal: true
+  });
+
+  r.on('exit', common.mustCall(() => {
+    const actual = output.split('\n');
+    console.log(actual);
+
+    // Validate that the for loop returns undefined
+    assert.ok(actual[actual.length - 2].includes('undefined'));
+  }));
+
+  inputStream.run(input);
+  r.close();
+}
+
+run([
+  'delete Array.prototype[Symbol.iterator];',
+  'for(const x of [3, 2, 1]);'
+]);
+
+run([
+  'const ArrayIteratorPrototype =',
+  '  Object.getPrototypeOf(Array.prototype[Symbol.iterator]());',
+  'delete ArrayIteratorPrototype.next;',
+  'for(const x of [3, 2, 1]);'
+]);

--- a/test/parallel/test-repl-unsafe-array-iteration.js
+++ b/test/parallel/test-repl-unsafe-array-iteration.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 const { spawn } = require('child_process');
 
 function run(input, expectation) {
-  const node = spawn('node');
+  const node = spawn(process.argv0);
 
   node.stderr.on('data', common.mustCall((data) => {
     assert.ok(data.includes(expectation));

--- a/test/parallel/test-repl-unsafe-array-iteration.js
+++ b/test/parallel/test-repl-unsafe-array-iteration.js
@@ -12,9 +12,16 @@ replProcess.on('error', common.mustNotCall());
 
 const replReadyState = (async function* () {
   let ready;
-  const replReadyBuffer = Buffer.from('> ');
+  const SPACE = ' '.charCodeAt();
+  const BRACKET = '>'.charCodeAt();
+  const DOT = '.'.charCodeAt();
   replProcess.stdout.on('data', (data) => {
-    ready = Buffer.compare(data, replReadyBuffer) === 0;
+    ready = data[data.length - 1] === SPACE && (
+      data[data.length - 2] === BRACKET || (
+        data[data.length - 2] === DOT &&
+        data[data.length - 3] === DOT &&
+        data[data.length - 4] === DOT
+      ));
   });
 
   const processCrashed = new Promise((resolve, reject) =>

--- a/test/parallel/test-repl-unsafe-array-iteration.js
+++ b/test/parallel/test-repl-unsafe-array-iteration.js
@@ -4,7 +4,7 @@ const ArrayStream = require('../common/arraystream');
 const assert = require('assert');
 const repl = require('repl');
 
-function run(input) {
+function run(input, expectation) {
   const inputStream = new ArrayStream();
   const outputStream = new ArrayStream();
   let output = '';
@@ -19,10 +19,9 @@ function run(input) {
 
   r.on('exit', common.mustCall(() => {
     const actual = output.split('\n');
-    console.log(actual);
 
     // Validate that the for loop returns undefined
-    assert.ok(actual[actual.length - 2].includes('undefined'));
+    assert.notStrictEqual(actual[actual.length - 2], expectation);
   }));
 
   inputStream.run(input);
@@ -32,11 +31,11 @@ function run(input) {
 run([
   'delete Array.prototype[Symbol.iterator];',
   'for(const x of [3, 2, 1]);'
-]);
+], 'Uncaught TypeError: [3,2,1] is not iterable');
 
 run([
   'const ArrayIteratorPrototype =',
   '  Object.getPrototypeOf(Array.prototype[Symbol.iterator]());',
   'delete ArrayIteratorPrototype.next;',
   'for(const x of [3, 2, 1]);'
-]);
+], 'Uncaught TypeError: undefined is not a function');

--- a/test/parallel/test-repl-unsafe-array-iteration.js
+++ b/test/parallel/test-repl-unsafe-array-iteration.js
@@ -21,7 +21,7 @@ function run(input, expectation) {
     const actual = output.split('\n');
 
     // Validate that the for loop returns undefined
-    assert.notStrictEqual(actual[actual.length - 2], expectation);
+    assert.strictEqual(actual[actual.length - 2], expectation);
   }));
 
   inputStream.run(input);


### PR DESCRIPTION
This was the only `for-let-of loop` in `lib` so I'm trying to make it more consistent with the other `for loop`s.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
