### PR TITLE
test,benchmark: stop requiring URL and URLSearchParams

### DIFF
--- a/benchmark/url/legacy-vs-whatwg-url-searchparams-parse.js
+++ b/benchmark/url/legacy-vs-whatwg-url-searchparams-parse.js
@@ -1,6 +1,5 @@
 'use strict';
 const common = require('../common.js');
-const { URLSearchParams } = require('url');
 const querystring = require('querystring');
 const searchParams = common.searchParams;
 

--- a/benchmark/url/legacy-vs-whatwg-url-searchparams-serialize.js
+++ b/benchmark/url/legacy-vs-whatwg-url-searchparams-serialize.js
@@ -1,6 +1,5 @@
 'use strict';
 const common = require('../common.js');
-const { URLSearchParams } = require('url');
 const querystring = require('querystring');
 const searchParams = common.searchParams;
 

--- a/benchmark/url/url-searchparams-iteration.js
+++ b/benchmark/url/url-searchparams-iteration.js
@@ -1,7 +1,6 @@
 'use strict';
 const common = require('../common.js');
 const assert = require('assert');
-const { URLSearchParams } = require('url');
 
 const bench = common.createBenchmark(main, {
   loopMethod: ['forEach', 'iterator'],

--- a/benchmark/url/url-searchparams-read.js
+++ b/benchmark/url/url-searchparams-read.js
@@ -1,6 +1,5 @@
 'use strict';
 const common = require('../common.js');
-const { URLSearchParams } = require('url');
 
 const bench = common.createBenchmark(main, {
   accessMethod: ['get', 'getAll', 'has'],

--- a/benchmark/url/url-searchparams-sort.js
+++ b/benchmark/url/url-searchparams-sort.js
@@ -1,6 +1,5 @@
 'use strict';
 const common = require('../common.js');
-const URLSearchParams = require('url').URLSearchParams;
 
 const inputs = {
   wpt: 'wpt',  // To work around tests

--- a/test/es-module/test-esm-dynamic-import.js
+++ b/test/es-module/test-esm-dynamic-import.js
@@ -1,7 +1,6 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const { URL } = require('url');
 
 const relativePath = '../fixtures/es-modules/test-esm-ok.mjs';
 const absolutePath = require.resolve('../fixtures/es-modules/test-esm-ok.mjs');

--- a/test/es-module/test-esm-loader-modulemap.js
+++ b/test/es-module/test-esm-loader-modulemap.js
@@ -7,7 +7,6 @@
 require('../common');
 
 const assert = require('assert');
-const { URL } = require('url');
 const { Loader } = require('internal/modules/esm/loader');
 const ModuleMap = require('internal/modules/esm/module_map');
 const ModuleJob = require('internal/modules/esm/module_job');

--- a/test/parallel/test-fs-exists.js
+++ b/test/parallel/test-fs-exists.js
@@ -23,7 +23,6 @@
 const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
-const { URL } = require('url');
 const f = __filename;
 
 assert.throws(() => fs.exists(f), { code: 'ERR_INVALID_CALLBACK' });

--- a/test/parallel/test-fs-null-bytes.js
+++ b/test/parallel/test-fs-null-bytes.js
@@ -23,7 +23,6 @@
 const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
-const URL = require('url').URL;
 
 function check(async, sync) {
   const argsSync = Array.prototype.slice.call(arguments, 2);

--- a/test/parallel/test-fs-whatwg-url.js
+++ b/test/parallel/test-fs-whatwg-url.js
@@ -6,7 +6,6 @@ const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
 const os = require('os');
-const URL = require('url').URL;
 
 function pathToFileURL(p) {
   if (!path.isAbsolute(p))

--- a/test/parallel/test-http-client-get-url.js
+++ b/test/parallel/test-http-client-get-url.js
@@ -24,7 +24,6 @@ const common = require('../common');
 const assert = require('assert');
 const http = require('http');
 const url = require('url');
-const URL = url.URL;
 const testPath = '/foo?bar';
 
 const server = http.createServer(common.mustCall((req, res) => {

--- a/test/parallel/test-http2-altsvc.js
+++ b/test/parallel/test-http2-altsvc.js
@@ -6,7 +6,6 @@ if (!common.hasCrypto)
 
 const assert = require('assert');
 const http2 = require('http2');
-const { URL } = require('url');
 const Countdown = require('../common/countdown');
 
 const server = http2.createServer();

--- a/test/parallel/test-http2-connect-method.js
+++ b/test/parallel/test-http2-connect-method.js
@@ -6,7 +6,6 @@ if (!common.hasCrypto)
 const assert = require('assert');
 const net = require('net');
 const http2 = require('http2');
-const { URL } = require('url');
 
 const {
   HTTP2_HEADER_METHOD,

--- a/test/parallel/test-http2-create-client-connect.js
+++ b/test/parallel/test-http2-create-client-connect.js
@@ -9,7 +9,6 @@ if (!common.hasCrypto)
 const fixtures = require('../common/fixtures');
 const h2 = require('http2');
 const url = require('url');
-const URL = url.URL;
 
 {
   const server = h2.createServer();

--- a/test/parallel/test-http2-response-splitting.js
+++ b/test/parallel/test-http2-response-splitting.js
@@ -9,7 +9,6 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 const assert = require('assert');
 const http2 = require('http2');
-const { URL } = require('url');
 
 // Response splitting example, credit: Amit Klein, Safebreach
 const str = '/welcome?lang=bar%c4%8d%c4%8aContent­Length:%200%c4%8d%c4%8a%c' +

--- a/test/parallel/test-https-client-get-url.js
+++ b/test/parallel/test-https-client-get-url.js
@@ -32,8 +32,6 @@ const assert = require('assert');
 const https = require('https');
 const url = require('url');
 
-const URL = url.URL;
-
 const options = {
   key: fixtures.readKey('agent1-key.pem'),
   cert: fixtures.readKey('agent1-cert.pem')

--- a/test/parallel/test-url-format-whatwg.js
+++ b/test/parallel/test-url-format-whatwg.js
@@ -6,7 +6,6 @@ if (!common.hasIntl)
 
 const assert = require('assert');
 const url = require('url');
-const URL = url.URL;
 
 const myURL = new URL('http://xn--lck1c3crb1723bpq4a.com/a?a=b#c');
 

--- a/test/parallel/test-vm-module-link.js
+++ b/test/parallel/test-vm-module-link.js
@@ -5,7 +5,6 @@
 const common = require('../common');
 
 const assert = require('assert');
-const { URL } = require('url');
 
 const { SourceTextModule } = require('vm');
 

--- a/test/parallel/test-whatwg-url-constructor.js
+++ b/test/parallel/test-whatwg-url-constructor.js
@@ -6,7 +6,6 @@ if (!common.hasIntl) {
 }
 
 const fixtures = require('../common/fixtures');
-const { URL, URLSearchParams } = require('url');
 const { test, assert_equals, assert_true, assert_throws } =
   require('../common/wpt').harness;
 

--- a/test/parallel/test-whatwg-url-custom-global.js
+++ b/test/parallel/test-whatwg-url-custom-global.js
@@ -4,7 +4,6 @@
 
 require('../common');
 const assert = require('assert');
-const { URL, URLSearchParams } = require('url');
 
 assert.deepStrictEqual(
   Object.getOwnPropertyDescriptor(global, 'URL'),

--- a/test/parallel/test-whatwg-url-custom-inspect.js
+++ b/test/parallel/test-whatwg-url-custom-inspect.js
@@ -9,7 +9,6 @@ if (!common.hasIntl) {
 }
 
 const util = require('util');
-const URL = require('url').URL;
 const assert = require('assert');
 
 const url = new URL('https://username:password@host.name:8080/path/name/?que=ry#hash');

--- a/test/parallel/test-whatwg-url-custom-parsing.js
+++ b/test/parallel/test-whatwg-url-custom-parsing.js
@@ -8,7 +8,6 @@ if (!common.hasIntl) {
   common.skip('missing Intl');
 }
 
-const URL = require('url').URL;
 const assert = require('assert');
 const fixtures = require('../common/fixtures');
 

--- a/test/parallel/test-whatwg-url-custom-properties.js
+++ b/test/parallel/test-whatwg-url-custom-properties.js
@@ -4,7 +4,6 @@
 // Tests below are not from WPT.
 
 require('../common');
-const URL = require('url').URL;
 const assert = require('assert');
 const urlToOptions = require('internal/url').urlToOptions;
 

--- a/test/parallel/test-whatwg-url-custom-searchparams-append.js
+++ b/test/parallel/test-whatwg-url-custom-searchparams-append.js
@@ -4,7 +4,6 @@
 
 require('../common');
 const assert = require('assert');
-const URLSearchParams = require('url').URLSearchParams;
 
 {
   const params = new URLSearchParams();

--- a/test/parallel/test-whatwg-url-custom-searchparams-constructor.js
+++ b/test/parallel/test-whatwg-url-custom-searchparams-constructor.js
@@ -4,7 +4,6 @@
 
 require('../common');
 const assert = require('assert');
-const URLSearchParams = require('url').URLSearchParams;
 
 function makeIterableFunc(array) {
   return Object.assign(() => {}, {

--- a/test/parallel/test-whatwg-url-custom-searchparams-delete.js
+++ b/test/parallel/test-whatwg-url-custom-searchparams-delete.js
@@ -4,7 +4,6 @@
 
 require('../common');
 const assert = require('assert');
-const { URL, URLSearchParams } = require('url');
 
 {
   const params = new URLSearchParams();

--- a/test/parallel/test-whatwg-url-custom-searchparams-entries.js
+++ b/test/parallel/test-whatwg-url-custom-searchparams-entries.js
@@ -2,7 +2,6 @@
 
 require('../common');
 const assert = require('assert');
-const URLSearchParams = require('url').URLSearchParams;
 
 // Tests below are not from WPT.
 const params = new URLSearchParams('a=b&c=d');

--- a/test/parallel/test-whatwg-url-custom-searchparams-foreach.js
+++ b/test/parallel/test-whatwg-url-custom-searchparams-foreach.js
@@ -4,7 +4,6 @@
 
 require('../common');
 const assert = require('assert');
-const { URLSearchParams } = require('url');
 
 {
   const params = new URLSearchParams();

--- a/test/parallel/test-whatwg-url-custom-searchparams-get.js
+++ b/test/parallel/test-whatwg-url-custom-searchparams-get.js
@@ -4,7 +4,6 @@
 
 require('../common');
 const assert = require('assert');
-const URLSearchParams = require('url').URLSearchParams;
 
 {
   const params = new URLSearchParams();

--- a/test/parallel/test-whatwg-url-custom-searchparams-getall.js
+++ b/test/parallel/test-whatwg-url-custom-searchparams-getall.js
@@ -4,7 +4,6 @@
 
 require('../common');
 const assert = require('assert');
-const URLSearchParams = require('url').URLSearchParams;
 
 {
   const params = new URLSearchParams();

--- a/test/parallel/test-whatwg-url-custom-searchparams-has.js
+++ b/test/parallel/test-whatwg-url-custom-searchparams-has.js
@@ -4,7 +4,6 @@
 
 require('../common');
 const assert = require('assert');
-const URLSearchParams = require('url').URLSearchParams;
 
 {
   const params = new URLSearchParams();

--- a/test/parallel/test-whatwg-url-custom-searchparams-inspect.js
+++ b/test/parallel/test-whatwg-url-custom-searchparams-inspect.js
@@ -5,7 +5,6 @@
 require('../common');
 const assert = require('assert');
 const util = require('util');
-const URLSearchParams = require('url').URLSearchParams;
 
 const sp = new URLSearchParams('?a=a&b=b&b=c');
 assert.strictEqual(util.inspect(sp),

--- a/test/parallel/test-whatwg-url-custom-searchparams-keys.js
+++ b/test/parallel/test-whatwg-url-custom-searchparams-keys.js
@@ -4,7 +4,6 @@
 
 require('../common');
 const assert = require('assert');
-const URLSearchParams = require('url').URLSearchParams;
 
 const params = new URLSearchParams('a=b&c=d');
 const keys = params.keys();

--- a/test/parallel/test-whatwg-url-custom-searchparams-set.js
+++ b/test/parallel/test-whatwg-url-custom-searchparams-set.js
@@ -4,7 +4,6 @@
 
 require('../common');
 const assert = require('assert');
-const URLSearchParams = require('url').URLSearchParams;
 
 {
   const params = new URLSearchParams();

--- a/test/parallel/test-whatwg-url-custom-searchparams-sort.js
+++ b/test/parallel/test-whatwg-url-custom-searchparams-sort.js
@@ -3,7 +3,6 @@
 // Tests below are not from WPT.
 
 require('../common');
-const { URL, URLSearchParams } = require('url');
 const { test, assert_array_equals } = require('../common/wpt').harness;
 
 // TODO(joyeecheung): upstream this to WPT, if possible - even

--- a/test/parallel/test-whatwg-url-custom-searchparams-stringifier.js
+++ b/test/parallel/test-whatwg-url-custom-searchparams-stringifier.js
@@ -4,7 +4,6 @@
 
 require('../common');
 const assert = require('assert');
-const URLSearchParams = require('url').URLSearchParams;
 
 {
   const params = new URLSearchParams();

--- a/test/parallel/test-whatwg-url-custom-searchparams-values.js
+++ b/test/parallel/test-whatwg-url-custom-searchparams-values.js
@@ -4,7 +4,6 @@
 
 require('../common');
 const assert = require('assert');
-const URLSearchParams = require('url').URLSearchParams;
 
 const params = new URLSearchParams('a=b&c=d');
 const values = params.values();

--- a/test/parallel/test-whatwg-url-custom-searchparams.js
+++ b/test/parallel/test-whatwg-url-custom-searchparams.js
@@ -4,7 +4,6 @@
 
 require('../common');
 const assert = require('assert');
-const { URL, URLSearchParams } = require('url');
 const fixtures = require('../common/fixtures');
 
 const serialized = 'a=a&a=1&a=true&a=undefined&a=null&a=%EF%BF%BD' +

--- a/test/parallel/test-whatwg-url-custom-setters.js
+++ b/test/parallel/test-whatwg-url-custom-setters.js
@@ -9,7 +9,6 @@ if (!common.hasIntl) {
 }
 
 const assert = require('assert');
-const URL = require('url').URL;
 const { test, assert_equals } = require('../common/wpt').harness;
 const fixtures = require('../common/fixtures');
 

--- a/test/parallel/test-whatwg-url-custom-tostringtag.js
+++ b/test/parallel/test-whatwg-url-custom-tostringtag.js
@@ -4,7 +4,6 @@
 
 require('../common');
 const assert = require('assert');
-const URL = require('url').URL;
 
 const toString = Object.prototype.toString;
 

--- a/test/parallel/test-whatwg-url-origin.js
+++ b/test/parallel/test-whatwg-url-origin.js
@@ -6,7 +6,6 @@ if (!common.hasIntl) {
 }
 
 const fixtures = require('../common/fixtures');
-const URL = require('url').URL;
 const { test, assert_equals } = require('../common/wpt').harness;
 
 const request = {

--- a/test/parallel/test-whatwg-url-setters.js
+++ b/test/parallel/test-whatwg-url-setters.js
@@ -6,7 +6,6 @@ if (!common.hasIntl) {
   common.skip('missing Intl');
 }
 
-const URL = require('url').URL;
 const { test, assert_equals } = require('../common/wpt').harness;
 const fixtures = require('../common/fixtures');
 

--- a/test/parallel/test-whatwg-url-toascii.js
+++ b/test/parallel/test-whatwg-url-toascii.js
@@ -6,7 +6,6 @@ if (!common.hasIntl) {
 }
 
 const fixtures = require('../common/fixtures');
-const { URL } = require('url');
 const { test, assert_equals, assert_throws } = require('../common/wpt').harness;
 
 const request = {

--- a/test/sequential/test-inspector-port-zero.js
+++ b/test/sequential/test-inspector-port-zero.js
@@ -4,7 +4,6 @@ const { mustCall, skipIfInspectorDisabled } = require('../common');
 skipIfInspectorDisabled();
 
 const assert = require('assert');
-const { URL } = require('url');
 const { spawn } = require('child_process');
 
 function test(arg, port = '') {


### PR DESCRIPTION
Since the URL and URLSearchParams classes are available in the
global object, there is no need to require them from 'url'.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
