### PR TITLE
child_process: fix bad abortSignal leak

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -758,11 +758,14 @@ function spawnWithSignal(file, args, options) {
   const opts = options && typeof options === 'object' && ('signal' in options) ?
     { ...options, signal: undefined } :
     options;
+
+  if (options?.signal) {
+    // Validate signal, if present
+    validateAbortSignal(options.signal, 'options.signal');
+  }
   const child = spawn(file, args, opts);
 
   if (options && options.signal) {
-    // Validate signal, if present
-    validateAbortSignal(options.signal, 'options.signal');
     function kill() {
       if (child._handle) {
         child._handle.kill(options.killSignal || 'SIGTERM');


### PR DESCRIPTION
The abort signal validation happens after spawn is called internally, so if a bad AbortSignal param is passed and the validation doesn't pass the spawned process still exists.

I just moved the validation to execute before the internal spawn call.