### PR TITLE
crypto: fix WebCrypto import of RSA-PSS keys

### DIFF
--- a/src/crypto/crypto_rsa.cc
+++ b/src/crypto/crypto_rsa.cc
@@ -367,7 +367,14 @@ Maybe<bool> ExportJWKRsaKey(
   int type = EVP_PKEY_id(pkey.get());
   CHECK(type == EVP_PKEY_RSA || type == EVP_PKEY_RSA_PSS);
 
-  RSA* rsa = EVP_PKEY_get0_RSA(pkey.get());
+  // TODO(tniessen): Remove the "else" branch once we drop support for OpenSSL
+  // versions older than 1.1.1e via FIPS / dynamic linking.
+  RSA* rsa;
+  if (OpenSSL_version_num() >= 0x1010105fL) {
+    rsa = EVP_PKEY_get0_RSA(pkey.get());
+  } else {
+    rsa = static_cast<RSA*>(EVP_PKEY_get0(pkey.get()));
+  }
   CHECK_NOT_NULL(rsa);
 
   const BIGNUM* n;
@@ -508,7 +515,14 @@ Maybe<bool> GetRsaKeyDetail(
   int type = EVP_PKEY_id(pkey.get());
   CHECK(type == EVP_PKEY_RSA || type == EVP_PKEY_RSA_PSS);
 
-  RSA* rsa = EVP_PKEY_get0_RSA(pkey.get());
+  // TODO(tniessen): Remove the "else" branch once we drop support for OpenSSL
+  // versions older than 1.1.1e via FIPS / dynamic linking.
+  RSA* rsa;
+  if (OpenSSL_version_num() >= 0x1010105fL) {
+    rsa = EVP_PKEY_get0_RSA(pkey.get());
+  } else {
+    rsa = static_cast<RSA*>(EVP_PKEY_get0(pkey.get()));
+  }
   CHECK_NOT_NULL(rsa);
 
   RSA_get0_key(rsa, &n, &e, nullptr);

--- a/test/parallel/test-webcrypto-rsa-pss-params.js
+++ b/test/parallel/test-webcrypto-rsa-pss-params.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const common = require('../common');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const {
+  createPrivateKey,
+  createPublicKey,
+  webcrypto: {
+    subtle
+  }
+} = require('crypto');
+
+const fixtures = require('../common/fixtures');
+
+{
+  const rsaPssKeyWithoutParams = fixtures.readKey('rsa_pss_private_2048.pem');
+
+  const pkcs8 = createPrivateKey(rsaPssKeyWithoutParams).export({
+    type: 'pkcs8',
+    format: 'der'
+  });
+  const spki = createPublicKey(rsaPssKeyWithoutParams).export({
+    type: 'spki',
+    format: 'der'
+  });
+
+  const hashes = ['SHA-1', 'SHA-256', 'SHA-384', 'SHA-512'];
+
+  const tasks = [];
+  for (const hash of hashes) {
+    const algorithm = { name: 'RSA-PSS', hash };
+    tasks.push(subtle.importKey('pkcs8', pkcs8, algorithm, true, ['sign']));
+    tasks.push(subtle.importKey('spki', spki, algorithm, true, ['verify']));
+  }
+
+  Promise.all(tasks).then(common.mustCall());
+}


### PR DESCRIPTION
This patch changes `GetRsaKeyDetail` to work in older supported versions of OpenSSL. The added test case fails CI without this patch.

I assume the WebCrypto implementation also does not handle imported `RSASSA-PSS-params` correctly, but it is out of scope for this PR to fix that. Last time I checked, OpenSSL made that step difficult.

Refs: https://github.com/openssl/openssl/pull/10217
Refs: https://github.com/nodejs/node/pull/36188

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
