### PR TITLE
doc: fix color contrast on <kbd> elements

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -633,7 +633,7 @@ kbd {
   border-radius: 3px;
   border: 1px solid #b4b4b4;
   box-shadow: 0 1px 1px rgba(0, 0, 0, .2);
-  color: var(--color-text-primary);
+  color: #333;
   display: inline-block;
   font-size: .85em;
   font-weight: 700;


### PR DESCRIPTION
`<kbd>` elements are unreadable with dark mode on.

On master:
![image](https://user-images.githubusercontent.com/14309773/106599291-25774400-6559-11eb-8ef3-dce270b0988a.png)

With this PR:
![image](https://user-images.githubusercontent.com/14309773/106599324-30ca6f80-6559-11eb-83b2-8459137e3789.png)

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
