### PR TITLE
test: increase fs promise coverage

### DIFF
--- a/test/parallel/test-fs-promises-file-handle-readFile.js
+++ b/test/parallel/test-fs-promises-file-handle-readFile.js
@@ -91,7 +91,7 @@ async function doReadAndCancel() {
     });
   }
 
-  // Validate file size is withing range for reading
+  // Validate file size is within range for reading
   {
     // Variable taken from https://github.com/nodejs/node/blob/master/lib/internal/fs/promises.js#L5
     const kIoMaxLength = 2 ** 31 - 1;

--- a/test/parallel/test-fs-promises-file-handle-readFile.js
+++ b/test/parallel/test-fs-promises-file-handle-readFile.js
@@ -6,9 +6,10 @@ const common = require('../common');
 // FileHandle.readFile method.
 
 const fs = require('fs');
-const { open } = fs.promises;
+const { open, readFile, writeFile } = fs.promises;
 const path = require('path');
 const tmpdir = require('../common/tmpdir');
+const tick = require('../common/tick');
 const assert = require('assert');
 const tmpDir = tmpdir.path;
 
@@ -45,6 +46,70 @@ async function validateReadFileProc() {
   assert.ok(hostname.length > 0);
 }
 
+async function doReadAndCancel() {
+  // Signal aborted from the start
+  {
+    const filePathForHandle = path.resolve(tmpDir, 'dogs-running.txt');
+    const fileHandle = await open(filePathForHandle, 'w+');
+    const buffer = Buffer.from('Dogs running'.repeat(10000), 'utf8');
+    fs.writeFileSync(filePathForHandle, buffer);
+    const controller = new AbortController();
+    const { signal } = controller;
+    controller.abort();
+    assert.rejects(readFile(fileHandle, { signal }), {
+      name: 'AbortError'
+    });
+  }
+
+  // Signal aborted on first tick
+  {
+    const filePathForHandle = path.resolve(tmpDir, 'dogs-running1.txt');
+    const fileHandle = await open(filePathForHandle, 'w+');
+    const buffer = Buffer.from('Dogs running'.repeat(10000), 'utf8');
+    fs.writeFileSync(filePathForHandle, buffer);
+    const controller = new AbortController();
+    const { signal } = controller;
+    tick(1, () => controller.abort());
+    assert.rejects(readFile(fileHandle, { signal }), {
+      name: 'AbortError'
+    });
+  }
+
+  // Signal aborted right before buffer read
+  {
+    const newFile = path.resolve(tmpDir, 'dogs-running2.txt');
+    const buffer = Buffer.from('Dogs running'.repeat(1000), 'utf8');
+    fs.writeFileSync(newFile, buffer);
+
+    const fileHandle = await open(newFile, 'r');
+
+    const controller = new AbortController();
+    const { signal } = controller;
+    tick(2, () => controller.abort());
+    assert.rejects(fileHandle.readFile({ signal, encoding: 'utf8' }), {
+      name: 'AbortError'
+    });
+  }
+
+  // Validate file size is withing range for reading
+  {
+    // Variable taken from https://github.com/nodejs/node/blob/master/lib/internal/fs/promises.js#L5
+    const kIoMaxLength = 2 ** 31 - 1;
+
+    const newFile = path.resolve(tmpDir, 'dogs-running3.txt');
+    const buffer = Buffer.alloc(kIoMaxLength + 1);
+    await writeFile(newFile, buffer);
+
+    const fileHandle = await open(newFile, 'r');
+
+    assert.rejects(fileHandle.readFile(), {
+      name: 'RangeError',
+      code: 'ERR_FS_FILE_TOO_LARGE'
+    });
+  }
+}
+
 validateReadFile()
-  .then(() => validateReadFileProc())
+  .then(validateReadFileProc)
+  .then(doReadAndCancel)
   .then(common.mustCall());

--- a/test/parallel/test-fs-promises-file-handle-readFile.js
+++ b/test/parallel/test-fs-promises-file-handle-readFile.js
@@ -56,7 +56,7 @@ async function doReadAndCancel() {
     const controller = new AbortController();
     const { signal } = controller;
     controller.abort();
-    assert.rejects(readFile(fileHandle, { signal }), {
+    await assert.rejects(readFile(fileHandle, { signal }), {
       name: 'AbortError'
     });
   }
@@ -70,7 +70,7 @@ async function doReadAndCancel() {
     const controller = new AbortController();
     const { signal } = controller;
     tick(1, () => controller.abort());
-    assert.rejects(readFile(fileHandle, { signal }), {
+    await assert.rejects(readFile(fileHandle, { signal }), {
       name: 'AbortError'
     });
   }
@@ -86,7 +86,7 @@ async function doReadAndCancel() {
     const controller = new AbortController();
     const { signal } = controller;
     tick(2, () => controller.abort());
-    assert.rejects(fileHandle.readFile({ signal, encoding: 'utf8' }), {
+    await assert.rejects(fileHandle.readFile({ signal, encoding: 'utf8' }), {
       name: 'AbortError'
     });
   }
@@ -102,7 +102,7 @@ async function doReadAndCancel() {
 
     const fileHandle = await open(newFile, 'r');
 
-    assert.rejects(fileHandle.readFile(), {
+    await assert.rejects(fileHandle.readFile(), {
       name: 'RangeError',
       code: 'ERR_FS_FILE_TOO_LARGE'
     });

--- a/test/parallel/test-fs-promises-file-handle-readFile.js
+++ b/test/parallel/test-fs-promises-file-handle-readFile.js
@@ -6,7 +6,12 @@ const common = require('../common');
 // FileHandle.readFile method.
 
 const fs = require('fs');
-const { open, readFile, writeFile } = fs.promises;
+const {
+  open,
+  readFile,
+  writeFile,
+  truncate
+} = fs.promises;
 const path = require('path');
 const tmpdir = require('../common/tmpdir');
 const tick = require('../common/tick');
@@ -97,8 +102,8 @@ async function doReadAndCancel() {
     const kIoMaxLength = 2 ** 31 - 1;
 
     const newFile = path.resolve(tmpDir, 'dogs-running3.txt');
-    const buffer = Buffer.alloc(kIoMaxLength + 1);
-    await writeFile(newFile, buffer);
+    await writeFile(newFile, Buffer.from('0'));
+    await truncate(newFile, kIoMaxLength + 1);
 
     const fileHandle = await open(newFile, 'r');
 

--- a/test/parallel/test-fs-promises-file-handle-writeFile.js
+++ b/test/parallel/test-fs-promises-file-handle-writeFile.js
@@ -3,10 +3,10 @@
 const common = require('../common');
 
 // The following tests validate base functionality for the fs.promises
-// FileHandle.readFile method.
+// FileHandle.writeFile method.
 
 const fs = require('fs');
-const { open } = fs.promises;
+const { open, writeFile } = fs.promises;
 const path = require('path');
 const tmpdir = require('../common/tmpdir');
 const assert = require('assert');
@@ -26,5 +26,19 @@ async function validateWriteFile() {
   await fileHandle.close();
 }
 
+// Signal aborted while writing file
+async function doWriteAndCancel() {
+  const filePathForHandle = path.resolve(tmpDir, 'dogs-running.txt');
+  const fileHandle = await open(filePathForHandle, 'w+');
+  const buffer = Buffer.from('dogs running'.repeat(10000), 'utf8');
+  const controller = new AbortController();
+  const { signal } = controller;
+  process.nextTick(() => controller.abort());
+  assert.rejects(writeFile(fileHandle, buffer, { signal }), {
+    name: 'AbortError'
+  });
+}
+
 validateWriteFile()
+  .then(doWriteAndCancel)
   .then(common.mustCall());

--- a/test/parallel/test-fs-promises-file-handle-writeFile.js
+++ b/test/parallel/test-fs-promises-file-handle-writeFile.js
@@ -34,7 +34,7 @@ async function doWriteAndCancel() {
   const controller = new AbortController();
   const { signal } = controller;
   process.nextTick(() => controller.abort());
-  assert.rejects(writeFile(fileHandle, buffer, { signal }), {
+  await assert.rejects(writeFile(fileHandle, buffer, { signal }), {
     name: 'AbortError'
   });
 }

--- a/test/parallel/test-fs-promises-writefile.js
+++ b/test/parallel/test-fs-promises-writefile.js
@@ -31,7 +31,7 @@ async function doWriteWithCancel() {
 }
 
 async function doAppend() {
-  await fsPromises.appendFile(dest, buffer2);
+  await fsPromises.appendFile(dest, buffer2, { flag: null });
   const data = fs.readFileSync(dest);
   const buf = Buffer.concat([buffer, buffer2]);
   assert.deepStrictEqual(buf, data);


### PR DESCRIPTION
1. Signal aborted while writing file
Refs: https://coverage.nodejs.org/coverage-0b6d3070a176d437/lib/internal/fs/promises.js.html#L278

2. Signal aborted on first tick
Refs: https://coverage.nodejs.org/coverage-0b6d3070a176d437/lib/internal/fs/promises.js.html#L301

3. Validate file size is withing range for reading
Refs: https://coverage.nodejs.org/coverage-0b6d3070a176d437/lib/internal/fs/promises.js.html#L312

4. Signal aborted right before buffer read
Refs: https://coverage.nodejs.org/coverage-0b6d3070a176d437/lib/internal/fs/promises.js.html#L321

5. Use fallback buffer allocation when input not buffer
Refs: https://coverage.nodejs.org/coverage-0b6d3070a176d437/lib/internal/fs/promises.js.html#L374

6. Specify symlink type
Refs: https://coverage.nodejs.org/coverage-0b6d3070a176d437/lib/internal/fs/promises.js.html#L539

7. Set modification times with lutimes
Refs: https://coverage.nodejs.org/coverage-0b6d3070a176d437/lib/internal/fs/promises.js.html#L635

8. Use fallback encoding when input is null
Refs: https://coverage.nodejs.org/coverage-0b6d3070a176d437/lib/internal/fs/promises.js.html#L665

9. Use fallback flag when input is null
Refs: https://coverage.nodejs.org/coverage-0b6d3070a176d437/lib/internal/fs/promises.js.html#L681



<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
