### PR TITLE
cluster: fix edge cases that throw ERR_INTERNAL_ASSERTION

### DIFF
--- a/lib/internal/cluster/child.js
+++ b/lib/internal/cluster/child.js
@@ -6,6 +6,7 @@ const {
   ObjectAssign,
   ReflectApply,
   SafeMap,
+  SafeSet,
 } = primordials;
 
 const assert = require('internal/assert');
@@ -74,14 +75,14 @@ cluster._getServer = function(obj, options, cb) {
       options.fd,
     ], ':');
 
-  let index = indexes.get(indexesKey);
+  let indexSet = indexes.get(indexesKey);
 
-  if (index === undefined)
-    index = 0;
-  else
-    index++;
-
-  indexes.set(indexesKey, index);
+  if (indexSet === undefined) {
+    indexSet = { nextIndex: 0, set: new SafeSet() };
+    indexes.set(indexesKey, indexSet);
+  }
+  const index = indexSet.nextIndex++;
+  indexSet.set.add(index);
 
   const message = {
     act: 'queryServer',
@@ -101,9 +102,9 @@ cluster._getServer = function(obj, options, cb) {
       obj._setServerData(reply.data);
 
     if (handle)
-      shared(reply, handle, indexesKey, cb);  // Shared listen socket.
+      shared(reply, handle, indexesKey, index, cb);  // Shared listen socket.
     else
-      rr(reply, indexesKey, cb);              // Round-robin.
+      rr(reply, indexesKey, index, cb);              // Round-robin.
   });
 
   obj.once('listening', () => {
@@ -115,8 +116,20 @@ cluster._getServer = function(obj, options, cb) {
   });
 };
 
+function removeIndexesKey(indexesKey, index) {
+  const indexSet = indexes.get(indexesKey);
+  if (!indexSet) {
+    return;
+  }
+
+  indexSet.set.delete(index);
+  if (indexSet.set.size === 0) {
+    indexes.delete(indexesKey);
+  }
+}
+
 // Shared listen socket.
-function shared(message, handle, indexesKey, cb) {
+function shared(message, handle, indexesKey, index, cb) {
   const key = message.key;
   // Monkey-patch the close() method so we can keep track of when it's
   // closed. Avoids resource leaks when the handle is short-lived.
@@ -125,7 +138,7 @@ function shared(message, handle, indexesKey, cb) {
   handle.close = function() {
     send({ act: 'close', key });
     handles.delete(key);
-    indexes.delete(indexesKey);
+    removeIndexesKey(indexesKey, index);
     return ReflectApply(close, handle, arguments);
   };
   assert(handles.has(key) === false);
@@ -134,7 +147,7 @@ function shared(message, handle, indexesKey, cb) {
 }
 
 // Round-robin. Primary distributes handles across workers.
-function rr(message, indexesKey, cb) {
+function rr(message, indexesKey, index, cb) {
   if (message.errno)
     return cb(message.errno, null);
 
@@ -158,7 +171,7 @@ function rr(message, indexesKey, cb) {
 
     send({ act: 'close', key });
     handles.delete(key);
-    indexes.delete(indexesKey);
+    removeIndexesKey(indexesKey, index);
     key = undefined;
   }
 

--- a/test/parallel/test-cluster-child-index-dgram.js
+++ b/test/parallel/test-cluster-child-index-dgram.js
@@ -1,0 +1,40 @@
+'use strict';
+const common = require('../common');
+const Countdown = require('../common/countdown');
+if (common.isWindows)
+  common.skip('dgram clustering is currently not supported on Windows.');
+
+const cluster = require('cluster');
+const dgram = require('dgram');
+
+// Test an edge case when using `cluster` and `dgram.Socket.bind()`
+// the port of `0`.
+const kPort = 0;
+
+function child() {
+  const kTime = 2;
+  const countdown = new Countdown(kTime * 2, () => {
+    process.exit(0);
+  });
+  for (let i = 0; i < kTime; i += 1) {
+    const socket = new dgram.Socket('udp4');
+    socket.bind(kPort, common.mustCall(() => {
+      // `process.nextTick()` or `socket2.close()` would throw
+      // ERR_SOCKET_DGRAM_NOT_RUNNING
+      process.nextTick(() => {
+        socket.close(countdown.dec());
+        const socket2 = new dgram.Socket('udp4');
+        socket2.bind(kPort, common.mustCall(() => {
+          process.nextTick(() => {
+            socket2.close(countdown.dec());
+          });
+        }));
+      });
+    }));
+  }
+}
+
+if (cluster.isMaster)
+  cluster.fork(__filename);
+else
+  child();

--- a/test/parallel/test-cluster-child-index-net.js
+++ b/test/parallel/test-cluster-child-index-net.js
@@ -1,0 +1,31 @@
+'use strict';
+const common = require('../common');
+const Countdown = require('../common/countdown');
+const cluster = require('cluster');
+const net = require('net');
+
+// Test an edge case when using `cluster` and `net.Server.listen()` to
+// the port of `0`.
+const kPort = 0;
+
+function child() {
+  const kTime = 2;
+  const countdown = new Countdown(kTime * 2, () => {
+    process.exit(0);
+  });
+  for (let i = 0; i < kTime; i += 1) {
+    const server = net.createServer();
+    server.listen(kPort, common.mustCall(() => {
+      server.close(countdown.dec());
+      const server2 = net.createServer();
+      server2.listen(kPort, common.mustCall(() => {
+        server2.close(countdown.dec());
+      }));
+    }));
+  }
+}
+
+if (cluster.isMaster)
+  cluster.fork(__filename);
+else
+  child();


### PR DESCRIPTION
Some cases use both `cluster` and `net`/`cluser` will throw
ERR_INTERNAL_ASSERTION when `listen`/`bind` to the port of `0`, like below:

```js
const cluster = require('cluster')
const dgram = require('dgram')

const kPort = 0;

function child() {
  for (let i = 0; i < 2; i += 1) {
    const socket = new dgram.Socket('udp4')
    socket.bind(kPort)
    setTimeout(() => {
      socket.close()
      const socket2 = new dgram.Socket('udp4')
      socket2.bind(kPort);
    }, 100)
  }
}

if (cluster.isMaster) {
  cluster.fork(__filename)
} else {
  child()
}
```

would throw: 

```
internal/assert.js:14
    throw new ERR_INTERNAL_ASSERTION(message);
    ^

Error [ERR_INTERNAL_ASSERTION]: This is caused by either a bug in Node.js or incorrect usage of Node.js internals.
Please open an issue with this stack trace at https://github.com/nodejs/node/issues

    at assert (internal/assert.js:14:11)
    at SharedHandle.add (internal/cluster/shared_handle.js:28:3)
    at queryServer (internal/cluster/master.js:309:10)
    at Worker.onmessage (internal/cluster/master.js:249:5)
    at ChildProcess.onInternalMessage (internal/cluster/utils.js:47:8)
    at ChildProcess.emit (events.js:326:22)
    at emit (internal/child_process.js:906:12)
    at processTicksAndRejections (internal/process/task_queues.js:81:21) {
  code: 'ERR_INTERNAL_ASSERTION'
}
```

After some investigation, I believe it's because we remove the `indexesKey` when `close` servers while it might reference more than one `index`:

https://github.com/nodejs/node/blob/8b8620d580314050175983402dfddf2674e8e22a/lib/internal/cluster/child.js#L127

This PR maitains a separate map of the index to fix the issue.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
