### PR TITLE
module: deprecate "main" index and extension lookups

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2724,21 +2724,22 @@ settings set when the Node.js binary was compiled. However, the property has
 been mutable by user code making it impossible to rely on. The ability to
 change the value has been deprecated and will be disabled in the future.
 
-### DEP0150: Folder index for "type": "module"
+### DEP0XXX: Main index lookup and extension searching
+
 <!-- YAML
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/36918
-    description: Runtime deprecation.
+    description: Documentation-only deprecation.
 -->
 
 Type: Documentation (supports [`--pending-deprecation`][])
 
-Previously, `index.js` lookup would apply for `require('pkg')` even for packages
-with a `"type": "module"` field in their package.json
+Previously, `index.js` and extension searching lookups would apply to
+`import 'pkg'` main entry point resolution, even when resolving ES modules.
 
-With this deprecation, all packages with `"type": "module"` require an explicit
-`"exports"` field entry point to resolve for the main.
+With this deprecation, all ES module main entry point resolutions require
+an explicit `"exports"` or `"main"` entry with the exact file extension.
 
 
 [Legacy URL API]: url.md#url_legacy_url_api

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2727,7 +2727,6 @@ been mutable by user code making it impossible to rely on. The ability to
 change the value has been deprecated and will be disabled in the future.
 
 ### DEP0XXX: Main index lookup and extension searching
-
 <!-- YAML
 changes:
   - version: REPLACEME

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2750,6 +2750,7 @@ an explicit [`"exports" or "main" entry`] with the exact file extension.
 [`--pending-deprecation`]: cli.md#cli_pending_deprecation
 [`--throw-deprecation`]: cli.md#cli_throw_deprecation
 [`--unhandled-rejections`]: cli.md#cli_unhandled_rejections_mode
+[`"exports" or "main" entry`]: packages.md#packages_main_entry_point_export
 [`Buffer.allocUnsafeSlow(size)`]: buffer.md#buffer_static_method_buffer_allocunsafeslow_size
 [`Buffer.from(array)`]: buffer.md#buffer_static_method_buffer_from_array
 [`Buffer.from(buffer)`]: buffer.md#buffer_static_method_buffer_from_buffer
@@ -2785,7 +2786,6 @@ an explicit [`"exports" or "main" entry`] with the exact file extension.
 [`ecdh.setPublicKey()`]: crypto.md#crypto_ecdh_setpublickey_publickey_encoding
 [`emitter.listenerCount(eventName)`]: events.md#events_emitter_listenercount_eventname
 [`events.listenerCount(emitter, eventName)`]: events.md#events_events_listenercount_emitter_eventname
-[`"exports" or "main" entry`]: packages.md#packages_main_entry_point_export
 [`fs.FileHandle`]: fs.md#fs_class_filehandle
 [`fs.access()`]: fs.md#fs_fs_access_path_mode_callback
 [`fs.createReadStream()`]: fs.md#fs_fs_createreadstream_path_options

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2742,7 +2742,6 @@ Previously, `index.js` and extension searching lookups would apply to
 With this deprecation, all ES module main entry point resolutions require
 an explicit [`"exports"` or `"main"` entry][] with the exact file extension.
 
-
 [Legacy URL API]: url.md#url_legacy_url_api
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
 [RFC 6066]: https://tools.ietf.org/html/rfc6066#section-3

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2732,7 +2732,7 @@ changes:
     description: Runtime deprecation.
 -->
 
-Type: Runtime
+Type: Documentation (supports [`--pending-deprecation`][])
 
 Previously, `index.js` lookup would apply for `require('pkg')` even for packages
 with a `"type": "module"` field in their package.json

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2719,7 +2719,7 @@ changes:
     description: Runtime deprecation.
 -->
 
-Type: Runtime.
+Type: Runtime
 
 The `process.config` property is intended to provide access to configuration
 settings set when the Node.js binary was compiled. However, the property has

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2719,6 +2719,8 @@ changes:
     description: Runtime deprecation.
 -->
 
