### PR TITLE
os: performance improvement in vector allocation

### DIFF
--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -112,16 +112,17 @@ static void GetCPUInfo(const FunctionCallbackInfo<Value>& args) {
   // assemble them into objects in JS than to call Object::Set() repeatedly
   // The array is in the format
   // [model, speed, (5 entries of cpu_times), model2, speed2, ...]
-  std::vector<Local<Value>> result(count * 7);
-  for (int i = 0, j = 0; i < count; i++) {
+  std::vector<Local<Value>> result;
+  result.reserve(count * 7);
+  for (int i = 0; i < count; i++) {
     uv_cpu_info_t* ci = cpu_infos + i;
-    result[j++] = OneByteString(isolate, ci->model);
-    result[j++] = Number::New(isolate, ci->speed);
-    result[j++] = Number::New(isolate, ci->cpu_times.user);
-    result[j++] = Number::New(isolate, ci->cpu_times.nice);
-    result[j++] = Number::New(isolate, ci->cpu_times.sys);
-    result[j++] = Number::New(isolate, ci->cpu_times.idle);
-    result[j++] = Number::New(isolate, ci->cpu_times.irq);
+    result.emplace_back(OneByteString(isolate, ci->model));
+    result.emplace_back(Number::New(isolate, ci->speed));
+    result.emplace_back(Number::New(isolate, ci->cpu_times.user));
+    result.emplace_back(Number::New(isolate, ci->cpu_times.nice));
+    result.emplace_back(Number::New(isolate, ci->cpu_times.sys));
+    result.emplace_back(Number::New(isolate, ci->cpu_times.idle));
+    result.emplace_back(Number::New(isolate, ci->cpu_times.irq));
   }
 
   uv_free_cpu_info(cpu_infos, count);
@@ -182,7 +183,8 @@ static void GetInterfaceAddresses(const FunctionCallbackInfo<Value>& args) {
   }
 
   Local<Value> no_scope_id = Integer::New(isolate, -1);
-  std::vector<Local<Value>> result(count * 7);
+  std::vector<Local<Value>> result;
+  result.reserve(count * 7);
   for (i = 0; i < count; i++) {
     const char* const raw_name = interfaces[i].name;
 
@@ -216,18 +218,18 @@ static void GetInterfaceAddresses(const FunctionCallbackInfo<Value>& args) {
       family = env->unknown_string();
     }
 
-    result[i * 7] = name;
-    result[i * 7 + 1] = OneByteString(isolate, ip);
-    result[i * 7 + 2] = OneByteString(isolate, netmask);
-    result[i * 7 + 3] = family;
-    result[i * 7 + 4] = FIXED_ONE_BYTE_STRING(isolate, mac);
-    result[i * 7 + 5] =
-      interfaces[i].is_internal ? True(isolate) : False(isolate);
+    result.emplace_back(name);
+    result.emplace_back(OneByteString(isolate, ip));
+    result.emplace_back(OneByteString(isolate, netmask));
+    result.emplace_back(family);
+    result.emplace_back(FIXED_ONE_BYTE_STRING(isolate, mac));
+    result.emplace_back(
+        interfaces[i].is_internal ? True(isolate) : False(isolate));
     if (interfaces[i].address.address4.sin_family == AF_INET6) {
       uint32_t scopeid = interfaces[i].address.address6.sin6_scope_id;
-      result[i * 7 + 6] = Integer::NewFromUnsigned(isolate, scopeid);
+      result.emplace_back(Integer::NewFromUnsigned(isolate, scopeid));
     } else {
-      result[i * 7 + 6] = no_scope_id;
+      result.emplace_back(no_scope_id);
     }
   }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

We were using the result vector with an object which is not a primitive
data type, and going with the constructor allocation pattern it creates
a size of that vector and also initializes the spaces with the data type
as well which is in our case is `Local<Value>`. It leads to waste of
some CPU cycles and instead we just wanted to have some reserved space
in our vector.

We can use `reserve` method on vector to reserve some space for the
vector but doesn't initialize the value since we are anyways doing it in
the following loop.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->