### PR TITLE
src: expose PlatformInit

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -580,7 +580,7 @@ static struct {
 #endif  // __POSIX__
 
 
-inline void PlatformInit() {
+void PlatformInit() {
 #ifdef __POSIX__
 #if HAVE_INSPECTOR
   sigset_t sigmask;

--- a/src/node.h
+++ b/src/node.h
@@ -235,6 +235,8 @@ enum OptionEnvvarSettings {
   kDisallowedInEnvironment
 };
 
+NODE_EXTERN void PlatformInit();
+
 NODE_EXTERN int ProcessGlobalArgs(std::vector<std::string>* args,
                       std::vector<std::string>* exec_args,
                       std::vector<std::string>* errors,


### PR DESCRIPTION
When Node.js is run, it registers signal handlers specific to Node.js as well as does a handful of other platform-specific setup modifications. When embedders are running in emulated Node.js mode, as Electron does with `ELECTRON_RUN_AS_NODE` it's likely that they'd also wish to handle these platform-specific things in indentical or nearly-so ways.

As such, it would be helpful to expose this method such that embedders can avoid needing to replicate all its logic themselves.  

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
