### PR TITLE
lib: remove v8_prof_polyfill from eslint ignore list

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,4 @@
 node_modules
-lib/internal/v8_prof_polyfill.js
 lib/punycode.js
 test/addons/??_*
 test/fixtures

--- a/lib/internal/v8_prof_polyfill.js
+++ b/lib/internal/v8_prof_polyfill.js
@@ -28,6 +28,7 @@
 'use strict';
 
 /* eslint-disable node-core/prefer-primordials */
+/* global Buffer, console */
 
 module.exports = { versionCheck };
 
@@ -38,8 +39,38 @@ if (module.id === 'internal/v8_prof_polyfill') return;
 
 // Node polyfill
 const fs = require('fs');
-const console = require('internal/console/global');
-const { Buffer } = require('buffer');
+const cp = require('child_process');
+const os = { // eslint-disable-line no-unused-vars
+  system: function(name, args) {
+    if (process.platform === 'linux' && name === 'nm') {
+      // Filter out vdso and vsyscall entries.
+      const arg = args[args.length - 1];
+      if (arg === '[vdso]' ||
+          arg === '[vsyscall]' ||
+          /^[0-9a-f]+-[0-9a-f]+$/.test(arg)) {
+        return '';
+      }
+    }
+    let out = cp.spawnSync(name, args).stdout.toString();
+    // Auto c++filt names, but not [iItT]
+    if (process.platform === 'darwin' && name === 'nm') {
+      // Nm prints an error along the lines of "Run xcodebuild -license" and
+      // exits when Xcode hasn't been properly installed or when its license
+      // hasn't been accepted yet. Basically any mention of xcodebuild in
+      // the output means the nm command is non-functional.
+      const match = out.match(/(?:^|\n)([^\n]*xcodebuild[^\n]*)(?:\n|$)/);
+      // eslint-disable-next-line no-restricted-syntax
+      if (match) throw new Error(match[1]);
+      out = macCppfiltNm(out);
+    }
+    return out;
+  }
+};
+const print = console.log; // eslint-disable-line no-unused-vars
+function read(fileName) { // eslint-disable-line no-unused-vars
+  return fs.readFileSync(fileName, 'utf8');
+}
+const quit = process.exit; // eslint-disable-line no-unused-vars
 
 // Polyfill "readline()".
 const logFile = arguments[arguments.length - 1]; // eslint-disable-line no-undef
@@ -103,4 +134,32 @@ function versionCheck(firstLine, expected) {
   for (let i = 0; i < 3; i++)
     if (curVer[i] !== firstLine[i + 1])
       return 'Testing v8 version different from logging version';
+}
+
+function macCppfiltNm(out) {
+  // Re-grouped copy-paste from `tickprocessor.js`
+  const FUNC_RE = /^([0-9a-fA-F]{8,16} [iItT] )(.*)$/gm;
+  const CLEAN_RE = /^[0-9a-fA-F]{8,16} [iItT] /;
+  let entries = out.match(FUNC_RE);
+  if (entries === null)
+    return out;
+
+  entries = entries.map((entry) => {
+    return entry.replace(CLEAN_RE, '');
+  });
+
+  let filtered;
+  try {
+    filtered = cp.spawnSync('c++filt', [ '-p', '-i' ], {
+      input: entries.join('\n')
+    }).stdout.toString();
+  } catch {
+    return out;
+  }
+
+  let i = 0;
+  filtered = filtered.split('\n');
+  return out.replace(FUNC_RE, (all, prefix, postfix) => {
+    return prefix + (filtered[i++] || postfix);
+  });
 }

