### PR TITLE
lib: simplify `primordials.uncurryThis`

### DIFF
--- a/lib/internal/per_context/primordials.js
+++ b/lib/internal/per_context/primordials.js
@@ -13,10 +13,10 @@
 // by the native module compiler.
 
 // `uncurryThis` is equivalent to `func => Function.prototype.call.bind(func)`.
-// It is using `call.bind(bind, call)` to avoid using `Function.prototype.bind`
-// after it may have been mutated by users.
+// It is using `bind.bind(call)` to avoid using `Function.prototype.bind`
+// and `Function.prototype.call` after it may have been mutated by users.
 const { bind, call } = Function.prototype;
-const uncurryThis = call.bind(bind, call);
+const uncurryThis = bind.bind(call);
 primordials.uncurryThis = uncurryThis;
 
 function copyProps(src, dest) {


### PR DESCRIPTION
While working on <https://github.com/nodejs/node/pull/36865>, it occurred to me that:
```js
Function.prototype.call.bind(Function.prototype.bind, Function.prototype.call)
```

is equivalent to:
```js
Function.prototype.bind.bind(Function.prototype.call)
```

except that it saves us one indirection through `Function.prototype.call`.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
