### PR TITLE
chore: update fs.l/statSync API history for throwIfNoEntry

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2578,6 +2578,10 @@ not the file that it refers to.
 <!-- YAML
 added: v0.1.30
 changes:
+  - version: v15.3.0
+    pr-url: https://github.com/nodejs/node/pull/33716
+    description: Accepts an additional `options` object to specify whether
+                 an exception should be thrown if the entry does not exist.
   - version: v10.5.0
     pr-url: https://github.com/nodejs/node/pull/20220
     description: Accepts an additional `options` object to specify whether
@@ -3823,6 +3827,10 @@ Stats {
 <!-- YAML
 added: v0.1.21
 changes:
+  - version: v15.3.0
+    pr-url: https://github.com/nodejs/node/pull/33716
+    description: Accepts an additional `options` object to specify whether
+                 an exception should be thrown if the entry does not exist.
   - version: v10.5.0
     pr-url: https://github.com/nodejs/node/pull/20220
     description: Accepts an additional `options` object to specify whether

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2580,7 +2580,7 @@ added: v0.1.30
 changes:
   - version: v15.3.0
     pr-url: https://github.com/nodejs/node/pull/33716
-    description: Accepts an additional `options` object to specify whether
+    description: Accepts a `throwIfNoEntry` option to specify whether
                  an exception should be thrown if the entry does not exist.
   - version: v10.5.0
     pr-url: https://github.com/nodejs/node/pull/20220
@@ -3829,7 +3829,7 @@ added: v0.1.21
 changes:
   - version: v15.3.0
     pr-url: https://github.com/nodejs/node/pull/33716
-    description: Accepts an additional `options` object to specify whether
+    description: Accepts a `throwIfNoEntry` option to specify whether
                  an exception should be thrown if the entry does not exist.
   - version: v10.5.0
     pr-url: https://github.com/nodejs/node/pull/20220


### PR DESCRIPTION
As suggested [here](https://github.com/nodejs/node/pull/33716#discussion_r540981593), now that there's a version number, the history in the API document can be updated to reflect [this PR](https://github.com/nodejs/node/pull/33716).