### PR TITLE
tools: avoid pending deprecation in doc generator

### DIFF
--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -24,7 +24,6 @@
 const common = require('./common.js');
 const fs = require('fs');
 const unified = require('unified');
-const find = require('unist-util-find');
 const visit = require('unist-util-visit');
 const markdown = require('remark-parse');
 const gfm = require('remark-gfm');
@@ -97,7 +96,13 @@ function toHTML({ input, content, filename, nodeVersion, versions }) {
 // Set the section name based on the first header.  Default to 'Index'.
 function firstHeader() {
   return (tree, file) => {
-    const heading = find(tree, { type: 'heading' });
+    let heading;
+    visit(tree, (node) => {
+      if (node.type === 'heading') {
+        heading = node;
+        return false;
+      }
+    });
 
     if (heading && heading.children.length) {
       const recursiveTextContent = (node) =>

--- a/tools/doc/package-lock.json
+++ b/tools/doc/package-lock.json
@@ -21,7 +21,6 @@
         "remark-rehype": "8.0.0",
         "to-vfile": "6.1.0",
         "unified": "9.2.0",
-        "unist-util-find": "^1.0.2",
         "unist-util-select": "3.0.4",
         "unist-util-visit": "2.0.3"
       },
@@ -440,12 +439,6 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
-    },
-    "node_modules/lodash.iteratee": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.iteratee/-/lodash.iteratee-4.7.0.tgz",
-      "integrity": "sha1-vkF32yiajMw8CZDx2ya1si/BVUw=",
-      "dev": true
     },
     "node_modules/longest-streak": {
       "version": "2.0.4",
@@ -958,40 +951,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/unist-util-find": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/unist-util-find/-/unist-util-find-1.0.2.tgz",
-      "integrity": "sha512-ft06UDYzqi9o9RmGP0sZWI/zvLLQiBW2/MD+rW6mDqbOWDcmknGX9orQPspfuGRYWr8eSJAmfsBcvOpfGRJseA==",
-      "dev": true,
-      "dependencies": {
-        "lodash.iteratee": "^4.5.0",
-        "unist-util-visit": "^1.1.0"
-      }
-    },
-    "node_modules/unist-util-find/node_modules/unist-util-is": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
-      "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==",
-      "dev": true
-    },
-    "node_modules/unist-util-find/node_modules/unist-util-visit": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
-      "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
-      "dev": true,
-      "dependencies": {
-        "unist-util-visit-parents": "^2.0.0"
-      }
-    },
-    "node_modules/unist-util-find/node_modules/unist-util-visit-parents": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
-      "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
-      "dev": true,
-      "dependencies": {
-        "unist-util-is": "^3.0.0"
-      }
-    },
     "node_modules/unist-util-generated": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-1.1.6.tgz",
@@ -1442,12 +1401,6 @@
         "argparse": "^2.0.1"
       }
     },
-    "lodash.iteratee": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.iteratee/-/lodash.iteratee-4.7.0.tgz",
-      "integrity": "sha1-vkF32yiajMw8CZDx2ya1si/BVUw=",
-      "dev": true
-    },
     "longest-streak": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
@@ -1814,42 +1767,6 @@
       "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-2.0.3.tgz",
       "integrity": "sha512-f98yt5pnlMWlzP539tPc4grGMsFaQQlP/vM396b00jngsiINumNmsY8rkXjfoi1c6QaM8nQ3vaGDuoKWbe/1Uw==",
       "dev": true
-    },
-    "unist-util-find": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/unist-util-find/-/unist-util-find-1.0.2.tgz",
-      "integrity": "sha512-ft06UDYzqi9o9RmGP0sZWI/zvLLQiBW2/MD+rW6mDqbOWDcmknGX9orQPspfuGRYWr8eSJAmfsBcvOpfGRJseA==",
-      "dev": true,
-      "requires": {
-        "lodash.iteratee": "^4.5.0",
-        "unist-util-visit": "^1.1.0"
-      },
-      "dependencies": {
-        "unist-util-is": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
-          "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==",
-          "dev": true
-        },
-        "unist-util-visit": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
-          "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
-          "dev": true,
-          "requires": {
-            "unist-util-visit-parents": "^2.0.0"
-          }
-        },
-        "unist-util-visit-parents": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
-          "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
-          "dev": true,
-          "requires": {
-            "unist-util-is": "^3.0.0"
-          }
-        }
-      }
     },
     "unist-util-generated": {
       "version": "1.1.6",

--- a/tools/doc/package.json
+++ b/tools/doc/package.json
@@ -17,7 +17,6 @@
     "remark-rehype": "8.0.0",
     "to-vfile": "6.1.0",
     "unified": "9.2.0",
-    "unist-util-find": "^1.0.2",
     "unist-util-select": "3.0.4",
     "unist-util-visit": "2.0.3"
   },


### PR DESCRIPTION
`unist-util-find` depends on `lodash.iteratee` which uses `process.binding()`.
Let's remove this dependency which is used in one place to do a very simple thing.