### PR TITLE
test: rename n-api to node-api

### DIFF
--- a/test/js-native-api/2_function_arguments/binding.c
+++ b/test/js-native-api/2_function_arguments/binding.c
@@ -4,35 +4,35 @@
 static napi_value Add(napi_env env, napi_callback_info info) {
   size_t argc = 2;
   napi_value args[2];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  NAPI_ASSERT(env, argc >= 2, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc >= 2, "Wrong number of arguments");
 
   napi_valuetype valuetype0;
-  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
+  NODE_API_CALL(env, napi_typeof(env, args[0], &valuetype0));
 
   napi_valuetype valuetype1;
-  NAPI_CALL(env, napi_typeof(env, args[1], &valuetype1));
+  NODE_API_CALL(env, napi_typeof(env, args[1], &valuetype1));
 
-  NAPI_ASSERT(env, valuetype0 == napi_number && valuetype1 == napi_number,
+  NODE_API_ASSERT(env, valuetype0 == napi_number && valuetype1 == napi_number,
       "Wrong argument type. Numbers expected.");
 
   double value0;
-  NAPI_CALL(env, napi_get_value_double(env, args[0], &value0));
+  NODE_API_CALL(env, napi_get_value_double(env, args[0], &value0));
 
   double value1;
-  NAPI_CALL(env, napi_get_value_double(env, args[1], &value1));
+  NODE_API_CALL(env, napi_get_value_double(env, args[1], &value1));
 
   napi_value sum;
-  NAPI_CALL(env, napi_create_double(env, value0 + value1, &sum));
+  NODE_API_CALL(env, napi_create_double(env, value0 + value1, &sum));
 
   return sum;
 }
 
 EXTERN_C_START
 napi_value Init(napi_env env, napi_value exports) {
-  napi_property_descriptor desc = DECLARE_NAPI_PROPERTY("add", Add);
-  NAPI_CALL(env, napi_define_properties(env, exports, 1, &desc));
+  napi_property_descriptor desc = DECLARE_NODE_API_PROPERTY("add", Add);
+  NODE_API_CALL(env, napi_define_properties(env, exports, 1, &desc));
   return exports;
 }
 EXTERN_C_END

--- a/test/js-native-api/3_callbacks/binding.c
+++ b/test/js-native-api/3_callbacks/binding.c
@@ -5,31 +5,31 @@
 static napi_value RunCallback(napi_env env, napi_callback_info info) {
   size_t argc = 2;
   napi_value args[2];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  NAPI_ASSERT(env, argc == 1,
+  NODE_API_ASSERT(env, argc == 1,
       "Wrong number of arguments. Expects a single argument.");
 
   napi_valuetype valuetype0;
-  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
-  NAPI_ASSERT(env, valuetype0 == napi_function,
+  NODE_API_CALL(env, napi_typeof(env, args[0], &valuetype0));
+  NODE_API_ASSERT(env, valuetype0 == napi_function,
       "Wrong type of arguments. Expects a function as first argument.");
 
   napi_valuetype valuetype1;
-  NAPI_CALL(env, napi_typeof(env, args[1], &valuetype1));
-  NAPI_ASSERT(env, valuetype1 == napi_undefined,
+  NODE_API_CALL(env, napi_typeof(env, args[1], &valuetype1));
+  NODE_API_ASSERT(env, valuetype1 == napi_undefined,
       "Additional arguments should be undefined.");
 
   napi_value argv[1];
   const char* str = "hello world";
   size_t str_len = strlen(str);
-  NAPI_CALL(env, napi_create_string_utf8(env, str, str_len, argv));
+  NODE_API_CALL(env, napi_create_string_utf8(env, str, str_len, argv));
 
   napi_value global;
-  NAPI_CALL(env, napi_get_global(env, &global));
+  NODE_API_CALL(env, napi_get_global(env, &global));
 
   napi_value cb = args[0];
-  NAPI_CALL(env, napi_call_function(env, global, cb, 1, argv, NULL));
+  NODE_API_CALL(env, napi_call_function(env, global, cb, 1, argv, NULL));
 
   return NULL;
 }
@@ -37,21 +37,21 @@ static napi_value RunCallback(napi_env env, napi_callback_info info) {
 static napi_value RunCallbackWithRecv(napi_env env, napi_callback_info info) {
   size_t argc = 2;
   napi_value args[2];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
   napi_value cb = args[0];
   napi_value recv = args[1];
-  NAPI_CALL(env, napi_call_function(env, recv, cb, 0, NULL, NULL));
+  NODE_API_CALL(env, napi_call_function(env, recv, cb, 0, NULL, NULL));
   return NULL;
 }
 
 EXTERN_C_START
 napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor desc[2] = {
-    DECLARE_NAPI_PROPERTY("RunCallback", RunCallback),
-    DECLARE_NAPI_PROPERTY("RunCallbackWithRecv", RunCallbackWithRecv),
+    DECLARE_NODE_API_PROPERTY("RunCallback", RunCallback),
+    DECLARE_NODE_API_PROPERTY("RunCallbackWithRecv", RunCallbackWithRecv),
   };
-  NAPI_CALL(env, napi_define_properties(env, exports, 2, desc));
+  NODE_API_CALL(env, napi_define_properties(env, exports, 2, desc));
   return exports;
 }
 EXTERN_C_END

--- a/test/js-native-api/4_object_factory/binding.c
+++ b/test/js-native-api/4_object_factory/binding.c
@@ -4,19 +4,19 @@
 static napi_value CreateObject(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
   napi_value obj;
-  NAPI_CALL(env, napi_create_object(env, &obj));
+  NODE_API_CALL(env, napi_create_object(env, &obj));
 
-  NAPI_CALL(env, napi_set_named_property(env, obj, "msg", args[0]));
+  NODE_API_CALL(env, napi_set_named_property(env, obj, "msg", args[0]));
 
   return obj;
 }
 
 EXTERN_C_START
 napi_value Init(napi_env env, napi_value exports) {
-  NAPI_CALL(env,
+  NODE_API_CALL(env,
       napi_create_function(env, "exports", -1, CreateObject, NULL, &exports));
   return exports;
 }

--- a/test/js-native-api/5_function_factory/binding.c
+++ b/test/js-native-api/5_function_factory/binding.c
@@ -3,20 +3,20 @@
 
 static napi_value MyFunction(napi_env env, napi_callback_info info) {
   napi_value str;
-  NAPI_CALL(env, napi_create_string_utf8(env, "hello world", -1, &str));
+  NODE_API_CALL(env, napi_create_string_utf8(env, "hello world", -1, &str));
   return str;
 }
 
 static napi_value CreateFunction(napi_env env, napi_callback_info info) {
   napi_value fn;
-  NAPI_CALL(env,
+  NODE_API_CALL(env,
     napi_create_function(env, "theFunction", -1, MyFunction, NULL, &fn));
   return fn;
 }
 
 EXTERN_C_START
 napi_value Init(napi_env env, napi_value exports) {
-  NAPI_CALL(env,
+  NODE_API_CALL(env,
       napi_create_function(env, "exports", -1, CreateFunction, NULL, &exports));
   return exports;
 }

--- a/test/js-native-api/6_object_wrap/myobject.cc
+++ b/test/js-native-api/6_object_wrap/myobject.cc
@@ -19,52 +19,50 @@ void MyObject::Init(napi_env env, napi_value exports) {
     { "value", nullptr, nullptr, GetValue, SetValue, 0, napi_default, 0 },
     { "valueReadonly", nullptr, nullptr, GetValue, nullptr, 0, napi_default,
       0 },
-    DECLARE_NAPI_PROPERTY("plusOne", PlusOne),
-    DECLARE_NAPI_PROPERTY("multiply", Multiply),
+    DECLARE_NODE_API_PROPERTY("plusOne", PlusOne),
+    DECLARE_NODE_API_PROPERTY("multiply", Multiply),
   };
 
   napi_value cons;
-  NAPI_CALL_RETURN_VOID(env, napi_define_class(
+  NODE_API_CALL_RETURN_VOID(env, napi_define_class(
       env, "MyObject", -1, New, nullptr,
       sizeof(properties) / sizeof(napi_property_descriptor),
       properties, &cons));
 
-  NAPI_CALL_RETURN_VOID(env, napi_create_reference(env, cons, 1, &constructor));
+  NODE_API_CALL_RETURN_VOID(env,
+      napi_create_reference(env, cons, 1, &constructor));
 
-  NAPI_CALL_RETURN_VOID(env,
+  NODE_API_CALL_RETURN_VOID(env,
       napi_set_named_property(env, exports, "MyObject", cons));
 }
 
 napi_value MyObject::New(napi_env env, napi_callback_info info) {
   napi_value new_target;
-  NAPI_CALL(env, napi_get_new_target(env, info, &new_target));
+  NODE_API_CALL(env, napi_get_new_target(env, info, &new_target));
   bool is_constructor = (new_target != nullptr);
 
   size_t argc = 1;
   napi_value args[1];
   napi_value _this;
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, &_this, nullptr));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, &_this, nullptr));
 
   if (is_constructor) {
     // Invoked as constructor: `new MyObject(...)`
     double value = 0;
 
     napi_valuetype valuetype;
-    NAPI_CALL(env, napi_typeof(env, args[0], &valuetype));
+    NODE_API_CALL(env, napi_typeof(env, args[0], &valuetype));
 
     if (valuetype != napi_undefined) {
-      NAPI_CALL(env, napi_get_value_double(env, args[0], &value));
+      NODE_API_CALL(env, napi_get_value_double(env, args[0], &value));
     }
 
     MyObject* obj = new MyObject(value);
 
     obj->env_ = env;
-    NAPI_CALL(env, napi_wrap(env,
-                             _this,
-                             obj,
-                             MyObject::Destructor,
-                             nullptr,  // finalize_hint
-                             &obj->wrapper_));
+    NODE_API_CALL(env,
+        napi_wrap(env, _this, obj, MyObject::Destructor,
+            nullptr /* finalize_hint */, &obj->wrapper_));
 
     return _this;
   }
@@ -74,24 +72,24 @@ napi_value MyObject::New(napi_env env, napi_callback_info info) {
   napi_value argv[1] = {args[0]};
 
   napi_value cons;
-  NAPI_CALL(env, napi_get_reference_value(env, constructor, &cons));
+  NODE_API_CALL(env, napi_get_reference_value(env, constructor, &cons));
 
   napi_value instance;
-  NAPI_CALL(env, napi_new_instance(env, cons, argc, argv, &instance));
+  NODE_API_CALL(env, napi_new_instance(env, cons, argc, argv, &instance));
 
   return instance;
 }
 
 napi_value MyObject::GetValue(napi_env env, napi_callback_info info) {
   napi_value _this;
-  NAPI_CALL(env,
+  NODE_API_CALL(env,
       napi_get_cb_info(env, info, nullptr, nullptr, &_this, nullptr));
 
   MyObject* obj;
-  NAPI_CALL(env, napi_unwrap(env, _this, reinterpret_cast<void**>(&obj)));
+  NODE_API_CALL(env, napi_unwrap(env, _this, reinterpret_cast<void**>(&obj)));
 
   napi_value num;
-  NAPI_CALL(env, napi_create_double(env, obj->value_, &num));
+  NODE_API_CALL(env, napi_create_double(env, obj->value_, &num));
 
   return num;
 }
@@ -100,28 +98,28 @@ napi_value MyObject::SetValue(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
   napi_value _this;
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, &_this, nullptr));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, &_this, nullptr));
 
   MyObject* obj;
-  NAPI_CALL(env, napi_unwrap(env, _this, reinterpret_cast<void**>(&obj)));
+  NODE_API_CALL(env, napi_unwrap(env, _this, reinterpret_cast<void**>(&obj)));
 
-  NAPI_CALL(env, napi_get_value_double(env, args[0], &obj->value_));
+  NODE_API_CALL(env, napi_get_value_double(env, args[0], &obj->value_));
 
   return nullptr;
 }
 
 napi_value MyObject::PlusOne(napi_env env, napi_callback_info info) {
   napi_value _this;
-  NAPI_CALL(env,
+  NODE_API_CALL(env,
       napi_get_cb_info(env, info, nullptr, nullptr, &_this, nullptr));
 
   MyObject* obj;
-  NAPI_CALL(env, napi_unwrap(env, _this, reinterpret_cast<void**>(&obj)));
+  NODE_API_CALL(env, napi_unwrap(env, _this, reinterpret_cast<void**>(&obj)));
 
   obj->value_ += 1;
 
   napi_value num;
-  NAPI_CALL(env, napi_create_double(env, obj->value_, &num));
+  NODE_API_CALL(env, napi_create_double(env, obj->value_, &num));
 
   return num;
 }
@@ -130,25 +128,25 @@ napi_value MyObject::Multiply(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
   napi_value _this;
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, &_this, nullptr));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, &_this, nullptr));
 
   double multiple = 1;
   if (argc >= 1) {
-    NAPI_CALL(env, napi_get_value_double(env, args[0], &multiple));
+    NODE_API_CALL(env, napi_get_value_double(env, args[0], &multiple));
   }
 
   MyObject* obj;
-  NAPI_CALL(env, napi_unwrap(env, _this, reinterpret_cast<void**>(&obj)));
+  NODE_API_CALL(env, napi_unwrap(env, _this, reinterpret_cast<void**>(&obj)));
 
   napi_value cons;
-  NAPI_CALL(env, napi_get_reference_value(env, constructor, &cons));
+  NODE_API_CALL(env, napi_get_reference_value(env, constructor, &cons));
 
   const int kArgCount = 1;
   napi_value argv[kArgCount];
-  NAPI_CALL(env, napi_create_double(env, obj->value_ * multiple, argv));
+  NODE_API_CALL(env, napi_create_double(env, obj->value_ * multiple, argv));
 
   napi_value instance;
-  NAPI_CALL(env, napi_new_instance(env, cons, kArgCount, argv, &instance));
+  NODE_API_CALL(env, napi_new_instance(env, cons, kArgCount, argv, &instance));
 
   return instance;
 }

--- a/test/js-native-api/7_factory_wrap/binding.cc
+++ b/test/js-native-api/7_factory_wrap/binding.cc
@@ -5,24 +5,25 @@
 napi_value CreateObject(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, nullptr, nullptr));
+  NODE_API_CALL(env,
+      napi_get_cb_info(env, info, &argc, args, nullptr, nullptr));
 
   napi_value instance;
-  NAPI_CALL(env, MyObject::NewInstance(env, args[0], &instance));
+  NODE_API_CALL(env, MyObject::NewInstance(env, args[0], &instance));
 
   return instance;
 }
 
 EXTERN_C_START
 napi_value Init(napi_env env, napi_value exports) {
-  NAPI_CALL(env, MyObject::Init(env));
+  NODE_API_CALL(env, MyObject::Init(env));
 
   napi_property_descriptor descriptors[] = {
-    DECLARE_NAPI_GETTER("finalizeCount", MyObject::GetFinalizeCount),
-    DECLARE_NAPI_PROPERTY("createObject", CreateObject),
+    DECLARE_NODE_API_GETTER("finalizeCount", MyObject::GetFinalizeCount),
+    DECLARE_NODE_API_PROPERTY("createObject", CreateObject),
   };
 
-  NAPI_CALL(env, napi_define_properties(
+  NODE_API_CALL(env, napi_define_properties(
       env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
 
   return exports;

--- a/test/js-native-api/7_factory_wrap/myobject.cc
+++ b/test/js-native-api/7_factory_wrap/myobject.cc
@@ -17,7 +17,7 @@ void MyObject::Destructor(napi_env env,
 
 napi_value MyObject::GetFinalizeCount(napi_env env, napi_callback_info info) {
   napi_value result;
-  NAPI_CALL(env, napi_create_int32(env, finalize_count, &result));
+  NODE_API_CALL(env, napi_create_int32(env, finalize_count, &result));
   return result;
 }
 
@@ -26,7 +26,7 @@ napi_ref MyObject::constructor;
 napi_status MyObject::Init(napi_env env) {
   napi_status status;
   napi_property_descriptor properties[] = {
-    DECLARE_NAPI_PROPERTY("plusOne", PlusOne),
+    DECLARE_NODE_API_PROPERTY("plusOne", PlusOne),
   };
 
   napi_value cons;
@@ -44,26 +44,24 @@ napi_value MyObject::New(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
   napi_value _this;
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, &_this, nullptr));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, &_this, nullptr));
 
   napi_valuetype valuetype;
-  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype));
+  NODE_API_CALL(env, napi_typeof(env, args[0], &valuetype));
 
   MyObject* obj = new MyObject();
 
   if (valuetype == napi_undefined) {
     obj->counter_ = 0;
   } else {
-    NAPI_CALL(env, napi_get_value_uint32(env, args[0], &obj->counter_));
+    NODE_API_CALL(env, napi_get_value_uint32(env, args[0], &obj->counter_));
   }
 
   obj->env_ = env;
-  NAPI_CALL(env, napi_wrap(env,
-                           _this,
-                           obj,
-                           MyObject::Destructor,
-                           nullptr, /* finalize_hint */
-                           &obj->wrapper_));
+  NODE_API_CALL(env,
+      napi_wrap(
+          env, _this, obj, MyObject::Destructor, nullptr /* finalize_hint */,
+          &obj->wrapper_));
 
   return _this;
 }
@@ -88,16 +86,16 @@ napi_status MyObject::NewInstance(napi_env env,
 
 napi_value MyObject::PlusOne(napi_env env, napi_callback_info info) {
   napi_value _this;
-  NAPI_CALL(env,
+  NODE_API_CALL(env,
       napi_get_cb_info(env, info, nullptr, nullptr, &_this, nullptr));
 
   MyObject* obj;
-  NAPI_CALL(env, napi_unwrap(env, _this, reinterpret_cast<void**>(&obj)));
+  NODE_API_CALL(env, napi_unwrap(env, _this, reinterpret_cast<void**>(&obj)));
 
   obj->counter_ += 1;
 
   napi_value num;
-  NAPI_CALL(env, napi_create_uint32(env, obj->counter_, &num));
+  NODE_API_CALL(env, napi_create_uint32(env, obj->counter_, &num));
 
   return num;
 }

--- a/test/js-native-api/8_passing_wrapped/binding.cc
+++ b/test/js-native-api/8_passing_wrapped/binding.cc
@@ -7,10 +7,11 @@ extern size_t finalize_count;
 static napi_value CreateObject(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, nullptr, nullptr));
+  NODE_API_CALL(env,
+      napi_get_cb_info(env, info, &argc, args, nullptr, nullptr));
 
   napi_value instance;
-  NAPI_CALL(env, MyObject::NewInstance(env, args[0], &instance));
+  NODE_API_CALL(env, MyObject::NewInstance(env, args[0], &instance));
 
   return instance;
 }
@@ -18,23 +19,26 @@ static napi_value CreateObject(napi_env env, napi_callback_info info) {
 static napi_value Add(napi_env env, napi_callback_info info) {
   size_t argc = 2;
   napi_value args[2];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, nullptr, nullptr));
+  NODE_API_CALL(env,
+      napi_get_cb_info(env, info, &argc, args, nullptr, nullptr));
 
   MyObject* obj1;
-  NAPI_CALL(env, napi_unwrap(env, args[0], reinterpret_cast<void**>(&obj1)));
+  NODE_API_CALL(env,
+      napi_unwrap(env, args[0], reinterpret_cast<void**>(&obj1)));
 
   MyObject* obj2;
-  NAPI_CALL(env, napi_unwrap(env, args[1], reinterpret_cast<void**>(&obj2)));
+  NODE_API_CALL(env,
+      napi_unwrap(env, args[1], reinterpret_cast<void**>(&obj2)));
 
   napi_value sum;
-  NAPI_CALL(env, napi_create_double(env, obj1->Val() + obj2->Val(), &sum));
+  NODE_API_CALL(env, napi_create_double(env, obj1->Val() + obj2->Val(), &sum));
 
   return sum;
 }
 
 static napi_value FinalizeCount(napi_env env, napi_callback_info info) {
   napi_value return_value;
-  NAPI_CALL(env, napi_create_uint32(env, finalize_count, &return_value));
+  NODE_API_CALL(env, napi_create_uint32(env, finalize_count, &return_value));
   return return_value;
 }
 
@@ -43,12 +47,12 @@ napi_value Init(napi_env env, napi_value exports) {
   MyObject::Init(env);
 
   napi_property_descriptor desc[] = {
-    DECLARE_NAPI_PROPERTY("createObject", CreateObject),
-    DECLARE_NAPI_PROPERTY("add", Add),
-    DECLARE_NAPI_PROPERTY("finalizeCount", FinalizeCount),
+    DECLARE_NODE_API_PROPERTY("createObject", CreateObject),
+    DECLARE_NODE_API_PROPERTY("add", Add),
+    DECLARE_NODE_API_PROPERTY("finalizeCount", FinalizeCount),
   };
 
-  NAPI_CALL(env,
+  NODE_API_CALL(env,
       napi_define_properties(env, exports, sizeof(desc) / sizeof(*desc), desc));
 
   return exports;

--- a/test/js-native-api/8_passing_wrapped/myobject.cc
+++ b/test/js-native-api/8_passing_wrapped/myobject.cc
@@ -36,17 +36,17 @@ napi_value MyObject::New(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
   napi_value _this;
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, &_this, nullptr));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, &_this, nullptr));
 
   MyObject* obj = new MyObject();
 
   napi_valuetype valuetype;
-  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype));
+  NODE_API_CALL(env, napi_typeof(env, args[0], &valuetype));
 
   if (valuetype == napi_undefined) {
     obj->val_ = 0;
   } else {
-    NAPI_CALL(env, napi_get_value_double(env, args[0], &obj->val_));
+    NODE_API_CALL(env, napi_get_value_double(env, args[0], &obj->val_));
   }
 
   obj->env_ = env;
@@ -54,12 +54,9 @@ napi_value MyObject::New(napi_env env, napi_callback_info info) {
   // The below call to napi_wrap() must request a reference to the wrapped
   // object via the out-parameter, because this ensures that we test the code
   // path that deals with a reference that is destroyed from its own finalizer.
-  NAPI_CALL(env, napi_wrap(env,
-                          _this,
-                          obj,
-                          MyObject::Destructor,
-                          nullptr,  // finalize_hint
-                          &obj->wrapper_));
+  NODE_API_CALL(env,
+      napi_wrap(env, _this, obj, MyObject::Destructor,
+          nullptr /* finalize_hint */, &obj->wrapper_));
 
   return _this;
 }

--- a/test/js-native-api/common.c
+++ b/test/js-native-api/common.c
@@ -14,38 +14,35 @@ void add_returned_status(napi_env env,
   napi_value prop_value;
 
   if (actual_status != expected_status) {
-    snprintf(napi_message_string, sizeof(napi_message_string), "Invalid status [%d]", actual_status);
+    snprintf(napi_message_string, sizeof(napi_message_string),
+        "Invalid status [%d]", actual_status);
   }
 
-  NAPI_CALL_RETURN_VOID(env,
-                        napi_create_string_utf8(
-                            env,
-                            (actual_status == expected_status ?
-                                expected_message :
-                                napi_message_string),
-                            NAPI_AUTO_LENGTH,
-                            &prop_value));
-  NAPI_CALL_RETURN_VOID(env,
-                        napi_set_named_property(env,
-                                                object,
-                                                key,
-                                                prop_value));
+  NODE_API_CALL_RETURN_VOID(env,
+      napi_create_string_utf8(
+                              env,
+                              (actual_status == expected_status ?
+                                  expected_message :
+                                  napi_message_string),
+                              NAPI_AUTO_LENGTH,
+                              &prop_value));
+  NODE_API_CALL_RETURN_VOID(env,
+      napi_set_named_property(env, object, key, prop_value));
 }
 
 void add_last_status(napi_env env, const char* key, napi_value return_value) {
     napi_value prop_value;
     const napi_extended_error_info* p_last_error;
-    NAPI_CALL_RETURN_VOID(env, napi_get_last_error_info(env, &p_last_error));
+    NODE_API_CALL_RETURN_VOID(env,
+        napi_get_last_error_info(env, &p_last_error));
 
-    NAPI_CALL_RETURN_VOID(env,
+    NODE_API_CALL_RETURN_VOID(env,
         napi_create_string_utf8(env,
                                 (p_last_error->error_message == NULL ?
                                     "napi_ok" :
                                     p_last_error->error_message),
                                 NAPI_AUTO_LENGTH,
                                 &prop_value));
-    NAPI_CALL_RETURN_VOID(env, napi_set_named_property(env,
-                                                       return_value,
-                                                       key,
-                                                       prop_value));
+    NODE_API_CALL_RETURN_VOID(env,
+        napi_set_named_property(env, return_value, key, prop_value));
 }

--- a/test/js-native-api/common.h
+++ b/test/js-native-api/common.h
@@ -1,7 +1,7 @@
 #include <js_native_api.h>
 
 // Empty value so that macros here are able to return NULL or void
-#define NAPI_RETVAL_NOTHING  // Intentionally blank #define
+#define NODE_API_RETVAL_NOTHING  // Intentionally blank #define
 
 #define GET_AND_THROW_LAST_ERROR(env)                                    \
   do {                                                                   \
@@ -18,7 +18,7 @@
     }                                                                    \
   } while (0)
 
