### PR TITLE
deps: V8: cherry-pick dfcdf7837e23

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.21',
+    'v8_embedder_string': '-node.22',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/parsing/parser-base.h
+++ b/deps/v8/src/parsing/parser-base.h
@@ -2989,12 +2989,15 @@ ParserBase<Impl>::ParseCoalesceExpression(ExpressionT expression) {
   bool first_nullish = true;
   while (peek() == Token::NULLISH) {
     SourceRange right_range;
-    SourceRangeScope right_range_scope(scanner(), &right_range);
-    Consume(Token::NULLISH);
-    int pos = peek_position();
-
-    // Parse BitwiseOR or higher.
-    ExpressionT y = ParseBinaryExpression(6);
+    int pos;
+    ExpressionT y;
+    {
+      SourceRangeScope right_range_scope(scanner(), &right_range);
+      Consume(Token::NULLISH);
+      pos = peek_position();
+      // Parse BitwiseOR or higher.
+      y = ParseBinaryExpression(6);
+    }
     if (first_nullish) {
       expression =
           factory()->NewBinaryOperation(Token::NULLISH, expression, y, pos);

--- a/deps/v8/test/mjsunit/code-coverage-block.js
+++ b/deps/v8/test/mjsunit/code-coverage-block.js
@@ -1177,4 +1177,22 @@ a(true);                                  // 0500
  {"start":0,"end":401,"count":2},
  {"start":154,"end":254,"count":0}]);
 
+ TestCoverage(
+"https://crbug.com/v8/11231 - nullish coalescing",
+`
+const a = true                            // 0000
+const b = false                           // 0050
+const c = undefined                       // 0100
+const d = a ?? 99                         // 0150
+const e = 33                              // 0200
+const f = b ?? (c ?? 99)                  // 0250
+const g = 33                              // 0300
+const h = c ?? (c ?? 'hello')             // 0350
+const i = c ?? b ?? 'hello'               // 0400
+`,
+[{"start":0,"end":449,"count":1},
+ {"start":162,"end":167,"count":0},
+ {"start":262,"end":274,"count":0},
+ {"start":417,"end":427,"count":0}]);
+
 %DebugToggleBlockCoverage(false);


### PR DESCRIPTION
Coverage for nullish coalescing was broken in v8, and eating more characters than one would expect:

<img width="294" alt="Screen Shot 2020-12-18 at 2 47 17 PM" src="https://user-images.githubusercontent.com/194609/102668172-20dd0480-4140-11eb-8937-d2f16d425797.png">

This patch fixes it:

<img width="377" alt="Screen Shot 2020-12-18 at 2 49 07 PM" src="https://user-images.githubusercontent.com/194609/102668212-35210180-4140-11eb-8872-1eb996694182.png">

Original commit message:

    [coverage] fix greedy nullish coalescing

    The SourceRangeScope helper was consuming too many characters, instead
    explicitly create SourceRange, based on scanner position.

    Bug: v8:11231
    Change-Id: I852d211227abacf867e8f1ab3e3ab06dbdba2a9b
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2576006
    Reviewed-by: Toon Verwaest <verwaest@chromium.org>
    Commit-Queue: Toon Verwaest <verwaest@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#71765}

Refs: https://github.com/v8/v8/commit/dfcdf7837e23cc0da31f9b2d4211f856413d13af

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

#### Related Issues

Fixes: https://github.com/nodejs/node/issues/36619

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
