### PR TITLE
workers: add periodic sync API

### DIFF
--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -647,6 +647,76 @@ If listeners are attached or removed using `.on('message')`, the port will
 be `ref()`ed and `unref()`ed automatically depending on whether
 listeners for the event exist.
 
+## Class: `PeriodicSyncEvent extends Event`
+<!-- YAML
+added: REPLACEME
+-->
+
+### `periodicSyncEvent.tag`
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {string}
+
+## Class: `PeriodicSyncManager`
+<!-- YAML
+added: REPLACEME
+-->
+
+The `PeriodicSyncManager` allows scheduling periodic notifications to be sent
+to a `Worker` to perform regular background operations.
+
+```js
+const worker = new Worker('worker.js');
+worker.periodicSync.register('foo', { minInterval: 10 * 1000 });
+
+// ...
+
+worker.periodicSync.unregister('foo');
+```
+
+Within the worker, periodic sync events are emitted using the `parentPort`. The
+event handler is invoked with a [`PeriodicSyncEvent`][] instance.
+
+```js
+const { parentPort } = require('worker_threads');
+
+parentPort.on('periodicSync', (event) => {
+  console.log(event.tag);
+});
+```
+
+Periodic sync tasks will not keep the worker or the main event loop thread
+active.
+
+### `periodicSync.getTags()`
+<!-- YAML
+added: REPLACEME
+-->
+
+* Returns: {Promise} An `Array` listing all registered tags.
+
+### `periodicSync.register(tag[, options])`
+<!-- YAML
+added: REPLACEME
+-->
+
+* `tag` {string}
+* `options` {object}
+  * `minInterval` {number} The minimum interval (in milliseconds) to
+    periodically trigger the notification. **Defaults**: `1000` milliseconds.
+    If a value less than `500` is provided, `500` is used.
+* Returns: {Promise}
+
+### `periodicSync.unregister(tag)`
+<!-- YAML
+added: REPLACEME
+-->
+
+* `tag` {string}
+* Returns: {Promise}
+
 ## Class: `Worker`
 <!-- YAML
 added: v10.5.0
@@ -955,6 +1025,13 @@ The event loop utilization of a worker is available only after the [`'online'`
 event][] emitted, and if called before this, or after the [`'exit'`
 event][], then all properties have the value of `0`.
 
+### `worker.periodicSync`
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: [`PeriodicSyncManager`][]
+
 ### `worker.postMessage(value[, transferList])`
 <!-- YAML
 added: v10.5.0
@@ -1087,6 +1164,8 @@ active handle in the event system. If the worker is already `unref()`ed calling
 [`FileHandle`]: fs.md#fs_class_filehandle
 [`KeyObject`]: crypto.md#crypto_class_keyobject
 [`MessagePort`]: #worker_threads_class_messageport
