### PR TITLE
http: remove _deferToConnect

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -30,7 +30,6 @@ const {
   ObjectAssign,
   ObjectKeys,
   ObjectSetPrototypeOf,
-  ReflectApply,
   RegExpPrototypeTest,
   String,
   StringPrototypeCharCodeAt,
@@ -314,7 +313,6 @@ function ClientRequest(input, options, cb) {
       return;
     }
     this.onSocket(socket);
-    this._deferToConnect(null, null, () => this._flush());
   };
 
   // initiate connection
@@ -329,16 +327,12 @@ function ClientRequest(input, options, cb) {
       if (newSocket && !called) {
         called = true;
         this.onSocket(newSocket);
-      } else {
-        return;
       }
     } else {
       debug('CLIENT use net.createConnection', options);
       this.onSocket(net.createConnection(options));
     }
   }
-
-  this._deferToConnect(null, null, () => this._flush());
 }
 ObjectSetPrototypeOf(ClientRequest.prototype, OutgoingMessage.prototype);
 ObjectSetPrototypeOf(ClientRequest, OutgoingMessage);
@@ -826,37 +820,7 @@ function onSocketNT(req, socket, err) {
     _destroy(req, null, err);
   } else {
     tickOnSocket(req, socket);
-  }
-}
-
-ClientRequest.prototype._deferToConnect = _deferToConnect;
-function _deferToConnect(method, arguments_, cb) {
-  // This function is for calls that need to happen once the socket is
-  // assigned to this request and writable. It's an important promisy
-  // thing for all the socket calls that happen either now
-  // (when a socket is assigned) or in the future (when a socket gets
-  // assigned out of the pool and is eventually writable).
-
-  const callSocketMethod = () => {
-    if (method)
-      ReflectApply(this.socket[method], this.socket, arguments_);
-
-    if (typeof cb === 'function')
-      cb();
-  };
-
-  const onSocket = () => {
-    if (this.socket.writable) {
-      callSocketMethod();
-    } else {
-      this.socket.once('connect', callSocketMethod);
-    }
-  };
-
-  if (!this.socket) {
-    this.once('socket', onSocket);
-  } else {
-    onSocket();
+    req._flush();
   }
 }
 
@@ -889,12 +853,16 @@ function setSocketTimeout(sock, msecs) {
 }
 
 ClientRequest.prototype.setNoDelay = function setNoDelay(noDelay) {
-  this._deferToConnect('setNoDelay', [noDelay]);
+  this.once('socket', (socket) => {
+    socket.setNoDelay(noDelay);
+  });
 };
 
 ClientRequest.prototype.setSocketKeepAlive =
     function setSocketKeepAlive(enable, initialDelay) {
-      this._deferToConnect('setKeepAlive', [enable, initialDelay]);
+      this.once('socket', (socket) => {
+        socket.setKeepAlive(enable, initialDelay);
+      });
     };
 
 ClientRequest.prototype.clearTimeout = function clearTimeout(cb) {

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -853,16 +853,24 @@ function setSocketTimeout(sock, msecs) {
 }
 
 ClientRequest.prototype.setNoDelay = function setNoDelay(noDelay) {
-  this.once('socket', (socket) => {
-    socket.setNoDelay(noDelay);
-  });
+  if (this.socket) {
+    this.socket.setNoDelay(noDelay);
+  } else {
+    this.once('socket', (socket) => {
+      socket.setNoDelay(noDelay);
+    });
+  }
 };
 
 ClientRequest.prototype.setSocketKeepAlive =
     function setSocketKeepAlive(enable, initialDelay) {
-      this.once('socket', (socket) => {
-        socket.setKeepAlive(enable, initialDelay);
-      });
+      if (this.socket) {
+        this.socket.setKeepAlive(enable, initialDelay);
+      } else {
+        this.once('socket', (socket) => {
+          socket.setKeepAlive(enable, initialDelay);
+        });
+      }
     };
 
 ClientRequest.prototype.clearTimeout = function clearTimeout(cb) {


### PR DESCRIPTION
Remove _deferConnect which adds unnecessary complexity. We just need to wait for the socket, not connect.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
