### PR TITLE
crypto: fix encrypted private -> public import

### DIFF
--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -428,9 +428,10 @@ function createSecretKey(key, encoding) {
 }
 
 function createPublicKey(key) {
-  const { format, type, data } = prepareAsymmetricKey(key, kCreatePublic);
+  const { format, type, data, passphrase } =
+    prepareAsymmetricKey(key, kCreatePublic);
   const handle = new KeyObjectHandle();
-  handle.init(kKeyTypePublic, data, format, type);
+  handle.init(kKeyTypePublic, data, format, type, passphrase);
   return new PublicKeyObject(handle);
 }
 

--- a/src/crypto/crypto_keys.cc
+++ b/src/crypto/crypto_keys.cc
@@ -939,7 +939,7 @@ void KeyObjectHandle::Init(const FunctionCallbackInfo<Value>& args) {
     break;
   }
   case kKeyTypePublic: {
-    CHECK_EQ(args.Length(), 4);
+    CHECK_EQ(args.Length(), 5);
 
     offset = 1;
     pkey = ManagedEVPPKey::GetPublicOrPrivateKeyFromJs(args, &offset);

--- a/test/parallel/test-crypto-key-objects.js
+++ b/test/parallel/test-crypto-key-objects.js
@@ -132,6 +132,21 @@ const privateDsa = fixtures.readKey('dsa_private_encrypted_1025.pem',
   assert.strictEqual(derivedPublicKey.asymmetricKeyType, 'rsa');
   assert.strictEqual(derivedPublicKey.symmetricKeySize, undefined);
 
+  // It should also be possible to import an encrypted private key as a public
+  // key.
+  const decryptedKey = createPublicKey({
+    key: privateKey.export({
+      type: 'pkcs8',
+      format: 'pem',
+      passphrase: '123',
+      cipher: 'aes-128-cbc'
+    }),
+    format: 'pem',
+    passphrase: '123'
+  });
+  assert.strictEqual(decryptedKey.type, 'public');
+  assert.strictEqual(decryptedKey.asymmetricKeyType, 'rsa');
+
   // Test exporting with an invalid options object, this should throw.
   for (const opt of [undefined, null, 'foo', 0, NaN]) {
     assert.throws(() => publicKey.export(opt), {


### PR DESCRIPTION
This patch fixes the added test case. There is no reason for `createPublicKey` to not allow importing encrypted private keys. With this patch, the behavior matches the documentation.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
