### PR TITLE
test: remove unused ecdhPeerKey

### DIFF
--- a/test/parallel/test-webcrypto-wrap-unwrap.js
+++ b/test/parallel/test-webcrypto-wrap-unwrap.js
@@ -243,7 +243,7 @@ async function testWrap(wrappingKey, unwrappingKey, key, wrap, format) {
   assert.deepStrictEqual(exported, exportedAgain);
 }
 
-async function testWrapping(name, keys, ecdhPeerKey) {
+async function testWrapping(name, keys) {
   const variations = [];
 
   const {
@@ -264,13 +264,9 @@ async function testWrapping(name, keys, ecdhPeerKey) {
 (async function() {
   await generateWrappingKeys();
   const keys = await generateKeysToWrap();
-  const ecdhPeerKey = await subtle.generateKey({
-    name: 'ECDH',
-    namedCurve: 'P-384'
-  }, true, ['deriveBits']);
   const variations = [];
   Object.keys(kWrappingData).forEach((name) => {
-    return testWrapping(name, keys, ecdhPeerKey);
+    return testWrapping(name, keys);
   });
   await Promise.all(variations);
 })().then(common.mustCall());


### PR DESCRIPTION
This commit removed ecdhPeerKey from test-webcrypto-wrap-unwrap.js which
seems to be unsued.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
