### PR TITLE
fs: add AbortSignal support to watch

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -4133,6 +4133,9 @@ this API: [`fs.utimes()`][].
 <!-- YAML
 added: v0.5.10
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/37190
+    description: Added support for closing the watcher with an AbortSignal.
   - version: v7.6.0
     pr-url: https://github.com/nodejs/node/pull/10739
     description: The `filename` parameter can be a WHATWG `URL` object using
@@ -4152,6 +4155,7 @@ changes:
     `false`.
   * `encoding` {string} Specifies the character encoding to be used for the
      filename passed to the listener. **Default:** `'utf8'`.
+  * `signal` {AbortSignal} allows closing the watcher with an AbortSignal.
 * `listener` {Function|undefined} **Default:** `undefined`
   * `eventType` {string}
   * `filename` {string|Buffer}
@@ -4173,6 +4177,9 @@ disappears in the directory.
 The listener callback is attached to the `'change'` event fired by
 [`fs.FSWatcher`][], but it is not the same thing as the `'change'` value of
 `eventType`.
+
+If a `signal` is passed, aborting the corresponding AbortController will close
+the returned [`fs.FSWatcher`][].
 
 ### Caveats
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1579,6 +1579,17 @@ function watch(filename, options, listener) {
   if (listener) {
     watcher.addListener('change', listener);
   }
+  if (options.signal) {
+    if (options.signal.aborted) {
+      process.nextTick(() => watcher.close());
+    } else {
+      const listener = () => watcher.close();
+      options.signal.addEventListener('abort', listener);
+      watcher.once('close', () => {
+        options.signal.removeEventListener('abort', listener);
+      });
+    }
+  }
 
   return watcher;
 }

--- a/test/parallel/test-fs-watch-abort-signal.js
+++ b/test/parallel/test-fs-watch-abort-signal.js
@@ -1,0 +1,32 @@
+// Flags: --expose-internals
+'use strict';
+
+// Verify that AbortSignal integration works for fs.watch
+
+const common = require('../common');
+
+if (common.isIBMi)
+  common.skip('IBMi does not support `fs.watch()`');
+
+const fs = require('fs');
+const fixtures = require('../common/fixtures');
+
+
+{
+  // Signal aborted after creating the watcher
+  const file = fixtures.path('empty.js');
+  const ac = new AbortController();
+  const { signal } = ac;
+  const watcher = fs.watch(file, { signal });
+  watcher.once('close', common.mustCall());
+  setImmediate(() => ac.abort());
+}
+{
+  // Signal aborted before creating the watcher
+  const file = fixtures.path('empty.js');
+  const ac = new AbortController();
+  const { signal } = ac;
+  ac.abort();
+  const watcher = fs.watch(file, { signal });
+  watcher.once('close', common.mustCall());
+}


### PR DESCRIPTION
Adds support for AbortSignal in fs.watch

Ref: https://github.com/nodejs/node/pull/37179

cc @nodejs/fs @jasnell 