### PR TITLE
doc: make explicit reverting node_version.h changes

### DIFF
--- a/doc/guides/releases.md
+++ b/doc/guides/releases.md
@@ -544,7 +544,13 @@ $ git cherry-pick v1.x^
 ```
 
 Git should stop to let you fix conflicts. Revert all changes that were made to
-`src/node_version.h`. If there are conflicts in `doc` due to updated `REPLACEME`
+`src/node_version.h`:
+
+```console
+$ git checkout --ours -- src/node_version.h
+```
+
+If there are conflicts in `doc` due to updated `REPLACEME`
 placeholders (that happens when a change previously landed on another release
 branch), keep both version numbers. Convert the YAML field to an array if it is
 not already one.

--- a/doc/guides/releases.md
+++ b/doc/guides/releases.md
@@ -547,7 +547,7 @@ Git should stop to let you fix conflicts. Revert all changes that were made to
 `src/node_version.h`:
 
 ```console
-$ git checkout --ours -- src/node_version.h
+$ git checkout --ours HEAD -- src/node_version.h
 ```
 
 If there are conflicts in `doc` due to updated `REPLACEME`


### PR DESCRIPTION
Add an explicit command to revert changes to `node_version.h` when
cherry-picking the release commit to the `master` branch.

cc @nodejs/releasers 

Refs: https://github.com/nodejs/node/pull/36460
Refs: https://github.com/nodejs/node/pull/36385

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
