### PR TITLE
src: fix leading backslash bug in URL

### DIFF
--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -1429,7 +1429,7 @@ void URL::Parse(const char* input,
     const char ch = p < end ? p[0] : kEOL;
     bool special = (url->flags & URL_FLAGS_SPECIAL);
     bool cannot_be_base;
-    const bool special_back_slash = (special && ch == '\\');
+    bool special_back_slash = (special && ch == '\\');
 
     switch (state) {
       case kSchemeStart:
@@ -1477,6 +1477,7 @@ void URL::Parse(const char* input,
             url->flags &= ~URL_FLAGS_SPECIAL;
             special = false;
           }
+          special_back_slash = (special && ch == '\\');
           buffer.clear();
           if (has_state_override)
             return;
@@ -1521,6 +1522,7 @@ void URL::Parse(const char* input,
             url->flags &= ~URL_FLAGS_SPECIAL;
             special = false;
           }
+          special_back_slash = (special && ch == '\\');
           if (base->flags & URL_FLAGS_HAS_PATH) {
             url->flags |= URL_FLAGS_HAS_PATH;
             url->path = base->path;
@@ -1544,6 +1546,7 @@ void URL::Parse(const char* input,
           url->flags |= URL_FLAGS_SPECIAL;
           special = true;
           state = kFile;
+          special_back_slash = (special && ch == '\\');
           continue;
         }
         break;
@@ -1573,6 +1576,7 @@ void URL::Parse(const char* input,
           url->flags &= ~URL_FLAGS_SPECIAL;
           special = false;
         }
+        special_back_slash = (special && ch == '\\');
         switch (ch) {
           case kEOL:
             if (base->flags & URL_FLAGS_HAS_USERNAME) {

--- a/test/cctest/test_url.cc
+++ b/test/cctest/test_url.cc
@@ -81,6 +81,52 @@ TEST_F(URLTest, Base3) {
   EXPECT_EQ(simple.path(), "/baz");
 }
 
+TEST_F(URLTest, Base4) {
+  const char* input = "\\x";
+  const char* base = "http://example.org/foo/bar";
+
+  URL simple(input, strlen(input), base, strlen(base));
+
+  EXPECT_FALSE(simple.flags() & URL_FLAGS_FAILED);
+  EXPECT_EQ(simple.protocol(), "http:");
+  EXPECT_EQ(simple.host(), "example.org");
+  EXPECT_EQ(simple.path(), "/x");
+}
+
+TEST_F(URLTest, Base5) {
+  const char* input = "/x";
+  const char* base = "http://example.org/foo/bar";
+
+  URL simple(input, strlen(input), base, strlen(base));
+
+  EXPECT_FALSE(simple.flags() & URL_FLAGS_FAILED);
+  EXPECT_EQ(simple.protocol(), "http:");
+  EXPECT_EQ(simple.host(), "example.org");
+  EXPECT_EQ(simple.path(), "/x");
+}
+
+TEST_F(URLTest, Base6) {
+  const char* input = "\\\\x";
+  const char* base = "http://example.org/foo/bar";
+
+  URL simple(input, strlen(input), base, strlen(base));
+
+  EXPECT_FALSE(simple.flags() & URL_FLAGS_FAILED);
+  EXPECT_EQ(simple.protocol(), "http:");
+  EXPECT_EQ(simple.host(), "x");
+}
+
+TEST_F(URLTest, Base7) {
+  const char* input = "//x";
+  const char* base = "http://example.org/foo/bar";
+
+  URL simple(input, strlen(input), base, strlen(base));
+
+  EXPECT_FALSE(simple.flags() & URL_FLAGS_FAILED);
+  EXPECT_EQ(simple.protocol(), "http:");
+  EXPECT_EQ(simple.host(), "x");
+}
+
 TEST_F(URLTest, TruncatedAfterProtocol) {
   char input[2] = { 'q', ':' };
   URL simple(input, sizeof(input));


### PR DESCRIPTION
The associated condition mentioned in the URL parsing algorithm of the
WHATWG URL Standard is:
url is special and c is U+005C (\\)
So, `special_back_slash` must be updated whenever `special` is updated.

Fixes: https://github.com/nodejs/node/issues/36559

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
