### PR TITLE
doc: use _code name_ rather than _codename_

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Looking for help? Check out the
 * **LTS**: Releases that receive Long-term Support, with a focus on stability
   and security. Every even-numbered major version will become an LTS release.
   LTS releases receive 12 months of _Active LTS_ support and a further 18 months
-  of _Maintenance_. LTS release lines have alphabetically-ordered codenames,
+  of _Maintenance_. LTS release lines have alphabetically-ordered code names,
   beginning with v4 Argon. There are no breaking changes or feature additions,
   except in some special circumstances.
 * **Nightly**: Code from the Current branch built every 24-hours when there are

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1782,12 +1782,11 @@ tarball.
 * `lts` {string} a string label identifying the [LTS][] label for this release.
   This property only exists for LTS releases and is `undefined` for all other
   release types, including _Current_ releases.
-  Valid values include the LTS Release Codenames (including those
-  that are no longer supported). A non-exhaustive example of
-  these codenames includes:
+  Valid values include the LTS Release code names (including those
+  that are no longer supported).
   * `'Dubnium'` for the 10.x LTS line beginning with 10.13.0.
   * `'Erbium'` for the 12.x LTS line beginning with 12.13.0.
-  For other LTS Release Codenames, see [Node.js Changelog Archive](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_ARCHIVE.md)
+  For other LTS Release code names, see [Node.js Changelog Archive](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_ARCHIVE.md)
 
 <!-- eslint-skip -->
 ```js

--- a/doc/guides/releases.md
+++ b/doc/guides/releases.md
@@ -497,7 +497,7 @@ $ git secure-tag <vx.y.z> <commit-sha> -sm "YYYY-MM-DD Node.js vx.y.z (<release-
 ```
 
 `release-type` is either "Current" or "LTS". For LTS releases, you should also
- include the release codename, for example:
+ include the release code name.
 
 ```text
 2019-10-22 Node.js v10.17.0 'Dubnium' (LTS) Release
@@ -740,7 +740,7 @@ To mark a release line as LTS, the following changes must be made to
 * The `NODE_MINOR_VERSION` macro must be incremented by one
 * The `NODE_PATCH_VERSION` macro must be set to `0`
 * The `NODE_VERSION_IS_LTS` macro must be set to `1`
-* The `NODE_VERSION_LTS_CODENAME` macro must be set to the codename selected
+* The `NODE_VERSION_LTS_CODENAME` macro must be set to the code name selected
 for the LTS release.
 
 For example:


### PR DESCRIPTION
This is excrutiatingly minor, but every authoritative resource I've
checked (which is to say, a few dictionaries) uses "code name" primarily
or exclusively. Let's follow suit.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

#### Related Issues

Fixes: https://github.com/nodejs/node/issues/<issue_number>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
