### PR TITLE
doc: clarify that N-API addons are context-aware

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -1613,8 +1613,8 @@ napi_value Init(napi_env env, napi_value exports) {
 }
 ```
 
-If the module will be loaded multiple times during the lifetime of the Node.js
-process, use the `NAPI_MODULE_INIT` macro to initialize the module:
+You can also use the `NAPI_MODULE_INIT` macro, which acts as a shorthand
+for `NODE_MODULE` and defining an `Init` function:
 
 ```C
 NAPI_MODULE_INIT() {
@@ -1631,13 +1631,9 @@ NAPI_MODULE_INIT() {
 }
 ```
 
-This macro includes `NAPI_MODULE`, and declares an `Init` function with a
-special name and with visibility beyond the addon. This will allow Node.js to
-initialize the module even if it is loaded multiple times.
-
-There are a few design considerations when declaring a module that may be loaded
-multiple times. The documentation of [context-aware addons][] provides more
-details.
+All N-API addons are context-aware, meaning they may be loaded multiple
+times. There are a few design considerations when declaring such a module.
+The documentation on [context-aware addons][] provides more details.
 
 The variables `env` and `exports` will be available inside the function body
 following the macro invocation.


### PR DESCRIPTION
The docs on N-API say that NAPI_MODULE_INIT must be used for the addon to be context-aware. That seems to be wrong, i.e. all N-API addons are context-aware(?)