### PR TITLE
src: simplify calls to BN_bin2bn in prime gen

### DIFF
--- a/src/crypto/crypto_random.cc
+++ b/src/crypto/crypto_random.cc
@@ -104,27 +104,19 @@ Maybe<bool> RandomPrimeTraits::AdditionalConfig(
   bool safe = args[offset + 1]->IsTrue();
 
   if (!args[offset + 2]->IsUndefined()) {
-    params->add.reset(BN_secure_new());
+    ArrayBufferOrViewContents<unsigned char> add(args[offset + 2]);
+    params->add.reset(BN_bin2bn(add.data(), add.size(), nullptr));
     if (!params->add) {
       THROW_ERR_CRYPTO_OPERATION_FAILED(env, "could not generate prime");
-      return Nothing<bool>();
-    }
-    ArrayBufferOrViewContents<unsigned char> add(args[offset + 2]);
-    if (BN_bin2bn(add.data(), add.size(), params->add.get()) == nullptr) {
-      THROW_ERR_INVALID_ARG_VALUE(env, "invalid options.add");
       return Nothing<bool>();
     }
   }
 
   if (!args[offset + 3]->IsUndefined()) {
-    params->rem.reset(BN_secure_new());
+    ArrayBufferOrViewContents<unsigned char> rem(args[offset + 3]);
+    params->rem.reset(BN_bin2bn(rem.data(), rem.size(), nullptr));
     if (!params->rem) {
       THROW_ERR_CRYPTO_OPERATION_FAILED(env, "could not generate prime");
-      return Nothing<bool>();
-    }
-    ArrayBufferOrViewContents<unsigned char> rem(args[offset + 3]);
-    if (BN_bin2bn(rem.data(), rem.size(), params->rem.get()) == nullptr) {
-      THROW_ERR_INVALID_ARG_VALUE(env, "invalid options.rem");
       return Nothing<bool>();
     }
   }


### PR DESCRIPTION
This is more or less equivalent to the previous implementation from https://github.com/nodejs/node/pull/36997, with two subtle differences.

1. The `add` and `rem` options are not stored in secure memory (if it is enabled). However, these options are mostly used for DH, in which case these parameters aren't secret. Either way, they are passed from JS through insecure memory (either as `BigInt` or `ArrayBuffer`), so it does not help much to protect them here. (I suggested storing the _prime_ in secure memory in https://github.com/nodejs/node/pull/36997, but not `add` or `rem`.)
2. Memory allocation failure now always throws `ERR_CRYPTO_OPERATION_FAILED`. Previously, it would either throw `ERR_CRYPTO_OPERATION_FAILED` if memory allocation failed during `BN_secure_new`, or `ERR_INVALID_ARG_VALUE` if memory allocation failed during `BN_bin2bn`. The latter doesn't make much sense because the failure of `BN_bin2bn` is most likely unrelated to the value of the options.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
