### PR TITLE
doc: clarify when messageerror is emitted

### DIFF
--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -452,7 +452,7 @@ added:
 
 The `'messageerror'` event is emitted when deserializing a message failed.
 
-Currently, this event is emitted when there is an error occuring while
+Currently, this event is emitted when there is an error occurring while
 instantiating the posted JS object on the receiving end. Such situations
 are rare, but can happen, for instance, when certain Node.js API objects
 are received in a `vm.Context` (where Node.js APIs are currently

--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -452,6 +452,12 @@ added:
 
 The `'messageerror'` event is emitted when deserializing a message failed.
 
+Currently, this event is emitted when there is an error occuring while
+instantiating the posted JS object on the receiving end. Such situations
+are rare, but can happen, for instance, when certain Node.js API objects
+are received in a `vm.Context` (where Node.js APIs are currently
+unavailable).
+
 ### `port.close()`
 <!-- YAML
 added: v10.5.0


### PR DESCRIPTION
Adapting addaleax's explanation from the issue.

Fixes: https://github.com/nodejs/node/issues/36333
Signed-off-by: James M Snell <jasnell@gmail.com>
 /cc @addaleax @naz