### PR TITLE
[v10.x Backport] Backport crypto fix to v10

### DIFF
--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -475,12 +475,19 @@ class Hash : public BaseObject {
 
   Hash(Environment* env, v8::Local<v8::Object> wrap)
       : BaseObject(env, wrap),
-        mdctx_(nullptr) {
+        mdctx_(nullptr),
+        md_len_(0) {
     MakeWeak();
+  }
+
+  ~Hash() override {
+    OPENSSL_cleanse(md_value_, md_len_);
   }
 
  private:
   EVPMDPointer mdctx_;
+  unsigned char md_value_[EVP_MAX_MD_SIZE];
+  unsigned int md_len_;
 };
 
 class SignBase : public BaseObject {

--- a/test/parallel/test-crypto-hash-stream-pipeline.js
+++ b/test/parallel/test-crypto-hash-stream-pipeline.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const common = require('../common');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const crypto = require('crypto');
+const stream = require('stream');
+
+const hash = crypto.createHash('md5');
+const s = new stream.PassThrough();
+const expect = 'e8dc4081b13434b45189a720b77b6818';
+
+s.write('abcdefgh');
+stream.pipeline(s, hash, common.mustCall(function(err) {
+  assert.ifError(err);
+  assert.strictEqual(hash.digest('hex'), expect);
+}));
+s.end();


### PR DESCRIPTION
This backports https://github.com/nodejs/node/commit/990feafcb to v10.x. This fixes an issue when using `stream.pipeline()` with an instance of `crypto.Hash`. 

It was fixed in 12.6.0, so this backports to v10.x and adds a test for it.