### PR TITLE
stream: improve Readable.from error handling

### DIFF
--- a/lib/internal/streams/from.js
+++ b/lib/internal/streams/from.js
@@ -53,9 +53,9 @@ function from(Readable, iterable, opts) {
   readable._destroy = function(error, cb) {
     PromisePrototypeThen(
       close(error),
-      () =>  cb(error),
+      () => cb(error),
       (e) => cb(error ?? e)
-    )
+    );
   };
 
   async function close(error) {

--- a/lib/internal/streams/from.js
+++ b/lib/internal/streams/from.js
@@ -43,9 +43,6 @@ function from(Readable, iterable, opts) {
   // being called before last iteration completion.
   let reading = false;
 
-  // Flag for when iterator needs to be explicitly closed.
-  let needToClose = false;
-
   readable._read = function() {
     if (!reading) {
       reading = true;
@@ -54,19 +51,23 @@ function from(Readable, iterable, opts) {
   };
 
   readable._destroy = function(error, cb) {
-    if (needToClose) {
-      needToClose = false;
-      PromisePrototypeThen(
-        close(),
-        () => process.nextTick(cb, error),
-        (e) => process.nextTick(cb, error || e),
-      );
-    } else {
-      cb(error);
-    }
+    PromisePrototypeThen(
+      close(error),
+      () =>  cb(error),
+      (e) => cb(error ?? e)
+    )
   };
 
-  async function close() {
+  async function close(error) {
+    const hadError = typeof error !== 'undefined';
+    const hasThrow = typeof iterator.return === 'function';
+    if (hadError && hasThrow) {
+      const { value, done } = await iterator.throw(error);
+      await value;
+      if (done) {
+        return;
+      }
+    }
     if (typeof iterator.return === 'function') {
       const { value } = await iterator.return();
       await value;
@@ -75,13 +76,9 @@ function from(Readable, iterable, opts) {
 
   async function next() {
     try {
-      needToClose = false;
       const { value, done } = await iterator.next();
-      needToClose = !done;
       if (done) {
         readable.push(null);
-      } else if (readable.destroyed) {
-        await close();
       } else {
         const res = await value;
         if (res === null) {

--- a/lib/internal/streams/from.js
+++ b/lib/internal/streams/from.js
@@ -54,13 +54,13 @@ function from(Readable, iterable, opts) {
     PromisePrototypeThen(
       close(error),
       () => process.nextTick(cb, error), // nextTick is here in case cb throws
-      (e) => process.nextTick(cb, error || e),
+      (e) => process.nextTick(cb, e || error),
     );
   };
 
   async function close(error) {
-    const hadError = typeof error !== 'undefined';
-    const hasThrow = typeof iterator.return === 'function';
+    const hadError = (error !== undefined) && (error !== null);
+    const hasThrow = typeof iterator.throw === 'function';
     if (hadError && hasThrow) {
       const { value, done } = await iterator.throw(error);
       await value;

--- a/lib/internal/streams/from.js
+++ b/lib/internal/streams/from.js
@@ -53,8 +53,8 @@ function from(Readable, iterable, opts) {
   readable._destroy = function(error, cb) {
     PromisePrototypeThen(
       close(error),
-      () => cb(error),
-      (e) => cb(error ?? e)
+      () => process.nextTick(cb, error), // nextTick is here in case cb throws
+      (e) => process.nextTick(cb, error || e),
     );
   };
 


### PR DESCRIPTION
This pull request aligns the behaviour of `Readable.from` with other stream behaviours namely:
 - Errors thrown in the stream now propagate via `.throw` and not via `.on` and reach catch blocks. This means things like `addAbortSignal` work with `Readable.from` now.
 - The generator is always closed, even if `next` was not called - this is because the previous implementation had a timing bug where if `next` was called and the stream was destroyed in the same tick - finally blocks would not run.


cc @ronag @mcollina @nodejs/streams 