### PR TITLE
worker: fix broadcast channel SharedArrayBuffer passing

### DIFF
--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -157,8 +157,7 @@ MaybeLocal<Value> Message::Deserialize(Environment* env,
   // Attach all transferred SharedArrayBuffers to their new Isolate.
   for (uint32_t i = 0; i < shared_array_buffers_.size(); ++i) {
     Local<SharedArrayBuffer> sab =
-        SharedArrayBuffer::New(env->isolate(),
-                               std::move(shared_array_buffers_[i]));
+        SharedArrayBuffer::New(env->isolate(), shared_array_buffers_[i]);
     shared_array_buffers.push_back(sab);
   }
 
@@ -1309,7 +1308,7 @@ Maybe<bool> SiblingGroup::Dispatch(
 
   // Transferables cannot be used when there is more
   // than a single destination.
-  if (size() > 2 && message->transferables().size()) {
+  if (size() > 2 && message->has_transferables()) {
     if (error != nullptr)
       *error = "Transferables cannot be used with multiple destinations.";
     return Nothing<bool>();

--- a/src/node_messaging.h
+++ b/src/node_messaging.h
@@ -94,6 +94,9 @@ class Message : public MemoryRetainer {
   const std::vector<std::unique_ptr<TransferData>>& transferables() const {
     return transferables_;
   }
+  bool has_transferables() const {
+    return !transferables_.empty() || !array_buffers_.empty();
+  }
 
   void MemoryInfo(MemoryTracker* tracker) const override;
 

--- a/test/parallel/test-worker-broadcastchannel.js
+++ b/test/parallel/test-worker-broadcastchannel.js
@@ -111,12 +111,19 @@ assert.throws(() => new BroadcastChannel(), {
 {
   const bc1 = new BroadcastChannel('channel3');
   const bc2 = new BroadcastChannel('channel3');
-  bc2.postMessage(new SharedArrayBuffer(10));
-  bc1.addEventListener('message', common.mustCall(({ data }) => {
-    assert(data instanceof SharedArrayBuffer);
-    bc1.close();
-    bc2.close();
-  }));
+  const bc3 = new BroadcastChannel('channel3');
+  bc3.postMessage(new SharedArrayBuffer(10));
+  let received = 0;
+  for (const bc of [bc1, bc2]) {
+    bc.addEventListener('message', common.mustCall(({ data }) => {
+      assert(data instanceof SharedArrayBuffer);
+      if (++received === 2) {
+        bc1.close();
+        bc2.close();
+        bc3.close();
+      }
+    }));
+  }
 }
 
 {


### PR DESCRIPTION
Make sure that `SharedArrayBuffer`s can be deserialized on multiple
receiving ends. As a drive-by, also fix the condition of the
internal assertion that should occur if there are transferables
passed to multiple destinations.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
