### PR TITLE
stream,zlib: do not use _stream_* anymore.

### DIFF
--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -215,7 +215,7 @@ function pipeline(...streams) {
         }
       } else {
         if (!PassThrough) {
-          PassThrough = require('_stream_passthrough');
+          PassThrough = require('internal/streams/passthrough');
         }
 
         // If the last argument to pipeline is not a stream

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -52,7 +52,7 @@ const {
   },
   hideStackFrames
 } = require('internal/errors');
-const Transform = require('_stream_transform');
+const { Transform, finished } = require('stream');
 const {
   deprecate
 } = require('internal/util');
@@ -62,7 +62,6 @@ const {
 } = require('internal/util/types');
 const binding = internalBinding('zlib');
 const assert = require('internal/assert');
-const finished = require('internal/streams/end-of-stream');
 const {
   Buffer,
   kMaxLength

--- a/test/parallel/test-zlib-no-stream.js
+++ b/test/parallel/test-zlib-no-stream.js
@@ -1,0 +1,14 @@
+/* eslint-disable node-core/required-modules */
+/* eslint-disable node-core/require-common-first */
+
+'use strict';
+
+// We are not loading common because it will load the stream module,
+// defeating the purpose of this test.
+
+const { gzipSync } = require('zlib');
+
+// Avoid regressions such as https://github.com/nodejs/node/issues/36615
+
+// This must not throw
+gzipSync('fooobar');


### PR DESCRIPTION
In two place we still used `_stream_*`, causing https://github.com/nodejs/node/issues/36615 and potentially other issues.

Note that https://github.com/nodejs/node/issues/36615 does not impact `master` for some independent reason. 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
