### PR TITLE
http: set lifo as the default scheduling strategy in Agent.

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -113,6 +113,9 @@ http.get({
 <!-- YAML
 added: v0.3.4
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/36685
+    description: Change the default scheduling from 'fifo' to 'lifo'.
   - version:
     - v14.5.0
     - v12.19.0
@@ -161,7 +164,7 @@ changes:
     In case of a high rate of request per second,
     the `'fifo'` scheduling will maximize the number of open sockets,
     while the `'lifo'` scheduling will keep it as low as possible.
-    **Default:** `'fifo'`.
+    **Default:** `'lifo'`.
   * `timeout` {number} Socket timeout in milliseconds.
     This will set the timeout when the socket is created.
 

--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -95,7 +95,7 @@ function Agent(options) {
   this.keepAlive = this.options.keepAlive || false;
   this.maxSockets = this.options.maxSockets || Agent.defaultMaxSockets;
   this.maxFreeSockets = this.options.maxFreeSockets || 256;
-  this.scheduling = this.options.scheduling || 'fifo';
+  this.scheduling = this.options.scheduling || 'lifo';
   this.maxTotalSockets = this.options.maxTotalSockets;
   this.totalSocketCount = 0;
 

--- a/test/parallel/test-http-agent-scheduling.js
+++ b/test/parallel/test-http-agent-scheduling.js
@@ -56,11 +56,11 @@ function defaultTest() {
 
     bulkRequest(url, agent, (ports) => {
       makeRequest(url, agent, (port) => {
-        assert.strictEqual(ports[0], port);
+        assert.strictEqual(ports[ports.length - 1], port);
         makeRequest(url, agent, (port) => {
-          assert.strictEqual(ports[1], port);
+          assert.strictEqual(ports[ports.length - 1], port);
           makeRequest(url, agent, (port) => {
-            assert.strictEqual(ports[2], port);
+            assert.strictEqual(ports[ports.length - 1], port);
             server.close();
             agent.destroy();
           });


### PR DESCRIPTION
In https://github.com/nodejs/node/pull/33278 we have added a `scheduling` option for our `http.Agent` to use a LIFO algorithm instead of FIFO. This greatly reduces the amount of ECONNRESET errors due to timeouts, and it's generically a better production experience for our users.

I propose to make this the default.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
