### PR TITLE
repl: disable blocking completions by default

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -298,6 +298,7 @@ function REPLServer(prompt,
     configurable: true
   });
 
+  this.allowBlockingCompletions = !!options.allowBlockingCompletions;
   this.useColors = !!options.useColors;
   this._domain = options.domain || domain.create();
   this.useGlobal = !!useGlobal;
@@ -1204,7 +1205,8 @@ function complete(line, callback) {
     if (completeOn.length) {
       filter = completeOn;
     }
-  } else if (RegExpPrototypeTest(requireRE, line)) {
+  } else if (RegExpPrototypeTest(requireRE, line) &&
+             this.allowBlockingCompletions) {
     // require('...<Tab>')
     const extensions = ObjectKeys(this.context.require.extensions);
     const indexes = ArrayPrototypeMap(extensions,
@@ -1265,7 +1267,8 @@ function complete(line, callback) {
     if (!subdir) {
       ArrayPrototypePush(completionGroups, _builtinLibs);
     }
-  } else if (RegExpPrototypeTest(fsAutoCompleteRE, line)) {
+  } else if (RegExpPrototypeTest(fsAutoCompleteRE, line) &&
+             this.allowBlockingCompletions) {
     [completionGroups, completeOn] = completeFSFunctions(line);
   // Handle variable member lookup.
   // We support simple chained expressions like the following (no function

--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -51,7 +51,12 @@ function getNoResultsFunction() {
 
 const works = [['inner.one'], 'inner.o'];
 const putIn = new ArrayStream();
-const testMe = repl.start('', putIn);
+const testMe = repl.start({
+  prompt: '',
+  input: putIn,
+  output: process.stdout,
+  allowBlockingCompletions: true
+});
 
 // Some errors are passed to the domain, but do not callback
 testMe._domain.on('error', assert.ifError);


### PR DESCRIPTION
It’s not okay for the REPL to be blocked for multiple seconds after
entering `require('` because the completion is performing blocking
fs operations on potentially huge directories. Turning the REPL
completion function asynchronous would be the right thing to do here,
but unfortunately the way the code is structured doesn’t play well
with that (in particular, it breaks the preview feature).
Therefore, disable these blocking calls by default.

Refs: https://github.com/nodejs/node/pull/33282#issuecomment-733646794

Example:

```
$ ls node_modules | wc
   1161    1161   14776
$ sync; echo 3 | sudo tee /proc/sys/vm/drop_caches
3
$ echo 'console.time(); repl.repl.complete(`require("`, () => {}); console.timeEnd();'|node -i
Welcome to Node.js v16.0.0-pre.
Type ".help" for more information.
> console.time(); repl.repl.complete(`require("`, () => {}); console.timeEnd();
default: 6.768s
undefined
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
