### PR TITLE
test: add tests for mode passed as an options object in mkdir and mkdirSync

### DIFF
--- a/test/parallel/test-fs-mkdir.js
+++ b/test/parallel/test-fs-mkdir.js
@@ -53,6 +53,25 @@ function nextdir() {
   }));
 }
 
+// fs.mkdir creates directory with mode passed as an options object
+{
+  const pathname = path.join(tmpdir.path, nextdir());
+
+  fs.mkdir(pathname, { mode: 0o777 }, common.mustCall(function(err) {
+    assert.strictEqual(err, null);
+    assert.strictEqual(fs.existsSync(pathname), true);
+  }));
+}
+
+// fs.mkdirSync creates directory with mode passed as an options object
+{
+  const pathname = path.join(tmpdir.path, nextdir());
+
+  fs.mkdirSync(pathname, { mode: 0o777 });
+
+  assert.strictEqual(fs.existsSync(pathname), true);
+}
+
 // mkdirSync successfully creates directory from given path
 {
   const pathname = path.join(tmpdir.path, nextdir());


### PR DESCRIPTION
This also adds coverage for `mkdirSync` inside the conditional where
`options.mode` is not `undefined`.

Refs: https://coverage.nodejs.org/coverage-e3e054d020ee5ef6/lib/fs.js.html#L1023

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
