### PR TITLE
deps: add Yarn 1.22.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ _UpgradeReport_Files/
 *.wixobj
 /tools/msvs/genfiles/
 /npm.wxs
+/yarn.wxs
 /tools/msvs/msi/Release/
 /tools/msvs/msi/obj/
 /tools/msvs/msi/x64/

--- a/Makefile
+++ b/Makefile
@@ -1029,12 +1029,10 @@ pkg: $(PKG)
 yarn-update:
 	rm -rf deps/yarn
 	mkdir -p deps/yarn
-	cd deps/yarn && wget -q https://yarnpkg.com/latest.tar.gz
-	cd deps/yarn && tar xf latest.tar.gz --strip-components=1
-	rm deps/yarn/latest.tar.gz
+	curl -s -L https://yarnpkg.com/latest.tar.gz | tar -xz --strip-components=1 -Cdeps/yarn
 	# Those shellscripts are originally meant for Yarn Windows packages; tweaked for Node Windows paths
-	perl -pi -e 's#"\$$basedir/yarn.js"#"\$$basedir/node_modules/yarn/bin/yarn.js"#g' deps/yarn/bin/yarn
-	perl -pi -e 's#"%~dp0\\yarn.js"#"%~dp0\\node_modules\\yarn\\bin\\yarn.js"#g' deps/yarn/bin/yarn.cmd
+	sed -i '' -E 's#"\$$basedir/yarn.js"#"\$$basedir/node_modules/yarn/bin/yarn.js"#g' deps/yarn/bin/yarn
+	sed -i '' -E 's#"%~dp0\\yarn.js"#"%~dp0\\node_modules\\yarn\\bin\\yarn.js"#g' deps/yarn/bin/yarn.cmd
 
 # Note: this is strictly for release builds on release machines only.
 pkg-upload: pkg

--- a/Makefile
+++ b/Makefile
@@ -1012,6 +1012,16 @@ $(PKG): release-only
 # Builds the macOS installer for releases.
 pkg: $(PKG)
 
+yarn-update:
+	rm -rf deps/yarn
+	mkdir -p deps/yarn
+	cd deps/yarn && wget -q https://yarnpkg.com/latest.tar.gz
+	cd deps/yarn && tar xf latest.tar.gz --strip-components=1
+	rm deps/yarn/latest.tar.gz
+	# Those shellscripts are originally meant for Yarn Windows packages; tweaked for Node Windows paths
+	perl -pi -e 's#"\$$basedir/yarn.js"#"\$$basedir/node_modules/yarn/bin/yarn.js"#g' deps/yarn/bin/yarn
+	perl -pi -e 's#"%~dp0\\yarn.js"#"%~dp0\\node_modules\\yarn\\bin\\yarn.js"#g' deps/yarn/bin/yarn.cmd
+
 # Note: this is strictly for release builds on release machines only.
 pkg-upload: pkg
 	ssh $(STAGINGSERVER) "mkdir -p nodejs/$(DISTTYPEDIR)/$(FULLVERSION)"

