### PR TITLE
doc: child_process: clarify `subprocess.pid` can be `undefined` when `ENOENT`

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -1253,9 +1253,11 @@ does not indicate that the child process has been terminated.
 added: v0.1.90
 -->
 
-* {integer}
+* {integer|undefined}
 
-Returns the process identifier (PID) of the child process.
+Returns the process identifier (PID) of the child process. If the child process
+fails to spawn due to errors, then the value is `undefined` and `error` is
+emitted.
 
 ```js
 const { spawn } = require('child_process');

--- a/test/parallel/test-child-process-cwd.js
+++ b/test/parallel/test-child-process-cwd.js
@@ -28,10 +28,13 @@ const assert = require('assert');
 const { spawn } = require('child_process');
 
 // Spawns 'pwd' with given options, then test
+// - whether the child pid is undefined or number,
 // - whether the exit code equals expectCode,
 // - optionally whether the trimmed stdout result matches expectData
-function testCwd(options, expectCode = 0, expectData) {
+function testCwd(options, expectPidType, expectCode = 0, expectData) {
   const child = spawn(...common.pwdCommand, options);
+
+  assert.strictEqual(typeof child.pid, expectPidType);
 
   child.stdout.setEncoding('utf8');
 
@@ -57,18 +60,18 @@ function testCwd(options, expectCode = 0, expectData) {
 
 // Assume does-not-exist doesn't exist, expect exitCode=-1 and errno=ENOENT
 {
-  testCwd({ cwd: 'does-not-exist' }, -1)
+  testCwd({ cwd: 'does-not-exist' }, 'undefined', -1)
     .on('error', common.mustCall(function(e) {
       assert.strictEqual(e.code, 'ENOENT');
     }));
 }
 
 // Assume these exist, and 'pwd' gives us the right directory back
-testCwd({ cwd: tmpdir.path }, 0, tmpdir.path);
+testCwd({ cwd: tmpdir.path }, 'number', 0, tmpdir.path);
 const shouldExistDir = common.isWindows ? process.env.windir : '/dev';
-testCwd({ cwd: shouldExistDir }, 0, shouldExistDir);
+testCwd({ cwd: shouldExistDir }, 'number', 0, shouldExistDir);
 
 // Spawn() shouldn't try to chdir() to invalid arg, so this should just work
-testCwd({ cwd: '' });
-testCwd({ cwd: undefined });
-testCwd({ cwd: null });
+testCwd({ cwd: '' }, 'number');
+testCwd({ cwd: undefined }, 'number');
+testCwd({ cwd: null }, 'number');

--- a/test/parallel/test-child-process-exec-error.js
+++ b/test/parallel/test-child-process-exec-error.js
@@ -24,17 +24,21 @@ const common = require('../common');
 const assert = require('assert');
 const child_process = require('child_process');
 
-function test(fn, code) {
-  fn('does-not-exist', common.mustCall(function(err) {
+function test(fn, code, expectPidType = 'number') {
+  const child = fn('does-not-exist', common.mustCall(function(err) {
     assert.strictEqual(err.code, code);
     assert(err.cmd.includes('does-not-exist'));
   }));
+
+  assert.strictEqual(typeof child.pid, expectPidType);
 }
 
+// With `shell: true`, expect pid (of the shell)
 if (common.isWindows) {
-  test(child_process.exec, 1); // Exit code of cmd.exe
+  test(child_process.exec, 1, 'number'); // Exit code of cmd.exe
 } else {
-  test(child_process.exec, 127); // Exit code of /bin/sh
+  test(child_process.exec, 127, 'number'); // Exit code of /bin/sh
 }
 
-test(child_process.execFile, 'ENOENT');
+// With `shell: false`, expect no pid
+test(child_process.execFile, 'ENOENT', 'undefined');

--- a/test/parallel/test-child-process-spawn-error.js
+++ b/test/parallel/test-child-process-spawn-error.js
@@ -41,6 +41,9 @@ assert.strictEqual(enoentChild.stdio[0], enoentChild.stdin);
 assert.strictEqual(enoentChild.stdio[1], enoentChild.stdout);
 assert.strictEqual(enoentChild.stdio[2], enoentChild.stderr);
 
+// Verify pid is not assigned.
+assert.strictEqual(enoentChild.pid, undefined);
+
 enoentChild.on('spawn', common.mustNotCall());
 
 enoentChild.on('error', common.mustCall(function(err) {


### PR DESCRIPTION
From the code `nodejs@8` and up should behave the same: https://github.com/nodejs/node/blame/v8.17.0/lib/internal/child_process.js#L290-L316

And a short test snippet:
```js
const { spawn } = require('child_process')

const subProcess = spawn('non-exist-command')
subProcess.on('error', (error) => console.warn('mute Unhandled "error" event:', error))
console.log('- pid:', subProcess.pid)
process.nextTick(() => console.log('- after error emit'))
console.log('== end of test ==')
```

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
