### PR TITLE
n-api: emit uncaught-exception on calling into modules

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -439,6 +439,18 @@ under this flag.
 
 To allow polyfills to be added, `--require` runs before freezing intrinsics.
 
+### `--force-node-api-uncaught-exceptions-policy`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+Enforces `uncaughtException` event on Node-API asynchronous callbacks.
+
+To prevent from an existing add-on from crashing the process, this flag is not
+enabled by default. In the future, this flag will be enabled by default to
+enforce the correct behavior.
+
 ### `--heapsnapshot-near-heap-limit=max_count`
 
 <!-- YAML
@@ -1638,6 +1650,7 @@ Node.js options that are allowed are:
 * `--experimental-wasm-modules`
 * `--force-context-aware`
 * `--force-fips`
+* `--force-node-api-uncaught-exceptions-policy`
 * `--frozen-intrinsics`
 * `--heapsnapshot-near-heap-limit`
 * `--heapsnapshot-signal`

--- a/src/node_api_internals.h
+++ b/src/node_api_internals.h
@@ -11,11 +11,18 @@
 struct node_napi_env__ : public napi_env__ {
   node_napi_env__(v8::Local<v8::Context> context,
                   const std::string& module_filename);
+  ~node_napi_env__();
 
   bool can_call_into_js() const override;
   v8::Maybe<bool> mark_arraybuffer_as_untransferable(
       v8::Local<v8::ArrayBuffer> ab) const override;
   void CallFinalizer(napi_finalize cb, void* data, void* hint) override;
+  template <bool enforceUncaughtExceptionPolicy>
+  void CallFinalizer(napi_finalize cb, void* data, void* hint);
+
+  void trigger_fatal_exception(v8::Local<v8::Value> local_err);
+  template <bool enforceUncaughtExceptionPolicy, typename T>
+  void CallbackIntoModule(T&& call);
 
   inline node::Environment* node_env() const {
     return node::Environment::GetCurrent(context());
@@ -23,6 +30,7 @@ struct node_napi_env__ : public napi_env__ {
   inline const char* GetFilename() const { return filename.c_str(); }
 
   std::string filename;
+  bool destructing = false;
 };
 
 using node_napi_env = node_napi_env__*;

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -432,6 +432,12 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             &EnvironmentOptions::force_async_hooks_checks,
             kAllowedInEnvironment,
             true);
+  AddOption(
+      "--force-node-api-uncaught-exceptions-policy",
+      "enforces 'uncaughtException' event on Node API asynchronous callbacks",
+      &EnvironmentOptions::force_node_api_uncaught_exceptions_policy,
+      kAllowedInEnvironment,
+      false);
   AddOption("--addons",
             "disable loading native addons",
             &EnvironmentOptions::allow_native_addons,

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -120,6 +120,7 @@ class EnvironmentOptions : public Options {
   bool experimental_repl_await = true;
   bool experimental_vm_modules = false;
   bool expose_internals = false;
+  bool force_node_api_uncaught_exceptions_policy = false;
   bool frozen_intrinsics = false;
   int64_t heap_snapshot_near_heap_limit = 0;
   std::string heap_snapshot_signal;

--- a/test/js-native-api/test_reference/test_finalizer.js
+++ b/test/js-native-api/test_reference/test_finalizer.js
@@ -1,0 +1,20 @@
+'use strict';
+// Flags: --expose-gc --force-node-api-uncaught-exceptions-policy
+
+const common = require('../../common');
+const test_reference = require(`./build/${common.buildType}/test_reference`);
+const assert = require('assert');
+
+process.on('uncaughtException', common.mustCall((err) => {
+  assert.throws(() => { throw err; }, /finalizer error/);
+}));
+
+(async function() {
+  {
+    test_reference.createExternalWithJsFinalize(
+      common.mustCall(() => {
+        throw new Error('finalizer error');
+      }));
+  }
+  global.gc();
+})().then(common.mustCall());

--- a/test/js-native-api/test_reference/test_reference.c
+++ b/test/js-native-api/test_reference/test_reference.c
@@ -21,6 +21,20 @@ static void FinalizeExternal(napi_env env, void* data, void* hint) {
   finalize_count++;
 }
 
+static void FinalizeExternalCallJs(napi_env env, void* data, void* hint) {
+  int *actual_value = data;
+  NODE_API_ASSERT_RETURN_VOID(env, actual_value == &test_value,
+      "The correct pointer was passed to the finalizer");
+
+  napi_ref finalizer_ref = (napi_ref)hint;
+  napi_value js_finalizer;
+  napi_value recv;
+  NODE_API_CALL_RETURN_VOID(env, napi_get_reference_value(env, finalizer_ref, &js_finalizer));
+  NODE_API_CALL_RETURN_VOID(env, napi_get_global(env, &recv));
+  NODE_API_CALL_RETURN_VOID(env, napi_call_function(env, recv, js_finalizer, 0, NULL, NULL));
+  NODE_API_CALL_RETURN_VOID(env, napi_delete_reference(env, finalizer_ref));
+}
+
 static napi_value CreateExternal(napi_env env, napi_callback_info info) {
   int* data = &test_value;
 
@@ -93,6 +107,31 @@ CreateExternalWithFinalize(napi_env env, napi_callback_info info) {
                            &test_value,
                            FinalizeExternal,
                            NULL, /* finalize_hint */
+                           &result));
+
+  finalize_count = 0;
+  return result;
+}
+
+static napi_value
+CreateExternalWithJsFinalize(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args[1];
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_ASSERT(env, argc == 1, "Wrong number of arguments");
+  napi_value finalizer = args[0];
+  napi_valuetype finalizer_valuetype;
+  NODE_API_CALL(env, napi_typeof(env, finalizer, &finalizer_valuetype));
+  NODE_API_ASSERT(env, finalizer_valuetype == napi_function, "Wrong type of first argument");
+  napi_ref finalizer_ref;
+  NODE_API_CALL(env, napi_create_reference(env, finalizer, 1, &finalizer_ref));
+
+  napi_value result;
+  NODE_API_CALL(env,
+      napi_create_external(env,
+                           &test_value,
+                           FinalizeExternalCallJs,
+                           finalizer_ref, /* finalize_hint */
                            &result));
 
   finalize_count = 0;
@@ -223,6 +262,8 @@ napi_value Init(napi_env env, napi_value exports) {
     DECLARE_NODE_API_PROPERTY("createExternal", CreateExternal),
     DECLARE_NODE_API_PROPERTY("createExternalWithFinalize",
         CreateExternalWithFinalize),
+    DECLARE_NODE_API_PROPERTY("createExternalWithJsFinalize",
+        CreateExternalWithJsFinalize),
     DECLARE_NODE_API_PROPERTY("checkExternal", CheckExternal),
     DECLARE_NODE_API_PROPERTY("createReference", CreateReference),
     DECLARE_NODE_API_PROPERTY("createSymbol", CreateSymbol),
@@ -234,7 +275,7 @@ napi_value Init(napi_env env, napi_value exports) {
     DECLARE_NODE_API_PROPERTY("decrementRefcount", DecrementRefcount),
     DECLARE_NODE_API_GETTER("referenceValue", GetReferenceValue),
     DECLARE_NODE_API_PROPERTY("validateDeleteBeforeFinalize",
-        ValidateDeleteBeforeFinalize),
+                          ValidateDeleteBeforeFinalize),
   };
 
   NODE_API_CALL(env, napi_define_properties(

--- a/test/node-api/test_buffer/test_buffer.c
+++ b/test/node-api/test_buffer/test_buffer.c
@@ -22,6 +22,17 @@ static void noopDeleter(napi_env env, void* data, void* finalize_hint) {
   deleterCallCount++;
 }
 
+static void malignDeleter(napi_env env, void* data, void* finalize_hint) {
+  NODE_API_ASSERT_RETURN_VOID(env, data != NULL && strcmp(data, theText) == 0, "invalid data");
+  napi_ref finalizer_ref = (napi_ref)finalize_hint;
+  napi_value js_finalizer;
+  napi_value recv;
+  NODE_API_CALL_RETURN_VOID(env, napi_get_reference_value(env, finalizer_ref, &js_finalizer));
+  NODE_API_CALL_RETURN_VOID(env, napi_get_global(env, &recv));
+  NODE_API_CALL_RETURN_VOID(env, napi_call_function(env, recv, js_finalizer, 0, NULL, NULL));
+  NODE_API_CALL_RETURN_VOID(env, napi_delete_reference(env, finalizer_ref));
+}
+
 static napi_value newBuffer(napi_env env, napi_callback_info info) {
   napi_value theBuffer;
   char* theCopy;
@@ -107,6 +118,30 @@ static napi_value staticBuffer(napi_env env, napi_callback_info info) {
   return theBuffer;
 }
 
+static napi_value malignFinalizerBuffer(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args[1];
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_ASSERT(env, argc == 1, "Wrong number of arguments");
+  napi_value finalizer = args[0];
+  napi_valuetype finalizer_valuetype;
+  NODE_API_CALL(env, napi_typeof(env, finalizer, &finalizer_valuetype));
+  NODE_API_ASSERT(env, finalizer_valuetype == napi_function, "Wrong type of first argument");
+  napi_ref finalizer_ref;
+  NODE_API_CALL(env, napi_create_reference(env, finalizer, 1, &finalizer_ref));
+
+  napi_value theBuffer;
+  NODE_API_CALL(
+      env,
+      napi_create_external_buffer(env,
+                                  sizeof(theText),
+                                  (void*)theText,
+                                  malignDeleter,
+                                  finalizer_ref,  // finalize_hint
+                                  &theBuffer));
+  return theBuffer;
+}
+
 static napi_value Init(napi_env env, napi_value exports) {
   napi_value theValue;
 
@@ -123,6 +158,7 @@ static napi_value Init(napi_env env, napi_value exports) {
     DECLARE_NODE_API_PROPERTY("bufferHasInstance", bufferHasInstance),
     DECLARE_NODE_API_PROPERTY("bufferInfo", bufferInfo),
     DECLARE_NODE_API_PROPERTY("staticBuffer", staticBuffer),
+    DECLARE_NODE_API_PROPERTY("malignFinalizerBuffer", malignFinalizerBuffer),
   };
 
   NODE_API_CALL(env, napi_define_properties(

--- a/test/node-api/test_buffer/test_finalizer.js
+++ b/test/node-api/test_buffer/test_finalizer.js
@@ -1,0 +1,21 @@
+'use strict';
+// Flags: --expose-gc --force-node-api-uncaught-exceptions-policy
+
+const common = require('../../common');
+const binding = require(`./build/${common.buildType}/test_buffer`);
+const assert = require('assert');
+const tick = require('util').promisify(require('../../common/tick'));
+
+process.on('uncaughtException', common.mustCall((err) => {
+  assert.throws(() => { throw err; }, /finalizer error/);
+}));
+
+(async function() {
+  {
+    binding.malignFinalizerBuffer(common.mustCall(() => {
+      throw new Error('finalizer error');
+    }));
+  }
+  global.gc();
+  await tick(10);
+})().then(common.mustCall());

--- a/test/node-api/test_threadsafe_function/binding.c
+++ b/test/node-api/test_threadsafe_function/binding.c
@@ -269,6 +269,35 @@ static napi_value StartThreadNoJsFunc(napi_env env, napi_callback_info info) {
     /** block_on_full */true, /** alt_ref_js_cb */true);
 }
 
+// Testing calling into JavaScript
+static void ThreadSafeFunctionFinalize(napi_env env,
+                              void* finalize_data,
+                              void* finalize_hint) {
+  napi_ref js_func_ref = (napi_ref) finalize_data;
+  napi_value js_func;
+  napi_value recv;
+  NODE_API_CALL_RETURN_VOID(env, napi_get_reference_value(env, js_func_ref, &js_func));
+  NODE_API_CALL_RETURN_VOID(env, napi_get_global(env, &recv));
+  NODE_API_CALL_RETURN_VOID(env, napi_call_function(env, recv, js_func, 0, NULL, NULL));
+  NODE_API_CALL_RETURN_VOID(env, napi_delete_reference(env, js_func_ref));
+}
+
+// Testing calling into JavaScript
+static napi_value CallIntoModule(napi_env env, napi_callback_info info) {
+  size_t argc = 4;
+  napi_value argv[4];
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, argv, NULL, NULL));
+
+  napi_ref finalize_func;
+  NODE_API_CALL(env, napi_create_reference(env, argv[3], 1, &finalize_func));
+
+  napi_threadsafe_function tsfn;
+  NODE_API_CALL(env, napi_create_threadsafe_function(env, argv[0], argv[1], argv[2], 0, 1, finalize_func, ThreadSafeFunctionFinalize, NULL, NULL, &tsfn));
+  NODE_API_CALL(env, napi_call_threadsafe_function(tsfn, NULL, napi_tsfn_blocking));
+  NODE_API_CALL(env, napi_release_threadsafe_function(tsfn, napi_tsfn_release));
+  return NULL;
+}
+
 // Module init
 static napi_value Init(napi_env env, napi_value exports) {
   size_t index;
@@ -307,6 +336,7 @@ static napi_value Init(napi_env env, napi_value exports) {
     DECLARE_NODE_API_PROPERTY("StopThread", StopThread),
     DECLARE_NODE_API_PROPERTY("Unref", Unref),
     DECLARE_NODE_API_PROPERTY("Release", Release),
+    DECLARE_NODE_API_PROPERTY("CallIntoModule", CallIntoModule),
   };
 
   NODE_API_CALL(env, napi_define_properties(env, exports,

--- a/test/node-api/test_threadsafe_function/test_force_uncaught_exception.js
+++ b/test/node-api/test_threadsafe_function/test_force_uncaught_exception.js
@@ -1,0 +1,22 @@
+'use strict';
+// Flags: --no-force-node-api-uncaught-exceptions-policy
+
+const common = require('../../common');
+const binding = require(`./build/${common.buildType}/binding`);
+
+process.on(
+  'uncaughtException',
+  common.mustNotCall('uncaught callback errors should be suppressed ' +
+    'with the option --no-force-node-api-uncaught-exceptions-policy')
+);
+
+binding.CallIntoModule(
+  common.mustCall(() => {
+    throw new Error('callback error');
+  }),
+  {},
+  'resource_name',
+  common.mustCall(function finalizer() {
+    throw new Error('finalizer error');
+  })
+);

--- a/test/node-api/test_threadsafe_function/test_uncaught_exception.js
+++ b/test/node-api/test_threadsafe_function/test_uncaught_exception.js
@@ -1,0 +1,27 @@
+'use strict';
+// Flags: --force-node-api-uncaught-exceptions-policy
+
+const common = require('../../common');
+const assert = require('assert');
+const binding = require(`./build/${common.buildType}/binding`);
+
+const callbackCheck = common.mustCall((err) => {
+  assert.throws(() => { throw err; }, /callback error/);
+  process.removeListener('uncaughtException', callbackCheck);
+  process.on('uncaughtException', finalizerCheck);
+});
+const finalizerCheck = common.mustCall((err) => {
+  assert.throws(() => { throw err; }, /finalizer error/);
+});
+process.on('uncaughtException', callbackCheck);
+
+binding.CallIntoModule(
+  common.mustCall(() => {
+    throw new Error('callback error');
+  }),
+  {},
+  'resource_name',
+  common.mustCall(function finalizer() {
+    throw new Error('finalizer error');
+  })
+);


### PR DESCRIPTION
Currently, those exceptions were swallowed and the execution may continue in an unstable state.

Following cases are covered in the PR that exceptions can be thrown on calling into modules:

1. TSFN callbacks
2. Finalizers

Fixes: https://github.com/nodejs/node/issues/36402

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] ~~documentation is changed or added~~
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
