### PR TITLE
lib,src: update cluster to use Parent

### DIFF
--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -691,7 +691,7 @@ added: v0.8.1
 deprecated: REPLACEME
 -->
 
-Deprecated alias for [`cluster.isPrimary()`][].
+Deprecated alias for [`cluster.isPrimary`][].
 details.
 
 ## `cluster.isPrimary`

--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -690,7 +690,7 @@ This can only be called from the primary process.
 added: v0.8.1
 -->
 
-Deprecated alias for isMaster, see isPrimary for more
+Deprecated alias for [`cluster.isPrimary`][].
 details.
 
 ## `cluster.isPrimary`

--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -691,7 +691,7 @@ added: v0.8.1
 deprecated: REPLACEME
 -->
 
-Deprecated alias for [`cluster.isPrimary`][].
+Deprecated alias for [`cluster.isPrimary()`][].
 details.
 
 ## `cluster.isPrimary`
@@ -789,11 +789,11 @@ This object is not intended to be changed or set manually.
 ## `cluster.setupMaster([settings])`
 <!-- YAML
 added: v0.7.1
+deprecated: REPLACEME
 changes:
   - version: v6.4.0
     pr-url: https://github.com/nodejs/node/pull/7838
     description: The `stdio` option is supported now.
-deprecated: REPLACEME
 -->
 
 Deprecated alias for [`.setupPrimary()`][].

