### PR TITLE
tools: fix md5 hash for ICU 68.1 src

### DIFF
--- a/tools/icu/current_ver.dep
+++ b/tools/icu/current_ver.dep
@@ -1,6 +1,6 @@
 [
   {
     "url": "https://github.com/unicode-org/icu/releases/download/release-68-1/icu4c-68_1-src.tgz",
-    "md5": "fd03b2d916dcadd3711b4c4a100a1713"
+    "md5": "6a99b541ea01f271257b121a4433c7c0"
   }
 ]


### PR DESCRIPTION
Correct md5sum hash for the tarball version of the ICU 68.1 source.
The previously recorded md5sum hash was for the zip version.

Fixes: https://github.com/nodejs/node/issues/36776

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
