### PR TITLE
string_decoder: throw ERR_STRING_TOO_LONG for UTF-8

### DIFF
--- a/src/string_decoder.cc
+++ b/src/string_decoder.cc
@@ -3,6 +3,7 @@
 
 #include "env-inl.h"
 #include "node_buffer.h"
+#include "node_errors.h"
 #include "node_external_reference.h"
 #include "string_bytes.h"
 #include "util.h"
@@ -30,11 +31,17 @@ MaybeLocal<String> MakeString(Isolate* isolate,
   Local<Value> error;
   MaybeLocal<Value> ret;
   if (encoding == UTF8) {
-    return String::NewFromUtf8(
+    MaybeLocal<String> utf8_string = String::NewFromUtf8(
         isolate,
         data,
         v8::NewStringType::kNormal,
         length);
+    if (utf8_string.IsEmpty()) {
+      isolate->ThrowException(node::ERR_STRING_TOO_LONG(isolate));
+      return MaybeLocal<String>();
+    } else {
+      return utf8_string;
+    }
   } else {
     ret = StringBytes::Encode(
         isolate,

--- a/test/parallel/test-string-decoder.js
+++ b/test/parallel/test-string-decoder.js
@@ -201,6 +201,13 @@ assert.throws(
   }
 );
 
+assert.throws(
+  () => new StringDecoder().write(Buffer.alloc(0x1fffffe8 + 1).fill('a')),
+  {
+    code: 'ERR_STRING_TOO_LONG',
+  }
+);
+
 // Test verifies that StringDecoder will correctly decode the given input
 // buffer with the given encoding to the expected output. It will attempt all
 // possible ways to write() the input buffer, see writeSequences(). The


### PR DESCRIPTION
String::NewFromUtf8 doesn't generate an exception in V8 when the string
is too long but is guaranteed to return an empty MaybeLocal only in
that case. Generate a Node.js exception when it happens.

Fixes: https://github.com/nodejs/node/issues/35676

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

