### PR TITLE
doc: document common warning types

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -462,6 +462,29 @@ The `*-deprecation` command-line flags only affect warnings that use the name
 See the [`process.emitWarning()`][process_emit_warning] method for issuing
 custom or application-specific warnings.
 
+#### Node.js warning names
+
+There are no strict guidelines for warning types (as identified by the `name`
+property) emitted by Node.js. New types of warnings can be added at any time.
+A few of the warning types that are most common include:
+
+* `'DeprecationWarning'` - Indicates use of a deprecated Node.js API or feature.
+  Such warnings must include a `'code'` property identifying the
+  [deprecation code][].
+* `'ExperimentalWarning'` - Indicates use of an experimental Node.js API or
+  feature. Such features must be used with caution as they may change at any
+  time and are not subject to the same strict semantic-versioning and long-term
+  support policies as supported features.
+* `'MaxListenersExceededWarning'` - Indicates that too many listeners for a
+  given event have been registered on either an `EventEmitter` or `EventTarget`.
+  This is often an indication of a memory leak.
+* `'TimeoutOverflowWarning'` - Indicates that a numeric value that cannot fit
+  within a 32-bit signed integer has been provided to either the `setTimeout()`
+  or `setInterval()` functions.
+* `'UnsupportedWarning'` - Indicates use of an unsupported option or feature
+  that will be ignored rather than treated as an error. One example is use of
+  the HTTP response status message when using the HTTP/2 compatibility API.
+
 ### Signal events
 
 <!--type=event-->
@@ -2676,6 +2699,7 @@ cases:
 [`subprocess.kill()`]: child_process.md#child_process_subprocess_kill_signal
 [`v8.setFlagsFromString()`]: v8.md#v8_v8_setflagsfromstring_flags
 [debugger]: debugger.md
+[deprecation code]: deprecations.md
 [note on process I/O]: process.md#process_a_note_on_process_i_o
 [process.cpuUsage]: #process_process_cpuusage_previousvalue
 [process_emit_warning]: #process_process_emitwarning_warning_type_code_ctor


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/24987
Signed-off-by: James M Snell <jasnell@gmail.com>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
