### PR TITLE
doc: list Unsupported Directory Import resolve err

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -1016,7 +1016,7 @@ The resolver can throw the following errors:
   subpath in the package for the given module.
 * _Package Import Not Defined_: Package imports do not define the specifier.
 * _Module Not Found_: The package or module requested does not exist.
-* _Unsupported Directory Import_: The resolved path cooresponds to a directory,
+* _Unsupported Directory Import_: The resolved path corresponds to a directory,
   which is not a supported target for module imports.
 
 ### Resolver Algorithm Specification

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -1016,8 +1016,8 @@ The resolver can throw the following errors:
   subpath in the package for the given module.
 * _Package Import Not Defined_: Package imports do not define the specifier.
 * _Module Not Found_: The package or module requested does not exist.
-* _Unsupported Directory Import_: There was an attempt to import a module
-  ending in a trailing _"/"_.
+* _Unsupported Directory Import_: The resolved path cooresponds to a directory,
+  which is not a supported target for module imports.
 
 ### Resolver Algorithm Specification
 

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -1016,6 +1016,8 @@ The resolver can throw the following errors:
   subpath in the package for the given module.
 * _Package Import Not Defined_: Package imports do not define the specifier.
 * _Module Not Found_: The package or module requested does not exist.
+* _Unsupported Directory Import_: There was an attempt to import a module
+  ending in a trailing _"/"_.
 
 ### Resolver Algorithm Specification
 


### PR DESCRIPTION
This updates the documentation of the resolver specification to include the Unsupported Directory Import in ths list of errors provided at the top of the specification, to ensure this list remains exhaustive of all the errors that might be thrown by the resolver.