### PR TITLE
crypto: add support for SM2

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1307,6 +1307,9 @@ API using additional attributes.
 <!-- YAML
 added: v11.6.0
 changes:
+  - version: REPLACEME
+    pr-url: ???
+    description: Added support for `'sm2'`.
   - version:
      - v13.9.0
      - v12.17.0
@@ -1336,6 +1339,7 @@ types are:
 * `'rsa-pss'` (OID 1.2.840.113549.1.1.10)
 * `'dsa'` (OID 1.2.840.10040.4.1)
 * `'ec'` (OID 1.2.840.10045.2.1)
+* `'sm2'` (OID 1.2.840.10045.2.1)
 * `'x25519'` (OID 1.3.101.110)
 * `'x448'` (OID 1.3.101.111)
 * `'ed25519'` (OID 1.3.101.112)
@@ -2555,6 +2559,9 @@ console.log(key.export().toString('hex'));  // e89..........41e
 <!-- YAML
 added: v10.12.0
 changes:
+  - version: REPLACEME
+    pr-url: ???
+    description: Add support for SM2.
   - version:
      - v13.9.0
      - v12.17.0
@@ -2573,7 +2580,7 @@ changes:
 -->
 
 * `type`: {string} Must be `'rsa'`, `'dsa'`, `'ec'`, `'ed25519'`, `'ed448'`,
-  `'x25519'`, `'x448'`, or `'dh'`.
+  `'x25519'`, `'x448'`, `'dh'`, or `'sm2'`.
 * `options`: {Object}
   * `modulusLength`: {number} Key size in bits (RSA, DSA).
   * `publicExponent`: {number} Public exponent (RSA). **Default:** `0x10001`.
@@ -2592,7 +2599,7 @@ changes:
   * `privateKey`: {string | Buffer | KeyObject}
 
 Generates a new asymmetric key pair of the given `type`. RSA, DSA, EC, Ed25519,
-Ed448, X25519, X448, and DH are currently supported.
+Ed448, X25519, X448, DH, and SM2 are currently supported.
 
 If a `publicKeyEncoding` or `privateKeyEncoding` was specified, this function
 behaves as if [`keyObject.export()`][] had been called on its result. Otherwise,
@@ -2630,6 +2637,9 @@ a `Promise` for an `Object` with `publicKey` and `privateKey` properties.
 <!-- YAML
 added: v10.12.0
 changes:
+  - version: REPLACEME
+    pr-url: ???
+    description: Add support for SM2.
   - version:
      - v13.9.0
      - v12.17.0
@@ -2645,7 +2655,7 @@ changes:
 -->
 
 * `type`: {string} Must be `'rsa'`, `'dsa'`, `'ec'`, `'ed25519'`, `'ed448'`,
-  `'x25519'`, `'x448'`, or `'dh'`.
+  `'x25519'`, `'x448'`, `'dh'`, or `'sm2'`.
 * `options`: {Object}
   * `modulusLength`: {number} Key size in bits (RSA, DSA).
   * `publicExponent`: {number} Public exponent (RSA). **Default:** `0x10001`.
@@ -2663,7 +2673,7 @@ changes:
   * `privateKey`: {string | Buffer | KeyObject}
 
 Generates a new asymmetric key pair of the given `type`. RSA, DSA, EC, Ed25519,
