### PR TITLE
tools,doc: add support for several flavors of JS code snippets

### DIFF
--- a/doc/api/wasi.md
+++ b/doc/api/wasi.md
@@ -29,6 +29,27 @@ const instance = await WebAssembly.instantiate(wasm, importObject);
 wasi.start(instance);
 ```
 
+```cjs
+'use strict';
+const fs = require('fs');
+const { WASI } = require('wasi');
+const wasi = new WASI({
+  args: process.argv,
+  env: process.env,
+  preopens: {
+    '/sandbox': '/some/real/path/that/wasm/can/access'
+  }
+});
+const importObject = { wasi_snapshot_preview1: wasi.wasiImport };
+
+(async () => {
+  const wasm = await WebAssembly.compile(fs.readFileSync('./demo.wasm'));
+  const instance = await WebAssembly.instantiate(wasm, importObject);
+
+  wasi.start(instance);
+})();
+```
+
 To run the above example, create a new WebAssembly text format file named
 `demo.wat`:
 

--- a/doc/api_assets/js-flavor-cjs.svg
+++ b/doc/api_assets/js-flavor-cjs.svg
@@ -1,0 +1,5 @@
+<!--
+ * Font Awesome Free 5.15.2 by @fontawesome - https://fontawesome.com
+ * License - https://fontawesome.com/license/free - CC BY 4.0
+-->
+<svg xmlns="http://www.w3.org/2000/svg" width="2719" height="384"><path d="M1191.326 384h192c106 0 192-86 192-192s-86-192-192-192h-192c-106 0-192 86-192 192s86 192 192 192zm0-320c70.8 0 128 57.3 128 128 0 70.8-57.3 128-128 128-70.8 0-128-57.3-128-128 0-70.8 57.3-128 128-128z"/><text stroke-width="42" font-family="sans-serif" font-weight="lighter" font-size="490" y="370">CJS</text><text stroke-width="42" font-weight="lighter" font-family="sans-serif" font-size="490" y="370" x="1682">ESM</text></svg>

--- a/doc/api_assets/js-flavor-esm.svg
+++ b/doc/api_assets/js-flavor-esm.svg
@@ -1,0 +1,5 @@
+<!--
+ * Font Awesome Free 5.15.2 by @fontawesome - https://fontawesome.com
+ * License - https://fontawesome.com/license/free - CC BY 4.0
+-->
+<svg xmlns="http://www.w3.org/2000/svg" height="384" width="2719"><defs><path d="M-136.321-230.336h2994.365v653.401H-136.321z"/></defs><path d="M1383.326 0h-192c-106 0-192 86-192 192s86 192 192 192h192c106 0 192-86 192-192s-86-192-192-192zm0 320c-70.8 0-128-57.3-128-128 0-70.8 57.3-128 128-128 70.8 0 128 57.3 128 128 0 70.8-57.3 128-128 128z"/><text stroke-width="42" font-family="sans-serif" font-weight="lighter" font-size="490" y="370">CJS</text><text stroke-width="42" font-weight="lighter" font-family="sans-serif" font-size="490" y="370" x="1682">ESM</text></svg>

--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -765,6 +765,33 @@ kbd {
   display: block;
 }
 
+.js-flavor-selector {
+  appearance: none;
+  float: right;
+  background-image: url(./js-flavor-cjs.svg);
+  background-size: contain;
+  background-repeat: no-repeat;
+  width: 142px;
+  height: 20px;
+}
+.js-flavor-selector:checked {
+  background-image: url(./js-flavor-esm.svg);
+}
+.js-flavor-selector:not(:checked) ~ .esm,
+.js-flavor-selector:checked ~ .cjs {
+  display: none;
+}
+.dark-mode .js-flavor-selector {
+  filter: invert(1);
+}
+@supports (aspect-ratio: 1 / 1) {
+  .js-flavor-selector {
+    height: 1.5em;
+    width: auto;
+    aspect-ratio: 2719 / 384;
+  }
+}
+
 @media print {
   html {
     height: auto;
@@ -814,5 +841,25 @@ kbd {
   }
   #apicontent {
     overflow: hidden;
+  }
+  .js-flavor-selector {
+    display: none;
+  }
+  .js-flavor-selector + * {
+    margin-bottom: 2rem;
+    padding-bottom: 2rem;
+    border-bottom: 1px solid var(--color-text-primary);
+  }
+  .js-flavor-selector ~ * {
+    display: block !important;
+    background-position: top right;
+    background-size: 142px 20px;
+    background-repeat: no-repeat;
+  }
+  .js-flavor-selector ~ .cjs {
+    background-image: url(./js-flavor-cjs.svg);
+  }
+  .js-flavor-selector ~ .mjs {
+    background-image: url(./js-flavor-esm.svg);
   }
 }

--- a/test/doctool/test-doctool-html.js
+++ b/test/doctool/test-doctool-html.js
@@ -129,7 +129,15 @@ const testData = [
   {
     file: fixtures.path('document_with_special_heading.md'),
     html: '<title>Sample markdown with special heading |',
-  }
+  },
+  {
+    file: fixtures.path('document_with_esm_and_cjs_code_snippet.md'),
+    html: '<input class="js-flavor-selector" type="checkbox" checked',
+  },
+  {
+    file: fixtures.path('document_with_cjs_and_esm_code_snippet.md'),
+    html: '<input class="js-flavor-selector" type="checkbox" aria-label',
+  },
 ];
 
 const spaces = /\s/g;

--- a/test/fixtures/document_with_cjs_and_esm_code_snippet.md
+++ b/test/fixtures/document_with_cjs_and_esm_code_snippet.md
@@ -1,0 +1,11 @@
+# Usage and Example
+
+CJS snippet is first, it should be the one displayed by default.
+
+```cjs
+require('path');
+```
+
+```mjs
+import 'node:url';
+```

--- a/test/fixtures/document_with_esm_and_cjs_code_snippet.md
+++ b/test/fixtures/document_with_esm_and_cjs_code_snippet.md
@@ -1,0 +1,11 @@
+# Usage and Example
+
+ESM snippet is first, it should be the one displayed by default.
+
+```mjs
+import 'node:url';
+```
+
+```cjs
+require('path');
+```


### PR DESCRIPTION
Enable code example using both modern ESM syntax and legacy CJS syntax.
It adds a toggle on the web interface to let users switch from one JavaScript flavor to the other.

`html.js` detects code snippets with a meta attribute:

````markdown
```mjs
export default {};
```
```cjs
'use strict';
module.exports = {};
```
````

And adds a `<input type=checkbox>` toggle:

![Toggle ESM](https://user-images.githubusercontent.com/14309773/110138039-d465a480-7dd1-11eb-8b30-d879bb51d2e3.png)
![Toggle CJS](https://user-images.githubusercontent.com/14309773/110138107-e9dace80-7dd1-11eb-967b-9f06d541bf45.png)


<details>

<summary>With dark mode on</summary>

![Toggle ESM, with dark mode](https://user-images.githubusercontent.com/14309773/110137906-a97b5080-7dd1-11eb-962a-8c3cf026d924.png)
![Toggle CJS, with dark-mode](https://user-images.githubusercontent.com/14309773/110137935-b0a25e80-7dd1-11eb-86ef-4dd5cb095792.png)

</details>


- [x] ✅ Doesn't require JavaScript on the client.
- [x] ✅ Doesn't break the accessibility of the docs.
- [x] ✅ Doesn't break GitHub auto-highlighting (well it breaks in the code diff, but it renders OK in the markdown preview, see https://github.com/aduh95/node/blob/doc-multi-syntax-snippets/doc/api/wasi.md).
- [ ] ❓ Use non-free content (the toggle used in this PR is derived from https://fontawesome.com/icons/toggle-on?style=solid, which is under [CC BY 4.0 License](https://fontawesome.com/license/free)).

_Originally suggested by @jasnell in https://github.com/nodejs/node/pull/37077#discussion_r565397566._