+Type: Runtime.
+
 The `process.config` property is intended to provide access to configuration
 settings set when the Node.js binary was compiled. However, the property has
 been mutable by user code making it impossible to rely on. The ability to

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2740,7 +2740,7 @@ Previously, `index.js` and extension searching lookups would apply to
 `import 'pkg'` main entry point resolution, even when resolving ES modules.
 
 With this deprecation, all ES module main entry point resolutions require
-an explicit [`"exports"`][] or [`"main"`][] entry with the exact file extension.
+an explicit [`"exports" or "main" entry`] with the exact file extension.
 
 
 [Legacy URL API]: url.md#url_legacy_url_api
@@ -2785,6 +2785,7 @@ an explicit [`"exports"`][] or [`"main"`][] entry with the exact file extension.
 [`ecdh.setPublicKey()`]: crypto.md#crypto_ecdh_setpublickey_publickey_encoding
 [`emitter.listenerCount(eventName)`]: events.md#events_emitter_listenercount_eventname
 [`events.listenerCount(emitter, eventName)`]: events.md#events_events_listenercount_emitter_eventname
+[`"exports" or "main" entry`]: packages.md#packages_main_entry_point_export
 [`fs.FileHandle`]: fs.md#fs_class_filehandle
 [`fs.access()`]: fs.md#fs_fs_access_path_mode_callback
 [`fs.createReadStream()`]: fs.md#fs_fs_createreadstream_path_options
@@ -2869,7 +2870,7 @@ an explicit [`"exports"`][] or [`"main"`][] entry with the exact file extension.
 [from_string_encoding]: buffer.md#buffer_static_method_buffer_from_string_encoding
 [legacy `urlObject`]: url.md#url_legacy_urlobject
 [static methods of `crypto.Certificate()`]: crypto.md#crypto_class_certificate
-[subpath exports]: #packages_subpath_exports
-[subpath folder mappings]: #packages_subpath_folder_mappings
-[subpath imports]: #packages_subpath_imports
-[subpath patterns]: #packages_subpath_patterns
+[subpath exports]: packages.md#packages_subpath_exports
+[subpath folder mappings]: packages.md#packages_subpath_folder_mappings
+[subpath imports]: packages.md#packages_subpath_imports
+[subpath patterns]: packages.md#packages_subpath_patterns

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2728,7 +2728,7 @@ change the value has been deprecated and will be disabled in the future.
 <!-- YAML
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/36918
     description: Runtime deprecation.
 -->
 

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2730,16 +2730,17 @@ change the value has been deprecated and will be disabled in the future.
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/36918
-    description: Documentation-only deprecation.
+    description: Documentation-only deprecation
+                 with `--pending-deprecation` support.
 -->
 
-Type: Documentation (supports [`--pending-deprecation`][])
+Type: Documentation-only (supports [`--pending-deprecation`][])
 
 Previously, `index.js` and extension searching lookups would apply to
 `import 'pkg'` main entry point resolution, even when resolving ES modules.
 
 With this deprecation, all ES module main entry point resolutions require
-an explicit `"exports"` or `"main"` entry with the exact file extension.
+an explicit [`"exports"`][] or [`"main"`][] entry with the exact file extension.
 
 
 [Legacy URL API]: url.md#url_legacy_url_api

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2719,12 +2719,27 @@ changes:
     description: Runtime deprecation.
 -->
 
-Type: Runtime
-
 The `process.config` property is intended to provide access to configuration
 settings set when the Node.js binary was compiled. However, the property has
 been mutable by user code making it impossible to rely on. The ability to
 change the value has been deprecated and will be disabled in the future.
+
+### DEP0150: Folder index for "type": "module"
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    description: Runtime deprecation.
+-->
+
+Type: Runtime
+
+Previously, `index.js` lookup would apply for `require('pkg')` even for packages
+with a `"type": "module"` field in their package.json
+
+With this deprecation, all packages with `"type": "module"` require an explicit
+`"exports"` field entry point to resolve for the main.
+
 
 [Legacy URL API]: url.md#url_legacy_url_api
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2740,17 +2740,17 @@ Previously, `index.js` and extension searching lookups would apply to
 `import 'pkg'` main entry point resolution, even when resolving ES modules.
 
 With this deprecation, all ES module main entry point resolutions require
