### PR TITLE
http: deprecated unnecessary 'upgrade' head argument

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2743,6 +2743,19 @@ Previously, `index.js` and extension searching lookups would apply to
 With this deprecation, all ES module main entry point resolutions require
 an explicit [`"exports"` or `"main"` entry][] with the exact file extension.
 
+<a id="DEPXXX"></a>
+### DEPXXX: `head` removed from `upgrade` event
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/33768
+    description: Documentation-only deprecation.
+ -->
+
+Type: Runtime.
+
+`head` is unshifted into the socket buffer.
+
 [Legacy URL API]: url.md#url_legacy_url_api
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
 [RFC 6066]: https://tools.ietf.org/html/rfc6066#section-3

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2743,8 +2743,7 @@ Previously, `index.js` and extension searching lookups would apply to
 With this deprecation, all ES module main entry point resolutions require
 an explicit [`"exports"` or `"main"` entry][] with the exact file extension.
 
-<a id="DEPXXX"></a>
-### DEPXXX: `head` removed from `upgrade` event
+### DEP0XXX: `head` removed from `upgrade` event
 <!-- YAML
 changes:
   - version: REPLACEME

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2748,11 +2748,11 @@ an explicit [`"exports"` or `"main"` entry][] with the exact file extension.
 <!-- YAML
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/33768
+    pr-url: https://github.com/nodejs/node/pull/36901
     description: Documentation-only deprecation.
  -->
 
-Type: Runtime.
+Type: Documentation-only.
 
 `head` is unshifted into the socket buffer.
 

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -569,11 +569,15 @@ See also: [`request.setTimeout()`][].
 ### Event: `'upgrade'`
 <!-- YAML
 added: v0.1.94
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    description: The `head` argument is deprecated and is always an
+    empty buffer.
 -->
 
 * `response` {http.IncomingMessage}
 * `socket` {stream.Duplex}
-* `head` {Buffer}
 
 Emitted each time a server responds to a request with an upgrade. If this
 event is not being listened for and the response status code is 101 Switching

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -412,13 +412,15 @@ emitted on the first call to `abort()`.
 
 ### Event: `'connect'`
 <!-- YAML
-added: v0.7.0
+added: v0.7.0changes:
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/36901
+    description: The `head` argument is deprecated and is always an
 -->
 
 * `response` {http.IncomingMessage}
 * `socket` {stream.Duplex}
-* `head` {Buffer}
-
 Emitted each time a server responds to a request with a `CONNECT` method. If
 this event is not being listened for, clients receiving a `CONNECT` method will
 have their connections closed.
@@ -1161,12 +1163,15 @@ Emitted when the server closes.
 ### Event: `'connect'`
 <!-- YAML
 added: v0.7.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/36901
+    description: The `head` argument is deprecated and is always an
 -->
 
 * `request` {http.IncomingMessage} Arguments for the HTTP request, as it is in
   the [`'request'`][] event
 * `socket` {stream.Duplex} Network socket between the server and client
-* `head` {Buffer} The first packet of the tunneling stream (may be empty)
 
 Emitted each time a client requests an HTTP `CONNECT` method. If this event is
 not listened for, then clients requesting a `CONNECT` method will have their
@@ -1223,12 +1228,14 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/19981
     description: Not listening to this event no longer causes the socket
                  to be destroyed if a client sends an Upgrade header.
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/36901
+    description: The `head` argument is deprecated and is always an
 -->
 
 * `request` {http.IncomingMessage} Arguments for the HTTP request, as it is in
   the [`'request'`][] event
 * `socket` {stream.Duplex} Network socket between the server and client
-* `head` {Buffer} The first packet of the upgraded stream (may be empty)
 
 Emitted each time a client requests an HTTP upgrade. Listening to this event
 is optional and clients cannot insist on a protocol change.

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -571,9 +571,9 @@ See also: [`request.setTimeout()`][].
 added: v0.1.94
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/36901
     description: The `head` argument is deprecated and is always an
-    empty buffer.
+                 empty buffer.
 -->
 
 * `response` {http.IncomingMessage}

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -412,7 +412,7 @@ emitted on the first call to `abort()`.
 
 ### Event: `'connect'`
 <!-- YAML
-added: v0.7.0changes:
+added: v0.7.0
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/36901

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -417,6 +417,7 @@ changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/36901
     description: The `head` argument is deprecated and is always an
+                 empty Buffer.
 -->
 
 * `response` {http.IncomingMessage}
@@ -1167,6 +1168,7 @@ changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/36901
     description: The `head` argument is deprecated and is always an
