### PR TITLE
test: fix warning in test_environment.cc

### DIFF
--- a/test/cctest/test_environment.cc
+++ b/test/cctest/test_environment.cc
@@ -1,6 +1,7 @@
 #include "node_buffer.h"
 #include "node_internals.h"
 #include "libplatform/libplatform.h"
+#include "util.h"
 
 #include <string>
 #include "gtest/gtest.h"
@@ -10,6 +11,7 @@
 
 using node::AtExit;
 using node::RunAtExit;
+using node::USE;
 
 static bool called_cb_1 = false;
 static bool called_cb_2 = false;
@@ -74,7 +76,7 @@ class RedirectStdErr {
     fflush(stderr);
     fgetpos(stderr, &pos_);
     fd_ = dup(fileno(stderr));
-    freopen(filename_, "w", stderr);
+    USE(freopen(filename_, "w", stderr));
   }
 
   ~RedirectStdErr() {


### PR DESCRIPTION
warning log:
```console
../test/cctest/test_environment.cc: In constructor ‘RedirectStdErr::RedirectStdErr(const char*)’:
../test/cctest/test_environment.cc:77:12: warning: ignoring return value of ‘FILE* freopen(const char*, const char*, FILE*)’, declared with attribute warn_unused_result [-Wunused-result]
     freopen(filename_, "w", stderr);
     ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
```
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
