### PR TITLE
doc: remove resolving-a-bug-report from contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,6 @@ See [details on our policy on Code of Conduct](./doc/guides/contributing/code-of
 * [Discussing non-technical topics](./doc/guides/contributing/issues.md#discussing-non-technical-topics)
 * [Submitting a Bug Report](./doc/guides/contributing/issues.md#submitting-a-bug-report)
 * [Triaging a Bug Report](./doc/guides/contributing/issues.md#triaging-a-bug-report)
-* [Resolving a Bug Report](./doc/guides/contributing/issues.md#resolving-a-bug-report)
 
 ## [Pull Requests](./doc/guides/contributing/pull-requests.md)
 

--- a/doc/guides/contributing/issues.md
+++ b/doc/guides/contributing/issues.md
@@ -4,7 +4,6 @@
 * [Discussing non-technical topics](#discussing-non-technical-topics)
 * [Submitting a Bug Report](#submitting-a-bug-report)
 * [Triaging a Bug Report](#triaging-a-bug-report)
-* [Resolving a Bug Report](#resolving-a-bug-report)
 
 ## Asking for General Help
 
@@ -87,14 +86,6 @@ The triage role enables the ability to carry out the most common triage
 activities, such as applying labels and closing/reopening/assigning issues.
 For more information on the roles and permissions, see ["Permission levels for
 repositories owned by an organization"](https://docs.github.com/en/github/setting-up-and-managing-organizations-and-teams/repository-permission-levels-for-an-organization#permission-levels-for-repositories-owned-by-an-organization).
-
-## Resolving a Bug Report
-
-In the vast majority of cases, issues are resolved by opening a Pull Request.
-The process for opening and reviewing a Pull Request is similar to that of
-opening and triaging issues, but carries with it a necessary review and approval
-workflow that ensures that the proposed changes meet the minimal quality and
-functional guidelines of the Node.js project.
 
 [Node.js help repository]: https://github.com/nodejs/help/issues
 [Technical Steering Committee (TSC) repository]: https://github.com/nodejs/TSC/issues


### PR DESCRIPTION
This section isn't particularly useful in this context and contributes
to making the document longer and less effective. This is part of a
larger effort to make the contributing docs brief, informative, and
friendly.

Refs: https://github.com/nodejs/TSC/issues/864#issuecomment-628646560

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
