### PR TITLE
test: fix test-memory-usage.js for IBMi

### DIFF
--- a/test/parallel/test-memory-usage.js
+++ b/test/parallel/test-memory-usage.js
@@ -26,8 +26,11 @@ const assert = require('assert');
 
 const r = process.memoryUsage();
 // On IBMi, the rss memory always returns zero
-if (!common.isIBMi)
+if (!common.isIBMi) {
   assert.ok(r.rss > 0);
+  assert.ok(process.memoryUsage.rss() > 0);
+}
+
 assert.ok(r.heapTotal > 0);
 assert.ok(r.heapUsed > 0);
 assert.ok(r.external > 0);
@@ -39,10 +42,8 @@ if (r.arrayBuffers > 0) {
   const ab = new ArrayBuffer(size);
 
   const after = process.memoryUsage();
-  assert(after.external - r.external >= size,
-         `${after.external} - ${r.external} >= ${size}`);
+  assert.ok(after.external - r.external >= size,
+            `${after.external} - ${r.external} >= ${size}`);
   assert.strictEqual(after.arrayBuffers - r.arrayBuffers, size,
                      `${after.arrayBuffers} - ${r.arrayBuffers} === ${size}`);
 }
-
-assert(process.memoryUsage.rss() > 0);


### PR DESCRIPTION
Newly added process.memoryUsage.rss() will presumably return 0 on IBMi
the same way process.memoryUsage().rss does. Allow IBMi to skip the new
assertion.

The test was using a mix of `assert()` and `assert.ok()`. This change
makes it consistently use `assert.ok()`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
