### PR TITLE
doc: fixup http.IncomingMessage deprecation code

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2699,8 +2699,7 @@ resolutions not in `node_modules`. This means there will not be deprecation
 warnings for `"exports"` in dependencies. With `--pending-deprecation`, a
 runtime warning results no matter where the `"exports"` usage occurs.
 
-<a id="DEP0148"></a>
-### DEP0148: `http.IncomingMessage#connection`
+### DEP0149: `http.IncomingMessage#connection`
 <!-- YAML
 changes:
   - version: REPLACEME


### PR DESCRIPTION
The merge in https://github.com/nodejs/node/commit/5ae5ca90effa17a5800ee2ea76429caf03199f3e had a conflict with the previously merged deprecation. This fixes up the code and removes the `<a>` tag for consistent formatting with other deprecations as well.
