### PR TITLE
bootstrap: include v8 and fs modules in the startup snapshot

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -67,6 +67,10 @@ const {
 
 const pathModule = require('path');
 const { isArrayBufferView } = require('internal/util/types');
+
+// We need to get the statValues from the binding at the callsite since
+// it's re-initialized after deserialization.
+
 const binding = internalBinding('fs');
 const { Buffer } = require('buffer');
 const {
@@ -81,7 +85,7 @@ const {
   uvException
 } = require('internal/errors');
 
-const { FSReqCallback, statValues } = binding;
+const { FSReqCallback } = binding;
 const { toPathIfFileURL } = require('internal/url');
 const internalUtil = require('internal/util');
 const {
@@ -1772,8 +1776,8 @@ function realpathSync(p, options) {
 
     // Continue if not a symlink, break if a pipe/socket
     if (knownHard[base] || cache?.get(base) === base) {
-      if (isFileType(statValues, S_IFIFO) ||
-          isFileType(statValues, S_IFSOCK)) {
+      if (isFileType(binding.statValues, S_IFIFO) ||
+          isFileType(binding.statValues, S_IFSOCK)) {
         break;
       }
       continue;
@@ -1915,8 +1919,8 @@ function realpath(p, options, callback) {
 
     // Continue if not a symlink, break if a pipe/socket
     if (knownHard[base]) {
-      if (isFileType(statValues, S_IFIFO) ||
-          isFileType(statValues, S_IFSOCK)) {
+      if (isFileType(binding.statValues, S_IFIFO) ||
+          isFileType(binding.statValues, S_IFSOCK)) {
         return callback(null, encodeRealpathResult(p, options));
       }
       return process.nextTick(LOOP);

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -347,6 +347,9 @@ process.emitWarning = emitWarning;
   // Note: only after this point are the timers effective
 }
 
+// Preload modules so that they are included in the builtin snapshot.
+require('fs');
+
 function setupPrepareStackTrace() {
   const {
     setEnhanceStackForFatalException,

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -349,6 +349,7 @@ process.emitWarning = emitWarning;
 
 // Preload modules so that they are included in the builtin snapshot.
 require('fs');
+require('v8');
 
 function setupPrepareStackTrace() {
   const {

--- a/lib/v8.js
+++ b/lib/v8.js
@@ -72,12 +72,13 @@ function getHeapSnapshot() {
   return new HeapSnapshotStream(handle);
 }
 
+// We need to get the buffer from the binding at the callsite since
+// it's re-initialized after deserialization.
+const binding = internalBinding('v8');
+
 const {
   cachedDataVersionTag,
   setFlagsFromString: _setFlagsFromString,
-  heapStatisticsBuffer,
-  heapSpaceStatisticsBuffer,
-  heapCodeStatisticsBuffer,
   updateHeapStatisticsBuffer,
   updateHeapSpaceStatisticsBuffer,
   updateHeapCodeStatisticsBuffer,
@@ -106,7 +107,7 @@ const {
   kCodeAndMetadataSizeIndex,
   kBytecodeAndMetadataSizeIndex,
   kExternalScriptSourceSizeIndex
-} = internalBinding('v8');
+} = binding;
 
 const kNumberOfHeapSpaces = kHeapSpaces.length;
 
@@ -116,7 +117,7 @@ function setFlagsFromString(flags) {
 }
 
 function getHeapStatistics() {
-  const buffer = heapStatisticsBuffer;
+  const buffer = binding.heapStatisticsBuffer;
 
   updateHeapStatisticsBuffer();
 
@@ -137,7 +138,7 @@ function getHeapStatistics() {
 
 function getHeapSpaceStatistics() {
   const heapSpaceStatistics = new Array(kNumberOfHeapSpaces);
-  const buffer = heapSpaceStatisticsBuffer;
+  const buffer = binding.heapSpaceStatisticsBuffer;
 
   for (let i = 0; i < kNumberOfHeapSpaces; i++) {
     updateHeapSpaceStatisticsBuffer(i);
@@ -154,7 +155,7 @@ function getHeapSpaceStatistics() {
 }
 
 function getHeapCodeStatistics() {
-  const buffer = heapCodeStatisticsBuffer;
+  const buffer = binding.heapCodeStatisticsBuffer;
 
   updateHeapCodeStatisticsBuffer();
   return {

--- a/src/aliased_buffer.h
+++ b/src/aliased_buffer.h
@@ -198,6 +198,11 @@ class AliasedBufferBase {
     return js_array_.Get(isolate_);
   }
 
+  void Release() {
+    DCHECK_NULL(index_);
+    js_array_.Reset();
+  }
+
   /**
   *  Get the underlying v8::ArrayBuffer underlying the TypedArray and
   *  overlaying the native buffer

--- a/src/base_object.h
+++ b/src/base_object.h
@@ -158,6 +158,9 @@ class BaseObject : public MemoryRetainer {
 
   virtual inline void OnGCCollect();
 
+  bool is_snapshotable() const { return is_snapshotable_; }
+  void set_is_snapshotable(bool val) { is_snapshotable_ = val; }
+
  private:
   v8::Local<v8::Object> WrappedObject() const override;
   bool IsRootNode() const override;
@@ -206,6 +209,7 @@ class BaseObject : public MemoryRetainer {
 
   Environment* env_;
   PointerData* pointer_data_ = nullptr;
+  bool is_snapshotable_ = false;
 };
 
 // Global alias for FromJSObject() to avoid churn.

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -1085,6 +1085,17 @@ void Environment::ForEachBaseObject(T&& iterator) {
   }
 }
 
+template <typename T>
+void Environment::ForEachBindingData(T&& iterator) {
+  BindingDataStore* map = static_cast<BindingDataStore*>(
+      context()->GetAlignedPointerFromEmbedderData(
+          ContextEmbedderIndex::kBindingListIndex));
+  DCHECK_NOT_NULL(map);
+  for (auto& it : *map) {
+    iterator(it.first, it.second);
+  }
+}
+
 void Environment::modify_base_object_count(int64_t delta) {
   base_object_count_ += delta;
 }

--- a/src/heap_utils.cc
+++ b/src/heap_utils.cc
@@ -1,6 +1,7 @@
 #include "diagnosticfilename-inl.h"
 #include "env-inl.h"
 #include "memory_tracker-inl.h"
+#include "node_external_reference.h"
 #include "stream_base-inl.h"
 #include "util-inl.h"
 
@@ -399,7 +400,15 @@ void Initialize(Local<Object> target,
   env->SetMethod(target, "createHeapSnapshotStream", CreateHeapSnapshotStream);
 }
 
+void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
+  registry->Register(BuildEmbedderGraph);
+  registry->Register(TriggerHeapSnapshot);
+  registry->Register(CreateHeapSnapshotStream);
+}
+
 }  // namespace heap
 }  // namespace node
 
 NODE_MODULE_CONTEXT_AWARE_INTERNAL(heap_utils, node::heap::Initialize)
+NODE_MODULE_EXTERNAL_REFERENCE(heap_utils,
+                               node::heap::RegisterExternalReferences)

--- a/src/inspector_profiler.cc
+++ b/src/inspector_profiler.cc
@@ -3,8 +3,9 @@
 #include "debug_utils-inl.h"
 #include "diagnosticfilename-inl.h"
 #include "memory_tracker-inl.h"
-#include "node_file.h"
 #include "node_errors.h"
+#include "node_external_reference.h"
+#include "node_file.h"
 #include "node_internals.h"
 #include "util-inl.h"
 #include "v8-inspector.h"
@@ -519,7 +520,16 @@ static void Initialize(Local<Object> target,
   env->SetMethod(target, "stopCoverage", StopCoverage);
 }
 
+void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
+  registry->Register(SetCoverageDirectory);
+  registry->Register(SetSourceMapCacheGetter);
+  registry->Register(TakeCoverage);
+  registry->Register(StopCoverage);
+}
+
 }  // namespace profiler
 }  // namespace node
 
 NODE_MODULE_CONTEXT_AWARE_INTERNAL(profiler, node::profiler::Initialize)
+NODE_MODULE_EXTERNAL_REFERENCE(profiler,
+                               node::profiler::RegisterExternalReferences)

--- a/src/node_dir.cc
+++ b/src/node_dir.cc
@@ -1,4 +1,5 @@
 #include "node_dir.h"
+#include "node_external_reference.h"
 #include "node_file-inl.h"
 #include "node_process.h"
 #include "memory_tracker-inl.h"
@@ -364,8 +365,16 @@ void Initialize(Local<Object> target,
   env->set_dir_instance_template(dirt);
 }
 
+void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
+  registry->Register(OpenDir);
+  registry->Register(DirHandle::New);
+  registry->Register(DirHandle::Read);
+  registry->Register(DirHandle::Close);
+}
+
 }  // namespace fs_dir
 
 }  // end namespace node
 
 NODE_MODULE_CONTEXT_AWARE_INTERNAL(fs_dir, node::fs_dir::Initialize)
+NODE_MODULE_EXTERNAL_REFERENCE(fs_dir, node::fs_dir::RegisterExternalReferences)

--- a/src/node_external_reference.h
+++ b/src/node_external_reference.h
@@ -53,6 +53,8 @@ class ExternalReferenceRegistry {
   V(credentials)                                                               \
   V(env_var)                                                                   \
   V(errors)                                                                    \
+  V(fs)                                                                        \
+  V(fs_dir)                                                                    \
   V(handle_wrap)                                                               \
   V(messaging)                                                                 \
   V(native_module)                                                             \

--- a/src/node_external_reference.h
+++ b/src/node_external_reference.h
@@ -56,6 +56,7 @@ class ExternalReferenceRegistry {
   V(fs)                                                                        \
   V(fs_dir)                                                                    \
   V(handle_wrap)                                                               \
+  V(heap_utils)                                                                \
   V(messaging)                                                                 \
   V(native_module)                                                             \
   V(process_methods)                                                           \
@@ -63,10 +64,14 @@ class ExternalReferenceRegistry {
   V(task_queue)                                                                \
   V(url)                                                                       \
   V(util)                                                                      \
+  V(serdes)                                                                    \
   V(string_decoder)                                                            \
+  V(stream_wrap)                                                               \
   V(trace_events)                                                              \
   V(timers)                                                                    \
   V(types)                                                                     \
+  V(uv)                                                                        \
+  V(v8)                                                                        \
   V(worker)
 
 #if NODE_HAVE_I18N_SUPPORT
@@ -76,7 +81,9 @@ class ExternalReferenceRegistry {
 #endif  // NODE_HAVE_I18N_SUPPORT
 
 #if HAVE_INSPECTOR
-#define EXTERNAL_REFERENCE_BINDING_LIST_INSPECTOR(V) V(inspector)
+#define EXTERNAL_REFERENCE_BINDING_LIST_INSPECTOR(V)                           \
+  V(inspector)                                                                 \
+  V(profiler)
 #else
 #define EXTERNAL_REFERENCE_BINDING_LIST_INSPECTOR(V)
 #endif  // HAVE_INSPECTOR

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -23,6 +23,7 @@
 #include "aliased_buffer.h"
 #include "memory_tracker-inl.h"
 #include "node_buffer.h"
+#include "node_external_reference.h"
 #include "node_process.h"
 #include "node_stat_watcher.h"
 #include "util-inl.h"
@@ -2398,6 +2399,47 @@ void BindingData::MemoryInfo(MemoryTracker* tracker) const {
                       file_handle_read_wrap_freelist);
 }
 
+BindingData::BindingData(Environment* env, v8::Local<v8::Object> wrap)
+    : SnapshotableObject(env, wrap, type_int),
+      stats_field_array(env->isolate(), kFsStatsBufferLength),
+      stats_field_bigint_array(env->isolate(), kFsStatsBufferLength) {
+  wrap->Set(env->context(),
+            FIXED_ONE_BYTE_STRING(env->isolate(), "statValues"),
+            stats_field_array.GetJSArray())
+      .Check();
+
+  wrap->Set(env->context(),
+            FIXED_ONE_BYTE_STRING(env->isolate(), "bigintStatValues"),
+            stats_field_bigint_array.GetJSArray())
+      .Check();
+}
+
+void BindingData::Deserialize(Local<Context> context,
+                              Local<Object> holder,
+                              int index,
+                              InternalFieldInfo* info) {
+  DCHECK_EQ(index, BaseObject::kSlot);
+  HandleScope scope(context->GetIsolate());
+  Environment* env = Environment::GetCurrent(context);
+  BindingData* binding = env->AddBindingData<BindingData>(context, holder);
+  CHECK_NOT_NULL(binding);
+}
+
+void BindingData::PrepareForSerialization(Local<Context> context,
+                                          v8::SnapshotCreator* creator) {
+  CHECK(file_handle_read_wrap_freelist.empty());
+  // We'll just re-initialize the buffers in the constructor since their
+  // contents can be thrown away once consumed in the previous call.
+  stats_field_array.Release();
+  stats_field_bigint_array.Release();
+}
+
+InternalFieldInfo* BindingData::Serialize(int index) {
+  DCHECK_EQ(index, BaseObject::kSlot);
+  InternalFieldInfo* info = InternalFieldInfo::New(type());
+  return info;
+}
+
 // TODO(addaleax): Remove once we're on C++17.
 constexpr FastStringKey BindingData::type_name;
 
@@ -2460,14 +2502,6 @@ void Initialize(Local<Object> target,
                 isolate,
                 static_cast<int32_t>(FsStatsOffset::kFsStatsFieldsNumber)))
       .Check();
-
-  target->Set(context,
-              FIXED_ONE_BYTE_STRING(isolate, "statValues"),
-              binding_data->stats_field_array.GetJSArray()).Check();
-
-  target->Set(context,
-              FIXED_ONE_BYTE_STRING(isolate, "bigintStatValues"),
-              binding_data->stats_field_bigint_array.GetJSArray()).Check();
 
   StatWatcher::Initialize(env, target);
 
@@ -2532,8 +2566,62 @@ void Initialize(Local<Object> target,
 BindingData* FSReqBase::binding_data() {
   return binding_data_.get();
 }
+
+void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
+  registry->Register(Access);
+  StatWatcher::RegisterExternalReferences(registry);
+
+  registry->Register(Close);
+  registry->Register(Open);
+  registry->Register(OpenFileHandle);
+  registry->Register(Read);
+  registry->Register(ReadBuffers);
+  registry->Register(Fdatasync);
+  registry->Register(Fsync);
+  registry->Register(Rename);
+  registry->Register(FTruncate);
+  registry->Register(RMDir);
+  registry->Register(MKDir);
+  registry->Register(ReadDir);
+  registry->Register(InternalModuleReadJSON);
+  registry->Register(InternalModuleStat);
+  registry->Register(Stat);
+  registry->Register(LStat);
+  registry->Register(FStat);
+  registry->Register(Link);
+  registry->Register(Symlink);
+  registry->Register(ReadLink);
+  registry->Register(Unlink);
+  registry->Register(WriteBuffer);
+  registry->Register(WriteBuffers);
+  registry->Register(WriteString);
+  registry->Register(RealPath);
+  registry->Register(CopyFile);
+
+  registry->Register(Chmod);
+  registry->Register(FChmod);
+  // registry->Register(LChmod);
+
+  registry->Register(Chown);
+  registry->Register(FChown);
+  registry->Register(LChown);
+
+  registry->Register(UTimes);
+  registry->Register(FUTimes);
+  registry->Register(LUTimes);
+
+  registry->Register(Mkdtemp);
+  registry->Register(NewFSReqCallback);
+
+  registry->Register(FileHandle::New);
+  registry->Register(FileHandle::Close);
+  registry->Register(FileHandle::ReleaseFD);
+  StreamBase::RegisterExternalReferences(registry);
+}
+
 }  // namespace fs
 
 }  // end namespace node
 
 NODE_MODULE_CONTEXT_AWARE_INTERNAL(fs, node::fs::Initialize)
+NODE_MODULE_EXTERNAL_REFERENCE(fs, node::fs::RegisterExternalReferences)

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -3,23 +3,19 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-#include "node.h"
 #include "aliased_buffer.h"
 #include "node_messaging.h"
+#include "node_snapshotable.h"
 #include "stream_base.h"
-#include <iostream>
 
 namespace node {
 namespace fs {
 
 class FileHandleReadWrap;
 
-class BindingData : public BaseObject {
+class BindingData : public SnapshotableObject {
  public:
-  explicit BindingData(Environment* env, v8::Local<v8::Object> wrap)
-      : BaseObject(env, wrap),
-        stats_field_array(env->isolate(), kFsStatsBufferLength),
-        stats_field_bigint_array(env->isolate(), kFsStatsBufferLength) {}
+  explicit BindingData(Environment* env, v8::Local<v8::Object> wrap);
 
   AliasedFloat64Array stats_field_array;
   AliasedBigUint64Array stats_field_bigint_array;
@@ -27,7 +23,10 @@ class BindingData : public BaseObject {
   std::vector<BaseObjectPtr<FileHandleReadWrap>>
       file_handle_read_wrap_freelist;
 
-  static constexpr FastStringKey type_name { "fs" };
+  SERIALIZABLE_OBJECT_METHODS()
+  static constexpr FastStringKey type_name{"node::fs::BindingData"};
+  static constexpr EmbedderObjectType type_int =
+      EmbedderObjectType::k_fs_binding_data;
 
   void MemoryInfo(MemoryTracker* tracker) const override;
   SET_SELF_SIZE(BindingData)

--- a/src/node_serdes.cc
+++ b/src/node_serdes.cc
@@ -1,8 +1,9 @@
-#include "node_internals.h"
+#include "base_object-inl.h"
 #include "node_buffer.h"
 #include "node_errors.h"
+#include "node_external_reference.h"
+#include "node_internals.h"
 #include "util-inl.h"
-#include "base_object-inl.h"
 
 namespace node {
 
@@ -26,7 +27,7 @@ using v8::Value;
 using v8::ValueDeserializer;
 using v8::ValueSerializer;
 
-namespace {
+namespace serdes {
 
 class SerializerContext : public BaseObject,
                           public ValueSerializer::Delegate {
@@ -503,7 +504,32 @@ void Initialize(Local<Object> target,
   env->SetConstructorFunction(target, "Deserializer", des);
 }
 
-}  // anonymous namespace
+void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
+  registry->Register(SerializerContext::New);
+
+  registry->Register(SerializerContext::WriteHeader);
+  registry->Register(SerializerContext::WriteValue);
+  registry->Register(SerializerContext::ReleaseBuffer);
+  registry->Register(SerializerContext::TransferArrayBuffer);
+  registry->Register(SerializerContext::WriteUint32);
+  registry->Register(SerializerContext::WriteUint64);
+  registry->Register(SerializerContext::WriteDouble);
+  registry->Register(SerializerContext::WriteRawBytes);
+  registry->Register(SerializerContext::SetTreatArrayBufferViewsAsHostObjects);
+
+  registry->Register(DeserializerContext::New);
+  registry->Register(DeserializerContext::ReadHeader);
+  registry->Register(DeserializerContext::ReadValue);
+  registry->Register(DeserializerContext::GetWireFormatVersion);
+  registry->Register(DeserializerContext::TransferArrayBuffer);
+  registry->Register(DeserializerContext::ReadUint32);
+  registry->Register(DeserializerContext::ReadUint64);
+  registry->Register(DeserializerContext::ReadDouble);
+  registry->Register(DeserializerContext::ReadRawBytes);
+}
+
+}  // namespace serdes
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(serdes, node::Initialize)
+NODE_MODULE_CONTEXT_AWARE_INTERNAL(serdes, node::serdes::Initialize)
+NODE_MODULE_EXTERNAL_REFERENCE(serdes, node::serdes::RegisterExternalReferences)

--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -1,39 +1,134 @@
 
 #include "node_snapshotable.h"
 #include "base_object-inl.h"
+#include "debug_utils-inl.h"
+#include "node_file.h"
+#include "node_v8.h"
 
 namespace node {
 
 using v8::Local;
 using v8::Object;
+using v8::SnapshotCreator;
 using v8::StartupData;
+
+SnapshotableObject::SnapshotableObject(Environment* env,
+                                       Local<Object> wrap,
+                                       EmbedderObjectType type)
+    : BaseObject(env, wrap), type_(type) {
+  set_is_snapshotable(true);
+}
+
+const char* SnapshotableObject::GetTypeNameChars() const {
+  switch (type_) {
+#define V(PropertyName, NativeTypeName)                                        \
+  case EmbedderObjectType::k_##PropertyName: {                                 \
+    return NativeTypeName::type_name.c_str();                                  \
+  }
+    SERIALIZABLE_OBJECT_TYPES(V)
+#undef V
+    default: { UNREACHABLE(); }
+  }
+}
+
+bool IsSnapshotableType(FastStringKey key) {
+#define V(PropertyName, NativeTypeName)                                        \
+  if (key == NativeTypeName::type_name) {                                      \
+    return true;                                                               \
+  }
+  SERIALIZABLE_OBJECT_TYPES(V)
+#undef V
+
+  return false;
+}
 
 void DeserializeNodeInternalFields(Local<Object> holder,
                                    int index,
-                                   v8::StartupData payload,
+                                   StartupData payload,
                                    void* env) {
+  per_process::Debug(DebugCategory::MKSNAPSHOT,
+                     "Deserialize internal field %d of %p, size=%d\n",
+                     static_cast<int>(index),
+                     (*holder),
+                     static_cast<int>(payload.raw_size));
   if (payload.raw_size == 0) {
     holder->SetAlignedPointerInInternalField(index, nullptr);
     return;
   }
-  // No embedder object in the builtin snapshot yet.
-  UNREACHABLE();
+
+  Environment* env_ptr = static_cast<Environment*>(env);
+  const InternalFieldInfo* info =
+      reinterpret_cast<const InternalFieldInfo*>(payload.data);
+
+  switch (info->type) {
+#define V(PropertyName, NativeTypeName)                                        \
+  case EmbedderObjectType::k_##PropertyName: {                                 \
+    per_process::Debug(DebugCategory::MKSNAPSHOT,                              \
+                       "Object %p is %s\n",                                    \
+                       (*holder),                                              \
+                       NativeTypeName::type_name.c_str());                     \
+    env_ptr->EnqueueDeserializeRequest(                                        \
+        NativeTypeName::Deserialize, holder, index, info->Copy());             \
+    break;                                                                     \
+  }
+    SERIALIZABLE_OBJECT_TYPES(V)
+#undef V
+    default: { UNREACHABLE(); }
+  }
 }
 
 StartupData SerializeNodeContextInternalFields(Local<Object> holder,
                                                int index,
                                                void* env) {
-  void* ptr = holder->GetAlignedPointerFromInternalField(index);
-  if (ptr == nullptr || ptr == env) {
-    return StartupData{nullptr, 0};
-  }
-  if (ptr == env && index == ContextEmbedderIndex::kEnvironment) {
+  per_process::Debug(DebugCategory::MKSNAPSHOT,
+                     "Serialize internal field, index=%d, holder=%p\n",
+                     static_cast<int>(index),
+                     *holder);
+  void* ptr = holder->GetAlignedPointerFromInternalField(BaseObject::kSlot);
+  if (ptr == nullptr) {
     return StartupData{nullptr, 0};
   }
 
-  // No embedder objects in the builtin snapshot yet.
-  UNREACHABLE();
-  return StartupData{nullptr, 0};
+  DCHECK(static_cast<BaseObject*>(ptr)->is_snapshotable());
+  SnapshotableObject* obj = static_cast<SnapshotableObject*>(ptr);
+  per_process::Debug(DebugCategory::MKSNAPSHOT,
+                     "Object %p is %s, ",
+                     *holder,
+                     obj->GetTypeNameChars());
+  InternalFieldInfo* info = obj->Serialize(index);
+  per_process::Debug(DebugCategory::MKSNAPSHOT,
+                     "payload size=%d\n",
+                     static_cast<int>(info->length));
+  return StartupData{reinterpret_cast<const char*>(info),
+                     static_cast<int>(info->length)};
+}
+
+void SerializeBindingData(Environment* env,
+                          SnapshotCreator* creator,
+                          EnvSerializeInfo* info) {
+  size_t i = 0;
+  env->ForEachBindingData([&](FastStringKey key,
+                              BaseObjectPtr<BaseObject> binding) {
+    per_process::Debug(DebugCategory::MKSNAPSHOT,
+                       "Serialize binding %i, %p, type=%s\n",
+                       static_cast<int>(i),
+                       *(binding->object()),
+                       key.c_str());
+
+    if (IsSnapshotableType(key)) {
+      size_t index = creator->AddData(env->context(), binding->object());
+      per_process::Debug(DebugCategory::MKSNAPSHOT,
+                         "Serialized with index=%d\n",
+                         static_cast<int>(index));
+      info->bindings.push_back({key.c_str(), i, index});
+      SnapshotableObject* ptr = static_cast<SnapshotableObject*>(binding.get());
+      ptr->PrepareForSerialization(env->context(), creator);
+    } else {
+      UNREACHABLE();
+    }
+
+    i++;
+  });
 }
 
 }  // namespace node

--- a/src/node_snapshotable.h
+++ b/src/node_snapshotable.h
@@ -13,7 +13,8 @@ class Environment;
 struct EnvSerializeInfo;
 
 #define SERIALIZABLE_OBJECT_TYPES(V)                                           \
-  V(fs_binding_data, fs::BindingData)
+  V(fs_binding_data, fs::BindingData)                                          \
+  V(v8_binding_data, v8_utils::BindingData)
 
 enum class EmbedderObjectType : uint8_t {
   k_default = 0,

--- a/src/node_snapshotable.h
+++ b/src/node_snapshotable.h
@@ -12,7 +12,8 @@ namespace node {
 class Environment;
 struct EnvSerializeInfo;
 
-#define SERIALIZABLE_OBJECT_TYPES(V)
+#define SERIALIZABLE_OBJECT_TYPES(V)                                           \
+  V(fs_binding_data, fs::BindingData)
 
 enum class EmbedderObjectType : uint8_t {
   k_default = 0,

--- a/src/node_snapshotable.h
+++ b/src/node_snapshotable.h
@@ -4,8 +4,105 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-#include "v8.h"
+#include "base_object.h"
+#include "util.h"
+
 namespace node {
+
+class Environment;
+struct EnvSerializeInfo;
+
+#define SERIALIZABLE_OBJECT_TYPES(V)
+
+enum class EmbedderObjectType : uint8_t {
+  k_default = 0,
+#define V(PropertyName, NativeType) k_##PropertyName,
+  SERIALIZABLE_OBJECT_TYPES(V)
+#undef V
+};
+
+// When serializing an embedder object, we'll serialize the native states
+// into a chunk that can be mapped into a subclass of InternalFieldInfo,
+// and pass it into the V8 callback as the payload of StartupData.
+// TODO(joyeecheung): the classification of types seem to be wrong.
+// We'd need a type for each field of each class of native object.
+// Maybe it's fine - we'll just use the type to invoke BaseObject constructors
+// and specify that the BaseObject has only one field for us to serialize.
+// And for non-BaseObject embedder objects, we'll use field-wise types.
+// The memory chunk looks like this:
+//
+// [   type   ] - EmbedderObjectType (a uint8_t)
+// [  length  ] - a size_t
+// [    ...   ] - custom bytes of size |length - header size|
+struct InternalFieldInfo {
+  EmbedderObjectType type;
+  size_t length;
+
+  InternalFieldInfo() = delete;
+
+  static InternalFieldInfo* New(EmbedderObjectType type) {
+    return New(type, sizeof(InternalFieldInfo));
+  }
+
+  static InternalFieldInfo* New(EmbedderObjectType type, size_t length) {
+    InternalFieldInfo* result =
+        reinterpret_cast<InternalFieldInfo*>(::operator new(length));
+    result->type = type;
+    result->length = length;
+    return result;
+  }
+
+  InternalFieldInfo* Copy() const {
+    InternalFieldInfo* result =
+        reinterpret_cast<InternalFieldInfo*>(::operator new(length));
+    memcpy(result, this, length);
+    return result;
+  }
+
+  void Delete() { ::operator delete(this); }
+};
+
+// An interface for snapshotable native objects to inherit from.
+// Use the SERIALIZABLE_OBJECT_METHODS() macro in the class to define
+// the following methods to implement:
+//
+// - PrepareForSerialization(): This would be run prior to context
+//   serialization. Use this method to e.g. release references that
+//   can be re-initialized, or perform property store operations
+//   that needs a V8 context.
+// - Serialize(): This would be called during context serialization,
+//   once for each embedder field of the object.
+//   Allocate and construct an InternalFieldInfo object that contains
+//   data that can be used to deserialize native states.
+// - Deserialize(): This would be called after the context is
+//   deserialized and the object graph is complete, once for each
+//   embedder field of the object. Use this to restore native states
+//   in the object.
+class SnapshotableObject : public BaseObject {
+ public:
+  SnapshotableObject(Environment* env,
+                     v8::Local<v8::Object> wrap,
+                     EmbedderObjectType type = EmbedderObjectType::k_default);
+  const char* GetTypeNameChars() const;
+
+  virtual void PrepareForSerialization(v8::Local<v8::Context> context,
+                                       v8::SnapshotCreator* creator) = 0;
+  virtual InternalFieldInfo* Serialize(int index) = 0;
+  // We'll make sure that the type is set in the constructor
+  EmbedderObjectType type() { return type_; }
+
+ private:
+  EmbedderObjectType type_;
+};
+
+#define SERIALIZABLE_OBJECT_METHODS()                                          \
+  void PrepareForSerialization(v8::Local<v8::Context> context,                 \
+                               v8::SnapshotCreator* creator) override;         \
+  InternalFieldInfo* Serialize(int index) override;                            \
+  static void Deserialize(v8::Local<v8::Context> context,                      \
+                          v8::Local<v8::Object> holder,                        \
+                          int index,                                           \
+                          InternalFieldInfo* info);
 
 v8::StartupData SerializeNodeContextInternalFields(v8::Local<v8::Object> holder,
                                                    int index,
@@ -14,6 +111,11 @@ void DeserializeNodeInternalFields(v8::Local<v8::Object> holder,
                                    int index,
                                    v8::StartupData payload,
                                    void* env);
+void SerializeBindingData(Environment* env,
+                          v8::SnapshotCreator* creator,
+                          EnvSerializeInfo* info);
+
+bool IsSnapshotableType(FastStringKey key);
 }  // namespace node
 
 #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS

--- a/src/node_stat_watcher.cc
+++ b/src/node_stat_watcher.cc
@@ -19,10 +19,11 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#include "memory_tracker-inl.h"
 #include "node_stat_watcher.h"
 #include "async_wrap-inl.h"
 #include "env-inl.h"
+#include "memory_tracker-inl.h"
+#include "node_external_reference.h"
 #include "node_file-inl.h"
 #include "util-inl.h"
 
@@ -55,6 +56,11 @@ void StatWatcher::Initialize(Environment* env, Local<Object> target) {
   env->SetConstructorFunction(target, "StatWatcher", t);
 }
 
+void StatWatcher::RegisterExternalReferences(
+    ExternalReferenceRegistry* registry) {
+  registry->Register(StatWatcher::New);
+  registry->Register(StatWatcher::Start);
+}
 
 StatWatcher::StatWatcher(fs::BindingData* binding_data,
                          Local<Object> wrap,

--- a/src/node_stat_watcher.h
+++ b/src/node_stat_watcher.h
@@ -35,10 +35,12 @@ class BindingData;
 }
 
 class Environment;
+class ExternalReferenceRegistry;
 
 class StatWatcher : public HandleWrap {
  public:
   static void Initialize(Environment* env, v8::Local<v8::Object> target);
+  static void RegisterExternalReferences(ExternalReferenceRegistry* registry);
 
  protected:
   StatWatcher(fs::BindingData* binding_data,

--- a/src/node_v8.h
+++ b/src/node_v8.h
@@ -5,18 +5,23 @@
 
 #include "aliased_buffer.h"
 #include "base_object.h"
+#include "node_snapshotable.h"
 #include "util.h"
 #include "v8.h"
 
 namespace node {
 class Environment;
+struct InternalFieldInfo;
 
 namespace v8_utils {
-class BindingData : public BaseObject {
+class BindingData : public SnapshotableObject {
  public:
   BindingData(Environment* env, v8::Local<v8::Object> obj);
 
+  SERIALIZABLE_OBJECT_METHODS()
   static constexpr FastStringKey type_name{"node::v8::BindingData"};
+  static constexpr EmbedderObjectType type_int =
+      EmbedderObjectType::k_v8_binding_data;
 
   AliasedFloat64Array heap_statistics_buffer;
   AliasedFloat64Array heap_space_statistics_buffer;

--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -3,11 +3,12 @@
 #include "stream_wrap.h"
 #include "allocated_buffer-inl.h"
 
+#include "env-inl.h"
+#include "js_stream.h"
 #include "node.h"
 #include "node_buffer.h"
 #include "node_errors.h"
-#include "env-inl.h"
-#include "js_stream.h"
+#include "node_external_reference.h"
 #include "string_bytes.h"
 #include "util-inl.h"
 #include "v8.h"
@@ -421,6 +422,29 @@ void StreamBase::AddMethods(Environment* env, Local<FunctionTemplate> t) {
       BaseObject::InternalFieldSet<
           StreamBase::kOnReadFunctionField,
           &Value::IsFunction>);
+}
+
+void StreamBase::RegisterExternalReferences(
+    ExternalReferenceRegistry* registry) {
+  registry->Register(GetFD);
+  registry->Register(GetExternal);
+  registry->Register(GetBytesRead);
+  registry->Register(GetBytesWritten);
+  registry->Register(JSMethod<&StreamBase::ReadStartJS>);
+  registry->Register(JSMethod<&StreamBase::ReadStopJS>);
+  registry->Register(JSMethod<&StreamBase::Shutdown>);
+  registry->Register(JSMethod<&StreamBase::UseUserBuffer>);
+  registry->Register(JSMethod<&StreamBase::Writev>);
+  registry->Register(JSMethod<&StreamBase::WriteBuffer>);
+  registry->Register(JSMethod<&StreamBase::WriteString<ASCII>>);
+  registry->Register(JSMethod<&StreamBase::WriteString<UTF8>>);
+  registry->Register(JSMethod<&StreamBase::WriteString<UCS2>>);
+  registry->Register(JSMethod<&StreamBase::WriteString<LATIN1>>);
+  registry->Register(
+      BaseObject::InternalFieldGet<StreamBase::kOnReadFunctionField>);
+  registry->Register(
+      BaseObject::InternalFieldSet<StreamBase::kOnReadFunctionField,
+                                   &Value::IsFunction>);
 }
 
 void StreamBase::GetFD(const FunctionCallbackInfo<Value>& args) {

--- a/src/stream_base.h
+++ b/src/stream_base.h
@@ -19,6 +19,7 @@ class ShutdownWrap;
 class WriteWrap;
 class StreamBase;
 class StreamResource;
+class ExternalReferenceRegistry;
 
 struct StreamWriteResult {
   bool async;
@@ -308,7 +309,7 @@ class StreamBase : public StreamResource {
 
   static void AddMethods(Environment* env,
                          v8::Local<v8::FunctionTemplate> target);
-
+  static void RegisterExternalReferences(ExternalReferenceRegistry* registry);
   virtual bool IsAlive() = 0;
   virtual bool IsClosing() = 0;
   virtual bool IsIPCPipe();

--- a/src/stream_wrap.h
+++ b/src/stream_wrap.h
@@ -31,6 +31,7 @@
 namespace node {
 
 class Environment;
+class ExternalReferenceRegistry;
 
 class LibuvStreamWrap : public HandleWrap, public StreamBase {
  public:
@@ -38,7 +39,7 @@ class LibuvStreamWrap : public HandleWrap, public StreamBase {
                          v8::Local<v8::Value> unused,
                          v8::Local<v8::Context> context,
                          void* priv);
-
+  static void RegisterExternalReferences(ExternalReferenceRegistry* registry);
   int GetFD() override;
   bool IsAlive() override;
   bool IsClosing() override;

--- a/src/uv.cc
+++ b/src/uv.cc
@@ -22,6 +22,7 @@
 #include "uv.h"
 #include "env-inl.h"
 #include "node.h"
+#include "node_external_reference.h"
 #include "node_process.h"
 
 namespace node {
@@ -42,7 +43,7 @@ static const struct UVError uv_errors_map[] = {
 };
 }  // namespace per_process
 
-namespace {
+namespace uv {
 
 using v8::Array;
 using v8::Context;
@@ -130,7 +131,12 @@ void Initialize(Local<Object> target,
   env->SetMethod(target, "getErrorMap", GetErrMap);
 }
 
-}  // anonymous namespace
+void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
+  registry->Register(ErrName);
+  registry->Register(GetErrMap);
+}
+}  // namespace uv
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(uv, node::Initialize)
+NODE_MODULE_CONTEXT_AWARE_INTERNAL(uv, node::uv::Initialize)
+NODE_MODULE_EXTERNAL_REFERENCE(uv, node::uv::RegisterExternalReferences)

--- a/test/parallel/test-bootstrap-modules.js
+++ b/test/parallel/test-bootstrap-modules.js
@@ -18,12 +18,15 @@ const expectedModules = new Set([
   'Internal Binding fs',
   'Internal Binding fs_dir',
   'Internal Binding fs_event_wrap',
+  'Internal Binding heap_utils',
   'Internal Binding messaging',
   'Internal Binding module_wrap',
   'Internal Binding native_module',
   'Internal Binding options',
   'Internal Binding process_methods',
   'Internal Binding report',
+  'Internal Binding serdes',
+  'Internal Binding stream_wrap',
   'Internal Binding string_decoder',
   'Internal Binding symbols',
   'Internal Binding task_queue',
@@ -33,6 +36,7 @@ const expectedModules = new Set([
   'Internal Binding url',
   'Internal Binding util',
   'Internal Binding uv',
+  'Internal Binding v8',
   'Internal Binding worker',
   'NativeModule buffer',
   'NativeModule events',
@@ -54,6 +58,7 @@ const expectedModules = new Set([
   'NativeModule internal/fs/promises',
   'NativeModule internal/fs/rimraf',
   'NativeModule internal/fs/watchers',
+  'NativeModule internal/heap_utils',
   'NativeModule internal/idna',
   'NativeModule internal/linkedlist',
   'NativeModule internal/modules/run_main',
@@ -81,6 +86,7 @@ const expectedModules = new Set([
   'NativeModule internal/process/warning',
   'NativeModule internal/querystring',
   'NativeModule internal/source_map/source_map_cache',
+  'NativeModule internal/stream_base_commons',
   'NativeModule internal/streams/add-abort-signal',
   'NativeModule internal/streams/buffer_list',
   'NativeModule internal/streams/destroy',
@@ -111,6 +117,7 @@ const expectedModules = new Set([
   'NativeModule timers',
   'NativeModule url',
   'NativeModule util',
+  'NativeModule v8',
   'NativeModule vm',
 ]);
 
@@ -150,6 +157,7 @@ if (process.features.inspector) {
   expectedModules.add('Internal Binding inspector');
   expectedModules.add('NativeModule internal/inspector_async_hook');
   expectedModules.add('NativeModule internal/util/inspector');
+  expectedModules.add('Internal Binding profiler');
 }
 
 if (process.env.NODE_V8_COVERAGE) {


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/35930
Refs: https://github.com/nodejs/node/issues/35711

The basic idea is:

1. Before serialization is done, iterate over supported embeder objects and perform whatever necessary to clean up the embedder objects. In the case of V8 and fs binding data, since we can discard the contents of these AliasedBuffers anyway, we'll just release them so that V8 don't error on unregistered global handles - I have a different [POC](https://github.com/joyeecheung/node/tree/baseobj) of actually storing them behind private symbols so that we can retrieve them at deserialization time, but in these two particular cases it doesn't seem to worth the trouble, we can just reinitialize these buffers.
2. At serialization time, we save whatever data we need for each embedder slot to be deserialized properly. For v8 and fs bindings we just need to return a type constant in the callback for V8
3. At deserialization time, we enqueue functions in the deserialization callback of the context. We don't invoke them right away because it's more convenient to dehydrate the objects when the graph is completed (also potentially it's better if different embedder fields of one object depend on each other and need to be deserialized in a particular order).

#### src: support serialization of binding data

This patch adds the SnapshotableObject interface. Native objects
supporting serialization can inherit from it, implementing
PrepareForSerialization(), Serialize() and Deserialize()
to control how the native states should be serialized and
deserialized.

See doc: https://docs.google.com/document/d/15bu038I36oILq5t4Qju1sS2nKudVB6NSGWz00oD48Q8/edit

#### bootstrap: include fs module into the builtin snapshot

#### bootstrap: include v8 module into the builtin snapshot