### PR TITLE
crypto: fix randomInt bias

### DIFF
--- a/lib/internal/crypto/random.js
+++ b/lib/internal/crypto/random.js
@@ -218,20 +218,20 @@ function randomInt(min, max, callback) {
                                `<= ${RAND_MAX}`, range);
   }
 
-  const excess = RAND_MAX % range;
-  const randLimit = RAND_MAX - excess;
+  // For (x % range) to produce an unbiased value greater than or equal to 0 and
+  // less than range, x must be drawn randomly from the set of integers greater
+  // than or equal to 0 and less than randLimit.
+  const randLimit = RAND_MAX - (RAND_MAX % range);
 
   if (isSync) {
     // Sync API
     while (true) {
       const x = randomBytes(6).readUIntBE(0, 6);
-      // If x > (maxVal - (maxVal % range)), we will get "modulo bias"
-      if (x > randLimit) {
-        // Try again
+      if (x >= randLimit) {
+        // Try again.
         continue;
       }
-      const n = (x % range) + min;
-      return n;
+      return (x % range) + min;
     }
   } else {
     // Async API
@@ -239,9 +239,8 @@ function randomInt(min, max, callback) {
       randomBytes(6, (err, bytes) => {
         if (err) return callback(err);
         const x = bytes.readUIntBE(0, 6);
-        // If x > (maxVal - (maxVal % range)), we will get "modulo bias"
-        if (x > randLimit) {
-          // Try again
+        if (x >= randLimit) {
+          // Try again.
           return pickAttempt();
         }
         const n = (x % range) + min;


### PR DESCRIPTION
@puzpuzpuz found this issue in https://github.com/nodejs/node/pull/35110#discussion_r551034065. Opening a separate PR to make sure this fix can land and be backported quickly, if necessary.

This patch also changes a few comments and definitions to make the necessary conditions easier to understand.

The actual effect of this bias is small, but the mere existence of bias defeats the purpose of this function.

Refs: https://github.com/nodejs/node/pull/34600

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
