### PR TITLE
cluster: restructure to same prototype for cluster child

### DIFF
--- a/lib/internal/cluster/child.js
+++ b/lib/internal/cluster/child.js
@@ -101,10 +101,13 @@ cluster._getServer = function(obj, options, cb) {
     if (typeof obj._setServerData === 'function')
       obj._setServerData(reply.data);
 
-    if (handle)
-      shared(reply, handle, indexesKey, index, cb);  // Shared listen socket.
-    else
-      rr(reply, indexesKey, index, cb);              // Round-robin.
+    if (handle) {
+      // Shared listen socket
+      shared(reply, { handle, indexesKey, index }, cb);
+    } else {
+      // Round-robin.
+      rr(reply, { indexesKey, index }, cb);
+    }
   });
 
   obj.once('listening', () => {
@@ -129,7 +132,7 @@ function removeIndexesKey(indexesKey, index) {
 }
 
 // Shared listen socket.
-function shared(message, handle, indexesKey, index, cb) {
+function shared(message, { handle, indexesKey, index }, cb) {
   const key = message.key;
   // Monkey-patch the close() method so we can keep track of when it's
   // closed. Avoids resource leaks when the handle is short-lived.
@@ -146,8 +149,8 @@ function shared(message, handle, indexesKey, index, cb) {
   cb(message.errno, handle);
 }
 
-// Round-robin. Primary distributes handles across workers.
-function rr(message, indexesKey, index, cb) {
+// Round-robin. Master distributes handles across workers.
+function rr(message, { indexesKey, index }, cb) {
   if (message.errno)
     return cb(message.errno, null);
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Since `rr` and `shared` both belongs to the same prototype declaration
and differes only in the handler declaration, this can be abstracted to
a same type of function arguments passing. Motivation behind this is they are
just extended handlers performing the same basic task so the layout (function structure)
should be consistent.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->