### PR TITLE
crypto: introduce X509Certificate API

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1645,6 +1645,259 @@ thrown.
 Because public keys can be derived from private keys, a private key may
 be passed instead of a public key.
 
+## Class: `X509Certificate`
+<!-- YAML
+added: REPLACEME
+-->
+
+Encapsulates an X509 certificate and provides read-only access to
+it's information.
+
+```js
+const { X509Certificate } = require('crypto');
+
+const x509 = new X509Certificate('{... pem encoded cert ...}');
+
+console.log(x509.subject);
+```
+
+### `new X509Certificate(buffer)`
+<!-- YAML
+added: REPLACEME
+-->
+
+* `buffer` {string|TypedArray|Buffer|DataView} A PEM or DER encoded
+  X509 Certificate.
+
+### `x509.ca`
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {boolean} Will be `true` if this is a Certificate Authority (ca)
+  certificate.
+
+### `x509.checkEmail(email[, options])`
+<!-- YAML
+added: REPLACEME
+-->
+
+* `email` {string}
+* `options` {Object}
+  * `subject` {string} `'always'` or `'never'`. **Defaults**: `'always'`.
+  * `wildcards` {boolean} **Defaults**: `true`.
+  * `partialWildcards` {boolean} **Defaults**: `true`.
+  * `multiLabelWildcards` {boolean} **Defaults**: `false`.
+  * `singleLabelSubdomains` {boolean} **Defaults**: `false`.
+* Returns: {string|undefined} Returns `email` if the certificate matches,
+  `undefined` if it does not.
+
+Checks whether the certificate matches the given email address.
+
+### `x509.checkHost(name[, options])`
+<!-- YAML
+added: REPLACEME
+-->
+
+* `name` {string}
+* `options` {Object}
+  * `subject` {string} `'always'` or `'never'`. **Defaults**: `'always'`.
+  * `wildcards` {boolean} **Defaults**: `true`.
+  * `partialWildcards` {boolean} **Defaults**: `true`.
+  * `multiLabelWildcards` {boolean} **Defaults**: `false`.
+  * `singleLabelSubdomains` {boolean} **Defaults**: `false`.
+* Returns: {string|undefined} Returns `name` if the certificate matches,
+  `undefined` if it does not.
+
+Checks whether the certificate matches the given host name.
+
+### `x509.checkIP(ip[, options])`
+<!-- YAML
+added: REPLACEME
+-->
+
+* `ip` {string}
+* `options` {Object}
+  * `subject` {string} `'always'` or `'never'`. **Defaults**: `'always'`.
+  * `wildcards` {boolean} **Defaults**: `true`.
+  * `partialWildcards` {boolean} **Defaults**: `true`.
+  * `multiLabelWildcards` {boolean} **Defaults**: `false`.
+  * `singleLabelSubdomains` {boolean} **Defaults**: `false`.
+* Returns: {string|undefined} Returns `ip` if the certificate matches,
+  `undefined` if it does not.
+
+Checks whether the certificate matches the given IP address (IPv4 or IPv6).
+
+### `x509.checkIssued(otherCert)`
+<!-- YAML
+added: REPLACEME
+-->
+
+* `otherCert` {X509Certificate}
+* Returns: {boolean}
+
+Checks whether this certificate was issued by the given `otherCert`.
+
+### `x509.checkPrivateKey(privateKey)`
+<!-- YAML
+added: REPLACEME
+-->
+
+* `privateKey` {KeyObject} A private key.
+* Returns: {boolean}
+
+Checks whether the public key for this certificate is consistent with
+the given private key.
+
+### `x509.fingerprint`
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {string}
+
+The SHA-1 fingerprint of this certificate.
+
+### `x509.fingerprint256`
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {string}
+
+The SHA-256 fingerprint of this certificate.
+
+### `x509.infoAccess`
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {string}
+
+The information access content of this certificate.
+
+### `x509.issuer`
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {string}
+
+The issuer identification included in this certificate.
+
+### `x509.keyUsage`
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {string[]}
+
+An array detailing the key usages for this certificate.
+
+### `x509.publicKey`
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {KeyObject}
+
+The public key {KeyObject} for this certificate.
+
+### `x509.raw`
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {Buffer}
+
+A `Buffer` containing the DER encoding of this certificate.
+
+### `x509.serialNumber`
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {string}
+
+The serial number of this certificate.
+
+### `x509.subject`
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {string}
+
+The complete subject of this certificate.
+
+### `x509.subjectAltName`
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {string}
+
+The subject alternative name specified for this certificate.
+
+### `x509.toJSON()`
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {string}
+
+There is no standard JSON encoding for X509 certificates. The
+`toJSON()` method returns a string containing the PEM encoded
+certificate.
+
+### `x509.toLegacyObject()`
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {Object}
+
+Returns information about this certificate using the legacy
+[certificate object][] encoding.
+
+### `x509.toString()`
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {string}
+
+Returns the PEM-encoded certificate.
+
+### `x509.validFrom`
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {string}
+
+The date/time from which this certificate is considered valid.
+
+### `x509.validTo`
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {string}
+
+The date/time until which this certificate is considered valid.
+
+### `x509.verify(publicKey)`
+<!-- YAML
+added: REPLACEME
+-->
+
+* `publicKey` {KeyObject} A public key.
+* Returns: {boolean}
+
+Verifies that this certificate was signed by the given public key.
+Does not perform any other validation checks on the certificate.
+
 ## `crypto` module methods and properties
 
 ### `crypto.constants`
@@ -3981,6 +4234,7 @@ See the [list of SSL OP Flags][] for details.
 [`util.promisify()`]: util.md#util_util_promisify_original
 [`verify.update()`]: #crypto_verify_update_data_inputencoding
 [`verify.verify()`]: #crypto_verify_verify_object_signature_signatureencoding
+[certificate object]: tls.md#tls_certificate_object
 [encoding]: buffer.md#buffer_buffers_and_character_encodings
 [initialization vector]: https://en.wikipedia.org/wiki/Initialization_vector
 [list of SSL OP Flags]: https://wiki.openssl.org/index.php/List_of_SSL_OP_Flags#Table_of_Options

--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -468,6 +468,9 @@ are part of the channel.
 <!-- YAML
 added: v10.5.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/36804
+    description: Added `X509Certificate` tot he list of cloneable types.
   - version:
     - v14.5.0
     - v12.19.0
@@ -495,8 +498,8 @@ In particular, the significant differences to `JSON` are:
 * `value` may contain typed arrays, both using `ArrayBuffer`s
    and `SharedArrayBuffer`s.
 * `value` may contain [`WebAssembly.Module`][] instances.
