### PR TITLE
doc: Update emitClose default for fs streams

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1765,6 +1765,9 @@ changes:
      - v15.4.0
     pr-url: https://github.com/nodejs/node/pull/35922
     description: The `fd` option accepts FileHandle arguments.
+  - version: v14.0.0
+    pr-url: https://github.com/nodejs/node/pull/31408
+    description: Change `emitClose` default to `true`.
   - version:
      - v13.6.0
      - v12.17.0
@@ -1799,7 +1802,7 @@ changes:
   * `fd` {integer|FileHandle} **Default:** `null`
   * `mode` {integer} **Default:** `0o666`
   * `autoClose` {boolean} **Default:** `true`
-  * `emitClose` {boolean} **Default:** `false`
+  * `emitClose` {boolean} **Default:** `true`
   * `start` {integer}
   * `end` {integer} **Default:** `Infinity`
   * `highWaterMark` {integer} **Default:** `64 * 1024`
@@ -1827,9 +1830,9 @@ If `fd` points to a character device that only supports blocking reads
 available. This can prevent the process from exiting and the stream from
 closing naturally.
 
-By default, the stream will not emit a `'close'` event after it has been
-destroyed. This is the opposite of the default for other `Readable` streams.
-Set the `emitClose` option to `true` to change this behavior.
+By default, the stream will emit a `'close'` event after it has been
+destroyed, like most `Readable` streams.  Set the `emitClose` option to
+`false` to change this behavior.
 
 By providing the `fs` option, it is possible to override the corresponding `fs`
 implementations for `open`, `read`, and `close`. When providing the `fs` option,
@@ -1876,6 +1879,9 @@ changes:
      - v15.4.0
     pr-url: https://github.com/nodejs/node/pull/35922
     description: The `fd` option accepts FileHandle arguments.
+  - version: v14.0.0
+    pr-url: https://github.com/nodejs/node/pull/31408
+    description: Change `emitClose` default to `true`.
   - version:
      - v13.6.0
      - v12.17.0
@@ -1908,7 +1914,7 @@ changes:
   * `fd` {integer|FileHandle} **Default:** `null`
   * `mode` {integer} **Default:** `0o666`
   * `autoClose` {boolean} **Default:** `true`
-  * `emitClose` {boolean} **Default:** `false`
+  * `emitClose` {boolean} **Default:** `true`
   * `start` {integer}
   * `fs` {Object|null} **Default:** `null`
 * Returns: {fs.WriteStream} See [Writable Stream][].
@@ -1925,9 +1931,9 @@ then the file descriptor won't be closed, even if there's an error.
 It is the application's responsibility to close it and make sure there's no
 file descriptor leak.
 
-By default, the stream will not emit a `'close'` event after it has been
-destroyed. This is the opposite of the default for other `Writable` streams.
-Set the `emitClose` option to `true` to change this behavior.
+By default, the stream will emit a `'close'` event after it has been
+destroyed, like most `Writable` streams.  Set the `emitClose` option to
+`false` to change this behavior.
 
 By providing the `fs` option it is possible to override the corresponding `fs`
 implementations for `open`, `write`, `writev` and `close`. Overriding `write()`


### PR DESCRIPTION
The default for the `emitClose` option was changed from `false` to `true` by nodejs/node#31408 which landed in f0d2df4 for v14.0.0.  This commit updates the `fs` doc to match the current behavior.

Thanks for considering,
Kevin

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->