### PR TITLE
node-api: allow retrieval of add-on file name

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -5975,8 +5975,9 @@ node_api_get_module_file_name(napi_env env, const char** result);
 ```
 
 * `[in] env`: The environment that the API is invoked under.
-* `[out] result`: A null-terminated string containing the absolute path of the
-  location from which the add-on was loaded. The string is owned by `env` and
+* `[out] result`: A URL containing the absolute path of the
+  location from which the add-on was loaded. For a file on the local
+  file system it will start with `file://`. The string is owned by `env` and
   must not be modified or freed.
 
 `result` may be an empty string if the add-on loading process fails to establish

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -5976,8 +5976,8 @@ node_api_get_module_file_name(napi_env env, const char** result);
 
 * `[in] env`: The environment that the API is invoked under.
 * `[out] result`: A null-terminated string containing the absolute path of the
-  file from which the add-on was loaded. The string is owned by `env` and must
-  not be modified or freed.
+  location from which the add-on was loaded. The string is owned by `env` and
+  must not be modified or freed.
 
 `result` may be an empty string if the add-on loading process fails to establish
 the add-on's file name during loading.

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -5977,8 +5977,8 @@ node_api_get_module_file_name(napi_env env, const char** result);
 * `[in] env`: The environment that the API is invoked under.
 * `[out] result`: A URL containing the absolute path of the
   location from which the add-on was loaded. For a file on the local
-  file system it will start with `file://`. The string is owned by `env` and
-  must not be modified or freed.
+  file system it will start with `file://`. The string is null-terminated and
+  owned by `env` and must thus not be modified or freed.
 
 `result` may be an empty string if the add-on loading process fails to establish
 the add-on's file name during loading.

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -5958,6 +5958,30 @@ idempotent.
 
 This API may only be called from the main thread.
 
+## Miscellaneous utilities
+
+## node_api_get_module_file_name
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+```c
+NAPI_EXTERN napi_status
+node_api_get_module_file_name(napi_env env, const char** result);
+
+```
+
+* `[in] env`: The environment that the API is invoked under.
+* `[out] result`: A null-terminated string containing the absolute path of the
+  file from which the add-on was loaded. The string is owned by `env` and must
+  not be modified or freed.
+
+`result` may be an empty string if the add-on loading process fails to establish
+the add-on's file name during loading.
+
 [ABI Stability]: https://nodejs.org/en/docs/guides/abi-stability/
 [AppVeyor]: https://www.appveyor.com
 [C++ Addons]: addons.md

--- a/src/env.h
+++ b/src/env.h
@@ -253,6 +253,7 @@ constexpr size_t kFsStatsBufferLength =
   V(fd_string, "fd")                                                           \
   V(fields_string, "fields")                                                   \
   V(file_string, "file")                                                       \
+  V(filename_string, "filename")                                               \
   V(fingerprint256_string, "fingerprint256")                                   \
   V(fingerprint_string, "fingerprint")                                         \
   V(flags_string, "flags")                                                     \

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -15,8 +15,9 @@
 #include <memory>
 
 struct node_napi_env__ : public napi_env__ {
-  explicit node_napi_env__(v8::Local<v8::Context> context):
-      napi_env__(context) {
+  explicit node_napi_env__(v8::Local<v8::Context> context,
+                           const std::string& module_filename):
+      napi_env__(context), filename(module_filename) {
     CHECK_NOT_NULL(node_env());
   }
 
@@ -46,6 +47,10 @@ struct node_napi_env__ : public napi_env__ {
       });
     });
   }
+
+  const char* GetFilename() const { return filename.c_str(); }
+
+  std::string filename;
 };
 
 typedef node_napi_env__* node_napi_env;
@@ -87,10 +92,11 @@ class BufferFinalizer : private Finalizer {
   };
 };
 
