### PR TITLE
process: runtime deprecate changing process.config

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2712,11 +2712,15 @@ Type: Documentation-only.
 
 Prefer [`message.socket`][] over [`message.connection`][].
 
-<a id="DEP0XXX"></a>
 ### DEP0XXX: Changing the value of `process.config`
 <!-- YAML
-added: REPLACEME
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/36902
+    description: Runtime deprecation.
 -->
+
+Type: Runtime
 
 The `process.config` property is intended to provide access to configuration
 settings set when the Node.js binary was compiled. However, the property has

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2712,6 +2712,17 @@ Type: Documentation-only.
 
 Prefer [`message.socket`][] over [`message.connection`][].
 
+<a id="DEP0XXX"></a>
+### DEP0XXX: Changing the value of `process.config`
+<!-- YAML
+added: REPLACEME
+-->
+
+The `process.config` property is intended to provide access to configuration
+settings set when the Node.js binary was compiled. However, the property has
+been mutable by user code making it impossible to rely on. The ability to
+change the value has been deprecated and will be disabled in the future.
+
 [Legacy URL API]: url.md#url_legacy_url_api
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
 [RFC 6066]: https://tools.ietf.org/html/rfc6066#section-3

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -759,6 +759,10 @@ This feature is not available in [`Worker`][] threads.
 ## `process.config`
 <!-- YAML
 added: v0.7.7
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/36902
+    description: Modifying process.config has been deprecated.
 -->
 
 * {Object}
@@ -802,6 +806,10 @@ An example of the possible output looks like:
 The `process.config` property is **not** read-only and there are existing
 modules in the ecosystem that are known to extend, modify, or entirely replace
 the value of `process.config`.
+
+Modifying the `process.config` property, or any child-property of the
+`process.config` object has been deprecated. The `process.config` will be made
+read-only in a future release.
 
 ## `process.connected`
 <!-- YAML

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -43,7 +43,10 @@ const {
   JSONParse,
   ObjectDefineProperty,
   ObjectGetPrototypeOf,
+  ObjectPreventExtensions,
   ObjectSetPrototypeOf,
+  ReflectGet,
+  ReflectSet,
   SymbolToStringTag,
 } = primordials;
 const config = internalBinding('config');
@@ -61,19 +64,70 @@ process._exiting = false;
 const nativeModule = internalBinding('native_module');
 
 // TODO(@jasnell): Once this has gone through one full major
-// release cycle, remove the setter and update the getter to
-// either return a read-only object or always return a freshly
-// parsed version of nativeModule.config.
-let processConfig = JSONParse(nativeModule.config);
+// release cycle, remove the Proxy and setter and update the
+// getter to either return a read-only object or always return
+// a freshly parsed version of nativeModule.config.
+
+const deprecationHandler = {
+  warned: false,
+  message: 'Setting process.config is deprecated. ' +
+           'In the future the property will be read-only.',
+  code: 'DEP0XXX',
+  maybeWarn() {
+    if (!this.warned) {
+      process.emitWarning(this.message, {
+        type: 'DeprecationWarning',
+        code: this.code
+      });
+      this.warned = true;
+    }
+  },
+
+  defineProperty(target, key, descriptor) {
+    this.maybeWarn();
+    return ObjectDefineProperty(target, key, descriptor);
+  },
+
+  deleteProperty(target, key) {
+    this.maybeWarn();
+    delete target[key];
+  },
+
+  preventExtensions(target) {
+    this.maybeWarn();
+    return ObjectPreventExtensions(target);
+  },
+
+  set(target, key, value) {
+    this.maybeWarn();
+    return ReflectSet(target, key, value);
+  },
+
+  get(target, key, receiver) {
+    const val = ReflectGet(target, key, receiver);
+    if (val != null && typeof val === 'object')
+      return new Proxy(val, deprecationHandler);
+    return val;
+  },
+
+  setPrototypeOf(target, proto) {
+    this.maybeWarn();
+    return ObjectSetPrototypeOf(target, proto);
+  }
+};
+
+let processConfig = new Proxy(
+  JSONParse(nativeModule.config),
+  deprecationHandler);
+
 ObjectDefineProperty(process, 'config', {
   enumerable: true,
   configurable: true,
   get() { return processConfig; },
-  set: deprecate(
-    (value) => { processConfig = value; },
-    'Setting process.config is deprecated. ' +
-    'In the future the property will be read-only.',
-    'DEP0XXX')
+  set(value) {
+    deprecationHandler.maybeWarn();
+    processConfig = value;
+  }
 });
 
 require('internal/worker/js_transferable').setup();

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -59,7 +59,23 @@ process._exiting = false;
 
 // process.config is serialized config.gypi
 const nativeModule = internalBinding('native_module');
-process.config = JSONParse(nativeModule.config);
+
+// TODO(@jasnell): Once this has gone through one full major
+// release cycle, remove the setter and update the getter to
+// either return a read-only object or always return a freshly
+// parsed version of nativeModule.config.
+let processConfig = JSONParse(nativeModule.config);
+ObjectDefineProperty(process, 'config', {
+  enumerable: true,
+  configurable: true,
+  get() { return processConfig; },
+  set: deprecate(
+    (value) => { processConfig = value; },
+    'Setting process.config is deprecated. ' +
+    'In the future the property will be read-only.',
+    'DEP0XXX')
+});
+
 require('internal/worker/js_transferable').setup();
 
 // Bootstrappers for all threads, including worker threads and main thread


### PR DESCRIPTION
The fact that `process.config` is mutable has long made it
unreliable when it really should just work. Start the process
of deprecating the ability to change it.

Fixes: https://github.com/nodejs/node/issues/7803
Signed-off-by: James M Snell <jasnell@gmail.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
