### PR TITLE
src: refactor binding data for deserialization support

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -744,6 +744,7 @@
         'src/node_union_bytes.h',
         'src/node_url.h',
         'src/node_version.h',
+        'src/node_v8.h',
         'src/node_v8_platform-inl.h',
         'src/node_wasi.h',
         'src/node_watchdog.h',

--- a/src/README.md
+++ b/src/README.md
@@ -422,7 +422,7 @@ that state is through the use of `Environment::AddBindingData`, which gives
 binding functions access to an object for storing such state.
 That object is always a [`BaseObject`][].
 
-Its class needs to have a static `binding_data_name` field based on a
+Its class needs to have a static `type_name` field based on a
 constant string, in order to disambiguate it from other classes of this type,
 and which could e.g. match the binding’s name (in the example above, that would
 be `cares_wrap`).
@@ -433,7 +433,7 @@ class BindingData : public BaseObject {
  public:
   BindingData(Environment* env, Local<Object> obj) : BaseObject(env, obj) {}
 
-  static constexpr FastStringKey binding_data_name { "http_parser" };
+  static constexpr FastStringKey type_name { "http_parser" };
 
   std::vector<char> parser_buffer;
   bool parser_buffer_in_use = false;

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -358,7 +358,7 @@ inline T* Environment::GetBindingData(v8::Local<v8::Context> context) {
       context->GetAlignedPointerFromEmbedderData(
           ContextEmbedderIndex::kBindingListIndex));
   DCHECK_NOT_NULL(map);
-  auto it = map->find(T::binding_data_name);
+  auto it = map->find(T::type_name);
   if (UNLIKELY(it == map->end())) return nullptr;
   T* result = static_cast<T*>(it->second.get());
   DCHECK_NOT_NULL(result);
@@ -377,7 +377,7 @@ inline T* Environment::AddBindingData(
       context->GetAlignedPointerFromEmbedderData(
           ContextEmbedderIndex::kBindingListIndex));
   DCHECK_NOT_NULL(map);
-  auto result = map->emplace(T::binding_data_name, item);
+  auto result = map->emplace(T::type_name, item);
   CHECK(result.second);
   DCHECK_EQ(GetBindingData<T>(context), item.get());
   return item.get();

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -2397,7 +2397,7 @@ void BindingData::MemoryInfo(MemoryTracker* tracker) const {
 }
 
 // TODO(addaleax): Remove once we're on C++17.
-constexpr FastStringKey BindingData::binding_data_name;
+constexpr FastStringKey BindingData::type_name;
 
 void Initialize(Local<Object> target,
                 Local<Value> unused,

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -27,7 +27,7 @@ class BindingData : public BaseObject {
   std::vector<BaseObjectPtr<FileHandleReadWrap>>
       file_handle_read_wrap_freelist;
 
-  static constexpr FastStringKey binding_data_name { "fs" };
+  static constexpr FastStringKey type_name { "fs" };
 
   void MemoryInfo(MemoryTracker* tracker) const override;
   SET_SELF_SIZE(BindingData)

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -3001,7 +3001,7 @@ void Http2State::MemoryInfo(MemoryTracker* tracker) const {
 }
 
 // TODO(addaleax): Remove once we're on C++17.
-constexpr FastStringKey Http2State::binding_data_name;
+constexpr FastStringKey Http2State::type_name;
 
 // Set up the process.binding('http2') binding.
 void Initialize(Local<Object> target,

--- a/src/node_http2_state.h
+++ b/src/node_http2_state.h
@@ -127,7 +127,7 @@ class Http2State : public BaseObject {
   SET_SELF_SIZE(Http2State)
   SET_MEMORY_INFO_NAME(Http2State)
 
-  static constexpr FastStringKey binding_data_name { "http2" };
+  static constexpr FastStringKey type_name { "http2" };
 
  private:
   struct http2_state_internal {

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -88,7 +88,7 @@ class BindingData : public BaseObject {
   BindingData(Environment* env, Local<Object> obj)
       : BaseObject(env, obj) {}
 
-  static constexpr FastStringKey binding_data_name { "http_parser" };
+  static constexpr FastStringKey type_name { "http_parser" };
 
   std::vector<char> parser_buffer;
   bool parser_buffer_in_use = false;
@@ -101,7 +101,7 @@ class BindingData : public BaseObject {
 };
 
 // TODO(addaleax): Remove once we're on C++17.
-constexpr FastStringKey BindingData::binding_data_name;
+constexpr FastStringKey BindingData::type_name;
 
 // helper class for the Parser
 struct StringPtr {

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -19,15 +19,16 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#include "node.h"
+#include "node_v8.h"
 #include "base_object-inl.h"
 #include "env-inl.h"
 #include "memory_tracker-inl.h"
+#include "node.h"
 #include "util-inl.h"
 #include "v8.h"
 
 namespace node {
-
+namespace v8_utils {
 using v8::Array;
 using v8::Context;
 using v8::FunctionCallbackInfo;
@@ -43,7 +44,6 @@ using v8::String;
 using v8::Uint32;
 using v8::V8;
 using v8::Value;
-
 
 #define HEAP_STATISTICS_PROPERTIES(V)                                         \
   V(0, total_heap_size, kTotalHeapSizeIndex)                                  \
@@ -62,7 +62,6 @@ using v8::Value;
 static constexpr size_t kHeapStatisticsPropertiesCount =
     HEAP_STATISTICS_PROPERTIES(V);
 #undef V
-
 
 #define HEAP_SPACE_STATISTICS_PROPERTIES(V)                                   \
   V(0, space_size, kSpaceSizeIndex)                                           \
@@ -85,32 +84,34 @@ static const size_t kHeapCodeStatisticsPropertiesCount =
     HEAP_CODE_STATISTICS_PROPERTIES(V);
 #undef V
 
-class BindingData : public BaseObject {
- public:
-  BindingData(Environment* env, Local<Object> obj)
-      : BaseObject(env, obj),
-        heap_statistics_buffer(env->isolate(), kHeapStatisticsPropertiesCount),
-        heap_space_statistics_buffer(env->isolate(),
-                                     kHeapSpaceStatisticsPropertiesCount),
-        heap_code_statistics_buffer(env->isolate(),
-                                    kHeapCodeStatisticsPropertiesCount) {}
+BindingData::BindingData(Environment* env, Local<Object> obj)
+    : BaseObject(env, obj),
+      heap_statistics_buffer(env->isolate(), kHeapStatisticsPropertiesCount),
+      heap_space_statistics_buffer(env->isolate(),
+                                   kHeapSpaceStatisticsPropertiesCount),
+      heap_code_statistics_buffer(env->isolate(),
+                                  kHeapCodeStatisticsPropertiesCount) {
+  obj->Set(env->context(),
+           FIXED_ONE_BYTE_STRING(env->isolate(), "heapStatisticsBuffer"),
+           heap_statistics_buffer.GetJSArray())
+      .Check();
+  obj->Set(env->context(),
+           FIXED_ONE_BYTE_STRING(env->isolate(), "heapCodeStatisticsBuffer"),
+           heap_code_statistics_buffer.GetJSArray())
+      .Check();
+  obj->Set(env->context(),
+           FIXED_ONE_BYTE_STRING(env->isolate(), "heapSpaceStatisticsBuffer"),
+           heap_space_statistics_buffer.GetJSArray())
+      .Check();
+}
 
-  static constexpr FastStringKey type_name { "v8" };
-
-  AliasedFloat64Array heap_statistics_buffer;
-  AliasedFloat64Array heap_space_statistics_buffer;
-  AliasedFloat64Array heap_code_statistics_buffer;
-
-  void MemoryInfo(MemoryTracker* tracker) const override {
-    tracker->TrackField("heap_statistics_buffer", heap_statistics_buffer);
-    tracker->TrackField("heap_space_statistics_buffer",
-                        heap_space_statistics_buffer);
-    tracker->TrackField("heap_code_statistics_buffer",
-                        heap_code_statistics_buffer);
-  }
-  SET_SELF_SIZE(BindingData)
-  SET_MEMORY_INFO_NAME(BindingData)
-};
+void BindingData::MemoryInfo(MemoryTracker* tracker) const {
+  tracker->TrackField("heap_statistics_buffer", heap_statistics_buffer);
+  tracker->TrackField("heap_space_statistics_buffer",
+                      heap_space_statistics_buffer);
+  tracker->TrackField("heap_code_statistics_buffer",
+                      heap_code_statistics_buffer);
+}
 
 // TODO(addaleax): Remove once we're on C++17.
 constexpr FastStringKey BindingData::type_name;
@@ -179,35 +180,11 @@ void Initialize(Local<Object> target,
 
   env->SetMethodNoSideEffect(target, "cachedDataVersionTag",
                              CachedDataVersionTag);
-
-  // Export symbols used by v8.getHeapStatistics()
   env->SetMethod(
       target, "updateHeapStatisticsBuffer", UpdateHeapStatisticsBuffer);
 
-  target
-      ->Set(env->context(),
-            FIXED_ONE_BYTE_STRING(env->isolate(), "heapStatisticsBuffer"),
-            binding_data->heap_statistics_buffer.GetJSArray())
-      .Check();
-
-#define V(i, _, name)                                                         \
-  target->Set(env->context(),                                                 \
-              FIXED_ONE_BYTE_STRING(env->isolate(), #name),                   \
-              Uint32::NewFromUnsigned(env->isolate(), i)).Check();
-
-  HEAP_STATISTICS_PROPERTIES(V)
-
-  // Export symbols used by v8.getHeapCodeStatistics()
   env->SetMethod(
       target, "updateHeapCodeStatisticsBuffer", UpdateHeapCodeStatisticsBuffer);
-
-  target
-      ->Set(env->context(),
-            FIXED_ONE_BYTE_STRING(env->isolate(), "heapCodeStatisticsBuffer"),
-            binding_data->heap_code_statistics_buffer.GetJSArray())
-      .Check();
-
-  HEAP_CODE_STATISTICS_PROPERTIES(V)
 
   size_t number_of_heap_spaces = env->isolate()->NumberOfHeapSpaces();
 
@@ -230,13 +207,15 @@ void Initialize(Local<Object> target,
                  "updateHeapSpaceStatisticsBuffer",
                  UpdateHeapSpaceStatisticsBuffer);
 
-  target
-      ->Set(env->context(),
-            FIXED_ONE_BYTE_STRING(env->isolate(),
-                                  "heapSpaceStatisticsBuffer"),
-            binding_data->heap_space_statistics_buffer.GetJSArray())
+#define V(i, _, name)                                                          \
+  target                                                                       \
+      ->Set(env->context(),                                                    \
+            FIXED_ONE_BYTE_STRING(env->isolate(), #name),                      \
+            Uint32::NewFromUnsigned(env->isolate(), i))                        \
       .Check();
 
+  HEAP_STATISTICS_PROPERTIES(V)
+  HEAP_CODE_STATISTICS_PROPERTIES(V)
   HEAP_SPACE_STATISTICS_PROPERTIES(V)
 #undef V
 
@@ -244,6 +223,7 @@ void Initialize(Local<Object> target,
   env->SetMethod(target, "setFlagsFromString", SetFlagsFromString);
 }
 
+}  // namespace v8_utils
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(v8, node::Initialize)
+NODE_MODULE_CONTEXT_AWARE_INTERNAL(v8, node::v8_utils::Initialize)

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -95,7 +95,7 @@ class BindingData : public BaseObject {
         heap_code_statistics_buffer(env->isolate(),
                                     kHeapCodeStatisticsPropertiesCount) {}
 
-  static constexpr FastStringKey binding_data_name { "v8" };
+  static constexpr FastStringKey type_name { "v8" };
 
   AliasedFloat64Array heap_statistics_buffer;
   AliasedFloat64Array heap_space_statistics_buffer;
@@ -113,7 +113,7 @@ class BindingData : public BaseObject {
 };
 
 // TODO(addaleax): Remove once we're on C++17.
-constexpr FastStringKey BindingData::binding_data_name;
+constexpr FastStringKey BindingData::type_name;
 
 void CachedDataVersionTag(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);

--- a/src/node_v8.h
+++ b/src/node_v8.h
@@ -1,0 +1,36 @@
+#ifndef SRC_NODE_V8_H_
+#define SRC_NODE_V8_H_
+
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
+#include "aliased_buffer.h"
+#include "base_object.h"
+#include "util.h"
+#include "v8.h"
+
+namespace node {
+class Environment;
+
+namespace v8_utils {
+class BindingData : public BaseObject {
+ public:
+  BindingData(Environment* env, v8::Local<v8::Object> obj);
+
+  static constexpr FastStringKey type_name{"node::v8::BindingData"};
+
+  AliasedFloat64Array heap_statistics_buffer;
+  AliasedFloat64Array heap_space_statistics_buffer;
+  AliasedFloat64Array heap_code_statistics_buffer;
+
+  void MemoryInfo(MemoryTracker* tracker) const override;
+  SET_SELF_SIZE(BindingData)
+  SET_MEMORY_INFO_NAME(BindingData)
+};
+
+}  // namespace v8_utils
+
+}  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
+#endif  // SRC_NODE_V8_H_


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/36943

#### src: rename binding_data_name to type_name in BindingData

Previously, this was a per-class string constant for BindingData
which is used as keys for identifying these objects in the binding
data map. These are just type names of the BindingData.
This patch renames the variable to type_name so that
we can generalize this constant for other BaseObjects and use
it for debugging and logging the types of other BaseObjects.

#### src: refactor v8 binding

1. Put the v8 binding data class into a header so we can reuse
  the class definition during deserialization.
2. Put the v8 binding code into node::v8_utils namespace for
  clarity.
3. Move the binding data property initialization into its
  constructor so that we can reuse it during deserialization
4. Reorder the v8 binding initialization so that we don't
  unnecessarily initialize the properties in a loop

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