--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -901,7 +901,7 @@ socket.on('data', (id) => {
 [`child_process` event: `'message'`]: child_process.md#child_process_event_message
 [`cluster.settings`]: #cluster_cluster_settings
 [`disconnect()`]: child_process.md#child_process_subprocess_disconnect
-[`.isPrimary()`]: #cluster_cluster_isprimary
+[`cluster.isPrimary()`]: #cluster_cluster_isprimary
 [`kill()`]: process.md#process_process_kill_pid_signal
 [`process` event: `'message'`]: process.md#process_event_message
 [`server.close()`]: net.md#net_event_close

--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -18,8 +18,8 @@ const cluster = require('cluster');
 const http = require('http');
 const numCPUs = require('os').cpus().length;
 
-if (cluster.isMaster) {
-  console.log(`Master ${process.pid} is running`);
+if (cluster.isParent) {
+  console.log(`Parent ${process.pid} is running`);
 
   // Fork workers.
   for (let i = 0; i < numCPUs; i++) {
@@ -45,7 +45,7 @@ Running Node.js will now share port 8000 between the workers:
 
 ```console
 $ node server.js
-Master 3596 is running
+Parent 3596 is running
 Worker 4324 started
 Worker 4520 started
 Worker 6056 started
@@ -66,12 +66,12 @@ The cluster module supports two methods of distributing incoming
 connections.
 
 The first one (and the default one on all platforms except Windows),
-is the round-robin approach, where the master process listens on a
+is the round-robin approach, where the parent process listens on a
 port, accepts new connections and distributes them across the workers
 in a round-robin fashion, with some built-in smarts to avoid
 overloading a worker process.
 
-The second approach is where the master process creates the listen
+The second approach is where the parent process creates the listen
 socket and sends it to interested workers. The workers then accept
 incoming connections directly.
 
@@ -81,16 +81,16 @@ to operating system scheduler vagaries. Loads have been observed
 where over 70% of all connections ended up in just two processes,
 out of a total of eight.
 
-Because `server.listen()` hands off most of the work to the master
+Because `server.listen()` hands off most of the work to the parent
 process, there are three cases where the behavior between a normal
 Node.js process and a cluster worker differs:
 
-1. `server.listen({fd: 7})` Because the message is passed to the master,
+1. `server.listen({fd: 7})` Because the message is passed to the parent,
    file descriptor 7 **in the parent** will be listened on, and the
    handle passed to the worker, rather than listening to the worker's
    idea of what the number 7 file descriptor references.
 2. `server.listen(handle)` Listening on handles explicitly will cause
-   the worker to use the supplied handle, rather than talk to the master
+   the worker to use the supplied handle, rather than talk to the parent
    process.
 3. `server.listen(0)` Normally, this will cause servers to listen on a
    random port. However, in a cluster, each worker will receive the
@@ -121,7 +121,7 @@ added: v0.7.0
 * Extends: {EventEmitter}
 
 A `Worker` object contains all public information and method about a worker.
-In the master it can be obtained using `cluster.workers`. In a worker
+In the parent it can be obtained using `cluster.workers`. In a worker
 it can be obtained using `cluster.worker`.
 
 ### Event: `'disconnect'`
@@ -201,14 +201,14 @@ Within a worker, `process.on('message')` may also be used.
 
 See [`process` event: `'message'`][].
 
-Here is an example using the message system. It keeps a count in the master
+Here is an example using the message system. It keeps a count in the parent
 process of the number of HTTP requests received by the workers:
 
 ```js
 const cluster = require('cluster');
 const http = require('http');
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
 
   // Keep track of http requests
   let numReqs = 0;
@@ -240,7 +240,7 @@ if (cluster.isMaster) {
     res.writeHead(200);
     res.end('hello world\n');
 
-    // Notify master about the request
+    // Notify parent about the request
     process.send({ cmd: 'notifyRequest' });
   }).listen(8000);
 }
@@ -275,7 +275,7 @@ changes:
 In a worker, this function will close all servers, wait for the `'close'` event
 on those servers, and then disconnect the IPC channel.
 
-In the master, an internal message is sent to the worker causing it to call
+In the parent, an internal message is sent to the worker causing it to call
 `.disconnect()` on itself.
 
 Causes `.exitedAfterDisconnect` to be set.
@@ -299,7 +299,7 @@ close them. It also may be useful to implement a timeout, killing a worker if
 the `'disconnect'` event has not been emitted after some time.
 
 ```js
-if (cluster.isMaster) {
+if (cluster.isParent) {
   const worker = cluster.fork();
   let timeout;
 
@@ -343,7 +343,7 @@ This property is `true` if the worker exited due to `.kill()` or
 worker has not exited, it is `undefined`.
 
 The boolean [`worker.exitedAfterDisconnect`][] allows distinguishing between
-voluntary and accidental exit, the master may choose not to respawn a worker
+voluntary and accidental exit, the parent may choose not to respawn a worker
 based on this value.
 
 ```js
@@ -375,8 +375,8 @@ While a worker is alive, this is the key that indexes it in
 added: v0.11.14
 -->
 
-This function returns `true` if the worker is connected to its master via its
-IPC channel, `false` otherwise. A worker is connected to its master after it
+This function returns `true` if the worker is connected to its parent via its
+IPC channel, `false` otherwise. A worker is connected to its parent after it
 has been created. It is disconnected after the `'disconnect'` event is emitted.
 
 ### `worker.isDead()`
@@ -392,8 +392,8 @@ const cluster = require('cluster');
 const http = require('http');
 const numCPUs = require('os').cpus().length;
 
-if (cluster.isMaster) {
-  console.log(`Master ${process.pid} is running`);
+if (cluster.isParent) {
+  console.log(`Parent ${process.pid} is running`);
 
   // Fork workers.
   for (let i = 0; i < numCPUs; i++) {
@@ -425,7 +425,7 @@ added: v0.9.12
 * `signal` {string} Name of the kill signal to send to the worker
   process. **Default**: `'SIGTERM'`
 
-This function will kill the worker. In the master, it does this by disconnecting
+This function will kill the worker. In the parent, it does this by disconnecting
 the `worker.process`, and once disconnected, killing with `signal`. In the
 worker, it does it by disconnecting the channel, and then exiting with code `0`.
 
@@ -478,18 +478,18 @@ changes:
 * `callback` {Function}
 * Returns: {boolean}
 
-Send a message to a worker or master, optionally with a handle.
+Send a message to a worker or parent, optionally with a handle.
 
-In the master this sends a message to a specific worker. It is identical to
+In the parent this sends a message to a specific worker. It is identical to
 [`ChildProcess.send()`][].
 
-In a worker this sends a message to the master. It is identical to
+In a worker this sends a message to the parent. It is identical to
 `process.send()`.
 
-This example will echo back all messages from the master:
+This example will echo back all messages from the parent:
 
 ```js
-if (cluster.isMaster) {
+if (cluster.isParent) {
   const worker = cluster.fork();
   worker.send('hi there');
 
@@ -583,7 +583,7 @@ added: v0.7.0
 
 After calling `listen()` from a worker, when the `'listening'` event is emitted
 on the server a `'listening'` event will also be emitted on `cluster` in the
-master.
+parent.
 
 The event handler is executed with two arguments, the `worker` contains the
 worker object and the `address` object contains the following connection
@@ -617,7 +617,7 @@ changes:
 * `message` {Object}
 * `handle` {undefined|Object}
 
-Emitted when the cluster master receives a message from any worker.
+Emitted when the cluster parent receives a message from any worker.
 
 See [`child_process` event: `'message'`][].
 
@@ -629,9 +629,9 @@ added: v0.7.0
 * `worker` {cluster.Worker}
 
 After forking a new worker, the worker should respond with an online message.
-When the master receives an online message it will emit this event.
+When the parent receives an online message it will emit this event.
 The difference between `'fork'` and `'online'` is that fork is emitted when the
-master forks a worker, and `'online'` is emitted when the worker is running.
+parent forks a worker, and `'online'` is emitted when the worker is running.
 
 ```js
 cluster.on('online', (worker) => {
@@ -646,11 +646,11 @@ added: v0.7.1
 
 * `settings` {Object}
 
-Emitted every time [`.setupMaster()`][] is called.
+Emitted every time [`.setupParent()`][] is called.
 
 The `settings` object is the `cluster.settings` object at the time
-[`.setupMaster()`][] was called and is advisory only, since multiple calls to
-[`.setupMaster()`][] can be made in a single tick.
+[`.setupParent()`][] was called and is advisory only, since multiple calls to
+[`.setupParent()`][] can be made in a single tick.
 
 If accuracy is important, use `cluster.settings`.
 
@@ -665,12 +665,12 @@ added: v0.7.7
 Calls `.disconnect()` on each worker in `cluster.workers`.
 
 When they are disconnected all internal handles will be closed, allowing the
-master process to die gracefully if no other event is waiting.
+parent process to die gracefully if no other event is waiting.
 
 The method takes an optional callback argument which will be called when
 finished.
 
-This can only be called from the master process.
+This can only be called from the parent process.
 
 ## `cluster.fork([env])`
 <!-- YAML
@@ -682,18 +682,26 @@ added: v0.6.0
 
 Spawn a new worker process.
 
-This can only be called from the master process.
+This can only be called from the parent process.
 
 ## `cluster.isMaster`
 <!-- YAML
 added: v0.8.1
 -->
 
+Deprecated alias for isMaster, see isParent for more
+details.
+
+## `cluster.isParent`
+<!-- YAML
+added: REPLACEME
+-->
+
 * {boolean}
 
-True if the process is a master. This is determined
+True if the process is a parent. This is determined
 by the `process.env.NODE_UNIQUE_ID`. If `process.env.NODE_UNIQUE_ID` is
-undefined, then `isMaster` is `true`.
+undefined, then `isParent` is `true`.
 
 ## `cluster.isWorker`
 <!-- YAML
@@ -702,7 +710,7 @@ added: v0.6.0
 
 * {boolean}
 
-True if the process is not a master (it is the negation of `cluster.isMaster`).
+True if the process is not a parent (it is the negation of `cluster.isParent`).
 
 ## `cluster.schedulingPolicy`
 <!-- YAML
@@ -712,7 +720,7 @@ added: v0.11.2
 The scheduling policy, either `cluster.SCHED_RR` for round-robin or
 `cluster.SCHED_NONE` to leave it to the operating system. This is a
 global setting and effectively frozen once either the first worker is spawned,
-or [`.setupMaster()`][] is called, whichever comes first.
+or [`.setupParent()`][] is called, whichever comes first.
 
 `SCHED_RR` is the default on all operating systems except Windows.
 Windows will change to `SCHED_RR` once libuv is able to effectively
@@ -767,11 +775,11 @@ changes:
   * `inspectPort` {number|Function} Sets inspector port of worker.
     This can be a number, or a function that takes no arguments and returns a
     number. By default each worker gets its own port, incremented from the
-    master's `process.debugPort`.
+    parent's `process.debugPort`.
   * `windowsHide` {boolean} Hide the forked processes console window that would
     normally be created on Windows systems. **Default:** `false`.
 
-After calling [`.setupMaster()`][] (or [`.fork()`][]) this settings object will
+After calling [`.setupParent()`][] (or [`.fork()`][]) this settings object will
 contain the settings, including the default values.
 
 This object is not intended to be changed or set manually.
@@ -785,36 +793,44 @@ changes:
     description: The `stdio` option is supported now.
 -->
 
+Deprecated alias for setupParent, see setupParent
+for more details.
+
+## `cluster.setupParent([settings])`
+<!-- YAML
+added: REPLACEME
+-->
+
 * `settings` {Object} See [`cluster.settings`][].
 
-`setupMaster` is used to change the default 'fork' behavior. Once called,
+`setupParent` is used to change the default 'fork' behavior. Once called,
 the settings will be present in `cluster.settings`.
 
 Any settings changes only affect future calls to [`.fork()`][] and have no
 effect on workers that are already running.
 
-The only attribute of a worker that cannot be set via `.setupMaster()` is
+The only attribute of a worker that cannot be set via `.setupParent()` is
 the `env` passed to [`.fork()`][].
 
 The defaults above apply to the first call only; the defaults for later
-calls are the current values at the time of `cluster.setupMaster()` is called.
+calls are the current values at the time of `cluster.setupParent()` is called.
 
 ```js
 const cluster = require('cluster');
-cluster.setupMaster({
+cluster.setupParent({
   exec: 'worker.js',
   args: ['--use', 'https'],
   silent: true
 });
 cluster.fork(); // https worker
-cluster.setupMaster({
+cluster.setupParent({
   exec: 'worker.js',
   args: ['--use', 'http']
 });
 cluster.fork(); // http worker
 ```
 
-This can only be called from the master process.
+This can only be called from the parent process.
 
 ## `cluster.worker`
 <!-- YAML
@@ -823,13 +839,13 @@ added: v0.7.0
 
 * {Object}
 
-A reference to the current worker object. Not available in the master process.
+A reference to the current worker object. Not available in the parent process.
 
 ```js
 const cluster = require('cluster');
 
-if (cluster.isMaster) {
-  console.log('I am master');
+if (cluster.isParent) {
+  console.log('I am parent');
   cluster.fork();
   cluster.fork();
 } else if (cluster.isWorker) {
@@ -845,7 +861,7 @@ added: v0.7.0
 * {Object}
 
 A hash that stores the active worker objects, keyed by `id` field. Makes it
-easy to loop through all the workers. It is only available in the master
+easy to loop through all the workers. It is only available in the parent
 process.
 
 A worker is removed from `cluster.workers` after the worker has disconnected
@@ -876,7 +892,7 @@ socket.on('data', (id) => {
 [Advanced serialization for `child_process`]: child_process.md#child_process_advanced_serialization
 [Child Process module]: child_process.md#child_process_child_process_fork_modulepath_args_options
 [`.fork()`]: #cluster_cluster_fork_env
-[`.setupMaster()`]: #cluster_cluster_setupmaster_settings
+[`.setupParent()`]: #cluster_cluster_setupparent_settings
 [`ChildProcess.send()`]: child_process.md#child_process_subprocess_send_message_sendhandle_options_callback
 [`child_process.fork()`]: child_process.md#child_process_child_process_fork_modulepath_args_options
 [`child_process` event: `'exit'`]: child_process.md#child_process_event_exit

--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -688,6 +688,7 @@ This can only be called from the primary process.
 ## `cluster.isMaster`
 <!-- YAML
 added: v0.8.1
+deprecated: REPLACEME
 -->
 
 Deprecated alias for [`cluster.isPrimary`][].
@@ -792,6 +793,7 @@ changes:
   - version: v6.4.0
     pr-url: https://github.com/nodejs/node/pull/7838
     description: The `stdio` option is supported now.
+deprecated: REPLACEME
 -->
 
 Deprecated alias for [`.setupPrimary()`][].
@@ -899,6 +901,7 @@ socket.on('data', (id) => {
 [`child_process` event: `'message'`]: child_process.md#child_process_event_message
 [`cluster.settings`]: #cluster_cluster_settings
 [`disconnect()`]: child_process.md#child_process_subprocess_disconnect
+[`.isPrimary()`]: #cluster_cluster_isprimary
 [`kill()`]: process.md#process_process_kill_pid_signal
 [`process` event: `'message'`]: process.md#process_event_message
 [`server.close()`]: net.md#net_event_close

--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -18,8 +18,8 @@ const cluster = require('cluster');
 const http = require('http');
 const numCPUs = require('os').cpus().length;
 
-if (cluster.isParent) {
-  console.log(`Parent ${process.pid} is running`);
+if (cluster.isPrimary) {
+  console.log(`Primary ${process.pid} is running`);
 
   // Fork workers.
   for (let i = 0; i < numCPUs; i++) {
@@ -45,7 +45,7 @@ Running Node.js will now share port 8000 between the workers:
 
 ```console
 $ node server.js
-Parent 3596 is running
+Primary 3596 is running
 Worker 4324 started
 Worker 4520 started
 Worker 6056 started
@@ -66,12 +66,12 @@ The cluster module supports two methods of distributing incoming
 connections.
 
 The first one (and the default one on all platforms except Windows),
-is the round-robin approach, where the parent process listens on a
+is the round-robin approach, where the primary process listens on a
 port, accepts new connections and distributes them across the workers
 in a round-robin fashion, with some built-in smarts to avoid
 overloading a worker process.
 
-The second approach is where the parent process creates the listen
+The second approach is where the primary process creates the listen
 socket and sends it to interested workers. The workers then accept
 incoming connections directly.
 
@@ -81,16 +81,16 @@ to operating system scheduler vagaries. Loads have been observed
 where over 70% of all connections ended up in just two processes,
 out of a total of eight.
 
-Because `server.listen()` hands off most of the work to the parent
+Because `server.listen()` hands off most of the work to the primary
 process, there are three cases where the behavior between a normal
 Node.js process and a cluster worker differs:
 
-1. `server.listen({fd: 7})` Because the message is passed to the parent,
+1. `server.listen({fd: 7})` Because the message is passed to the primary,
    file descriptor 7 **in the parent** will be listened on, and the
    handle passed to the worker, rather than listening to the worker's
    idea of what the number 7 file descriptor references.
 2. `server.listen(handle)` Listening on handles explicitly will cause
-   the worker to use the supplied handle, rather than talk to the parent
+   the worker to use the supplied handle, rather than talk to the primary
    process.
 3. `server.listen(0)` Normally, this will cause servers to listen on a
    random port. However, in a cluster, each worker will receive the
@@ -121,7 +121,7 @@ added: v0.7.0
 * Extends: {EventEmitter}
 
 A `Worker` object contains all public information and method about a worker.
-In the parent it can be obtained using `cluster.workers`. In a worker
+In the primary it can be obtained using `cluster.workers`. In a worker
 it can be obtained using `cluster.worker`.
 
 ### Event: `'disconnect'`
@@ -201,14 +201,14 @@ Within a worker, `process.on('message')` may also be used.
 
 See [`process` event: `'message'`][].
 
-Here is an example using the message system. It keeps a count in the parent
+Here is an example using the message system. It keeps a count in the primary
 process of the number of HTTP requests received by the workers:
 
 ```js
 const cluster = require('cluster');
 const http = require('http');
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
 
   // Keep track of http requests
   let numReqs = 0;
@@ -240,7 +240,7 @@ if (cluster.isParent) {
     res.writeHead(200);
     res.end('hello world\n');
 
-    // Notify parent about the request
+    // Notify primary about the request
     process.send({ cmd: 'notifyRequest' });
   }).listen(8000);
 }
@@ -275,7 +275,7 @@ changes:
 In a worker, this function will close all servers, wait for the `'close'` event
 on those servers, and then disconnect the IPC channel.
 
-In the parent, an internal message is sent to the worker causing it to call
+In the primary, an internal message is sent to the worker causing it to call
 `.disconnect()` on itself.
 
 Causes `.exitedAfterDisconnect` to be set.
@@ -299,7 +299,7 @@ close them. It also may be useful to implement a timeout, killing a worker if
 the `'disconnect'` event has not been emitted after some time.
 
 ```js
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   const worker = cluster.fork();
   let timeout;
 
@@ -343,7 +343,7 @@ This property is `true` if the worker exited due to `.kill()` or
 worker has not exited, it is `undefined`.
 
 The boolean [`worker.exitedAfterDisconnect`][] allows distinguishing between
-voluntary and accidental exit, the parent may choose not to respawn a worker
+voluntary and accidental exit, the primary may choose not to respawn a worker
 based on this value.
 
 ```js
@@ -375,8 +375,8 @@ While a worker is alive, this is the key that indexes it in
 added: v0.11.14
 -->
 
-This function returns `true` if the worker is connected to its parent via its
-IPC channel, `false` otherwise. A worker is connected to its parent after it
+This function returns `true` if the worker is connected to its primary via its
+IPC channel, `false` otherwise. A worker is connected to its primary after it
 has been created. It is disconnected after the `'disconnect'` event is emitted.
 
 ### `worker.isDead()`
@@ -392,8 +392,8 @@ const cluster = require('cluster');
 const http = require('http');
 const numCPUs = require('os').cpus().length;
 
-if (cluster.isParent) {
-  console.log(`Parent ${process.pid} is running`);
+if (cluster.isPrimary) {
+  console.log(`Primary ${process.pid} is running`);
 
   // Fork workers.
   for (let i = 0; i < numCPUs; i++) {
@@ -425,9 +425,10 @@ added: v0.9.12
 * `signal` {string} Name of the kill signal to send to the worker
   process. **Default**: `'SIGTERM'`
 
-This function will kill the worker. In the parent, it does this by disconnecting
-the `worker.process`, and once disconnected, killing with `signal`. In the
-worker, it does it by disconnecting the channel, and then exiting with code `0`.
+This function will kill the worker. In the primary, it does this
+by disconnecting the `worker.process`, and once disconnected, killing
+with `signal`. In the worker, it does it by disconnecting the channel,
+and then exiting with code `0`.
 
 Because `kill()` attempts to gracefully disconnect the worker process, it is
 susceptible to waiting indefinitely for the disconnect to complete. For example,
@@ -478,18 +479,18 @@ changes:
 * `callback` {Function}
 * Returns: {boolean}
 
-Send a message to a worker or parent, optionally with a handle.
+Send a message to a worker or primary, optionally with a handle.
 
-In the parent this sends a message to a specific worker. It is identical to
+In the primary this sends a message to a specific worker. It is identical to
 [`ChildProcess.send()`][].
 
-In a worker this sends a message to the parent. It is identical to
+In a worker this sends a message to the primary. It is identical to
 `process.send()`.
 
-This example will echo back all messages from the parent:
+This example will echo back all messages from the primary:
 
 ```js
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   const worker = cluster.fork();
   worker.send('hi there');
 
@@ -583,7 +584,7 @@ added: v0.7.0
 
 After calling `listen()` from a worker, when the `'listening'` event is emitted
 on the server a `'listening'` event will also be emitted on `cluster` in the
-parent.
+primary.
 
 The event handler is executed with two arguments, the `worker` contains the
 worker object and the `address` object contains the following connection
@@ -617,7 +618,7 @@ changes:
 * `message` {Object}
 * `handle` {undefined|Object}
 
-Emitted when the cluster parent receives a message from any worker.
+Emitted when the cluster primary receives a message from any worker.
 
 See [`child_process` event: `'message'`][].
 
@@ -629,9 +630,9 @@ added: v0.7.0
 * `worker` {cluster.Worker}
 
 After forking a new worker, the worker should respond with an online message.
-When the parent receives an online message it will emit this event.
+When the primary receives an online message it will emit this event.
 The difference between `'fork'` and `'online'` is that fork is emitted when the
-parent forks a worker, and `'online'` is emitted when the worker is running.
+primary forks a worker, and `'online'` is emitted when the worker is running.
 
 ```js
 cluster.on('online', (worker) => {
@@ -646,11 +647,11 @@ added: v0.7.1
 
 * `settings` {Object}
 
-Emitted every time [`.setupParent()`][] is called.
+Emitted every time [`.setupPrimary()`][] is called.
 
 The `settings` object is the `cluster.settings` object at the time
-[`.setupParent()`][] was called and is advisory only, since multiple calls to
-[`.setupParent()`][] can be made in a single tick.
+[`.setupPrimary()`][] was called and is advisory only, since multiple calls to
+[`.setupPrimary()`][] can be made in a single tick.
 
 If accuracy is important, use `cluster.settings`.
 
@@ -665,12 +666,12 @@ added: v0.7.7
 Calls `.disconnect()` on each worker in `cluster.workers`.
 
 When they are disconnected all internal handles will be closed, allowing the
-parent process to die gracefully if no other event is waiting.
+primary process to die gracefully if no other event is waiting.
 
 The method takes an optional callback argument which will be called when
 finished.
 
-This can only be called from the parent process.
+This can only be called from the primary process.
 
 ## `cluster.fork([env])`
 <!-- YAML
@@ -682,26 +683,26 @@ added: v0.6.0
 
 Spawn a new worker process.
 
-This can only be called from the parent process.
+This can only be called from the primary process.
 
 ## `cluster.isMaster`
 <!-- YAML
 added: v0.8.1
 -->
 
-Deprecated alias for isMaster, see isParent for more
+Deprecated alias for isMaster, see isPrimary for more
 details.
 
-## `cluster.isParent`
+## `cluster.isPrimary`
 <!-- YAML
 added: REPLACEME
 -->
 
 * {boolean}
 
-True if the process is a parent. This is determined
+True if the process is a primary. This is determined
 by the `process.env.NODE_UNIQUE_ID`. If `process.env.NODE_UNIQUE_ID` is
-undefined, then `isParent` is `true`.
+undefined, then `isPrimary` is `true`.
 
 ## `cluster.isWorker`
 <!-- YAML
@@ -710,7 +711,7 @@ added: v0.6.0
 
 * {boolean}
 
-True if the process is not a parent (it is the negation of `cluster.isParent`).
+True if the process is not a primary (it is the negation of `cluster.isPrimary`).
 
 ## `cluster.schedulingPolicy`
 <!-- YAML
@@ -720,7 +721,7 @@ added: v0.11.2
 The scheduling policy, either `cluster.SCHED_RR` for round-robin or
 `cluster.SCHED_NONE` to leave it to the operating system. This is a
 global setting and effectively frozen once either the first worker is spawned,
-or [`.setupParent()`][] is called, whichever comes first.
+or [`.setupPrimary()`][] is called, whichever comes first.
 
 `SCHED_RR` is the default on all operating systems except Windows.
 Windows will change to `SCHED_RR` once libuv is able to effectively
@@ -775,11 +776,11 @@ changes:
   * `inspectPort` {number|Function} Sets inspector port of worker.
     This can be a number, or a function that takes no arguments and returns a
     number. By default each worker gets its own port, incremented from the
-    parent's `process.debugPort`.
+    primary's `process.debugPort`.
   * `windowsHide` {boolean} Hide the forked processes console window that would
     normally be created on Windows systems. **Default:** `false`.
 
-After calling [`.setupParent()`][] (or [`.fork()`][]) this settings object will
+After calling [`.setupPrimary()`][] (or [`.fork()`][]) this settings object will
 contain the settings, including the default values.
 
 This object is not intended to be changed or set manually.
@@ -793,44 +794,44 @@ changes:
     description: The `stdio` option is supported now.
 -->
 
-Deprecated alias for setupParent, see setupParent
+Deprecated alias for setupPrimary, see setupPrimary
 for more details.
 
-## `cluster.setupParent([settings])`
+## `cluster.setupPrimary([settings])`
 <!-- YAML
 added: REPLACEME
 -->
 
 * `settings` {Object} See [`cluster.settings`][].
 
-`setupParent` is used to change the default 'fork' behavior. Once called,
+`setupPrimary` is used to change the default 'fork' behavior. Once called,
 the settings will be present in `cluster.settings`.
 
 Any settings changes only affect future calls to [`.fork()`][] and have no
 effect on workers that are already running.
 
-The only attribute of a worker that cannot be set via `.setupParent()` is
+The only attribute of a worker that cannot be set via `.setupPrimary()` is
 the `env` passed to [`.fork()`][].
 
 The defaults above apply to the first call only; the defaults for later
-calls are the current values at the time of `cluster.setupParent()` is called.
+calls are the current values at the time of `cluster.setupPrimary()` is called.
 
 ```js
 const cluster = require('cluster');
-cluster.setupParent({
+cluster.setupPrimary({
   exec: 'worker.js',
   args: ['--use', 'https'],
   silent: true
 });
 cluster.fork(); // https worker
-cluster.setupParent({
+cluster.setupPrimary({
   exec: 'worker.js',
   args: ['--use', 'http']
 });
 cluster.fork(); // http worker
 ```
 
-This can only be called from the parent process.
+This can only be called from the primary process.
 
 ## `cluster.worker`
 <!-- YAML
@@ -839,13 +840,13 @@ added: v0.7.0
 
 * {Object}
 
-A reference to the current worker object. Not available in the parent process.
+A reference to the current worker object. Not available in the primary process.
 
 ```js
 const cluster = require('cluster');
 
-if (cluster.isParent) {
-  console.log('I am parent');
+if (cluster.isPrimary) {
+  console.log('I am primary');
   cluster.fork();
   cluster.fork();
 } else if (cluster.isWorker) {
@@ -861,7 +862,7 @@ added: v0.7.0
 * {Object}
 
 A hash that stores the active worker objects, keyed by `id` field. Makes it
-easy to loop through all the workers. It is only available in the parent
+easy to loop through all the workers. It is only available in the primary
 process.
 
 A worker is removed from `cluster.workers` after the worker has disconnected
@@ -892,7 +893,7 @@ socket.on('data', (id) => {
 [Advanced serialization for `child_process`]: child_process.md#child_process_advanced_serialization
 [Child Process module]: child_process.md#child_process_child_process_fork_modulepath_args_options
 [`.fork()`]: #cluster_cluster_fork_env
-[`.setupParent()`]: #cluster_cluster_setupparent_settings
+[`.setupPrimary()`]: #cluster_cluster_setupprimary_settings
 [`ChildProcess.send()`]: child_process.md#child_process_subprocess_send_message_sendhandle_options_callback
 [`child_process.fork()`]: child_process.md#child_process_child_process_fork_modulepath_args_options
 [`child_process` event: `'exit'`]: child_process.md#child_process_event_exit

--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -794,8 +794,7 @@ changes:
     description: The `stdio` option is supported now.
 -->
 
-Deprecated alias for setupPrimary, see setupPrimary
-for more details.
+Deprecated alias for [`.setupPrimary()`][].
 
 ## `cluster.setupPrimary([settings])`
 <!-- YAML

--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -901,7 +901,7 @@ socket.on('data', (id) => {
 [`child_process` event: `'message'`]: child_process.md#child_process_event_message
 [`cluster.settings`]: #cluster_cluster_settings
 [`disconnect()`]: child_process.md#child_process_subprocess_disconnect
-[`cluster.isPrimary()`]: #cluster_cluster_isprimary
+[`cluster.isPrimary`]: #cluster_cluster_isprimary
 [`kill()`]: process.md#process_process_kill_pid_signal
 [`process` event: `'message'`]: process.md#process_event_message
 [`server.close()`]: net.md#net_event_close

--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -126,7 +126,7 @@ When sharing a UDP socket across multiple `cluster` workers, the
 ```js
 const cluster = require('cluster');
 const dgram = require('dgram');
-if (cluster.isMaster) {
+if (cluster.isParent) {
   cluster.fork(); // Works ok.
   cluster.fork(); // Fails with EADDRINUSE.
 } else {

--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -126,7 +126,7 @@ When sharing a UDP socket across multiple `cluster` workers, the
 ```js
 const cluster = require('cluster');
 const dgram = require('dgram');
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   cluster.fork(); // Works ok.
   cluster.fork(); // Fails with EADDRINUSE.
 } else {

--- a/doc/api/domain.md
+++ b/doc/api/domain.md
@@ -55,7 +55,7 @@ triggered the error, while letting the others finish in their normal
 time, and stop listening for new requests in that worker.
 
 In this way, `domain` usage goes hand-in-hand with the cluster module,
-since the parent process can fork a new worker when a worker
+since the primary process can fork a new worker when a worker
 encounters an error. For Node.js programs that scale to multiple
 machines, the terminating proxy or service registry can take note of
 the failure, and react accordingly.
@@ -90,9 +90,9 @@ appropriately, and handle errors with much greater safety.
 const cluster = require('cluster');
 const PORT = +process.env.PORT || 1337;
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   // A more realistic scenario would have more than 2 workers,
-  // and perhaps not put the parent and worker in the same file.
+  // and perhaps not put the primary and worker in the same file.
   //
   // It is also possible to get a bit fancier about logging, and
   // implement whatever custom logic is needed to prevent DoS
@@ -100,7 +100,7 @@ if (cluster.isParent) {
   //
   // See the options in the cluster documentation.
   //
-  // The important thing is that the parent does very little,
+  // The important thing is that the primary does very little,
   // increasing our resilience to unexpected errors.
 
   cluster.fork();
@@ -142,8 +142,8 @@ if (cluster.isParent) {
         // Stop taking new requests.
         server.close();
 
-        // Let the parent know we're dead. This will trigger a
-        // 'disconnect' in the cluster parent, and then it will fork
+        // Let the primary know we're dead. This will trigger a
+        // 'disconnect' in the cluster primary, and then it will fork
         // a new worker.
         cluster.worker.disconnect();
 

--- a/doc/api/domain.md
+++ b/doc/api/domain.md
@@ -55,7 +55,7 @@ triggered the error, while letting the others finish in their normal
 time, and stop listening for new requests in that worker.
 
 In this way, `domain` usage goes hand-in-hand with the cluster module,
-since the master process can fork a new worker when a worker
+since the parent process can fork a new worker when a worker
 encounters an error. For Node.js programs that scale to multiple
 machines, the terminating proxy or service registry can take note of
 the failure, and react accordingly.
@@ -90,9 +90,9 @@ appropriately, and handle errors with much greater safety.
 const cluster = require('cluster');
 const PORT = +process.env.PORT || 1337;
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   // A more realistic scenario would have more than 2 workers,
-  // and perhaps not put the master and worker in the same file.
+  // and perhaps not put the parent and worker in the same file.
   //
   // It is also possible to get a bit fancier about logging, and
   // implement whatever custom logic is needed to prevent DoS
@@ -100,7 +100,7 @@ if (cluster.isMaster) {
   //
   // See the options in the cluster documentation.
   //
-  // The important thing is that the master does very little,
+  // The important thing is that the parent does very little,
   // increasing our resilience to unexpected errors.
 
   cluster.fork();
@@ -142,8 +142,8 @@ if (cluster.isMaster) {
         // Stop taking new requests.
         server.close();
 
-        // Let the master know we're dead. This will trigger a
-        // 'disconnect' in the cluster master, and then it will fork
+        // Let the parent know we're dead. This will trigger a
+        // 'disconnect' in the cluster parent, and then it will fork
         // a new worker.
         cluster.worker.disconnect();
 

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -21,5 +21,5 @@
 
 'use strict';
 
-const childOrMaster = 'NODE_UNIQUE_ID' in process.env ? 'child' : 'master';
-module.exports = require(`internal/cluster/${childOrMaster}`);
+const childOrParent = 'NODE_UNIQUE_ID' in process.env ? 'child' : 'parent';
+module.exports = require(`internal/cluster/${childOrParent}`);

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -21,5 +21,5 @@
 
 'use strict';
 
-const childOrParent = 'NODE_UNIQUE_ID' in process.env ? 'child' : 'parent';
-module.exports = require(`internal/cluster/${childOrParent}`);
+const childOrPrimary = 'NODE_UNIQUE_ID' in process.env ? 'child' : 'primary';
+module.exports = require(`internal/cluster/${childOrPrimary}`);

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -157,13 +157,13 @@ function replaceHandle(self, newHandle) {
   const state = self[kStateSymbol];
   const oldHandle = state.handle;
 
-  // Set up the handle that we got from master.
+  // Set up the handle that we got from parent.
   newHandle.lookup = oldHandle.lookup;
   newHandle.bind = oldHandle.bind;
   newHandle.send = oldHandle.send;
   newHandle[owner_symbol] = self;
 
-  // Replace the existing handle by the handle we got from master.
+  // Replace the existing handle by the handle we got from parent.
   oldHandle.close();
   state.handle = newHandle;
   // Check if the udp handle was connected and set the state accordingly
@@ -183,7 +183,7 @@ function bufferSize(self, size, buffer) {
   return ret;
 }
 
-// Query master process to get the server handle and utilize it.
+// Query parent process to get the server handle and utilize it.
 function bindServerHandle(self, options, errCb) {
   if (!cluster)
     cluster = require('cluster');

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -157,13 +157,13 @@ function replaceHandle(self, newHandle) {
   const state = self[kStateSymbol];
   const oldHandle = state.handle;
 
-  // Set up the handle that we got from parent.
+  // Set up the handle that we got from primary.
   newHandle.lookup = oldHandle.lookup;
   newHandle.bind = oldHandle.bind;
   newHandle.send = oldHandle.send;
   newHandle[owner_symbol] = self;
 
-  // Replace the existing handle by the handle we got from parent.
+  // Replace the existing handle by the handle we got from primary.
   oldHandle.close();
   state.handle = newHandle;
   // Check if the udp handle was connected and set the state accordingly
@@ -183,7 +183,7 @@ function bufferSize(self, size, buffer) {
   return ret;
 }
 
-// Query parent process to get the server handle and utilize it.
+// Query primary process to get the server handle and utilize it.
 function bindServerHandle(self, options, errCb) {
   if (!cluster)
     cluster = require('cluster');

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -852,7 +852,7 @@ function setupChannel(target, channel, serializationMode) {
       }
     }
 
-    /* If the master is > 2 read() calls behind, please stop sending. */
+    /* If the parent is > 2 read() calls behind, please stop sending. */
     return channel.writeQueueSize < (65536 * 2);
   };
 

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -852,7 +852,7 @@ function setupChannel(target, channel, serializationMode) {
       }
     }
 
-    /* If the parent is > 2 read() calls behind, please stop sending. */
+    /* If the primary is > 2 read() calls behind, please stop sending. */
     return channel.writeQueueSize < (65536 * 2);
   };
 

--- a/lib/internal/cluster/child.js
+++ b/lib/internal/cluster/child.js
@@ -22,7 +22,7 @@ const noop = FunctionPrototype;
 module.exports = cluster;
 
 cluster.isWorker = true;
-cluster.isMaster = false; // Deprecated Alias must be same as isPrimary
+cluster.isMaster = false; // Deprecated alias. Must be same as isPrimary.
 cluster.isPrimary = false;
 cluster.worker = null;
 cluster.Worker = Worker;

--- a/lib/internal/cluster/child.js
+++ b/lib/internal/cluster/child.js
@@ -22,8 +22,8 @@ const noop = FunctionPrototype;
 module.exports = cluster;
 
 cluster.isWorker = true;
-cluster.isMaster = false; // Deprecated Alias must be same as isParent
-cluster.isParent = false;
+cluster.isMaster = false; // Deprecated Alias must be same as isPrimary
+cluster.isPrimary = false;
 cluster.worker = null;
 cluster.Worker = Worker;
 
@@ -40,7 +40,7 @@ cluster._setupWorker = function() {
     worker.emit('disconnect');
 
     if (!worker.exitedAfterDisconnect) {
-      // Unexpected disconnect, parent exited, or some such nastiness, so
+      // Unexpected disconnect, primary exited, or some such nastiness, so
       // worker exits immediately.
       process.exit(0);
     }
@@ -133,7 +133,7 @@ function shared(message, handle, indexesKey, cb) {
   cb(message.errno, handle);
 }
 
-// Round-robin. Parent distributes handles across workers.
+// Round-robin. Primary distributes handles across workers.
 function rr(message, indexesKey, cb) {
   if (message.errno)
     return cb(message.errno, null);
@@ -141,7 +141,7 @@ function rr(message, indexesKey, cb) {
   let key = message.key;
 
   function listen(backlog) {
-    // TODO(bnoordhuis) Send a message to the parent that tells it to
+    // TODO(bnoordhuis) Send a message to the primary that tells it to
     // update the backlog size. The actual backlog should probably be
     // the largest requested size by any worker.
     return 0;
@@ -150,9 +150,9 @@ function rr(message, indexesKey, cb) {
   function close() {
     // lib/net.js treats server._handle.close() as effectively synchronous.
     // That means there is a time window between the call to close() and
-    // the ack by the parent process in which we can still receive handles.
+    // the ack by the primary process in which we can still receive handles.
     // onconnection() below handles that by sending those handles back to
-    // the parent.
+    // the primary.
     if (key === undefined)
       return;
 
@@ -200,7 +200,7 @@ function send(message, cb) {
   return sendHelper(process, message, null, cb);
 }
 
-function _disconnect(parentInitiated) {
+function _disconnect(primaryInitiated) {
   this.exitedAfterDisconnect = true;
   let waitingCount = 1;
 
@@ -209,10 +209,10 @@ function _disconnect(parentInitiated) {
 
     if (waitingCount === 0) {
       // If disconnect is worker initiated, wait for ack to be sure
-      // exitedAfterDisconnect is properly set in the parent, otherwise, if
-      // it's parent initiated there's no need to send the
+      // exitedAfterDisconnect is properly set in the primary, otherwise, if
+      // it's primary initiated there's no need to send the
       // exitedAfterDisconnect message
-      if (parentInitiated) {
+      if (primaryInitiated) {
         process.disconnect();
       } else {
         send({ act: 'exitedAfterDisconnect' }, () => process.disconnect());

--- a/lib/internal/cluster/child.js
+++ b/lib/internal/cluster/child.js
@@ -22,7 +22,8 @@ const noop = FunctionPrototype;
 module.exports = cluster;
 
 cluster.isWorker = true;
-cluster.isMaster = false;
+cluster.isMaster = false; // Deprecated Alias must be same as isParent
+cluster.isParent = false;
 cluster.worker = null;
 cluster.Worker = Worker;
 
@@ -39,7 +40,7 @@ cluster._setupWorker = function() {
     worker.emit('disconnect');
 
     if (!worker.exitedAfterDisconnect) {
-      // Unexpected disconnect, master exited, or some such nastiness, so
+      // Unexpected disconnect, parent exited, or some such nastiness, so
       // worker exits immediately.
       process.exit(0);
     }
@@ -132,7 +133,7 @@ function shared(message, handle, indexesKey, cb) {
   cb(message.errno, handle);
 }
 
-// Round-robin. Master distributes handles across workers.
+// Round-robin. Parent distributes handles across workers.
 function rr(message, indexesKey, cb) {
   if (message.errno)
     return cb(message.errno, null);
@@ -140,7 +141,7 @@ function rr(message, indexesKey, cb) {
   let key = message.key;
 
   function listen(backlog) {
-    // TODO(bnoordhuis) Send a message to the master that tells it to
+    // TODO(bnoordhuis) Send a message to the parent that tells it to
     // update the backlog size. The actual backlog should probably be
     // the largest requested size by any worker.
     return 0;
@@ -149,9 +150,9 @@ function rr(message, indexesKey, cb) {
   function close() {
     // lib/net.js treats server._handle.close() as effectively synchronous.
     // That means there is a time window between the call to close() and
-    // the ack by the master process in which we can still receive handles.
+    // the ack by the parent process in which we can still receive handles.
     // onconnection() below handles that by sending those handles back to
-    // the master.
+    // the parent.
     if (key === undefined)
       return;
 
@@ -199,7 +200,7 @@ function send(message, cb) {
   return sendHelper(process, message, null, cb);
 }
 
-function _disconnect(masterInitiated) {
+function _disconnect(parentInitiated) {
   this.exitedAfterDisconnect = true;
   let waitingCount = 1;
 
@@ -208,10 +209,10 @@ function _disconnect(masterInitiated) {
 
     if (waitingCount === 0) {
       // If disconnect is worker initiated, wait for ack to be sure
-      // exitedAfterDisconnect is properly set in the master, otherwise, if
-      // it's master initiated there's no need to send the
+      // exitedAfterDisconnect is properly set in the parent, otherwise, if
+      // it's parent initiated there's no need to send the
       // exitedAfterDisconnect message
-      if (masterInitiated) {
+      if (parentInitiated) {
         process.disconnect();
       } else {
         send({ act: 'exitedAfterDisconnect' }, () => process.disconnect());

--- a/lib/internal/cluster/parent.js
+++ b/lib/internal/cluster/parent.js
@@ -30,12 +30,13 @@ module.exports = cluster;
 
 const handles = new SafeMap();
 cluster.isWorker = false;
-cluster.isMaster = true;
+cluster.isMaster = true; // Deprecated Alias must be same as isParent
+cluster.isParent = true;
 cluster.Worker = Worker;
 cluster.workers = {};
 cluster.settings = {};
 cluster.SCHED_NONE = SCHED_NONE;  // Leave it to the operating system.
-cluster.SCHED_RR = SCHED_RR;      // Master distributes connections.
+cluster.SCHED_RR = SCHED_RR;      // Parent distributes connections.
 
 let ids = 0;
 let debugPortOffset = 1;
@@ -56,7 +57,7 @@ else if (process.platform === 'win32') {
 
 cluster.schedulingPolicy = schedulingPolicy;
 
-cluster.setupMaster = function(options) {
+cluster.setupParent = function(options) {
   const settings = {
     args: ArrayPrototypeSlice(process.argv, 2),
     exec: process.argv[1],
@@ -104,6 +105,9 @@ cluster.setupMaster = function(options) {
     }
   });
 };
+
+// Deprecated alias must be same as setupParent
+cluster.setupMaster = cluster.setupParent;
 
 function setupSettingsNT(settings) {
   cluster.emit('setup', settings);
@@ -170,7 +174,7 @@ function removeHandlesForWorker(worker) {
 }
 
 cluster.fork = function(env) {
-  cluster.setupMaster();
+  cluster.setupParent();
   const id = ++ids;
   const workerProcess = createWorkerProcess(id, env);
   const worker = new Worker({
@@ -203,7 +207,7 @@ cluster.fork = function(env) {
     /*
      * Now is a good time to remove the handles
      * associated with this worker because it is
-     * not connected to the master anymore.
+     * not connected to the parent anymore.
      */
     removeHandlesForWorker(worker);
 
@@ -357,7 +361,7 @@ function send(worker, message, handle, cb) {
   return sendHelper(worker.process, message, handle, cb);
 }
 
-// Extend generic Worker with methods specific to the master process.
+// Extend generic Worker with methods specific to the parent process.
 Worker.prototype.disconnect = function() {
   this.exitedAfterDisconnect = true;
   send(this, { act: 'disconnect' });

--- a/lib/internal/cluster/primary.js
+++ b/lib/internal/cluster/primary.js
@@ -30,7 +30,7 @@ module.exports = cluster;
 
 const handles = new SafeMap();
 cluster.isWorker = false;
-cluster.isMaster = true; // Deprecated Alias must be same as isPrimary
+cluster.isMaster = true; // Deprecated alias. Must be same as isPrimary.
 cluster.isPrimary = true;
 cluster.Worker = Worker;
 cluster.workers = {};

--- a/lib/internal/cluster/primary.js
+++ b/lib/internal/cluster/primary.js
@@ -30,13 +30,13 @@ module.exports = cluster;
 
 const handles = new SafeMap();
 cluster.isWorker = false;
-cluster.isMaster = true; // Deprecated Alias must be same as isParent
-cluster.isParent = true;
+cluster.isMaster = true; // Deprecated Alias must be same as isPrimary
+cluster.isPrimary = true;
 cluster.Worker = Worker;
 cluster.workers = {};
 cluster.settings = {};
 cluster.SCHED_NONE = SCHED_NONE;  // Leave it to the operating system.
-cluster.SCHED_RR = SCHED_RR;      // Parent distributes connections.
+cluster.SCHED_RR = SCHED_RR;      // Primary distributes connections.
 
 let ids = 0;
 let debugPortOffset = 1;
@@ -57,7 +57,7 @@ else if (process.platform === 'win32') {
 
 cluster.schedulingPolicy = schedulingPolicy;
 
-cluster.setupParent = function(options) {
+cluster.setupPrimary = function(options) {
   const settings = {
     args: ArrayPrototypeSlice(process.argv, 2),
     exec: process.argv[1],
@@ -106,8 +106,8 @@ cluster.setupParent = function(options) {
   });
 };
 
-// Deprecated alias must be same as setupParent
-cluster.setupMaster = cluster.setupParent;
+// Deprecated alias must be same as setupPrimary
+cluster.setupMaster = cluster.setupPrimary;
 
 function setupSettingsNT(settings) {
   cluster.emit('setup', settings);
@@ -174,7 +174,7 @@ function removeHandlesForWorker(worker) {
 }
 
 cluster.fork = function(env) {
-  cluster.setupParent();
+  cluster.setupPrimary();
   const id = ++ids;
   const workerProcess = createWorkerProcess(id, env);
   const worker = new Worker({
@@ -207,7 +207,7 @@ cluster.fork = function(env) {
     /*
      * Now is a good time to remove the handles
      * associated with this worker because it is
-     * not connected to the parent anymore.
+     * not connected to the primary anymore.
      */
     removeHandlesForWorker(worker);
 
@@ -361,7 +361,7 @@ function send(worker, message, handle, cb) {
   return sendHelper(worker.process, message, handle, cb);
 }
 
-// Extend generic Worker with methods specific to the parent process.
+// Extend generic Worker with methods specific to the primary process.
 Worker.prototype.disconnect = function() {
   this.exitedAfterDisconnect = true;
   send(this, { act: 'disconnect' });

--- a/lib/internal/cluster/worker.js
+++ b/lib/internal/cluster/worker.js
@@ -9,7 +9,7 @@ const EventEmitter = require('events');
 
 module.exports = Worker;
 
-// Common Worker implementation shared between the cluster parent and workers.
+// Common Worker implementation shared between the cluster primary and workers.
 function Worker(options) {
   if (!(this instanceof Worker))
     return new Worker(options);

--- a/lib/internal/cluster/worker.js
+++ b/lib/internal/cluster/worker.js
@@ -9,7 +9,7 @@ const EventEmitter = require('events');
 
 module.exports = Worker;
 
-// Common Worker implementation shared between the cluster master and workers.
+// Common Worker implementation shared between the cluster parent and workers.
 function Worker(options) {
   if (!(this instanceof Worker))
     return new Worker(options);

--- a/lib/net.js
+++ b/lib/net.js
@@ -1336,7 +1336,7 @@ function listenInCluster(server, address, port, addressType,
 
   if (cluster === undefined) cluster = require('cluster');
 
-  if (cluster.isParent || exclusive) {
+  if (cluster.isPrimary || exclusive) {
     // Will create a new handle
     // _listen2 sets up the listened handle, it is still named like this
     // to avoid breaking code that wraps this method
@@ -1352,10 +1352,10 @@ function listenInCluster(server, address, port, addressType,
     flags,
   };
 
-  // Get the parent's server handle, and listen on it
-  cluster._getServer(server, serverQuery, listenOnParentHandle);
+  // Get the primary's server handle, and listen on it
+  cluster._getServer(server, serverQuery, listenOnPrimaryHandle);
 
-  function listenOnParentHandle(err, handle) {
+  function listenOnPrimaryHandle(err, handle) {
     err = checkBindError(err, port, handle);
 
     if (err) {
@@ -1363,7 +1363,7 @@ function listenInCluster(server, address, port, addressType,
       return server.emit('error', ex);
     }
 
-    // Reuse parent's server handle
+    // Reuse primary's server handle
     server._handle = handle;
     // _listen2 sets up the listened handle, it is still named like this
     // to avoid breaking code that wraps this method
@@ -1425,7 +1425,7 @@ Server.prototype.listen = function(...args) {
       lookupAndListen(this, options.port | 0, options.host, backlog,
                       options.exclusive, flags);
     } else { // Undefined host, listens on unspecified address
-      // Default addressType 4 will be used to search for parent server
+      // Default addressType 4 will be used to search for primary server
       listenInCluster(this, null, options.port | 0, 4,
                       backlog, undefined, options.exclusive);
     }

--- a/lib/net.js
+++ b/lib/net.js
@@ -1336,7 +1336,7 @@ function listenInCluster(server, address, port, addressType,
 
   if (cluster === undefined) cluster = require('cluster');
 
-  if (cluster.isMaster || exclusive) {
+  if (cluster.isParent || exclusive) {
     // Will create a new handle
     // _listen2 sets up the listened handle, it is still named like this
     // to avoid breaking code that wraps this method
@@ -1352,10 +1352,10 @@ function listenInCluster(server, address, port, addressType,
     flags,
   };
 
-  // Get the master's server handle, and listen on it
-  cluster._getServer(server, serverQuery, listenOnMasterHandle);
+  // Get the parent's server handle, and listen on it
+  cluster._getServer(server, serverQuery, listenOnParentHandle);
 
-  function listenOnMasterHandle(err, handle) {
+  function listenOnParentHandle(err, handle) {
     err = checkBindError(err, port, handle);
 
     if (err) {
@@ -1363,7 +1363,7 @@ function listenInCluster(server, address, port, addressType,
       return server.emit('error', ex);
     }
 
-    // Reuse master's server handle
+    // Reuse parent's server handle
     server._handle = handle;
     // _listen2 sets up the listened handle, it is still named like this
     // to avoid breaking code that wraps this method
@@ -1425,7 +1425,7 @@ Server.prototype.listen = function(...args) {
       lookupAndListen(this, options.port | 0, options.host, backlog,
                       options.exclusive, flags);
     } else { // Undefined host, listens on unspecified address
-      // Default addressType 4 will be used to search for master server
+      // Default addressType 4 will be used to search for parent server
       listenInCluster(this, null, options.port | 0, 4,
                       backlog, undefined, options.exclusive);
     }

--- a/node.gyp
+++ b/node.gyp
@@ -117,7 +117,7 @@
       'lib/internal/child_process.js',
       'lib/internal/child_process/serialization.js',
       'lib/internal/cluster/child.js',
-      'lib/internal/cluster/master.js',
+      'lib/internal/cluster/parent.js',
       'lib/internal/cluster/round_robin_handle.js',
       'lib/internal/cluster/shared_handle.js',
       'lib/internal/cluster/utils.js',

--- a/node.gyp
+++ b/node.gyp
@@ -117,7 +117,7 @@
       'lib/internal/child_process.js',
       'lib/internal/child_process/serialization.js',
       'lib/internal/cluster/child.js',
-      'lib/internal/cluster/parent.js',
+      'lib/internal/cluster/primary.js',
       'lib/internal/cluster/round_robin_handle.js',
       'lib/internal/cluster/shared_handle.js',
       'lib/internal/cluster/utils.js',

--- a/test/async-hooks/test-callback-error.js
+++ b/test/async-hooks/test-callback-error.js
@@ -30,7 +30,7 @@ switch (arg) {
     return;
 }
 
-// This part should run only for the master test
+// This part should run only for the parent test
 assert.ok(!arg);
 {
   // console.log should stay until this test's flakiness is solved

--- a/test/async-hooks/test-callback-error.js
+++ b/test/async-hooks/test-callback-error.js
@@ -30,7 +30,7 @@ switch (arg) {
     return;
 }
 
-// This part should run only for the parent test
+// This part should run only for the primary test
 assert.ok(!arg);
 {
   // console.log should stay until this test's flakiness is solved
@@ -75,7 +75,7 @@ assert.ok(!arg);
     assert.strictEqual(child.status, null);
     // Most posix systems will show 'SIGABRT', but alpine34 does not
     if (child.signal !== 'SIGABRT') {
-      console.log(`parent received signal ${child.signal}\nchild's stderr:`);
+      console.log(`primary received signal ${child.signal}\nchild's stderr:`);
       console.log(child.stderr);
       process.exit(1);
     }

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -61,7 +61,7 @@ if (process.argv.length === 2 &&
     isMainThread &&
     hasCrypto &&
     require.main &&
-    require('cluster').isMaster) {
+    require('cluster').isParent) {
   // The copyright notice is relatively big and the flags could come afterwards.
   const bytesToRead = 1500;
   const buffer = Buffer.allocUnsafe(bytesToRead);

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -61,7 +61,7 @@ if (process.argv.length === 2 &&
     isMainThread &&
     hasCrypto &&
     require.main &&
-    require('cluster').isParent) {
+    require('cluster').isPrimary) {
   // The copyright notice is relatively big and the flags could come afterwards.
   const bytesToRead = 1500;
   const buffer = Buffer.allocUnsafe(bytesToRead);

--- a/test/fixtures/cluster-preload-test.js
+++ b/test/fixtures/cluster-preload-test.js
@@ -1,5 +1,5 @@
 const cluster = require('cluster');
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   cluster.fork(); // one child
   cluster.on('exit', function(worker, code, signal) {
     console.log(`worker terminated with code ${code}`);

--- a/test/fixtures/cluster-preload-test.js
+++ b/test/fixtures/cluster-preload-test.js
@@ -1,5 +1,5 @@
 const cluster = require('cluster');
-if (cluster.isMaster) {
+if (cluster.isParent) {
   cluster.fork(); // one child
   cluster.on('exit', function(worker, code, signal) {
     console.log(`worker terminated with code ${code}`);

--- a/test/fixtures/cluster-preload.js
+++ b/test/fixtures/cluster-preload.js
@@ -8,5 +8,5 @@ const expectedPaths = require('module')._nodeModulePaths(process.cwd());
 assert.deepStrictEqual(module.parent.paths, expectedPaths);
 
 const cluster = require('cluster');
-cluster.isParent || process.exit(42 + cluster.worker.id); // +42 to distinguish
-// from exit(1) for other random reasons
+cluster.isPrimary || process.exit(42 + cluster.worker.id); // +42 to distinguish
+ // from exit(1) for other random reasons

--- a/test/fixtures/cluster-preload.js
+++ b/test/fixtures/cluster-preload.js
@@ -8,5 +8,5 @@ const expectedPaths = require('module')._nodeModulePaths(process.cwd());
 assert.deepStrictEqual(module.parent.paths, expectedPaths);
 
 const cluster = require('cluster');
-cluster.isMaster || process.exit(42 + cluster.worker.id); // +42 to distinguish
+cluster.isParent || process.exit(42 + cluster.worker.id); // +42 to distinguish
 // from exit(1) for other random reasons

--- a/test/fixtures/cluster-preload.js
+++ b/test/fixtures/cluster-preload.js
@@ -9,4 +9,4 @@ assert.deepStrictEqual(module.parent.paths, expectedPaths);
 
 const cluster = require('cluster');
 cluster.isPrimary || process.exit(42 + cluster.worker.id); // +42 to distinguish
- // from exit(1) for other random reasons
+// from exit(1) for other random reasons

--- a/test/fixtures/clustered-server/app.js
+++ b/test/fixtures/clustered-server/app.js
@@ -10,7 +10,7 @@ function handleRequest(request, response) {
 const NUMBER_OF_WORKERS = 2;
 var workersOnline = 0;
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   cluster.on('online', function() {
     if (++workersOnline === NUMBER_OF_WORKERS) {
       console.error('all workers are running');

--- a/test/fixtures/clustered-server/app.js
+++ b/test/fixtures/clustered-server/app.js
@@ -10,7 +10,7 @@ function handleRequest(request, response) {
 const NUMBER_OF_WORKERS = 2;
 var workersOnline = 0;
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   cluster.on('online', function() {
     if (++workersOnline === NUMBER_OF_WORKERS) {
       console.error('all workers are running');

--- a/test/known_issues/test-dgram-bind-shared-ports-after-port-0.js
+++ b/test/known_issues/test-dgram-bind-shared-ports-after-port-0.js
@@ -13,7 +13,7 @@ const cluster = require('cluster');
 const dgram = require('dgram');
 const BYE = 'bye';
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   const worker1 = cluster.fork();
 
   // Verify that Windows doesn't support this scenario
@@ -40,7 +40,7 @@ if (cluster.isMaster) {
       worker2.send(BYE);
     });
   });
-  // end master code
+  // end parent code
 } else {
   // worker code
   process.on('message', (msg) => msg === BYE && process.exit(0));

--- a/test/known_issues/test-dgram-bind-shared-ports-after-port-0.js
+++ b/test/known_issues/test-dgram-bind-shared-ports-after-port-0.js
@@ -13,7 +13,7 @@ const cluster = require('cluster');
 const dgram = require('dgram');
 const BYE = 'bye';
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   const worker1 = cluster.fork();
 
   // Verify that Windows doesn't support this scenario
@@ -40,7 +40,7 @@ if (cluster.isParent) {
       worker2.send(BYE);
     });
   });
-  // end parent code
+  // end primary code
 } else {
   // worker code
   process.on('message', (msg) => msg === BYE && process.exit(0));

--- a/test/known_issues/test-inspector-cluster-port-clash.js
+++ b/test/known_issues/test-inspector-cluster-port-clash.js
@@ -47,7 +47,7 @@ function serialFork() {
   });
 }
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   cluster.on('online', common.mustCall((worker) => worker.send('dbgport'), 2));
 
   // Block one of the ports with a listening socket.

--- a/test/known_issues/test-inspector-cluster-port-clash.js
+++ b/test/known_issues/test-inspector-cluster-port-clash.js
@@ -47,7 +47,7 @@ function serialFork() {
   });
 }
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   cluster.on('online', common.mustCall((worker) => worker.send('dbgport'), 2));
 
   // Block one of the ports with a listening socket.

--- a/test/parallel/test-child-process-fork-closed-channel-segfault.js
+++ b/test/parallel/test-child-process-fork-closed-channel-segfault.js
@@ -8,8 +8,8 @@ const assert = require('assert');
 const cluster = require('cluster');
 const net = require('net');
 
-if (!cluster.isMaster) {
-  // Exit on first received handle to leave the queue non-empty in master
+if (!cluster.isParent) {
+  // Exit on first received handle to leave the queue non-empty in parent
   process.on('message', function() {
     process.exit(1);
   });

--- a/test/parallel/test-child-process-fork-closed-channel-segfault.js
+++ b/test/parallel/test-child-process-fork-closed-channel-segfault.js
@@ -8,8 +8,8 @@ const assert = require('assert');
 const cluster = require('cluster');
 const net = require('net');
 
-if (!cluster.isParent) {
-  // Exit on first received handle to leave the queue non-empty in parent
+if (!cluster.isPrimary) {
+  // Exit on first received handle to leave the queue non-empty in primary
   process.on('message', function() {
     process.exit(1);
   });

--- a/test/parallel/test-child-process-recv-handle.js
+++ b/test/parallel/test-child-process-recv-handle.js
@@ -31,9 +31,9 @@ const spawn = require('child_process').spawn;
 if (process.argv[2] === 'worker')
   worker();
 else
-  parent();
+  primary();
 
-function parent() {
+function primary() {
   // spawn() can only create one IPC channel so we use stdin/stdout as an
   // ad-hoc command channel.
   const proc = spawn(process.execPath, [

--- a/test/parallel/test-child-process-recv-handle.js
+++ b/test/parallel/test-child-process-recv-handle.js
@@ -31,9 +31,9 @@ const spawn = require('child_process').spawn;
 if (process.argv[2] === 'worker')
   worker();
 else
-  master();
+  parent();
 
-function master() {
+function parent() {
   // spawn() can only create one IPC channel so we use stdin/stdout as an
   // ad-hoc command channel.
   const proc = spawn(process.execPath, [

--- a/test/parallel/test-child-process-silent.js
+++ b/test/parallel/test-child-process-silent.js
@@ -33,7 +33,7 @@ if (process.argv[2] === 'pipe') {
   // Child IPC test
   process.send('message from child');
   process.on('message', function() {
-    process.send('got message from master');
+    process.send('got message from parent');
   });
 
 } else if (process.argv[2] === 'parent') {
@@ -80,7 +80,7 @@ if (process.argv[2] === 'pipe') {
     }
 
     if (childReceiving === false) {
-      childReceiving = (message === 'got message from master');
+      childReceiving = (message === 'got message from parent');
     }
 
     if (childReceiving === true) {

--- a/test/parallel/test-child-process-silent.js
+++ b/test/parallel/test-child-process-silent.js
@@ -33,11 +33,11 @@ if (process.argv[2] === 'pipe') {
   // Child IPC test
   process.send('message from child');
   process.on('message', function() {
-    process.send('got message from parent');
+    process.send('got message from primary');
   });
 
-} else if (process.argv[2] === 'parent') {
-  // Parent | start child pipe test
+} else if (process.argv[2] === 'primary') {
+  // Primary | start child pipe test
 
   const child = childProcess.fork(process.argv[1], ['pipe'], { silent: true });
 
@@ -49,19 +49,19 @@ if (process.argv[2] === 'pipe') {
   });
 
 } else {
-  // Testcase | start parent && child IPC test
+  // Testcase | start primary && child IPC test
 
-  // testing: is stderr and stdout piped to parent
-  const args = [process.argv[1], 'parent'];
-  const parent = childProcess.spawn(process.execPath, args);
+  // testing: is stderr and stdout piped to primary
+  const args = [process.argv[1], 'primary'];
+  const primary = childProcess.spawn(process.execPath, args);
 
   // Got any stderr or std data
   let stdoutData = false;
-  parent.stdout.on('data', function() {
+  primary.stdout.on('data', function() {
     stdoutData = true;
   });
   let stderrData = false;
-  parent.stderr.on('data', function() {
+  primary.stderr.on('data', function() {
     stderrData = true;
   });
 
@@ -80,7 +80,7 @@ if (process.argv[2] === 'pipe') {
     }
 
     if (childReceiving === false) {
-      childReceiving = (message === 'got message from parent');
+      childReceiving = (message === 'got message from primary');
     }
 
     if (childReceiving === true) {
@@ -93,7 +93,7 @@ if (process.argv[2] === 'pipe') {
   process.on('exit', function() {
     // clean up
     child.kill();
-    parent.kill();
+    primary.kill();
 
     // Check std(out|err) pipes
     assert.ok(!stdoutData);

--- a/test/parallel/test-cluster-advanced-serialization.js
+++ b/test/parallel/test-cluster-advanced-serialization.js
@@ -3,7 +3,7 @@ const common = require('../common');
 const assert = require('assert');
 const cluster = require('cluster');
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   cluster.settings.serialization = 'advanced';
   const worker = cluster.fork();
   const circular = {};

--- a/test/parallel/test-cluster-advanced-serialization.js
+++ b/test/parallel/test-cluster-advanced-serialization.js
@@ -3,7 +3,7 @@ const common = require('../common');
 const assert = require('assert');
 const cluster = require('cluster');
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   cluster.settings.serialization = 'advanced';
   const worker = cluster.fork();
   const circular = {};

--- a/test/parallel/test-cluster-basic.js
+++ b/test/parallel/test-cluster-basic.js
@@ -38,7 +38,7 @@ function forEach(obj, fn) {
 
 if (cluster.isWorker) {
   require('http').Server(common.mustNotCall()).listen(0, '127.0.0.1');
-} else if (cluster.isMaster) {
+} else if (cluster.isParent) {
 
   const checks = {
     cluster: {

--- a/test/parallel/test-cluster-basic.js
+++ b/test/parallel/test-cluster-basic.js
@@ -38,7 +38,7 @@ function forEach(obj, fn) {
 
 if (cluster.isWorker) {
   require('http').Server(common.mustNotCall()).listen(0, '127.0.0.1');
-} else if (cluster.isParent) {
+} else if (cluster.isPrimary) {
 
   const checks = {
     cluster: {

--- a/test/parallel/test-cluster-bind-privileged-port.js
+++ b/test/parallel/test-cluster-bind-privileged-port.js
@@ -39,7 +39,7 @@ const assert = require('assert');
 const cluster = require('cluster');
 const net = require('net');
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   cluster.fork().on('exit', common.mustCall((exitCode) => {
     assert.strictEqual(exitCode, 0);
   }));

--- a/test/parallel/test-cluster-bind-privileged-port.js
+++ b/test/parallel/test-cluster-bind-privileged-port.js
@@ -39,7 +39,7 @@ const assert = require('assert');
 const cluster = require('cluster');
 const net = require('net');
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   cluster.fork().on('exit', common.mustCall((exitCode) => {
     assert.strictEqual(exitCode, 0);
   }));

--- a/test/parallel/test-cluster-bind-twice.js
+++ b/test/parallel/test-cluster-bind-twice.js
@@ -29,7 +29,7 @@
 //
 //          <supervisor>
 //         /            \
-//    <master 1>     <master 2>
+//    <parent 1>     <parent 2>
 //       /                \
 //  <worker 1>         <worker 2>
 //
@@ -78,7 +78,7 @@ if (!id) {
   }));
 
 } else if (id === 'one') {
-  if (cluster.isMaster) return startWorker();
+  if (cluster.isParent) return startWorker();
 
   const server = http.createServer(common.mustNotCall());
   server.listen(0, common.mustCall(() => {
@@ -89,7 +89,7 @@ if (!id) {
     if (m === 'QUIT') process.exit();
   }));
 } else if (id === 'two') {
-  if (cluster.isMaster) return startWorker();
+  if (cluster.isParent) return startWorker();
 
   const server = http.createServer(common.mustNotCall());
   process.on('message', common.mustCall((m) => {

--- a/test/parallel/test-cluster-bind-twice.js
+++ b/test/parallel/test-cluster-bind-twice.js
@@ -29,7 +29,7 @@
 //
 //          <supervisor>
 //         /            \
-//    <parent 1>     <parent 2>
+//    <primary 1>     <primary 2>
 //       /                \
 //  <worker 1>         <worker 2>
 //
@@ -78,7 +78,7 @@ if (!id) {
   }));
 
 } else if (id === 'one') {
-  if (cluster.isParent) return startWorker();
+  if (cluster.isPrimary) return startWorker();
 
   const server = http.createServer(common.mustNotCall());
   server.listen(0, common.mustCall(() => {
@@ -89,7 +89,7 @@ if (!id) {
     if (m === 'QUIT') process.exit();
   }));
 } else if (id === 'two') {
-  if (cluster.isParent) return startWorker();
+  if (cluster.isPrimary) return startWorker();
 
   const server = http.createServer(common.mustNotCall());
   process.on('message', common.mustCall((m) => {

--- a/test/parallel/test-cluster-call-and-destroy.js
+++ b/test/parallel/test-cluster-call-and-destroy.js
@@ -3,7 +3,7 @@ const common = require('../common');
 const cluster = require('cluster');
 const assert = require('assert');
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   const worker = cluster.fork();
   worker.on('disconnect', common.mustCall(() => {
     assert.strictEqual(worker.isConnected(), false);

--- a/test/parallel/test-cluster-call-and-destroy.js
+++ b/test/parallel/test-cluster-call-and-destroy.js
@@ -3,7 +3,7 @@ const common = require('../common');
 const cluster = require('cluster');
 const assert = require('assert');
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   const worker = cluster.fork();
   worker.on('disconnect', common.mustCall(() => {
     assert.strictEqual(worker.isConnected(), false);

--- a/test/parallel/test-cluster-concurrent-disconnect.js
+++ b/test/parallel/test-cluster-concurrent-disconnect.js
@@ -8,7 +8,7 @@ const assert = require('assert');
 const cluster = require('cluster');
 const os = require('os');
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   const workers = [];
   const numCPUs = os.cpus().length;
   let waitOnline = numCPUs;

--- a/test/parallel/test-cluster-concurrent-disconnect.js
+++ b/test/parallel/test-cluster-concurrent-disconnect.js
@@ -8,7 +8,7 @@ const assert = require('assert');
 const cluster = require('cluster');
 const os = require('os');
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   const workers = [];
   const numCPUs = os.cpus().length;
   let waitOnline = numCPUs;

--- a/test/parallel/test-cluster-cwd.js
+++ b/test/parallel/test-cluster-cwd.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 const cluster = require('cluster');
 const tmpdir = require('../common/tmpdir');
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   tmpdir.refresh();
 
   assert.strictEqual(cluster.settings.cwd, undefined);
@@ -12,7 +12,7 @@ if (cluster.isParent) {
     assert.strictEqual(msg, process.cwd());
   }));
 
-  cluster.setupParent({ cwd: tmpdir.path });
+  cluster.setupPrimary({ cwd: tmpdir.path });
   assert.strictEqual(cluster.settings.cwd, tmpdir.path);
   cluster.fork().on('message', common.mustCall((msg) => {
     assert.strictEqual(msg, tmpdir.path);

--- a/test/parallel/test-cluster-cwd.js
+++ b/test/parallel/test-cluster-cwd.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 const cluster = require('cluster');
 const tmpdir = require('../common/tmpdir');
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   tmpdir.refresh();
 
   assert.strictEqual(cluster.settings.cwd, undefined);
@@ -12,7 +12,7 @@ if (cluster.isMaster) {
     assert.strictEqual(msg, process.cwd());
   }));
 
-  cluster.setupMaster({ cwd: tmpdir.path });
+  cluster.setupParent({ cwd: tmpdir.path });
   assert.strictEqual(cluster.settings.cwd, tmpdir.path);
   cluster.fork().on('message', common.mustCall((msg) => {
     assert.strictEqual(msg, tmpdir.path);

--- a/test/parallel/test-cluster-dgram-1.js
+++ b/test/parallel/test-cluster-dgram-1.js
@@ -31,13 +31,13 @@ const assert = require('assert');
 const cluster = require('cluster');
 const dgram = require('dgram');
 
-if (cluster.isParent)
-  parent();
+if (cluster.isPrimary)
+  primary();
 else
   worker();
 
 
-function parent() {
+function primary() {
   let listening = 0;
 
   // Fork 4 workers.
@@ -100,7 +100,7 @@ function worker() {
   socket.on('message', common.mustCall((data, info) => {
     received++;
 
-    // Every 10 messages, notify the parent.
+    // Every 10 messages, notify the primary.
     if (received === PACKETS_PER_WORKER) {
       process.send({ received });
       socket.close();

--- a/test/parallel/test-cluster-dgram-1.js
+++ b/test/parallel/test-cluster-dgram-1.js
@@ -31,13 +31,13 @@ const assert = require('assert');
 const cluster = require('cluster');
 const dgram = require('dgram');
 
-if (cluster.isMaster)
-  master();
+if (cluster.isParent)
+  parent();
 else
   worker();
 
 
-function master() {
+function parent() {
   let listening = 0;
 
   // Fork 4 workers.
@@ -100,7 +100,7 @@ function worker() {
   socket.on('message', common.mustCall((data, info) => {
     received++;
 
-    // Every 10 messages, notify the master.
+    // Every 10 messages, notify the parent.
     if (received === PACKETS_PER_WORKER) {
       process.send({ received });
       socket.close();

--- a/test/parallel/test-cluster-dgram-2.js
+++ b/test/parallel/test-cluster-dgram-2.js
@@ -31,13 +31,13 @@ const cluster = require('cluster');
 const dgram = require('dgram');
 const assert = require('assert');
 
-if (cluster.isParent)
-  parent();
+if (cluster.isPrimary)
+  primary();
 else
   worker();
 
 
-function parent() {
+function primary() {
   let received = 0;
 
   // Start listening on a socket.
@@ -69,7 +69,7 @@ function parent() {
 
 
 function worker() {
-  // Create udp socket and send packets to parent.
+  // Create udp socket and send packets to primary.
   const socket = dgram.createSocket('udp4');
   const buf = Buffer.from('hello world');
 

--- a/test/parallel/test-cluster-dgram-2.js
+++ b/test/parallel/test-cluster-dgram-2.js
@@ -31,13 +31,13 @@ const cluster = require('cluster');
 const dgram = require('dgram');
 const assert = require('assert');
 
-if (cluster.isMaster)
-  master();
+if (cluster.isParent)
+  parent();
 else
   worker();
 
 
-function master() {
+function parent() {
   let received = 0;
 
   // Start listening on a socket.
@@ -69,7 +69,7 @@ function master() {
 
 
 function worker() {
-  // Create udp socket and send packets to master.
+  // Create udp socket and send packets to parent.
   const socket = dgram.createSocket('udp4');
   const buf = Buffer.from('hello world');
 

--- a/test/parallel/test-cluster-dgram-bind-fd.js
+++ b/test/parallel/test-cluster-dgram-bind-fd.js
@@ -11,13 +11,13 @@ const assert = require('assert');
 const cluster = require('cluster');
 const dgram = require('dgram');
 
-if (cluster.isParent)
-  parent();
+if (cluster.isPrimary)
+  primary();
 else
   worker();
 
 
-function parent() {
+function primary() {
   const { internalBinding } = require('internal/test/binding');
   const { UDP } = internalBinding('udp_wrap');
 
@@ -97,7 +97,7 @@ function worker() {
     socket.on('message', common.mustCall((data, info) => {
       received++;
 
-      // Every 10 messages, notify the parent.
+      // Every 10 messages, notify the primary.
       if (received === PACKETS_PER_WORKER) {
         process.send({ received });
         socket.close();

--- a/test/parallel/test-cluster-dgram-bind-fd.js
+++ b/test/parallel/test-cluster-dgram-bind-fd.js
@@ -11,13 +11,13 @@ const assert = require('assert');
 const cluster = require('cluster');
 const dgram = require('dgram');
 
-if (cluster.isMaster)
-  master();
+if (cluster.isParent)
+  parent();
 else
   worker();
 
 
-function master() {
+function parent() {
   const { internalBinding } = require('internal/test/binding');
   const { UDP } = internalBinding('udp_wrap');
 
@@ -97,7 +97,7 @@ function worker() {
     socket.on('message', common.mustCall((data, info) => {
       received++;
 
-      // Every 10 messages, notify the master.
+      // Every 10 messages, notify the parent.
       if (received === PACKETS_PER_WORKER) {
         process.send({ received });
         socket.close();

--- a/test/parallel/test-cluster-dgram-ipv6only.js
+++ b/test/parallel/test-cluster-dgram-ipv6only.js
@@ -12,7 +12,7 @@ const dgram = require('dgram');
 
 // This test ensures that the `ipv6Only` option in `dgram.createSock()`
 // works as expected.
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   cluster.fork().on('exit', common.mustCall((code) => {
     assert.strictEqual(code, 0);
   }));

--- a/test/parallel/test-cluster-dgram-ipv6only.js
+++ b/test/parallel/test-cluster-dgram-ipv6only.js
@@ -12,7 +12,7 @@ const dgram = require('dgram');
 
 // This test ensures that the `ipv6Only` option in `dgram.createSock()`
 // works as expected.
-if (cluster.isMaster) {
+if (cluster.isParent) {
   cluster.fork().on('exit', common.mustCall((code) => {
     assert.strictEqual(code, 0);
   }));

--- a/test/parallel/test-cluster-dgram-reuse.js
+++ b/test/parallel/test-cluster-dgram-reuse.js
@@ -7,7 +7,7 @@ const assert = require('assert');
 const cluster = require('cluster');
 const dgram = require('dgram');
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   cluster.fork().on('exit', common.mustCall((code) => {
     assert.strictEqual(code, 0);
   }));

--- a/test/parallel/test-cluster-dgram-reuse.js
+++ b/test/parallel/test-cluster-dgram-reuse.js
@@ -7,7 +7,7 @@ const assert = require('assert');
 const cluster = require('cluster');
 const dgram = require('dgram');
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   cluster.fork().on('exit', common.mustCall((code) => {
     assert.strictEqual(code, 0);
   }));

--- a/test/parallel/test-cluster-disconnect-before-exit.js
+++ b/test/parallel/test-cluster-disconnect-before-exit.js
@@ -23,7 +23,7 @@
 const common = require('../common');
 const cluster = require('cluster');
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   const worker = cluster.fork().on('online', common.mustCall(disconnect));
 
   function disconnect() {

--- a/test/parallel/test-cluster-disconnect-before-exit.js
+++ b/test/parallel/test-cluster-disconnect-before-exit.js
@@ -23,7 +23,7 @@
 const common = require('../common');
 const cluster = require('cluster');
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   const worker = cluster.fork().on('online', common.mustCall(disconnect));
 
   function disconnect() {

--- a/test/parallel/test-cluster-disconnect-exitedAfterDisconnect-race.js
+++ b/test/parallel/test-cluster-disconnect-exitedAfterDisconnect-race.js
@@ -7,7 +7,7 @@ const common = require('../common');
 const assert = require('assert');
 const cluster = require('cluster');
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   cluster.on('exit', (worker, code) => {
     assert.strictEqual(code, 0, `worker exited with code: ${code}, expected 0`);
   });

--- a/test/parallel/test-cluster-disconnect-exitedAfterDisconnect-race.js
+++ b/test/parallel/test-cluster-disconnect-exitedAfterDisconnect-race.js
@@ -7,7 +7,7 @@ const common = require('../common');
 const assert = require('assert');
 const cluster = require('cluster');
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   cluster.on('exit', (worker, code) => {
     assert.strictEqual(code, 0, `worker exited with code: ${code}, expected 0`);
   });

--- a/test/parallel/test-cluster-disconnect-idle-worker.js
+++ b/test/parallel/test-cluster-disconnect-idle-worker.js
@@ -25,7 +25,7 @@ const assert = require('assert');
 const cluster = require('cluster');
 const fork = cluster.fork;
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   fork(); // It is intentionally called `fork` instead of
   fork(); // `cluster.fork` to test that `this` is not used
   cluster.disconnect(common.mustCall(() => {

--- a/test/parallel/test-cluster-disconnect-idle-worker.js
+++ b/test/parallel/test-cluster-disconnect-idle-worker.js
@@ -25,7 +25,7 @@ const assert = require('assert');
 const cluster = require('cluster');
 const fork = cluster.fork;
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   fork(); // It is intentionally called `fork` instead of
   fork(); // `cluster.fork` to test that `this` is not used
   cluster.disconnect(common.mustCall(() => {

--- a/test/parallel/test-cluster-disconnect-leak.js
+++ b/test/parallel/test-cluster-disconnect-leak.js
@@ -8,7 +8,7 @@ const cluster = require('cluster');
 
 cluster.schedulingPolicy = cluster.SCHED_NONE;
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   const worker = cluster.fork();
 
   // This is the important part of the test: Confirm that `disconnect` fires.

--- a/test/parallel/test-cluster-disconnect-leak.js
+++ b/test/parallel/test-cluster-disconnect-leak.js
@@ -8,7 +8,7 @@ const cluster = require('cluster');
 
 cluster.schedulingPolicy = cluster.SCHED_NONE;
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   const worker = cluster.fork();
 
   // This is the important part of the test: Confirm that `disconnect` fires.

--- a/test/parallel/test-cluster-disconnect-race.js
+++ b/test/parallel/test-cluster-disconnect-race.js
@@ -13,7 +13,7 @@ const cluster = require('cluster');
 
 cluster.schedulingPolicy = cluster.SCHED_NONE;
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   let worker2;
 
   const worker1 = cluster.fork();

--- a/test/parallel/test-cluster-disconnect-race.js
+++ b/test/parallel/test-cluster-disconnect-race.js
@@ -13,7 +13,7 @@ const cluster = require('cluster');
 
 cluster.schedulingPolicy = cluster.SCHED_NONE;
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   let worker2;
 
   const worker1 = cluster.fork();

--- a/test/parallel/test-cluster-disconnect-unshared-tcp.js
+++ b/test/parallel/test-cluster-disconnect-unshared-tcp.js
@@ -26,7 +26,7 @@ process.env.NODE_CLUSTER_SCHED_POLICY = 'none';
 const cluster = require('cluster');
 const net = require('net');
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   const unbound = cluster.fork().on('online', bind);
 
   function bind() {

--- a/test/parallel/test-cluster-disconnect-unshared-tcp.js
+++ b/test/parallel/test-cluster-disconnect-unshared-tcp.js
@@ -26,7 +26,7 @@ process.env.NODE_CLUSTER_SCHED_POLICY = 'none';
 const cluster = require('cluster');
 const net = require('net');
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   const unbound = cluster.fork().on('online', bind);
 
   function bind() {

--- a/test/parallel/test-cluster-disconnect-unshared-udp.js
+++ b/test/parallel/test-cluster-disconnect-unshared-udp.js
@@ -29,7 +29,7 @@ if (common.isWindows)
 const cluster = require('cluster');
 const dgram = require('dgram');
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   const unbound = cluster.fork().on('online', bind);
 
   function bind() {

--- a/test/parallel/test-cluster-disconnect-unshared-udp.js
+++ b/test/parallel/test-cluster-disconnect-unshared-udp.js
@@ -29,7 +29,7 @@ if (common.isWindows)
 const cluster = require('cluster');
 const dgram = require('dgram');
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   const unbound = cluster.fork().on('online', bind);
 
   function bind() {

--- a/test/parallel/test-cluster-disconnect.js
+++ b/test/parallel/test-cluster-disconnect.js
@@ -33,7 +33,7 @@ if (cluster.isWorker) {
   net.createServer((socket) => {
     socket.end('echo');
   }).listen(0, '127.0.0.1');
-} else if (cluster.isMaster) {
+} else if (cluster.isParent) {
   const servers = 2;
   const serverPorts = new Set();
 

--- a/test/parallel/test-cluster-disconnect.js
+++ b/test/parallel/test-cluster-disconnect.js
@@ -33,7 +33,7 @@ if (cluster.isWorker) {
   net.createServer((socket) => {
     socket.end('echo');
   }).listen(0, '127.0.0.1');
-} else if (cluster.isParent) {
+} else if (cluster.isPrimary) {
   const servers = 2;
   const serverPorts = new Set();
 

--- a/test/parallel/test-cluster-eaccess.js
+++ b/test/parallel/test-cluster-eaccess.js
@@ -23,22 +23,22 @@
 const common = require('../common');
 
 // Test that errors propagated from cluster workers are properly
-// received in their master. Creates an EADDRINUSE condition by forking
-// a process in child cluster and propagates the error to the master.
+// received in their parent. Creates an EADDRINUSE condition by forking
+// a process in child cluster and propagates the error to the parent.
 
 const assert = require('assert');
 const cluster = require('cluster');
 const fork = require('child_process').fork;
 const net = require('net');
 
-if (cluster.isMaster && process.argv.length !== 3) {
-  // cluster.isMaster
+if (cluster.isParent && process.argv.length !== 3) {
+  // cluster.isParent
   const tmpdir = require('../common/tmpdir');
   tmpdir.refresh();
   const PIPE_NAME = common.PIPE;
   const worker = cluster.fork({ PIPE_NAME });
 
-  // Makes sure master is able to fork the worker
+  // Makes sure parent is able to fork the worker
   cluster.on('fork', common.mustCall());
 
   // Makes sure the worker is ready
@@ -59,7 +59,7 @@ if (cluster.isMaster && process.argv.length !== 3) {
     const server = net.createServer().listen(PIPE_NAME, function() {
       // Message child process so that it can exit
       cp.send('end');
-      // Inform master about the unexpected situation
+      // Inform parent about the unexpected situation
       process.send('PIPE should have been in use.');
     });
 

--- a/test/parallel/test-cluster-eaccess.js
+++ b/test/parallel/test-cluster-eaccess.js
@@ -23,22 +23,22 @@
 const common = require('../common');
 
 // Test that errors propagated from cluster workers are properly
-// received in their parent. Creates an EADDRINUSE condition by forking
-// a process in child cluster and propagates the error to the parent.
+// received in their primary. Creates an EADDRINUSE condition by forking
+// a process in child cluster and propagates the error to the primary.
 
 const assert = require('assert');
 const cluster = require('cluster');
 const fork = require('child_process').fork;
 const net = require('net');
 
-if (cluster.isParent && process.argv.length !== 3) {
-  // cluster.isParent
+if (cluster.isPrimary && process.argv.length !== 3) {
+  // cluster.isPrimary
   const tmpdir = require('../common/tmpdir');
   tmpdir.refresh();
   const PIPE_NAME = common.PIPE;
   const worker = cluster.fork({ PIPE_NAME });
 
-  // Makes sure parent is able to fork the worker
+  // Makes sure primary is able to fork the worker
   cluster.on('fork', common.mustCall());
 
   // Makes sure the worker is ready
@@ -59,14 +59,14 @@ if (cluster.isParent && process.argv.length !== 3) {
     const server = net.createServer().listen(PIPE_NAME, function() {
       // Message child process so that it can exit
       cp.send('end');
-      // Inform parent about the unexpected situation
+      // Inform primary about the unexpected situation
       process.send('PIPE should have been in use.');
     });
 
     server.on('error', function(err) {
       // Message to child process tells it to exit
       cp.send('end');
-      // Propagate error to parent
+      // Propagate error to primary
       process.send(err);
     });
   }));

--- a/test/parallel/test-cluster-eaddrinuse.js
+++ b/test/parallel/test-cluster-eaddrinuse.js
@@ -21,7 +21,7 @@
 
 'use strict';
 // Check that having a worker bind to a port that's already taken doesn't
-// leave the parent process in a confused state. Releasing the port and
+// leave the primary process in a confused state. Releasing the port and
 // trying again should Just Work[TM].
 
 const common = require('../common');

--- a/test/parallel/test-cluster-eaddrinuse.js
+++ b/test/parallel/test-cluster-eaddrinuse.js
@@ -21,7 +21,7 @@
 
 'use strict';
 // Check that having a worker bind to a port that's already taken doesn't
-// leave the master process in a confused state. Releasing the port and
+// leave the parent process in a confused state. Releasing the port and
 // trying again should Just Work[TM].
 
 const common = require('../common');

--- a/test/parallel/test-cluster-fork-env.js
+++ b/test/parallel/test-cluster-fork-env.js
@@ -36,7 +36,7 @@ if (cluster.isWorker) {
   });
 
   assert.strictEqual(result, true);
-} else if (cluster.isMaster) {
+} else if (cluster.isParent) {
 
   const checks = {
     using: false,

--- a/test/parallel/test-cluster-fork-env.js
+++ b/test/parallel/test-cluster-fork-env.js
@@ -36,7 +36,7 @@ if (cluster.isWorker) {
   });
 
   assert.strictEqual(result, true);
-} else if (cluster.isParent) {
+} else if (cluster.isPrimary) {
 
   const checks = {
     using: false,

--- a/test/parallel/test-cluster-fork-stdio.js
+++ b/test/parallel/test-cluster-fork-stdio.js
@@ -4,10 +4,10 @@ const assert = require('assert');
 const cluster = require('cluster');
 const net = require('net');
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   const buf = Buffer.from('foobar');
 
-  cluster.setupParent({
+  cluster.setupPrimary({
     stdio: ['pipe', 'pipe', 'pipe', 'ipc', 'pipe']
   });
 

--- a/test/parallel/test-cluster-fork-stdio.js
+++ b/test/parallel/test-cluster-fork-stdio.js
@@ -4,10 +4,10 @@ const assert = require('assert');
 const cluster = require('cluster');
 const net = require('net');
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   const buf = Buffer.from('foobar');
 
-  cluster.setupMaster({
+  cluster.setupParent({
     stdio: ['pipe', 'pipe', 'pipe', 'ipc', 'pipe']
   });
 

--- a/test/parallel/test-cluster-fork-windowsHide.js
+++ b/test/parallel/test-cluster-fork-windowsHide.js
@@ -14,7 +14,7 @@ if (!process.argv[2]) {
   //   by D with `detached: true`, no console window will pop up for W.
   //
   // So, we have to spawn a detached process first to run the actual test.
-  const master = child_process.spawn(
+  const parent = child_process.spawn(
     process.argv[0],
     [process.argv[1], '--cluster'],
     { detached: true, stdio: ['ignore', 'ignore', 'ignore', 'ipc'] });
@@ -31,19 +31,19 @@ if (!process.argv[2]) {
     })
   };
 
-  master.on('message', (msg) => {
+  parent.on('message', (msg) => {
     const handler = messageHandlers[msg.type];
     assert.ok(handler);
     handler(msg);
   });
 
-  master.on('exit', common.mustCall((code, signal) => {
+  parent.on('exit', common.mustCall((code, signal) => {
     assert.strictEqual(code, 0);
     assert.strictEqual(signal, null);
   }));
 
-} else if (cluster.isMaster) {
-  cluster.setupMaster({
+} else if (cluster.isParent) {
+  cluster.setupParent({
     silent: true,
     windowsHide: true
   });

--- a/test/parallel/test-cluster-fork-windowsHide.js
+++ b/test/parallel/test-cluster-fork-windowsHide.js
@@ -14,7 +14,7 @@ if (!process.argv[2]) {
   //   by D with `detached: true`, no console window will pop up for W.
   //
   // So, we have to spawn a detached process first to run the actual test.
-  const parent = child_process.spawn(
+  const primary = child_process.spawn(
     process.argv[0],
     [process.argv[1], '--cluster'],
     { detached: true, stdio: ['ignore', 'ignore', 'ignore', 'ipc'] });
@@ -31,19 +31,19 @@ if (!process.argv[2]) {
     })
   };
 
-  parent.on('message', (msg) => {
+  primary.on('message', (msg) => {
     const handler = messageHandlers[msg.type];
     assert.ok(handler);
     handler(msg);
   });
 
-  parent.on('exit', common.mustCall((code, signal) => {
+  primary.on('exit', common.mustCall((code, signal) => {
     assert.strictEqual(code, 0);
     assert.strictEqual(signal, null);
   }));
 
-} else if (cluster.isParent) {
-  cluster.setupParent({
+} else if (cluster.isPrimary) {
+  cluster.setupPrimary({
     silent: true,
     windowsHide: true
   });

--- a/test/parallel/test-cluster-http-pipe.js
+++ b/test/parallel/test-cluster-http-pipe.js
@@ -31,7 +31,7 @@ const assert = require('assert');
 const cluster = require('cluster');
 const http = require('http');
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   const tmpdir = require('../common/tmpdir');
   tmpdir.refresh();
   const worker = cluster.fork();

--- a/test/parallel/test-cluster-http-pipe.js
+++ b/test/parallel/test-cluster-http-pipe.js
@@ -31,7 +31,7 @@ const assert = require('assert');
 const cluster = require('cluster');
 const http = require('http');
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   const tmpdir = require('../common/tmpdir');
   tmpdir.refresh();
   const worker = cluster.fork();

--- a/test/parallel/test-cluster-invalid-message.js
+++ b/test/parallel/test-cluster-invalid-message.js
@@ -3,7 +3,7 @@ const common = require('../common');
 const assert = require('assert');
 const cluster = require('cluster');
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   const worker = cluster.fork();
 
   worker.on('exit', common.mustCall((code, signal) => {

--- a/test/parallel/test-cluster-invalid-message.js
+++ b/test/parallel/test-cluster-invalid-message.js
@@ -3,7 +3,7 @@ const common = require('../common');
 const assert = require('assert');
 const cluster = require('cluster');
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   const worker = cluster.fork();
 
   worker.on('exit', common.mustCall((code, signal) => {

--- a/test/parallel/test-cluster-ipc-throw.js
+++ b/test/parallel/test-cluster-ipc-throw.js
@@ -8,7 +8,7 @@ cluster.schedulingPolicy = cluster.SCHED_RR;
 
 const server = http.createServer();
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   server.listen({ port: 0 }, common.mustCall(() => {
     const worker = cluster.fork({ PORT: server.address().port });
     worker.on('exit', common.mustCall(() => {

--- a/test/parallel/test-cluster-ipc-throw.js
+++ b/test/parallel/test-cluster-ipc-throw.js
@@ -8,7 +8,7 @@ cluster.schedulingPolicy = cluster.SCHED_RR;
 
 const server = http.createServer();
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   server.listen({ port: 0 }, common.mustCall(() => {
     const worker = cluster.fork({ PORT: server.address().port });
     worker.on('exit', common.mustCall(() => {

--- a/test/parallel/test-cluster-kill-disconnect.js
+++ b/test/parallel/test-cluster-kill-disconnect.js
@@ -9,7 +9,7 @@ const common = require('../common');
 const assert = require('assert');
 const cluster = require('cluster');
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   function forkWorker(action) {
     const worker = cluster.fork({ action });
     worker.on('disconnect', common.mustCall(() => {

--- a/test/parallel/test-cluster-kill-disconnect.js
+++ b/test/parallel/test-cluster-kill-disconnect.js
@@ -9,7 +9,7 @@ const common = require('../common');
 const assert = require('assert');
 const cluster = require('cluster');
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   function forkWorker(action) {
     const worker = cluster.fork({ action });
     worker.on('disconnect', common.mustCall(() => {

--- a/test/parallel/test-cluster-kill-infinite-loop.js
+++ b/test/parallel/test-cluster-kill-infinite-loop.js
@@ -3,7 +3,7 @@ const common = require('../common');
 const cluster = require('cluster');
 const assert = require('assert');
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   const worker = cluster.fork();
 
   worker.on('online', common.mustCall(() => {

--- a/test/parallel/test-cluster-kill-infinite-loop.js
+++ b/test/parallel/test-cluster-kill-infinite-loop.js
@@ -3,7 +3,7 @@ const common = require('../common');
 const cluster = require('cluster');
 const assert = require('assert');
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   const worker = cluster.fork();
 
   worker.on('online', common.mustCall(() => {

--- a/test/parallel/test-cluster-listening-port.js
+++ b/test/parallel/test-cluster-listening-port.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 const cluster = require('cluster');
 const net = require('net');
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   cluster.fork();
   cluster.on('listening', common.mustCall(function(worker, address) {
     const port = address.port;

--- a/test/parallel/test-cluster-listening-port.js
+++ b/test/parallel/test-cluster-listening-port.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 const cluster = require('cluster');
 const net = require('net');
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   cluster.fork();
   cluster.on('listening', common.mustCall(function(worker, address) {
     const port = address.port;

--- a/test/parallel/test-cluster-message.js
+++ b/test/parallel/test-cluster-message.js
@@ -40,7 +40,7 @@ if (cluster.isWorker) {
   function maybeReply() {
     if (!socket || !message) return;
 
-    // Tell master using TCP socket that a message is received.
+    // Tell parent using TCP socket that a message is received.
     socket.write(JSON.stringify({
       code: 'received message',
       echo: message
@@ -61,14 +61,14 @@ if (cluster.isWorker) {
   });
 
   server.listen(0, '127.0.0.1');
-} else if (cluster.isMaster) {
+} else if (cluster.isParent) {
 
   const checks = {
     global: {
       'receive': false,
       'correct': false
     },
-    master: {
+    parent: {
       'receive': false,
       'correct': false
     },
@@ -101,7 +101,7 @@ if (cluster.isWorker) {
 
   // When a IPC message is received from the worker
   worker.on('message', function(message) {
-    check('master', message === 'message from worker');
+    check('parent', message === 'message from worker');
   });
   cluster.on('message', function(worker_, message) {
     assert.strictEqual(worker_, worker);
@@ -113,7 +113,7 @@ if (cluster.isWorker) {
 
     client = net.connect(address.port, function() {
       // Send message to worker.
-      worker.send('message from master');
+      worker.send('message from parent');
     });
 
     client.on('data', function(data) {
@@ -121,7 +121,7 @@ if (cluster.isWorker) {
       data = JSON.parse(data.toString());
 
       if (data.code === 'received message') {
-        check('worker', data.echo === 'message from master');
+        check('worker', data.echo === 'message from parent');
       } else {
         throw new Error(`wrong TCP message received: ${data}`);
       }

--- a/test/parallel/test-cluster-message.js
+++ b/test/parallel/test-cluster-message.js
@@ -40,7 +40,7 @@ if (cluster.isWorker) {
   function maybeReply() {
     if (!socket || !message) return;
 
-    // Tell parent using TCP socket that a message is received.
+    // Tell primary using TCP socket that a message is received.
     socket.write(JSON.stringify({
       code: 'received message',
       echo: message
@@ -61,14 +61,14 @@ if (cluster.isWorker) {
   });
 
   server.listen(0, '127.0.0.1');
-} else if (cluster.isParent) {
+} else if (cluster.isPrimary) {
 
   const checks = {
     global: {
       'receive': false,
       'correct': false
     },
-    parent: {
+    primary: {
       'receive': false,
       'correct': false
     },
@@ -101,7 +101,7 @@ if (cluster.isWorker) {
 
   // When a IPC message is received from the worker
   worker.on('message', function(message) {
-    check('parent', message === 'message from worker');
+    check('primary', message === 'message from worker');
   });
   cluster.on('message', function(worker_, message) {
     assert.strictEqual(worker_, worker);
@@ -113,7 +113,7 @@ if (cluster.isWorker) {
 
     client = net.connect(address.port, function() {
       // Send message to worker.
-      worker.send('message from parent');
+      worker.send('message from primary');
     });
 
     client.on('data', function(data) {
@@ -121,7 +121,7 @@ if (cluster.isWorker) {
       data = JSON.parse(data.toString());
 
       if (data.code === 'received message') {
-        check('worker', data.echo === 'message from parent');
+        check('worker', data.echo === 'message from primary');
       } else {
         throw new Error(`wrong TCP message received: ${data}`);
       }

--- a/test/parallel/test-cluster-net-listen-ipv6only-false.js
+++ b/test/parallel/test-cluster-net-listen-ipv6only-false.js
@@ -13,7 +13,7 @@ const net = require('net');
 const host = '::';
 const WORKER_COUNT = 3;
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   const workers = [];
   let address;
 

--- a/test/parallel/test-cluster-net-listen-ipv6only-false.js
+++ b/test/parallel/test-cluster-net-listen-ipv6only-false.js
@@ -13,7 +13,7 @@ const net = require('net');
 const host = '::';
 const WORKER_COUNT = 3;
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   const workers = [];
   let address;
 

--- a/test/parallel/test-cluster-net-listen-relative-path.js
+++ b/test/parallel/test-cluster-net-listen-relative-path.js
@@ -23,7 +23,7 @@ const socketName = 'A'.repeat(101 - socketDir.length);
 assert.ok(path.resolve(socketDir, socketName).length > 100,
           'absolute socket path should be longer than 100 bytes');
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   // Ensure that the worker exits peacefully.
   tmpdir.refresh();
   process.chdir(tmpdir.path);

--- a/test/parallel/test-cluster-net-listen-relative-path.js
+++ b/test/parallel/test-cluster-net-listen-relative-path.js
@@ -23,7 +23,7 @@ const socketName = 'A'.repeat(101 - socketDir.length);
 assert.ok(path.resolve(socketDir, socketName).length > 100,
           'absolute socket path should be longer than 100 bytes');
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   // Ensure that the worker exits peacefully.
   tmpdir.refresh();
   process.chdir(tmpdir.path);

--- a/test/parallel/test-cluster-net-listen.js
+++ b/test/parallel/test-cluster-net-listen.js
@@ -25,7 +25,7 @@ const assert = require('assert');
 const cluster = require('cluster');
 const net = require('net');
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   // Ensure that the worker exits peacefully
   cluster.fork().on('exit', common.mustCall(function(statusCode) {
     assert.strictEqual(statusCode, 0);

--- a/test/parallel/test-cluster-net-listen.js
+++ b/test/parallel/test-cluster-net-listen.js
@@ -25,7 +25,7 @@ const assert = require('assert');
 const cluster = require('cluster');
 const net = require('net');
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   // Ensure that the worker exits peacefully
   cluster.fork().on('exit', common.mustCall(function(statusCode) {
     assert.strictEqual(statusCode, 0);

--- a/test/parallel/test-cluster-net-send.js
+++ b/test/parallel/test-cluster-net-send.js
@@ -26,7 +26,7 @@ const fork = require('child_process').fork;
 const net = require('net');
 
 if (process.argv[2] !== 'child') {
-  console.error(`[${process.pid}] parent`);
+  console.error(`[${process.pid}] primary`);
 
   const worker = fork(__filename, ['child']);
   let called = false;

--- a/test/parallel/test-cluster-net-send.js
+++ b/test/parallel/test-cluster-net-send.js
@@ -26,7 +26,7 @@ const fork = require('child_process').fork;
 const net = require('net');
 
 if (process.argv[2] !== 'child') {
-  console.error(`[${process.pid}] master`);
+  console.error(`[${process.pid}] parent`);
 
   const worker = fork(__filename, ['child']);
   let called = false;

--- a/test/parallel/test-cluster-parent-error.js
+++ b/test/parallel/test-cluster-parent-error.js
@@ -73,10 +73,10 @@ if (cluster.isWorker) {
   const workers = [];
 
   // Spawn a cluster process
-  const master = fork(process.argv[1], ['cluster'], { silent: true });
+  const parent = fork(process.argv[1], ['cluster'], { silent: true });
 
   // Handle messages from the cluster
-  master.on('message', common.mustCall((data) => {
+  parent.on('message', common.mustCall((data) => {
     // Add worker pid to list and progress tracker
     if (data.cmd === 'worker') {
       workers.push(data.workerPID);
@@ -84,7 +84,7 @@ if (cluster.isWorker) {
   }, totalWorkers));
 
   // When cluster is dead
-  master.on('exit', common.mustCall((code) => {
+  parent.on('exit', common.mustCall((code) => {
     // Check that the cluster died accidentally (non-zero exit code)
     assert.strictEqual(code, 1);
 
@@ -92,7 +92,7 @@ if (cluster.isWorker) {
     // flaky – another process might end up being started right after the
     // workers finished and receive the same PID.
     const pollWorkers = () => {
-      // When master is dead all workers should be dead too
+      // When parent is dead all workers should be dead too
       if (workers.some((pid) => common.isAlive(pid))) {
         setTimeout(pollWorkers, 50);
       }

--- a/test/parallel/test-cluster-parent-kill.js
+++ b/test/parallel/test-cluster-parent-kill.js
@@ -52,19 +52,19 @@ if (cluster.isWorker) {
   const fork = require('child_process').fork;
 
   // Spawn a cluster process
-  const master = fork(process.argv[1], ['cluster']);
+  const parent = fork(process.argv[1], ['cluster']);
 
   // get pid info
   let pid = null;
-  master.once('message', (data) => {
+  parent.once('message', (data) => {
     pid = data.pid;
   });
 
-  // When master is dead
+  // When parent is dead
   let alive = true;
-  master.on('exit', common.mustCall((code) => {
+  parent.on('exit', common.mustCall((code) => {
 
-    // Make sure that the master died on purpose
+    // Make sure that the parent died on purpose
     assert.strictEqual(code, 0);
 
     // Check worker process status
@@ -82,7 +82,7 @@ if (cluster.isWorker) {
     assert.strictEqual(typeof pid, 'number',
                        `got ${pid} instead of a worker pid`);
     assert.strictEqual(alive, false,
-                       `worker was alive after master died (alive = ${alive})`);
+                       `worker was alive after parent died (alive = ${alive})`);
   });
 
 }

--- a/test/parallel/test-cluster-primary-error.js
+++ b/test/parallel/test-cluster-primary-error.js
@@ -73,10 +73,10 @@ if (cluster.isWorker) {
   const workers = [];
 
   // Spawn a cluster process
-  const parent = fork(process.argv[1], ['cluster'], { silent: true });
+  const primary = fork(process.argv[1], ['cluster'], { silent: true });
 
   // Handle messages from the cluster
-  parent.on('message', common.mustCall((data) => {
+  primary.on('message', common.mustCall((data) => {
     // Add worker pid to list and progress tracker
     if (data.cmd === 'worker') {
       workers.push(data.workerPID);
@@ -84,7 +84,7 @@ if (cluster.isWorker) {
   }, totalWorkers));
 
   // When cluster is dead
-  parent.on('exit', common.mustCall((code) => {
+  primary.on('exit', common.mustCall((code) => {
     // Check that the cluster died accidentally (non-zero exit code)
     assert.strictEqual(code, 1);
 
@@ -92,7 +92,7 @@ if (cluster.isWorker) {
     // flaky – another process might end up being started right after the
     // workers finished and receive the same PID.
     const pollWorkers = () => {
-      // When parent is dead all workers should be dead too
+      // When primary is dead all workers should be dead too
       if (workers.some((pid) => common.isAlive(pid))) {
         setTimeout(pollWorkers, 50);
       }

--- a/test/parallel/test-cluster-primary-kill.js
+++ b/test/parallel/test-cluster-primary-kill.js
@@ -52,19 +52,19 @@ if (cluster.isWorker) {
   const fork = require('child_process').fork;
 
   // Spawn a cluster process
-  const parent = fork(process.argv[1], ['cluster']);
+  const primary = fork(process.argv[1], ['cluster']);
 
   // get pid info
   let pid = null;
-  parent.once('message', (data) => {
+  primary.once('message', (data) => {
     pid = data.pid;
   });
 
-  // When parent is dead
+  // When primary is dead
   let alive = true;
-  parent.on('exit', common.mustCall((code) => {
+  primary.on('exit', common.mustCall((code) => {
 
-    // Make sure that the parent died on purpose
+    // Make sure that the primary died on purpose
     assert.strictEqual(code, 0);
 
     // Check worker process status
@@ -82,7 +82,8 @@ if (cluster.isWorker) {
     assert.strictEqual(typeof pid, 'number',
                        `got ${pid} instead of a worker pid`);
     assert.strictEqual(alive, false,
-                       `worker was alive after parent died (alive = ${alive})`);
+                       `worker was alive after primary died (alive = ${alive})`
+    );
   });
 
 }

--- a/test/parallel/test-cluster-process-disconnect.js
+++ b/test/parallel/test-cluster-process-disconnect.js
@@ -3,7 +3,7 @@ const common = require('../common');
 const assert = require('assert');
 const cluster = require('cluster');
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   const worker = cluster.fork();
   worker.on('exit', common.mustCall((code, signal) => {
     assert.strictEqual(

--- a/test/parallel/test-cluster-process-disconnect.js
+++ b/test/parallel/test-cluster-process-disconnect.js
@@ -3,7 +3,7 @@ const common = require('../common');
 const assert = require('assert');
 const cluster = require('cluster');
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   const worker = cluster.fork();
   worker.on('exit', common.mustCall((code, signal) => {
     assert.strictEqual(

--- a/test/parallel/test-cluster-rr-domain-listen.js
+++ b/test/parallel/test-cluster-rr-domain-listen.js
@@ -34,7 +34,7 @@ if (cluster.isWorker) {
   const http = require('http');
   http.Server(() => {}).listen(0, '127.0.0.1');
 
-} else if (cluster.isMaster) {
+} else if (cluster.isParent) {
 
   // Kill worker when listening
   cluster.on('listening', function() {

--- a/test/parallel/test-cluster-rr-domain-listen.js
+++ b/test/parallel/test-cluster-rr-domain-listen.js
@@ -34,7 +34,7 @@ if (cluster.isWorker) {
   const http = require('http');
   http.Server(() => {}).listen(0, '127.0.0.1');
 
-} else if (cluster.isParent) {
+} else if (cluster.isPrimary) {
 
   // Kill worker when listening
   cluster.on('listening', function() {

--- a/test/parallel/test-cluster-rr-ref.js
+++ b/test/parallel/test-cluster-rr-ref.js
@@ -4,7 +4,7 @@ const common = require('../common');
 const cluster = require('cluster');
 const net = require('net');
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   cluster.fork().on('message', function(msg) {
     if (msg === 'done') this.kill();
   });

--- a/test/parallel/test-cluster-rr-ref.js
+++ b/test/parallel/test-cluster-rr-ref.js
@@ -4,7 +4,7 @@ const common = require('../common');
 const cluster = require('cluster');
 const net = require('net');
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   cluster.fork().on('message', function(msg) {
     if (msg === 'done') this.kill();
   });

--- a/test/parallel/test-cluster-send-deadlock.js
+++ b/test/parallel/test-cluster-send-deadlock.js
@@ -20,15 +20,15 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-// Testing mutual send of handles: from parent to worker, and from worker to
-// parent.
+// Testing mutual send of handles: from primary to worker, and from worker to
+// primary.
 
 require('../common');
 const assert = require('assert');
 const cluster = require('cluster');
 const net = require('net');
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   const worker = cluster.fork();
   worker.on('exit', (code, signal) => {
     assert.strictEqual(code, 0, `Worker exited with an error code: ${code}`);

--- a/test/parallel/test-cluster-send-deadlock.js
+++ b/test/parallel/test-cluster-send-deadlock.js
@@ -20,15 +20,15 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-// Testing mutual send of handles: from master to worker, and from worker to
-// master.
+// Testing mutual send of handles: from parent to worker, and from worker to
+// parent.
 
 require('../common');
 const assert = require('assert');
 const cluster = require('cluster');
 const net = require('net');
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   const worker = cluster.fork();
   worker.on('exit', (code, signal) => {
     assert.strictEqual(code, 0, `Worker exited with an error code: ${code}`);

--- a/test/parallel/test-cluster-send-handle-twice.js
+++ b/test/parallel/test-cluster-send-handle-twice.js
@@ -31,7 +31,7 @@ const workers = {
   toStart: 1
 };
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   for (let i = 0; i < workers.toStart; ++i) {
     const worker = cluster.fork();
     worker.on('exit', common.mustCall(function(code, signal) {

--- a/test/parallel/test-cluster-send-handle-twice.js
+++ b/test/parallel/test-cluster-send-handle-twice.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-// Testing to send an handle twice to the parent process.
+// Testing to send an handle twice to the primary process.
 
 const common = require('../common');
 const assert = require('assert');
@@ -31,7 +31,7 @@ const workers = {
   toStart: 1
 };
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   for (let i = 0; i < workers.toStart; ++i) {
     const worker = cluster.fork();
     worker.on('exit', common.mustCall(function(code, signal) {

--- a/test/parallel/test-cluster-send-socket-to-worker-http-server.js
+++ b/test/parallel/test-cluster-send-socket-to-worker-http-server.js
@@ -10,7 +10,7 @@ const cluster = require('cluster');
 const http = require('http');
 const net = require('net');
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   const worker = cluster.fork();
   const server = net.createServer(common.mustCall((socket) => {
     worker.send('socket', socket);

--- a/test/parallel/test-cluster-send-socket-to-worker-http-server.js
+++ b/test/parallel/test-cluster-send-socket-to-worker-http-server.js
@@ -10,7 +10,7 @@ const cluster = require('cluster');
 const http = require('http');
 const net = require('net');
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   const worker = cluster.fork();
   const server = net.createServer(common.mustCall((socket) => {
     worker.send('socket', socket);

--- a/test/parallel/test-cluster-server-restart-none.js
+++ b/test/parallel/test-cluster-server-restart-none.js
@@ -5,7 +5,7 @@ const cluster = require('cluster');
 
 cluster.schedulingPolicy = cluster.SCHED_NONE;
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   const worker1 = cluster.fork();
   worker1.on('listening', common.mustCall(() => {
     const worker2 = cluster.fork();

--- a/test/parallel/test-cluster-server-restart-none.js
+++ b/test/parallel/test-cluster-server-restart-none.js
@@ -5,7 +5,7 @@ const cluster = require('cluster');
 
 cluster.schedulingPolicy = cluster.SCHED_NONE;
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   const worker1 = cluster.fork();
   worker1.on('listening', common.mustCall(() => {
     const worker2 = cluster.fork();

--- a/test/parallel/test-cluster-server-restart-rr.js
+++ b/test/parallel/test-cluster-server-restart-rr.js
@@ -5,7 +5,7 @@ const cluster = require('cluster');
 
 cluster.schedulingPolicy = cluster.SCHED_RR;
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   const worker1 = cluster.fork();
   worker1.on('listening', common.mustCall(() => {
     const worker2 = cluster.fork();

--- a/test/parallel/test-cluster-server-restart-rr.js
+++ b/test/parallel/test-cluster-server-restart-rr.js
@@ -5,7 +5,7 @@ const cluster = require('cluster');
 
 cluster.schedulingPolicy = cluster.SCHED_RR;
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   const worker1 = cluster.fork();
   worker1.on('listening', common.mustCall(() => {
     const worker2 = cluster.fork();

--- a/test/parallel/test-cluster-setup-master-argv.js
+++ b/test/parallel/test-cluster-setup-master-argv.js
@@ -36,4 +36,4 @@ cluster.on('setup', common.mustCall(function() {
 assert.notStrictEqual(process.argv[process.argv.length - 1], 'OMG,OMG');
 process.argv.push('OMG,OMG');
 process.argv.push('OMG,OMG');
-cluster.setupMaster();
+cluster.setupParent();

--- a/test/parallel/test-cluster-setup-master-cumulative.js
+++ b/test/parallel/test-cluster-setup-master-cumulative.js
@@ -24,12 +24,12 @@ require('../common');
 const assert = require('assert');
 const cluster = require('cluster');
 
-assert(cluster.isMaster);
+assert(cluster.isParent);
 
 // cluster.settings should not be initialized until needed
 assert.deepStrictEqual(cluster.settings, {});
 
-cluster.setupMaster();
+cluster.setupParent();
 assert.deepStrictEqual(cluster.settings, {
   args: process.argv.slice(2),
   exec: process.argv[1],
@@ -38,21 +38,21 @@ assert.deepStrictEqual(cluster.settings, {
 });
 console.log('ok sets defaults');
 
-cluster.setupMaster({ exec: 'overridden' });
+cluster.setupParent({ exec: 'overridden' });
 assert.strictEqual(cluster.settings.exec, 'overridden');
 console.log('ok overrides defaults');
 
-cluster.setupMaster({ args: ['foo', 'bar'] });
+cluster.setupParent({ args: ['foo', 'bar'] });
 assert.strictEqual(cluster.settings.exec, 'overridden');
 assert.deepStrictEqual(cluster.settings.args, ['foo', 'bar']);
 
-cluster.setupMaster({ execArgv: ['baz', 'bang'] });
+cluster.setupParent({ execArgv: ['baz', 'bang'] });
 assert.strictEqual(cluster.settings.exec, 'overridden');
 assert.deepStrictEqual(cluster.settings.args, ['foo', 'bar']);
 assert.deepStrictEqual(cluster.settings.execArgv, ['baz', 'bang']);
 console.log('ok preserves unchanged settings on repeated calls');
 
-cluster.setupMaster();
+cluster.setupParent();
 assert.deepStrictEqual(cluster.settings, {
   args: ['foo', 'bar'],
   exec: 'overridden',

--- a/test/parallel/test-cluster-setup-master-emit.js
+++ b/test/parallel/test-cluster-setup-master-emit.js
@@ -24,14 +24,14 @@ const common = require('../common');
 const assert = require('assert');
 const cluster = require('cluster');
 
-assert(cluster.isMaster);
+assert(cluster.isParent);
 
 function emitAndCatch(next) {
   cluster.once('setup', common.mustCall(function(settings) {
     assert.strictEqual(settings.exec, 'new-exec');
     setImmediate(next);
   }));
-  cluster.setupMaster({ exec: 'new-exec' });
+  cluster.setupParent({ exec: 'new-exec' });
 }
 
 function emitAndCatch2(next) {
@@ -39,7 +39,7 @@ function emitAndCatch2(next) {
     assert('exec' in settings);
     setImmediate(next);
   }));
-  cluster.setupMaster();
+  cluster.setupParent();
 }
 
 emitAndCatch(common.mustCall(function() {

--- a/test/parallel/test-cluster-setup-master-multiple.js
+++ b/test/parallel/test-cluster-setup-master-multiple.js
@@ -25,7 +25,7 @@ const assert = require('assert');
 const cluster = require('cluster');
 const debug = require('util').debuglog('test');
 
-assert(cluster.isMaster);
+assert(cluster.isParent);
 
 // The cluster.settings object is cloned even though the current implementation
 // makes that unnecessary. This is to make the test less fragile if the
@@ -48,7 +48,7 @@ const execs = [
 ];
 
 process.on('exit', () => {
-  // Tests that "setup" is emitted for every call to setupMaster
+  // Tests that "setup" is emitted for every call to setupParent
   assert.strictEqual(configs.length, execs.length);
 
   assert.strictEqual(configs[0].exec, execs[0]);
@@ -59,7 +59,7 @@ process.on('exit', () => {
 // Make changes to cluster settings
 execs.forEach((v, i) => {
   setTimeout(() => {
-    cluster.setupMaster({ exec: v });
+    cluster.setupParent({ exec: v });
   }, i * 100);
 });
 

--- a/test/parallel/test-cluster-setup-master.js
+++ b/test/parallel/test-cluster-setup-master.js
@@ -29,7 +29,7 @@ if (cluster.isWorker) {
   // Just keep the worker alive
   process.send(process.argv[2]);
 
-} else if (cluster.isMaster) {
+} else if (cluster.isParent) {
 
   const checks = {
     args: false,
@@ -40,8 +40,8 @@ if (cluster.isWorker) {
   const totalWorkers = 2;
   let settings;
 
-  // Setup master
-  cluster.setupMaster({
+  // Setup parent
+  cluster.setupParent({
     args: ['custom argument'],
     silent: true
   });

--- a/test/parallel/test-cluster-setup-primary-argv.js
+++ b/test/parallel/test-cluster-setup-primary-argv.js
@@ -24,24 +24,16 @@ const common = require('../common');
 const assert = require('assert');
 const cluster = require('cluster');
 
-assert(cluster.isParent);
+setTimeout(common.mustNotCall('setup not emitted'), 1000).unref();
 
-function emitAndCatch(next) {
-  cluster.once('setup', common.mustCall(function(settings) {
-    assert.strictEqual(settings.exec, 'new-exec');
-    setImmediate(next);
-  }));
-  cluster.setupParent({ exec: 'new-exec' });
-}
-
-function emitAndCatch2(next) {
-  cluster.once('setup', common.mustCall(function(settings) {
-    assert('exec' in settings);
-    setImmediate(next);
-  }));
-  cluster.setupParent();
-}
-
-emitAndCatch(common.mustCall(function() {
-  emitAndCatch2(common.mustCall());
+cluster.on('setup', common.mustCall(function() {
+  const clusterArgs = cluster.settings.args;
+  const realArgs = process.argv;
+  assert.strictEqual(clusterArgs[clusterArgs.length - 1],
+                     realArgs[realArgs.length - 1]);
 }));
+
+assert.notStrictEqual(process.argv[process.argv.length - 1], 'OMG,OMG');
+process.argv.push('OMG,OMG');
+process.argv.push('OMG,OMG');
+cluster.setupPrimary();

--- a/test/parallel/test-cluster-setup-primary-cumulative.js
+++ b/test/parallel/test-cluster-setup-primary-cumulative.js
@@ -20,20 +20,43 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const cluster = require('cluster');
 
-setTimeout(common.mustNotCall('setup not emitted'), 1000).unref();
+assert(cluster.isPrimary);
 
-cluster.on('setup', common.mustCall(function() {
-  const clusterArgs = cluster.settings.args;
-  const realArgs = process.argv;
-  assert.strictEqual(clusterArgs[clusterArgs.length - 1],
-                     realArgs[realArgs.length - 1]);
-}));
+// cluster.settings should not be initialized until needed
+assert.deepStrictEqual(cluster.settings, {});
 
-assert.notStrictEqual(process.argv[process.argv.length - 1], 'OMG,OMG');
-process.argv.push('OMG,OMG');
-process.argv.push('OMG,OMG');
-cluster.setupParent();
+cluster.setupPrimary();
+assert.deepStrictEqual(cluster.settings, {
+  args: process.argv.slice(2),
+  exec: process.argv[1],
+  execArgv: process.execArgv,
+  silent: false,
+});
+console.log('ok sets defaults');
+
+cluster.setupPrimary({ exec: 'overridden' });
+assert.strictEqual(cluster.settings.exec, 'overridden');
+console.log('ok overrides defaults');
+
+cluster.setupPrimary({ args: ['foo', 'bar'] });
+assert.strictEqual(cluster.settings.exec, 'overridden');
+assert.deepStrictEqual(cluster.settings.args, ['foo', 'bar']);
+
+cluster.setupPrimary({ execArgv: ['baz', 'bang'] });
+assert.strictEqual(cluster.settings.exec, 'overridden');
+assert.deepStrictEqual(cluster.settings.args, ['foo', 'bar']);
+assert.deepStrictEqual(cluster.settings.execArgv, ['baz', 'bang']);
+console.log('ok preserves unchanged settings on repeated calls');
+
+cluster.setupPrimary();
+assert.deepStrictEqual(cluster.settings, {
+  args: ['foo', 'bar'],
+  exec: 'overridden',
+  execArgv: ['baz', 'bang'],
+  silent: false,
+});
+console.log('ok preserves current settings');

--- a/test/parallel/test-cluster-setup-primary-emit.js
+++ b/test/parallel/test-cluster-setup-primary-emit.js
@@ -20,43 +20,28 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const cluster = require('cluster');
 
-assert(cluster.isParent);
+assert(cluster.isPrimary);
 
-// cluster.settings should not be initialized until needed
-assert.deepStrictEqual(cluster.settings, {});
+function emitAndCatch(next) {
+  cluster.once('setup', common.mustCall(function(settings) {
+    assert.strictEqual(settings.exec, 'new-exec');
+    setImmediate(next);
+  }));
+  cluster.setupPrimary({ exec: 'new-exec' });
+}
 
-cluster.setupParent();
-assert.deepStrictEqual(cluster.settings, {
-  args: process.argv.slice(2),
-  exec: process.argv[1],
-  execArgv: process.execArgv,
-  silent: false,
-});
-console.log('ok sets defaults');
+function emitAndCatch2(next) {
+  cluster.once('setup', common.mustCall(function(settings) {
+    assert('exec' in settings);
+    setImmediate(next);
+  }));
+  cluster.setupPrimary();
+}
 
-cluster.setupParent({ exec: 'overridden' });
-assert.strictEqual(cluster.settings.exec, 'overridden');
-console.log('ok overrides defaults');
-
-cluster.setupParent({ args: ['foo', 'bar'] });
-assert.strictEqual(cluster.settings.exec, 'overridden');
-assert.deepStrictEqual(cluster.settings.args, ['foo', 'bar']);
-
-cluster.setupParent({ execArgv: ['baz', 'bang'] });
-assert.strictEqual(cluster.settings.exec, 'overridden');
-assert.deepStrictEqual(cluster.settings.args, ['foo', 'bar']);
-assert.deepStrictEqual(cluster.settings.execArgv, ['baz', 'bang']);
-console.log('ok preserves unchanged settings on repeated calls');
-
-cluster.setupParent();
-assert.deepStrictEqual(cluster.settings, {
-  args: ['foo', 'bar'],
-  exec: 'overridden',
-  execArgv: ['baz', 'bang'],
-  silent: false,
-});
-console.log('ok preserves current settings');
+emitAndCatch(common.mustCall(function() {
+  emitAndCatch2(common.mustCall());
+}));

--- a/test/parallel/test-cluster-setup-primary-multiple.js
+++ b/test/parallel/test-cluster-setup-primary-multiple.js
@@ -25,7 +25,7 @@ const assert = require('assert');
 const cluster = require('cluster');
 const debug = require('util').debuglog('test');
 
-assert(cluster.isParent);
+assert(cluster.isPrimary);
 
 // The cluster.settings object is cloned even though the current implementation
 // makes that unnecessary. This is to make the test less fragile if the
@@ -48,7 +48,7 @@ const execs = [
 ];
 
 process.on('exit', () => {
-  // Tests that "setup" is emitted for every call to setupParent
+  // Tests that "setup" is emitted for every call to setupPrimary
   assert.strictEqual(configs.length, execs.length);
 
   assert.strictEqual(configs[0].exec, execs[0]);
@@ -59,7 +59,7 @@ process.on('exit', () => {
 // Make changes to cluster settings
 execs.forEach((v, i) => {
   setTimeout(() => {
-    cluster.setupParent({ exec: v });
+    cluster.setupPrimary({ exec: v });
   }, i * 100);
 });
 

--- a/test/parallel/test-cluster-setup-primary.js
+++ b/test/parallel/test-cluster-setup-primary.js
@@ -29,7 +29,7 @@ if (cluster.isWorker) {
   // Just keep the worker alive
   process.send(process.argv[2]);
 
-} else if (cluster.isParent) {
+} else if (cluster.isPrimary) {
 
   const checks = {
     args: false,
@@ -40,8 +40,8 @@ if (cluster.isWorker) {
   const totalWorkers = 2;
   let settings;
 
-  // Setup parent
-  cluster.setupParent({
+  // Setup primary
+  cluster.setupPrimary({
     args: ['custom argument'],
     silent: true
   });

--- a/test/parallel/test-cluster-shared-handle-bind-error.js
+++ b/test/parallel/test-cluster-shared-handle-bind-error.js
@@ -25,8 +25,8 @@ const assert = require('assert');
 const cluster = require('cluster');
 const net = require('net');
 
-if (cluster.isParent) {
-  // Parent opens and binds the socket and shares it with the worker.
+if (cluster.isPrimary) {
+  // Primary opens and binds the socket and shares it with the worker.
   cluster.schedulingPolicy = cluster.SCHED_NONE;
   // Hog the TCP port so that when the worker tries to bind, it'll fail.
   const server = net.createServer(common.mustNotCall());

--- a/test/parallel/test-cluster-shared-handle-bind-error.js
+++ b/test/parallel/test-cluster-shared-handle-bind-error.js
@@ -25,8 +25,8 @@ const assert = require('assert');
 const cluster = require('cluster');
 const net = require('net');
 
-if (cluster.isMaster) {
-  // Master opens and binds the socket and shares it with the worker.
+if (cluster.isParent) {
+  // Parent opens and binds the socket and shares it with the worker.
   cluster.schedulingPolicy = cluster.SCHED_NONE;
   // Hog the TCP port so that when the worker tries to bind, it'll fail.
   const server = net.createServer(common.mustNotCall());

--- a/test/parallel/test-cluster-shared-handle-bind-privileged-port.js
+++ b/test/parallel/test-cluster-shared-handle-bind-privileged-port.js
@@ -39,8 +39,8 @@ const assert = require('assert');
 const cluster = require('cluster');
 const net = require('net');
 
-if (cluster.isMaster) {
-  // Master opens and binds the socket and shares it with the worker.
+if (cluster.isParent) {
+  // Parent opens and binds the socket and shares it with the worker.
   cluster.schedulingPolicy = cluster.SCHED_NONE;
   cluster.fork().on('exit', common.mustCall(function(exitCode) {
     assert.strictEqual(exitCode, 0);

--- a/test/parallel/test-cluster-shared-handle-bind-privileged-port.js
+++ b/test/parallel/test-cluster-shared-handle-bind-privileged-port.js
@@ -39,8 +39,8 @@ const assert = require('assert');
 const cluster = require('cluster');
 const net = require('net');
 
-if (cluster.isParent) {
-  // Parent opens and binds the socket and shares it with the worker.
+if (cluster.isPrimary) {
+  // Primary opens and binds the socket and shares it with the worker.
   cluster.schedulingPolicy = cluster.SCHED_NONE;
   cluster.fork().on('exit', common.mustCall(function(exitCode) {
     assert.strictEqual(exitCode, 0);

--- a/test/parallel/test-cluster-shared-leak.js
+++ b/test/parallel/test-cluster-shared-leak.js
@@ -9,7 +9,7 @@ const net = require('net');
 const cluster = require('cluster');
 cluster.schedulingPolicy = cluster.SCHED_NONE;
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   let conn, worker2;
 
   const worker1 = cluster.fork();

--- a/test/parallel/test-cluster-shared-leak.js
+++ b/test/parallel/test-cluster-shared-leak.js
@@ -9,7 +9,7 @@ const net = require('net');
 const cluster = require('cluster');
 cluster.schedulingPolicy = cluster.SCHED_NONE;
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   let conn, worker2;
 
   const worker1 = cluster.fork();

--- a/test/parallel/test-cluster-uncaught-exception.js
+++ b/test/parallel/test-cluster-uncaught-exception.js
@@ -34,16 +34,16 @@ const MAGIC_EXIT_CODE = 42;
 const isTestRunner = process.argv[2] !== 'child';
 
 if (isTestRunner) {
-  const parent = fork(__filename, ['child']);
-  parent.on('exit', common.mustCall((code) => {
+  const primary = fork(__filename, ['child']);
+  primary.on('exit', common.mustCall((code) => {
     assert.strictEqual(code, MAGIC_EXIT_CODE);
   }));
-} else if (cluster.isParent) {
+} else if (cluster.isPrimary) {
   process.on('uncaughtException', common.mustCall(() => {
     process.nextTick(() => process.exit(MAGIC_EXIT_CODE));
   }));
   cluster.fork();
-  throw new Error('kill parent');
+  throw new Error('kill primary');
 } else { // worker
   process.exit();
 }

--- a/test/parallel/test-cluster-uncaught-exception.js
+++ b/test/parallel/test-cluster-uncaught-exception.js
@@ -34,16 +34,16 @@ const MAGIC_EXIT_CODE = 42;
 const isTestRunner = process.argv[2] !== 'child';
 
 if (isTestRunner) {
-  const master = fork(__filename, ['child']);
-  master.on('exit', common.mustCall((code) => {
+  const parent = fork(__filename, ['child']);
+  parent.on('exit', common.mustCall((code) => {
     assert.strictEqual(code, MAGIC_EXIT_CODE);
   }));
-} else if (cluster.isMaster) {
+} else if (cluster.isParent) {
   process.on('uncaughtException', common.mustCall(() => {
     process.nextTick(() => process.exit(MAGIC_EXIT_CODE));
   }));
   cluster.fork();
-  throw new Error('kill master');
+  throw new Error('kill parent');
 } else { // worker
   process.exit();
 }

--- a/test/parallel/test-cluster-worker-death.js
+++ b/test/parallel/test-cluster-worker-death.js
@@ -24,7 +24,7 @@ const common = require('../common');
 const assert = require('assert');
 const cluster = require('cluster');
 
-if (!cluster.isParent) {
+if (!cluster.isPrimary) {
   process.exit(42);
 } else {
   const worker = cluster.fork();

--- a/test/parallel/test-cluster-worker-death.js
+++ b/test/parallel/test-cluster-worker-death.js
@@ -24,7 +24,7 @@ const common = require('../common');
 const assert = require('assert');
 const cluster = require('cluster');
 
-if (!cluster.isMaster) {
+if (!cluster.isParent) {
   process.exit(42);
 } else {
   const worker = cluster.fork();

--- a/test/parallel/test-cluster-worker-destroy.js
+++ b/test/parallel/test-cluster-worker-destroy.js
@@ -24,7 +24,7 @@
 // The goal of this test is to cover the Workers' implementation of
 // Worker.prototype.destroy. Worker.prototype.destroy is called within
 // the worker's context: once when the worker is still connected to the
-// master, and another time when it's not connected to it, so that we cover
+// parent, and another time when it's not connected to it, so that we cover
 // both code paths.
 
 const common = require('../common');
@@ -32,7 +32,7 @@ const assert = require('assert');
 const cluster = require('cluster');
 let worker1, worker2;
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   worker1 = cluster.fork();
   worker2 = cluster.fork();
 

--- a/test/parallel/test-cluster-worker-destroy.js
+++ b/test/parallel/test-cluster-worker-destroy.js
@@ -24,7 +24,7 @@
 // The goal of this test is to cover the Workers' implementation of
 // Worker.prototype.destroy. Worker.prototype.destroy is called within
 // the worker's context: once when the worker is still connected to the
-// parent, and another time when it's not connected to it, so that we cover
+// primary, and another time when it's not connected to it, so that we cover
 // both code paths.
 
 const common = require('../common');
@@ -32,7 +32,7 @@ const assert = require('assert');
 const cluster = require('cluster');
 let worker1, worker2;
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   worker1 = cluster.fork();
   worker2 = cluster.fork();
 

--- a/test/parallel/test-cluster-worker-disconnect-on-error.js
+++ b/test/parallel/test-cluster-worker-disconnect-on-error.js
@@ -7,7 +7,7 @@ const assert = require('assert');
 cluster.schedulingPolicy = cluster.SCHED_NONE;
 
 const server = http.createServer();
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   let worker;
 
   server.listen(0, common.mustSucceed(() => {

--- a/test/parallel/test-cluster-worker-disconnect-on-error.js
+++ b/test/parallel/test-cluster-worker-disconnect-on-error.js
@@ -7,7 +7,7 @@ const assert = require('assert');
 cluster.schedulingPolicy = cluster.SCHED_NONE;
 
 const server = http.createServer();
-if (cluster.isMaster) {
+if (cluster.isParent) {
   let worker;
 
   server.listen(0, common.mustSucceed(() => {

--- a/test/parallel/test-cluster-worker-disconnect.js
+++ b/test/parallel/test-cluster-worker-disconnect.js
@@ -34,7 +34,7 @@ if (cluster.isWorker) {
     process.exit(42);
   }));
 
-} else if (cluster.isMaster) {
+} else if (cluster.isParent) {
 
   const checks = {
     cluster: {

--- a/test/parallel/test-cluster-worker-disconnect.js
+++ b/test/parallel/test-cluster-worker-disconnect.js
@@ -34,7 +34,7 @@ if (cluster.isWorker) {
     process.exit(42);
   }));
 
-} else if (cluster.isParent) {
+} else if (cluster.isPrimary) {
 
   const checks = {
     cluster: {

--- a/test/parallel/test-cluster-worker-events.js
+++ b/test/parallel/test-cluster-worker-events.js
@@ -26,7 +26,7 @@ const cluster = require('cluster');
 
 const OK = 2;
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
 
   const worker = cluster.fork();
 

--- a/test/parallel/test-cluster-worker-events.js
+++ b/test/parallel/test-cluster-worker-events.js
@@ -26,7 +26,7 @@ const cluster = require('cluster');
 
 const OK = 2;
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
 
   const worker = cluster.fork();
 

--- a/test/parallel/test-cluster-worker-exit.js
+++ b/test/parallel/test-cluster-worker-exit.js
@@ -42,7 +42,7 @@ if (cluster.isWorker) {
   }));
   server.listen(0, '127.0.0.1');
 
-} else if (cluster.isMaster) {
+} else if (cluster.isParent) {
 
   const expected_results = {
     cluster_emitDisconnect: [1, "the cluster did not emit 'disconnect'"],

--- a/test/parallel/test-cluster-worker-exit.js
+++ b/test/parallel/test-cluster-worker-exit.js
@@ -22,7 +22,7 @@
 'use strict';
 // test-cluster-worker-exit.js
 // verifies that, when a child process exits (by calling `process.exit(code)`)
-// - the parent receives the proper events in the proper order, no duplicates
+// - the primary receives the proper events in the proper order, no duplicates
 // - the exitCode and signalCode are correct in the 'exit' event
 // - the worker.exitedAfterDisconnect flag, and worker.state are correct
 // - the worker process actually goes away
@@ -42,7 +42,7 @@ if (cluster.isWorker) {
   }));
   server.listen(0, '127.0.0.1');
 
-} else if (cluster.isParent) {
+} else if (cluster.isPrimary) {
 
   const expected_results = {
     cluster_emitDisconnect: [1, "the cluster did not emit 'disconnect'"],

--- a/test/parallel/test-cluster-worker-init.js
+++ b/test/parallel/test-cluster-worker-init.js
@@ -29,7 +29,7 @@ const assert = require('assert');
 const cluster = require('cluster');
 const msg = 'foo';
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   const worker = cluster.fork();
 
   worker.on('message', common.mustCall((message) => {

--- a/test/parallel/test-cluster-worker-init.js
+++ b/test/parallel/test-cluster-worker-init.js
@@ -29,7 +29,7 @@ const assert = require('assert');
 const cluster = require('cluster');
 const msg = 'foo';
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   const worker = cluster.fork();
 
   worker.on('message', common.mustCall((message) => {

--- a/test/parallel/test-cluster-worker-isconnected.js
+++ b/test/parallel/test-cluster-worker-isconnected.js
@@ -3,7 +3,7 @@ const common = require('../common');
 const cluster = require('cluster');
 const assert = require('assert');
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   const worker = cluster.fork();
 
   assert.strictEqual(worker.isConnected(), true);

--- a/test/parallel/test-cluster-worker-isconnected.js
+++ b/test/parallel/test-cluster-worker-isconnected.js
@@ -3,7 +3,7 @@ const common = require('../common');
 const cluster = require('cluster');
 const assert = require('assert');
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   const worker = cluster.fork();
 
   assert.strictEqual(worker.isConnected(), true);

--- a/test/parallel/test-cluster-worker-isdead.js
+++ b/test/parallel/test-cluster-worker-isdead.js
@@ -3,7 +3,7 @@ require('../common');
 const cluster = require('cluster');
 const assert = require('assert');
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   const worker = cluster.fork();
   let workerDead = worker.isDead();
   assert.ok(!workerDead,

--- a/test/parallel/test-cluster-worker-isdead.js
+++ b/test/parallel/test-cluster-worker-isdead.js
@@ -3,7 +3,7 @@ require('../common');
 const cluster = require('cluster');
 const assert = require('assert');
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   const worker = cluster.fork();
   let workerDead = worker.isDead();
   assert.ok(!workerDead,

--- a/test/parallel/test-cluster-worker-kill.js
+++ b/test/parallel/test-cluster-worker-kill.js
@@ -22,7 +22,7 @@
 'use strict';
 // test-cluster-worker-kill.js
 // verifies that, when a child process is killed (we use SIGKILL)
-// - the parent receives the proper events in the proper order, no duplicates
+// - the primary receives the proper events in the proper order, no duplicates
 // - the exitCode and signalCode are correct in the 'exit' event
 // - the worker.exitedAfterDisconnect flag, and worker.state are correct
 // - the worker process actually goes away
@@ -38,7 +38,7 @@ if (cluster.isWorker) {
   server.once('listening', common.mustCall(() => { }));
   server.listen(0, '127.0.0.1');
 
-} else if (cluster.isParent) {
+} else if (cluster.isPrimary) {
 
   const KILL_SIGNAL = 'SIGKILL';
   const expected_results = {

--- a/test/parallel/test-cluster-worker-kill.js
+++ b/test/parallel/test-cluster-worker-kill.js
@@ -38,7 +38,7 @@ if (cluster.isWorker) {
   server.once('listening', common.mustCall(() => { }));
   server.listen(0, '127.0.0.1');
 
-} else if (cluster.isMaster) {
+} else if (cluster.isParent) {
 
   const KILL_SIGNAL = 'SIGKILL';
   const expected_results = {

--- a/test/parallel/test-cluster-worker-no-exit.js
+++ b/test/parallel/test-cluster-worker-no-exit.js
@@ -40,7 +40,7 @@ let server;
 // 3 wait to confirm it did not exit
 // 4 destroy connection
 // 5 confirm it does exit
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   server = net.createServer(function(conn) {
     server.close();
     worker.disconnect();

--- a/test/parallel/test-cluster-worker-no-exit.js
+++ b/test/parallel/test-cluster-worker-no-exit.js
@@ -40,7 +40,7 @@ let server;
 // 3 wait to confirm it did not exit
 // 4 destroy connection
 // 5 confirm it does exit
-if (cluster.isMaster) {
+if (cluster.isParent) {
   server = net.createServer(function(conn) {
     server.close();
     worker.disconnect();

--- a/test/parallel/test-cluster-worker-wait-server-close.js
+++ b/test/parallel/test-cluster-worker-wait-server-close.js
@@ -28,7 +28,7 @@ if (cluster.isWorker) {
     assert(serverClosed);
     clearInterval(keepOpen);
   });
-} else if (cluster.isParent) {
+} else if (cluster.isPrimary) {
   // start worker
   const worker = cluster.fork();
 

--- a/test/parallel/test-cluster-worker-wait-server-close.js
+++ b/test/parallel/test-cluster-worker-wait-server-close.js
@@ -28,7 +28,7 @@ if (cluster.isWorker) {
     assert(serverClosed);
     clearInterval(keepOpen);
   });
-} else if (cluster.isMaster) {
+} else if (cluster.isParent) {
   // start worker
   const worker = cluster.fork();
 

--- a/test/parallel/test-dgram-cluster-bind-error.js
+++ b/test/parallel/test-dgram-cluster-bind-error.js
@@ -7,7 +7,7 @@ const dgram = require('dgram');
 const { internalBinding } = require('internal/test/binding');
 const { UV_UNKNOWN } = internalBinding('uv');
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   cluster.fork();
 } else {
   // When the socket attempts to bind, it requests a handle from the cluster.

--- a/test/parallel/test-dgram-cluster-bind-error.js
+++ b/test/parallel/test-dgram-cluster-bind-error.js
@@ -7,7 +7,7 @@ const dgram = require('dgram');
 const { internalBinding } = require('internal/test/binding');
 const { UV_UNKNOWN } = internalBinding('uv');
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   cluster.fork();
 } else {
   // When the socket attempts to bind, it requests a handle from the cluster.

--- a/test/parallel/test-dgram-cluster-close-during-bind.js
+++ b/test/parallel/test-dgram-cluster-close-during-bind.js
@@ -7,7 +7,7 @@ const assert = require('assert');
 const cluster = require('cluster');
 const dgram = require('dgram');
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   cluster.fork();
 } else {
   // When the socket attempts to bind, it requests a handle from the cluster.

--- a/test/parallel/test-dgram-cluster-close-during-bind.js
+++ b/test/parallel/test-dgram-cluster-close-during-bind.js
@@ -7,7 +7,7 @@ const assert = require('assert');
 const cluster = require('cluster');
 const dgram = require('dgram');
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   cluster.fork();
 } else {
   // When the socket attempts to bind, it requests a handle from the cluster.

--- a/test/parallel/test-dgram-exclusive-implicit-bind.js
+++ b/test/parallel/test-dgram-exclusive-implicit-bind.js
@@ -30,16 +30,16 @@ const dgram = require('dgram');
 // number causes all sockets bound to that number to share a port.
 //
 // The 2 workers that call bind() will share a port, the two workers that do
-// not will not share a port, so parent will see 3 unique source ports.
+// not will not share a port, so primary will see 3 unique source ports.
 
 // Note that on Windows, clustered dgram is not supported. Since explicit
 // binding causes the dgram to be clustered, don't fork the workers that bind.
 // This is a useful test, still, because it demonstrates that by avoiding
 // clustering, client (ephemeral, implicitly bound) dgram sockets become
-// supported while using cluster, though servers still cause the parent to error
-// with ENOTSUP.
+// supported while using cluster, though servers still cause the primary
+// to error with ENOTSUP.
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   let messages = 0;
   const ports = {};
   const pids = [];

--- a/test/parallel/test-dgram-exclusive-implicit-bind.js
+++ b/test/parallel/test-dgram-exclusive-implicit-bind.js
@@ -30,16 +30,16 @@ const dgram = require('dgram');
 // number causes all sockets bound to that number to share a port.
 //
 // The 2 workers that call bind() will share a port, the two workers that do
-// not will not share a port, so master will see 3 unique source ports.
+// not will not share a port, so parent will see 3 unique source ports.
 
 // Note that on Windows, clustered dgram is not supported. Since explicit
 // binding causes the dgram to be clustered, don't fork the workers that bind.
 // This is a useful test, still, because it demonstrates that by avoiding
 // clustering, client (ephemeral, implicitly bound) dgram sockets become
-// supported while using cluster, though servers still cause the master to error
+// supported while using cluster, though servers still cause the parent to error
 // with ENOTSUP.
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   let messages = 0;
   const ports = {};
   const pids = [];

--- a/test/parallel/test-inspect-support-for-node_options.js
+++ b/test/parallel/test-inspect-support-for-node_options.js
@@ -13,7 +13,7 @@ function checkForInspectSupport(flag) {
   const numWorkers = 2;
   process.env.NODE_OPTIONS = flag;
 
-  if (cluster.isMaster) {
+  if (cluster.isParent) {
     for (let i = 0; i < numWorkers; i++) {
       cluster.fork();
     }

--- a/test/parallel/test-inspect-support-for-node_options.js
+++ b/test/parallel/test-inspect-support-for-node_options.js
@@ -13,7 +13,7 @@ function checkForInspectSupport(flag) {
   const numWorkers = 2;
   process.env.NODE_OPTIONS = flag;
 
-  if (cluster.isParent) {
+  if (cluster.isPrimary) {
     for (let i = 0; i < numWorkers; i++) {
       cluster.fork();
     }

--- a/test/parallel/test-inspector-port-zero-cluster.js
+++ b/test/parallel/test-inspector-port-zero-cluster.js
@@ -28,11 +28,11 @@ function serialFork() {
   });
 }
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   Promise.all([serialFork(), serialFork(), serialFork()])
     .then(common.mustCall((ports) => {
       ports.splice(0, 0, process.debugPort);
-      // 4 = [parent, worker1, worker2, worker3].length()
+      // 4 = [primary, worker1, worker2, worker3].length()
       assert.strictEqual(ports.length, 4);
       assert(ports.every((port) => port > 0));
       assert(ports.every((port) => port < 65536));

--- a/test/parallel/test-inspector-port-zero-cluster.js
+++ b/test/parallel/test-inspector-port-zero-cluster.js
@@ -28,11 +28,11 @@ function serialFork() {
   });
 }
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   Promise.all([serialFork(), serialFork(), serialFork()])
     .then(common.mustCall((ports) => {
       ports.splice(0, 0, process.debugPort);
-      // 4 = [master, worker1, worker2, worker3].length()
+      // 4 = [parent, worker1, worker2, worker3].length()
       assert.strictEqual(ports.length, 4);
       assert(ports.every((port) => port > 0));
       assert(ports.every((port) => port < 65536));

--- a/test/parallel/test-net-listen-exclusive-random-ports.js
+++ b/test/parallel/test-net-listen-exclusive-random-ports.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 const cluster = require('cluster');
 const net = require('net');
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   const worker1 = cluster.fork();
 
   worker1.on('message', function(port1) {

--- a/test/parallel/test-net-listen-exclusive-random-ports.js
+++ b/test/parallel/test-net-listen-exclusive-random-ports.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 const cluster = require('cluster');
 const net = require('net');
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   const worker1 = cluster.fork();
 
   worker1.on('message', function(port1) {

--- a/test/parallel/test-net-socket-constructor.js
+++ b/test/parallel/test-net-socket-constructor.js
@@ -26,7 +26,7 @@ function test(sock, readable, writable) {
   assert.strictEqual(socket.writable, writable);
 }
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   test(undefined, true, true);
 
   const server = net.createServer(common.mustCall((socket) => {
@@ -48,7 +48,7 @@ if (cluster.isMaster) {
     test(socket, true, true);
   }));
 
-  cluster.setupMaster({
+  cluster.setupParent({
     stdio: ['pipe', 'pipe', 'pipe', 'ipc', 'pipe', 'pipe', 'pipe']
   });
 

--- a/test/parallel/test-net-socket-constructor.js
+++ b/test/parallel/test-net-socket-constructor.js
@@ -26,7 +26,7 @@ function test(sock, readable, writable) {
   assert.strictEqual(socket.writable, writable);
 }
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   test(undefined, true, true);
 
   const server = net.createServer(common.mustCall((socket) => {
@@ -48,7 +48,7 @@ if (cluster.isParent) {
     test(socket, true, true);
   }));
 
-  cluster.setupParent({
+  cluster.setupPrimary({
     stdio: ['pipe', 'pipe', 'pipe', 'ipc', 'pipe', 'pipe', 'pipe']
   });
 

--- a/test/parallel/test-process-remove-all-signal-listeners.js
+++ b/test/parallel/test-process-remove-all-signal-listeners.js
@@ -8,7 +8,7 @@ const assert = require('assert');
 const spawn = require('child_process').spawn;
 
 if (process.argv[2] !== '--do-test') {
-  // We are the master, fork a child so we can verify it exits with correct
+  // We are the parent, fork a child so we can verify it exits with correct
   // status.
   process.env.DOTEST = 'y';
   const child = spawn(process.execPath, [__filename, '--do-test']);

--- a/test/parallel/test-process-remove-all-signal-listeners.js
+++ b/test/parallel/test-process-remove-all-signal-listeners.js
@@ -8,7 +8,7 @@ const assert = require('assert');
 const spawn = require('child_process').spawn;
 
 if (process.argv[2] !== '--do-test') {
-  // We are the parent, fork a child so we can verify it exits with correct
+  // We are the primary, fork a child so we can verify it exits with correct
   // status.
   process.env.DOTEST = 'y';
   const child = spawn(process.execPath, [__filename, '--do-test']);

--- a/test/parallel/test-tls-ticket-cluster.js
+++ b/test/parallel/test-tls-ticket-cluster.js
@@ -32,7 +32,7 @@ const fixtures = require('../common/fixtures');
 const workerCount = 4;
 const expectedReqCount = 16;
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   let reusedCount = 0;
   let reqCount = 0;
   let lastSession = null;
@@ -40,7 +40,7 @@ if (cluster.isMaster) {
   let workerPort = null;
 
   function shoot() {
-    console.error('[master] connecting', workerPort, 'session?', !!lastSession);
+    console.error('[parent] connecting', workerPort, 'session?', !!lastSession);
     const c = tls.connect(workerPort, {
       session: lastSession,
       rejectUnauthorized: false
@@ -69,7 +69,7 @@ if (cluster.isMaster) {
   function fork() {
     const worker = cluster.fork();
     worker.on('message', ({ msg, port }) => {
-      console.error('[master] got %j', msg);
+      console.error('[parent] got %j', msg);
       if (msg === 'reused') {
         ++reusedCount;
       } else if (msg === 'listening' && !shootOnce) {
@@ -80,7 +80,7 @@ if (cluster.isMaster) {
     });
 
     worker.on('exit', () => {
-      console.error('[master] worker died');
+      console.error('[parent] worker died');
     });
   }
   for (let i = 0; i < workerCount; i++) {

--- a/test/parallel/test-tls-ticket-cluster.js
+++ b/test/parallel/test-tls-ticket-cluster.js
@@ -32,7 +32,7 @@ const fixtures = require('../common/fixtures');
 const workerCount = 4;
 const expectedReqCount = 16;
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   let reusedCount = 0;
   let reqCount = 0;
   let lastSession = null;
@@ -40,7 +40,8 @@ if (cluster.isParent) {
   let workerPort = null;
 
   function shoot() {
-    console.error('[parent] connecting', workerPort, 'session?', !!lastSession);
+    console.error('[primary] connecting',
+                  workerPort, 'session?', !!lastSession);
     const c = tls.connect(workerPort, {
       session: lastSession,
       rejectUnauthorized: false
@@ -69,7 +70,7 @@ if (cluster.isParent) {
   function fork() {
     const worker = cluster.fork();
     worker.on('message', ({ msg, port }) => {
-      console.error('[parent] got %j', msg);
+      console.error('[primary] got %j', msg);
       if (msg === 'reused') {
         ++reusedCount;
       } else if (msg === 'listening' && !shootOnce) {
@@ -80,7 +81,7 @@ if (cluster.isParent) {
     });
 
     worker.on('exit', () => {
-      console.error('[parent] worker died');
+      console.error('[primary] worker died');
     });
   }
   for (let i = 0; i < workerCount; i++) {

--- a/test/sequential/test-cluster-inspect-brk.js
+++ b/test/sequential/test-cluster-inspect-brk.js
@@ -9,10 +9,10 @@ const assert = require('assert');
 const cluster = require('cluster');
 const debuggerPort = common.PORT;
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   function test(execArgv) {
 
-    cluster.setupParent({
+    cluster.setupPrimary({
       execArgv: execArgv,
       stdio: ['pipe', 'pipe', 'pipe', 'ipc', 'pipe']
     });

--- a/test/sequential/test-cluster-inspect-brk.js
+++ b/test/sequential/test-cluster-inspect-brk.js
@@ -9,10 +9,10 @@ const assert = require('assert');
 const cluster = require('cluster');
 const debuggerPort = common.PORT;
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   function test(execArgv) {
 
-    cluster.setupMaster({
+    cluster.setupParent({
       execArgv: execArgv,
       stdio: ['pipe', 'pipe', 'pipe', 'ipc', 'pipe']
     });

--- a/test/sequential/test-cluster-net-listen-ipv6only-none.js
+++ b/test/sequential/test-cluster-net-listen-ipv6only-none.js
@@ -14,7 +14,7 @@ cluster.schedulingPolicy = cluster.SCHED_NONE;
 const host = '::';
 const WORKER_ACCOUNT = 3;
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   const workers = [];
 
   for (let i = 0; i < WORKER_ACCOUNT; i += 1) {

--- a/test/sequential/test-cluster-net-listen-ipv6only-none.js
+++ b/test/sequential/test-cluster-net-listen-ipv6only-none.js
@@ -14,7 +14,7 @@ cluster.schedulingPolicy = cluster.SCHED_NONE;
 const host = '::';
 const WORKER_ACCOUNT = 3;
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   const workers = [];
 
   for (let i = 0; i < WORKER_ACCOUNT; i += 1) {

--- a/test/sequential/test-cluster-net-listen-ipv6only-rr.js
+++ b/test/sequential/test-cluster-net-listen-ipv6only-rr.js
@@ -14,7 +14,7 @@ cluster.schedulingPolicy = cluster.SCHED_RR;
 const host = '::';
 const WORKER_ACCOUNT = 3;
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   const workers = [];
   let address;
 
@@ -51,7 +51,7 @@ if (cluster.isMaster) {
   }));
 } else {
   // As the cluster member has the potential to grab any port
-  // from the environment, this can cause collision when master
+  // from the environment, this can cause collision when parent
   // obtains the port from cluster member and tries to listen on.
   // So move this to sequential, and provide a static port.
   // Refs: https://github.com/nodejs/node/issues/25813

--- a/test/sequential/test-cluster-net-listen-ipv6only-rr.js
+++ b/test/sequential/test-cluster-net-listen-ipv6only-rr.js
@@ -14,7 +14,7 @@ cluster.schedulingPolicy = cluster.SCHED_RR;
 const host = '::';
 const WORKER_ACCOUNT = 3;
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   const workers = [];
   let address;
 
@@ -51,7 +51,7 @@ if (cluster.isParent) {
   }));
 } else {
   // As the cluster member has the potential to grab any port
-  // from the environment, this can cause collision when parent
+  // from the environment, this can cause collision when primary
   // obtains the port from cluster member and tries to listen on.
   // So move this to sequential, and provide a static port.
   // Refs: https://github.com/nodejs/node/issues/25813

--- a/test/sequential/test-cluster-send-handle-large-payload.js
+++ b/test/sequential/test-cluster-send-handle-large-payload.js
@@ -7,7 +7,7 @@ const net = require('net');
 
 const payload = 'a'.repeat(800004);
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   const server = net.createServer();
 
   server.on('connection', common.mustCall((socket) => { socket.unref(); }));
@@ -33,7 +33,7 @@ if (cluster.isParent) {
     assert.strictEqual(payload, received);
     assert(handle instanceof net.Socket);
 
-    // On macOS, the parent process might not receive a message if it is sent
+    // On macOS, the primary process might not receive a message if it is sent
     // to soon, and then subsequent messages are also sometimes not received.
     //
     // (Is this a bug or expected operating system behavior like the way a file

--- a/test/sequential/test-cluster-send-handle-large-payload.js
+++ b/test/sequential/test-cluster-send-handle-large-payload.js
@@ -7,7 +7,7 @@ const net = require('net');
 
 const payload = 'a'.repeat(800004);
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   const server = net.createServer();
 
   server.on('connection', common.mustCall((socket) => { socket.unref(); }));

--- a/test/sequential/test-dgram-bind-shared-ports.js
+++ b/test/sequential/test-dgram-bind-shared-ports.js
@@ -31,7 +31,7 @@ const dgram = require('dgram');
 const BYE = 'bye';
 const WORKER2_NAME = 'wrker2';
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   const worker1 = cluster.fork();
 
   if (common.isWindows) {
@@ -65,7 +65,7 @@ if (cluster.isMaster) {
     assert.strictEqual(signal, null);
     assert.strictEqual(code, 0);
   }));
-  // end master code
+  // end parent code
 } else {
   // worker code
   process.on('message', common.mustCallAtLeast((msg) => {

--- a/test/sequential/test-dgram-bind-shared-ports.js
+++ b/test/sequential/test-dgram-bind-shared-ports.js
@@ -31,7 +31,7 @@ const dgram = require('dgram');
 const BYE = 'bye';
 const WORKER2_NAME = 'wrker2';
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   const worker1 = cluster.fork();
 
   if (common.isWindows) {
@@ -65,7 +65,7 @@ if (cluster.isParent) {
     assert.strictEqual(signal, null);
     assert.strictEqual(code, 0);
   }));
-  // end parent code
+  // end primary code
 } else {
   // worker code
   process.on('message', common.mustCallAtLeast((msg) => {

--- a/test/sequential/test-inspector-port-cluster.js
+++ b/test/sequential/test-inspector-port-cluster.js
@@ -18,12 +18,12 @@ let offset = 0;
 // for different execArgv combinations
 
 function testRunnerMain() {
-  let defaultPortCase = spawnParent({
+  let defaultPortCase = spawnPrimary({
     execArgv: ['--inspect'],
     workers: [{ expectedPort: 9230 }]
   });
 
-  spawnParent({
+  spawnPrimary({
     execArgv: ['--inspect=65534'],
     workers: [
       { expectedPort: 65535 },
@@ -35,7 +35,7 @@ function testRunnerMain() {
 
   let port = debuggerPort + offset++ * 5;
 
-  spawnParent({
+  spawnPrimary({
     execArgv: [`--inspect=${port}`],
     workers: [
       { expectedPort: port + 1 },
@@ -46,28 +46,28 @@ function testRunnerMain() {
 
   port = debuggerPort + offset++ * 5;
 
-  spawnParent({
+  spawnPrimary({
     execArgv: ['--inspect', `--inspect-port=${port}`],
     workers: [{ expectedPort: port + 1 }]
   });
 
   port = debuggerPort + offset++ * 5;
 
-  spawnParent({
+  spawnPrimary({
     execArgv: ['--inspect', `--debug-port=${port}`],
     workers: [{ expectedPort: port + 1 }]
   });
 
   port = debuggerPort + offset++ * 5;
 
-  spawnParent({
+  spawnPrimary({
     execArgv: [`--inspect=0.0.0.0:${port}`],
     workers: [{ expectedPort: port + 1, expectedHost: '0.0.0.0' }]
   });
 
   port = debuggerPort + offset++ * 5;
 
-  spawnParent({
+  spawnPrimary({
     execArgv: [`--inspect=127.0.0.1:${port}`],
     workers: [{ expectedPort: port + 1, expectedHost: '127.0.0.1' }]
   });
@@ -75,14 +75,14 @@ function testRunnerMain() {
   if (common.hasIPv6) {
     port = debuggerPort + offset++ * 5;
 
-    spawnParent({
+    spawnPrimary({
       execArgv: [`--inspect=[::]:${port}`],
       workers: [{ expectedPort: port + 1, expectedHost: '::' }]
     });
 
     port = debuggerPort + offset++ * 5;
 
-    spawnParent({
+    spawnPrimary({
       execArgv: [`--inspect=[::1]:${port}`],
       workers: [{ expectedPort: port + 1, expectedHost: '::1' }]
     });
@@ -93,7 +93,7 @@ function testRunnerMain() {
 
   port = debuggerPort + offset++ * 5;
 
-  spawnParent({
+  spawnPrimary({
     execArgv: [`--inspect=${port}`],
     clusterSettings: { inspectPort: port + 2 },
     workers: [{ expectedPort: port + 2 }]
@@ -101,7 +101,7 @@ function testRunnerMain() {
 
   port = debuggerPort + offset++ * 5;
 
-  spawnParent({
+  spawnPrimary({
     execArgv: [`--inspect=${port}`],
     clusterSettings: { inspectPort: 'addTwo' },
     workers: [
@@ -112,7 +112,7 @@ function testRunnerMain() {
 
   port = debuggerPort + offset++ * 5;
 
-  spawnParent({
+  spawnPrimary({
     execArgv: [`--inspect=${port}`],
     clusterSettings: { inspectPort: 'string' },
     workers: [{}]
@@ -120,7 +120,7 @@ function testRunnerMain() {
 
   port = debuggerPort + offset++ * 5;
 
-  spawnParent({
+  spawnPrimary({
     execArgv: [`--inspect=${port}`],
     clusterSettings: { inspectPort: 'null' },
     workers: [{}]
@@ -128,7 +128,7 @@ function testRunnerMain() {
 
   port = debuggerPort + offset++ * 5;
 
-  spawnParent({
+  spawnPrimary({
     execArgv: [`--inspect=${port}`],
     clusterSettings: { inspectPort: 'bignumber' },
     workers: [{}]
@@ -136,7 +136,7 @@ function testRunnerMain() {
 
   port = debuggerPort + offset++ * 5;
 
-  spawnParent({
+  spawnPrimary({
     execArgv: [`--inspect=${port}`],
     clusterSettings: { inspectPort: 'negativenumber' },
     workers: [{}]
@@ -144,7 +144,7 @@ function testRunnerMain() {
 
   port = debuggerPort + offset++ * 5;
 
-  spawnParent({
+  spawnPrimary({
     execArgv: [`--inspect=${port}`],
     clusterSettings: { inspectPort: 'bignumberfunc' },
     workers: [{}]
@@ -152,7 +152,7 @@ function testRunnerMain() {
 
   port = debuggerPort + offset++ * 5;
 
-  spawnParent({
+  spawnPrimary({
     execArgv: [`--inspect=${port}`],
     clusterSettings: { inspectPort: 'strfunc' },
     workers: [{}]
@@ -160,7 +160,7 @@ function testRunnerMain() {
 
   port = debuggerPort + offset++ * 5;
 
-  spawnParent({
+  spawnPrimary({
     execArgv: [],
     clusterSettings: { inspectPort: port, execArgv: ['--inspect'] },
     workers: [
@@ -170,7 +170,7 @@ function testRunnerMain() {
 
   port = debuggerPort + offset++ * 5;
 
-  spawnParent({
+  spawnPrimary({
     execArgv: [`--inspect=${port}`],
     clusterSettings: { inspectPort: 0 },
     workers: [
@@ -182,7 +182,7 @@ function testRunnerMain() {
 
   port = debuggerPort + offset++ * 5;
 
-  spawnParent({
+  spawnPrimary({
     execArgv: [],
     clusterSettings: { inspectPort: 0 },
     workers: [
@@ -194,7 +194,7 @@ function testRunnerMain() {
 
   defaultPortCase.then(() => {
     port = debuggerPort + offset++ * 5;
-    defaultPortCase = spawnParent({
+    defaultPortCase = spawnPrimary({
       execArgv: ['--inspect'],
       clusterSettings: { inspectPort: port + 2 },
       workers: [
@@ -204,7 +204,7 @@ function testRunnerMain() {
   });
 }
 
-function parentProcessMain() {
+function primaryProcessMain() {
   const workers = JSON.parse(process.env.workers);
   const clusterSettings = JSON.parse(process.env.clusterSettings) || {};
   const badPortError = { name: 'RangeError', code: 'ERR_SOCKET_BAD_PORT' };
@@ -236,7 +236,7 @@ function parentProcessMain() {
       );
     } else if (clusterSettings.inspectPort === 'string') {
       clusterSettings.inspectPort = 'string';
-      cluster.setupParent(clusterSettings);
+      cluster.setupPrimary(clusterSettings);
 
       assert.throws(() => {
         cluster.fork(params).on('exit', common.mustCall(checkExitCode));
@@ -245,7 +245,7 @@ function parentProcessMain() {
       return;
     } else if (clusterSettings.inspectPort === 'null') {
       clusterSettings.inspectPort = null;
-      cluster.setupParent(clusterSettings);
+      cluster.setupPrimary(clusterSettings);
 
       assert.throws(() => {
         cluster.fork(params).on('exit', common.mustCall(checkExitCode));
@@ -254,7 +254,7 @@ function parentProcessMain() {
       return;
     } else if (clusterSettings.inspectPort === 'bignumber') {
       clusterSettings.inspectPort = 1293812;
-      cluster.setupParent(clusterSettings);
+      cluster.setupPrimary(clusterSettings);
 
       assert.throws(() => {
         cluster.fork(params).on('exit', common.mustCall(checkExitCode));
@@ -263,7 +263,7 @@ function parentProcessMain() {
       return;
     } else if (clusterSettings.inspectPort === 'negativenumber') {
       clusterSettings.inspectPort = -9776;
-      cluster.setupParent(clusterSettings);
+      cluster.setupPrimary(clusterSettings);
 
       assert.throws(() => {
         cluster.fork(params).on('exit', common.mustCall(checkExitCode));
@@ -276,7 +276,7 @@ function parentProcessMain() {
         workers.length
       );
 
-      cluster.setupParent(clusterSettings);
+      cluster.setupPrimary(clusterSettings);
 
       assert.throws(() => {
         cluster.fork(params).on('exit', common.mustCall(checkExitCode));
@@ -289,7 +289,7 @@ function parentProcessMain() {
         workers.length
       );
 
-      cluster.setupParent(clusterSettings);
+      cluster.setupPrimary(clusterSettings);
 
       assert.throws(() => {
         cluster.fork(params).on('exit', common.mustCall(checkExitCode));
@@ -298,7 +298,7 @@ function parentProcessMain() {
       return;
     }
 
-    cluster.setupParent(clusterSettings);
+    cluster.setupPrimary(clusterSettings);
 
     cluster.fork(params).on('exit', common.mustCall(checkExitCode));
   }
@@ -324,7 +324,7 @@ function workerProcessMain() {
   process.exit();
 }
 
-function spawnParent({ execArgv, workers, clusterSettings = {} }) {
+function spawnPrimary({ execArgv, workers, clusterSettings = {} }) {
   return new Promise((resolve) => {
     childProcess.fork(__filename, {
       env: { ...process.env,
@@ -347,8 +347,8 @@ function checkExitCode(code, signal) {
 
 if (!process.env.testProcess) {
   testRunnerMain();
-} else if (cluster.isParent) {
-  parentProcessMain();
+} else if (cluster.isPrimary) {
+  primaryProcessMain();
 } else {
   workerProcessMain();
 }

--- a/test/sequential/test-inspector-port-cluster.js
+++ b/test/sequential/test-inspector-port-cluster.js
@@ -18,12 +18,12 @@ let offset = 0;
 // for different execArgv combinations
 
 function testRunnerMain() {
-  let defaultPortCase = spawnMaster({
+  let defaultPortCase = spawnParent({
     execArgv: ['--inspect'],
     workers: [{ expectedPort: 9230 }]
   });
 
-  spawnMaster({
+  spawnParent({
     execArgv: ['--inspect=65534'],
     workers: [
       { expectedPort: 65535 },
@@ -35,7 +35,7 @@ function testRunnerMain() {
 
   let port = debuggerPort + offset++ * 5;
 
-  spawnMaster({
+  spawnParent({
     execArgv: [`--inspect=${port}`],
     workers: [
       { expectedPort: port + 1 },
@@ -46,28 +46,28 @@ function testRunnerMain() {
 
   port = debuggerPort + offset++ * 5;
 
-  spawnMaster({
+  spawnParent({
     execArgv: ['--inspect', `--inspect-port=${port}`],
     workers: [{ expectedPort: port + 1 }]
   });
 
   port = debuggerPort + offset++ * 5;
 
-  spawnMaster({
+  spawnParent({
     execArgv: ['--inspect', `--debug-port=${port}`],
     workers: [{ expectedPort: port + 1 }]
   });
 
   port = debuggerPort + offset++ * 5;
 
-  spawnMaster({
+  spawnParent({
     execArgv: [`--inspect=0.0.0.0:${port}`],
     workers: [{ expectedPort: port + 1, expectedHost: '0.0.0.0' }]
   });
 
   port = debuggerPort + offset++ * 5;
 
-  spawnMaster({
+  spawnParent({
     execArgv: [`--inspect=127.0.0.1:${port}`],
     workers: [{ expectedPort: port + 1, expectedHost: '127.0.0.1' }]
   });
@@ -75,14 +75,14 @@ function testRunnerMain() {
   if (common.hasIPv6) {
     port = debuggerPort + offset++ * 5;
 
-    spawnMaster({
+    spawnParent({
       execArgv: [`--inspect=[::]:${port}`],
       workers: [{ expectedPort: port + 1, expectedHost: '::' }]
     });
 
     port = debuggerPort + offset++ * 5;
 
-    spawnMaster({
+    spawnParent({
       execArgv: [`--inspect=[::1]:${port}`],
       workers: [{ expectedPort: port + 1, expectedHost: '::1' }]
     });
@@ -93,7 +93,7 @@ function testRunnerMain() {
 
   port = debuggerPort + offset++ * 5;
 
-  spawnMaster({
+  spawnParent({
     execArgv: [`--inspect=${port}`],
     clusterSettings: { inspectPort: port + 2 },
     workers: [{ expectedPort: port + 2 }]
@@ -101,7 +101,7 @@ function testRunnerMain() {
 
   port = debuggerPort + offset++ * 5;
 
-  spawnMaster({
+  spawnParent({
     execArgv: [`--inspect=${port}`],
     clusterSettings: { inspectPort: 'addTwo' },
     workers: [
@@ -112,7 +112,7 @@ function testRunnerMain() {
 
   port = debuggerPort + offset++ * 5;
 
-  spawnMaster({
+  spawnParent({
     execArgv: [`--inspect=${port}`],
     clusterSettings: { inspectPort: 'string' },
     workers: [{}]
@@ -120,7 +120,7 @@ function testRunnerMain() {
 
   port = debuggerPort + offset++ * 5;
 
-  spawnMaster({
+  spawnParent({
     execArgv: [`--inspect=${port}`],
     clusterSettings: { inspectPort: 'null' },
     workers: [{}]
@@ -128,7 +128,7 @@ function testRunnerMain() {
 
   port = debuggerPort + offset++ * 5;
 
-  spawnMaster({
+  spawnParent({
     execArgv: [`--inspect=${port}`],
     clusterSettings: { inspectPort: 'bignumber' },
     workers: [{}]
@@ -136,7 +136,7 @@ function testRunnerMain() {
 
   port = debuggerPort + offset++ * 5;
 
-  spawnMaster({
+  spawnParent({
     execArgv: [`--inspect=${port}`],
     clusterSettings: { inspectPort: 'negativenumber' },
     workers: [{}]
@@ -144,7 +144,7 @@ function testRunnerMain() {
 
   port = debuggerPort + offset++ * 5;
 
-  spawnMaster({
+  spawnParent({
     execArgv: [`--inspect=${port}`],
     clusterSettings: { inspectPort: 'bignumberfunc' },
     workers: [{}]
@@ -152,7 +152,7 @@ function testRunnerMain() {
 
   port = debuggerPort + offset++ * 5;
 
-  spawnMaster({
+  spawnParent({
     execArgv: [`--inspect=${port}`],
     clusterSettings: { inspectPort: 'strfunc' },
     workers: [{}]
@@ -160,7 +160,7 @@ function testRunnerMain() {
 
   port = debuggerPort + offset++ * 5;
 
-  spawnMaster({
+  spawnParent({
     execArgv: [],
     clusterSettings: { inspectPort: port, execArgv: ['--inspect'] },
     workers: [
@@ -170,7 +170,7 @@ function testRunnerMain() {
 
   port = debuggerPort + offset++ * 5;
 
-  spawnMaster({
+  spawnParent({
     execArgv: [`--inspect=${port}`],
     clusterSettings: { inspectPort: 0 },
     workers: [
@@ -182,7 +182,7 @@ function testRunnerMain() {
 
   port = debuggerPort + offset++ * 5;
 
-  spawnMaster({
+  spawnParent({
     execArgv: [],
     clusterSettings: { inspectPort: 0 },
     workers: [
@@ -194,7 +194,7 @@ function testRunnerMain() {
 
   defaultPortCase.then(() => {
     port = debuggerPort + offset++ * 5;
-    defaultPortCase = spawnMaster({
+    defaultPortCase = spawnParent({
       execArgv: ['--inspect'],
       clusterSettings: { inspectPort: port + 2 },
       workers: [
@@ -204,7 +204,7 @@ function testRunnerMain() {
   });
 }
 
-function masterProcessMain() {
+function parentProcessMain() {
   const workers = JSON.parse(process.env.workers);
   const clusterSettings = JSON.parse(process.env.clusterSettings) || {};
   const badPortError = { name: 'RangeError', code: 'ERR_SOCKET_BAD_PORT' };
@@ -236,7 +236,7 @@ function masterProcessMain() {
       );
     } else if (clusterSettings.inspectPort === 'string') {
       clusterSettings.inspectPort = 'string';
-      cluster.setupMaster(clusterSettings);
+      cluster.setupParent(clusterSettings);
 
       assert.throws(() => {
         cluster.fork(params).on('exit', common.mustCall(checkExitCode));
@@ -245,7 +245,7 @@ function masterProcessMain() {
       return;
     } else if (clusterSettings.inspectPort === 'null') {
       clusterSettings.inspectPort = null;
-      cluster.setupMaster(clusterSettings);
+      cluster.setupParent(clusterSettings);
 
       assert.throws(() => {
         cluster.fork(params).on('exit', common.mustCall(checkExitCode));
@@ -254,7 +254,7 @@ function masterProcessMain() {
       return;
     } else if (clusterSettings.inspectPort === 'bignumber') {
       clusterSettings.inspectPort = 1293812;
-      cluster.setupMaster(clusterSettings);
+      cluster.setupParent(clusterSettings);
 
       assert.throws(() => {
         cluster.fork(params).on('exit', common.mustCall(checkExitCode));
@@ -263,7 +263,7 @@ function masterProcessMain() {
       return;
     } else if (clusterSettings.inspectPort === 'negativenumber') {
       clusterSettings.inspectPort = -9776;
-      cluster.setupMaster(clusterSettings);
+      cluster.setupParent(clusterSettings);
 
       assert.throws(() => {
         cluster.fork(params).on('exit', common.mustCall(checkExitCode));
@@ -276,7 +276,7 @@ function masterProcessMain() {
         workers.length
       );
 
-      cluster.setupMaster(clusterSettings);
+      cluster.setupParent(clusterSettings);
 
       assert.throws(() => {
         cluster.fork(params).on('exit', common.mustCall(checkExitCode));
@@ -289,7 +289,7 @@ function masterProcessMain() {
         workers.length
       );
 
-      cluster.setupMaster(clusterSettings);
+      cluster.setupParent(clusterSettings);
 
       assert.throws(() => {
         cluster.fork(params).on('exit', common.mustCall(checkExitCode));
@@ -298,7 +298,7 @@ function masterProcessMain() {
       return;
     }
 
-    cluster.setupMaster(clusterSettings);
+    cluster.setupParent(clusterSettings);
 
     cluster.fork(params).on('exit', common.mustCall(checkExitCode));
   }
@@ -324,7 +324,7 @@ function workerProcessMain() {
   process.exit();
 }
 
-function spawnMaster({ execArgv, workers, clusterSettings = {} }) {
+function spawnParent({ execArgv, workers, clusterSettings = {} }) {
   return new Promise((resolve) => {
     childProcess.fork(__filename, {
       env: { ...process.env,
@@ -347,8 +347,8 @@ function checkExitCode(code, signal) {
 
 if (!process.env.testProcess) {
   testRunnerMain();
-} else if (cluster.isMaster) {
-  masterProcessMain();
+} else if (cluster.isParent) {
+  parentProcessMain();
 } else {
   workerProcessMain();
 }

--- a/test/sequential/test-net-listen-shared-ports.js
+++ b/test/sequential/test-net-listen-shared-ports.js
@@ -25,7 +25,7 @@ const assert = require('assert');
 const cluster = require('cluster');
 const net = require('net');
 
-if (cluster.isMaster) {
+if (cluster.isParent) {
   const worker1 = cluster.fork();
 
   worker1.on('message', common.mustCall(function(msg) {

--- a/test/sequential/test-net-listen-shared-ports.js
+++ b/test/sequential/test-net-listen-shared-ports.js
@@ -25,7 +25,7 @@ const assert = require('assert');
 const cluster = require('cluster');
 const net = require('net');
 
-if (cluster.isParent) {
+if (cluster.isPrimary) {
   const worker1 = cluster.fork();
 
   worker1.on('message', common.mustCall(function(msg) {


### PR DESCRIPTION
Doc deprecate isMaster and setupMaster in favor
of isParent and setupParent.

Signed-off-by: Michael Dawson <mdawson@devrus.com>

Given the effort to change the `master` branch to `main`, this may be appropriate as a path forward on the other main reference to `master` in in the project. 

It could be breaking despite the original methods not going away in the context of monkey patching as existing monkey patches would not cover both methods. 

Just thought I'd see what people think in terms of what it currently would like like as a change.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
