### PR TITLE
crypto: add contributeEntropy method

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1961,6 +1961,19 @@ is currently in use. Setting to true requires a FIPS build of Node.js.
 This property is deprecated. Please use `crypto.setFips()` and
 `crypto.getFips()` instead.
 
+### `crypto.contributeEntropy(data)`
+<!-- YAML
+added: REPLACEME
+-->
+
+* `data` {ArrayBuffer|SharedArrayBuffer|TypedArray|Buffer|DataView}
+* Returns {boolean} `true` if the pseudorandon number generator state has
+  enough collected entropy to generate suitably random data.
+
+Contributes the given data to the pseudorandom number generator used by the
+crypto module for generating random bytes. The given `data` should be
+unpredictable.
+
 ### `crypto.createCipher(algorithm, password[, options])`
 <!-- YAML
 added: v0.1.94

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1967,7 +1967,7 @@ added: REPLACEME
 -->
 
 * `data` {ArrayBuffer|SharedArrayBuffer|TypedArray|Buffer|DataView}
-* Returns {boolean} `true` if the pseudorandon number generator state has
+* Returns {boolean} `true` if the pseudorandom number generator state has
   enough collected entropy to generate suitably random data.
 
 Contributes the given data to the pseudorandom number generator used by the

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -50,6 +50,7 @@ const {
   timingSafeEqual,
 } = internalBinding('crypto');
 const {
+  contributeEntropy,
   randomBytes,
   randomFill,
   randomFillSync,
@@ -170,6 +171,7 @@ function createVerify(algorithm, options) {
 
 module.exports = {
   // Methods
+  contributeEntropy,
   createCipheriv,
   createDecipheriv,
   createDiffieHellman,

--- a/lib/internal/crypto/random.js
+++ b/lib/internal/crypto/random.js
@@ -10,6 +10,7 @@ const {
 
 const {
   RandomBytesJob,
+  contributeEntropy: _contributeEntropy,
   kCryptoJobAsync,
   kCryptoJobSync,
   secureBuffer,
@@ -387,6 +388,21 @@ function randomUUID(options) {
   return uuid.latin1Slice(0, 36);
 }
 
+function contributeEntropy(data) {
+  if (!isAnyArrayBuffer(data) && !isArrayBufferView(data)) {
+    throw new ERR_INVALID_ARG_TYPE(
+      'data',
+      [
+        'ArrayBuffer',
+        'TypedArray',
+        'Buffer',
+        'DataView'
+      ],
+      data);
+  }
+  return _contributeEntropy(data) === 1;
+}
+
 module.exports = {
   randomBytes,
   randomFill,
@@ -394,4 +410,5 @@ module.exports = {
   randomInt,
   getRandomValues,
   randomUUID,
+  contributeEntropy,
 };

--- a/src/crypto/crypto_random.cc
+++ b/src/crypto/crypto_random.cc
@@ -64,9 +64,18 @@ bool RandomBytesTraits::DeriveBits(
   return RAND_bytes(params.buffer, params.size) != 0;
 }
 
+namespace {
+void ContributeEntropy(const FunctionCallbackInfo<Value>& args) {
+  ArrayBufferOrViewContents<char> data(args[0]);
+  RAND_add(data.data(), data.size(), data.size());
+  args.GetReturnValue().Set(RAND_status());
+}
+}  // namespace
+
 namespace Random {
 void Initialize(Environment* env, Local<Object> target) {
   RandomBytesJob::Initialize(env, target);
+  env->SetMethod(target, "contributeEntropy", ContributeEntropy);
 }
 }  // namespace Random
 }  // namespace crypto

--- a/test/parallel/test-crypto-contributeentropy.js
+++ b/test/parallel/test-crypto-contributeentropy.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const common = require('../common');
+
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+  return;
+}
+
+const assert = require('assert');
+const {
+  contributeEntropy,
+  randomFillSync,
+} = require('crypto');
+
+[1, 'hello', false, {}, []].forEach((i) => {
+  assert.throws(() => contributeEntropy(i), {
+    code: 'ERR_INVALID_ARG_TYPE'
+  });
+});
+
+[
+  Buffer.from('hello'),
+  randomFillSync(new ArrayBuffer(10)),
+  randomFillSync(new SharedArrayBuffer(10)),
+  randomFillSync(new Uint8Array(10)),
+  randomFillSync(new DataView(new ArrayBuffer(10)))
+].forEach((i) => {
+  const ret = contributeEntropy(i);
+  assert.strictEqual(typeof ret, 'boolean');
+});


### PR DESCRIPTION
Provides a simple method used to contribute additional entropy to the openssl prng. (thin wrapper for `RAND_add()`...)

Signed-off-by: James M Snell <jasnell@gmail.com>
