### PR TITLE
deps: upgrade npm to 7.4.3

### DIFF
--- a/deps/npm/.npmignore
+++ b/deps/npm/.npmignore
@@ -12,6 +12,7 @@ node_modules/.bin
 node_modules/npm-registry-mock
 /npmrc
 /release/
+/coverage/
 
 # don't need these in the npm package.
 html/*.png

--- a/deps/npm/CHANGELOG.md
+++ b/deps/npm/CHANGELOG.md
@@ -1,3 +1,23 @@
+## v7.4.3 (2021-01-21)
+
+### DOCUMENTATION
+
+* [`ec1f06d06`](https://github.com/npm/cli/commit/ec1f06d06447a29c74bee063cff103ede7a2111b)
+  [#2498](https://github.com/npm/cli/issues/2498)
+  docs(npm): update `npm` docs
+  ([@darcyclarke](https://github.com/darcyclarke))
+
+### DEPENDENCIES
+* [`bc23284cd`](https://github.com/npm/cli/commit/bc23284cd5c4cc4532875aff14df94213727a509)
+  [#2511](https://github.com/npm/cli/issues/2511)
+  remove coverage files
+  ([@ruyadorno](https://github.com/ruyadorno))
+* [`fcbc676b8`](https://github.com/npm/cli/commit/fcbc676b88e1b7c8d01a3799683cd388a82c44d6)
+  `pacote@11.2.3`
+* [`ebd3a24ff`](https://github.com/npm/cli/commit/ebd3a24ff8381f2def306136b745d1615fd6139f)
+  `@npmcli/arborist@2.0.6`
+    * Preserve git+https auth when provided
+
 ## v7.4.2 (2021-01-15)
 
 ### DEPENDENCIES

--- a/deps/npm/docs/content/commands/npm.md
+++ b/deps/npm/docs/content/commands/npm.md
@@ -133,19 +133,12 @@ See [`config`](/using-npm/config) for much much more information.
 Patches welcome!
 
 If you would like to contribute, but don't know what to work on, read
-the contributing guidelines and check the issues list.
-
-* [CONTRIBUTING.md](https://github.com/npm/cli/blob/latest/CONTRIBUTING.md)
-* [Bug tracker](https://github.com/npm/cli/issues)
+the [contributing guidelines](https://github.com/npm/cli/blob/latest/CONTRIBUTING.md)
+and check the issues list.
 
 ### Bugs
 
-When you find issues, please report them:
-
-* web:
-  <https://github.com/npm/npm/issues>
-* archived web:
-  <https://npm.community/c/bugs>
+When you find issues, please report them: <https://github.com/npm/cli/issues>
 
 Be sure to follow the template and bug reporting guidelines.
 
@@ -158,13 +151,6 @@ Discuss new feature ideas on our discussion forum:
 Or suggest formal RFC proposals:
 
 * <https://github.com/npm/rfcs>
-
-### Author
-
-[Isaac Z. Schlueter](http://blog.izs.me/) ::
-[isaacs](https://github.com/isaacs/) ::
-[@izs](https://twitter.com/izs) ::
-<i@izs.me>
 
 ### See Also
 * [npm help](/commands/npm-help)

--- a/deps/npm/docs/output/commands/npm-ls.html
+++ b/deps/npm/docs/output/commands/npm-ls.html
@@ -159,7 +159,7 @@ tree at all, use <a href="../commands/npm-explain.html"><code>npm explain</code>
 the results to only the paths to the packages named.  Note that nested
 packages will <em>also</em> show the paths to the specified packages.  For
 example, running <code>npm ls promzard</code> in npm’s source tree will show:</p>
-<pre lang="bash"><code>npm@7.4.2 /path/to/npm
+<pre lang="bash"><code>npm@7.4.3 /path/to/npm
 └─┬ init-package-json@0.0.4
   └── promzard@0.1.5
 </code></pre>

--- a/deps/npm/docs/output/commands/npm.html
+++ b/deps/npm/docs/output/commands/npm.html
@@ -141,14 +141,14 @@ npm command-line interface
 
 <section id="table_of_contents">
 <h2 id="table-of-contents">Table of contents</h2>
-<div id="_table_of_contents"><ul><li><a href="#synopsis">Synopsis</a></li><li><a href="#version">Version</a></li><li><a href="#description">Description</a></li><li><a href="#important">Important</a></li><li><a href="#introduction">Introduction</a></li><li><a href="#dependencies">Dependencies</a></li><li><a href="#directories">Directories</a></li><li><a href="#developer-usage">Developer Usage</a></li><ul><li><a href="#configuration">Configuration</a></li></ul><li><a href="#contributions">Contributions</a></li><li><a href="#bugs">Bugs</a></li><li><a href="#feature-requests">Feature Requests</a></li><li><a href="#author">Author</a></li><li><a href="#see-also">See Also</a></li></ul></div>
+<div id="_table_of_contents"><ul><li><a href="#synopsis">Synopsis</a></li><li><a href="#version">Version</a></li><li><a href="#description">Description</a></li><li><a href="#important">Important</a></li><li><a href="#introduction">Introduction</a></li><li><a href="#dependencies">Dependencies</a></li><li><a href="#directories">Directories</a></li><li><a href="#developer-usage">Developer Usage</a></li><ul><li><a href="#configuration">Configuration</a></li></ul><li><a href="#contributions">Contributions</a></li><li><a href="#bugs">Bugs</a></li><li><a href="#feature-requests">Feature Requests</a></li><li><a href="#see-also">See Also</a></li></ul></div>
 </section>
 
 <div id="_content"><h3 id="synopsis">Synopsis</h3>
 <pre lang="bash"><code>npm &lt;command&gt; [args]
 </code></pre>
 <h3 id="version">Version</h3>
-<p>7.4.2</p>
+<p>7.4.3</p>
 <h3 id="description">Description</h3>
 <p>npm is the package manager for the Node JavaScript platform.  It puts
 modules in place so that node can find them, and manages dependency
@@ -246,19 +246,10 @@ lib/utils/config-defs.js.  These must not be changed.</li>
 <h3 id="contributions">Contributions</h3>
 <p>Patches welcome!</p>
 <p>If you would like to contribute, but don’t know what to work on, read
-the contributing guidelines and check the issues list.</p>
-<ul>
-<li><a href="https://github.com/npm/cli/blob/latest/CONTRIBUTING.md">CONTRIBUTING.md</a></li>
-<li><a href="https://github.com/npm/cli/issues">Bug tracker</a></li>
-</ul>
+the <a href="https://github.com/npm/cli/blob/latest/CONTRIBUTING.md">contributing guidelines</a>
+and check the issues list.</p>
 <h3 id="bugs">Bugs</h3>
-<p>When you find issues, please report them:</p>
-<ul>
-<li>web:
-<a href="https://github.com/npm/npm/issues">https://github.com/npm/npm/issues</a></li>
-<li>archived web:
-<a href="https://npm.community/c/bugs">https://npm.community/c/bugs</a></li>
-</ul>
+<p>When you find issues, please report them: <a href="https://github.com/npm/cli/issues">https://github.com/npm/cli/issues</a></p>
 <p>Be sure to follow the template and bug reporting guidelines.</p>
 <h3 id="feature-requests">Feature Requests</h3>
 <p>Discuss new feature ideas on our discussion forum:</p>
@@ -269,11 +260,6 @@ the contributing guidelines and check the issues list.</p>
 <ul>
 <li><a href="https://github.com/npm/rfcs">https://github.com/npm/rfcs</a></li>
 </ul>
-<h3 id="author">Author</h3>
-<p><a href="http://blog.izs.me/">Isaac Z. Schlueter</a> ::
-<a href="https://github.com/isaacs/">isaacs</a> ::
-<a href="https://twitter.com/izs">@izs</a> ::
-<a href="mailto:i@izs.me">i@izs.me</a></p>
 <h3 id="see-also">See Also</h3>
 <ul>
 <li><a href="../commands/npm-help.html">npm help</a></li>

--- a/deps/npm/man/man1/npm-ls.1
+++ b/deps/npm/man/man1/npm-ls.1
@@ -26,7 +26,7 @@ example, running \fBnpm ls promzard\fP in npm's source tree will show:
 .P
 .RS 2
 .nf
-npm@7\.4\.2 /path/to/npm
+npm@7\.4\.3 /path/to/npm
 └─┬ init\-package\-json@0\.0\.4
   └── promzard@0\.1\.5
 .fi

--- a/deps/npm/man/man1/npm.1
+++ b/deps/npm/man/man1/npm.1
@@ -10,7 +10,7 @@ npm <command> [args]
 .RE
 .SS Version
 .P
-7\.4\.2
+7\.4\.3
 .SS Description
 .P
 npm is the package manager for the Node JavaScript platform\.  It puts
@@ -141,26 +141,11 @@ See npm help \fBconfig\fP for much much more information\.
 Patches welcome!
 .P
 If you would like to contribute, but don't know what to work on, read
-the contributing guidelines and check the issues list\.
-.RS 0
-.IP \(bu 2
-CONTRIBUTING\.md \fIhttps://github\.com/npm/cli/blob/latest/CONTRIBUTING\.md\fR
-.IP \(bu 2
-Bug tracker \fIhttps://github\.com/npm/cli/issues\fR
-
-.RE
+the contributing guidelines \fIhttps://github\.com/npm/cli/blob/latest/CONTRIBUTING\.md\fR
+and check the issues list\.
 .SS Bugs
 .P
-When you find issues, please report them:
-.RS 0
-.IP \(bu 2
-web:
-https://github\.com/npm/npm/issues
-.IP \(bu 2
-archived web:
-https://npm\.community/c/bugs
-
-.RE
+When you find issues, please report them: https://github\.com/npm/cli/issues
 .P
 Be sure to follow the template and bug reporting guidelines\.
 .SS Feature Requests
@@ -178,12 +163,6 @@ Or suggest formal RFC proposals:
 https://github\.com/npm/rfcs
 
 .RE
-.SS Author
-.P
-Isaac Z\. Schlueter \fIhttp://blog\.izs\.me/\fR ::
-isaacs \fIhttps://github\.com/isaacs/\fR ::
-@izs \fIhttps://twitter\.com/izs\fR ::
-i@izs\.me
 .SS See Also
 .RS 0
 .IP \(bu 2

--- a/deps/npm/node_modules/@npmcli/arborist/lib/arborist/reify.js
+++ b/deps/npm/node_modules/@npmcli/arborist/lib/arborist/reify.js
@@ -830,9 +830,14 @@ module.exports = cls => class Reifier extends cls {
           const pname = child.package.name
           const alias = name !== pname
           updateDepSpec(pkg, name, (alias ? `npm:${pname}@` : '') + range)
-        } else if (req.hosted)
-          updateDepSpec(pkg, name, req.hosted.shortcut({ noCommittish: false }))
-        else
+        } else if (req.hosted) {
+          // save the git+https url if it has auth, otherwise shortcut
+          const h = req.hosted
+          const opt = { noCommittish: false }
+          const save = h.https && h.auth ? `git+${h.https(opt)}`
+            : h.shortcut(opt)
+          updateDepSpec(pkg, name, save)
+        } else
           updateDepSpec(pkg, name, req.saveSpec)
       }
 

--- a/deps/npm/node_modules/@npmcli/arborist/lib/consistent-resolve.js
+++ b/deps/npm/node_modules/@npmcli/arborist/lib/consistent-resolve.js
@@ -9,6 +9,7 @@ const consistentResolve = (resolved, fromPath, toPath, relPaths = false) => {
     return null
 
   try {
+    const hostedOpt = { noCommittish: false }
     const {
       fetchSpec,
       saveSpec,
@@ -20,7 +21,9 @@ const consistentResolve = (resolved, fromPath, toPath, relPaths = false) => {
     const isPath = type === 'file' || type === 'directory'
     return isPath && !relPaths ? `file:${fetchSpec}`
       : isPath ? 'file:' + (toPath ? relpath(toPath, fetchSpec) : fetchSpec)
-      : hosted ? 'git+' + hosted.sshurl({ noCommittish: false })
+      : hosted ? `git+${
+        hosted.auth ? hosted.https(hostedOpt) : hosted.sshurl(hostedOpt)
+      }`
       : type === 'git' ? saveSpec
       // always return something.  'foo' is interpreted as 'foo@' otherwise.
       : rawSpec === '' && raw.slice(-1) !== '@' ? raw

--- a/deps/npm/node_modules/@npmcli/arborist/package.json
+++ b/deps/npm/node_modules/@npmcli/arborist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@npmcli/arborist",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Manage node_modules trees",
   "dependencies": {
     "@npmcli/installed-package-contents": "^1.0.5",
@@ -20,7 +20,7 @@
     "npm-package-arg": "^8.1.0",
     "npm-pick-manifest": "^6.1.0",
     "npm-registry-fetch": "^9.0.0",
-    "pacote": "^11.2.1",
+    "pacote": "^11.2.3",
     "parse-conflict-json": "^1.1.1",
     "promise-all-reject-late": "^1.0.0",
     "promise-call-limit": "^1.0.1",

--- a/deps/npm/node_modules/pacote/lib/fetcher.js
+++ b/deps/npm/node_modules/pacote/lib/fetcher.js
@@ -47,6 +47,8 @@ class FetcherBase {
       throw new TypeError('options object is required')
     this.spec = npa(spec, opts.where)
 
+    this.allowGitIgnore = !!opts.allowGitIgnore
+
     // a bit redundant because presumably the caller already knows this,
     // but it makes it easier to not have to keep track of the requested
     // spec when we're dispatching thousands of these at once, and normalizing
@@ -414,7 +416,7 @@ class FetcherBase {
           const base = basename(entry.path)
           if (base === '.npmignore')
             sawIgnores.add(entry.path)
-          else if (base === '.gitignore') {
+          else if (base === '.gitignore' && !this.allowGitIgnore) {
             // rename, but only if there's not already a .npmignore
             const ni = entry.path.replace(/\.gitignore$/, '.npmignore')
             if (sawIgnores.has(ni))

--- a/deps/npm/node_modules/pacote/lib/git.js
+++ b/deps/npm/node_modules/pacote/lib/git.js
@@ -24,13 +24,16 @@ const _cloneRepo = Symbol('_cloneRepo')
 const _setResolvedWithSha = Symbol('_setResolvedWithSha')
 const _prepareDir = Symbol('_prepareDir')
 
-// get the repository url.  prefer ssh, fall back to git://
+// get the repository url.
+// prefer https if there's auth, since ssh will drop that.
+// otherwise, prefer ssh if available (more secure).
 // We have to add the git+ back because npa suppresses it.
-const repoUrl = (hosted, opts) =>
-  hosted.sshurl && addGitPlus(hosted.sshurl(opts)) ||
-  hosted.https && addGitPlus(hosted.https(opts))
+const repoUrl = (h, opts) =>
+  h.sshurl && !(h.https && h.auth) && addGitPlus(h.sshurl(opts)) ||
+  h.https && addGitPlus(h.https(opts))
 
-const addGitPlus = url => url && `git+${url}`
+// add git+ to the url, but only one time.
+const addGitPlus = url => url && `git+${url}`.replace(/^(git\+)+/, 'git+')
 
 class GitFetcher extends Fetcher {
   constructor (spec, opts) {
@@ -51,6 +54,11 @@ class GitFetcher extends Fetcher {
       this.resolvedSha = ''
   }
 
+  // just exposed to make it easier to test all the combinations
+  static repoUrl (hosted, opts) {
+    return repoUrl(hosted, opts)
+  }
+
   get types () {
     return ['git']
   }
@@ -69,13 +77,16 @@ class GitFetcher extends Fetcher {
   }
 
   // first try https, since that's faster and passphrase-less for
-  // public repos.  Fall back to SSH to support private repos.
-  // NB: we always store the SSH url in the 'resolved' field.
+  // public repos, and supports private repos when auth is provided.
+  // Fall back to SSH to support private repos
+  // NB: we always store the https url in resolved field if auth
+  // is present, otherwise ssh if the hosted type provides it
   [_resolvedFromHosted] (hosted) {
     return this[_resolvedFromRepo](hosted.https && hosted.https())
       .catch(er => {
         const ssh = hosted.sshurl && hosted.sshurl()
-        if (!ssh)
+        // no fallthrough if we can't fall through or have https auth
+        if (!ssh || hosted.auth)
           throw er
         return this[_resolvedFromRepo](ssh)
       })
@@ -121,9 +132,11 @@ class GitFetcher extends Fetcher {
   // either a git url with a hash, or a tarball download URL
   [_addGitSha] (sha) {
     if (this.spec.hosted) {
-      this[_setResolvedWithSha](
-        this.spec.hosted.shortcut({ noCommittish: true }) + '#' + sha
-      )
+      const h = this.spec.hosted
+      const opt = { noCommittish: true }
+      const base = h.https && h.auth ? h.https(opt) : h.shortcut(opt)
+
+      this[_setResolvedWithSha](`${base}#${sha}`)
     } else {
       const u = url.format(new url.URL(`#${sha}`, this.spec.rawSpec))
       this[_setResolvedWithSha](url.format(u))
@@ -207,6 +220,7 @@ class GitFetcher extends Fetcher {
         const nameat = this.spec.name ? `${this.spec.name}@` : ''
         return new RemoteFetcher(h.tarball({ noCommittish: false }), {
           ...this.opts,
+          allowGitIgnore: true,
           pkgid: `git:${nameat}${this.resolved}`,
           resolved: this.resolved,
           integrity: null, // it'll always be different, if we have one
@@ -231,14 +245,19 @@ class GitFetcher extends Fetcher {
     })
   }
 
+  // first try https, since that's faster and passphrase-less for
+  // public repos, and supports private repos when auth is provided.
+  // Fall back to SSH to support private repos
+  // NB: we always store the https url in resolved field if auth
+  // is present, otherwise ssh if the hosted type provides it
   [_cloneHosted] (ref, tmp) {
     const hosted = this.spec.hosted
     const https = hosted.https()
     return this[_cloneRepo](hosted.https({ noCommittish: true }), ref, tmp)
       .catch(er => {
         const ssh = hosted.sshurl && hosted.sshurl({ noCommittish: true })
-        /* istanbul ignore if - should be covered by the resolve() call */
-        if (!ssh)
+        // no fallthrough if we can't fall through or have https auth
+        if (!ssh || hosted.auth)
           throw er
         return this[_cloneRepo](ssh, ref, tmp)
       })

