### PR TITLE
doc: deprecate (doc-only) .aborted property and 'abort', 'aborted' event in http

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2831,6 +2831,28 @@ Type: Documentation-only (supports [`--pending-deprecation`][])
 The remapping of specifiers ending in `"/"` like `import 'pkg/x/'` is deprecated
 for package `"exports"` and `"imports"` pattern resolutions.
 
+### DEP0XXX: `.aborted` property and `'abort'`, `'aborted'` event in `http`
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/36670
+    description: Documentation-only deprecation.
+-->
+
+Type: Documentation-only
+
+Move to {Stream} API instead, as the [`http.ClientRequest`][],
+[`http.ServerResponse`][], and [`http.IncomingMessage`][] are all stream-based.
+Check `stream.destroyed` instead of the `.aborted` property, and listen for
+`'close'` instead of `'abort'`, `'aborted'` event.
+
+The `.aborted` property and `'abort'` event are only useful for detecting
+`.abort()` calls. For closing a request early, use the Stream
+`.destroy([error])` then check the `.destroyed` property and `'close'` event
+should have the same effect. The receiving end should also check the
+[`readable.readableEnded`][] value on [`http.IncomingMessage`][] to get whether
+it was an aborted or graceful destroy.
+
 [Legacy URL API]: url.md#legacy-url-api
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
 [RFC 6066]: https://tools.ietf.org/html/rfc6066#section-3
@@ -2888,6 +2910,9 @@ for package `"exports"` and `"imports"` pattern resolutions.
 [`fs.read()`]: fs.md#fsreadfd-buffer-offset-length-position-callback
 [`fs.readSync()`]: fs.md#fsreadsyncfd-buffer-offset-length-position
 [`fs.stat()`]: fs.md#fsstatpath-options-callback
+[`http.ClientRequest`]: http.md#class-httpclientrequest
+[`http.IncomingMessage`]: http.md#class-httpincomingmessage
+[`http.ServerResponse`]: http.md#class-httpserverresponse
 [`http.get()`]: http.md#httpgetoptions-callback
 [`http.request()`]: http.md#httprequestoptions-callback
 [`https.get()`]: https.md#httpsgetoptions-callback
@@ -2900,6 +2925,7 @@ for package `"exports"` and `"imports"` pattern resolutions.
 [`process.env`]: process.md#processenv
 [`process.mainModule`]: process.md#processmainmodule
 [`punycode`]: punycode.md
+[`readable.readableEnded`]: stream.md#readablereadableended
 [`request.abort()`]: http.md#requestabort
 [`request.connection`]: http.md#requestconnection
 [`request.destroy()`]: http.md#requestdestroyerror

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -407,7 +407,10 @@ body which has been transmitted are equal or not.
 ### Event: `'abort'`
 <!-- YAML
 added: v1.4.1
+deprecated: REPLACEME
 -->
+
+> Stability: 0 - Deprecated. Listen for the `'close'` event instead.
 
 Emitted when the request has been aborted by the client. This event is only
 emitted on the first call to `abort()`.
@@ -564,7 +567,7 @@ added: v0.7.8
 -->
 
 Emitted when the underlying socket times out from inactivity. This only notifies
-that the socket has been idle. The request must be aborted manually.
+that the socket has been idle. The request must be destroyed manually.
 
 See also: [`request.setTimeout()`][].
 
@@ -645,11 +648,14 @@ in the response to be dropped and the socket to be destroyed.
 ### `request.aborted`
 <!-- YAML
 added: v0.11.14
+deprecated: REPLACEME
 changes:
   - version: v11.0.0
     pr-url: https://github.com/nodejs/node/pull/20230
     description: The `aborted` property is no longer a timestamp number.
 -->
+
+> Stability: 0 - Deprecated. Check [`request.destroyed`][] instead.
 
 * {boolean}
 
@@ -1972,7 +1978,10 @@ may be reused multiple times in case of keep-alive.
 ### Event: `'aborted'`
 <!-- YAML
 added: v0.3.8
+deprecated: REPLACEME
 -->
+
+> Stability: 0 - Deprecated. Listen for `'close'` event instead.
 
 Emitted when the request has been aborted.
 
@@ -1986,7 +1995,10 @@ Indicates that the underlying connection was closed.
 ### `message.aborted`
 <!-- YAML
 added: v10.1.0
+deprecated: REPLACEME
 -->
+
+> Stability: 0 - Deprecated. Check `message.destroyed` from {stream.Readable}.
 
 * {boolean}
 
@@ -3221,6 +3233,7 @@ try {
 [`outgoingMessage.socket`]: #outgoingmessagesocket
 [`removeHeader(name)`]: #requestremoveheadername
 [`request.destroy()`]: #requestdestroyerror
+[`request.destroyed`]: #requestdestroyed
 [`request.end()`]: #requestenddata-encoding-callback
 [`request.flushHeaders()`]: #requestflushheaders
 [`request.getHeader()`]: #requestgetheadername


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Refs: https://github.com/nodejs/node/pull/36641
Refs: https://github.com/nodejs/node/issues/36617#issuecomment-751443964

Documentation-only deprecate `.aborted` property and `'abort'`, `'aborted'` event in `http`, and suggest using the corresponding Stream API instead.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
