### PR TITLE
deps: upgrade npm to 7.5.1

### DIFF
--- a/deps/npm/AUTHORS
+++ b/deps/npm/AUTHORS
@@ -748,3 +748,5 @@ Jeff Griffiths <jeff@eko-recordings.ca>
 Michael Garvin <gar+gh@danger.computer>
 Gar <gar+gh@danger.computer>
 dr-js <dr@dr.run>
+Pavan Bellamkonda <31280326+pavanbellamkonda@users.noreply.github.com>
+Alexander Riccio <test35965@gmail.com>

--- a/deps/npm/CHANGELOG.md
+++ b/deps/npm/CHANGELOG.md
@@ -1,3 +1,45 @@
+## v7.5.1 (2021-02-01
+
+### BUG FIXES
+
+* [`0ea134e41`](https://github.com/npm/cli/commit/0ea134e4190f322138299c51672eab5387ec41bb)
+  [#2587](https://github.com/npm/cli/issues/2587)
+  pass all settings through to pacote.packument, fixes #2060
+  ([@nlf](https://github.com/nlf))
+* [`8c5ca2f51`](https://github.com/npm/cli/commit/8c5ca2f516f5ac87f3bbd7f1fd95c0b283a21f14)
+  Add test for npm-usage.js, and fix 'npm --long' output
+  ([@isaacs](https://github.com/isaacs))
+
+### DEPENDENCIES
+
+* [`7e4e88e93`](https://github.com/npm/cli/commit/7e4e88e938323e34a2a41176472d8e43e84bd4dd)
+  `@npmcli/arborist@2.1.1`, `pacote@11.2.4`
+  * Properly raise ERESOLVE errors on root dev dependencies
+  * Ignore ERESOLVE errors when performing git dep 'prepare' scripts
+  * Always reinstall packages that are explicitly requested
+  * fix global update all so it actually updates things
+  * Install bins properly when global root is a link
+  ([@isaacs](https://github.com/isaacs))
+
+### DOCUMENTATION
+
+* [`23dac2fef`](https://github.com/npm/cli/commit/23dac2feff1d02193791c7e39d9e93bc9bf8e624)
+  [#2557](https://github.com/npm/cli/issues/2557)
+  npm team revamp
+  ([@ruyadorno](https://github.com/ruyadorno))
+* [`dd05ba0c0`](https://github.com/npm/cli/commit/dd05ba0c0b2f4c70eb8558c0ecc54889efbe98f5)
+  [#2572](https://github.com/npm/cli/issues/2572)
+  add note about `--force` overriding peer dependencies
+  ([@isaacs](https://github.com/isaacs))
+* [`e27639780`](https://github.com/npm/cli/commit/e276397809aceb01cc468e02a83bc6f2265376d9)
+  [#2584](https://github.com/npm/cli/issues/2584)
+  Fixed the spelling of contributor as it was written as conributor
+  ([@pavanbellamkonda](https://github.com/pavanbellamkonda))
+* [`13a5e3178`](https://github.com/npm/cli/commit/13a5e31781cdaa37d3f007e1c8583c7cb591c62a)
+  [#2502](https://github.com/npm/cli/issues/2502)
+  elaborate that npm help uses browser
+  ([@ariccio](https://github.com/ariccio))
+
 ## v7.5.0 (2021-01-28)
 
 ### FEATURES

--- a/deps/npm/CONTRIBUTING.md
+++ b/deps/npm/CONTRIBUTING.md
@@ -29,7 +29,7 @@ $ cd ./npm && npm install
 $ npm run test
 ```
 
-**5. Open a [Pull Request](https://github.com/npm/cli/pulls) for your work & become the newest conributor to `npm`! 🎉**
+**5. Open a [Pull Request](https://github.com/npm/cli/pulls) for your work & become the newest contributor to `npm`! 🎉**
 
 ## Test Coverage
 

--- a/deps/npm/docs/content/commands/npm-team.md
+++ b/deps/npm/docs/content/commands/npm-team.md
@@ -14,8 +14,6 @@ npm team add <scope:team> <user>
 npm team rm <scope:team> <user>
 
 npm team ls <scope>|<scope:team>
-
-npm team edit <scope:team>
 ```
 
 ### Description
@@ -24,31 +22,76 @@ Used to manage teams in organizations, and change team memberships. Does not
 handle permissions for packages.
 
 Teams must always be fully qualified with the organization/scope they belong to
-when operating on them, separated by a colon (`:`). That is, if you have a `wombats` team in a `wisdom` organization, you must always refer to that team as `wisdom:wombats` in these commands.
+when operating on them, separated by a colon (`:`). That is, if you have a
+`newteam` team in an `org` organization, you must always refer to that team
+as `@org:newteam` in these commands.
 
-If you have two-factor authentication enabled in `auth-and-writes` mode, then you can provide a code from your authenticator with `[--otp <otpcode>]`. If you don't include this then you will be prompted.
+If you have two-factor authentication enabled in `auth-and-writes` mode, then
+you can provide a code from your authenticator with `[--otp <otpcode>]`.
+If you don't include this then you will be prompted.
 
 * create / destroy:
-  Create a new team, or destroy an existing one. Note: You cannot remove the `developers` team, <a href="https://docs.npmjs.com/about-developers-team" target="_blank">learn more.</a>
-* add / rm:
-  Add a user to an existing team, or remove a user from a team they belong to.
+  Create a new team, or destroy an existing one. Note: You cannot remove the
+  `developers` team, <a href="https://docs.npmjs.com/about-developers-team" target="_blank">learn more.</a>
+
+  Here's how to create a new team `newteam` under the `org` org:
+
+  ```bash
+  npm team create @org:newteam
+  ```
+
+  You should see a confirming message such as: `+@org:newteam` once the new
+  team has been created.
+
+* add:
+  Add a user to an existing team.
+
+  Adding a new user `username` to a team named `newteam` under the `org` org:
+
+  ```bash
+  npm team add @org:newteam username
+  ```
+
+  On success, you should see a message: `username added to @org:newteam`
+
+* rm:
+  Using `npm team rm` you can also remove users from a team they belong to.
+
+  Here's an example removing user `username` from `newteam` team
+  in `org` organization:
+
+  ```bash
+  npm team rm @org:newteam username
+  ```
+
+  Once the user is removed a confirmation message is displayed:
+  `username removed from @org:newteam`
 
 * ls:
   If performed on an organization name, will return a list of existing teams
   under that organization. If performed on a team, it will instead return a list
   of all users belonging to that particular team.
 
-* edit:
-  Edit a current team.
+  Here's an example of how to list all teams from an org named `org`:
+
+  ```bash
+  npm team ls @org
+  ```
+
+  Example listing all members of a team named `newteam`:
+
+  ```bash
+  npm team ls @org:newteam
+  ```
 
 ### Details
 
 `npm team` always operates directly on the current registry, configurable from
 the command line using `--registry=<registry url>`.
 
-In order to create teams and manage team membership, you must be a *team admin*
-under the given organization. Listing teams and team memberships may be done by
-any member of the organizations.
+You must be a *team admin* to create teams and manage team membership, under
+the given organization. Listing teams and team memberships may be done by
+any member of the organization.
 
 Organization creation and management of team admins and *organization* members
 is done through the website, not the npm CLI.
@@ -59,4 +102,5 @@ use the `npm access` command to grant or revoke the appropriate permissions.
 ### See Also
 
 * [npm access](/commands/npm-access)
+* [npm config](/commands/npm-config)
 * [npm registry](/using-npm/registry)

--- a/deps/npm/docs/content/using-npm/config.md
+++ b/deps/npm/docs/content/using-npm/config.md
@@ -472,6 +472,7 @@ mistakes, unnecessary performance degradation, and malicious input.
   range (including SemVer-major changes).
 * Allow a module to be installed as a direct dependency of itself.
 * Allow unpublishing all versions of a published package.
+* Allow conflicting peerDependencies to be installed in the root project.
 
 If you don't have a clear idea of what you want to do, it is strongly
 recommended that you do not use this option!

--- a/deps/npm/docs/output/commands/npm-ls.html
+++ b/deps/npm/docs/output/commands/npm-ls.html
@@ -159,7 +159,7 @@ tree at all, use <a href="../commands/npm-explain.html"><code>npm explain</code>
 the results to only the paths to the packages named.  Note that nested
 packages will <em>also</em> show the paths to the specified packages.  For
 example, running <code>npm ls promzard</code> in npm’s source tree will show:</p>
-<pre lang="bash"><code>npm@7.5.0 /path/to/npm
+<pre lang="bash"><code>npm@7.5.1 /path/to/npm
 └─┬ init-package-json@0.0.4
   └── promzard@0.1.5
 </code></pre>

--- a/deps/npm/docs/output/commands/npm-team.html
+++ b/deps/npm/docs/output/commands/npm-team.html
@@ -152,41 +152,65 @@ npm team add &lt;scope:team&gt; &lt;user&gt;
 npm team rm &lt;scope:team&gt; &lt;user&gt;
 
 npm team ls &lt;scope&gt;|&lt;scope:team&gt;
-
-npm team edit &lt;scope:team&gt;
 </code></pre>
 <h3 id="description">Description</h3>
 <p>Used to manage teams in organizations, and change team memberships. Does not
 handle permissions for packages.</p>
 <p>Teams must always be fully qualified with the organization/scope they belong to
-when operating on them, separated by a colon (<code>:</code>). That is, if you have a <code>wombats</code> team in a <code>wisdom</code> organization, you must always refer to that team as <code>wisdom:wombats</code> in these commands.</p>
-<p>If you have two-factor authentication enabled in <code>auth-and-writes</code> mode, then you can provide a code from your authenticator with <code>[--otp &lt;otpcode&gt;]</code>. If you don’t include this then you will be prompted.</p>
+when operating on them, separated by a colon (<code>:</code>). That is, if you have a
+<code>newteam</code> team in an <code>org</code> organization, you must always refer to that team
+as <code>@org:newteam</code> in these commands.</p>
+<p>If you have two-factor authentication enabled in <code>auth-and-writes</code> mode, then
+you can provide a code from your authenticator with <code>[--otp &lt;otpcode&gt;]</code>.
+If you don’t include this then you will be prompted.</p>
 <ul>
 <li>
 <p>create / destroy:
-Create a new team, or destroy an existing one. Note: You cannot remove the <code>developers</code> team, <!-- raw HTML omitted -->learn more.<!-- raw HTML omitted --></p>
+Create a new team, or destroy an existing one. Note: You cannot remove the
+<code>developers</code> team, <!-- raw HTML omitted -->learn more.<!-- raw HTML omitted --></p>
+<p>Here’s how to create a new team <code>newteam</code> under the <code>org</code> org:</p>
+<pre lang="bash"><code>npm team create @org:newteam
+</code></pre>
+<p>You should see a confirming message such as: <code>+@org:newteam</code> once the new
+team has been created.</p>
 </li>
 <li>
-<p>add / rm:
-Add a user to an existing team, or remove a user from a team they belong to.</p>
+<p>add:
+Add a user to an existing team.</p>
+<p>Adding a new user <code>username</code> to a team named <code>newteam</code> under the <code>org</code> org:</p>
+<pre lang="bash"><code>npm team add @org:newteam username
+</code></pre>
+<p>On success, you should see a message: <code>username added to @org:newteam</code></p>
+</li>
+<li>
+<p>rm:
+Using <code>npm team rm</code> you can also remove users from a team they belong to.</p>
+<p>Here’s an example removing user <code>username</code> from <code>newteam</code> team
+in <code>org</code> organization:</p>
+<pre lang="bash"><code>npm team rm @org:newteam username
+</code></pre>
+<p>Once the user is removed a confirmation message is displayed:
+<code>username removed from @org:newteam</code></p>
 </li>
 <li>
 <p>ls:
 If performed on an organization name, will return a list of existing teams
 under that organization. If performed on a team, it will instead return a list
 of all users belonging to that particular team.</p>
-</li>
-<li>
-<p>edit:
-Edit a current team.</p>
+<p>Here’s an example of how to list all teams from an org named <code>org</code>:</p>
+<pre lang="bash"><code>npm team ls @org
+</code></pre>
+<p>Example listing all members of a team named <code>newteam</code>:</p>
+<pre lang="bash"><code>npm team ls @org:newteam
+</code></pre>
 </li>
 </ul>
 <h3 id="details">Details</h3>
 <p><code>npm team</code> always operates directly on the current registry, configurable from
 the command line using <code>--registry=&lt;registry url&gt;</code>.</p>
-<p>In order to create teams and manage team membership, you must be a <em>team admin</em>
-under the given organization. Listing teams and team memberships may be done by
-any member of the organizations.</p>
+<p>You must be a <em>team admin</em> to create teams and manage team membership, under
+the given organization. Listing teams and team memberships may be done by
+any member of the organization.</p>
 <p>Organization creation and management of team admins and <em>organization</em> members
 is done through the website, not the npm CLI.</p>
 <p>To use teams to manage permissions on packages belonging to your organization,
@@ -194,6 +218,7 @@ use the <code>npm access</code> command to grant or revoke the appropriate permi
 <h3 id="see-also">See Also</h3>
 <ul>
 <li><a href="../commands/npm-access.html">npm access</a></li>
+<li><a href="../commands/npm-config.html">npm config</a></li>
 <li><a href="../using-npm/registry.html">npm registry</a></li>
 </ul>
 </div>

--- a/deps/npm/docs/output/commands/npm.html
+++ b/deps/npm/docs/output/commands/npm.html
@@ -148,7 +148,7 @@ npm command-line interface
 <pre lang="bash"><code>npm &lt;command&gt; [args]
 </code></pre>
 <h3 id="version">Version</h3>
-<p>7.5.0</p>
+<p>7.5.1</p>
 <h3 id="description">Description</h3>
 <p>npm is the package manager for the Node JavaScript platform.  It puts
 modules in place so that node can find them, and manages dependency

--- a/deps/npm/docs/output/using-npm/config.html
+++ b/deps/npm/docs/output/using-npm/config.html
@@ -534,6 +534,7 @@ different version of <code>node</code>, even if <code>--engines-strict</code> is
 range (including SemVer-major changes).</li>
 <li>Allow a module to be installed as a direct dependency of itself.</li>
 <li>Allow unpublishing all versions of a published package.</li>
+<li>Allow conflicting peerDependencies to be installed in the root project.</li>
 </ul>
 <p>If you don’t have a clear idea of what you want to do, it is strongly
 recommended that you do not use this option!</p>

--- a/deps/npm/lib/access.js
+++ b/deps/npm/lib/access.js
@@ -8,7 +8,6 @@ const output = require('./utils/output.js')
 const otplease = require('./utils/otplease.js')
 const usageUtil = require('./utils/usage.js')
 const getIdentity = require('./utils/get-identity.js')
-const { prefix } = npm
 
 const usage = usageUtil(
   'npm access',
@@ -165,7 +164,7 @@ const getPackage = async (name, requireScope) => {
     return name.trim()
   else {
     try {
-      const pkg = await readPackageJson(path.resolve(prefix, 'package.json'))
+      const pkg = await readPackageJson(path.resolve(npm.prefix, 'package.json'))
       name = pkg.name
     } catch (err) {
       if (err.code === 'ENOENT') {

--- a/deps/npm/lib/ci.js
+++ b/deps/npm/lib/ci.js
@@ -3,6 +3,8 @@ const Arborist = require('@npmcli/arborist')
 const rimraf = util.promisify(require('rimraf'))
 const reifyFinish = require('./utils/reify-finish.js')
 const runScript = require('@npmcli/run-script')
+const fs = require('fs')
+const readdir = util.promisify(fs.readdir)
 
 const log = require('npmlog')
 const npm = require('./npm.js')
@@ -12,6 +14,16 @@ const usage = usageUtil('ci', 'npm ci')
 const completion = require('./utils/completion/none.js')
 
 const cmd = (args, cb) => ci().then(() => cb()).catch(cb)
+
+const removeNodeModules = async where => {
+  const rimrafOpts = { glob: false }
+  process.emit('time', 'npm-ci:rm')
+  const path = `${where}/node_modules`
+  // get the list of entries so we can skip the glob for performance
+  const entries = await readdir(path, null).catch(er => [])
+  await Promise.all(entries.map(f => rimraf(`${path}/${f}`, rimrafOpts)))
+  process.emit('timeEnd', 'npm-ci:rm')
+}
 
 const ci = async () => {
   if (npm.flatOptions.global) {
@@ -33,7 +45,7 @@ const ci = async () => {
         'later to generate a package-lock.json file, then try again.'
       throw new Error(msg)
     }),
-    rimraf(`${where}/node_modules/*`, { glob: { dot: true, nosort: true, silent: true } }),
+    removeNodeModules(where),
   ])
   // npm ci should never modify the lockfile or package.json
   await arb.reify({ ...npm.flatOptions, save: false })

--- a/deps/npm/lib/help-search.js
+++ b/deps/npm/lib/help-search.js
@@ -135,12 +135,11 @@ const searchFiles = async (args, data, files) => {
 
   // coverage is ignored here because the contents of results are
   // nondeterministic due to either glob or readFiles or Object.entries
-  return results.sort((a, b) =>
+  return results.sort(/* istanbul ignore next */ (a, b) =>
     a.found.length > b.found.length ? -1
     : a.found.length < b.found.length ? 1
     : a.totalHits > b.totalHits ? -1
     : a.totalHits < b.totalHits ? 1
-    /* istanbul ignore next */
     : a.lines.length > b.lines.length ? -1
     : a.lines.length < b.lines.length ? 1
     : 0).slice(0, 10)

--- a/deps/npm/lib/outdated.js
+++ b/deps/npm/lib/outdated.js
@@ -108,6 +108,7 @@ async function outdated_ (tree, deps, opts) {
 
   async function getPackument (spec) {
     const packument = await pacote.packument(spec, {
+      ...npm.flatOptions,
       fullMetadata: npm.flatOptions.long,
       preferOnline: true,
     })

--- a/deps/npm/lib/utils/ansi-trim.js
+++ b/deps/npm/lib/utils/ansi-trim.js
@@ -1,7 +1,3 @@
-function ansiTrim (str) {
-  var r = new RegExp('\x1b(?:\\[(?:\\d+[ABCDEFGJKSTm]|\\d+;\\d+[Hfm]|' +
-        '\\d+;\\d+;\\d+m|6n|s|u|\\?25[lh])|\\w)', 'g')
-  return str.replace(r, '')
-}
-
-module.exports = ansiTrim
+const r = new RegExp('\x1b(?:\\[(?:\\d+[ABCDEFGJKSTm]|\\d+;\\d+[Hfm]|' +
+          '\\d+;\\d+;\\d+m|6n|s|u|\\?25[lh])|\\w)', 'g')
+module.exports = str => str.replace(r, '')

--- a/deps/npm/lib/utils/pulse-till-done.js
+++ b/deps/npm/lib/utils/pulse-till-done.js
@@ -1,4 +1,3 @@
-const validate = require('aproba')
 const log = require('npmlog')
 
 let pulsers = 0
@@ -18,7 +17,6 @@ function pulseStop () {
 }
 
 module.exports = function (prefix, cb) {
-  validate('SF', [prefix, cb])
   if (!prefix)
     prefix = 'network'
   pulseStart(prefix)

--- a/deps/npm/man/man1/npm-access.1
+++ b/deps/npm/man/man1/npm-access.1
@@ -1,4 +1,4 @@
-.TH "NPM\-ACCESS" "1" "January 2021" "" ""
+.TH "NPM\-ACCESS" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-access\fR \- Set access level on published packages
 .SS Synopsis

--- a/deps/npm/man/man1/npm-adduser.1
+++ b/deps/npm/man/man1/npm-adduser.1
@@ -1,4 +1,4 @@
-.TH "NPM\-ADDUSER" "1" "January 2021" "" ""
+.TH "NPM\-ADDUSER" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-adduser\fR \- Add a registry user account
 .SS Synopsis

--- a/deps/npm/man/man1/npm-audit.1
+++ b/deps/npm/man/man1/npm-audit.1
@@ -1,4 +1,4 @@
-.TH "NPM\-AUDIT" "1" "January 2021" "" ""
+.TH "NPM\-AUDIT" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-audit\fR \- Run a security audit
 .SS Synopsis

--- a/deps/npm/man/man1/npm-bin.1
+++ b/deps/npm/man/man1/npm-bin.1
@@ -1,4 +1,4 @@
-.TH "NPM\-BIN" "1" "January 2021" "" ""
+.TH "NPM\-BIN" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-bin\fR \- Display npm bin folder
 .SS Synopsis

--- a/deps/npm/man/man1/npm-bugs.1
+++ b/deps/npm/man/man1/npm-bugs.1
@@ -1,4 +1,4 @@
-.TH "NPM\-BUGS" "1" "January 2021" "" ""
+.TH "NPM\-BUGS" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-bugs\fR \- Report bugs for a package in a web browser
 .SS Synopsis

--- a/deps/npm/man/man1/npm-cache.1
+++ b/deps/npm/man/man1/npm-cache.1
@@ -1,4 +1,4 @@
-.TH "NPM\-CACHE" "1" "January 2021" "" ""
+.TH "NPM\-CACHE" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-cache\fR \- Manipulates packages cache
 .SS Synopsis

--- a/deps/npm/man/man1/npm-ci.1
+++ b/deps/npm/man/man1/npm-ci.1
@@ -1,4 +1,4 @@
-.TH "NPM\-CI" "1" "January 2021" "" ""
+.TH "NPM\-CI" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-ci\fR \- Install a project with a clean slate
 .SS Synopsis

--- a/deps/npm/man/man1/npm-completion.1
+++ b/deps/npm/man/man1/npm-completion.1
@@ -1,4 +1,4 @@
-.TH "NPM\-COMPLETION" "1" "January 2021" "" ""
+.TH "NPM\-COMPLETION" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-completion\fR \- Tab Completion for npm
 .SS Synopsis

--- a/deps/npm/man/man1/npm-config.1
+++ b/deps/npm/man/man1/npm-config.1
@@ -1,4 +1,4 @@
-.TH "NPM\-CONFIG" "1" "January 2021" "" ""
+.TH "NPM\-CONFIG" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-config\fR \- Manage the npm configuration files
 .SS Synopsis

--- a/deps/npm/man/man1/npm-dedupe.1
+++ b/deps/npm/man/man1/npm-dedupe.1
@@ -1,4 +1,4 @@
-.TH "NPM\-DEDUPE" "1" "January 2021" "" ""
+.TH "NPM\-DEDUPE" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-dedupe\fR \- Reduce duplication
 .SS Synopsis

--- a/deps/npm/man/man1/npm-deprecate.1
+++ b/deps/npm/man/man1/npm-deprecate.1
@@ -1,4 +1,4 @@
-.TH "NPM\-DEPRECATE" "1" "January 2021" "" ""
+.TH "NPM\-DEPRECATE" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-deprecate\fR \- Deprecate a version of a package
 .SS Synopsis

--- a/deps/npm/man/man1/npm-diff.1
+++ b/deps/npm/man/man1/npm-diff.1
@@ -1,4 +1,4 @@
-.TH "NPM\-DIFF" "1" "January 2021" "" ""
+.TH "NPM\-DIFF" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-diff\fR \- The registry diff command
 .SS Synopsis

--- a/deps/npm/man/man1/npm-dist-tag.1
+++ b/deps/npm/man/man1/npm-dist-tag.1
@@ -1,4 +1,4 @@
-.TH "NPM\-DIST\-TAG" "1" "January 2021" "" ""
+.TH "NPM\-DIST\-TAG" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-dist-tag\fR \- Modify package distribution tags
 .SS Synopsis

--- a/deps/npm/man/man1/npm-docs.1
+++ b/deps/npm/man/man1/npm-docs.1
@@ -1,4 +1,4 @@
-.TH "NPM\-DOCS" "1" "January 2021" "" ""
+.TH "NPM\-DOCS" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-docs\fR \- Open documentation for a package in a web browser
 .SS Synopsis

--- a/deps/npm/man/man1/npm-doctor.1
+++ b/deps/npm/man/man1/npm-doctor.1
@@ -1,4 +1,4 @@
-.TH "NPM\-DOCTOR" "1" "January 2021" "" ""
+.TH "NPM\-DOCTOR" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-doctor\fR \- Check your npm environment
 .SS Synopsis

--- a/deps/npm/man/man1/npm-edit.1
+++ b/deps/npm/man/man1/npm-edit.1
@@ -1,4 +1,4 @@
-.TH "NPM\-EDIT" "1" "January 2021" "" ""
+.TH "NPM\-EDIT" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-edit\fR \- Edit an installed package
 .SS Synopsis

--- a/deps/npm/man/man1/npm-exec.1
+++ b/deps/npm/man/man1/npm-exec.1
@@ -1,4 +1,4 @@
-.TH "NPM\-EXEC" "1" "January 2021" "" ""
+.TH "NPM\-EXEC" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-exec\fR \- Run a command from a local or remote npm package
 .SS Synopsis

--- a/deps/npm/man/man1/npm-explain.1
+++ b/deps/npm/man/man1/npm-explain.1
@@ -1,4 +1,4 @@
-.TH "NPM\-EXPLAIN" "1" "January 2021" "" ""
+.TH "NPM\-EXPLAIN" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-explain\fR \- Explain installed packages
 .SS Synopsis

--- a/deps/npm/man/man1/npm-explore.1
+++ b/deps/npm/man/man1/npm-explore.1
@@ -1,4 +1,4 @@
-.TH "NPM\-EXPLORE" "1" "January 2021" "" ""
+.TH "NPM\-EXPLORE" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-explore\fR \- Browse an installed package
 .SS Synopsis

--- a/deps/npm/man/man1/npm-fund.1
+++ b/deps/npm/man/man1/npm-fund.1
@@ -1,4 +1,4 @@
-.TH "NPM\-FUND" "1" "January 2021" "" ""
+.TH "NPM\-FUND" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-fund\fR \- Retrieve funding information
 .SS Synopsis

--- a/deps/npm/man/man1/npm-help-search.1
+++ b/deps/npm/man/man1/npm-help-search.1
@@ -1,4 +1,4 @@
-.TH "NPM\-HELP\-SEARCH" "1" "January 2021" "" ""
+.TH "NPM\-HELP\-SEARCH" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-help-search\fR \- Search npm help documentation
 .SS Synopsis

--- a/deps/npm/man/man1/npm-help.1
+++ b/deps/npm/man/man1/npm-help.1
@@ -1,4 +1,4 @@
-.TH "NPM\-HELP" "1" "January 2021" "" ""
+.TH "NPM\-HELP" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-help\fR \- Get help on npm
 .SS Synopsis

--- a/deps/npm/man/man1/npm-hook.1
+++ b/deps/npm/man/man1/npm-hook.1
@@ -1,4 +1,4 @@
-.TH "NPM\-HOOK" "1" "January 2021" "" ""
+.TH "NPM\-HOOK" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-hook\fR \- Manage registry hooks
 .SS Synopsis

--- a/deps/npm/man/man1/npm-init.1
+++ b/deps/npm/man/man1/npm-init.1
@@ -1,4 +1,4 @@
-.TH "NPM\-INIT" "1" "January 2021" "" ""
+.TH "NPM\-INIT" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-init\fR \- create a package\.json file
 .SS Synopsis

--- a/deps/npm/man/man1/npm-install-ci-test.1
+++ b/deps/npm/man/man1/npm-install-ci-test.1
@@ -1,4 +1,4 @@
-.TH "NPM\-INSTALL\-CI\-TEST" "1" "January 2021" "" ""
+.TH "NPM\-INSTALL\-CI\-TEST" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-install-ci-test\fR \- Install a project with a clean slate and run tests
 .SS Synopsis

--- a/deps/npm/man/man1/npm-install-test.1
+++ b/deps/npm/man/man1/npm-install-test.1
@@ -1,4 +1,4 @@
-.TH "NPM\-INSTALL\-TEST" "1" "January 2021" "" ""
+.TH "NPM\-INSTALL\-TEST" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-install-test\fR \- Install package(s) and run tests
 .SS Synopsis

--- a/deps/npm/man/man1/npm-install.1
+++ b/deps/npm/man/man1/npm-install.1
@@ -1,4 +1,4 @@
-.TH "NPM\-INSTALL" "1" "January 2021" "" ""
+.TH "NPM\-INSTALL" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-install\fR \- Install a package
 .SS Synopsis

--- a/deps/npm/man/man1/npm-link.1
+++ b/deps/npm/man/man1/npm-link.1
@@ -1,4 +1,4 @@
-.TH "NPM\-LINK" "1" "January 2021" "" ""
+.TH "NPM\-LINK" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-link\fR \- Symlink a package folder
 .SS Synopsis

--- a/deps/npm/man/man1/npm-logout.1
+++ b/deps/npm/man/man1/npm-logout.1
@@ -1,4 +1,4 @@
-.TH "NPM\-LOGOUT" "1" "January 2021" "" ""
+.TH "NPM\-LOGOUT" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-logout\fR \- Log out of the registry
 .SS Synopsis

--- a/deps/npm/man/man1/npm-ls.1
+++ b/deps/npm/man/man1/npm-ls.1
@@ -1,4 +1,4 @@
-.TH "NPM\-LS" "1" "January 2021" "" ""
+.TH "NPM\-LS" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-ls\fR \- List installed packages
 .SS Synopsis
@@ -26,7 +26,7 @@ example, running \fBnpm ls promzard\fP in npm's source tree will show:
 .P
 .RS 2
 .nf
-npm@7\.5\.0 /path/to/npm
+npm@7\.5\.1 /path/to/npm
 └─┬ init\-package\-json@0\.0\.4
   └── promzard@0\.1\.5
 .fi

--- a/deps/npm/man/man1/npm-org.1
+++ b/deps/npm/man/man1/npm-org.1
@@ -1,4 +1,4 @@
-.TH "NPM\-ORG" "1" "January 2021" "" ""
+.TH "NPM\-ORG" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-org\fR \- Manage orgs
 .SS Synopsis

--- a/deps/npm/man/man1/npm-outdated.1
+++ b/deps/npm/man/man1/npm-outdated.1
@@ -1,4 +1,4 @@
-.TH "NPM\-OUTDATED" "1" "January 2021" "" ""
+.TH "NPM\-OUTDATED" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-outdated\fR \- Check for outdated packages
 .SS Synopsis

--- a/deps/npm/man/man1/npm-owner.1
+++ b/deps/npm/man/man1/npm-owner.1
@@ -1,4 +1,4 @@
-.TH "NPM\-OWNER" "1" "January 2021" "" ""
+.TH "NPM\-OWNER" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-owner\fR \- Manage package owners
 .SS Synopsis

--- a/deps/npm/man/man1/npm-pack.1
+++ b/deps/npm/man/man1/npm-pack.1
@@ -1,4 +1,4 @@
-.TH "NPM\-PACK" "1" "January 2021" "" ""
+.TH "NPM\-PACK" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-pack\fR \- Create a tarball from a package
 .SS Synopsis

--- a/deps/npm/man/man1/npm-ping.1
+++ b/deps/npm/man/man1/npm-ping.1
@@ -1,4 +1,4 @@
-.TH "NPM\-PING" "1" "January 2021" "" ""
+.TH "NPM\-PING" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-ping\fR \- Ping npm registry
 .SS Synopsis

--- a/deps/npm/man/man1/npm-prefix.1
+++ b/deps/npm/man/man1/npm-prefix.1
@@ -1,4 +1,4 @@
-.TH "NPM\-PREFIX" "1" "January 2021" "" ""
+.TH "NPM\-PREFIX" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-prefix\fR \- Display prefix
 .SS Synopsis

--- a/deps/npm/man/man1/npm-profile.1
+++ b/deps/npm/man/man1/npm-profile.1
@@ -1,4 +1,4 @@
-.TH "NPM\-PROFILE" "1" "January 2021" "" ""
+.TH "NPM\-PROFILE" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-profile\fR \- Change settings on your registry profile
 .SS Synopsis

--- a/deps/npm/man/man1/npm-prune.1
+++ b/deps/npm/man/man1/npm-prune.1
@@ -1,4 +1,4 @@
-.TH "NPM\-PRUNE" "1" "January 2021" "" ""
+.TH "NPM\-PRUNE" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-prune\fR \- Remove extraneous packages
 .SS Synopsis

--- a/deps/npm/man/man1/npm-publish.1
+++ b/deps/npm/man/man1/npm-publish.1
@@ -1,4 +1,4 @@
-.TH "NPM\-PUBLISH" "1" "January 2021" "" ""
+.TH "NPM\-PUBLISH" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-publish\fR \- Publish a package
 .SS Synopsis

--- a/deps/npm/man/man1/npm-rebuild.1
+++ b/deps/npm/man/man1/npm-rebuild.1
@@ -1,4 +1,4 @@
-.TH "NPM\-REBUILD" "1" "January 2021" "" ""
+.TH "NPM\-REBUILD" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-rebuild\fR \- Rebuild a package
 .SS Synopsis

--- a/deps/npm/man/man1/npm-repo.1
+++ b/deps/npm/man/man1/npm-repo.1
@@ -1,4 +1,4 @@
-.TH "NPM\-REPO" "1" "January 2021" "" ""
+.TH "NPM\-REPO" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-repo\fR \- Open package repository page in the browser
 .SS Synopsis

--- a/deps/npm/man/man1/npm-restart.1
+++ b/deps/npm/man/man1/npm-restart.1
@@ -1,4 +1,4 @@
-.TH "NPM\-RESTART" "1" "January 2021" "" ""
+.TH "NPM\-RESTART" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-restart\fR \- Restart a package
 .SS Synopsis

--- a/deps/npm/man/man1/npm-root.1
+++ b/deps/npm/man/man1/npm-root.1
@@ -1,4 +1,4 @@
-.TH "NPM\-ROOT" "1" "January 2021" "" ""
+.TH "NPM\-ROOT" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-root\fR \- Display npm root
 .SS Synopsis

--- a/deps/npm/man/man1/npm-run-script.1
+++ b/deps/npm/man/man1/npm-run-script.1
@@ -1,4 +1,4 @@
-.TH "NPM\-RUN\-SCRIPT" "1" "January 2021" "" ""
+.TH "NPM\-RUN\-SCRIPT" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-run-script\fR \- Run arbitrary package scripts
 .SS Synopsis

--- a/deps/npm/man/man1/npm-search.1
+++ b/deps/npm/man/man1/npm-search.1
@@ -1,4 +1,4 @@
-.TH "NPM\-SEARCH" "1" "January 2021" "" ""
+.TH "NPM\-SEARCH" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-search\fR \- Search for packages
 .SS Synopsis

--- a/deps/npm/man/man1/npm-set-script.1
+++ b/deps/npm/man/man1/npm-set-script.1
@@ -1,4 +1,4 @@
-.TH "NPM\-SET\-SCRIPT" "1" "January 2021" "" ""
+.TH "NPM\-SET\-SCRIPT" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-set-script\fR \- Set tasks in the scripts section of package\.json
 .SS Synopsis

--- a/deps/npm/man/man1/npm-shrinkwrap.1
+++ b/deps/npm/man/man1/npm-shrinkwrap.1
@@ -1,4 +1,4 @@
-.TH "NPM\-SHRINKWRAP" "1" "January 2021" "" ""
+.TH "NPM\-SHRINKWRAP" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-shrinkwrap\fR \- Lock down dependency versions for publication
 .SS Synopsis

--- a/deps/npm/man/man1/npm-star.1
+++ b/deps/npm/man/man1/npm-star.1
@@ -1,4 +1,4 @@
-.TH "NPM\-STAR" "1" "January 2021" "" ""
+.TH "NPM\-STAR" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-star\fR \- Mark your favorite packages
 .SS Synopsis

--- a/deps/npm/man/man1/npm-stars.1
+++ b/deps/npm/man/man1/npm-stars.1
@@ -1,4 +1,4 @@
-.TH "NPM\-STARS" "1" "January 2021" "" ""
+.TH "NPM\-STARS" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-stars\fR \- View packages marked as favorites
 .SS Synopsis

--- a/deps/npm/man/man1/npm-start.1
+++ b/deps/npm/man/man1/npm-start.1
@@ -1,4 +1,4 @@
-.TH "NPM\-START" "1" "January 2021" "" ""
+.TH "NPM\-START" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-start\fR \- Start a package
 .SS Synopsis

--- a/deps/npm/man/man1/npm-stop.1
+++ b/deps/npm/man/man1/npm-stop.1
@@ -1,4 +1,4 @@
-.TH "NPM\-STOP" "1" "January 2021" "" ""
+.TH "NPM\-STOP" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-stop\fR \- Stop a package
 .SS Synopsis

--- a/deps/npm/man/man1/npm-team.1
+++ b/deps/npm/man/man1/npm-team.1
@@ -1,4 +1,4 @@
-.TH "NPM\-TEAM" "1" "January 2021" "" ""
+.TH "NPM\-TEAM" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-team\fR \- Manage organization teams and team memberships
 .SS Synopsis
@@ -12,8 +12,6 @@ npm team add <scope:team> <user>
 npm team rm <scope:team> <user>
 
 npm team ls <scope>|<scope:team>
-
-npm team edit <scope:team>
 .fi
 .RE
 .SS Description
@@ -22,24 +20,70 @@ Used to manage teams in organizations, and change team memberships\. Does not
 handle permissions for packages\.
 .P
 Teams must always be fully qualified with the organization/scope they belong to
-when operating on them, separated by a colon (\fB:\fP)\. That is, if you have a \fBwombats\fP team in a \fBwisdom\fP organization, you must always refer to that team as \fBwisdom:wombats\fP in these commands\.
+when operating on them, separated by a colon (\fB:\fP)\. That is, if you have a
+\fBnewteam\fP team in an \fBorg\fP organization, you must always refer to that team
+as \fB@org:newteam\fP in these commands\.
 .P
-If you have two\-factor authentication enabled in \fBauth\-and\-writes\fP mode, then you can provide a code from your authenticator with \fB[\-\-otp <otpcode>]\fP\|\. If you don't include this then you will be prompted\.
+If you have two\-factor authentication enabled in \fBauth\-and\-writes\fP mode, then
+you can provide a code from your authenticator with \fB[\-\-otp <otpcode>]\fP\|\.
+If you don't include this then you will be prompted\.
 .RS 0
 .IP \(bu 2
 create / destroy:
-Create a new team, or destroy an existing one\. Note: You cannot remove the \fBdevelopers\fP team, <a href="https://docs\.npmjs\.com/about\-developers\-team" target="_blank">learn more\.</a>
+Create a new team, or destroy an existing one\. Note: You cannot remove the
+\fBdevelopers\fP team, <a href="https://docs\.npmjs\.com/about\-developers\-team" target="_blank">learn more\.</a>
+Here's how to create a new team \fBnewteam\fP under the \fBorg\fP org:
+.P
+.RS 2
+.nf
+npm team create @org:newteam
+.fi
+.RE
+You should see a confirming message such as: \fB+@org:newteam\fP once the new
+team has been created\.
 .IP \(bu 2
-add / rm:
-Add a user to an existing team, or remove a user from a team they belong to\.
+add:
+Add a user to an existing team\.
+Adding a new user \fBusername\fP to a team named \fBnewteam\fP under the \fBorg\fP org:
+.P
+.RS 2
+.nf
+npm team add @org:newteam username
+.fi
+.RE
+On success, you should see a message: \fBusername added to @org:newteam\fP
+.IP \(bu 2
+rm:
+Using \fBnpm team rm\fP you can also remove users from a team they belong to\.
+Here's an example removing user \fBusername\fP from \fBnewteam\fP team
+in \fBorg\fP organization:
+.P
+.RS 2
+.nf
+npm team rm @org:newteam username
+.fi
+.RE
+Once the user is removed a confirmation message is displayed:
+\fBusername removed from @org:newteam\fP
 .IP \(bu 2
 ls:
 If performed on an organization name, will return a list of existing teams
 under that organization\. If performed on a team, it will instead return a list
 of all users belonging to that particular team\.
-.IP \(bu 2
-edit:
-Edit a current team\.
+Here's an example of how to list all teams from an org named \fBorg\fP:
+.P
+.RS 2
+.nf
+npm team ls @org
+.fi
+.RE
+Example listing all members of a team named \fBnewteam\fP:
+.P
+.RS 2
+.nf
+npm team ls @org:newteam
+.fi
+.RE
 
 .RE
 .SS Details
@@ -47,9 +91,9 @@ Edit a current team\.
 \fBnpm team\fP always operates directly on the current registry, configurable from
 the command line using \fB\-\-registry=<registry url>\fP\|\.
 .P
-In order to create teams and manage team membership, you must be a \fIteam admin\fR
-under the given organization\. Listing teams and team memberships may be done by
-any member of the organizations\.
+You must be a \fIteam admin\fR to create teams and manage team membership, under
+the given organization\. Listing teams and team memberships may be done by
+any member of the organization\.
 .P
 Organization creation and management of team admins and \fIorganization\fR members
 is done through the website, not the npm CLI\.
@@ -60,6 +104,8 @@ use the \fBnpm access\fP command to grant or revoke the appropriate permissions\
 .RS 0
 .IP \(bu 2
 npm help access
+.IP \(bu 2
+npm help config
 .IP \(bu 2
 npm help registry
 

--- a/deps/npm/man/man1/npm-test.1
+++ b/deps/npm/man/man1/npm-test.1
@@ -1,4 +1,4 @@
-.TH "NPM\-TEST" "1" "January 2021" "" ""
+.TH "NPM\-TEST" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-test\fR \- Test a package
 .SS Synopsis

--- a/deps/npm/man/man1/npm-token.1
+++ b/deps/npm/man/man1/npm-token.1
@@ -1,4 +1,4 @@
-.TH "NPM\-TOKEN" "1" "January 2021" "" ""
+.TH "NPM\-TOKEN" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-token\fR \- Manage your authentication tokens
 .SS Synopsis

--- a/deps/npm/man/man1/npm-uninstall.1
+++ b/deps/npm/man/man1/npm-uninstall.1
@@ -1,4 +1,4 @@
-.TH "NPM\-UNINSTALL" "1" "January 2021" "" ""
+.TH "NPM\-UNINSTALL" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-uninstall\fR \- Remove a package
 .SS Synopsis

--- a/deps/npm/man/man1/npm-unpublish.1
+++ b/deps/npm/man/man1/npm-unpublish.1
@@ -1,4 +1,4 @@
-.TH "NPM\-UNPUBLISH" "1" "January 2021" "" ""
+.TH "NPM\-UNPUBLISH" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-unpublish\fR \- Remove a package from the registry
 .SS Synopsis

--- a/deps/npm/man/man1/npm-unstar.1
+++ b/deps/npm/man/man1/npm-unstar.1
@@ -1,4 +1,4 @@
-.TH "NPM\-UNSTAR" "1" "January 2021" "" ""
+.TH "NPM\-UNSTAR" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-unstar\fR \- Remove an item from your favorite packages
 .SS Synopsis

--- a/deps/npm/man/man1/npm-update.1
+++ b/deps/npm/man/man1/npm-update.1
@@ -1,4 +1,4 @@
-.TH "NPM\-UPDATE" "1" "January 2021" "" ""
+.TH "NPM\-UPDATE" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-update\fR \- Update packages
 .SS Synopsis

--- a/deps/npm/man/man1/npm-version.1
+++ b/deps/npm/man/man1/npm-version.1
@@ -1,4 +1,4 @@
-.TH "NPM\-VERSION" "1" "January 2021" "" ""
+.TH "NPM\-VERSION" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-version\fR \- Bump a package version
 .SS Synopsis

--- a/deps/npm/man/man1/npm-view.1
+++ b/deps/npm/man/man1/npm-view.1
@@ -1,4 +1,4 @@
-.TH "NPM\-VIEW" "1" "January 2021" "" ""
+.TH "NPM\-VIEW" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-view\fR \- View registry info
 .SS Synopsis

--- a/deps/npm/man/man1/npm-whoami.1
+++ b/deps/npm/man/man1/npm-whoami.1
@@ -1,4 +1,4 @@
-.TH "NPM\-WHOAMI" "1" "January 2021" "" ""
+.TH "NPM\-WHOAMI" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-whoami\fR \- Display npm username
 .SS Synopsis

--- a/deps/npm/man/man1/npm.1
+++ b/deps/npm/man/man1/npm.1
@@ -1,4 +1,4 @@
-.TH "NPM" "1" "January 2021" "" ""
+.TH "NPM" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpm\fR \- javascript package manager
 .SS Synopsis
@@ -10,7 +10,7 @@ npm <command> [args]
 .RE
 .SS Version
 .P
-7\.5\.0
+7\.5\.1
 .SS Description
 .P
 npm is the package manager for the Node JavaScript platform\.  It puts

--- a/deps/npm/man/man1/npx.1
+++ b/deps/npm/man/man1/npx.1
@@ -1,4 +1,4 @@
-.TH "NPX" "1" "January 2021" "" ""
+.TH "NPX" "1" "February 2021" "" ""
 .SH "NAME"
 \fBnpx\fR \- Run a command from a local or remote npm package
 .SS Synopsis

--- a/deps/npm/man/man5/folders.5
+++ b/deps/npm/man/man5/folders.5
@@ -1,4 +1,4 @@
-.TH "FOLDERS" "5" "January 2021" "" ""
+.TH "FOLDERS" "5" "February 2021" "" ""
 .SH "NAME"
 \fBfolders\fR \- Folder Structures Used by npm
 .SS Description

--- a/deps/npm/man/man5/install.5
+++ b/deps/npm/man/man5/install.5
@@ -1,4 +1,4 @@
-.TH "INSTALL" "5" "January 2021" "" ""
+.TH "INSTALL" "5" "February 2021" "" ""
 .SH "NAME"
 \fBinstall\fR \- Download and install node and npm
 .SS Description

--- a/deps/npm/man/man5/npm-shrinkwrap-json.5
+++ b/deps/npm/man/man5/npm-shrinkwrap-json.5
@@ -1,4 +1,4 @@
-.TH "NPM\-SHRINKWRAP\.JSON" "5" "January 2021" "" ""
+.TH "NPM\-SHRINKWRAP\.JSON" "5" "February 2021" "" ""
 .SH "NAME"
 \fBnpm-shrinkwrap.json\fR \- A publishable lockfile
 .SS Description

--- a/deps/npm/man/man5/npmrc.5
+++ b/deps/npm/man/man5/npmrc.5
@@ -1,4 +1,4 @@
-.TH "NPMRC" "5" "January 2021" "" ""
+.TH "NPMRC" "5" "February 2021" "" ""
 .SH "NAME"
 \fBnpmrc\fR \- The npm config files
 .SS Description

--- a/deps/npm/man/man5/package-json.5
+++ b/deps/npm/man/man5/package-json.5
@@ -1,4 +1,4 @@
-.TH "PACKAGE\.JSON" "5" "January 2021" "" ""
+.TH "PACKAGE\.JSON" "5" "February 2021" "" ""
 .SH "NAME"
 \fBpackage.json\fR \- Specifics of npm's package\.json handling
 .SS Description

--- a/deps/npm/man/man5/package-lock-json.5
+++ b/deps/npm/man/man5/package-lock-json.5
@@ -1,4 +1,4 @@
-.TH "PACKAGE\-LOCK\.JSON" "5" "January 2021" "" ""
+.TH "PACKAGE\-LOCK\.JSON" "5" "February 2021" "" ""
 .SH "NAME"
 \fBpackage-lock.json\fR \- A manifestation of the manifest
 .SS Description

--- a/deps/npm/man/man7/config.7
+++ b/deps/npm/man/man7/config.7
@@ -1,4 +1,4 @@
-.TH "CONFIG" "7" "January 2021" "" ""
+.TH "CONFIG" "7" "February 2021" "" ""
 .SH "NAME"
 \fBconfig\fR \- More than you probably want to know about npm configuration
 .SS Description
@@ -634,6 +634,8 @@ range (including SemVer\-major changes)\.
 Allow a module to be installed as a direct dependency of itself\.
 .IP \(bu 2
 Allow unpublishing all versions of a published package\.
+.IP \(bu 2
+Allow conflicting peerDependencies to be installed in the root project\.
 
 .RE
 .P

--- a/deps/npm/man/man7/developers.7
+++ b/deps/npm/man/man7/developers.7
@@ -1,4 +1,4 @@
-.TH "DEVELOPERS" "7" "January 2021" "" ""
+.TH "DEVELOPERS" "7" "February 2021" "" ""
 .SH "NAME"
 \fBdevelopers\fR \- Developer Guide
 .SS Description

--- a/deps/npm/man/man7/orgs.7
+++ b/deps/npm/man/man7/orgs.7
@@ -1,4 +1,4 @@
-.TH "ORGS" "7" "January 2021" "" ""
+.TH "ORGS" "7" "February 2021" "" ""
 .SH "NAME"
 \fBorgs\fR \- Working with Teams & Orgs
 .SS Description

--- a/deps/npm/man/man7/registry.7
+++ b/deps/npm/man/man7/registry.7
@@ -1,4 +1,4 @@
-.TH "REGISTRY" "7" "January 2021" "" ""
+.TH "REGISTRY" "7" "February 2021" "" ""
 .SH "NAME"
 \fBregistry\fR \- The JavaScript Package Registry
 .SS Description

--- a/deps/npm/man/man7/removal.7
+++ b/deps/npm/man/man7/removal.7
@@ -1,4 +1,4 @@
-.TH "REMOVAL" "7" "January 2021" "" ""
+.TH "REMOVAL" "7" "February 2021" "" ""
 .SH "NAME"
 \fBremoval\fR \- Cleaning the Slate
 .SS Synopsis

--- a/deps/npm/man/man7/scope.7
+++ b/deps/npm/man/man7/scope.7
@@ -1,4 +1,4 @@
-.TH "SCOPE" "7" "January 2021" "" ""
+.TH "SCOPE" "7" "February 2021" "" ""
 .SH "NAME"
 \fBscope\fR \- Scoped packages
 .SS Description

--- a/deps/npm/man/man7/scripts.7
+++ b/deps/npm/man/man7/scripts.7
@@ -1,4 +1,4 @@
-.TH "SCRIPTS" "7" "January 2021" "" ""
+.TH "SCRIPTS" "7" "February 2021" "" ""
 .SH "NAME"
 \fBscripts\fR \- How npm handles the "scripts" field
 .SS Description

--- a/deps/npm/man/man7/workspaces.7
+++ b/deps/npm/man/man7/workspaces.7
@@ -1,4 +1,4 @@
-.TH "WORKSPACES" "7" "January 2021" "" ""
+.TH "WORKSPACES" "7" "February 2021" "" ""
 .SH "NAME"
 \fBworkspaces\fR \- Working with workspaces
 .SS Description

--- a/deps/npm/node_modules/@npmcli/arborist/lib/arborist/build-ideal-tree.js
+++ b/deps/npm/node_modules/@npmcli/arborist/lib/arborist/build-ideal-tree.js
@@ -416,7 +416,7 @@ module.exports = cls => class IdealTreeBuilder extends cls {
       await this[_add](options)
 
     // triggers a refresh of all edgesOut
-    if (options.add && options.add.length || options.rm && options.rm.length)
+    if (options.add && options.add.length || options.rm && options.rm.length || this[_global])
       tree.package = tree.package
     process.emit('timeEnd', 'idealTree:userRequests')
   }
@@ -1148,6 +1148,7 @@ This is a one-time fix-up, please be patient...
   [_placeDep] (dep, node, edge, peerEntryEdge = null, peerPath = []) {
     if (edge.to &&
         !edge.error &&
+        !this[_explicitRequests].has(edge.name) &&
         !this[_updateNames].includes(edge.name) &&
         !this[_isVulnerable](edge.to))
       return []

--- a/deps/npm/node_modules/@npmcli/arborist/lib/arborist/reify.js
+++ b/deps/npm/node_modules/@npmcli/arborist/lib/arborist/reify.js
@@ -233,7 +233,7 @@ module.exports = cls => class Reifier extends cls {
     const actualOpt = this[_global] ? {
       ignoreMissing: true,
       global: true,
-      filter: (node, kid) => !node.isRoot && node !== node.root.target
+      filter: (node, kid) => this[_explicitRequests].size === 0 || !node.isProjectRoot
         ? true
         : (node.edgesOut.has(kid) || this[_explicitRequests].has(kid)),
     } : { ignoreMissing: true }
@@ -605,7 +605,7 @@ module.exports = cls => class Reifier extends cls {
       tree: this.diff,
       visit: diff => {
         const node = diff.ideal
-        if (node && !node.isRoot && node.package.bundleDependencies &&
+        if (node && !node.isProjectRoot && node.package.bundleDependencies &&
             node.package.bundleDependencies.length) {
           maxBundleDepth = Math.max(maxBundleDepth, node.depth)
           if (!bundlesByDepth.has(node.depth))
@@ -811,7 +811,7 @@ module.exports = cls => class Reifier extends cls {
     dfwalk({
       tree: this.diff,
       leave: diff => {
-        if (!diff.ideal.isRoot)
+        if (!diff.ideal.isProjectRoot)
           nodes.push(diff.ideal)
       },
       // process adds before changes, ignore removals

--- a/deps/npm/node_modules/@npmcli/arborist/lib/node.js
+++ b/deps/npm/node_modules/@npmcli/arborist/lib/node.js
@@ -247,7 +247,7 @@ class Node {
 
   // true for packages installed directly in the global node_modules folder
   get globalTop () {
-    return this.global && this.parent.isRoot
+    return this.global && this.parent.isProjectRoot
   }
 
   get workspaces () {
@@ -294,8 +294,11 @@ class Node {
     const { name = '', version = '' } = this.package
     // root package will prefer package name over folder name,
     // and never be called an alias.
-    const myname = this.isRoot ? name || this.name : this.name
-    const alias = !this.isRoot && name && myname !== name ? `npm:${name}@` : ''
+    const { isProjectRoot } = this
+    const myname = isProjectRoot ? name || this.name
+      : this.name
+    const alias = !isProjectRoot && name && myname !== name ? `npm:${name}@`
+      : ''
     return `${myname}@${alias}${version}`
   }
 
@@ -339,14 +342,14 @@ class Node {
   }
 
   [_explain] (edge, seen) {
-    if (this.isRoot && !this.sourceReference) {
+    if (this.isProjectRoot && !this.sourceReference) {
       return {
         location: this.path,
       }
     }
 
     const why = {
-      name: this.isRoot ? this.package.name : this.name,
+      name: this.isProjectRoot ? this.package.name : this.name,
       version: this.package.version,
     }
     if (this.errors.length || !this.package.name || !this.package.version) {
@@ -384,7 +387,7 @@ class Node {
       // and are not keeping it held in this spot anyway.
       const edges = []
       for (const edge of this.edgesIn) {
-        if (!edge.valid && !edge.from.isRoot)
+        if (!edge.valid && !edge.from.isProjectRoot)
           continue
 
         edges.push(edge)
@@ -453,7 +456,7 @@ class Node {
   }
 
   get isWorkspace () {
-    if (this.isRoot)
+    if (this.isProjectRoot)
       return false
     const { root } = this
     const { type, to } = root.edgesOut.get(this.package.name) || {}
@@ -733,7 +736,9 @@ class Node {
     // Linked targets that are disconnected from the tree are tops,
     // but don't have a 'path' field, only a 'realpath', because we
     // don't know their canonical location. We don't need their devDeps.
-    if (this.isTop && this.path && !this.sourceReference)
+    const { isTop, path, sourceReference } = this
+    const { isTop: srcTop, path: srcPath } = sourceReference || {}
+    if (isTop && path && (!sourceReference || srcTop && srcPath))
       this[_loadDepType](this.package.devDependencies, 'dev')
 
     const pd = this.package.peerDependencies
@@ -902,8 +907,8 @@ class Node {
     if (this.isLink)
       return node.isLink && this.target.matches(node.target)
 
-    // if they're two root nodes, they're different if the paths differ
-    if (this.isRoot && node.isRoot)
+    // if they're two project root nodes, they're different if the paths differ
+    if (this.isProjectRoot && node.isProjectRoot)
       return this.path === node.path
 
     // if the integrity matches, then they're the same.

--- a/deps/npm/node_modules/@npmcli/arborist/package.json
+++ b/deps/npm/node_modules/@npmcli/arborist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@npmcli/arborist",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Manage node_modules trees",
   "dependencies": {
     "@npmcli/installed-package-contents": "^1.0.5",
@@ -20,7 +20,7 @@
     "npm-package-arg": "^8.1.0",
     "npm-pick-manifest": "^6.1.0",
     "npm-registry-fetch": "^9.0.0",
-    "pacote": "^11.2.3",
+    "pacote": "^11.2.4",
     "parse-conflict-json": "^1.1.1",
     "promise-all-reject-late": "^1.0.0",
     "promise-call-limit": "^1.0.1",
@@ -55,7 +55,7 @@
     "postversion": "npm publish",
     "prepublishOnly": "git push origin --follow-tags",
     "eslint": "eslint",
-    "lint": "npm run eslint -- \"lib/**/*.js\"",
+    "lint": "npm run eslint -- \"lib/**/*.js\" \"test/arborist/*.js\" \"test/*.js\"",
     "lintfix": "npm run lint -- --fix",
     "benchmark": "node scripts/benchmark.js",
     "benchclean": "rm -rf scripts/benchmark/*/"

--- a/deps/npm/node_modules/pacote/lib/fetcher.js
+++ b/deps/npm/node_modules/pacote/lib/fetcher.js
@@ -103,7 +103,7 @@ class FetcherBase {
     this.npmBin = opts.npmBin || 'npm'
 
     // command to install deps for preparing
-    this.npmInstallCmd = opts.npmInstallCmd || [ 'install' ]
+    this.npmInstallCmd = opts.npmInstallCmd || [ 'install', '--force' ]
 
     // XXX fill more of this in based on what we know from this.opts
     // we explicitly DO NOT fill in --tag, though, since we are often

--- a/deps/npm/node_modules/pacote/package.json
+++ b/deps/npm/node_modules/pacote/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pacote",
-  "version": "11.2.3",
+  "version": "11.2.4",
   "description": "JavaScript package downloader",
   "author": "Isaac Z. Schlueter <i@izs.me> (https://izs.me)",
   "bin": {

--- a/deps/npm/package.json
+++ b/deps/npm/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.5.0",
+  "version": "7.5.1",
   "name": "npm",
   "description": "a package manager for JavaScript",
   "keywords": [
@@ -42,14 +42,13 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@npmcli/arborist": "^2.1.0",
+    "@npmcli/arborist": "^2.1.1",
     "@npmcli/ci-detect": "^1.2.0",
     "@npmcli/config": "^1.2.8",
     "@npmcli/run-script": "^1.8.1",
     "abbrev": "~1.1.1",
     "ansicolors": "~0.3.2",
     "ansistyles": "~0.1.3",
-    "aproba": "^2.0.0",
     "archy": "~1.0.0",
     "byte-size": "^7.0.0",
     "cacache": "^15.0.5",
@@ -119,7 +118,6 @@
     "abbrev",
     "ansicolors",
     "ansistyles",
-    "aproba",
     "archy",
     "byte-size",
     "cacache",

--- a/deps/npm/tap-snapshots/test-lib-utils-npm-usage.js-TAP.test.js
+++ b/deps/npm/tap-snapshots/test-lib-utils-npm-usage.js-TAP.test.js
@@ -1,0 +1,495 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/lib/utils/npm-usage.js TAP basic usage > must match snapshot 1`] = `
+
+Usage: npm <command>
+
+npm install        install all the dependencies in your project
+npm install <foo>  add the <foo> dependency to your project
+npm test           run this project's tests
+npm run <foo>      run the script named <foo>
+npm <command> -h   quick help on <command>
+npm -l             display usage info for all commands
+npm help <term>    search for help on <term>
+npm help npm       more involved overview
+
+All commands:
+
+    access, adduser, audit, bin, bugs, cache, ci, completion,
+    config, dedupe, deprecate, diff, dist-tag, docs, doctor,
+    edit, exec, explain, explore, find-dupes, fund, get, help,
+    hook, init, install, install-ci-test, install-test, link,
+    ll, login, logout, ls, org, outdated, owner, pack, ping,
+    prefix, profile, prune, publish, rebuild, repo, restart,
+    root, run-script, search, set, set-script, shrinkwrap, star,
+    stars, start, stop, team, test, token, uninstall, unpublish,
+    unstar, update, version, view, whoami
+
+Specify configs in the ini-formatted file:
+    /some/config/file/.npmrc
+or on the command line via: npm <command> --key=value
+
+More configuration info: npm help config
+Configuration fields: npm help 7 config
+
+npm@{VERSION} {BASEDIR}
+
+`
+
+exports[`test/lib/utils/npm-usage.js TAP did you mean? > must match snapshot 1`] = `
+
+Usage: npm <command>
+
+npm install        install all the dependencies in your project
+npm install <foo>  add the <foo> dependency to your project
+npm test           run this project's tests
+npm run <foo>      run the script named <foo>
+npm <command> -h   quick help on <command>
+npm -l             display usage info for all commands
+npm help <term>    search for help on <term>
+npm help npm       more involved overview
+
+All commands:
+
+    access, adduser, audit, bin, bugs, cache, ci, completion,
+    config, dedupe, deprecate, diff, dist-tag, docs, doctor,
+    edit, exec, explain, explore, find-dupes, fund, get, help,
+    hook, init, install, install-ci-test, install-test, link,
+    ll, login, logout, ls, org, outdated, owner, pack, ping,
+    prefix, profile, prune, publish, rebuild, repo, restart,
+    root, run-script, search, set, set-script, shrinkwrap, star,
+    stars, start, stop, team, test, token, uninstall, unpublish,
+    unstar, update, version, view, whoami
+
+Specify configs in the ini-formatted file:
+    /some/config/file/.npmrc
+or on the command line via: npm <command> --key=value
+
+More configuration info: npm help config
+Configuration fields: npm help 7 config
+
+npm@{VERSION} {BASEDIR}
+
+`
+
+exports[`test/lib/utils/npm-usage.js TAP did you mean? > must match snapshot 2`] = `
+
+Did you mean one of these?
+    install
+    uninstall
+`
+
+exports[`test/lib/utils/npm-usage.js TAP set process.stdout.columns columns=0 > must match snapshot 1`] = `
+
+Usage: npm <command>
+
+npm install        install all the dependencies in your project
+npm install <foo>  add the <foo> dependency to your project
+npm test           run this project's tests
+npm run <foo>      run the script named <foo>
+npm <command> -h   quick help on <command>
+npm -l             display usage info for all commands
+npm help <term>    search for help on <term>
+npm help npm       more involved overview
+
+All commands:
+
+    access, adduser, audit, bin, bugs, cache, ci, completion,
+    config, dedupe, deprecate, diff, dist-tag, docs, doctor,
+    edit, exec, explain, explore, find-dupes, fund, get, help,
+    hook, init, install, install-ci-test, install-test, link,
+    ll, login, logout, ls, org, outdated, owner, pack, ping,
+    prefix, profile, prune, publish, rebuild, repo, restart,
+    root, run-script, search, set, set-script, shrinkwrap, star,
+    stars, start, stop, team, test, token, uninstall, unpublish,
+    unstar, update, version, view, whoami
+
+Specify configs in the ini-formatted file:
+    /some/config/file/.npmrc
+or on the command line via: npm <command> --key=value
+
+More configuration info: npm help config
+Configuration fields: npm help 7 config
+
+npm@{VERSION} {BASEDIR}
+
+`
+
+exports[`test/lib/utils/npm-usage.js TAP set process.stdout.columns columns=90 > must match snapshot 1`] = `
+
+Usage: npm <command>
+
+npm install        install all the dependencies in your project
+npm install <foo>  add the <foo> dependency to your project
+npm test           run this project's tests
+npm run <foo>      run the script named <foo>
+npm <command> -h   quick help on <command>
+npm -l             display usage info for all commands
+npm help <term>    search for help on <term>
+npm help npm       more involved overview
+
+All commands:
+
+    access, adduser, audit, bin, bugs, cache, ci, completion,
+    config, dedupe, deprecate, diff, dist-tag, docs, doctor,
+    edit, exec, explain, explore, find-dupes, fund, get, help,
+    hook, init, install, install-ci-test, install-test, link,
+    ll, login, logout, ls, org, outdated, owner, pack, ping,
+    prefix, profile, prune, publish, rebuild, repo, restart,
+    root, run-script, search, set, set-script, shrinkwrap, star,
+    stars, start, stop, team, test, token, uninstall, unpublish,
+    unstar, update, version, view, whoami
+
+Specify configs in the ini-formatted file:
+    /some/config/file/.npmrc
+or on the command line via: npm <command> --key=value
+
+More configuration info: npm help config
+Configuration fields: npm help 7 config
+
+npm@{VERSION} {BASEDIR}
+
+`
+
+exports[`test/lib/utils/npm-usage.js TAP with browser > must match snapshot 1`] = `
+
+Usage: npm <command>
+
+npm install        install all the dependencies in your project
+npm install <foo>  add the <foo> dependency to your project
+npm test           run this project's tests
+npm run <foo>      run the script named <foo>
+npm <command> -h   quick help on <command>
+npm -l             display usage info for all commands
+npm help <term>    search for help on <term> (in a browser)
+npm help npm       more involved overview (in a browser)
+
+All commands:
+
+    access, adduser, audit, bin, bugs, cache, ci, completion,
+    config, dedupe, deprecate, diff, dist-tag, docs, doctor,
+    edit, exec, explain, explore, find-dupes, fund, get, help,
+    hook, init, install, install-ci-test, install-test, link,
+    ll, login, logout, ls, org, outdated, owner, pack, ping,
+    prefix, profile, prune, publish, rebuild, repo, restart,
+    root, run-script, search, set, set-script, shrinkwrap, star,
+    stars, start, stop, team, test, token, uninstall, unpublish,
+    unstar, update, version, view, whoami
+
+Specify configs in the ini-formatted file:
+    /some/config/file/.npmrc
+or on the command line via: npm <command> --key=value
+
+More configuration info: npm help config
+Configuration fields: npm help 7 config
+
+npm@{VERSION} {BASEDIR}
+
+`
+
+exports[`test/lib/utils/npm-usage.js TAP with long > must match snapshot 1`] = `
+
+Usage: npm <command>
+
+npm install        install all the dependencies in your project
+npm install <foo>  add the <foo> dependency to your project
+npm test           run this project's tests
+npm run <foo>      run the script named <foo>
+npm <command> -h   quick help on <command>
+npm -l             display usage info for all commands
+npm help <term>    search for help on <term>
+npm help npm       more involved overview
+
+All commands:
+
+    access          npm access public [<package>]
+                    npm access restricted [<package>]
+                    npm access grant <read-only|read-write> <scope:team> [<package>]
+                    npm access revoke <scope:team> [<package>]
+                    npm access 2fa-required [<package>]
+                    npm access 2fa-not-required [<package>]
+                    npm access ls-packages [<user>|<scope>|<scope:team>]
+                    npm access ls-collaborators [<package> [<user>]]
+                    npm access edit [<package>]
+
+    adduser         npm adduser [--registry=url] [--scope=@orgname] [--always-auth]
+
+                    aliases: login, add-user
+
+    audit           npm audit [--json] [--production]
+                    npm audit fix [--force|--package-lock-only|--dry-run|--production|--only=(dev|prod)]
+
+    bin             npm bin [-g]
+
+    bugs            npm bugs [<pkgname>]
+
+                    alias: issues
+
+    cache           npm cache add <tarball file>
+                    npm cache add <folder>
+                    npm cache add <tarball url>
+                    npm cache add <git url>
+                    npm cache add <name>@<version>
+                    npm cache clean
+                    npm cache verify
+
+    ci              npm ci
+
+                    aliases: clean-install, ic, install-clean, isntall-clean
+
+    completion      source <(npm completion)
+
+    config          npm config set <key>=<value> [<key>=<value> ...]
+                    npm config get [<key> [<key> ...]]
+                    npm config delete <key> [<key> ...]
+                    npm config list [--json]
+                    npm config edit
+                    npm set <key>=<value> [<key>=<value> ...]
+                    npm get [<key> [<key> ...]]
+
+                    alias: c
+
+    dedupe          npm dedupe
+
+                    alias: ddp
+
+    deprecate       npm deprecate <pkg>[@<version>] <message>
+
+    diff            npm diff [...<paths>]
+                    npm diff --diff=<pkg-name> [...<paths>]
+                    npm diff --diff=<version-a> [--diff=<version-b>] [...<paths>]
+                    npm diff --diff=<spec-a> [--diff=<spec-b>] [...<paths>]
+                    npm diff [--diff-ignore-all-space] [--diff-name-only] [...<paths>] [...<paths>]
+
+    dist-tag        npm dist-tag add <pkg>@<version> [<tag>]
+                    npm dist-tag rm <pkg> <tag>
+                    npm dist-tag ls [<pkg>]
+
+                    alias: dist-tags
+
+    docs            npm docs [<pkgname> [<pkgname> ...]]
+
+                    alias: home
+
+    doctor          npm doctor
+
+    edit            npm edit <pkg>[/<subpkg>...]
+
+    exec            Run a command from a local or remote npm package.
+
+                    npm exec -- <pkg>[@<version>] [args...]
+                    npm exec --package=<pkg>[@<version>] -- <cmd> [args...]
+                    npm exec -c '<cmd> [args...]'
+                    npm exec --package=foo -c '<cmd> [args...]'
+
+                    npx <pkg>[@<specifier>] [args...]
+                    npx -p <pkg>[@<specifier>] <cmd> [args...]
+                    npx -c '<cmd> [args...]'
+                    npx -p <pkg>[@<specifier>] -c '<cmd> [args...]'
+                    Run without --call or positional args to open interactive subshell
+
+
+                    alias: x
+                    common options:
+                    --package=<pkg> (may be specified multiple times)
+                    -p is a shorthand for --package only when using npx executable
+                    -c <cmd> --call=<cmd> (may not be mixed with positional arguments)
+
+    explain         npm explain <folder | specifier>
+
+                    alias: why
+
+    explore         npm explore <pkg> [ -- <command>]
+
+    find-dupes      npm find-dupes
+
+    fund            npm fund
+
+                    common options: npm fund [--json] [--browser] [--unicode] [[<@scope>/]<pkg> [--which=<fundingSourceNumber>]
+
+    get             npm get [<key> ...] (See \`npm config\`)
+
+    help            npm help <term> [<terms..>]
+
+                    alias: hlep
+
+    hook            npm hook add <pkg> <url> <secret> [--type=<type>]
+                    npm hook ls [pkg]
+                    npm hook rm <id>
+                    npm hook update <id> <url> <secret>
+
+    init
+                    npm init [--force|-f|--yes|-y|--scope]
+                    npm init <@scope> (same as \`npx <@scope>/create\`)
+                    npm init [<@scope>/]<name> (same as \`npx [<@scope>/]create-<name>\`)
+
+                    aliases: create, innit
+
+    install         npm install (with no args, in package dir)
+                    npm install [<@scope>/]<pkg>
+                    npm install [<@scope>/]<pkg>@<tag>
+                    npm install [<@scope>/]<pkg>@<version>
+                    npm install [<@scope>/]<pkg>@<version range>
+                    npm install <alias>@npm:<name>
+                    npm install <folder>
+                    npm install <tarball file>
+                    npm install <tarball url>
+                    npm install <git:// url>
+                    npm install <github username>/<github project>
+
+                    aliases: i, in, ins, inst, insta, instal, isnt, isnta, isntal, add
+                    common options: [--save-prod|--save-dev|--save-optional|--save-peer] [--save-exact] [--no-save]
+
+    install-ci-test npm install-ci-test [args]
+                    Same args as \`npm ci\`
+
+                    alias: cit
+
+    install-test    npm install-test [args]
+                    Same args as \`npm install\`
+
+                    alias: it
+
+    link            npm link (in package dir)
+                    npm link [<@scope>/]<pkg>[@<version>]
+
+                    alias: ln
+
+    ll              npm ls [[<@scope>/]<pkg> ...]
+
+                    alias: list
+
+    login           npm adduser [--registry=url] [--scope=@orgname] [--always-auth]
+
+                    aliases: login, add-user
+
+    logout          npm logout [--registry=<url>] [--scope=<@scope>]
+
+    ls              npm ls [[<@scope>/]<pkg> ...]
+
+                    alias: list
+
+    org             npm org set orgname username [developer | admin | owner]
+                    npm org rm orgname username
+                    npm org ls orgname [<username>]
+
+    outdated        npm outdated [[<@scope>/]<pkg> ...]
+
+    owner           npm owner add <user> [<@scope>/]<pkg>
+                    npm owner rm <user> [<@scope>/]<pkg>
+                    npm owner ls [<@scope>/]<pkg>
+
+                    alias: author
+
+    pack            npm pack [[<@scope>/]<pkg>...] [--dry-run]
+
+    ping            npm ping
+                    ping registry
+
+    prefix          npm prefix [-g]
+
+    profile         npm profile disable-2fa
+
+
+                    common options: npm profile get [<key>]
+
+
+    prune           npm prune [[<@scope>/]<pkg>...] [--production]
+
+    publish         npm publish [<folder>] [--tag <tag>] [--access <public|restricted>] [--dry-run]
+
+                    Publishes '.' if no argument supplied
+                    Sets tag \`latest\` if no --tag specified
+
+    rebuild         npm rebuild [[<@scope>/]<name>[@<version>] ...]
+
+                    alias: rb
+
+    repo            npm repo [<pkgname> [<pkgname> ...]]
+
+    restart         npm restart [-- <args>]
+
+    root            npm root [-g]
+
+    run-script      npm run-script <command> [-- <args>]
+
+                    aliases: run, rum, urn
+
+    search          npm search [-l|--long] [--json] [--parseable] [--no-description] [search terms ...]
+
+                    aliases: s, se, find
+
+    set             npm set <key>=<value> [<key>=<value> ...] (See \`npm config\`)
+
+    set-script      npm set-script [<script>] [<command>]
+
+    shrinkwrap      npm shrinkwrap
+
+    star            npm star [<pkg>...]
+                    npm unstar [<pkg>...]
+
+    stars           npm stars [<user>]
+
+    start           npm start [-- <args>]
+
+    stop            npm stop [-- <args>]
+
+    team            npm team create <scope:team> [--otp <otpcode>]
+                    npm team destroy <scope:team> [--otp <otpcode>]
+                    npm team add <scope:team> <user> [--otp <otpcode>]
+                    npm team rm <scope:team> <user> [--otp <otpcode>]
+                    npm team ls <scope>|<scope:team>
+
+
+    test            npm test [-- <args>]
+
+                    aliases: tst, t
+
+    token           npm token list
+                    npm token revoke <id|token>
+                    npm token create [--read-only] [--cidr=list]
+
+    uninstall       npm uninstall [<@scope>/]<pkg>[@<version>]... [-S|--save|--no-save]
+
+                    aliases: un, unlink, remove, rm, r
+
+    unpublish       npm unpublish [<@scope>/]<pkg>[@<version>]
+
+    unstar          npm star [<pkg>...]
+                    npm unstar [<pkg>...]
+
+    update          npm update [-g] [<pkg>...]
+
+                    aliases: up, upgrade, udpate
+
+    version         npm version [<newversion> | major | minor | patch | premajor | preminor | prepatch | prerelease [--preid=<prerelease-id>] | from-git]
+                    (run in package dir)
+
+                    'npm -v' or 'npm --version' to print npm version ({VERSION})
+                    'npm view <pkg> version' to view a package's published version
+                    'npm ls' to inspect current package/dependency versions
+
+                    alias: verison
+
+    view            npm view [<@scope>/]<pkg>[@<version>] [<field>[.subfield]...]
+
+                    aliases: v, info, show
+
+    whoami          npm whoami [--registry <registry>]
+                    (just prints username according to given registry)
+
+Specify configs in the ini-formatted file:
+    /some/config/file/.npmrc
+or on the command line via: npm <command> --key=value
+
+More configuration info: npm help config
+Configuration fields: npm help 7 config
+
+npm@{VERSION} {BASEDIR}
+
+`

--- a/deps/npm/test/lib/ci.js
+++ b/deps/npm/test/lib/ci.js
@@ -51,9 +51,45 @@ test('should use Arborist and run-script', (t) => {
     'prepare',
     'postprepare',
   ]
+
+  // set to true when timer starts, false when it ends
+  // when the test is done, we assert that all timers ended
+  const timers = {}
+  const onTime = msg => {
+    if (timers[msg])
+      throw new Error(`saw duplicate timer: ${msg}`)
+    timers[msg] = true
+  }
+  const onTimeEnd = msg => {
+    if (!timers[msg])
+      throw new Error(`ended timer that was not started: ${msg}`)
+    timers[msg] = false
+  }
+  process.on('time', onTime)
+  process.on('timeEnd', onTimeEnd)
+  t.teardown(() => {
+    process.removeListener('time', onTime)
+    process.removeListener('timeEnd', onTimeEnd)
+  })
+
+  const path = t.testdir({
+    node_modules: {
+      foo: {
+        'package.json': JSON.stringify({
+          name: 'foo',
+          version: '1.2.3',
+        }),
+      },
+      '.dotdir': {},
+      '.dotfile': 'a file with a dot',
+    },
+  })
+  const expectRimrafs = 3
+  let actualRimrafs = 0
+
   const ci = requireInject('../../lib/ci.js', {
     '../../lib/npm.js': {
-      prefix: 'foo',
+      prefix: path,
       flatOptions: {
         global: false,
       },
@@ -72,13 +108,11 @@ test('should use Arborist and run-script', (t) => {
         t.ok(true, 'reify is called')
       }
     },
-    util: {
-      inherits: () => {},
-      promisify: (fn) => fn,
-    },
-    rimraf: (path) => {
+    rimraf: (path, ...args) => {
+      actualRimrafs++
       t.ok(path, 'rimraf called with path')
-      return Promise.resolve(true)
+      // callback is always last arg
+      args.pop()()
     },
     '../../lib/utils/reify-output.js': function (arb) {
       t.ok(arb, 'gets arborist tree')
@@ -87,6 +121,10 @@ test('should use Arborist and run-script', (t) => {
   ci(null, er => {
     if (er)
       throw er
+    for (const [msg, result] of Object.entries(timers))
+      t.notOk(result, `properly resolved ${msg} timer`)
+    t.match(timers, { 'npm-ci:rm': false }, 'saw the rimraf timer')
+    t.equal(actualRimrafs, expectRimrafs, 'removed the right number of things')
     t.strictSame(scripts, [], 'called all scripts')
     t.end()
   })

--- a/deps/npm/test/lib/utils/ansi-trim.js
+++ b/deps/npm/test/lib/utils/ansi-trim.js
@@ -1,0 +1,5 @@
+const t = require('tap')
+const ansiTrim = require('../../../lib/utils/ansi-trim.js')
+const chalk = require('chalk')
+t.equal(ansiTrim('foo'), 'foo', 'does nothing if no ansis')
+t.equal(ansiTrim(chalk.red('foo')), 'foo', 'strips out ansis')

--- a/deps/npm/test/lib/utils/npm-usage.js
+++ b/deps/npm/test/lib/utils/npm-usage.js
@@ -1,0 +1,127 @@
+const t = require('tap')
+
+const deref = require('../../../lib/utils/deref-command.js')
+const npm = {
+  argv: [],
+  deref,
+  config: {
+    _options: {
+      viewer: null,
+      long: false,
+      userconfig: '/some/config/file/.npmrc',
+    },
+    get: k => {
+      if (npm.config._options[k] === undefined)
+        throw new Error('unknown config')
+      return npm.config._options[k]
+    },
+    set: (k, v) => {
+      npm.config._options[k] = v
+    },
+  },
+  log: {},
+  version: '{VERSION}',
+}
+
+const OUTPUT = []
+const output = (...msg) => OUTPUT.push(msg)
+
+const { dirname } = require('path')
+const basedir = dirname(dirname(dirname(__dirname)))
+t.cleanSnapshot = str => str.split(basedir).join('{BASEDIR}')
+  .split(require('../../../package.json').version).join('{VERSION}')
+
+const requireInject = require('require-inject')
+const usage = requireInject('../../../lib/utils/npm-usage.js', {
+  '../../../lib/npm.js': npm,
+  '../../../lib/utils/output.js': output,
+})
+
+t.test('basic usage', t => {
+  usage()
+  t.equal(OUTPUT.length, 1)
+  t.equal(OUTPUT[0].length, 1)
+  t.matchSnapshot(OUTPUT[0][0])
+  OUTPUT.length = 0
+  t.end()
+})
+
+t.test('with browser', t => {
+  npm.config.set('viewer', 'browser')
+  usage()
+  t.equal(OUTPUT.length, 1)
+  t.equal(OUTPUT[0].length, 1)
+  t.matchSnapshot(OUTPUT[0][0])
+  OUTPUT.length = 0
+  npm.config.set('viewer', null)
+  t.end()
+})
+
+t.test('with long', t => {
+  npm.config.set('long', true)
+  usage()
+  t.equal(OUTPUT.length, 1)
+  t.equal(OUTPUT[0].length, 1)
+  t.matchSnapshot(OUTPUT[0][0])
+  OUTPUT.length = 0
+  npm.config.set('long', false)
+  t.end()
+})
+
+t.test('did you mean?', t => {
+  npm.argv.push('unistnall')
+  usage()
+  t.equal(OUTPUT.length, 2)
+  t.equal(OUTPUT[0].length, 1)
+  t.equal(OUTPUT[1].length, 1)
+  t.matchSnapshot(OUTPUT[0][0])
+  t.matchSnapshot(OUTPUT[1][0])
+  OUTPUT.length = 0
+  npm.argv.length = 0
+  t.end()
+})
+
+t.test('did you mean?', t => {
+  npm.argv.push('unistnall')
+  const { exitCode } = process
+  t.teardown(() => {
+    if (t.passing())
+      process.exitCode = exitCode
+  })
+  // make sure it fails when invalid
+  usage(false)
+  t.equal(process.exitCode, 1)
+  OUTPUT.length = 0
+  npm.argv.length = 0
+  t.end()
+})
+
+t.test('set process.stdout.columns', t => {
+  const { columns } = process.stdout
+  t.teardown(() => {
+    Object.defineProperty(process.stdout, 'columns', {
+      value: columns,
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    })
+  })
+  const cases = [0, 90]
+  for (const cols of cases) {
+    t.test(`columns=${cols}`, t => {
+      Object.defineProperty(process.stdout, 'columns', {
+        value: cols,
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      })
+      usage()
+      t.equal(OUTPUT.length, 1)
+      t.equal(OUTPUT[0].length, 1)
+      t.matchSnapshot(OUTPUT[0][0])
+      OUTPUT.length = 0
+      t.end()
+    })
+  }
+  t.end()
+})


### PR DESCRIPTION
## v7.5.1 (2021-02-01)

### BUG FIXES

* [`0ea134e41`](https://github.com/npm/cli/commit/0ea134e4190f322138299c51672eab5387ec41bb) [#2587](https://github.com/npm/cli/issues/2587) pass all settings through to pacote.packument, fixes #2060 ([@nlf](https://github.com/nlf))
* [`894fa0ac2`](https://github.com/npm/cli/commit/894fa0ac2237f0d50cdb52d15a3e74d7443bdd97) Add test for npm-usage.js, and fix 'npm --long' output ([@isaacs](https://github.com/isaacs))

### DEPENDENCIES

* [`7e4e88e93`](https://github.com/npm/cli/commit/7e4e88e938323e34a2a41176472d8e43e84bd4dd) `@npmcli/arborist@2.1.1`, `pacote@11.2.4`:
  * Properly raise ERESOLVE errors on root dev dependencies
  * Ignore ERESOLVE errors when performing git dep 'prepare' scripts
  * Always reinstall packages that are explicitly requested
  * fix global update all so it actually updates things
  * Install bins properly when global root is a link ([@isaacs](https://github.com/isaacs))

### DOCUMENTATION

* [`23dac2fef`](https://github.com/npm/cli/commit/23dac2feff1d02193791c7e39d9e93bc9bf8e624) [#2557](https://github.com/npm/cli/issues/2557) npm team revamp ([@ruyadorno](https://github.com/ruyadorno))
* [`dd05ba0c0`](https://github.com/npm/cli/commit/dd05ba0c0b2f4c70eb8558c0ecc54889efbe98f5) [#2572](https://github.com/npm/cli/issues/2572) add note about `--force` overriding peer dependencies ([@isaacs](https://github.com/isaacs))
* [`e27639780`](https://github.com/npm/cli/commit/e276397809aceb01cc468e02a83bc6f2265376d9) [#2584](https://github.com/npm/cli/issues/2584) Fixed the spelling of contributor as it was written as conributor ([@pavanbellamkonda](https://github.com/pavanbellamkonda))
* [`13a5e3178`](https://github.com/npm/cli/commit/13a5e31781cdaa37d3f007e1c8583c7cb591c62a) [#2502](https://github.com/npm/cli/issues/2502) elaborate that npm help uses browser ([@ariccio](https://github.com/ariccio))
