### PR TITLE
doc: add alternative version links to the packages page

### DIFF
--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -1,5 +1,6 @@
 # Modules: Packages
 
+<!--introduced_in=v12.20.0-->
 <!-- type=misc -->
 <!-- YAML
 changes:


### PR DESCRIPTION
This adds the `View another version ▼` dropdown to `/api/packages.html`. It was introduced in v14.13.0 and then backported to v12.20.0