### PR TITLE
test: split heap snapshot limit tests

### DIFF
--- a/test/parallel/test-heapsnapshot-near-heap-limit-worker.js
+++ b/test/parallel/test-heapsnapshot-near-heap-limit-worker.js
@@ -1,0 +1,36 @@
+'use strict';
+
+require('../common');
+const tmpdir = require('../common/tmpdir');
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+const fixtures = require('../common/fixtures');
+const fs = require('fs');
+const env = {
+  ...process.env,
+  NODE_DEBUG_NATIVE: 'diagnostics'
+};
+
+{
+  tmpdir.refresh();
+  const child = spawnSync(process.execPath, [
+    fixtures.path('workload', 'grow-worker.js')
+  ], {
+    cwd: tmpdir.path,
+    env: {
+      TEST_SNAPSHOTS: 1,
+      TEST_OLD_SPACE_SIZE: 50,
+      ...env
+    }
+  });
+  console.log(child.stdout.toString());
+  const stderr = child.stderr.toString();
+  console.log(stderr);
+  // There should be one snapshot taken and then after the
+  // snapshot heap limit callback is popped, the OOM callback
+  // becomes effective.
+  assert(stderr.includes('ERR_WORKER_OUT_OF_MEMORY'));
+  const list = fs.readdirSync(tmpdir.path)
+    .filter((file) => file.endsWith('.heapsnapshot'));
+  assert.strictEqual(list.length, 1);
+}

--- a/test/parallel/test-heapsnapshot-near-heap-limit.js
+++ b/test/parallel/test-heapsnapshot-near-heap-limit.js
@@ -86,29 +86,3 @@ const env = {
     .filter((file) => file.endsWith('.heapsnapshot'));
   assert(list.length > 0 && list.length <= 3);
 }
-
-
-{
-  console.log('\nTesting worker');
-  tmpdir.refresh();
-  const child = spawnSync(process.execPath, [
-    fixtures.path('workload', 'grow-worker.js')
-  ], {
-    cwd: tmpdir.path,
-    env: {
-      TEST_SNAPSHOTS: 1,
-      TEST_OLD_SPACE_SIZE: 50,
-      ...env
-    }
-  });
-  console.log(child.stdout.toString());
-  const stderr = child.stderr.toString();
-  console.log(stderr);
-  // There should be one snapshot taken and then after the
-  // snapshot heap limit callback is popped, the OOM callback
-  // becomes effective.
-  assert(stderr.includes('ERR_WORKER_OUT_OF_MEMORY'));
-  const list = fs.readdirSync(tmpdir.path)
-    .filter((file) => file.endsWith('.heapsnapshot'));
-  assert.strictEqual(list.length, 1);
-}


### PR DESCRIPTION
test/parallel/test-heapsnapshot-near-heap-limit.js is timing out in CI
on low-memory and slow-CPU devices. Split off the worker test to its own
test file to allow the test to finish in time.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