-Ed448, X25519, X448, and DH are currently supported.
+Ed448, X25519, X448, DH, and SM2 are currently supported.
 
 If a `publicKeyEncoding` or `privateKeyEncoding` was specified, this function
 behaves as if [`keyObject.export()`][] had been called on its result. Otherwise,

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -2360,6 +2360,9 @@ input.on('readable', () => {
 <!-- YAML
 added: v11.6.0
 changes:
+  - version: REPLACEME
+    pr-url: ???
+    description: Add `asymmetricKeyType` option.
   - version: v15.0.0
     pr-url: https://github.com/nodejs/node/pull/35093
     description: The key can also be an ArrayBuffer. The encoding option was
@@ -2375,6 +2378,7 @@ changes:
      required only if the `format` is `'der'` and ignored if it is `'pem'`.
   * `passphrase`: {string | Buffer} The passphrase to use for decryption.
   * `encoding`: {string} The string encoding to use when `key` is a string.
+  * `asymmetricKeyType` {string} The requested asymmetric key type.
 * Returns: {KeyObject}
 <!--lint enable maximum-line-length remark-lint-->
 
@@ -2385,10 +2389,18 @@ must be an object with the properties described above.
 If the private key is encrypted, a `passphrase` must be specified. The length
 of the passphrase is limited to 1024 bytes.
 
+If the `asymmetricKeyType` is specified, Node.js will attempt to assign the
+given type to the key. This can be used, for example, to distinguish between
+EC keys on the SM2 curve (`'ec'`) and SM2 keys (`'sm2'`). If the given type
+cannot be assigned to the key, the function fails.
+
 ### `crypto.createPublicKey(key)`
 <!-- YAML
 added: v11.6.0
 changes:
+  - version: REPLACEME
+    pr-url: ???
+    description: Add `asymmetricKeyType` option.
   - version: v15.0.0
     pr-url: https://github.com/nodejs/node/pull/35093
     description: The key can also be an ArrayBuffer. The encoding option was
@@ -2409,6 +2421,7 @@ changes:
   * `type`: {string} Must be `'pkcs1'` or `'spki'`. This option is required
     only if the `format` is `'der'`.
   * `encoding` {string} The string encoding to use when `key` is a string.
+  * `asymmetricKeyType` {string} The requested asymmetric key type.
 * Returns: {KeyObject}
 <!--lint enable maximum-line-length remark-lint-->
 
@@ -2418,6 +2431,11 @@ with type `'private'`, the public key is derived from the given private key;
 otherwise, `key` must be an object with the properties described above.
 
 If the format is `'pem'`, the `'key'` may also be an X.509 certificate.
+
+If the `asymmetricKeyType` is specified, Node.js will attempt to assign the
+given type to the key. This can be used, for example, to distinguish between
+EC keys on the SM2 curve (`'ec'`) and SM2 keys (`'sm2'`). If the given type
+cannot be assigned to the key, the function fails.
 
 Because public keys can be derived from private keys, a private key may be
 passed instead of a public key. In that case, this function behaves as if

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -3637,6 +3637,9 @@ Throws an error if FIPS mode is not available.
 <!-- YAML
 added: v12.0.0
 changes:
+  - version: REPLACEME
+    pr-url: ???
+    description: Add support for SM2.
   - version:
      - v13.2.0
      - v12.16.0
@@ -3653,7 +3656,7 @@ changes:
 
 Calculates and returns the signature for `data` using the given private key and
 algorithm. If `algorithm` is `null` or `undefined`, then the algorithm is
-dependent upon the key type (especially Ed25519 and Ed448).
+dependent upon the key type (especially Ed25519, Ed448, and SM2).
 
 If `key` is not a [`KeyObject`][], this function behaves as if `key` had been
 passed to [`crypto.createPrivateKey()`][]. If it is an object, the following
@@ -3674,6 +3677,9 @@ additional properties can be passed:
   `crypto.constants.RSA_PSS_SALTLEN_DIGEST` sets the salt length to the digest
   size, `crypto.constants.RSA_PSS_SALTLEN_MAX_SIGN` (default) sets it to the
   maximum permissible value.
+* `sm2Identifier` {ArrayBuffer|Buffer|TypedArray|DataView} For SM2, this option
+  specifies the SM2 identifier. The same identifier must be specified during
+  verification.
 
 ### `crypto.timingSafeEqual(a, b)`
 <!-- YAML
@@ -3709,6 +3715,9 @@ not introduce timing vulnerabilities.
 <!-- YAML
 added: v12.0.0
 changes:
+  - version: REPLACEME
+    pr-url: ???
+    description: Add support for SM2.
   - version: v15.0.0
     pr-url: https://github.com/nodejs/node/pull/35093
     description: The data, key, and signature arguments can also be ArrayBuffer.
@@ -3729,7 +3738,7 @@ changes:
 
 Verifies the given signature for `data` using the given key and algorithm. If
 `algorithm` is `null` or `undefined`, then the algorithm is dependent upon the
-key type (especially Ed25519 and Ed448).
+key type (especially Ed25519, Ed448, and SM2).
 
 If `key` is not a [`KeyObject`][], this function behaves as if `key` had been
 passed to [`crypto.createPublicKey()`][]. If it is an object, the following
@@ -3750,6 +3759,8 @@ additional properties can be passed:
   `crypto.constants.RSA_PSS_SALTLEN_DIGEST` sets the salt length to the digest
   size, `crypto.constants.RSA_PSS_SALTLEN_MAX_SIGN` (default) sets it to the
   maximum permissible value.
+* `sm2Identifier` {ArrayBuffer|Buffer|TypedArray|DataView} For SM2, this option
+  specifies the SM2 identifier.
 
 The `signature` argument is the previously calculated signature for the `data`.
 

--- a/lib/internal/crypto/cipher.js
+++ b/lib/internal/crypto/cipher.js
@@ -65,7 +65,7 @@ let StringDecoder;
 
 function rsaFunctionFor(method, defaultPadding, keyType) {
   return (options, buffer) => {
-    const { format, type, data, passphrase } =
+    const { format, type, data, passphrase, asymmetricKeyType } =
       keyType === 'private' ?
         preparePrivateKey(options) :
         preparePublicOrPrivateKey(options);
@@ -77,8 +77,8 @@ function rsaFunctionFor(method, defaultPadding, keyType) {
     if (oaepLabel !== undefined)
       oaepLabel = getArrayBufferOrView(oaepLabel, 'key.oaepLabel', encoding);
     buffer = getArrayBufferOrView(buffer, 'buffer', encoding);
-    return method(data, format, type, passphrase, buffer, padding, oaepHash,
-                  oaepLabel);
+    return method(data, format, type, passphrase, asymmetricKeyType, buffer,
+                  padding, oaepHash, oaepLabel);
   };
 }
 

--- a/lib/internal/crypto/keygen.js
+++ b/lib/internal/crypto/keygen.js
@@ -16,8 +16,10 @@ const {
   kCryptoJobSync,
   kKeyVariantRSA_PSS,
   kKeyVariantRSA_SSA_PKCS1_V1_5,
+  EVP_PKEY_EC,
   EVP_PKEY_ED25519,
   EVP_PKEY_ED448,
+  EVP_PKEY_SM2,
   EVP_PKEY_X25519,
   EVP_PKEY_X448,
   OPENSSL_EC_NAMED_CURVE,
@@ -244,6 +246,16 @@ function createJob(mode, type, options) {
         mode,
         namedCurve,
         paramEncoding,
+        EVP_PKEY_EC,
+        ...encoding);
+    }
+    case 'sm2':
+    {
+      return new EcKeyPairGenJob(
+        mode,
+        'SM2',
+        OPENSSL_EC_NAMED_CURVE,
+        EVP_PKEY_SM2,
         ...encoding);
     }
     case 'ed25519':

--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -20,6 +20,16 @@ const {
   kKeyEncodingPKCS8,
   kKeyEncodingSPKI,
   kKeyEncodingSEC1,
+  EVP_PKEY_DH,
+  EVP_PKEY_DSA,
+  EVP_PKEY_EC,
+  EVP_PKEY_ED25519,
+  EVP_PKEY_ED448,
+  EVP_PKEY_RSA,
+  EVP_PKEY_RSA_PSS,
+  EVP_PKEY_SM2,
+  EVP_PKEY_X25519,
+  EVP_PKEY_X448
 } = internalBinding('crypto');
 
 const {
@@ -359,13 +369,41 @@ function prepareAsymmetricKey(key, ctx) {
     // Expect PEM by default, mostly for backward compatibility.
     return { format: kKeyFormatPEM, data: getArrayBufferOrView(key, 'key') };
   } else if (typeof key === 'object') {
-    const { key: data, encoding } = key;
+    const { key: data, encoding, asymmetricKeyType: typeStr } = key;
+
+    let asymmetricKeyType;
+    if (typeStr == null)
+      asymmetricKeyType = undefined;
+    else if (typeStr === 'dh')
+      asymmetricKeyType = EVP_PKEY_DH;
+    else if (typeStr === 'dsa')
+      asymmetricKeyType = EVP_PKEY_DSA;
+    else if (typeStr === 'ec')
+      asymmetricKeyType = EVP_PKEY_EC;
+    else if (typeStr === 'ed25519')
+      asymmetricKeyType = EVP_PKEY_ED25519;
+    else if (typeStr === 'ed448')
+      asymmetricKeyType = EVP_PKEY_ED448;
+    else if (typeStr === 'rsa')
+      asymmetricKeyType = EVP_PKEY_RSA;
+    else if (typeStr === 'rsa-pss')
+      asymmetricKeyType = EVP_PKEY_RSA_PSS;
+    else if (typeStr === 'sm2')
+      asymmetricKeyType = EVP_PKEY_SM2;
+    else if (typeStr === 'x25519')
+      asymmetricKeyType = EVP_PKEY_X25519;
+    else if (typeStr === 'x448')
+      asymmetricKeyType = EVP_PKEY_X448;
+    else
+      throw new ERR_INVALID_ARG_VALUE('options.asymmetricKeyType', typeStr);
+
     // The 'key' property can be a KeyObject as well to allow specifying
     // additional options such as padding along with the key.
+    const common = { asymmetricKeyType };
     if (isKeyObject(data))
-      return { data: getKeyObjectHandle(data, ctx) };
+      return { data: getKeyObjectHandle(data, ctx), ...common };
     else if (isCryptoKey(data))
-      return { data: getKeyObjectHandle(data[kKeyObject], ctx) };
+      return { data: getKeyObjectHandle(data[kKeyObject], ctx), ...common };
     // Either PEM or DER using PKCS#1 or SPKI.
     if (!isStringOrBuffer(data)) {
       throw new ERR_INVALID_ARG_TYPE(
@@ -378,6 +416,7 @@ function prepareAsymmetricKey(key, ctx) {
       (ctx === kConsumePrivate || ctx === kCreatePrivate) ? false : undefined;
     return {
       data: getArrayBufferOrView(data, 'key', encoding),
+      ...common,
       ...parseKeyEncoding(key, undefined, isPublic)
     };
   }
@@ -428,17 +467,19 @@ function createSecretKey(key, encoding) {
 }
 
 function createPublicKey(key) {
-  const { format, type, data } = prepareAsymmetricKey(key, kCreatePublic);
+  const { format, type, data, passphrase, asymmetricKeyType } =
+    prepareAsymmetricKey(key, kCreatePublic);
   const handle = new KeyObjectHandle();
-  handle.init(kKeyTypePublic, data, format, type);
+  handle.init(kKeyTypePublic, data, format, type, passphrase, asymmetricKeyType);
   return new PublicKeyObject(handle);
 }
 
 function createPrivateKey(key) {
-  const { format, type, data, passphrase } =
+  const { format, type, data, passphrase, asymmetricKeyType } =
     prepareAsymmetricKey(key, kCreatePrivate);
   const handle = new KeyObjectHandle();
-  handle.init(kKeyTypePrivate, data, format, type, passphrase);
+  handle.init(kKeyTypePrivate, data, format, type, passphrase,
+              asymmetricKeyType);
   return new PrivateKeyObject(handle);
 }
 

--- a/lib/internal/crypto/sig.js
+++ b/lib/internal/crypto/sig.js
@@ -122,7 +122,8 @@ Sign.prototype.sign = function sign(options, encoding) {
   if (!options)
     throw new ERR_CRYPTO_SIGN_KEY_REQUIRED();
 
-  const { data, format, type, passphrase } = preparePrivateKey(options, true);
+  const { data, format, type, passphrase, asymmetricKeyType } =
+    preparePrivateKey(options, true);
 
   // Options specific to RSA
   const rsaPadding = getPadding(options);
@@ -131,8 +132,9 @@ Sign.prototype.sign = function sign(options, encoding) {
   // Options specific to (EC)DSA
   const dsaSigEnc = getDSASignatureEncoding(options);
 
-  const ret = this[kHandle].sign(data, format, type, passphrase, rsaPadding,
-                                 pssSaltLength, dsaSigEnc);
+  const ret = this[kHandle].sign(data, format, type, passphrase,
+                                 asymmetricKeyType, rsaPadding, pssSaltLength,
+                                 dsaSigEnc);
 
   encoding = encoding || getDefaultEncoding();
   if (encoding && encoding !== 'buffer')
@@ -154,7 +156,8 @@ function signOneShot(algorithm, data, key) {
     data: keyData,
     format: keyFormat,
     type: keyType,
-    passphrase: keyPassphrase
+    passphrase: keyPassphrase,
+    asymmetricKeyType: keyAsymmetricKeyType
   } = preparePrivateKey(key);
 
   // Options specific to RSA
@@ -167,9 +170,9 @@ function signOneShot(algorithm, data, key) {
   // Option specific to SM2.
   const sm2Identifier = getSm2Identifier(key);
 
-  return _signOneShot(keyData, keyFormat, keyType, keyPassphrase, data,
-                      algorithm, rsaPadding, pssSaltLength, dsaSigEnc,
-                      sm2Identifier);
+  return _signOneShot(keyData, keyFormat, keyType, keyPassphrase,
+                      keyAsymmetricKeyType, data, algorithm, rsaPadding,
+                      pssSaltLength, dsaSigEnc, sm2Identifier);
 }
 
 function Verify(algorithm, options) {
@@ -193,7 +196,8 @@ Verify.prototype.verify = function verify(options, signature, sigEncoding) {
     data,
     format,
     type,
-    passphrase
+    passphrase,
+    asymmetricKeyType
   } = preparePublicOrPrivateKey(options, true);
 
   sigEncoding = sigEncoding || getDefaultEncoding();
@@ -207,8 +211,8 @@ Verify.prototype.verify = function verify(options, signature, sigEncoding) {
 
   signature = getArrayBufferOrView(signature, 'signature', sigEncoding);
 
-  return this[kHandle].verify(data, format, type, passphrase, signature,
-                              rsaPadding, pssSaltLength, dsaSigEnc);
+  return this[kHandle].verify(data, format, type, passphrase, asymmetricKeyType,
+                              signature, rsaPadding, pssSaltLength, dsaSigEnc);
 };
 
 function verifyOneShot(algorithm, data, key, signature) {
@@ -229,7 +233,8 @@ function verifyOneShot(algorithm, data, key, signature) {
     data: keyData,
     format: keyFormat,
     type: keyType,
-    passphrase: keyPassphrase
+    passphrase: keyPassphrase,
+    asymmetricKeyType: keyAsymmetricKeyType
   } = preparePublicOrPrivateKey(key);
 
   // Options specific to RSA
@@ -250,9 +255,9 @@ function verifyOneShot(algorithm, data, key, signature) {
     );
   }
 
-  return _verifyOneShot(keyData, keyFormat, keyType, keyPassphrase, signature,
-                        data, algorithm, rsaPadding, pssSaltLength, dsaSigEnc,
-                        sm2Identifier);
+  return _verifyOneShot(keyData, keyFormat, keyType, keyPassphrase,
+                        keyAsymmetricKeyType, signature, data, algorithm,
+                        rsaPadding, pssSaltLength, dsaSigEnc, sm2Identifier);
 }
 
 module.exports = {

--- a/lib/internal/crypto/sig.js
+++ b/lib/internal/crypto/sig.js
@@ -108,6 +108,16 @@ function getIntOption(name, options) {
   return undefined;
 }
 
+function getSm2Identifier(options) {
+  if (typeof options === 'object') {
+    const { sm2Identifier } = options;
+    if (sm2Identifier != null) {
+      return getArrayBufferOrView(sm2Identifier, 'sm2Identifier');
+    }
+  }
+  return undefined;
+}
+
 Sign.prototype.sign = function sign(options, encoding) {
   if (!options)
     throw new ERR_CRYPTO_SIGN_KEY_REQUIRED();
@@ -154,8 +164,12 @@ function signOneShot(algorithm, data, key) {
   // Options specific to (EC)DSA
   const dsaSigEnc = getDSASignatureEncoding(key);
 
+  // Option specific to SM2.
+  const sm2Identifier = getSm2Identifier(key);
+
   return _signOneShot(keyData, keyFormat, keyType, keyPassphrase, data,
-                      algorithm, rsaPadding, pssSaltLength, dsaSigEnc);
+                      algorithm, rsaPadding, pssSaltLength, dsaSigEnc,
+                      sm2Identifier);
 }
 
 function Verify(algorithm, options) {
@@ -225,6 +239,9 @@ function verifyOneShot(algorithm, data, key, signature) {
   // Options specific to (EC)DSA
   const dsaSigEnc = getDSASignatureEncoding(key);
 
+  // Option specific to SM2.
+  const sm2Identifier = getSm2Identifier(key);
+
   if (!isArrayBufferView(signature)) {
     throw new ERR_INVALID_ARG_TYPE(
       'signature',
@@ -234,7 +251,8 @@ function verifyOneShot(algorithm, data, key, signature) {
   }
 
   return _verifyOneShot(keyData, keyFormat, keyType, keyPassphrase, signature,
-                        data, algorithm, rsaPadding, pssSaltLength, dsaSigEnc);
+                        data, algorithm, rsaPadding, pssSaltLength, dsaSigEnc,
+                        sm2Identifier);
 }
 
 module.exports = {

--- a/src/crypto/crypto_ec.cc
+++ b/src/crypto/crypto_ec.cc
@@ -572,6 +572,7 @@ Maybe<bool> EcKeyGenTraits::AdditionalConfig(
   Environment* env = Environment::GetCurrent(args);
   CHECK(args[*offset]->IsString());  // curve name
   CHECK(args[*offset + 1]->IsInt32());  // param encoding
+  CHECK(args[*offset + 2]->IsInt32());  // target key type
 
   Utf8Value curve_name(env->isolate(), args[*offset]);
   params->params.curve_nid = GetCurveFromName(*curve_name);
@@ -587,7 +588,14 @@ Maybe<bool> EcKeyGenTraits::AdditionalConfig(
     return Nothing<bool>();
   }
 
-  *offset += 2;
+  params->alias_key_type = args[*offset + 2].As<Int32>()->Value();
+  if (params->alias_key_type != EVP_PKEY_EC &&
+      params->alias_key_type != EVP_PKEY_SM2) {
+    THROW_ERR_OUT_OF_RANGE(env, "Invalid alias_key_type specified");
+    return Nothing<bool>();
+  }
+
+  *offset += 3;
 
   return Just(true);
 }

--- a/src/crypto/crypto_keys.cc
+++ b/src/crypto/crypto_keys.cc
@@ -1126,6 +1126,8 @@ Local<Value> KeyObjectHandle::GetAsymmetricKeyType() const {
     return env()->crypto_ed25519_string();
   case EVP_PKEY_ED448:
     return env()->crypto_ed448_string();
+  case EVP_PKEY_SM2:
+    return env()->crypto_sm2_string();
   case EVP_PKEY_X25519:
     return env()->crypto_x25519_string();
   case EVP_PKEY_X448:
@@ -1361,8 +1363,10 @@ void Initialize(Environment* env, Local<Object> target) {
   NODE_DEFINE_CONSTANT(target, kWebCryptoKeyFormatSPKI);
   NODE_DEFINE_CONSTANT(target, kWebCryptoKeyFormatJWK);
 
+  NODE_DEFINE_CONSTANT(target, EVP_PKEY_EC);
   NODE_DEFINE_CONSTANT(target, EVP_PKEY_ED25519);
   NODE_DEFINE_CONSTANT(target, EVP_PKEY_ED448);
+  NODE_DEFINE_CONSTANT(target, EVP_PKEY_SM2);
   NODE_DEFINE_CONSTANT(target, EVP_PKEY_X25519);
   NODE_DEFINE_CONSTANT(target, EVP_PKEY_X448);
   NODE_DEFINE_CONSTANT(target, kKeyEncodingPKCS1);

--- a/src/crypto/crypto_sig.h
+++ b/src/crypto/crypto_sig.h
@@ -22,7 +22,7 @@ class SignBase : public BaseObject {
  public:
   typedef enum {
     kSignOk,
-    kSignUnknownDigest,
+    kSignInvalidDigest,
     kSignInit,
     kSignNotInitialised,
     kSignUpdate,

--- a/src/env.h
+++ b/src/env.h
@@ -204,6 +204,7 @@ constexpr size_t kFsStatsBufferLength =
   V(crypto_ec_string, "ec")                                                    \
   V(crypto_ed25519_string, "ed25519")                                          \
   V(crypto_ed448_string, "ed448")                                              \
+  V(crypto_sm2_string, "sm2")                                                  \
   V(crypto_x25519_string, "x25519")                                            \
   V(crypto_x448_string, "x448")                                                \
   V(crypto_rsa_string, "rsa")                                                  \

--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -64,6 +64,7 @@ void OnFatalError(const char* location, const char* message);
   V(ERR_MEMORY_ALLOCATION_FAILED, Error)                                       \
   V(ERR_MESSAGE_TARGET_CONTEXT_UNAVAILABLE, Error)                             \
   V(ERR_MISSING_ARGS, TypeError)                                               \
+  V(ERR_MISSING_OPTION, TypeError)                                             \
   V(ERR_MISSING_TRANSFERABLE_IN_TRANSFER_LIST, TypeError)                      \
   V(ERR_MISSING_PASSPHRASE, TypeError)                                         \
   V(ERR_MISSING_PLATFORM_FOR_WORKER, Error)                                    \

--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -33,6 +33,7 @@ void OnFatalError(const char* location, const char* message);
   V(ERR_BUFFER_TOO_LARGE, Error)                                               \
   V(ERR_CONSTRUCT_CALL_REQUIRED, TypeError)                                    \
   V(ERR_CONSTRUCT_CALL_INVALID, TypeError)                                     \
+  V(ERR_CRYPTO_INCOMPATIBLE_KEY, Error)                                        \
   V(ERR_CRYPTO_INITIALIZATION_FAILED, Error)                                   \
   V(ERR_CRYPTO_INVALID_AUTH_TAG, TypeError)                                    \
   V(ERR_CRYPTO_INVALID_COUNTER, TypeError)                                     \
@@ -110,6 +111,8 @@ void OnFatalError(const char* location, const char* message);
     "Buffer is not available for the current Context")                         \
   V(ERR_CONSTRUCT_CALL_INVALID, "Constructor cannot be called")                \
   V(ERR_CONSTRUCT_CALL_REQUIRED, "Cannot call constructor without `new`")      \
+  V(ERR_CRYPTO_INCOMPATIBLE_KEY,                                               \
+    "The requested key type does not match the actual key type")               \
   V(ERR_CRYPTO_INITIALIZATION_FAILED, "Initialization failed")                 \
   V(ERR_CRYPTO_INVALID_AUTH_TAG, "Invalid authentication tag")                 \
   V(ERR_CRYPTO_INVALID_COUNTER, "Invalid counter")                             \

--- a/test/parallel/test-crypto-sm2.js
+++ b/test/parallel/test-crypto-sm2.js
@@ -250,3 +250,15 @@ const {
     assert.strictEqual(e, ecPublicExport);
   }
 }
+
+{
+  // EC keys on the SM2 curve should still allow normal operation.
+
+  // TODO(tniessen): Later versions of OpenSSL allow SM3 here. Test that.
+
+  const data = randomBytes(100);
+
+  const signature = sign('sha256', data, ecdsaPrivateKey);
+  const isValid = verify('sha256', data, ecdsaPublicKey, signature);
+  assert.strictEqual(isValid, true);
+}

--- a/test/parallel/test-crypto-sm2.js
+++ b/test/parallel/test-crypto-sm2.js
@@ -5,7 +5,11 @@ if (!common.hasCrypto)
 
 const assert = require('assert');
 const {
-  generateKeyPairSync
+  generateKeyPairSync,
+  getHashes,
+  randomBytes,
+  sign,
+  verify
 }= require('crypto');
 
 
@@ -33,4 +37,108 @@ const {
 
   assert.strictEqual(ecdsaPublicKey.asymmetricKeyType, 'ec');
   assert.strictEqual(ecdsaPrivateKey.asymmetricKeyType, 'ec');
+}
+
+{
+  // Test the basic behavior of SM2 signatures.
+
+  const sizes = [0, 10, 100, 1000];
+
+  for (const dataSize of [0, 10, 100, 1000]) {
+    const data = randomBytes(dataSize);
+
+    for (const idSize of [0, 10, 100, 1000]) {
+      const sm2Identifier = randomBytes(idSize);
+      const otherSm2Identifier = randomBytes(idSize === 0 ? 1 : idSize);
+
+      // Generate valid signatures.
+      const validSignatures = [null, 'SM3'].map((algo) => {
+        return sign(algo, data, {
+          key: sm2PrivateKey,
+          sm2Identifier
+        });
+      });
+
+      // Test the generated signatures.
+      for (const signature of validSignatures) {
+        for (const algo of [null, 'SM3']) {
+          // Ensure that signatures are validated correctly.
+          const signatureIsValid = verify(algo, data, {
+            key: sm2PublicKey,
+            sm2Identifier
+          }, signature);
+          assert.strictEqual(signatureIsValid, true);
+
+          // Providing a different identifier should cause verification to fail.
+          const isValidWithWrongId = verify(algo, data, {
+            key: sm2PublicKey,
+            sm2Identifier: otherSm2Identifier
+          }, signature);
+          assert.strictEqual(isValidWithWrongId, false);
+        }
+      }
+    }
+  }
+}
+
+{
+  // Test that no hash functions other than SM3 are allowed.
+
+  const data = randomBytes(100);
+  const options = {
+    key: sm2PrivateKey,
+    sm2Identifier: randomBytes(10)
+  };
+  const sigBuf = Buffer.alloc(10);
+
+  for (const hash of getHashes()) {
+    if (!hash.startsWith('sm3') && !hash.endsWith('SM3')) {
+      const args = [hash, data, options];
+      for (const fn of [() => sign(...args), () => verify(...args, sigBuf)]) {
+        assert.throws(fn, {
+          code: 'ERR_CRYPTO_INVALID_DIGEST',
+          name: 'TypeError'
+        });
+      }
+    }
+  }
+}
+
+{
+  // Test without identifier.
+
+  const possibleOptions = [
+    sm2PrivateKey,
+    { key: sm2PrivateKey },
+    { key: sm2PrivateKey, sm2Identifier: null }
+  ];
+  const sigBuf = Buffer.alloc(10);
+
+  for (const options of possibleOptions) {
+    const args = [null, Buffer.alloc(0), options];
+    for (const fn of [() => sign(...args), () => verify(...args, sigBuf)]) {
+      assert.throws(fn, {
+        code: 'ERR_MISSING_OPTION',
+        message: 'sm2Identifier is required',
+        name: 'TypeError'
+      });
+    }
+  }
+}
+
+{
+  // Test invalid identifiers.
+
+  const key = sm2PrivateKey;
+  const sigBuf = Buffer.alloc(10);
+
+  for (const sm2Identifier of [true, false, 0, 1, () => {}, {}, []]) {
+    const args = [null, Buffer.alloc(0), { key, sm2Identifier }];
+    for (const fn of [() => sign(...args), () => verify(...args, sigBuf)]) {
+      assert.throws(fn, {
+        code: 'ERR_INVALID_ARG_TYPE',
+        name: 'TypeError'
+      });
+    }
+  }
 }

--- a/test/parallel/test-crypto-sm2.js
+++ b/test/parallel/test-crypto-sm2.js
@@ -1,0 +1,36 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const {
+  generateKeyPairSync
+}= require('crypto');
+
+
+// Generate an SM2 key pair.
+const {
+  publicKey: sm2PublicKey,
+  privateKey: sm2PrivateKey
+} = generateKeyPairSync('sm2');
+
+// While this key pair also uses the SM2 curve, it produces ECDSA signatures.
+const {
+  publicKey: ecdsaPublicKey,
+  privateKey: ecdsaPrivateKey
+} = generateKeyPairSync('ec', {
+  namedCurve: 'SM2'
+});
+
+
+{
+  // Even though the key structures and curves are exactly the same, their key
+  // type should be different.
+
+  assert.strictEqual(sm2PublicKey.asymmetricKeyType, 'sm2');
+  assert.strictEqual(sm2PrivateKey.asymmetricKeyType, 'sm2');
+
+  assert.strictEqual(ecdsaPublicKey.asymmetricKeyType, 'ec');
+  assert.strictEqual(ecdsaPrivateKey.asymmetricKeyType, 'ec');
+}


### PR DESCRIPTION
These commits add support for SM2 from the [SM9 standard](https://en.wikipedia.org/wiki/SM9_%28cryptography_standard%29). It requires a fair amount of hacks within our codebase, so if anyone has any other integration ideas, I'd be happy to hear them.

## Asymmetric Key Type `'sm2'`

A new asymmetric key type is added: `'sm2'`.

Unlike previous asymmetric key types, it does not have a unique OID, and does, in fact, share an OID with `'ec'`, meaning that there is no longer a 1:1 correlation between OIDs and asymmetric key types.

## Key Pair Generation

SM2 key pairs can be generated using `crypto.generateKeyPair('sm2')`.

No options are accepted.

## Digital Signatures

SM2 signatures require an additional "identifier" that must be specified by the signing and the verifying party. To accomodate this, an `sm2Identifier` option was added to `crypto.sign` and `crypto.verify`.

There is no documented way of producing SM2 signatures with the OpenSSL APIs that we are using in the `Sign` and `Verify` classes. Therefore, these classes currently do not support SM2 signatures.

## Key Agreement

Currently not implemented due to lack of support within OpenSSL. Might also be insecure in its original form, see Xu et al. [doi:10.1007/978-3-642-25513-7_12](https://doi.org/10.1007/978-3-642-25513-7_12):

> In this paper, we have shown that the SM2 key exchange protocol is potentially vulnerable to an unknown key-share attack. The weakness is due to the fact that the identifiers of the communicants are not appropriately integrated into the exchanged cryptographic messages. However, the attack presented here should not discourage use of the SM2 protocol, as long as appropriate countermeasures are taken. We also have suggested a simple modification to resist our described attacks while the merits of the original protocol are left unchanged.

Should be added to `crypto.diffieHellman()` if it makes sense in the future.

## Key Import

Because the PKCS#8 and SPKI encodings of SM2 keys are indistinguishable from EC keys on the SM2 curve, the `createPublicKey` and `createPrivateKey` functions now accept an additional `asymmetricKeyType` option. If specified, Node.js will attempt to create a `KeyObject` of the given type. As a side effect, this allows users to enforce a specific asymmetric key type when importing key material, e.g., `'rsa'`. For SM2, this means that the key will first be parsed as EC, and its type will then be changed to SM2 if the user specified `asymmetricKeyType: 'sm2'`.

The default behavior matches OpenSSL: When loading a key with OID `1.2.840.10045.2.1` on the SM2 curve without specifying `asymmetricKeyType: 'sm2'`, it will create an EC key, not an SM2 key.

## Note on SM3

While OpenSSL 1.1.1 supports SM3 as a hash function and as the digest for SM2 signatures, it does not allow SM3 as the digest for other signatures. Future releases might change that.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