--- a/lib/internal/v8_prof_polyfill.js
+++ b/lib/internal/v8_prof_polyfill.js
@@ -54,7 +54,7 @@ const os = { // eslint-disable-line no-unused-vars
     let out = cp.spawnSync(name, args).stdout.toString();
     // Auto c++filt names, but not [iItT]
     if (process.platform === 'darwin' && name === 'nm') {
-      // Nm prints an error along the lines of "Run xcodebuild -license" and
+      // `nm` prints an error along the lines of "Run xcodebuild -license" and
       // exits when Xcode hasn't been properly installed or when its license
       // hasn't been accepted yet. Basically any mention of xcodebuild in
       // the output means the nm command is non-functional.
@@ -144,9 +144,7 @@ function macCppfiltNm(out) {
   if (entries === null)
     return out;
 
-  entries = entries.map((entry) => {
-    return entry.replace(CLEAN_RE, '');
-  });
+  entries = entries.map((entry) => entry.replace(CLEAN_RE, ''));
 
   let filtered;
   try {

--- a/lib/internal/v8_prof_polyfill.js
+++ b/lib/internal/v8_prof_polyfill.js
@@ -25,7 +25,11 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-/* eslint-disable no-restricted-globals */
+'use strict';
+
+const {
+  JSONStringify,
+} = primordials;
 
 module.exports = { versionCheck };
 
@@ -36,43 +40,14 @@ if (module.id === 'internal/v8_prof_polyfill') return;
 
 // Node polyfill
 const fs = require('fs');
-const cp = require('child_process');
-const os = {
-  system: function(name, args) {
-    if (process.platform === 'linux' && name === 'nm') {
-      // Filter out vdso and vsyscall entries.
-      const arg = args[args.length - 1];
-      if (arg === '[vdso]' ||
-          arg === '[vsyscall]' ||
-          /^[0-9a-f]+-[0-9a-f]+$/.test(arg)) {
-        return '';
-      }
-    }
-    let out = cp.spawnSync(name, args).stdout.toString();
-    // Auto c++filt names, but not [iItT]
-    if (process.platform === 'darwin' && name === 'nm') {
-      // nm prints an error along the lines of "Run xcodebuild -license" and
-      // exits when Xcode hasn't been properly installed or when its license
-      // hasn't been accepted yet. Basically any mention of xcodebuild in
-      // the output means the nm command is non-functional.
-      const match = out.match(/(?:^|\n)([^\n]*xcodebuild[^\n]*)(?:\n|$)/);
-      if (match) throw new Error(match[1]);
-      out = macCppfiltNm(out);
-    }
-    return out;
-  }
-};
-const print = console.log;
-function read(fileName) {
-  return fs.readFileSync(fileName, 'utf8');
-}
-const quit = process.exit;
+const console = require('internal/console/global');
+const { Buffer } = require('buffer');
 
 // Polyfill "readline()".
-const logFile = arguments[arguments.length - 1];
+const logFile = arguments[arguments.length - 1]; // eslint-disable-line no-undef
 try {
   fs.accessSync(logFile);
-} catch(e) {
+} catch {
   console.error('Please provide a valid isolate file as the final argument.');
   process.exit(1);
 }
@@ -108,7 +83,7 @@ function readline() {
     if (bytes === 0) {
       process.emitWarning(`Profile file ${logFile} is broken`, {
         code: 'BROKEN_PROFILE_FILE',
-        detail: `${JSON.stringify(line)} at the file end is broken`
+        detail: `${JSONStringify(line)} at the file end is broken`
       });
       return '';
     }
@@ -121,8 +96,8 @@ function versionCheck(firstLine, expected) {
   // whereas process.versions.v8 is either "$major.$minor.$build-$embedder" or
   // "$major.$minor.$build.$patch-$embedder".
   firstLine = firstLine.split(',');
-  const curVer = expected.split(/[.\-]/);
-  if (firstLine.length !== 6 && firstLine.length !== 7 ||
+  const curVer = expected.split(/[.-]/);
+  if ((firstLine.length !== 6 && firstLine.length !== 7) ||
       firstLine[0] !== 'v8-version') {
     return 'Unable to read v8-version from log file.';
   }
@@ -130,32 +105,4 @@ function versionCheck(firstLine, expected) {
   for (let i = 0; i < 3; i++)
     if (curVer[i] !== firstLine[i + 1])
       return 'Testing v8 version different from logging version';
-}
-
-function macCppfiltNm(out) {
-  // Re-grouped copy-paste from `tickprocessor.js`
-  const FUNC_RE = /^([0-9a-fA-F]{8,16} [iItT] )(.*)$/gm;
-  const CLEAN_RE = /^[0-9a-fA-F]{8,16} [iItT] /;
-  let entries = out.match(FUNC_RE);
-  if (entries === null)
-    return out;
-
-  entries = entries.map((entry) => {
-    return entry.replace(CLEAN_RE, '')
-  });
-
-  let filtered;
-  try {
-    filtered = cp.spawnSync('c++filt', [ '-p' , '-i' ], {
-      input: entries.join('\n')
-    }).stdout.toString();
-  } catch {
-    return out;
-  }
-
-  let i = 0;
-  filtered = filtered.split('\n');
-  return out.replace(FUNC_RE, (all, prefix, postfix) => {
-    return prefix + (filtered[i++] || postfix);
-  });
 }

--- a/lib/internal/v8_prof_polyfill.js
+++ b/lib/internal/v8_prof_polyfill.js
@@ -27,9 +27,7 @@
 
 'use strict';
 
-const {
-  JSONStringify,
-} = primordials;
+/* eslint-disable node-core/prefer-primordials */
 
 module.exports = { versionCheck };
 
@@ -83,7 +81,7 @@ function readline() {
     if (bytes === 0) {
       process.emitWarning(`Profile file ${logFile} is broken`, {
         code: 'BROKEN_PROFILE_FILE',
-        detail: `${JSONStringify(line)} at the file end is broken`
+        detail: `${JSON.stringify(line)} at the file end is broken`
       });
       return '';
     }


### PR DESCRIPTION
I couldn't find a reason why linter is disabled for this file, so this PR enables it.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
