### PR TITLE
stream: only use legacy close listeners if not willEmitClose

### DIFF
--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -129,7 +129,9 @@ function eos(stream, options, callback) {
 
   if (isRequest(stream)) {
     stream.on('complete', onfinish);
-    stream.on('abort', onclose);
+    if (!willEmitClose) {
+      stream.on('abort', onclose);
+    }
     if (stream.req) onrequest();
     else stream.on('request', onrequest);
   } else if (writable && !wState) { // legacy streams
@@ -138,7 +140,7 @@ function eos(stream, options, callback) {
   }
 
   // Not all streams will emit 'close' after 'aborted'.
-  if (typeof stream.aborted === 'boolean') {
+  if (!willEmitClose && typeof stream.aborted === 'boolean') {
     stream.on('aborted', onclose);
   }
 

--- a/test/parallel/test-stream-finished.js
+++ b/test/parallel/test-stream-finished.js
@@ -492,3 +492,26 @@ testClosed((opts) => new Writable({ write() {}, ...opts }));
       .on('response', common.mustCall());
   });
 }
+
+
+{
+  const w = new Writable({
+    write(chunk, encoding, callback) {
+      process.nextTick(callback);
+    }
+  });
+  w.aborted = false;
+  w.end();
+  let closed = false;
+  w.on('finish', () => {
+    assert.strictEqual(closed, false);
+    w.emit('aborted');
+  });
+  w.on('close', common.mustCall(() => {
+    closed = true;
+  }));
+
+  finished(w, common.mustCall(() => {
+    assert.strictEqual(closed, true);
+  }));
+}


### PR DESCRIPTION
Some streams that willEmitClose unecessarily fallback to legacy
events.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