--- a/deps/yarn/LICENSE
+++ b/deps/yarn/LICENSE
@@ -1,0 +1,26 @@
+BSD 2-Clause License
+
+For Yarn software
+
+Copyright (c) 2016-present, Yarn Contributors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/deps/yarn/README.md
+++ b/deps/yarn/README.md
@@ -1,0 +1,60 @@
+<p align="center">
+  <a href="https://yarnpkg.com/">
+    <img alt="Yarn" src="https://github.com/yarnpkg/assets/blob/master/yarn-kitten-full.png?raw=true" width="546">
+  </a>
+</p>
+
+<p align="center">
+  Fast, reliable, and secure dependency management.
+</p>
+
+<p align="center">
+  <a href="https://circleci.com/gh/yarnpkg/yarn"><img alt="Circle Status" src="https://circleci.com/gh/yarnpkg/yarn.svg?style=shield&circle-token=5f0a78473b0f440afb218bf2b82323cc6b3cb43f"></a>
+  <a href="https://ci.appveyor.com/project/kittens/yarn/branch/master"><img alt="Appveyor Status" src="https://ci.appveyor.com/api/projects/status/0xdv8chwe2kmk463?svg=true"></a>
+  <a href="https://dev.azure.com/yarnpkg/yarn/_build"><img alt="Azure Pipelines status" src="https://dev.azure.com/yarnpkg/yarn/_apis/build/status/Yarn%20Acceptance%20Tests"></a>
+  <a href="https://discord.gg/yarnpkg"><img alt="Discord Chat" src="https://img.shields.io/discord/226791405589233664.svg"></a>
+  <a href="http://commitizen.github.io/cz-cli/"><img alt="Commitizen friendly" src="https://img.shields.io/badge/commitizen-friendly-brightgreen.svg"></a>
+</p>
+
+---
+
+**Fast:** Yarn caches every package it has downloaded, so it never needs to download the same package again. It also does almost everything concurrently to maximize resource utilization. This means even faster installs.
+
+**Reliable:** Using a detailed but concise lockfile format and a deterministic algorithm for install operations, Yarn is able to guarantee that any installation that works on one system will work exactly the same on another system.
+
+**Secure:** Yarn uses checksums to verify the integrity of every installed package before its code is executed.
+
+## Features
+
+* **Offline Mode.** If you've installed a package before, then you can install it again without an internet connection.
+* **Deterministic.** The same dependencies will be installed in the same exact way on any machine, regardless of installation order.
+* **Network Performance.** Yarn efficiently queues requests and avoids request waterfalls in order to maximize network utilization.
+* **Network Resilience.** A single request that fails will not cause the entire installation to fail. Requests are automatically retried upon failure.
+* **Flat Mode.** Yarn resolves mismatched versions of dependencies to a single version to avoid creating duplicates.
+* **More emojis.** 🐈
+
+## Installing Yarn
+
+Read the [Installation Guide](https://yarnpkg.com/en/docs/install) on our website for detailed instructions on how to install Yarn.
+
+## Using Yarn
+
+Read the [Usage Guide](https://yarnpkg.com/en/docs/usage) on our website for detailed instructions on how to use Yarn.
+
+## Contributing to Yarn
+
+Contributions are always welcome, no matter how large or small. Substantial feature requests should be proposed as an [RFC](https://github.com/yarnpkg/rfcs). Before contributing, please read the [code of conduct](CODE_OF_CONDUCT.md).
+
+See [Contributing](https://yarnpkg.com/org/contributing/).
+
+## Prior art
+
+Yarn wouldn't exist if it wasn't for excellent prior art. Yarn has been inspired by the following projects:
+
+ - [Bundler](https://github.com/bundler/bundler)
+ - [Cargo](https://github.com/rust-lang/cargo)
+ - [npm](https://github.com/npm/cli)
+
+## Credits
+
+Thanks to [Sam Holmes](https://github.com/samholmes) for donating the npm package name!

--- a/deps/yarn/bin/yarn
+++ b/deps/yarn/bin/yarn
@@ -1,0 +1,35 @@
+#!/bin/sh
+argv0=$(echo "$0" | sed -e 's,\\,/,g')
+basedir=$(dirname "$(readlink "$0" || echo "$argv0")")
+
+case "$(uname -s)" in
+  Darwin) basedir="$( cd "$( dirname "$argv0" )" && pwd )";;
+  Linux) basedir=$(dirname "$(readlink -f "$0" || echo "$argv0")");;
+  *CYGWIN*) basedir=`cygpath -w "$basedir"`;;
+  *MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+command_exists() {
+  command -v "$1" >/dev/null 2>&1;
+}
+
+if command_exists node; then
+  if [ "$YARN_FORCE_WINPTY" = 1 ] || command_exists winpty && test -t 1; then
+    winpty node "$basedir/node_modules/yarn/bin/yarn.js" "$@"
+  else
+    exec node "$basedir/node_modules/yarn/bin/yarn.js" "$@"
+  fi
+  ret=$?
+# Debian and Ubuntu use "nodejs" as the name of the binary, not "node", so we
+# search for that too. See:
+# https://lists.debian.org/debian-devel-announce/2012/07/msg00002.html
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=614907
+elif command_exists nodejs; then
+  exec nodejs "$basedir/node_modules/yarn/bin/yarn.js" "$@"
+  ret=$?
+else
+  >&2 echo 'Yarn requires Node.js 4.0 or higher to be installed.'
+  ret=1
+fi
+
+exit $ret

--- a/deps/yarn/bin/yarn.cmd
+++ b/deps/yarn/bin/yarn.cmd
@@ -1,0 +1,2 @@
+@echo off
+node "%~dp0\node_modules\yarn\bin\yarn.js" %*

--- a/deps/yarn/bin/yarn.js
+++ b/deps/yarn/bin/yarn.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+/* eslint-disable no-var */
+/* eslint-disable flowtype/require-valid-file-annotation */
+'use strict';
+
+var ver = process.versions.node;
+var majorVer = parseInt(ver.split('.')[0], 10);
+
+if (majorVer < 4) {
+  console.error('Node version ' + ver + ' is not supported, please use Node.js 4.0 or higher.');
+  process.exit(1); // eslint-disable-line no-process-exit
+} else {
+  try {
+    require(__dirname + '/../lib/v8-compile-cache.js');
+  } catch (err) {
+    // We don't have/need this on legacy builds and dev builds
+  }
+
+  // Just requiring this package will trigger a yarn run since the
+  // `require.main === module` check inside `cli/index.js` will always
+  // be truthy when built with webpack :(
+  // `lib/cli` may be `lib/cli/index.js` or `lib/cli.js` depending on the build.
+  var cli = require(__dirname + '/../lib/cli');
+  if (!cli.autoRun) {
+    cli.default().catch(function(error) {
+      console.error(error.stack || error.message || error);
+      process.exitCode = 1;
+    });
+  }
+}

--- a/deps/yarn/bin/yarnpkg
+++ b/deps/yarn/bin/yarnpkg
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require('./yarn.js');

--- a/deps/yarn/bin/yarnpkg.cmd
+++ b/deps/yarn/bin/yarnpkg.cmd
@@ -1,0 +1,2 @@
+@echo off
+"%~dp0\yarn.cmd" %*

--- a/deps/yarn/lib/v8-compile-cache.js
+++ b/deps/yarn/lib/v8-compile-cache.js
@@ -1,0 +1,351 @@
+'use strict';
+
+const Module = require('module');
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const os = require('os');
+
+const hasOwnProperty = Object.prototype.hasOwnProperty;
+
+//------------------------------------------------------------------------------
+// FileSystemBlobStore
+//------------------------------------------------------------------------------
+
+class FileSystemBlobStore {
+  constructor(directory, prefix) {
+    const name = prefix ? slashEscape(prefix + '.') : '';
+    this._blobFilename = path.join(directory, name + 'BLOB');
+    this._mapFilename = path.join(directory, name + 'MAP');
+    this._lockFilename = path.join(directory, name + 'LOCK');
+    this._directory = directory;
+    this._load();
+  }
+
+  has(key, invalidationKey) {
+    if (hasOwnProperty.call(this._memoryBlobs, key)) {
+      return this._invalidationKeys[key] === invalidationKey;
+    } else if (hasOwnProperty.call(this._storedMap, key)) {
+      return this._storedMap[key][0] === invalidationKey;
+    }
+    return false;
+  }
+
+  get(key, invalidationKey) {
+    if (hasOwnProperty.call(this._memoryBlobs, key)) {
+      if (this._invalidationKeys[key] === invalidationKey) {
+        return this._memoryBlobs[key];
+      }
+    } else if (hasOwnProperty.call(this._storedMap, key)) {
+      const mapping = this._storedMap[key];
+      if (mapping[0] === invalidationKey) {
+        return this._storedBlob.slice(mapping[1], mapping[2]);
+      }
+    }
+  }
+
+  set(key, invalidationKey, buffer) {
+    this._invalidationKeys[key] = invalidationKey;
+    this._memoryBlobs[key] = buffer;
+    this._dirty = true;
+  }
+
+  delete(key) {
+    if (hasOwnProperty.call(this._memoryBlobs, key)) {
+      this._dirty = true;
+      delete this._memoryBlobs[key];
+    }
+    if (hasOwnProperty.call(this._invalidationKeys, key)) {
+      this._dirty = true;
+      delete this._invalidationKeys[key];
+    }
+    if (hasOwnProperty.call(this._storedMap, key)) {
+      this._dirty = true;
+      delete this._storedMap[key];
+    }
+  }
+
+  isDirty() {
+    return this._dirty;
+  }
+
+  save() {
+    const dump = this._getDump();
+    const blobToStore = Buffer.concat(dump[0]);
+    const mapToStore = JSON.stringify(dump[1]);
+
+    try {
+      mkdirpSync(this._directory);
+      fs.writeFileSync(this._lockFilename, 'LOCK', {flag: 'wx'});
+    } catch (error) {
+      // Swallow the exception if we fail to acquire the lock.
+      return false;
+    }
+
+    try {
+      fs.writeFileSync(this._blobFilename, blobToStore);
+      fs.writeFileSync(this._mapFilename, mapToStore);
+    } catch (error) {
+      throw error;
+    } finally {
+      fs.unlinkSync(this._lockFilename);
+    }
+
+    return true;
+  }
+
+  _load() {
+    try {
+      this._storedBlob = fs.readFileSync(this._blobFilename);
+      this._storedMap = JSON.parse(fs.readFileSync(this._mapFilename));
+    } catch (e) {
+      this._storedBlob = Buffer.alloc(0);
+      this._storedMap = {};
+    }
+    this._dirty = false;
+    this._memoryBlobs = {};
+    this._invalidationKeys = {};
+  }
+
+  _getDump() {
+    const buffers = [];
+    const newMap = {};
+    let offset = 0;
+
+    function push(key, invalidationKey, buffer) {
+      buffers.push(buffer);
+      newMap[key] = [invalidationKey, offset, offset + buffer.length];
+      offset += buffer.length;
+    }
+
+    for (const key of Object.keys(this._memoryBlobs)) {
+      const buffer = this._memoryBlobs[key];
+      const invalidationKey = this._invalidationKeys[key];
+      push(key, invalidationKey, buffer);
+    }
+
+    for (const key of Object.keys(this._storedMap)) {
+      if (hasOwnProperty.call(newMap, key)) continue;
+      const mapping = this._storedMap[key];
+      const buffer = this._storedBlob.slice(mapping[1], mapping[2]);
+      push(key, mapping[0], buffer);
+    }
+
+    return [buffers, newMap];
+  }
+}
+
+//------------------------------------------------------------------------------
+// NativeCompileCache
+//------------------------------------------------------------------------------
+
+class NativeCompileCache {
+  constructor() {
+    this._cacheStore = null;
+    this._previousModuleCompile = null;
+  }
+
+  setCacheStore(cacheStore) {
+    this._cacheStore = cacheStore;
+  }
+
+  install() {
+    const self = this;
+    this._previousModuleCompile = Module.prototype._compile;
+    Module.prototype._compile = function(content, filename) {
+      const mod = this;
+      function require(id) {
+        return mod.require(id);
+      }
+      require.resolve = function(request) {
+        return Module._resolveFilename(request, mod);
+      };
+      require.main = process.mainModule;
+
+      // Enable support to add extra extension types
+      require.extensions = Module._extensions;
+      require.cache = Module._cache;
+
+      const dirname = path.dirname(filename);
+
+      const compiledWrapper = self._moduleCompile(filename, content);
+
+      // We skip the debugger setup because by the time we run, node has already
+      // done that itself.
+
+      const args = [mod.exports, require, mod, filename, dirname, process, global];
+      return compiledWrapper.apply(mod.exports, args);
+    };
+  }
+
+  uninstall() {
+    Module.prototype._compile = this._previousModuleCompile;
+  }
+
+  _moduleCompile(filename, content) {
+    // https://github.com/nodejs/node/blob/v7.5.0/lib/module.js#L511
+
+    // Remove shebang
+    var contLen = content.length;
+    if (contLen >= 2) {
+      if (content.charCodeAt(0) === 35/*#*/ &&
+          content.charCodeAt(1) === 33/*!*/) {
+        if (contLen === 2) {
+          // Exact match
+          content = '';
+        } else {
+          // Find end of shebang line and slice it off
+          var i = 2;
+          for (; i < contLen; ++i) {
+            var code = content.charCodeAt(i);
+            if (code === 10/*\n*/ || code === 13/*\r*/) break;
+          }
+          if (i === contLen) {
+            content = '';
+          } else {
+            // Note that this actually includes the newline character(s) in the
+            // new output. This duplicates the behavior of the regular
+            // expression that was previously used to replace the shebang line
+            content = content.slice(i);
+          }
+        }
+      }
+    }
+
+    // create wrapper function
+    var wrapper = Module.wrap(content);
+
+    var invalidationKey = crypto
+      .createHash('sha1')
+      .update(content, 'utf8')
+      .digest('hex');
+
+    var buffer = this._cacheStore.get(filename, invalidationKey);
+
+    var script = new vm.Script(wrapper, {
+      filename: filename,
+      lineOffset: 0,
+      displayErrors: true,
+      cachedData: buffer,
+      produceCachedData: true,
+    });
+
+    if (script.cachedDataProduced) {
+      this._cacheStore.set(filename, invalidationKey, script.cachedData);
+    } else if (script.cachedDataRejected) {
+      this._cacheStore.delete(filename);
+    }
+
+    var compiledWrapper = script.runInThisContext({
+      filename: filename,
+      lineOffset: 0,
+      columnOffset: 0,
+      displayErrors: true,
+    });
+
+    return compiledWrapper;
+  }
+}
+
+//------------------------------------------------------------------------------
+// utilities
+//
+// https://github.com/substack/node-mkdirp/blob/f2003bb/index.js#L55-L98
+// https://github.com/zertosh/slash-escape/blob/e7ebb99/slash-escape.js
+//------------------------------------------------------------------------------
+
+function mkdirpSync(p_) {
+  _mkdirpSync(path.resolve(p_), parseInt('0777', 8) & ~process.umask());
+}
+
+function _mkdirpSync(p, mode) {
+  try {
+    fs.mkdirSync(p, mode);
+  } catch (err0) {
+    if (err0.code === 'ENOENT') {
+      _mkdirpSync(path.dirname(p));
+      _mkdirpSync(p);
+    } else {
+      try {
+        const stat = fs.statSync(p);
+        if (!stat.isDirectory()) { throw err0; }
+      } catch (err1) {
+        throw err0;
+      }
+    }
+  }
+}
+
+function slashEscape(str) {
+  const ESCAPE_LOOKUP = {
+    '\\': 'zB',
+    ':': 'zC',
+    '/': 'zS',
+    '\x00': 'z0',
+    'z': 'zZ',
+  };
+  return str.replace(/[\\:\/\x00z]/g, match => (ESCAPE_LOOKUP[match]));
+}
+
+function supportsCachedData() {
+  const script = new vm.Script('""', {produceCachedData: true});
+  // chakracore, as of v1.7.1.0, returns `false`.
+  return script.cachedDataProduced === true;
+}
+
+function getCacheDir() {
+  // Avoid cache ownership issues on POSIX systems.
+  const dirname = typeof process.getuid === 'function'
+    ? 'v8-compile-cache-' + process.getuid()
+    : 'v8-compile-cache';
+  const version = typeof process.versions.v8 === 'string'
+    ? process.versions.v8
+    : typeof process.versions.chakracore === 'string'
+      ? 'chakracore-' + process.versions.chakracore
+      : 'node-' + process.version;
+  const cacheDir = path.join(os.tmpdir(), dirname, version);
+  return cacheDir;
+}
+
+function getParentName() {
+  // `module.parent.filename` is undefined or null when:
+  //    * node -e 'require("v8-compile-cache")'
+  //    * node -r 'v8-compile-cache'
+  //    * Or, requiring from the REPL.
+  const parentName = module.parent && typeof module.parent.filename === 'string'
+    ? module.parent.filename
+    : process.cwd();
+  return parentName;
+}
+
+//------------------------------------------------------------------------------
+// main
+//------------------------------------------------------------------------------
+
+if (!process.env.DISABLE_V8_COMPILE_CACHE && supportsCachedData()) {
+  const cacheDir = getCacheDir();
+  const prefix = getParentName();
+  const blobStore = new FileSystemBlobStore(cacheDir, prefix);
+
+  const nativeCompileCache = new NativeCompileCache();
+  nativeCompileCache.setCacheStore(blobStore);
+  nativeCompileCache.install();
+
+  process.once('exit', code => {
+    if (blobStore.isDirty()) {
+      blobStore.save();
+    }
+    nativeCompileCache.uninstall();
+  });
+}
+
+module.exports.__TEST__ = {
+  FileSystemBlobStore,
+  NativeCompileCache,
+  mkdirpSync,
+  slashEscape,
+  supportsCachedData,
+  getCacheDir,
+  getParentName,
+};

--- a/deps/yarn/package.json
+++ b/deps/yarn/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "yarn",
+  "installationMethod": "tar",
+  "version": "1.22.5",
+  "license": "BSD-2-Clause",
+  "preferGlobal": true,
+  "description": "📦🐈 Fast, reliable, and secure dependency management.",
+  "resolutions": {
+    "sshpk": "^1.14.2"
+  },
+  "engines": {
+    "node": ">=4.0.0"
+  },
+  "repository": "yarnpkg/yarn",
+  "bin": {
+    "yarn": "./bin/yarn.js",
+    "yarnpkg": "./bin/yarn.js"
+  },
+  "config": {
+    "commitizen": {
+      "path": "./node_modules/cz-conventional-changelog"
+    }
+  }
+}

--- a/test/parallel/test-yarn-install.js
+++ b/test/parallel/test-yarn-install.js
@@ -12,7 +12,7 @@ const fixtures = require('../common/fixtures');
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 const yarnSandbox = path.join(tmpdir.path, 'yarn-sandbox');
-fs.mkdirSync(npmSandbox);
+fs.mkdirSync(yarnSandbox);
 const homeDir = path.join(tmpdir.path, 'home');
 fs.mkdirSync(homeDir);
 const installDir = path.join(tmpdir.path, 'install-dir');

--- a/test/parallel/test-yarn-install.js
+++ b/test/parallel/test-yarn-install.js
@@ -1,0 +1,65 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const path = require('path');
+const exec = require('child_process').exec;
+const assert = require('assert');
+const fs = require('fs');
+const fixtures = require('../common/fixtures');
+
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+const yarnSandbox = path.join(tmpdir.path, 'yarn-sandbox');
+fs.mkdirSync(npmSandbox);
+const homeDir = path.join(tmpdir.path, 'home');
+fs.mkdirSync(homeDir);
+const installDir = path.join(tmpdir.path, 'install-dir');
+fs.mkdirSync(installDir);
+
+const yarnPath = path.join(
+  __dirname,
+  '..',
+  '..',
+  'deps',
+  'yarn',
+  'bin',
+  'yarn.js'
+);
+
+const pkgContent = JSON.stringify({
+  dependencies: {
+    'package-name': fixtures.path('packages/main')
+  }
+});
+
+const pkgPath = path.join(installDir, 'package.json');
+
+fs.writeFileSync(pkgPath, pkgContent);
+
+const env = { ...process.env,
+              PATH: path.dirname(process.execPath),
+              NPM_CONFIG_PREFIX: path.join(yarnSandbox, 'yarn-prefix'),
+              NPM_CONFIG_TMP: path.join(yarnSandbox, 'yarn-tmp'),
+              NPM_CONFIG_AUDIT: false,
+              NPM_CONFIG_UPDATE_NOTIFIER: false,
+              HOME: homeDir };
+
+exec(`${process.execPath} ${yarnPath} install`, {
+  cwd: installDir,
+  env: env
+}, common.mustCall(handleExit));
+
+function handleExit(error, stdout, stderr) {
+  const code = error ? error.code : 0;
+  const signalCode = error ? error.signal : null;
+
+  if (code !== 0) {
+    process.stderr.write(stderr);
+  }
+
+  assert.strictEqual(code, 0, `yarn install got error code ${code}`);
+  assert.strictEqual(signalCode, null, `unexpected signal: ${signalCode}`);
+  assert(fs.existsSync(`${installDir}/node_modules/package-name`));
+}

--- a/test/parallel/test-yarn-version.js
+++ b/test/parallel/test-yarn-version.js
@@ -1,0 +1,18 @@
+'use strict';
+require('../common');
+
+const path = require('path');
+const assert = require('assert');
+
+const yarnPathPackageJson = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  'deps',
+  'yarn',
+  'package.json'
+);
+
+const pkg = require(yarnPathPackageJson);
+assert(pkg.version.match(/^\d+\.\d+\.\d+$/),
+       `unexpected version number: ${pkg.version}`);

--- a/tools/install.py
+++ b/tools/install.py
@@ -79,8 +79,8 @@ def uninstall(paths, dst):
   for path in paths:
     try_remove(path, dst)
 
-def npm_files(action):
-  target_path = 'lib/node_modules/npm/'
+def package_files(action, name, bins):
+  target_path = 'lib/node_modules/' + name + '/'
 
   # don't install npm if the target path is a symlink, it probably means
   # that a dev version of npm is installed there
@@ -88,28 +88,33 @@ def npm_files(action):
 
   # npm has a *lot* of files and it'd be a pain to maintain a fixed list here
   # so we walk its source directory instead...
-  for dirname, subdirs, basenames in os.walk('deps/npm', topdown=True):
+  root = 'deps/' + name
+  for dirname, subdirs, basenames in os.walk(root, topdown=True):
     subdirs[:] = [subdir for subdir in subdirs if subdir != 'test']
     paths = [os.path.join(dirname, basename) for basename in basenames]
-    action(paths, target_path + dirname[9:] + '/')
+    action(paths, target_path + dirname[len(root) + 1:] + '/')
 
-  # create/remove symlink
-  link_path = abspath(install_path, 'bin/npm')
-  if action == uninstall:
-    action([link_path], 'bin/npm')
-  elif action == install:
-    try_symlink('../lib/node_modules/npm/bin/npm-cli.js', link_path)
-  else:
-    assert 0  # unhandled action type
+  # create/remove symlinks
+  for bin_name, bin_target in bins.items():
+    link_path = abspath(install_path, 'bin/' + bin_name)
+    if action == uninstall:
+      action([link_path], 'bin/' + bin_name)
+    elif action == install:
+      try_symlink('../lib/node_modules/' + name + '/' + bin_target, link_path)
+    else:
+      assert 0  # unhandled action type
 
-  # create/remove symlink
-  link_path = abspath(install_path, 'bin/npx')
-  if action == uninstall:
-    action([link_path], 'bin/npx')
-  elif action == install:
-    try_symlink('../lib/node_modules/npm/bin/npx-cli.js', link_path)
-  else:
-    assert 0 # unhandled action type
+def npm_files(action):
+  package_files(action, 'npm', {
+    'npm': 'bin/npm-cli.js',
+    'npx': 'bin/npx-cli.js',
+  })
+
+def yarn_files(action):
+  package_files(action, 'yarn', {
+    'yarn': 'bin/yarn.js',
+    'yarnpkg': 'bin/yarn.js',
+  })
 
 def subdir_files(path, dest, action):
   ret = {}
@@ -152,7 +157,9 @@ def files(action):
   else:
     action(['doc/node.1'], 'share/man/man1/')
 
-  if 'true' == variables.get('node_install_npm'): npm_files(action)
+  if 'true' == variables.get('node_install_npm'):
+    npm_files(action)
+    yarn_files(action)
 
   headers(action)
 

--- a/tools/license-builder.sh
+++ b/tools/license-builder.sh
@@ -70,8 +70,9 @@ addlicense "SipHash" "deps/v8/src/third_party/siphash" \
 addlicense "zlib" "deps/zlib" \
            "$(sed -e '/The data format used by the zlib library/,$d' -e 's/^\/\* *//' -e 's/^ *//' "${rootdir}"/deps/zlib/zlib.h)"
 
-# npm
+# Package managers
 addlicense "npm" "deps/npm" "$(cat "${rootdir}"/deps/npm/LICENSE)"
+addlicense "yarn" "deps/yarn" "$(cat ${rootdir}/deps/yarn/LICENSE)"
 
 # Build tools
 addlicense "GYP" "tools/gyp" "$(cat "${rootdir}"/tools/gyp/LICENSE)"

--- a/tools/license-builder.sh
+++ b/tools/license-builder.sh
@@ -72,7 +72,7 @@ addlicense "zlib" "deps/zlib" \
 
 # Package managers
 addlicense "npm" "deps/npm" "$(cat "${rootdir}"/deps/npm/LICENSE)"
-addlicense "yarn" "deps/yarn" "$(cat ${rootdir}/deps/yarn/LICENSE)"
+addlicense "yarn" "deps/yarn" "$(cat "${rootdir}"/deps/yarn/LICENSE)"
 
 # Build tools
 addlicense "GYP" "tools/gyp" "$(cat "${rootdir}"/tools/gyp/LICENSE)"

--- a/tools/macos-installer/pkgbuild/yarn/scripts/postinstall
+++ b/tools/macos-installer/pkgbuild/yarn/scripts/postinstall
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+cd /usr/local/bin || exit 1
+ln -sf ../lib/node_modules/yarn/bin/yarn.js yarn
+ln -sf ../lib/node_modules/yarn/bin/yarn.js yarnpkg

--- a/tools/macos-installer/pkgbuild/yarn/scripts/preinstall
+++ b/tools/macos-installer/pkgbuild/yarn/scripts/preinstall
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+[[ -d /usr/local/lib/node_modules/yarn ]] \
+  && rm -rf /usr/local/lib/node_modules/yarn
+exit 0

--- a/tools/macos-installer/productbuild/Resources/en.lproj/conclusion.html.tmpl
+++ b/tools/macos-installer/productbuild/Resources/en.lproj/conclusion.html.tmpl
@@ -16,6 +16,7 @@
      <ul>
        <li>Node.js {nodeversion} to <code>/usr/local/bin/node</code></li>
        <li>npm {npmversion} to <code>/usr/local/bin/npm</code></li>
+       <li>Yarn {yarnversion} to <code>/usr/local/bin/yarn</code></li>
      </ul>
      <p>Make sure that <code>/usr/local/bin</code> is in your <code>$PATH</code>.</p>
    </div>

--- a/tools/macos-installer/productbuild/Resources/en.lproj/welcome.html.tmpl
+++ b/tools/macos-installer/productbuild/Resources/en.lproj/welcome.html.tmpl
@@ -13,6 +13,7 @@
     <ul>
       <li>Node.js {nodeversion} to <code>/usr/local/bin/node</code></li>
       <li>npm {npmversion} to <code>/usr/local/bin/npm</code></li>
+      <li>Yarn {yarnversion} to <code>/usr/local/bin/yarn</code></li>
     </ul>
   </div>
  </body>

--- a/tools/macos-installer/productbuild/distribution.xml.tmpl
+++ b/tools/macos-installer/productbuild/distribution.xml.tmpl
@@ -6,11 +6,13 @@
     <background alignment="topleft" file="osx_installer_logo.png"/>
     <pkg-ref id="org.nodejs.node.pkg" auth="root"/>
     <pkg-ref id="org.nodejs.npm.pkg" auth="root"/>
+    <pkg-ref id="org.nodejs.yarn.pkg" auth="root"/>
     <options customize="allow" require-scripts="false"/>
     <license file="license.rtf"/>
     <choices-outline>
       <line choice="org.nodejs.node.pkg" />
       <line choice="org.nodejs.npm.pkg"/>
+      <line choice="org.nodejs.yarn.pkg"/>
     </choices-outline>
     <choice id="org.nodejs.node.pkg" visible="true" title="Node.js {nodeversion}">
         <pkg-ref id="org.nodejs.node.pkg"/>
@@ -20,4 +22,8 @@
         <pkg-ref id="org.nodejs.npm.pkg"/>
     </choice>
     <pkg-ref id="org.nodejs.npm.pkg" version="{npmversion}" onConclusion="none">npm-{npmversion}.pkg</pkg-ref>
+    <choice id="org.nodejs.yarn.pkg" visible="true" title="Yarn {yarnversion}">
+        <pkg-ref id="org.nodejs.yarn.pkg"/>
+    </choice>
+    <pkg-ref id="org.nodejs.yarn.pkg" version="{yarnversion}" onConclusion="none">yarn-{yarnversion}.pkg</pkg-ref>
 </installer-gui-script>

--- a/tools/msvs/msi/i18n/de-de.wxl
+++ b/tools/msvs/msi/i18n/de-de.wxl
@@ -18,6 +18,9 @@
     <String Id="npm_Title">npm-Paketmanager</String>
     <String Id="npm_Description">Installiert npm, den empfohlenen Paketmanager für [ProductName].</String>
 
+    <String Id="yarn_Title">Yarn-Paketmanager</String>
+    <String Id="yarn_Description">Installiert Yarn, den empfohlenen Paketmanager für [ProductName].</String>
+
     <String Id="DocumentationShortcuts_Title">Link zur Online-Dokumentation</String>
     <String Id="DocumentationShortcuts_Description">Fügt Startmenü-Einträge zur Online-Dokumentation von [ProductName] [FullVersion] und zur [ProductName]-Website hinzu.</String>
 

--- a/tools/msvs/msi/i18n/en-us.wxl
+++ b/tools/msvs/msi/i18n/en-us.wxl
@@ -26,6 +26,9 @@
     <String Id="npm_Title">npm package manager</String>
     <String Id="npm_Description">Install npm, the recommended package manager for [ProductName].</String>
 
+    <String Id="yarn_Title">Yarn package manager</String>
+    <String Id="yarn_Description">Install Yarn, the recommended package manager for [ProductName].</String>
+
     <String Id="DocumentationShortcuts_Title">Online documentation shortcuts</String>
     <String Id="DocumentationShortcuts_Description">Add start menu entries that link the online documentation for [ProductName] [FullVersion] and the [ProductName] website.</String>
 

--- a/tools/msvs/msi/i18n/it-it.wxl
+++ b/tools/msvs/msi/i18n/it-it.wxl
@@ -18,6 +18,9 @@
     <String Id="npm_Title">npm package manager</String>
     <String Id="npm_Description">Installa npm, il package manager raccomandato per [ProductName].</String>
 
+    <String Id="npm_Title">Yarn package manager</String>
+    <String Id="npm_Description">Installa Yarn, il package manager raccomandato per [ProductName].</String>
+
     <String Id="DocumentationShortcuts_Title">Collegamenti alla documentazione online</String>
     <String Id="DocumentationShortcuts_Description">Aggiunge i collegamenti al menu start alla documentazione online per [ProductName] [FullVersion] e per il sito web di [ProductName].</String>
 

--- a/tools/msvs/msi/i18n/zh-cn.wxl
+++ b/tools/msvs/msi/i18n/zh-cn.wxl
@@ -18,6 +18,9 @@
     <String Id="npm_Title">npm 包管理器</String>
     <String Id="npm_Description">安装 npm， [ProductName] 的推荐包管理器。</String>
 
+    <String Id="npm_Title">Yarn 包管理器</String>
+    <String Id="npm_Description">安装 Yarn， [ProductName] 的推荐包管理器。</String>
+
     <String Id="DocumentationShortcuts_Title">在线文档的快捷方式</String>
     <String Id="DocumentationShortcuts_Description">在开始菜单内添加 [ProductName] [FullVersion] 的在线文档链接和 [ProductName] 的网站链接。</String>
 

--- a/tools/msvs/msi/nodemsi.wixproj
+++ b/tools/msvs/msi/nodemsi.wixproj
@@ -16,33 +16,33 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <OutputPath>..\..\..\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>Debug;ProductVersion=$(NodeVersion);FullVersion=$(FullVersion);DistTypeDir=$(DistTypeDir);NoETW=$(NoETW);NpmSourceDir=..\..\..\Release\node-v$(FullVersion)-win-$(Platform)\node_modules\npm\;ProgramFilesFolderId=ProgramFilesFolder</DefineConstants>
+    <DefineConstants>Debug;ProductVersion=$(NodeVersion);FullVersion=$(FullVersion);DistTypeDir=$(DistTypeDir);NoETW=$(NoETW);NpmSourceDir=..\..\..\Release\node-v$(FullVersion)-win-$(Platform)\node_modules\npm\;YarnSourceDir=..\..\..\Release\node-v$(FullVersion)-win-$(Platform)\node_modules\yarn\;ProgramFilesFolderId=ProgramFilesFolder</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <OutputPath>..\..\..\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>Debug;ProductVersion=$(NodeVersion);FullVersion=$(FullVersion);DistTypeDir=$(DistTypeDir);NoETW=$(NoETW);NpmSourceDir=..\..\..\Release\node-v$(FullVersion)-win-$(Platform)\node_modules\npm\;ProgramFilesFolderId=ProgramFilesFolder</DefineConstants>
+    <DefineConstants>Debug;ProductVersion=$(NodeVersion);FullVersion=$(FullVersion);DistTypeDir=$(DistTypeDir);NoETW=$(NoETW);NpmSourceDir=..\..\..\Release\node-v$(FullVersion)-win-$(Platform)\node_modules\npm\;YarnSourceDir=..\..\..\Release\node-v$(FullVersion)-win-$(Platform)\node_modules\yarn\;ProgramFilesFolderId=ProgramFilesFolder</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
     <OutputPath>..\..\..\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>Debug;ProductVersion=$(NodeVersion);FullVersion=$(FullVersion);DistTypeDir=$(DistTypeDir);NoETW=$(NoETW);NpmSourceDir=..\..\..\Release\node-v$(FullVersion)-win-$(Platform)\node_modules\npm\;ProgramFilesFolderId=ProgramFiles64Folder</DefineConstants>
+    <DefineConstants>Debug;ProductVersion=$(NodeVersion);FullVersion=$(FullVersion);DistTypeDir=$(DistTypeDir);NoETW=$(NoETW);NpmSourceDir=..\..\..\Release\node-v$(FullVersion)-win-$(Platform)\node_modules\npm\;YarnSourceDir=..\..\..\Release\node-v$(FullVersion)-win-$(Platform)\node_modules\yarn\;ProgramFilesFolderId=ProgramFiles64Folder</DefineConstants>
     <Cultures>en-US</Cultures>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
     <OutputPath>..\..\..\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>Debug;ProductVersion=$(NodeVersion);FullVersion=$(FullVersion);DistTypeDir=$(DistTypeDir);NoETW=$(NoETW);NpmSourceDir=..\..\..\Release\node-v$(FullVersion)-win-$(Platform)\node_modules\npm\;ProgramFilesFolderId=ProgramFiles64Folder</DefineConstants>
+    <DefineConstants>Debug;ProductVersion=$(NodeVersion);FullVersion=$(FullVersion);DistTypeDir=$(DistTypeDir);NoETW=$(NoETW);NpmSourceDir=..\..\..\Release\node-v$(FullVersion)-win-$(Platform)\node_modules\npm\;YarnSourceDir=..\..\..\Release\node-v$(FullVersion)-win-$(Platform)\node_modules\yarn\;ProgramFilesFolderId=ProgramFiles64Folder</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|arm64' ">
     <OutputPath>..\..\..\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>Debug;ProductVersion=$(NodeVersion);FullVersion=$(FullVersion);DistTypeDir=$(DistTypeDir);NoETW=$(NoETW);NpmSourceDir=..\..\..\Release\node-v$(FullVersion)-win-$(Platform)\node_modules\npm\;ProgramFilesFolderId=ProgramFiles64Folder</DefineConstants>
+    <DefineConstants>Debug;ProductVersion=$(NodeVersion);FullVersion=$(FullVersion);DistTypeDir=$(DistTypeDir);NoETW=$(NoETW);NpmSourceDir=..\..\..\Release\node-v$(FullVersion)-win-$(Platform)\node_modules\npm\;YarnSourceDir=..\..\..\Release\node-v$(FullVersion)-win-$(Platform)\node_modules\yarn\;ProgramFilesFolderId=ProgramFiles64Folder</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|arm64' ">
     <OutputPath>..\..\..\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>Debug;ProductVersion=$(NodeVersion);FullVersion=$(FullVersion);DistTypeDir=$(DistTypeDir);NoETW=$(NoETW);NpmSourceDir=..\..\..\Release\node-v$(FullVersion)-win-$(Platform)\node_modules\npm\;ProgramFilesFolderId=ProgramFiles64Folder</DefineConstants>
+    <DefineConstants>Debug;ProductVersion=$(NodeVersion);FullVersion=$(FullVersion);DistTypeDir=$(DistTypeDir);NoETW=$(NoETW);NpmSourceDir=..\..\..\Release\node-v$(FullVersion)-win-$(Platform)\node_modules\npm\;YarnSourceDir=..\..\..\Release\node-v$(FullVersion)-win-$(Platform)\node_modules\yarn\;ProgramFilesFolderId=ProgramFiles64Folder</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
     <EnableProjectHarvesting>True</EnableProjectHarvesting>
@@ -51,6 +51,9 @@
     <Compile Include="product.wxs" />
     <Compile Include="..\..\..\npm.wxs">
       <Link>npm.wxs</Link>
+    </Compile>
+    <Compile Include="..\..\..\yarn.wxs">
+      <Link>yarn.wxs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>
@@ -84,6 +87,8 @@
   <Import Project="$(WixTargetsPath)" />
   <Target Name="BeforeBuild">
     <HeatDirectory ToolPath="$(WixToolPath)" Directory="..\..\..\Release\node-v$(FullVersion)-win-$(Platform)\node_modules\npm" PreprocessorVariable="var.NpmSourceDir" DirectoryRefId="NodeModulesFolder" ComponentGroupName="NpmSourceFiles" GenerateGuidsNow="true" SuppressFragments="false" OutputFile="..\..\..\npm.wxs" RunAsSeparateProcess="true">
+    </HeatDirectory>
+    <HeatDirectory ToolPath="$(WixToolPath)" Directory="..\..\..\Release\node-v$(FullVersion)-win-$(Platform)\node_modules\yarn" PreprocessorVariable="var.YarnSourceDir" DirectoryRefId="NodeModulesFolder" ComponentGroupName="YarnSourceFiles" GenerateGuidsNow="true" SuppressFragments="false" OutputFile="..\..\..\yarn.wxs" RunAsSeparateProcess="true">
     </HeatDirectory>
   </Target>
   <PropertyGroup>

--- a/tools/msvs/msi/product.wxs
+++ b/tools/msvs/msi/product.wxs
@@ -96,6 +96,15 @@
       <ComponentGroupRef Id="NpmSourceFiles"/>
     </Feature>
 
+    <Feature Id="yarn"
+             Level="1"
+             Title="!(loc.yarn_Title)"
+             Description="!(loc.yarn_Description)">
+      <ComponentRef Id="YarnCmdScript"/>
+      <ComponentRef Id="YarnBashScript"/>
+      <ComponentGroupRef Id="YarnSourceFiles"/>
+    </Feature>
+
     <Feature Level="1"
              Id="DocumentationShortcuts"
              Title="!(loc.DocumentationShortcuts_Title)"
@@ -219,6 +228,14 @@
 
       <Component Id="NpxBashScript">
         <File Id="npx.sh" KeyPath="yes" Source="$(var.NpmSourceDir)\bin\npx"/>
+      </Component>
+
+      <Component Id="YarnCmdScript">
+        <File Id="yarn.cmd" KeyPath="yes" Source="$(var.YarnSourceDir)\bin\yarn.cmd"/>
+      </Component>
+
+      <Component Id="YarnBashScript">
+        <File Id="yarn.sh" KeyPath="yes" Source="$(var.YarnSourceDir)\bin\yarn"/>
       </Component>
 
       <Directory Id="NodeModulesFolder" Name="node_modules">

--- a/tools/osx-pkg-postinstall.sh
+++ b/tools/osx-pkg-postinstall.sh
@@ -2,5 +2,9 @@
 # TODO Can this be done inside the .pmdoc?
 # TODO Can we extract $PREFIX from the installer?
 cd /usr/local/bin || exit
+
 ln -sf ../lib/node_modules/npm/bin/npm-cli.js npm
 ln -sf ../lib/node_modules/npm/bin/npx-cli.js npx
+
+ln -sf ../lib/node_modules/npm/bin/yarn.js yarn
+ln -sf ../lib/node_modules/npm/bin/yarn.js yarnpkg

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -403,6 +403,7 @@ copy /Y ..\README.md %TARGET_NAME%\ > nul
 if errorlevel 1 echo Cannot copy README.md && goto package_error
 copy /Y ..\CHANGELOG.md %TARGET_NAME%\ > nul
 if errorlevel 1 echo Cannot copy CHANGELOG.md && goto package_error
+
 robocopy ..\deps\npm %TARGET_NAME%\node_modules\npm /e /xd test > nul
 if errorlevel 8 echo Cannot copy npm package && goto package_error
 copy /Y ..\deps\npm\bin\npm %TARGET_NAME%\ > nul
@@ -413,6 +414,14 @@ copy /Y ..\deps\npm\bin\npx %TARGET_NAME%\ > nul
 if errorlevel 1 echo Cannot copy npx && goto package_error
 copy /Y ..\deps\npm\bin\npx.cmd %TARGET_NAME%\ > nul
 if errorlevel 1 echo Cannot copy npx.cmd && goto package_error
+
+robocopy ..\deps\yarn %TARGET_NAME%\node_modules\yarn /e /xd test > nul
+if errorlevel 8 echo Cannot copy Yarn package && goto package_error
+copy /Y ..\deps\yarn\bin\yarn %TARGET_NAME%\ > nul
+if errorlevel 1 echo Cannot copy yarn && goto package_error
+copy /Y ..\deps\yarn\bin\yarn.cmd %TARGET_NAME%\ > nul
+if errorlevel 1 echo Cannot copy yarn.cmd && goto package_error
+
 copy /Y ..\tools\msvs\nodevars.bat %TARGET_NAME%\ > nul
 if errorlevel 1 echo Cannot copy nodevars.bat && goto package_error
 copy /Y ..\tools\msvs\install_tools\*.* %TARGET_NAME%\ > nul


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Ref https://github.com/nodejs/node/discussions/37193 (and https://github.com/nodejs/node/discussions/37193#discussioncomment-332622 in particular, cc @jasnell @mcollina)

This commit adds Yarn to the Node release tarballs and installers. I tested:

- Windows (`.\vcbuild.bat msi` and ran the resulting exe)
- MacOS (`make pkg` and ran the resulting pkg)
- Linux (untar'd the `.tar.gz` file)

In all cases, running `yarn --version` yielded the correct Yarn version (1.22.5 for infra reasons, which is for all purposes identical to 1.22.10 minus a postinstall script which has no impact whatsoever in this situation).

---

* This PR changes close to nothing for existing Node.js users (this PR doesn't remove `npm` from the Node.js project, and you can still install Yarn separately from Node.js), it's meant to improve the experience of new users.
* Reasons for integrating Yarn v1 (rather than v2) are outlined in https://github.com/nodejs/node/pull/37277#issuecomment-775586604 and more in depth in https://github.com/nodejs/node/discussions/37193#discussioncomment-341160
* Please keep the discussion focused on Yarn v1, integration of other package managers can happen in a separate issue.