### PR TITLE
http: abortIncoming only on socket close

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -581,11 +581,7 @@ function socketOnTimeout() {
 
 function socketOnClose(socket, state) {
   debug('server socket close');
-  // Mark this parser as reusable
-  if (socket.parser) {
-    freeParser(socket.parser, null, socket);
-  }
-
+  freeParser(socket.parser, null, socket);
   abortIncoming(state.incoming);
 }
 
@@ -602,18 +598,15 @@ function socketOnEnd(server, socket, parser, state) {
 
   if (ret instanceof Error) {
     debug('parse error');
+    // socketOnError has additional logic and will call socket.destroy(err).
     FunctionPrototypeCall(socketOnError, socket, ret);
-    return;
-  }
-
-  if (!server.httpAllowHalfOpen) {
-    abortIncoming(state.incoming);
-    if (socket.writable) socket.end();
+  } else if (!server.httpAllowHalfOpen) {
+    socket.end();
   } else if (state.outgoing.length) {
     state.outgoing[state.outgoing.length - 1]._last = true;
   } else if (socket._httpMessage) {
     socket._httpMessage._last = true;
-  } else if (socket.writable) {
+  } else {
     socket.end();
   }
 }
@@ -628,6 +621,7 @@ function socketOnData(server, socket, parser, state, d) {
 
 function onRequestTimeout(socket) {
   socket[kRequestTimeout] = undefined;
+  // socketOnError has additional logic and will call socket.destroy(err).
   ReflectApply(socketOnError, socket, [new ERR_HTTP_REQUEST_TIMEOUT()]);
 }
 


### PR DESCRIPTION
Don't call abortIncoming twice for same socket, i.e. both during 'end' and 'close'. Also does some minor cleanup.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
