### PR TITLE
util: add internal createDeferredPromise()

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -37,7 +37,6 @@ const {
   ObjectAssign,
   ObjectDefineProperty,
   ObjectPrototypeHasOwnProperty,
-  Promise,
   RegExpPrototypeTest,
   SafeSet,
   StringPrototypeSlice,
@@ -47,6 +46,7 @@ const {
 const {
   promisify,
   convertToValidSignal,
+  createDeferredPromise,
   getSystemErrorName
 } = require('internal/util');
 const { isArrayBufferView } = require('internal/util/types');
@@ -185,12 +185,7 @@ function exec(command, options, callback) {
 
 const customPromiseExecFunction = (orig) => {
   return (...args) => {
-    let resolve;
-    let reject;
-    const promise = new Promise((res, rej) => {
-      resolve = res;
-      reject = rej;
-    });
+    const { promise, resolve, reject } = createDeferredPromise();
 
     promise.child = orig(...args, (err, stdout, stderr) => {
       if (err !== null) {

--- a/lib/internal/blob.js
+++ b/lib/internal/blob.js
@@ -3,7 +3,6 @@
 const {
   ArrayFrom,
   ObjectSetPrototypeOf,
-  Promise,
   PromiseResolve,
   RegExpPrototypeTest,
   StringPrototypeToLowerCase,
@@ -29,6 +28,7 @@ const {
 } = require('internal/util/types');
 
 const {
+  createDeferredPromise,
   customInspectSymbol: kInspect,
   emitExperimentalWarning,
 } = require('internal/util');
@@ -55,15 +55,6 @@ const kType = Symbol('kType');
 const kLength = Symbol('kLength');
 
 let Buffer;
-
-function deferred() {
-  let res, rej;
-  const promise = new Promise((resolve, reject) => {
-    res = resolve;
-    rej = reject;
-  });
-  return { promise, resolve: res, reject: rej };
-}
 
 function lazyBuffer() {
   if (Buffer === undefined)
@@ -210,7 +201,7 @@ class Blob extends JSTransferable {
       promise,
       resolve,
       reject
-    } = deferred();
+    } = createDeferredPromise();
     job.ondone = (err, ab) => {
       if (err !== undefined)
         return reject(new AbortError());

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -420,11 +420,23 @@ function sleep(msec) {
   _sleep(msec);
 }
 
+function createDeferredPromise() {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
+
 module.exports = {
   assertCrypto,
   cachedResult,
   convertToValidSignal,
   createClassWrapper,
+  createDeferredPromise,
   decorateErrorStack,
   deprecate,
   emitExperimentalWarning,


### PR DESCRIPTION
The pattern of resolving/rejecting a Promise from outside of its executor happens numerous times throughout the codebase (more than what is updated here in fact). This commit abstracts that logic into an internal utility function.