-static inline napi_env NewEnv(v8::Local<v8::Context> context) {
+static inline napi_env
+NewEnv(v8::Local<v8::Context> context, const std::string& module_filename) {
   node_napi_env result;
 
-  result = new node_napi_env__(context);
+  result = new node_napi_env__(context, module_filename);
   // TODO(addaleax): There was previously code that tried to delete the
   // napi_env when its v8::Context was garbage collected;
   // However, as long as N-API addons using this napi_env are in place,
@@ -552,16 +558,30 @@ void napi_module_register_by_symbol(v8::Local<v8::Object> exports,
                                     v8::Local<v8::Value> module,
                                     v8::Local<v8::Context> context,
                                     napi_addon_register_func init) {
+  node::Environment* node_env = node::Environment::GetCurrent(context);
+  std::string module_filename = "";
   if (init == nullptr) {
-    node::Environment* node_env = node::Environment::GetCurrent(context);
     CHECK_NOT_NULL(node_env);
     node_env->ThrowError(
         "Module has no declared entry point.");
     return;
   }
 
+  // We set `env->filename` from `module.filename` here, but we could just as
+  // easily add a private property to `exports` in `process.dlopen`, which
+  // receives the file name from JS, and retrieve *that* here. Thus, we are not
+  // endorsing commonjs here by making use of `module.filename`.
+  v8::Local<v8::Value> filename_js;
+  v8::Local<v8::Object> modobj;
+  if (module->ToObject(context).ToLocal(&modobj) &&
+      modobj->Get(context, node_env->filename_string()).ToLocal(&filename_js) &&
+      filename_js->IsString()) {
+    node::Utf8Value filename(node_env->isolate(), filename_js);  // Cast
+    module_filename = *filename;
+  }
+
   // Create a new napi_env for this specific module.
-  napi_env env = v8impl::NewEnv(context);
+  napi_env env = v8impl::NewEnv(context, module_filename);
 
   napi_value _exports;
   env->CallIntoModule([&](napi_env env) {
@@ -1256,4 +1276,12 @@ napi_status
 napi_ref_threadsafe_function(napi_env env, napi_threadsafe_function func) {
   CHECK_NOT_NULL(func);
   return reinterpret_cast<v8impl::ThreadSafeFunction*>(func)->Ref();
+}
+
+napi_status node_api_get_module_file_name(napi_env env, const char** result) {
+  CHECK_ENV(env);
+  CHECK_ARG(env, result);
+
+  *result = static_cast<node_napi_env>(env)->GetFilename();
+  return napi_clear_last_error(env);
 }

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -577,7 +577,12 @@ void napi_module_register_by_symbol(v8::Local<v8::Object> exports,
       modobj->Get(context, node_env->filename_string()).ToLocal(&filename_js) &&
       filename_js->IsString()) {
     node::Utf8Value filename(node_env->isolate(), filename_js);  // Cast
-    module_filename = *filename;
+
+    // Turn the absolute path into a URL. Currently the absolute path is always
+    // a file system path.
+    // TODO(gabrielschulhof): Pass the `filename` through unchanged if/when we
+    // receive it as a URL already.
+    module_filename = std::string("file://") + (*filename);
   }
 
   // Create a new napi_env for this specific module.

--- a/src/node_api.h
+++ b/src/node_api.h
@@ -261,6 +261,9 @@ NAPI_EXTERN napi_status napi_add_async_cleanup_hook(
 NAPI_EXTERN napi_status napi_remove_async_cleanup_hook(
     napi_async_cleanup_hook_handle remove_handle);
 
+NAPI_EXTERN napi_status
+node_api_get_module_file_name(napi_env env, const char** result);
+
 #endif  // NAPI_EXPERIMENTAL
 
 EXTERN_C_END

--- a/test/node-api/test_general/test.js
+++ b/test/node-api/test_general/test.js
@@ -5,7 +5,9 @@ const filename = require.resolve(`./build/${common.buildType}/test_general`);
 const test_general = require(filename);
 const assert = require('assert');
 
-assert.strictEqual(test_general.filename, filename);
+// TODO(gabrielschulhof): This test may need updating if/when the filename
+// becomes a full-fledged URL.
+assert.strictEqual(test_general.filename, `file://${filename}`);
 
 const [ major, minor, patch, release ] = test_general.testGetNodeVersion();
 assert.strictEqual(process.version.split('-')[0],

--- a/test/node-api/test_general/test.js
+++ b/test/node-api/test_general/test.js
@@ -1,8 +1,11 @@
 'use strict';
 
 const common = require('../../common');
-const test_general = require(`./build/${common.buildType}/test_general`);
+const filename = require.resolve(`./build/${common.buildType}/test_general`);
+const test_general = require(filename);
 const assert = require('assert');
+
+assert.strictEqual(test_general.filename, filename);
 
 const [ major, minor, patch, release ] = test_general.testGetNodeVersion();
 assert.strictEqual(process.version.split('-')[0],

--- a/test/node-api/test_general/test_general.c
+++ b/test/node-api/test_general/test_general.c
@@ -1,3 +1,4 @@
+#define NAPI_EXPERIMENTAL
 #include <node_api.h>
 #include <stdlib.h>
 #include "../../js-native-api/common.h"
@@ -20,9 +21,21 @@ static napi_value testGetNodeVersion(napi_env env, napi_callback_info info) {
   return result;
 }
 
+static napi_value GetFilename(napi_env env, napi_callback_info info) {
+  const char* filename;
+  napi_value result;
+
+  NODE_API_CALL(env, node_api_get_module_file_name(env, &filename));
+  NODE_API_CALL(env,
+      napi_create_string_utf8(env, filename, NAPI_AUTO_LENGTH, &result));
+
+  return result;
+}
+
 static napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
     DECLARE_NODE_API_PROPERTY("testGetNodeVersion", testGetNodeVersion),
+    DECLARE_NODE_API_GETTER("filename", GetFilename),
   };
 
   NODE_API_CALL(env, napi_define_properties(


### PR DESCRIPTION
Unlike JS-only modules, native add-ons are always associated with a
dynamic shared object from which they are loaded. Being able to
retrieve its absolute path is important to native-only add-ons, i.e.
add-ons that are not themselves being loaded from a JS-only module
located in the same package as the native add-on itself.

Currently, the file name is obtained at environment construction time
from the JS `module.filename`. Nevertheless, the presence of `module`
is not required, because the file name could also be passed in via a
private property added onto `exports` from the `process.dlopen`
binding.

Fixes: https://github.com/nodejs/node-addon-api/issues/449

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
