### PR TITLE
dgram: support AbortSignal in createSocket

### DIFF
--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -735,6 +735,9 @@ chained.
 <!-- YAML
 added: v0.11.13
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/37026
+    description: AbortSignal support was added.
   - version: v11.4.0
     pr-url: https://github.com/nodejs/node/pull/23798
     description: The `ipv6Only` option is supported.
@@ -759,6 +762,7 @@ changes:
   * `recvBufferSize` {number} Sets the `SO_RCVBUF` socket value.
   * `sendBufferSize` {number} Sets the `SO_SNDBUF` socket value.
   * `lookup` {Function} Custom lookup function. **Default:** [`dns.lookup()`][].
+  * `signal` {AbortSignal} An AbortSignal that may be used to close a socket.
 * `callback` {Function} Attached as a listener for `'message'` events. Optional.
 * Returns: {dgram.Socket}
 
@@ -769,6 +773,20 @@ method will bind the socket to the "all interfaces" address on a random port
 (it does the right thing for both `udp4` and `udp6` sockets). The bound address
 and port can be retrieved using [`socket.address().address`][] and
 [`socket.address().port`][].
+
+If the `signal` option is enabled, calling `.abort()` on the corresponding
+`AbortController` is similar to calling `.close()` on the socket:
+
+```js
+const controller = new AbortController();
+const { signal } = controller;
+const server = dgram.createSocket({ type: 'udp4', signal });
+server.on('message', (msg, rinfo) => {
+  console.log(`server got: ${msg} from ${rinfo.address}:${rinfo.port}`);
+});
+// Later, when you want to close the server.
+controller.abort();
+```
 
 ### `dgram.createSocket(type[, callback])`
 <!-- YAML

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -52,6 +52,7 @@ const {
 } = errors.codes;
 const {
   isInt32,
+  validateAbortSignal,
   validateString,
   validateNumber,
   validatePort,
@@ -125,6 +126,20 @@ function Socket(type, listener) {
     recvBufferSize,
     sendBufferSize
   };
+
+  if (options?.signal !== undefined) {
+    const { signal } = options;
+    validateAbortSignal(signal, 'options.signal');
+    const onAborted = () => {
+      this.close();
+    };
+    if (signal.aborted) {
+      onAborted();
+    } else {
+      signal.addEventListener('abort', onAborted);
+      this.once('close', () => signal.removeEventListener('abort', onAborted));
+    }
+  }
 }
 ObjectSetPrototypeOf(Socket.prototype, EventEmitter.prototype);
 ObjectSetPrototypeOf(Socket, EventEmitter);

--- a/test/parallel/test-dgram-close-signal.js
+++ b/test/parallel/test-dgram-close-signal.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const dgram = require('dgram');
+
+{
+  // Test bad signal.
+  assert.throws(
+    () => dgram.createSocket({ type: 'udp4', signal: {} }),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      name: 'TypeError'
+    });
+}
+
+{
+  // Test close.
+  const controller = new AbortController();
+  const { signal } = controller;
+  const server = dgram.createSocket({ type: 'udp4', signal });
+  server.on('close', common.mustCall());
+  controller.abort();
+}
+
+{
+  // Test close with pre-aborted signal.
+  const controller = new AbortController();
+  controller.abort();
+  const { signal } = controller;
+  const server = dgram.createSocket({ type: 'udp4', signal });
+  server.on('close', common.mustCall());
+}


### PR DESCRIPTION
dgram: support AbortSignal in createSocket

Add `AbortSignal` support to `dgram.createSocket`. Added `signal` to the `createSocket` options, which calls `close` on the socket when aborted.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x]  commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)