+                 empty Buffer.
 -->
 
 * `request` {http.IncomingMessage} Arguments for the HTTP request, as it is in
@@ -1231,6 +1233,7 @@ changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/36901
     description: The `head` argument is deprecated and is always an
+                 empty Buffer.
 -->
 
 * `request` {http.IncomingMessage} Arguments for the HTTP request, as it is in

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -576,7 +576,7 @@ changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/36901
     description: The `head` argument is deprecated and is always an
-                 empty buffer.
+                 empty Buffer.
 -->
 
 * `response` {http.IncomingMessage}

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1226,14 +1226,14 @@ per connection (in the case of HTTP Keep-Alive connections).
 <!-- YAML
 added: v0.1.94
 changes:
-  - version: v10.0.0
-    pr-url: https://github.com/nodejs/node/pull/19981
-    description: Not listening to this event no longer causes the socket
-                 to be destroyed if a client sends an Upgrade header.
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/36901
     description: The `head` argument is deprecated and is always an
                  empty Buffer.
+  - version: v10.0.0
+    pr-url: https://github.com/nodejs/node/pull/19981
+    description: Not listening to this event no longer causes the socket
+                 to be destroyed if a client sends an Upgrade header.
 -->
 
 * `request` {http.IncomingMessage} Arguments for the HTTP request, as it is in

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -598,7 +598,7 @@ const server = http.createServer((req, res) => {
   res.writeHead(200, { 'Content-Type': 'text/plain' });
   res.end('okay');
 });