-#define NAPI_ASSERT_BASE(env, assertion, message, ret_val)               \
+#define NODE_API_ASSERT_BASE(env, assertion, message, ret_val)           \
   do {                                                                   \
     if (!(assertion)) {                                                  \
       napi_throw_error(                                                  \
@@ -31,15 +31,15 @@
 
 // Returns NULL on failed assertion.
 // This is meant to be used inside napi_callback methods.
-#define NAPI_ASSERT(env, assertion, message)                             \
-  NAPI_ASSERT_BASE(env, assertion, message, NULL)
+#define NODE_API_ASSERT(env, assertion, message)                         \
+  NODE_API_ASSERT_BASE(env, assertion, message, NULL)
 
 // Returns empty on failed assertion.
 // This is meant to be used inside functions with void return type.
-#define NAPI_ASSERT_RETURN_VOID(env, assertion, message)                 \
-  NAPI_ASSERT_BASE(env, assertion, message, NAPI_RETVAL_NOTHING)
+#define NODE_API_ASSERT_RETURN_VOID(env, assertion, message)             \
+  NODE_API_ASSERT_BASE(env, assertion, message, NODE_API_RETVAL_NOTHING)
 
-#define NAPI_CALL_BASE(env, the_call, ret_val)                           \
+#define NODE_API_CALL_BASE(env, the_call, ret_val)                       \
   do {                                                                   \
     if ((the_call) != napi_ok) {                                         \
       GET_AND_THROW_LAST_ERROR((env));                                   \
@@ -48,17 +48,17 @@
   } while (0)
 
 // Returns NULL if the_call doesn't return napi_ok.
-#define NAPI_CALL(env, the_call)                                         \
-  NAPI_CALL_BASE(env, the_call, NULL)
+#define NODE_API_CALL(env, the_call)                                     \
+  NODE_API_CALL_BASE(env, the_call, NULL)
 
 // Returns empty if the_call doesn't return napi_ok.
-#define NAPI_CALL_RETURN_VOID(env, the_call)                             \
-  NAPI_CALL_BASE(env, the_call, NAPI_RETVAL_NOTHING)
+#define NODE_API_CALL_RETURN_VOID(env, the_call)                         \
+  NODE_API_CALL_BASE(env, the_call, NODE_API_RETVAL_NOTHING)
 
-#define DECLARE_NAPI_PROPERTY(name, func)                                \
+#define DECLARE_NODE_API_PROPERTY(name, func)                            \
   { (name), NULL, (func), NULL, NULL, NULL, napi_default, NULL }
 
-#define DECLARE_NAPI_GETTER(name, func)                                  \
+#define DECLARE_NODE_API_GETTER(name, func)                              \
   { (name), NULL, NULL, (func), NULL, NULL, napi_default, NULL }
 
 void add_returned_status(napi_env env,

--- a/test/js-native-api/test_array/test_array.c
+++ b/test/js-native-api/test_array/test_array.c
@@ -5,42 +5,42 @@
 static napi_value TestGetElement(napi_env env, napi_callback_info info) {
   size_t argc = 2;
   napi_value args[2];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  NAPI_ASSERT(env, argc >= 2, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc >= 2, "Wrong number of arguments");
 
   napi_valuetype valuetype0;
-  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
+  NODE_API_CALL(env, napi_typeof(env, args[0], &valuetype0));
 
-  NAPI_ASSERT(env, valuetype0 == napi_object,
+  NODE_API_ASSERT(env, valuetype0 == napi_object,
       "Wrong type of arguments. Expects an array as first argument.");
 
   napi_valuetype valuetype1;
-  NAPI_CALL(env, napi_typeof(env, args[1], &valuetype1));
+  NODE_API_CALL(env, napi_typeof(env, args[1], &valuetype1));
 
-  NAPI_ASSERT(env, valuetype1 == napi_number,
+  NODE_API_ASSERT(env, valuetype1 == napi_number,
       "Wrong type of arguments. Expects an integer as second argument.");
 
   napi_value array = args[0];
   int32_t index;
-  NAPI_CALL(env, napi_get_value_int32(env, args[1], &index));
+  NODE_API_CALL(env, napi_get_value_int32(env, args[1], &index));
 
-  NAPI_ASSERT(env, index >= 0, "Invalid index. Expects a positive integer.");
+  NODE_API_ASSERT(env, index >= 0, "Invalid index. Expects a positive integer.");
 
   bool isarray;
-  NAPI_CALL(env, napi_is_array(env, array, &isarray));
+  NODE_API_CALL(env, napi_is_array(env, array, &isarray));
 
   if (!isarray) {
     return NULL;
   }
 
   uint32_t length;
-  NAPI_CALL(env, napi_get_array_length(env, array, &length));
+  NODE_API_CALL(env, napi_get_array_length(env, array, &length));
 
-  NAPI_ASSERT(env, ((uint32_t)index < length), "Index out of bounds!");
+  NODE_API_ASSERT(env, ((uint32_t)index < length), "Index out of bounds!");
 
   napi_value ret;
-  NAPI_CALL(env, napi_get_element(env, array, index, &ret));
+  NODE_API_CALL(env, napi_get_element(env, array, index, &ret));
 
   return ret;
 }
@@ -48,38 +48,38 @@ static napi_value TestGetElement(napi_env env, napi_callback_info info) {
 static napi_value TestHasElement(napi_env env, napi_callback_info info) {
   size_t argc = 2;
   napi_value args[2];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  NAPI_ASSERT(env, argc >= 2, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc >= 2, "Wrong number of arguments");
 
   napi_valuetype valuetype0;
-  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
+  NODE_API_CALL(env, napi_typeof(env, args[0], &valuetype0));
 
-  NAPI_ASSERT(env, valuetype0 == napi_object,
+  NODE_API_ASSERT(env, valuetype0 == napi_object,
       "Wrong type of arguments. Expects an array as first argument.");
 
   napi_valuetype valuetype1;
-  NAPI_CALL(env, napi_typeof(env, args[1], &valuetype1));
+  NODE_API_CALL(env, napi_typeof(env, args[1], &valuetype1));
 
-  NAPI_ASSERT(env, valuetype1 == napi_number,
+  NODE_API_ASSERT(env, valuetype1 == napi_number,
       "Wrong type of arguments. Expects an integer as second argument.");
 
   napi_value array = args[0];
   int32_t index;
-  NAPI_CALL(env, napi_get_value_int32(env, args[1], &index));
+  NODE_API_CALL(env, napi_get_value_int32(env, args[1], &index));
 
   bool isarray;
-  NAPI_CALL(env, napi_is_array(env, array, &isarray));
+  NODE_API_CALL(env, napi_is_array(env, array, &isarray));
 
   if (!isarray) {
     return NULL;
   }
 
   bool has_element;
-  NAPI_CALL(env, napi_has_element(env, array, index, &has_element));
+  NODE_API_CALL(env, napi_has_element(env, array, index, &has_element));
 
   napi_value ret;
-  NAPI_CALL(env, napi_get_boolean(env, has_element, &ret));
+  NODE_API_CALL(env, napi_get_boolean(env, has_element, &ret));
 
   return ret;
 }
@@ -88,17 +88,17 @@ static napi_value TestDeleteElement(napi_env env, napi_callback_info info) {
   size_t argc = 2;
   napi_value args[2];
 
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
-  NAPI_ASSERT(env, argc == 2, "Wrong number of arguments");
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_ASSERT(env, argc == 2, "Wrong number of arguments");
 
   napi_valuetype valuetype0;
-  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
-  NAPI_ASSERT(env, valuetype0 == napi_object,
+  NODE_API_CALL(env, napi_typeof(env, args[0], &valuetype0));
+  NODE_API_ASSERT(env, valuetype0 == napi_object,
       "Wrong type of arguments. Expects an array as first argument.");
 
   napi_valuetype valuetype1;
-  NAPI_CALL(env, napi_typeof(env, args[1], &valuetype1));
-  NAPI_ASSERT(env, valuetype1 == napi_number,
+  NODE_API_CALL(env, napi_typeof(env, args[1], &valuetype1));
+  NODE_API_ASSERT(env, valuetype1 == napi_number,
       "Wrong type of arguments. Expects an integer as second argument.");
 
   napi_value array = args[0];
@@ -106,15 +106,15 @@ static napi_value TestDeleteElement(napi_env env, napi_callback_info info) {
   bool result;
   napi_value ret;
 
-  NAPI_CALL(env, napi_get_value_int32(env, args[1], &index));
-  NAPI_CALL(env, napi_is_array(env, array, &result));
+  NODE_API_CALL(env, napi_get_value_int32(env, args[1], &index));
+  NODE_API_CALL(env, napi_is_array(env, array, &result));
 
   if (!result) {
     return NULL;
   }
 
-  NAPI_CALL(env, napi_delete_element(env, array, index, &result));
-  NAPI_CALL(env, napi_get_boolean(env, result, &ret));
+  NODE_API_CALL(env, napi_delete_element(env, array, index, &result));
+  NODE_API_CALL(env, napi_get_boolean(env, result, &ret));
 
   return ret;
 }
@@ -122,26 +122,26 @@ static napi_value TestDeleteElement(napi_env env, napi_callback_info info) {
 static napi_value New(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  NAPI_ASSERT(env, argc >= 1, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc >= 1, "Wrong number of arguments");
 
   napi_valuetype valuetype0;
-  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
+  NODE_API_CALL(env, napi_typeof(env, args[0], &valuetype0));
 
-  NAPI_ASSERT(env, valuetype0 == napi_object,
+  NODE_API_ASSERT(env, valuetype0 == napi_object,
       "Wrong type of arguments. Expects an array as first argument.");
 
   napi_value ret;
-  NAPI_CALL(env, napi_create_array(env, &ret));
+  NODE_API_CALL(env, napi_create_array(env, &ret));
 
   uint32_t i, length;
-  NAPI_CALL(env, napi_get_array_length(env, args[0], &length));
+  NODE_API_CALL(env, napi_get_array_length(env, args[0], &length));
 
   for (i = 0; i < length; i++) {
     napi_value e;
-    NAPI_CALL(env, napi_get_element(env, args[0], i, &e));
-    NAPI_CALL(env, napi_set_element(env, ret, i, e));
+    NODE_API_CALL(env, napi_get_element(env, args[0], i, &e));
+    NODE_API_CALL(env, napi_set_element(env, ret, i, e));
   }
 
   return ret;
@@ -150,21 +150,21 @@ static napi_value New(napi_env env, napi_callback_info info) {
 static napi_value NewWithLength(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  NAPI_ASSERT(env, argc >= 1, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc >= 1, "Wrong number of arguments");
 
   napi_valuetype valuetype0;
-  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
+  NODE_API_CALL(env, napi_typeof(env, args[0], &valuetype0));
 
-  NAPI_ASSERT(env, valuetype0 == napi_number,
+  NODE_API_ASSERT(env, valuetype0 == napi_number,
       "Wrong type of arguments. Expects an integer the first argument.");
 
   int32_t array_length;
-  NAPI_CALL(env, napi_get_value_int32(env, args[0], &array_length));
+  NODE_API_CALL(env, napi_get_value_int32(env, args[0], &array_length));
 
   napi_value ret;
-  NAPI_CALL(env, napi_create_array_with_length(env, array_length, &ret));
+  NODE_API_CALL(env, napi_create_array_with_length(env, array_length, &ret));
 
   return ret;
 }
@@ -172,14 +172,14 @@ static napi_value NewWithLength(napi_env env, napi_callback_info info) {
 EXTERN_C_START
 napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
-    DECLARE_NAPI_PROPERTY("TestGetElement", TestGetElement),
-    DECLARE_NAPI_PROPERTY("TestHasElement", TestHasElement),
-    DECLARE_NAPI_PROPERTY("TestDeleteElement", TestDeleteElement),
-    DECLARE_NAPI_PROPERTY("New", New),
-    DECLARE_NAPI_PROPERTY("NewWithLength", NewWithLength),
+    DECLARE_NODE_API_PROPERTY("TestGetElement", TestGetElement),
+    DECLARE_NODE_API_PROPERTY("TestHasElement", TestHasElement),
+    DECLARE_NODE_API_PROPERTY("TestDeleteElement", TestDeleteElement),
+    DECLARE_NODE_API_PROPERTY("New", New),
+    DECLARE_NODE_API_PROPERTY("NewWithLength", NewWithLength),
   };
 
-  NAPI_CALL(env, napi_define_properties(
+  NODE_API_CALL(env, napi_define_properties(
       env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
 
   return exports;

--- a/test/js-native-api/test_bigint/test_bigint.c
+++ b/test/js-native-api/test_bigint/test_bigint.c
@@ -7,23 +7,23 @@
 static napi_value IsLossless(napi_env env, napi_callback_info info) {
   size_t argc = 2;
   napi_value args[2];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
   bool is_signed;
-  NAPI_CALL(env, napi_get_value_bool(env, args[1], &is_signed));
+  NODE_API_CALL(env, napi_get_value_bool(env, args[1], &is_signed));
 
   bool lossless;
 
   if (is_signed) {
     int64_t input;
-    NAPI_CALL(env, napi_get_value_bigint_int64(env, args[0], &input, &lossless));
+    NODE_API_CALL(env, napi_get_value_bigint_int64(env, args[0], &input, &lossless));
   } else {
     uint64_t input;
-    NAPI_CALL(env, napi_get_value_bigint_uint64(env, args[0], &input, &lossless));
+    NODE_API_CALL(env, napi_get_value_bigint_uint64(env, args[0], &input, &lossless));
   }
 
   napi_value output;
-  NAPI_CALL(env, napi_get_boolean(env, lossless, &output));
+  NODE_API_CALL(env, napi_get_boolean(env, lossless, &output));
 
   return output;
 }
@@ -31,22 +31,22 @@ static napi_value IsLossless(napi_env env, napi_callback_info info) {
 static napi_value TestInt64(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  NAPI_ASSERT(env, argc >= 1, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc >= 1, "Wrong number of arguments");
 
   napi_valuetype valuetype0;
-  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
+  NODE_API_CALL(env, napi_typeof(env, args[0], &valuetype0));
 
-  NAPI_ASSERT(env, valuetype0 == napi_bigint,
+  NODE_API_ASSERT(env, valuetype0 == napi_bigint,
       "Wrong type of arguments. Expects a bigint as first argument.");
 
   int64_t input;
   bool lossless;
-  NAPI_CALL(env, napi_get_value_bigint_int64(env, args[0], &input, &lossless));
+  NODE_API_CALL(env, napi_get_value_bigint_int64(env, args[0], &input, &lossless));
 
   napi_value output;
-  NAPI_CALL(env, napi_create_bigint_int64(env, input, &output));
+  NODE_API_CALL(env, napi_create_bigint_int64(env, input, &output));
 
   return output;
 }
@@ -54,23 +54,23 @@ static napi_value TestInt64(napi_env env, napi_callback_info info) {
 static napi_value TestUint64(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  NAPI_ASSERT(env, argc >= 1, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc >= 1, "Wrong number of arguments");
 
   napi_valuetype valuetype0;
-  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
+  NODE_API_CALL(env, napi_typeof(env, args[0], &valuetype0));
 
-  NAPI_ASSERT(env, valuetype0 == napi_bigint,
+  NODE_API_ASSERT(env, valuetype0 == napi_bigint,
       "Wrong type of arguments. Expects a bigint as first argument.");
 
   uint64_t input;
   bool lossless;
-  NAPI_CALL(env, napi_get_value_bigint_uint64(
+  NODE_API_CALL(env, napi_get_value_bigint_uint64(
         env, args[0], &input, &lossless));
 
   napi_value output;
-  NAPI_CALL(env, napi_create_bigint_uint64(env, input, &output));
+  NODE_API_CALL(env, napi_create_bigint_uint64(env, input, &output));
 
   return output;
 }
@@ -78,32 +78,32 @@ static napi_value TestUint64(napi_env env, napi_callback_info info) {
 static napi_value TestWords(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  NAPI_ASSERT(env, argc >= 1, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc >= 1, "Wrong number of arguments");
 
   napi_valuetype valuetype0;
-  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
+  NODE_API_CALL(env, napi_typeof(env, args[0], &valuetype0));
 
-  NAPI_ASSERT(env, valuetype0 == napi_bigint,
+  NODE_API_ASSERT(env, valuetype0 == napi_bigint,
       "Wrong type of arguments. Expects a bigint as first argument.");
 
   size_t expected_word_count;
-  NAPI_CALL(env, napi_get_value_bigint_words(
+  NODE_API_CALL(env, napi_get_value_bigint_words(
         env, args[0], NULL, &expected_word_count, NULL));
 
   int sign_bit;
   size_t word_count = 10;
   uint64_t words[10];
 
-  NAPI_CALL(env, napi_get_value_bigint_words(
+  NODE_API_CALL(env, napi_get_value_bigint_words(
         env, args[0], &sign_bit, &word_count, words));
 
-  NAPI_ASSERT(env, word_count == expected_word_count,
+  NODE_API_ASSERT(env, word_count == expected_word_count,
       "word counts do not match");
 
   napi_value output;
-  NAPI_CALL(env, napi_create_bigint_words(
+  NODE_API_CALL(env, napi_create_bigint_words(
         env, sign_bit, word_count, words, &output));
 
   return output;
@@ -117,7 +117,7 @@ static napi_value CreateTooBigBigInt(napi_env env, napi_callback_info info) {
 
   napi_value output;
 
-  NAPI_CALL(env, napi_create_bigint_words(
+  NODE_API_CALL(env, napi_create_bigint_words(
         env, sign_bit, word_count, words, &output));
 
   return output;
@@ -142,15 +142,15 @@ static napi_value MakeBigIntWordsThrow(napi_env env, napi_callback_info info) {
 EXTERN_C_START
 napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
-    DECLARE_NAPI_PROPERTY("IsLossless", IsLossless),
-    DECLARE_NAPI_PROPERTY("TestInt64", TestInt64),
-    DECLARE_NAPI_PROPERTY("TestUint64", TestUint64),
-    DECLARE_NAPI_PROPERTY("TestWords", TestWords),
-    DECLARE_NAPI_PROPERTY("CreateTooBigBigInt", CreateTooBigBigInt),
-    DECLARE_NAPI_PROPERTY("MakeBigIntWordsThrow", MakeBigIntWordsThrow),
+    DECLARE_NODE_API_PROPERTY("IsLossless", IsLossless),
+    DECLARE_NODE_API_PROPERTY("TestInt64", TestInt64),
+    DECLARE_NODE_API_PROPERTY("TestUint64", TestUint64),
+    DECLARE_NODE_API_PROPERTY("TestWords", TestWords),
+    DECLARE_NODE_API_PROPERTY("CreateTooBigBigInt", CreateTooBigBigInt),
+    DECLARE_NODE_API_PROPERTY("MakeBigIntWordsThrow", MakeBigIntWordsThrow),
   };
 
-  NAPI_CALL(env, napi_define_properties(
+  NODE_API_CALL(env, napi_define_properties(
       env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
 
   return exports;

--- a/test/js-native-api/test_constructor/test_constructor.c
+++ b/test/js-native-api/test_constructor/test_constructor.c
@@ -19,7 +19,7 @@ static napi_value TestDefineClass(napi_env env,
     napi_enumerable | napi_static,
     NULL};
 
-  NAPI_CALL(env, napi_create_object(env, &return_value));
+  NODE_API_CALL(env, napi_create_object(env, &return_value));
 
   status = napi_define_class(NULL,
                              "TrackedFunction",
@@ -98,12 +98,12 @@ static napi_value TestDefineClass(napi_env env,
 
 static napi_value GetValue(napi_env env, napi_callback_info info) {
   size_t argc = 0;
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, NULL, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, NULL, NULL, NULL));
 
-  NAPI_ASSERT(env, argc == 0, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc == 0, "Wrong number of arguments");
 
   napi_value number;
-  NAPI_CALL(env, napi_create_double(env, value_, &number));
+  NODE_API_CALL(env, napi_create_double(env, value_, &number));
 
   return number;
 }
@@ -111,11 +111,11 @@ static napi_value GetValue(napi_env env, napi_callback_info info) {
 static napi_value SetValue(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  NAPI_ASSERT(env, argc == 1, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc == 1, "Wrong number of arguments");
 
-  NAPI_CALL(env, napi_get_value_double(env, args[0], &value_));
+  NODE_API_CALL(env, napi_get_value_double(env, args[0], &value_));
 
   return NULL;
 }
@@ -123,28 +123,28 @@ static napi_value SetValue(napi_env env, napi_callback_info info) {
 static napi_value Echo(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  NAPI_ASSERT(env, argc == 1, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc == 1, "Wrong number of arguments");
 
   return args[0];
 }
 
 static napi_value New(napi_env env, napi_callback_info info) {
   napi_value _this;
-  NAPI_CALL(env, napi_get_cb_info(env, info, NULL, NULL, &_this, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, NULL, NULL, &_this, NULL));
 
   return _this;
 }
 
 static napi_value GetStaticValue(napi_env env, napi_callback_info info) {
   size_t argc = 0;
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, NULL, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, NULL, NULL, NULL));
 
-  NAPI_ASSERT(env, argc == 0, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc == 0, "Wrong number of arguments");
 
   napi_value number;
-  NAPI_CALL(env, napi_create_double(env, static_value_, &number));
+  NODE_API_CALL(env, napi_create_double(env, static_value_, &number));
 
   return number;
 }
@@ -152,7 +152,7 @@ static napi_value GetStaticValue(napi_env env, napi_callback_info info) {
 
 static napi_value NewExtra(napi_env env, napi_callback_info info) {
   napi_value _this;
-  NAPI_CALL(env, napi_get_cb_info(env, info, NULL, NULL, &_this, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, NULL, NULL, &_this, NULL));
 
   return _this;
 }
@@ -160,9 +160,9 @@ static napi_value NewExtra(napi_env env, napi_callback_info info) {
 EXTERN_C_START
 napi_value Init(napi_env env, napi_value exports) {
   napi_value number, cons;
-  NAPI_CALL(env, napi_create_double(env, value_, &number));
+  NODE_API_CALL(env, napi_create_double(env, value_, &number));
 
-  NAPI_CALL(env, napi_define_class(
+  NODE_API_CALL(env, napi_define_class(
       env, "MyObject_Extra", 8, NewExtra, NULL, 0, NULL, &cons));
 
   napi_property_descriptor properties[] = {
@@ -188,7 +188,7 @@ napi_value Init(napi_env env, napi_value exports) {
         napi_enumerable | napi_static, NULL },
   };
 
-  NAPI_CALL(env, napi_define_class(env, "MyObject", NAPI_AUTO_LENGTH, New,
+  NODE_API_CALL(env, napi_define_class(env, "MyObject", NAPI_AUTO_LENGTH, New,
       NULL, sizeof(properties)/sizeof(*properties), properties, &cons));
 
   return cons;

--- a/test/js-native-api/test_conversions/test_conversions.c
+++ b/test/js-native-api/test_conversions/test_conversions.c
@@ -5,13 +5,13 @@
 static napi_value AsBool(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
   bool value;
-  NAPI_CALL(env, napi_get_value_bool(env, args[0], &value));
+  NODE_API_CALL(env, napi_get_value_bool(env, args[0], &value));
 
   napi_value output;
-  NAPI_CALL(env, napi_get_boolean(env, value, &output));
+  NODE_API_CALL(env, napi_get_boolean(env, value, &output));
 
   return output;
 }
@@ -19,13 +19,13 @@ static napi_value AsBool(napi_env env, napi_callback_info info) {
 static napi_value AsInt32(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
   int32_t value;
-  NAPI_CALL(env, napi_get_value_int32(env, args[0], &value));
+  NODE_API_CALL(env, napi_get_value_int32(env, args[0], &value));
 
   napi_value output;
-  NAPI_CALL(env, napi_create_int32(env, value, &output));
+  NODE_API_CALL(env, napi_create_int32(env, value, &output));
 
   return output;
 }
@@ -33,13 +33,13 @@ static napi_value AsInt32(napi_env env, napi_callback_info info) {
 static napi_value AsUInt32(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
   uint32_t value;
-  NAPI_CALL(env, napi_get_value_uint32(env, args[0], &value));
+  NODE_API_CALL(env, napi_get_value_uint32(env, args[0], &value));
 
   napi_value output;
-  NAPI_CALL(env, napi_create_uint32(env, value, &output));
+  NODE_API_CALL(env, napi_create_uint32(env, value, &output));
 
   return output;
 }
@@ -47,13 +47,13 @@ static napi_value AsUInt32(napi_env env, napi_callback_info info) {
 static napi_value AsInt64(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
   int64_t value;
-  NAPI_CALL(env, napi_get_value_int64(env, args[0], &value));
+  NODE_API_CALL(env, napi_get_value_int64(env, args[0], &value));
 
   napi_value output;
-  NAPI_CALL(env, napi_create_int64(env, (double)value, &output));
+  NODE_API_CALL(env, napi_create_int64(env, (double)value, &output));
 
   return output;
 }
@@ -61,13 +61,13 @@ static napi_value AsInt64(napi_env env, napi_callback_info info) {
 static napi_value AsDouble(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
   double value;
-  NAPI_CALL(env, napi_get_value_double(env, args[0], &value));
+  NODE_API_CALL(env, napi_get_value_double(env, args[0], &value));
 
   napi_value output;
-  NAPI_CALL(env, napi_create_double(env, value, &output));
+  NODE_API_CALL(env, napi_create_double(env, value, &output));
 
   return output;
 }
@@ -75,14 +75,14 @@ static napi_value AsDouble(napi_env env, napi_callback_info info) {
 static napi_value AsString(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
   char value[100];
-  NAPI_CALL(env,
+  NODE_API_CALL(env,
     napi_get_value_string_utf8(env, args[0], value, sizeof(value), NULL));
 
   napi_value output;
-  NAPI_CALL(env, napi_create_string_utf8(
+  NODE_API_CALL(env, napi_create_string_utf8(
       env, value, NAPI_AUTO_LENGTH, &output));
 
   return output;
@@ -91,10 +91,10 @@ static napi_value AsString(napi_env env, napi_callback_info info) {
 static napi_value ToBool(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
   napi_value output;
-  NAPI_CALL(env, napi_coerce_to_bool(env, args[0], &output));
+  NODE_API_CALL(env, napi_coerce_to_bool(env, args[0], &output));
 
   return output;
 }
@@ -102,10 +102,10 @@ static napi_value ToBool(napi_env env, napi_callback_info info) {
 static napi_value ToNumber(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
   napi_value output;
-  NAPI_CALL(env, napi_coerce_to_number(env, args[0], &output));
+  NODE_API_CALL(env, napi_coerce_to_number(env, args[0], &output));
 
   return output;
 }
@@ -113,10 +113,10 @@ static napi_value ToNumber(napi_env env, napi_callback_info info) {
 static napi_value ToObject(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
   napi_value output;
-  NAPI_CALL(env, napi_coerce_to_object(env, args[0], &output));
+  NODE_API_CALL(env, napi_coerce_to_object(env, args[0], &output));
 
   return output;
 }
@@ -124,10 +124,10 @@ static napi_value ToObject(napi_env env, napi_callback_info info) {
 static napi_value ToString(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
   napi_value output;
-  NAPI_CALL(env, napi_coerce_to_string(env, args[0], &output));
+  NODE_API_CALL(env, napi_coerce_to_string(env, args[0], &output));
 
   return output;
 }
@@ -135,19 +135,19 @@ static napi_value ToString(napi_env env, napi_callback_info info) {
 EXTERN_C_START
 napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
-    DECLARE_NAPI_PROPERTY("asBool", AsBool),
-    DECLARE_NAPI_PROPERTY("asInt32", AsInt32),
-    DECLARE_NAPI_PROPERTY("asUInt32", AsUInt32),
-    DECLARE_NAPI_PROPERTY("asInt64", AsInt64),
-    DECLARE_NAPI_PROPERTY("asDouble", AsDouble),
-    DECLARE_NAPI_PROPERTY("asString", AsString),
-    DECLARE_NAPI_PROPERTY("toBool", ToBool),
-    DECLARE_NAPI_PROPERTY("toNumber", ToNumber),
-    DECLARE_NAPI_PROPERTY("toObject", ToObject),
-    DECLARE_NAPI_PROPERTY("toString", ToString),
+    DECLARE_NODE_API_PROPERTY("asBool", AsBool),
+    DECLARE_NODE_API_PROPERTY("asInt32", AsInt32),
+    DECLARE_NODE_API_PROPERTY("asUInt32", AsUInt32),
+    DECLARE_NODE_API_PROPERTY("asInt64", AsInt64),
+    DECLARE_NODE_API_PROPERTY("asDouble", AsDouble),
+    DECLARE_NODE_API_PROPERTY("asString", AsString),
+    DECLARE_NODE_API_PROPERTY("toBool", ToBool),
+    DECLARE_NODE_API_PROPERTY("toNumber", ToNumber),
+    DECLARE_NODE_API_PROPERTY("toObject", ToObject),
+    DECLARE_NODE_API_PROPERTY("toString", ToString),
   };
 
-  NAPI_CALL(env, napi_define_properties(
+  NODE_API_CALL(env, napi_define_properties(
       env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
 
   init_test_null(env, exports);

--- a/test/js-native-api/test_conversions/test_null.c
+++ b/test/js-native-api/test_conversions/test_null.c
@@ -7,7 +7,7 @@
   static napi_value binding_name(napi_env env, napi_callback_info info) { \
     napi_value return_value;                                              \
     output_type result;                                                   \
-    NAPI_CALL(env, napi_create_object(env, &return_value));               \
+    NODE_API_CALL(env, napi_create_object(env, &return_value));           \
     add_returned_status(env,                                              \
                         "envIsNull",                                      \
                         return_value,                                     \
@@ -35,7 +35,7 @@ GEN_NULL_CHECK_BINDING(CoerceToString, napi_value, napi_coerce_to_string)
 #define GEN_NULL_CHECK_STRING_BINDING(binding_name, arg_type, api)         \
   static napi_value binding_name(napi_env env, napi_callback_info info) {  \
     napi_value return_value;                                               \
-    NAPI_CALL(env, napi_create_object(env, &return_value));                \
+    NODE_API_CALL(env, napi_create_object(env, &return_value));            \
     arg_type buf1[4];                                                      \
     size_t length1 = 3;                                                    \
     add_returned_status(env,                                               \
@@ -51,7 +51,7 @@ GEN_NULL_CHECK_BINDING(CoerceToString, napi_value, napi_coerce_to_string)
     api(env, return_value, NULL, 3, NULL);                                 \
     add_last_status(env, "wrongTypeIn", return_value);                     \
     napi_value string;                                                     \
-    NAPI_CALL(env,                                                         \
+    NODE_API_CALL(env,                                                     \
               napi_create_string_utf8(env,                                 \
                                       "Something",                         \
                                       NAPI_AUTO_LENGTH,                    \
@@ -75,21 +75,21 @@ void init_test_null(napi_env env, napi_value exports) {
   napi_value test_null;
 
   const napi_property_descriptor test_null_props[] = {
-    DECLARE_NAPI_PROPERTY("getValueBool", GetValueBool),
-    DECLARE_NAPI_PROPERTY("getValueInt32", GetValueInt32),
-    DECLARE_NAPI_PROPERTY("getValueUint32", GetValueUint32),
-    DECLARE_NAPI_PROPERTY("getValueInt64", GetValueInt64),
-    DECLARE_NAPI_PROPERTY("getValueDouble", GetValueDouble),
-    DECLARE_NAPI_PROPERTY("coerceToBool", CoerceToBool),
-    DECLARE_NAPI_PROPERTY("coerceToObject", CoerceToObject),
-    DECLARE_NAPI_PROPERTY("coerceToString", CoerceToString),
-    DECLARE_NAPI_PROPERTY("getValueStringUtf8", GetValueStringUtf8),
-    DECLARE_NAPI_PROPERTY("getValueStringLatin1", GetValueStringLatin1),
-    DECLARE_NAPI_PROPERTY("getValueStringUtf16", GetValueStringUtf16),
+    DECLARE_NODE_API_PROPERTY("getValueBool", GetValueBool),
+    DECLARE_NODE_API_PROPERTY("getValueInt32", GetValueInt32),
+    DECLARE_NODE_API_PROPERTY("getValueUint32", GetValueUint32),
+    DECLARE_NODE_API_PROPERTY("getValueInt64", GetValueInt64),
+    DECLARE_NODE_API_PROPERTY("getValueDouble", GetValueDouble),
+    DECLARE_NODE_API_PROPERTY("coerceToBool", CoerceToBool),
+    DECLARE_NODE_API_PROPERTY("coerceToObject", CoerceToObject),
+    DECLARE_NODE_API_PROPERTY("coerceToString", CoerceToString),
+    DECLARE_NODE_API_PROPERTY("getValueStringUtf8", GetValueStringUtf8),
+    DECLARE_NODE_API_PROPERTY("getValueStringLatin1", GetValueStringLatin1),
+    DECLARE_NODE_API_PROPERTY("getValueStringUtf16", GetValueStringUtf16),
   };
 
-  NAPI_CALL_RETURN_VOID(env, napi_create_object(env, &test_null));
-  NAPI_CALL_RETURN_VOID(env, napi_define_properties(
+  NODE_API_CALL_RETURN_VOID(env, napi_create_object(env, &test_null));
+  NODE_API_CALL_RETURN_VOID(env, napi_define_properties(
       env, test_null, sizeof(test_null_props) / sizeof(*test_null_props),
       test_null_props));
 
@@ -97,6 +97,6 @@ void init_test_null(napi_env env, napi_value exports) {
     "testNull", NULL, NULL, NULL, NULL, test_null, napi_enumerable, NULL
   };
 
-  NAPI_CALL_RETURN_VOID(env,
+  NODE_API_CALL_RETURN_VOID(env,
       napi_define_properties(env, exports, 1, &test_null_set));
 }

--- a/test/js-native-api/test_dataview/test_dataview.c
+++ b/test/js-native-api/test_dataview/test_dataview.c
@@ -5,44 +5,44 @@
 static napi_value CreateDataView(napi_env env, napi_callback_info info) {
   size_t argc = 3;
   napi_value args [3];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  NAPI_ASSERT(env, argc == 3, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc == 3, "Wrong number of arguments");
 
   napi_valuetype valuetype0;
   napi_value arraybuffer = args[0];
 
-  NAPI_CALL(env, napi_typeof(env, arraybuffer, &valuetype0));
-  NAPI_ASSERT(env, valuetype0 == napi_object,
+  NODE_API_CALL(env, napi_typeof(env, arraybuffer, &valuetype0));
+  NODE_API_ASSERT(env, valuetype0 == napi_object,
               "Wrong type of arguments. Expects a ArrayBuffer as the first "
               "argument.");
 
   bool is_arraybuffer;
-  NAPI_CALL(env, napi_is_arraybuffer(env, arraybuffer, &is_arraybuffer));
-  NAPI_ASSERT(env, is_arraybuffer,
+  NODE_API_CALL(env, napi_is_arraybuffer(env, arraybuffer, &is_arraybuffer));
+  NODE_API_ASSERT(env, is_arraybuffer,
               "Wrong type of arguments. Expects a ArrayBuffer as the first "
               "argument.");
 
   napi_valuetype valuetype1;
-  NAPI_CALL(env, napi_typeof(env, args[1], &valuetype1));
+  NODE_API_CALL(env, napi_typeof(env, args[1], &valuetype1));
 
-  NAPI_ASSERT(env, valuetype1 == napi_number,
+  NODE_API_ASSERT(env, valuetype1 == napi_number,
       "Wrong type of arguments. Expects a number as second argument.");
 
   size_t byte_offset = 0;
-  NAPI_CALL(env, napi_get_value_uint32(env, args[1], (uint32_t*)(&byte_offset)));
+  NODE_API_CALL(env, napi_get_value_uint32(env, args[1], (uint32_t*)(&byte_offset)));
 
   napi_valuetype valuetype2;
-  NAPI_CALL(env, napi_typeof(env, args[2], &valuetype2));
+  NODE_API_CALL(env, napi_typeof(env, args[2], &valuetype2));
 
-  NAPI_ASSERT(env, valuetype2 == napi_number,
+  NODE_API_ASSERT(env, valuetype2 == napi_number,
       "Wrong type of arguments. Expects a number as third argument.");
 
   size_t length = 0;
-  NAPI_CALL(env, napi_get_value_uint32(env, args[2], (uint32_t*)(&length)));
+  NODE_API_CALL(env, napi_get_value_uint32(env, args[2], (uint32_t*)(&length)));
 
   napi_value output_dataview;
-  NAPI_CALL(env,
+  NODE_API_CALL(env,
             napi_create_dataview(env, length, arraybuffer,
                                  byte_offset, &output_dataview));
 
@@ -52,32 +52,32 @@ static napi_value CreateDataView(napi_env env, napi_callback_info info) {
 static napi_value CreateDataViewFromJSDataView(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args [1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  NAPI_ASSERT(env, argc == 1, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc == 1, "Wrong number of arguments");
 
   napi_valuetype valuetype;
   napi_value input_dataview = args[0];
 
-  NAPI_CALL(env, napi_typeof(env, input_dataview, &valuetype));
-  NAPI_ASSERT(env, valuetype == napi_object,
+  NODE_API_CALL(env, napi_typeof(env, input_dataview, &valuetype));
+  NODE_API_ASSERT(env, valuetype == napi_object,
               "Wrong type of arguments. Expects a DataView as the first "
               "argument.");
 
   bool is_dataview;
-  NAPI_CALL(env, napi_is_dataview(env, input_dataview, &is_dataview));
-  NAPI_ASSERT(env, is_dataview,
+  NODE_API_CALL(env, napi_is_dataview(env, input_dataview, &is_dataview));
+  NODE_API_ASSERT(env, is_dataview,
               "Wrong type of arguments. Expects a DataView as the first "
               "argument.");
   size_t byte_offset = 0;
   size_t length = 0;
   napi_value buffer;
-  NAPI_CALL(env,
+  NODE_API_CALL(env,
             napi_get_dataview_info(env, input_dataview, &length, NULL,
                                    &buffer, &byte_offset));
 
   napi_value output_dataview;
-  NAPI_CALL(env,
+  NODE_API_CALL(env,
             napi_create_dataview(env, length, buffer,
                                  byte_offset, &output_dataview));
 
@@ -88,12 +88,12 @@ static napi_value CreateDataViewFromJSDataView(napi_env env, napi_callback_info 
 EXTERN_C_START
 napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
-    DECLARE_NAPI_PROPERTY("CreateDataView", CreateDataView),
-    DECLARE_NAPI_PROPERTY("CreateDataViewFromJSDataView",
+    DECLARE_NODE_API_PROPERTY("CreateDataView", CreateDataView),
+    DECLARE_NODE_API_PROPERTY("CreateDataViewFromJSDataView",
         CreateDataViewFromJSDataView)
   };
 
-  NAPI_CALL(env, napi_define_properties(
+  NODE_API_CALL(env, napi_define_properties(
       env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
 
   return exports;

--- a/test/js-native-api/test_date/test_date.c
+++ b/test/js-native-api/test_date/test_date.c
@@ -4,21 +4,21 @@
 static napi_value createDate(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  NAPI_ASSERT(env, argc >= 1, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc >= 1, "Wrong number of arguments");
 
   napi_valuetype valuetype0;
-  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
+  NODE_API_CALL(env, napi_typeof(env, args[0], &valuetype0));
 
-  NAPI_ASSERT(env, valuetype0 == napi_number,
-              "Wrong type of arguments. Expects a number as first argument.");
+  NODE_API_ASSERT(env, valuetype0 == napi_number,
+      "Wrong type of arguments. Expects a number as first argument.");
 
   double time;
-  NAPI_CALL(env, napi_get_value_double(env, args[0], &time));
+  NODE_API_CALL(env, napi_get_value_double(env, args[0], &time));
 
   napi_value date;
-  NAPI_CALL(env, napi_create_date(env, time, &date));
+  NODE_API_CALL(env, napi_create_date(env, time, &date));
 
   return date;
 }
@@ -28,9 +28,9 @@ static napi_value isDate(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   bool is_date;
 
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, &date, NULL, NULL));
-  NAPI_CALL(env, napi_is_date(env, date, &is_date));
-  NAPI_CALL(env, napi_get_boolean(env, is_date, &result));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, &date, NULL, NULL));
+  NODE_API_CALL(env, napi_is_date(env, date, &is_date));
+  NODE_API_CALL(env, napi_get_boolean(env, is_date, &result));
 
   return result;
 }
@@ -40,9 +40,9 @@ static napi_value getDateValue(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   double value;
 
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, &date, NULL, NULL));
-  NAPI_CALL(env, napi_get_date_value(env, date, &value));
-  NAPI_CALL(env, napi_create_double(env, value, &result));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, &date, NULL, NULL));
+  NODE_API_CALL(env, napi_get_date_value(env, date, &value));
+  NODE_API_CALL(env, napi_create_double(env, value, &result));
 
   return result;
 }
@@ -50,12 +50,12 @@ static napi_value getDateValue(napi_env env, napi_callback_info info) {
 EXTERN_C_START
 napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
-    DECLARE_NAPI_PROPERTY("createDate", createDate),
-    DECLARE_NAPI_PROPERTY("isDate", isDate),
-    DECLARE_NAPI_PROPERTY("getDateValue", getDateValue),
+    DECLARE_NODE_API_PROPERTY("createDate", createDate),
+    DECLARE_NODE_API_PROPERTY("isDate", isDate),
+    DECLARE_NODE_API_PROPERTY("getDateValue", getDateValue),
   };
 
-  NAPI_CALL(env, napi_define_properties(
+  NODE_API_CALL(env, napi_define_properties(
       env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
 
   return exports;

--- a/test/js-native-api/test_error/test_error.c
+++ b/test/js-native-api/test_error/test_error.c
@@ -4,13 +4,13 @@
 static napi_value checkError(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
   bool r;
-  NAPI_CALL(env, napi_is_error(env, args[0], &r));
+  NODE_API_CALL(env, napi_is_error(env, args[0], &r));
 
   napi_value result;
-  NAPI_CALL(env, napi_get_boolean(env, r, &result));
+  NODE_API_CALL(env, napi_get_boolean(env, r, &result));
 
   return result;
 }
@@ -18,44 +18,42 @@ static napi_value checkError(napi_env env, napi_callback_info info) {
 static napi_value throwExistingError(napi_env env, napi_callback_info info) {
   napi_value message;
   napi_value error;
-  NAPI_CALL(env, napi_create_string_utf8(
+  NODE_API_CALL(env, napi_create_string_utf8(
       env, "existing error", NAPI_AUTO_LENGTH, &message));
-  NAPI_CALL(env, napi_create_error(env, NULL,  message, &error));
-  NAPI_CALL(env, napi_throw(env, error));
+  NODE_API_CALL(env, napi_create_error(env, NULL,  message, &error));
+  NODE_API_CALL(env, napi_throw(env, error));
   return NULL;
 }
 
 static napi_value throwError(napi_env env, napi_callback_info info) {
-  NAPI_CALL(env, napi_throw_error(env, NULL, "error"));
+  NODE_API_CALL(env, napi_throw_error(env, NULL, "error"));
   return NULL;
 }
 
 static napi_value throwRangeError(napi_env env, napi_callback_info info) {
-  NAPI_CALL(env, napi_throw_range_error(env, NULL, "range error"));
+  NODE_API_CALL(env, napi_throw_range_error(env, NULL, "range error"));
   return NULL;
 }
 
 static napi_value throwTypeError(napi_env env, napi_callback_info info) {
-  NAPI_CALL(env, napi_throw_type_error(env, NULL, "type error"));
+  NODE_API_CALL(env, napi_throw_type_error(env, NULL, "type error"));
   return NULL;
 }
 
 static napi_value throwErrorCode(napi_env env, napi_callback_info info) {
-  NAPI_CALL(env, napi_throw_error(env, "ERR_TEST_CODE", "Error [error]"));
+  NODE_API_CALL(env, napi_throw_error(env, "ERR_TEST_CODE", "Error [error]"));
   return NULL;
 }
 
 static napi_value throwRangeErrorCode(napi_env env, napi_callback_info info) {
-  NAPI_CALL(env, napi_throw_range_error(env,
-                                        "ERR_TEST_CODE",
-                                        "RangeError [range error]"));
+  NODE_API_CALL(env,
+      napi_throw_range_error(env, "ERR_TEST_CODE", "RangeError [range error]"));
   return NULL;
 }
 
 static napi_value throwTypeErrorCode(napi_env env, napi_callback_info info) {
-  NAPI_CALL(env, napi_throw_type_error(env,
-                                       "ERR_TEST_CODE",
-                                       "TypeError [type error]"));
+  NODE_API_CALL(env,
+      napi_throw_type_error(env, "ERR_TEST_CODE", "TypeError [type error]"));
   return NULL;
 }
 
@@ -63,27 +61,27 @@ static napi_value throwTypeErrorCode(napi_env env, napi_callback_info info) {
 static napi_value createError(napi_env env, napi_callback_info info) {
   napi_value result;
   napi_value message;
-  NAPI_CALL(env, napi_create_string_utf8(
+  NODE_API_CALL(env, napi_create_string_utf8(
       env, "error", NAPI_AUTO_LENGTH, &message));
-  NAPI_CALL(env, napi_create_error(env, NULL, message, &result));
+  NODE_API_CALL(env, napi_create_error(env, NULL, message, &result));
   return result;
 }
 
 static napi_value createRangeError(napi_env env, napi_callback_info info) {
   napi_value result;
   napi_value message;
-  NAPI_CALL(env, napi_create_string_utf8(
+  NODE_API_CALL(env, napi_create_string_utf8(
       env, "range error", NAPI_AUTO_LENGTH, &message));
-  NAPI_CALL(env, napi_create_range_error(env, NULL, message, &result));
+  NODE_API_CALL(env, napi_create_range_error(env, NULL, message, &result));
   return result;
 }
 
 static napi_value createTypeError(napi_env env, napi_callback_info info) {
   napi_value result;
   napi_value message;
-  NAPI_CALL(env, napi_create_string_utf8(
+  NODE_API_CALL(env, napi_create_string_utf8(
       env, "type error", NAPI_AUTO_LENGTH, &message));
-  NAPI_CALL(env, napi_create_type_error(env, NULL, message, &result));
+  NODE_API_CALL(env, napi_create_type_error(env, NULL, message, &result));
   return result;
 }
 
@@ -91,11 +89,11 @@ static napi_value createErrorCode(napi_env env, napi_callback_info info) {
   napi_value result;
   napi_value message;
   napi_value code;
-  NAPI_CALL(env, napi_create_string_utf8(
+  NODE_API_CALL(env, napi_create_string_utf8(
       env, "Error [error]", NAPI_AUTO_LENGTH, &message));
-  NAPI_CALL(env, napi_create_string_utf8(
+  NODE_API_CALL(env, napi_create_string_utf8(
       env, "ERR_TEST_CODE", NAPI_AUTO_LENGTH, &code));
-  NAPI_CALL(env, napi_create_error(env, code, message, &result));
+  NODE_API_CALL(env, napi_create_error(env, code, message, &result));
   return result;
 }
 
@@ -103,13 +101,12 @@ static napi_value createRangeErrorCode(napi_env env, napi_callback_info info) {
   napi_value result;
   napi_value message;
   napi_value code;
-  NAPI_CALL(env, napi_create_string_utf8(env,
-                                         "RangeError [range error]",
-                                         NAPI_AUTO_LENGTH,
-                                         &message));
-  NAPI_CALL(env, napi_create_string_utf8(
+  NODE_API_CALL(env,
+      napi_create_string_utf8(
+          env, "RangeError [range error]", NAPI_AUTO_LENGTH, &message));
+  NODE_API_CALL(env, napi_create_string_utf8(
       env, "ERR_TEST_CODE", NAPI_AUTO_LENGTH, &code));
-  NAPI_CALL(env, napi_create_range_error(env, code, message, &result));
+  NODE_API_CALL(env, napi_create_range_error(env, code, message, &result));
   return result;
 }
 
@@ -117,45 +114,44 @@ static napi_value createTypeErrorCode(napi_env env, napi_callback_info info) {
   napi_value result;
   napi_value message;
   napi_value code;
-  NAPI_CALL(env, napi_create_string_utf8(env,
-                                         "TypeError [type error]",
-                                         NAPI_AUTO_LENGTH,
-                                         &message));
-  NAPI_CALL(env, napi_create_string_utf8(
+  NODE_API_CALL(env,
+      napi_create_string_utf8(
+          env, "TypeError [type error]", NAPI_AUTO_LENGTH, &message));
+  NODE_API_CALL(env, napi_create_string_utf8(
       env, "ERR_TEST_CODE", NAPI_AUTO_LENGTH, &code));
-  NAPI_CALL(env, napi_create_type_error(env, code, message, &result));
+  NODE_API_CALL(env, napi_create_type_error(env, code, message, &result));
   return result;
 }
 
 static napi_value throwArbitrary(napi_env env, napi_callback_info info) {
   napi_value arbitrary;
   size_t argc = 1;
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, &arbitrary, NULL, NULL));
-  NAPI_CALL(env, napi_throw(env, arbitrary));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, &arbitrary, NULL, NULL));
+  NODE_API_CALL(env, napi_throw(env, arbitrary));
   return NULL;
 }
 
 EXTERN_C_START
 napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
-    DECLARE_NAPI_PROPERTY("checkError", checkError),
-    DECLARE_NAPI_PROPERTY("throwExistingError", throwExistingError),
-    DECLARE_NAPI_PROPERTY("throwError", throwError),
-    DECLARE_NAPI_PROPERTY("throwRangeError", throwRangeError),
-    DECLARE_NAPI_PROPERTY("throwTypeError", throwTypeError),
-    DECLARE_NAPI_PROPERTY("throwErrorCode", throwErrorCode),
-    DECLARE_NAPI_PROPERTY("throwRangeErrorCode", throwRangeErrorCode),
-    DECLARE_NAPI_PROPERTY("throwTypeErrorCode", throwTypeErrorCode),
-    DECLARE_NAPI_PROPERTY("throwArbitrary", throwArbitrary),
-    DECLARE_NAPI_PROPERTY("createError", createError),
-    DECLARE_NAPI_PROPERTY("createRangeError", createRangeError),
-    DECLARE_NAPI_PROPERTY("createTypeError", createTypeError),
-    DECLARE_NAPI_PROPERTY("createErrorCode", createErrorCode),
-    DECLARE_NAPI_PROPERTY("createRangeErrorCode", createRangeErrorCode),
-    DECLARE_NAPI_PROPERTY("createTypeErrorCode", createTypeErrorCode),
+    DECLARE_NODE_API_PROPERTY("checkError", checkError),
+    DECLARE_NODE_API_PROPERTY("throwExistingError", throwExistingError),
+    DECLARE_NODE_API_PROPERTY("throwError", throwError),
+    DECLARE_NODE_API_PROPERTY("throwRangeError", throwRangeError),
+    DECLARE_NODE_API_PROPERTY("throwTypeError", throwTypeError),
+    DECLARE_NODE_API_PROPERTY("throwErrorCode", throwErrorCode),
+    DECLARE_NODE_API_PROPERTY("throwRangeErrorCode", throwRangeErrorCode),
+    DECLARE_NODE_API_PROPERTY("throwTypeErrorCode", throwTypeErrorCode),
+    DECLARE_NODE_API_PROPERTY("throwArbitrary", throwArbitrary),
+    DECLARE_NODE_API_PROPERTY("createError", createError),
+    DECLARE_NODE_API_PROPERTY("createRangeError", createRangeError),
+    DECLARE_NODE_API_PROPERTY("createTypeError", createTypeError),
+    DECLARE_NODE_API_PROPERTY("createErrorCode", createErrorCode),
+    DECLARE_NODE_API_PROPERTY("createRangeErrorCode", createRangeErrorCode),
+    DECLARE_NODE_API_PROPERTY("createTypeErrorCode", createTypeErrorCode),
   };
 
-  NAPI_CALL(env, napi_define_properties(
+  NODE_API_CALL(env, napi_define_properties(
       env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
 
   return exports;

--- a/test/js-native-api/test_exception/test_exception.c
+++ b/test/js-native-api/test_exception/test_exception.c
@@ -6,16 +6,16 @@ static bool exceptionWasPending = false;
 static napi_value returnException(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
   napi_value global;
-  NAPI_CALL(env, napi_get_global(env, &global));
+  NODE_API_CALL(env, napi_get_global(env, &global));
 
   napi_value result;
   napi_status status = napi_call_function(env, global, args[0], 0, 0, &result);
   if (status == napi_pending_exception) {
     napi_value ex;
-    NAPI_CALL(env, napi_get_and_clear_last_exception(env, &ex));
+    NODE_API_CALL(env, napi_get_and_clear_last_exception(env, &ex));
     return ex;
   }
 
@@ -25,35 +25,35 @@ static napi_value returnException(napi_env env, napi_callback_info info) {
 static napi_value allowException(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
   napi_value global;
-  NAPI_CALL(env, napi_get_global(env, &global));
+  NODE_API_CALL(env, napi_get_global(env, &global));
 
   napi_value result;
   napi_call_function(env, global, args[0], 0, 0, &result);
   // Ignore status and check napi_is_exception_pending() instead.
 
-  NAPI_CALL(env, napi_is_exception_pending(env, &exceptionWasPending));
+  NODE_API_CALL(env, napi_is_exception_pending(env, &exceptionWasPending));
   return NULL;
 }
 
 static napi_value wasPending(napi_env env, napi_callback_info info) {
   napi_value result;
-  NAPI_CALL(env, napi_get_boolean(env, exceptionWasPending, &result));
+  NODE_API_CALL(env, napi_get_boolean(env, exceptionWasPending, &result));
 
   return result;
 }
 
 static void finalizer(napi_env env, void *data, void *hint) {
-  NAPI_CALL_RETURN_VOID(env,
+  NODE_API_CALL_RETURN_VOID(env,
       napi_throw_error(env, NULL, "Error during Finalize"));
 }
 
 static napi_value createExternal(napi_env env, napi_callback_info info) {
   napi_value external;
 
-  NAPI_CALL(env,
+  NODE_API_CALL(env,
       napi_create_external(env, NULL, finalizer, NULL, &external));
 
   return external;
@@ -62,21 +62,21 @@ static napi_value createExternal(napi_env env, napi_callback_info info) {
 EXTERN_C_START
 napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
-    DECLARE_NAPI_PROPERTY("returnException", returnException),
-    DECLARE_NAPI_PROPERTY("allowException", allowException),
-    DECLARE_NAPI_PROPERTY("wasPending", wasPending),
-    DECLARE_NAPI_PROPERTY("createExternal", createExternal),
+    DECLARE_NODE_API_PROPERTY("returnException", returnException),
+    DECLARE_NODE_API_PROPERTY("allowException", allowException),
+    DECLARE_NODE_API_PROPERTY("wasPending", wasPending),
+    DECLARE_NODE_API_PROPERTY("createExternal", createExternal),
   };
-  NAPI_CALL(env, napi_define_properties(
+  NODE_API_CALL(env, napi_define_properties(
       env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
 
   napi_value error, code, message;
-  NAPI_CALL(env, napi_create_string_utf8(env, "Error during Init",
+  NODE_API_CALL(env, napi_create_string_utf8(env, "Error during Init",
       NAPI_AUTO_LENGTH, &message));
-  NAPI_CALL(env, napi_create_string_utf8(env, "", NAPI_AUTO_LENGTH, &code));
-  NAPI_CALL(env, napi_create_error(env, code, message, &error));
-  NAPI_CALL(env, napi_set_named_property(env, error, "binding", exports));
-  NAPI_CALL(env, napi_throw(env, error));
+  NODE_API_CALL(env, napi_create_string_utf8(env, "", NAPI_AUTO_LENGTH, &code));
+  NODE_API_CALL(env, napi_create_error(env, code, message, &error));
+  NODE_API_CALL(env, napi_set_named_property(env, error, "binding", exports));
+  NODE_API_CALL(env, napi_throw(env, error));
 
   return exports;
 }

--- a/test/js-native-api/test_function/test_function.c
+++ b/test/js-native-api/test_function/test_function.c
@@ -6,7 +6,7 @@ static napi_value TestCreateFunctionParameters(napi_env env,
   napi_status status;
   napi_value result, return_value;
 
-  NAPI_CALL(env, napi_create_object(env, &return_value));
+  NODE_API_CALL(env, napi_create_object(env, &return_value));
 
   status = napi_create_function(NULL,
                                 "TrackedFunction",
@@ -55,24 +55,24 @@ static napi_value TestCreateFunctionParameters(napi_env env,
 static napi_value TestCallFunction(napi_env env, napi_callback_info info) {
   size_t argc = 10;
   napi_value args[10];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  NAPI_ASSERT(env, argc > 0, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc > 0, "Wrong number of arguments");
 
   napi_valuetype valuetype0;
-  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
+  NODE_API_CALL(env, napi_typeof(env, args[0], &valuetype0));
 
-  NAPI_ASSERT(env, valuetype0 == napi_function,
+  NODE_API_ASSERT(env, valuetype0 == napi_function,
       "Wrong type of arguments. Expects a function as first argument.");
 
   napi_value* argv = args + 1;
   argc = argc - 1;
 
   napi_value global;
-  NAPI_CALL(env, napi_get_global(env, &global));
+  NODE_API_CALL(env, napi_get_global(env, &global));
 
   napi_value result;
-  NAPI_CALL(env, napi_call_function(env, global, args[0], argc, argv, &result));
+  NODE_API_CALL(env, napi_call_function(env, global, args[0], argc, argv, &result));
 
   return result;
 }
@@ -86,24 +86,20 @@ static void finalize_function(napi_env env, void* data, void* hint) {
 
   // Retrieve the JavaScript undefined value.
   napi_value undefined;
-  NAPI_CALL_RETURN_VOID(env, napi_get_undefined(env, &undefined));
+  NODE_API_CALL_RETURN_VOID(env, napi_get_undefined(env, &undefined));
 
   // Retrieve the JavaScript function we must call.
   napi_value js_function;
-  NAPI_CALL_RETURN_VOID(env, napi_get_reference_value(env, ref, &js_function));
+  NODE_API_CALL_RETURN_VOID(env, napi_get_reference_value(env, ref, &js_function));
 
   // Call the JavaScript function to indicate that the generated JavaScript
   // function is about to be gc-ed.
-  NAPI_CALL_RETURN_VOID(env, napi_call_function(env,
-                                                undefined,
-                                                js_function,
-                                                0,
-                                                NULL,
-                                                NULL));
+  NODE_API_CALL_RETURN_VOID(env,
+      napi_call_function(env, undefined, js_function, 0, NULL, NULL));
 
   // Destroy the persistent reference to the function we just called so as to
   // properly clean up.
-  NAPI_CALL_RETURN_VOID(env, napi_delete_reference(env, ref));
+  NODE_API_CALL_RETURN_VOID(env, napi_delete_reference(env, ref));
 }
 
 static napi_value MakeTrackedFunction(napi_env env, napi_callback_info info) {
@@ -114,41 +110,30 @@ static napi_value MakeTrackedFunction(napi_env env, napi_callback_info info) {
   // Retrieve and validate from the arguments the function we will use to
   // indicate to JavaScript that the function we are about to create is about to
   // be gc-ed.
-  NAPI_CALL(env, napi_get_cb_info(env,
-                                  info,
-                                  &argc,
-                                  &js_finalize_cb,
-                                  NULL,
-                                  NULL));
-  NAPI_ASSERT(env, argc == 1, "Wrong number of arguments");
-  NAPI_CALL(env, napi_typeof(env, js_finalize_cb, &arg_type));
-  NAPI_ASSERT(env, arg_type == napi_function, "Argument must be a function");
+  NODE_API_CALL(env,
+      napi_get_cb_info(env, info, &argc, &js_finalize_cb, NULL, NULL));
+  NODE_API_ASSERT(env, argc == 1, "Wrong number of arguments");
+  NODE_API_CALL(env, napi_typeof(env, js_finalize_cb, &arg_type));
+  NODE_API_ASSERT(env, arg_type == napi_function, "Argument must be a function");
 
   // Dynamically create a function.
   napi_value result;
-  NAPI_CALL(env, napi_create_function(env,
-                                      "TrackedFunction",
-                                      NAPI_AUTO_LENGTH,
-                                      TestFunctionName,
-                                      NULL,
-                                      &result));
+  NODE_API_CALL(env,
+      napi_create_function(
+          env, "TrackedFunction", NAPI_AUTO_LENGTH, TestFunctionName, NULL,
+          &result));
 
   // Create a strong reference to the function we will call when the tracked
   // function is about to be gc-ed.
   napi_ref js_finalize_cb_ref;
-  NAPI_CALL(env, napi_create_reference(env,
-                                       js_finalize_cb,
-                                       1,
-                                       &js_finalize_cb_ref));
+  NODE_API_CALL(env,
+      napi_create_reference(env, js_finalize_cb, 1, &js_finalize_cb_ref));
 
   // Attach a finalizer to the dynamically created function and pass it the
   // strong reference we created in the previous step.
-  NAPI_CALL(env, napi_wrap(env,
-                           result,
-                           js_finalize_cb_ref,
-                           finalize_function,
-                           NULL,
-                           NULL));
+  NODE_API_CALL(env,
+      napi_wrap(
+          env, result, js_finalize_cb_ref, finalize_function, NULL, NULL));
 
   return result;
 }
@@ -156,45 +141,39 @@ static napi_value MakeTrackedFunction(napi_env env, napi_callback_info info) {
 EXTERN_C_START
 napi_value Init(napi_env env, napi_value exports) {
   napi_value fn1;
-  NAPI_CALL(env, napi_create_function(
+  NODE_API_CALL(env, napi_create_function(
       env, NULL, NAPI_AUTO_LENGTH, TestCallFunction, NULL, &fn1));
 
   napi_value fn2;
-  NAPI_CALL(env, napi_create_function(
+  NODE_API_CALL(env, napi_create_function(
       env, "Name", NAPI_AUTO_LENGTH, TestFunctionName, NULL, &fn2));
 
   napi_value fn3;
-  NAPI_CALL(env, napi_create_function(
+  NODE_API_CALL(env, napi_create_function(
       env, "Name_extra", 5, TestFunctionName, NULL, &fn3));
 
   napi_value fn4;
-  NAPI_CALL(env, napi_create_function(env,
-                                      "MakeTrackedFunction",
-                                      NAPI_AUTO_LENGTH,
-                                      MakeTrackedFunction,
-                                      NULL,
-                                      &fn4));
+  NODE_API_CALL(env,
+      napi_create_function(
+          env, "MakeTrackedFunction", NAPI_AUTO_LENGTH, MakeTrackedFunction,
+          NULL, &fn4));
 
   napi_value fn5;
-  NAPI_CALL(env, napi_create_function(env,
-                                      "TestCreateFunctionParameters",
-                                      NAPI_AUTO_LENGTH,
-                                      TestCreateFunctionParameters,
-                                      NULL,
-                                      &fn5));
+  NODE_API_CALL(env,
+      napi_create_function(
+          env, "TestCreateFunctionParameters", NAPI_AUTO_LENGTH,
+          TestCreateFunctionParameters, NULL, &fn5));
 
-  NAPI_CALL(env, napi_set_named_property(env, exports, "TestCall", fn1));
-  NAPI_CALL(env, napi_set_named_property(env, exports, "TestName", fn2));
-  NAPI_CALL(env, napi_set_named_property(env, exports, "TestNameShort", fn3));
-  NAPI_CALL(env, napi_set_named_property(env,
-                                         exports,
-                                         "MakeTrackedFunction",
-                                         fn4));
+  NODE_API_CALL(env, napi_set_named_property(env, exports, "TestCall", fn1));
+  NODE_API_CALL(env, napi_set_named_property(env, exports, "TestName", fn2));
+  NODE_API_CALL(env,
+      napi_set_named_property(env, exports, "TestNameShort", fn3));
+  NODE_API_CALL(env,
+      napi_set_named_property(env, exports, "MakeTrackedFunction", fn4));
 
-  NAPI_CALL(env, napi_set_named_property(env,
-                                         exports,
-                                         "TestCreateFunctionParameters",
-                                         fn5));
+  NODE_API_CALL(env,
+      napi_set_named_property(
+          env, exports, "TestCreateFunctionParameters", fn5));
 
   return exports;
 }

--- a/test/js-native-api/test_general/test_general.c
+++ b/test/js-native-api/test_general/test_general.c
@@ -7,12 +7,12 @@
 static napi_value testStrictEquals(napi_env env, napi_callback_info info) {
   size_t argc = 2;
   napi_value args[2];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
   bool bool_result;
   napi_value result;
-  NAPI_CALL(env, napi_strict_equals(env, args[0], args[1], &bool_result));
-  NAPI_CALL(env, napi_get_boolean(env, bool_result, &result));
+  NODE_API_CALL(env, napi_strict_equals(env, args[0], args[1], &bool_result));
+  NODE_API_CALL(env, napi_get_boolean(env, bool_result, &result));
 
   return result;
 }
@@ -20,10 +20,10 @@ static napi_value testStrictEquals(napi_env env, napi_callback_info info) {
 static napi_value testGetPrototype(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
   napi_value result;
-  NAPI_CALL(env, napi_get_prototype(env, args[0], &result));
+  NODE_API_CALL(env, napi_get_prototype(env, args[0], &result));
 
   return result;
 }
@@ -31,52 +31,52 @@ static napi_value testGetPrototype(napi_env env, napi_callback_info info) {
 static napi_value testGetVersion(napi_env env, napi_callback_info info) {
   uint32_t version;
   napi_value result;
-  NAPI_CALL(env, napi_get_version(env, &version));
-  NAPI_CALL(env, napi_create_uint32(env, version, &result));
+  NODE_API_CALL(env, napi_get_version(env, &version));
+  NODE_API_CALL(env, napi_create_uint32(env, version, &result));
   return result;
 }
 
 static napi_value doInstanceOf(napi_env env, napi_callback_info info) {
   size_t argc = 2;
   napi_value args[2];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
   bool instanceof;
-  NAPI_CALL(env, napi_instanceof(env, args[0], args[1], &instanceof));
+  NODE_API_CALL(env, napi_instanceof(env, args[0], args[1], &instanceof));
 
   napi_value result;
-  NAPI_CALL(env, napi_get_boolean(env, instanceof, &result));
+  NODE_API_CALL(env, napi_get_boolean(env, instanceof, &result));
 
   return result;
 }
 
 static napi_value getNull(napi_env env, napi_callback_info info) {
   napi_value result;
-  NAPI_CALL(env, napi_get_null(env, &result));
+  NODE_API_CALL(env, napi_get_null(env, &result));
   return result;
 }
 
 static napi_value getUndefined(napi_env env, napi_callback_info info) {
   napi_value result;
-  NAPI_CALL(env, napi_get_undefined(env, &result));
+  NODE_API_CALL(env, napi_get_undefined(env, &result));
   return result;
 }
 
 static napi_value createNapiError(napi_env env, napi_callback_info info) {
   napi_value value;
-  NAPI_CALL(env, napi_create_string_utf8(env, "xyz", 3, &value));
+  NODE_API_CALL(env, napi_create_string_utf8(env, "xyz", 3, &value));
 
   double double_value;
   napi_status status = napi_get_value_double(env, value, &double_value);
 
-  NAPI_ASSERT(env, status != napi_ok, "Failed to produce error condition");
+  NODE_API_ASSERT(env, status != napi_ok, "Failed to produce error condition");
 
   const napi_extended_error_info *error_info = 0;
-  NAPI_CALL(env, napi_get_last_error_info(env, &error_info));
+  NODE_API_CALL(env, napi_get_last_error_info(env, &error_info));
 
-  NAPI_ASSERT(env, error_info->error_code == status,
+  NODE_API_ASSERT(env, error_info->error_code == status,
       "Last error info code should match last status");
-  NAPI_ASSERT(env, error_info->error_message,
+  NODE_API_ASSERT(env, error_info->error_message,
       "Last error info message should not be null");
 
   return NULL;
@@ -84,11 +84,11 @@ static napi_value createNapiError(napi_env env, napi_callback_info info) {
 
 static napi_value testNapiErrorCleanup(napi_env env, napi_callback_info info) {
   const napi_extended_error_info *error_info = 0;
-  NAPI_CALL(env, napi_get_last_error_info(env, &error_info));
+  NODE_API_CALL(env, napi_get_last_error_info(env, &error_info));
 
   napi_value result;
   bool is_ok = error_info->error_code == napi_ok;
-  NAPI_CALL(env, napi_get_boolean(env, is_ok, &result));
+  NODE_API_CALL(env, napi_get_boolean(env, is_ok, &result));
 
   return result;
 }
@@ -96,35 +96,35 @@ static napi_value testNapiErrorCleanup(napi_env env, napi_callback_info info) {
 static napi_value testNapiTypeof(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
   napi_valuetype argument_type;
-  NAPI_CALL(env, napi_typeof(env, args[0], &argument_type));
+  NODE_API_CALL(env, napi_typeof(env, args[0], &argument_type));
 
   napi_value result = NULL;
   if (argument_type == napi_number) {
-    NAPI_CALL(env, napi_create_string_utf8(
+    NODE_API_CALL(env, napi_create_string_utf8(
         env, "number", NAPI_AUTO_LENGTH, &result));
   } else if (argument_type == napi_string) {
-    NAPI_CALL(env, napi_create_string_utf8(
+    NODE_API_CALL(env, napi_create_string_utf8(
         env, "string", NAPI_AUTO_LENGTH, &result));
   } else if (argument_type == napi_function) {
-    NAPI_CALL(env, napi_create_string_utf8(
+    NODE_API_CALL(env, napi_create_string_utf8(
         env, "function", NAPI_AUTO_LENGTH, &result));
   } else if (argument_type == napi_object) {
-    NAPI_CALL(env, napi_create_string_utf8(
+    NODE_API_CALL(env, napi_create_string_utf8(
         env, "object", NAPI_AUTO_LENGTH, &result));
   } else if (argument_type == napi_boolean) {
-    NAPI_CALL(env, napi_create_string_utf8(
+    NODE_API_CALL(env, napi_create_string_utf8(
         env, "boolean", NAPI_AUTO_LENGTH, &result));
   } else if (argument_type == napi_undefined) {
-    NAPI_CALL(env, napi_create_string_utf8(
+    NODE_API_CALL(env, napi_create_string_utf8(
         env, "undefined", NAPI_AUTO_LENGTH, &result));
   } else if (argument_type == napi_symbol) {
-    NAPI_CALL(env, napi_create_string_utf8(
+    NODE_API_CALL(env, napi_create_string_utf8(
         env, "symbol", NAPI_AUTO_LENGTH, &result));
   } else if (argument_type == napi_null) {
-    NAPI_CALL(env, napi_create_string_utf8(
+    NODE_API_CALL(env, napi_create_string_utf8(
         env, "null", NAPI_AUTO_LENGTH, &result));
   }
   return result;
@@ -134,7 +134,7 @@ static bool deref_item_called = false;
 static void deref_item(napi_env env, void* data, void* hint) {
   (void) hint;
 
-  NAPI_ASSERT_RETURN_VOID(env, data == &deref_item_called,
+  NODE_API_ASSERT_RETURN_VOID(env, data == &deref_item_called,
     "Finalize callback was called with the correct pointer");
 
   deref_item_called = true;
@@ -143,7 +143,7 @@ static void deref_item(napi_env env, void* data, void* hint) {
 static napi_value deref_item_was_called(napi_env env, napi_callback_info info) {
   napi_value it_was_called;
 
-  NAPI_CALL(env, napi_get_boolean(env, deref_item_called, &it_was_called));
+  NODE_API_CALL(env, napi_get_boolean(env, deref_item_called, &it_was_called));
 
   return it_was_called;
 }
@@ -155,8 +155,8 @@ static napi_value wrap_first_arg(napi_env env,
   size_t argc = 1;
   napi_value to_wrap;
 
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, &to_wrap, NULL, NULL));
-  NAPI_CALL(env, napi_wrap(env, to_wrap, data, finalizer, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, &to_wrap, NULL, NULL));
+  NODE_API_CALL(env, napi_wrap(env, to_wrap, data, finalizer, NULL, NULL));
 
   return to_wrap;
 }
@@ -171,8 +171,8 @@ static napi_value unwrap(napi_env env, napi_callback_info info) {
   napi_value wrapped;
   void* data;
 
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, &wrapped, NULL, NULL));
-  NAPI_CALL(env, napi_unwrap(env, wrapped, &data));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, &wrapped, NULL, NULL));
+  NODE_API_CALL(env, napi_unwrap(env, wrapped, &data));
 
   return NULL;
 }
@@ -182,8 +182,8 @@ static napi_value remove_wrap(napi_env env, napi_callback_info info) {
   napi_value wrapped;
   void* data;
 
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, &wrapped, NULL, NULL));
-  NAPI_CALL(env, napi_remove_wrap(env, wrapped, &data));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, &wrapped, NULL, NULL));
+  NODE_API_CALL(env, napi_remove_wrap(env, wrapped, &data));
 
   return NULL;
 }
@@ -200,7 +200,7 @@ static napi_value test_finalize_wrap(napi_env env, napi_callback_info info) {
 static napi_value finalize_was_called(napi_env env, napi_callback_info info) {
   napi_value it_was_called;
 
-  NAPI_CALL(env, napi_get_boolean(env, finalize_called, &it_was_called));
+  NODE_API_CALL(env, napi_get_boolean(env, finalize_called, &it_was_called));
 
   return it_was_called;
 }
@@ -209,8 +209,8 @@ static napi_value testAdjustExternalMemory(napi_env env, napi_callback_info info
   napi_value result;
   int64_t adjustedValue;
 
-  NAPI_CALL(env, napi_adjust_external_memory(env, 1, &adjustedValue));
-  NAPI_CALL(env, napi_create_double(env, (double)adjustedValue, &result));
+  NODE_API_CALL(env, napi_adjust_external_memory(env, 1, &adjustedValue));
+  NODE_API_CALL(env, napi_create_double(env, (double)adjustedValue, &result));
 
   return result;
 }
@@ -219,9 +219,9 @@ static napi_value testNapiRun(napi_env env, napi_callback_info info) {
   napi_value script, result;
   size_t argc = 1;
 
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, &script, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, &script, NULL, NULL));
 
-  NAPI_CALL(env, napi_run_script(env, script, &result));
+  NODE_API_CALL(env, napi_run_script(env, script, &result));
 
   return result;
 }
@@ -229,11 +229,11 @@ static napi_value testNapiRun(napi_env env, napi_callback_info info) {
 static void finalizer_only_callback(napi_env env, void* data, void* hint) {
   napi_ref js_cb_ref = data;
   napi_value js_cb, undefined;
-  NAPI_CALL_RETURN_VOID(env, napi_get_reference_value(env, js_cb_ref, &js_cb));
-  NAPI_CALL_RETURN_VOID(env, napi_get_undefined(env, &undefined));
-  NAPI_CALL_RETURN_VOID(env,
+  NODE_API_CALL_RETURN_VOID(env, napi_get_reference_value(env, js_cb_ref, &js_cb));
+  NODE_API_CALL_RETURN_VOID(env, napi_get_undefined(env, &undefined));
+  NODE_API_CALL_RETURN_VOID(env,
       napi_call_function(env, undefined, js_cb, 0, NULL, NULL));
-  NAPI_CALL_RETURN_VOID(env, napi_delete_reference(env, js_cb_ref));
+  NODE_API_CALL_RETURN_VOID(env, napi_delete_reference(env, js_cb_ref));
 }
 
 static napi_value add_finalizer_only(napi_env env, napi_callback_info info) {
@@ -241,15 +241,11 @@ static napi_value add_finalizer_only(napi_env env, napi_callback_info info) {
   napi_value argv[2];
   napi_ref js_cb_ref;
 
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, argv, NULL, NULL));
-  NAPI_CALL(env, napi_create_reference(env, argv[1], 1, &js_cb_ref));
-  NAPI_CALL(env,
-      napi_add_finalizer(env,
-                         argv[0],
-                         js_cb_ref,
-                         finalizer_only_callback,
-                         NULL,
-                         NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, argv, NULL, NULL));
+  NODE_API_CALL(env, napi_create_reference(env, argv[1], 1, &js_cb_ref));
+  NODE_API_CALL(env,
+      napi_add_finalizer(
+          env, argv[0], js_cb_ref, finalizer_only_callback, NULL, NULL));
   return NULL;
 }
 
@@ -273,9 +269,9 @@ static napi_value env_cleanup_wrap(napi_env env, napi_callback_info info) {
   napi_value argv[2];
   uint32_t value;
   uintptr_t ptr_value;
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, argv, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, argv, NULL, NULL));
 
-  NAPI_CALL(env, napi_get_value_uint32(env, argv[1], &value));
+  NODE_API_CALL(env, napi_get_value_uint32(env, argv[1], &value));
 
   ptr_value = value;
   return wrap_first_arg(env, info, cleanup_env_finalizer, (void*)ptr_value);
@@ -284,28 +280,28 @@ static napi_value env_cleanup_wrap(napi_env env, napi_callback_info info) {
 EXTERN_C_START
 napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
-    DECLARE_NAPI_PROPERTY("testStrictEquals", testStrictEquals),
-    DECLARE_NAPI_PROPERTY("testGetPrototype", testGetPrototype),
-    DECLARE_NAPI_PROPERTY("testGetVersion", testGetVersion),
-    DECLARE_NAPI_PROPERTY("testNapiRun", testNapiRun),
-    DECLARE_NAPI_PROPERTY("doInstanceOf", doInstanceOf),
-    DECLARE_NAPI_PROPERTY("getUndefined", getUndefined),
-    DECLARE_NAPI_PROPERTY("getNull", getNull),
-    DECLARE_NAPI_PROPERTY("createNapiError", createNapiError),
-    DECLARE_NAPI_PROPERTY("testNapiErrorCleanup", testNapiErrorCleanup),
-    DECLARE_NAPI_PROPERTY("testNapiTypeof", testNapiTypeof),
-    DECLARE_NAPI_PROPERTY("wrap", wrap),
-    DECLARE_NAPI_PROPERTY("envCleanupWrap", env_cleanup_wrap),
-    DECLARE_NAPI_PROPERTY("unwrap", unwrap),
-    DECLARE_NAPI_PROPERTY("removeWrap", remove_wrap),
-    DECLARE_NAPI_PROPERTY("addFinalizerOnly", add_finalizer_only),
-    DECLARE_NAPI_PROPERTY("testFinalizeWrap", test_finalize_wrap),
-    DECLARE_NAPI_PROPERTY("finalizeWasCalled", finalize_was_called),
-    DECLARE_NAPI_PROPERTY("derefItemWasCalled", deref_item_was_called),
-    DECLARE_NAPI_PROPERTY("testAdjustExternalMemory", testAdjustExternalMemory)
+    DECLARE_NODE_API_PROPERTY("testStrictEquals", testStrictEquals),
+    DECLARE_NODE_API_PROPERTY("testGetPrototype", testGetPrototype),
+    DECLARE_NODE_API_PROPERTY("testGetVersion", testGetVersion),
+    DECLARE_NODE_API_PROPERTY("testNapiRun", testNapiRun),
+    DECLARE_NODE_API_PROPERTY("doInstanceOf", doInstanceOf),
+    DECLARE_NODE_API_PROPERTY("getUndefined", getUndefined),
+    DECLARE_NODE_API_PROPERTY("getNull", getNull),
+    DECLARE_NODE_API_PROPERTY("createNapiError", createNapiError),
+    DECLARE_NODE_API_PROPERTY("testNapiErrorCleanup", testNapiErrorCleanup),
+    DECLARE_NODE_API_PROPERTY("testNapiTypeof", testNapiTypeof),
+    DECLARE_NODE_API_PROPERTY("wrap", wrap),
+    DECLARE_NODE_API_PROPERTY("envCleanupWrap", env_cleanup_wrap),
+    DECLARE_NODE_API_PROPERTY("unwrap", unwrap),
+    DECLARE_NODE_API_PROPERTY("removeWrap", remove_wrap),
+    DECLARE_NODE_API_PROPERTY("addFinalizerOnly", add_finalizer_only),
+    DECLARE_NODE_API_PROPERTY("testFinalizeWrap", test_finalize_wrap),
+    DECLARE_NODE_API_PROPERTY("finalizeWasCalled", finalize_was_called),
+    DECLARE_NODE_API_PROPERTY("derefItemWasCalled", deref_item_was_called),
+    DECLARE_NODE_API_PROPERTY("testAdjustExternalMemory", testAdjustExternalMemory)
   };
 
-  NAPI_CALL(env, napi_define_properties(
+  NODE_API_CALL(env, napi_define_properties(
       env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
 
   return exports;

--- a/test/js-native-api/test_handle_scope/test_handle_scope.c
+++ b/test/js-native-api/test_handle_scope/test_handle_scope.c
@@ -11,9 +11,9 @@ static napi_value NewScope(napi_env env, napi_callback_info info) {
   napi_handle_scope scope;
   napi_value output = NULL;
 
-  NAPI_CALL(env, napi_open_handle_scope(env, &scope));
-  NAPI_CALL(env, napi_create_object(env, &output));
-  NAPI_CALL(env, napi_close_handle_scope(env, scope));
+  NODE_API_CALL(env, napi_open_handle_scope(env, &scope));
+  NODE_API_CALL(env, napi_create_object(env, &output));
+  NODE_API_CALL(env, napi_close_handle_scope(env, scope));
   return NULL;
 }
 
@@ -22,10 +22,10 @@ static napi_value NewScopeEscape(napi_env env, napi_callback_info info) {
   napi_value output = NULL;
   napi_value escapee = NULL;
 
-  NAPI_CALL(env, napi_open_escapable_handle_scope(env, &scope));
-  NAPI_CALL(env, napi_create_object(env, &output));
-  NAPI_CALL(env, napi_escape_handle(env, scope, output, &escapee));
-  NAPI_CALL(env, napi_close_escapable_handle_scope(env, scope));
+  NODE_API_CALL(env, napi_open_escapable_handle_scope(env, &scope));
+  NODE_API_CALL(env, napi_create_object(env, &output));
+  NODE_API_CALL(env, napi_escape_handle(env, scope, output, &escapee));
+  NODE_API_CALL(env, napi_close_escapable_handle_scope(env, scope));
   return escapee;
 }
 
@@ -35,12 +35,12 @@ static napi_value NewScopeEscapeTwice(napi_env env, napi_callback_info info) {
   napi_value escapee = NULL;
   napi_status status;
 
-  NAPI_CALL(env, napi_open_escapable_handle_scope(env, &scope));
-  NAPI_CALL(env, napi_create_object(env, &output));
-  NAPI_CALL(env, napi_escape_handle(env, scope, output, &escapee));
+  NODE_API_CALL(env, napi_open_escapable_handle_scope(env, &scope));
+  NODE_API_CALL(env, napi_create_object(env, &output));
+  NODE_API_CALL(env, napi_escape_handle(env, scope, output, &escapee));
   status = napi_escape_handle(env, scope, output, &escapee);
-  NAPI_ASSERT(env, status == napi_escape_called_twice, "Escaping twice fails");
-  NAPI_CALL(env, napi_close_escapable_handle_scope(env, scope));
+  NODE_API_ASSERT(env, status == napi_escape_called_twice, "Escaping twice fails");
+  NODE_API_CALL(env, napi_close_escapable_handle_scope(env, scope));
   return NULL;
 }
 
@@ -51,33 +51,33 @@ static napi_value NewScopeWithException(napi_env env, napi_callback_info info) {
   napi_status status;
   napi_value output = NULL;
 
-  NAPI_CALL(env, napi_open_handle_scope(env, &scope));
-  NAPI_CALL(env, napi_create_object(env, &output));
+  NODE_API_CALL(env, napi_open_handle_scope(env, &scope));
+  NODE_API_CALL(env, napi_create_object(env, &output));
 
   argc = 1;
-  NAPI_CALL(env, napi_get_cb_info(
+  NODE_API_CALL(env, napi_get_cb_info(
       env, info, &argc, &exception_function, NULL, NULL));
 
   status = napi_call_function(
       env, output, exception_function, 0, NULL, NULL);
-  NAPI_ASSERT(env, status == napi_pending_exception,
+  NODE_API_ASSERT(env, status == napi_pending_exception,
       "Function should have thrown.");
 
   // Closing a handle scope should still work while an exception is pending.
-  NAPI_CALL(env, napi_close_handle_scope(env, scope));
+  NODE_API_CALL(env, napi_close_handle_scope(env, scope));
   return NULL;
 }
 
 EXTERN_C_START
 napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor properties[] = {
-    DECLARE_NAPI_PROPERTY("NewScope", NewScope),
-    DECLARE_NAPI_PROPERTY("NewScopeEscape", NewScopeEscape),
-    DECLARE_NAPI_PROPERTY("NewScopeEscapeTwice", NewScopeEscapeTwice),
-    DECLARE_NAPI_PROPERTY("NewScopeWithException", NewScopeWithException),
+    DECLARE_NODE_API_PROPERTY("NewScope", NewScope),
+    DECLARE_NODE_API_PROPERTY("NewScopeEscape", NewScopeEscape),
+    DECLARE_NODE_API_PROPERTY("NewScopeEscapeTwice", NewScopeEscapeTwice),
+    DECLARE_NODE_API_PROPERTY("NewScopeWithException", NewScopeWithException),
   };
 
-  NAPI_CALL(env, napi_define_properties(
+  NODE_API_CALL(env, napi_define_properties(
       env, exports, sizeof(properties) / sizeof(*properties), properties));
 
   return exports;

--- a/test/js-native-api/test_instance_data/test_instance_data.c
+++ b/test/js-native-api/test_instance_data/test_instance_data.c
@@ -13,8 +13,8 @@ static napi_value Increment(napi_env env, napi_callback_info info) {
   AddonData* data;
   napi_value result;
 
-  NAPI_CALL(env, napi_get_instance_data(env, (void**)&data));
-  NAPI_CALL(env, napi_create_uint32(env, ++data->value, &result));
+  NODE_API_CALL(env, napi_get_instance_data(env, (void**)&data));
+  NODE_API_CALL(env, napi_create_uint32(env, ++data->value, &result));
 
   return result;
 }
@@ -25,7 +25,7 @@ static void DeleteAddonData(napi_env env, void* raw_data, void* hint) {
     printf("deleting addon data\n");
   }
   if (data->js_cb_ref != NULL) {
-    NAPI_CALL_RETURN_VOID(env, napi_delete_reference(env, data->js_cb_ref));
+    NODE_API_CALL_RETURN_VOID(env, napi_delete_reference(env, data->js_cb_ref));
   }
   free(data);
 }
@@ -33,7 +33,7 @@ static void DeleteAddonData(napi_env env, void* raw_data, void* hint) {
 static napi_value SetPrintOnDelete(napi_env env, napi_callback_info info) {
   AddonData* data;
 
-  NAPI_CALL(env, napi_get_instance_data(env, (void**)&data));
+  NODE_API_CALL(env, napi_get_instance_data(env, (void**)&data));
   data->print = true;
 
   return NULL;
@@ -44,14 +44,14 @@ static void TestFinalizer(napi_env env, void* raw_data, void* hint) {
   (void) hint;
 
   AddonData* data;
-  NAPI_CALL_RETURN_VOID(env, napi_get_instance_data(env, (void**)&data));
+  NODE_API_CALL_RETURN_VOID(env, napi_get_instance_data(env, (void**)&data));
   napi_value js_cb, undefined;
-  NAPI_CALL_RETURN_VOID(env,
+  NODE_API_CALL_RETURN_VOID(env,
       napi_get_reference_value(env, data->js_cb_ref, &js_cb));
-  NAPI_CALL_RETURN_VOID(env, napi_get_undefined(env, &undefined));
-  NAPI_CALL_RETURN_VOID(env,
+  NODE_API_CALL_RETURN_VOID(env, napi_get_undefined(env, &undefined));
+  NODE_API_CALL_RETURN_VOID(env,
       napi_call_function(env, undefined, js_cb, 0, NULL, NULL));
-  NAPI_CALL_RETURN_VOID(env, napi_delete_reference(env, data->js_cb_ref));
+  NODE_API_CALL_RETURN_VOID(env, napi_delete_reference(env, data->js_cb_ref));
   data->js_cb_ref = NULL;
 }
 
@@ -60,13 +60,13 @@ static napi_value ObjectWithFinalizer(napi_env env, napi_callback_info info) {
   napi_value result, js_cb;
   size_t argc = 1;
 
-  NAPI_CALL(env, napi_get_instance_data(env, (void**)&data));
-  NAPI_ASSERT(env, data->js_cb_ref == NULL, "reference must be NULL");
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, &js_cb, NULL, NULL));
-  NAPI_CALL(env, napi_create_object(env, &result));
-  NAPI_CALL(env,
+  NODE_API_CALL(env, napi_get_instance_data(env, (void**)&data));
+  NODE_API_ASSERT(env, data->js_cb_ref == NULL, "reference must be NULL");
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, &js_cb, NULL, NULL));
+  NODE_API_CALL(env, napi_create_object(env, &result));
+  NODE_API_CALL(env,
       napi_add_finalizer(env, result, NULL, TestFinalizer, NULL, NULL));
-  NAPI_CALL(env, napi_create_reference(env, js_cb, 1, &data->js_cb_ref));
+  NODE_API_CALL(env, napi_create_reference(env, js_cb, 1, &data->js_cb_ref));
 
   return result;
 }
@@ -78,18 +78,17 @@ napi_value Init(napi_env env, napi_value exports) {
   data->print = false;
   data->js_cb_ref = NULL;
 
-  NAPI_CALL(env, napi_set_instance_data(env, data, DeleteAddonData, NULL));
+  NODE_API_CALL(env, napi_set_instance_data(env, data, DeleteAddonData, NULL));
 
   napi_property_descriptor props[] = {
-    DECLARE_NAPI_PROPERTY("increment", Increment),
-    DECLARE_NAPI_PROPERTY("setPrintOnDelete", SetPrintOnDelete),
-    DECLARE_NAPI_PROPERTY("objectWithFinalizer", ObjectWithFinalizer),
+    DECLARE_NODE_API_PROPERTY("increment", Increment),
+    DECLARE_NODE_API_PROPERTY("setPrintOnDelete", SetPrintOnDelete),
+    DECLARE_NODE_API_PROPERTY("objectWithFinalizer", ObjectWithFinalizer),
   };
 
-  NAPI_CALL(env, napi_define_properties(env,
-                                        exports,
-                                        sizeof(props) / sizeof(*props),
-                                        props));
+  NODE_API_CALL(env,
+      napi_define_properties(
+          env, exports, sizeof(props) / sizeof(*props), props));
 
   return exports;
 }

--- a/test/js-native-api/test_new_target/binding.c
+++ b/test/js-native-api/test_new_target/binding.c
@@ -3,21 +3,21 @@
 
 static napi_value BaseClass(napi_env env, napi_callback_info info) {
   napi_value newTargetArg;
-  NAPI_CALL(env, napi_get_new_target(env, info, &newTargetArg));
+  NODE_API_CALL(env, napi_get_new_target(env, info, &newTargetArg));
   napi_value thisArg;
-  NAPI_CALL(env, napi_get_cb_info(env, info, NULL, NULL, &thisArg, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, NULL, NULL, &thisArg, NULL));
   napi_value undefined;
-  NAPI_CALL(env, napi_get_undefined(env, &undefined));
+  NODE_API_CALL(env, napi_get_undefined(env, &undefined));
 
   // this !== new.target since we are being invoked through super()
   bool result;
-  NAPI_CALL(env, napi_strict_equals(env, newTargetArg, thisArg, &result));
-  NAPI_ASSERT(env, !result, "this !== new.target");
+  NODE_API_CALL(env, napi_strict_equals(env, newTargetArg, thisArg, &result));
+  NODE_API_ASSERT(env, !result, "this !== new.target");
 
   // new.target !== undefined because we should be called as a new expression
-  NAPI_ASSERT(env, newTargetArg != NULL, "newTargetArg != NULL");
-  NAPI_CALL(env, napi_strict_equals(env, newTargetArg, undefined, &result));
-  NAPI_ASSERT(env, !result, "new.target !== undefined");
+  NODE_API_ASSERT(env, newTargetArg != NULL, "newTargetArg != NULL");
+  NODE_API_CALL(env, napi_strict_equals(env, newTargetArg, undefined, &result));
+  NODE_API_ASSERT(env, !result, "new.target !== undefined");
 
   return thisArg;
 }
@@ -25,45 +25,45 @@ static napi_value BaseClass(napi_env env, napi_callback_info info) {
 static napi_value Constructor(napi_env env, napi_callback_info info) {
   bool result;
   napi_value newTargetArg;
-  NAPI_CALL(env, napi_get_new_target(env, info, &newTargetArg));
+  NODE_API_CALL(env, napi_get_new_target(env, info, &newTargetArg));
   size_t argc = 1;
   napi_value argv;
   napi_value thisArg;
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, &argv, &thisArg, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, &argv, &thisArg, NULL));
   napi_value undefined;
-  NAPI_CALL(env, napi_get_undefined(env, &undefined));
+  NODE_API_CALL(env, napi_get_undefined(env, &undefined));
 
   // new.target !== undefined because we should be called as a new expression
-  NAPI_ASSERT(env, newTargetArg != NULL, "newTargetArg != NULL");
-  NAPI_CALL(env, napi_strict_equals(env, newTargetArg, undefined, &result));
-  NAPI_ASSERT(env, !result, "new.target !== undefined");
+  NODE_API_ASSERT(env, newTargetArg != NULL, "newTargetArg != NULL");
+  NODE_API_CALL(env, napi_strict_equals(env, newTargetArg, undefined, &result));
+  NODE_API_ASSERT(env, !result, "new.target !== undefined");
 
   // arguments[0] should be Constructor itself (test harness passed it)
-  NAPI_CALL(env, napi_strict_equals(env, newTargetArg, argv, &result));
-  NAPI_ASSERT(env, result, "new.target === Constructor");
+  NODE_API_CALL(env, napi_strict_equals(env, newTargetArg, argv, &result));
+  NODE_API_ASSERT(env, result, "new.target === Constructor");
 
   return thisArg;
 }
 
 static napi_value OrdinaryFunction(napi_env env, napi_callback_info info) {
   napi_value newTargetArg;
-  NAPI_CALL(env, napi_get_new_target(env, info, &newTargetArg));
+  NODE_API_CALL(env, napi_get_new_target(env, info, &newTargetArg));
 
-  NAPI_ASSERT(env, newTargetArg == NULL, "newTargetArg == NULL");
+  NODE_API_ASSERT(env, newTargetArg == NULL, "newTargetArg == NULL");
 
   napi_value _true;
-  NAPI_CALL(env, napi_get_boolean(env, true, &_true));
+  NODE_API_CALL(env, napi_get_boolean(env, true, &_true));
   return _true;
 }
 
 EXTERN_C_START
 napi_value Init(napi_env env, napi_value exports) {
   const napi_property_descriptor desc[] = {
-    DECLARE_NAPI_PROPERTY("BaseClass", BaseClass),
-    DECLARE_NAPI_PROPERTY("OrdinaryFunction", OrdinaryFunction),
-    DECLARE_NAPI_PROPERTY("Constructor", Constructor)
+    DECLARE_NODE_API_PROPERTY("BaseClass", BaseClass),
+    DECLARE_NODE_API_PROPERTY("OrdinaryFunction", OrdinaryFunction),
+    DECLARE_NODE_API_PROPERTY("Constructor", Constructor)
   };
-  NAPI_CALL(env, napi_define_properties(env, exports, 3, desc));
+  NODE_API_CALL(env, napi_define_properties(env, exports, 3, desc));
   return exports;
 }
 EXTERN_C_END

--- a/test/js-native-api/test_number/test_number.c
+++ b/test/js-native-api/test_number/test_number.c
@@ -4,21 +4,21 @@
 static napi_value Test(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  NAPI_ASSERT(env, argc >= 1, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc >= 1, "Wrong number of arguments");
 
   napi_valuetype valuetype0;
-  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
+  NODE_API_CALL(env, napi_typeof(env, args[0], &valuetype0));
 
-  NAPI_ASSERT(env, valuetype0 == napi_number,
+  NODE_API_ASSERT(env, valuetype0 == napi_number,
       "Wrong type of arguments. Expects a number as first argument.");
 
   double input;
-  NAPI_CALL(env, napi_get_value_double(env, args[0], &input));
+  NODE_API_CALL(env, napi_get_value_double(env, args[0], &input));
 
   napi_value output;
-  NAPI_CALL(env, napi_create_double(env, input, &output));
+  NODE_API_CALL(env, napi_create_double(env, input, &output));
 
   return output;
 }
@@ -26,21 +26,21 @@ static napi_value Test(napi_env env, napi_callback_info info) {
 static napi_value TestUint32Truncation(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  NAPI_ASSERT(env, argc >= 1, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc >= 1, "Wrong number of arguments");
 
   napi_valuetype valuetype0;
-  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
+  NODE_API_CALL(env, napi_typeof(env, args[0], &valuetype0));
 
-  NAPI_ASSERT(env, valuetype0 == napi_number,
+  NODE_API_ASSERT(env, valuetype0 == napi_number,
       "Wrong type of arguments. Expects a number as first argument.");
 
   uint32_t input;
-  NAPI_CALL(env, napi_get_value_uint32(env, args[0], &input));
+  NODE_API_CALL(env, napi_get_value_uint32(env, args[0], &input));
 
   napi_value output;
-  NAPI_CALL(env, napi_create_uint32(env, input, &output));
+  NODE_API_CALL(env, napi_create_uint32(env, input, &output));
 
   return output;
 }
@@ -48,21 +48,21 @@ static napi_value TestUint32Truncation(napi_env env, napi_callback_info info) {
 static napi_value TestInt32Truncation(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  NAPI_ASSERT(env, argc >= 1, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc >= 1, "Wrong number of arguments");
 
   napi_valuetype valuetype0;
-  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
+  NODE_API_CALL(env, napi_typeof(env, args[0], &valuetype0));
 
-  NAPI_ASSERT(env, valuetype0 == napi_number,
+  NODE_API_ASSERT(env, valuetype0 == napi_number,
       "Wrong type of arguments. Expects a number as first argument.");
 
   int32_t input;
-  NAPI_CALL(env, napi_get_value_int32(env, args[0], &input));
+  NODE_API_CALL(env, napi_get_value_int32(env, args[0], &input));
 
   napi_value output;
-  NAPI_CALL(env, napi_create_int32(env, input, &output));
+  NODE_API_CALL(env, napi_create_int32(env, input, &output));
 
   return output;
 }
@@ -70,21 +70,21 @@ static napi_value TestInt32Truncation(napi_env env, napi_callback_info info) {
 static napi_value TestInt64Truncation(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  NAPI_ASSERT(env, argc >= 1, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc >= 1, "Wrong number of arguments");
 
   napi_valuetype valuetype0;
-  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
+  NODE_API_CALL(env, napi_typeof(env, args[0], &valuetype0));
 
-  NAPI_ASSERT(env, valuetype0 == napi_number,
+  NODE_API_ASSERT(env, valuetype0 == napi_number,
       "Wrong type of arguments. Expects a number as first argument.");
 
   int64_t input;
-  NAPI_CALL(env, napi_get_value_int64(env, args[0], &input));
+  NODE_API_CALL(env, napi_get_value_int64(env, args[0], &input));
 
   napi_value output;
-  NAPI_CALL(env, napi_create_int64(env, input, &output));
+  NODE_API_CALL(env, napi_create_int64(env, input, &output));
 
   return output;
 }
@@ -92,13 +92,13 @@ static napi_value TestInt64Truncation(napi_env env, napi_callback_info info) {
 EXTERN_C_START
 napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
-    DECLARE_NAPI_PROPERTY("Test", Test),
-    DECLARE_NAPI_PROPERTY("TestInt32Truncation", TestInt32Truncation),
-    DECLARE_NAPI_PROPERTY("TestUint32Truncation", TestUint32Truncation),
-    DECLARE_NAPI_PROPERTY("TestInt64Truncation", TestInt64Truncation),
+    DECLARE_NODE_API_PROPERTY("Test", Test),
+    DECLARE_NODE_API_PROPERTY("TestInt32Truncation", TestInt32Truncation),
+    DECLARE_NODE_API_PROPERTY("TestUint32Truncation", TestUint32Truncation),
+    DECLARE_NODE_API_PROPERTY("TestInt64Truncation", TestInt64Truncation),
   };
 
-  NAPI_CALL(env, napi_define_properties(
+  NODE_API_CALL(env, napi_define_properties(
       env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
 
   return exports;

--- a/test/js-native-api/test_object/test_null.c
+++ b/test/js-native-api/test_object/test_null.c
@@ -6,9 +6,9 @@
 static napi_value SetProperty(napi_env env, napi_callback_info info) {
   napi_value return_value, object, key;
 
-  NAPI_CALL(env, napi_create_object(env, &return_value));
-  NAPI_CALL(env, napi_create_object(env, &object));
-  NAPI_CALL(env,
+  NODE_API_CALL(env, napi_create_object(env, &return_value));
+  NODE_API_CALL(env, napi_create_object(env, &object));
+  NODE_API_CALL(env,
       napi_create_string_utf8(env, "someString", NAPI_AUTO_LENGTH, &key));
 
   add_returned_status(env,
@@ -33,9 +33,9 @@ static napi_value SetProperty(napi_env env, napi_callback_info info) {
 static napi_value GetProperty(napi_env env, napi_callback_info info) {
   napi_value return_value, object, key, prop;
 
-  NAPI_CALL(env, napi_create_object(env, &return_value));
-  NAPI_CALL(env, napi_create_object(env, &object));
-  NAPI_CALL(env,
+  NODE_API_CALL(env, napi_create_object(env, &return_value));
+  NODE_API_CALL(env, napi_create_object(env, &object));
+  NODE_API_CALL(env,
       napi_create_string_utf8(env, "someString", NAPI_AUTO_LENGTH, &key));
 
   add_returned_status(env,
@@ -62,9 +62,9 @@ static napi_value TestBoolValuedPropApi(napi_env env,
   napi_value return_value, object, key;
   bool result;
 
-  NAPI_CALL(env, napi_create_object(env, &return_value));
-  NAPI_CALL(env, napi_create_object(env, &object));
-  NAPI_CALL(env,
+  NODE_API_CALL(env, napi_create_object(env, &return_value));
+  NODE_API_CALL(env, napi_create_object(env, &object));
+  NODE_API_CALL(env,
       napi_create_string_utf8(env, "someString", NAPI_AUTO_LENGTH, &key));
 
   add_returned_status(env,
@@ -101,8 +101,8 @@ static napi_value DeleteProperty(napi_env env, napi_callback_info info) {
 static napi_value SetNamedProperty(napi_env env, napi_callback_info info) {
   napi_value return_value, object;
 
-  NAPI_CALL(env, napi_create_object(env, &return_value));
-  NAPI_CALL(env, napi_create_object(env, &object));
+  NODE_API_CALL(env, napi_create_object(env, &return_value));
+  NODE_API_CALL(env, napi_create_object(env, &object));
 
   add_returned_status(env,
                       "envIsNull",
@@ -126,8 +126,8 @@ static napi_value SetNamedProperty(napi_env env, napi_callback_info info) {
 static napi_value GetNamedProperty(napi_env env, napi_callback_info info) {
   napi_value return_value, object, prop;
 
-  NAPI_CALL(env, napi_create_object(env, &return_value));
-  NAPI_CALL(env, napi_create_object(env, &object));
+  NODE_API_CALL(env, napi_create_object(env, &return_value));
+  NODE_API_CALL(env, napi_create_object(env, &object));
 
   add_returned_status(env,
                       "envIsNull",
@@ -152,8 +152,8 @@ static napi_value HasNamedProperty(napi_env env, napi_callback_info info) {
   napi_value return_value, object;
   bool result;
 
-  NAPI_CALL(env, napi_create_object(env, &return_value));
-  NAPI_CALL(env, napi_create_object(env, &object));
+  NODE_API_CALL(env, napi_create_object(env, &return_value));
+  NODE_API_CALL(env, napi_create_object(env, &object));
 
   add_returned_status(env,
                       "envIsNull",
@@ -177,8 +177,8 @@ static napi_value HasNamedProperty(napi_env env, napi_callback_info info) {
 static napi_value SetElement(napi_env env, napi_callback_info info) {
   napi_value return_value, object;
 
-  NAPI_CALL(env, napi_create_object(env, &return_value));
-  NAPI_CALL(env, napi_create_object(env, &object));
+  NODE_API_CALL(env, napi_create_object(env, &return_value));
+  NODE_API_CALL(env, napi_create_object(env, &object));
 
   add_returned_status(env,
                       "envIsNull",
@@ -199,8 +199,8 @@ static napi_value SetElement(napi_env env, napi_callback_info info) {
 static napi_value GetElement(napi_env env, napi_callback_info info) {
   napi_value return_value, object, prop;
 
-  NAPI_CALL(env, napi_create_object(env, &return_value));
-  NAPI_CALL(env, napi_create_object(env, &object));
+  NODE_API_CALL(env, napi_create_object(env, &return_value));
+  NODE_API_CALL(env, napi_create_object(env, &object));
 
   add_returned_status(env,
                       "envIsNull",
@@ -223,8 +223,8 @@ static napi_value TestBoolValuedElementApi(napi_env env,
   napi_value return_value, object;
   bool result;
 
-  NAPI_CALL(env, napi_create_object(env, &return_value));
-  NAPI_CALL(env, napi_create_object(env, &object));
+  NODE_API_CALL(env, napi_create_object(env, &return_value));
+  NODE_API_CALL(env, napi_create_object(env, &object));
 
   add_returned_status(env,
                       "envIsNull",
@@ -257,8 +257,8 @@ static napi_value DefineProperties(napi_env env, napi_callback_info info) {
     "prop", NULL, DefineProperties, NULL, NULL, NULL, napi_enumerable, NULL
   };
 
-  NAPI_CALL(env, napi_create_object(env, &object));
-  NAPI_CALL(env, napi_create_object(env, &return_value));
+  NODE_API_CALL(env, napi_create_object(env, &object));
+  NODE_API_CALL(env, napi_create_object(env, &return_value));
 
   add_returned_status(env,
                       "envIsNull",
@@ -289,7 +289,7 @@ static napi_value DefineProperties(napi_env env, napi_callback_info info) {
 static napi_value GetPropertyNames(napi_env env, napi_callback_info info) {
   napi_value return_value, props;
 
-  NAPI_CALL(env, napi_create_object(env, &return_value));
+  NODE_API_CALL(env, napi_create_object(env, &return_value));
 
   add_returned_status(env,
                       "envIsNull",
@@ -310,7 +310,7 @@ static napi_value GetPropertyNames(napi_env env, napi_callback_info info) {
 static napi_value GetAllPropertyNames(napi_env env, napi_callback_info info) {
   napi_value return_value, props;
 
-  NAPI_CALL(env, napi_create_object(env, &return_value));
+  NODE_API_CALL(env, napi_create_object(env, &return_value));
 
   add_returned_status(env,
                       "envIsNull",
@@ -346,7 +346,7 @@ static napi_value GetAllPropertyNames(napi_env env, napi_callback_info info) {
 static napi_value GetPrototype(napi_env env, napi_callback_info info) {
   napi_value return_value, proto;
 
-  NAPI_CALL(env, napi_create_object(env, &return_value));
+  NODE_API_CALL(env, napi_create_object(env, &return_value));
 
   add_returned_status(env,
                       "envIsNull",
@@ -368,26 +368,26 @@ void init_test_null(napi_env env, napi_value exports) {
   napi_value test_null;
 
   const napi_property_descriptor test_null_props[] = {
-    DECLARE_NAPI_PROPERTY("setProperty", SetProperty),
-    DECLARE_NAPI_PROPERTY("getProperty", GetProperty),
-    DECLARE_NAPI_PROPERTY("hasProperty", HasProperty),
-    DECLARE_NAPI_PROPERTY("hasOwnProperty", HasOwnProperty),
-    DECLARE_NAPI_PROPERTY("deleteProperty", DeleteProperty),
-    DECLARE_NAPI_PROPERTY("setNamedProperty", SetNamedProperty),
-    DECLARE_NAPI_PROPERTY("getNamedProperty", GetNamedProperty),
-    DECLARE_NAPI_PROPERTY("hasNamedProperty", HasNamedProperty),
-    DECLARE_NAPI_PROPERTY("setElement", SetElement),
-    DECLARE_NAPI_PROPERTY("getElement", GetElement),
-    DECLARE_NAPI_PROPERTY("hasElement", HasElement),
-    DECLARE_NAPI_PROPERTY("deleteElement", DeleteElement),
-    DECLARE_NAPI_PROPERTY("defineProperties", DefineProperties),
-    DECLARE_NAPI_PROPERTY("getPropertyNames", GetPropertyNames),
-    DECLARE_NAPI_PROPERTY("getAllPropertyNames", GetAllPropertyNames),
-    DECLARE_NAPI_PROPERTY("getPrototype", GetPrototype),
+    DECLARE_NODE_API_PROPERTY("setProperty", SetProperty),
+    DECLARE_NODE_API_PROPERTY("getProperty", GetProperty),
+    DECLARE_NODE_API_PROPERTY("hasProperty", HasProperty),
+    DECLARE_NODE_API_PROPERTY("hasOwnProperty", HasOwnProperty),
+    DECLARE_NODE_API_PROPERTY("deleteProperty", DeleteProperty),
+    DECLARE_NODE_API_PROPERTY("setNamedProperty", SetNamedProperty),
+    DECLARE_NODE_API_PROPERTY("getNamedProperty", GetNamedProperty),
+    DECLARE_NODE_API_PROPERTY("hasNamedProperty", HasNamedProperty),
+    DECLARE_NODE_API_PROPERTY("setElement", SetElement),
+    DECLARE_NODE_API_PROPERTY("getElement", GetElement),
+    DECLARE_NODE_API_PROPERTY("hasElement", HasElement),
+    DECLARE_NODE_API_PROPERTY("deleteElement", DeleteElement),
+    DECLARE_NODE_API_PROPERTY("defineProperties", DefineProperties),
+    DECLARE_NODE_API_PROPERTY("getPropertyNames", GetPropertyNames),
+    DECLARE_NODE_API_PROPERTY("getAllPropertyNames", GetAllPropertyNames),
+    DECLARE_NODE_API_PROPERTY("getPrototype", GetPrototype),
   };
 
-  NAPI_CALL_RETURN_VOID(env, napi_create_object(env, &test_null));
-  NAPI_CALL_RETURN_VOID(env, napi_define_properties(
+  NODE_API_CALL_RETURN_VOID(env, napi_create_object(env, &test_null));
+  NODE_API_CALL_RETURN_VOID(env, napi_define_properties(
       env, test_null, sizeof(test_null_props) / sizeof(*test_null_props),
       test_null_props));
 
@@ -395,6 +395,6 @@ void init_test_null(napi_env env, napi_value exports) {
     "testNull", NULL, NULL, NULL, NULL, test_null, napi_enumerable, NULL
   };
 
-  NAPI_CALL_RETURN_VOID(env,
+  NODE_API_CALL_RETURN_VOID(env,
       napi_define_properties(env, exports, 1, &test_null_set));
 }

--- a/test/js-native-api/test_object/test_object.c
+++ b/test/js-native-api/test_object/test_object.c
@@ -9,25 +9,25 @@ static int test_value = 3;
 static napi_value Get(napi_env env, napi_callback_info info) {
   size_t argc = 2;
   napi_value args[2];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  NAPI_ASSERT(env, argc >= 2, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc >= 2, "Wrong number of arguments");
 
   napi_valuetype valuetype0;
-  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
+  NODE_API_CALL(env, napi_typeof(env, args[0], &valuetype0));
 
-  NAPI_ASSERT(env, valuetype0 == napi_object,
+  NODE_API_ASSERT(env, valuetype0 == napi_object,
       "Wrong type of arguments. Expects an object as first argument.");
 
   napi_valuetype valuetype1;
-  NAPI_CALL(env, napi_typeof(env, args[1], &valuetype1));
+  NODE_API_CALL(env, napi_typeof(env, args[1], &valuetype1));
 
-  NAPI_ASSERT(env, valuetype1 == napi_string || valuetype1 == napi_symbol,
+  NODE_API_ASSERT(env, valuetype1 == napi_string || valuetype1 == napi_symbol,
       "Wrong type of arguments. Expects a string or symbol as second.");
 
   napi_value object = args[0];
   napi_value output;
-  NAPI_CALL(env, napi_get_property(env, object, args[1], &output));
+  NODE_API_CALL(env, napi_get_property(env, object, args[1], &output));
 
   return output;
 }
@@ -37,30 +37,30 @@ static napi_value GetNamed(napi_env env, napi_callback_info info) {
   napi_value args[2];
   char key[256] = "";
   size_t key_length;
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  NAPI_ASSERT(env, argc >= 2, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc >= 2, "Wrong number of arguments");
 
   napi_valuetype value_type0;
-  NAPI_CALL(env, napi_typeof(env, args[0], &value_type0));
+  NODE_API_CALL(env, napi_typeof(env, args[0], &value_type0));
 
-  NAPI_ASSERT(env, value_type0 == napi_object,
+  NODE_API_ASSERT(env, value_type0 == napi_object,
       "Wrong type of arguments. Expects an object as first argument.");
 
   napi_valuetype value_type1;
-  NAPI_CALL(env, napi_typeof(env, args[1], &value_type1));
+  NODE_API_CALL(env, napi_typeof(env, args[1], &value_type1));
 
-  NAPI_ASSERT(env, value_type1 == napi_string,
+  NODE_API_ASSERT(env, value_type1 == napi_string,
       "Wrong type of arguments. Expects a string as second.");
 
   napi_value object = args[0];
-  NAPI_CALL(env,
+  NODE_API_CALL(env,
       napi_get_value_string_utf8(env, args[1], key, 255, &key_length));
   key[255] = 0;
-  NAPI_ASSERT(env, key_length <= 255,
+  NODE_API_ASSERT(env, key_length <= 255,
       "Cannot accommodate keys longer than 255 bytes");
   napi_value output;
-  NAPI_CALL(env, napi_get_named_property(env, object, key, &output));
+  NODE_API_CALL(env, napi_get_named_property(env, object, key, &output));
 
   return output;
 }
@@ -68,18 +68,18 @@ static napi_value GetNamed(napi_env env, napi_callback_info info) {
 static napi_value GetPropertyNames(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  NAPI_ASSERT(env, argc >= 1, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc >= 1, "Wrong number of arguments");
 
   napi_valuetype value_type0;
-  NAPI_CALL(env, napi_typeof(env, args[0], &value_type0));
+  NODE_API_CALL(env, napi_typeof(env, args[0], &value_type0));
 
-  NAPI_ASSERT(env, value_type0 == napi_object,
+  NODE_API_ASSERT(env, value_type0 == napi_object,
       "Wrong type of arguments. Expects an object as first argument.");
 
   napi_value output;
-  NAPI_CALL(env, napi_get_property_names(env, args[0], &output));
+  NODE_API_CALL(env, napi_get_property_names(env, args[0], &output));
 
   return output;
 }
@@ -87,26 +87,22 @@ static napi_value GetPropertyNames(napi_env env, napi_callback_info info) {
 static napi_value GetSymbolNames(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  NAPI_ASSERT(env, argc >= 1, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc >= 1, "Wrong number of arguments");
 
   napi_valuetype value_type0;
-  NAPI_CALL(env, napi_typeof(env, args[0], &value_type0));
+  NODE_API_CALL(env, napi_typeof(env, args[0], &value_type0));
 
-  NAPI_ASSERT(env,
+  NODE_API_ASSERT(env,
               value_type0 == napi_object,
               "Wrong type of arguments. Expects an object as first argument.");
 
   napi_value output;
-  NAPI_CALL(env,
-            napi_get_all_property_names(
-                env,
-                args[0],
-                napi_key_include_prototypes,
-                napi_key_skip_strings,
-                napi_key_numbers_to_strings,
-                &output));
+  NODE_API_CALL(env,
+      napi_get_all_property_names(
+          env, args[0], napi_key_include_prototypes, napi_key_skip_strings,
+          napi_key_numbers_to_strings, &output));
 
   return output;
 }
@@ -114,26 +110,26 @@ static napi_value GetSymbolNames(napi_env env, napi_callback_info info) {
 static napi_value Set(napi_env env, napi_callback_info info) {
   size_t argc = 3;
   napi_value args[3];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  NAPI_ASSERT(env, argc >= 3, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc >= 3, "Wrong number of arguments");
 
   napi_valuetype valuetype0;
-  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
+  NODE_API_CALL(env, napi_typeof(env, args[0], &valuetype0));
 
-  NAPI_ASSERT(env, valuetype0 == napi_object,
+  NODE_API_ASSERT(env, valuetype0 == napi_object,
       "Wrong type of arguments. Expects an object as first argument.");
 
   napi_valuetype valuetype1;
-  NAPI_CALL(env, napi_typeof(env, args[1], &valuetype1));
+  NODE_API_CALL(env, napi_typeof(env, args[1], &valuetype1));
 
-  NAPI_ASSERT(env, valuetype1 == napi_string || valuetype1 == napi_symbol,
+  NODE_API_ASSERT(env, valuetype1 == napi_string || valuetype1 == napi_symbol,
       "Wrong type of arguments. Expects a string or symbol as second.");
 
-  NAPI_CALL(env, napi_set_property(env, args[0], args[1], args[2]));
+  NODE_API_CALL(env, napi_set_property(env, args[0], args[1], args[2]));
 
   napi_value valuetrue;
-  NAPI_CALL(env, napi_get_boolean(env, true, &valuetrue));
+  NODE_API_CALL(env, napi_get_boolean(env, true, &valuetrue));
 
   return valuetrue;
 }
@@ -143,32 +139,32 @@ static napi_value SetNamed(napi_env env, napi_callback_info info) {
   napi_value args[3];
   char key[256] = "";
   size_t key_length;
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  NAPI_ASSERT(env, argc >= 3, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc >= 3, "Wrong number of arguments");
 
   napi_valuetype value_type0;
-  NAPI_CALL(env, napi_typeof(env, args[0], &value_type0));
+  NODE_API_CALL(env, napi_typeof(env, args[0], &value_type0));
 
-  NAPI_ASSERT(env, value_type0 == napi_object,
+  NODE_API_ASSERT(env, value_type0 == napi_object,
       "Wrong type of arguments. Expects an object as first argument.");
 
   napi_valuetype value_type1;
-  NAPI_CALL(env, napi_typeof(env, args[1], &value_type1));
+  NODE_API_CALL(env, napi_typeof(env, args[1], &value_type1));
 
-  NAPI_ASSERT(env, value_type1 == napi_string,
+  NODE_API_ASSERT(env, value_type1 == napi_string,
       "Wrong type of arguments. Expects a string as second.");
 
-  NAPI_CALL(env,
+  NODE_API_CALL(env,
       napi_get_value_string_utf8(env, args[1], key, 255, &key_length));
   key[255] = 0;
-  NAPI_ASSERT(env, key_length <= 255,
+  NODE_API_ASSERT(env, key_length <= 255,
       "Cannot accommodate keys longer than 255 bytes");
 
-  NAPI_CALL(env, napi_set_named_property(env, args[0], key, args[2]));
+  NODE_API_CALL(env, napi_set_named_property(env, args[0], key, args[2]));
 
   napi_value value_true;
-  NAPI_CALL(env, napi_get_boolean(env, true, &value_true));
+  NODE_API_CALL(env, napi_get_boolean(env, true, &value_true));
 
   return value_true;
 }
@@ -176,27 +172,27 @@ static napi_value SetNamed(napi_env env, napi_callback_info info) {
 static napi_value Has(napi_env env, napi_callback_info info) {
   size_t argc = 2;
   napi_value args[2];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  NAPI_ASSERT(env, argc >= 2, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc >= 2, "Wrong number of arguments");
 
   napi_valuetype valuetype0;
-  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
+  NODE_API_CALL(env, napi_typeof(env, args[0], &valuetype0));
 
-  NAPI_ASSERT(env, valuetype0 == napi_object,
+  NODE_API_ASSERT(env, valuetype0 == napi_object,
       "Wrong type of arguments. Expects an object as first argument.");
 
   napi_valuetype valuetype1;
-  NAPI_CALL(env, napi_typeof(env, args[1], &valuetype1));
+  NODE_API_CALL(env, napi_typeof(env, args[1], &valuetype1));
 
-  NAPI_ASSERT(env, valuetype1 == napi_string || valuetype1 == napi_symbol,
+  NODE_API_ASSERT(env, valuetype1 == napi_string || valuetype1 == napi_symbol,
       "Wrong type of arguments. Expects a string or symbol as second.");
 
   bool has_property;
-  NAPI_CALL(env, napi_has_property(env, args[0], args[1], &has_property));
+  NODE_API_CALL(env, napi_has_property(env, args[0], args[1], &has_property));
 
   napi_value ret;
-  NAPI_CALL(env, napi_get_boolean(env, has_property, &ret));
+  NODE_API_CALL(env, napi_get_boolean(env, has_property, &ret));
 
   return ret;
 }
@@ -206,33 +202,33 @@ static napi_value HasNamed(napi_env env, napi_callback_info info) {
   napi_value args[2];
   char key[256] = "";
   size_t key_length;
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  NAPI_ASSERT(env, argc >= 2, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc >= 2, "Wrong number of arguments");
 
   napi_valuetype value_type0;
-  NAPI_CALL(env, napi_typeof(env, args[0], &value_type0));
+  NODE_API_CALL(env, napi_typeof(env, args[0], &value_type0));
 
-  NAPI_ASSERT(env, value_type0 == napi_object,
+  NODE_API_ASSERT(env, value_type0 == napi_object,
       "Wrong type of arguments. Expects an object as first argument.");
 
   napi_valuetype value_type1;
-  NAPI_CALL(env, napi_typeof(env, args[1], &value_type1));
+  NODE_API_CALL(env, napi_typeof(env, args[1], &value_type1));
 
-  NAPI_ASSERT(env, value_type1 == napi_string || value_type1 == napi_symbol,
+  NODE_API_ASSERT(env, value_type1 == napi_string || value_type1 == napi_symbol,
       "Wrong type of arguments. Expects a string as second.");
 
-  NAPI_CALL(env,
+  NODE_API_CALL(env,
       napi_get_value_string_utf8(env, args[1], key, 255, &key_length));
   key[255] = 0;
-  NAPI_ASSERT(env, key_length <= 255,
+  NODE_API_ASSERT(env, key_length <= 255,
       "Cannot accommodate keys longer than 255 bytes");
 
   bool has_property;
-  NAPI_CALL(env, napi_has_named_property(env, args[0], key, &has_property));
+  NODE_API_CALL(env, napi_has_named_property(env, args[0], key, &has_property));
 
   napi_value ret;
-  NAPI_CALL(env, napi_get_boolean(env, has_property, &ret));
+  NODE_API_CALL(env, napi_get_boolean(env, has_property, &ret));
 
   return ret;
 }
@@ -240,27 +236,27 @@ static napi_value HasNamed(napi_env env, napi_callback_info info) {
 static napi_value HasOwn(napi_env env, napi_callback_info info) {
   size_t argc = 2;
   napi_value args[2];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  NAPI_ASSERT(env, argc == 2, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc == 2, "Wrong number of arguments");
 
   napi_valuetype valuetype0;
-  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
+  NODE_API_CALL(env, napi_typeof(env, args[0], &valuetype0));
 
-  NAPI_ASSERT(env, valuetype0 == napi_object,
+  NODE_API_ASSERT(env, valuetype0 == napi_object,
       "Wrong type of arguments. Expects an object as first argument.");
 
   // napi_valuetype valuetype1;
-  // NAPI_CALL(env, napi_typeof(env, args[1], &valuetype1));
+  // NODE_API_CALL(env, napi_typeof(env, args[1], &valuetype1));
   //
-  // NAPI_ASSERT(env, valuetype1 == napi_string || valuetype1 == napi_symbol,
+  // NODE_API_ASSERT(env, valuetype1 == napi_string || valuetype1 == napi_symbol,
   //   "Wrong type of arguments. Expects a string or symbol as second.");
 
   bool has_property;
-  NAPI_CALL(env, napi_has_own_property(env, args[0], args[1], &has_property));
+  NODE_API_CALL(env, napi_has_own_property(env, args[0], args[1], &has_property));
 
   napi_value ret;
-  NAPI_CALL(env, napi_get_boolean(env, has_property, &ret));
+  NODE_API_CALL(env, napi_get_boolean(env, has_property, &ret));
 
   return ret;
 }
@@ -269,42 +265,42 @@ static napi_value Delete(napi_env env, napi_callback_info info) {
   size_t argc = 2;
   napi_value args[2];
 
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
-  NAPI_ASSERT(env, argc == 2, "Wrong number of arguments");
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_ASSERT(env, argc == 2, "Wrong number of arguments");
 
   napi_valuetype valuetype0;
-  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
-  NAPI_ASSERT(env, valuetype0 == napi_object,
+  NODE_API_CALL(env, napi_typeof(env, args[0], &valuetype0));
+  NODE_API_ASSERT(env, valuetype0 == napi_object,
       "Wrong type of arguments. Expects an object as first argument.");
 
   napi_valuetype valuetype1;
-  NAPI_CALL(env, napi_typeof(env, args[1], &valuetype1));
-  NAPI_ASSERT(env, valuetype1 == napi_string || valuetype1 == napi_symbol,
+  NODE_API_CALL(env, napi_typeof(env, args[1], &valuetype1));
+  NODE_API_ASSERT(env, valuetype1 == napi_string || valuetype1 == napi_symbol,
       "Wrong type of arguments. Expects a string or symbol as second.");
 
   bool result;
   napi_value ret;
-  NAPI_CALL(env, napi_delete_property(env, args[0], args[1], &result));
-  NAPI_CALL(env, napi_get_boolean(env, result, &ret));
+  NODE_API_CALL(env, napi_delete_property(env, args[0], args[1], &result));
+  NODE_API_CALL(env, napi_get_boolean(env, result, &ret));
 
   return ret;
 }
 
 static napi_value New(napi_env env, napi_callback_info info) {
   napi_value ret;
-  NAPI_CALL(env, napi_create_object(env, &ret));
+  NODE_API_CALL(env, napi_create_object(env, &ret));
 
   napi_value num;
-  NAPI_CALL(env, napi_create_int32(env, 987654321, &num));
+  NODE_API_CALL(env, napi_create_int32(env, 987654321, &num));
 
-  NAPI_CALL(env, napi_set_named_property(env, ret, "test_number", num));
+  NODE_API_CALL(env, napi_set_named_property(env, ret, "test_number", num));
 
   napi_value str;
   const char* str_val = "test string";
   size_t str_len = strlen(str_val);
-  NAPI_CALL(env, napi_create_string_utf8(env, str_val, str_len, &str));
+  NODE_API_CALL(env, napi_create_string_utf8(env, str_val, str_len, &str));
 
-  NAPI_CALL(env, napi_set_named_property(env, ret, "test_string", str));
+  NODE_API_CALL(env, napi_set_named_property(env, ret, "test_string", str));
 
   return ret;
 }
@@ -312,34 +308,34 @@ static napi_value New(napi_env env, napi_callback_info info) {
 static napi_value Inflate(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  NAPI_ASSERT(env, argc >= 1, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc >= 1, "Wrong number of arguments");
 
   napi_valuetype valuetype0;
-  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
+  NODE_API_CALL(env, napi_typeof(env, args[0], &valuetype0));
 
-  NAPI_ASSERT(env, valuetype0 == napi_object,
+  NODE_API_ASSERT(env, valuetype0 == napi_object,
       "Wrong type of arguments. Expects an object as first argument.");
 
   napi_value obj = args[0];
   napi_value propertynames;
-  NAPI_CALL(env, napi_get_property_names(env, obj, &propertynames));
+  NODE_API_CALL(env, napi_get_property_names(env, obj, &propertynames));
 
   uint32_t i, length;
-  NAPI_CALL(env, napi_get_array_length(env, propertynames, &length));
+  NODE_API_CALL(env, napi_get_array_length(env, propertynames, &length));
 
   for (i = 0; i < length; i++) {
     napi_value property_str;
-    NAPI_CALL(env, napi_get_element(env, propertynames, i, &property_str));
+    NODE_API_CALL(env, napi_get_element(env, propertynames, i, &property_str));
 
     napi_value value;
-    NAPI_CALL(env, napi_get_property(env, obj, property_str, &value));
+    NODE_API_CALL(env, napi_get_property(env, obj, property_str, &value));
 
     double double_val;
-    NAPI_CALL(env, napi_get_value_double(env, value, &double_val));
-    NAPI_CALL(env, napi_create_double(env, double_val + 1, &value));
-    NAPI_CALL(env, napi_set_property(env, obj, property_str, value));
+    NODE_API_CALL(env, napi_get_value_double(env, value, &double_val));
+    NODE_API_CALL(env, napi_create_double(env, double_val + 1, &value));
+    NODE_API_CALL(env, napi_set_property(env, obj, property_str, value));
   }
 
   return obj;
@@ -348,23 +344,23 @@ static napi_value Inflate(napi_env env, napi_callback_info info) {
 static napi_value Wrap(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value arg;
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, &arg, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, &arg, NULL, NULL));
 
-  NAPI_CALL(env, napi_wrap(env, arg, &test_value, NULL, NULL, NULL));
+  NODE_API_CALL(env, napi_wrap(env, arg, &test_value, NULL, NULL, NULL));
   return NULL;
 }
 
 static napi_value Unwrap(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value arg;
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, &arg, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, &arg, NULL, NULL));
 
   void* data;
-  NAPI_CALL(env, napi_unwrap(env, arg, &data));
+  NODE_API_CALL(env, napi_unwrap(env, arg, &data));
 
   bool is_expected = (data != NULL && *(int*)data == 3);
   napi_value result;
-  NAPI_CALL(env, napi_get_boolean(env, is_expected, &result));
+  NODE_API_CALL(env, napi_get_boolean(env, is_expected, &result));
   return result;
 }
 
@@ -373,11 +369,11 @@ static napi_value TestSetProperty(napi_env env,
   napi_status status;
   napi_value object, key, value;
 
-  NAPI_CALL(env, napi_create_object(env, &object));
+  NODE_API_CALL(env, napi_create_object(env, &object));
 
-  NAPI_CALL(env, napi_create_string_utf8(env, "", NAPI_AUTO_LENGTH, &key));
+  NODE_API_CALL(env, napi_create_string_utf8(env, "", NAPI_AUTO_LENGTH, &key));
 
-  NAPI_CALL(env, napi_create_object(env, &value));
+  NODE_API_CALL(env, napi_create_object(env, &value));
 
   status = napi_set_property(NULL, object, key, value);
 
@@ -409,9 +405,9 @@ static napi_value TestHasProperty(napi_env env,
   napi_value object, key;
   bool result;
 
-  NAPI_CALL(env, napi_create_object(env, &object));
+  NODE_API_CALL(env, napi_create_object(env, &object));
 
-  NAPI_CALL(env, napi_create_string_utf8(env, "", NAPI_AUTO_LENGTH, &key));
+  NODE_API_CALL(env, napi_create_string_utf8(env, "", NAPI_AUTO_LENGTH, &key));
 
   status = napi_has_property(NULL, object, key, &result);
 
@@ -442,11 +438,11 @@ static napi_value TestGetProperty(napi_env env,
   napi_status status;
   napi_value object, key, result;
 
-  NAPI_CALL(env, napi_create_object(env, &object));
+  NODE_API_CALL(env, napi_create_object(env, &object));
 
-  NAPI_CALL(env, napi_create_string_utf8(env, "", NAPI_AUTO_LENGTH, &key));
+  NODE_API_CALL(env, napi_create_string_utf8(env, "", NAPI_AUTO_LENGTH, &key));
 
-  NAPI_CALL(env, napi_create_object(env, &result));
+  NODE_API_CALL(env, napi_create_object(env, &result));
 
   status = napi_get_property(NULL, object, key, &result);
 
@@ -476,10 +472,10 @@ static napi_value TestFreeze(napi_env env,
                              napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
   napi_value object = args[0];
-  NAPI_CALL(env, napi_object_freeze(env, object));
+  NODE_API_CALL(env, napi_object_freeze(env, object));
 
   return object;
 }
@@ -488,10 +484,10 @@ static napi_value TestSeal(napi_env env,
                            napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
   napi_value object = args[0];
-  NAPI_CALL(env, napi_object_seal(env, object));
+  NODE_API_CALL(env, napi_object_seal(env, object));
 
   return object;
 }
@@ -508,10 +504,10 @@ TypeTaggedInstance(napi_env env, napi_callback_info info) {
   uint32_t type_index;
   napi_value instance, which_type;
 
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, &which_type, NULL, NULL));
-  NAPI_CALL(env, napi_get_value_uint32(env, which_type, &type_index));
-  NAPI_CALL(env, napi_create_object(env, &instance));
-  NAPI_CALL(env, napi_type_tag_object(env, instance, &type_tags[type_index]));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, &which_type, NULL, NULL));
+  NODE_API_CALL(env, napi_get_value_uint32(env, which_type, &type_index));
+  NODE_API_CALL(env, napi_create_object(env, &instance));
+  NODE_API_CALL(env, napi_type_tag_object(env, instance, &type_tags[type_index]));
 
   return instance;
 }
@@ -523,13 +519,13 @@ CheckTypeTag(napi_env env, napi_callback_info info) {
   napi_value argv[2], js_result;
   uint32_t type_index;
 
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, argv, NULL, NULL));
-  NAPI_CALL(env, napi_get_value_uint32(env, argv[0], &type_index));
-  NAPI_CALL(env, napi_check_object_type_tag(env,
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, argv, NULL, NULL));
+  NODE_API_CALL(env, napi_get_value_uint32(env, argv[0], &type_index));
+  NODE_API_CALL(env, napi_check_object_type_tag(env,
                                             argv[1],
                                             &type_tags[type_index],
                                             &result));
-  NAPI_CALL(env, napi_get_boolean(env, result, &js_result));
+  NODE_API_CALL(env, napi_get_boolean(env, result, &js_result));
 
   return js_result;
 }
@@ -537,32 +533,32 @@ CheckTypeTag(napi_env env, napi_callback_info info) {
 EXTERN_C_START
 napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
-    DECLARE_NAPI_PROPERTY("Get", Get),
-    DECLARE_NAPI_PROPERTY("GetNamed", GetNamed),
-    DECLARE_NAPI_PROPERTY("GetPropertyNames", GetPropertyNames),
-    DECLARE_NAPI_PROPERTY("GetSymbolNames", GetSymbolNames),
-    DECLARE_NAPI_PROPERTY("Set", Set),
-    DECLARE_NAPI_PROPERTY("SetNamed", SetNamed),
-    DECLARE_NAPI_PROPERTY("Has", Has),
-    DECLARE_NAPI_PROPERTY("HasNamed", HasNamed),
-    DECLARE_NAPI_PROPERTY("HasOwn", HasOwn),
-    DECLARE_NAPI_PROPERTY("Delete", Delete),
-    DECLARE_NAPI_PROPERTY("New", New),
-    DECLARE_NAPI_PROPERTY("Inflate", Inflate),
-    DECLARE_NAPI_PROPERTY("Wrap", Wrap),
-    DECLARE_NAPI_PROPERTY("Unwrap", Unwrap),
-    DECLARE_NAPI_PROPERTY("TestSetProperty", TestSetProperty),
-    DECLARE_NAPI_PROPERTY("TestHasProperty", TestHasProperty),
-    DECLARE_NAPI_PROPERTY("TypeTaggedInstance", TypeTaggedInstance),
-    DECLARE_NAPI_PROPERTY("CheckTypeTag", CheckTypeTag),
-    DECLARE_NAPI_PROPERTY("TestGetProperty", TestGetProperty),
-    DECLARE_NAPI_PROPERTY("TestFreeze", TestFreeze),
-    DECLARE_NAPI_PROPERTY("TestSeal", TestSeal),
+    DECLARE_NODE_API_PROPERTY("Get", Get),
+    DECLARE_NODE_API_PROPERTY("GetNamed", GetNamed),
+    DECLARE_NODE_API_PROPERTY("GetPropertyNames", GetPropertyNames),
+    DECLARE_NODE_API_PROPERTY("GetSymbolNames", GetSymbolNames),
+    DECLARE_NODE_API_PROPERTY("Set", Set),
+    DECLARE_NODE_API_PROPERTY("SetNamed", SetNamed),
+    DECLARE_NODE_API_PROPERTY("Has", Has),
+    DECLARE_NODE_API_PROPERTY("HasNamed", HasNamed),
+    DECLARE_NODE_API_PROPERTY("HasOwn", HasOwn),
+    DECLARE_NODE_API_PROPERTY("Delete", Delete),
+    DECLARE_NODE_API_PROPERTY("New", New),
+    DECLARE_NODE_API_PROPERTY("Inflate", Inflate),
+    DECLARE_NODE_API_PROPERTY("Wrap", Wrap),
+    DECLARE_NODE_API_PROPERTY("Unwrap", Unwrap),
+    DECLARE_NODE_API_PROPERTY("TestSetProperty", TestSetProperty),
+    DECLARE_NODE_API_PROPERTY("TestHasProperty", TestHasProperty),
+    DECLARE_NODE_API_PROPERTY("TypeTaggedInstance", TypeTaggedInstance),
+    DECLARE_NODE_API_PROPERTY("CheckTypeTag", CheckTypeTag),
+    DECLARE_NODE_API_PROPERTY("TestGetProperty", TestGetProperty),
+    DECLARE_NODE_API_PROPERTY("TestFreeze", TestFreeze),
+    DECLARE_NODE_API_PROPERTY("TestSeal", TestSeal),
   };
 
   init_test_null(env, exports);
 
-  NAPI_CALL(env, napi_define_properties(
+  NODE_API_CALL(env, napi_define_properties(
       env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
 
   return exports;

--- a/test/js-native-api/test_promise/test_promise.c
+++ b/test/js-native-api/test_promise/test_promise.c
@@ -11,7 +11,7 @@ static napi_value createPromise(napi_env env, napi_callback_info info) {
     return NULL;
   }
 
-  NAPI_CALL(env, napi_create_promise(env, &deferred, &promise));
+  NODE_API_CALL(env, napi_create_promise(env, &deferred, &promise));
 
   return promise;
 }
@@ -22,12 +22,12 @@ concludeCurrentPromise(napi_env env, napi_callback_info info) {
   size_t argc = 2;
   bool resolution;
 
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, argv, NULL, NULL));
-  NAPI_CALL(env, napi_get_value_bool(env, argv[1], &resolution));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, argv, NULL, NULL));
+  NODE_API_CALL(env, napi_get_value_bool(env, argv[1], &resolution));
   if (resolution) {
-    NAPI_CALL(env, napi_resolve_deferred(env, deferred, argv[0]));
+    NODE_API_CALL(env, napi_resolve_deferred(env, deferred, argv[0]));
   } else {
-    NAPI_CALL(env, napi_reject_deferred(env, deferred, argv[0]));
+    NODE_API_CALL(env, napi_reject_deferred(env, deferred, argv[0]));
   }
 
   deferred = NULL;
@@ -40,9 +40,9 @@ static napi_value isPromise(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   bool is_promise;
 
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, &promise, NULL, NULL));
-  NAPI_CALL(env, napi_is_promise(env, promise, &is_promise));
-  NAPI_CALL(env, napi_get_boolean(env, is_promise, &result));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, &promise, NULL, NULL));
+  NODE_API_CALL(env, napi_is_promise(env, promise, &is_promise));
+  NODE_API_CALL(env, napi_get_boolean(env, is_promise, &result));
 
   return result;
 }
@@ -50,12 +50,12 @@ static napi_value isPromise(napi_env env, napi_callback_info info) {
 EXTERN_C_START
 napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
-    DECLARE_NAPI_PROPERTY("createPromise", createPromise),
-    DECLARE_NAPI_PROPERTY("concludeCurrentPromise", concludeCurrentPromise),
-    DECLARE_NAPI_PROPERTY("isPromise", isPromise),
+    DECLARE_NODE_API_PROPERTY("createPromise", createPromise),
+    DECLARE_NODE_API_PROPERTY("concludeCurrentPromise", concludeCurrentPromise),
+    DECLARE_NODE_API_PROPERTY("isPromise", isPromise),
   };
 
-  NAPI_CALL(env, napi_define_properties(
+  NODE_API_CALL(env, napi_define_properties(
       env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
 
   return exports;

--- a/test/js-native-api/test_properties/test_properties.c
+++ b/test/js-native-api/test_properties/test_properties.c
@@ -5,12 +5,12 @@ static double value_ = 1;
 
 static napi_value GetValue(napi_env env, napi_callback_info info) {
   size_t argc = 0;
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, NULL, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, NULL, NULL, NULL));
 
-  NAPI_ASSERT(env, argc == 0, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc == 0, "Wrong number of arguments");
 
   napi_value number;
-  NAPI_CALL(env, napi_create_double(env, value_, &number));
+  NODE_API_CALL(env, napi_create_double(env, value_, &number));
 
   return number;
 }
@@ -18,11 +18,11 @@ static napi_value GetValue(napi_env env, napi_callback_info info) {
 static napi_value SetValue(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  NAPI_ASSERT(env, argc == 1, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc == 1, "Wrong number of arguments");
 
-  NAPI_CALL(env, napi_get_value_double(env, args[0], &value_));
+  NODE_API_CALL(env, napi_get_value_double(env, args[0], &value_));
 
   return NULL;
 }
@@ -30,9 +30,9 @@ static napi_value SetValue(napi_env env, napi_callback_info info) {
 static napi_value Echo(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  NAPI_ASSERT(env, argc == 1, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc == 1, "Wrong number of arguments");
 
   return args[0];
 }
@@ -40,21 +40,21 @@ static napi_value Echo(napi_env env, napi_callback_info info) {
 static napi_value HasNamedProperty(napi_env env, napi_callback_info info) {
   size_t argc = 2;
   napi_value args[2];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  NAPI_ASSERT(env, argc == 2, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc == 2, "Wrong number of arguments");
 
   // Extract the name of the property to check
   char buffer[128];
   size_t copied;
-  NAPI_CALL(env,
+  NODE_API_CALL(env,
       napi_get_value_string_utf8(env, args[1], buffer, sizeof(buffer), &copied));
 
   // do the check and create the boolean return value
   bool value;
   napi_value result;
-  NAPI_CALL(env, napi_has_named_property(env, args[0], buffer, &value));
-  NAPI_CALL(env, napi_get_boolean(env, value, &result));
+  NODE_API_CALL(env, napi_has_named_property(env, args[0], buffer, &value));
+  NODE_API_CALL(env, napi_get_boolean(env, value, &result));
 
   return result;
 }
@@ -62,23 +62,20 @@ static napi_value HasNamedProperty(napi_env env, napi_callback_info info) {
 EXTERN_C_START
 napi_value Init(napi_env env, napi_value exports) {
   napi_value number;
-  NAPI_CALL(env, napi_create_double(env, value_, &number));
+  NODE_API_CALL(env, napi_create_double(env, value_, &number));
 
   napi_value name_value;
-  NAPI_CALL(env, napi_create_string_utf8(env,
-                                         "NameKeyValue",
-                                         NAPI_AUTO_LENGTH,
-                                         &name_value));
+  NODE_API_CALL(env,
+      napi_create_string_utf8(
+          env, "NameKeyValue", NAPI_AUTO_LENGTH, &name_value));
 
   napi_value symbol_description;
   napi_value name_symbol;
-  NAPI_CALL(env, napi_create_string_utf8(env,
-                                         "NameKeySymbol",
-                                         NAPI_AUTO_LENGTH,
-                                         &symbol_description));
-  NAPI_CALL(env, napi_create_symbol(env,
-                                    symbol_description,
-                                    &name_symbol));
+  NODE_API_CALL(env,
+      napi_create_string_utf8(
+          env, "NameKeySymbol", NAPI_AUTO_LENGTH, &symbol_description));
+  NODE_API_CALL(env,
+      napi_create_symbol(env, symbol_description, &name_symbol));
 
   napi_property_descriptor properties[] = {
     { "echo", 0, Echo, 0, 0, 0, napi_enumerable, 0 },
@@ -94,7 +91,7 @@ napi_value Init(napi_env env, napi_value exports) {
     { "hasNamedProperty", 0, HasNamedProperty, 0, 0, 0, napi_default, 0 },
   };
 
-  NAPI_CALL(env, napi_define_properties(
+  NODE_API_CALL(env, napi_define_properties(
       env, exports, sizeof(properties) / sizeof(*properties), properties));
 
   return exports;

--- a/test/js-native-api/test_reference/test_reference.c
+++ b/test/js-native-api/test_reference/test_reference.c
@@ -9,13 +9,13 @@ static napi_ref test_reference = NULL;
 
 static napi_value GetFinalizeCount(napi_env env, napi_callback_info info) {
   napi_value result;
-  NAPI_CALL(env, napi_create_int32(env, finalize_count, &result));
+  NODE_API_CALL(env, napi_create_int32(env, finalize_count, &result));
   return result;
 }
 
 static void FinalizeExternal(napi_env env, void* data, void* hint) {
   int *actual_value = data;
-  NAPI_ASSERT_RETURN_VOID(env, actual_value == &test_value,
+  NODE_API_ASSERT_RETURN_VOID(env, actual_value == &test_value,
       "The correct pointer was passed to the finalizer");
   finalize_count++;
 }
@@ -24,7 +24,7 @@ static napi_value CreateExternal(napi_env env, napi_callback_info info) {
   int* data = &test_value;
 
   napi_value result;
-  NAPI_CALL(env,
+  NODE_API_CALL(env,
       napi_create_external(env,
                            data,
                            NULL, /* finalize_cb */
@@ -38,7 +38,7 @@ static napi_value CreateExternal(napi_env env, napi_callback_info info) {
 static napi_value
 CreateExternalWithFinalize(napi_env env, napi_callback_info info) {
   napi_value result;
-  NAPI_CALL(env,
+  NODE_API_CALL(env,
       napi_create_external(env,
                            &test_value,
                            FinalizeExternal,
@@ -52,84 +52,84 @@ CreateExternalWithFinalize(napi_env env, napi_callback_info info) {
 static napi_value CheckExternal(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value arg;
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, &arg, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, &arg, NULL, NULL));
 
-  NAPI_ASSERT(env, argc == 1, "Expected one argument.");
+  NODE_API_ASSERT(env, argc == 1, "Expected one argument.");
 
   napi_valuetype argtype;
-  NAPI_CALL(env, napi_typeof(env, arg, &argtype));
+  NODE_API_CALL(env, napi_typeof(env, arg, &argtype));
 
-  NAPI_ASSERT(env, argtype == napi_external, "Expected an external value.");
+  NODE_API_ASSERT(env, argtype == napi_external, "Expected an external value.");
 
   void* data;
-  NAPI_CALL(env, napi_get_value_external(env, arg, &data));
+  NODE_API_CALL(env, napi_get_value_external(env, arg, &data));
 
-  NAPI_ASSERT(env, data != NULL && *(int*)data == test_value,
+  NODE_API_ASSERT(env, data != NULL && *(int*)data == test_value,
       "An external data value of 1 was expected.");
 
   return NULL;
 }
 
 static napi_value CreateReference(napi_env env, napi_callback_info info) {
-  NAPI_ASSERT(env, test_reference == NULL,
+  NODE_API_ASSERT(env, test_reference == NULL,
       "The test allows only one reference at a time.");
 
   size_t argc = 2;
   napi_value args[2];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
-  NAPI_ASSERT(env, argc == 2, "Expected two arguments.");
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_ASSERT(env, argc == 2, "Expected two arguments.");
 
   uint32_t initial_refcount;
-  NAPI_CALL(env, napi_get_value_uint32(env, args[1], &initial_refcount));
+  NODE_API_CALL(env, napi_get_value_uint32(env, args[1], &initial_refcount));
 
-  NAPI_CALL(env,
+  NODE_API_CALL(env,
       napi_create_reference(env, args[0], initial_refcount, &test_reference));
 
-  NAPI_ASSERT(env, test_reference != NULL,
+  NODE_API_ASSERT(env, test_reference != NULL,
       "A reference should have been created.");
 
   return NULL;
 }
 
 static napi_value DeleteReference(napi_env env, napi_callback_info info) {
-  NAPI_ASSERT(env, test_reference != NULL,
+  NODE_API_ASSERT(env, test_reference != NULL,
       "A reference must have been created.");
 
-  NAPI_CALL(env, napi_delete_reference(env, test_reference));
+  NODE_API_CALL(env, napi_delete_reference(env, test_reference));
   test_reference = NULL;
   return NULL;
 }
 
 static napi_value IncrementRefcount(napi_env env, napi_callback_info info) {
-  NAPI_ASSERT(env, test_reference != NULL,
+  NODE_API_ASSERT(env, test_reference != NULL,
       "A reference must have been created.");
 
   uint32_t refcount;
-  NAPI_CALL(env, napi_reference_ref(env, test_reference, &refcount));
+  NODE_API_CALL(env, napi_reference_ref(env, test_reference, &refcount));
 
   napi_value result;
-  NAPI_CALL(env, napi_create_uint32(env, refcount, &result));
+  NODE_API_CALL(env, napi_create_uint32(env, refcount, &result));
   return result;
 }
 
 static napi_value DecrementRefcount(napi_env env, napi_callback_info info) {
-  NAPI_ASSERT(env, test_reference != NULL,
+  NODE_API_ASSERT(env, test_reference != NULL,
       "A reference must have been created.");
 
   uint32_t refcount;
-  NAPI_CALL(env, napi_reference_unref(env, test_reference, &refcount));
+  NODE_API_CALL(env, napi_reference_unref(env, test_reference, &refcount));
 
   napi_value result;
-  NAPI_CALL(env, napi_create_uint32(env, refcount, &result));
+  NODE_API_CALL(env, napi_create_uint32(env, refcount, &result));
   return result;
 }
 
 static napi_value GetReferenceValue(napi_env env, napi_callback_info info) {
-  NAPI_ASSERT(env, test_reference != NULL,
+  NODE_API_ASSERT(env, test_reference != NULL,
       "A reference must have been created.");
 
   napi_value result;
-  NAPI_CALL(env, napi_get_reference_value(env, test_reference, &result));
+  NODE_API_CALL(env, napi_get_reference_value(env, test_reference, &result));
   return result;
 }
 
@@ -146,15 +146,12 @@ static void DeleteBeforeFinalizeFinalizer(
 static napi_value ValidateDeleteBeforeFinalize(napi_env env, napi_callback_info info) {
   napi_value wrapObject;
   size_t argc = 1;
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, &wrapObject, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, &wrapObject, NULL, NULL));
 
   napi_ref* ref_t = malloc(sizeof(napi_ref));
-  NAPI_CALL(env, napi_wrap(env,
-                          wrapObject,
-                          ref_t,
-                          DeleteBeforeFinalizeFinalizer,
-                          NULL,
-                          NULL));
+  NODE_API_CALL(env,
+      napi_wrap(
+          env, wrapObject, ref_t, DeleteBeforeFinalizeFinalizer, NULL, NULL));
 
   // Create a reference that will be eligible for collection at the same
   // time as the wrapped object by passing in the same wrapObject.
@@ -165,28 +162,28 @@ static napi_value ValidateDeleteBeforeFinalize(napi_env env, napi_callback_info 
   // for the reference) calls napi_delete_reference validating that
   // napi_delete_reference can be called before the finalizer for the
   // reference runs.
-  NAPI_CALL(env, napi_create_reference(env, wrapObject, 0, ref_t));
+  NODE_API_CALL(env, napi_create_reference(env, wrapObject, 0, ref_t));
   return wrapObject;
 }
 
 EXTERN_C_START
 napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
-    DECLARE_NAPI_GETTER("finalizeCount", GetFinalizeCount),
-    DECLARE_NAPI_PROPERTY("createExternal", CreateExternal),
-    DECLARE_NAPI_PROPERTY("createExternalWithFinalize",
+    DECLARE_NODE_API_GETTER("finalizeCount", GetFinalizeCount),
+    DECLARE_NODE_API_PROPERTY("createExternal", CreateExternal),
+    DECLARE_NODE_API_PROPERTY("createExternalWithFinalize",
         CreateExternalWithFinalize),
-    DECLARE_NAPI_PROPERTY("checkExternal", CheckExternal),
-    DECLARE_NAPI_PROPERTY("createReference", CreateReference),
-    DECLARE_NAPI_PROPERTY("deleteReference", DeleteReference),
-    DECLARE_NAPI_PROPERTY("incrementRefcount", IncrementRefcount),
-    DECLARE_NAPI_PROPERTY("decrementRefcount", DecrementRefcount),
-    DECLARE_NAPI_GETTER("referenceValue", GetReferenceValue),
-    DECLARE_NAPI_PROPERTY("validateDeleteBeforeFinalize",
-                          ValidateDeleteBeforeFinalize),
+    DECLARE_NODE_API_PROPERTY("checkExternal", CheckExternal),
+    DECLARE_NODE_API_PROPERTY("createReference", CreateReference),
+    DECLARE_NODE_API_PROPERTY("deleteReference", DeleteReference),
+    DECLARE_NODE_API_PROPERTY("incrementRefcount", IncrementRefcount),
+    DECLARE_NODE_API_PROPERTY("decrementRefcount", DecrementRefcount),
+    DECLARE_NODE_API_GETTER("referenceValue", GetReferenceValue),
+    DECLARE_NODE_API_PROPERTY("validateDeleteBeforeFinalize",
+        ValidateDeleteBeforeFinalize),
   };
 
-  NAPI_CALL(env, napi_define_properties(
+  NODE_API_CALL(env, napi_define_properties(
       env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
 
   return exports;

--- a/test/js-native-api/test_string/test_string.c
+++ b/test/js-native-api/test_string/test_string.c
@@ -6,25 +6,25 @@
 static napi_value TestLatin1(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  NAPI_ASSERT(env, argc >= 1, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc >= 1, "Wrong number of arguments");
 
   napi_valuetype valuetype;
-  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype));
+  NODE_API_CALL(env, napi_typeof(env, args[0], &valuetype));
 
-  NAPI_ASSERT(env, valuetype == napi_string,
+  NODE_API_ASSERT(env, valuetype == napi_string,
       "Wrong type of argment. Expects a string.");
 
   char buffer[128];
   size_t buffer_size = 128;
   size_t copied;
 
-  NAPI_CALL(env,
+  NODE_API_CALL(env,
       napi_get_value_string_latin1(env, args[0], buffer, buffer_size, &copied));
 
   napi_value output;
-  NAPI_CALL(env, napi_create_string_latin1(env, buffer, copied, &output));
+  NODE_API_CALL(env, napi_create_string_latin1(env, buffer, copied, &output));
 
   return output;
 }
@@ -32,25 +32,25 @@ static napi_value TestLatin1(napi_env env, napi_callback_info info) {
 static napi_value TestUtf8(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  NAPI_ASSERT(env, argc >= 1, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc >= 1, "Wrong number of arguments");
 
   napi_valuetype valuetype;
-  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype));
+  NODE_API_CALL(env, napi_typeof(env, args[0], &valuetype));
 
-  NAPI_ASSERT(env, valuetype == napi_string,
+  NODE_API_ASSERT(env, valuetype == napi_string,
       "Wrong type of argment. Expects a string.");
 
   char buffer[128];
   size_t buffer_size = 128;
   size_t copied;
 
-  NAPI_CALL(env,
+  NODE_API_CALL(env,
       napi_get_value_string_utf8(env, args[0], buffer, buffer_size, &copied));
 
   napi_value output;
-  NAPI_CALL(env, napi_create_string_utf8(env, buffer, copied, &output));
+  NODE_API_CALL(env, napi_create_string_utf8(env, buffer, copied, &output));
 
   return output;
 }
@@ -58,25 +58,25 @@ static napi_value TestUtf8(napi_env env, napi_callback_info info) {
 static napi_value TestUtf16(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  NAPI_ASSERT(env, argc >= 1, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc >= 1, "Wrong number of arguments");
 
   napi_valuetype valuetype;
-  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype));
+  NODE_API_CALL(env, napi_typeof(env, args[0], &valuetype));
 
-  NAPI_ASSERT(env, valuetype == napi_string,
+  NODE_API_ASSERT(env, valuetype == napi_string,
       "Wrong type of argment. Expects a string.");
 
   char16_t buffer[128];
   size_t buffer_size = 128;
   size_t copied;
 
-  NAPI_CALL(env,
+  NODE_API_CALL(env,
       napi_get_value_string_utf16(env, args[0], buffer, buffer_size, &copied));
 
   napi_value output;
-  NAPI_CALL(env, napi_create_string_utf16(env, buffer, copied, &output));
+  NODE_API_CALL(env, napi_create_string_utf16(env, buffer, copied, &output));
 
   return output;
 }
@@ -85,25 +85,25 @@ static napi_value
 TestLatin1Insufficient(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  NAPI_ASSERT(env, argc >= 1, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc >= 1, "Wrong number of arguments");
 
   napi_valuetype valuetype;
-  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype));
+  NODE_API_CALL(env, napi_typeof(env, args[0], &valuetype));
 
-  NAPI_ASSERT(env, valuetype == napi_string,
+  NODE_API_ASSERT(env, valuetype == napi_string,
       "Wrong type of argment. Expects a string.");
 
   char buffer[4];
   size_t buffer_size = 4;
   size_t copied;
 
-  NAPI_CALL(env,
+  NODE_API_CALL(env,
       napi_get_value_string_latin1(env, args[0], buffer, buffer_size, &copied));
 
   napi_value output;
-  NAPI_CALL(env, napi_create_string_latin1(env, buffer, copied, &output));
+  NODE_API_CALL(env, napi_create_string_latin1(env, buffer, copied, &output));
 
   return output;
 }
@@ -111,25 +111,25 @@ TestLatin1Insufficient(napi_env env, napi_callback_info info) {
 static napi_value TestUtf8Insufficient(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  NAPI_ASSERT(env, argc >= 1, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc >= 1, "Wrong number of arguments");
 
   napi_valuetype valuetype;
-  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype));
+  NODE_API_CALL(env, napi_typeof(env, args[0], &valuetype));
 
-  NAPI_ASSERT(env, valuetype == napi_string,
+  NODE_API_ASSERT(env, valuetype == napi_string,
       "Wrong type of argment. Expects a string.");
 
   char buffer[4];
   size_t buffer_size = 4;
   size_t copied;
 
-  NAPI_CALL(env,
+  NODE_API_CALL(env,
       napi_get_value_string_utf8(env, args[0], buffer, buffer_size, &copied));
 
   napi_value output;
-  NAPI_CALL(env, napi_create_string_utf8(env, buffer, copied, &output));
+  NODE_API_CALL(env, napi_create_string_utf8(env, buffer, copied, &output));
 
   return output;
 }
@@ -137,25 +137,25 @@ static napi_value TestUtf8Insufficient(napi_env env, napi_callback_info info) {
 static napi_value TestUtf16Insufficient(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  NAPI_ASSERT(env, argc >= 1, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc >= 1, "Wrong number of arguments");
 
   napi_valuetype valuetype;
-  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype));
+  NODE_API_CALL(env, napi_typeof(env, args[0], &valuetype));
 
-  NAPI_ASSERT(env, valuetype == napi_string,
+  NODE_API_ASSERT(env, valuetype == napi_string,
       "Wrong type of argment. Expects a string.");
 
   char16_t buffer[4];
   size_t buffer_size = 4;
   size_t copied;
 
-  NAPI_CALL(env,
+  NODE_API_CALL(env,
       napi_get_value_string_utf16(env, args[0], buffer, buffer_size, &copied));
 
   napi_value output;
-  NAPI_CALL(env, napi_create_string_utf16(env, buffer, copied, &output));
+  NODE_API_CALL(env, napi_create_string_utf16(env, buffer, copied, &output));
 
   return output;
 }
@@ -163,21 +163,21 @@ static napi_value TestUtf16Insufficient(napi_env env, napi_callback_info info) {
 static napi_value Utf16Length(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  NAPI_ASSERT(env, argc >= 1, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc >= 1, "Wrong number of arguments");
 
   napi_valuetype valuetype;
-  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype));
+  NODE_API_CALL(env, napi_typeof(env, args[0], &valuetype));
 
-  NAPI_ASSERT(env, valuetype == napi_string,
+  NODE_API_ASSERT(env, valuetype == napi_string,
       "Wrong type of argment. Expects a string.");
 
   size_t length;
-  NAPI_CALL(env, napi_get_value_string_utf16(env, args[0], NULL, 0, &length));
+  NODE_API_CALL(env, napi_get_value_string_utf16(env, args[0], NULL, 0, &length));
 
   napi_value output;
-  NAPI_CALL(env, napi_create_uint32(env, (uint32_t)length, &output));
+  NODE_API_CALL(env, napi_create_uint32(env, (uint32_t)length, &output));
 
   return output;
 }
@@ -185,21 +185,22 @@ static napi_value Utf16Length(napi_env env, napi_callback_info info) {
 static napi_value Utf8Length(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  NAPI_ASSERT(env, argc >= 1, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc >= 1, "Wrong number of arguments");
 
   napi_valuetype valuetype;
-  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype));
+  NODE_API_CALL(env, napi_typeof(env, args[0], &valuetype));
 
-  NAPI_ASSERT(env, valuetype == napi_string,
+  NODE_API_ASSERT(env, valuetype == napi_string,
       "Wrong type of argment. Expects a string.");
 
   size_t length;
-  NAPI_CALL(env, napi_get_value_string_utf8(env, args[0], NULL, 0, &length));
+  NODE_API_CALL(env,
+      napi_get_value_string_utf8(env, args[0], NULL, 0, &length));
 
   napi_value output;
-  NAPI_CALL(env, napi_create_uint32(env, (uint32_t)length, &output));
+  NODE_API_CALL(env, napi_create_uint32(env, (uint32_t)length, &output));
 
   return output;
 }
@@ -207,11 +208,12 @@ static napi_value Utf8Length(napi_env env, napi_callback_info info) {
 static napi_value TestLargeUtf8(napi_env env, napi_callback_info info) {
   napi_value output;
   if (SIZE_MAX > INT_MAX) {
-    NAPI_CALL(env, napi_create_string_utf8(env, "", ((size_t)INT_MAX) + 1, &output));
+    NODE_API_CALL(env,
+        napi_create_string_utf8(env, "", ((size_t)INT_MAX) + 1, &output));
   } else {
     // just throw the expected error as there is nothing to test
     // in this case since we can't overflow
-    NAPI_CALL(env, napi_throw_error(env, NULL, "Invalid argument"));
+    NODE_API_CALL(env, napi_throw_error(env, NULL, "Invalid argument"));
   }
 
   return output;
@@ -220,11 +222,12 @@ static napi_value TestLargeUtf8(napi_env env, napi_callback_info info) {
 static napi_value TestLargeLatin1(napi_env env, napi_callback_info info) {
   napi_value output;
   if (SIZE_MAX > INT_MAX) {
-    NAPI_CALL(env, napi_create_string_latin1(env, "", ((size_t)INT_MAX) + 1, &output));
+    NODE_API_CALL(env,
+        napi_create_string_latin1(env, "", ((size_t)INT_MAX) + 1, &output));
   } else {
     // just throw the expected error as there is nothing to test
     // in this case since we can't overflow
-    NAPI_CALL(env, napi_throw_error(env, NULL, "Invalid argument"));
+    NODE_API_CALL(env, napi_throw_error(env, NULL, "Invalid argument"));
   }
 
   return output;
@@ -233,13 +236,13 @@ static napi_value TestLargeLatin1(napi_env env, napi_callback_info info) {
 static napi_value TestLargeUtf16(napi_env env, napi_callback_info info) {
   napi_value output;
   if (SIZE_MAX > INT_MAX) {
-    NAPI_CALL(env, napi_create_string_utf16(env,
-                                            ((const char16_t*)""),
-                                            ((size_t)INT_MAX) + 1, &output));
+    NODE_API_CALL(env,
+        napi_create_string_utf16(
+            env, ((const char16_t*)""), ((size_t)INT_MAX) + 1, &output));
   } else {
     // just throw the expected error as there is nothing to test
     // in this case since we can't overflow
-    NAPI_CALL(env, napi_throw_error(env, NULL, "Invalid argument"));
+    NODE_API_CALL(env, napi_throw_error(env, NULL, "Invalid argument"));
   }
 
   return output;
@@ -248,16 +251,16 @@ static napi_value TestLargeUtf16(napi_env env, napi_callback_info info) {
 static napi_value TestMemoryCorruption(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  NAPI_ASSERT(env, argc == 1, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc == 1, "Wrong number of arguments");
 
   char buf[10] = { 0 };
-  NAPI_CALL(env, napi_get_value_string_utf8(env, args[0], buf, 0, NULL));
+  NODE_API_CALL(env, napi_get_value_string_utf8(env, args[0], buf, 0, NULL));
 
   char zero[10] = { 0 };
   if (memcmp(buf, zero, sizeof(buf)) != 0) {
-    NAPI_CALL(env, napi_throw_error(env, NULL, "Buffer overwritten"));
+    NODE_API_CALL(env, napi_throw_error(env, NULL, "Buffer overwritten"));
   }
 
   return NULL;
@@ -266,21 +269,21 @@ static napi_value TestMemoryCorruption(napi_env env, napi_callback_info info) {
 EXTERN_C_START
 napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor properties[] = {
-    DECLARE_NAPI_PROPERTY("TestLatin1", TestLatin1),
-    DECLARE_NAPI_PROPERTY("TestLatin1Insufficient", TestLatin1Insufficient),
-    DECLARE_NAPI_PROPERTY("TestUtf8", TestUtf8),
-    DECLARE_NAPI_PROPERTY("TestUtf8Insufficient", TestUtf8Insufficient),
-    DECLARE_NAPI_PROPERTY("TestUtf16", TestUtf16),
-    DECLARE_NAPI_PROPERTY("TestUtf16Insufficient", TestUtf16Insufficient),
-    DECLARE_NAPI_PROPERTY("Utf16Length", Utf16Length),
-    DECLARE_NAPI_PROPERTY("Utf8Length", Utf8Length),
-    DECLARE_NAPI_PROPERTY("TestLargeUtf8", TestLargeUtf8),
-    DECLARE_NAPI_PROPERTY("TestLargeLatin1", TestLargeLatin1),
-    DECLARE_NAPI_PROPERTY("TestLargeUtf16", TestLargeUtf16),
-    DECLARE_NAPI_PROPERTY("TestMemoryCorruption", TestMemoryCorruption),
+    DECLARE_NODE_API_PROPERTY("TestLatin1", TestLatin1),
+    DECLARE_NODE_API_PROPERTY("TestLatin1Insufficient", TestLatin1Insufficient),
+    DECLARE_NODE_API_PROPERTY("TestUtf8", TestUtf8),
+    DECLARE_NODE_API_PROPERTY("TestUtf8Insufficient", TestUtf8Insufficient),
+    DECLARE_NODE_API_PROPERTY("TestUtf16", TestUtf16),
+    DECLARE_NODE_API_PROPERTY("TestUtf16Insufficient", TestUtf16Insufficient),
+    DECLARE_NODE_API_PROPERTY("Utf16Length", Utf16Length),
+    DECLARE_NODE_API_PROPERTY("Utf8Length", Utf8Length),
+    DECLARE_NODE_API_PROPERTY("TestLargeUtf8", TestLargeUtf8),
+    DECLARE_NODE_API_PROPERTY("TestLargeLatin1", TestLargeLatin1),
+    DECLARE_NODE_API_PROPERTY("TestLargeUtf16", TestLargeUtf16),
+    DECLARE_NODE_API_PROPERTY("TestMemoryCorruption", TestMemoryCorruption),
   };
 
-  NAPI_CALL(env, napi_define_properties(
+  NODE_API_CALL(env, napi_define_properties(
       env, exports, sizeof(properties) / sizeof(*properties), properties));
 
   return exports;

--- a/test/js-native-api/test_symbol/test_symbol.c
+++ b/test/js-native-api/test_symbol/test_symbol.c
@@ -4,21 +4,21 @@
 static napi_value New(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
   napi_value description = NULL;
   if (argc >= 1) {
     napi_valuetype valuetype;
-    NAPI_CALL(env, napi_typeof(env, args[0], &valuetype));
+    NODE_API_CALL(env, napi_typeof(env, args[0], &valuetype));
 
-    NAPI_ASSERT(env, valuetype == napi_string,
+    NODE_API_ASSERT(env, valuetype == napi_string,
         "Wrong type of arguments. Expects a string.");
 
     description = args[0];
   }
 
   napi_value symbol;
-  NAPI_CALL(env, napi_create_symbol(env, description, &symbol));
+  NODE_API_CALL(env, napi_create_symbol(env, description, &symbol));
 
   return symbol;
 }
@@ -26,10 +26,10 @@ static napi_value New(napi_env env, napi_callback_info info) {
 EXTERN_C_START
 napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor properties[] = {
-    DECLARE_NAPI_PROPERTY("New", New),
+    DECLARE_NODE_API_PROPERTY("New", New),
   };
 
-  NAPI_CALL(env, napi_define_properties(
+  NODE_API_CALL(env, napi_define_properties(
       env, exports, sizeof(properties) / sizeof(*properties), properties));
 
   return exports;

--- a/test/js-native-api/test_typedarray/test_typedarray.c
+++ b/test/js-native-api/test_typedarray/test_typedarray.c
@@ -6,51 +6,51 @@
 static napi_value Multiply(napi_env env, napi_callback_info info) {
   size_t argc = 2;
   napi_value args[2];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  NAPI_ASSERT(env, argc == 2, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc == 2, "Wrong number of arguments");
 
   napi_valuetype valuetype0;
-  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
+  NODE_API_CALL(env, napi_typeof(env, args[0], &valuetype0));
 
-  NAPI_ASSERT(env, valuetype0 == napi_object,
+  NODE_API_ASSERT(env, valuetype0 == napi_object,
       "Wrong type of arguments. Expects a typed array as first argument.");
 
   napi_value input_array = args[0];
   bool is_typedarray;
-  NAPI_CALL(env, napi_is_typedarray(env, input_array, &is_typedarray));
+  NODE_API_CALL(env, napi_is_typedarray(env, input_array, &is_typedarray));
 
-  NAPI_ASSERT(env, is_typedarray,
+  NODE_API_ASSERT(env, is_typedarray,
       "Wrong type of arguments. Expects a typed array as first argument.");
 
   napi_valuetype valuetype1;
-  NAPI_CALL(env, napi_typeof(env, args[1], &valuetype1));
+  NODE_API_CALL(env, napi_typeof(env, args[1], &valuetype1));
 
-  NAPI_ASSERT(env, valuetype1 == napi_number,
+  NODE_API_ASSERT(env, valuetype1 == napi_number,
       "Wrong type of arguments. Expects a number as second argument.");
 
   double multiplier;
-  NAPI_CALL(env, napi_get_value_double(env, args[1], &multiplier));
+  NODE_API_CALL(env, napi_get_value_double(env, args[1], &multiplier));
 
   napi_typedarray_type type;
   napi_value input_buffer;
   size_t byte_offset;
   size_t i, length;
-  NAPI_CALL(env, napi_get_typedarray_info(
+  NODE_API_CALL(env, napi_get_typedarray_info(
       env, input_array, &type, &length, NULL, &input_buffer, &byte_offset));
 
   void* data;
   size_t byte_length;
-  NAPI_CALL(env, napi_get_arraybuffer_info(
+  NODE_API_CALL(env, napi_get_arraybuffer_info(
       env, input_buffer, &data, &byte_length));
 
   napi_value output_buffer;
   void* output_ptr = NULL;
-  NAPI_CALL(env, napi_create_arraybuffer(
+  NODE_API_CALL(env, napi_create_arraybuffer(
       env, byte_length, &output_ptr, &output_buffer));
 
   napi_value output_array;
-  NAPI_CALL(env, napi_create_typedarray(
+  NODE_API_CALL(env, napi_create_typedarray(
       env, type, length, output_buffer, byte_offset, &output_array));
 
   if (type == napi_uint8_array) {
@@ -89,7 +89,7 @@ static napi_value External(napi_env env, napi_callback_info info) {
   externalData[2] = 2;
 
   napi_value output_buffer;
-  NAPI_CALL(env, napi_create_external_arraybuffer(
+  NODE_API_CALL(env, napi_create_external_arraybuffer(
       env,
       externalData,
       nElem*sizeof(int8_t),
@@ -98,7 +98,7 @@ static napi_value External(napi_env env, napi_callback_info info) {
       &output_buffer));
 
   napi_value output_array;
-  NAPI_CALL(env, napi_create_typedarray(env,
+  NODE_API_CALL(env, napi_create_typedarray(env,
       napi_int8_array,
       nElem,
       output_buffer,
@@ -112,7 +112,7 @@ static napi_value External(napi_env env, napi_callback_info info) {
 static napi_value NullArrayBuffer(napi_env env, napi_callback_info info) {
   static void* data = NULL;
   napi_value arraybuffer;
-  NAPI_CALL(env,
+  NODE_API_CALL(env,
       napi_create_external_arraybuffer(env, data, 0, NULL, NULL, &arraybuffer));
   return arraybuffer;
 }
@@ -120,67 +120,67 @@ static napi_value NullArrayBuffer(napi_env env, napi_callback_info info) {
 static napi_value CreateTypedArray(napi_env env, napi_callback_info info) {
   size_t argc = 4;
   napi_value args[4];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  NAPI_ASSERT(env, argc == 2 || argc == 4, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc == 2 || argc == 4, "Wrong number of arguments");
 
   napi_value input_array = args[0];
   napi_valuetype valuetype0;
-  NAPI_CALL(env, napi_typeof(env, input_array, &valuetype0));
+  NODE_API_CALL(env, napi_typeof(env, input_array, &valuetype0));
 
-  NAPI_ASSERT(env, valuetype0 == napi_object,
+  NODE_API_ASSERT(env, valuetype0 == napi_object,
       "Wrong type of arguments. Expects a typed array as first argument.");
 
   bool is_typedarray;
-  NAPI_CALL(env, napi_is_typedarray(env, input_array, &is_typedarray));
+  NODE_API_CALL(env, napi_is_typedarray(env, input_array, &is_typedarray));
 
-  NAPI_ASSERT(env, is_typedarray,
+  NODE_API_ASSERT(env, is_typedarray,
       "Wrong type of arguments. Expects a typed array as first argument.");
 
   napi_valuetype valuetype1;
   napi_value input_buffer = args[1];
-  NAPI_CALL(env, napi_typeof(env, input_buffer, &valuetype1));
+  NODE_API_CALL(env, napi_typeof(env, input_buffer, &valuetype1));
 
-  NAPI_ASSERT(env, valuetype1 == napi_object,
+  NODE_API_ASSERT(env, valuetype1 == napi_object,
       "Wrong type of arguments. Expects an array buffer as second argument.");
 
   bool is_arraybuffer;
-  NAPI_CALL(env, napi_is_arraybuffer(env, input_buffer, &is_arraybuffer));
+  NODE_API_CALL(env, napi_is_arraybuffer(env, input_buffer, &is_arraybuffer));
 
-  NAPI_ASSERT(env, is_arraybuffer,
+  NODE_API_ASSERT(env, is_arraybuffer,
       "Wrong type of arguments. Expects an array buffer as second argument.");
 
   napi_typedarray_type type;
   napi_value in_array_buffer;
   size_t byte_offset;
   size_t length;
-  NAPI_CALL(env, napi_get_typedarray_info(
+  NODE_API_CALL(env, napi_get_typedarray_info(
       env, input_array, &type, &length, NULL, &in_array_buffer, &byte_offset));
 
   if (argc == 4) {
     napi_valuetype valuetype2;
-    NAPI_CALL(env, napi_typeof(env, args[2], &valuetype2));
+    NODE_API_CALL(env, napi_typeof(env, args[2], &valuetype2));
 
-    NAPI_ASSERT(env, valuetype2 == napi_number,
+    NODE_API_ASSERT(env, valuetype2 == napi_number,
         "Wrong type of arguments. Expects a number as third argument.");
 
     uint32_t uint32_length;
-    NAPI_CALL(env, napi_get_value_uint32(env, args[2], &uint32_length));
+    NODE_API_CALL(env, napi_get_value_uint32(env, args[2], &uint32_length));
     length = uint32_length;
 
     napi_valuetype valuetype3;
-    NAPI_CALL(env, napi_typeof(env, args[3], &valuetype3));
+    NODE_API_CALL(env, napi_typeof(env, args[3], &valuetype3));
 
-    NAPI_ASSERT(env, valuetype3 == napi_number,
+    NODE_API_ASSERT(env, valuetype3 == napi_number,
         "Wrong type of arguments. Expects a number as third argument.");
 
     uint32_t uint32_byte_offset;
-    NAPI_CALL(env, napi_get_value_uint32(env, args[3], &uint32_byte_offset));
+    NODE_API_CALL(env, napi_get_value_uint32(env, args[3], &uint32_byte_offset));
     byte_offset = uint32_byte_offset;
   }
 
   napi_value output_array;
-  NAPI_CALL(env, napi_create_typedarray(
+  NODE_API_CALL(env, napi_create_typedarray(
       env, type, length, input_buffer, byte_offset, &output_array));
 
   return output_array;
@@ -189,16 +189,20 @@ static napi_value CreateTypedArray(napi_env env, napi_callback_info info) {
 static napi_value Detach(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
-  NAPI_ASSERT(env, argc == 1, "Wrong number of arguments.");
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_ASSERT(env, argc == 1, "Wrong number of arguments.");
 
   bool is_typedarray;
-  NAPI_CALL(env, napi_is_typedarray(env, args[0], &is_typedarray));
-  NAPI_ASSERT(env, is_typedarray, "Wrong type of arguments. Expects a typedarray as first argument.");
+  NODE_API_CALL(env, napi_is_typedarray(env, args[0], &is_typedarray));
+  NODE_API_ASSERT(
+      env, is_typedarray,
+      "Wrong type of arguments. Expects a typedarray as first argument.");
 
   napi_value arraybuffer;
-  NAPI_CALL(env, napi_get_typedarray_info(env, args[0], NULL, NULL, NULL, &arraybuffer, NULL));
-  NAPI_CALL(env, napi_detach_arraybuffer(env, arraybuffer));
+  NODE_API_CALL(env,
+      napi_get_typedarray_info(
+          env, args[0], NULL, NULL, NULL, &arraybuffer, NULL));
+  NODE_API_CALL(env, napi_detach_arraybuffer(env, arraybuffer));
 
   return NULL;
 }
@@ -206,20 +210,21 @@ static napi_value Detach(napi_env env, napi_callback_info info) {
 static napi_value IsDetached(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
-  NAPI_ASSERT(env, argc == 1, "Wrong number of arguments.");
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_ASSERT(env, argc == 1, "Wrong number of arguments.");
 
   napi_value array_buffer = args[0];
   bool is_arraybuffer;
-  NAPI_CALL(env, napi_is_arraybuffer(env, array_buffer, &is_arraybuffer));
-  NAPI_ASSERT(env, is_arraybuffer,
+  NODE_API_CALL(env, napi_is_arraybuffer(env, array_buffer, &is_arraybuffer));
+  NODE_API_ASSERT(env, is_arraybuffer,
       "Wrong type of arguments. Expects an array buffer as first argument.");
 
   bool is_detached;
-  NAPI_CALL(env, napi_is_detached_arraybuffer(env, array_buffer, &is_detached));
+  NODE_API_CALL(env,
+      napi_is_detached_arraybuffer(env, array_buffer, &is_detached));
 
   napi_value result;
-  NAPI_CALL(env, napi_get_boolean(env, is_detached, &result));
+  NODE_API_CALL(env, napi_get_boolean(env, is_detached, &result));
 
   return result;
 }
@@ -227,15 +232,15 @@ static napi_value IsDetached(napi_env env, napi_callback_info info) {
 EXTERN_C_START
 napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
-    DECLARE_NAPI_PROPERTY("Multiply", Multiply),
-    DECLARE_NAPI_PROPERTY("External", External),
-    DECLARE_NAPI_PROPERTY("NullArrayBuffer", NullArrayBuffer),
-    DECLARE_NAPI_PROPERTY("CreateTypedArray", CreateTypedArray),
-    DECLARE_NAPI_PROPERTY("Detach", Detach),
-    DECLARE_NAPI_PROPERTY("IsDetached", IsDetached),
+    DECLARE_NODE_API_PROPERTY("Multiply", Multiply),
+    DECLARE_NODE_API_PROPERTY("External", External),
+    DECLARE_NODE_API_PROPERTY("NullArrayBuffer", NullArrayBuffer),
+    DECLARE_NODE_API_PROPERTY("CreateTypedArray", CreateTypedArray),
+    DECLARE_NODE_API_PROPERTY("Detach", Detach),
+    DECLARE_NODE_API_PROPERTY("IsDetached", IsDetached),
   };
 
-  NAPI_CALL(env, napi_define_properties(
+  NODE_API_CALL(env, napi_define_properties(
       env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
 
   return exports;

--- a/test/node-api/1_hello_world/binding.c
+++ b/test/node-api/1_hello_world/binding.c
@@ -6,12 +6,12 @@ static napi_value Method(napi_env env, napi_callback_info info) {
   napi_value world;
   const char* str = "world";
   size_t str_len = strlen(str);
-  NAPI_CALL(env, napi_create_string_utf8(env, str, str_len, &world));
+  NODE_API_CALL(env, napi_create_string_utf8(env, str, str_len, &world));
   return world;
 }
 
 NAPI_MODULE_INIT() {
-  napi_property_descriptor desc = DECLARE_NAPI_PROPERTY("hello", Method);
-  NAPI_CALL(env, napi_define_properties(env, exports, 1, &desc));
+  napi_property_descriptor desc = DECLARE_NODE_API_PROPERTY("hello", Method);
+  NODE_API_CALL(env, napi_define_properties(env, exports, 1, &desc));
   return exports;
 }

--- a/test/node-api/test_async/test_async.c
+++ b/test/node-api/test_async/test_async.c
@@ -50,20 +50,20 @@ static void Complete(napi_env env, napi_status status, void* data) {
 
   napi_value argv[2];
 
-  NAPI_CALL_RETURN_VOID(env, napi_get_null(env, &argv[0]));
-  NAPI_CALL_RETURN_VOID(env, napi_create_int32(env, c->_output, &argv[1]));
+  NODE_API_CALL_RETURN_VOID(env, napi_get_null(env, &argv[0]));
+  NODE_API_CALL_RETURN_VOID(env, napi_create_int32(env, c->_output, &argv[1]));
   napi_value callback;
-  NAPI_CALL_RETURN_VOID(env,
+  NODE_API_CALL_RETURN_VOID(env,
       napi_get_reference_value(env, c->_callback, &callback));
   napi_value global;
-  NAPI_CALL_RETURN_VOID(env, napi_get_global(env, &global));
+  NODE_API_CALL_RETURN_VOID(env, napi_get_global(env, &global));
 
   napi_value result;
-  NAPI_CALL_RETURN_VOID(env,
+  NODE_API_CALL_RETURN_VOID(env,
     napi_call_function(env, global, callback, 2, argv, &result));
 
-  NAPI_CALL_RETURN_VOID(env, napi_delete_reference(env, c->_callback));
-  NAPI_CALL_RETURN_VOID(env, napi_delete_async_work(env, c->_request));
+  NODE_API_CALL_RETURN_VOID(env, napi_delete_reference(env, c->_callback));
+  NODE_API_CALL_RETURN_VOID(env, napi_delete_async_work(env, c->_request));
 }
 
 static napi_value Test(napi_env env, napi_callback_info info) {
@@ -72,33 +72,33 @@ static napi_value Test(napi_env env, napi_callback_info info) {
   napi_value _this;
   napi_value resource_name;
   void* data;
-  NAPI_CALL(env,
+  NODE_API_CALL(env,
     napi_get_cb_info(env, info, &argc, argv, &_this, &data));
-  NAPI_ASSERT(env, argc >= 3, "Not enough arguments, expected 2.");
+  NODE_API_ASSERT(env, argc >= 3, "Not enough arguments, expected 2.");
 
   napi_valuetype t;
-  NAPI_CALL(env, napi_typeof(env, argv[0], &t));
-  NAPI_ASSERT(env, t == napi_number,
+  NODE_API_CALL(env, napi_typeof(env, argv[0], &t));
+  NODE_API_ASSERT(env, t == napi_number,
       "Wrong first argument, integer expected.");
-  NAPI_CALL(env, napi_typeof(env, argv[1], &t));
-  NAPI_ASSERT(env, t == napi_object,
+  NODE_API_CALL(env, napi_typeof(env, argv[1], &t));
+  NODE_API_ASSERT(env, t == napi_object,
     "Wrong second argument, object expected.");
-  NAPI_CALL(env, napi_typeof(env, argv[2], &t));
-  NAPI_ASSERT(env, t == napi_function,
+  NODE_API_CALL(env, napi_typeof(env, argv[2], &t));
+  NODE_API_ASSERT(env, t == napi_function,
     "Wrong third argument, function expected.");
 
   the_carrier._output = 0;
 
-  NAPI_CALL(env,
+  NODE_API_CALL(env,
       napi_get_value_int32(env, argv[0], &the_carrier._input));
-  NAPI_CALL(env,
+  NODE_API_CALL(env,
     napi_create_reference(env, argv[2], 1, &the_carrier._callback));
 
-  NAPI_CALL(env, napi_create_string_utf8(
+  NODE_API_CALL(env, napi_create_string_utf8(
       env, "TestResource", NAPI_AUTO_LENGTH, &resource_name));
-  NAPI_CALL(env, napi_create_async_work(env, argv[1], resource_name,
+  NODE_API_CALL(env, napi_create_async_work(env, argv[1], resource_name,
     Execute, Complete, &the_carrier, &the_carrier._request));
-  NAPI_CALL(env,
+  NODE_API_CALL(env,
       napi_queue_async_work(env, the_carrier._request));
 
   return NULL;
@@ -106,7 +106,7 @@ static napi_value Test(napi_env env, napi_callback_info info) {
 
 static void BusyCancelComplete(napi_env env, napi_status status, void* data) {
   carrier* c = (carrier*)(data);
-  NAPI_CALL_RETURN_VOID(env, napi_delete_async_work(env, c->_request));
+  NODE_API_CALL_RETURN_VOID(env, napi_delete_async_work(env, c->_request));
 }
 
 static void CancelComplete(napi_env env, napi_status status, void* data) {
@@ -116,17 +116,17 @@ static void CancelComplete(napi_env env, napi_status status, void* data) {
     // ok we got the status we expected so make the callback to
     // indicate the cancel succeeded.
     napi_value callback;
-    NAPI_CALL_RETURN_VOID(env,
+    NODE_API_CALL_RETURN_VOID(env,
         napi_get_reference_value(env, c->_callback, &callback));
     napi_value global;
-    NAPI_CALL_RETURN_VOID(env, napi_get_global(env, &global));
+    NODE_API_CALL_RETURN_VOID(env, napi_get_global(env, &global));
     napi_value result;
-    NAPI_CALL_RETURN_VOID(env,
+    NODE_API_CALL_RETURN_VOID(env,
       napi_call_function(env, global, callback, 0, NULL, &result));
   }
 
-  NAPI_CALL_RETURN_VOID(env, napi_delete_async_work(env, c->_request));
-  NAPI_CALL_RETURN_VOID(env, napi_delete_reference(env, c->_callback));
+  NODE_API_CALL_RETURN_VOID(env, napi_delete_async_work(env, c->_request));
+  NODE_API_CALL_RETURN_VOID(env, napi_delete_reference(env, c->_callback));
 }
 
 static void CancelExecute(napi_env env, void* data) {
@@ -144,31 +144,31 @@ static napi_value TestCancel(napi_env env, napi_callback_info info) {
   napi_value resource_name;
   void* data;
 
-  NAPI_CALL(env, napi_create_string_utf8(
+  NODE_API_CALL(env, napi_create_string_utf8(
       env, "TestResource", NAPI_AUTO_LENGTH, &resource_name));
 
   // make sure the work we are going to cancel will not be
   // able to start by using all the threads in the pool
   for (int i = 1; i < MAX_CANCEL_THREADS; i++) {
-    NAPI_CALL(env, napi_create_async_work(env, NULL, resource_name,
+    NODE_API_CALL(env, napi_create_async_work(env, NULL, resource_name,
       CancelExecute, BusyCancelComplete,
       &async_carrier[i], &async_carrier[i]._request));
-    NAPI_CALL(env, napi_queue_async_work(env, async_carrier[i]._request));
+    NODE_API_CALL(env, napi_queue_async_work(env, async_carrier[i]._request));
   }
 
   // now queue the work we are going to cancel and then cancel it.
   // cancel will fail if the work has already started, but
   // we have prevented it from starting by consuming all of the
   // workers above.
-  NAPI_CALL(env,
+  NODE_API_CALL(env,
     napi_get_cb_info(env, info, &argc, argv, &_this, &data));
-  NAPI_CALL(env, napi_create_async_work(env, NULL, resource_name,
+  NODE_API_CALL(env, napi_create_async_work(env, NULL, resource_name,
     CancelExecute, CancelComplete,
     &async_carrier[0], &async_carrier[0]._request));
-  NAPI_CALL(env,
+  NODE_API_CALL(env,
       napi_create_reference(env, argv[0], 1, &async_carrier[0]._callback));
-  NAPI_CALL(env, napi_queue_async_work(env, async_carrier[0]._request));
-  NAPI_CALL(env, napi_cancel_async_work(env, async_carrier[0]._request));
+  NODE_API_CALL(env, napi_queue_async_work(env, async_carrier[0]._request));
+  NODE_API_CALL(env, napi_cancel_async_work(env, async_carrier[0]._request));
   return NULL;
 }
 
@@ -181,46 +181,46 @@ static void RepeatedWorkerThread(napi_env env, void* data) {}
 
 static void RepeatedWorkComplete(napi_env env, napi_status status, void* data) {
   napi_value cb, js_status;
-  NAPI_CALL_RETURN_VOID(env,
+  NODE_API_CALL_RETURN_VOID(env,
       napi_get_reference_value(env, repeated_work_info.ref, &cb));
-  NAPI_CALL_RETURN_VOID(env,
+  NODE_API_CALL_RETURN_VOID(env,
       napi_delete_async_work(env, repeated_work_info.work));
-  NAPI_CALL_RETURN_VOID(env,
+  NODE_API_CALL_RETURN_VOID(env,
       napi_delete_reference(env, repeated_work_info.ref));
   repeated_work_info.work = NULL;
   repeated_work_info.ref = NULL;
-  NAPI_CALL_RETURN_VOID(env,
+  NODE_API_CALL_RETURN_VOID(env,
       napi_create_uint32(env, (uint32_t)status, &js_status));
-  NAPI_CALL_RETURN_VOID(env,
+  NODE_API_CALL_RETURN_VOID(env,
       napi_call_function(env, cb, cb, 1, &js_status, NULL));
 }
 
 static napi_value DoRepeatedWork(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value cb, name;
-  NAPI_ASSERT(env, repeated_work_info.ref == NULL,
+  NODE_API_ASSERT(env, repeated_work_info.ref == NULL,
       "Reference left over from previous work");
-  NAPI_ASSERT(env, repeated_work_info.work == NULL,
+  NODE_API_ASSERT(env, repeated_work_info.work == NULL,
       "Work pointer left over from previous work");
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, &cb, NULL, NULL));
-  NAPI_CALL(env, napi_create_reference(env, cb, 1, &repeated_work_info.ref));
-  NAPI_CALL(env,
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, &cb, NULL, NULL));
+  NODE_API_CALL(env, napi_create_reference(env, cb, 1, &repeated_work_info.ref));
+  NODE_API_CALL(env,
       napi_create_string_utf8(env, "Repeated Work", NAPI_AUTO_LENGTH, &name));
-  NAPI_CALL(env,
+  NODE_API_CALL(env,
       napi_create_async_work(env, NULL, name, RepeatedWorkerThread,
           RepeatedWorkComplete, &repeated_work_info, &repeated_work_info.work));
-  NAPI_CALL(env, napi_queue_async_work(env, repeated_work_info.work));
+  NODE_API_CALL(env, napi_queue_async_work(env, repeated_work_info.work));
   return NULL;
 }
 
 static napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor properties[] = {
-    DECLARE_NAPI_PROPERTY("Test", Test),
-    DECLARE_NAPI_PROPERTY("TestCancel", TestCancel),
-    DECLARE_NAPI_PROPERTY("DoRepeatedWork", DoRepeatedWork),
+    DECLARE_NODE_API_PROPERTY("Test", Test),
+    DECLARE_NODE_API_PROPERTY("TestCancel", TestCancel),
+    DECLARE_NODE_API_PROPERTY("DoRepeatedWork", DoRepeatedWork),
   };
 
-  NAPI_CALL(env, napi_define_properties(
+  NODE_API_CALL(env, napi_define_properties(
       env, exports, sizeof(properties) / sizeof(*properties), properties));
 
   return exports;

--- a/test/node-api/test_async_context/binding.c
+++ b/test/node-api/test_async_context/binding.c
@@ -10,9 +10,9 @@ static napi_value MakeCallback(napi_env env, napi_callback_info info) {
   size_t n;
   napi_value args[MAX_ARGUMENTS];
   // NOLINTNEXTLINE (readability/null_usage)
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  NAPI_ASSERT(env, argc > 0, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc > 0, "Wrong number of arguments");
 
   napi_value async_context_wrap = args[0];
   napi_value recv = args[1];
@@ -24,17 +24,17 @@ static napi_value MakeCallback(napi_env env, napi_callback_info info) {
   }
 
   napi_valuetype func_type;
-  NAPI_CALL(env, napi_typeof(env, func, &func_type));
+  NODE_API_CALL(env, napi_typeof(env, func, &func_type));
 
   napi_async_context context;
-  NAPI_CALL(env, napi_unwrap(env, async_context_wrap, (void**)&context));
+  NODE_API_CALL(env, napi_unwrap(env, async_context_wrap, (void**)&context));
 
   napi_value result;
   if (func_type == napi_function) {
-    NAPI_CALL(env, napi_make_callback(
+    NODE_API_CALL(env, napi_make_callback(
         env, context, recv, func, argc - RESERVED_ARGS, argv, &result));
   } else {
-    NAPI_ASSERT(env, false, "Unexpected argument type");
+    NODE_API_ASSERT(env, false, "Unexpected argument type");
   }
 
   return result;
@@ -42,8 +42,8 @@ static napi_value MakeCallback(napi_env env, napi_callback_info info) {
 
 static void AsyncDestroyCb(napi_env env, void* data, void* hint) {
   napi_status status = napi_async_destroy(env, (napi_async_context)data);
-  // We cannot use NAPI_ASSERT_RETURN_VOID because we need to have a JS stack
-  // below in order to use exceptions.
+  // We cannot use NODE_API_ASSERT_RETURN_VOID because we need to have a JS
+  // stack below in order to use exceptions.
   assert(status == napi_ok);
 }
 
@@ -51,37 +51,37 @@ static void AsyncDestroyCb(napi_env env, void* data, void* hint) {
 
 static napi_value CreateAsyncResource(napi_env env, napi_callback_info info) {
   napi_value async_context_wrap;
-  NAPI_CALL(env, napi_create_object(env, &async_context_wrap));
+  NODE_API_CALL(env, napi_create_object(env, &async_context_wrap));
 
   size_t argc = CREATE_ASYNC_RESOURCE_ARGC;
   napi_value args[CREATE_ASYNC_RESOURCE_ARGC];
   // NOLINTNEXTLINE (readability/null_usage)
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
   napi_value resource = args[0];
   napi_value js_destroy_on_finalizer = args[1];
   napi_valuetype resource_type;
-  NAPI_CALL(env, napi_typeof(env, resource, &resource_type));
+  NODE_API_CALL(env, napi_typeof(env, resource, &resource_type));
   if (resource_type != napi_object) {
     resource = NULL;
   }
 
   napi_value resource_name;
-  NAPI_CALL(env, napi_create_string_utf8(
+  NODE_API_CALL(env, napi_create_string_utf8(
       env, "test_async", NAPI_AUTO_LENGTH, &resource_name));
 
   napi_async_context context;
-  NAPI_CALL(env, napi_async_init(env, resource, resource_name, &context));
+  NODE_API_CALL(env, napi_async_init(env, resource, resource_name, &context));
 
   bool destroy_on_finalizer = true;
   if (argc == 2) {
-    NAPI_CALL(env, napi_get_value_bool(env, js_destroy_on_finalizer, &destroy_on_finalizer));
+    NODE_API_CALL(env, napi_get_value_bool(env, js_destroy_on_finalizer, &destroy_on_finalizer));
   }
   if (resource_type == napi_object && destroy_on_finalizer) {
-    NAPI_CALL(env, napi_add_finalizer(
+    NODE_API_CALL(env, napi_add_finalizer(
         env, resource, (void*)context, AsyncDestroyCb, NULL, NULL));
   }
-  NAPI_CALL(env, napi_wrap(env, async_context_wrap, context, NULL, NULL, NULL));
+  NODE_API_CALL(env, napi_wrap(env, async_context_wrap, context, NULL, NULL, NULL));
   return async_context_wrap;
 }
 
@@ -91,15 +91,15 @@ static napi_value DestroyAsyncResource(napi_env env, napi_callback_info info) {
   size_t argc = DESTROY_ASYNC_RESOURCE_ARGC;
   napi_value args[DESTROY_ASYNC_RESOURCE_ARGC];
   // NOLINTNEXTLINE (readability/null_usage)
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
-  NAPI_ASSERT(env, argc == 1, "Wrong number of arguments");
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_ASSERT(env, argc == 1, "Wrong number of arguments");
 
   napi_value async_context_wrap = args[0];
 
   napi_async_context async_context;
-  NAPI_CALL(env,
+  NODE_API_CALL(env,
             napi_remove_wrap(env, async_context_wrap, (void**)&async_context));
-  NAPI_CALL(env, napi_async_destroy(env, async_context));
+  NODE_API_CALL(env, napi_async_destroy(env, async_context));
 
   return async_context_wrap;
 }
@@ -107,20 +107,20 @@ static napi_value DestroyAsyncResource(napi_env env, napi_callback_info info) {
 static
 napi_value Init(napi_env env, napi_value exports) {
   napi_value fn;
-  NAPI_CALL(env, napi_create_function(
+  NODE_API_CALL(env, napi_create_function(
       // NOLINTNEXTLINE (readability/null_usage)
       env, NULL, NAPI_AUTO_LENGTH, MakeCallback, NULL, &fn));
-  NAPI_CALL(env, napi_set_named_property(env, exports, "makeCallback", fn));
-  NAPI_CALL(env, napi_create_function(
+  NODE_API_CALL(env, napi_set_named_property(env, exports, "makeCallback", fn));
+  NODE_API_CALL(env, napi_create_function(
       // NOLINTNEXTLINE (readability/null_usage)
       env, NULL, NAPI_AUTO_LENGTH, CreateAsyncResource, NULL, &fn));
-  NAPI_CALL(env, napi_set_named_property(
+  NODE_API_CALL(env, napi_set_named_property(
       env, exports, "createAsyncResource", fn));
 
-  NAPI_CALL(env, napi_create_function(
+  NODE_API_CALL(env, napi_create_function(
       // NOLINTNEXTLINE (readability/null_usage)
       env, NULL, NAPI_AUTO_LENGTH, DestroyAsyncResource, NULL, &fn));
-  NAPI_CALL(env, napi_set_named_property(
+  NODE_API_CALL(env, napi_set_named_property(
       env, exports, "destroyAsyncResource", fn));
 
   return exports;

--- a/test/node-api/test_buffer/test_buffer.c
+++ b/test/node-api/test_buffer/test_buffer.c
@@ -8,14 +8,16 @@ static const char theText[] =
 
 static int deleterCallCount = 0;
 static void deleteTheText(napi_env env, void* data, void* finalize_hint) {
-  NAPI_ASSERT_RETURN_VOID(env, data != NULL && strcmp(data, theText) == 0, "invalid data");
+  NODE_API_ASSERT_RETURN_VOID(
+      env, data != NULL && strcmp(data, theText) == 0, "invalid data");
   (void)finalize_hint;
   free(data);
   deleterCallCount++;
 }
 
 static void noopDeleter(napi_env env, void* data, void* finalize_hint) {
-  NAPI_ASSERT_RETURN_VOID(env, data != NULL && strcmp(data, theText) == 0, "invalid data");
+  NODE_API_ASSERT_RETURN_VOID(
+      env, data != NULL && strcmp(data, theText) == 0, "invalid data");
   (void)finalize_hint;
   deleterCallCount++;
 }
@@ -25,13 +27,10 @@ static napi_value newBuffer(napi_env env, napi_callback_info info) {
   char* theCopy;
   const unsigned int kBufferSize = sizeof(theText);
 
-  NAPI_CALL(env,
-            napi_create_buffer(
-                env,
-                sizeof(theText),
-                (void**)(&theCopy),
-                &theBuffer));
-  NAPI_ASSERT(env, theCopy, "Failed to copy static text for newBuffer");
+  NODE_API_CALL(env,
+      napi_create_buffer(
+          env, sizeof(theText), (void**)(&theCopy), &theBuffer));
+  NODE_API_ASSERT(env, theCopy, "Failed to copy static text for newBuffer");
   memcpy(theCopy, theText, kBufferSize);
 
   return theBuffer;
@@ -40,28 +39,25 @@ static napi_value newBuffer(napi_env env, napi_callback_info info) {
 static napi_value newExternalBuffer(napi_env env, napi_callback_info info) {
   napi_value theBuffer;
   char* theCopy = strdup(theText);
-  NAPI_ASSERT(env, theCopy, "Failed to copy static text for newExternalBuffer");
-  NAPI_CALL(env,
-            napi_create_external_buffer(
-                env,
-                sizeof(theText),
-                theCopy,
-                deleteTheText,
-                NULL,  // finalize_hint
-                &theBuffer));
+  NODE_API_ASSERT(
+      env, theCopy, "Failed to copy static text for newExternalBuffer");
+  NODE_API_CALL(env,
+      napi_create_external_buffer(
+          env, sizeof(theText), theCopy, deleteTheText,
+          NULL /* finalize_hint */, &theBuffer));
 
   return theBuffer;
 }
 
 static napi_value getDeleterCallCount(napi_env env, napi_callback_info info) {
   napi_value callCount;
-  NAPI_CALL(env, napi_create_int32(env, deleterCallCount, &callCount));
+  NODE_API_CALL(env, napi_create_int32(env, deleterCallCount, &callCount));
   return callCount;
 }
 
 static napi_value copyBuffer(napi_env env, napi_callback_info info) {
   napi_value theBuffer;
-  NAPI_CALL(env, napi_create_buffer_copy(
+  NODE_API_CALL(env, napi_create_buffer_copy(
       env, sizeof(theText), theText, NULL, &theBuffer));
   return theBuffer;
 }
@@ -69,38 +65,34 @@ static napi_value copyBuffer(napi_env env, napi_callback_info info) {
 static napi_value bufferHasInstance(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
-  NAPI_ASSERT(env, argc == 1, "Wrong number of arguments");
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_ASSERT(env, argc == 1, "Wrong number of arguments");
   napi_value theBuffer = args[0];
   bool hasInstance;
   napi_valuetype theType;
-  NAPI_CALL(env, napi_typeof(env, theBuffer, &theType));
-  NAPI_ASSERT(env,
-              theType == napi_object,
-              "bufferHasInstance: instance is not an object");
-  NAPI_CALL(env, napi_is_buffer(env, theBuffer, &hasInstance));
-  NAPI_ASSERT(env, hasInstance, "bufferHasInstance: instance is not a buffer");
+  NODE_API_CALL(env, napi_typeof(env, theBuffer, &theType));
+  NODE_API_ASSERT(env,
+      theType == napi_object, "bufferHasInstance: instance is not an object");
+  NODE_API_CALL(env, napi_is_buffer(env, theBuffer, &hasInstance));
+  NODE_API_ASSERT(env, hasInstance, "bufferHasInstance: instance is not a buffer");
   napi_value returnValue;
-  NAPI_CALL(env, napi_get_boolean(env, hasInstance, &returnValue));
+  NODE_API_CALL(env, napi_get_boolean(env, hasInstance, &returnValue));
   return returnValue;
 }
 
 static napi_value bufferInfo(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
-  NAPI_ASSERT(env, argc == 1, "Wrong number of arguments");
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_ASSERT(env, argc == 1, "Wrong number of arguments");
   napi_value theBuffer = args[0];
   char *bufferData;
   napi_value returnValue;
   size_t bufferLength;
-  NAPI_CALL(env,
-            napi_get_buffer_info(
-                env,
-                theBuffer,
-                (void**)(&bufferData),
-                &bufferLength));
-  NAPI_CALL(env, napi_get_boolean(env,
+  NODE_API_CALL(env,
+      napi_get_buffer_info(
+          env, theBuffer, (void**)(&bufferData), &bufferLength));
+  NODE_API_CALL(env, napi_get_boolean(env,
       !strcmp(bufferData, theText) && bufferLength == sizeof(theText),
       &returnValue));
   return returnValue;
@@ -108,35 +100,32 @@ static napi_value bufferInfo(napi_env env, napi_callback_info info) {
 
 static napi_value staticBuffer(napi_env env, napi_callback_info info) {
   napi_value theBuffer;
-  NAPI_CALL(
-      env,
-      napi_create_external_buffer(env,
-                                  sizeof(theText),
-                                  (void*)theText,
-                                  noopDeleter,
-                                  NULL,  // finalize_hint
-                                  &theBuffer));
+  NODE_API_CALL(env,
+      napi_create_external_buffer(
+          env, sizeof(theText), (void*)theText, noopDeleter,
+          NULL /* finalize_hint */, &theBuffer));
   return theBuffer;
 }
 
 static napi_value Init(napi_env env, napi_value exports) {
   napi_value theValue;
 
-  NAPI_CALL(env,
+  NODE_API_CALL(env,
       napi_create_string_utf8(env, theText, sizeof(theText), &theValue));
-  NAPI_CALL(env, napi_set_named_property(env, exports, "theText", theValue));
+  NODE_API_CALL(env,
+      napi_set_named_property(env, exports, "theText", theValue));
 
   napi_property_descriptor methods[] = {
-    DECLARE_NAPI_PROPERTY("newBuffer", newBuffer),
-    DECLARE_NAPI_PROPERTY("newExternalBuffer", newExternalBuffer),
-    DECLARE_NAPI_PROPERTY("getDeleterCallCount", getDeleterCallCount),
-    DECLARE_NAPI_PROPERTY("copyBuffer", copyBuffer),
-    DECLARE_NAPI_PROPERTY("bufferHasInstance", bufferHasInstance),
-    DECLARE_NAPI_PROPERTY("bufferInfo", bufferInfo),
-    DECLARE_NAPI_PROPERTY("staticBuffer", staticBuffer),
+    DECLARE_NODE_API_PROPERTY("newBuffer", newBuffer),
+    DECLARE_NODE_API_PROPERTY("newExternalBuffer", newExternalBuffer),
+    DECLARE_NODE_API_PROPERTY("getDeleterCallCount", getDeleterCallCount),
+    DECLARE_NODE_API_PROPERTY("copyBuffer", copyBuffer),
+    DECLARE_NODE_API_PROPERTY("bufferHasInstance", bufferHasInstance),
+    DECLARE_NODE_API_PROPERTY("bufferInfo", bufferInfo),
+    DECLARE_NODE_API_PROPERTY("staticBuffer", staticBuffer),
   };
 
-  NAPI_CALL(env, napi_define_properties(
+  NODE_API_CALL(env, napi_define_properties(
       env, exports, sizeof(methods) / sizeof(methods[0]), methods));
 
   return exports;

--- a/test/node-api/test_callback_scope/binding.c
+++ b/test/node-api/test_callback_scope/binding.c
@@ -7,37 +7,34 @@ static napi_value RunInCallbackScope(napi_env env, napi_callback_info info) {
   size_t argc;
   napi_value args[3];
 
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, NULL, NULL, NULL));
-  NAPI_ASSERT(env, argc == 3 , "Wrong number of arguments");
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, NULL, NULL, NULL));
+  NODE_API_ASSERT(env, argc == 3 , "Wrong number of arguments");
 
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
   napi_valuetype valuetype;
-  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype));
-  NAPI_ASSERT(env, valuetype == napi_object,
+  NODE_API_CALL(env, napi_typeof(env, args[0], &valuetype));
+  NODE_API_ASSERT(env, valuetype == napi_object,
       "Wrong type of arguments. Expects an object as first argument.");
 
-  NAPI_CALL(env, napi_typeof(env, args[1], &valuetype));
-  NAPI_ASSERT(env, valuetype == napi_string,
+  NODE_API_CALL(env, napi_typeof(env, args[1], &valuetype));
+  NODE_API_ASSERT(env, valuetype == napi_string,
       "Wrong type of arguments. Expects a string as second argument.");
 
-  NAPI_CALL(env, napi_typeof(env, args[2], &valuetype));
-  NAPI_ASSERT(env, valuetype == napi_function,
+  NODE_API_CALL(env, napi_typeof(env, args[2], &valuetype));
+  NODE_API_ASSERT(env, valuetype == napi_function,
       "Wrong type of arguments. Expects a function as third argument.");
 
   napi_async_context context;
-  NAPI_CALL(env, napi_async_init(env, args[0], args[1], &context));
+  NODE_API_CALL(env, napi_async_init(env, args[0], args[1], &context));
 
   napi_callback_scope scope = NULL;
-  NAPI_CALL(
-      env,
-      napi_open_callback_scope(env,
-                               args[0],
-                               context,
-                               &scope));
+  NODE_API_CALL(env,
+      napi_open_callback_scope(env, args[0], context, &scope));
 
-  // if the function has an exception pending after the call that is ok
-  // so we don't use NAPI_CALL as we must close the callback scope regardless
+  // If the function has an exception pending after the call that is ok
+  // so we don't use NODE_API_CALL as we must close the callback scope
+  // regardless.
   napi_value result = NULL;
   napi_status function_call_result =
       napi_call_function(env, args[0], args[2], 0, NULL, &result);
@@ -45,8 +42,8 @@ static napi_value RunInCallbackScope(napi_env env, napi_callback_info info) {
     GET_AND_THROW_LAST_ERROR((env));
   }
 
-  NAPI_CALL(env, napi_close_callback_scope(env, scope));
-  NAPI_CALL(env, napi_async_destroy(env, context));
+  NODE_API_CALL(env, napi_close_callback_scope(env, scope));
+  NODE_API_CALL(env, napi_async_destroy(env, context));
 
   return result;
 }
@@ -58,34 +55,32 @@ static void Callback(uv_work_t* req, int ignored) {
   napi_env env = shared_env;
 
   napi_handle_scope handle_scope = NULL;
-  NAPI_CALL_RETURN_VOID(env, napi_open_handle_scope(env, &handle_scope));
+  NODE_API_CALL_RETURN_VOID(env, napi_open_handle_scope(env, &handle_scope));
 
   napi_value resource_name;
-  NAPI_CALL_RETURN_VOID(env, napi_create_string_utf8(
+  NODE_API_CALL_RETURN_VOID(env, napi_create_string_utf8(
       env, "test", NAPI_AUTO_LENGTH, &resource_name));
   napi_async_context context;
-  NAPI_CALL_RETURN_VOID(env,
-                        napi_async_init(env, NULL, resource_name, &context));
+  NODE_API_CALL_RETURN_VOID(env,
+      napi_async_init(env, NULL, resource_name, &context));
 
   napi_value resource_object;
-  NAPI_CALL_RETURN_VOID(env, napi_create_object(env, &resource_object));
+  NODE_API_CALL_RETURN_VOID(env, napi_create_object(env, &resource_object));
 
   napi_value undefined_value;
-  NAPI_CALL_RETURN_VOID(env, napi_get_undefined(env, &undefined_value));
+  NODE_API_CALL_RETURN_VOID(env, napi_get_undefined(env, &undefined_value));
 
   napi_callback_scope scope = NULL;
-  NAPI_CALL_RETURN_VOID(env, napi_open_callback_scope(env,
-                                                      resource_object,
-                                                      context,
-                                                      &scope));
+  NODE_API_CALL_RETURN_VOID(env,
+      napi_open_callback_scope(env, resource_object, context, &scope));
 
-  NAPI_CALL_RETURN_VOID(env,
-                        napi_resolve_deferred(env, deferred, undefined_value));
+  NODE_API_CALL_RETURN_VOID(env,
+      napi_resolve_deferred(env, deferred, undefined_value));
 
-  NAPI_CALL_RETURN_VOID(env, napi_close_callback_scope(env, scope));
+  NODE_API_CALL_RETURN_VOID(env, napi_close_callback_scope(env, scope));
 
-  NAPI_CALL_RETURN_VOID(env, napi_close_handle_scope(env, handle_scope));
-  NAPI_CALL_RETURN_VOID(env, napi_async_destroy(env, context));
+  NODE_API_CALL_RETURN_VOID(env, napi_close_handle_scope(env, handle_scope));
+  NODE_API_CALL_RETURN_VOID(env, napi_async_destroy(env, context));
   free(req);
 }
 
@@ -95,10 +90,10 @@ static napi_value TestResolveAsync(napi_env env, napi_callback_info info) {
   napi_value promise = NULL;
   if (deferred == NULL) {
     shared_env = env;
-    NAPI_CALL(env, napi_create_promise(env, &deferred, &promise));
+    NODE_API_CALL(env, napi_create_promise(env, &deferred, &promise));
 
     uv_loop_t* loop = NULL;
-    NAPI_CALL(env, napi_get_uv_event_loop(env, &loop));
+    NODE_API_CALL(env, napi_get_uv_event_loop(env, &loop));
 
     uv_work_t* req = malloc(sizeof(*req));
     uv_queue_work(loop,
@@ -111,11 +106,11 @@ static napi_value TestResolveAsync(napi_env env, napi_callback_info info) {
 
 static napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
-    DECLARE_NAPI_PROPERTY("runInCallbackScope", RunInCallbackScope),
-    DECLARE_NAPI_PROPERTY("testResolveAsync", TestResolveAsync)
+    DECLARE_NODE_API_PROPERTY("runInCallbackScope", RunInCallbackScope),
+    DECLARE_NODE_API_PROPERTY("testResolveAsync", TestResolveAsync)
   };
 
-  NAPI_CALL(env, napi_define_properties(
+  NODE_API_CALL(env, napi_define_properties(
       env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
 
   return exports;

--- a/test/node-api/test_exception/test_exception.c
+++ b/test/node-api/test_exception/test_exception.c
@@ -2,7 +2,7 @@
 #include "../../js-native-api/common.h"
 
 static void finalizer(napi_env env, void *data, void *hint) {
-  NAPI_CALL_RETURN_VOID(env,
+  NODE_API_CALL_RETURN_VOID(env,
       napi_throw_error(env, NULL, "Error during Finalize"));
 }
 
@@ -10,16 +10,16 @@ static char buffer_data[12];
 
 static napi_value createExternalBuffer(napi_env env, napi_callback_info info) {
   napi_value buffer;
-  NAPI_CALL(env, napi_create_external_buffer(env, sizeof(buffer_data),
+  NODE_API_CALL(env, napi_create_external_buffer(env, sizeof(buffer_data),
       buffer_data, finalizer, NULL, &buffer));
   return buffer;
 }
 
 static napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
-    DECLARE_NAPI_PROPERTY("createExternalBuffer", createExternalBuffer),
+    DECLARE_NODE_API_PROPERTY("createExternalBuffer", createExternalBuffer),
   };
-  NAPI_CALL(env, napi_define_properties(
+  NODE_API_CALL(env, napi_define_properties(
       env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
   return exports;
 }

--- a/test/node-api/test_fatal/test_fatal.c
+++ b/test/node-api/test_fatal/test_fatal.c
@@ -14,11 +14,11 @@ static napi_value TestStringLength(napi_env env, napi_callback_info info) {
 
 static napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor properties[] = {
-    DECLARE_NAPI_PROPERTY("Test", Test),
-    DECLARE_NAPI_PROPERTY("TestStringLength", TestStringLength),
+    DECLARE_NODE_API_PROPERTY("Test", Test),
+    DECLARE_NODE_API_PROPERTY("TestStringLength", TestStringLength),
   };
 
-  NAPI_CALL(env, napi_define_properties(
+  NODE_API_CALL(env, napi_define_properties(
       env, exports, sizeof(properties) / sizeof(*properties), properties));
 
   return exports;

--- a/test/node-api/test_fatal_exception/test_fatal_exception.c
+++ b/test/node-api/test_fatal_exception/test_fatal_exception.c
@@ -5,19 +5,19 @@ static napi_value Test(napi_env env, napi_callback_info info) {
   napi_value err;
   size_t argc = 1;
 
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, &err, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, &err, NULL, NULL));
 
-  NAPI_CALL(env, napi_fatal_exception(env, err));
+  NODE_API_CALL(env, napi_fatal_exception(env, err));
 
   return NULL;
 }
 
 static napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor properties[] = {
-    DECLARE_NAPI_PROPERTY("Test", Test),
+    DECLARE_NODE_API_PROPERTY("Test", Test),
   };
 
-  NAPI_CALL(env, napi_define_properties(
+  NODE_API_CALL(env, napi_define_properties(
       env, exports, sizeof(properties) / sizeof(*properties), properties));
 
   return exports;

--- a/test/node-api/test_general/test_general.c
+++ b/test/node-api/test_general/test_general.c
@@ -5,28 +5,27 @@
 static napi_value testGetNodeVersion(napi_env env, napi_callback_info info) {
   const napi_node_version* node_version;
   napi_value result, major, minor, patch, release;
-  NAPI_CALL(env, napi_get_node_version(env, &node_version));
-  NAPI_CALL(env, napi_create_uint32(env, node_version->major, &major));
-  NAPI_CALL(env, napi_create_uint32(env, node_version->minor, &minor));
-  NAPI_CALL(env, napi_create_uint32(env, node_version->patch, &patch));
-  NAPI_CALL(env, napi_create_string_utf8(env,
-                                         node_version->release,
-                                         NAPI_AUTO_LENGTH,
-                                         &release));
-  NAPI_CALL(env, napi_create_array_with_length(env, 4, &result));
-  NAPI_CALL(env, napi_set_element(env, result, 0, major));
-  NAPI_CALL(env, napi_set_element(env, result, 1, minor));
-  NAPI_CALL(env, napi_set_element(env, result, 2, patch));
-  NAPI_CALL(env, napi_set_element(env, result, 3, release));
+  NODE_API_CALL(env, napi_get_node_version(env, &node_version));
+  NODE_API_CALL(env, napi_create_uint32(env, node_version->major, &major));
+  NODE_API_CALL(env, napi_create_uint32(env, node_version->minor, &minor));
+  NODE_API_CALL(env, napi_create_uint32(env, node_version->patch, &patch));
+  NODE_API_CALL(env,
+      napi_create_string_utf8(
+          env, node_version->release, NAPI_AUTO_LENGTH, &release));
+  NODE_API_CALL(env, napi_create_array_with_length(env, 4, &result));
+  NODE_API_CALL(env, napi_set_element(env, result, 0, major));
+  NODE_API_CALL(env, napi_set_element(env, result, 1, minor));
+  NODE_API_CALL(env, napi_set_element(env, result, 2, patch));
+  NODE_API_CALL(env, napi_set_element(env, result, 3, release));
   return result;
 }
 
 static napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
-    DECLARE_NAPI_PROPERTY("testGetNodeVersion", testGetNodeVersion),
+    DECLARE_NODE_API_PROPERTY("testGetNodeVersion", testGetNodeVersion),
   };
 
-  NAPI_CALL(env, napi_define_properties(
+  NODE_API_CALL(env, napi_define_properties(
       env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
 
   return exports;

--- a/test/node-api/test_make_callback/binding.c
+++ b/test/node-api/test_make_callback/binding.c
@@ -10,9 +10,9 @@ static napi_value MakeCallback(napi_env env, napi_callback_info info) {
   size_t n;
   napi_value args[MAX_ARGUMENTS];
   // NOLINTNEXTLINE (readability/null_usage)
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  NAPI_ASSERT(env, argc > 0, "Wrong number of arguments");
+  NODE_API_ASSERT(env, argc > 0, "Wrong number of arguments");
 
   napi_value resource = args[0];
   napi_value recv = args[1];
@@ -25,24 +25,24 @@ static napi_value MakeCallback(napi_env env, napi_callback_info info) {
 
   napi_valuetype func_type;
 
-  NAPI_CALL(env, napi_typeof(env, func, &func_type));
+  NODE_API_CALL(env, napi_typeof(env, func, &func_type));
 
   napi_value resource_name;
-  NAPI_CALL(env, napi_create_string_utf8(
+  NODE_API_CALL(env, napi_create_string_utf8(
       env, "test", NAPI_AUTO_LENGTH, &resource_name));
 
   napi_async_context context;
-  NAPI_CALL(env, napi_async_init(env, resource, resource_name, &context));
+  NODE_API_CALL(env, napi_async_init(env, resource, resource_name, &context));
 
   napi_value result;
   if (func_type == napi_function) {
-    NAPI_CALL(env, napi_make_callback(
+    NODE_API_CALL(env, napi_make_callback(
         env, context, recv, func, argc - RESERVED_ARGS, argv, &result));
   } else {
-    NAPI_ASSERT(env, false, "Unexpected argument type");
+    NODE_API_ASSERT(env, false, "Unexpected argument type");
   }
 
-  NAPI_CALL(env, napi_async_destroy(env, context));
+  NODE_API_CALL(env, napi_async_destroy(env, context));
 
   return result;
 }
@@ -50,10 +50,10 @@ static napi_value MakeCallback(napi_env env, napi_callback_info info) {
 static
 napi_value Init(napi_env env, napi_value exports) {
   napi_value fn;
-  NAPI_CALL(env, napi_create_function(
+  NODE_API_CALL(env, napi_create_function(
       // NOLINTNEXTLINE (readability/null_usage)
       env, NULL, NAPI_AUTO_LENGTH, MakeCallback, NULL, &fn));
-  NAPI_CALL(env, napi_set_named_property(env, exports, "makeCallback", fn));
+  NODE_API_CALL(env, napi_set_named_property(env, exports, "makeCallback", fn));
   return exports;
 }
 

--- a/test/node-api/test_make_callback_recurse/binding.c
+++ b/test/node-api/test_make_callback_recurse/binding.c
@@ -5,7 +5,7 @@ static napi_value MakeCallback(napi_env env, napi_callback_info info) {
   size_t argc = 2;
   napi_value args[2];
   // NOLINTNEXTLINE (readability/null_usage)
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
   napi_value recv = args[0];
   napi_value func = args[1];
@@ -14,13 +14,13 @@ static napi_value MakeCallback(napi_env env, napi_callback_info info) {
     recv, func, 0 /* argc */, NULL /* argv */, NULL /* result */);
 
   bool isExceptionPending;
-  NAPI_CALL(env, napi_is_exception_pending(env, &isExceptionPending));
+  NODE_API_CALL(env, napi_is_exception_pending(env, &isExceptionPending));
   if (isExceptionPending && !(status == napi_pending_exception)) {
     // if there is an exception pending we don't expect any
     // other error
     napi_value pending_error;
     status = napi_get_and_clear_last_exception(env, &pending_error);
-    NAPI_CALL(env,
+    NODE_API_CALL(env,
       napi_throw_error((env),
                         NULL,
                         "error when only pending exception expected"));
@@ -31,10 +31,10 @@ static napi_value MakeCallback(napi_env env, napi_callback_info info) {
 
 static napi_value Init(napi_env env, napi_value exports) {
   napi_value fn;
-  NAPI_CALL(env, napi_create_function(
+  NODE_API_CALL(env, napi_create_function(
       // NOLINTNEXTLINE (readability/null_usage)
       env, NULL, NAPI_AUTO_LENGTH, MakeCallback, NULL, &fn));
-  NAPI_CALL(env, napi_set_named_property(env, exports, "makeCallback", fn));
+  NODE_API_CALL(env, napi_set_named_property(env, exports, "makeCallback", fn));
   return exports;
 }
 

--- a/test/node-api/test_policy/binding.c
+++ b/test/node-api/test_policy/binding.c
@@ -6,12 +6,12 @@ static napi_value Method(napi_env env, napi_callback_info info) {
   napi_value world;
   const char* str = "world";
   size_t str_len = strlen(str);
-  NAPI_CALL(env, napi_create_string_utf8(env, str, str_len, &world));
+  NODE_API_CALL(env, napi_create_string_utf8(env, str, str_len, &world));
   return world;
 }
 
 NAPI_MODULE_INIT() {
-  napi_property_descriptor desc = DECLARE_NAPI_PROPERTY("hello", Method);
-  NAPI_CALL(env, napi_define_properties(env, exports, 1, &desc));
+  napi_property_descriptor desc = DECLARE_NODE_API_PROPERTY("hello", Method);
+  NODE_API_CALL(env, napi_define_properties(env, exports, 1, &desc));
   return exports;
 }

--- a/test/node-api/test_threadsafe_function/binding.c
+++ b/test/node-api/test_threadsafe_function/binding.c
@@ -122,9 +122,9 @@ static void data_source_thread(void* data) {
 static void call_js(napi_env env, napi_value cb, void* hint, void* data) {
   if (!(env == NULL || cb == NULL)) {
     napi_value argv, undefined;
-    NAPI_CALL_RETURN_VOID(env, napi_create_int32(env, *(int*)data, &argv));
-    NAPI_CALL_RETURN_VOID(env, napi_get_undefined(env, &undefined));
-    NAPI_CALL_RETURN_VOID(env, napi_call_function(env, undefined, cb, 1, &argv,
+    NODE_API_CALL_RETURN_VOID(env, napi_create_int32(env, *(int*)data, &argv));
+    NODE_API_CALL_RETURN_VOID(env, napi_get_undefined(env, &undefined));
+    NODE_API_CALL_RETURN_VOID(env, napi_call_function(env, undefined, cb, 1, &argv,
         NULL));
   }
 }
@@ -134,10 +134,10 @@ static napi_ref alt_ref;
 static void call_ref(napi_env env, napi_value _, void* hint, void* data) {
   if (!(env == NULL || alt_ref == NULL)) {
     napi_value fn, argv, undefined;
-    NAPI_CALL_RETURN_VOID(env, napi_get_reference_value(env, alt_ref, &fn));
-    NAPI_CALL_RETURN_VOID(env, napi_create_int32(env, *(int*)data, &argv));
-    NAPI_CALL_RETURN_VOID(env, napi_get_undefined(env, &undefined));
-    NAPI_CALL_RETURN_VOID(env, napi_call_function(env, undefined, fn, 1, &argv,
+    NODE_API_CALL_RETURN_VOID(env, napi_get_reference_value(env, alt_ref, &fn));
+    NODE_API_CALL_RETURN_VOID(env, napi_create_int32(env, *(int*)data, &argv));
+    NODE_API_CALL_RETURN_VOID(env, napi_get_undefined(env, &undefined));
+    NODE_API_CALL_RETURN_VOID(env, napi_call_function(env, undefined, fn, 1, &argv,
         NULL));
   }
 }
@@ -146,17 +146,17 @@ static void call_ref(napi_env env, napi_value _, void* hint, void* data) {
 static napi_value StopThread(napi_env env, napi_callback_info info) {
   size_t argc = 2;
   napi_value argv[2];
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, argv, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, argv, NULL, NULL));
   napi_valuetype value_type;
-  NAPI_CALL(env, napi_typeof(env, argv[0], &value_type));
-  NAPI_ASSERT(env, value_type == napi_function,
+  NODE_API_CALL(env, napi_typeof(env, argv[0], &value_type));
+  NODE_API_ASSERT(env, value_type == napi_function,
       "StopThread argument is a function");
-  NAPI_ASSERT(env, (ts_fn != NULL), "Existing threadsafe function");
-  NAPI_CALL(env,
+  NODE_API_ASSERT(env, (ts_fn != NULL), "Existing threadsafe function");
+  NODE_API_CALL(env,
       napi_create_reference(env, argv[0], 1, &(ts_info.js_finalize_cb)));
   bool abort;
-  NAPI_CALL(env, napi_get_value_bool(env, argv[1], &abort));
-  NAPI_CALL(env,
+  NODE_API_CALL(env, napi_get_value_bool(env, argv[1], &abort));
+  NODE_API_CALL(env,
       napi_release_threadsafe_function(ts_fn,
           abort ? napi_tsfn_abort : napi_tsfn_release));
   ts_fn = NULL;
@@ -174,15 +174,15 @@ static void join_the_threads(napi_env env, void *data, void *hint) {
     uv_thread_join(&the_threads[1]);
   }
 
-  NAPI_CALL_RETURN_VOID(env,
+  NODE_API_CALL_RETURN_VOID(env,
       napi_get_reference_value(env, the_hint->js_finalize_cb, &js_cb));
-  NAPI_CALL_RETURN_VOID(env, napi_get_undefined(env, &undefined));
-  NAPI_CALL_RETURN_VOID(env,
+  NODE_API_CALL_RETURN_VOID(env, napi_get_undefined(env, &undefined));
+  NODE_API_CALL_RETURN_VOID(env,
       napi_call_function(env, undefined, js_cb, 0, NULL, NULL));
-  NAPI_CALL_RETURN_VOID(env, napi_delete_reference(env,
+  NODE_API_CALL_RETURN_VOID(env, napi_delete_reference(env,
       the_hint->js_finalize_cb));
   if (alt_ref != NULL) {
-    NAPI_CALL_RETURN_VOID(env, napi_delete_reference(env, alt_ref));
+    NODE_API_CALL_RETURN_VOID(env, napi_delete_reference(env, alt_ref));
     alt_ref = NULL;
   }
 }
@@ -196,37 +196,39 @@ static napi_value StartThreadInternal(napi_env env,
   size_t argc = 4;
   napi_value argv[4];
 
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, argv, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, argv, NULL, NULL));
   if (alt_ref_js_cb) {
-    NAPI_CALL(env, napi_create_reference(env, argv[0], 1, &alt_ref));
+    NODE_API_CALL(env, napi_create_reference(env, argv[0], 1, &alt_ref));
     argv[0] = NULL;
   }
 
   ts_info.block_on_full =
       (block_on_full ? napi_tsfn_blocking : napi_tsfn_nonblocking);
 
-  NAPI_ASSERT(env, (ts_fn == NULL), "Existing thread-safe function");
+  NODE_API_ASSERT(env, (ts_fn == NULL), "Existing thread-safe function");
   napi_value async_name;
-  NAPI_CALL(env, napi_create_string_utf8(env, "N-API Thread-safe Function Test",
-      NAPI_AUTO_LENGTH, &async_name));
-  NAPI_CALL(env, napi_get_value_uint32(env, argv[3], &ts_info.max_queue_size));
-  NAPI_CALL(env, napi_create_threadsafe_function(env,
-                                                 argv[0],
-                                                 NULL,
-                                                 async_name,
-                                                 ts_info.max_queue_size,
-                                                 2,
-                                                 uv_threads,
-                                                 join_the_threads,
-                                                 &ts_info,
-                                                 cb,
-                                                 &ts_fn));
+  NODE_API_CALL(env, napi_create_string_utf8(env,
+      "N-API Thread-safe Function Test", NAPI_AUTO_LENGTH, &async_name));
+  NODE_API_CALL(env,
+      napi_get_value_uint32(env, argv[3], &ts_info.max_queue_size));
+  NODE_API_CALL(env, napi_create_threadsafe_function(env,
+                                                     argv[0],
+                                                     NULL,
+                                                     async_name,
+                                                     ts_info.max_queue_size,
+                                                     2,
+                                                     uv_threads,
+                                                     join_the_threads,
+                                                     &ts_info,
+                                                     cb,
+                                                     &ts_fn));
   bool abort;
-  NAPI_CALL(env, napi_get_value_bool(env, argv[1], &abort));
+  NODE_API_CALL(env, napi_get_value_bool(env, argv[1], &abort));
   ts_info.abort = abort ? napi_tsfn_abort : napi_tsfn_release;
-  NAPI_CALL(env, napi_get_value_bool(env, argv[2], &(ts_info.start_secondary)));
+  NODE_API_CALL(env,
+      napi_get_value_bool(env, argv[2], &(ts_info.start_secondary)));
 
-  NAPI_ASSERT(env,
+  NODE_API_ASSERT(env,
       (uv_thread_create(&uv_threads[0], data_source_thread, ts_fn) == 0),
       "Thread creation");
 
@@ -234,14 +236,14 @@ static napi_value StartThreadInternal(napi_env env,
 }
 
 static napi_value Unref(napi_env env, napi_callback_info info) {
-  NAPI_ASSERT(env, ts_fn != NULL, "No existing thread-safe function");
-  NAPI_CALL(env, napi_unref_threadsafe_function(env, ts_fn));
+  NODE_API_ASSERT(env, ts_fn != NULL, "No existing thread-safe function");
+  NODE_API_CALL(env, napi_unref_threadsafe_function(env, ts_fn));
   return NULL;
 }
 
 static napi_value Release(napi_env env, napi_callback_info info) {
-  NAPI_ASSERT(env, ts_fn != NULL, "No existing thread-safe function");
-  NAPI_CALL(env, napi_release_threadsafe_function(ts_fn, napi_tsfn_release));
+  NODE_API_ASSERT(env, ts_fn != NULL, "No existing thread-safe function");
+  NODE_API_CALL(env, napi_release_threadsafe_function(ts_fn, napi_tsfn_release));
   return NULL;
 }
 
@@ -298,16 +300,16 @@ static napi_value Init(napi_env env, napi_value exports) {
       napi_enumerable,
       NULL
     },
-    DECLARE_NAPI_PROPERTY("StartThread", StartThread),
-    DECLARE_NAPI_PROPERTY("StartThreadNoNative", StartThreadNoNative),
-    DECLARE_NAPI_PROPERTY("StartThreadNonblocking", StartThreadNonblocking),
-    DECLARE_NAPI_PROPERTY("StartThreadNoJsFunc", StartThreadNoJsFunc),
-    DECLARE_NAPI_PROPERTY("StopThread", StopThread),
-    DECLARE_NAPI_PROPERTY("Unref", Unref),
-    DECLARE_NAPI_PROPERTY("Release", Release),
+    DECLARE_NODE_API_PROPERTY("StartThread", StartThread),
+    DECLARE_NODE_API_PROPERTY("StartThreadNoNative", StartThreadNoNative),
+    DECLARE_NODE_API_PROPERTY("StartThreadNonblocking", StartThreadNonblocking),
+    DECLARE_NODE_API_PROPERTY("StartThreadNoJsFunc", StartThreadNoJsFunc),
+    DECLARE_NODE_API_PROPERTY("StopThread", StopThread),
+    DECLARE_NODE_API_PROPERTY("Unref", Unref),
+    DECLARE_NODE_API_PROPERTY("Release", Release),
   };
 
-  NAPI_CALL(env, napi_define_properties(env, exports,
+  NODE_API_CALL(env, napi_define_properties(env, exports,
     sizeof(properties)/sizeof(properties[0]), properties));
 
   return exports;

--- a/test/node-api/test_uv_loop/test_uv_loop.cc
+++ b/test/node-api/test_uv_loop/test_uv_loop.cc
@@ -13,7 +13,7 @@ void* SetImmediate(napi_env env, T&& cb) {
   uv_loop_t* loop = nullptr;
   uv_check_t* check = new uv_check_t;
   check->data = ptr;
-  NAPI_ASSERT(env,
+  NODE_API_ASSERT(env,
               napi_get_uv_event_loop(env, &loop) == napi_ok,
               "can get event loop");
   uv_check_init(loop, check);
@@ -45,30 +45,30 @@ napi_value SetImmediateBinding(napi_env env, napi_callback_info info) {
   napi_value argv[1];
   napi_value _this;
   void* data;
-  NAPI_CALL(env,
+  NODE_API_CALL(env,
     napi_get_cb_info(env, info, &argc, argv, &_this, &data));
-  NAPI_ASSERT(env, argc >= 1, "Not enough arguments, expected 1.");
+  NODE_API_ASSERT(env, argc >= 1, "Not enough arguments, expected 1.");
 
   napi_valuetype t;
-  NAPI_CALL(env, napi_typeof(env, argv[0], &t));
-  NAPI_ASSERT(env, t == napi_function,
+  NODE_API_CALL(env, napi_typeof(env, argv[0], &t));
+  NODE_API_ASSERT(env, t == napi_function,
       "Wrong first argument, function expected.");
 
   napi_ref cbref;
-  NAPI_CALL(env,
+  NODE_API_CALL(env,
     napi_create_reference(env, argv[0], 1, &cbref));
 
   SetImmediate(env, [=]() -> char* {
     napi_value undefined;
     napi_value callback;
     napi_handle_scope scope;
-    NAPI_CALL(env, napi_open_handle_scope(env, &scope));
-    NAPI_CALL(env, napi_get_undefined(env, &undefined));
-    NAPI_CALL(env, napi_get_reference_value(env, cbref, &callback));
-    NAPI_CALL(env, napi_delete_reference(env, cbref));
-    NAPI_CALL(env,
+    NODE_API_CALL(env, napi_open_handle_scope(env, &scope));
+    NODE_API_CALL(env, napi_get_undefined(env, &undefined));
+    NODE_API_CALL(env, napi_get_reference_value(env, cbref, &callback));
+    NODE_API_CALL(env, napi_delete_reference(env, cbref));
+    NODE_API_CALL(env,
         napi_call_function(env, undefined, callback, 0, nullptr, nullptr));
-    NAPI_CALL(env, napi_close_handle_scope(env, scope));
+    NODE_API_CALL(env, napi_close_handle_scope(env, scope));
     return &dummy;
   });
 
@@ -77,10 +77,10 @@ napi_value SetImmediateBinding(napi_env env, napi_callback_info info) {
 
 napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor properties[] = {
-    DECLARE_NAPI_PROPERTY("SetImmediate", SetImmediateBinding)
+    DECLARE_NODE_API_PROPERTY("SetImmediate", SetImmediateBinding)
   };
 
-  NAPI_CALL(env, napi_define_properties(
+  NODE_API_CALL(env, napi_define_properties(
       env, exports, sizeof(properties) / sizeof(*properties), properties));
 
   return exports;

--- a/test/node-api/test_worker_buffer_callback/test_worker_buffer_callback.c
+++ b/test/node-api/test_worker_buffer_callback/test_worker_buffer_callback.c
@@ -8,7 +8,7 @@ uint32_t free_call_count = 0;
 
 napi_value GetFreeCallCount(napi_env env, napi_callback_info info) {
   napi_value value;
-  NAPI_CALL(env, napi_create_uint32(env, free_call_count, &value));
+  NODE_API_CALL(env, napi_create_uint32(env, free_call_count, &value));
   return value;
 }
 
@@ -19,10 +19,10 @@ static void finalize_cb(napi_env env, void* finalize_data, void* hint) {
 
 NAPI_MODULE_INIT() {
   napi_property_descriptor properties[] = {
-    DECLARE_NAPI_PROPERTY("getFreeCallCount", GetFreeCallCount)
+    DECLARE_NODE_API_PROPERTY("getFreeCallCount", GetFreeCallCount)
   };
 
-  NAPI_CALL(env, napi_define_properties(
+  NODE_API_CALL(env, napi_define_properties(
       env, exports, sizeof(properties) / sizeof(*properties), properties));
 
   // This is a slight variation on the non-N-API test: We create an ArrayBuffer
@@ -32,7 +32,7 @@ NAPI_MODULE_INIT() {
 
   char* data = malloc(sizeof(char));
 
-  NAPI_CALL(env, napi_create_external_arraybuffer(
+  NODE_API_CALL(env, napi_create_external_arraybuffer(
       env,
       data,
       sizeof(char),
@@ -40,7 +40,7 @@ NAPI_MODULE_INIT() {
       NULL,
       &buffer));
 
-  NAPI_CALL(env, napi_set_named_property(env, exports, "buffer", buffer));
+  NODE_API_CALL(env, napi_set_named_property(env, exports, "buffer", buffer));
 
   return exports;
 }

--- a/test/node-api/test_worker_terminate/test_worker_terminate.c
+++ b/test/node-api/test_worker_terminate/test_worker_terminate.c
@@ -9,12 +9,12 @@ napi_value Test(napi_env env, napi_callback_info info) {
   napi_value argv[1];
   napi_status status;
 
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, argv, &recv, NULL));
-  NAPI_ASSERT(env, argc >= 1, "Not enough arguments, expected 1.");
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, argv, &recv, NULL));
+  NODE_API_ASSERT(env, argc >= 1, "Not enough arguments, expected 1.");
 
   napi_valuetype t;
-  NAPI_CALL(env, napi_typeof(env, argv[0], &t));
-  NAPI_ASSERT(env, t == napi_function,
+  NODE_API_CALL(env, napi_typeof(env, argv[0], &t));
+  NODE_API_ASSERT(env, t == napi_function,
       "Wrong first argument, function expected.");
 
   status = napi_call_function(env, recv, argv[0], 0, NULL, NULL);
@@ -27,10 +27,10 @@ napi_value Test(napi_env env, napi_callback_info info) {
 
 napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor properties[] = {
-    DECLARE_NAPI_PROPERTY("Test", Test)
+    DECLARE_NODE_API_PROPERTY("Test", Test)
   };
 
-  NAPI_CALL(env, napi_define_properties(
+  NODE_API_CALL(env, napi_define_properties(
       env, exports, sizeof(properties) / sizeof(*properties), properties));
 
   return exports;

--- a/test/node-api/test_worker_terminate_finalization/test_worker_terminate_finalization.c
+++ b/test/node-api/test_worker_terminate_finalization/test_worker_terminate_finalization.c
@@ -10,8 +10,8 @@ int wrappedNativeData;
 napi_ref ref;
 void WrapFinalizer(napi_env env, void* data, void* hint) {
   uint32_t count;
-  NAPI_CALL_RETURN_VOID(env, napi_reference_unref(env, ref, &count));
-  NAPI_CALL_RETURN_VOID(env, napi_delete_reference(env, ref));
+  NODE_API_CALL_RETURN_VOID(env, napi_reference_unref(env, ref, &count));
+  NODE_API_CALL_RETURN_VOID(env, napi_delete_reference(env, ref));
 }
 
 void BufferFinalizer(napi_env env, void* data, void* hint) {
@@ -24,19 +24,23 @@ napi_value Test(napi_env env, napi_callback_info info) {
   napi_value result;
   void* bufferData = malloc(BUFFER_SIZE);
 
-  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, argv, NULL, NULL));
-  NAPI_CALL(env, napi_create_external_buffer(env, BUFFER_SIZE, bufferData, BufferFinalizer, bufferData, &result));
-  NAPI_CALL(env, napi_create_reference(env, result, 1, &ref));
-  NAPI_CALL(env, napi_wrap(env, argv[0], (void*) &wrappedNativeData, WrapFinalizer, NULL, NULL));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, argv, NULL, NULL));
+  NODE_API_CALL(env,
+      napi_create_external_buffer(
+          env, BUFFER_SIZE, bufferData, BufferFinalizer, bufferData, &result));
+  NODE_API_CALL(env, napi_create_reference(env, result, 1, &ref));
+  NODE_API_CALL(env,
+      napi_wrap(
+          env, argv[0], (void*) &wrappedNativeData, WrapFinalizer, NULL, NULL));
   return NULL;
 }
 
 napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor properties[] = {
-    DECLARE_NAPI_PROPERTY("Test", Test)
+    DECLARE_NODE_API_PROPERTY("Test", Test)
   };
 
-  NAPI_CALL(env, napi_define_properties(
+  NODE_API_CALL(env, napi_define_properties(
       env, exports, sizeof(properties) / sizeof(*properties), properties));
 
   return exports;


### PR DESCRIPTION
This renames the macros used in the tests from `NAPI_*` to
`NODE_API_*`.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
