### PR TITLE
events: refactor to use optional chaining

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -203,7 +203,7 @@ EventEmitter.init = function(opts) {
   this._maxListeners = this._maxListeners || undefined;
 
 
-  if (opts && opts.captureRejections) {
+  if (opts?.captureRejections) {
     if (typeof opts.captureRejections !== 'boolean') {
       throw new ERR_INVALID_ARG_TYPE('options.captureRejections',
                                      'boolean', opts.captureRejections);
@@ -709,9 +709,9 @@ function getEventListeners(emitterOrTarget, type) {
 }
 
 async function once(emitter, name, options = {}) {
-  const signal = options ? options.signal : undefined;
+  const signal = options?.signal;
   validateAbortSignal(signal, 'options.signal');
-  if (signal && signal.aborted)
+  if (signal?.aborted)
     throw lazyDOMException('The operation was aborted', 'AbortError');
   return new Promise((resolve, reject) => {
     const errorListener = (err) => {
@@ -765,7 +765,7 @@ function eventTargetAgnosticRemoveListener(emitter, name, listener, flags) {
 
 function eventTargetAgnosticAddListener(emitter, name, listener, flags) {
   if (typeof emitter.on === 'function') {
-    if (flags && flags.once) {
+    if (flags?.once) {
       emitter.once(name, listener);
     } else {
       emitter.on(name, listener);
@@ -780,9 +780,9 @@ function eventTargetAgnosticAddListener(emitter, name, listener, flags) {
 }
 
 function on(emitter, event, options) {
-  const { signal } = { ...options };
+  const signal = options?.signal;
   validateAbortSignal(signal, 'options.signal');
-  if (signal && signal.aborted) {
+  if (signal?.aborted) {
     throw lazyDOMException('The operation was aborted', 'AbortError');
   }
 

--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -95,7 +95,7 @@ class Event {
     this[kDefaultPrevented] = false;
     this[kTimestamp] = lazyNow();
     this[kPropagationStopped] = false;
-    if (options != null && options[kTrustEvent]) {
+    if (options?.[kTrustEvent]) {
       isTrustedSet.add(this);
     }
 
@@ -185,7 +185,7 @@ ObjectDefineProperty(Event.prototype, SymbolToStringTag, {
 class NodeCustomEvent extends Event {
   constructor(type, options) {
     super(type, options);
-    if (options && options.detail) {
+    if (options?.detail) {
       this.detail = options.detail;
     }
   }
@@ -340,10 +340,7 @@ class EventTarget {
       return;
 
     type = String(type);
-    // TODO(@jasnell): If it's determined this cannot be backported
-    // to 12.x, then this can be simplified to:
-    //   const capture = Boolean(options?.capture);
-    const capture = options != null && options.capture === true;
+    const capture = options?.capture === true;
 
     const root = this[kEvents].get(type);
     if (root === undefined || root.next === undefined)
@@ -555,9 +552,7 @@ ObjectDefineProperties(NodeEventTarget.prototype, {
 
 function shouldAddListener(listener) {
   if (typeof listener === 'function' ||
-      (listener != null &&
-       typeof listener === 'object' &&
-       typeof listener.handleEvent === 'function')) {
+      typeof listener?.handleEvent === 'function') {
     return true;
   }
 
@@ -586,7 +581,7 @@ function validateEventListenerOptions(options) {
 // It stands in its current implementation as a compromise.
 // Ref: https://github.com/nodejs/node/pull/33661
 function isEventTarget(obj) {
-  return obj && obj.constructor && obj.constructor[kIsEventTarget];
+  return obj?.constructor?.[kIsEventTarget];
 }
 
 function addCatch(that, promise, event) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->



<details>
 <summary>Benchmark running on my computer, performance looks good</summary>

```
                                                           confidence improvement accuracy (*)    (**)   (***)
 events/ee-add-remove.js n=1000000                                ***      4.30 %      ±2.08% ±2.77% ±3.61%
 events/ee-emit.js listeners=1 argc=0 n=2000000                            2.90 %      ±3.52% ±4.68% ±6.09%
 events/ee-emit.js listeners=1 argc=10 n=2000000                           1.92 %      ±3.73% ±4.96% ±6.45%
 events/ee-emit.js listeners=1 argc=2 n=2000000                            2.20 %      ±2.87% ±3.83% ±5.00%
 events/ee-emit.js listeners=1 argc=4 n=2000000                           -0.39 %      ±2.89% ±3.84% ±5.00%
 events/ee-emit.js listeners=10 argc=0 n=2000000                  ***      4.52 %      ±2.30% ±3.06% ±3.99%
 events/ee-emit.js listeners=10 argc=10 n=2000000                   *      2.49 %      ±1.88% ±2.51% ±3.27%
 events/ee-emit.js listeners=10 argc=2 n=2000000                   **      2.97 %      ±2.13% ±2.84% ±3.70%
 events/ee-emit.js listeners=10 argc=4 n=2000000                  ***      3.65 %      ±2.09% ±2.78% ±3.62%
 events/ee-emit.js listeners=5 argc=0 n=2000000                   ***      6.47 %      ±2.15% ±2.86% ±3.72%
 events/ee-emit.js listeners=5 argc=10 n=2000000                           2.22 %      ±2.27% ±3.02% ±3.93%
 events/ee-emit.js listeners=5 argc=2 n=2000000                            1.60 %      ±2.92% ±3.89% ±5.06%
 events/ee-emit.js listeners=5 argc=4 n=2000000                   ***      4.25 %      ±2.34% ±3.12% ±4.07%
 events/ee-listener-count-on-prototype.js n=50000000               **     -1.74 %      ±1.27% ±1.70% ±2.21%
 events/ee-listeners.js raw='false' listeners=5 n=5000000          **      3.73 %      ±2.37% ±3.16% ±4.12%
 events/ee-listeners.js raw='false' listeners=50 n=5000000        ***     14.41 %      ±2.32% ±3.09% ±4.02%
 events/ee-listeners.js raw='true' listeners=5 n=5000000                  -2.63 %      ±2.69% ±3.58% ±4.65%
 events/ee-listeners.js raw='true' listeners=50 n=5000000         ***     29.31 %      ±3.29% ±4.40% ±5.76%
 events/ee-once.js argc=0 n=20000000                              ***      7.21 %      ±3.15% ±4.19% ±5.46%
 events/ee-once.js argc=1 n=20000000                              ***      5.66 %      ±3.06% ±4.07% ±5.29%
 events/ee-once.js argc=4 n=20000000                              ***      6.00 %      ±2.72% ±3.62% ±4.71%
 events/ee-once.js argc=5 n=20000000                               **      4.62 %      ±2.93% ±3.90% ±5.09%
 events/eventtarget.js listeners=1 n=1000000                      ***      4.41 %      ±1.93% ±2.57% ±3.35%
 events/eventtarget.js listeners=10 n=1000000                       *      2.75 %      ±2.34% ±3.11% ±4.05%
 events/eventtarget.js listeners=5 n=1000000                      ***      3.50 %      ±1.87% ±2.49% ±3.25%

Be aware that when doing many comparisons the risk of a false-positive
result increases. In this case there are 25 comparisons, you can thus
expect the following amount of false-positive results:
  1.25 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.25 false positives, when considering a   1% risk acceptance (**, ***),
  0.03 false positives, when considering a 0.1% risk acceptance (***)
```

</details>

Benchmark commands: `node ./node-master/benchmark/compare.js --old ./node-master/out/Release/node --new ./node/out/Release/node -- events`

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