-an explicit [`"exports" or "main" entry`] with the exact file extension.
+an explicit [`"exports"` or `"main"` entry][] with the exact file extension.
 
 
 [Legacy URL API]: url.md#url_legacy_url_api
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
 [RFC 6066]: https://tools.ietf.org/html/rfc6066#section-3
 [WHATWG URL API]: url.md#url_the_whatwg_url_api
+[`"exports"` or `"main"` entry]: packages.md#packages_main_entry_point_export
 [`--pending-deprecation`]: cli.md#cli_pending_deprecation
 [`--throw-deprecation`]: cli.md#cli_throw_deprecation
 [`--unhandled-rejections`]: cli.md#cli_unhandled_rejections_mode
-[`"exports" or "main" entry`]: packages.md#packages_main_entry_point_export
 [`Buffer.allocUnsafeSlow(size)`]: buffer.md#buffer_static_method_buffer_allocunsafeslow_size
 [`Buffer.from(array)`]: buffer.md#buffer_static_method_buffer_from_array
 [`Buffer.from(buffer)`]: buffer.md#buffer_static_method_buffer_from_buffer

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -1086,9 +1086,6 @@ The resolver can throw the following errors:
 >          **PACKAGE_EXPORTS_RESOLVE**(_packageURL_, _packageSubpath_,
 >           _pjson.exports_, _defaultConditions_).
 >    1. Otherwise, if _packageSubpath_ is equal to _"."_, then
->       1. If _pjson_ is not **null** and _pjson_._type_ is equal to _"module"_,
->          then,
->          1. Throw a _Package Path Not Exports_ error.
 >       1. Return the result applying the legacy **LOAD_AS_DIRECTORY**
 >          CommonJS resolver to _packageURL_, throwing a _Module Not Found_
 >          error for no resolution.

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -1086,6 +1086,9 @@ The resolver can throw the following errors:
 >          **PACKAGE_EXPORTS_RESOLVE**(_packageURL_, _packageSubpath_,
 >           _pjson.exports_, _defaultConditions_).
 >    1. Otherwise, if _packageSubpath_ is equal to _"."_, then
+>       1. If _pjson_ is not **null** and _pjson_._type_ is equal to _"module"_,
+>          then,
+>          1. Throw a _Package Path Not Exports_ error.
 >       1. Return the result applying the legacy **LOAD_AS_DIRECTORY**
 >          CommonJS resolver to _packageURL_, throwing a _Module Not Found_
 >          error for no resolution.

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -103,17 +103,18 @@ function emitLegacyIndexDeprecation(url, packageJSONUrl, base, main) {
     process.emitWarning(
       `Package ${pkgPath} has a "main" field set to ${JSONStringify(main)}, ` +
       `excluding the full filename and extension to the resolved file at "${
-        StringPrototypeSlice(path, pkgPath.length)}", imported from ${basePath}.\n Automatic ` +
-      'extension resolution of the "main" field is deprecated for ES modules.',
+        StringPrototypeSlice(path, pkgPath.length)}", imported from ${
+        basePath}.\n Automatic extension resolution of the "main" field is` +
+      'deprecated for ES modules.',
       'DeprecationWarning',
       'DEP0150'
     );
   else
     process.emitWarning(
       `No "main" or "exports" field defined in the package.json for ${pkgPath
-      } resolving the main entry point "${StringPrototypeSlice(path, pkgPath.length)}", ` +
-      `imported from ${basePath}.\nDefault "index" lookups for the main are ` +
-      'deprecated for explicit definitions.',
+      } resolving the main entry point "${
+        StringPrototypeSlice(path, pkgPath.length)}", imported from ${basePath
+      }.\nDefault "index" lookups for the main are deprecated for ES modules.`,
       'DeprecationWarning',
       'DEP0150'
     );

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -90,6 +90,16 @@ function emitFolderMapDeprecation(match, pjsonUrl, isExports, base) {
   );
 }
 
