### PR TITLE
benchmark: fix http/headers.js with test-double

### DIFF
--- a/benchmark/http/headers.js
+++ b/benchmark/http/headers.js
@@ -4,7 +4,7 @@ const common = require('../common.js');
 const http = require('http');
 
 const bench = common.createBenchmark(main, {
-  n: [10, 1000],
+  n: [10, 600],
   len: [1, 100],
   duration: 5
 });


### PR DESCRIPTION
The http/headers.js benchmark fails if wrk or autocannon are not
installed. This is because the benchmark exceeds the default permissible
length for HTTP headers. Reduce the largest benchmarks to fit within the
8192 default as that is what we should be optimizing for.

Fixes: https://github.com/nodejs/node/issues/31022

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
