### PR TITLE
test: specify global object for globals

### DIFF
--- a/test/parallel/test-fs-write.js
+++ b/test/parallel/test-fs-write.js
@@ -36,8 +36,10 @@ const fn4 = path.join(tmpdir.path, 'write4.txt');
 const expected = 'ümlaut.';
 const constants = fs.constants;
 
-/* eslint-disable no-undef */
-common.allowGlobals(externalizeString, isOneByteString, x);
+const { externalizeString, isOneByteString } = global;
+
+// Account for extra globals exposed by --expose_externalize_string.
+common.allowGlobals(externalizeString, isOneByteString, global.x);
 
 {
   const expected = 'ümlaut sechzig';  // Must be a unique string.
@@ -78,7 +80,6 @@ common.allowGlobals(externalizeString, isOneByteString, x);
   fs.closeSync(fd);
   assert.strictEqual(fs.readFileSync(fn, 'utf8'), expected);
 }
-/* eslint-enable no-undef */
 
 fs.open(fn, 'w', 0o644, common.mustSucceed((fd) => {
   const done = common.mustSucceed((written) => {


### PR DESCRIPTION
Be explicit about using `global.externalizeString()` etc. in
test-fs-write instead of disabling the `no-undef` ESLint rule.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
