### PR TITLE
docs: Add references in punycode.md

### DIFF
--- a/doc/api/punycode.md
+++ b/doc/api/punycode.md
@@ -12,7 +12,9 @@ deprecated: v7.0.0
 **The version of the punycode module bundled in Node.js is being deprecated**.
 In a future major version of Node.js this module will be removed. Users
 currently depending on the `punycode` module should switch to using the
-userland-provided [Punycode.js][] module instead.
+userland-provided [Punycode.js][] module instead. For punycode-based URL
+encoding, see [`url.domainToASCII`][] or, more generally, the
+[WHATWG URL API][].
 
 The `punycode` module is a bundled version of the [Punycode.js][] module. It
 can be accessed using:
@@ -150,3 +152,5 @@ Returns a string identifying the current [Punycode.js][] version number.
 
 [Punycode]: https://tools.ietf.org/html/rfc3492
 [Punycode.js]: https://github.com/bestiejs/punycode.js
+[WHATWG URL API]: url.md#the-whatwg-url-api
+[`url.domainToASCII`]: url.md#urldomaintoasciidomain

--- a/doc/api/punycode.md
+++ b/doc/api/punycode.md
@@ -152,5 +152,5 @@ Returns a string identifying the current [Punycode.js][] version number.
 
 [Punycode]: https://tools.ietf.org/html/rfc3492
 [Punycode.js]: https://github.com/bestiejs/punycode.js
-[WHATWG URL API]: url.md#the-whatwg-url-api
-[`url.domainToASCII`]: url.md#urldomaintoasciidomain
+[WHATWG URL API]: url.md#url_the_whatwg_url_api
+[`url.domainToASCII`]: url.md#url_url_domaintoascii_domain


### PR DESCRIPTION
Add references to related `url` functions in `punycode.md`. These provide
guidance to users who may be investigating the punycode module for URL
encoding.

This is based on confusion I personally experienced reading the deprecation 
notice.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
