### PR TITLE
v8: Fix native `serdes` constructors

### DIFF
--- a/lib/v8.js
+++ b/lib/v8.js
@@ -35,8 +35,8 @@ const {
 const { Buffer } = require('buffer');
 const { validateString } = require('internal/validators');
 const {
-  Serializer: _Serializer,
-  Deserializer: _Deserializer
+  Serializer,
+  Deserializer
 } = internalBinding('serdes');
 
 let profiler = {};
@@ -69,13 +69,6 @@ function getHeapSnapshot() {
   assert(handle);
   return new HeapSnapshotStream(handle);
 }
-
-// Calling exposed c++ functions directly throws exception as it expected to be
-// called with new operator and caused an assert to fire.
-// Creating JS wrapper so that it gets caught at JS layer.
-class Serializer extends _Serializer { }
-
-class Deserializer extends _Deserializer { }
 
 const {
   cachedDataVersionTag,

--- a/src/node_serdes.cc
+++ b/src/node_serdes.cc
@@ -169,6 +169,10 @@ Maybe<bool> SerializerContext::WriteHostObject(Isolate* isolate,
 
 void SerializerContext::New(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  if (!args.IsConstructCall()) {
+    return THROW_ERR_CONSTRUCT_CALL_REQUIRED(
+        env, "Class constructor Serializer cannot be invoked without 'new'");
+  }
 
   new SerializerContext(env, args.This());
 }
@@ -319,6 +323,10 @@ MaybeLocal<Object> DeserializerContext::ReadHostObject(Isolate* isolate) {
 
 void DeserializerContext::New(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  if (!args.IsConstructCall()) {
+    return THROW_ERR_CONSTRUCT_CALL_REQUIRED(
+        env, "Class constructor Deserializer cannot be invoked without 'new'");
+  }
 
   if (!args[0]->IsArrayBufferView()) {
     return node::THROW_ERR_INVALID_ARG_TYPE(
@@ -470,6 +478,7 @@ void Initialize(Local<Object> target,
   Local<String> serializerString =
       FIXED_ONE_BYTE_STRING(env->isolate(), "Serializer");
   ser->SetClassName(serializerString);
+  ser->ReadOnlyPrototype();
   target->Set(env->context(),
               serializerString,
               ser->GetFunction(env->context()).ToLocalChecked()).Check();
@@ -496,6 +505,8 @@ void Initialize(Local<Object> target,
 
   Local<String> deserializerString =
       FIXED_ONE_BYTE_STRING(env->isolate(), "Deserializer");
+  des->SetLength(1);
+  des->ReadOnlyPrototype();
   des->SetClassName(deserializerString);
   target->Set(env->context(),
               deserializerString,

--- a/test/parallel/test-v8-serdes.js
+++ b/test/parallel/test-v8-serdes.js
@@ -25,11 +25,6 @@ const objects = [
 
 const hostObject = new (internalBinding('js_stream').JSStream)();
 
-const serializerTypeError =
-  /^TypeError: Class constructor Serializer cannot be invoked without 'new'$/;
-const deserializerTypeError =
-  /^TypeError: Class constructor Deserializer cannot be invoked without 'new'$/;
-
 {
   const ser = new v8.DefaultSerializer();
   ser.writeHeader();
@@ -186,8 +181,16 @@ const deserializerTypeError =
 }
 
 {
-  assert.throws(v8.Serializer, serializerTypeError);
-  assert.throws(v8.Deserializer, deserializerTypeError);
+  assert.throws(() => v8.Serializer(), {
+    constructor: TypeError,
+    message: "Class constructor Serializer cannot be invoked without 'new'",
+    code: 'ERR_CONSTRUCT_CALL_REQUIRED'
+  });
+  assert.throws(() => v8.Deserializer(), {
+    constructor: TypeError,
+    message: "Class constructor Deserializer cannot be invoked without 'new'",
+    code: 'ERR_CONSTRUCT_CALL_REQUIRED'
+  });
 }
 
 


### PR DESCRIPTION
This removes the indirection added by the `class Serializer extends _Serializer {}` by utilising `THROW_ERR_CONSTRUCT_CALL_REQUIRED` from `node_errors.h`, which is used by `MessageChannel` to avoid the same issue.

---

This also makes it so that a `new Serializer()` or `new Deserializer(buffer)` call with a poisoned `Array.prototype[Symbol.iterator]` works fine.

---

This also prevents:
```js
Object.getPrototypeOf(require('v8').Serializer)()
```
from crashing the node process.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

#### Related Issues

Fixes: <https://github.com/nodejs/node/issues/13326>

**Refs:** <https://github.com/nodejs/node/pull/13541>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
