### PR TITLE
deps: V8: backport dfcf1e86fac0

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.23',
+    'v8_embedder_string': '-node.24',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/common/message-template.h
+++ b/deps/v8/src/common/message-template.h
@@ -575,6 +575,8 @@ namespace internal {
   T(DataCloneErrorOutOfMemory, "Data cannot be cloned, out of memory.")        \
   T(DataCloneErrorDetachedArrayBuffer,                                         \
     "An ArrayBuffer is detached and could not be cloned.")                     \
+  T(DataCloneErrorNonDetachableArrayBuffer,                                    \
+    "ArrayBuffer is not detachable and could not be cloned.")                  \
   T(DataCloneErrorSharedArrayBufferTransferred,                                \
     "A SharedArrayBuffer could not be cloned. SharedArrayBuffer must not be "  \
     "transferred.")                                                            \

--- a/deps/v8/src/objects/value-serializer.cc
+++ b/deps/v8/src/objects/value-serializer.cc
@@ -860,6 +860,11 @@ Maybe<bool> ValueSerializer::WriteJSArrayBuffer(
     WriteVarint(index.FromJust());
     return ThrowIfOutOfMemory();
   }
+  if (!array_buffer->is_detachable()) {
+    ThrowDataCloneError(
+        MessageTemplate::kDataCloneErrorNonDetachableArrayBuffer);
+    return Nothing<bool>();
+  }
 
   uint32_t* transfer_entry = array_buffer_transfer_map_.Find(array_buffer);
   if (transfer_entry) {

--- a/deps/v8/test/mjsunit/wasm/worker-memory.js
+++ b/deps/v8/test/mjsunit/wasm/worker-memory.js
@@ -11,6 +11,13 @@
   assertThrows(() => worker.postMessage(memory), Error);
 })();
 
+(function TestPostMessageUnsharedMemoryBuffer() {
+  let worker = new Worker('', {type: 'string'});
+  let memory = new WebAssembly.Memory({initial: 1, maximum: 2});
+
+  assertThrows(() => worker.postMessage(memory.buffer), Error);
+})();
+
 // Can't use assert in a worker.
 let workerHelpers =
   `function assertTrue(value, msg) {


### PR DESCRIPTION
Original commit message:

    [wasm] PostMessage of Memory.buffer should throw

    PostMessage of an ArrayBuffer that is not detachable should result
    in a DataCloneError.

    Bug: chromium:1170176, chromium:961059
    Change-Id: Ib89bbc10d2b58918067fd1a90365cad10a0db9ec
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2653810
    Reviewed-by: Adam Klein <adamk@chromium.org>
    Reviewed-by: Andreas Haas <ahaas@chromium.org>
    Commit-Queue: Deepti Gandluri <gdeepti@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#72415}

Refs: https://github.com/v8/v8/commit/dfcf1e86fac0a7b067caf8fdfc13eaf3e3f445e4