-* `value` may not contain native (C++-backed) objects other than `MessagePort`s,
-  [`FileHandle`][]s, and [`KeyObject`][]s.
+* `value` may not contain native (C++-backed) objects other than {MessagePort}s,
+  {FileHandle}s, {KeyObject}s, and {X509Certificate}s.
 
 ```js
 const { MessageChannel } = require('worker_threads');
@@ -1123,7 +1126,6 @@ active handle in the event system. If the worker is already `unref()`ed calling
 [`ERR_WORKER_NOT_RUNNING`]: errors.md#ERR_WORKER_NOT_RUNNING
 [`EventTarget`]: https://developer.mozilla.org/en-US/docs/Web/API/EventTarget
 [`FileHandle`]: fs.md#fs_class_filehandle
-[`KeyObject`]: crypto.md#crypto_class_keyobject
 [`MessagePort`]: #worker_threads_class_messageport
 [`SharedArrayBuffer`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer
 [`Uint8Array`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -107,6 +107,9 @@ const {
   Hmac
 } = require('internal/crypto/hash');
 const {
+  X509Certificate
+} = require('internal/crypto/x509');
+const {
   getCiphers,
   getCurves,
   getDefaultEncoding,
@@ -223,7 +226,8 @@ module.exports = {
   Hmac,
   KeyObject,
   Sign,
-  Verify
+  Verify,
+  X509Certificate,
 };
 
 function setFipsDisabled() {

--- a/lib/internal/crypto/x509.js
+++ b/lib/internal/crypto/x509.js
@@ -1,0 +1,334 @@
+'use strict';
+
+const {
+  ObjectSetPrototypeOf,
+  SafeMap,
+  Symbol,
+} = primordials;
+
+const {
+  parseX509,
+  X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT,
+  X509_CHECK_FLAG_NEVER_CHECK_SUBJECT,
+  X509_CHECK_FLAG_NO_WILDCARDS,
+  X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS,
+  X509_CHECK_FLAG_MULTI_LABEL_WILDCARDS,
+  X509_CHECK_FLAG_SINGLE_LABEL_SUBDOMAINS,
+} = internalBinding('crypto');
+
+const {
+  PublicKeyObject,
+  isKeyObject,
+} = require('internal/crypto/keys');
+
+const {
+  customInspectSymbol: kInspect,
+} = require('internal/util');
+
+const {
+  validateBoolean,
+  validateObject,
+  validateString,
+} = require('internal/validators');
+
+const { inspect } = require('internal/util/inspect');
+
+const { Buffer } = require('buffer');
+
+const {
+  isArrayBufferView,
+} = require('internal/util/types');
+
+const {
+  codes: {
+    ERR_INVALID_ARG_TYPE,
+    ERR_INVALID_ARG_VALUE,
+  }
+} = require('internal/errors');
+
+const {
+  JSTransferable,
+  kClone,
+  kDeserialize,
+} = require('internal/worker/js_transferable');
+
+const {
+  kHandle,
+} = require('internal/crypto/util');
+
+const kInternalState = Symbol('kInternalState');
+
+function isX509Certificate(value) {
+  return value[kInternalState] !== undefined;
+}
+
+function getFlags(options = {}) {
+  validateObject(options, 'options');
+  const {
+    subject = 'always',  // Can be 'always' or 'never'
+    wildcards = true,
+    partialWildcards = true,
+    multiLabelWildcards = false,
+    singleLabelSubdomains = false,
+  } = { ...options };
+  let flags = 0;
+  validateString(subject, 'options.subject');
+  validateBoolean(wildcards, 'options.wildcards');
+  validateBoolean(partialWildcards, 'options.partialWildcards');
+  validateBoolean(multiLabelWildcards, 'options.multiLabelWildcards');
+  validateBoolean(singleLabelSubdomains, 'options.singleLabelSubdomains');
+  switch (subject) {
+    case 'always': flags |= X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT; break;
+    case 'never': flags |= X509_CHECK_FLAG_NEVER_CHECK_SUBJECT; break;
+    default:
+      throw new ERR_INVALID_ARG_VALUE('options.subject', subject);
+  }
+  if (!wildcards) flags |= X509_CHECK_FLAG_NO_WILDCARDS;
+  if (!partialWildcards) flags |= X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS;
+  if (multiLabelWildcards) flags |= X509_CHECK_FLAG_MULTI_LABEL_WILDCARDS;
+  if (singleLabelSubdomains) flags |= X509_CHECK_FLAG_SINGLE_LABEL_SUBDOMAINS;
+  return flags;
+}
+
+class X509Certificate extends JSTransferable {
+  [kInternalState] = new SafeMap();
+
+  constructor(buffer) {
+    if (typeof buffer === 'string')
+      buffer = Buffer.from(buffer);
+    if (!isArrayBufferView(buffer)) {
+      throw new ERR_INVALID_ARG_TYPE(
+        'buffer',
+        ['string', 'Buffer', 'TypedArray', 'DataView'],
+        buffer);
+    }
+    super();
+    this[kHandle] = parseX509(buffer);
+  }
+
+  [kInspect](depth, options) {
+    if (depth < 0)
+      return this;
+
+    const opts = {
+      ...options,
+      depth: options.depth == null ? null : options.depth - 1
+    };
+
+    return `X509Certificate ${inspect({
+      subject: this.subject,
+      subjectAltName: this.subjectAltName,
+      issuer: this.issuer,
+      infoAccess: this.infoAccess,
+      validFrom: this.validFrom,
+      validTo: this.validTo,
+      fingerprint: this.fingerprint,
+      fingerprint256: this.fingerprint256,
+      keyUsage: this.keyUsage,
+      serialNumber: this.serialNumber,
+    }, opts)}`;
+  }
+
+  [kClone]() {
+    const handle = this[kHandle];
+    return {
+      data: { handle },
+      deserializeInfo: 'internal/crypto/x509:InternalX509Certificate'
+    };
+  }
+
+  [kDeserialize]({ handle }) {
+    this[kHandle] = handle;
+  }
+
+  get subject() {
+    let value = this[kInternalState].get('subject');
+    if (value === undefined) {
+      value = this[kHandle].subject();
+      this[kInternalState].set('subject', value);
+    }
+    return value;
+  }
+
+  get subjectAltName() {
+    let value = this[kInternalState].get('subjectAltName');
+    if (value === undefined) {
+      value = this[kHandle].subjectAltName();
+      this[kInternalState].set('subjectAltName', value);
+    }
+    return value;
+  }
+
+  get issuer() {
+    let value = this[kInternalState].get('issuer');
+    if (value === undefined) {
+      value = this[kHandle].issuer();
+      this[kInternalState].set('issuer', value);
+    }
+    return value;
+  }
+
+  get infoAccess() {
+    let value = this[kInternalState].get('infoAccess');
+    if (value === undefined) {
+      value = this[kHandle].infoAccess();
+      this[kInternalState].set('infoAccess', value);
+    }
+    return value;
+  }
+
+  get validFrom() {
+    let value = this[kInternalState].get('validFrom');
+    if (value === undefined) {
+      value = this[kHandle].validFrom();
+      this[kInternalState].set('validFrom', value);
+    }
+    return value;
+  }
+
+  get validTo() {
+    let value = this[kInternalState].get('validTo');
+    if (value === undefined) {
+      value = this[kHandle].validTo();
+      this[kInternalState].set('validTo', value);
+    }
+    return value;
+  }
+
+  get fingerprint() {
+    let value = this[kInternalState].get('fingerprint');
+    if (value === undefined) {
+      value = this[kHandle].fingerprint();
+      this[kInternalState].set('fingerprint', value);
+    }
+    return value;
+  }
+
+  get fingerprint256() {
+    let value = this[kInternalState].get('fingerprint256');
+    if (value === undefined) {
+      value = this[kHandle].fingerprint256();
+      this[kInternalState].set('fingerprint256', value);
+    }
+    return value;
+  }
+
+  get keyUsage() {
+    let value = this[kInternalState].get('keyUsage');
+    if (value === undefined) {
+      value = this[kHandle].keyUsage();
+      this[kInternalState].set('keyUsage', value);
+    }
+    return value;
+  }
+
+  get serialNumber() {
+    let value = this[kInternalState].get('serialNumber');
+    if (value === undefined) {
+      value = this[kHandle].serialNumber();
+      this[kInternalState].set('serialNumber', value);
+    }
+    return value;
+  }
+
+  get raw() {
+    let value = this[kInternalState].get('raw');
+    if (value === undefined) {
+      value = this[kHandle].raw();
+      this[kInternalState].set('raw', value);
+    }
+    return value;
+  }
+
+  get publicKey() {
+    let value = this[kInternalState].get('publicKey');
+    if (value === undefined) {
+      value = new PublicKeyObject(this[kHandle].publicKey());
+      this[kInternalState].set('publicKey', value);
+    }
+    return value;
+  }
+
+  toString() {
+    let value = this[kInternalState].get('pem');
+    if (value === undefined) {
+      value = this[kHandle].pem();
+      this[kInternalState].set('pem', value);
+    }
+    return value;
+  }
+
+  // There's no standardized JSON encoding for X509 certs so we
+  // fallback to providing the PEM encoding as a string.
+  toJSON() { return this.toString(); }
+
+  get ca() {
+    let value = this[kInternalState].get('ca');
+    if (value === undefined) {
+      value = this[kHandle].checkCA();
+      this[kInternalState].set('ca', value);
+    }
+    return value;
+  }
+
+  checkHost(name, options) {
+    validateString(name, 'name');
+    return this[kHandle].checkHost(name, getFlags(options));
+  }
+
+  checkEmail(email, options) {
+    validateString(email, 'email');
+    return this[kHandle].checkEmail(email, getFlags(options));
+  }
+
+  checkIP(ip, options) {
+    validateString(ip, 'ip');
+    return this[kHandle].checkIP(ip, getFlags(options));
+  }
+
+  checkIssued(otherCert) {
+    if (!isX509Certificate(otherCert))
+      throw new ERR_INVALID_ARG_TYPE('otherCert', 'X509Certificate', otherCert);
+    return this[kHandle].checkIssued(otherCert[kHandle]);
+  }
+
+  checkPrivateKey(pkey) {
+    if (!isKeyObject(pkey))
+      throw new ERR_INVALID_ARG_TYPE('pkey', 'KeyObject', pkey);
+    if (pkey.type !== 'private')
+      throw new ERR_INVALID_ARG_VALUE('pkey', pkey);
+    return this[kHandle].checkPrivateKey(pkey[kHandle]);
+  }
+
+  verify(pkey) {
+    if (!isKeyObject(pkey))
+      throw new ERR_INVALID_ARG_TYPE('pkey', 'KeyObject', pkey);
+    if (pkey.type !== 'public')
+      throw new ERR_INVALID_ARG_VALUE('pkey', pkey);
+    return this[kHandle].verify(pkey[kHandle]);
+  }
+
+  toLegacyObject() {
+    return this[kHandle].toLegacy();
+  }
+}
+
+class InternalX509Certificate extends JSTransferable {
+  [kInternalState] = new SafeMap();
+
+  constructor(handle) {
+    super();
+    this[kHandle] = handle;
+  }
+}
+
+InternalX509Certificate.prototype.constructor = X509Certificate;
+ObjectSetPrototypeOf(
+  InternalX509Certificate.prototype,
+  X509Certificate.prototype);
+
+module.exports = {
+  X509Certificate,
+  InternalX509Certificate,
+  isX509Certificate,
+};

--- a/node.gyp
+++ b/node.gyp
@@ -143,6 +143,7 @@
       'lib/internal/crypto/sig.js',
       'lib/internal/crypto/util.js',
       'lib/internal/crypto/webcrypto.js',
+      'lib/internal/crypto/x509.js',
       'lib/internal/constants.js',
       'lib/internal/dgram.js',
       'lib/internal/dns/promises.js',
@@ -941,6 +942,7 @@
             'src/crypto/crypto_scrypt.cc',
             'src/crypto/crypto_tls.cc',
             'src/crypto/crypto_aes.cc',
+            'src/crypto/crypto_x509.cc',
             'src/crypto/crypto_bio.h',
             'src/crypto/crypto_clienthello-inl.h',
             'src/crypto/crypto_dh.h',
@@ -965,6 +967,7 @@
             'src/crypto/crypto_sig.h',
             'src/crypto/crypto_random.h',
             'src/crypto/crypto_timing.h',
+            'src/crypto/crypto_x509.h',
             'src/node_crypto.cc',
             'src/node_crypto.h'
           ],

--- a/src/crypto/crypto_common.h
+++ b/src/crypto/crypto_common.h
@@ -124,6 +124,61 @@ v8::MaybeLocal<v8::Object> X509ToObject(
     Environment* env,
     X509* cert);
 
+v8::MaybeLocal<v8::Value> GetValidTo(
+    Environment* env,
+    X509* cert,
+    const BIOPointer& bio);
+
+v8::MaybeLocal<v8::Value> GetValidFrom(
+    Environment* env,
+    X509* cert,
+    const BIOPointer& bio);
+
+v8::MaybeLocal<v8::Value> GetFingerprintDigest(
+    Environment* env,
+    const EVP_MD* method,
+    X509* cert);
+
+v8::MaybeLocal<v8::Value> GetKeyUsage(Environment* env, X509* cert);
+
+v8::MaybeLocal<v8::Value> GetSerialNumber(Environment* env, X509* cert);
+
+v8::MaybeLocal<v8::Object> GetRawDERCertificate(Environment* env, X509* cert);
+
+v8::Local<v8::Value> ToV8Value(Environment* env, const BIOPointer& bio);
+bool SafeX509ExtPrint(const BIOPointer& out, X509_EXTENSION* ext);
+
+v8::MaybeLocal<v8::Value> GetSubject(
+    Environment* env,
+    const BIOPointer& bio,
+    X509* cert);
+
+v8::MaybeLocal<v8::Value> GetIssuerString(
+    Environment* env,
+    const BIOPointer& bio,
+    X509* cert);
+
+template <int nid>
+v8::MaybeLocal<v8::Value> GetInfoString(
+    Environment* env,
+    const BIOPointer& bio,
+    X509* cert) {
+  int index = X509_get_ext_by_NID(cert, nid, -1);
+  if (index < 0)
+    return Undefined(env->isolate());
+
+  X509_EXTENSION* ext = X509_get_ext(cert, index);
+  CHECK_NOT_NULL(ext);
+
+  if (!SafeX509ExtPrint(bio, ext) &&
+      X509V3_EXT_print(bio.get(), ext, 0, 0) != 1) {
+    USE(BIO_reset(bio.get()));
+    return v8::Null(env->isolate());
+  }
+
+  return ToV8Value(env, bio);
+}
+
 }  // namespace crypto
 }  // namespace node
 

--- a/src/crypto/crypto_context.cc
+++ b/src/crypto/crypto_context.cc
@@ -49,7 +49,6 @@ static X509_STORE* root_cert_store;
 
 static bool extra_root_certs_loaded = false;
 
-namespace {
 // Takes a string or buffer and loads it into a BIO.
 // Caller responsible for BIO_free_all-ing the returned object.
 BIOPointer LoadBIO(Environment* env, Local<Value> v) {
@@ -68,6 +67,7 @@ BIOPointer LoadBIO(Environment* env, Local<Value> v) {
   return nullptr;
 }
 
+namespace {
 int SSL_CTX_use_certificate_chain(SSL_CTX* ctx,
                                   X509Pointer&& x,
                                   STACK_OF(X509)* extra_certs,

--- a/src/crypto/crypto_context.h
+++ b/src/crypto/crypto_context.h
@@ -23,6 +23,8 @@ void IsExtraRootCertsFileLoaded(
 
 X509_STORE* NewRootCertStore();
 
+BIOPointer LoadBIO(Environment* env, v8::Local<v8::Value> v);
+
 class SecureContext final : public BaseObject {
  public:
   using GetSessionCb = SSL_SESSION* (*)(SSL*, const unsigned char*, int, int*);

--- a/src/crypto/crypto_x509.cc
+++ b/src/crypto/crypto_x509.cc
@@ -1,0 +1,531 @@
+#include "base_object-inl.h"
+#include "crypto_x509.h"
+#include "crypto_common.h"
+#include "crypto_context.h"
+#include "crypto_keys.h"
+#include "crypto_bio.h"
+#include "env-inl.h"
+#include "memory_tracker-inl.h"
+#include "node_errors.h"
+#include "util-inl.h"
+#include "v8.h"
+
+#include <string>
+#include <vector>
+
+namespace node {
+
+using v8::Array;
+using v8::ArrayBufferView;
+using v8::Context;
+using v8::EscapableHandleScope;
+using v8::Function;
+using v8::FunctionCallbackInfo;
+using v8::FunctionTemplate;
+using v8::Local;
+using v8::MaybeLocal;
+using v8::Object;
+using v8::Uint32;
+using v8::Value;
+
+namespace crypto {
+
+ManagedX509::ManagedX509(X509Pointer&& cert) : cert_(std::move(cert)) {}
+
+ManagedX509::ManagedX509(const ManagedX509& that) {
+  *this = that;
+}
+
+ManagedX509& ManagedX509::operator=(const ManagedX509& that) {
+  cert_.reset(that.get());
+
+  if (cert_)
+    X509_up_ref(cert_.get());
+
+  return *this;
+}
+
+void ManagedX509::MemoryInfo(MemoryTracker* tracker) const {
+  // This is an approximation based on the der encoding size.
+  int size = i2d_X509(cert_.get(), nullptr);
+  tracker->TrackFieldWithSize("cert", size);
+}
+
+Local<FunctionTemplate> X509Certificate::GetConstructorTemplate(
+    Environment* env) {
+  Local<FunctionTemplate> tmpl = env->x509_constructor_template();
+  if (tmpl.IsEmpty()) {
+    tmpl = FunctionTemplate::New(env->isolate());
+    tmpl->InstanceTemplate()->SetInternalFieldCount(1);
+    tmpl->Inherit(BaseObject::GetConstructorTemplate(env));
+    tmpl->SetClassName(
+        FIXED_ONE_BYTE_STRING(env->isolate(), "X509Certificate"));
+    env->SetProtoMethod(tmpl, "subject", Subject);
+    env->SetProtoMethod(tmpl, "subjectAltName", SubjectAltName);
+    env->SetProtoMethod(tmpl, "infoAccess", InfoAccess);
+    env->SetProtoMethod(tmpl, "issuer", Issuer);
+    env->SetProtoMethod(tmpl, "validTo", ValidTo);
+    env->SetProtoMethod(tmpl, "validFrom", ValidFrom);
+    env->SetProtoMethod(tmpl, "fingerprint", Fingerprint);
+    env->SetProtoMethod(tmpl, "fingerprint256", Fingerprint256);
+    env->SetProtoMethod(tmpl, "keyUsage", KeyUsage);
+    env->SetProtoMethod(tmpl, "serialNumber", SerialNumber);
+    env->SetProtoMethod(tmpl, "pem", Pem);
+    env->SetProtoMethod(tmpl, "raw", Raw);
+    env->SetProtoMethod(tmpl, "publicKey", PublicKey);
+    env->SetProtoMethod(tmpl, "checkCA", CheckCA);
+    env->SetProtoMethod(tmpl, "checkHost", CheckHost);
+    env->SetProtoMethod(tmpl, "checkEmail", CheckEmail);
+    env->SetProtoMethod(tmpl, "checkIP", CheckIP);
+    env->SetProtoMethod(tmpl, "checkIssued", CheckIssued);
+    env->SetProtoMethod(tmpl, "checkPrivateKey", CheckPrivateKey);
+    env->SetProtoMethod(tmpl, "verify", Verify);
+    env->SetProtoMethod(tmpl, "toLegacy", ToLegacy);
+    env->set_x509_constructor_template(tmpl);
+  }
+  return tmpl;
+}
+
+bool X509Certificate::HasInstance(Environment* env, Local<Object> object) {
+  return GetConstructorTemplate(env)->HasInstance(object);
+}
+
+MaybeLocal<Object> X509Certificate::New(
+    Environment* env,
+    X509Pointer cert) {
+  std::shared_ptr<ManagedX509> mcert(new ManagedX509(std::move(cert)));
+  return New(env, std::move(mcert));
+}
+
+MaybeLocal<Object> X509Certificate::New(
+    Environment* env,
+    std::shared_ptr<ManagedX509> cert) {
+  EscapableHandleScope scope(env->isolate());
+  Local<Function> ctor;
+  if (!GetConstructorTemplate(env)->GetFunction(env->context()).ToLocal(&ctor))
+    return MaybeLocal<Object>();
+
+  Local<Object> obj;
+  if (!ctor->NewInstance(env->context()).ToLocal(&obj))
+    return MaybeLocal<Object>();
+
+  new X509Certificate(env, obj, std::move(cert));
+  return scope.Escape(obj);
+}
+
+MaybeLocal<Object> X509Certificate::GetCert(
+    Environment* env,
+    const SSLPointer& ssl) {
+  ClearErrorOnReturn clear_error_on_return;
+  X509* cert = SSL_get_certificate(ssl.get());
+  if (cert == nullptr)
+    return MaybeLocal<Object>();
+
+  X509Pointer ptr(cert);
+  return New(env, std::move(ptr));
+}
+
+MaybeLocal<Object> X509Certificate::GetPeerCert(
+    Environment* env,
+    const SSLPointer& ssl,
+    GetPeerCertificateFlag flag) {
+  EscapableHandleScope scope(env->isolate());
+  ClearErrorOnReturn clear_error_on_return;
+  Local<Object> obj;
+  MaybeLocal<Object> maybe_cert;
+
+  bool is_server =
+      static_cast<int>(flag) & static_cast<int>(GetPeerCertificateFlag::SERVER);
+  bool abbreviated =
+      static_cast<int>(flag)
+      & static_cast<int>(GetPeerCertificateFlag::ABBREVIATED);
+
+  X509Pointer cert(is_server ? SSL_get_peer_certificate(ssl.get()) : nullptr);
+  STACK_OF(X509)* ssl_certs = SSL_get_peer_cert_chain(ssl.get());
+  if (!cert && (ssl_certs == nullptr || sk_X509_num(ssl_certs) == 0))
+    return MaybeLocal<Object>();
+
+  std::vector<Local<Value>> certs;
+
+  if (!cert) cert.reset(sk_X509_value(ssl_certs, 0));
+  if (!X509Certificate::New(env, std::move(cert)).ToLocal(&obj))
+    return MaybeLocal<Object>();
+
+  certs.push_back(obj);
+
+  int count = sk_X509_num(ssl_certs);
+  if (!abbreviated) {
+    for (int i = 0; i < count; i++) {
+      cert.reset(X509_dup(sk_X509_value(ssl_certs, i)));
+      if (!cert || !X509Certificate::New(env, std::move(cert)).ToLocal(&obj))
+        return MaybeLocal<Object>();
+      certs.push_back(obj);
+    }
+  }
+
+  return scope.Escape(Array::New(env->isolate(), certs.data(), certs.size()));
+}
+
+void X509Certificate::Parse(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+
+  CHECK(args[0]->IsArrayBufferView());
+  ArrayBufferViewContents<unsigned char> buf(args[0].As<ArrayBufferView>());
+  const unsigned char* data = buf.data();
+  unsigned data_len = buf.length();
+
+  ClearErrorOnReturn clear_error_on_return;
+  BIOPointer bio(LoadBIO(env, args[0]));
+  if (!bio)
+    return ThrowCryptoError(env, ERR_get_error());
+
+  Local<Object> cert;
+
+  X509Pointer pem(PEM_read_bio_X509_AUX(
+      bio.get(), nullptr, NoPasswordCallback, nullptr));
+  if (!pem) {
+    // Try as DER, but return the original PEM failure if it isn't DER.
+    MarkPopErrorOnReturn mark_here;
+
+    X509Pointer der(d2i_X509(nullptr, &data, data_len));
+    if (!der)
+      return ThrowCryptoError(env, ERR_get_error());
+
+    if (!X509Certificate::New(env, std::move(der)).ToLocal(&cert))
+      return;
+  } else if (!X509Certificate::New(env, std::move(pem)).ToLocal(&cert)) {
+    return;
+  }
+
+  args.GetReturnValue().Set(cert);
+}
+
+void X509Certificate::Subject(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  X509Certificate* cert;
+  ASSIGN_OR_RETURN_UNWRAP(&cert, args.Holder());
+  BIOPointer bio(BIO_new(BIO_s_mem()));
+  Local<Value> ret;
+  if (GetSubject(env, bio, cert->get()).ToLocal(&ret))
+    args.GetReturnValue().Set(ret);
+}
+
+void X509Certificate::Issuer(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  X509Certificate* cert;
+  ASSIGN_OR_RETURN_UNWRAP(&cert, args.Holder());
+  BIOPointer bio(BIO_new(BIO_s_mem()));
+  Local<Value> ret;
+  if (GetIssuerString(env, bio, cert->get()).ToLocal(&ret))
+    args.GetReturnValue().Set(ret);
+}
+
+void X509Certificate::SubjectAltName(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  X509Certificate* cert;
+  ASSIGN_OR_RETURN_UNWRAP(&cert, args.Holder());
+  BIOPointer bio(BIO_new(BIO_s_mem()));
+  Local<Value> ret;
+  if (GetInfoString<NID_subject_alt_name>(env, bio, cert->get()).ToLocal(&ret))
+    args.GetReturnValue().Set(ret);
+}
+
+void X509Certificate::InfoAccess(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  X509Certificate* cert;
+  ASSIGN_OR_RETURN_UNWRAP(&cert, args.Holder());
+  BIOPointer bio(BIO_new(BIO_s_mem()));
+  Local<Value> ret;
+  if (GetInfoString<NID_info_access>(env, bio, cert->get()).ToLocal(&ret))
+    args.GetReturnValue().Set(ret);
+}
+
+void X509Certificate::ValidFrom(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  X509Certificate* cert;
+  ASSIGN_OR_RETURN_UNWRAP(&cert, args.Holder());
+  BIOPointer bio(BIO_new(BIO_s_mem()));
+  Local<Value> ret;
+  if (GetValidFrom(env, cert->get(), bio).ToLocal(&ret))
+    args.GetReturnValue().Set(ret);
+}
+
+void X509Certificate::ValidTo(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  X509Certificate* cert;
+  ASSIGN_OR_RETURN_UNWRAP(&cert, args.Holder());
+  BIOPointer bio(BIO_new(BIO_s_mem()));
+  Local<Value> ret;
+  if (GetValidTo(env, cert->get(), bio).ToLocal(&ret))
+    args.GetReturnValue().Set(ret);
+}
+
+void X509Certificate::Fingerprint(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  X509Certificate* cert;
+  ASSIGN_OR_RETURN_UNWRAP(&cert, args.Holder());
+  Local<Value> ret;
+  if (GetFingerprintDigest(env, EVP_sha1(), cert->get()).ToLocal(&ret))
+    args.GetReturnValue().Set(ret);
+}
+
+void X509Certificate::Fingerprint256(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  X509Certificate* cert;
+  ASSIGN_OR_RETURN_UNWRAP(&cert, args.Holder());
+  Local<Value> ret;
+  if (GetFingerprintDigest(env, EVP_sha256(), cert->get()).ToLocal(&ret))
+    args.GetReturnValue().Set(ret);
+}
+
+void X509Certificate::KeyUsage(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  X509Certificate* cert;
+  ASSIGN_OR_RETURN_UNWRAP(&cert, args.Holder());
+  Local<Value> ret;
+  if (GetKeyUsage(env, cert->get()).ToLocal(&ret))
+    args.GetReturnValue().Set(ret);
+}
+
+void X509Certificate::SerialNumber(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  X509Certificate* cert;
+  ASSIGN_OR_RETURN_UNWRAP(&cert, args.Holder());
+  Local<Value> ret;
+  if (GetSerialNumber(env, cert->get()).ToLocal(&ret))
+    args.GetReturnValue().Set(ret);
+}
+
+void X509Certificate::Raw(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  X509Certificate* cert;
+  ASSIGN_OR_RETURN_UNWRAP(&cert, args.Holder());
+  Local<Value> ret;
+  if (GetRawDERCertificate(env, cert->get()).ToLocal(&ret))
+    args.GetReturnValue().Set(ret);
+}
+
+void X509Certificate::PublicKey(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  X509Certificate* cert;
+  ASSIGN_OR_RETURN_UNWRAP(&cert, args.Holder());
+
+  EVPKeyPointer pkey(X509_get_pubkey(cert->get()));
+  ManagedEVPPKey epkey(std::move(pkey));
+  std::shared_ptr<KeyObjectData> key_data =
+      KeyObjectData::CreateAsymmetric(kKeyTypePublic, epkey);
+
+  Local<Value> ret;
+  if (KeyObjectHandle::Create(env, key_data).ToLocal(&ret))
+    args.GetReturnValue().Set(ret);
+}
+
+void X509Certificate::Pem(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  X509Certificate* cert;
+  ASSIGN_OR_RETURN_UNWRAP(&cert, args.Holder());
+  BIOPointer bio(BIO_new(BIO_s_mem()));
+  if (PEM_write_bio_X509(bio.get(), cert->get()))
+    args.GetReturnValue().Set(ToV8Value(env, bio));
+}
+
+void X509Certificate::CheckCA(const FunctionCallbackInfo<Value>& args) {
+  X509Certificate* cert;
+  ASSIGN_OR_RETURN_UNWRAP(&cert, args.Holder());
+  args.GetReturnValue().Set(X509_check_ca(cert->get()) == 1);
+}
+
+void X509Certificate::CheckHost(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  X509Certificate* cert;
+  ASSIGN_OR_RETURN_UNWRAP(&cert, args.Holder());
+
+  CHECK(args[0]->IsString());  // name
+  CHECK(args[1]->IsUint32());  // flags
+
+  Utf8Value name(env->isolate(), args[0]);
+  uint32_t flags = args[1].As<Uint32>()->Value();
+  char* peername;
+
+  switch (X509_check_host(
+              cert->get(),
+              *name,
+              name.length(),
+              flags,
+              &peername)) {
+    case 1:  {  // Match!
+      Local<Value> ret = args[0];
+      if (peername != nullptr) {
+        ret = OneByteString(env->isolate(), peername);
+        OPENSSL_free(peername);
+      }
+      return args.GetReturnValue().Set(ret);
+    }
+    case 0:  // No Match!
+      return;  // No return value is set
+    case -2:  // Error!
+      return THROW_ERR_INVALID_ARG_VALUE(env, "Invalid name");
+    default:  // Error!
+      return THROW_ERR_CRYPTO_OPERATION_FAILED(env);
+  }
+}
+
+void X509Certificate::CheckEmail(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  X509Certificate* cert;
+  ASSIGN_OR_RETURN_UNWRAP(&cert, args.Holder());
+
+  CHECK(args[0]->IsString());  // name
+  CHECK(args[1]->IsUint32());  // flags
+
+  Utf8Value name(env->isolate(), args[0]);
+  uint32_t flags = args[1].As<Uint32>()->Value();
+
+  switch (X509_check_email(
+              cert->get(),
+              *name,
+              name.length(),
+              flags)) {
+    case 1:  // Match!
+      return args.GetReturnValue().Set(args[0]);
+    case 0:  // No Match!
+      return;  // No return value is set
+    case -2:  // Error!
+      return THROW_ERR_INVALID_ARG_VALUE(env, "Invalid name");
+    default:  // Error!
+      return THROW_ERR_CRYPTO_OPERATION_FAILED(env);
+  }
+}
+
+void X509Certificate::CheckIP(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  X509Certificate* cert;
+  ASSIGN_OR_RETURN_UNWRAP(&cert, args.Holder());
+
+  CHECK(args[0]->IsString());  // IP
+  CHECK(args[1]->IsUint32());  // flags
+
+  Utf8Value name(env->isolate(), args[0]);
+  uint32_t flags = args[1].As<Uint32>()->Value();
+
+  switch (X509_check_ip_asc(cert->get(), *name, flags)) {
+    case 1:  // Match!
+      return args.GetReturnValue().Set(args[0]);
+    case 0:  // No Match!
+      return;  // No return value is set
+    case -2:  // Error!
+      return THROW_ERR_INVALID_ARG_VALUE(env, "Invalid IP");
+    default:  // Error!
+      return THROW_ERR_CRYPTO_OPERATION_FAILED(env);
+  }
+}
+
+void X509Certificate::CheckIssued(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  X509Certificate* cert;
+  ASSIGN_OR_RETURN_UNWRAP(&cert, args.Holder());
+
+  CHECK(args[0]->IsObject());
+  CHECK(X509Certificate::HasInstance(env, args[0].As<Object>()));
+
+  X509Certificate* issuer;
+  ASSIGN_OR_RETURN_UNWRAP(&issuer, args[0]);
+
+  args.GetReturnValue().Set(
+    X509_check_issued(issuer->get(), cert->get()) == X509_V_OK);
+}
+
+void X509Certificate::CheckPrivateKey(const FunctionCallbackInfo<Value>& args) {
+  X509Certificate* cert;
+  ASSIGN_OR_RETURN_UNWRAP(&cert, args.Holder());
+
+  CHECK(args[0]->IsObject());
+  KeyObjectHandle* key;
+  ASSIGN_OR_RETURN_UNWRAP(&key, args[0]);
+  CHECK_EQ(key->Data()->GetKeyType(), kKeyTypePrivate);
+
+  args.GetReturnValue().Set(
+      X509_check_private_key(
+          cert->get(),
+          key->Data()->GetAsymmetricKey().get()) == 1);
+}
+
+void X509Certificate::Verify(const FunctionCallbackInfo<Value>& args) {
+  X509Certificate* cert;
+  ASSIGN_OR_RETURN_UNWRAP(&cert, args.Holder());
+
+  CHECK(args[0]->IsObject());
+  KeyObjectHandle* key;
+  ASSIGN_OR_RETURN_UNWRAP(&key, args[0]);
+  CHECK_EQ(key->Data()->GetKeyType(), kKeyTypePublic);
+
+  args.GetReturnValue().Set(
+      X509_verify(
+          cert->get(),
+          key->Data()->GetAsymmetricKey().get()) > 0);
+}
+
+void X509Certificate::ToLegacy(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  X509Certificate* cert;
+  ASSIGN_OR_RETURN_UNWRAP(&cert, args.Holder());
+  Local<Value> ret;
+  if (X509ToObject(env, cert->get()).ToLocal(&ret))
+    args.GetReturnValue().Set(ret);
+}
+
+X509Certificate::X509Certificate(
+    Environment* env,
+    Local<Object> object,
+    std::shared_ptr<ManagedX509> cert)
+    : BaseObject(env, object),
+      cert_(std::move(cert)) {
+  MakeWeak();
+}
+
+void X509Certificate::MemoryInfo(MemoryTracker* tracker) const {
+  tracker->TrackField("cert", cert_);
+}
+
+BaseObjectPtr<BaseObject>
+X509Certificate::X509CertificateTransferData::Deserialize(
+    Environment* env,
+    Local<Context> context,
+    std::unique_ptr<worker::TransferData> self) {
+  if (context != env->context()) {
+    THROW_ERR_MESSAGE_TARGET_CONTEXT_UNAVAILABLE(env);
+    return {};
+  }
+
+  Local<Value> handle;
+  if (!X509Certificate::New(env, data_).ToLocal(&handle))
+    return {};
+
+  return BaseObjectPtr<BaseObject>(
+      Unwrap<X509Certificate>(handle.As<Object>()));
+}
+
+
+BaseObject::TransferMode X509Certificate::GetTransferMode() const {
+  return BaseObject::TransferMode::kCloneable;
+}
+
+std::unique_ptr<worker::TransferData> X509Certificate::CloneForMessaging()
+    const {
+  return std::make_unique<X509CertificateTransferData>(cert_);
+}
+
+
+void X509Certificate::Initialize(Environment* env, Local<Object> target) {
+  env->SetMethod(target, "parseX509", X509Certificate::Parse);
+
+  NODE_DEFINE_CONSTANT(target, X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT);
+  NODE_DEFINE_CONSTANT(target, X509_CHECK_FLAG_NEVER_CHECK_SUBJECT);
+  NODE_DEFINE_CONSTANT(target, X509_CHECK_FLAG_NO_WILDCARDS);
+  NODE_DEFINE_CONSTANT(target, X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS);
+  NODE_DEFINE_CONSTANT(target, X509_CHECK_FLAG_MULTI_LABEL_WILDCARDS);
+  NODE_DEFINE_CONSTANT(target, X509_CHECK_FLAG_SINGLE_LABEL_SUBDOMAINS);
+}
+
+}  // namespace crypto
+}  // namespace node

--- a/src/crypto/crypto_x509.h
+++ b/src/crypto/crypto_x509.h
@@ -1,0 +1,136 @@
+#ifndef SRC_CRYPTO_CRYPTO_X509_H_
+#define SRC_CRYPTO_CRYPTO_X509_H_
+
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
+#include "base_object.h"
+#include "crypto/crypto_util.h"
+#include "env.h"
+#include "memory_tracker.h"
+#include "node_worker.h"
+#include "v8.h"
+
+namespace node {
+namespace crypto {
+
+// The ManagedX509 class is essentially a smart pointer for
+// X509 objects that allows an X509Certificate instance to
+// be cloned at the JS level while pointing at the same
+// underlying X509 instance.
+class ManagedX509 : public MemoryRetainer {
+ public:
+  ManagedX509() = default;
+  explicit ManagedX509(X509Pointer&& cert);
+  ManagedX509(const ManagedX509& that);
+  ManagedX509& operator=(const ManagedX509& that);
+
+  operator bool() const { return !!cert_; }
+  X509* get() const { return cert_.get(); }
+
+  void MemoryInfo(MemoryTracker* tracker) const override;
+  SET_MEMORY_INFO_NAME(ManagedX509)
+  SET_SELF_SIZE(ManagedX509)
+
+ private:
+  X509Pointer cert_;
+};
+
+class X509Certificate : public BaseObject {
+ public:
+  enum class GetPeerCertificateFlag {
+    ABBREVIATED,
+    SERVER
+  };
+
+  static void Initialize(Environment* env, v8::Local<v8::Object> target);
+  static v8::Local<v8::FunctionTemplate> GetConstructorTemplate(
+      Environment* env);
+  static bool HasInstance(Environment* env, v8::Local<v8::Object> object);
+
+  static v8::MaybeLocal<v8::Object> New(
+      Environment* env,
+      X509Pointer cert);
+
+  static v8::MaybeLocal<v8::Object> New(
+      Environment* env,
+      std::shared_ptr<ManagedX509> cert);
+
+  static v8::MaybeLocal<v8::Object> GetCert(
+      Environment* env,
+      const SSLPointer& ssl);
+
+  static v8::MaybeLocal<v8::Object> GetPeerCert(
+      Environment* env,
+      const SSLPointer& ssl,
+      GetPeerCertificateFlag flag);
+
+  static v8::Local<v8::Object> Wrap(
+      Environment* env,
+      v8::Local<v8::Object> object,
+      X509Pointer cert);
+
+  static void Parse(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void Subject(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void SubjectAltName(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void Issuer(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void InfoAccess(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void ValidFrom(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void ValidTo(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void Fingerprint(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void Fingerprint256(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void KeyUsage(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void SerialNumber(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void Raw(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void PublicKey(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void Pem(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void CheckCA(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void CheckHost(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void CheckEmail(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void CheckIP(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void CheckIssued(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void CheckPrivateKey(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void Verify(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void ToLegacy(const v8::FunctionCallbackInfo<v8::Value>& args);
+
+  X509* get() { return cert_->get(); }
+
+  void MemoryInfo(MemoryTracker* tracker) const override;
+  SET_MEMORY_INFO_NAME(X509Certificate);
+  SET_SELF_SIZE(X509Certificate);
+
+  class X509CertificateTransferData : public worker::TransferData {
+   public:
+    explicit X509CertificateTransferData(
+        const std::shared_ptr<ManagedX509>& data)
+        : data_(data) {}
+
+    BaseObjectPtr<BaseObject> Deserialize(
+        Environment* env,
+        v8::Local<v8::Context> context,
+        std::unique_ptr<worker::TransferData> self) override;
+
+    SET_MEMORY_INFO_NAME(X509CertificateTransferData)
+    SET_SELF_SIZE(X509CertificateTransferData)
+    SET_NO_MEMORY_INFO()
+
+   private:
+    std::shared_ptr<ManagedX509> data_;
+  };
+
+  BaseObject::TransferMode GetTransferMode() const override;
+  std::unique_ptr<worker::TransferData> CloneForMessaging() const override;
+
+ private:
+  X509Certificate(
+      Environment* env,
+      v8::Local<v8::Object> object,
+      std::shared_ptr<ManagedX509> cert);
+
+  std::shared_ptr<ManagedX509> cert_;
+};
+
+}  // namespace crypto
+}  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+#endif  // SRC_CRYPTO_CRYPTO_X509_H_

--- a/src/env.h
+++ b/src/env.h
@@ -476,6 +476,7 @@ constexpr size_t kFsStatsBufferLength =
   V(tty_constructor_template, v8::FunctionTemplate)                            \
   V(write_wrap_template, v8::ObjectTemplate)                                   \
   V(worker_heap_snapshot_taker_template, v8::ObjectTemplate)                   \
+  V(x509_constructor_template, v8::FunctionTemplate)                           \
   QUIC_ENVIRONMENT_STRONG_PERSISTENT_TEMPLATES(V)
 
 #if defined(NODE_EXPERIMENTAL_QUIC) && NODE_EXPERIMENTAL_QUIC

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -64,6 +64,7 @@ void Initialize(Local<Object> target,
   Timing::Initialize(env, target);
   Util::Initialize(env, target);
   Verify::Initialize(env, target);
+  X509Certificate::Initialize(env, target);
 
 #ifndef OPENSSL_NO_SCRYPT
   ScryptJob::Initialize(env, target);

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -50,6 +50,7 @@
 #include "crypto/crypto_tls.h"
 #include "crypto/crypto_timing.h"
 #include "crypto/crypto_util.h"
+#include "crypto/crypto_x509.h"
 
 #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 

--- a/test/parallel/test-crypto-x509.js
+++ b/test/parallel/test-crypto-x509.js
@@ -1,0 +1,245 @@
+// Flags: --expose-internals
+'use strict';
+const common = require('../common');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const {
+  X509Certificate,
+  createPrivateKey,
+} = require('crypto');
+
+const {
+  isX509Certificate
+} = require('internal/crypto/x509');
+
+const assert = require('assert');
+const fixtures = require('../common/fixtures');
+const { readFileSync } = require('fs');
+
+const cert = readFileSync(fixtures.path('keys', 'agent1-cert.pem'));
+const key = readFileSync(fixtures.path('keys', 'agent1-key.pem'));
+const ca = readFileSync(fixtures.path('keys', 'ca1-cert.pem'));
+
+const privateKey = createPrivateKey(key);
+
+[1, {}, false, null].forEach((i) => {
+  assert.throws(() => new X509Certificate(i), {
+    code: 'ERR_INVALID_ARG_TYPE'
+  });
+});
+
+const subjectCheck = `C=US
+ST=CA
+L=SF
+O=Joyent
+OU=Node.js
+CN=agent1
+emailAddress=ry@tinyclouds.org`;
+
+const issuerCheck = `C=US
+ST=CA
+L=SF
+O=Joyent
+OU=Node.js
+CN=ca1
+emailAddress=ry@tinyclouds.org`;
+
+const infoAccessCheck = `OCSP - URI:http://ocsp.nodejs.org/
+CA Issuers - URI:http://ca.nodejs.org/ca.cert
+`;
+
+const der = Buffer.from(
+  '308202d830820241a003020102020900ecc9b856270da9a830' +
+  '0d06092a864886f70d01010b0500307a310b30090603550406' +
+  '13025553310b300906035504080c024341310b300906035504' +
+  '070c025346310f300d060355040a0c064a6f79656e74311030' +
+  '0e060355040b0c074e6f64652e6a73310c300a06035504030c' +
+  '036361313120301e06092a864886f70d010901161172794074' +
+  '696e79636c6f7564732e6f72673020170d3138313131363138' +
+  '343232315a180f32323932303833303138343232315a307d31' +
+  '0b3009060355040613025553310b300906035504080c024341' +
+  '310b300906035504070c025346310f300d060355040a0c064a' +
+  '6f79656e743110300e060355040b0c074e6f64652e6a73310f' +
+  '300d06035504030c066167656e74313120301e06092a864886' +
+  'f70d010901161172794074696e79636c6f7564732e6f726730' +
+  '819f300d06092a864886f70d010101050003818d0030818902' +
+  '818100ef5440701637e28abb038e5641f828d834c342a9d25e' +
+  'dbb86a2bf6fbd809cb8e037a98b71708e001242e4deb54c616' +
+  '4885f599dd87a23215745955be20417e33c4d0d1b80c9da3de' +
+  '419a2607195d2fb75657b0bbfb5eb7d0bba5122d1b6964c7b5' +
+  '70d50b8ec001eeb68dfb584437508f3129928d673b30a3e0bf' +
+  '4f50609e63710203010001a361305f305d06082b0601050507' +
+  '01010451304f302306082b060105050730018617687474703a' +
+  '2f2f6f6373702e6e6f64656a732e6f72672f302806082b0601' +
+  '0505073002861c687474703a2f2f63612e6e6f64656a732e6f' +
+  '72672f63612e63657274300d06092a864886f70d01010b0500' +
+  '038181007acabf1d99e1fb05edbdd54608886dd6c509fc5820' +
+  '2be8274f8139b60f8ea219666f7eff9737e92a732b318ef423' +
+  '7da94123dcac4f9a28e76fe663b26d42482ac6d66d380bbdfe' +
+  '0230083e743e7966671752b82f692e1034e9bfc9d0cd829888' +
+  '6c6c996e7c3d231e02ad5399a170b525b74f11d7ed13a7a815' +
+  'f4b974253a8d66', 'hex');
+
+{
+  const x509 = new X509Certificate(cert);
+
+  assert(isX509Certificate(x509));
+
+  assert(!x509.ca);
+  assert.strictEqual(x509.subject, subjectCheck);
+  assert.strictEqual(x509.subjectAltName, undefined);
+  assert.strictEqual(x509.issuer, issuerCheck);
+  assert.strictEqual(x509.infoAccess, infoAccessCheck);
+  assert.strictEqual(x509.validFrom, 'Nov 16 18:42:21 2018 GMT');
+  assert.strictEqual(x509.validTo, 'Aug 30 18:42:21 2292 GMT');
+  assert.strictEqual(
+    x509.fingerprint,
+    'D7:FD:F6:42:92:A8:83:51:8E:80:48:62:66:DA:85:C2:EE:A6:A1:CD');
+  assert.strictEqual(
+    x509.fingerprint256,
+    'B0:BE:46:49:B8:29:63:E0:6F:63:C8:8A:57:9C:3F:9B:72:C6:F5:89:E3:0D:' +
+    '84:AC:5B:08:9A:20:89:B6:8F:D6'
+  );
+  assert.strictEqual(x509.keyUsage, undefined);
+  assert.strictEqual(x509.serialNumber, 'ECC9B856270DA9A8');
+
+  assert.deepStrictEqual(x509.raw, der);
+
+  assert(x509.publicKey);
+  assert.strictEqual(x509.publicKey.type, 'public');
+
+  assert.strictEqual(x509.toString(), cert.toString());
+  assert.strictEqual(x509.toJSON(), x509.toString());
+
+  assert(x509.checkPrivateKey(privateKey));
+  assert.throws(() => x509.checkPrivateKey(x509.publicKey), {
+    code: 'ERR_INVALID_ARG_VALUE'
+  });
+
+  assert.strictEqual(x509.checkIP('127.0.0.1'), undefined);
+  assert.strictEqual(x509.checkIP('::'), undefined);
+  assert.strictEqual(x509.checkHost('agent1'), 'agent1');
+  assert.strictEqual(x509.checkHost('agent2'), undefined);
+  assert.strictEqual(x509.checkEmail('ry@tinyclouds.org'), 'ry@tinyclouds.org');
+  assert.strictEqual(x509.checkEmail('sally@example.com'), undefined);
+  assert.throws(() => x509.checkHost('agent\x001'), {
+    code: 'ERR_INVALID_ARG_VALUE'
+  });
+  assert.throws(() => x509.checkIP('[::]'), {
+    code: 'ERR_INVALID_ARG_VALUE'
+  });
+  assert.throws(() => x509.checkEmail('not\x00hing'), {
+    code: 'ERR_INVALID_ARG_VALUE'
+  });
+
+  [1, false, null].forEach((i) => {
+    assert.throws(() => x509.checkHost('agent1', i), {
+      code: 'ERR_INVALID_ARG_TYPE'
+    });
+    assert.throws(() => x509.checkHost('agent1', { subject: i }), {
+      code: 'ERR_INVALID_ARG_TYPE'
+    });
+  });
+
+  [
+    'wildcards',
+    'partialWildcards',
+    'multiLabelWildcards',
+    'singleLabelSubdomains'
+  ].forEach((key) => {
+    [1, '', null, {}].forEach((i) => {
+      assert.throws(() => x509.checkHost('agent1', { [key]: i }), {
+        code: 'ERR_INVALID_ARG_TYPE'
+      });
+    });
+  });
+
+  const ca_cert = new X509Certificate(ca);
+
+  assert(x509.checkIssued(ca_cert));
+  assert(!x509.checkIssued(x509));
+  assert(x509.verify(ca_cert.publicKey));
+  assert(!x509.verify(x509.publicKey));
+
+  assert.throws(() => x509.checkIssued({}), {
+    code: 'ERR_INVALID_ARG_TYPE'
+  });
+  assert.throws(() => x509.checkIssued(''), {
+    code: 'ERR_INVALID_ARG_TYPE'
+  });
+  assert.throws(() => x509.verify({}), {
+    code: 'ERR_INVALID_ARG_TYPE'
+  });
+  assert.throws(() => x509.verify(''), {
+    code: 'ERR_INVALID_ARG_TYPE'
+  });
+  assert.throws(() => x509.verify(privateKey), {
+    code: 'ERR_INVALID_ARG_VALUE'
+  });
+
+  // X509Certificate can be cloned via MessageChannel/MessagePort
+  const mc = new MessageChannel();
+  mc.port1.onmessage = common.mustCall(({ data }) => {
+    assert(isX509Certificate(data));
+    assert.deepStrictEqual(data.raw, x509.raw);
+    mc.port1.close();
+  });
+  mc.port2.postMessage(x509);
+
+  // Verify that legacy encoding works
+  const legacyObjectCheck = {
+    subject: 'C=US\n' +
+      'ST=CA\n' +
+      'L=SF\n' +
+      'O=Joyent\n' +
+      'OU=Node.js\n' +
+      'CN=agent1\n' +
+      'emailAddress=ry@tinyclouds.org',
+    issuer:
+      'C=US\n' +
+      'ST=CA\n' +
+      'L=SF\n' +
+      'O=Joyent\n' +
+      'OU=Node.js\n' +
+      'CN=ca1\n' +
+      'emailAddress=ry@tinyclouds.org',
+    infoAccess:
+      'OCSP - URI:http://ocsp.nodejs.org/\n' +
+      'CA Issuers - URI:http://ca.nodejs.org/ca.cert\n',
+    modulus: 'EF5440701637E28ABB038E5641F828D834C342A9D25EDBB86A2BF' +
+             '6FBD809CB8E037A98B71708E001242E4DEB54C6164885F599DD87' +
+             'A23215745955BE20417E33C4D0D1B80C9DA3DE419A2607195D2FB' +
+             '75657B0BBFB5EB7D0BBA5122D1B6964C7B570D50B8EC001EEB68D' +
+             'FB584437508F3129928D673B30A3E0BF4F50609E6371',
+    bits: 1024,
+    exponent: '0x10001',
+    valid_from: 'Nov 16 18:42:21 2018 GMT',
+    valid_to: 'Aug 30 18:42:21 2292 GMT',
+    fingerprint: 'D7:FD:F6:42:92:A8:83:51:8E:80:48:62:66:DA:85:C2:EE:A6:A1:CD',
+    fingerprint256:
+      'B0:BE:46:49:B8:29:63:E0:6F:63:C8:8A:57:9C:3F:9B:72:' +
+      'C6:F5:89:E3:0D:84:AC:5B:08:9A:20:89:B6:8F:D6',
+    serialNumber: 'ECC9B856270DA9A8'
+  };
+
+  const legacyObject = x509.toLegacyObject();
+
+  assert.deepStrictEqual(legacyObject.raw, x509.raw);
+  assert.strictEqual(legacyObject.subject, legacyObjectCheck.subject);
+  assert.strictEqual(legacyObject.issuer, legacyObjectCheck.issuer);
+  assert.strictEqual(legacyObject.infoAccess, legacyObjectCheck.infoAccess);
+  assert.strictEqual(legacyObject.modulus, legacyObjectCheck.modulus);
+  assert.strictEqual(legacyObject.bits, legacyObjectCheck.bits);
+  assert.strictEqual(legacyObject.exponent, legacyObjectCheck.exponent);
+  assert.strictEqual(legacyObject.valid_from, legacyObjectCheck.valid_from);
+  assert.strictEqual(legacyObject.valid_to, legacyObjectCheck.valid_to);
+  assert.strictEqual(legacyObject.fingerprint, legacyObjectCheck.fingerprint);
+  assert.strictEqual(
+    legacyObject.fingerprint256,
+    legacyObjectCheck.fingerprint256);
+  assert.strictEqual(
+    legacyObject.serialNumber,
+    legacyObjectCheck.serialNumber);
+}

--- a/tools/doc/type-parser.js
+++ b/tools/doc/type-parser.js
@@ -217,6 +217,8 @@ const customTypesMap = {
 
   'MessagePort': 'worker_threads.html#worker_threads_class_messageport',
 
+  'X509Certificate': 'crypto.html#crypto_class_x509certificate',
+
   'zlib options': 'zlib.html#zlib_class_options',
 };
 


### PR DESCRIPTION
Introduces the `crypto.X509Certificate` object.

```js
const { X509Certificate } = require('crypto');

const x509 = new X509Certificate('{pem encoded cert}');
console.log(x509.subject);
```

/cc @addaleax @panva @nodejs/crypto

(note.. this PR does not do it yet, but an eventual goal is to update the existing APIs on TLSSocket for getting the cert and peercert so that they return `X509Certificate` instances instead of the legacy objects)