### PR TITLE
doc: improve crypto.randomUUID() text

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -3167,7 +3167,7 @@ added: REPLACEME
 
 * `options` {Object}
   * `disableEntropyCache` {boolean} By default, to improve performance,
-    Node.js will pre-emptively generate and persistently cache enough
+    Node.js generates and caches enough
     random data to generate up to 128 random UUIDs. To generate a UUID
     without using the cache, set `disableEntropyCache` to `true`.
     **Defaults**: `false`.


### PR DESCRIPTION
* Use present tense.
* Remove "persistently" which suggests that the cache persists across
  Node.js runs.
* Remove "pre-emptively". I think "proactively" is what was meant as
  nothing is being pre-empted here. Regardless of what the adverby
  should be, it seems unnecessary.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
