### PR TITLE
net: add support for finished after .destroy()

### DIFF
--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -169,12 +169,8 @@ IncomingMessage.prototype._destroy = function _destroy(err, cb) {
     this.emit('aborted');
   }
 
-  // If aborted and the underlying socket is not already destroyed,
-  // destroy it.
-  // We have to check if the socket is already destroyed because finished
-  // does not call the callback when this methdod is invoked from `_http_client`
-  // in `test/parallel/test-http-client-spurious-aborted.js`
-  if (this.socket && !this.socket.destroyed && this.aborted) {
+  // If aborted destroy socket.
+  if (this.socket && this.aborted) {
     this.socket.destroy(err);
     const cleanup = finished(this.socket, (e) => {
       cleanup();

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -9,6 +9,14 @@ const {
 } = require('internal/errors').codes;
 const { once } = require('internal/util');
 
+function isSocket(stream) {
+  return (
+    typeof stream.connect === 'function' &&
+    typeof stream.setNoDelay === 'function' &&
+    typeof stream.setKeepAlive === 'function'
+  );
+}
+
 function isRequest(stream) {
   return stream.setHeader && typeof stream.abort === 'function';
 }
@@ -75,7 +83,7 @@ function eos(stream, options, callback) {
   let willEmitClose = (
     state &&
     state.autoDestroy &&
-    state.emitClose &&
+    (state.emitClose || isSocket(stream)) &&
     state.closed === false &&
     isReadable(stream) === readable &&
     isWritable(stream) === writable

--- a/lib/net.js
+++ b/lib/net.js
@@ -663,6 +663,12 @@ Socket.prototype._destroy = function(exception, cb) {
 
     this._handle.close(() => {
       debug('emit close');
+      if (this._writableState) {
+        this._writableState.closed = true;
+      }
+      if (this._readableState) {
+        this._readableState.closed = true;
+      }
       this.emit('close', isException);
     });
     this._handle.onread = noop;
@@ -1633,6 +1639,12 @@ Server.prototype._emitCloseIfDrained = function() {
 
 function emitCloseNT(self) {
   debug('SERVER: emit close');
+  if (self._writableState) {
+    self._writableState.closed = true;
+  }
+  if (self._readableState) {
+    self._readableState.closed = true;
+  }
   self.emit('close');
 }
 

--- a/test/parallel/test-net-finished.js
+++ b/test/parallel/test-net-finished.js
@@ -1,0 +1,25 @@
+'use strict';
+const common = require('../common');
+const net = require('net');
+const { finished } = require('stream');
+
+const server = net.createServer(function(con) {
+  con.on('close', common.mustCall());
+});
+
+server.listen(0, common.mustCall(function() {
+  const con = net.connect({
+    port: this.address().port
+  })
+  .on('connect', () => {
+    finished(con, common.mustCall());
+    con.destroy();
+    finished(con, common.mustCall());
+    con.on('close', common.mustCall(() => {
+      finished(con, common.mustCall(() => {
+        server.close();
+      }));
+    }));
+  })
+  .end();
+}));


### PR DESCRIPTION
Calling `finished(socket, cb)` would previously not
invoked the callback if the socket was already detroyed.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
