### PR TITLE
doc: remove TOC summary for pages with no TOC

### DIFF
--- a/doc/template.html
+++ b/doc/template.html
@@ -55,10 +55,7 @@
         <hr>
       </header>
 
-      <details id="toc" open>
-        <summary>Table of Contents</summary>
-        __TOC__
-      </details>
+      __TOC__
 
       <div id="apicontent">
         __CONTENT__

--- a/tools/doc/allhtml.js
+++ b/tools/doc/allhtml.js
@@ -59,9 +59,11 @@ let all = toc.replace(/index\.html/g, 'all.html')
 all = all.replace(/<title>.*?\| /, '<title>');
 
 // Insert the combined table of contents.
-const tocStart = /<\w+ id="toc"[^>]*>\s*<\w+>.*?<\/\w+>\s*/.exec(all);
+const tocStart = /<!-- TOC -->/.exec(all);
 all = all.slice(0, tocStart.index + tocStart[0].length) +
+  '<details id="toc" open><summary>Table of contents</summary>\n' +
   '<ul>\n' + contents + '</ul>\n' +
+  '</details>\n' +
   all.slice(tocStart.index + tocStart[0].length);
 
 // Replace apicontent with the concatenated set of apicontents from each source.

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -382,13 +382,19 @@ function buildToc({ filename, apilinks }) {
       node.children.push({ type: 'html', value: anchor });
     });
 
-    file.toc = unified()
-      .use(markdown)
-      .use(gfm)
-      .use(remark2rehype, { allowDangerousHtml: true })
-      .use(raw)
-      .use(htmlStringify)
-      .processSync(toc).toString();
+    if (toc !== '') {
+      file.toc = '<details id="toc" open><summary>Table of contents</summary>' +
+        unified()
+          .use(markdown)
+          .use(gfm)
+          .use(remark2rehype, { allowDangerousHtml: true })
+          .use(raw)
+          .use(htmlStringify)
+          .processSync(toc).toString() +
+        '</details>';
+    } else {
+      file.toc = '<!-- TOC -->';
+    }
   };
 }
 


### PR DESCRIPTION
Remove the table of contents summary for pages with no table of
contents. Currently, this affects at least index.html.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
