### PR TITLE
benchmark: add benchmark for coverage

### DIFF
--- a/benchmark/fixtures/coverage-many-branches.js
+++ b/benchmark/fixtures/coverage-many-branches.js
@@ -1,0 +1,115 @@
+'use strict';
+
+// Exercise coverage of a class. Note, this logic is silly and exists solely
+// to generate branch coverage code paths:
+class CoveredClass {
+  constructor(x, y, opts) {
+    this.x = x;
+    this.y = y;
+    // Exercise coverage of nullish coalescing:
+    this.opts = opts ?? (Math.random() > 0.5 ? {} : undefined);
+  }
+  add() {
+    return this.x + this.y;
+  }
+  addSpecial() {
+    // Exercise coverage of optional chains:
+    if (this.opts?.special && this.opts?.special?.x && this.opts?.special?.y) {
+      return this.opts.special.x + this.opts.special.y;
+    }
+    return add();
+  }
+  mult() {
+    return this.x * this.y;
+  }
+  multSpecial() {
+    if (this.opts?.special && this.opts?.special?.x && this.opts?.special?.y) {
+      return this.opts.special.x * this.opts.special.y;
+    }
+    return mult();
+  }
+}
+
+// Excercise coverage of functions:
+function add(x, y) {
+  const mt = new CoveredClass(x, y);
+  return mt.add();
+}
+
+function addSpecial(x, y) {
+  let mt;
+  if (Math.random() > 0.5) {
+    mt = new CoveredClass(x, y);
+  } else {
+    mt = new CoveredClass(x, y, {
+      special: {
+        x: Math.random() * x,
+        y: Math.random() * y
+      }
+    });
+  }
+  return mt.addSpecial();
+}
+
+function mult(x, y) {
+  const mt = new CoveredClass(x, y);
+  return mt.mult();
+}
+
+function multSpecial(x, y) {
+  let mt;
+  if (Math.random() > 0.5) {
+    mt = new CoveredClass(x, y);
+  } else {
+    mt = new CoveredClass(x, y, {
+      special: {
+        x: Math.random() * x,
+        y: Math.random() * y
+      }
+    });
+  }
+  return mt.multSpecial();
+}
+
+for (let i = 0; i < parseInt(process.env.N); i++) {
+  const operations = ['add', 'addSpecial', 'mult', 'multSpecial'];
+  for (const operation of operations) {
+    // Exercise coverage of switch statements:
+    switch (operation) {
+      case 'add':
+        if (add(Math.random() * 10, Math.random() * 10) > 10) {
+          // Exercise coverage of ternary operations:
+          let r = addSpecial(Math.random() * 10, Math.random() * 10) > 10 ?
+            mult(Math.random() * 10, Math.random() * 10) :
+            add(Math.random() * 10, Math.random() * 10);
+          // Exercise && and ||
+          if (r && Math.random() > 0.5 || Math.random() < 0.5) r++;
+        }
+        break;
+      case 'addSpecial':
+        if (addSpecial(Math.random() * 10, Math.random() * 10) > 10 &&
+            add(Math.random() * 10, Math.random() * 10) > 10) {
+          let r = mult(Math.random() * 10, Math.random() * 10) > 10 ?
+            add(Math.random() * 10, Math.random() * 10) > 10 :
+            mult(Math.random() * 10, Math.random() * 10);
+          if (r && Math.random() > 0.5 || Math.random() < 0.5) r++;
+        }
+        break;
+      case 'mult':
+        if (mult(Math.random() * 10, Math.random() * 10) > 10) {
+          let r = multSpecial(Math.random() * 10, Math.random() * 10) > 10 ?
+            add(Math.random() * 10, Math.random() * 10) :
+            mult(Math.random() * 10, Math.random() * 10);
+          if (r && Math.random() > 0.5 || Math.random() < 0.5) r++;
+        }
+        break;
+      case 'multSpecial':
+        while (multSpecial(Math.random() * 10, Math.random() * 10) < 10) {
+          mult(Math.random() * 10, Math.random() * 10);
+        }
+        break;
+      default:
+        break;
+    }
+  }
+}

--- a/benchmark/process/coverage.js
+++ b/benchmark/process/coverage.js
@@ -1,0 +1,32 @@
+// This benchmark is meant to exercise a grab bag of code paths that would
+// be expected to run slower under coverage.
+'use strict';
+
+const common = require('../common.js');
+const bench = common.createBenchmark(main, {
+  n: [1e5]
+});
+const path = require('path');
+const { rmSync } = require('fs');
+const { spawnSync } = require('child_process');
+const tmpdir = require('../../test/common/tmpdir');
+
+const coverageDir = path.join(tmpdir.path, `./cov-${Date.now()}`);
+
+function main({ n }) {
+  bench.start();
+  const result = spawnSync(process.execPath, [
+    require.resolve('../fixtures/coverage-many-branches'),
+  ], {
+    env: {
+      NODE_V8_COVERAGE: coverageDir,
+      N: n,
+      ...process.env
+    }
+  });
+  bench.end(n);
+  rmSync(coverageDir, { recursive: true, force: true });
+  if (result.status !== 0) {
+    throw new Error(result.stderr.toString('utf8'));
+  }
+}


### PR DESCRIPTION
Working on #36956, I became a bit worried that as we extend code coverage to support more types of branching, performance might start to become unacceptable.

I created this benchmark to experiment:

**Node 14.15.4, NODE_V8_COVERAGE, vs., no coverage:**

`process/coverage.js n=100000        ***    -18.94 %       ±0.77% ±1.02% ±1.30%`

**Node 15.6.0, NODE_V8_COVERAGE, vs., no coverage:**

` process/coverage.js n=100000        ***    -17.95 %       ±1.08% ±1.43% ±1.83%`

**Coverage with #36956, vs., no coverage:**

`process/coverage.js n=100000        ***    -19.37 %       ±1.36% ±1.79% ±2.30%`

## To Summarize

In the current release of 14/15, we see that running Node with coverage decreases performance by about 18%.

With the introduction of optional chaining in this benchmark, we see a 1 - 2% additional hit to performance.

## Other interesting facts

* I benchmarked `coverage.js` using Istanbul, vs., NODE_V8_COVERAGE, it was 37.46% slower than no coverage.
* I benchmarked #36956 with no coverage, vs., 15.6.0 with no coverage; there did not appear to be a significant difference in performance (`0.37 %       ±1.14% ±1.50% ±1.92%`).

## Conclusions

* My gut is that it's worth taking the 1 - 2% performance hit to support a new type of branching in our coverage reporting.
* As new constructs like this are added to JavaScript, we need to be mindful that the cost of branch coverage will continue to increase.
* I was excited to see that v8's coverage offers a significant performance benefit over pre-instrumenting the JavaScript code.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

CC: @schuay