### PR TITLE
[v14.x Backport] lib: add throws option to fs.f/l/statSync

### DIFF
--- a/benchmark/fs/bench-statSync-failure.js
+++ b/benchmark/fs/bench-statSync-failure.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const common = require('../common');
+const fs = require('fs');
+const path = require('path');
+
+const bench = common.createBenchmark(main, {
+  n: [1e6],
+  statSyncType: ['throw', 'noThrow']
+});
+
+
+function main({ n, statSyncType }) {
+  const arg = path.join(__dirname, 'non.existent');
+
+  bench.start();
+  for (let i = 0; i < n; i++) {
+    if (statSyncType === 'noThrow') {
+      fs.statSync(arg, { throwIfNoEntry: false });
+    } else {
+      try {
+        fs.statSync(arg);
+      } catch {
+      }
+    }
+  }
+  bench.end(n);
+}

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2560,6 +2560,9 @@ changes:
 * `options` {Object}
   * `bigint` {boolean} Whether the numeric values in the returned
     [`fs.Stats`][] object should be `bigint`. **Default:** `false`.
+  * `throwIfNoEntry` {boolean} Whether an exception will be thrown
+    if no file system entry exists, rather than returning `undefined`.
+    **Default:** `true`.
 * Returns: {fs.Stats}
 
 Synchronous lstat(2).
@@ -3765,6 +3768,9 @@ changes:
 * `options` {Object}
   * `bigint` {boolean} Whether the numeric values in the returned
     [`fs.Stats`][] object should be `bigint`. **Default:** `false`.
+  * `throwIfNoEntry` {boolean} Whether an exception will be thrown
+    if no file system entry exists, rather than returning `undefined`.
+    **Default:** `true`.
 * Returns: {fs.Stats}
 
 Synchronous stat(2).

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2546,6 +2546,10 @@ not the file that it refers to.
 <!-- YAML
 added: v0.1.30
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/33716
+    description: Accepts a `throwIfNoEntry` option to specify whether
+                 an exception should be thrown if the entry does not exist.
   - version: v10.5.0
     pr-url: https://github.com/nodejs/node/pull/20220
     description: Accepts an additional `options` object to specify whether
@@ -3754,6 +3758,10 @@ Stats {
 <!-- YAML
 added: v0.1.21
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/33716
+    description: Accepts a `throwIfNoEntry` option to specify whether
+                 an exception should be thrown if the entry does not exist.
   - version: v10.5.0
     pr-url: https://github.com/nodejs/node/pull/20220
     description: Accepts an additional `options` object to specify whether

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -71,6 +71,7 @@ const {
     ERR_INVALID_CALLBACK,
     ERR_FEATURE_UNAVAILABLE_ON_PLATFORM
   },
+  uvErrmapGet,
   uvException
 } = require('internal/errors');
 
@@ -1061,7 +1062,20 @@ function stat(path, options = { bigint: false }, callback) {
   binding.stat(pathModule.toNamespacedPath(path), options.bigint, req);
 }
 
-function fstatSync(fd, options = { bigint: false }) {
+function hasNoEntryError(ctx) {
+  if (ctx.errno) {
+    const uvErr = uvErrmapGet(ctx.errno);
+    return uvErr && uvErr[0] === 'ENOENT';
+  }
+
+  if (ctx.error) {
+    return ctx.error.code === 'ENOENT';
+  }
+
+  return false;
+}
+
+function fstatSync(fd, options = { bigint: false, throwIfNoEntry: true }) {
   validateInt32(fd, 'fd', 0);
   const ctx = { fd };
   const stats = binding.fstat(fd, options.bigint, undefined, ctx);
@@ -1069,20 +1083,26 @@ function fstatSync(fd, options = { bigint: false }) {
   return getStatsFromBinding(stats);
 }
 
-function lstatSync(path, options = { bigint: false }) {
+function lstatSync(path, options = { bigint: false, throwIfNoEntry: true }) {
   path = getValidatedPath(path);
   const ctx = { path };
   const stats = binding.lstat(pathModule.toNamespacedPath(path),
                               options.bigint, undefined, ctx);
+  if (options.throwIfNoEntry === false && hasNoEntryError(ctx)) {
+    return undefined;
+  }
   handleErrorFromBinding(ctx);
   return getStatsFromBinding(stats);
 }
 
-function statSync(path, options = { bigint: false }) {
+function statSync(path, options = { bigint: false, throwIfNoEntry: true }) {
   path = getValidatedPath(path);
   const ctx = { path };
   const stats = binding.stat(pathModule.toNamespacedPath(path),
                              options.bigint, undefined, ctx);
+  if (options.throwIfNoEntry === false && hasNoEntryError(ctx)) {
+    return undefined;
+  }
   handleErrorFromBinding(ctx);
   return getStatsFromBinding(stats);
 }

--- a/test/parallel/test-fs-stat-bigint.js
+++ b/test/parallel/test-fs-stat-bigint.js
@@ -122,6 +122,33 @@ if (!common.isWindows) {
   fs.closeSync(fd);
 }
 
+{
+  assert.throws(
+    () => fs.statSync('does_not_exist'),
+    { code: 'ENOENT' });
+  assert.strictEqual(
+    fs.statSync('does_not_exist', { throwIfNoEntry: false }),
+    undefined);
+}
+
+{
+  assert.throws(
+    () => fs.lstatSync('does_not_exist'),
+    { code: 'ENOENT' });
+  assert.strictEqual(
+    fs.lstatSync('does_not_exist', { throwIfNoEntry: false }),
+    undefined);
+}
+
+{
+  assert.throws(
+    () => fs.fstatSync(9999),
+    { code: 'EBADF' });
+  assert.throws(
+    () => fs.fstatSync(9999, { throwIfNoEntry: false }),
+    { code: 'EBADF' });
+}
+
 const runCallbackTest = (func, arg, done) => {
   const startTime = process.hrtime.bigint();
   func(arg, { bigint: true }, common.mustCall((err, bigintStats) => {


### PR DESCRIPTION
Backport of https://github.com/nodejs/node/pull/33716 and https://github.com/nodejs/node/pull/36882.

~Note that https://github.com/nodejs/node/pull/36882 hasn't been released to v15.x for two weeks; however it's a doc-only change, IMHO it would make sense two backport the two PRs at the same time in the next v14.x minor release.~

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
