### PR TITLE
lib: use <array>.push and <array>.unshift instead of <array>.concat

### DIFF
--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -22,7 +22,7 @@
 'use strict';
 
 const {
-  ArrayPrototypeConcat,
+  ArrayPrototypePushApply,
   MathMin,
   Symbol,
   RegExpPrototypeTest,
@@ -66,7 +66,7 @@ function parserOnHeaders(headers, url) {
   // Once we exceeded headers limit - stop collecting them
   if (this.maxHeaderPairs <= 0 ||
       this._headers.length < this.maxHeaderPairs) {
-    this._headers = ArrayPrototypeConcat(this._headers, headers);
+    ArrayPrototypePushApply(this._headers, headers);
   }
   this._url += url;
 }

--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -4,8 +4,8 @@
 // message port.
 
 const {
-  ArrayPrototypeConcat,
   ArrayPrototypeForEach,
+  ArrayPrototypePushApply,
   ArrayPrototypeSplice,
   ObjectDefineProperty,
   PromisePrototypeCatch,
@@ -126,7 +126,7 @@ port.on('message', (message) => {
     loadPreloadModules();
     initializeFrozenIntrinsics();
     if (argv !== undefined) {
-      process.argv = ArrayPrototypeConcat(process.argv, argv);
+      ArrayPrototypePushApply(process.argv, argv);
     }
     publicWorker.parentPort = publicPort;
     publicWorker.workerData = workerData;

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -32,6 +32,7 @@ const {
   ArrayPrototypeSlice,
   ArrayPrototypeSplice,
   ArrayPrototypeUnshift,
+  ArrayPrototypeUnshiftApply,
   Boolean,
   Error,
   JSONParse,
@@ -1204,7 +1205,7 @@ Module._initPaths = function() {
     path.resolve(process.execPath, '..') :
     path.resolve(process.execPath, '..', '..');
 
-  let paths = [path.resolve(prefixDir, 'lib', 'node')];
+  const paths = [path.resolve(prefixDir, 'lib', 'node')];
 
   if (homeDir) {
     ArrayPrototypeUnshift(paths, path.resolve(homeDir, '.node_libraries'));
@@ -1212,10 +1213,10 @@ Module._initPaths = function() {
   }
 
   if (nodePath) {
-    paths = ArrayPrototypeConcat(ArrayPrototypeFilter(
+    ArrayPrototypeUnshiftApply(paths, ArrayPrototypeFilter(
       StringPrototypeSplit(nodePath, path.delimiter),
       Boolean
-    ), paths);
+    ));
   }
 
   modulePaths = paths;


### PR DESCRIPTION
Using `push` and `unshift` methods is more performant than reassigning a
new array created with `concat`.

Benchmark for `unshift`: https://jsben.ch/KeLG4
Benchmark for `push`: https://jsben.ch/QtIzg


<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
