### PR TITLE
test: increase coverage for diagnostics_channel

### DIFF
--- a/test/parallel/test-diagnostics-channel-object-channel-pub-sub.js
+++ b/test/parallel/test-diagnostics-channel-object-channel-pub-sub.js
@@ -40,4 +40,4 @@ assert.ok(!channel.hasSubscribers);
 
 assert.throws(() => {
   channel.subscribe(null);
-}, /ERR_INVALID_ARG_TYPE/);
+}, { code: 'ERR_INVALID_ARG_TYPE' });

--- a/test/parallel/test-diagnostics-channel-object-channel-pub-sub.js
+++ b/test/parallel/test-diagnostics-channel-object-channel-pub-sub.js
@@ -37,3 +37,7 @@ channel.publish(input);
 // Should not publish after subscriber is unsubscribed
 channel.unsubscribe(subscriber);
 assert.ok(!channel.hasSubscribers);
+
+assert.throws(() => {
+  channel.subscribe(null);
+}, /ERR_INVALID_ARG_TYPE/);

--- a/test/parallel/test-diagnostics-channel-symbol-named.js
+++ b/test/parallel/test-diagnostics-channel-symbol-named.js
@@ -20,3 +20,9 @@ channel.subscribe(common.mustCall((message, name) => {
 }));
 
 channel.publish(input);
+
+{
+  assert.throws(() => {
+    dc.channel(null);
+  }, /ERR_INVALID_ARG_TYPE/);
+}


### PR DESCRIPTION
1. test subscribe with invalid args
https://coverage.nodejs.org/coverage-21f2e8859dfbf09f/lib/diagnostics_channel.js.html#L27

2. test create channel with invalid args
https://coverage.nodejs.org/coverage-21f2e8859dfbf09f/lib/diagnostics_channel.js.html#L98

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

#### Related Issues

Fixes: https://github.com/nodejs/node/issues/<issue_number>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
