### PR TITLE
http: add bytesWritten property

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1421,15 +1421,13 @@ Attempting to set a header field name or value that contains invalid characters
 will result in a [`TypeError`][] being thrown.
 
 ### `response.bytesWritten`
+<!-- YAML
+added: REPLACEME
+-->
 
 * {Integer}
 
 Number of bytes written to response body.
-
-### `response.connection`
-<!-- YAML
-added: REPLACEME
--->
 
 ### `response.connection`
 <!-- YAML

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1420,6 +1420,17 @@ response.end();
 Attempting to set a header field name or value that contains invalid characters
 will result in a [`TypeError`][] being thrown.
 
+### `response.bytesWritten`
+
+* {Integer}
+
+Number of bytes written to response body.
+
+### `response.connection`
+<!-- YAML
+added: REPLACEME
+-->
+
 ### `response.connection`
 <!-- YAML
 added: v0.3.0

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1425,7 +1425,7 @@ will result in a [`TypeError`][] being thrown.
 added: REPLACEME
 -->
 
-* {Integer}
+* {integer}
 
 Number of bytes written to response body.
 

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -3271,6 +3271,12 @@ message) to the response.
 Attempting to set a header field name or value that contains invalid characters
 will result in a [`TypeError`][] being thrown.
 
+### `response.bytesWritten`
+
+* {Integer}
+
+Number of bytes written to response body.
+
 #### `response.connection`
 <!-- YAML
 added: v8.4.0

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -3272,6 +3272,9 @@ Attempting to set a header field name or value that contains invalid characters
 will result in a [`TypeError`][] being thrown.
 
 ### `response.bytesWritten`
+<!-- YAML
+added: REPLACEME
+-->
 
 * {Integer}
 

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -3276,7 +3276,7 @@ will result in a [`TypeError`][] being thrown.
 added: REPLACEME
 -->
 
-* {Integer}
+* {integer}
 
 Number of bytes written to response body.
 

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -695,9 +695,11 @@ OutgoingMessage.prototype.write = function write(chunk, encoding, callback) {
     encoding = null;
   }
 
-  const ret = write_(this, chunk, encoding, callback, false);
+  const buf = typeof chunk === 'string' ? Buffer.from(chunk, encoding) : chunk;
 
-  this[kBytesWritten] += Buffer.byteLength(chunk, encoding);
+  const ret = write_(this, buf, null, callback, false);
+
+  this[kBytesWritten] += buf.length;
 
   if (!ret)
     this[kNeedDrain] = true;

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -145,6 +145,10 @@ ObjectSetPrototypeOf(OutgoingMessage, Stream);
 ObjectDefineProperty(OutgoingMessage.prototype, 'bytesWritten', {
   get() {
     return this[kBytesWritten];
+  },
+  set(value) {
+    // Compat
+    this[kBytesWritten] = value;
   }
 });
 

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -80,6 +80,7 @@ const HIGH_WATER_MARK = getDefaultHighWaterMark();
 const { CRLF, debug } = common;
 
 const kCorked = Symbol('corked');
+const kBytesWritten = Symbol('bytesWritten');
 
 const nop = FunctionPrototype;
 
