### PR TITLE
build, tools, win: check if python is a executable program

### DIFF
--- a/tools/msvs/find_python.cmd
+++ b/tools/msvs/find_python.cmd
@@ -61,7 +61,7 @@ exit /b 0
 %~1 -V
 :: 9009 means error file not found
 if %errorlevel% equ 9009 (
-  echo Not a executable Python program
+  echo Not an executable Python program
   exit /b 1
 )
 exit /b 0

--- a/tools/msvs/find_python.cmd
+++ b/tools/msvs/find_python.cmd
@@ -46,6 +46,8 @@ exit /b 1
 
 :found-python
 echo Python found in %p%\python.exe
+call :check-python %p%\python.exe
+if errorlevel 1 goto :no-python
 endlocal ^
   & set "pt=%p%" ^
   & set "need_path_ext=%need_path%"
@@ -53,6 +55,15 @@ set "VCBUILD_PYTHON_LOCATION=%pt%\python.exe"
 if %need_path_ext%==1 set "PATH=%pt%;%PATH%"
 set "pt="
 set "need_path_ext="
+exit /b 0
+
+:check-python
+%~1 -V
+:: 9009 means error file not found
+if %errorlevel% equ 9009 (
+  echo Not a executable Python program
+  exit /b 1
+)
 exit /b 0
 
 :no-python


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/36694

After Windows 10 version 1903, placeholder files named "python.exe" and "python3.exe" appear, not executable programs, and open the MS Store when running without parameters.

Refs: https://devblogs.microsoft.com/python/python-in-the-windows-10-may-2019-update

before install python
![image](https://user-images.githubusercontent.com/14026360/103366924-c1e39c00-4afe-11eb-8d30-703e6797ac4b.png)

after
![image](https://user-images.githubusercontent.com/14026360/103366962-dc1d7a00-4afe-11eb-902d-97941a7fd23f.png)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
