### PR TITLE
lib: add --expose-primordials flag

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -233,9 +233,9 @@ ObjectDefineProperty(Module, 'wrapper', {
   }
 });
 
-ObjectDefineProperty(Module.prototype, 'isPreloading', {
-  get() { return isPreloading; }
-});
+const isPreloadingDesc = { get() { return isPreloading; } };
+ObjectDefineProperty(Module.prototype, 'isPreloading', isPreloadingDesc);
+ObjectDefineProperty(NativeModule.prototype, 'isPreloading', isPreloadingDesc);
 
 function getModuleParent() {
   return moduleParentCache.get(this);

--- a/lib/internal/test/binding.js
+++ b/lib/internal/test/binding.js
@@ -4,4 +4,9 @@ process.emitWarning(
   'These APIs are for internal testing only. Do not use them.',
   'internal/test/binding');
 
-module.exports = { internalBinding };
+if (module.isPreloading) {
+  globalThis.internalBinding = internalBinding;
+  globalThis.primordials = primordials;
+}
+
+module.exports = { internalBinding, primordials };


### PR DESCRIPTION
Provide a way to expose the `primordials` on the global object. This is useful to run Node.js internals modules to help with Node.js core development.

```console
$ node --expose-internals -r internal/test/binding lib/fs.js
(node:5299) internal/test/binding: These APIs are for internal testing only. Do not use them.
(Use `node --trace-warnings ...` to show where the warning was created)
```

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
