### PR TITLE
lib: add `bound apply` variants of varargs `primordials`

### DIFF
--- a/lib/internal/per_context/primordials.js
+++ b/lib/internal/per_context/primordials.js
@@ -81,6 +81,9 @@ function copyPropsRenamed(src, dest, prefix) {
       ReflectDefineProperty(dest, name, desc);
       if (varargsMethods.includes(name)) {
         ReflectDefineProperty(dest, `${name}Apply`, {
+          // `src` is bound as the `this` so that the static `this` points
+          // to the object it was defined on,
+          // e.g.: `ArrayOfApply` gets a `this` of `Array`:
           value: applyBind(desc.value, src),
         });
       }

--- a/lib/internal/per_context/primordials.js
+++ b/lib/internal/per_context/primordials.js
@@ -21,9 +21,35 @@ const {
 // `uncurryThis` is equivalent to `func => Function.prototype.call.bind(func)`.
 // It is using `bind.bind(call)` to avoid using `Function.prototype.bind`
 // and `Function.prototype.call` after it may have been mutated by users.
-const { bind, call } = Function.prototype;
+const { apply, bind, call } = Function.prototype;
 const uncurryThis = bind.bind(call);
 primordials.uncurryThis = uncurryThis;
+
+// `applyBind` is equivalent to `func => Function.prototype.apply.bind(func)`.
+// It is using `bind.bind(apply)` to avoid using `Function.prototype.bind`
+// and `Function.prototype.apply` after it may have been mutated by users.
+const applyBind = bind.bind(apply);
+primordials.applyBind = applyBind;
+
+// Methods that accept a variable number of arguments, and thus it's useful to
+// also create `${prefix}${key}Apply`, which uses `Function.prototype.apply`,
+// instead of `Function.prototype.call`, and thus doesn't require iterator
+// destructuring.
+const varargsMethods = [
+  // 'ArrayPrototypeConcat' is omitted, because it performs the spread
+  // on its own for arrays and array-likes with a truthy
+  // @@isConcatSpreadable symbol property.
+  'ArrayOf',
+  'ArrayPrototypePush',
+  'ArrayPrototypeUnshift',
+  // 'FunctionPrototypeCall' is omitted, since there's 'ReflectApply'
+  // and 'FunctionPrototypeApply'.
+  'MathHypot',
+  'MathMax',
+  'MathMin',
+  'StringPrototypeConcat',
+  'TypedArrayOf',
+];
 
 function getNewKey(key) {
   return typeof key === 'symbol' ?
@@ -51,7 +77,13 @@ function copyPropsRenamed(src, dest, prefix) {
     if ('get' in desc) {
       copyAccessor(dest, prefix, newKey, desc);
     } else {
-      ReflectDefineProperty(dest, `${prefix}${newKey}`, desc);
+      const name = `${prefix}${newKey}`;
+      ReflectDefineProperty(dest, name, desc);
+      if (varargsMethods.includes(name)) {
+        ReflectDefineProperty(dest, `${name}Apply`, {
+          value: applyBind(desc.value, src),
+        });
+      }
     }
   }
 }
@@ -63,10 +95,18 @@ function copyPropsRenamedBound(src, dest, prefix) {
     if ('get' in desc) {
       copyAccessor(dest, prefix, newKey, desc);
     } else {
-      if (typeof desc.value === 'function') {
-        desc.value = desc.value.bind(src);
+      const { value } = desc;
+      if (typeof value === 'function') {
+        desc.value = value.bind(src);
       }
-      ReflectDefineProperty(dest, `${prefix}${newKey}`, desc);
+
+      const name = `${prefix}${newKey}`;
+      ReflectDefineProperty(dest, name, desc);
+      if (varargsMethods.includes(name)) {
+        ReflectDefineProperty(dest, `${name}Apply`, {
+          value: applyBind(value, src),
+        });
+      }
     }
   }
 }
@@ -78,10 +118,18 @@ function copyPrototype(src, dest, prefix) {
     if ('get' in desc) {
       copyAccessor(dest, prefix, newKey, desc);
     } else {
-      if (typeof desc.value === 'function') {
-        desc.value = uncurryThis(desc.value);
+      const { value } = desc;
+      if (typeof value === 'function') {
+        desc.value = uncurryThis(value);
       }
-      ReflectDefineProperty(dest, `${prefix}${newKey}`, desc);
+
+      const name = `${prefix}${newKey}`;
+      ReflectDefineProperty(dest, name, desc);
+      if (varargsMethods.includes(name)) {
+        ReflectDefineProperty(dest, `${name}Apply`, {
+          value: applyBind(value),
+        });
+      }
     }
   }
 }

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -6,6 +6,7 @@ const {
   ArrayPrototypeFilter,
   ArrayPrototypeForEach,
   ArrayPrototypePush,
+  ArrayPrototypePushApply,
   ArrayPrototypeSort,
   ArrayPrototypeUnshift,
   BigIntPrototypeValueOf,
@@ -665,7 +666,7 @@ function getKeys(value, showHidden) {
   if (showHidden) {
     keys = ObjectGetOwnPropertyNames(value);
     if (symbols.length !== 0)
-      ArrayPrototypePush(keys, ...symbols);
+      ArrayPrototypePushApply(keys, symbols);
   } else {
     // This might throw if `value` is a Module Namespace Object from an
     // unevaluated module, but we don't want to perform the actual type
@@ -681,7 +682,7 @@ function getKeys(value, showHidden) {
     }
     if (symbols.length !== 0) {
       const filter = (key) => ObjectPrototypePropertyIsEnumerable(value, key);
-      ArrayPrototypePush(keys, ...ArrayPrototypeFilter(symbols, filter));
+      ArrayPrototypePushApply(keys, ArrayPrototypeFilter(symbols, filter));
     }
   }
   return keys;

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -43,6 +43,7 @@ const {
   MathCeil,
   MathFloor,
   MathMax,
+  MathMaxApply,
   NumberIsFinite,
   NumberIsNaN,
   ObjectDefineProperty,
@@ -634,7 +635,7 @@ Interface.prototype._tabComplete = function(lastKeypressWasTab) {
     // Apply/show completions.
     const completionsWidth = ArrayPrototypeMap(completions,
                                                (e) => getStringWidth(e));
-    const width = MathMax(...completionsWidth) + 2; // 2 space padding
+    const width = MathMaxApply(completionsWidth) + 2; // 2 space padding
     let maxColumns = MathFloor(this.columns / width) || 1;
     if (maxColumns === Infinity) {
       maxColumns = 1;

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1313,6 +1313,7 @@ function complete(line, callback) {
       if (!this.useGlobal) {
         // When the context is not `global`, builtins are not own
         // properties of it.
+        // `globalBuiltins` is a `SafeSet`, not an Array-like.
         ArrayPrototypePush(contextOwnNames, ...globalBuiltins);
       }
       ArrayPrototypePush(completionGroups, contextOwnNames);

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -28,7 +28,7 @@ const {
   ArrayPrototypePush,
   Error,
   FunctionPrototypeBind,
-  MathMax,
+  MathMaxApply,
   NumberIsFinite,
   NumberIsNaN,
   ObjectDefineProperties,
@@ -788,7 +788,7 @@ function createConvenienceMethod(ctor, sync) {
   };
 }
 
-const kMaxBrotliParam = MathMax(...ArrayPrototypeMap(
+const kMaxBrotliParam = MathMaxApply(ArrayPrototypeMap(
   ObjectKeys(constants),
   (key) => (StringPrototypeStartsWith(key, 'BROTLI_PARAM_') ?
     constants[key] :

--- a/test/parallel/test-primordials-apply.js
+++ b/test/parallel/test-primordials-apply.js
@@ -1,0 +1,74 @@
+// Flags: --expose-internals
+'use strict';
+
+require('../common');
+
+const assert = require('assert');
+const {
+  ArrayOfApply,
+  ArrayPrototypePushApply,
+  ArrayPrototypeUnshiftApply,
+  MathMaxApply,
+  MathMinApply,
+  StringPrototypeConcatApply,
+  TypedArrayOfApply,
+} = require('internal/test/binding').primordials;
+
+{
+  const arr1 = [1, 2, 3];
+  const arr2 = ArrayOfApply(arr1);
+
+  assert.deepStrictEqual(arr2, arr1);
+  assert.notStrictEqual(arr2, arr1);
+}
+
+{
+  const array = [1, 2, 3];
+  const i32Array = TypedArrayOfApply(Int32Array, array);
+
+  assert(i32Array instanceof Int32Array);
+  assert.strictEqual(i32Array.length, array.length);
+  for (let i = 0, { length } = array; i < length; i++) {
+    assert.strictEqual(i32Array[i], array[i], `i32Array[${i}] === array[${i}]`);
+  }
+}
+
+{
+  const arr1 = [1, 2, 3];
+  const arr2 = [4, 5, 6];
+
+  const expected = [...arr1, ...arr2];
+
+  assert.strictEqual(ArrayPrototypePushApply(arr1, arr2), expected.length);
+  assert.deepStrictEqual(arr1, expected);
+}
+
+{
+  const arr1 = [1, 2, 3];
+  const arr2 = [4, 5, 6];
+
+  const expected = [...arr2, ...arr1];
+
+  assert.strictEqual(ArrayPrototypeUnshiftApply(arr1, arr2), expected.length);
+  assert.deepStrictEqual(arr1, expected);
+}
+
+{
+  const array = [1, 2, 3];
+  assert.strictEqual(MathMaxApply(array), 3);
+  assert.strictEqual(MathMinApply(array), 1);
+}
+
+{
+  let hint;
+  const obj = { [Symbol.toPrimitive](h) {
+    hint = h;
+    return '[object Object]';
+  } };
+
+  const args = ['foo ', obj, ' bar'];
+  const result = StringPrototypeConcatApply('', args);
+
+  assert.strictEqual(hint, 'string');
+  assert.strictEqual(result, 'foo [object Object] bar');
+}


### PR DESCRIPTION
This removes the need for iterator destructuring of variable arguments for `ArrayPrototypePush` by adding `bound apply` variants of varargs `primordials`.

---

**Refs:** <https://github.com/nodejs/node/pull/36740#discussion_r559745321>, which inspired me to do this.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
