### PR TITLE
lib: refactor to use more primordials in internal/encoding.js

### DIFF
--- a/lib/internal/encoding.js
+++ b/lib/internal/encoding.js
@@ -4,10 +4,11 @@
 // https://encoding.spec.whatwg.org
 
 const {
-  Map,
   ObjectCreate,
   ObjectDefineProperties,
   ObjectGetOwnPropertyDescriptors,
+  SafeMap,
+  StringPrototypeSlice,
   Symbol,
   SymbolToStringTag,
   Uint32Array,
@@ -73,7 +74,7 @@ const CONVERTER_FLAGS_IGNORE_BOM = 0x4;
 
 const empty = new Uint8Array(0);
 
-const encodings = new Map([
+const encodings = new SafeMap([
   ['unicode-1-1-utf-8', 'utf-8'],
   ['utf8', 'utf-8'],
   ['utf-8', 'utf-8'],
@@ -308,7 +309,7 @@ function trimAsciiWhitespace(label) {
     label[e - 1] === '\u0020')) {
     e--;
   }
-  return label.slice(s, e);
+  return StringPrototypeSlice(label, s, e);
 }
 
 function getEncodingFromLabel(label) {
@@ -503,7 +504,7 @@ function makeTextDecoderJS() {
         // If the very first result in the stream is a BOM, and we are not
         // explicitly told to ignore it, then we discard it.
         if (result[0] === '\ufeff') {
-          result = result.slice(1);
+          result = StringPrototypeSlice(result, 1);
         }
         this[kBOMSeen] = true;
       }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
