### PR TITLE
build: run some workflows only on nodejs/node

### DIFF
--- a/.github/workflows/close-stalled.yml
+++ b/.github/workflows/close-stalled.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   stale:
+    if: github.repository == 'nodejs/node'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/stale@v3

--- a/.github/workflows/comment-stalled.yml
+++ b/.github/workflows/comment-stalled.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   staleComment:
+    if: github.repository == 'nodejs/node'
     runs-on: ubuntu-latest
     steps:
       - name: Post comment

--- a/.github/workflows/license-builder.yml
+++ b/.github/workflows/license-builder.yml
@@ -7,7 +7,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  update_routes:
+  update_license:
+    if: github.repository == 'nodejs/node'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This updates the close-stalled, comment-stalled and license-builder
workflows to skip them on repositories that are not nodejs/node.
