### PR TITLE
deps: upgrade npm to 7.5.2

### DIFF
--- a/deps/npm/CHANGELOG.md
+++ b/deps/npm/CHANGELOG.md
@@ -1,3 +1,23 @@
+## v7.5.2 (2021-02-02
+
+### BUG FIXES
+
+* [`37613e4e6`](https://github.com/npm/cli/commit/37613e4e686e4891210acaabc9c23f41456eda3f)
+[#2395](https://github.com/npm/cli/issues/2395)
+[#2329](https://github.com/npm/cli/issues/2329)
+fix(exec): use latest version when possible
+([@wraithgar](https://github.com/wraithgar))
+* [`567c9bd03`](https://github.com/npm/cli/commit/567c9bd03a7669111fbba6eb6d1f12ed7cad5a1b)
+fix(lib/npm): do not clobber config.execPath
+([@wraithgar](https://github.com/wraithgar))
+
+### DEPENDENCIES
+
+* [`643709706`](https://github.com/npm/cli/commit/64370970653af5c8d7a2be2c2144e355aa6431b0)
+`@npmcli/config@1.2.9` ([@isaacs](https://github.com/isaacs))
+  * [`4c6be4a`](https://github.com/npm/config/commit/4c6be4a66a3e89ae607e08172b8543b588a95fb5) Restore npm v6 behavior with `INIT_CWD`
+  * [`bbebc66`](https://github.com/npm/config/commit/bbebc668888f71dba57959682364b6ff26ff4fac) Do not set the `PREFIX` environment variable
+
 ## v7.5.1 (2021-02-01
 
 ### BUG FIXES

--- a/deps/npm/docs/output/commands/npm-ls.html
+++ b/deps/npm/docs/output/commands/npm-ls.html
@@ -159,7 +159,7 @@ tree at all, use <a href="../commands/npm-explain.html"><code>npm explain</code>
 the results to only the paths to the packages named.  Note that nested
 packages will <em>also</em> show the paths to the specified packages.  For
 example, running <code>npm ls promzard</code> in npm’s source tree will show:</p>
-<pre lang="bash"><code>npm@7.5.1 /path/to/npm
+<pre lang="bash"><code>npm@7.5.2 /path/to/npm
 └─┬ init-package-json@0.0.4
   └── promzard@0.1.5
 </code></pre>

--- a/deps/npm/docs/output/commands/npm.html
+++ b/deps/npm/docs/output/commands/npm.html
@@ -148,7 +148,7 @@ npm command-line interface
 <pre lang="bash"><code>npm &lt;command&gt; [args]
 </code></pre>
 <h3 id="version">Version</h3>
-<p>7.5.1</p>
+<p>7.5.2</p>
 <h3 id="description">Description</h3>
 <p>npm is the package manager for the Node JavaScript platform.  It puts
 modules in place so that node can find them, and manages dependency

--- a/deps/npm/lib/npm.js
+++ b/deps/npm/lib/npm.js
@@ -173,8 +173,8 @@ const npm = module.exports = new class extends EventEmitter {
     if (node && node.toUpperCase() !== process.execPath.toUpperCase()) {
       log.verbose('node symlink', node)
       process.execPath = node
+      this.config.execPath = node
     }
-    this.config.execPath = node
 
     await this.config.load()
     this.argv = this.config.parsedArgv.remain

--- a/deps/npm/man/man1/npm-ls.1
+++ b/deps/npm/man/man1/npm-ls.1
@@ -26,7 +26,7 @@ example, running \fBnpm ls promzard\fP in npm's source tree will show:
 .P
 .RS 2
 .nf
-npm@7\.5\.1 /path/to/npm
+npm@7\.5\.2 /path/to/npm
 └─┬ init\-package\-json@0\.0\.4
   └── promzard@0\.1\.5
 .fi

--- a/deps/npm/man/man1/npm.1
+++ b/deps/npm/man/man1/npm.1
@@ -10,7 +10,7 @@ npm <command> [args]
 .RE
 .SS Version
 .P
-7\.5\.1
+7\.5\.2
 .SS Description
 .P
 npm is the package manager for the Node JavaScript platform\.  It puts

--- a/deps/npm/node_modules/@npmcli/config/lib/set-envs.js
+++ b/deps/npm/node_modules/@npmcli/config/lib/set-envs.js
@@ -53,13 +53,7 @@ const setEnvs = (config) => {
     list: [cliConf, envConf],
   } = config
 
-  const { DESTDIR } = env
-  if (platform !== 'win32' && DESTDIR && globalPrefix.indexOf(DESTDIR) === 0)
-    env.PREFIX = globalPrefix.substr(DESTDIR.length)
-  else
-    env.PREFIX = globalPrefix
-
-  env.INIT_CWD = env.INIT_CWD || process.cwd()
+  env.INIT_CWD = process.cwd()
 
   // if the key is the default value,
   //   if the environ is NOT the default value,

--- a/deps/npm/node_modules/@npmcli/config/package.json
+++ b/deps/npm/node_modules/@npmcli/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@npmcli/config",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "files": [
     "lib"
   ],

--- a/deps/npm/package.json
+++ b/deps/npm/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.5.1",
+  "version": "7.5.2",
   "name": "npm",
   "description": "a package manager for JavaScript",
   "keywords": [
@@ -44,7 +44,7 @@
   "dependencies": {
     "@npmcli/arborist": "^2.1.1",
     "@npmcli/ci-detect": "^1.2.0",
-    "@npmcli/config": "^1.2.8",
+    "@npmcli/config": "^1.2.9",
     "@npmcli/run-script": "^1.8.1",
     "abbrev": "~1.1.1",
     "ansicolors": "~0.3.2",


### PR DESCRIPTION
## v7.5.2 (2021-02-02)

### BUG FIXES

* [`37613e4e6`](https://github.com/npm/cli/commit/37613e4e686e4891210acaabc9c23f41456eda3f) [#2395](https://github.com/npm/cli/issues/2395) [#2329](https://github.com/npm/cli/issues/2329) fix(exec): use latest version when possible ([@wraithgar](https://github.com/wraithgar))
* [`567c9bd03`](https://github.com/npm/cli/commit/567c9bd03a7669111fbba6eb6d1f12ed7cad5a1b) fix(lib/npm): do not clobber config.execPath ([@wraithgar](https://github.com/wraithgar))

### DEPENDENCIES

* [`643709706`](https://github.com/npm/cli/commit/64370970653af5c8d7a2be2c2144e355aa6431b0) `@npmcli/config@1.2.9` ([@isaacs](https://github.com/isaacs))
  * [`4c6be4a`](https://github.com/npm/config/commit/4c6be4a66a3e89ae607e08172b8543b588a95fb5) Restore npm v6 behavior with `INIT_CWD`
  * [`bbebc66`](https://github.com/npm/config/commit/bbebc668888f71dba57959682364b6ff26ff4fac) Do not set the `PREFIX` environment variable