### PR TITLE
src: use BaseObject::kInternalFieldCount in X509Certificate constructor

### DIFF
--- a/src/crypto/crypto_x509.cc
+++ b/src/crypto/crypto_x509.cc
@@ -56,7 +56,8 @@ Local<FunctionTemplate> X509Certificate::GetConstructorTemplate(
   Local<FunctionTemplate> tmpl = env->x509_constructor_template();
   if (tmpl.IsEmpty()) {
     tmpl = FunctionTemplate::New(env->isolate());
-    tmpl->InstanceTemplate()->SetInternalFieldCount(1);
+    tmpl->InstanceTemplate()->SetInternalFieldCount(
+        BaseObject::kInternalFieldCount);
     tmpl->Inherit(BaseObject::GetConstructorTemplate(env));
     tmpl->SetClassName(
         FIXED_ONE_BYTE_STRING(env->isolate(), "X509Certificate"));


### PR DESCRIPTION
Use defined constant instead of hard-coding the field count