### PR TITLE
test: increase coverage for events

### DIFF
--- a/test/parallel/test-event-emitter-max-listeners.js
+++ b/test/parallel/test-event-emitter-max-listeners.js
@@ -56,3 +56,17 @@ for (const obj of throwsObjs) {
 }
 
 e.emit('maxListeners');
+
+{
+  const { EventEmitter, defaultMaxListeners } = events;
+  for (const obj of throwsObjs) {
+    assert.throws(() => EventEmitter.setMaxListeners(obj), {
+      code: 'ERR_OUT_OF_RANGE',
+    });
+  }
+
+  assert.throws(
+    () => EventEmitter.setMaxListeners(defaultMaxListeners, 'INVALID_EMITTER'),
+    { code: 'ERR_INVALID_ARG_TYPE' }
+  );
+}

--- a/test/parallel/test-events-once.js
+++ b/test/parallel/test-events-once.js
@@ -23,6 +23,18 @@ async function onceAnEvent() {
   strictEqual(ee.listenerCount('myevent'), 0);
 }
 
+async function onceAnEventWithNullOptions() {
+  const ee = new EventEmitter();
+
+  process.nextTick(() => {
+    ee.emit('myevent', 42);
+  });
+
+  const [value] = await once(ee, 'myevent', null);
+  strictEqual(value, 42);
+}
+
+
 async function onceAnEventWithTwoArgs() {
   const ee = new EventEmitter();
 
@@ -195,6 +207,7 @@ async function eventTargetAbortSignalAfterEvent() {
 
 Promise.all([
   onceAnEvent(),
+  onceAnEventWithNullOptions(),
   onceAnEventWithTwoArgs(),
   catchesErrors(),
   stopListeningAfterCatchingError(),

--- a/test/parallel/test-events-static-geteventlisteners.js
+++ b/test/parallel/test-events-static-geteventlisteners.js
@@ -4,6 +4,7 @@ const common = require('../common');
 
 const {
   deepStrictEqual,
+  throws
 } = require('assert');
 
 const { getEventListeners, EventEmitter } = require('events');
@@ -33,4 +34,10 @@ const { getEventListeners, EventEmitter } = require('events');
   deepStrictEqual(getEventListeners(target, 'foo'), [fn1, fn2]);
   deepStrictEqual(getEventListeners(target, 'bar'), []);
   deepStrictEqual(getEventListeners(target, 'baz'), [fn1]);
+}
+
+{
+  throws(() => {
+    getEventListeners('INVALID_EMITTER');
+  }, /ERR_INVALID_ARG_TYPE/);
 }

--- a/test/parallel/test-eventtarget.js
+++ b/test/parallel/test-eventtarget.js
@@ -13,7 +13,7 @@ const {
 
 const { once } = require('events');
 
-const { promisify } = require('util');
+const { promisify, inspect } = require('util');
 const delay = promisify(setTimeout);
 
 // The globals are defined.
@@ -540,4 +540,33 @@ let asyncTest = Promise.resolve();
   }));
   et.addEventListener('foo', listener);
   et.dispatchEvent(new Event('foo'));
+}
+
+{
+  const ev = new Event('test');
+  const evConstructorName = inspect(ev, {
+    depth: -1
+  });
+  strictEqual(evConstructorName, 'Event');
+
+  const inspectResult = inspect(ev, {
+    depth: 1
+  });
+  ok(inspectResult.includes('Event'));
+}
+
+{
+  const et = new EventTarget();
+  const inspectResult = inspect(et, {
+    depth: 1
+  });
+  ok(inspectResult.includes('EventTarget'));
+}
+
+{
+  const ev = new Event('test');
+  strictEqual(ev.constructor.name, 'Event');
+
+  const et = new EventTarget();
+  strictEqual(et.constructor.name, 'EventTarget');
 }


### PR DESCRIPTION
1. test `EventEmitter.setMaxListeners` with invalid listener count
https://coverage.nodejs.org/coverage-0b6d3070a176d437/lib/events.js.html#L171

2. test `EventEmitter.setMaxListeners` with invalid emitter
https://coverage.nodejs.org/coverage-0b6d3070a176d437/lib/events.js.html#L186

3. test `getEventListeners` with invalid emiiter
Refs: https://coverage.nodejs.org/coverage-0b6d3070a176d437/lib/events.js.html#L706

4. test `events.once` with options: null
Refs: https://coverage.nodejs.org/coverage-0b6d3070a176d437/lib/events.js.html#L712

5. add test case for `inspect new Event()`
Refs: https://coverage.nodejs.org/coverage-0b6d3070a176d437/lib/internal/event_target.js.html#L111

6. add test case for `insepct new EventTarget()`
Refs: https://coverage.nodejs.org/coverage-0b6d3070a176d437/lib/internal/event_target.js.html#L446

7. add test case for `Event` and `EventTarget` constructor name

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
