### PR TITLE
stream: do not use _stream_* anymore

### DIFF
--- a/lib/_stream_duplex.js
+++ b/lib/_stream_duplex.js
@@ -1,6 +1,5 @@
 'use strict';
 
-// TODO(mcollina): deprecate this file
+// Keep this file as an alias for the full stream module.
 
-const Duplex = require('internal/streams/duplex');
-module.exports = Duplex;
+module.exports = require('stream').Duplex;

--- a/lib/_stream_passthrough.js
+++ b/lib/_stream_passthrough.js
@@ -1,6 +1,5 @@
 'use strict';
 
-// TODO(mcollina): deprecate this file
+// Keep this file as an alias for the full stream module.
 
-const PassThrough = require('internal/streams/passthrough');
-module.exports = PassThrough;
+module.exports = require('stream').PassThrough;

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -1,6 +1,5 @@
 'use strict';
 
-// TODO(mcollina): deprecate this file
+// Keep this file as an alias for the full stream module.
 
-const Readable = require('internal/streams/readable');
-module.exports = Readable;
+module.exports = require('stream').Readable;

--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -1,6 +1,5 @@
 'use strict';
 
-// TODO(mcollina): deprecate this file
+// Keep this file as an alias for the full stream module.
 
-const Transform = require('internal/streams/transform');
-module.exports = Transform;
+module.exports = require('stream').Transform;

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -1,6 +1,5 @@
 'use strict';
 
-// TODO(mcollina): deprecate this file
+// Keep this file as an alias for the full stream module.
 
-const Writable = require('internal/streams/writable');
-module.exports = Writable;
+module.exports = require('stream').Writable;

--- a/test/parallel/test-stream-aliases-legacy.js
+++ b/test/parallel/test-stream-aliases-legacy.js
@@ -1,0 +1,14 @@
+'use strict';
+
+require('../common');
+
+const assert = require('assert');
+const stream = require('stream');
+
+// Verify that all individual aliases are left in place.
+
+assert.strictEqual(stream.Readable, require('_stream_readable'));
+assert.strictEqual(stream.Writable, require('_stream_writable'));
+assert.strictEqual(stream.Duplex, require('_stream_duplex'));
+assert.strictEqual(stream.Transform, require('_stream_transform'));
+assert.strictEqual(stream.PassThrough, require('_stream_passthrough'));

