### PR TITLE
cli: display process warning stack traces by default

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1042,12 +1042,12 @@ to be an `Error` instance).
 
 Enabling this option may affect garbage collection behavior negatively.
 
-### `--trace-warnings`
+### `--no-trace-warnings`
 <!-- YAML
 added: v6.0.0
 -->
 
-Print stack traces for process warnings (including deprecations).
+Disable printing of stack traces for process warnings (including deprecations).
 
 ### `--track-heap-objects`
 <!-- YAML
@@ -1378,7 +1378,7 @@ Node.js options that are allowed are:
 * `--trace-sync-io`
 * `--trace-tls`
 * `--trace-uncaught`
-* `--trace-warnings`
+* `--no-trace-warnings`
 * `--track-heap-objects`
 * `--unhandled-rejections`
 * `--use-bundled-ca`

--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -786,7 +786,7 @@ emitter.once('event', () => {
 });
 ```
 
-The [`--trace-warnings`][] command-line flag can be used to display the
+The [`--no-trace-warnings`][] command-line flag can be used to hide the
 stack trace for such warnings.
 
 The emitted warning can be inspected with [`process.on('warning')`][] and will
@@ -1610,7 +1610,7 @@ and `removeEventListener()` is that `removeListener()` will return a reference
 to the `EventTarget`.
 
 [WHATWG-EventTarget]: https://dom.spec.whatwg.org/#interface-eventtarget
-[`--trace-warnings`]: cli.md#cli_trace_warnings
+[`--no-trace-warnings`]: cli.md#cli_no_trace_warnings
 [`EventTarget` Web API]: https://dom.spec.whatwg.org/#eventtarget
 [`EventTarget` error handling]: #events_eventtarget_error_handling
 [`Event` Web API]: https://dom.spec.whatwg.org/#event

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -442,7 +442,7 @@ $ node --no-warnings
 > Do not do that!
 ```
 
-The `--trace-warnings` command-line option can be used to have the default
+The `--no-trace-warnings` command-line option can be used to hide the default
 console output for warnings include the full stack trace of the warning.
 
 Launching Node.js using the `--throw-deprecation` command-line flag will

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -221,7 +221,7 @@ If either the `--no-deprecation` or `--no-warnings` command-line flags are
 used, or if the `process.noDeprecation` property is set to `true` *prior* to
 the first deprecation warning, the `util.deprecate()` method does nothing.
 
-If the `--trace-deprecation` or `--trace-warnings` command-line flags are set,
+If the `--trace-deprecation` command-line flags is set,
 or the `process.traceDeprecation` property is set to `true`, a warning and a
 stack trace are printed to `stderr` the first time the deprecated function is
 called.

--- a/doc/node.1
+++ b/doc/node.1
@@ -441,8 +441,8 @@ instance).
 .Pp
 Enabling this option may affect garbage collection behavior negatively.
 .
