### PR TITLE
test: process.nextTick for beforeExit case

### DIFF
--- a/test/parallel/test-process-beforeexit.js
+++ b/test/parallel/test-process-beforeexit.js
@@ -55,6 +55,14 @@ function tryRepeatedTimer() {
   const repeatedTimer = common.mustCall(function() {
     if (++n < N)
       setTimeout(repeatedTimer, 1);
+    else // n == N
+      process.once('beforeExit', common.mustCall(tryNextTick));
   }, N);
   setTimeout(repeatedTimer, 1);
+}
+
+function tryNextTick() {
+  process.nextTick(common.mustCall(function() {
+    process.once('beforeExit', common.mustNotCall(function() {}));
+  }));
 }

--- a/test/parallel/test-process-beforeexit.js
+++ b/test/parallel/test-process-beforeexit.js
@@ -63,6 +63,6 @@ function tryRepeatedTimer() {
 
 function tryNextTick() {
   process.nextTick(common.mustCall(function() {
-    process.once('beforeExit', common.mustNotCall(function() {}));
+    process.once('beforeExit', common.mustNotCall());
   }));
 }

--- a/test/parallel/test-process-beforeexit.js
+++ b/test/parallel/test-process-beforeexit.js
@@ -50,7 +50,8 @@ function tryListen() {
 // to keep the event loop open, which can use another timer to keep the event
 // loop open, etc.
 //
-// After N times, call function tryNextTick to test behaviors of nextTick
+// After N times, call function `tryNextTick` to test behaviors of the
+// `process.nextTick`
 function tryRepeatedTimer() {
   const N = 5;
   let n = 0;
@@ -63,7 +64,7 @@ function tryRepeatedTimer() {
   setTimeout(repeatedTimer, 1);
 }
 
-// Test if the callback of process.nextTick can be invoked
+// Test if the callback of `process.nextTick` can be invoked
 function tryNextTick() {
   process.nextTick(common.mustCall(function() {
     process.once('beforeExit', common.mustNotCall());

--- a/test/parallel/test-process-beforeexit.js
+++ b/test/parallel/test-process-beforeexit.js
@@ -49,6 +49,8 @@ function tryListen() {
 // Test that a function invoked from the beforeExit handler can use a timer
 // to keep the event loop open, which can use another timer to keep the event
 // loop open, etc.
+// 
+// After N times, call function tryNextTick to test behaviors of process.nextTick
 function tryRepeatedTimer() {
   const N = 5;
   let n = 0;
@@ -61,6 +63,7 @@ function tryRepeatedTimer() {
   setTimeout(repeatedTimer, 1);
 }
 
+// Test if the callback of process.nextTick can be invoked
 function tryNextTick() {
   process.nextTick(common.mustCall(function() {
     process.once('beforeExit', common.mustNotCall());

--- a/test/parallel/test-process-beforeexit.js
+++ b/test/parallel/test-process-beforeexit.js
@@ -49,8 +49,8 @@ function tryListen() {
 // Test that a function invoked from the beforeExit handler can use a timer
 // to keep the event loop open, which can use another timer to keep the event
 // loop open, etc.
-// 
-// After N times, call function tryNextTick to test behaviors of process.nextTick
+//
+// After N times, call function tryNextTick to test behaviors of nextTick
 function tryRepeatedTimer() {
   const N = 5;
   let n = 0;

--- a/test/parallel/test-process-beforeexit.js
+++ b/test/parallel/test-process-beforeexit.js
@@ -51,7 +51,7 @@ function tryListen() {
 // loop open, etc.
 //
 // After N times, call function `tryNextTick` to test behaviors of the
-// `process.nextTick`
+// `process.nextTick`.
 function tryRepeatedTimer() {
   const N = 5;
   let n = 0;
@@ -64,7 +64,7 @@ function tryRepeatedTimer() {
   setTimeout(repeatedTimer, 1);
 }
 
-// Test if the callback of `process.nextTick` can be invoked
+// Test if the callback of `process.nextTick` can be invoked.
 function tryNextTick() {
   process.nextTick(common.mustCall(function() {
     process.once('beforeExit', common.mustNotCall());


### PR DESCRIPTION
This is a test for test case `test/parallel/test-process-beforeexit.js` to test the behavior of `process.nextTick` with `process.on('beforeExit', ()=>{})` event