### PR TITLE
Read exactly two tokens from Linux transparent huge pages sysfs config

### DIFF
--- a/src/large_pages/node_large_page.cc
+++ b/src/large_pages/node_large_page.cc
@@ -261,7 +261,7 @@ bool IsTransparentHugePagesEnabled() {
   std::ifstream ifs;
 
   // File format reference:
-  // https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/huge_memory.c?id=13391c60da3308ed9980de0168f74cce6c62ac1d#n162
+  // https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/huge_memory.c?id=13391c60da3308ed9980de0168f74cce6c62ac1d#n163
   ifs.open("/sys/kernel/mm/transparent_hugepage/enabled");
   if (!ifs) {
     PrintWarning("could not open /sys/kernel/mm/transparent_hugepage/enabled");

--- a/src/large_pages/node_large_page.cc
+++ b/src/large_pages/node_large_page.cc
@@ -279,7 +279,9 @@ bool IsTransparentHugePagesConfigured(std::istream* configuration) {
 
 bool IsTransparentHugePagesEnabled() {
   std::istream* configuration = GetTransparentHugePagesConfiguration();
-  if (configuration == nullptr) return false;
+  if (configuration == nullptr) {
+    return false;
+  }
   bool enabled = IsTransparentHugePagesConfigured(configuration);
   delete configuration;
   return enabled;

--- a/src/large_pages/node_large_page.cc
+++ b/src/large_pages/node_large_page.cc
@@ -257,30 +257,24 @@ struct text_region FindNodeTextRegion() {
 }
 
 #if defined(__linux__)
-std::istream *GetTransparentHugePagesConfiguration() {
-  std::ifstream *ifs = new std::ifstream();
-
-  ifs->open("/sys/kernel/mm/transparent_hugepage/enabled");
-  if (!*ifs) {
-    PrintWarning("could not open /sys/kernel/mm/transparent_hugepage/enabled");
-    return nullptr;
-  }
-
-  return ifs;
-}
-
 bool IsTransparentHugePagesEnabled() {
-  std::istream *configuration = GetTransparentHugePagesConfiguration();
-  if (configuration == nullptr) {
+  std::ifstream ifs;
+
+  ifs.open("/sys/kernel/mm/transparent_hugepage/enabled");
+  if (!ifs) {
+    PrintWarning("could not open /sys/kernel/mm/transparent_hugepage/enabled");
     return false;
   }
 
   bool enabled = false;
-  std::string token;
-  while (*configuration >> token) {
-    enabled = enabled || token == "[always]" || token == "[madvise]";
+  if (ifs.is_open()) {
+    std::string token;
+    while (ifs >> token) {
+      enabled = enabled || token == "[always]" || token == "[madvise]";
+    }
   }
-  delete configuration;
+  ifs.close();
+
   return enabled;
 }
 #elif defined(__FreeBSD__)

--- a/src/large_pages/node_large_page.cc
+++ b/src/large_pages/node_large_page.cc
@@ -269,7 +269,7 @@ std::istream* GetTransparentHugePagesConfiguration() {
   return ifs;
 }
 
-bool IsTransparentHugePagesConfigured(std::istream* configuration) {
+bool IsTransparentHugePagesEnabledViaConfiguration(std::istream* configuration) {
   std::string token;
   while (*configuration >> token) {
     if (token == "[always]" || token == "[madvise]") return true;
@@ -282,7 +282,7 @@ bool IsTransparentHugePagesEnabled() {
   if (configuration == nullptr) {
     return false;
   }
-  bool enabled = IsTransparentHugePagesConfigured(configuration);
+  bool enabled = IsTransparentHugePagesEnabledViaConfiguration(configuration);
   delete configuration;
   return enabled;
 }

--- a/src/large_pages/node_large_page.cc
+++ b/src/large_pages/node_large_page.cc
@@ -270,11 +270,12 @@ std::istream *GetTransparentHugePagesConfiguration() {
 }
 
 bool IsTransparentHugePagesEnabledViaConfiguration(std::istream *configuration) {
+  bool enabled = false;
   std::string token;
   while (*configuration >> token) {
-    if (token == "[always]" || token == "[madvise]") return true;
+    enabled = enabled || token == "[always]" || token == "[madvise]";
   }
-  return false;
+  return enabled;
 }
 
 bool IsTransparentHugePagesEnabled() {

--- a/src/large_pages/node_large_page.cc
+++ b/src/large_pages/node_large_page.cc
@@ -266,7 +266,7 @@ bool IsTransparentHugePagesEnabled() {
     return false;
   }
 
-  bool enabled;
+  bool enabled = false;
   if (ifs.is_open()) {
     std::string token;
     while (ifs >> token) {

--- a/src/large_pages/node_large_page.cc
+++ b/src/large_pages/node_large_page.cc
@@ -270,12 +270,11 @@ std::istream *GetTransparentHugePagesConfiguration() {
 }
 
 bool IsTransparentHugePagesEnabledViaConfiguration(std::istream *configuration) {
-  bool enabled = false;
   std::string token;
   while (*configuration >> token) {
-    enabled = enabled || token == "[always]" || token == "[madvise]";
+    if (token == "[always]" || token == "[madvise]") return true;
   }
-  return enabled;
+  return false;
 }
 
 bool IsTransparentHugePagesEnabled() {

--- a/src/large_pages/node_large_page.cc
+++ b/src/large_pages/node_large_page.cc
@@ -279,9 +279,7 @@ bool IsTransparentHugePagesConfigured(std::istream* configuration) {
 
 bool IsTransparentHugePagesEnabled() {
   std::istream* configuration = GetTransparentHugePagesConfiguration();
-  if (configuration == nullptr) {
-    return false;
-  }
+  if (configuration == nullptr) return false;
   bool enabled = IsTransparentHugePagesConfigured(configuration);
   delete configuration;
   return enabled;

--- a/src/large_pages/node_large_page.cc
+++ b/src/large_pages/node_large_page.cc
@@ -266,16 +266,13 @@ bool IsTransparentHugePagesEnabled() {
     return false;
   }
 
-  bool enabled;
+  std::string always, madvise;
   if (ifs.is_open()) {
-    std::string token;
-    while (ifs >> token) {
-      enabled = enabled || token == "[always]" || token == "[madvise]";
-    }
+    ifs >> always >> madvise;
   }
   ifs.close();
 
-  return enabled;
+  return always == "[always]" || madvise == "[madvise]";
 }
 #elif defined(__FreeBSD__)
 bool IsSuperPagesEnabled() {

--- a/src/large_pages/node_large_page.cc
+++ b/src/large_pages/node_large_page.cc
@@ -269,17 +269,21 @@ std::istream *GetTransparentHugePagesConfiguration() {
   return ifs;
 }
 
-bool IsTransparentHugePagesEnabled() {
-  std::istream *configuration = GetTransparentHugePagesConfiguration();
-  if (configuration == nullptr) {
-    return false;
-  }
-
+bool IsTransparentHugePagesEnabledViaConfiguration(std::istream *configuration) {
   bool enabled = false;
   std::string token;
   while (*configuration >> token) {
     enabled = enabled || token == "[always]" || token == "[madvise]";
   }
+  return enabled;
+}
+
+bool IsTransparentHugePagesEnabled() {
+  std::istream *configuration = GetTransparentHugePagesConfiguration();
+  if (configuration == nullptr) {
+    return false;
+  }
+  bool enabled = IsTransparentHugePagesEnabledViaConfiguration(configuration);
   delete configuration;
   return enabled;
 }

--- a/src/large_pages/node_large_page.cc
+++ b/src/large_pages/node_large_page.cc
@@ -261,7 +261,7 @@ bool IsTransparentHugePagesEnabled() {
   std::ifstream ifs;
 
   // File format reference:
-  // https://github.com/torvalds/linux/blob/13391c60da3308ed9980de0168f74cce6c62ac1d/mm/huge_memory.c#L162-L177
+  // https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/huge_memory.c?id=13391c60da3308ed9980de0168f74cce6c62ac1d#n162
   ifs.open("/sys/kernel/mm/transparent_hugepage/enabled");
   if (!ifs) {
     PrintWarning("could not open /sys/kernel/mm/transparent_hugepage/enabled");

--- a/src/large_pages/node_large_page.cc
+++ b/src/large_pages/node_large_page.cc
@@ -260,6 +260,8 @@ struct text_region FindNodeTextRegion() {
 bool IsTransparentHugePagesEnabled() {
   std::ifstream ifs;
 
+  // File format reference:
+  // https://github.com/torvalds/linux/blob/13391c60da3308ed9980de0168f74cce6c62ac1d/mm/huge_memory.c#L162-L177
   ifs.open("/sys/kernel/mm/transparent_hugepage/enabled");
   if (!ifs) {
     PrintWarning("could not open /sys/kernel/mm/transparent_hugepage/enabled");

--- a/src/large_pages/node_large_page.cc
+++ b/src/large_pages/node_large_page.cc
@@ -268,7 +268,7 @@ bool IsTransparentHugePagesEnabled() {
 
   std::string always, madvise;
   if (ifs.is_open()) {
-    while (ifs >> always >> madvise) {}
+    ifs >> always >> madvise;
   }
   ifs.close();
 

--- a/src/large_pages/node_large_page.cc
+++ b/src/large_pages/node_large_page.cc
@@ -257,8 +257,8 @@ struct text_region FindNodeTextRegion() {
 }
 
 #if defined(__linux__)
-std::istream* GetTransparentHugePagesConfiguration() {
-  std::ifstream* ifs = new std::ifstream();
+std::istream *GetTransparentHugePagesConfiguration() {
+  std::ifstream *ifs = new std::ifstream();
 
   ifs->open("/sys/kernel/mm/transparent_hugepage/enabled");
   if (!*ifs) {
@@ -269,7 +269,7 @@ std::istream* GetTransparentHugePagesConfiguration() {
   return ifs;
 }
 
-bool IsTransparentHugePagesEnabledViaConfiguration(std::istream* configuration) {
+bool IsTransparentHugePagesEnabledViaConfiguration(std::istream *configuration) {
   std::string token;
   while (*configuration >> token) {
     if (token == "[always]" || token == "[madvise]") return true;
@@ -278,7 +278,7 @@ bool IsTransparentHugePagesEnabledViaConfiguration(std::istream* configuration) 
 }
 
 bool IsTransparentHugePagesEnabled() {
-  std::istream* configuration = GetTransparentHugePagesConfiguration();
+  std::istream *configuration = GetTransparentHugePagesConfiguration();
   if (configuration == nullptr) {
     return false;
   }

--- a/src/large_pages/node_large_page.cc
+++ b/src/large_pages/node_large_page.cc
@@ -269,21 +269,17 @@ std::istream *GetTransparentHugePagesConfiguration() {
   return ifs;
 }
 
-bool IsTransparentHugePagesEnabledViaConfiguration(std::istream *configuration) {
-  bool enabled = false;
-  std::string token;
-  while (*configuration >> token) {
-    enabled = enabled || token == "[always]" || token == "[madvise]";
-  }
-  return enabled;
-}
-
 bool IsTransparentHugePagesEnabled() {
   std::istream *configuration = GetTransparentHugePagesConfiguration();
   if (configuration == nullptr) {
     return false;
   }
-  bool enabled = IsTransparentHugePagesEnabledViaConfiguration(configuration);
+
+  bool enabled = false;
+  std::string token;
+  while (*configuration >> token) {
+    enabled = enabled || token == "[always]" || token == "[madvise]";
+  }
   delete configuration;
   return enabled;
 }

--- a/src/large_pages/node_large_page.cc
+++ b/src/large_pages/node_large_page.cc
@@ -266,13 +266,16 @@ bool IsTransparentHugePagesEnabled() {
     return false;
   }
 
-  std::string always, madvise;
+  bool enabled;
   if (ifs.is_open()) {
-    ifs >> always >> madvise;
+    std::string token;
+    while (ifs >> token) {
+      enabled = enabled || token == "[always]" || token == "[madvise]";
+    }
   }
   ifs.close();
 
-  return always == "[always]" || madvise == "[madvise]";
+  return enabled;
 }
 #elif defined(__FreeBSD__)
 bool IsSuperPagesEnabled() {

--- a/src/large_pages/node_large_page.cc
+++ b/src/large_pages/node_large_page.cc
@@ -257,8 +257,8 @@ struct text_region FindNodeTextRegion() {
 }
 
 #if defined(__linux__)
-std::istream *GetTransparentHugePagesConfiguration() {
-  std::ifstream *ifs = new std::ifstream();
+std::istream* GetTransparentHugePagesConfiguration() {
+  std::ifstream* ifs = new std::ifstream();
 
   ifs->open("/sys/kernel/mm/transparent_hugepage/enabled");
   if (!*ifs) {
@@ -269,7 +269,7 @@ std::istream *GetTransparentHugePagesConfiguration() {
   return ifs;
 }
 
-bool IsTransparentHugePagesEnabledViaConfiguration(std::istream *configuration) {
+bool IsTransparentHugePagesEnabledViaConfiguration(std::istream* configuration) {
   std::string token;
   while (*configuration >> token) {
     if (token == "[always]" || token == "[madvise]") return true;
@@ -278,7 +278,7 @@ bool IsTransparentHugePagesEnabledViaConfiguration(std::istream *configuration) 
 }
 
 bool IsTransparentHugePagesEnabled() {
-  std::istream *configuration = GetTransparentHugePagesConfiguration();
+  std::istream* configuration = GetTransparentHugePagesConfiguration();
   if (configuration == nullptr) {
     return false;
   }

--- a/src/large_pages/node_large_page.cc
+++ b/src/large_pages/node_large_page.cc
@@ -269,7 +269,7 @@ std::istream* GetTransparentHugePagesConfiguration() {
   return ifs;
 }
 
-bool IsTransparentHugePagesEnabledViaConfiguration(std::istream* configuration) {
+bool IsTransparentHugePagesConfigured(std::istream* configuration) {
   std::string token;
   while (*configuration >> token) {
     if (token == "[always]" || token == "[madvise]") return true;
@@ -282,7 +282,7 @@ bool IsTransparentHugePagesEnabled() {
   if (configuration == nullptr) {
     return false;
   }
-  bool enabled = IsTransparentHugePagesEnabledViaConfiguration(configuration);
+  bool enabled = IsTransparentHugePagesConfigured(configuration);
   delete configuration;
   return enabled;
 }

--- a/src/large_pages/node_large_page.cc
+++ b/src/large_pages/node_large_page.cc
@@ -266,7 +266,7 @@ bool IsTransparentHugePagesEnabled() {
     return false;
   }
 
-  bool enabled = false;
+  bool enabled;
   if (ifs.is_open()) {
     std::string token;
     while (ifs >> token) {


### PR DESCRIPTION
There was an unexpected and hard-to-spot issue here: the `/sys/kernel/mm/transparent_hugepage/enabled` file contains three entries, and the std::ifstream reader was reading two values on each loop iteration, resulting in incorrect behaviour.

Resolves #37064

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.