-.It Fl -trace-warnings
-Print stack traces for process warnings (including deprecations).
+.It Fl -no-trace-warnings
+Disable printing of stack traces for process warnings (including deprecations).
 .
 .It Fl -track-heap-objects
 Track heap object allocations for heap snapshots.

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -115,7 +115,7 @@ function patchProcessObject(expandArgv1) {
   addReadOnlyProcessAlias('_preload_modules', '--require');
   addReadOnlyProcessAlias('noDeprecation', '--no-deprecation');
   addReadOnlyProcessAlias('noProcessWarnings', '--no-warnings');
-  addReadOnlyProcessAlias('traceProcessWarnings', '--trace-warnings');
+  addReadOnlyProcessAlias('noTraceProcessWarnings', '--no-trace-warnings');
   addReadOnlyProcessAlias('throwDeprecation', '--throw-deprecation');
   addReadOnlyProcessAlias('profProcess', '--prof-process');
   addReadOnlyProcessAlias('traceDeprecation', '--trace-deprecation');

--- a/lib/internal/process/warning.js
+++ b/lib/internal/process/warning.js
@@ -74,12 +74,12 @@ function onWarning(warning) {
   if (!(warning instanceof Error)) return;
   const isDeprecation = warning.name === 'DeprecationWarning';
   if (isDeprecation && process.noDeprecation) return;
-  const trace = process.noTraceProcessWarnings ||
+  const trace = !process.noTraceProcessWarnings ||
                 (isDeprecation && process.traceDeprecation);
   let msg = `(${process.release.name}:${process.pid}) `;
   if (warning.code)
     msg += `[${warning.code}] `;
-  if (!trace && warning.stack) {
+  if (trace && warning.stack) {
     msg += `${warning.stack}`;
   } else {
     msg +=
@@ -90,7 +90,7 @@ function onWarning(warning) {
   if (typeof warning.detail === 'string') {
     msg += `\n${warning.detail}`;
   }
-  if (trace && !traceWarningHelperShown) {
+  if (isDeprecation && !traceWarningHelperShown) {
     const flag = '--trace-deprecation';
     const argv0 = require('path').basename(process.argv0 || 'node', '.exe');
     msg += `\n(Use \`${argv0} ${flag} ...\` to show where the warning ` +

--- a/lib/internal/process/warning.js
+++ b/lib/internal/process/warning.js
@@ -74,12 +74,12 @@ function onWarning(warning) {
   if (!(warning instanceof Error)) return;
   const isDeprecation = warning.name === 'DeprecationWarning';
   if (isDeprecation && process.noDeprecation) return;
-  const trace = process.traceProcessWarnings ||
+  const trace = process.noTraceProcessWarnings ||
                 (isDeprecation && process.traceDeprecation);
   let msg = `(${process.release.name}:${process.pid}) `;
   if (warning.code)
     msg += `[${warning.code}] `;
-  if (trace && warning.stack) {
+  if (!trace && warning.stack) {
     msg += `${warning.stack}`;
   } else {
     msg +=
@@ -90,11 +90,11 @@ function onWarning(warning) {
   if (typeof warning.detail === 'string') {
     msg += `\n${warning.detail}`;
   }
-  if (!trace && !traceWarningHelperShown) {
-    const flag = isDeprecation ? '--trace-deprecation' : '--trace-warnings';
+  if (trace && !traceWarningHelperShown) {
+    const flag = '--trace-deprecation';
     const argv0 = require('path').basename(process.argv0 || 'node', '.exe');
     msg += `\n(Use \`${argv0} ${flag} ...\` to show where the warning ` +
-           'was created)';
+            'was created)';
     traceWarningHelperShown = true;
   }
   const warningFile = lazyOption();

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -479,9 +479,9 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "show stack traces for the `throw` behind uncaught exceptions",
             &EnvironmentOptions::trace_uncaught,
             kAllowedInEnvironment);
-  AddOption("--trace-warnings",
-            "show stack traces on process warnings",
-            &EnvironmentOptions::trace_warnings,
+  AddOption("--no-trace-warnings",
+            "hide stack traces on process warnings",
+            &EnvironmentOptions::no_trace_warnings,
             kAllowedInEnvironment);
   AddOption("--unhandled-rejections",
             "define unhandled rejections behavior. Options are 'strict' (raise "

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -479,6 +479,10 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "show stack traces for the `throw` behind uncaught exceptions",
             &EnvironmentOptions::trace_uncaught,
             kAllowedInEnvironment);
+  AddOption("--trace-warnings",
+            "show stack traces on process warnings",
+            &EnvironmentOptions::trace_warnings,
+            kAllowedInEnvironment);
   AddOption("--no-trace-warnings",
             "hide stack traces on process warnings",
             &EnvironmentOptions::no_trace_warnings,

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -149,6 +149,7 @@ class EnvironmentOptions : public Options {
   bool trace_tls = false;
   bool trace_uncaught = false;
   bool no_trace_warnings = false;
+  bool trace_warnings = true;
   std::string unhandled_rejections;
   std::string userland_loader;
   bool verify_base_objects =

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -148,7 +148,7 @@ class EnvironmentOptions : public Options {
   bool trace_sync_io = false;
   bool trace_tls = false;
   bool trace_uncaught = false;
-  bool trace_warnings = false;
+  bool no_trace_warnings = false;
   std::string unhandled_rejections;
   std::string userland_loader;
   bool verify_base_objects =

--- a/test/message/unhandled_promise_trace_warnings.js
+++ b/test/message/unhandled_promise_trace_warnings.js
@@ -1,4 +1,4 @@
-// Flags: --trace-warnings --unhandled-rejections=warn
+// Flags: --unhandled-rejections=warn
 'use strict';
 require('../common');
 const p = Promise.reject(new Error('This was rejected'));

--- a/test/parallel/test-cli-node-options.js
+++ b/test/parallel/test-cli-node-options.js
@@ -25,7 +25,7 @@ expectNoWorker(`   --require ${printA}    --require ${printA}`, 'A\nB\n');
 expect('--no-deprecation', 'B\n');
 expect('--no-warnings', 'B\n');
 expect('--no_warnings', 'B\n');
-expect('--trace-warnings', 'B\n');
+expect('--no-trace-warnings', 'B\n');
 expect('--redirect-warnings=_', 'B\n');
 expect('--trace-deprecation', 'B\n');
 expect('--trace-sync-io', 'B\n');

--- a/test/parallel/test-worker-execargv.js
+++ b/test/parallel/test-worker-execargv.js
@@ -12,7 +12,7 @@ const decoder = new StringDecoder('utf8');
 // Do not use isMainThread so that this test itself can be run inside a Worker.
 if (!process.env.HAS_STARTED_WORKER) {
   process.env.HAS_STARTED_WORKER = 1;
-  const w = new Worker(__filename, { execArgv: ['--trace-warnings'] });
+  const w = new Worker(__filename, { execArgv: [] });
   w.stderr.on('data', common.mustCall((chunk) => {
     const error = decoder.write(chunk);
     assert.ok(
@@ -22,11 +22,11 @@ if (!process.env.HAS_STARTED_WORKER) {
 
   new Worker(
     "require('worker_threads').parentPort.postMessage(process.execArgv)",
-    { eval: true, execArgv: ['--trace-warnings'] })
+    { eval: true, execArgv: [] })
     .on('message', common.mustCall((data) => {
-      assert.deepStrictEqual(data, ['--trace-warnings']);
+      assert.deepStrictEqual(data, []);
     }));
 } else {
   process.emitWarning('some warning');
-  assert.deepStrictEqual(process.execArgv, ['--trace-warnings']);
+  assert.deepStrictEqual(process.execArgv, []);
 }

--- a/test/parallel/test-worker-execargv.js
+++ b/test/parallel/test-worker-execargv.js
@@ -12,7 +12,7 @@ const decoder = new StringDecoder('utf8');
 // Do not use isMainThread so that this test itself can be run inside a Worker.
 if (!process.env.HAS_STARTED_WORKER) {
   process.env.HAS_STARTED_WORKER = 1;
-  const w = new Worker(__filename, { execArgv: [] });
+  const w = new Worker(__filename, { execArgv: ['--no-trace-warnings'] });
   w.stderr.on('data', common.mustCall((chunk) => {
     const error = decoder.write(chunk);
     assert.ok(

--- a/test/sequential/test-process-warnings.js
+++ b/test/sequential/test-process-warnings.js
@@ -8,8 +8,8 @@ const warnmod = require.resolve(fixtures.path('warnings.js'));
 const node = process.execPath;
 
 const normal = [warnmod];
-const noWarn = ['--no-warnings', warnmod];
-const traceWarn = ['--trace-warnings', warnmod];
+const noWarn = ['--no-warnings', '--no-trace-warnings', warnmod];
+const traceWarn = [warnmod];
 
 const warningMessage = /^\(.+\)\sWarning: a bad practice warning/;
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

#### Description

close #33349 
Delete `--trace-warnings` cli flag and add `--no-trace-warnings`.
It's my first contributing to `node` so please tell me if I did a mistake or something is bad.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
