### PR TITLE
crypto: deprecate KeyObject.from but support CryptoKeys in create*Key

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2747,7 +2747,7 @@ an explicit [`"exports"` or `"main"` entry][] with the exact file extension.
 <!-- YAML
 changes:
   - version: REPLACEME
-    pr-url: TODO
+    pr-url: https://github.com/nodejs/node/pull/37240
     description: Documentation-only deprecation.
 -->
 

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2743,6 +2743,18 @@ Previously, `index.js` and extension searching lookups would apply to
 With this deprecation, all ES module main entry point resolutions require
 an explicit [`"exports"` or `"main"` entry][] with the exact file extension.
 
+### DEP0XXX: `KeyObject.from`
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: TODO
+    description: Documentation-only deprecation.
+-->
+
+Type: Documentation-only.
+
+Use `KeyObject.fromCryptoKey` instead.
+
 [Legacy URL API]: url.md#url_legacy_url_api
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
 [RFC 6066]: https://tools.ietf.org/html/rfc6066#section-3

--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -72,8 +72,9 @@ const kKeyUsages = Symbol('kKeyUsages');
 // Key input contexts.
 const kConsumePublic = 0;
 const kConsumePrivate = 1;
-const kCreatePublic = 2;
-const kCreatePrivate = 3;
+const kCreateContextFlag = 2;
+const kCreatePublic = kConsumePublic | kCreateContextFlag;
+const kCreatePrivate = kConsumePrivate | kCreateContextFlag;
 
 const encodingNames = [];
 for (const m of [[kKeyEncodingPKCS1, 'pkcs1'], [kKeyEncodingPKCS8, 'pkcs8'],
@@ -404,7 +405,7 @@ function prepareAsymmetricKey(key, ctx) {
     // Best case: A key object, as simple as that.
     return { data: getKeyObjectHandle(key, ctx) };
   } else if (isCryptoKey(key)) {
-    const actualCtx = (ctx === kCreatePublic) ? kConsumePublic : ctx;
+    const actualCtx = ctx & ~kCreateContextFlag;
     return { data: getKeyObjectHandle(key[kKeyObject], actualCtx) };
   } else if (isStringOrBuffer(key)) {
     // Expect PEM by default, mostly for backward compatibility.
@@ -416,7 +417,7 @@ function prepareAsymmetricKey(key, ctx) {
     if (isKeyObject(data)) {
       return { data: getKeyObjectHandle(data, ctx) };
     } else if (isCryptoKey(data)) {
-      const actualCtx = (ctx === kCreatePublic) ? kConsumePublic : ctx;
+      const actualCtx = ctx & ~kCreateContextFlag;
       return { data: getKeyObjectHandle(data[kKeyObject], actualCtx) };
     }
     // Either PEM or DER using PKCS#1 or SPKI.
@@ -472,7 +473,7 @@ function prepareSecretKey(key, encoding, bufferOnly = false) {
 }
 
 function createSecretKey(key, encoding) {
-  key = prepareSecretKey(key, encoding, true);
+  key = prepareSecretKey(key, encoding, false);
   if (key.byteLength === 0)
     throw new ERR_OUT_OF_RANGE('key.byteLength', '> 0', key.byteLength);
   const handle = new KeyObjectHandle();

--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -473,7 +473,11 @@ function prepareSecretKey(key, encoding, bufferOnly = false) {
 }
 
 function createSecretKey(key, encoding) {
-  key = prepareSecretKey(key, encoding, false);
+  // TODO(tniessen): This doesn't really work.
+  if (isCryptoKey(key))
+    return key[kKeyObject];
+
+  key = prepareSecretKey(key, encoding, true);
   if (key.byteLength === 0)
     throw new ERR_OUT_OF_RANGE('key.byteLength', '> 0', key.byteLength);
   const handle = new KeyObjectHandle();

--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -116,10 +116,6 @@ const [
     }
 
     static from(key) {
-      return KeyObject.fromCryptoKey(key);
-    }
-
-    static fromCryptoKey(key) {
       if (!isCryptoKey(key))
         throw new ERR_INVALID_ARG_TYPE('key', 'CryptoKey', key);
       return key[kKeyObject];

--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -116,6 +116,10 @@ const [
     }
 
     static from(key) {
+      return KeyObject.fromCryptoKey(key);
+    }
+
+    static fromCryptoKey(key) {
       if (!isCryptoKey(key))
         throw new ERR_INVALID_ARG_TYPE('key', 'CryptoKey', key);
       return key[kKeyObject];

--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -408,7 +408,8 @@ function prepareAsymmetricKey(key, ctx) {
     // Best case: A key object, as simple as that.
     return { data: getKeyObjectHandle(key, ctx) };
   } else if (isCryptoKey(key)) {
-    return { data: getKeyObjectHandle(key[kKeyObject], ctx) };
+    const actualCtx = (ctx === kCreatePublic) ? kConsumePublic : ctx;
+    return { data: getKeyObjectHandle(key[kKeyObject], actualCtx) };
   } else if (isStringOrBuffer(key)) {
     // Expect PEM by default, mostly for backward compatibility.
     return { format: kKeyFormatPEM, data: getArrayBufferOrView(key, 'key') };
@@ -416,10 +417,12 @@ function prepareAsymmetricKey(key, ctx) {
     const { key: data, encoding } = key;
     // The 'key' property can be a KeyObject as well to allow specifying
     // additional options such as padding along with the key.
-    if (isKeyObject(data))
+    if (isKeyObject(data)) {
       return { data: getKeyObjectHandle(data, ctx) };
-    else if (isCryptoKey(data))
-      return { data: getKeyObjectHandle(data[kKeyObject], ctx) };
+    } else if (isCryptoKey(data)) {
+      const actualCtx = (ctx === kCreatePublic) ? kConsumePublic : ctx;
+      return { data: getKeyObjectHandle(data[kKeyObject], actualCtx) };
+    }
     // Either PEM or DER using PKCS#1 or SPKI.
     if (!isStringOrBuffer(data)) {
       throw new ERR_INVALID_ARG_TYPE(

--- a/src/crypto/crypto_keys.cc
+++ b/src/crypto/crypto_keys.cc
@@ -952,7 +952,7 @@ void KeyObjectHandle::Init(const FunctionCallbackInfo<Value>& args) {
     CHECK_EQ(args.Length(), 5);
 
     offset = 1;
-    pkey = ManagedEVPPKey::GetPrivateKeyFromJs(args, &offset, false);
+    pkey = ManagedEVPPKey::GetPrivateKeyFromJs(args, &offset, true);
     if (!pkey)
       return;
     key->data_ = KeyObjectData::CreateAsymmetric(type, pkey);

--- a/test/parallel/test-webcrypto-to-keyobject.js
+++ b/test/parallel/test-webcrypto-to-keyobject.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const { Buffer } = require('buffer');
+const {
+  createSecretKey,
+  createPublicKey,
+  createPrivateKey,
+  webcrypto: { subtle }
+} = require('crypto');
+
+(async function() {
+  const { publicKey, privateKey } = await subtle.generateKey({
+    name: 'RSA-OAEP',
+    modulusLength: 1024,
+    publicExponent: Buffer.from([1, 0, 1]),
+    hash: 'SHA-256'
+  }, false, ['encrypt', 'decrypt']);
+
+  const nodePublicKey = createPublicKey(publicKey);
+  assert.strictEqual(nodePublicKey.type, 'public');
+  assert.strictEqual(nodePublicKey.asymmetricKeyType, 'rsa');
+  assert.strictEqual(nodePublicKey.asymmetricKeyDetails.modulusLength, 1024);
+
+  const nodePublicKeyFromPrivate = createPublicKey(privateKey);
+  assert.strictEqual(nodePublicKeyFromPrivate.type, 'public');
+  assert.strictEqual(nodePublicKeyFromPrivate.asymmetricKeyType, 'rsa');
+  assert.strictEqual(
+    nodePublicKeyFromPrivate.asymmetricKeyDetails.modulusLength, 1024);
+
+  const nodePrivateKey = createPrivateKey(privateKey);
+  assert.strictEqual(nodePrivateKey.type, 'private');
+  assert.strictEqual(nodePrivateKey.asymmetricKeyType, 'rsa');
+  assert.strictEqual(nodePrivateKey.asymmetricKeyDetails.modulusLength, 1024);
+
+  const aesKey = await subtle.generateKey({
+    name: 'AES-GCM',
+    length: 256
+  }, false, ['encrypt', 'decrypt']);
+
+  const nodeSecretKey = createSecretKey(aesKey);
+  assert.strictEqual(nodeSecretKey.type, 'secret');
+  assert.strictEqual(nodeSecretKey.symmetricKeySize, 32);
+})().then(common.mustCall());


### PR DESCRIPTION
~This renames `KeyObject.from` to `KeyObject.fromCryptoKey`. Currently, it only accepts `CryptoKey` instances as inputs, and I don't see that changing any time soon.~

This is mainly for API safety. `KeyObject.from` is a very generic name for something that has a very specific purpose. Also, the name says absolutely nothing about the type of the parameter:

```js
function something(someKeyThing) {
  // ...
  KeyObject.from(someKeyThing); // What is the input here?!
  // ...
}
```

~The function is currently undocumented, I'll update this if/when https://github.com/nodejs/node/pull/37198 lands.~

~I don't think this function is being tested at all, but I might have missed it. I'd love to hear other opinions if someone thinks we should keep the function as it is (modulo being documented).~

This deprecates `KeyObject.from` and adds support for `CryptoKey` instances to `createPrivateKey` etc.

It's also questionable that non-`extractable` instances of `CryptoKey` can apparently be converted to unprotected `KeyObject`s , which then allow extracting the key material. Not sure if that's a feature or a bug.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
