### PR TITLE
crypto: diffieHellman throw error on invalid object

### DIFF
--- a/lib/internal/crypto/diffiehellman.js
+++ b/lib/internal/crypto/diffiehellman.js
@@ -290,8 +290,7 @@ function getFormat(format) {
 const dhEnabledKeyTypes = new SafeSet(['dh', 'ec', 'x448', 'x25519']);
 
 function diffieHellman(options) {
-  if (typeof options !== 'object')
-    throw new ERR_INVALID_ARG_TYPE('options', 'object', options);
+  validateObject(options, 'options');
 
   const { privateKey, publicKey } = options;
   if (!(privateKey instanceof KeyObject))

--- a/test/parallel/test-crypto-dh-stateless.js
+++ b/test/parallel/test-crypto-dh-stateless.js
@@ -12,6 +12,20 @@ assert.throws(() => crypto.diffieHellman(), {
   message: 'The "options" argument must be of type object. Received undefined'
 });
 
+assert.throws(() => crypto.diffieHellman(null), {
+  name: 'TypeError',
+  code: 'ERR_INVALID_ARG_TYPE',
+  message: 'The "options" argument must be of type object. Received null'
+});
+
+assert.throws(() => crypto.diffieHellman([]), {
+  name: 'TypeError',
+  code: 'ERR_INVALID_ARG_TYPE',
+  message:
+    'The "options" argument must be of type object. ' +
+    'Received an instance of Array',
+});
+
 function test({ publicKey: alicePublicKey, privateKey: alicePrivateKey },
               { publicKey: bobPublicKey, privateKey: bobPrivateKey },
               expectedValue) {


### PR DESCRIPTION
```js
const crypto = require('crypto')
crypto.diffieHellman(null)
```

Before:
```
node:internal/crypto/diffiehellman:297
  const { privateKey, publicKey } = options;
          ^

TypeError: Cannot destructure property 'privateKey' of 'options' as it is null.
    at Object.diffieHellman (node:internal/crypto/diffiehellman:297:11)
```

After:
```
TypeError [ERR_INVALID_ARG_TYPE]: The "options" argument must be of type object. Received null
      at Object.diffieHellman (node:internal/crypto/diffiehellman:293:3)
```

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
