### PR TITLE
process: add _getActiveHandles documentation

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -2569,6 +2569,17 @@ process has been running.
 The return value includes fractions of a second. Use `Math.floor()` to get whole
 seconds.
 
+## `process._getActiveHandles()`
+<!-- YAML
+added: REPLACEME
+-->
+
+* Returns: {Array}
+
+The `process.getActiveHandles` method returns the list of handles that are
+currently opened up by the process. These can be open file descriptors,
+conenction, resources that are actively being held by the process.
+
 ## `process.version`
 <!-- YAML
 added: v0.1.3


### PR DESCRIPTION
Documenting activeHandles documentation in the process API which can be
used by the developers to make functions/modules to track the health of
their node process.

Though i am aware of the reason that why it is not documented yet, even though being very
much helpful for instrumentation of process stats. I might be lacking some
information around the context but wanted to float this PR so that iteration can
be done on this PR and developers are aware of this awesome function.
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->