--- a/test/parallel/test-stream-pipe-after-end.js
+++ b/test/parallel/test-stream-pipe-after-end.js
@@ -22,8 +22,7 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const Readable = require('_stream_readable');
-const Writable = require('_stream_writable');
+const { Readable, Writable } = require('stream');
 
 class TestReadable extends Readable {
   constructor(opt) {

--- a/test/parallel/test-stream-pipe-needDrain.js
+++ b/test/parallel/test-stream-pipe-needDrain.js
@@ -2,8 +2,7 @@
 
 const common = require('../common');
 const assert = require('assert');
-const Readable = require('_stream_readable');
-const Writable = require('_stream_writable');
+const { Readable, Writable } = require('stream');
 
 // Pipe should pause temporarily if writable needs drain.
 {

--- a/test/parallel/test-stream2-base64-single-char-read-end.js
+++ b/test/parallel/test-stream2-base64-single-char-read-end.js
@@ -21,8 +21,7 @@
 
 'use strict';
 require('../common');
-const R = require('_stream_readable');
-const W = require('_stream_writable');
+const { Readable: R, Writable: W } = require('stream');
 const assert = require('assert');
 
 const src = new R({ encoding: 'base64' });

--- a/test/parallel/test-stream2-basic.js
+++ b/test/parallel/test-stream2-basic.js
@@ -22,8 +22,7 @@
 'use strict';
 
 const common = require('../common');
-const R = require('_stream_readable');
-const W = require('_stream_writable');
+const { Readable: R, Writable: W } = require('stream');
 const assert = require('assert');
 
 const EE = require('events').EventEmitter;

--- a/test/parallel/test-stream2-compatibility.js
+++ b/test/parallel/test-stream2-compatibility.js
@@ -21,8 +21,7 @@
 
 'use strict';
 require('../common');
-const R = require('_stream_readable');
-const W = require('_stream_writable');
+const { Readable: R, Writable: W } = require('stream');
 const assert = require('assert');
 
 let ondataCalled = 0;

--- a/test/parallel/test-stream2-decode-partial.js
+++ b/test/parallel/test-stream2-decode-partial.js
@@ -1,6 +1,6 @@
 'use strict';
 require('../common');
-const Readable = require('_stream_readable');
+const { Readable } = require('stream');
 const assert = require('assert');
 
 let buf = '';

--- a/test/parallel/test-stream2-objects.js
+++ b/test/parallel/test-stream2-objects.js
@@ -22,8 +22,7 @@
 'use strict';
 
 const common = require('../common');
-const Readable = require('_stream_readable');
-const Writable = require('_stream_writable');
+const { Readable, Writable } = require('stream');
 const assert = require('assert');
 
 function toArray(callback) {

--- a/test/parallel/test-stream2-readable-from-list.js
+++ b/test/parallel/test-stream2-readable-from-list.js
@@ -23,7 +23,7 @@
 'use strict';
 require('../common');
 const assert = require('assert');
-const fromList = require('_stream_readable')._fromList;
+const fromList = require('stream').Readable._fromList;
 const BufferList = require('internal/streams/buffer_list');
 const util = require('util');
 

--- a/test/parallel/test-stream2-readable-non-empty-end.js
+++ b/test/parallel/test-stream2-readable-non-empty-end.js
@@ -22,7 +22,7 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const Readable = require('_stream_readable');
+const { Readable } = require('stream');
 
 let len = 0;
 const chunks = new Array(10);

--- a/test/parallel/test-stream2-readable-wrap-destroy.js
+++ b/test/parallel/test-stream2-readable-wrap-destroy.js
@@ -1,7 +1,7 @@
 'use strict';
 const common = require('../common');
 
-const Readable = require('_stream_readable');
+const { Readable } = require('stream');
 const EE = require('events').EventEmitter;
 
 const oldStream = new EE();

--- a/test/parallel/test-stream2-readable-wrap-empty.js
+++ b/test/parallel/test-stream2-readable-wrap-empty.js
@@ -22,7 +22,7 @@
 'use strict';
 const common = require('../common');
 
-const Readable = require('_stream_readable');
+const { Readable } = require('stream');
 const EE = require('events').EventEmitter;
 
 const oldStream = new EE();

--- a/test/parallel/test-stream2-readable-wrap-error.js
+++ b/test/parallel/test-stream2-readable-wrap-error.js
@@ -2,7 +2,7 @@
 const common = require('../common');
 const assert = require('assert');
 
-const Readable = require('_stream_readable');
+const { Readable } = require('stream');
 const EE = require('events').EventEmitter;
 
 class LegacyStream extends EE {

--- a/test/parallel/test-stream2-readable-wrap.js
+++ b/test/parallel/test-stream2-readable-wrap.js
@@ -22,8 +22,7 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const Readable = require('_stream_readable');
-const Writable = require('_stream_writable');
+const { Readable, Writable } = require('stream');
 const EE = require('events').EventEmitter;
 
 function runTest(highWaterMark, objectMode, produce) {

--- a/test/parallel/test-stream2-set-encoding.js
+++ b/test/parallel/test-stream2-set-encoding.js
@@ -22,7 +22,7 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const R = require('_stream_readable');
+const { Readable: R } = require('stream');
 
 class TestReader extends R {
   constructor(n, opts) {

--- a/test/parallel/test-stream2-transform.js
+++ b/test/parallel/test-stream2-transform.js
@@ -22,8 +22,7 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const PassThrough = require('_stream_passthrough');
-const Transform = require('_stream_transform');
+const { PassThrough, Transform } = require('stream');
 
 {
   // Verify writable side consumption

--- a/test/parallel/test-stream2-writable.js
+++ b/test/parallel/test-stream2-writable.js
@@ -22,8 +22,7 @@
 'use strict';
 
 const common = require('../common');
-const W = require('_stream_writable');
-const D = require('_stream_duplex');
+const { Writable: W, Duplex: D } = require('stream');
 const assert = require('assert');
 
 class TestWriter extends W {


### PR DESCRIPTION
Remove all leftover usage of `_stream_*` and keep all of them as legacy.
We do not deprecate the old modules to avoid disrupition and ease
maintainance.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
