### PR TITLE
src: rename crypto_ecdh.(h|cc) to crypto_ec.(h|cc)

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -931,7 +931,7 @@
             'src/crypto/crypto_timing.cc',
             'src/crypto/crypto_cipher.cc',
             'src/crypto/crypto_context.cc',
-            'src/crypto/crypto_ecdh.cc',
+            'src/crypto/crypto_ec.cc',
             'src/crypto/crypto_hmac.cc',
             'src/crypto/crypto_random.cc',
             'src/crypto/crypto_rsa.cc',

--- a/src/crypto/crypto_ec.cc
+++ b/src/crypto/crypto_ec.cc
@@ -1,4 +1,4 @@
-#include "crypto/crypto_ecdh.h"
+#include "crypto/crypto_ec.h"
 #include "crypto/crypto_common.h"
 #include "crypto/crypto_util.h"
 #include "allocated_buffer-inl.h"

--- a/src/crypto/crypto_ec.h
+++ b/src/crypto/crypto_ec.h
@@ -1,5 +1,5 @@
-#ifndef SRC_CRYPTO_CRYPTO_ECDH_H_
-#define SRC_CRYPTO_CRYPTO_ECDH_H_
+#ifndef SRC_CRYPTO_CRYPTO_EC_H_
+#define SRC_CRYPTO_CRYPTO_EC_H_
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
@@ -174,4 +174,4 @@ ByteSource ConvertFromWebCryptoSignature(
 }  // namespace node
 
 #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
-#endif  // SRC_CRYPTO_CRYPTO_ECDH_H_
+#endif  // SRC_CRYPTO_CRYPTO_EC_H_

--- a/src/crypto/crypto_keys.cc
+++ b/src/crypto/crypto_keys.cc
@@ -1,7 +1,7 @@
 #include "crypto/crypto_keys.h"
 #include "crypto/crypto_common.h"
 #include "crypto/crypto_dsa.h"
-#include "crypto/crypto_ecdh.h"
+#include "crypto/crypto_ec.h"
 #include "crypto/crypto_dh.h"
 #include "crypto/crypto_rsa.h"
 #include "crypto/crypto_util.h"

--- a/src/crypto/crypto_sig.cc
+++ b/src/crypto/crypto_sig.cc
@@ -1,5 +1,5 @@
 #include "crypto/crypto_sig.h"
-#include "crypto/crypto_ecdh.h"
+#include "crypto/crypto_ec.h"
 #include "crypto/crypto_keys.h"
 #include "crypto/crypto_util.h"
 #include "allocated_buffer-inl.h"

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -34,7 +34,7 @@
 #include "crypto/crypto_context.h"
 #include "crypto/crypto_dh.h"
 #include "crypto/crypto_dsa.h"
-#include "crypto/crypto_ecdh.h"
+#include "crypto/crypto_ec.h"
 #include "crypto/crypto_groups.h"
 #include "crypto/crypto_hash.h"
 #include "crypto/crypto_hkdf.h"


### PR DESCRIPTION
`crypto_ecdh.h` and `crypto_ecdh.cc` define and implement things that are not only relevant to ECDH, but also to other ECC mechanisms, including ECDSA. The files should, therefore, just be called `crypto_ec.*`.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
