### PR TITLE
test: increase buffer list coverage

### DIFF
--- a/test/parallel/test-stream-buffer-list.js
+++ b/test/parallel/test-stream-buffer-list.js
@@ -48,3 +48,37 @@ const shifted = list.shift();
 testIterator(list, 0);
 assert.strictEqual(shifted, buf);
 assert.deepStrictEqual(list, new BufferList());
+
+{
+  const list = new BufferList();
+  list.push('foo');
+  list.push('bar');
+  list.push('foo');
+  list.push('bar');
+  assert.strictEqual(list.consume(6, true), 'foobar');
+  assert.strictEqual(list.consume(6, true), 'foobar');
+}
+
+{
+  const list = new BufferList();
+  list.push('foo');
+  list.push('bar');
+  assert.strictEqual(list.consume(5, true), 'fooba');
+}
+
+{
+  const list = new BufferList();
+  list.push(buf);
+  list.push(buf);
+  list.push(buf);
+  list.push(buf);
+  assert.strictEqual(list.consume(6).toString(), 'foofoo');
+  assert.strictEqual(list.consume(6).toString(), 'foofoo');
+}
+
+{
+  const list = new BufferList();
+  list.push(buf);
+  list.push(buf);
+  assert.strictEqual(list.consume(5).toString(), 'foofo');
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

1. test consuming `BufferList` which has strings with > 1 items 
https://coverage.nodejs.org/coverage-0b6d3070a176d437/lib/internal/streams/buffer_list.js.html#L116

2. test consuming `BufferList` with > 1 items
https://coverage.nodejs.org/coverage-0b6d3070a176d437/lib/internal/streams/buffer_list.js.html#L152

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
