### PR TITLE
WIP net: enable emitclose in socket

### DIFF
--- a/lib/internal/streams/destroy.js
+++ b/lib/internal/streams/destroy.js
@@ -6,8 +6,8 @@ const {
 const {
   FunctionPrototypeCall,
   Symbol,
+  Boolean
 } = primordials;
-
 const kDestroy = Symbol('kDestroy');
 const kConstruct = Symbol('kConstruct');
 
@@ -155,12 +155,15 @@ function _destroy(self, err, cb) {
 
 function emitErrorCloseNT(self, err) {
   emitErrorNT(self, err);
-  emitCloseNT(self);
+  emitCloseNT(self, err);
 }
 
-function emitCloseNT(self) {
+function emitCloseNT(self, err) {
   const r = self._readableState;
   const w = self._writableState;
+  const emitClose = (w && w.emitClose) || (r && r.emitClose);
+  const shouldPassErrorFlag = (w && w.errorFlagOnClose) ||
+    (r && r.errorFlagOnClose);
 
   if (w) {
     w.closeEmitted = true;
@@ -169,8 +172,12 @@ function emitCloseNT(self) {
     r.closeEmitted = true;
   }
 
-  if ((w && w.emitClose) || (r && r.emitClose)) {
-    self.emit('close');
+  if (emitClose) {
+    if (shouldPassErrorFlag) {
+      self.emit('close', Boolean(err));
+    } else {
+      self.emit('close');
+    }
   }
 }
 

--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -142,6 +142,10 @@ function ReadableState(options, stream, isDuplex) {
   // Should close be emitted on destroy. Defaults to true.
   this.emitClose = !options || options.emitClose !== false;
 
+  // Should a boolean flag be passed as argument when emitting close if an error
+  // occurred
+  this.errorFlagOnClose = options && options.errorFlagOnClose === true;
+
   // Should .destroy() be called after 'end' (and potentially 'finish').
   this.autoDestroy = !options || options.autoDestroy !== false;
 

--- a/lib/internal/streams/writable.js
+++ b/lib/internal/streams/writable.js
@@ -186,6 +186,10 @@ function WritableState(options, stream, isDuplex) {
   // Should close be emitted on destroy. Defaults to true.
   this.emitClose = !options || options.emitClose !== false;
 
+  // Should a boolean flag be passed as argument when emitting close if an error
+  // occurred
+  this.errorFlagOnClose = options && options.errorFlagOnClose === true;
+
   // Should .destroy() be called after 'finish' (and potentially 'end').
   this.autoDestroy = !options || options.autoDestroy !== false;
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -299,8 +299,9 @@ function Socket(options) {
 
   // Default to *not* allowing half open sockets.
   options.allowHalfOpen = Boolean(options.allowHalfOpen);
-  // For backwards compat do not emit close on destroy.
-  options.emitClose = false;
+  // For backward compatibility, pass a flag when emitting close for
+  // comunicating that an error occurred.
+  options.errorFlagOnClose = true;
   options.autoDestroy = true;
   // Handle strings directly.
   options.decodeStrings = false;
@@ -655,28 +656,20 @@ Socket.prototype._destroy = function(exception, cb) {
   if (this._handle) {
     if (this !== process.stderr)
       debug('close handle');
-    const isException = exception ? true : false;
+
     // `bytesRead` and `kBytesWritten` should be accessible after `.destroy()`
     this[kBytesRead] = this._handle.bytesRead;
     this[kBytesWritten] = this._handle.bytesWritten;
 
     this._handle.close(() => {
       debug('emit close');
-      if (this._writableState) {
-        this._writableState.closed = true;
-      }
-      if (this._readableState) {
-        this._readableState.closed = true;
-      }
-      this.emit('close', isException);
+      cb(exception);
     });
     this._handle.onread = noop;
     this._handle = null;
     this._sockname = null;
-    cb(exception);
   } else {
     cb(exception);
-    process.nextTick(emitCloseNT, this);
   }
 
   if (this._server) {
@@ -1655,12 +1648,6 @@ Server.prototype._emitCloseIfDrained = function() {
 
 function emitCloseNT(self) {
   debug('SERVER: emit close');
-  if (self._writableState) {
-    self._writableState.closed = true;
-  }
-  if (self._readableState) {
-    self._readableState.closed = true;
-  }
   self.emit('close');
 }
 

--- a/test/parallel/test-http2-respond-with-file-connection-abort.js
+++ b/test/parallel/test-http2-respond-with-file-connection-abort.js
@@ -25,6 +25,10 @@ server.listen(0, common.mustCall(() => {
 
   req.on('response', common.mustCall(() => {}));
   req.once('data', common.mustCall(() => {
+    // TODO: is this test needed?
+    // It errors with ERR_HTTP2_NO_SOCKET_MANIPULATION because we are
+    // calling destroy on the Proxy(ed) socket of the Http2ClientSession
+    // which causes `emit` to becalled and the error to be thrown.
     net.Socket.prototype.destroy.call(client.socket);
     server.close();
   }));

--- a/test/parallel/test-tls-socket-close.js
+++ b/test/parallel/test-tls-socket-close.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
@@ -7,6 +8,10 @@ const assert = require('assert');
 const tls = require('tls');
 const net = require('net');
 const fixtures = require('../common/fixtures');
+
+// TODO: is this test needed?
+// It fails with a timeout error because the `error` event is never emitted.
+// `write` doesn't error, is that a good thing?
 
 // Regression test for https://github.com/nodejs/node/issues/8074
 //


### PR DESCRIPTION
This is a WIP. It might take a while.

This PR should enable `emitClose` in `net.Socket`, ideally without changing any tests.

Fixes: #36636

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
