### PR TITLE
lib: avoid unsafe String methods that depend on RegExp prototype methods

### DIFF
--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -26,7 +26,7 @@ const tls = require('tls');
 const {
   ArrayPrototypePush,
   ObjectCreate,
-  StringPrototypeReplace,
+  RegExpPrototypeSymbolReplace,
 } = primordials;
 
 const {
@@ -135,13 +135,15 @@ function translatePeerCertificate(c) {
     c.infoAccess = ObjectCreate(null);
 
     // XXX: More key validation?
-    StringPrototypeReplace(info, /([^\n:]*):([^\n]*)(?:\n|$)/g,
-                           (all, key, val) => {
-                             if (key in c.infoAccess)
-                               ArrayPrototypePush(c.infoAccess[key], val);
-                             else
-                               c.infoAccess[key] = [val];
-                           });
+    RegExpPrototypeSymbolReplace(
+      /([^\n:]*):([^\n]*)(?:\n|$)/g,
+      info,
+      (all, key, val) => {
+        if (key in c.infoAccess)
+          ArrayPrototypePush(c.infoAccess[key], val);
+        else
+          c.infoAccess[key] = [val];
+      });
   }
   return c;
 }

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -31,8 +31,9 @@ const {
   ObjectSetPrototypeOf,
   ReflectApply,
   RegExp,
+  RegExpPrototypeSymbolReplace,
   RegExpPrototypeTest,
-  StringPrototypeReplace,
+  StringPrototypeReplaceAll,
   StringPrototypeSlice,
   Symbol,
   SymbolFor,
@@ -1444,9 +1445,10 @@ Server.prototype.addContext = function(servername, context) {
     throw new ERR_TLS_REQUIRED_SERVER_NAME();
   }
 
-  const re = new RegExp('^' + StringPrototypeReplace(
-    StringPrototypeReplace(servername, /([.^$+?\-\\[\]{}])/g, '\\$1'),
-    /\*/g, '[^.]*'
+  const re = new RegExp('^' + StringPrototypeReplaceAll(
+    RegExpPrototypeSymbolReplace(/([.^$+?\-\\[\]{}])/g, servername, '\\$1'),
+    '*',
+    '[^.]*',
   ) + '$');
   ArrayPrototypePush(this._contexts,
                      [re, tls.createSecureContext(context).context]);

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -35,13 +35,14 @@ const {
   ObjectKeys,
   ObjectPrototypeIsPrototypeOf,
   ReflectApply,
+  RegExpPrototypeSymbolReplace,
   RegExpPrototypeTest,
   SafeMap,
   String,
   StringPrototypeCharCodeAt,
   StringPrototypeIncludes,
   StringPrototypeIndexOf,
-  StringPrototypeReplace,
+  StringPrototypeReplaceAll,
   StringPrototypeSlice,
   StringPrototypeSplit,
   StringPrototypeStartsWith,
@@ -271,9 +272,10 @@ function parseCode(code, offset) {
 
   return [
     node.node.start,
-    StringPrototypeReplace(StringPrototypeSlice(code,
-                                                node.node.start, node.node.end),
-                           escapeSequencesRegExp, escapeFn),
+    RegExpPrototypeSymbolReplace(
+      escapeSequencesRegExp,
+      StringPrototypeSlice(code, node.node.start, node.node.end),
+      escapeFn),
   ];
 }
 
@@ -346,7 +348,7 @@ function getErrMessage(message, fn) {
     // Always normalize indentation, otherwise the message could look weird.
     if (StringPrototypeIncludes(message, '\n')) {
       if (EOL === '\r\n') {
-        message = StringPrototypeReplace(message, /\r\n/g, '\n');
+        message = StringPrototypeReplaceAll(message, '\r\n', '\n');
       }
       const frames = StringPrototypeSplit(message, '\n');
       message = ArrayPrototypeShift(frames);

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -36,8 +36,8 @@ const {
   ObjectDefineProperties,
   ObjectDefineProperty,
   ObjectSetPrototypeOf,
+  RegExpPrototypeSymbolReplace,
   StringPrototypeCharCodeAt,
-  StringPrototypeReplace,
   StringPrototypeSlice,
   StringPrototypeToLowerCase,
   StringPrototypeTrim,
@@ -832,8 +832,8 @@ Buffer.prototype[customInspectSymbol] = function inspect(recurseTimes, ctx) {
   const max = INSPECT_MAX_BYTES;
   const actualMax = MathMin(max, this.length);
   const remaining = this.length - max;
-  let str = StringPrototypeTrim(StringPrototypeReplace(
-    this.hexSlice(0, actualMax), /(.{2})/g, '$1 '));
+  let str = StringPrototypeTrim(RegExpPrototypeSymbolReplace(
+    /(.{2})/g, this.hexSlice(0, actualMax), '$1 '));
   if (remaining > 0)
     str += ` ... ${remaining} more byte${remaining > 1 ? 's' : ''}`;
   // Inspect special properties as well, if possible.

--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -29,7 +29,7 @@ const {
   StringPrototypeIncludes,
   StringPrototypePadStart,
   StringPrototypeRepeat,
-  StringPrototypeReplace,
+  StringPrototypeReplaceAll,
   StringPrototypeSlice,
   StringPrototypeSplit,
   Symbol,
@@ -265,7 +265,7 @@ ObjectDefineProperties(Console.prototype, {
 
       if (groupIndent.length !== 0) {
         if (StringPrototypeIncludes(string, '\n')) {
-          string = StringPrototypeReplace(string, /\n/g, `\n${groupIndent}`);
+          string = StringPrototypeReplaceAll(string, '\n', `\n${groupIndent}`);
         }
         string = groupIndent + string;
       }

--- a/lib/internal/dns/utils.js
+++ b/lib/internal/dns/utils.js
@@ -7,8 +7,8 @@ const {
   ArrayPrototypePush,
   FunctionPrototypeBind,
   NumberParseInt,
-  StringPrototypeMatch,
-  StringPrototypeReplace,
+  RegExpPrototypeExec,
+  RegExpPrototypeSymbolReplace,
 } = primordials;
 
 const errors = require('internal/errors');
@@ -86,7 +86,7 @@ class Resolver {
       if (ipVersion !== 0)
         return ArrayPrototypePush(newSet, [ipVersion, serv, IANA_DNS_PORT]);
 
-      const match = StringPrototypeMatch(serv, IPv6RE);
+      const match = RegExpPrototypeExec(IPv6RE, serv);
 
       // Check for an IPv6 in brackets.
       if (match) {
@@ -94,13 +94,14 @@ class Resolver {
 
         if (ipVersion !== 0) {
           const port = NumberParseInt(
-            StringPrototypeReplace(serv, addrSplitRE, '$2')) || IANA_DNS_PORT;
+            RegExpPrototypeSymbolReplace(addrSplitRE, serv, '$2')
+          ) || IANA_DNS_PORT;
           return ArrayPrototypePush(newSet, [ipVersion, match[1], port]);
         }
       }
 
       // addr::port
-      const addrSplitMatch = StringPrototypeMatch(serv, addrSplitRE);
+      const addrSplitMatch = RegExpPrototypeExec(addrSplitRE, serv);
 
       if (addrSplitMatch) {
         const hostIP = addrSplitMatch[1];

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -41,6 +41,7 @@ const {
   ObjectPrototypeHasOwnProperty,
   RangeError,
   ReflectApply,
+  RegExpPrototypeExec,
   RegExpPrototypeTest,
   SafeArrayIterator,
   SafeMap,
@@ -48,7 +49,6 @@ const {
   String,
   StringPrototypeEndsWith,
   StringPrototypeIncludes,
-  StringPrototypeMatch,
   StringPrototypeSlice,
   StringPrototypeSplit,
   StringPrototypeStartsWith,
@@ -422,7 +422,7 @@ function getMessage(key, args, self) {
   }
 
   const expectedLength =
-    (StringPrototypeMatch(msg, /%[dfijoOs]/g) || []).length;
+    (RegExpPrototypeExec(/%[dfijoOs]/g, msg) || []).length;
   assert(
     expectedLength === args.length,
     `Code: ${key}; The provided arguments length (${args.length}) does not ` +

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -19,7 +19,7 @@ const {
   ReflectOwnKeys,
   StringPrototypeEndsWith,
   StringPrototypeIncludes,
-  StringPrototypeReplace,
+  StringPrototypeReplaceAll,
   Symbol,
   TypedArrayPrototypeIncludes,
 } = primordials;
@@ -393,7 +393,7 @@ function preprocessSymlinkDestination(path, type, linkPath) {
     return pathModule.toNamespacedPath(path);
   }
   // Windows symlinks don't tolerate forward slashes.
-  return StringPrototypeReplace(path, /\//g, '\\');
+  return StringPrototypeReplaceAll(path, '/', '\\');
 }
 
 // Constructor for file stats.

--- a/lib/internal/main/print_help.js
+++ b/lib/internal/main/print_help.js
@@ -8,11 +8,11 @@ const {
   MathMax,
   ObjectKeys,
   RegExp,
+  RegExpPrototypeSymbolReplace,
   StringPrototypeLocaleCompare,
   StringPrototypeSlice,
   StringPrototypeTrimLeft,
   StringPrototypeRepeat,
-  StringPrototypeReplace,
   SafeMap,
 } = primordials;
 
@@ -77,14 +77,14 @@ const envVars = new SafeMap(ArrayPrototypeConcat([
 
 
 function indent(text, depth) {
-  return StringPrototypeReplace(text, /^/gm, StringPrototypeRepeat(' ', depth));
+  return RegExpPrototypeSymbolReplace(/^/gm, text, StringPrototypeRepeat(' ', depth));
 }
 
 function fold(text, width) {
-  return StringPrototypeReplace(text,
-                                new RegExp(`([^\n]{0,${width}})( |$)`, 'g'),
-                                (_, newLine, end) =>
-                                  newLine + (end === ' ' ? '\n' : ''));
+  return RegExpPrototypeSymbolReplace(
+    new RegExp(`([^\n]{0,${width}})( |$)`, 'g'),
+    text,
+    (_, newLine, end) => newLine + (end === ' ' ? '\n' : ''));
 }
 
 function getArgDescription(type) {

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -58,7 +58,6 @@ const {
   StringPrototypeEndsWith,
   StringPrototypeLastIndexOf,
   StringPrototypeIndexOf,
-  StringPrototypeMatch,
   StringPrototypeRepeat,
   StringPrototypeSlice,
   StringPrototypeSplit,
@@ -472,7 +471,7 @@ const EXPORTS_PATTERN = /^((?:@[^/\\%]+\/)?[^./\\%][^/\\%]*)(\/.*)?$/;
 function resolveExports(nmPath, request) {
   // The implementation's behavior is meant to mirror resolution in ESM.
   const { 1: name, 2: expansion = '' } =
-    StringPrototypeMatch(request, EXPORTS_PATTERN) || [];
+    RegExpPrototypeExec(EXPORTS_PATTERN, request) || [];
   if (!name)
     return;
   const pkgPath = path.resolve(nmPath, name);

--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -12,12 +12,12 @@ const {
   PromiseResolve,
   PromisePrototypeCatch,
   ReflectApply,
+  RegExpPrototypeExec,
   RegExpPrototypeTest,
+  RegExpPrototypeSymbolReplace,
   SafeArrayIterator,
   SafeSet,
   StringPrototypeIncludes,
-  StringPrototypeMatch,
-  StringPrototypeReplace,
   StringPrototypeSplit,
   StringPrototypeStartsWith,
 } = primordials;
@@ -136,14 +136,14 @@ class ModuleJob {
           StringPrototypeIncludes(e.message,
                                   ' does not provide an export named')) {
         const splitStack = StringPrototypeSplit(e.stack, '\n');
-        const parentFileUrl = StringPrototypeReplace(
-          splitStack[0],
+        const parentFileUrl = RegExpPrototypeSymbolReplace(
           /:\d+$/,
+          splitStack[0],
           ''
         );
-        const { 1: childSpecifier, 2: name } = StringPrototypeMatch(
-          e.message,
-          /module '(.*)' does not provide an export named '(.+)'/);
+        const { 1: childSpecifier, 2: name } = RegExpPrototypeExec(
+          /module '(.*)' does not provide an export named '(.+)'/,
+          e.message);
         const { url: childFileURL } = await this.loader.resolve(
           childSpecifier, parentFileUrl,
         );
@@ -162,9 +162,9 @@ class ModuleJob {
           // line which causes the error. For multi-line import statements we
           // cannot generate an equivalent object destructuring assignment by
           // just parsing the error stack.
-          const oneLineNamedImports = StringPrototypeMatch(importStatement, /{.*}/);
+          const oneLineNamedImports = RegExpPrototypeExec(/{.*}/, importStatement);
           const destructuringAssignment = oneLineNamedImports &&
-            StringPrototypeReplace(oneLineNamedImports, /\s+as\s+/g, ': ');
+            RegExpPrototypeSymbolReplace(/\s+as\s+/g, oneLineNamedImports, ': ');
           e.message = `Named export '${name}' not found. The requested module` +
             ` '${childSpecifier}' is a CommonJS module, which may not support` +
             ' all module.exports as named exports.\nCommonJS modules can ' +

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -13,7 +13,7 @@ const {
   SafeArrayIterator,
   SafeMap,
   SafeSet,
-  StringPrototypeReplace,
+  StringPrototypeReplaceAll,
   StringPrototypeSlice,
   StringPrototypeStartsWith,
   SyntaxErrorPrototype,
@@ -164,14 +164,13 @@ function enrichCJSError(err, content, filename) {
 
 // Strategy for loading a node-style CommonJS module
 const isWindows = process.platform === 'win32';
-const winSepRegEx = /\//g;
 translators.set('commonjs', async function commonjsStrategy(url, source,
                                                             isMain) {
   debug(`Translating CJSModule ${url}`);
 
   let filename = internalURLModule.fileURLToPath(new URL(url));
   if (isWindows)
-    filename = StringPrototypeReplace(filename, winSepRegEx, '\\');
+    filename = StringPrototypeReplaceAll(filename, '/', '\\');
 
   if (!cjsParse) await initCJSParse();
   const { module, exportNames } = cjsPreparseModuleExports(filename);
@@ -290,7 +289,7 @@ translators.set('json', async function jsonStrategy(url, source) {
   let module;
   if (pathname) {
     modulePath = isWindows ?
-      StringPrototypeReplace(pathname, winSepRegEx, '\\') : pathname;
+      StringPrototypeReplaceAll(pathname, '/', '\\') : pathname;
     module = CJSModule._cache[modulePath];
     if (module && module.loaded) {
       const exports = module.exports;

--- a/lib/internal/policy/manifest.js
+++ b/lib/internal/policy/manifest.js
@@ -10,11 +10,11 @@ const {
   ObjectKeys,
   ObjectSetPrototypeOf,
   RegExpPrototypeExec,
+  RegExpPrototypeSymbolReplace,
   RegExpPrototypeTest,
   SafeMap,
   SafeSet,
   StringPrototypeEndsWith,
-  StringPrototypeReplace,
   Symbol,
   uncurryThis,
 } = primordials;
@@ -651,10 +651,10 @@ const emptyOrProtocolOrResolve = (resourceHREF, base) => {
   if (resourceHREF === '') return '';
   if (StringPrototypeEndsWith(resourceHREF, ':')) {
     // URL parse will trim these anyway, save the compute
-    resourceHREF = StringPrototypeReplace(
-      resourceHREF,
+    resourceHREF = RegExpPrototypeSymbolReplace(
       // eslint-disable-next-line
       /^[\x00-\x1F\x20]|\x09\x0A\x0D|[\x00-\x1F\x20]$/g,
+      resourceHREF,
       ''
     );
     if (RegExpPrototypeTest(/^[a-zA-Z][a-zA-Z+\-.]*:$/, resourceHREF)) {

--- a/lib/internal/process/per_thread.js
+++ b/lib/internal/process/per_thread.js
@@ -16,13 +16,14 @@ const {
   NumberMAX_SAFE_INTEGER,
   ObjectFreeze,
   ReflectApply,
+  RegExpPrototypeSymbolReplace,
   RegExpPrototypeTest,
   SafeArrayIterator,
   Set,
   SetPrototypeEntries,
   SetPrototypeValues,
   StringPrototypeEndsWith,
-  StringPrototypeReplace,
+  StringPrototypeReplaceAll,
   StringPrototypeSlice,
   StringPrototypeStartsWith,
   Symbol,
@@ -250,7 +251,6 @@ function wrapProcessMethods(binding) {
   };
 }
 
-const replaceUnderscoresRegex = /_/g;
 const leadingDashesRegex = /^--?/;
 const trailingValuesRegex = /=.*$/;
 
@@ -296,7 +296,7 @@ function buildAllowedFlags() {
   }
 
   const trimLeadingDashes =
-    (flag) => StringPrototypeReplace(flag, leadingDashesRegex, '');
+    (flag) => RegExpPrototypeSymbolReplace(leadingDashesRegex, flag, '');
 
   // Save these for comparison against flags provided to
   // process.allowedNodeEnvironmentFlags.has() which lack leading dashes.
@@ -332,9 +332,9 @@ function buildAllowedFlags() {
       // on a dummy option set and see whether it rejects the argument or
       // not.
       if (typeof key === 'string') {
-        key = StringPrototypeReplace(key, replaceUnderscoresRegex, '-');
+        key = StringPrototypeReplaceAll(key, '_', '-');
         if (RegExpPrototypeTest(leadingDashesRegex, key)) {
-          key = StringPrototypeReplace(key, trailingValuesRegex, '');
+          key = RegExpPrototypeSymbolReplace(trailingValuesRegex, key, '');
           return ArrayPrototypeIncludes(this[kInternal].array, key);
         }
         return ArrayPrototypeIncludes(nodeFlags, key);

--- a/lib/internal/readline/utils.js
+++ b/lib/internal/readline/utils.js
@@ -3,11 +3,11 @@
 const {
   ArrayPrototypeSlice,
   ArrayPrototypeSort,
+  RegExpPrototypeExec,
   RegExpPrototypeTest,
   StringFromCharCode,
   StringPrototypeCharCodeAt,
   StringPrototypeCodePointAt,
-  StringPrototypeMatch,
   StringPrototypeSlice,
   StringPrototypeToLowerCase,
   Symbol,
@@ -190,11 +190,13 @@ function* emitKeys(stream) {
         const cmd = StringPrototypeSlice(s, cmdStart);
         let match;
 
-        if ((match = StringPrototypeMatch(cmd, /^(\d\d?)(;(\d))?([~^$])$/))) {
+        if (
+          (match = RegExpPrototypeExec(/^(\d\d?)(;(\d))?([~^$])$/, cmd))
+        ) {
           code += match[1] + match[4];
           modifier = (match[3] || 1) - 1;
         } else if (
-          (match = StringPrototypeMatch(cmd, /^((\d;)?(\d))?([A-Za-z])$/))
+          (match = RegExpPrototypeExec(/^((\d;)?(\d))?([A-Za-z])$/, cmd))
         ) {
           code += match[4];
           modifier = (match[3] || 1) - 1;

--- a/lib/internal/repl/history.js
+++ b/lib/internal/repl/history.js
@@ -4,7 +4,7 @@ const {
   ArrayPrototypeJoin,
   Boolean,
   FunctionPrototype,
-  StringPrototypeSplit,
+  RegExpPrototypeSymbolSplit,
   StringPrototypeTrim,
 } = primordials;
 
@@ -90,7 +90,7 @@ function setupHistory(repl, historyPath, ready) {
     }
 
     if (data) {
-      repl.history = StringPrototypeSplit(data, /[\n\r]+/, repl.historySize);
+      repl.history = RegExpPrototypeSymbolSplit(/[\n\r]+/, data, repl.historySize);
     } else {
       repl.history = [];
     }

--- a/lib/internal/repl/utils.js
+++ b/lib/internal/repl/utils.js
@@ -13,7 +13,7 @@ const {
   StringPrototypeEndsWith,
   StringPrototypeIndexOf,
   StringPrototypeLastIndexOf,
-  StringPrototypeReplace,
+  StringPrototypeReplaceAll,
   StringPrototypeSlice,
   StringPrototypeStartsWith,
   StringPrototypeToLowerCase,
@@ -287,9 +287,9 @@ function setupPreview(repl, contextSymbol, bufferSymbol, active) {
   function isInStrictMode(repl) {
     return repl.replMode === REPL_MODE_STRICT || ArrayPrototypeIncludes(
       ArrayPrototypeMap(process.execArgv,
-                        (e) => StringPrototypeReplace(
+                        (e) => StringPrototypeReplaceAll(
                           StringPrototypeToLowerCase(e),
-                          /_/g,
+                          '_',
                           '-'
                         )),
       '--use-strict');

--- a/lib/internal/source_map/prepare_stack_trace.js
+++ b/lib/internal/source_map/prepare_stack_trace.js
@@ -5,9 +5,9 @@ const {
   ArrayPrototypeJoin,
   ArrayPrototypeMap,
   ErrorPrototypeToString,
+  RegExpPrototypeSymbolSplit,
   StringPrototypeRepeat,
   StringPrototypeSlice,
-  StringPrototypeSplit,
   StringPrototypeStartsWith,
   SafeStringIterator,
 } = primordials;
@@ -151,7 +151,7 @@ function getErrorSource(
     sourceMap.payload,
     originalSourcePathNoScheme
   );
-  const lines = StringPrototypeSplit(source, /\r?\n/, originalLine + 1);
+  const lines = RegExpPrototypeSymbolSplit(/\r?\n/, source, originalLine + 1);
   const line = lines[originalLine];
   if (!line) return exceptionLine;
 

--- a/lib/internal/source_map/source_map_cache.js
+++ b/lib/internal/source_map/source_map_cache.js
@@ -7,9 +7,10 @@ const {
   ObjectKeys,
   ObjectGetOwnPropertyDescriptor,
   ObjectPrototypeHasOwnProperty,
+  RegExpPrototypeExec,
+  RegExpPrototypeSymbolSplit,
   RegExpPrototypeTest,
   SafeMap,
-  StringPrototypeMatch,
   StringPrototypeSplit,
 } = primordials;
 
@@ -82,9 +83,9 @@ function maybeCacheSourceMap(filename, content, cjsModuleInstance) {
     debug(err.stack);
     return;
   }
-  const match = StringPrototypeMatch(
+  const match = RegExpPrototypeExec(
+    /\/[*/]#\s+sourceMappingURL=(?<sourceMappingURL>[^\s]+)/,
     content,
-    /\/[*/]#\s+sourceMappingURL=(?<sourceMappingURL>[^\s]+)/
   );
   if (match) {
     const data = dataFromUrl(filename, match.groups.sourceMappingURL);
@@ -133,7 +134,7 @@ function lineLengths(content) {
   // We purposefully keep \r as part of the line-length calculation, in
   // cases where there is a \r\n separator, so that this can be taken into
   // account in coverage calculations.
-  return ArrayPrototypeMap(StringPrototypeSplit(content, /\n|\u2028|\u2029/), (line) => {
+  return ArrayPrototypeMap(RegExpPrototypeSymbolSplit(/\n|\u2028|\u2029/, content), (line) => {
     return line.length;
   });
 }

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -79,6 +79,7 @@ const {
   RegExp,
   RegExpPrototypeExec,
   RegExpPrototypeSymbolReplace,
+  RegExpPrototypeSymbolSplit,
   RegExpPrototypeTest,
   SafeSet,
   SafeWeakSet,
@@ -86,9 +87,7 @@ const {
   StringPrototypeCodePointAt,
   StringPrototypeEndsWith,
   StringPrototypeIncludes,
-  StringPrototypeMatch,
   StringPrototypeRepeat,
-  StringPrototypeReplace,
   StringPrototypeSlice,
   StringPrototypeSplit,
   StringPrototypeStartsWith,
@@ -673,22 +672,25 @@ function REPLServer(prompt,
         if (e.stack) {
           if (e.name === 'SyntaxError') {
             // Remove stack trace.
-            e.stack = StringPrototypeReplace(StringPrototypeReplace(e.stack,
-                                                                    /^REPL\d+:\d+\r?\n/, ''),
-                                             /^\s+at\s.*\n?/gm, '');
+            e.stack = RegExpPrototypeSymbolReplace(
+              /^\s+at\s.*\n?/gm,
+              RegExpPrototypeSymbolReplace(/^REPL\d+:\d+\r?\n/, e.stack, ''),
+              '',
+            );
             const importErrorStr = 'Cannot use import statement outside a ' +
               'module';
             if (StringPrototypeIncludes(e.message, importErrorStr)) {
               e.message = 'Cannot use import statement inside the Node.js ' +
                 'REPL, alternatively use dynamic import';
-              e.stack = StringPrototypeReplace(e.stack,
-                                               /SyntaxError:.*\n/,
-                                               `SyntaxError: ${e.message}\n`);
+              e.stack = RegExpPrototypeSymbolReplace(
+                /SyntaxError:.*\n/,
+                e.stack,
+                `SyntaxError: ${e.message}\n`);
             }
           } else if (self.replMode === module.exports.REPL_MODE_STRICT) {
-            e.stack = StringPrototypeReplace(
-              e.stack,
+            e.stack = RegExpPrototypeSymbolReplace(
               /(\s+at\s+REPL\d+:)(\d+)/,
+              e.stack,
               (_, pre, line) => pre + (line - 1)
             );
           }
@@ -718,7 +720,7 @@ function REPLServer(prompt,
       if (errStack === '') {
         errStack = self.writer(e);
       }
-      const lines = StringPrototypeSplit(errStack, /(?<=\n)/);
+      const lines = RegExpPrototypeSymbolSplit(/(?<=\n)/, errStack);
       let matched = false;
 
       errStack = '';
@@ -851,7 +853,7 @@ function REPLServer(prompt,
 
       // code alignment
       const matches = self._sawKeyPress ?
-        StringPrototypeMatch(cmd, /^\s+/) : null;
+        RegExpPrototypeExec(/^\s+/, cmd) : null;
       if (matches) {
         const prefix = matches[0];
         self.write(prefix);
@@ -871,7 +873,7 @@ function REPLServer(prompt,
       if (StringPrototypeCharAt(trimmedCmd, 0) === '.' &&
           StringPrototypeCharAt(trimmedCmd, 1) !== '.' &&
           NumberIsNaN(NumberParseFloat(trimmedCmd))) {
-        const matches = StringPrototypeMatch(trimmedCmd, /^\.([^\s]+)\s*(.*)$/);
+        const matches = RegExpPrototypeExec(/^\.([^\s]+)\s*(.*)$/, trimmedCmd);
         const keyword = matches && matches[1];
         const rest = matches && matches[2];
         if (ReflectApply(_parseREPLKeyword, self, [keyword, rest]) === true) {
@@ -1241,7 +1243,7 @@ function gracefulReaddir(...args) {
 
 function completeFSFunctions(line) {
   let baseName = '';
-  let filePath = StringPrototypeMatch(line, fsAutoCompleteRE)[1];
+  let filePath = RegExpPrototypeExec(fsAutoCompleteRE, line)[1];
   let fileList = gracefulReaddir(filePath, { withFileTypes: true });
 
   if (!fileList) {
@@ -1283,13 +1285,13 @@ function complete(line, callback) {
   let filter = '';
   if (RegExpPrototypeTest(/^\s*\.(\w*)$/, line)) {
     ArrayPrototypePush(completionGroups, ObjectKeys(this.commands));
-    completeOn = StringPrototypeMatch(line, /^\s*\.(\w*)$/)[1];
+    completeOn = RegExpPrototypeExec(/^\s*\.(\w*)$/, line)[1];
     if (completeOn.length) {
       filter = completeOn;
     }
   } else if (RegExpPrototypeTest(requireRE, line)) {
     // require('...<Tab>')
-    const match = StringPrototypeMatch(line, requireRE);
+    const match = RegExpPrototypeExec(line, requireRE);
     completeOn = match[1];
     filter = completeOn;
     if (this.allowBlockingCompletions) {
@@ -1348,7 +1350,7 @@ function complete(line, callback) {
     ArrayPrototypePush(completionGroups, _builtinLibs, nodeSchemeBuiltinLibs);
   } else if (RegExpPrototypeTest(importRE, line)) {
     // import('...<Tab>')
-    const match = StringPrototypeMatch(line, importRE);
+    const match = RegExpPrototypeExec(line, importRE);
     completeOn = match[1];
     filter = completeOn;
     if (this.allowBlockingCompletions) {
@@ -1615,8 +1617,8 @@ function _memory(cmd) {
 
   // Going down is { and (   e.g. function() {
   // going up is } and )
-  let dw = StringPrototypeMatch(cmd, /[{(]/g);
-  let up = StringPrototypeMatch(cmd, /[})]/g);
+  let dw = RegExpPrototypeExec(/[{(]/g, cmd);
+  let up = RegExpPrototypeExec(/[})]/g, cmd);
   up = up ? up.length : 0;
   dw = dw ? dw.length : 0;
   let depth = dw - up;

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -32,12 +32,12 @@ const {
   ArrayPrototypeSome,
   ObjectDefineProperty,
   ObjectFreeze,
+  RegExpPrototypeSymbolReplace,
   RegExpPrototypeTest,
   StringFromCharCode,
   StringPrototypeCharCodeAt,
   StringPrototypeEndsWith,
   StringPrototypeIncludes,
-  StringPrototypeReplace,
   StringPrototypeSlice,
   StringPrototypeSplit,
   StringPrototypeStartsWith,
@@ -147,7 +147,7 @@ exports.convertALPNProtocols = function convertALPNProtocols(protocols, out) {
 };
 
 function unfqdn(host) {
-  return StringPrototypeReplace(host, /[.]$/, '');
+  return RegExpPrototypeSymbolReplace(/[.]$/, host, '');
 }
 
 // String#toLowerCase() is locale-sensitive so we use
@@ -158,7 +158,7 @@ function toLowerCase(c) {
 
 function splitHost(host) {
   return StringPrototypeSplit(
-    StringPrototypeReplace(unfqdn(host), /[A-Z]/g, toLowerCase),
+    RegExpPrototypeSymbolReplace(/[A-Z]/g, unfqdn(host), toLowerCase),
     '.'
   );
 }

--- a/typings/primordials.d.ts
+++ b/typings/primordials.d.ts
@@ -379,6 +379,11 @@ declare namespace Primordials {
   export const RegExpPrototypeCompile: UncurryThis<typeof RegExp.prototype.compile>
   export const RegExpPrototypeToString: UncurryThis<typeof RegExp.prototype.toString>
   export const RegExpPrototypeTest: UncurryThis<typeof RegExp.prototype.test>
+  export const RegExpPrototypeSymbolMatch: UncurryThis<typeof RegExp.prototype[typeof Symbol.match]>
+  export const RegExpPrototypeSymbolMatchAll: UncurryThis<typeof RegExp.prototype[typeof Symbol.matchAll]>
+  export const RegExpPrototypeSymbolReplace: UncurryThis<typeof RegExp.prototype[typeof Symbol.replace]>
+  export const RegExpPrototypeSymbolSearch: UncurryThis<typeof RegExp.prototype[typeof Symbol.search]>
+  export const RegExpPrototypeSymbolSplit: UncurryThis<typeof RegExp.prototype[typeof Symbol.split]>
   export const Set: typeof globalThis.Set;
   export const SetLength: typeof Set.length
   export const SetName: typeof Set.name


### PR DESCRIPTION
The string prototype methods that take `RegExp` arguments depend on the following properties not being mutated by user code:

| The `String.prototype` method | depends on the `RegExp.prototype` method
| --- | ---
| <code>[String.prototype.match]</code> | <code>[RegExp.prototype\[Symbol.match\]][RegExp.prototype-@@match]</code>, which depends<br/>on <code>[RegExp.prototype.exec]</code>
| <code>[String.prototype.matchAll]</code> | <code>[RegExp.prototype\[Symbol.matchAll\]][RegExp.prototype-@@matchAll]</code>, which depends<br/>on <code>[%RegExpStringIteratorPrototype%]</code>
| <code>[String.prototype.replace]</code> | <code>[RegExp.prototype\[Symbol.replace\]][RegExp.prototype-@@replace]</code>
| <code>[String.prototype.replaceAll]</code> | <code>[RegExp.prototype\[Symbol.replace\]][RegExp.prototype-@@replace]</code>
| <code>[String.prototype.search]</code> | <code>[RegExp.prototype\[Symbol.search\]][RegExp.prototype-@@search]</code>
| <code>[String.prototype.split]</code> | <code>[RegExp.prototype\[Symbol.split\]][RegExp.prototype-@@split]</code>

Note that the string‑taking overloads are safe‑ish.

---

Alternatively, it might be a good idea to create `SafeRegExp`.

[String.prototype.match]: https://tc39.es/ecma262/#sec-string.prototype.match
[String.prototype.matchAll]: https://tc39.es/ecma262/#sec-string.prototype.matchall
[String.prototype.replace]: https://tc39.es/ecma262/#sec-string.prototype.replace
[String.prototype.replaceAll]: https://tc39.es/ecma262/#sec-string.prototype.replaceall
[String.prototype.search]: https://tc39.es/ecma262/#sec-string.prototype.search
[String.prototype.split]: https://tc39.es/ecma262/#sec-string.prototype.split
[RegExp.prototype.exec]: https://tc39.es/ecma262/#sec-regexp.prototype.exec
[RegExp.prototype-@@match]: https://tc39.es/ecma262/#sec-regexp.prototype-@@match
[RegExp.prototype-@@matchAll]: https://tc39.es/ecma262/#sec-regexp-prototype-matchall
[RegExp.prototype-@@replace]: https://tc39.es/ecma262/#sec-regexp.prototype-@@replace
[RegExp.prototype-@@search]: https://tc39.es/ecma262/#sec-regexp.prototype-@@search
[RegExp.prototype-@@split]: https://tc39.es/ecma262/#sec-regexp.prototype-@@split
[%RegExpStringIteratorPrototype%]: https://tc39.es/ecma262/#sec-%regexpstringiteratorprototype%-object

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
