### PR TITLE
stdio: lazy read ReadStream

### DIFF
--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -166,6 +166,8 @@ function ReadableState(options, stream, isDuplex) {
   // If true, a maybeReadMore has been scheduled.
   this.readingMore = false;
 
+  this.didRead = false;
+
   this.decoder = null;
   this.encoding = null;
   if (options && options.encoding) {
@@ -203,7 +205,9 @@ function Readable(options) {
   Stream.call(this, options);
 
   destroyImpl.construct(this, () => {
-    maybeReadMore(this, this._readableState);
+    if (this._readableState.didRead) {
+      maybeReadMore(this, this._readableState);
+    }
   });
 }
 
@@ -400,6 +404,8 @@ Readable.prototype.read = function(n) {
   }
   const state = this._readableState;
   const nOrig = n;
+
+  this.didRead = true;
 
   // If we're asking for more than the current hwm, then raise the hwm.
   if (n > state.highWaterMark)

--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -166,8 +166,6 @@ function ReadableState(options, stream, isDuplex) {
   // If true, a maybeReadMore has been scheduled.
   this.readingMore = false;
 
-  this.didRead = false;
-
   this.decoder = null;
   this.encoding = null;
   if (options && options.encoding) {
@@ -205,7 +203,7 @@ function Readable(options) {
   Stream.call(this, options);
 
   destroyImpl.construct(this, () => {
-    if (this._readableState.didRead) {
+    if (this._readableState.needReadable) {
       maybeReadMore(this, this._readableState);
     }
   });
@@ -404,8 +402,6 @@ Readable.prototype.read = function(n) {
   }
   const state = this._readableState;
   const nOrig = n;
-
-  this.didRead = true;
 
   // If we're asking for more than the current hwm, then raise the hwm.
   if (n > state.highWaterMark)

--- a/test/parallel/test-stdin-from-file-spawn.js
+++ b/test/parallel/test-stdin-from-file-spawn.js
@@ -1,0 +1,42 @@
+'use strict';
+const common = require('../common');
+const process = require('process');
+
+let defaultShell;
+if (process.platform === 'linux' || process.platform === 'darwin') {
+  defaultShell = '/bin/sh';
+} else if (process.platform === 'win32') {
+  defaultShell = 'cmd.exe';
+} else {
+  common.skip('This is test exists only on Linux/Win32/OSX');
+}
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const tmpdir = require('../common/tmpdir');
+
+const tmpDir = tmpdir.path;
+tmpdir.refresh();
+const tmpCmdFile = path.join(tmpDir, 'test-stdin-from-file-spawn-cmd');
+const tmpJsFile = path.join(tmpDir, 'test-stdin-from-file-spawn.js');
+fs.writeFileSync(tmpCmdFile, 'echo hello');
+fs.writeFileSync(tmpJsFile, `
+'use strict';
+const { spawn } = require('child_process');
+// Reference the object to invoke the getter
+process.stdin;
+setTimeout(() => {
+  let ok = false;
+  const child = spawn(process.env.SHELL || '${defaultShell}',
+    [], { stdio: ['inherit', 'pipe'] });
+  child.stdout.on('data', () => {
+    ok = true;
+  });
+  child.on('close', () => {
+    process.exit(ok ? 0 : -1);
+  });
+}, 100);
+`);
+
+execSync(`${process.argv[0]} ${tmpJsFile} < ${tmpCmdFile}`);

--- a/test/parallel/test-stream-construct.js
+++ b/test/parallel/test-stream-construct.js
@@ -268,3 +268,13 @@ testDestroy((opts) => new Writable({
     assert.strictEqual(constructed, true);
   }));
 }
+
+{
+  // Construct should not cause stream to read.
+  new Readable({
+    construct: common.mustCall((callback) => {
+      callback();
+    }),
+    read: common.mustNotCall()
+  });
+}


### PR DESCRIPTION
All stdio ReadStream's use manual start to avoid
consuming data for example when a process
execs/spawns.

Using stream._construct would cause the Readable
to incorrectly greedily start reading.

Refs: https://github.com/nodejs/node/issues/36251

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
