### PR TITLE
test: guard large string decoder allocation

### DIFF
--- a/test/parallel/test-string-decoder.js
+++ b/test/parallel/test-string-decoder.js
@@ -201,12 +201,14 @@ assert.throws(
   }
 );
 
-assert.throws(
-  () => new StringDecoder().write(Buffer.alloc(0x1fffffe8 + 1).fill('a')),
-  {
-    code: 'ERR_STRING_TOO_LONG',
-  }
-);
+if (common.enoughTestMem) {
+  assert.throws(
+    () => new StringDecoder().write(Buffer.alloc(0x1fffffe8 + 1).fill('a')),
+    {
+      code: 'ERR_STRING_TOO_LONG',
+    }
+  );
+}
 
 // Test verifies that StringDecoder will correctly decode the given input
 // buffer with the given encoding to the expected output. It will attempt all


### PR DESCRIPTION
Use common.enoughTestMem to avoid "Array buffer allocation failed"
error on low memory devices.

Fixes: https://github.com/nodejs/node/issues/36792
