### PR TITLE
doc: os.uptime() temporary bug notice

### DIFF
--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -373,7 +373,7 @@ rare virtualization cases. The issue arises when the virtualized
 guest instance shares the kernel with the host system.
 Due to the fact that libuv uses a syscall that
 provides host's uptime instead of guest's
-uptime on OpenVZ, `os.uptime()` may also provide 
+uptime on OpenVZ, `os.uptime()` may also provide
 erroneous result.
 
 Please refer to <https://github.com/nodejs/node/issues/36244> and

--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -370,8 +370,11 @@ Returns the system uptime in number of seconds.
 
 The value returned can be inaccurate in some
 rare virtualization cases. The issue arises when the virtualized
-guest instance shares the kernel with the host system due to a bug
-in libuv. `os.uptime()` may thus provide the host's uptime instead of guest's.
+guest instance shares the kernel with the host system.
+Due to the fact that libuv uses a syscall that
+provides host's uptime instead of guest's 
+uptime on OpenVZ, `os.uptime()` may also provide 
+erroneous result.
 
 Please refer to <https://github.com/nodejs/node/issues/36244> and
 <https://github.com/libuv/libuv/issues/3068> for an exploration of

--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -366,14 +366,15 @@ changes:
 
 * Returns: {integer}
 
-Returns the system uptime in number of seconds. 
+Returns the system uptime in number of seconds.
 
-Please be aware that the value returned can be inaccurate in some rare virtualization cases.
-The issue arises when the virtualized guest instance shares the kernel with the host system 
-due to a bug in libuv. `os.uptime()` may thus provide the host's uptime instead of guest's.
+Please be aware that the value returned can be inaccurate in some
+rare virtualization cases. The issue arises when the virtualized
+guest instance shares the kernel with the host system due to a bug
+in libuv. `os.uptime()` may thus provide the host's uptime instead of guest's.
 
-Please refer to <https://github.com/nodejs/node/issues/36244> and 
-<https://github.com/libuv/libuv/issues/3068> for an exploration of 
+Please refer to <https://github.com/nodejs/node/issues/36244> and
+<https://github.com/libuv/libuv/issues/3068> for an exploration of
 this issue, until it is resolved by libuv.
 
 ## `os.userInfo([options])`

--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -372,7 +372,7 @@ The value returned can be inaccurate in some
 rare virtualization cases. The issue arises when the virtualized
 guest instance shares the kernel with the host system.
 Due to the fact that libuv uses a syscall that
-provides host's uptime instead of guest's 
+provides host's uptime instead of guest's
 uptime on OpenVZ, `os.uptime()` may also provide 
 erroneous result.
 

--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -366,7 +366,15 @@ changes:
 
 * Returns: {integer}
 
-Returns the system uptime in number of seconds.
+Returns the system uptime in number of seconds. 
+
+Please be aware that the value returned can be inaccurate in some rare virtualization cases.
+The issue arises when the virtualized guest instance shares the kernel with the host system 
+due to a bug in libuv. `os.uptime()` may thus provide the host's uptime instead of guest's.
+
+Please refer to <https://github.com/nodejs/node/issues/36244> and 
+<https://github.com/libuv/libuv/issues/3068> for an exploration of 
+this issue, until it is resolved by libuv.
 
 ## `os.userInfo([options])`
 <!-- YAML

--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -368,7 +368,7 @@ changes:
 
 Returns the system uptime in number of seconds.
 
-Please be aware that the value returned can be inaccurate in some
+The value returned can be inaccurate in some
 rare virtualization cases. The issue arises when the virtualized
 guest instance shares the kernel with the host system due to a bug
 in libuv. `os.uptime()` may thus provide the host's uptime instead of guest's.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This commit makes it clear that `os.uptime()` is currently unreliable in some virtualization cases, until https://github.com/libuv/libuv/issues/3068 is resolved (and thus https://github.com/nodejs/node/issues/36244). At least one member of Node.js (@benjamingr) in the aforementioned issue appears to be in favour of at least a temporary notice, until the issue is resolved by libuv. 

However, since similar issues may reappear in the future with the evolution of virtualization technology, I believe it is prudent to leave a permanent notice on `os.uptime()` doc, so perhaps it is also worth to consider. 
