### PR TITLE
test: skip tests consistently in parallel.status

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -70,6 +70,6 @@ test-tls-env-extra-ca: SKIP
 # https://github.com/nodejs/node/pull/34209
 test-dgram-error-message-address: SKIP
 # https://github.com/nodejs/node/issues/36929
-test-crypto-secure-heap: PASS,FLAKY
+test-crypto-secure-heap: SKIP
 # https://github.com/nodejs/node/issues/36925
-test-fs-read-type: PASS,FLAKY
+test-fs-read-type: SKIP


### PR DESCRIPTION
Some tests are marked SKIP,FLAKY (resulting in yellow/unstable CI when
they fail) and others are marked SKIP (which means the results don't
affect CI at all). There doesn't seem to be any reason for the
difference. Mark them all as SKIP as IBM i for consistency and to have
the luxury of a green daily CI. We'll want these to be at least
SKIP,FLAKY (and preferably not skipped at all) before IBM i is supported.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
