### PR TITLE
tools: use `is None` consistently in Python

### DIFF
--- a/tools/genv8constants.py
+++ b/tools/genv8constants.py
@@ -95,7 +95,7 @@ for line in pipe:
       curr_octet += 1
 
   match = pattern.match(line)
-  if match == None:
+  if match is None:
     continue
 
   # Print previous symbol

--- a/tools/genv8constants.py
+++ b/tools/genv8constants.py
@@ -113,3 +113,5 @@ outfile.write("""
 
 #endif /* V8_CONSTANTS_H */
 """)
+
+outfile.close()

--- a/tools/genv8constants.py
+++ b/tools/genv8constants.py
@@ -14,7 +14,7 @@ import sys
 import errno
 
 if len(sys.argv) != 3:
-  print("usage: objsym.py outfile libv8_base.a")
+  print("Usage: genv8constants.py outfile libv8_base.a")
   sys.exit(2)
 
 outfile = open(sys.argv[1], 'w')


### PR DESCRIPTION
We use `is None` instead of `== None` everywhere (which mostly just
means test.py) except in one place in genv8constants.py. Switch to `is
None` in genv8constants.py. This is slightly more efficient, although I
can't imagine that makes a measurable difference here.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

#### Related Issues

Fixes: https://github.com/nodejs/node/issues/<issue_number>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
