### PR TITLE
http_client: prevent domain fronting (Host mismatch) when using proxy

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -36,7 +36,7 @@ const {
   StringPrototypeCharCodeAt,
   StringPrototypeIncludes,
   StringPrototypeIndexOf,
-  StringPrototypeReplace,
+  StringPrototypeMatch,
   StringPrototypeStartsWith,
   StringPrototypeToUpperCase,
   Symbol,
@@ -272,6 +272,17 @@ function ClientRequest(input, options, cb) {
 
     if (host && !this.getHeader('host') && setHost) {
       let hostHeader = host;
+      let hostHeaderPort = port;
+
+      // Prevent potential domain fronting misjudgement when using proxy
+      // Overwrite the default Host request header with the host of path
+      if (!StringPrototypeStartsWith(this.path, '/')) {
+        const proxyURL = new URL(StringPrototypeMatch(
+          this.path, '^.+://') ? this.path : `http://${this.path}`);
+        hostHeader = proxyURL.hostname;
+        hostHeaderPort = proxyURL.port || (
+          proxyURL.protocol === 'https:' ? '443' : '80');
+      }
 
       // For the Host header, ensure that IPv6 addresses are enclosed
       // in square brackets, as defined by URI formatting
@@ -283,17 +294,9 @@ function ClientRequest(input, options, cb) {
         hostHeader = `[${hostHeader}]`;
       }
 
-      if (port && +port !== defaultPort) {
-        hostHeader += ':' + port;
+      if (hostHeaderPort && +hostHeaderPort !== defaultPort) {
+        hostHeader += ':' + hostHeaderPort;
       }
-
-      // Prevent potential domain fronting misjudgement when using proxy
-      // Overwrite the "default Host requst header" with the host of path
-      if (!StringPrototypeStartsWith(this.path, '/')) {
-        hostHeader = new URL(
-          `http://${StringPrototypeReplace(this.path, /^.*:\/\//, '')}`).host;
-      }
-
       this.setHeader('Host', hostHeader);
     }
 

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -36,6 +36,8 @@ const {
   StringPrototypeCharCodeAt,
   StringPrototypeIncludes,
   StringPrototypeIndexOf,
+  StringPrototypeReplace,
+  StringPrototypeStartsWith,
   StringPrototypeToUpperCase,
   Symbol,
   TypedArrayPrototypeSlice,
@@ -287,9 +289,9 @@ function ClientRequest(input, options, cb) {
 
       // Prevent potential domain fronting misjudgement when using proxy
       // Overwrite the "default Host requst header" with the host of path
-      if (!this.path.startsWith('/')) {
+      if (!StringPrototypeStartsWith(this.path, '/')) {
         hostHeader = new URL(
-          `http://${this.path.replace(/^.*:\/\//, '')}`).host;
+          `http://${StringPrototypeReplace(this.path, /^.*:\/\//, '')}`).host;
       }
 
       this.setHeader('Host', hostHeader);

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -36,7 +36,6 @@ const {
   StringPrototypeCharCodeAt,
   StringPrototypeIncludes,
   StringPrototypeIndexOf,
-  StringPrototypeMatch,
   StringPrototypeStartsWith,
   StringPrototypeToUpperCase,
   Symbol,
@@ -277,8 +276,8 @@ function ClientRequest(input, options, cb) {
       // Prevent potential domain fronting misjudgement when using proxy
       // Overwrite the default Host request header with the host of path
       if (!StringPrototypeStartsWith(this.path, '/')) {
-        const proxyURL = new URL(StringPrototypeMatch(
-          this.path, '^.+://') ? this.path : `http://${this.path}`);
+        const proxyURL = new URL(RegExpPrototypeTest(
+          /^[^:]+:\/\//, this.path) ? this.path : `http://${this.path}`);
         hostHeader = proxyURL.hostname;
         hostHeaderPort = proxyURL.port || (
           proxyURL.protocol === 'https:' ? '443' : '80');

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -284,6 +284,14 @@ function ClientRequest(input, options, cb) {
       if (port && +port !== defaultPort) {
         hostHeader += ':' + port;
       }
+
+      // Prevent potential domain fronting misjudgement when using proxy
+      // Overwrite the "default Host requst header" with the host of path
+      if (!this.path.startsWith('/')) {
+        hostHeader = new URL(
+          `http://${this.path.replace(/^.*:\/\//, '')}`).host;
+      }
+
       this.setHeader('Host', hostHeader);
     }
 

--- a/test/parallel/test-tls-over-http-tunnel.js
+++ b/test/parallel/test-tls-over-http-tunnel.js
@@ -61,7 +61,8 @@ const proxy = net.createServer((clientSocket) => {
                          `CONNECT localhost:${server.address().port} ` +
                          'HTTP/1.1\r\n' +
                          'Proxy-Connections: keep-alive\r\n' +
-                         `Host: localhost:${proxy.address().port}\r\n` +
+                         // Match header Host with destination Host
+                         `Host: localhost:${server.address().port}\r\n` +
                          'Connection: close\r\n\r\n');
 
       console.log('PROXY: got CONNECT request');


### PR DESCRIPTION
## Purpose
This PR is to prevent domain fronting warning/misjudgment (Host mismatch with the one in header) issue when using proxy

## Explanation
We are informed by the security team in our company that our http requests contain mismatched Destination Host and Header Host.

According to the [tutorial](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host), `a Host header field must be sent in all HTTP/1.1 request messages`.
That's why Node.js do the [`setHeader('Host', hostHeader)`](https://github.com/nodejs/node/blob/v14.15.4/lib/_http_client.js#L271) with the given [`host`](https://github.com/nodejs/node/blob/v14.15.4/lib/_http_client.js#L162-L163) (options.hostname/host or localhost) by default.

However, the `Host` in the header field should be changed as the `destination (actual) host` instead of using the `proxy (original) host` unless user force overwrite it with `options.headers['Host']`.

## Implementation
Since [`this.path = options.path || '/'`](https://github.com/nodejs/node/blob/v14.15.4/lib/_http_client.js#L200) set the path as `/` by default, I decide to check if the path has its own host (i.e., NOT start with a slash) with `!this.path.startsWith('/')`.

Next, use the built-in `new URL(path).host` to get the host, while the ~~`http://${this.path.replace(/^.*:\/\//, '')}`~~ is used to prevent invalid URL, such as `❌github.com` (vs. `✔️https://github.com`) that raises an exception.
> **UPDATE (Jan 9)**: MOVE the implementation UP before the [IPv6 address check](https://github.com/nodejs/node/blob/3919518031d6905be840fb79dd6e5bfda7addc81/lib/_http_client.js#L287-L295) and separate the [`hostHeader` and `hostHeaderPort`](https://github.com/nodejs/node/blob/3919518031d6905be840fb79dd6e5bfda7addc81/lib/_http_client.js#L282-L284) to fit the original implementation.
> Also, use [`` this.path.match('^.+://') ? this.path : `http://${this.path}` ``](https://github.com/nodejs/node/blob/3919518031d6905be840fb79dd6e5bfda7addc81/lib/_http_client.js#L281) to replace ~~`http://${this.path.replace(/^.*:\/\//, '')}`~~ in order to keep the [`proxyURL.protocol` used for `proxyURL.port`](https://github.com/nodejs/node/blob/3919518031d6905be840fb79dd6e5bfda7addc81/lib/_http_client.js#L283-L284)

> **UPDATE(Jan 17)**: REPLACE `StringPrototypeMatch` with `RegExpPrototypeTest` due to better performance as suggested
>> @aduh95: `RegExpPrototypeTest` is way more efficient than `StringPrototypeMatch` IIRC. It might be worth to store the RegEx in global variable to avoid re-building it at each call.

## Further discussion
### Origin
This issue was found when running the Azure DevOps task with API calls.
The sample call stack would like: [`microsoft/azure-devops-node-api@8.1.1`](https://github.com/microsoft/azure-devops-node-api/blob/2e02035b9e0db7d831da7f6fe89d6e879123bee0/api/CoreApi.ts#L797) → [`microsoft/typed-rest-client/RestClient@1.2.0`](https://github.com/microsoft/typed-rest-client/blob/bdd88a921c2b5d27ff6cdcfe798996befc99c976/lib/RestClient.ts#L76-L77) → [`microsoft/typed-rest-client/HttpClient (tunnelAgent)`](https://github.com/microsoft/typed-rest-client/blob/bdd88a921c2b5d27ff6cdcfe798996befc99c976/lib/HttpClient.ts#L450-L456) → ~~[`request/tunnel-agent#32`](https://github.com/request/tunnel-agent/issues/32)~~ [`koichik/node-tunnel@0.0.4`](https://github.com/koichik/node-tunnel/blob/f2dfda3c8df1f75c62ab410d239f70b73aa3145b/lib/tunnel.js#L106-L110).
> **UPDATE (Jan 6)**: The `microsoft/typed-rest-client@1.2.0` used [`tunnel@0.0.4`](https://github.com/microsoft/typed-rest-client/blob/db2ee7395941593068b05d3c6e80030d7dec09d5/package.json#L43), which also met this issue, and it was fiexd in `tunnel@0.0.6` and`microsoft/typed-rest-client@1.7.2`

Actually, the request/tunnel-agent#32 and request/tunnel-agent#40 address this issue (host mismatch instead of domain fronting though) but that library has been out of maintenance since Mar. 2017.
Besides, this issue occurs mainly because the way Node.js generating the default Host header field; therefore, it influences not only the `request/tunnel-agent` and `koichik/node-tunnel` but MUCH more widely.
> **UPDATE (Jan 6)**: The koichik/node-tunnel#29 also addressed this issue in [`tunnel@v0.0.6`](https://www.npmjs.com/package/tunnel/v/0.0.6) by [force adding a header](https://github.com/koichik/node-tunnel/blob/v0.0.6/lib/tunnel.js#L112-L114)
> Update dependency to [`microsoft/azure-devops-node-api@^10.1.0`](https://github.com/microsoft/azure-devops-node-api/blob/417f07133a7f6e2b18745afbdca6268fcc7801a8/package.json#L28) fix the Host header mismatch issue for API calls

### Compare to the `curl` and `requests`
Since Node.js doesn't have a built-in proxy support for HttpClient (or I just missed one ...?), the simplest workaround would be the one mentioned on [Stack Overflow](https://stackoverflow.com/a/6781592) (put the proxy in the `host` and original target in the `path`).
However, unlike the `curl` and `requests` (Python) that have built-in proxy support, Node.js doesn't handle the Host field in header correctly as expected.
> **UPDATE (Jan 6)**: Seems [`tunnel`](https://www.npmjs.com/package/tunnel) is a reasonable alternative choice with FOUR MILLION downloads per week (although [`tunnel-agent`](https://www.npmjs.com/package/tunnel-agent) has fifteen million...)

I'm not sure if making this change goes against the design concept of the `http_client` or not, but I think it's important to get correct Host in header even though it doesn't matter or even be noticed in most cases.

The sample code and the result screenshot for GET requests using `curl`, `requests`, and `http_client` with proxy are shown below respectively.
```sh
# shell script
curl -v http://www.google.com -x http://XXX.XXX.XXX.XXX
```

```python
# Python
import requests

if __name__ == '__main__':
    proxies = {'http': 'http://XXX.XXX.XXX.XXX'}
    req = requests.get(url='http://www.google.com', proxies=proxies)
```

```js
// Node.js
(() => {
  const http = require('http');
  const options = {
    host: 'XXX.XXX.XXX.XXX',  // proxy
    port: 80,
    path: 'http://www.google.com',
  };

  http.get(options, (res) => {
    console.log(`header: ${res.req._header}`);
  });
})();
```
<img src="https://user-images.githubusercontent.com/37973545/103919244-cb968080-514a-11eb-9fc1-8d5c241b44dd.png" width="850"/>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
