### PR TITLE
util: simplify constructor retrieval in inspect()

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -3,21 +3,14 @@
 const {
   Array,
   ArrayIsArray,
-  BigInt64Array,
   BigIntPrototypeValueOf,
-  BigUint64Array,
   BooleanPrototypeValueOf,
   DatePrototypeGetTime,
   DatePrototypeToISOString,
   DatePrototypeToString,
   ErrorPrototypeToString,
-  Float32Array,
-  Float64Array,
   FunctionPrototypeCall,
   FunctionPrototypeToString,
-  Int8Array,
-  Int16Array,
-  Int32Array,
   JSONStringify,
   Map,
   MapPrototypeGetSize,
@@ -59,10 +52,8 @@ const {
   SymbolIterator,
   SymbolToStringTag,
   TypedArrayPrototypeGetLength,
-  Uint16Array,
-  Uint32Array,
+  TypedArrayPrototypeGetSymbolToStringTag,
   Uint8Array,
-  Uint8ClampedArray,
   uncurryThis,
 } = primordials;
 
@@ -120,17 +111,6 @@ const {
   isNumberObject,
   isBooleanObject,
   isBigIntObject,
-  isUint8Array,
-  isUint8ClampedArray,
-  isUint16Array,
-  isUint32Array,
-  isInt8Array,
-  isInt16Array,
-  isInt32Array,
-  isFloat32Array,
-  isFloat64Array,
-  isBigInt64Array,
-  isBigUint64Array
 } = require('internal/util/types');
 
 const assert = require('internal/assert');
@@ -712,26 +692,6 @@ function formatProxy(ctx, proxy, recurseTimes) {
     ctx, res, '', ['Proxy [', ']'], kArrayExtrasType, recurseTimes);
 }
 
-function findTypedConstructor(value) {
-  for (const [check, clazz] of [
-    [isUint8Array, Uint8Array],
-    [isUint8ClampedArray, Uint8ClampedArray],
-    [isUint16Array, Uint16Array],
-    [isUint32Array, Uint32Array],
-    [isInt8Array, Int8Array],
-    [isInt16Array, Int16Array],
-    [isInt32Array, Int32Array],
-    [isFloat32Array, Float32Array],
-    [isFloat64Array, Float64Array],
-    [isBigInt64Array, BigInt64Array],
-    [isBigUint64Array, BigUint64Array]
-  ]) {
-    if (check(value)) {
-      return clazz;
-    }
-  }
-}
-
 // Note: using `formatValue` directly requires the indentation level to be
 // corrected by setting `ctx.indentationLvL += diff` and then to decrease the
 // value afterwards again.
@@ -879,10 +839,9 @@ function formatRaw(ctx, value, recurseTimes, typedArray) {
       let bound = value;
       let fallback = '';
       if (constructor === null) {
-        const constr = findTypedConstructor(value);
-        fallback = constr.name;
+        fallback = TypedArrayPrototypeGetSymbolToStringTag(value);
         // Reconstruct the array information.
-        bound = new constr(value);
+        bound = new primordials[fallback](value);
       }
       const size = TypedArrayPrototypeGetLength(value);
       const prefix = getPrefix(constructor, tag, fallback, `(${size})`);


### PR DESCRIPTION
Instead of looping through a list of typed arrays, use
TypedArrayPrototypeGetSymbolToStringTag.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
