### PR TITLE
test: fix variable name for non-RSA keys

### DIFF
--- a/test/parallel/test-webcrypto-sign-verify-rsa.js
+++ b/test/parallel/test-webcrypto-sign-verify-rsa.js
@@ -23,7 +23,7 @@ async function testVerify({
     noVerifyPublicKey,
     privateKey,
     hmacKey,
-    rsaKeys
+    ecdsaKeys
   ] = await Promise.all([
     subtle.importKey(
       'spki',
@@ -85,7 +85,7 @@ async function testVerify({
     });
 
   await assert.rejects(
-    subtle.verify(algorithm, rsaKeys.publicKey, signature, plaintext), {
+    subtle.verify(algorithm, ecdsaKeys.publicKey, signature, plaintext), {
       message: /Unable to use this key to verify/
     });
 
@@ -138,7 +138,7 @@ async function testSign({
     noSignPrivateKey,
     privateKey,
     hmacKey,
-    rsaKeys,
+    ecdsaKeys
   ] = await Promise.all([
     subtle.importKey(
       'spki',
@@ -205,7 +205,7 @@ async function testSign({
     });
 
   await assert.rejects(
-    subtle.sign(algorithm, rsaKeys.privateKey, plaintext), {
+    subtle.sign(algorithm, ecdsaKeys.privateKey, plaintext), {
       message: /Unable to use this key to sign/
     });
 }


### PR DESCRIPTION
The point here is that the keys are _not_ RSA keys, so the variable name `rsaKeys` is misleading/wrong. These ECDSA keys are used to test that the RSA algorithm rejects non-RSA keys.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
