### PR TITLE
doc: use ESM syntax for WASI example

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -57,6 +57,7 @@ module.exports = {
         'doc/api/module.md',
         'doc/api/modules.md',
         'doc/api/packages.md',
+        'doc/api/wasi.md',
         'test/es-module/test-esm-type-flag.js',
         'test/es-module/test-esm-type-flag-alias.js',
         '*.mjs',

--- a/doc/api/wasi.md
+++ b/doc/api/wasi.md
@@ -11,9 +11,9 @@ specification. WASI gives sandboxed WebAssembly applications access to the
 underlying operating system via a collection of POSIX-like functions.
 
 ```js
-'use strict';
-const fs = require('fs');
-const { WASI } = require('wasi');
+import fs from 'fs';
+import { WASI } from 'wasi';
+
 const wasi = new WASI({
   args: process.argv,
   env: process.env,
@@ -23,12 +23,10 @@ const wasi = new WASI({
 });
 const importObject = { wasi_snapshot_preview1: wasi.wasiImport };
 
-(async () => {
-  const wasm = await WebAssembly.compile(fs.readFileSync('./demo.wasm'));
-  const instance = await WebAssembly.instantiate(wasm, importObject);
+const wasm = await WebAssembly.compile(fs.readFileSync('./demo.wasm'));
+const instance = await WebAssembly.instantiate(wasm, importObject);
 
-  wasi.start(instance);
-})();
+wasi.start(instance);
 ```
 
 To run the above example, create a new WebAssembly text format file named


### PR DESCRIPTION
Using top-level await and ESM makes sense here I think, and it makes the example easier to follow.
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
