### PR TITLE
src: use correct outer Context’s microtask queue

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.20',
+    'v8_embedder_string': '-node.21',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -10417,8 +10417,11 @@ class V8_EXPORT Context {
    */
   void Exit();
 
-  /** Returns an isolate associated with a current context. */
+  /** Returns the isolate associated with a current context. */
   Isolate* GetIsolate();
+
+  /** Returns the microtask queue associated with a current context. */
+  MicrotaskQueue* GetMicrotaskQueue();
 
   /**
    * The field at kDebugIdIndex used to be reserved for the inspector.

--- a/deps/v8/src/api/api.cc
+++ b/deps/v8/src/api/api.cc
@@ -6118,6 +6118,12 @@ v8::Isolate* Context::GetIsolate() {
   return reinterpret_cast<Isolate*>(env->GetIsolate());
 }
 
+v8::MicrotaskQueue* Context::GetMicrotaskQueue() {
+  i::Handle<i::Context> env = Utils::OpenHandle(this);
+  CHECK(env->IsNativeContext());
+  return i::Handle<i::NativeContext>::cast(env)->microtask_queue();
+}
+
 v8::Local<v8::Object> Context::Global() {
   i::Handle<i::Context> context = Utils::OpenHandle(this);
   i::Isolate* isolate = context->GetIsolate();

--- a/deps/v8/test/cctest/test-api.cc
+++ b/deps/v8/test/cctest/test-api.cc
@@ -28348,3 +28348,13 @@ TEST(TriggerThreadSafeMetricsEvent) {
   CHECK_EQ(recorder->count_, 1);  // Increased.
   CHECK_EQ(recorder->module_count_, 42);
 }
+
+THREADED_TEST(MicrotaskQueueOfContext) {
+  auto microtask_queue = v8::MicrotaskQueue::New(CcTest::isolate());
+  v8::HandleScope scope(CcTest::isolate());
+  v8::Local<Context> context = Context::New(
+      CcTest::isolate(), nullptr, v8::MaybeLocal<ObjectTemplate>(),
+      v8::MaybeLocal<Value>(), v8::DeserializeInternalFieldsCallback(),
+      microtask_queue.get());
+  CHECK_EQ(context->GetMicrotaskQueue(), microtask_queue.get());
+}

--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -827,7 +827,8 @@ void AsyncWrap::EmitDestroy(Environment* env, double async_id) {
   // interrupt to get this Microtask scheduled as fast as possible.
   if (env->destroy_async_id_list()->size() == 16384) {
     env->RequestInterrupt([](Environment* env) {
-      env->isolate()->EnqueueMicrotask(
+      env->context()->GetMicrotaskQueue()->EnqueueMicrotask(
+        env->isolate(),
         [](void* arg) {
           DestroyAsyncIdsCallback(static_cast<Environment*>(arg));
         }, env);

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -199,7 +199,9 @@ MaybeLocal<Context> ContextifyContext::CreateV8Context(
       object_template,
       {},       // global object
       {},       // deserialization callback
-      microtask_queue() ? microtask_queue().get() : nullptr);
+      microtask_queue() ?
+          microtask_queue().get() :
+          env->isolate()->GetCurrentContext()->GetMicrotaskQueue());
   if (ctx.IsEmpty()) return MaybeLocal<Context>();
   // Only partially initialize the context - the primordials are left out
   // and only initialized when necessary.

--- a/src/node_task_queue.cc
+++ b/src/node_task_queue.cc
@@ -96,7 +96,8 @@ static void EnqueueMicrotask(const FunctionCallbackInfo<Value>& args) {
 
   CHECK(args[0]->IsFunction());
 
-  isolate->EnqueueMicrotask(args[0].As<Function>());
+  isolate->GetCurrentContext()->GetMicrotaskQueue()
+      ->EnqueueMicrotask(isolate, args[0].As<Function>());
 }
 
 static void RunMicrotasks(const FunctionCallbackInfo<Value>& args) {

--- a/test/cctest/test_environment.cc
+++ b/test/cctest/test_environment.cc
@@ -653,8 +653,7 @@ TEST_F(EnvironmentTest, NestedMicrotaskQueue) {
       "require('vm').runInNewContext("
       "    'Promise.resolve().then(() => mustCall(1 << 2))',"
       "    { mustCall }"
-      ");"
-      ).ToLocalChecked();
+      ");").ToLocalChecked();
   EXPECT_EQ(callback_calls, 1 << 1);
   isolate_->PerformMicrotaskCheckpoint();
   EXPECT_EQ(callback_calls, 1 << 1);

--- a/test/cctest/test_environment.cc
+++ b/test/cctest/test_environment.cc
@@ -608,3 +608,59 @@ TEST_F(NodeZeroIsolateTestFixture, CtrlCWithOnlySafeTerminationTest) {
   isolate->Dispose();
 }
 #endif  // _WIN32
+
+TEST_F(EnvironmentTest, NestedMicrotaskQueue) {
+  const v8::HandleScope handle_scope(isolate_);
+  const Argv argv;
+
+  std::unique_ptr<v8::MicrotaskQueue> queue = v8::MicrotaskQueue::New(isolate_);
+  v8::Local<v8::Context> context = v8::Context::New(
+      isolate_, nullptr, {}, {}, {}, queue.get());
+  node::InitializeContext(context);
+  v8::Context::Scope context_scope(context);
+
+  int callback_calls = 0;
+  v8::Local<v8::Function> must_call = v8::Function::New(
+      context,
+      [](const v8::FunctionCallbackInfo<v8::Value>& info) {
+        int* callback_calls =
+            static_cast<int*>(info.Data().As<v8::External>()->Value());
+        *callback_calls |= info[0].As<v8::Int32>()->Value();
+      },
+      v8::External::New(isolate_, static_cast<void*>(&callback_calls)))
+          .ToLocalChecked();
+  context->Global()->Set(
+      context,
+      v8::String::NewFromUtf8Literal(isolate_, "mustCall"),
+      must_call).Check();
+
+  node::IsolateData* isolate_data = node::CreateIsolateData(
+      isolate_, &NodeTestFixture::current_loop, platform.get());
+  CHECK_NE(nullptr, isolate_data);
+
+  node::Environment* env = node::CreateEnvironment(
+      isolate_data, context, {}, {});
+  CHECK_NE(nullptr, env);
+
+  node::LoadEnvironment(
+      env,
+      "Promise.resolve().then(() => mustCall(1 << 0));\n"
+      "require('vm').runInNewContext("
+      "    'Promise.resolve().then(() => mustCall(1 << 1))',"
+      "    { mustCall },"
+      "    { microtaskMode: 'afterEvaluate' }"
+      ");"
+      "require('vm').runInNewContext("
+      "    'Promise.resolve().then(() => mustCall(1 << 2))',"
+      "    { mustCall }"
+      ");"
+      ).ToLocalChecked();
+  EXPECT_EQ(callback_calls, 1 << 1);
+  isolate_->PerformMicrotaskCheckpoint();
+  EXPECT_EQ(callback_calls, 1 << 1);
+  queue->PerformCheckpoint(isolate_);
+  EXPECT_EQ(callback_calls, (1 << 0) | (1 << 1) | (1 << 2));
+
+  node::FreeEnvironment(env);
+  node::FreeIsolateData(isolate_data);
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
##### deps: V8: backport 4bf051d536a1

Original commit message:

    [api] Add Context::GetMicrotaskQueue method

    Add a method that returns the microtask queue that is being used
    by the `v8::Context`.

    This is helpful in non-monolithic embedders like Node.js, which
    accept Contexts created by its own embedders like Electron, or
    for native Node.js addons. In particular, it enables:

    1. Making sure that “nested” `Context`s use the correct microtask
       queue, i.e. the one from the outer Context.
    2. Enqueueing microtasks into the correct microtask queue.

    Previously, these things only worked when the microtask queue for
    a given Context was the Isolate’s default queue.

    As an alternative, I considered adding a way to make new `Context`s
    inherit the queue from the `Context` that was entered at the time
    of their creation, but that seemed a bit more “magic”, less flexible,
    and didn’t take care of concern 2 listed above.

    Change-Id: I15ed796df90f23c97a545a8e1b30a3bf4a5c4320
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2579914
    Reviewed-by: Toon Verwaest <verwaest@chromium.org>
    Commit-Queue: Toon Verwaest <verwaest@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#71710}

Refs: https://github.com/v8/v8/commit/4bf051d536a172e7932845d82f918ad7280c7873

##### src: use correct outer Context’s microtask queue

Fall back to using the outer context’s microtask queue, rather than
the Isolate’s default one. This would otherwise result in surprising
behavior if an embedder specified a custom microtask queue for the
main Node.js context.
