### PR TITLE
benchmark: make output RFC 4180 compliant

### DIFF
--- a/benchmark/compare.js
+++ b/benchmark/compare.js
@@ -56,7 +56,7 @@ for (const filename of benchmarks) {
 // queue.length = binary.length * runs * benchmarks.length
 
 // Print csv header
-console.log('"binary", "filename", "configuration", "rate", "time"');
+console.log('"binary","filename","configuration","rate","time"');
 
 const kStartOfQueue = 0;
 
@@ -85,8 +85,8 @@ if (showProgress) {
       // Escape quotes (") for correct csv formatting
       conf = conf.replace(/"/g, '""');
 
-      console.log(`"${job.binary}", "${job.filename}", "${conf}", ` +
-                  `${data.rate}, ${data.time}`);
+      console.log(`"${job.binary}","${job.filename}","${conf}",` +
+                  `${data.rate},${data.time}`);
       if (showProgress) {
         // One item in the subqueue has been completed.
         progress.completeConfig(data);


### PR DESCRIPTION
I had trouble importing the generated CSV into other software because it doesn't conform to RFC 4180, the de facto standard for CSV.

Relevant information from the RFC:

> Spaces are considered part of a field and should not be ignored. [...] If fields are not enclosed with double quotes, then double quotes may not appear inside the fields.

Since spaces are considered part of a field, we end up with fields of the form `' "foo"'` (note the space in front of the quoted value), and now the quote isn't the first character within the field, so it violates the RFC.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
