### PR TITLE
src: fix error handling for CryptoJob::ToResult

### DIFF
--- a/src/crypto/crypto_keygen.h
+++ b/src/crypto/crypto_keygen.h
@@ -96,10 +96,13 @@ class KeyGenJob final : public CryptoJob<KeyGenTraits> {
     Environment* env = AsyncWrap::env();
     CryptoErrorStore* errors = CryptoJob<KeyGenTraits>::errors();
     AdditionalParams* params = CryptoJob<KeyGenTraits>::params();
-    if (status_ == KeyGenJobStatus::OK &&
-        LIKELY(!KeyGenTraits::EncodeKey(env, params, result).IsNothing())) {
-      *err = Undefined(env->isolate());
-      return v8::Just(true);
+
+    if (status_ == KeyGenJobStatus::OK) {
+      v8::Maybe<bool> ret = KeyGenTraits::EncodeKey(env, params, result);
+      if (ret.IsJust() && ret.FromJust()) {
+        *err = Undefined(env->isolate());
+      }
+      return ret;
     }
 
     if (errors->Empty())

--- a/src/crypto/crypto_keys.cc
+++ b/src/crypto/crypto_keys.cc
@@ -602,6 +602,11 @@ size_t ManagedEVPPKey::size_of_public_key() const {
       pkey_.get(), nullptr, &len) == 1) ? len : 0;
 }
 
+// This maps true to Just<bool>(true) and false to Nothing<bool>().
+static inline Maybe<bool> Tristate(bool b) {
+  return b ? Just(true) : Nothing<bool>();
+}
+
 Maybe<bool> ManagedEVPPKey::ToEncodedPublicKey(
     Environment* env,
     ManagedEVPPKey key,
@@ -613,9 +618,10 @@ Maybe<bool> ManagedEVPPKey::ToEncodedPublicKey(
     // private key.
     std::shared_ptr<KeyObjectData> data =
           KeyObjectData::CreateAsymmetric(kKeyTypePublic, std::move(key));
-    return Just(KeyObjectHandle::Create(env, data).ToLocal(out));
+    return Tristate(KeyObjectHandle::Create(env, data).ToLocal(out));
   }
-  return Just(WritePublicKey(env, key.get(), config).ToLocal(out));
+
+  return Tristate(WritePublicKey(env, key.get(), config).ToLocal(out));
 }
 
 Maybe<bool> ManagedEVPPKey::ToEncodedPrivateKey(
@@ -627,10 +633,10 @@ Maybe<bool> ManagedEVPPKey::ToEncodedPrivateKey(
   if (config.output_key_object_) {
     std::shared_ptr<KeyObjectData> data =
         KeyObjectData::CreateAsymmetric(kKeyTypePrivate, std::move(key));
-    return Just(KeyObjectHandle::Create(env, data).ToLocal(out));
+    return Tristate(KeyObjectHandle::Create(env, data).ToLocal(out));
   }
 
-  return Just(WritePrivateKey(env, key.get(), config).ToLocal(out));
+  return Tristate(WritePrivateKey(env, key.get(), config).ToLocal(out));
 }
 
 NonCopyableMaybe<PrivateKeyEncodingConfig>


### PR DESCRIPTION
The added test case crashes in recent versions of Node.js 15 due to a change in OpenSSL and improper error handling in node core.

The first problem is that `ManagedEVPPKey::ToEncodedPublicKey` and `ManagedEVPPKey::ToEncodedPrivateKey` returned `Just(false)` to indicate that an exception was thrown, but `KeyPairGenTraits::EncodeKey` only checks `IsNothing()` and not `FromJust()`. This leads to JavaScript handles being empty, and, consequently, to a crash in V8.

The next problem is that some code paths in `ToResult` throw exceptions whereas others leave error handling to `CryptoJob::AfterThreadPoolWork`. In the test case added here, the function `WritePublicKey` throws an exception because the curve does not have an OID.

I am not entirely sure why these functions use `Maybe<bool>` as their return type. Overall, I am pretty sure we need to rework substantial parts of the error handling logic in the crypto subsystem. Hopefully, this PR can still provide a reasonable workaround to avoid crashes for now.

I tried to keep the existing behavior of ignoring any results that are equal to `Just(false)`, meaning that returning `Just(false)` from `ToResult` causes the operation to never complete or fail.

When `ToResult` returns `Nothing<bool>()`, the `AfterThreadPoolWork` function now assumes that an exception was thrown, and passes it to the job callback.

In synchronous mode, both `Just(false)` and `Nothing<bool>()` are ignored, which leads to exceptions being propagated to JavaScript correctly.

@jasnell I'd love to hear your opinion. I am happy to implement and test another solution. We should clarify the semantics of the tristate `Maybe<bool>`.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
