### PR TITLE
fs: improve promises.readFile performance

### DIFF
--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -331,7 +331,7 @@ async function readFileHandle(filehandle, options) {
       ArrayPrototypePush(chunks, buffer.slice(0, bytesRead));
   } while (!endOfFile);
 
-  const result = Buffer.concat(chunks);
+  const result = chunks.length === 1 ? chunks[0] : Buffer.concat(chunks);
 
   return options.encoding ? result.toString(options.encoding) : result;
 }

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -317,7 +317,7 @@ async function readFileHandle(filehandle, options) {
   const chunks = [];
   let isFirstChunk = true;
   const firstChunkSize = size === 0 ? kReadFileMaxChunkSize : size;
-  const chunkSize = Math.min(firstChunkSize, kReadFileMaxChunkSize);
+  const chunkSize = MathMin(firstChunkSize, kReadFileMaxChunkSize);
   let endOfFile = false;
   do {
     if (signal?.aborted) {

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -315,20 +315,21 @@ async function readFileHandle(filehandle, options) {
     throw new ERR_FS_FILE_TOO_LARGE(size);
 
   const chunks = [];
-  const chunkSize = size === 0 ?
-    kReadFileMaxChunkSize :
-    MathMin(size, kReadFileMaxChunkSize);
+  let isFirstChunk = true;
+  const firstChunkSize = size === 0 ? kReadFileMaxChunkSize : size;
+  const chunkSize = Math.min(firstChunkSize, kReadFileMaxChunkSize);
   let endOfFile = false;
   do {
     if (signal?.aborted) {
       throw lazyDOMException('The operation was aborted', 'AbortError');
     }
-    const buf = Buffer.alloc(chunkSize);
+    const buf = Buffer.alloc(isFirstChunk ? firstChunkSize : chunkSize);
     const { bytesRead, buffer } =
-      await read(filehandle, buf, 0, chunkSize, -1);
+      await read(filehandle, buf, 0, buf.length, -1);
     endOfFile = bytesRead === 0;
     if (bytesRead > 0)
       ArrayPrototypePush(chunks, buffer.slice(0, bytesRead));
+    isFirstChunk = false;
   } while (!endOfFile);
 
   const result = chunks.length === 1 ? chunks[0] : Buffer.concat(chunks);


### PR DESCRIPTION
##### fs: only use Buffer.concat in promises.readFile when necessary


##### fs: read full size if known in promises.readFile

If we have an estimate of the file size available from the previous
stat call, use that for the size of the first chunk to be read.
This increases performance by reading more data (and, most likely,
all data) at once without incurring memory overhead in most situations.


<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
