### PR TITLE
http: explain the unused argument in IncomingMessage._read

### DIFF
--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -155,6 +155,10 @@ IncomingMessage.prototype.setTimeout = function setTimeout(msecs, callback) {
 // argument adaptor frame creation inside V8 in case that number of actual
 // arguments is different from expected arguments.
 // Ref: https://bugs.chromium.org/p/v8/issues/detail?id=10201
+// NOTE: Argument adapt frame issue might be solved in V8 engine v8.9.
+// Refactoring `n` out might be possible when V8 is upgraded to that
+// version.
+// Ref: https://v8.dev/blog/v8-release-89
 IncomingMessage.prototype._read = function _read(n) {
   if (!this._consuming) {
     this._readableState.readingMore = false;

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -151,7 +151,10 @@ IncomingMessage.prototype.setTimeout = function setTimeout(msecs, callback) {
   return this;
 };
 
-
+// Argument n cannot be factored out due to the overhead of
+// argument adaptor frame creation inside V8 in case that number of actual
+// arguments is different from expected arguments.
+// Ref: https://bugs.chromium.org/p/v8/issues/detail?id=10201
 IncomingMessage.prototype._read = function _read(n) {
   if (!this._consuming) {
     this._readableState.readingMore = false;

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -152,7 +152,7 @@ IncomingMessage.prototype.setTimeout = function setTimeout(msecs, callback) {
 };
 
 
-IncomingMessage.prototype._read = function _read() {
+IncomingMessage.prototype._read = function _read(n) {
   if (!this._consuming) {
     this._readableState.readingMore = false;
     this._consuming = true;

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -152,7 +152,7 @@ IncomingMessage.prototype.setTimeout = function setTimeout(msecs, callback) {
 };
 
 
-IncomingMessage.prototype._read = function _read(n) {
+IncomingMessage.prototype._read = function _read() {
   if (!this._consuming) {
     this._readableState.readingMore = false;
     this._consuming = true;


### PR DESCRIPTION
It removes parameter `n` of `IncomingMessage` since it is not used in the function body.