### PR TITLE
readline: check for null input in question()

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -371,7 +371,7 @@ Interface.prototype.prompt = function(preserveCursor) {
 
 Interface.prototype.question = function(query, options, cb) {
   cb = typeof options === 'function' ? options : cb;
-  options = typeof options === 'object' ? options : {};
+  options = typeof options === 'object' && options !== null ? options : {};
 
   if (options.signal) {
     options.signal.addEventListener('abort', () => {
@@ -392,7 +392,7 @@ Interface.prototype.question = function(query, options, cb) {
 };
 
 Interface.prototype.question[promisify.custom] = function(query, options) {
-  options = typeof options === 'object' ? options : {};
+  options = typeof options === 'object' && options !== null ? options : {};
 
   return new Promise((resolve, reject) => {
     this.question(query, options, resolve);


### PR DESCRIPTION
`question()` checks for objects passed as the recently added `options` argument. This commit improves that logic to also check for null.