### PR TITLE
fs: use a default callback for fs.close()

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1617,10 +1617,13 @@ This is the synchronous version of [`fs.chown()`][].
 
 See also: chown(2).
 
-## `fs.close(fd, callback)`
+## `fs.close(fd[, callback])`
 <!-- YAML
 added: v0.0.2
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: A default callback is now use if one is not provided.
   - version: v10.0.0
     pr-url: https://github.com/nodejs/node/pull/12562
     description: The `callback` parameter is no longer optional. Not passing
@@ -1640,6 +1643,9 @@ to the completion callback.
 
 Calling `fs.close()` on any file descriptor (`fd`) that is currently in use
 through any other `fs` operation may lead to undefined behavior.
+
+If the `callback` argument is omitted, a default callback function that rethrows
+any error as an uncaught exception will be used.
 
 ## `fs.closeSync(fd)`
 <!-- YAML

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1622,8 +1622,8 @@ See also: chown(2).
 added: v0.0.2
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/00000
-    description: A default callback is now use if one is not provided.
+    pr-url: https://github.com/nodejs/node/pull/37174
+    description: A default callback is now used if one is not provided.
   - version: v10.0.0
     pr-url: https://github.com/nodejs/node/pull/12562
     description: The `callback` parameter is no longer optional. Not passing

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -438,7 +438,11 @@ function readFileSync(path, options) {
   return buffer;
 }
 
-function close(fd, callback) {
+function defaultCloseCallback(err) {
+  if (err != null) throw err;
+}
+
+function close(fd, callback = defaultCloseCallback) {
   validateInt32(fd, 'fd', 0);
   callback = makeCallback(callback);
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -444,7 +444,8 @@ function defaultCloseCallback(err) {
 
 function close(fd, callback = defaultCloseCallback) {
   validateInt32(fd, 'fd', 0);
-  callback = makeCallback(callback);
+  if (callback !== defaultCloseCallback)
+    callback = makeCallback(callback);
 
   const req = new FSReqCallback();
   req.oncomplete = callback;


### PR DESCRIPTION
The `fs.close()` function requires a callback. Most often the only thing
that callback does is check and rethrow the error if one occurs. To
eliminate common boilerplate, make the callback optional with a default
that checks and rethrows the error as an uncaught exception.

```js
fs.close(fd);

// is equivalent to

fs.close(fd, (err) => {
  if (err != null) throw err;
});
```

/cc @mcollina

Signed-off-by: James M Snell <jasnell@gmail.com>
