### PR TITLE
util: remove unreachable defensive coding

### DIFF
--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -44,15 +44,6 @@ const {
   isSymbolObject,
   isFloat32Array,
   isFloat64Array,
-  isUint8Array,
-  isUint8ClampedArray,
-  isUint16Array,
-  isUint32Array,
-  isInt8Array,
-  isInt16Array,
-  isInt32Array,
-  isBigInt64Array,
-  isBigUint64Array
 } = types;
 const {
   getOwnNonIndexProperties,
@@ -124,38 +115,6 @@ function isEqualBoxedPrimitive(val1, val2) {
   }
   /* c8 ignore next */
   assert.fail(`Unknown boxed type ${val1}`);
-}
-
-function isIdenticalTypedArrayType(a, b) {
-  // Fast path to reduce type checks in the common case.
-  const check = types[`is${TypedArrayPrototypeGetSymbolToStringTag(a)}`];
-  if (check !== undefined && check(a)) {
-    return check(b);
-  }
-  // Manipulated Symbol.toStringTag.
-  for (const check of [
-    isUint16Array,
-    isUint32Array,
-    isInt8Array,
-    isInt16Array,
-    isInt32Array,
-    isFloat32Array,
-    isFloat64Array,
-    isBigInt64Array,
-    isBigUint64Array,
-    isUint8ClampedArray,
-    isUint8Array
-  ]) {
-    if (check(a)) {
-      return check(b);
-    }
-  }
-  /* c8 ignore next 4 */
-  assert.fail(
-    'Unknown TypedArray type checking ' +
-    `${TypedArrayPrototypeGetSymbolToStringTag(a)} ${a}\n` +
-    `and ${TypedArrayPrototypeGetSymbolToStringTag(b)} ${b}`
-  );
 }
 
 // Notes: Type tags are historical [[Class]] properties that can be set by
@@ -241,8 +200,10 @@ function innerDeepEqual(val1, val2, strict, memos) {
       return false;
     }
   } else if (isArrayBufferView(val1)) {
-    if (!isIdenticalTypedArrayType(val1, val2))
+    if (TypedArrayPrototypeGetSymbolToStringTag(val1) !==
+        TypedArrayPrototypeGetSymbolToStringTag(val2)) {
       return false;
+    }
     if (!strict && (isFloat32Array(val1) || isFloat64Array(val1))) {
       if (!areSimilarFloatArrays(val1, val2)) {
         return false;


### PR DESCRIPTION
Now that we are using primordials in the first part of
isIdenticalTypedArrayType(), the defensive coding to get the correct
result (when Symbol.toStringTag is manipulated) is no longer reachable
or necessary. Remove the code.

Refs: https://coverage.nodejs.org/coverage-873d21cdc1266273/lib/internal/util/comparisons.js.html#L135

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
