### PR TITLE
tools: fix release script sign function

### DIFF
--- a/tools/release.sh
+++ b/tools/release.sh
@@ -103,9 +103,9 @@ sign() {
   # shellcheck disable=SC2086,SC2029
   shapath=$(ssh ${customsshkey} "${webuser}@${webhost}" $signcmd nodejs $1)
 
-  echo "${shapath}" | grep -q '^/.*/SHASUMS256.txt$' || \
-    echo 'Error: No SHASUMS file returned by sign!' \
-    exit 1
+  echo "${shapath}" | grep -q '^/.*/SHASUMS256.txt$' || (\
+    echo 'Error: No SHASUMS file returned by sign!' &&\
+    exit 1)
 
   echo ""
   echo "# Signing SHASUMS for $1..."
@@ -141,7 +141,8 @@ sign() {
     fi
 
     if [ "X${yorn}" = "Xy" ]; then
-      scp "${customsshkey}" "${tmpdir}/${shafile}" "${tmpdir}/${shafile}.asc" "${tmpdir}/${shafile}.sig" "${webuser}@${webhost}:${shadir}/"
+      # shellcheck disable=SC2086
+      scp ${customsshkey} "${tmpdir}/${shafile}" "${tmpdir}/${shafile}.asc" "${tmpdir}/${shafile}.sig" "${webuser}@${webhost}:${shadir}/"
       # shellcheck disable=SC2086,SC2029
       ssh ${customsshkey} "${webuser}@${webhost}" chmod 644 "${shadir}/${shafile}.asc" "${shadir}/${shafile}.sig"
       break


### PR DESCRIPTION
I forgot one `scp` command in the previous fix (https://github.com/nodejs/node/pull/36540), this PR is fixing that.

@BethGriggs Apologies for breaking your release flow twice in a row, I really hope this time's the last one 🙈

Refs: https://github.com/nodejs/node/pull/36540#issuecomment-747777947
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
