### PR TITLE
tools: avoid crashing CQ when git push fails

### DIFF
--- a/tools/actions/commit-queue.sh
+++ b/tools/actions/commit-queue.sh
@@ -37,6 +37,18 @@ gitHubCurl() {
        --header 'content-type: application/json' "$@"
 }
 
+commit_queue_failed() {
+  gitHubCurl "$(labelsUrl "${1}")" POST --data '{"labels": ["'"${COMMIT_QUEUE_FAILED_LABEL}"'"]}'
+
+  # shellcheck disable=SC2154
+  cqurl="${GITHUB_SERVER_URL}/${OWNER}/${REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+  jq -n --arg content "<details><summary>Commit Queue failed</summary><pre>$(cat output)</pre><a href='$cqurl'>$cqurl</a></details>" '{body: $content}' > output.json
+  cat output.json
+
+  gitHubCurl "$(commentsUrl "${1}")" POST --data @output.json
+
+  rm output output.json
+}
 
 # TODO(mmarchini): should this be set with whoever added the label for each PR?
 git config --local user.email "github-bot@iojs.org"
@@ -65,26 +77,20 @@ for pr in "$@"; do
   # TODO(mmarchini): workaround for ncu not returning the expected status code,
   # if the "Landed in..." message was not on the output we assume land failed
   if ! tail -n 10 output | grep '. Post "Landed in .*/pull/'"${pr}"; then
-    gitHubCurl "$(labelsUrl "$pr")" POST --data '{"labels": ["'"${COMMIT_QUEUE_FAILED_LABEL}"'"]}'
-
-    # shellcheck disable=SC2154
-    cqurl="${GITHUB_SERVER_URL}/${OWNER}/${REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-    jq -n --arg content "<details><summary>Commit Queue failed</summary><pre>$(cat output)</pre><a href='$cqurl'>$cqurl</a></details>" '{body: $content}' > output.json
-    cat output.json
-
-    gitHubCurl "$(commentsUrl "$pr")" POST --data @output.json
-
-    rm output output.json
+    commit_queue_failed "$pr"
     # If `git node land --abort` fails, we're in unknown state. Better to stop
     # the script here, current PR was removed from the queue so it shouldn't
     # interfer again in the future
     git node land --abort --yes
   else
-    rm output
-
     commits="$(git rev-parse $UPSTREAM/$DEFAULT_BRANCH)...$(git rev-parse HEAD)"
 
-    git push $UPSTREAM $DEFAULT_BRANCH
+    git push $UPSTREAM $DEFAULT_BRANCH >> output 2>&1 || (\
+      commit_queue_failed "$pr" && \
+      continue \
+    )
+
+    rm output
 
     gitHubCurl "$(commentsUrl "$pr")" POST --data '{"body": "Landed in '"$commits"'"}'
 


### PR DESCRIPTION
This is useful in case someone pushed to the master branch while the CQ was trying to land a PR, or if the CQ bot doesn't have the correct credentials. Currently it silently crashes, without adding a `commit-queue-failed` label on the PRs; with this PR, it should always add a label and comment on the PR.

/cc @mmarchini 

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
