### PR TITLE
http: add test case for req-res close ordering

### DIFF
--- a/test/parallel/test-http-req-res-close.js
+++ b/test/parallel/test-http-req-res-close.js
@@ -4,34 +4,128 @@ const common = require('../common');
 const http = require('http');
 const assert = require('assert');
 
-const server = http.Server(common.mustCall((req, res) => {
-  let resClosed = false;
+// When the response is ended immediately, `req` should emit `close`
+// after `res`
+{
+  const server = http.Server(common.mustCall((req, res) => {
+    let resClosed = false;
+    let reqClosed = false;
 
-  res.end();
-  let resFinished = false;
-  res.on('finish', common.mustCall(() => {
-    resFinished = true;
-    assert.strictEqual(resClosed, false);
-    assert.strictEqual(res.destroyed, false);
-    assert.strictEqual(resClosed, false);
-  }));
-  assert.strictEqual(req.destroyed, false);
-  res.on('close', common.mustCall(() => {
-    resClosed = true;
-    assert.strictEqual(resFinished, true);
-    assert.strictEqual(res.destroyed, true);
-  }));
-  assert.strictEqual(req.destroyed, false);
-  req.on('end', common.mustCall(() => {
+    res.end();
+    let resFinished = false;
+    res.on('finish', common.mustCall(() => {
+      resFinished = true;
+      assert.strictEqual(resClosed, false);
+      assert.strictEqual(res.destroyed, false);
+      assert.strictEqual(resClosed, false);
+    }));
     assert.strictEqual(req.destroyed, false);
+    res.on('close', common.mustCall(() => {
+      resClosed = true;
+      assert.strictEqual(resFinished, true);
+      assert.strictEqual(reqClosed, false);
+      assert.strictEqual(res.destroyed, true);
+    }));
+    assert.strictEqual(req.destroyed, false);
+    req.on('end', common.mustCall(() => {
+      assert.strictEqual(req.destroyed, false);
+    }));
+    req.on('close', common.mustCall(() => {
+      reqClosed = true;
+      assert.strictEqual(resClosed, true);
+      assert.strictEqual(req.destroyed, true);
+      assert.strictEqual(req._readableState.ended, true);
+    }));
+    res.socket.on('close', () => server.close());
   }));
-  req.on('close', common.mustCall(() => {
-    assert.strictEqual(req.destroyed, true);
-    assert.strictEqual(req._readableState.ended, true);
-  }));
-  res.socket.on('close', () => server.close());
-}));
 
-server.listen(0, common.mustCall(() => {
-  http.get({ port: server.address().port }, common.mustCall());
-}));
+  server.listen(0, common.mustCall(() => {
+    http.get({ port: server.address().port }, common.mustCall());
+  }));
+}
+
+// When there's no `data` handler attached to `req`,
+// `req` should emit `close` after `res`.
+{
+  const server = http.Server(common.mustCall((req, res) => {
+    let resClosed = false;
+    let reqClosed = false;
+
+    // This time, don't end the response immediately
+    setTimeout(() => res.end(), 100);
+    let resFinished = false;
+    res.on('finish', common.mustCall(() => {
+      resFinished = true;
+      assert.strictEqual(resClosed, false);
+      assert.strictEqual(res.destroyed, false);
+      assert.strictEqual(resClosed, false);
+    }));
+    assert.strictEqual(req.destroyed, false);
+    res.on('close', common.mustCall(() => {
+      resClosed = true;
+      assert.strictEqual(resFinished, true);
+      assert.strictEqual(reqClosed, false);
+      assert.strictEqual(res.destroyed, true);
+    }));
+    assert.strictEqual(req.destroyed, false);
+    req.on('end', common.mustCall(() => {
+      assert.strictEqual(req.destroyed, false);
+    }));
+    req.on('close', common.mustCall(() => {
+      reqClosed = true;
+      assert.strictEqual(resClosed, true);
+      assert.strictEqual(req.destroyed, true);
+      assert.strictEqual(req._readableState.ended, true);
+    }));
+    res.socket.on('close', () => server.close());
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    http.get({ port: server.address().port }, common.mustCall());
+  }));
+}
+
+// When a `data` handler is `attached` to `req`
+// (i.e. the server is consuming  data from it), `req` should emit `close`
+// before `res`.
+// https://github.com/nodejs/node/pull/33035 introduced this change in behavior.
+// See https://github.com/nodejs/node/pull/33035#issuecomment-751482764
+{
+  const server = http.Server(common.mustCall((req, res) => {
+    let resClosed = false;
+    let reqClosed = false;
+
+    // Don't end the response immediately
+    setTimeout(() => res.end(), 100);
+    let resFinished = false;
+    req.on('data', () => {});
+    res.on('finish', common.mustCall(() => {
+      resFinished = true;
+      assert.strictEqual(resClosed, false);
+      assert.strictEqual(res.destroyed, false);
+      assert.strictEqual(resClosed, false);
+    }));
+    assert.strictEqual(req.destroyed, false);
+    res.on('close', common.mustCall(() => {
+      resClosed = true;
+      assert.strictEqual(resFinished, true);
+      assert.strictEqual(reqClosed, true);
+      assert.strictEqual(res.destroyed, true);
+    }));
+    assert.strictEqual(req.destroyed, false);
+    req.on('end', common.mustCall(() => {
+      assert.strictEqual(req.destroyed, false);
+    }));
+    req.on('close', common.mustCall(() => {
+      reqClosed = true;
+      assert.strictEqual(resClosed, false);
+      assert.strictEqual(req.destroyed, true);
+      assert.strictEqual(req._readableState.ended, true);
+    }));
+    res.socket.on('close', () => server.close());
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    http.get({ port: server.address().port }, common.mustCall());
+  }));
+}


### PR DESCRIPTION
Since the PR https://github.com/nodejs/node/pull/33035 has changed the ordering of the close event, add a test case.
IncomingMessage will emit close before the response is sent in case the server is consuming data from it.
See comment https://github.com/nodejs/node/pull/33035#issuecomment-751489998

-----

As @kanongil pointed out, `IncomingMessage` is emitting close before the response when the server attaches a handler to the request `data` event. Otherwise, the order is the same as it was before the change in the linked PR. 

The test should catch eventual regressions, but let's also use this as a point for discussing this behavior further, if needed.

@ronag @mcollina 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me, and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
