### PR TITLE
doc: update Buffer encoding option count

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -99,7 +99,7 @@ The character encodings currently supported by Node.js are the following:
 Converting a `Buffer` into a string using one of the above is referred to as
 decoding, and converting a string into a `Buffer` is referred to as encoding.
 
-Node.js also supports the following two binary-to-text encodings. For
+Node.js also supports the following binary-to-text encodings. For
 binary-to-text encodings, the naming convention is reversed: Converting a
 `Buffer` into a string is typically referred to as encoding, and converting a
 string into a `Buffer` as decoding.


### PR DESCRIPTION
#36952 added the `base64url` encoding option.

Easier to just remove the count of options so it doesn’t need to be updated to four, five, etc. in the future.