### PR TITLE
doc: fix `writable._construct()` example

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -2078,10 +2078,9 @@ class WriteStream extends Writable {
   constructor(filename) {
     super();
     this.filename = filename;
-    this.fd = fd;
   }
   _construct(callback) {
-    fs.open(this.filename, (fd, err) => {
+    fs.open(this.filename, (err, fd) => {
       if (err) {
         callback(err);
       } else {


### PR DESCRIPTION
This is my first pull request, please correct me if I'm missing something. The proposed changes include two small bug fixes in the `Stream` reference, namely in the [writable._construct()](https://nodejs.org/api/stream.html#stream_writable_construct_callback) example:

1. Incorrect property appointment in the `constructor` - no `fd` parameter is passed. Instead, `this.fd` is appointed in the `_construct()` method. Removing this line from the `constructor()` fixes the error.
2. The `fs.open()` callback parameters switched places according to the [fs.open](https://nodejs.org/api/fs.html#fs_fs_open_path_flags_mode_callback) reference (and my tests).

##### Checklist

- [ x] documentation is changed or added