+function emitLegacyIndexTypeModuleDeprecation(packageJSONUrl, base) {
+  const pkgPath = fileURLToPath(new URL('.', packageJSONUrl));
+  const basePath = fileURLToPath(base);
+  process.emitWarning(
+    `Package ${pkgPath} has a "type": "module" field in its package.json, but` +
+    ` does not define an "exports" field, imported from ${basePath}.\nLegacy ` +
+    'main resolution lookups are deprecated for packages with "type": "module".'
+  );
+}
+
 function getConditionsSet(conditions) {
   if (conditions !== undefined && conditions !== DEFAULT_CONDITIONS) {
     if (!ArrayIsArray(conditions)) {
@@ -681,8 +691,11 @@ function packageResolve(specifier, base, conditions) {
       return packageExportsResolve(
         packageJSONUrl, packageSubpath, packageConfig, base, conditions
       ).resolved;
-    if (packageSubpath === '.')
+    if (packageSubpath === '.') {
+      if (packageConfig.type === 'module')
+        emitLegacyIndexTypeModuleDeprecation(packageJSONUrl, base);
       return legacyMainResolve(packageJSONUrl, packageConfig, base);
+    }
     return new URL(packageSubpath, packageJSONUrl);
     // Cross-platform root check.
   } while (packageJSONPath.length !== lastPath.length);

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -104,14 +104,18 @@ function emitLegacyIndexDeprecation(url, packageJSONUrl, base, main) {
       `Package ${pkgPath} has a "main" field set to ${JSONStringify(main)}, ` +
       `excluding the full extension to the resolved file at "${
         path.slice(pkgPath.length)}", imported from ${basePath}.\n Automatic ` +
-      'extension resolution of the "main" field is deprecated for ES modules.'
+      'extension resolution of the "main" field is deprecated for ES modules.',
+      'DeprecationWarning',
+      'DEP0150'
     );
   else
     process.emitWarning(
       `No "main" or "exports" field defined in the package.json for ${pkgPath
       } resolving the main entry point "${path.slice(pkgPath.length)}", ` +
       `imported from ${basePath}.\nDefault "index" lookups for the main are ` +
-      'deprecated for explicit definitions.'
+      'deprecated for explicit definitions.',
+      'DeprecationWarning',
+      'DEP0150'
     );
 }
 

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -90,16 +90,29 @@ function emitFolderMapDeprecation(match, pjsonUrl, isExports, base) {
   );
 }
 
-function emitLegacyIndexTypeModuleDeprecation(packageJSONUrl, base) {
+function emitLegacyIndexDeprecation(url, packageJSONUrl, base, main) {
   if (!pendingDeprecation)
     return;
+  const { format } = defaultGetFormat(url);
+  if (format !== 'module')
+    return;
+  const path = fileURLToPath(url);
   const pkgPath = fileURLToPath(new URL('.', packageJSONUrl));
   const basePath = fileURLToPath(base);
-  process.emitWarning(
-    `Package ${pkgPath} has a "type": "module" field in its package.json, but` +
-    ` does not define an "exports" field, imported from ${basePath}.\nLegacy ` +
-    'main resolution lookups are deprecated for packages with "type": "module".'
-  );
+  if (main)
+    process.emitWarning(
+      `Package ${pkgPath} has a "main" field set to ${JSONStringify(main)}, ` +
+      `excluding the full extension to the resolved file at "${
+        path.slice(pkgPath.length)}", imported from ${basePath}.\n Automatic ` +
+      'extension resolution of the "main" field is deprecated for ES modules.'
+    );
+  else
+    process.emitWarning(
+      `No "main" or "exports" field defined in the package.json for ${pkgPath
+      } resolving the main entry point "${path.slice(pkgPath.length)}", ` +
+      `imported from ${basePath}.\nDefault "index" lookups for the main are ` +
+      'deprecated for explicit definitions.'
+    );
 }
 
 function getConditionsSet(conditions) {
@@ -221,41 +234,33 @@ function legacyMainResolve(packageJSONUrl, packageConfig, base) {
     if (fileExists(guess = new URL(`./${packageConfig.main}`,
                                    packageJSONUrl))) {
       return guess;
-    }
-    if (fileExists(guess = new URL(`./${packageConfig.main}.js`,
-                                   packageJSONUrl))) {
-      return guess;
-    }
-    if (fileExists(guess = new URL(`./${packageConfig.main}.json`,
-                                   packageJSONUrl))) {
-      return guess;
-    }
-    if (fileExists(guess = new URL(`./${packageConfig.main}.node`,
-                                   packageJSONUrl))) {
-      return guess;
-    }
-    if (fileExists(guess = new URL(`./${packageConfig.main}/index.js`,
-                                   packageJSONUrl))) {
-      return guess;
-    }
-    if (fileExists(guess = new URL(`./${packageConfig.main}/index.json`,
-                                   packageJSONUrl))) {
-      return guess;
-    }
-    if (fileExists(guess = new URL(`./${packageConfig.main}/index.node`,
-                                   packageJSONUrl))) {
+    } else if (fileExists(guess = new URL(`./${packageConfig.main}.js`,
+                                          packageJSONUrl)));
+    else if (fileExists(guess = new URL(`./${packageConfig.main}.json`,
+                                        packageJSONUrl)));
+    else if (fileExists(guess = new URL(`./${packageConfig.main}.node`,
+                                        packageJSONUrl)));
+    else if (fileExists(guess = new URL(`./${packageConfig.main}/index.js`,
+                                        packageJSONUrl)));
+    else if (fileExists(guess = new URL(`./${packageConfig.main}/index.json`,
+                                        packageJSONUrl)));
+    else if (fileExists(guess = new URL(`./${packageConfig.main}/index.node`,
+                                        packageJSONUrl)));
+    else guess = undefined;
+    if (guess) {
+      emitLegacyIndexDeprecation(guess, packageJSONUrl, base,
+                                 packageConfig.main);
       return guess;
     }
     // Fallthrough.
   }
-  if (fileExists(guess = new URL('./index.js', packageJSONUrl))) {
-    return guess;
-  }
+  if (fileExists(guess = new URL('./index.js', packageJSONUrl)));
   // So fs.
-  if (fileExists(guess = new URL('./index.json', packageJSONUrl))) {
-    return guess;
-  }
-  if (fileExists(guess = new URL('./index.node', packageJSONUrl))) {
+  else if (fileExists(guess = new URL('./index.json', packageJSONUrl)));
+  else if (fileExists(guess = new URL('./index.node', packageJSONUrl)));
+  else guess = undefined;
+  if (guess) {
+    emitLegacyIndexDeprecation(guess, packageJSONUrl, base, packageConfig.main);
     return guess;
   }
   // Not found.
@@ -693,11 +698,8 @@ function packageResolve(specifier, base, conditions) {
       return packageExportsResolve(
         packageJSONUrl, packageSubpath, packageConfig, base, conditions
       ).resolved;
-    if (packageSubpath === '.') {
-      if (packageConfig.type === 'module')
-        emitLegacyIndexTypeModuleDeprecation(packageJSONUrl, base);
+    if (packageSubpath === '.')
       return legacyMainResolve(packageJSONUrl, packageConfig, base);
-    }
     return new URL(packageSubpath, packageJSONUrl);
     // Cross-platform root check.
   } while (packageJSONPath.length !== lastPath.length);
@@ -906,3 +908,6 @@ module.exports = {
   packageExportsResolve,
   packageImportsResolve
 };
+
+// cycle
+const { defaultGetFormat } = require('internal/modules/esm/get_format');

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -103,7 +103,7 @@ function emitLegacyIndexDeprecation(url, packageJSONUrl, base, main) {
     process.emitWarning(
       `Package ${pkgPath} has a "main" field set to ${JSONStringify(main)}, ` +
       `excluding the full filename and extension to the resolved file at "${
-        path.slice(pkgPath.length)}", imported from ${basePath}.\n Automatic ` +
+        StringPrototypeSlice(path, pkgPath.length)}", imported from ${basePath}.\n Automatic ` +
       'extension resolution of the "main" field is deprecated for ES modules.',
       'DeprecationWarning',
       'DEP0150'
@@ -111,7 +111,7 @@ function emitLegacyIndexDeprecation(url, packageJSONUrl, base, main) {
   else
     process.emitWarning(
       `No "main" or "exports" field defined in the package.json for ${pkgPath
-      } resolving the main entry point "${path.slice(pkgPath.length)}", ` +
+      } resolving the main entry point "${StringPrototypeSlice(path, pkgPath.length)}", ` +
       `imported from ${basePath}.\nDefault "index" lookups for the main are ` +
       'deprecated for explicit definitions.',
       'DeprecationWarning',

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -102,7 +102,7 @@ function emitLegacyIndexDeprecation(url, packageJSONUrl, base, main) {
   if (main)
     process.emitWarning(
       `Package ${pkgPath} has a "main" field set to ${JSONStringify(main)}, ` +
-      `excluding the full extension to the resolved file at "${
+      `excluding the full filename and extension to the resolved file at "${
         path.slice(pkgPath.length)}", imported from ${basePath}.\n Automatic ` +
       'extension resolution of the "main" field is deprecated for ES modules.',
       'DeprecationWarning',

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -91,6 +91,8 @@ function emitFolderMapDeprecation(match, pjsonUrl, isExports, base) {
 }
 
 function emitLegacyIndexTypeModuleDeprecation(packageJSONUrl, base) {
+  if (!pendingDeprecation)
+    return;
   const pkgPath = fileURLToPath(new URL('.', packageJSONUrl));
   const basePath = fileURLToPath(base);
   process.emitWarning(

--- a/test/es-module/test-esm-exports-pending-deprecations.mjs
+++ b/test/es-module/test-esm-exports-pending-deprecations.mjs
@@ -7,7 +7,8 @@ const expectedWarnings = [
   '"./sub/"',
   '"./fallbackdir/"',
   '"./subpath/"',
-  'no_exports'
+  'no_exports',
+  'default_index'
 ];
 
 process.addListener('warning', mustCall((warning) => {

--- a/test/es-module/test-esm-exports-pending-deprecations.mjs
+++ b/test/es-module/test-esm-exports-pending-deprecations.mjs
@@ -6,7 +6,8 @@ let curWarning = 0;
 const expectedWarnings = [
   '"./sub/"',
   '"./fallbackdir/"',
-  '"./subpath/"'
+  '"./subpath/"',
+  'no_exports'
 ];
 
 process.addListener('warning', mustCall((warning) => {

--- a/test/es-module/test-esm-exports.mjs
+++ b/test/es-module/test-esm-exports.mjs
@@ -46,7 +46,7 @@ import fromInside from '../fixtures/node_modules/pkgexports/lib/hole.js';
     validSpecifiers.set('pkgexports/subpath/dir2/', { default: 'index' });
   } else {
     // no exports or main field
-    validSpecifiers.set('no_exports', { default: 'main' });
+    validSpecifiers.set('no_exports', { default: 'index' });
     // main field without extension
     validSpecifiers.set('default_index', { default: 'main' });
   }

--- a/test/es-module/test-esm-exports.mjs
+++ b/test/es-module/test-esm-exports.mjs
@@ -45,8 +45,9 @@ import fromInside from '../fixtures/node_modules/pkgexports/lib/hole.js';
     validSpecifiers.set('pkgexports/subpath/dir2', { default: 'index' });
     validSpecifiers.set('pkgexports/subpath/dir2/', { default: 'index' });
   } else {
-    // no exports field
+    // no exports or main field
     validSpecifiers.set('no_exports', { default: 'main' });
+    // main field without extension
     validSpecifiers.set('default_index', { default: 'main' });
   }
 

--- a/test/es-module/test-esm-exports.mjs
+++ b/test/es-module/test-esm-exports.mjs
@@ -45,9 +45,9 @@ import fromInside from '../fixtures/node_modules/pkgexports/lib/hole.js';
     validSpecifiers.set('pkgexports/subpath/dir2', { default: 'index' });
     validSpecifiers.set('pkgexports/subpath/dir2/', { default: 'index' });
   } else {
-    // no exports or main field
+    // No exports or main field
     validSpecifiers.set('no_exports', { default: 'index' });
-    // main field without extension
+    // Main field without extension
     validSpecifiers.set('default_index', { default: 'main' });
   }
 

--- a/test/es-module/test-esm-exports.mjs
+++ b/test/es-module/test-esm-exports.mjs
@@ -47,6 +47,7 @@ import fromInside from '../fixtures/node_modules/pkgexports/lib/hole.js';
   } else {
     // no exports field
     validSpecifiers.set('no_exports', { default: 'main' });
+    validSpecifiers.set('default_index', { default: 'main' });
   }
 
   for (const [validSpecifier, expected] of validSpecifiers) {

--- a/test/es-module/test-esm-exports.mjs
+++ b/test/es-module/test-esm-exports.mjs
@@ -35,7 +35,7 @@ import fromInside from '../fixtures/node_modules/pkgexports/lib/hole.js';
     ['pkgexports-sugar', { default: 'main' }],
     // Path patterns
     ['pkgexports/subpath/sub-dir1', { default: 'main' }],
-    ['pkgexports/features/dir1', { default: 'main' }]
+    ['pkgexports/features/dir1', { default: 'main' }],
   ]);
 
   if (isRequire) {
@@ -44,6 +44,9 @@ import fromInside from '../fixtures/node_modules/pkgexports/lib/hole.js';
     validSpecifiers.set('pkgexports/subpath/dir1/', { default: 'main' });
     validSpecifiers.set('pkgexports/subpath/dir2', { default: 'index' });
     validSpecifiers.set('pkgexports/subpath/dir2/', { default: 'index' });
+  } else {
+    // no exports field
+    validSpecifiers.set('no_exports', { default: 'main' });
   }
 
   for (const [validSpecifier, expected] of validSpecifiers) {

--- a/test/fixtures/node_modules/default_index/index.js
+++ b/test/fixtures/node_modules/default_index/index.js
@@ -1,0 +1,1 @@
+export default 'main'

--- a/test/fixtures/node_modules/default_index/package.json
+++ b/test/fixtures/node_modules/default_index/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "index",
+  "type": "module"
+}

--- a/test/fixtures/node_modules/no_exports/index.js
+++ b/test/fixtures/node_modules/no_exports/index.js
@@ -1,0 +1,1 @@
+export default 'main'

--- a/test/fixtures/node_modules/no_exports/index.js
+++ b/test/fixtures/node_modules/no_exports/index.js
@@ -1,1 +1,1 @@
-export default 'main'
+export default 'index'

--- a/test/fixtures/node_modules/no_exports/package.json
+++ b/test/fixtures/node_modules/no_exports/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}


### PR DESCRIPTION
This adds a new deprecation warning when importing a main that resolves to an ES module that relies on the "index" or extension searching "main" resolution semantics.

In the next major this can become a runtime error, while for now it is behind `--pending-deprecation` only.

This is an update to the previous iteration which allows "main" and "exports" to continue to coexist without encapsulation being enforced.

The two warnings shown are for extensions not present:

```
Package /home/guybedford/Projects/node/test/fixtures/node_modules/default_index/ has a "main" field set to "index", excluding the full extension to the resolved file at "index.js", imported from /home/guybedford/Projects/node/test/fixtures/pkgexports.mjs.
 Automatic extension resolution of the "main" field is deprecated for ES modules.
```

and for no main field present:

```
No "main" or "exports" field defined in the package.json for /home/guybedford/Projects/node/test/fixtures/node_modules/no_exports/ resolving the main entry point "index.js", imported from /home/guybedford/Projects/node/test/fixtures/pkgexports.mjs.
Default "index" lookups for the main are deprecated for explicit definitions.
```

The warning is shown for third party packages and local packages equally.

This approach was taken after discussion that pushing encapsulation or deprecating the main would be too strong of a move to make.