### PR TITLE
Revert "http2: refactor to use primordials instead of <string>.indexOf"

### DIFF
--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -11,7 +11,6 @@ const {
   ObjectPrototypeHasOwnProperty,
   ReflectApply,
   ReflectGetPrototypeOf,
-  StringPrototypeIncludes,
   StringPrototypeToLowerCase,
   StringPrototypeTrim,
   Symbol,
@@ -82,9 +81,7 @@ let statusConnectionHeaderWarned = false;
 // close as possible to the current require('http') API
 
 const assertValidHeader = hideStackFrames((name, value) => {
-  if (name === '' ||
-      typeof name !== 'string' ||
-      StringPrototypeIncludes(name, ' ')) {
+  if (name === '' || typeof name !== 'string' || name.indexOf(' ') >= 0) {
     throw new ERR_INVALID_HTTP_TOKEN('Header name', name);
   }
   if (isPseudoHeader(name)) {


### PR DESCRIPTION
This reverts commit 3af175fb5e6cfdb1de57dc19fc3827c804333545.

Opening this as a draft PR so I can easily run benchmarks.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
