### PR TITLE
lib: avoid crash on `fs.fstatSync(-0)` call

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1099,7 +1099,8 @@ function hasNoEntryError(ctx) {
 function fstatSync(fd, options = { bigint: false, throwIfNoEntry: true }) {
   validateInt32(fd, 'fd', 0);
   const ctx = { fd };
-  const stats = binding.fstat(fd, options.bigint, undefined, ctx);
+  // The fd should be `fd | 0` just for the edgecase when `fd = -0`
+  const stats = binding.fstat(fd | 0, options.bigint, undefined, ctx);
   handleErrorFromBinding(ctx);
   return getStatsFromBinding(stats);
 }

--- a/test/parallel/test-fs-stat.js
+++ b/test/parallel/test-fs-stat.js
@@ -69,6 +69,8 @@ fs.open('.', 'r', undefined, common.mustCall(function(err, fd) {
   fs.close(fd, common.mustSucceed());
 }));
 
+assert.ok(fs.fstatSync(-0));
+
 fs.stat(__filename, common.mustSucceed((s) => {
   assert.strictEqual(s.isDirectory(), false);
   assert.strictEqual(s.isFile(), true);


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/37122

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
