### PR TITLE
build: fix compiling against openssl with no-psk

### DIFF
--- a/src/crypto/crypto_tls.cc
+++ b/src/crypto/crypto_tls.cc
@@ -1339,8 +1339,6 @@ int TLSWrap::SelectSNIContextCallback(SSL* s, int* ad, void* arg) {
   return SSL_TLSEXT_ERR_OK;
 }
 
-#ifndef OPENSSL_NO_PSK
-
 int TLSWrap::SetCACerts(SecureContext* sc) {
   int err = SSL_set1_verify_cert_store(
       ssl_.get(), SSL_CTX_get_cert_store(sc->ctx_.get()));
@@ -1354,6 +1352,8 @@ int TLSWrap::SetCACerts(SecureContext* sc) {
   SSL_set_client_CA_list(ssl_.get(), list);
   return 1;
 }
+
+#ifndef OPENSSL_NO_PSK
 
 void TLSWrap::SetPskIdentityHint(const FunctionCallbackInfo<Value>& args) {
   TLSWrap* p;


### PR DESCRIPTION
fixes #36464

Node 15 prior to this commit will not compile if openssl is built with
no-psk. Compiling emits an error like this:

```
crypto_tls.cc:(.text+0x4c27): undefined reference to `node::crypto::TLSWrap::SetCACerts(node::crypto::SecureContext*)'
```

Blame on crypto_tls.cc shows the file was created in a refactor. Before
that refactor SetCACerts was defined outside OPENSSL_NO_PSK ifndef

https://github.com/nodejs/node/blob/6751b6dc3da102f259b74b7453032edadc7a37ca/src/crypto/crypto_ssl.cc#L839

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
