### PR TITLE
src: expose BaseObject::kInternalFieldCount in post-mortem metadata

### DIFF
--- a/src/node_postmortem_metadata.cc
+++ b/src/node_postmortem_metadata.cc
@@ -36,6 +36,7 @@
 
 extern "C" {
 int nodedbg_const_ContextEmbedderIndex__kEnvironment__int;
+int nodedbg_const_BaseObject__kInternalFieldCount__int;
 uintptr_t nodedbg_offset_ExternalString__data__uintptr_t;
 uintptr_t nodedbg_offset_ReqWrap__req_wrap_queue___ListNode_ReqWrapQueue;
 
@@ -50,6 +51,8 @@ namespace node {
 int GenDebugSymbols() {
   nodedbg_const_ContextEmbedderIndex__kEnvironment__int =
       ContextEmbedderIndex::kEnvironment;
+  nodedbg_const_BaseObject__kInternalFieldCount__int =
+      BaseObject::kInternalFieldCount;
 
   nodedbg_offset_ExternalString__data__uintptr_t = NODE_OFF_EXTSTR_DATA;
   nodedbg_offset_ReqWrap__req_wrap_queue___ListNode_ReqWrapQueue =

--- a/test/cctest/test_node_postmortem_metadata.cc
+++ b/test/cctest/test_node_postmortem_metadata.cc
@@ -14,6 +14,7 @@ extern uintptr_t
     nodedbg_offset_Environment__handle_wrap_queue___Environment_HandleWrapQueue;
 extern int debug_symbols_generated;
 extern int nodedbg_const_ContextEmbedderIndex__kEnvironment__int;
+extern int nodedbg_const_BaseObject__kInternalFieldCount__int;
 extern uintptr_t
     nodedbg_offset_Environment_HandleWrapQueue__head___ListNode_HandleWrap;
 extern uintptr_t
@@ -68,6 +69,12 @@ TEST_F(DebugSymbolsTest, ContextEmbedderEnvironmentIndex) {
             kEnvironmentIndex);
 }
 
+TEST_F(DebugSymbolsTest, BaseObjectkInternalFieldCount) {
+  int kInternalFieldCount = node::BaseObject::kInternalFieldCount;
+  EXPECT_EQ(nodedbg_const_BaseObject__kInternalFieldCount__int,
+            kInternalFieldCount);
+}
+
 TEST_F(DebugSymbolsTest, ExternalStringDataOffset) {
   EXPECT_EQ(nodedbg_offset_ExternalString__data__uintptr_t,
             NODE_OFF_EXTSTR_DATA);
@@ -89,7 +96,8 @@ TEST_F(DebugSymbolsTest, BaseObjectPersistentHandle) {
   Env env{handle_scope, argv};
 
   v8::Local<v8::ObjectTemplate> obj_templ = v8::ObjectTemplate::New(isolate_);
-  obj_templ->SetInternalFieldCount(1);
+  obj_templ->SetInternalFieldCount(
+      nodedbg_const_BaseObject__kInternalFieldCount__int);
 
   v8::Local<v8::Object> object =
       obj_templ->NewInstance(env.context()).ToLocalChecked();
@@ -139,7 +147,8 @@ TEST_F(DebugSymbolsTest, HandleWrapList) {
   uv_tcp_t handle;
 
   auto obj_template = v8::FunctionTemplate::New(isolate_);
-  obj_template->InstanceTemplate()->SetInternalFieldCount(1);
+  obj_template->InstanceTemplate()->SetInternalFieldCount(
+      nodedbg_const_BaseObject__kInternalFieldCount__int);
 
   v8::Local<v8::Object> object = obj_template->GetFunction(env.context())
                                      .ToLocalChecked()
@@ -171,7 +180,8 @@ TEST_F(DebugSymbolsTest, ReqWrapList) {
   tail = *reinterpret_cast<uintptr_t*>(tail);
 
   auto obj_template = v8::FunctionTemplate::New(isolate_);
-  obj_template->InstanceTemplate()->SetInternalFieldCount(1);
+  obj_template->InstanceTemplate()->SetInternalFieldCount(
+      nodedbg_const_BaseObject__kInternalFieldCount__int);
 
   v8::Local<v8::Object> object = obj_template->GetFunction(env.context())
                                      .ToLocalChecked()


### PR DESCRIPTION
So that the debugger does not have to hard-code the number of
internal fields of BaseObjects.

Refs: https://github.com/nodejs/node/pull/36943

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
