### PR TITLE
tls: add ability to get cert/peer cert as X509Certificate object

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1804,6 +1804,16 @@ added: v15.6.0
 
 The issuer identification included in this certificate.
 
+### `x509.issuerCertificate`
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {X509Certificate}
+
+The issuer certificate or `undefined` if the issuer certificate is not
+available.
+
 ### `x509.keyUsage`
 <!-- YAML
 added: v15.6.0

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -904,6 +904,41 @@ added: v0.11.4
 Always returns `true`. This may be used to distinguish TLS sockets from regular
 `net.Socket` instances.
 
+### `tlsSocket.exportKeyingMaterial(length, label[, context])`
+<!-- YAML
+added:
+ - v13.10.0
+ - v12.17.0
+-->
+
+* `length` {number} number of bytes to retrieve from keying material
+* `label` {string} an application specific label, typically this will be a
+  value from the
+  [IANA Exporter Label Registry](https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#exporter-labels).
+* `context` {Buffer} Optionally provide a context.
+
+* Returns: {Buffer} requested bytes of the keying material
+
+Keying material is used for validations to prevent different kind of attacks in
+network protocols, for example in the specifications of IEEE 802.1X.
+
+Example
+
+```js
+const keyingMaterial = tlsSocket.exportKeyingMaterial(
+  128,
+  'client finished');
+
+/**
+ Example return value of keyingMaterial:
+ <Buffer 76 26 af 99 c5 56 8e 42 09 91 ef 9f 93 cb ad 6c 7b 65 f8 53 f1 d8 d9
+    12 5a 33 b8 b5 25 df 7b 37 9f e0 e2 4f b8 67 83 a3 2f cd 5d 41 42 4c 91
+    74 ef 2c ... 78 more bytes>
+*/
+```
+See the OpenSSL [`SSL_export_keying_material`][] documentation for more
+information.
+
 ### `tlsSocket.getCertificate()`
 <!-- YAML
 added: v11.2.0
@@ -1113,6 +1148,18 @@ provided by SSL/TLS is not desired or is not enough.
 Corresponds to the `SSL_get_peer_finished` routine in OpenSSL and may be used
 to implement the `tls-unique` channel binding from [RFC 5929][].
 
+### `tlsSocket.getPeerX509Certificate()`
+<!-- YAML
+added: REPLACEME
+-->
+
+* Returns: {X509Certificate}
+
+Returns the peer certificate as an {X509Certificate} object.
+
+If there is no peer certificate, or the socket has been destroyed,
+`undefined` will be returned.
+
 ### `tlsSocket.getProtocol()`
 <!-- YAML
 added: v5.7.0
@@ -1164,41 +1211,6 @@ See
 [SSL_get_shared_sigalgs](https://www.openssl.org/docs/man1.1.1/man3/SSL_get_shared_sigalgs.html)
 for more information.
 
-### `tlsSocket.exportKeyingMaterial(length, label[, context])`
-<!-- YAML
-added:
- - v13.10.0
- - v12.17.0
--->
-
-* `length` {number} number of bytes to retrieve from keying material
-* `label` {string} an application specific label, typically this will be a
-  value from the
-  [IANA Exporter Label Registry](https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#exporter-labels).
-* `context` {Buffer} Optionally provide a context.
-
-* Returns: {Buffer} requested bytes of the keying material
-
-Keying material is used for validations to prevent different kind of attacks in
-network protocols, for example in the specifications of IEEE 802.1X.
-
-Example
-
-```js
-const keyingMaterial = tlsSocket.exportKeyingMaterial(
-  128,
-  'client finished');
-
-/**
- Example return value of keyingMaterial:
- <Buffer 76 26 af 99 c5 56 8e 42 09 91 ef 9f 93 cb ad 6c 7b 65 f8 53 f1 d8 d9
-    12 5a 33 b8 b5 25 df 7b 37 9f e0 e2 4f b8 67 83 a3 2f cd 5d 41 42 4c 91
-    74 ef 2c ... 78 more bytes>
-*/
-```
-See the OpenSSL [`SSL_export_keying_material`][] documentation for more
-information.
-
 ### `tlsSocket.getTLSTicket()`
 <!-- YAML
 added: v0.11.4
@@ -1212,6 +1224,18 @@ For a client, returns the TLS session ticket if one is available, or
 It may be useful for debugging.
 
 See [Session Resumption][] for more information.
+
+### `tlsSocket.getX509Certificate()`
+<!-- YAML
+added: REPLACEME
+-->
+
+* Returns: {X509Certificate}
+
+Returns the local certificate as an {X509Certificate} object.
+
+If there is no local certificate, or the socket has been destroyed,
+`undefined` will be returned.
 
 ### `tlsSocket.isSessionReused()`
 <!-- YAML

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -90,6 +90,9 @@ const {
   validateString,
   validateUint32
 } = require('internal/validators');
+const {
+  InternalX509Certificate
+} = require('internal/crypto/x509');
 const traceTls = getOptionValue('--trace-tls');
 const tlsKeylog = getOptionValue('--tls-keylog');
 const { appendFile } = require('fs');
@@ -996,6 +999,16 @@ TLSSocket.prototype.getCertificate = function() {
   }
 
   return null;
+};
+
+TLSSocket.prototype.getPeerX509Certificate = function(detailed) {
+  const cert = this._handle?.getPeerX509Certificate();
+  return cert ? new InternalX509Certificate(cert) : undefined;
+};
+
+TLSSocket.prototype.getX509Certificate = function() {
+  const cert = this._handle?.getX509Certificate();
+  return cert ? new InternalX509Certificate(cert) : undefined;
 };
 
 // Proxy TLSSocket handle methods

--- a/lib/internal/crypto/x509.js
+++ b/lib/internal/crypto/x509.js
@@ -90,6 +90,15 @@ function getFlags(options = {}) {
   return flags;
 }
 
+class InternalX509Certificate extends JSTransferable {
+  [kInternalState] = new SafeMap();
+
+  constructor(handle) {
+    super();
+    this[kHandle] = handle;
+  }
+}
+
 class X509Certificate extends JSTransferable {
   [kInternalState] = new SafeMap();
 
@@ -164,6 +173,17 @@ class X509Certificate extends JSTransferable {
     if (value === undefined) {
       value = this[kHandle].issuer();
       this[kInternalState].set('issuer', value);
+    }
+    return value;
+  }
+
+  get issuerCertificate() {
+    let value = this[kInternalState].get('issuerCertificate');
+    if (value === undefined) {
+      const cert = this[kHandle].getIssuerCert();
+      if (cert)
+        value = new InternalX509Certificate(this[kHandle].getIssuerCert());
+      this[kInternalState].set('issuerCertificate', value);
     }
     return value;
   }
@@ -310,15 +330,6 @@ class X509Certificate extends JSTransferable {
 
   toLegacyObject() {
     return this[kHandle].toLegacy();
-  }
-}
-
-class InternalX509Certificate extends JSTransferable {
-  [kInternalState] = new SafeMap();
-
-  constructor(handle) {
-    super();
-    this[kHandle] = handle;
   }
 }
 

--- a/src/crypto/crypto_tls.cc
+++ b/src/crypto/crypto_tls.cc
@@ -1591,6 +1591,20 @@ void TLSWrap::GetPeerCertificate(const FunctionCallbackInfo<Value>& args) {
     args.GetReturnValue().Set(ret);
 }
 
+void TLSWrap::GetPeerX509Certificate(const FunctionCallbackInfo<Value>& args) {
+  TLSWrap* w;
+  ASSIGN_OR_RETURN_UNWRAP(&w, args.Holder());
+  Environment* env = w->env();
+
+  X509Certificate::GetPeerCertificateFlag flag = w->is_server()
+      ? X509Certificate::GetPeerCertificateFlag::SERVER
+      : X509Certificate::GetPeerCertificateFlag::NONE;
+
+  Local<Value> ret;
+  if (X509Certificate::GetPeerCert(env, w->ssl_, flag).ToLocal(&ret))
+    args.GetReturnValue().Set(ret);
+}
+
 void TLSWrap::GetCertificate(const FunctionCallbackInfo<Value>& args) {
   TLSWrap* w;
   ASSIGN_OR_RETURN_UNWRAP(&w, args.Holder());
@@ -1598,6 +1612,15 @@ void TLSWrap::GetCertificate(const FunctionCallbackInfo<Value>& args) {
 
   Local<Value> ret;
   if (GetCert(env, w->ssl_).ToLocal(&ret))
+    args.GetReturnValue().Set(ret);
+}
+
+void TLSWrap::GetX509Certificate(const FunctionCallbackInfo<Value>& args) {
+  TLSWrap* w;
+  ASSIGN_OR_RETURN_UNWRAP(&w, args.Holder());
+  Environment* env = w->env();
+  Local<Value> ret;
+  if (X509Certificate::GetCert(env, w->ssl_).ToLocal(&ret))
     args.GetReturnValue().Set(ret);
 }
 
@@ -2051,11 +2074,14 @@ void TLSWrap::Initialize(
   env->SetProtoMethodNoSideEffect(t, "getALPNNegotiatedProtocol",
                                   GetALPNNegotiatedProto);
   env->SetProtoMethodNoSideEffect(t, "getCertificate", GetCertificate);
+  env->SetProtoMethodNoSideEffect(t, "getX509Certificate", GetX509Certificate);
   env->SetProtoMethodNoSideEffect(t, "getCipher", GetCipher);
   env->SetProtoMethodNoSideEffect(t, "getEphemeralKeyInfo",
                                   GetEphemeralKeyInfo);
   env->SetProtoMethodNoSideEffect(t, "getFinished", GetFinished);
   env->SetProtoMethodNoSideEffect(t, "getPeerCertificate", GetPeerCertificate);
+  env->SetProtoMethodNoSideEffect(t, "getPeerX509Certificate",
+                                  GetPeerX509Certificate);
   env->SetProtoMethodNoSideEffect(t, "getPeerFinished", GetPeerFinished);
   env->SetProtoMethodNoSideEffect(t, "getProtocol", GetProtocol);
   env->SetProtoMethodNoSideEffect(t, "getSession", GetSession);

--- a/src/crypto/crypto_tls.h
+++ b/src/crypto/crypto_tls.h
@@ -184,11 +184,15 @@ class TLSWrap : public AsyncWrap,
   static void GetALPNNegotiatedProto(
       const v8::FunctionCallbackInfo<v8::Value>& args);
   static void GetCertificate(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void GetX509Certificate(
+      const v8::FunctionCallbackInfo<v8::Value>& args);
   static void GetCipher(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void GetEphemeralKeyInfo(
       const v8::FunctionCallbackInfo<v8::Value>& args);
   static void GetFinished(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void GetPeerCertificate(
+      const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void GetPeerX509Certificate(
       const v8::FunctionCallbackInfo<v8::Value>& args);
   static void GetPeerFinished(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void GetProtocol(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/src/crypto/crypto_x509.h
+++ b/src/crypto/crypto_x509.h
@@ -38,7 +38,7 @@ class ManagedX509 : public MemoryRetainer {
 class X509Certificate : public BaseObject {
  public:
   enum class GetPeerCertificateFlag {
-    ABBREVIATED,
+    NONE,
     SERVER
   };
 
@@ -49,11 +49,13 @@ class X509Certificate : public BaseObject {
 
   static v8::MaybeLocal<v8::Object> New(
       Environment* env,
-      X509Pointer cert);
+      X509Pointer cert,
+      STACK_OF(X509)* issuer_chain = nullptr);
 
   static v8::MaybeLocal<v8::Object> New(
       Environment* env,
-      std::shared_ptr<ManagedX509> cert);
+      std::shared_ptr<ManagedX509> cert,
+      STACK_OF(X509)* issuer_chain = nullptr);
 
   static v8::MaybeLocal<v8::Object> GetCert(
       Environment* env,
@@ -91,6 +93,7 @@ class X509Certificate : public BaseObject {
   static void CheckPrivateKey(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Verify(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void ToLegacy(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void GetIssuerCert(const v8::FunctionCallbackInfo<v8::Value>& args);
 
   X509* get() { return cert_->get(); }
 
@@ -124,9 +127,11 @@ class X509Certificate : public BaseObject {
   X509Certificate(
       Environment* env,
       v8::Local<v8::Object> object,
-      std::shared_ptr<ManagedX509> cert);
+      std::shared_ptr<ManagedX509> cert,
+      STACK_OF(X509)* issuer_chain = nullptr);
 
   std::shared_ptr<ManagedX509> cert_;
+  BaseObjectPtr<X509Certificate> issuer_cert_;
 };
 
 }  // namespace crypto

--- a/test/parallel/test-tls-getcertificate-x509.js
+++ b/test/parallel/test-tls-getcertificate-x509.js
@@ -1,0 +1,43 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const tls = require('tls');
+const fixtures = require('../common/fixtures');
+const { X509Certificate } = require('crypto');
+
+const options = {
+  key: fixtures.readKey('agent6-key.pem'),
+  cert: fixtures.readKey('agent6-cert.pem')
+};
+
+const server = tls.createServer(options, function(cleartext) {
+  cleartext.end('World');
+});
+
+server.once('secureConnection', common.mustCall(function(socket) {
+  const cert = socket.getX509Certificate();
+  assert(cert instanceof X509Certificate);
+  assert.strictEqual(
+    cert.serialNumber,
+    'D0082F458B6EFBE8');
+}));
+
+server.listen(0, common.mustCall(function() {
+  const socket = tls.connect({
+    port: this.address().port,
+    rejectUnauthorized: false
+  }, common.mustCall(function() {
+    const peerCert = socket.getPeerX509Certificate();
+    assert(peerCert.issuerCertificate instanceof X509Certificate);
+    assert.strictEqual(peerCert.issuerCertificate.issuerCertificate, undefined);
+    assert.strictEqual(
+      peerCert.issuerCertificate.serialNumber,
+      'ECC9B856270DA9A7'
+    );
+    server.close();
+  }));
+  socket.end('Hello');
+}));


### PR DESCRIPTION
Adds new `getX509Certificate()` and `getPeerX509Certificate()` as options on `TLSSocket` to get the cert/peercert as the new `X509Certificate` object.

Signed-off-by: James M Snell <jasnell@gmail.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
