### PR TITLE
doc: refactor fs docs structure

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -54,6 +54,7 @@ module.exports = {
     {
       files: [
         'doc/api/esm.md',
+        'doc/api/fs.md',
         'doc/api/module.md',
         'doc/api/modules.md',
         'doc/api/packages.md',


### PR DESCRIPTION
Makes a fairly radical update to the `fs` module documentation, splitting the three api flavors into distinct sections, moving the promise APIs up to the top, and updating the examples to use ESM syntax. This is done to put emphasis on the ESM and Promise model. The example snippets are also set up with metadata in preparation for #37162

@nodejs/documentation 