### PR TITLE
doc: remove issue template duplication from contributing docs

### DIFF
--- a/doc/guides/contributing/issues.md
+++ b/doc/guides/contributing/issues.md
@@ -19,37 +19,10 @@ should be directed to the [Technical Steering Committee (TSC) repository][].
 ## Submitting a Bug Report
 
 When opening a new issue in the `nodejs/node` issue tracker, users will be
-presented with a basic template that should be filled in.
-
-```markdown
-<!--
-Thank you for reporting an issue.
-
-This issue tracker is for bugs and issues found within Node.js core.
-If you require more general support please file an issue on our help
-repo. https://github.com/nodejs/help
-
-
-Please fill in as much of the template below as you're able.
-
-Version: output of `node -v`
-Platform: output of `uname -a` (UNIX), or version and 32 or 64-bit (Windows)
-Subsystem: if known, please specify affected core module name
-
-If possible, please provide code that demonstrates the problem, keeping it as
-simple and free of external dependencies as you are able.
--->
-
-* **Version**:
-* **Platform**:
-* **Subsystem**:
-
-<!-- Enter your issue details below this comment. -->
-```
-
-If you believe that you have uncovered a bug in Node.js, please fill out this
-form, following the template to the best of your ability. Do not worry if you
-cannot answer every detail, just fill in what you can.
+presented with a choice of issue templates. If you believe that you have
+uncovered a bug in Node.js, please fill out the `Bug Report` template to the
+best of your ability. Do not worry if you cannot answer every detail; just fill
+in what you can.
 
 The two most important pieces of information we need in order to properly
 evaluate the report is a description of the behavior you are seeing and a simple


### PR DESCRIPTION
The replicated issue template is out of date. There isn't much reason to
replicate it here anyway, so let's remove it and describe what the user
should do briefly.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