-server.on('upgrade', (req, socket, head) => {
+server.on('upgrade', (req, socket) => {
   socket.write('HTTP/1.1 101 Web Socket Protocol Handshake\r\n' +
                'Upgrade: WebSocket\r\n' +
                'Connection: Upgrade\r\n' +
@@ -623,7 +623,7 @@ server.listen(1337, '127.0.0.1', () => {
   const req = http.request(options);
   req.end();
 
-  req.on('upgrade', (res, socket, upgradeHead) => {
+  req.on('upgrade', (res, socket) => {
     console.log('got upgraded!');
     socket.end();
     process.exit(0);

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -79,6 +79,8 @@ const {
 
 const { addAbortSignal, finished } = require('stream');
 
+const EMPTY_BUF = Buffer.alloc(0);
+
 const INVALID_PATH_REGEX = /[^\u0021-\u00ff]/;
 const kError = Symbol('kError');
 
@@ -525,7 +527,11 @@ function socketOnData(d) {
       socket._httpMessage = null;
       socket.readableFlowing = null;
 
-      req.emit(eventName, res, socket, bodyHead);
+      if (bodyHead.length) {
+        socket.unshift(bodyHead);
+      }
+
+      req.emit(eventName, res, socket, EMPTY_BUF);
       req.destroyed = true;
       req._closed = true;
       req.emit('close');

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -717,10 +717,12 @@ function onParserExecuteCommon(server, socket, parser, state, ret, d) {
 
       socket.readableFlowing = null;
 
+      socket.unshift(bodyHead);
+
       // Clear the requestTimeout after upgrading the connection.
       clearRequestTimeout(req);
 
-      server.emit(eventName, req, socket, bodyHead);
+      server.emit(eventName, req, socket, Buffer.alloc(0));
     } else {
       // Got CONNECT method, but have no handler.
       socket.destroy();

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -166,6 +166,8 @@ const STATUS_CODES = {
   511: 'Network Authentication Required' // RFC 6585 6
 };
 
+const EMPTY_BUF = Buffer.alloc(0);
+
 const kOnMessageBegin = HTTPParser.kOnMessageBegin | 0;
 const kOnExecute = HTTPParser.kOnExecute | 0;
 const kOnTimeout = HTTPParser.kOnTimeout | 0;
@@ -717,12 +719,14 @@ function onParserExecuteCommon(server, socket, parser, state, ret, d) {
 
       socket.readableFlowing = null;
 
-      if (bodyHead.length > 0) socket.unshift(bodyHead);
+      if (bodyHead.length) {
+        socket.unshift(bodyHead);
+      }
 
       // Clear the requestTimeout after upgrading the connection.
       clearRequestTimeout(req);
 
-      server.emit(eventName, req, socket, Buffer.alloc(0));
+      server.emit(eventName, req, socket, EMPTY_BUF);
     } else {
       // Got CONNECT method, but have no handler.
       socket.destroy();

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -717,7 +717,7 @@ function onParserExecuteCommon(server, socket, parser, state, ret, d) {
 
       socket.readableFlowing = null;
 
-      socket.unshift(bodyHead);
+      if (bodyHead.length > 0) socket.unshift(bodyHead);
 
       // Clear the requestTimeout after upgrading the connection.
       clearRequestTimeout(req);

--- a/test/parallel/test-http-connect-req-res.js
+++ b/test/parallel/test-http-connect-req-res.js
@@ -55,7 +55,7 @@ server.listen(0, common.mustCall(function() {
     let data = firstBodyChunk.toString();
 
     // Test that the firstBodyChunk was not parsed as HTTP
-    assert.strictEqual(data, 'Head');
+    assert.strictEqual(data, '');
 
     socket.on('data', function(buf) {
       data += buf.toString();

--- a/test/parallel/test-http-upgrade-binary.js
+++ b/test/parallel/test-http-upgrade-binary.js
@@ -21,7 +21,8 @@ net.createServer(mustCall(function(conn) {
     port: this.address().port,
     headers: { 'Connection': 'upgrade', 'Upgrade': 'websocket' },
   }).on('upgrade', mustCall((res, conn, head) => {
-    assert.strictEqual(head.length, 1);
+    assert.strictEqual(head.length, 0);
+    head = conn.read(1);
     assert.strictEqual(head[0], 128);
     conn.destroy();
   }));

--- a/test/parallel/test-http-upgrade-client2.js
+++ b/test/parallel/test-http-upgrade-client2.js
@@ -52,7 +52,7 @@ server.listen(0, common.mustCall(function() {
       wasUpgrade = true;
 
       request.removeListener('upgrade', onUpgrade);
-      socket.end();
+      socket.destroy();
     }
     request.on('upgrade', onUpgrade);
 

--- a/test/parallel/test-http-upgrade-client2.js
+++ b/test/parallel/test-http-upgrade-client2.js
@@ -52,8 +52,7 @@ server.listen(0, common.mustCall(function() {
       wasUpgrade = true;
 
       request.removeListener('upgrade', onUpgrade);
-      socket.end();
-      socket.on('data', common.mustCall());
+      socket.destroy();
     }
     request.on('upgrade', onUpgrade);
 

--- a/test/parallel/test-http-upgrade-client2.js
+++ b/test/parallel/test-http-upgrade-client2.js
@@ -52,7 +52,8 @@ server.listen(0, common.mustCall(function() {
       wasUpgrade = true;
 
       request.removeListener('upgrade', onUpgrade);
-      socket.destroy();
+      socket.end();
+      socket.resume();
     }
     request.on('upgrade', onUpgrade);
 

--- a/test/parallel/test-http-upgrade-client2.js
+++ b/test/parallel/test-http-upgrade-client2.js
@@ -53,7 +53,7 @@ server.listen(0, common.mustCall(function() {
 
       request.removeListener('upgrade', onUpgrade);
       socket.end();
-      socket.resume();
+      socket.on('data', common.mustCall());
     }
     request.on('upgrade', onUpgrade);
 

--- a/test/parallel/test-http-upgrade-server.js
+++ b/test/parallel/test-http-upgrade-server.js
@@ -103,6 +103,8 @@ function test_upgrade_with_listener() {
     } else if (state === 2) {
       buf += data;
       conn.write('kill', 'utf8');
+    } else {
+      buf += data;
     }
   });
 

--- a/test/parallel/test-http-upgrade-server.js
+++ b/test/parallel/test-http-upgrade-server.js
@@ -100,7 +100,7 @@ function test_upgrade_with_listener() {
 
     if (state === 1) {
       assert.strictEqual(data.substr(0, 12), 'HTTP/1.1 101');
-      assert.strictEqual(request_upgradeHead.toString('utf8'), 'WjN}|M(6');
+      assert.strictEqual(request_upgradeHead.toString('utf8'), '');
       conn.write('test', 'utf8');
     } else if (state === 2) {
       assert.strictEqual(data, 'test');

--- a/test/parallel/test-http-upgrade-server.js
+++ b/test/parallel/test-http-upgrade-server.js
@@ -100,7 +100,6 @@ function test_upgrade_with_listener() {
 
     if (state === 1) {
       assert.strictEqual(data.substr(0, 12), 'HTTP/1.1 101');
-      assert.strictEqual(request_upgradeHead.toString('utf8'), '');
       conn.write('test', 'utf8');
     } else if (state === 2) {
       assert.strictEqual(data, 'test');


### PR DESCRIPTION
The head argument for 'upgrade' is unnecessary and the corresponding
data can simply be unshifted back into the socket buffer.

Always provide an empty Buffer for backwards compat.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
