### PR TITLE
src: avoid implicit type conversions

### DIFF
--- a/src/base64.h
+++ b/src/base64.h
@@ -36,9 +36,9 @@ static inline const char* base64_select_table(Base64Mode mode) {
 static inline constexpr size_t base64_encoded_size(
     size_t size,
     Base64Mode mode = Base64Mode::NORMAL) {
-  return mode == Base64Mode::NORMAL
-      ? ((size + 2) / 3 * 4)
-      : std::ceil(static_cast<double>(size * 4) / 3);
+  return mode == Base64Mode::NORMAL ? ((size + 2) / 3 * 4)
+                                    : static_cast<size_t>(std::ceil(
+                                          static_cast<double>(size * 4) / 3));
 }
 
 // Doesn't check for padding at the end.  Can be 1-2 bytes over.

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -1901,7 +1901,7 @@ void AfterGetAddrInfo(uv_getaddrinfo_t* req, int status, struct addrinfo* res) {
     Null(env->isolate())
   };
 
-  uint64_t n = 0;
+  uint32_t n = 0;
   const bool verbatim = req_wrap->verbatim();
 
   if (status == 0) {

--- a/src/heap_utils.cc
+++ b/src/heap_utils.cc
@@ -118,16 +118,16 @@ class JSGraph : public EmbedderGraph {
           name_str += " ";
           name_str += n->Name();
         }
-        if (!String::NewFromUtf8(isolate_, name_str.c_str())
-                 .ToLocal(&value) ||
+        if (!String::NewFromUtf8(isolate_, name_str.c_str()).ToLocal(&value) ||
             obj->Set(context, name_string, value).IsNothing() ||
             obj->Set(context,
                      is_root_string,
                      Boolean::New(isolate_, n->IsRootNode()))
                 .IsNothing() ||
-            obj->Set(context,
-                     size_string,
-                     Number::New(isolate_, n->SizeInBytes()))
+            obj->Set(
+                   context,
+                   size_string,
+                   Number::New(isolate_, static_cast<double>(n->SizeInBytes())))
                 .IsNothing() ||
             obj->Set(context, edges_string, Array::New(isolate_)).IsNothing()) {
           return MaybeLocal<Array>();
@@ -172,7 +172,7 @@ class JSGraph : public EmbedderGraph {
             return MaybeLocal<Array>();
           }
         } else {
-          edge_name_value = Number::New(isolate_, j++);
+          edge_name_value = Number::New(isolate_, static_cast<double>(j++));
         }
         if (edge_obj->Set(context, name_string, edge_name_value).IsNothing() ||
             edge_obj->Set(context, to_string, to_object).IsNothing() ||
@@ -262,7 +262,7 @@ class HeapSnapshotStream : public AsyncWrap,
         avail = buf.len;
       memcpy(buf.base, data, avail);
       data += avail;
-      len -= avail;
+      len -= static_cast<int>(avail);
       EmitRead(size, buf);
     }
     return kContinue;

--- a/src/js_stream.cc
+++ b/src/js_stream.cc
@@ -178,7 +178,7 @@ void JSStream::ReadBuffer(const FunctionCallbackInfo<Value>& args) {
 
     memcpy(buf.base, data, avail);
     data += avail;
-    len -= avail;
+    len -= static_cast<int>(avail);
     wrap->EmitRead(avail, buf);
   }
 }

--- a/src/js_udp_wrap.cc
+++ b/src/js_udp_wrap.cc
@@ -161,7 +161,7 @@ void JSUDPWrap::EmitReceived(const FunctionCallbackInfo<Value>& args) {
     ssize_t avail = std::min<size_t>(buf.len, len);
     memcpy(buf.base, data, avail);
     data += avail;
-    len -= avail;
+    len -= static_cast<int>(avail);
     wrap->listener()->OnRecv(
         avail, buf, reinterpret_cast<sockaddr*>(&addr), flags);
   }

--- a/src/node.cc
+++ b/src/node.cc
@@ -1023,7 +1023,7 @@ InitializationResult InitializeOncePerProcess(int argc, char** argv) {
 #endif  // HAVE_OPENSSL
 
   per_process::v8_platform.Initialize(
-      per_process::cli_options->v8_thread_pool_size);
+      static_cast<int>(per_process::cli_options->v8_thread_pool_size));
   V8::Initialize();
   performance::performance_v8_start = PERFORMANCE_NOW();
   per_process::v8_initialized = true;

--- a/src/node_dir.cc
+++ b/src/node_dir.cc
@@ -217,9 +217,10 @@ static void AfterDirRead(uv_fs_t* req) {
   Local<Array> js_array;
   if (!DirentListToArray(env,
                          dir->dirents,
-                         req->result,
+                         static_cast<int>(req->result),
                          req_wrap->encoding(),
-                         &error).ToLocal(&js_array)) {
+                         &error)
+           .ToLocal(&js_array)) {
     // Clear libuv resources *before* delivering results to JS land because
     // that can schedule another operation on the same uv_dir_t. Ditto below.
     after.Clear();
@@ -244,7 +245,7 @@ void DirHandle::Read(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&dir, args.Holder());
 
   CHECK(args[1]->IsNumber());
-  uint64_t buffer_size = args[1].As<Number>()->Value();
+  uint64_t buffer_size = static_cast<uint64_t>(args[1].As<Number>()->Value());
 
   if (buffer_size != dir->dirents_.size()) {
     dir->dirents_.resize(buffer_size);
@@ -280,9 +281,10 @@ void DirHandle::Read(const FunctionCallbackInfo<Value>& args) {
     Local<Array> js_array;
     if (!DirentListToArray(env,
                            dir->dir()->dirents,
-                           req_wrap_sync.req.result,
+                           static_cast<int>(req_wrap_sync.req.result),
                            encoding,
-                           &error).ToLocal(&js_array)) {
+                           &error)
+             .ToLocal(&js_array)) {
       Local<Object> ctx = args[2].As<Object>();
       USE(ctx->Set(env->context(), env->error_string(), error));
       return;

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -367,7 +367,8 @@ MaybeLocal<Promise> FileHandle::ClosePromise() {
       Isolate* isolate = close->env()->isolate();
       if (req->result < 0) {
         HandleScope handle_scope(isolate);
-        close->Reject(UVException(isolate, req->result, "close"));
+        close->Reject(
+            UVException(isolate, static_cast<int>(req->result), "close"));
       } else {
         close->Resolve();
       }
@@ -491,7 +492,7 @@ int FileHandle::ReadStart() {
     BaseObjectPtr<FileHandleReadWrap> read_wrap =
         std::move(handle->current_read_);
 
-    int result = req->result;
+    ssize_t result = req->result;
     uv_buf_t buffer = read_wrap->buffer_;
 
     uv_fs_req_cleanup(req);
@@ -555,7 +556,7 @@ int FileHandle::DoShutdown(ShutdownWrap* req_wrap) {
     FileHandle* handle = static_cast<FileHandle*>(wrap->stream());
     handle->AfterClose();
 
-    int result = req->result;
+    int result = static_cast<int>(req->result);
     uv_fs_req_cleanup(req);
     wrap->Done(result);
   }});
@@ -623,13 +624,12 @@ void FSReqAfterScope::Clear() {
 // in JS for more flexibility.
 void FSReqAfterScope::Reject(uv_fs_t* req) {
   BaseObjectPtr<FSReqBase> wrap { wrap_ };
-  Local<Value> exception =
-      UVException(wrap_->env()->isolate(),
-                  req->result,
-                  wrap_->syscall(),
-                  nullptr,
-                  req->path,
-                  wrap_->data());
+  Local<Value> exception = UVException(wrap_->env()->isolate(),
+                                       static_cast<int>(req->result),
+                                       wrap_->syscall(),
+                                       nullptr,
+                                       req->path,
+                                       wrap_->data());
   Clear();
   wrap->Reject(exception);
 }
@@ -663,11 +663,12 @@ void AfterInteger(uv_fs_t* req) {
   FSReqBase* req_wrap = FSReqBase::from_req(req);
   FSReqAfterScope after(req_wrap, req);
 
-  if (req->result >= 0 && req_wrap->is_plain_open())
-    req_wrap->env()->AddUnmanagedFd(req->result);
+  int result = static_cast<int>(req->result);
+  if (result >= 0 && req_wrap->is_plain_open())
+    req_wrap->env()->AddUnmanagedFd(result);
 
   if (after.Proceed())
-    req_wrap->Resolve(Integer::New(req_wrap->env()->isolate(), req->result));
+    req_wrap->Resolve(Integer::New(req_wrap->env()->isolate(), result));
 }
 
 void AfterOpenFileHandle(uv_fs_t* req) {
@@ -675,7 +676,8 @@ void AfterOpenFileHandle(uv_fs_t* req) {
   FSReqAfterScope after(req_wrap, req);
 
   if (after.Proceed()) {
-    FileHandle* fd = FileHandle::New(req_wrap->binding_data(), req->result);
+    FileHandle* fd = FileHandle::New(req_wrap->binding_data(),
+                                     static_cast<int>(req->result));
     if (fd == nullptr) return;
     req_wrap->Resolve(fd->object());
   }
@@ -1430,7 +1432,7 @@ int MKDirpAsync(uv_loop_t* loop,
     Environment* env = req_wrap->env();
     uv_loop_t* loop = env->event_loop();
     std::string path = req->path;
-    int err = req->result;
+    int err = static_cast<int>(req->result);
 
     while (true) {
       switch (err) {
@@ -1476,7 +1478,7 @@ int MKDirpAsync(uv_loop_t* loop,
           int err = uv_fs_stat(loop, req, path.c_str(),
                                uv_fs_callback_t{[](uv_fs_t* req) {
             FSReqBase* req_wrap = FSReqBase::from_req(req);
-            int err = req->result;
+            int err = static_cast<int>(req->result);
             if (reinterpret_cast<intptr_t>(req->data) == UV_EEXIST &&
                   req_wrap->continuation_data()->paths().size() > 0) {
               if (err == 0 && S_ISDIR(req->statbuf.st_mode)) {

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -380,7 +380,7 @@ class Parser : public AsyncWrap, public StreamListener {
       return -1;
     }
 
-    return val;
+    return static_cast<int>(val);
   }
 
 
@@ -403,10 +403,10 @@ class Parser : public AsyncWrap, public StreamListener {
     }
 
     Local<Value> argv[3] = {
-      current_buffer_,
-      Integer::NewFromUnsigned(env()->isolate(), at - current_buffer_data_),
-      Integer::NewFromUnsigned(env()->isolate(), length)
-    };
+        current_buffer_,
+        Integer::NewFromUnsigned(
+            env()->isolate(), static_cast<uint32_t>(at - current_buffer_data_)),
+        Integer::NewFromUnsigned(env()->isolate(), length)};
 
     MaybeLocal<Value> r = MakeCallback(cb.As<Function>(),
                                        arraysize(argv),
@@ -549,7 +549,8 @@ class Parser : public AsyncWrap, public StreamListener {
 
     if (args.Length() > 2) {
       CHECK(args[2]->IsNumber());
-      max_http_header_size = args[2].As<Number>()->Value();
+      max_http_header_size =
+          static_cast<uint64_t>(args[2].As<Number>()->Value());
     }
     if (max_http_header_size == 0) {
       max_http_header_size = env->options()->max_http_header_size;
@@ -557,7 +558,7 @@ class Parser : public AsyncWrap, public StreamListener {
 
     if (args.Length() > 4) {
       CHECK(args[4]->IsInt32());
-      headers_timeout = args[4].As<Number>()->Value();
+      headers_timeout = args[4].As<Int32>()->Value();
     }
 
     llhttp_type_t type =
@@ -683,7 +684,7 @@ class Parser : public AsyncWrap, public StreamListener {
     // check header parsing time
     if (header_parsing_start_time_ != 0 && headers_timeout_ != 0) {
       uint64_t now = uv_hrtime();
-      uint64_t parsing_time = (now - header_parsing_start_time_) / 1e6;
+      uint64_t parsing_time = (now - header_parsing_start_time_) / 1000000;
 
       if (parsing_time > headers_timeout_) {
         Local<Value> cb =
@@ -781,8 +782,9 @@ class Parser : public AsyncWrap, public StreamListener {
       if (err == HPE_USER) {
         const char* colon = strchr(errno_reason, ':');
         CHECK_NOT_NULL(colon);
-        code = OneByteString(env()->isolate(), errno_reason,
-                             colon - errno_reason);
+        code = OneByteString(env()->isolate(),
+                             errno_reason,
+                             static_cast<int>(colon - errno_reason));
         reason = OneByteString(env()->isolate(), colon + 1);
       } else {
         code = OneByteString(env()->isolate(), llhttp_errno_name(err));

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -945,12 +945,14 @@ void GetOptions(const FunctionCallbackInfo<Value>& args) {
                              *_ppop_instance.Lookup<bool>(field, opts));
         break;
       case kInteger:
-        value = Number::New(isolate,
-                            *_ppop_instance.Lookup<int64_t>(field, opts));
+        value = Number::New(
+            isolate,
+            static_cast<double>(*_ppop_instance.Lookup<int64_t>(field, opts)));
         break;
       case kUInteger:
-        value = Number::New(isolate,
-                            *_ppop_instance.Lookup<uint64_t>(field, opts));
+        value = Number::New(
+            isolate,
+            static_cast<double>(*_ppop_instance.Lookup<uint64_t>(field, opts)));
         break;
       case kString:
         if (!ToV8Value(context,

--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -118,11 +118,16 @@ static void GetCPUInfo(const FunctionCallbackInfo<Value>& args) {
     uv_cpu_info_t* ci = cpu_infos + i;
     result.emplace_back(OneByteString(isolate, ci->model));
     result.emplace_back(Number::New(isolate, ci->speed));
-    result.emplace_back(Number::New(isolate, ci->cpu_times.user));
-    result.emplace_back(Number::New(isolate, ci->cpu_times.nice));
-    result.emplace_back(Number::New(isolate, ci->cpu_times.sys));
-    result.emplace_back(Number::New(isolate, ci->cpu_times.idle));
-    result.emplace_back(Number::New(isolate, ci->cpu_times.irq));
+    result.emplace_back(
+        Number::New(isolate, static_cast<double>(ci->cpu_times.user)));
+    result.emplace_back(
+        Number::New(isolate, static_cast<double>(ci->cpu_times.nice)));
+    result.emplace_back(
+        Number::New(isolate, static_cast<double>(ci->cpu_times.sys)));
+    result.emplace_back(
+        Number::New(isolate, static_cast<double>(ci->cpu_times.idle)));
+    result.emplace_back(
+        Number::New(isolate, static_cast<double>(ci->cpu_times.irq)));
   }
 
   uv_free_cpu_info(cpu_infos, count);
@@ -131,13 +136,13 @@ static void GetCPUInfo(const FunctionCallbackInfo<Value>& args) {
 
 
 static void GetFreeMemory(const FunctionCallbackInfo<Value>& args) {
-  double amount = uv_get_free_memory();
+  double amount = static_cast<double>(uv_get_free_memory());
   args.GetReturnValue().Set(amount);
 }
 
 
 static void GetTotalMemory(const FunctionCallbackInfo<Value>& args) {
-  double amount = uv_get_total_memory();
+  double amount = static_cast<double>(uv_get_total_memory());
   args.GetReturnValue().Set(amount);
 }
 

--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -88,7 +88,7 @@ std::ostream& operator<<(std::ostream& o,
 
 void PerformanceState::Mark(enum PerformanceMilestone milestone,
                              uint64_t ts) {
-  this->milestones[milestone] = ts;
+  this->milestones[milestone] = static_cast<double>(ts);
   TRACE_EVENT_INSTANT_WITH_TIMESTAMP0(
       TRACING_CATEGORY_NODE1(bootstrap),
       GetPerformanceMilestoneName(milestone),

--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -203,12 +203,14 @@ static void MemoryUsage(const FunctionCallbackInfo<Value>& args) {
   if (err)
     return env->ThrowUVException(err, "uv_resident_set_memory");
 
-  fields[0] = rss;
-  fields[1] = v8_heap_stats.total_heap_size();
-  fields[2] = v8_heap_stats.used_heap_size();
-  fields[3] = v8_heap_stats.external_memory();
-  fields[4] = array_buffer_allocator == nullptr ?
-      0 : array_buffer_allocator->total_mem_usage();
+  fields[0] = static_cast<double>(rss);
+  fields[1] = static_cast<double>(v8_heap_stats.total_heap_size());
+  fields[2] = static_cast<double>(v8_heap_stats.used_heap_size());
+  fields[3] = static_cast<double>(v8_heap_stats.external_memory());
+  fields[4] =
+      array_buffer_allocator == nullptr
+          ? 0
+          : static_cast<double>(array_buffer_allocator->total_mem_usage());
 }
 
 void RawDebug(const FunctionCallbackInfo<Value>& args) {
@@ -291,20 +293,20 @@ static void ResourceUsage(const FunctionCallbackInfo<Value>& args) {
 
   fields[0] = MICROS_PER_SEC * rusage.ru_utime.tv_sec + rusage.ru_utime.tv_usec;
   fields[1] = MICROS_PER_SEC * rusage.ru_stime.tv_sec + rusage.ru_stime.tv_usec;
-  fields[2] = rusage.ru_maxrss;
-  fields[3] = rusage.ru_ixrss;
-  fields[4] = rusage.ru_idrss;
-  fields[5] = rusage.ru_isrss;
-  fields[6] = rusage.ru_minflt;
-  fields[7] = rusage.ru_majflt;
-  fields[8] = rusage.ru_nswap;
-  fields[9] = rusage.ru_inblock;
-  fields[10] = rusage.ru_oublock;
-  fields[11] = rusage.ru_msgsnd;
-  fields[12] = rusage.ru_msgrcv;
-  fields[13] = rusage.ru_nsignals;
-  fields[14] = rusage.ru_nvcsw;
-  fields[15] = rusage.ru_nivcsw;
+  fields[2] = static_cast<double>(rusage.ru_maxrss);
+  fields[3] = static_cast<double>(rusage.ru_ixrss);
+  fields[4] = static_cast<double>(rusage.ru_idrss);
+  fields[5] = static_cast<double>(rusage.ru_isrss);
+  fields[6] = static_cast<double>(rusage.ru_minflt);
+  fields[7] = static_cast<double>(rusage.ru_majflt);
+  fields[8] = static_cast<double>(rusage.ru_nswap);
+  fields[9] = static_cast<double>(rusage.ru_inblock);
+  fields[10] = static_cast<double>(rusage.ru_oublock);
+  fields[11] = static_cast<double>(rusage.ru_msgsnd);
+  fields[12] = static_cast<double>(rusage.ru_msgrcv);
+  fields[13] = static_cast<double>(rusage.ru_nsignals);
+  fields[14] = static_cast<double>(rusage.ru_nvcsw);
+  fields[15] = static_cast<double>(rusage.ru_nivcsw);
 }
 
 #ifdef __POSIX__
@@ -355,7 +357,7 @@ static void DebugProcess(const FunctionCallbackInfo<Value>& args) {
   });
 
   CHECK(args[0]->IsNumber());
-  pid = args[0].As<Integer>()->Value();
+  pid = static_cast<DWORD>(args[0].As<Integer>()->Value());
 
   process =
       OpenProcess(PROCESS_CREATE_THREAD | PROCESS_QUERY_INFORMATION |

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -99,7 +99,7 @@ void Worker::UpdateResourceConstraints(ResourceConstraints* constraints) {
 
   if (resource_limits_[kMaxYoungGenerationSizeMb] > 0) {
     constraints->set_max_young_generation_size_in_bytes(
-        resource_limits_[kMaxYoungGenerationSizeMb] * kMB);
+        static_cast<size_t>(resource_limits_[kMaxYoungGenerationSizeMb] * kMB));
   } else {
     resource_limits_[kMaxYoungGenerationSizeMb] =
         constraints->max_young_generation_size_in_bytes() / kMB;
@@ -107,7 +107,7 @@ void Worker::UpdateResourceConstraints(ResourceConstraints* constraints) {
 
   if (resource_limits_[kMaxOldGenerationSizeMb] > 0) {
     constraints->set_max_old_generation_size_in_bytes(
-        resource_limits_[kMaxOldGenerationSizeMb] * kMB);
+        static_cast<size_t>(resource_limits_[kMaxOldGenerationSizeMb] * kMB));
   } else {
     resource_limits_[kMaxOldGenerationSizeMb] =
         constraints->max_old_generation_size_in_bytes() / kMB;
@@ -115,7 +115,7 @@ void Worker::UpdateResourceConstraints(ResourceConstraints* constraints) {
 
   if (resource_limits_[kCodeRangeSizeMb] > 0) {
     constraints->set_code_range_size_in_bytes(
-        resource_limits_[kCodeRangeSizeMb] * kMB);
+        static_cast<size_t>(resource_limits_[kCodeRangeSizeMb] * kMB));
   } else {
     resource_limits_[kCodeRangeSizeMb] =
         constraints->code_range_size_in_bytes() / kMB;
@@ -575,7 +575,8 @@ void Worker::StartThread(const FunctionCallbackInfo<Value>& args) {
       w->resource_limits_[kStackSizeMb] = kStackBufferSize / kMB;
       w->stack_size_ = kStackBufferSize;
     } else {
-      w->stack_size_ = w->resource_limits_[kStackSizeMb] * kMB;
+      w->stack_size_ =
+          static_cast<size_t>(w->resource_limits_[kStackSizeMb] * kMB);
     }
   } else {
     w->resource_limits_[kStackSizeMb] = w->stack_size_ / kMB;


### PR DESCRIPTION
This fixes a bunch of C4244 ('conversion' conversion from 'type1' to
'type2', possible loss of data) MSVC warnings in the code base.
