### PR TITLE
tools: enable object-curly-newline in ESLint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -258,6 +258,7 @@ module.exports = {
     'no-void': 'error',
     'no-whitespace-before-property': 'error',
     'no-with': 'error',
+    'object-curly-newline': 'error',
     'object-curly-spacing': ['error', 'always'],
     'one-var': ['error', { initialized: 'never' }],
     'one-var-declaration-per-line': 'error',

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -3675,7 +3675,8 @@ will be emitted.
 const body = 'hello world';
 response.writeHead(200, {
   'Content-Length': Buffer.byteLength(body),
-  'Content-Type': 'text/plain; charset=utf-8' });
+  'Content-Type': 'text/plain; charset=utf-8',
+});
 ```
 
 `Content-Length` is given in bytes not characters. The

--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -91,9 +91,10 @@ const { resource_symbol, owner_symbol } = internalBinding('symbols');
 // Each constant tracks how many callbacks there are for any given step of
 // async execution. These are tracked so if the user didn't include callbacks
 // for a given step, that step can bail out early.
-const { kInit, kBefore, kAfter, kDestroy, kTotals, kPromiseResolve,
-        kCheck, kExecutionAsyncId, kAsyncIdCounter, kTriggerAsyncId,
-        kDefaultTriggerAsyncId, kStackLength, kUsesExecutionAsyncResource
+const {
+  kInit, kBefore, kAfter, kDestroy, kTotals, kPromiseResolve,
+  kCheck, kExecutionAsyncId, kAsyncIdCounter, kTriggerAsyncId,
+  kDefaultTriggerAsyncId, kStackLength, kUsesExecutionAsyncResource,
 } = async_wrap.constants;
 
 const { async_id_symbol,

--- a/lib/internal/encoding.js
+++ b/lib/internal/encoding.js
@@ -363,10 +363,8 @@ ObjectDefineProperties(
     'encode': { enumerable: true },
     'encodeInto': { enumerable: true },
     'encoding': { enumerable: true },
-    [SymbolToStringTag]: {
-      configurable: true,
-      value: 'TextEncoder'
-    } });
+    [SymbolToStringTag]: { configurable: true, value: 'TextEncoder' },
+  });
 
 const TextDecoder =
   internalBinding('config').hasIntl ?

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -126,9 +126,10 @@ const {
 } = require('internal/validators');
 const fsPromisesInternal = require('internal/fs/promises');
 const { utcDate } = require('internal/http');
-const { onServerStream,
-        Http2ServerRequest,
-        Http2ServerResponse,
+const {
+  Http2ServerRequest,
+  Http2ServerResponse,
+  onServerStream,
 } = require('internal/http2/compat');
 
 const {

--- a/test/doctool/test-doctool-json.js
+++ b/test/doctool/test-doctool-json.js
@@ -121,8 +121,7 @@ const testData = [
                   { 'version': 'v4.2.0',
                     'pr-url': 'https://github.com/nodejs/node/pull/3276',
                     'description': 'The `error` parameter can now be ' +
-                      'an arrow function.'
-                  }
+                      'an arrow function.' }
                 ]
               },
               desc: '<p>Describe <code>Foobar II</code> in more detail ' +

--- a/test/node-api/test_threadsafe_function/test.js
+++ b/test/node-api/test_threadsafe_function/test.js
@@ -36,7 +36,8 @@ function testWithJSMarshaller({
   quitAfter,
   abort,
   maxQueueSize,
-  launchSecondary }) {
+  launchSecondary,
+}) {
   return new Promise((resolve) => {
     const array = [];
     binding[threadStarter](function testCallback(value) {

--- a/test/parallel/test-dns.js
+++ b/test/parallel/test-dns.js
@@ -362,18 +362,15 @@ assert.throws(() => {
           expire: 1800,
           minttl: 3333333333
         },
-      ]
-    },
+      ] },
 
     { method: 'resolve4',
       options: { ttl: true },
-      answers: [ { type: 'A', address: '1.2.3.4', ttl: 3333333333 } ]
-    },
+      answers: [ { type: 'A', address: '1.2.3.4', ttl: 3333333333 } ] },
 
     { method: 'resolve6',
       options: { ttl: true },
-      answers: [ { type: 'AAAA', address: '::42', ttl: 3333333333 } ]
-    },
+      answers: [ { type: 'AAAA', address: '::42', ttl: 3333333333 } ] },
 
     { method: 'resolveSoa',
       answers: [
@@ -387,8 +384,7 @@ assert.throws(() => {
           expire: 1800,
           minttl: 3333333333
         }
-      ]
-    },
+      ] },
   ];
 
   const server = dgram.createSocket('udp4');

--- a/test/parallel/test-fs-open-flags.js
+++ b/test/parallel/test-fs-open-flags.js
@@ -38,8 +38,7 @@ const { O_APPEND = 0,
         O_SYNC = 0,
         O_DSYNC = 0,
         O_TRUNC = 0,
-        O_WRONLY = 0
-} = fs.constants;
+        O_WRONLY = 0 } = fs.constants;
 
 const { stringToFlags } = require('internal/fs/utils');
 

--- a/test/parallel/test-fs-readfile.js
+++ b/test/parallel/test-fs-readfile.js
@@ -15,20 +15,15 @@ tmpdir.refresh();
 
 const fileInfo = [
   { name: path.join(tmpdir.path, `${prefix}-1K.txt`),
-    len: 1024,
-  },
+    len: 1024 },
   { name: path.join(tmpdir.path, `${prefix}-64K.txt`),
-    len: 64 * 1024,
-  },
+    len: 64 * 1024 },
   { name: path.join(tmpdir.path, `${prefix}-64KLessOne.txt`),
-    len: (64 * 1024) - 1,
-  },
+    len: (64 * 1024) - 1 },
   { name: path.join(tmpdir.path, `${prefix}-1M.txt`),
-    len: 1 * 1024 * 1024,
-  },
+    len: 1 * 1024 * 1024 },
   { name: path.join(tmpdir.path, `${prefix}-1MPlusOne.txt`),
-    len: (1 * 1024 * 1024) + 1,
-  },
+    len: (1 * 1024 * 1024) + 1 },
 ];
 
 // Populate each fileInfo (and file) with unique fill.

--- a/test/parallel/test-http2-max-settings.js
+++ b/test/parallel/test-http2-max-settings.js
@@ -27,7 +27,8 @@ server.listen(0, common.mustCall(() => {
         // The actual settings values do not matter.
         headerTableSize: 1000,
         enablePush: false,
-      } });
+      },
+    });
 
   client.on('error', common.mustCall(() => {
     server.close();

--- a/test/parallel/test-inspector-esm.js
+++ b/test/parallel/test-inspector-esm.js
@@ -48,15 +48,14 @@ async function testBreakpoint(session) {
       'params': { 'lineNumber': 7,
                   'url': session.scriptURL(),
                   'columnNumber': 0,
-                  'condition': ''
-      }
-    },
+                  'condition': '' } },
     { 'method': 'Debugger.resume' },
   ];
   await session.send(commands);
   const { scriptSource } = await session.send({
     'method': 'Debugger.getScriptSource',
-    'params': { 'scriptId': session.mainScriptId } });
+    'params': { 'scriptId': session.mainScriptId },
+  });
   assert(scriptSource && (scriptSource.includes(session.script())),
          `Script source is wrong: ${scriptSource}`);
 

--- a/test/parallel/test-npm-install.js
+++ b/test/parallel/test-npm-install.js
@@ -44,8 +44,7 @@ const env = { ...process.env,
               NPM_CONFIG_TMP: path.join(npmSandbox, 'npm-tmp'),
               NPM_CONFIG_AUDIT: false,
               NPM_CONFIG_UPDATE_NOTIFIER: false,
-              HOME: homeDir,
-};
+              HOME: homeDir };
 
 exec(`${process.execPath} ${npmPath} install`, {
   cwd: installDir,

--- a/test/parallel/test-path-parse-format.js
+++ b/test/parallel/test-path-parse-format.js
@@ -132,8 +132,7 @@ const trailingTests = [
         dir: 'D:\\foo\\\\',
         base: 'bar.baz',
         ext: '.baz',
-        name: 'bar'
-      }
+        name: 'bar' }
      ]
     ]
   ],

--- a/test/parallel/test-process-env-allowed-flags-are-documented.js
+++ b/test/parallel/test-process-env-allowed-flags-are-documented.js
@@ -41,7 +41,8 @@ for (const line of [...nodeOptionsLines, ...v8OptionsLines]) {
 
 // Filter out options that are conditionally present.
 const conditionalOpts = [
-  { include: common.hasCrypto,
+  {
+    include: common.hasCrypto,
     filter: (opt) => {
       return [
         '--openssl-config',
@@ -51,8 +52,8 @@ const conditionalOpts = [
         '--secure-heap',
         '--secure-heap-min',
       ].includes(opt);
-    } },
-  {
+    }
+  }, {
     // We are using openssl_is_fips from the configuration because it could be
     // the case that OpenSSL is FIPS compatible but fips has not been enabled
     // (starting node with --enable-fips). If we use common.hasFipsCrypto
@@ -60,11 +61,14 @@ const conditionalOpts = [
     // want to check options which will be available regardless of whether fips
     // is enabled at runtime or not.
     include: process.config.variables.openssl_is_fips,
-    filter: (opt) => opt.includes('-fips') },
-  { include: common.hasIntl,
-    filter: (opt) => opt === '--icu-data-dir' },
-  { include: process.features.inspector,
-    filter: (opt) => opt.startsWith('--inspect') || opt === '--debug-port' },
+    filter: (opt) => opt.includes('-fips')
+  }, {
+    include: common.hasIntl,
+    filter: (opt) => opt === '--icu-data-dir'
+  }, {
+    include: process.features.inspector,
+    filter: (opt) => opt.startsWith('--inspect') || opt === '--debug-port'
+  },
 ];
 documented.forEach((opt) => {
   conditionalOpts.forEach(({ include, filter }) => {

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -54,7 +54,8 @@ function getInterface(options) {
   const rli = new readline.Interface({
     input: fi,
     output: fi,
-    ...options });
+    ...options,
+  });
   return [rli, fi];
 }
 

--- a/test/parallel/test-stdin-script-child.js
+++ b/test/parallel/test-stdin-script-child.js
@@ -6,8 +6,7 @@ const { spawn } = require('child_process');
 for (const args of [[], ['-']]) {
   const child = spawn(process.execPath, args, {
     env: { ...process.env,
-           NODE_DEBUG: process.argv[2]
-    }
+           NODE_DEBUG: process.argv[2] }
   });
   const wanted = `${child.pid}\n`;
   let found = '';

--- a/test/parallel/test-tls-check-server-identity.js
+++ b/test/parallel/test-tls-check-server-identity.js
@@ -124,12 +124,13 @@ const tests = [
     cert: { subject: { CN: '*n.b.com' } },
     error: 'Host: \n.b.com. is not cert\'s CN: *n.b.com'
   },
-  { host: 'b.a.com', cert: {
-    subjectaltname: 'DNS:omg.com',
-    subject: { CN: '*.a.com' } },
+  { host: 'b.a.com',
+    cert: {
+      subjectaltname: 'DNS:omg.com',
+      subject: { CN: '*.a.com' },
+    },
     error: 'Host: b.a.com. is not in the cert\'s altnames: ' +
-           'DNS:omg.com'
-  },
+           'DNS:omg.com' },
   {
     host: 'b.a.com',
     cert: { subject: { CN: 'b*b.a.com' } },

--- a/test/parallel/test-tls-client-verify.js
+++ b/test/parallel/test-tls-client-verify.js
@@ -36,8 +36,7 @@ const testCases = [
       { ok: true, key: 'agent1-key', cert: 'agent1-cert' },
       { ok: false, key: 'agent2-key', cert: 'agent2-cert' },
       { ok: false, key: 'agent3-key', cert: 'agent3-cert' }
-    ]
-  },
+    ] },
 
   { ca: [],
     key: 'agent2-key',
@@ -46,8 +45,7 @@ const testCases = [
       { ok: false, key: 'agent1-key', cert: 'agent1-cert' },
       { ok: false, key: 'agent2-key', cert: 'agent2-cert' },
       { ok: false, key: 'agent3-key', cert: 'agent3-cert' }
-    ]
-  },
+    ] },
 
   { ca: ['ca1-cert', 'ca2-cert'],
     key: 'agent2-key',
@@ -56,8 +54,7 @@ const testCases = [
       { ok: true, key: 'agent1-key', cert: 'agent1-cert' },
       { ok: false, key: 'agent2-key', cert: 'agent2-cert' },
       { ok: true, key: 'agent3-key', cert: 'agent3-cert' }
-    ]
-  }
+    ] }
 ];
 
 

--- a/test/parallel/test-tls-server-verify.js
+++ b/test/parallel/test-tls-server-verify.js
@@ -54,8 +54,7 @@ const testCases =
       { name: 'agent2', shouldReject: false, shouldAuth: false },
       { name: 'agent3', shouldReject: false, shouldAuth: false },
       { name: 'nocert', shouldReject: false, shouldAuth: false }
-     ]
-  },
+     ] },
 
    { title: 'Allow both authed and unauthed connections with CA1',
      requestCert: true,
@@ -67,8 +66,7 @@ const testCases =
      { name: 'agent2', shouldReject: false, shouldAuth: false },
      { name: 'agent3', shouldReject: false, shouldAuth: false },
      { name: 'nocert', shouldReject: false, shouldAuth: false }
-    ]
-   },
+    ] },
 
    { title: 'Do not request certs at connection. Do that later',
      requestCert: false,
@@ -80,8 +78,7 @@ const testCases =
      { name: 'agent2', shouldReject: false, shouldAuth: false },
      { name: 'agent3', shouldReject: false, shouldAuth: false },
      { name: 'nocert', shouldReject: false, shouldAuth: false }
-    ]
-   },
+    ] },
 
    { title: 'Allow only authed connections with CA1',
      requestCert: true,
@@ -93,8 +90,7 @@ const testCases =
      { name: 'agent2', shouldReject: true },
      { name: 'agent3', shouldReject: true },
      { name: 'nocert', shouldReject: true }
-    ]
-   },
+    ] },
 
    { title: 'Allow only authed connections with CA1 and CA2',
      requestCert: true,
@@ -106,8 +102,7 @@ const testCases =
      { name: 'agent2', shouldReject: true },
      { name: 'agent3', shouldReject: false, shouldAuth: true },
      { name: 'nocert', shouldReject: true }
-    ]
-   },
+    ] },
 
 
    { title: 'Allow only certs signed by CA2 but not in the CRL',
@@ -123,8 +118,7 @@ const testCases =
        // Agent4 has a cert in the CRL.
        { name: 'agent4', shouldReject: true, shouldAuth: false },
        { name: 'nocert', shouldReject: true }
-     ]
-   }
+     ] }
   ];
 
 function filenamePEM(n) {

--- a/test/parallel/test-trace-events-async-hooks-dynamic.js
+++ b/test/parallel/test-trace-events-async-hooks-dynamic.js
@@ -31,8 +31,7 @@ const proc = cp.spawnSync(
     cwd: tmpdir.path,
     env: { ...process.env,
            'NODE_DEBUG_NATIVE': 'tracing',
-           'NODE_DEBUG': 'tracing'
-    }
+           'NODE_DEBUG': 'tracing' }
   });
 
 console.log('process exit with signal:', proc.signal);

--- a/test/parallel/test-trace-events-async-hooks-worker.js
+++ b/test/parallel/test-trace-events-async-hooks-worker.js
@@ -38,8 +38,7 @@ const proc = cp.spawnSync(
     cwd: tmpdir.path,
     env: { ...process.env,
            'NODE_DEBUG_NATIVE': 'tracing',
-           'NODE_DEBUG': 'tracing'
-    }
+           'NODE_DEBUG': 'tracing' }
   });
 
 console.log('process exit with signal:', proc.signal);

--- a/test/parallel/test-webcrypto-encrypt-decrypt-rsa.js
+++ b/test/parallel/test-webcrypto-encrypt-decrypt-rsa.js
@@ -29,13 +29,12 @@ async function importVectorKey(
   return { publicKey, privateKey };
 }
 
-async function testDecryption({
-  ciphertext,
-  algorithm,
-  plaintext,
-  hash,
-  publicKeyBuffer,
-  privateKeyBuffer }) {
+async function testDecryption({ ciphertext,
+                                algorithm,
+                                plaintext,
+                                hash,
+                                publicKeyBuffer,
+                                privateKeyBuffer }) {
   if (ciphertext === undefined)
     return;
 
@@ -108,12 +107,11 @@ async function testEncryption(
     encodedPlaintext);
 }
 
-async function testEncryptionLongPlaintext({
-  algorithm,
-  plaintext,
-  hash,
-  publicKeyBuffer,
-  privateKeyBuffer }) {
+async function testEncryptionLongPlaintext({ algorithm,
+                                             plaintext,
+                                             hash,
+                                             publicKeyBuffer,
+                                             privateKeyBuffer }) {
   const {
     publicKey,
   } = await importVectorKey(
@@ -133,12 +131,11 @@ async function testEncryptionLongPlaintext({
     });
 }
 
-async function testEncryptionWrongKey({
-  algorithm,
-  plaintext,
-  hash,
-  publicKeyBuffer,
-  privateKeyBuffer }) {
+async function testEncryptionWrongKey({ algorithm,
+                                        plaintext,
+                                        hash,
+                                        publicKeyBuffer,
+                                        privateKeyBuffer }) {
   const {
     privateKey,
   } = await importVectorKey(
@@ -154,12 +151,11 @@ async function testEncryptionWrongKey({
     });
 }
 
-async function testEncryptionBadUsage({
-  algorithm,
-  plaintext,
-  hash,
-  publicKeyBuffer,
-  privateKeyBuffer }) {
+async function testEncryptionBadUsage({ algorithm,
+                                        plaintext,
+                                        hash,
+                                        publicKeyBuffer,
+                                        privateKeyBuffer }) {
   const {
     publicKey,
   } = await importVectorKey(
@@ -175,12 +171,11 @@ async function testEncryptionBadUsage({
     });
 }
 
-async function testDecryptionWrongKey({
-  ciphertext,
-  algorithm,
-  hash,
-  publicKeyBuffer,
-  privateKeyBuffer }) {
+async function testDecryptionWrongKey({ ciphertext,
+                                        algorithm,
+                                        hash,
+                                        publicKeyBuffer,
+                                        privateKeyBuffer }) {
   if (ciphertext === undefined)
     return;
 
@@ -200,12 +195,11 @@ async function testDecryptionWrongKey({
     });
 }
 
-async function testDecryptionBadUsage({
-  ciphertext,
-  algorithm,
-  hash,
-  publicKeyBuffer,
-  privateKeyBuffer }) {
+async function testDecryptionBadUsage({ ciphertext,
+                                        algorithm,
+                                        hash,
+                                        publicKeyBuffer,
+                                        privateKeyBuffer }) {
   if (ciphertext === undefined)
     return;
 

--- a/test/parallel/test-webcrypto-encrypt-decrypt.js
+++ b/test/parallel/test-webcrypto-encrypt-decrypt.js
@@ -53,11 +53,13 @@ const { subtle, getRandomValues } = require('crypto').webcrypto;
       length: 256
     }, true, ['encrypt', 'decrypt']);
 
-    const ciphertext = await subtle.encrypt({
-      name: 'AES-CTR', counter, length: 64 }, key, buf);
+    const ciphertext = await subtle.encrypt(
+      { name: 'AES-CTR', counter, length: 64 }, key, buf,
+    );
 
-    const plaintext = await subtle.decrypt({
-      name: 'AES-CTR', counter, length: 64 }, key, ciphertext);
+    const plaintext = await subtle.decrypt(
+      { name: 'AES-CTR', counter, length: 64 }, key, ciphertext,
+    );
 
     assert.strictEqual(
       Buffer.from(plaintext).toString('hex'),
@@ -78,11 +80,13 @@ const { subtle, getRandomValues } = require('crypto').webcrypto;
       length: 256
     }, true, ['encrypt', 'decrypt']);
 
-    const ciphertext = await subtle.encrypt({
-      name: 'AES-CBC', iv }, key, buf);
+    const ciphertext = await subtle.encrypt(
+      { name: 'AES-CBC', iv }, key, buf,
+    );
 
-    const plaintext = await subtle.decrypt({
-      name: 'AES-CBC', iv }, key, ciphertext);
+    const plaintext = await subtle.decrypt(
+      { name: 'AES-CBC', iv }, key, ciphertext,
+    );
 
     assert.strictEqual(
       Buffer.from(plaintext).toString('hex'),
@@ -103,11 +107,13 @@ const { subtle, getRandomValues } = require('crypto').webcrypto;
       length: 256
     }, true, ['encrypt', 'decrypt']);
 
-    const ciphertext = await subtle.encrypt({
-      name: 'AES-GCM', iv }, key, buf);
+    const ciphertext = await subtle.encrypt(
+      { name: 'AES-GCM', iv }, key, buf,
+    );
 
-    const plaintext = await subtle.decrypt({
-      name: 'AES-GCM', iv }, key, ciphertext);
+    const plaintext = await subtle.decrypt(
+      { name: 'AES-GCM', iv }, key, ciphertext,
+    );
 
     assert.strictEqual(
       Buffer.from(plaintext).toString('hex'),

--- a/test/parallel/test-webcrypto-keygen.js
+++ b/test/parallel/test-webcrypto-keygen.js
@@ -75,7 +75,8 @@ const vectors = {
       'sign',
       'verify'
     ],
-    mandatoryUsages: ['sign'] },
+    mandatoryUsages: ['sign'],
+  },
   'RSA-PSS': {
     algorithm: {
       modulusLength: 1024,

--- a/test/parallel/test-webcrypto-sign-verify-ecdsa.js
+++ b/test/parallel/test-webcrypto-sign-verify-ecdsa.js
@@ -10,14 +10,13 @@ const { subtle } = require('crypto').webcrypto;
 
 const vectors = require('../fixtures/crypto/ecdsa')();
 
-async function testVerify({
-  name,
-  hash,
-  namedCurve,
-  publicKeyBuffer,
-  privateKeyBuffer,
-  signature,
-  plaintext }) {
+async function testVerify({ name,
+                            hash,
+                            namedCurve,
+                            publicKeyBuffer,
+                            privateKeyBuffer,
+                            signature,
+                            plaintext }) {
   const [
     publicKey,
     noVerifyPublicKey,
@@ -128,14 +127,13 @@ async function testVerify({
     });
 }
 
-async function testSign({
-  name,
-  hash,
-  namedCurve,
-  publicKeyBuffer,
-  privateKeyBuffer,
-  signature,
-  plaintext }) {
+async function testSign({ name,
+                          hash,
+                          namedCurve,
+                          publicKeyBuffer,
+                          privateKeyBuffer,
+                          signature,
+                          plaintext }) {
   const [
     publicKey,
     noSignPrivateKey,

--- a/test/parallel/test-webcrypto-sign-verify-hmac.js
+++ b/test/parallel/test-webcrypto-sign-verify-hmac.js
@@ -10,11 +10,10 @@ const { subtle } = require('crypto').webcrypto;
 
 const vectors = require('../fixtures/crypto/hmac')();
 
-async function testVerify({
-  hash,
-  keyBuffer,
-  signature,
-  plaintext }) {
+async function testVerify({ hash,
+                            keyBuffer,
+                            signature,
+                            plaintext }) {
   const name = 'HMAC';
   const [
     key,
@@ -104,11 +103,10 @@ async function testVerify({
     });
 }
 
-async function testSign({
-  hash,
-  keyBuffer,
-  signature,
-  plaintext }) {
+async function testSign({ hash,
+                          keyBuffer,
+                          signature,
+                          plaintext }) {
   const name = 'HMAC';
   const [
     key,

--- a/test/parallel/test-webcrypto-sign-verify-node-dsa.js
+++ b/test/parallel/test-webcrypto-sign-verify-node-dsa.js
@@ -10,13 +10,12 @@ const { subtle } = require('crypto').webcrypto;
 
 const dsa = require('../fixtures/crypto/dsa');
 
-async function testVerify({
-  algorithm,
-  hash,
-  publicKeyBuffer,
-  privateKeyBuffer,
-  signature,
-  plaintext }) {
+async function testVerify({ algorithm,
+                            hash,
+                            publicKeyBuffer,
+                            privateKeyBuffer,
+                            signature,
+                            plaintext }) {
   const [
     publicKey,
     noVerifyPublicKey,
@@ -131,7 +130,8 @@ async function testSign({
   publicKeyBuffer,
   privateKeyBuffer,
   signature,
-  plaintext }) {
+  plaintext,
+}) {
   const [
     publicKey,
     noSignPrivateKey,

--- a/test/parallel/test-webcrypto-sign-verify-rsa.js
+++ b/test/parallel/test-webcrypto-sign-verify-rsa.js
@@ -17,7 +17,8 @@ async function testVerify({
   publicKeyBuffer,
   privateKeyBuffer,
   signature,
-  plaintext }) {
+  plaintext,
+}) {
   const [
     publicKey,
     noVerifyPublicKey,
@@ -132,7 +133,8 @@ async function testSign({
   publicKeyBuffer,
   privateKeyBuffer,
   signature,
-  plaintext }) {
+  plaintext,
+}) {
   const [
     publicKey,
     noSignPrivateKey,

--- a/test/parallel/test-webcrypto-wrap-unwrap.js
+++ b/test/parallel/test-webcrypto-wrap-unwrap.js
@@ -180,7 +180,8 @@ async function generateKeysToWrap() {
     return [{
       algorithm: params.algorithm,
       usages: params.usages,
-      key: keys }];
+      key: keys,
+    }];
   }));
 
   return allkeys.flat();

--- a/test/sequential/test-inspector-break-when-eval.js
+++ b/test/sequential/test-inspector-break-when-eval.js
@@ -36,9 +36,7 @@ async function breakOnLine(session) {
       'params': { 'lineNumber': 9,
                   'url': pathToFileURL(script).toString(),
                   'columnNumber': 0,
-                  'condition': ''
-      }
-    },
+                  'condition': '' } },
     { 'method': 'Runtime.evaluate',
       'params': { 'expression': 'sum()',
                   'objectGroup': 'console',
@@ -48,9 +46,7 @@ async function breakOnLine(session) {
                   'returnByValue': false,
                   'generatePreview': true,
                   'userGesture': true,
-                  'awaitPromise': false
-      }
-    }
+                  'awaitPromise': false } }
   ];
   session.send(commands);
   await session.waitForBreakOnLine(9, pathToFileURL(script).toString());

--- a/test/sequential/test-inspector-port-cluster.js
+++ b/test/sequential/test-inspector-port-cluster.js
@@ -330,8 +330,7 @@ function spawnPrimary({ execArgv, workers, clusterSettings = {} }) {
       env: { ...process.env,
              workers: JSON.stringify(workers),
              clusterSettings: JSON.stringify(clusterSettings),
-             testProcess: true
-      },
+             testProcess: true },
       execArgv: execArgv.concat(['--expose-internals'])
     }).on('exit', common.mustCall((code, signal) => {
       checkExitCode(code, signal);

--- a/test/sequential/test-inspector.js
+++ b/test/sequential/test-inspector.js
@@ -86,15 +86,14 @@ async function testBreakpoint(session) {
       'params': { 'lineNumber': 5,
                   'url': session.scriptURL(),
                   'columnNumber': 0,
-                  'condition': ''
-      }
-    },
+                  'condition': '' } },
     { 'method': 'Debugger.resume' },
   ];
   await session.send(commands);
   const { scriptSource } = await session.send({
     'method': 'Debugger.getScriptSource',
-    'params': { 'scriptId': session.mainScriptId } });
+    'params': { 'scriptId': session.mainScriptId },
+  });
   assert(scriptSource && (scriptSource.includes(session.script())),
          `Script source is wrong: ${scriptSource}`);
 

--- a/test/sequential/test-stream2-stderr-sync.js
+++ b/test/sequential/test-stream2-stderr-sync.js
@@ -67,7 +67,8 @@ function child2() {
   const socket = new net.Socket({
     fd: 2,
     readable: false,
-    writable: true });
+    writable: true,
+  });
   socket.write('child 2\n');
   socket.write('foo\n');
   socket.write('bar\n');


### PR DESCRIPTION
I saw a PR review comment  about newlines in desructured
assignments, and this would be the rule to enforce these kinds of nits.
Start by just enabling the rule. We can incrementally adjust it to be
more strict.

Refs: https://eslint.org/docs/rules/object-curly-newline
Refs: https://github.com/nodejs/node/pull/37028#pullrequestreview-574744497