### PR TITLE
doc: remove unnecessary contributing.md section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,6 @@ See [details on our policy on Code of Conduct](./doc/guides/contributing/code-of
 
 ## [Issues](./doc/guides/contributing/issues.md)
 
-* [How to Contribute in Issues](./doc/guides/contributing/issues.md#how-to-contribute-in-issues)
 * [Asking for General Help](./doc/guides/contributing/issues.md#asking-for-general-help)
 * [Discussing non-technical topics](./doc/guides/contributing/issues.md#discussing-non-technical-topics)
 * [Submitting a Bug Report](./doc/guides/contributing/issues.md#submitting-a-bug-report)

--- a/doc/guides/contributing/issues.md
+++ b/doc/guides/contributing/issues.md
@@ -1,27 +1,10 @@
 # Issues
 
-* [How to Contribute in Issues](#how-to-contribute-in-issues)
 * [Asking for General Help](#asking-for-general-help)
 * [Discussing non-technical topics](#discussing-non-technical-topics)
 * [Submitting a Bug Report](#submitting-a-bug-report)
 * [Triaging a Bug Report](#triaging-a-bug-report)
 * [Resolving a Bug Report](#resolving-a-bug-report)
-
-## How to Contribute in Issues
-
-For any issue, there are fundamentally three ways an individual can
-contribute:
-
-1. By opening the issue for discussion: For instance, if you believe that you
-   have uncovered a bug in Node.js, creating a new issue in the `nodejs/node`
-   issue tracker is the way to report it.
-2. By helping to triage the issue: This can be done either by providing
-   supporting details (a test case that demonstrates a bug), or providing
-   suggestions on how to address the issue.
-3. By helping to resolve the issue: Typically this is done either in the form
-   of demonstrating that the issue reported is not a problem after all, or more
-   often, by opening a Pull Request that changes some bit of something in
-   `nodejs/node` in a concrete and reviewable manner.
 
 ## Asking for General Help
 


### PR DESCRIPTION
Remove "How to Contribute in Issues". This is not Node.js-specific and
is likely to cause many readers to tune out. If we want to include this
kind of how-all-issue-trackers-are-intended-to-work information, let's
link to an external source. But I think it's OK to simply remove it.

Refs: https://github.com/nodejs/TSC/issues/864#issuecomment-628646560

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
