### PR TITLE
Revert "test: mark test-cluster-bind-privileged-port flaky on arm"

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -36,9 +36,6 @@ test-async-hooks-http-parser-destroy: PASS,FLAKY
 # https://github.com/nodejs/node/pull/31178
 test-crypto-dh-stateless: SKIP
 test-crypto-keygen: SKIP
-# https://github.com/nodejs/node/issues/36847
-test-cluster-bind-privileged-port: PASS,FLAKY
-test-cluster-shared-handle-bind-privileged-port: PASS,FLAKY
 
 [$system==solaris] # Also applies to SmartOS
 


### PR DESCRIPTION
This reverts commit a45a40419719ff443b80ea32175486c4f78fd628.

Solved by marking ports <1024 as privileged on Docker containers.

Ref: https://github.com/nodejs/node/pull/36850
Ref: https://github.com/nodejs/node/issues/36847
Ref: https://github.com/nodejs/build/pull/2521

/cc @nodejs/build 