### PR TITLE
deps: V8: workaround for darwin arm64 code page decommit failures

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.24',
+    'v8_embedder_string': '-node.25',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/base/platform/platform-posix.cc
+++ b/deps/v8/src/base/platform/platform-posix.cc
@@ -415,6 +415,16 @@ bool OS::SetPermissions(void* address, size_t size, MemoryPermission access) {
 
   int prot = GetProtectionFromMemoryPermission(access);
   int ret = mprotect(address, size, prot);
+  
+  // MacOS 11.2 on Apple Silicon refuses to switch permissions from
+  // rwx to none. Just use madvise instead.
+  #if defined(V8_OS_MACOSX)
+    if (ret != 0 && access == OS::MemoryPermission::kNoAccess) {
+     ret = madvise(address, size, MADV_FREE_REUSABLE);
+     return ret == 0;
+    }
+  #endif
+
   if (ret == 0 && access == OS::MemoryPermission::kNoAccess) {
     // This is advisory; ignore errors and continue execution.
     USE(DiscardSystemPages(address, size));


### PR DESCRIPTION
Original commit from v8 repo:

```
[mac][wasm] Work around MacOS 11.2 code page decommit failures

MacOS 11.2 refuses to set "no access" permissions on memory that
we previously used for JIT-compiled code. It is still unclear
whether this is WAI on the part of the kernel. In the meantime,
as a workaround, we use madvise(..., MADV_FREE_REUSABLE) instead
of mprotect(..., NONE) when discarding code pages. This is inspired
by what Chromium's gin platform does.

Fixed: v8:11389
Change-Id: I866586932573b4253002436ae5eee4e0411c45fc
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2679688
Commit-Queue: Jakob Kummerow <jkummerow@chromium.org>
Commit-Queue: Michael Lippautz <mlippautz@chromium.org>
Auto-Submit: Jakob Kummerow <jkummerow@chromium.org>
Reviewed-by: Michael Lippautz <mlippautz@chromium.org>
Cr-Commit-Position: refs/heads/master@{#72559}
```

Fixes #37061
Ref: https://bugs.chromium.org/p/v8/issues/detail?id=11389#c18

For test:
- make -j8
- Run the following gist:
https://gist.githubusercontent.com/targos/8ca8f7a0c76847f29f5658a93c30af1c/raw/adf420ca34e1e0a74c5a70ece059c3d0d2c5c043/crash.js

```bash
./node crash.js
{"exports":[],"reexports":[]}
```

This is my first time PR. I don't know whether it's a good way to merge this workaround or not. Anyway, inform me ;)