### PR TITLE
module: disable package self resolution when name contains a colon

### DIFF
--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -613,7 +613,8 @@ Then any module _in that package_ can reference an export in the package itself:
 import { something } from 'a-package'; // Imports "something" from ./main.mjs.
 ```
 
-Self-referencing is available only if `package.json` has [`"exports"`][], and
+Self-referencing is available only if `package.json` has a [`"name"`][] that
+does not contain the character `:`, and a [`"exports"`][] field, and
 will allow importing only what that [`"exports"`][] (in the `package.json`)
 allows. So the code below, given the previous package, will generate a runtime
 error:

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -54,6 +54,7 @@ const {
   StringPrototypeCharCodeAt,
   StringPrototypeEndsWith,
   StringPrototypeLastIndexOf,
+  StringPrototypeIncludes,
   StringPrototypeIndexOf,
   StringPrototypeMatch,
   StringPrototypeSlice,
@@ -430,6 +431,7 @@ function trySelfParentPath(parent) {
 
 function trySelf(parentPath, request) {
   if (!parentPath) return false;
+  if (StringPrototypeIncludes(request, ':')) return false;
 
   const { data: pkg, path: pkgPath } = readPackageScope(parentPath) || {};
   if (!pkg || pkg.exports === undefined) return false;

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -445,6 +445,11 @@ function trySelf(parentPath, request) {
     return false;
   }
 
+  if (StringPrototypeIncludes(pkg.name, ':')) {
+    throw new ERR_INVALID_MODULE_SPECIFIER(
+      request, 'is not a valid package name', parentPath);
+  }
+
   try {
     return finalizeEsmResolution(packageExportsResolve(
       pathToFileURL(pkgPath + '/package.json'), expansion, pkg,
@@ -900,10 +905,6 @@ Module._resolveFilename = function(request, parent, isMain, options) {
   const parentPath = trySelfParentPath(parent);
   const selfResolved = trySelf(parentPath, request);
   if (selfResolved) {
-    if (StringPrototypeIncludes(request, ':')) {
-      throw new ERR_INVALID_MODULE_SPECIFIER(
-        request, 'is not a valid package name', parentPath);
-    }
     const cacheKey = request + '\x00' +
          (paths.length === 1 ? paths[0] : ArrayPrototypeJoin(paths, '\x00'));
     Module._pathCache[cacheKey] = selfResolved;

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -431,7 +431,6 @@ function trySelfParentPath(parent) {
 
 function trySelf(parentPath, request) {
   if (!parentPath) return false;
-  if (StringPrototypeIncludes(request, ':')) return false;
 
   const { data: pkg, path: pkgPath } = readPackageScope(parentPath) || {};
   if (!pkg || pkg.exports === undefined) return false;
@@ -901,6 +900,10 @@ Module._resolveFilename = function(request, parent, isMain, options) {
   const parentPath = trySelfParentPath(parent);
   const selfResolved = trySelf(parentPath, request);
   if (selfResolved) {
+    if (StringPrototypeIncludes(request, ':')) {
+      throw new ERR_INVALID_MODULE_SPECIFIER(
+        request, 'is not a valid package name', parentPath);
+    }
     const cacheKey = request + '\x00' +
          (paths.length === 1 ? paths[0] : ArrayPrototypeJoin(paths, '\x00'));
     Module._pathCache[cacheKey] = selfResolved;

--- a/test/fixtures/self_ref_module_with_colon/bin.js
+++ b/test/fixtures/self_ref_module_with_colon/bin.js
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+
+'use strict';
+
+try {
+  console.log(require('file:package'));
+} catch (e) {
+  console.log(e);
+}
+import('file:package').then(console.log, console.log);
+import('file%3Apackage').then(console.log, console.log);

--- a/test/fixtures/self_ref_module_with_colon/index.js
+++ b/test/fixtures/self_ref_module_with_colon/index.js
@@ -1,0 +1,4 @@
+'use strict'
+
+module.exports = 'Self resolution working';
+

--- a/test/fixtures/self_ref_module_with_colon/package.json
+++ b/test/fixtures/self_ref_module_with_colon/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "file:package",
+  "exports": "./index.js"
+}

--- a/test/message/test-self-referential-package.js
+++ b/test/message/test-self-referential-package.js
@@ -1,0 +1,11 @@
+'use strict';
+
+require('../common');
+const { spawn } = require('child_process');
+
+const fixtures = require('../common/fixtures');
+const selfRefModule = fixtures.path('self_ref_module_with_colon');
+
+spawn(process.argv0, [`${selfRefModule}/bin.js`], {
+  stdio: 'inherit'
+});

--- a/test/message/test-self-referential-package.out
+++ b/test/message/test-self-referential-package.out
@@ -1,0 +1,44 @@
+Error: Cannot find module 'file:package'
+Require stack:
+- */self_ref_module_with_colon/bin.js
+    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:*)
+    at Function.Module._load (node:internal/modules/cjs/loader:*)
+    at Module.require (node:internal/modules/cjs/loader:*)
+    at require (node:internal/modules/cjs/helpers:*)
+    at Object.<anonymous> (*/self_ref_module_with_colon/bin.js:*)
+    at Module._compile (node:internal/modules/cjs/loader:*)
+    at Object.Module._extensions..js (node:internal/modules/cjs/loader:*)
+    at Module.load (node:internal/modules/cjs/loader:*)
+    at Function.Module._load (node:internal/modules/cjs/loader:*)
+    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:*) {
+  code: 'MODULE_NOT_FOUND',
+  requireStack: [
+    '*/self_ref_module_with_colon/bin.js'
+  ]
+}
+Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/package' imported from */self_ref_module_with_colon/bin.js
+    at new NodeError (node:internal/errors:*)
+    at finalizeResolution (node:internal/modules/esm/resolve:*)
+    at moduleResolve (node:internal/modules/esm/resolve:*)
+    at Loader.defaultResolve [as _resolve] (node:internal/modules/esm/resolve:*)
+    at Loader.resolve (node:internal/modules/esm/loader:*)
+    at Loader.getModuleJob (node:internal/modules/esm/loader:*)
+    at Loader.import (node:internal/modules/esm/loader:*)
+    at importModuleDynamically (node:internal/modules/cjs/loader:*)
+    at importModuleDynamicallyWrapper (node:internal/vm/module:*)
+    at importModuleDynamically (node:vm:*) {
+  code: 'ERR_MODULE_NOT_FOUND'
+}
+TypeError [ERR_INVALID_MODULE_SPECIFIER]: Invalid module "file%3Apackage" is not a valid package name imported from */self_ref_module_with_colon/bin.js
+    at new NodeError (node:internal/errors:*)
+    at parsePackageName (node:internal/modules/esm/resolve:*)
+    at packageResolve (node:internal/modules/esm/resolve:*)
+    at moduleResolve (node:internal/modules/esm/resolve:*)
+    at Loader.defaultResolve [as _resolve] (node:internal/modules/esm/resolve:*)
+    at Loader.resolve (node:internal/modules/esm/loader:*)
+    at Loader.getModuleJob (node:internal/modules/esm/loader:*)
+    at Loader.import (node:internal/modules/esm/loader:*)
+    at importModuleDynamically (node:internal/modules/cjs/loader:*)
+    at importModuleDynamicallyWrapper (node:internal/vm/module:*) {
+  code: 'ERR_INVALID_MODULE_SPECIFIER'
+}

--- a/test/message/test-self-referential-package.out
+++ b/test/message/test-self-referential-package.out
@@ -1,5 +1,6 @@
 TypeError [ERR_INVALID_MODULE_SPECIFIER]: Invalid module "file:package" is not a valid package name imported from *
     at new NodeError (node:internal/errors:*)
+    at trySelf (node:internal/modules/cjs/loader:*)
     at Function.Module._resolveFilename (node:internal/modules/cjs/loader:*)
     at Function.Module._load (node:internal/modules/cjs/loader:*)
     at Module.require (node:internal/modules/cjs/loader:*)
@@ -7,8 +8,7 @@ TypeError [ERR_INVALID_MODULE_SPECIFIER]: Invalid module "file:package" is not a
     at Object.<anonymous> (*)
     at Module._compile (node:internal/modules/cjs/loader:*)
     at Object.Module._extensions..js (node:internal/modules/cjs/loader:*)
-    at Module.load (node:internal/modules/cjs/loader:*)
-    at Function.Module._load (node:internal/modules/cjs/loader:*) {
+    at Module.load (node:internal/modules/cjs/loader:*) {
   code: 'ERR_INVALID_MODULE_SPECIFIER'
 }
 Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/package' imported from *

--- a/test/message/test-self-referential-package.out
+++ b/test/message/test-self-referential-package.out
@@ -1,22 +1,17 @@
-Error: Cannot find module 'file:package'
-Require stack:
-- */self_ref_module_with_colon/bin.js
+TypeError [ERR_INVALID_MODULE_SPECIFIER]: Invalid module "file:package" is not a valid package name imported from *
+    at new NodeError (node:internal/errors:*)
     at Function.Module._resolveFilename (node:internal/modules/cjs/loader:*)
     at Function.Module._load (node:internal/modules/cjs/loader:*)
     at Module.require (node:internal/modules/cjs/loader:*)
     at require (node:internal/modules/cjs/helpers:*)
-    at Object.<anonymous> (*/self_ref_module_with_colon/bin.js:*)
+    at Object.<anonymous> (*)
     at Module._compile (node:internal/modules/cjs/loader:*)
     at Object.Module._extensions..js (node:internal/modules/cjs/loader:*)
     at Module.load (node:internal/modules/cjs/loader:*)
-    at Function.Module._load (node:internal/modules/cjs/loader:*)
-    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:*) {
-  code: 'MODULE_NOT_FOUND',
-  requireStack: [
-    '*/self_ref_module_with_colon/bin.js'
-  ]
+    at Function.Module._load (node:internal/modules/cjs/loader:*) {
+  code: 'ERR_INVALID_MODULE_SPECIFIER'
 }
-Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/package' imported from */self_ref_module_with_colon/bin.js
+Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/package' imported from *
     at new NodeError (node:internal/errors:*)
     at finalizeResolution (node:internal/modules/esm/resolve:*)
     at moduleResolve (node:internal/modules/esm/resolve:*)
@@ -29,7 +24,7 @@ Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/package' imported from */self
     at importModuleDynamically (node:vm:*) {
   code: 'ERR_MODULE_NOT_FOUND'
 }
-TypeError [ERR_INVALID_MODULE_SPECIFIER]: Invalid module "file%3Apackage" is not a valid package name imported from */self_ref_module_with_colon/bin.js
+TypeError [ERR_INVALID_MODULE_SPECIFIER]: Invalid module "file%%3Apackage" is not a valid package name imported from *
     at new NodeError (node:internal/errors:*)
     at parsePackageName (node:internal/modules/esm/resolve:*)
     at packageResolve (node:internal/modules/esm/resolve:*)


### PR DESCRIPTION
There is a discrepancy between package self resolution in CJS and ESM contexts. This commit fixes this by forbidding self-resolution of packages whose names contain a colon.

Currently, ESM understands specifier with a column as a URL scheme (E.G.: `file:package` references `package` under the scheme `file:`), while CJS interpret the specifier as a path, so the colon is just another valid character (I.E.: `file:package` references a package named `file:package`).

I think this should be considered as a bug fix and backported as far as we can, this is especially important considering it affects stuff like `require('node:fs')` which should take a different meaning soon (see https://github.com/nodejs/node/pull/37246).

Note that while this is technically a breaking change, I'm confident it should not affect the ecosystem as npm already requires a name that doesn't contain colons (https://docs.npmjs.com/creating-a-package-json-file#required-name-and-version-fields), plus package self-resolution usually affects dev-env only.

/cc @nodejs/modules

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