+[`PeriodicSyncEvent`]: #worker_threads_class_periodicsyncevent
+[`PeriodicSyncManager`]: #worker_threads_class_periodicsyncmanager
 [`SharedArrayBuffer`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer
 [`Uint8Array`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array
 [`WebAssembly.Module`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module

--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -43,6 +43,7 @@ const {
     // Messages that may be either received or posted
     STDIO_PAYLOAD,
     STDIO_WANTS_MORE_DATA,
+    PERIODIC_SYNC,
   },
   kStdioWantsMoreDataCallback
 } = workerIo;
@@ -63,6 +64,13 @@ setupInspectorHooks();
 setupDebugEnv();
 
 setupWarningHandler();
+
+class PeriodicSyncEvent extends Event {
+  constructor(tag) {
+    super('periodicSync');
+    this.tag = tag;
+  }
+}
 
 // Since worker threads cannot switch cwd, we do not need to
 // overwrite the process.env.NODE_V8_COVERAGE variable.
@@ -180,6 +188,8 @@ port.on('message', (message) => {
     const { stream, chunks } = message;
     for (const { chunk, encoding } of chunks)
       process[stream].push(chunk, encoding);
+  } else if (message.type === PERIODIC_SYNC) {
+    publicWorker.parentPort.dispatchEvent(new PeriodicSyncEvent(message.tag));
   } else {
     assert(
       message.type === STDIO_WANTS_MORE_DATA,

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -1,8 +1,11 @@
 'use strict';
 
 /* global SharedArrayBuffer */
+/* global clearInterval */
+/* global setInterval */
 
 const {
+  ArrayFrom,
   ArrayIsArray,
   ArrayPrototypeMap,
   ArrayPrototypePush,
@@ -15,6 +18,7 @@ const {
   Promise,
   PromiseResolve,
   RegExpPrototypeTest,
+  SafeMap,
   String,
   Symbol,
   SymbolFor,
@@ -68,6 +72,10 @@ const {
   kTotalResourceLimitCount
 } = internalBinding('worker');
 
+const {
+  validateInteger
+} = require('internal/validators');
+
 const kHandle = Symbol('kHandle');
 const kPublicPort = Symbol('kPublicPort');
 const kDispose = Symbol('kDispose');
@@ -93,6 +101,68 @@ if (isMainThread) {
     Atomics.add(cwdCounter, 0, 1);
     originalChdir(path);
   };
+}
+
+const kTimers = Symbol('kTimers');
+
+function triggerPeriodicSync(worker, tag) {
+  if (worker[kPort]) {
+    worker[kPort].postMessage({
+      type: messageTypes.PERIODIC_SYNC,
+      tag,
+    });
+  }
+}
+
+class PeriodicSyncManager {
+  constructor(worker) {
+    this[kTimers] = new SafeMap();
+    this[kHandle] = worker;
+  }
+
+  async register(tag, options = {}) {
+    if (this[kHandle] === undefined)
+      return;
+    tag = `${tag}`;
+    if (typeof options !== 'object' || options === null)
+      throw new ERR_INVALID_ARG_TYPE(options, 'object', options);
+    const {
+      minInterval = 1000
+    } = { ...options };
+    validateInteger(minInterval, 'options.minInterval');
+    await this.unregister(tag);
+    const interval = setInterval(
+      triggerPeriodicSync,
+      MathMax(minInterval, 500),
+      this[kHandle],
+      tag);
+    interval.unref();
+    this[kTimers].set(tag, interval);
+  }
+
+  async getTags() {
+    if (this[kHandle] === undefined)
+      return;
+    return ArrayFrom(this[kTimers].keys());
+  }
+
+  async unregister(tag) {
+    if (this[kHandle] === undefined)
+      return;
+    tag = `${tag}`;
+    const interval = this[kTimers].get(tag);
+    if (interval !== undefined) {
+      clearInterval(interval);
+      this[kTimers].delete(tag);
+    }
+  }
+
+  [kOnExit]() {
+    for (const items of this[kTimers])
+      clearInterval(items[1]);
+    this[kTimers] = undefined;
+    this[kHandle] = undefined;
+  }
 }
 
 class Worker extends EventEmitter {
@@ -238,12 +308,15 @@ class Worker extends EventEmitter {
     this.performance = {
       eventLoopUtilization: FunctionPrototypeBind(eventLoopUtilization, this),
     };
+    this.periodicSync = new PeriodicSyncManager(this);
     // Actually start the new thread now that everything is in place.
     this[kHandle].startThread();
   }
 
   [kOnExit](code, customErr, customErrReason) {
     debug(`[${threadId}] hears end event for Worker ${this.threadId}`);
+    if (typeof this.periodicSync[kOnExit] === 'function')
+      this.periodicSync[kOnExit]();
     drainMessagePort(this[kPublicPort]);
     drainMessagePort(this[kPort]);
     this[kDispose]();

--- a/lib/internal/worker/io.js
+++ b/lib/internal/worker/io.js
@@ -76,7 +76,8 @@ const messageTypes = {
   ERROR_MESSAGE: 'errorMessage',
   STDIO_PAYLOAD: 'stdioPayload',
   STDIO_WANTS_MORE_DATA: 'stdioWantsMoreData',
-  LOAD_SCRIPT: 'loadScript'
+  LOAD_SCRIPT: 'loadScript',
+  PERIODIC_SYNC: 'periodicSync',
 };
 
 // We have to mess with the MessagePort prototype a bit, so that a) we can make

--- a/test/parallel/test-worker-periodicsync.js
+++ b/test/parallel/test-worker-periodicsync.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const common = require('../common');
+const { Worker } = require('worker_threads');
+const assert = require('assert');
+
+(async () => {
+  const worker = new Worker(`
+    const { parentPort } = require('worker_threads');
+    const assert = require('assert');
+    parentPort.on('periodicSync', ({ type, tag }) => {
+      assert.strictEqual(type, 'periodicSync');
+      assert.strictEqual(tag, 'foo');
+      parentPort.postMessage({ type, tag });
+    });
+    parentPort.on('message', () => { /** nop to keep worker alive **/ });
+  `, { eval: true });
+
+  let calls = 0;
+
+  worker.on('message', common.mustCall(({ type, tag }) => {
+    assert.strictEqual(type, 'periodicSync');
+    assert.strictEqual(tag, 'foo');
+    if (++calls === 2)
+      worker.terminate();
+  }, 2));
+
+  assert(worker.periodicSync);
+
+  await worker.periodicSync.register('foo', { minInterval: 100 });
+  assert.deepStrictEqual(await worker.periodicSync.getTags(), ['foo']);
+
+  assert.rejects(worker.periodicSync.register('bar', { minInterval: 'a' }), {
+    code: 'ERR_INVALID_ARG_TYPE'
+  });
+  assert.rejects(worker.periodicSync.register(Symbol('bob')), TypeError);
+})().then(common.mustCall());


### PR DESCRIPTION
Based on the [Periodic Sync Web API](https://developer.mozilla.org/en-US/docs/Web/API/PeriodicSyncManager)

This is a pretty simple addition. Periodic syncs are effectively
a collection of named interval timers that will, from the thread
that created the worker, trigger a `periodicSync` event within the
worker on the `parentPort`. This can be used, for instance, to
schedule various regular synchronization tasks within the worker.

Signed-off-by: James M Snell <jasnell@gmail.com>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
