### PR TITLE
tools: add GitHub Action linter for pr-url

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -98,3 +98,12 @@ jobs:
       - uses: mszostok/codeowners-validator@v0.4.0
         with:
           checks: "files,duppatterns"
+  lint-pr-url:
+    if: ${{ github.event.pull_request }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      # GH Actions squashes all PR commits, HEAD^ refers to the base branch.
+      - run: git diff HEAD^ HEAD -G"pr-url:" -- "*.md" | ./tools/lint-pr-url.mjs ${{ github.event.pull_request.html_url }}

--- a/tools/lint-pr-url.mjs
+++ b/tools/lint-pr-url.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+
+// Usage:
+// git diff upstream/master...HEAD -G"pr-url:" -- "*.md" | \
+// ./tools/lint-pr-url.mjs <expected-pr-url>
+
+import process from 'node:process';
+import readline from 'node:readline';
+
+const [, , expectedPrUrl] = process.argv;
+
+const fileDelimiter = /^\+\+\+ b\/(.+\.md)$/;
+const changeDelimiter = /^@@ -\d+,\d+ \+(\d+),\d+ @@/;
+const prUrlDefinition = /^\+\s+pr-url: (.+)$/;
+
+const validatePrUrl = (url) => url == null || url === expectedPrUrl;
+
+let currentFile;
+let currentLine;
+
+const diff = readline.createInterface({ input: process.stdin });
+for await (const line of diff) {
+  if (fileDelimiter.test(line)) {
+    currentFile = line.match(fileDelimiter)[1];
+    console.log(`Parsing changes in ${currentFile}.`);
+  } else if (changeDelimiter.test(line)) {
+    currentLine = Number(line.match(changeDelimiter)[1]);
+  } else if (!validatePrUrl(line.match(prUrlDefinition)?.[1])) {
+    console.warn(
+      `::warning file=${currentFile},line=${currentLine++},col=${line.length}` +
+      '::pr-url doesn\'t match the actual PR URL.'
+    );
+  } else if (line[0] !== '-') {
+    // Increment line counter if line is not being deleted.
+    currentLine++;
+  }
+}


### PR DESCRIPTION
The PR URL is unknown when someone starts working on a change, they may
be tempted to use a placeholder with a "fake" PR URL value to make the
linter pass on their local machine. This commit adds warnings when a
pr-url doesn't correspond to the actual PR URL to help reviewers spot
those "fake" URLs before landing.

![screen capture](https://user-images.githubusercontent.com/14309773/107154239-26054580-6972-11eb-9c1b-9611effd5dba.png)


<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
