### PR TITLE
src: inline AsyncCleanupHookHandle in headers

### DIFF
--- a/src/api/hooks.cc
+++ b/src/api/hooks.cc
@@ -145,7 +145,7 @@ static void RunAsyncCleanupHook(void* arg) {
   info->fun(info->arg, FinishAsyncCleanupHook, info);
 }
 
-ACHHandle* AddEnvironmentCleanupHookRaw(
+ACHHandle* AddEnvironmentCleanupHookInternal(
     Isolate* isolate,
     AsyncCleanupHook fun,
     void* arg) {
@@ -160,7 +160,7 @@ ACHHandle* AddEnvironmentCleanupHookRaw(
   return new ACHHandle { info };
 }
 
-void RemoveEnvironmentCleanupHookRaw(
+void RemoveEnvironmentCleanupHookInternal(
     ACHHandle* handle) {
   if (handle->info->started) return;
   handle->info->self.reset();

--- a/src/api/hooks.cc
+++ b/src/api/hooks.cc
@@ -145,7 +145,7 @@ static void RunAsyncCleanupHook(void* arg) {
   info->fun(info->arg, FinishAsyncCleanupHook, info);
 }
 
-AsyncCleanupHookHandle AddEnvironmentCleanupHook(
+ACHHandle* AddEnvironmentCleanupHookRaw(
     Isolate* isolate,
     AsyncCleanupHook fun,
     void* arg) {
@@ -157,11 +157,11 @@ AsyncCleanupHookHandle AddEnvironmentCleanupHook(
   info->arg = arg;
   info->self = info;
   env->AddCleanupHook(RunAsyncCleanupHook, info.get());
-  return AsyncCleanupHookHandle(new ACHHandle { info });
+  return new ACHHandle { info };
 }
 
-void RemoveEnvironmentCleanupHook(
-    AsyncCleanupHookHandle handle) {
+void RemoveEnvironmentCleanupHookRaw(
+    ACHHandle* handle) {
   if (handle->info->started) return;
   handle->info->self.reset();
   handle->info->env->RemoveCleanupHook(RunAsyncCleanupHook, handle->info.get());

--- a/src/node.h
+++ b/src/node.h
@@ -925,7 +925,9 @@ struct ACHHandle;
 struct NODE_EXTERN DeleteACHHandle { void operator()(ACHHandle*) const; };
 typedef std::unique_ptr<ACHHandle, DeleteACHHandle> AsyncCleanupHookHandle;
 
-NODE_EXTERN ACHHandle* AddEnvironmentCleanupHookRaw(
+/* This function is not intended to be used externally, it exists to aid in
+ * keeping ABI compatibility between Node and Electron. */
+NODE_EXTERN ACHHandle* AddEnvironmentCleanupHookInternal(
     v8::Isolate* isolate,
     void (*fun)(void* arg, void (*cb)(void*), void* cbarg),
     void* arg);
@@ -933,13 +935,15 @@ inline AsyncCleanupHookHandle AddEnvironmentCleanupHook(
     v8::Isolate* isolate,
     void (*fun)(void* arg, void (*cb)(void*), void* cbarg),
     void* arg) {
-  return AsyncCleanupHookHandle(AddEnvironmentCleanupHookRaw(isolate, fun,
+  return AsyncCleanupHookHandle(AddEnvironmentCleanupHookInternal(isolate, fun,
       arg));
 }
 
-NODE_EXTERN void RemoveEnvironmentCleanupHookRaw(ACHHandle* holder);
+/* This function is not intended to be used externally, it exists to aid in
+ * keeping ABI compatibility between Node and Electron. */
+NODE_EXTERN void RemoveEnvironmentCleanupHookInternal(ACHHandle* holder);
 inline void RemoveEnvironmentCleanupHook(AsyncCleanupHookHandle holder) {
-  RemoveEnvironmentCleanupHookRaw(holder.get());
+  RemoveEnvironmentCleanupHookInternal(holder.get());
 }
 
 /* Returns the id of the current execution context. If the return value is

--- a/src/node.h
+++ b/src/node.h
@@ -925,12 +925,22 @@ struct ACHHandle;
 struct NODE_EXTERN DeleteACHHandle { void operator()(ACHHandle*) const; };
 typedef std::unique_ptr<ACHHandle, DeleteACHHandle> AsyncCleanupHookHandle;
 
-NODE_EXTERN AsyncCleanupHookHandle AddEnvironmentCleanupHook(
+NODE_EXTERN ACHHandle* AddEnvironmentCleanupHookRaw(
     v8::Isolate* isolate,
     void (*fun)(void* arg, void (*cb)(void*), void* cbarg),
     void* arg);
+inline AsyncCleanupHookHandle AddEnvironmentCleanupHook(
+    v8::Isolate* isolate,
+    void (*fun)(void* arg, void (*cb)(void*), void* cbarg),
+    void* arg) {
+  return AsyncCleanupHookHandle(AddEnvironmentCleanupHookRaw(isolate, fun,
+      arg));
+}
 
-NODE_EXTERN void RemoveEnvironmentCleanupHook(AsyncCleanupHookHandle holder);
+NODE_EXTERN void RemoveEnvironmentCleanupHookRaw(ACHHandle* holder);
+inline void RemoveEnvironmentCleanupHook(AsyncCleanupHookHandle holder) {
+  RemoveEnvironmentCleanupHookRaw(holder.get());
+}
 
 /* Returns the id of the current execution context. If the return value is
  * zero then no execution has been set. This will happen if the user handles


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/36349

It doesn't look like there is any documentation for this feature as of yet, since it seems to be experimental (and I might be the only user of it), so I didn't need to do anything for documentation. Testing covers this area in both N-API and for regular addons. Having trouble Running the `InspectorSocketServerTest` locally, but was able to dig through the makefile to find a test target for the affected work.

@addaleax Pinging you as requested. Thank you for all your help!