### PR TITLE
test: increased externalized string length

### DIFF
--- a/test/parallel/test-fs-write.js
+++ b/test/parallel/test-fs-write.js
@@ -40,7 +40,7 @@ const constants = fs.constants;
 common.allowGlobals(externalizeString, isOneByteString, x);
 
 {
-  const expected = 'ümlaut eins';  // Must be a unique string.
+  const expected = 'ümlaut sechzig';  // Must be a unique string.
   externalizeString(expected);
   assert.strictEqual(isOneByteString(expected), true);
   const fd = fs.openSync(fn, 'w');
@@ -50,7 +50,7 @@ common.allowGlobals(externalizeString, isOneByteString, x);
 }
 
 {
-  const expected = 'ümlaut zwei';  // Must be a unique string.
+  const expected = 'ümlaut neunzig';  // Must be a unique string.
   externalizeString(expected);
   assert.strictEqual(isOneByteString(expected), true);
   const fd = fs.openSync(fn, 'w');
@@ -60,7 +60,7 @@ common.allowGlobals(externalizeString, isOneByteString, x);
 }
 
 {
-  const expected = '中文 1';  // Must be a unique string.
+  const expected = 'Zhōngwén 1';  // Must be a unique string.
   externalizeString(expected);
   assert.strictEqual(isOneByteString(expected), false);
   const fd = fs.openSync(fn, 'w');
@@ -70,7 +70,7 @@ common.allowGlobals(externalizeString, isOneByteString, x);
 }
 
 {
-  const expected = '中文 2';  // Must be a unique string.
+  const expected = 'Zhōngwén 2';  // Must be a unique string.
   externalizeString(expected);
   assert.strictEqual(isOneByteString(expected), false);
   const fd = fs.openSync(fn, 'w');


### PR DESCRIPTION
Refs https://chromium-review.googlesource.com/c/v8/v8/+/2565511.

V8 has removed the ability to externalize internal external uncached strings via `MakeExternal`, as it is not thread-safe. This means that the examples that are in the test at present will begin to fail once Node.js rolls in the relevant CL, because their small size made them internal external uncached strings. This preemptively fixes the issue by making the strings bigger so they become internal & external & cached.

Electron hit and fixed this in https://github.com/electron/electron/pull/26535/commits/0bf50b0a81c8ff35081f9df546a15104a72c3f23

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
