### PR TITLE
lib: support returning Safe collections from C++

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -273,6 +273,29 @@ void Environment::CreateProperties() {
   CHECK(primordials->IsObject());
   set_primordials(primordials.As<Object>());
 
+  Local<String> prototype_string =
+      FIXED_ONE_BYTE_STRING(isolate(), "prototype");
+
+#define V(EnvPropertyName, PrimordialsPropertyName)                            \
+  {                                                                            \
+    Local<Value> ctor =                                                        \
+        primordials.As<Object>()                                               \
+            ->Get(ctx,                                                         \
+                  FIXED_ONE_BYTE_STRING(isolate(), PrimordialsPropertyName))   \
+            .ToLocalChecked();                                                 \
+    CHECK(ctor->IsObject());                                                   \
+    Local<Value> prototype =                                                   \
+        ctor.As<Object>()->Get(ctx, prototype_string).ToLocalChecked();        \
+    CHECK(prototype->IsObject());                                              \
+    set_##EnvPropertyName(prototype.As<Object>());                             \
+  }
+
+  V(primordials_safe_map_prototype_object, "SafeMap");
+  V(primordials_safe_set_prototype_object, "SafeSet");
+  V(primordials_safe_weak_map_prototype_object, "SafeWeakMap");
+  V(primordials_safe_weak_set_prototype_object, "SafeWeakSet");
+#undef V
+
   Local<Object> process_object =
       node::CreateProcessObject(this).FromMaybe(Local<Object>());
   set_process_object(process_object);

--- a/src/env.h
+++ b/src/env.h
@@ -550,6 +550,10 @@ constexpr size_t kFsStatsBufferLength =
   V(prepare_stack_trace_callback, v8::Function)                                \
   V(process_object, v8::Object)                                                \
   V(primordials, v8::Object)                                                   \
+  V(primordials_safe_map_prototype_object, v8::Object)                         \
+  V(primordials_safe_set_prototype_object, v8::Object)                         \
+  V(primordials_safe_weak_map_prototype_object, v8::Object)                    \
+  V(primordials_safe_weak_set_prototype_object, v8::Object)                    \
   V(promise_hook_handler, v8::Function)                                        \
   V(promise_reject_callback, v8::Function)                                     \
   V(script_data_constructor_function, v8::Function)                            \

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -917,6 +917,12 @@ void GetOptions(const FunctionCallbackInfo<Value>& args) {
   });
 
   Local<Map> options = Map::New(isolate);
+  if (options
+          ->SetPrototype(context, env->primordials_safe_map_prototype_object())
+          .IsNothing()) {
+    return;
+  }
+
   for (const auto& item : _ppop_instance.options_) {
     Local<Value> value;
     const auto& option_info = item.second;
@@ -1004,6 +1010,12 @@ void GetOptions(const FunctionCallbackInfo<Value>& args) {
 
   Local<Value> aliases;
   if (!ToV8Value(context, _ppop_instance.aliases_).ToLocal(&aliases)) return;
+
+  if (aliases.As<Object>()
+          ->SetPrototype(context, env->primordials_safe_map_prototype_object())
+          .IsNothing()) {
+    return;
+  }
 
   Local<Object> ret = Object::New(isolate);
   if (ret->Set(context, env->options_string(), options).IsNothing() ||

--- a/src/uv.cc
+++ b/src/uv.cc
@@ -81,6 +81,8 @@ void GetErrMap(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = env->isolate();
   Local<Context> context = env->context();
 
+  // This can't return a SafeMap, because the uv binding can be referenced
+  // by user code by using `process.binding('uv').getErrorMap()`:
   Local<Map> err_map = Map::New(isolate);
 
   size_t errors_len = arraysize(per_process::uv_errors_map);

--- a/test/parallel/test-options-binding.js
+++ b/test/parallel/test-options-binding.js
@@ -1,0 +1,21 @@
+// Flags: --expose-internals
+'use strict';
+
+const common = require('../common');
+const { primordials } = require('internal/test/binding');
+const {
+  SafeMap,
+} = primordials;
+
+const { options, aliases, getOptionValue } = require('internal/options');
+const assert = require('assert');
+
+assert(options instanceof SafeMap,
+       "require('internal/options').options is a SafeMap");
+
+assert(aliases instanceof SafeMap,
+       "require('internal/options').aliases is a SafeMap");
+
+Map.prototype.get =
+  common.mustNotCall('%Map.prototype.get% must not be called');
+assert.strictEqual(getOptionValue('--expose-internals'), true);

--- a/test/parallel/test-options-binding.js
+++ b/test/parallel/test-options-binding.js
@@ -2,10 +2,7 @@
 'use strict';
 
 const common = require('../common');
-const { primordials } = require('internal/test/binding');
-const {
-  SafeMap,
-} = primordials;
+const { primordials: { SafeMap } } = require('internal/test/binding');
 
 const { options, aliases, getOptionValue } = require('internal/options');
 const assert = require('assert');
@@ -17,5 +14,5 @@ assert(aliases instanceof SafeMap,
        "require('internal/options').aliases is a SafeMap");
 
 Map.prototype.get =
-  common.mustNotCall('%Map.prototype.get% must not be called');
+  common.mustNotCall('`getOptionValue` must not call user-mutable method');
 assert.strictEqual(getOptionValue('--expose-internals'), true);


### PR DESCRIPTION
**Refs:** <https://github.com/nodejs/node/pull/36652>

This works similarly to what’s done to support constructing `Buffer` instances from **C++**, but unlike `Buffer.prototype`, the `Safe*` collection prototypes can be captured as soon as `InitializePrimordials` has finished running `lib/internal/per_context/primordials.js`.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
