### PR TITLE
zlib: refactor to use primordial instead of <string>.startsWith

### DIFF
--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -37,6 +37,7 @@ const {
   ObjectKeys,
   ObjectSetPrototypeOf,
   ReflectApply,
+  StringPrototypeStartsWith,
   Symbol,
   TypedArrayPrototypeFill,
   Uint32Array,
@@ -786,7 +787,9 @@ function createConvenienceMethod(ctor, sync) {
 
 const kMaxBrotliParam = MathMax(...ArrayPrototypeMap(
   ObjectKeys(constants),
-  (key) => (key.startsWith('BROTLI_PARAM_') ? constants[key] : 0)
+  (key) => (StringPrototypeStartsWith(key, 'BROTLI_PARAM_') ?
+    constants[key] :
+    0)
 ));
 
 const brotliInitParamsArray = new Uint32Array(kMaxBrotliParam + 1);
@@ -927,7 +930,7 @@ ObjectDefineProperties(module.exports, {
 // These should be considered deprecated
 // expose all the zlib constants
 for (const bkey of ObjectKeys(constants)) {
-  if (bkey.startsWith('BROTLI')) continue;
+  if (StringPrototypeStartsWith(bkey, 'BROTLI')) continue;
   ObjectDefineProperty(module.exports, bkey, {
     enumerable: false, value: constants[bkey], writable: false
   });


### PR DESCRIPTION


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
