### PR TITLE
readline: replace _questionCancel with a symbol

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -116,6 +116,7 @@ const kMincrlfDelay = 100;
 const lineEnding = /\r?\n|\r(?!\n)/;
 
 const kLineObjectStream = Symbol('line object stream');
+const kQuestionCancel = Symbol('kQuestionCancel');
 
 const KEYPRESS_DECODER = Symbol('keypress-decoder');
 const ESCAPE_DECODER = Symbol('escape-decoder');
@@ -224,7 +225,7 @@ function Interface(input, output, completer, terminal) {
       };
   }
 
-  this._questionCancel = FunctionPrototypeBind(_questionCancel, this);
+  this[kQuestionCancel] = FunctionPrototypeBind(_questionCancel, this);
 
   this.setPrompt(prompt);
 
@@ -375,7 +376,7 @@ Interface.prototype.question = function(query, options, cb) {
 
   if (options.signal) {
     options.signal.addEventListener('abort', () => {
-      this._questionCancel();
+      this[kQuestionCancel]();
     }, { once: true });
   }
 


### PR DESCRIPTION
This commit avoids exposing a new underscored property on
readline Interface instances.