@@ -132,6 +133,7 @@ function OutgoingMessage() {
   this.socket = null;
   this._header = null;
   this[kOutHeaders] = null;
+  this[kBytesWritten] = 0;
 
   this._keepAliveTimeout = 0;
 
@@ -139,6 +141,12 @@ function OutgoingMessage() {
 }
 ObjectSetPrototypeOf(OutgoingMessage.prototype, Stream.prototype);
 ObjectSetPrototypeOf(OutgoingMessage, Stream);
+
+ObjectDefineProperty(OutgoingMessage.prototype, 'bytesWritten', {
+  get() {
+    return this[kBytesWritten];
+  }
+});
 
 ObjectDefineProperty(OutgoingMessage.prototype, 'writableFinished', {
   get() {
@@ -684,6 +692,9 @@ OutgoingMessage.prototype.write = function write(chunk, encoding, callback) {
   }
 
   const ret = write_(this, chunk, encoding, callback, false);
+
+  this[kBytesWritten] += Buffer.byteLength(chunk, encoding);
+
   if (!ret)
     this[kNeedDrain] = true;
   return ret;

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -494,6 +494,10 @@ class Http2ServerResponse extends Stream {
     return this.headersSent;
   }
 
+  get bytesWritten() {
+    return this.stream.bytesWritten;
+  }
+
   get writableEnded() {
     const state = this[kState];
     return state.ending;

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -2113,11 +2113,10 @@ class Http2Stream extends Duplex {
       shutdownWritable.call(this, endCheckCallback);
     });
 
-    if (writev) {
+    if (writev)
       req = writevGeneric(this, data, writeCallback);
-    } else {
+    else
       req = writeGeneric(this, data, encoding, writeCallback);
-    }
 
     trackWriteState(this, req.bytes);
   }

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1908,7 +1908,7 @@ class Http2Stream extends Duplex {
       writeQueueSize: 0,
       trailersReady: false,
       endAfterHeaders: false,
-      bytesWritten: 0
+      bytesWritten: 0,
     };
 
     // Fields used by the compat API to avoid megamorphisms.

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1966,6 +1966,11 @@ class Http2Stream extends Duplex {
     return this[kState].bytesWritten;
   }
 
+  set bytesWritten(value) {
+    // Compat
+    this[kState].bytesWritten = value;
+  }
+
   get bufferSize() {
     // `bufferSize` properties of `net.Socket` are `undefined` when
     // their `_handle` are falsy. Here we avoid the behavior.

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -2127,8 +2127,9 @@ class Http2Stream extends Duplex {
   }
 
   write(data, encoding, cb) {
-    const ret = super.write(data, encoding, cb);
-    this[kState].bytesWritten += Buffer.byteLength(data, encoding);
+    const buf = typeof data === 'string' ? Buffer.from(data, encoding) : data;
+    const ret = super.write(data, null, cb);
+    this[kState].bytesWritten += buf.length;
     return ret;
   }
 

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -130,6 +130,7 @@ const { onServerStream,
         Http2ServerRequest,
         Http2ServerResponse,
 } = require('internal/http2/compat');
+const { Buffer } = require('buffer');
 
 const {
   assertIsObject,
@@ -1906,7 +1907,8 @@ class Http2Stream extends Duplex {
       rstCode: NGHTTP2_NO_ERROR,
       writeQueueSize: 0,
       trailersReady: false,
-      endAfterHeaders: false
+      endAfterHeaders: false,
+      bytesWritten: 0
     };
 
     // Fields used by the compat API to avoid megamorphisms.
@@ -1958,6 +1960,10 @@ class Http2Stream extends Duplex {
       writableState: this._writableState
     };
     return `Http2Stream ${format(obj)}`;
+  }
+
+  get bytesWritten() {
+    return this[kState].bytesWritten;
   }
 
   get bufferSize() {
@@ -2107,12 +2113,19 @@ class Http2Stream extends Duplex {
       shutdownWritable.call(this, endCheckCallback);
     });
 
-    if (writev)
+    if (writev) {
       req = writevGeneric(this, data, writeCallback);
-    else
+    } else {
       req = writeGeneric(this, data, encoding, writeCallback);
+    }
 
     trackWriteState(this, req.bytes);
+  }
+
+  write(data, encoding, cb) {
+    const ret = super.write(data, encoding, cb);
+    this[kState].bytesWritten += Buffer.byteLength(data, encoding);
+    return ret;
   }
 
   _write(data, encoding, cb) {

--- a/test/parallel/test-http-byteswritten.js
+++ b/test/parallel/test-http-byteswritten.js
@@ -37,15 +37,21 @@ const httpServer = http.createServer(common.mustCall(function(req, res) {
 
   // Write 1.5mb to cause some requests to buffer
   // Also, mix up the encodings a bit.
+  let bytesWritten = 0;
   const chunk = '7'.repeat(1024);
   const bchunk = Buffer.from(chunk);
   for (let i = 0; i < 1024; i++) {
     res.write(chunk);
+    bytesWritten += chunk.length;
     res.write(bchunk);
+    bytesWritten += bchunk.length;
     res.write(chunk, 'hex');
+    bytesWritten += Buffer.byteLength(chunk, 'hex');
+
   }
   // Get .bytesWritten while buffer is not empty
   assert(res.connection.bytesWritten > 0);
+  assert.strictEqual(res.bytesWritten, bytesWritten);
 
   res.end(body);
 }));

--- a/test/parallel/test-http2-buffersize.js
+++ b/test/parallel/test-http2-buffersize.js
@@ -40,9 +40,11 @@ const { once } = require('events');
     for (let j = 0; j < kSockets; j += 1) {
       const stream = client.request({ ':method': 'POST' });
       stream.on('data', () => {});
-
+      let bytesWritten = 0;
       for (let i = 0; i < kTimes; i += 1) {
         stream.write(Buffer.allocUnsafe(kBufferSize), mustSucceed());
+        bytesWritten += kBufferSize;
+        assert.strictEqual(stream.bytesWritten, bytesWritten);
         const expectedSocketBufferSize = kBufferSize * (i + 1);
         assert.strictEqual(stream.bufferSize, expectedSocketBufferSize);
       }

--- a/test/parallel/test-http2-compat-serverresponse-write.js
+++ b/test/parallel/test-http2-compat-serverresponse-write.js
@@ -27,6 +27,7 @@ const assert = require('assert');
     server.once('request', mustCall((request, response) => {
       // response.write() returns true
       assert(response.write('muahaha', 'utf8', mustCall()));
+      assert.strictEqual(response.bytesWritten, Buffer.byteLength('muahaha'));
 
       response.stream.close(0, mustCall(() => {
         response.on('error', mustNotCall());


### PR DESCRIPTION
Adds a bytesWritten property which can be used to inspect
how many bytes have been dispatched to response body.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
