### PR TITLE
util: prefer `Reflect.ownKeys(…)` in `util.inspect(…)`

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -43,6 +43,7 @@ const {
   ObjectPrototypePropertyIsEnumerable,
   ObjectSeal,
   ObjectSetPrototypeOf,
+  ReflectOwnKeys,
   RegExp,
   RegExpPrototypeTest,
   RegExpPrototypeToString,
@@ -615,11 +616,7 @@ function addPrototypeProperties(ctx, main, obj, recurseTimes, output) {
       ArrayPrototypeForEach(keys, (key) => keySet.add(key));
     }
     // Get all own property names and symbols.
-    keys = ObjectGetOwnPropertyNames(obj);
-    const symbols = ObjectGetOwnPropertySymbols(obj);
-    if (symbols.length !== 0) {
-      ArrayPrototypePush(keys, ...symbols);
-    }
+    keys = ReflectOwnKeys(obj);
     for (const key of keys) {
       // Ignore the `constructor` property and keys that exist on layers above.
       if (key === 'constructor' ||
@@ -667,7 +664,7 @@ function getKeys(value, showHidden) {
   if (showHidden) {
     keys = ObjectGetOwnPropertyNames(value);
     if (symbols.length !== 0)
-      keys.push(...symbols);
+      ArrayPrototypePush(keys, ...symbols);
   } else {
     // This might throw if `value` is a Module Namespace Object from an
     // unevaluated module, but we don't want to perform the actual type


### PR DESCRIPTION
Using `Reflect.ownKeys(obj)` instead of:
```js
const keys = Object.getOwnPropertyNames(obj);
const symbols = Object.getOwnPropertySymbols(obj);
if (symbols.length !== 0) {
	keys.push(...symbols);
}
```

is more efficient, as it only has to call `obj.[[OwnPropertyKeys]]()` once and return the resulting List as an `Array`, instead of calling it twice and returning two separate arrays, which have the `string` and `symbol` keys filtered: <https://tc39.es/ecma262/#sec-getownpropertykeys>, which are then joined back using `%Array.prototype.push%`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
