### PR TITLE
doc: fix 404 links in module.md

### DIFF
--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -1,6 +1,9 @@
 # Modules: `module` API
 
-<!--introduced_in=v0.3.7-->
+<!--introduced_in=v12.20.0-->
+<!-- YAML
+added: v0.3.7
+-->
 
 ## The `Module` object
 


### PR DESCRIPTION
Currently the docs show links for all the available docs it has:

![image](https://user-images.githubusercontent.com/14309773/106742246-135ed980-661d-11eb-9700-89df44ebc180.png)

But the page is actually available only on v12 and v14+.
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
