### PR TITLE
test: remove outdated V8 flag

### DIFF
--- a/test/node-api/test_buffer/test.js
+++ b/test/node-api/test_buffer/test.js
@@ -1,5 +1,5 @@
 'use strict';
-// Flags: --expose-gc --no-concurrent-array-buffer-freeing --no-concurrent-array-buffer-sweeping
+// Flags: --expose-gc --no-concurrent-array-buffer-sweeping
 
 const common = require('../../common');
 const binding = require(`./build/${common.buildType}/test_buffer`);


### PR DESCRIPTION
The flag is going to be removed upstream in V8 9.0.

Refs: https://github.com/v8/v8/commit/0a480c30d553c1b8dddb0dddcbdec5fb6f3101ff
