### PR TITLE
timers: remove flaky setInterval test

### DIFF
--- a/test/parallel/test-timers-promisified.js
+++ b/test/parallel/test-timers-promisified.js
@@ -348,28 +348,6 @@ process.on('multipleResolves', common.mustNotCall());
       assert.strictEqual(loopCount, 5);
     }));
   }
-
-  {
-    // Check that if we abort when we have some callbacks left,
-    // we actually call them.
-    const controller = new AbortController();
-    const { signal } = controller;
-    const delay = 10;
-    let totalIterations = 0;
-    const timeoutLoop = runInterval(async (iterationNumber) => {
-      if (iterationNumber === 2) {
-        await setTimeout(delay * 2);
-        controller.abort();
-      }
-      if (iterationNumber > totalIterations) {
-        totalIterations = iterationNumber;
-      }
-    }, delay, signal);
-
-    timeoutLoop.catch(common.mustCall(() => {
-      assert.ok(totalIterations >= 3, `iterations was ${totalIterations} < 3`);
-    }));
-  }
 }
 
 {


### PR DESCRIPTION
The test added in #37153 relies on an incorrect assumption regarding the timing of setInterval. Since it is causing failures in CI we should remove it until we address the underlying issue to unbreak CI.