### PR TITLE
attach `req` as `res.req`

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1598,6 +1598,15 @@ Removes a header that's queued for implicit sending.
 response.removeHeader('Content-Encoding');
 ```
 
+### `response.req`
+<!-- YAML
+added: REPLACEME
+-->
+
+* {http.IncomingMessage}
+
+A reference to the original HTTP `request` object.
+
 ### `response.sendDate`
 <!-- YAML
 added: v0.7.5

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -3437,6 +3437,15 @@ Removes a header that has been queued for implicit sending.
 response.removeHeader('Content-Encoding');
 ```
 
+### `response.req`
+<!-- YAML
+added: REPLACEME
+-->
+
+* {http2.Http2ServerRequest}
+
+A reference to the original HTTP2 `request` object.
+
 #### `response.sendDate`
 <!-- YAML
 added: v8.4.0

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -181,6 +181,7 @@ function ServerResponse(req) {
 
   if (req.method === 'HEAD') this._hasBody = false;
 
+  this.req = req;
   this.sendDate = true;
   this._sent100 = false;
   this._expect_continue = false;

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -529,6 +529,10 @@ class Http2ServerResponse extends Stream {
     return this[kStream].headersSent;
   }
 
+  get req() {
+    return this[kStream][kRequest];
+  }
+
   get sendDate() {
     return this[kState].sendDate;
   }

--- a/test/parallel/test-http-server.js
+++ b/test/parallel/test-http-server.js
@@ -49,6 +49,8 @@ const server = http.createServer(function(req, res) {
   res.id = request_number;
   req.id = request_number++;
 
+  assert.strictEqual(res.req, req);
+
   if (req.id === 0) {
     assert.strictEqual(req.method, 'GET');
     assert.strictEqual(url.parse(req.url).pathname, '/hello');

--- a/test/parallel/test-http2-compat-serverresponse.js
+++ b/test/parallel/test-http2-compat-serverresponse.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const h2 = require('http2');
+
+// Http2ServerResponse should expose convenience properties
+
+const server = h2.createServer();
+server.listen(0, common.mustCall(function() {
+  const port = server.address().port;
+  server.once('request', common.mustCall(function(request, response) {
+    assert.strictEqual(response.req, request);
+
+    response.on('finish', common.mustCall(function() {
+      process.nextTick(() => {
+        server.close();
+      });
+    }));
+    response.end();
+  }));
+
+  const url = `http://localhost:${port}`;
+  const client = h2.connect(url, common.mustCall(function() {
+    const headers = {
+      ':path': '/foobar',
+      ':method': 'GET',
+      ':scheme': 'http',
+      ':authority': `localhost:${port}`
+    };
+    const request = client.request(headers);
+    request.on('end', common.mustCall(function() {
+      client.close();
+    }));
+    request.end();
+    request.resume();
+  }));
+}));


### PR DESCRIPTION
This change adds a `res.req` property which refers to the original `IncomingMessage` request object. 

The reasons for this small change are explained in https://github.com/nodejs/node/issues/28673, but a quick summary:

- All existing Node HTTP frameworks do this under the covers when wrapping `http.createServer`.
- Referencing the original request is required to handle certain HTTP edge cases when writing responses.
- Node's internals already reference the `req` in multiple places when determining response-specific behavior.
- Retrieving the `res` from the `req` is already possible, this just adds the reverse.
- This would give userland the ability to easily handle these valid HTTP-related edge cases.
- This would allow for intuitive Lodash-like HTTP helper libraries, instead of relying on monolithic Express-like frameworks.

I'd recommend reading https://github.com/nodejs/node/issues/28673 in full, I put a lot of thought/research into the different arguments. 

You can imagine a world where you aren't forced to use frameworks for HTTP in Node, and instead we might benefit from a Lodash-like utility library with smaller, functional utilities…

![image](https://user-images.githubusercontent.com/311752/102029823-042a8080-3d7e-11eb-9545-c23c88934ac8.png)

…this would be helpful not only to those who don't want to use frameworks, but also those attempting to building framework-independent libraries and utilities, which is currently almost impossible in the Node ecosystem.

Thanks!

---

Also, to be clear, I'm not wed to the `res.req` naming scheme if it needs to be changed for any reason. As long as there's a way to access the original request I don't care what the way is.


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
