### PR TITLE
doc: add performance notes for fs.readFile

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -3162,6 +3162,28 @@ system requests but rather the internal buffering `fs.readFile` performs.
    the call to `fs.readFile()` with the same file descriptor, would give
    `'World'`, rather than `'Hello World'`.
 
+### Performance Considerations
+
+The `fs.readFile()` method asynchronously reads the contents of a file into
+memory one chunk at a time, allowing the event loop to turn between each chunk.
+This allows the read operation to have less impact on other activity that may
+be using the underlying libuv thread pool but means that it will take longer
+to read a complete file into memory.
+
+The additional read overhead can vary broadly on different systems and depends
+on the type of file being read. If the file type is not a regular file (a pipe
+for instance) and Node.js is unable to determine an actual file size, each read
+operation will load on 64kb of data. For regular files, each read will process
+512kb of data.
+
+For applications that require as-fast-as-possible reading of file contents, it
+is better to use `fs.read()` directly and for application code to manage
+reading the full contents of the file itself.
+
+The Node.js GitHub issue [#25741][] provides more information and a detailed
+analysis on the performance of `fs.readFile()` for multiple file sizes in
+different Node.js versions.
+
 ## `fs.readFileSync(path[, options])`
 <!-- YAML
 added: v0.1.8
@@ -6214,6 +6236,7 @@ through `fs.open()` or `fs.writeFile()` or `fsPromises.open()`) will fail with
 A call to `fs.ftruncate()` or `filehandle.truncate()` can be used to reset
 the file contents.
 
+[#25741]: https://github.com/nodejs/node/issues/25741
 [Caveats]: #fs_caveats
 [Common System Errors]: errors.md#errors_common_system_errors
 [FS constants]: #fs_fs_constants_1


### PR DESCRIPTION
Issue https://github.com/nodejs/node/issues/25741 discusses a number of
performance considerations for fs.readFile, which was changed in Node.js
10.x to split discreet chunk reads over multiple event loop turns. While
the fs.readFile() operation is certainly slower than it was pre 10.x,
it's unlikely to be faster. Document the performance consideration and
link back to the issue for more in depth analysis.

Signed-off-by: James M Snell <jasnell@gmail.com>
Fixes: https://github.com/nodejs/node/issues/25741

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
