### PR TITLE
test: add test for reused AbortController with execfile()

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -376,6 +376,8 @@ function execFile(file /* , args, options, callback */) {
   }
   if (options.signal) {
     if (options.signal.aborted) {
+      if (!ex)
+        ex = new AbortError();
       process.nextTick(() => kill());
     } else {
       const childController = new AbortController();

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -368,6 +368,12 @@ function execFile(file /* , args, options, callback */) {
     }
   }
 
+  function abortHandler() {
+    if (!ex)
+      ex = new AbortError();
+    process.nextTick(() => kill());
+  }
+
   if (options.timeout > 0) {
     timeoutId = setTimeout(function delayedKill() {
       kill();
@@ -376,16 +382,11 @@ function execFile(file /* , args, options, callback */) {
   }
   if (options.signal) {
     if (options.signal.aborted) {
-      if (!ex)
-        ex = new AbortError();
-      process.nextTick(() => kill());
+      process.nextTick(abortHandler);
     } else {
       const childController = new AbortController();
-      options.signal.addEventListener('abort', () => {
-        if (!ex)
-          ex = new AbortError();
-        kill();
-      }, { signal: childController.signal });
+      options.signal.addEventListener('abort', abortHandler,
+                                      { signal: childController.signal });
       child.once('close', () => childController.abort());
     }
   }

--- a/test/parallel/test-child-process-execfile.js
+++ b/test/parallel/test-child-process-execfile.js
@@ -53,25 +53,19 @@ const execOpts = { encoding: 'utf8', shell: true };
   const ac = new AbortController();
   const { signal } = ac;
 
-  const firstCheck = common.mustCall((err) => {
-    assert.strictEqual(err.code, 'ABORT_ERR');
-    assert.strictEqual(err.name, 'AbortError');
-    assert.strictEqual(err.signal, undefined);
-  });
+  const test = () => {
+    const check = common.mustCall((err) => {
+      assert.strictEqual(err.code, 'ABORT_ERR');
+      assert.strictEqual(err.name, 'AbortError');
+      assert.strictEqual(err.signal, undefined);
+    });
+    execFile(process.execPath, [echoFixture, 0], { signal }, check);
+  };
 
-  const secondCheck = common.mustCall((err) => {
-    assert.strictEqual(err.code, null);
-    assert.strictEqual(err.name, 'Error');
-    assert.strictEqual(err.signal, 'SIGTERM');
-  });
-
-  execFile(process.execPath, [echoFixture, 0], { signal }, (err) => {
-    firstCheck(err);
-    // Test that re-using the aborted signal results in immediate SIGTERM.
-    execFile(process.execPath, [echoFixture, 0], { signal }, secondCheck);
-  });
-
+  test();
   ac.abort();
+  // Verify that it still works the same way now that the signal is aborted.
+  test();
 }
 
 {

--- a/test/parallel/test-child-process-spawn-controller.js
+++ b/test/parallel/test-child-process-spawn-controller.js
@@ -4,18 +4,38 @@ const common = require('../common');
 const assert = require('assert');
 const cp = require('child_process');
 
-// Verify that passing an AbortSignal works
-const controller = new AbortController();
-const { signal } = controller;
+{
+  // Verify that passing an AbortSignal works
+  const controller = new AbortController();
+  const { signal } = controller;
 
-const echo = cp.spawn('echo', ['fun'], {
-  encoding: 'utf8',
-  shell: true,
-  signal
-});
+  const echo = cp.spawn('echo', ['fun'], {
+    encoding: 'utf8',
+    shell: true,
+    signal
+  });
 
-echo.on('error', common.mustCall((e) => {
-  assert.strictEqual(e.name, 'AbortError');
-}));
+  echo.on('error', common.mustCall((e) => {
+    assert.strictEqual(e.name, 'AbortError');
+  }));
 
-controller.abort();
+  controller.abort();
+}
+
+{
+  // Verify that passing an already-aborted signal works.
+  const controller = new AbortController();
+  const { signal } = controller;
+
+  controller.abort();
+
+  const echo = cp.spawn('echo', ['fun'], {
+    encoding: 'utf8',
+    shell: true,
+    signal
+  });
+
+  echo.on('error', common.mustCall((e) => {
+    assert.strictEqual(e.name, 'AbortError');
+  }));
+}


### PR DESCRIPTION
Test that reusing an aborted AbortController with execfile() results in
immediate SIGTERM.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
