### PR TITLE
test: increase coverage for stream

### DIFF
--- a/test/parallel/test-readable-from.js
+++ b/test/parallel/test-readable-from.js
@@ -3,7 +3,13 @@
 const { mustCall } = require('../common');
 const { once } = require('events');
 const { Readable } = require('stream');
-const { strictEqual } = require('assert');
+const { strictEqual, throws } = require('assert');
+
+{
+  throws(() => {
+    Readable.from(null);
+  }, /ERR_INVALID_ARG_TYPE/);
+}
 
 async function toReadableBasicSupport() {
   async function* generate() {

--- a/test/parallel/test-stream-add-abort-signal.js
+++ b/test/parallel/test-stream-add-abort-signal.js
@@ -1,0 +1,27 @@
+// Flags: --expose-internals
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const { addAbortSignal, Readable } = require('stream');
+const {
+  addAbortSignalNoValidate,
+} = require('internal/streams/add-abort-signal');
+
+{
+  assert.throws(() => {
+    addAbortSignal('INVALID_SIGNAL');
+  }, /ERR_INVALID_ARG_TYPE/);
+
+  const ac = new AbortController();
+  assert.throws(() => {
+    addAbortSignal(ac.signal, 'INVALID_STREAM');
+  }, /ERR_INVALID_ARG_TYPE/);
+}
+
+{
+  const r = new Readable({
+    read: () => {},
+  });
+  assert.deepStrictEqual(r, addAbortSignalNoValidate('INVALID_SIGNAL', r));
+}

--- a/test/parallel/test-stream-writable-destroy.js
+++ b/test/parallel/test-stream-writable-destroy.js
@@ -446,3 +446,18 @@ const assert = require('assert');
   write.write('asd');
   ac.abort();
 }
+
+{
+  const ac = new AbortController();
+  ac.abort();
+
+  const write = new Writable({
+    signal: ac.signal,
+    write(chunk, enc, cb) { cb(); }
+  });
+
+  write.on('error', common.mustCall((e) => {
+    assert.strictEqual(e.name, 'AbortError');
+    assert.strictEqual(write.destroyed, true);
+  }));
+}


### PR DESCRIPTION
1. test addAbortSignal with invalid signal
Refs: https://coverage.nodejs.org/coverage-a1509261770cb645/lib/internal/streams/add-abort-signal.js.html#L17

2. test addAbortSignal with invalid stream
Refs: https://coverage.nodejs.org/coverage-a1509261770cb645/lib/internal/streams/add-abort-signal.js.html#L28

3. test addAbortSignalNoValidate with invalid signal
Refs: https://coverage.nodejs.org/coverage-a1509261770cb645/lib/internal/streams/add-abort-signal.js.html#L34

4. test addAbortSignalNoValidate with aborted signal
Refs:  https://coverage.nodejs.org/coverage-a1509261770cb645/lib/internal/streams/add-abort-signal.js.html#L40

5. test Readable.from with invalid args
Refs: https://coverage.nodejs.org/coverage-a1509261770cb645/lib/internal/streams/from.js.html#L31

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
