### PR TITLE
process: use frozen array for process.allowedNodeEnvironmentFlags

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -577,15 +577,15 @@ This feature is not available in [`Worker`][] threads.
 added: v10.10.0
 -->
 
-* {Set}
+* {string[]}
 
 The `process.allowedNodeEnvironmentFlags` property is a special,
-read-only `Set` of flags allowable within the [`NODE_OPTIONS`][]
+read-only `Array` of flags allowable within the [`NODE_OPTIONS`][]
 environment variable.
 
-`process.allowedNodeEnvironmentFlags` extends `Set`, but overrides
-`Set.prototype.has` to recognize several different possible flag
-representations. `process.allowedNodeEnvironmentFlags.has()` will
+`process.allowedNodeEnvironmentFlags` is a frozen `Array`, but overrides
+`Array.prototype.includes` to recognize several different possible flag
+representations. `process.allowedNodeEnvironmentFlags.includes()` will
 return `true` in the following cases:
 
 * Flags may omit leading single (`-`) or double (`--`) dashes; e.g.,
@@ -612,10 +612,6 @@ process.allowedNodeEnvironmentFlags.forEach((flag) => {
   // ...
 });
 ```
-
-The methods `add()`, `clear()`, and `delete()` of
-`process.allowedNodeEnvironmentFlags` do nothing, and will fail
-silently.
 
 If Node.js was compiled *without* [`NODE_OPTIONS`][] support (shown in
 [`process.config`][]), `process.allowedNodeEnvironmentFlags` will

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -575,6 +575,10 @@ This feature is not available in [`Worker`][] threads.
 ## `process.allowedNodeEnvironmentFlags`
 <!-- YAML
 added: v10.10.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/37171
+    description: Use a frozen array instead of a subclass of `Set`.
 -->
 
 * {string[]}

--- a/lib/internal/process/per_thread.js
+++ b/lib/internal/process/per_thread.js
@@ -6,17 +6,18 @@
 
 const {
   ArrayPrototypeEvery,
+  ArrayPrototypeIncludes,
   ArrayPrototypeMap,
   ArrayPrototypePush,
   ArrayPrototypeSplice,
   BigUint64Array,
   Float64Array,
+  FunctionPrototype,
   NumberMAX_SAFE_INTEGER,
-  ObjectDefineProperty,
   ObjectFreeze,
   ReflectApply,
+  ReflectGet,
   RegExpPrototypeTest,
-  SafeSet,
   StringPrototypeEndsWith,
   StringPrototypeReplace,
   StringPrototypeSlice,
@@ -293,55 +294,53 @@ function buildAllowedFlags() {
 
   // Save these for comparison against flags provided to
   // process.allowedNodeEnvironmentFlags.has() which lack leading dashes.
-  const nodeFlags = new SafeSet(ArrayPrototypeMap(allowedNodeEnvironmentFlags,
-                                                  trimLeadingDashes));
+  const nodeFlags =
+    ArrayPrototypeMap(allowedNodeEnvironmentFlags, trimLeadingDashes);
 
-  class NodeEnvironmentFlagsSet extends SafeSet {
-    constructor(...args) {
-      super(...args);
+  return new Proxy(ObjectFreeze(allowedNodeEnvironmentFlags), {
+    get(target, key, receiver) {
+      switch (key) {
+        case 'add':
+          // No-op, `Set` API compatible
+          return () => receiver;
 
-      // The super constructor consumes `add`, but
-      // disallow any future adds.
-      ObjectDefineProperty(this, 'add', {
-        value: () => this
-      });
-    }
+        case 'delete':
+          // No-op, `Set` API compatible
+          return () => false;
 
-    delete() {
-      // No-op, `Set` API compatible
-      return false;
-    }
+        case 'clear':
+          // No-op, `Set` API compatible
+          return FunctionPrototype;
 
-    clear() {
-      // No-op
-    }
+        case 'has':
+        case 'includes':
+          return (key) => {
+            // This will return `true` based on various possible
+            // permutations of a flag, including present/missing leading
+            // dash(es) and/or underscores-for-dashes.
+            // Strips any values after `=`, inclusive.
+            // TODO(addaleax): It might be more flexible to run the option
+            // parser on a dummy option set and see whether it rejects the
+            // argument or not.
+            if (typeof key === 'string') {
+              key = StringPrototypeReplace(key, replaceUnderscoresRegex, '-');
+              if (RegExpPrototypeTest(leadingDashesRegex, key)) {
+                key = StringPrototypeReplace(key, trailingValuesRegex, '');
+                return ArrayPrototypeIncludes(target, key);
+              }
+              return ArrayPrototypeIncludes(nodeFlags, key);
+            }
+            return false;
+          };
 
-    has(key) {
-      // This will return `true` based on various possible
-      // permutations of a flag, including present/missing leading
-      // dash(es) and/or underscores-for-dashes.
-      // Strips any values after `=`, inclusive.
-      // TODO(addaleax): It might be more flexible to run the option parser
-      // on a dummy option set and see whether it rejects the argument or
-      // not.
-      if (typeof key === 'string') {
-        key = StringPrototypeReplace(key, replaceUnderscoresRegex, '-');
-        if (RegExpPrototypeTest(leadingDashesRegex, key)) {
-          key = StringPrototypeReplace(key, trailingValuesRegex, '');
-          return super.has(key);
-        }
-        return nodeFlags.has(key);
+        case 'size':
+          return target.length;
+
+        default:
+          return ReflectGet(target, key);
       }
-      return false;
-    }
-  }
-
-  ObjectFreeze(NodeEnvironmentFlagsSet.prototype.constructor);
-  ObjectFreeze(NodeEnvironmentFlagsSet.prototype);
-
-  return ObjectFreeze(new NodeEnvironmentFlagsSet(
-    allowedNodeEnvironmentFlags
-  ));
+    },
+  });
 }
 
 // Lazy load internal/trace_events_async_hooks only if the async_hooks

--- a/test/parallel/test-process-env-allowed-flags.js
+++ b/test/parallel/test-process-env-allowed-flags.js
@@ -70,8 +70,15 @@ const assert = require('assert');
   assert.throws(
     () => process.allowedNodeEnvironmentFlags.push('foo'),
     /object is not extensible/);
-  assert.strictEqual(process.allowedNodeEnvironmentFlags.includes('foo'),
-                     false);
+  assert.throws(
+    () => Array.prototype.push.call(process.allowedNodeEnvironmentFlags, 'foo'),
+    /object is not extensible/);
+  assert.strictEqual(
+    process.allowedNodeEnvironmentFlags.includes('foo'),
+    false);
+  assert.strictEqual(
+    Array.prototype.includes.call(process.allowedNodeEnvironmentFlags, 'foo'),
+    false);
 
   const thisArg = {};
   process.allowedNodeEnvironmentFlags.forEach(

--- a/test/parallel/test-process-env-allowed-flags.js
+++ b/test/parallel/test-process-env-allowed-flags.js
@@ -62,14 +62,23 @@ const assert = require('assert');
                      true);
 
   process.allowedNodeEnvironmentFlags.add('foo');
+  assert.throws(
+    () => Set.prototype.add.call(process.allowedNodeEnvironmentFlags, 'foo'),
+    /Set\.prototype\.add called on incompatible receiver/);
   assert.strictEqual(process.allowedNodeEnvironmentFlags.has('foo'), false);
+
+  assert.throws(
+    () => process.allowedNodeEnvironmentFlags.push('foo'),
+    /object is not extensible/);
+  assert.strictEqual(process.allowedNodeEnvironmentFlags.includes('foo'),
+                     false);
 
   const thisArg = {};
   process.allowedNodeEnvironmentFlags.forEach(
-    common.mustCallAtLeast(function(flag, _, set) {
+    common.mustCallAtLeast(function(flag, _, arr) {
       assert.notStrictEqual(flag, 'foo');
       assert.strictEqual(this, thisArg);
-      assert.strictEqual(set, process.allowedNodeEnvironmentFlags);
+      assert.strictEqual(arr, process.allowedNodeEnvironmentFlags);
     }),
     thisArg
   );
@@ -88,6 +97,8 @@ const assert = require('assert');
   }
 
   const size = process.allowedNodeEnvironmentFlags.size;
+
+  assert.strictEqual(process.allowedNodeEnvironmentFlags.length, size);
 
   process.allowedNodeEnvironmentFlags.clear();
   assert.strictEqual(process.allowedNodeEnvironmentFlags.size, size);

--- a/test/parallel/test-process-env-allowed-flags.js
+++ b/test/parallel/test-process-env-allowed-flags.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 // Assert legit flags are allowed, and bogus flags are disallowed
@@ -63,14 +63,39 @@ const assert = require('assert');
 
   process.allowedNodeEnvironmentFlags.add('foo');
   assert.strictEqual(process.allowedNodeEnvironmentFlags.has('foo'), false);
-  process.allowedNodeEnvironmentFlags.forEach((flag) => {
-    assert.strictEqual(flag === 'foo', false);
-  });
 
-  process.allowedNodeEnvironmentFlags.clear();
-  assert.strictEqual(process.allowedNodeEnvironmentFlags.size > 0, true);
+  const thisArg = {};
+  process.allowedNodeEnvironmentFlags.forEach(
+    common.mustCallAtLeast(function(flag, _, set) {
+      assert.notStrictEqual(flag, 'foo');
+      assert.strictEqual(this, thisArg);
+      assert.strictEqual(set, process.allowedNodeEnvironmentFlags);
+    }),
+    thisArg
+  );
+
+  for (const flag of process.allowedNodeEnvironmentFlags.keys()) {
+    assert.notStrictEqual(flag, 'foo');
+  }
+  for (const flag of process.allowedNodeEnvironmentFlags.values()) {
+    assert.notStrictEqual(flag, 'foo');
+  }
+  for (const flag of process.allowedNodeEnvironmentFlags) {
+    assert.notStrictEqual(flag, 'foo');
+  }
+  for (const [flag] of process.allowedNodeEnvironmentFlags.entries()) {
+    assert.notStrictEqual(flag, 'foo');
+  }
 
   const size = process.allowedNodeEnvironmentFlags.size;
+
+  process.allowedNodeEnvironmentFlags.clear();
+  assert.strictEqual(process.allowedNodeEnvironmentFlags.size, size);
+
   process.allowedNodeEnvironmentFlags.delete('-r');
+  assert.strictEqual(process.allowedNodeEnvironmentFlags.size, size);
+
+  assert.throws(() => process.allowedNodeEnvironmentFlags.splice(0),
+                /Cannot delete property/);
   assert.strictEqual(process.allowedNodeEnvironmentFlags.size, size);
 }


### PR DESCRIPTION
Maintain no-op calls of `Set` prototype methods to `process.allowedNodeEnvironmentFlags` for backward compatibility.

Labeled as `semver-major` as it makes following code throw:

```js
Set.prototype.add.call(process.allowedNodeEnvironmentFlags, '--user-option`);
process.allowedNodeEnvironmentFlags.has('--user-option') === true;
```

_Originally suggested by @Trott in https://github.com/nodejs/node/pull/36660#pullrequestreview-579893872._

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
