### PR TITLE
process: disallow adding options to process.allowedNodeEnvironmentFlags

### DIFF
--- a/lib/internal/process/per_thread.js
+++ b/lib/internal/process/per_thread.js
@@ -6,6 +6,7 @@
 
 const {
   ArrayPrototypeEvery,
+  ArrayPrototypeForEach,
   ArrayPrototypeIncludes,
   ArrayPrototypeMap,
   ArrayPrototypePush,
@@ -18,6 +19,8 @@ const {
   RegExpPrototypeTest,
   SafeArrayIterator,
   Set,
+  SetPrototypeEntries,
+  SetPrototypeValues,
   StringPrototypeEndsWith,
   StringPrototypeReplace,
   StringPrototypeSlice,
@@ -44,7 +47,7 @@ const {
 } = require('internal/validators');
 const constants = internalBinding('constants').os.signals;
 
-const kSet = Symbol('internal set');
+const kInternal = Symbol('internal properties');
 
 function assert(x, msg) {
   if (!x) throw new ERR_ASSERTION(msg || 'assertion error');
@@ -302,9 +305,9 @@ function buildAllowedFlags() {
                                       trimLeadingDashes);
 
   class NodeEnvironmentFlagsSet extends Set {
-    constructor(iterable) {
+    constructor(array) {
       super();
-      this[kSet] = new Set(new SafeArrayIterator(iterable));
+      this[kInternal] = { array };
     }
 
     add() {
@@ -333,7 +336,7 @@ function buildAllowedFlags() {
         key = StringPrototypeReplace(key, replaceUnderscoresRegex, '-');
         if (RegExpPrototypeTest(leadingDashesRegex, key)) {
           key = StringPrototypeReplace(key, trailingValuesRegex, '');
-          return this[kSet].has(key);
+          return ArrayPrototypeIncludes(this[kInternal].array, key);
         }
         return ArrayPrototypeIncludes(nodeFlags, key);
       }
@@ -341,19 +344,26 @@ function buildAllowedFlags() {
     }
 
     entries() {
-      return this[kSet].entries();
+      this[kInternal].set ??=
+        new Set(new SafeArrayIterator(this[kInternal].array));
+      return SetPrototypeEntries(this[kInternal].set);
     }
 
     forEach(callback, thisArg = undefined) {
-      this[kSet].forEach((v) => ReflectApply(callback, thisArg, [v, v, this]));
+      ArrayPrototypeForEach(
+        this[kInternal].array,
+        (v) => ReflectApply(callback, thisArg, [v, v, this])
+      );
     }
 
     get size() {
-      return this[kSet].size;
+      return this[kInternal].array.length;
     }
 
     values() {
-      return this[kSet].values();
+      this[kInternal].set ??=
+        new Set(new SafeArrayIterator(this[kInternal].array));
+      return SetPrototypeValues(this[kInternal].set);
     }
   }
   NodeEnvironmentFlagsSet.prototype.keys =

--- a/lib/internal/process/per_thread.js
+++ b/lib/internal/process/per_thread.js
@@ -6,21 +6,24 @@
 
 const {
   ArrayPrototypeEvery,
+  ArrayPrototypeIncludes,
   ArrayPrototypeMap,
   ArrayPrototypePush,
   ArrayPrototypeSplice,
   BigUint64Array,
   Float64Array,
   NumberMAX_SAFE_INTEGER,
-  ObjectDefineProperty,
   ObjectFreeze,
   ReflectApply,
   RegExpPrototypeTest,
-  SafeSet,
+  SafeArrayIterator,
+  Set,
   StringPrototypeEndsWith,
   StringPrototypeReplace,
   StringPrototypeSlice,
   StringPrototypeStartsWith,
+  Symbol,
+  SymbolIterator,
   Uint32Array,
 } = primordials;
 
@@ -40,6 +43,8 @@ const {
   validateObject,
 } = require('internal/validators');
 const constants = internalBinding('constants').os.signals;
+
+const kSet = Symbol('internal set');
 
 function assert(x, msg) {
   if (!x) throw new ERR_ASSERTION(msg || 'assertion error');
@@ -293,18 +298,18 @@ function buildAllowedFlags() {
 
   // Save these for comparison against flags provided to
   // process.allowedNodeEnvironmentFlags.has() which lack leading dashes.
-  const nodeFlags = new SafeSet(ArrayPrototypeMap(allowedNodeEnvironmentFlags,
-                                                  trimLeadingDashes));
+  const nodeFlags = ArrayPrototypeMap(allowedNodeEnvironmentFlags,
+                                      trimLeadingDashes);
 
-  class NodeEnvironmentFlagsSet extends SafeSet {
-    constructor(...args) {
-      super(...args);
+  class NodeEnvironmentFlagsSet extends Set {
+    constructor(iterable) {
+      super();
+      this[kSet] = new Set(new SafeArrayIterator(iterable));
+    }
 
-      // The super constructor consumes `add`, but
-      // disallow any future adds.
-      ObjectDefineProperty(this, 'add', {
-        value: () => this
-      });
+    add() {
+      // No-op, `Set` API compatible
+      return this;
     }
 
     delete() {
@@ -313,7 +318,7 @@ function buildAllowedFlags() {
     }
 
     clear() {
-      // No-op
+      // No-op, `Set` API compatible
     }
 
     has(key) {
@@ -328,13 +333,32 @@ function buildAllowedFlags() {
         key = StringPrototypeReplace(key, replaceUnderscoresRegex, '-');
         if (RegExpPrototypeTest(leadingDashesRegex, key)) {
           key = StringPrototypeReplace(key, trailingValuesRegex, '');
-          return super.has(key);
+          return this[kSet].has(key);
         }
-        return nodeFlags.has(key);
+        return ArrayPrototypeIncludes(nodeFlags, key);
       }
       return false;
     }
+
+    entries() {
+      return this[kSet].entries();
+    }
+
+    forEach(callback, thisArg = undefined) {
+      this[kSet].forEach((v) => ReflectApply(callback, thisArg, [v, v, this]));
+    }
+
+    get size() {
+      return this[kSet].size;
+    }
+
+    values() {
+      return this[kSet].values();
+    }
   }
+  NodeEnvironmentFlagsSet.prototype.keys =
+  NodeEnvironmentFlagsSet.prototype[SymbolIterator] =
+    NodeEnvironmentFlagsSet.prototype.values;
 
   ObjectFreeze(NodeEnvironmentFlagsSet.prototype.constructor);
   ObjectFreeze(NodeEnvironmentFlagsSet.prototype);

--- a/test/parallel/test-process-env-allowed-flags.js
+++ b/test/parallel/test-process-env-allowed-flags.js
@@ -62,6 +62,7 @@ const assert = require('assert');
                      true);
 
   process.allowedNodeEnvironmentFlags.add('foo');
+  assert.strictEqual(process.allowedNodeEnvironmentFlags.has('foo'), false);
   Set.prototype.add.call(process.allowedNodeEnvironmentFlags, 'foo');
   assert.strictEqual(process.allowedNodeEnvironmentFlags.has('foo'), false);
 

--- a/test/parallel/test-process-env-allowed-flags.js
+++ b/test/parallel/test-process-env-allowed-flags.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 // Assert legit flags are allowed, and bogus flags are disallowed
@@ -62,15 +62,41 @@ const assert = require('assert');
                      true);
 
   process.allowedNodeEnvironmentFlags.add('foo');
+  Set.prototype.add.call(process.allowedNodeEnvironmentFlags, 'foo');
   assert.strictEqual(process.allowedNodeEnvironmentFlags.has('foo'), false);
-  process.allowedNodeEnvironmentFlags.forEach((flag) => {
-    assert.strictEqual(flag === 'foo', false);
-  });
 
-  process.allowedNodeEnvironmentFlags.clear();
-  assert.strictEqual(process.allowedNodeEnvironmentFlags.size > 0, true);
+  const thisArg = {};
+  process.allowedNodeEnvironmentFlags.forEach(
+    common.mustCallAtLeast(function(flag, _, set) {
+      assert.notStrictEqual(flag, 'foo');
+      assert.strictEqual(this, thisArg);
+      assert.strictEqual(set, process.allowedNodeEnvironmentFlags);
+    }),
+    thisArg
+  );
+
+  for (const flag of process.allowedNodeEnvironmentFlags.keys()) {
+    assert.notStrictEqual(flag, 'foo');
+  }
+  for (const flag of process.allowedNodeEnvironmentFlags.values()) {
+    assert.notStrictEqual(flag, 'foo');
+  }
+  for (const flag of process.allowedNodeEnvironmentFlags) {
+    assert.notStrictEqual(flag, 'foo');
+  }
+  for (const [flag] of process.allowedNodeEnvironmentFlags.entries()) {
+    assert.notStrictEqual(flag, 'foo');
+  }
 
   const size = process.allowedNodeEnvironmentFlags.size;
+
+  process.allowedNodeEnvironmentFlags.clear();
+  assert.strictEqual(process.allowedNodeEnvironmentFlags.size, size);
+  Set.prototype.clear.call(process.allowedNodeEnvironmentFlags);
+  assert.strictEqual(process.allowedNodeEnvironmentFlags.size, size);
+
   process.allowedNodeEnvironmentFlags.delete('-r');
+  assert.strictEqual(process.allowedNodeEnvironmentFlags.size, size);
+  Set.prototype.delete.call(process.allowedNodeEnvironmentFlags, '-r');
   assert.strictEqual(process.allowedNodeEnvironmentFlags.size, size);
 }


### PR DESCRIPTION
Make no-op direct calls of `Set` prototype methods to `process.allowedNodeEnvironmentFlags`.

```js
Set.prototype.add.call(process.allowedNodeEnvironmentFlags, '--user-option`);
process.allowedNodeEnvironmentFlags.has('--user-option') === false;
```

This also reverts the parent class to `Set` instead of `SafeSet`, it's probably better not to have `SafeSet` accessible from user-land.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