--- a/deps/npm/node_modules/pacote/package.json
+++ b/deps/npm/node_modules/pacote/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pacote",
-  "version": "11.2.1",
+  "version": "11.2.3",
   "description": "JavaScript package downloader",
   "author": "Isaac Z. Schlueter <i@izs.me> (https://izs.me)",
   "bin": {

--- a/deps/npm/package.json
+++ b/deps/npm/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.4.2",
+  "version": "7.4.3",
   "name": "npm",
   "description": "a package manager for JavaScript",
   "keywords": [
@@ -42,7 +42,7 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@npmcli/arborist": "^2.0.5",
+    "@npmcli/arborist": "^2.0.6",
     "@npmcli/ci-detect": "^1.2.0",
     "@npmcli/config": "^1.2.8",
     "@npmcli/run-script": "^1.8.1",
@@ -90,7 +90,7 @@
     "npm-user-validate": "^1.0.1",
     "npmlog": "~4.1.2",
     "opener": "^1.5.2",
-    "pacote": "^11.2.1",
+    "pacote": "^11.2.3",
     "parse-conflict-json": "^1.1.1",
     "qrcode-terminal": "^0.12.0",
     "read": "~1.0.7",
@@ -180,7 +180,7 @@
   ],
   "devDependencies": {
     "cmark-gfm": "^0.8.5",
-    "eslint": "^7.14.0",
+    "eslint": "^7.18.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",


### PR DESCRIPTION
## v7.4.3 (2021-01-21)

### DOCUMENTATION

* [`ec1f06d06`](https://github.com/npm/cli/commit/ec1f06d06447a29c74bee063cff103ede7a2111b) [#2498](https://github.com/npm/cli/issues/2498) docs(npm): update `npm` docs ([@darcyclarke](https://github.com/darcyclarke))

### DEPENDENCIES
* [`fcbc676b8`](https://github.com/npm/cli/commit/fcbc676b88e1b7c8d01a3799683cd388a82c44d6) `pacote@11.2.3`
* [`ebd3a24ff`](https://github.com/npm/cli/commit/ebd3a24ff8381f2def306136b745d1615fd6139f) `@npmcli/arborist@2.0.6`
    * Preserve git+https auth when provided

