### PR TITLE
crypto: generateKeyPair('ec') should not support NODE-ED* and NODE-X*

### DIFF
--- a/lib/internal/crypto/ec.js
+++ b/lib/internal/crypto/ec.js
@@ -166,7 +166,8 @@ async function ecGenerateKey(algorithm, extractable, keyUsages) {
       // Fall through
   }
   return new Promise((resolve, reject) => {
-    let genKeyType, genOpts = {};
+    let genKeyType;
+    let genOpts;
     switch (namedCurve) {
       case 'NODE-ED25519':
         genKeyType = 'ed25519';

--- a/lib/internal/crypto/ec.js
+++ b/lib/internal/crypto/ec.js
@@ -166,7 +166,25 @@ async function ecGenerateKey(algorithm, extractable, keyUsages) {
       // Fall through
   }
   return new Promise((resolve, reject) => {
-    generateKeyPair('ec', { namedCurve }, (err, pubKey, privKey) => {
+    let generate;
+    switch (namedCurve) {
+      case 'NODE-ED25519':
+        generate = generateKeyPair.bind(undefined, 'ed25519');
+        break;
+      case 'NODE-ED448':
+        generate = generateKeyPair.bind(undefined, 'ed448');
+        break;
+      case 'NODE-X25519':
+        generate = generateKeyPair.bind(undefined, 'x25519');
+        break;
+      case 'NODE-X448':
+        generate = generateKeyPair.bind(undefined, 'x448');
+        break;
+      default:
+        generate = generateKeyPair.bind(undefined, 'ec', { namedCurve });
+        break;
+    }
+    generate((err, pubKey, privKey) => {
       if (err) {
         return reject(lazyDOMException(
           'The operation failed for an operation-specific reason',

--- a/lib/internal/crypto/ec.js
+++ b/lib/internal/crypto/ec.js
@@ -166,25 +166,26 @@ async function ecGenerateKey(algorithm, extractable, keyUsages) {
       // Fall through
   }
   return new Promise((resolve, reject) => {
-    let generate;
+    let genKeyType, genOpts = {};
     switch (namedCurve) {
       case 'NODE-ED25519':
-        generate = generateKeyPair.bind(undefined, 'ed25519');
+        genKeyType = 'ed25519';
         break;
       case 'NODE-ED448':
-        generate = generateKeyPair.bind(undefined, 'ed448');
+        genKeyType = 'ed448';
         break;
       case 'NODE-X25519':
-        generate = generateKeyPair.bind(undefined, 'x25519');
+        genKeyType = 'x25519';
         break;
       case 'NODE-X448':
-        generate = generateKeyPair.bind(undefined, 'x448');
+        genKeyType = 'x448';
         break;
       default:
-        generate = generateKeyPair.bind(undefined, 'ec', { namedCurve });
+        genKeyType = 'ec';
+        genOpts = { namedCurve };
         break;
     }
-    generate((err, pubKey, privKey) => {
+    generateKeyPair(genKeyType, genOpts, (err, pubKey, privKey) => {
       if (err) {
         return reject(lazyDOMException(
           'The operation failed for an operation-specific reason',

--- a/src/crypto/crypto_ec.cc
+++ b/src/crypto/crypto_ec.cc
@@ -39,6 +39,22 @@ int GetCurveFromName(const char* name) {
   return nid;
 }
 
+int GetOKPCurveFromName(const char* name) {
+  int nid;
+  if (strcmp(name, "NODE-ED25519") == 0) {
+    nid = EVP_PKEY_ED25519;
+  } else if (strcmp(name, "NODE-ED448") == 0) {
+    nid = EVP_PKEY_ED448;
+  } else if (strcmp(name, "NODE-X25519") == 0) {
+    nid = EVP_PKEY_X25519;
+  } else if (strcmp(name, "NODE-X448") == 0) {
+    nid = EVP_PKEY_X448;
+  } else {
+    nid = NID_undef;
+  }
+  return nid;
+}
+
 void ECDH::Initialize(Environment* env, Local<Object> target) {
   Local<FunctionTemplate> t = env->NewFunctionTemplate(New);
   t->Inherit(BaseObject::GetConstructorTemplate(env));
@@ -431,7 +447,7 @@ Maybe<bool> ECDHBitsTraits::AdditionalConfig(
     return Nothing<bool>();
   }
 
-  params->id_ = GetCurveFromName(*name);
+  params->id_ = GetOKPCurveFromName(*name);
   params->private_ = private_key->Data();
   params->public_ = public_key->Data();
 

--- a/src/crypto/crypto_ec.cc
+++ b/src/crypto/crypto_ec.cc
@@ -36,18 +36,6 @@ int GetCurveFromName(const char* name) {
   int nid = EC_curve_nist2nid(name);
   if (nid == NID_undef)
     nid = OBJ_sn2nid(name);
-  // If there is still no match, check manually for known curves
-  if (nid == NID_undef) {
-    if (strcmp(name, "NODE-ED25519") == 0) {
-      nid = EVP_PKEY_ED25519;
-    } else if (strcmp(name, "NODE-ED448") == 0) {
-      nid = EVP_PKEY_ED448;
-    } else if (strcmp(name, "NODE-X25519") == 0) {
-      nid = EVP_PKEY_X25519;
-    } else if (strcmp(name, "NODE-X448") == 0) {
-      nid = EVP_PKEY_X448;
-    }
-  }
   return nid;
 }
 

--- a/src/crypto/crypto_ec.h
+++ b/src/crypto/crypto_ec.h
@@ -17,6 +17,7 @@
 namespace node {
 namespace crypto {
 int GetCurveFromName(const char* name);
+int GetOKPCurveFromName(const char* name);
 
 class ECDH final : public BaseObject {
  public:

--- a/src/crypto/crypto_keys.cc
+++ b/src/crypto/crypto_keys.cc
@@ -1058,7 +1058,7 @@ void KeyObjectHandle::InitEDRaw(const FunctionCallbackInfo<Value>& args) {
       ? EVP_PKEY_new_raw_private_key
       : EVP_PKEY_new_raw_public_key;
 
-  int id = GetCurveFromName(*name);
+  int id = GetOKPCurveFromName(*name);
 
   switch (id) {
     case EVP_PKEY_X25519:

--- a/test/parallel/test-crypto-keygen.js
+++ b/test/parallel/test-crypto-keygen.js
@@ -1283,3 +1283,19 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     }));
   }
 }
+
+{
+  // Proprietary Web Cryptography API ECDH/ECDSA namedCurve parameters
+  // should not be recognized in this API.
+  // See https://github.com/nodejs/node/issues/37055
+  const curves = ['NODE-ED25519', 'NODE-ED448', 'NODE-X25519', 'NODE-X448'];
+  for (const namedCurve of curves) {
+    assert.throws(
+      () => generateKeyPair('ec', { namedCurve }, common.mustNotCall()),
+      {
+        name: 'TypeError',
+        message: 'Invalid EC curve name'
+      }
+    );
+  }
+}


### PR DESCRIPTION
The following "curves" were added to the `'ec'` key type in https://github.com/nodejs/node/pull/36879.

- `NODE-ED25519`
- `NODE-ED448`
- `NODE-X25519`
- `NODE-X448`

However, none of these are pure EC curves, for example, Curve25519 does not work with ECDSA, which is one of the reasons why `crypto.getCurves()` does not include Curve25519. **This PR makes these "curves" only recognized from the Web Cryptography API experimental interface.**

Fixes https://github.com/nodejs/node/issues/37055

cc @jasnell @tniessen 