### PR TITLE
doc: discourage error event

### DIFF
--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -1247,12 +1247,21 @@ target.addEventListener('foo', handler4, { once: true });
 ### `EventTarget` error handling
 
 When a registered event listener throws (or returns a Promise that rejects),
-by default the error is forwarded to the `process.on('error')` event
-on `process.nextTick()`. Throwing within an event listener will *not* stop
-the other registered handlers from being invoked.
+by default the error is treated as an uncaught exception on
+`process.nextTick()`. This means uncaught exceptions in `EventTarget`s will
+terminate the Node.js process by default.
 
-The `EventTarget` does not implement any special default handling for
-`'error'` type events.
+Throwing within an event listener will *not* stop the other registered handlers
+from being invoked.
+
+The `EventTarget` does not implement any special default handling for `'error'`
+type events like `EventEmitter`.
+
+Currently errors are first forwarded to the `process.on('error')` event
+before reaching `process.on('uncaughtException')`. This behavior is
+deprecated and will change in a future release to align `EventTarget` with
+other Node.js APIs. Any code relying on the `process.on('error')` event should
+be aligned with the new behavior.
 
 ### Class: `Event`
 <!-- YAML


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/37237#issuecomment-774119972

Refs: https://github.com/nodejs/node/pull/37237

Basically - the "error" event is being removed from the code - it was never documented on `process` but in order to be cautious the change is still semver-major.

This PR changes the wording to indicate the future behaviour.

Bikeshedding/suggestions welcome