### PR TITLE
fs.mkdir: Add explicit note about undefined path when recursive

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2642,6 +2642,7 @@ Asynchronously creates a directory.
 
 The callback is given a possible exception and, if `recursive` is `true`, the
 first directory path created, `(err, [path])`.
+Note that `path` can still be `undefined` when `recursive` is `true`, if no directory was created.
 
 The optional `options` argument can be an integer specifying `mode` (permission
 and sticky bits), or an object with a `mode` property and a `recursive`

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2642,7 +2642,8 @@ Asynchronously creates a directory.
 
 The callback is given a possible exception and, if `recursive` is `true`, the
 first directory path created, `(err, [path])`.
-Note that `path` can still be `undefined` when `recursive` is `true`, if no directory was created.
+`path` can still be `undefined` when `recursive` is `true`, if no directory was
+created.
 
 The optional `options` argument can be an integer specifying `mode` (permission
 and sticky bits), or an object with a `mode` property and a `recursive`


### PR DESCRIPTION
Came up when changing the TypeScript types in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/50721