### PR TITLE
stream: finished waits for 'close' on OutgoingMessage

### DIFF
--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -21,8 +21,9 @@ function isRequest(stream) {
   return stream.setHeader && typeof stream.abort === 'function';
 }
 
-function isOutgoingMessage(stream) {
+function isServerResponse(stream) {
   return (
+    typeof stream._sent100 === 'boolean' &&
     typeof stream._removedConnection === 'boolean' &&
     typeof stream._removedContLen === 'boolean' &&
     typeof stream._removedTE === 'boolean' &&
@@ -89,7 +90,7 @@ function eos(stream, options, callback) {
   // TODO (ronag): Improve soft detection to include core modules and
   // common ecosystem modules that do properly emit 'close' but fail
   // this generic check.
-  let willEmitClose = isOutgoingMessage(stream) || (
+  let willEmitClose = isServerResponse(stream) || (
     state &&
     state.autoDestroy &&
     (state.emitClose || isSocket(stream)) &&

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -21,6 +21,15 @@ function isRequest(stream) {
   return stream.setHeader && typeof stream.abort === 'function';
 }
 
+function isOutgoingMessage(stream) {
+  return (
+    typeof stream._removedConnection === 'boolean' &&
+    typeof stream._removedContLen === 'boolean' &&
+    typeof stream._removedTE === 'boolean' &&
+    typeof stream._closed === 'boolean'
+  );
+}
+
 function isReadable(stream) {
   return typeof stream.readable === 'boolean' ||
     typeof stream.readableEnded === 'boolean' ||
@@ -80,7 +89,7 @@ function eos(stream, options, callback) {
   // TODO (ronag): Improve soft detection to include core modules and
   // common ecosystem modules that do properly emit 'close' but fail
   // this generic check.
-  let willEmitClose = (
+  let willEmitClose = isOutgoingMessage(stream) || (
     state &&
     state.autoDestroy &&
     (state.emitClose || isSocket(stream)) &&

--- a/test/parallel/test-http-outgoing-finished.js
+++ b/test/parallel/test-http-outgoing-finished.js
@@ -1,0 +1,32 @@
+'use strict';
+const common = require('../common');
+const { finished } = require('stream');
+
+const http = require('http');
+const assert = require('assert');
+
+const server = http.createServer(function(req, res) {
+  let closed = false;
+  res
+    .on('close', common.mustCall(() => {
+      closed = true;
+      finished(res, common.mustCall(() => {
+        server.close();
+      }));
+    }))
+    .end();
+  finished(res, common.mustCall(() => {
+    assert.strictEqual(closed, true);
+  }));
+
+}).listen(0, function() {
+  http
+    .request({
+      port: this.address().port,
+      method: 'GET'
+    })
+    .on('response', function(res) {
+      res.resume();
+    })
+    .end();
+});


### PR DESCRIPTION
Don't invoke finished callback until OutgoingMessage has
emitted 'close'.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
