### PR TITLE
src: fix dead code in RandomPrimeTraits

### DIFF
--- a/src/crypto/crypto_random.cc
+++ b/src/crypto/crypto_random.cc
@@ -110,8 +110,7 @@ Maybe<bool> RandomPrimeTraits::AdditionalConfig(
       return Nothing<bool>();
     }
     ArrayBufferOrViewContents<unsigned char> add(args[offset + 2]);
-    BN_bin2bn(add.data(), add.size(), params->add.get());
-    if (!params->add) {
+    if (BN_bin2bn(add.data(), add.size(), params->add.get()) == nullptr) {
       THROW_ERR_INVALID_ARG_VALUE(env, "invalid options.add");
       return Nothing<bool>();
     }
@@ -124,8 +123,7 @@ Maybe<bool> RandomPrimeTraits::AdditionalConfig(
       return Nothing<bool>();
     }
     ArrayBufferOrViewContents<unsigned char> rem(args[offset + 3]);
-    BN_bin2bn(rem.data(), rem.size(), params->rem.get());
-    if (!params->rem) {
+    if (BN_bin2bn(rem.data(), rem.size(), params->rem.get()) == nullptr) {
       THROW_ERR_INVALID_ARG_VALUE(env, "invalid options.rem");
       return Nothing<bool>();
     }


### PR DESCRIPTION
`params->add` and `params->rem` have already been allocated successfully at these points, and won't be deallocated by the calls to `BN_bin2bn`, so these branches are effectively dead. Instead, the return value of `BN_bin2bn` should be checked.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
