### PR TITLE
[v14.x backport] stream: accept iterable as a valid first argument

### DIFF
--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -142,7 +142,10 @@ async function pump(iterable, writable, finish) {
 function pipeline(...streams) {
   const callback = once(popCallback(streams));
 
-  if (ArrayIsArray(streams[0])) streams = streams[0];
+  // stream.pipeline(streams, callback)
+  if (ArrayIsArray(streams[0]) && streams.length === 1) {
+    streams = streams[0];
+  }
 
   if (streams.length < 2) {
     throw new ERR_MISSING_ARGS('streams');

--- a/test/parallel/test-stream-pipeline.js
+++ b/test/parallel/test-stream-pipeline.js
@@ -1216,3 +1216,19 @@ const net = require('net');
     assert.strictEqual(res, 'helloworld');
   }));
 }
+
+{
+  pipeline([1, 2, 3], PassThrough({ objectMode: true }),
+           common.mustSucceed(() => {}));
+
+  let res = '';
+  const w = new Writable({
+    write(chunk, encoding, callback) {
+      res += chunk;
+      callback();
+    },
+  });
+  pipeline(['1', '2', '3'], w, common.mustSucceed(() => {
+    assert.strictEqual(res, '123');
+  }));
+}


### PR DESCRIPTION
Backport of https://github.com/nodejs/node/pull/36479

Followed instructions in [How to Backport a Pull Request to a Release Line](https://github.com/nodejs/node/blob/master/doc/guides/backporting-to-release-lines.md)

Motivation: Getting https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49868 merged for Node 14, to make the types there reflect what's been in the documentation for Node.js since Node.js 13.10