### PR TITLE
doc: revise method text in async_hooks.md

### DIFF
--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -1010,7 +1010,7 @@ added:
 -->
 
 Creates a new instance of `AsyncLocalStorage`. Store is only provided within a
-`run` or after `enterWith` method call.
+`run()` call or after an `enterWith()` call.
 
 ### `asyncLocalStorage.disable()`
 <!-- YAML
@@ -1019,7 +1019,7 @@ added:
  - v12.17.0
 -->
 
-This method disables the instance of `AsyncLocalStorage`. All subsequent calls
+Disables the instance of `AsyncLocalStorage`. All subsequent calls
 to `asyncLocalStorage.getStore()` will return `undefined` until
 `asyncLocalStorage.run()` or `asyncLocalStorage.enterWith()` is called again.
 
@@ -1031,7 +1031,7 @@ Calling `asyncLocalStorage.disable()` is required before the
 provided by the `asyncLocalStorage`, as those objects are garbage collected
 along with the corresponding async resources.
 
-This method is to be used when the `asyncLocalStorage` is not in use anymore
+Use this method when the `asyncLocalStorage` is not in use anymore
 in the current process.
 
 ### `asyncLocalStorage.getStore()`
@@ -1043,10 +1043,10 @@ added:
 
 * Returns: {any}
 
-This method returns the current store.
-If this method is called outside of an asynchronous context initialized by
-calling `asyncLocalStorage.run()` or `asyncLocalStorage.enterWith()`, it will
-return `undefined`.
+Returns the current store.
+If called outside of an asynchronous context initialized by
+calling `asyncLocalStorage.run()` or `asyncLocalStorage.enterWith()`, it
+returns `undefined`.
 
 ### `asyncLocalStorage.enterWith(store)`
 <!-- YAML
@@ -1057,7 +1057,7 @@ added:
 
 * `store` {any}
 
-This method transitions into the context for the remainder of the current
+Transitions into the context for the remainder of the current
 synchronous execution and then persists the store through any following
 asynchronous calls.
 
@@ -1077,7 +1077,7 @@ This transition will continue for the _entire_ synchronous execution.
 This means that if, for example, the context is entered within an event
 handler subsequent event handlers will also run within that context unless
 specifically bound to another context with an `AsyncResource`. That is why
-`run` should be preferred over `enterWith` unless there are strong reasons
+`run()` should be preferred over `enterWith()` unless there are strong reasons
 to use the latter method.
 
 ```js
@@ -1106,7 +1106,7 @@ added:
 * `callback` {Function}
 * `...args` {any}
 
-This methods runs a function synchronously within a context and return its
+Runs a function synchronously within a context and returns its
 return value. The store is not accessible outside of the callback function or
 the asynchronous operations created within the callback.
 
@@ -1140,7 +1140,7 @@ added:
 * `callback` {Function}
 * `...args` {any}
 
-This methods runs a function synchronously outside of a context and return its
+Runs a function synchronously outside of a context and returns its
 return value. The store is not accessible within the callback function or
 the asynchronous operations created within the callback. Any `getStore()`
 call done within the callback function will always return `undefined`.


### PR DESCRIPTION
Fix two typographical errors ("This methods") and general minor edits
around the use of the word "method" in async_hooks.md.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
