### PR TITLE
buffer: make FastBuffer safe to construct

### DIFF
--- a/lib/internal/buffer.js
+++ b/lib/internal/buffer.js
@@ -949,7 +949,14 @@ function writeFloatBackwards(val, offset = 0) {
   return offset;
 }
 
-class FastBuffer extends Uint8Array {}
+class FastBuffer extends Uint8Array {
+  // Using an explicit constructor here is necessary to avoid relying on
+  // `Array.prototype[Symbol.iterator]`, which can be mutated by users.
+  // eslint-disable-next-line no-useless-constructor
+  constructor(bufferOrLength, byteOffset, length) {
+    super(bufferOrLength, byteOffset, length);
+  }
+}
 
 function addBufferPrototypeMethods(proto) {
   proto.readBigUInt64LE = readBigUInt64LE;


### PR DESCRIPTION
Default constructor iterates over the argument when calling the `super` constructor, we can get better result by passing an exact number of arguments on Apple Silicon processors.

<details>
<summary>Benchmark I run locally</summary>

```
                                                                     confidence improvement accuracy (*)   (**)  (***)
 buffers/buffer-creation.js n=600000 len=10 type='fast-alloc-fill'           ***      3.12 %       ±1.34% ±1.79% ±2.34%
 buffers/buffer-creation.js n=600000 len=10 type='fast-alloc'                         1.34 %       ±1.37% ±1.83% ±2.41%
 buffers/buffer-creation.js n=600000 len=10 type='fast-allocUnsafe'          ***      2.81 %       ±0.22% ±0.29% ±0.38%
 buffers/buffer-creation.js n=600000 len=10 type='slow-allocUnsafe'          ***      1.06 %       ±0.47% ±0.63% ±0.82%
 buffers/buffer-creation.js n=600000 len=1024 type='fast-alloc-fill'         ***      2.07 %       ±0.66% ±0.88% ±1.15%
 buffers/buffer-creation.js n=600000 len=1024 type='fast-alloc'                       1.10 %       ±1.42% ±1.89% ±2.47%
 buffers/buffer-creation.js n=600000 len=1024 type='fast-allocUnsafe'        ***      2.04 %       ±0.78% ±1.04% ±1.35%
 buffers/buffer-creation.js n=600000 len=1024 type='slow-allocUnsafe'                 1.22 %       ±3.00% ±4.00% ±5.21%
 buffers/buffer-creation.js n=600000 len=4096 type='fast-alloc-fill'                 -0.57 %       ±0.69% ±0.92% ±1.19%
 buffers/buffer-creation.js n=600000 len=4096 type='fast-alloc'                      -0.55 %       ±0.65% ±0.86% ±1.12%
 buffers/buffer-creation.js n=600000 len=4096 type='fast-allocUnsafe'        ***      6.19 %       ±1.30% ±1.72% ±2.24%
 buffers/buffer-creation.js n=600000 len=4096 type='slow-allocUnsafe'        ***      5.92 %       ±1.09% ±1.46% ±1.90%
 buffers/buffer-creation.js n=600000 len=8192 type='fast-alloc-fill'                  0.88 %       ±0.98% ±1.30% ±1.70%
 buffers/buffer-creation.js n=600000 len=8192 type='fast-alloc'                      -0.22 %       ±1.16% ±1.54% ±2.00%
 buffers/buffer-creation.js n=600000 len=8192 type='fast-allocUnsafe'                 0.81 %       ±1.50% ±2.00% ±2.62%
 buffers/buffer-creation.js n=600000 len=8192 type='slow-allocUnsafe'                 1.11 %       ±1.17% ±1.56% ±2.03%

Be aware that when doing many comparisons the risk of a false-positive
result increases. In this case there are 16 comparisons, you can thus
expect the following amount of false-positive results:
  0.80 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.16 false positives, when considering a   1% risk acceptance (**, ***),
  0.02 false positives, when considering a 0.1% risk acceptance (***)
```

</details>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

#### Related Issues

Refs: https://github.com/nodejs/node/pull/36428
Refs: https://github.com/nodejs/node/pull/36532

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
