### PR TITLE
deps: V8: cherry-pick beebee4f80ff

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.18',
+    'v8_embedder_string': '-node.19',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/profiler/profiler-listener.cc
+++ b/deps/v8/src/profiler/profiler-listener.cc
@@ -113,7 +113,8 @@ void ProfilerListener::CodeCreateEvent(LogEventsAndTags tag,
     // profiler as is stored on the code object, except that we transform source
     // positions to line numbers here, because we only care about attributing
     // ticks to a given line.
-    for (SourcePositionTableIterator it(abstract_code->source_position_table());
+    for (SourcePositionTableIterator it(
+             handle(abstract_code->source_position_table(), isolate_));
          !it.done(); it.Advance()) {
       int position = it.source_position().ScriptOffset();
       int inlining_id = it.source_position().InliningId();

--- a/test/addons/cpu-profiler-crash/binding.cc
+++ b/test/addons/cpu-profiler-crash/binding.cc
@@ -1,0 +1,16 @@
+#include "node.h"
+#include "v8.h"
+#include "v8-profiler.h"
+
+static void StartCpuProfiler(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  v8::CpuProfiler* profiler = v8::CpuProfiler::New(args.GetIsolate());
+  v8::Local<v8::String> profile_title = v8::String::NewFromUtf8(
+    args.GetIsolate(),
+    "testing",
+    v8::NewStringType::kInternalized).ToLocalChecked();
+  profiler->StartProfiling(profile_title, true);
+}
+
+NODE_MODULE_INIT(/* exports, module, context */) {
+  NODE_SET_METHOD(exports, "startCpuProfiler", StartCpuProfiler);
+}

--- a/test/addons/cpu-profiler-crash/binding.gyp
+++ b/test/addons/cpu-profiler-crash/binding.gyp
@@ -1,0 +1,9 @@
+{
+  'targets': [
+    {
+      'target_name': 'binding',
+      'sources': [ 'binding.cc' ],
+      'includes': ['../common.gypi'],
+    }
+  ]
+}

--- a/test/addons/cpu-profiler-crash/test.js
+++ b/test/addons/cpu-profiler-crash/test.js
@@ -1,0 +1,20 @@
+'use strict';
+
+// This test crashes most of the time unless the v8 patch:
+// https://github.com/v8/v8/commit/beebee4f80ff2eb91187ef1e8fa00b8ff82a20b3
+// is applied.
+const common = require('../../common');
+const bindings = require(`./build/${common.buildType}/binding`);
+
+function fn() { setImmediate(fn); }
+setInterval(function() {
+  for (let i = 0; i < 1000000; i++)
+    fn();
+  clearInterval(this);
+  setTimeout(process.reallyExit, 2000);
+}, 0);
+
+
+setTimeout(() => {
+  bindings.startCpuProfiler();
+}, 1000);


### PR DESCRIPTION
It contains the following commits:

> deps: V8: cherry-pick beebee4f80ff
>     
> Original commit message:
> ```
> cpu-profiler: Use Handle version of SourcePositionTableIterator
> 
> The surrounding code can trigger an allocation through InliningStack
> which can eventually end up allocating a line ends array.
>     
> This is fine as-is because the existing iterator code makes a copy
> of the byte array. It just triggers the no_gc dcheck in debug mode.
> 
> Fixed: v8:10778
> Change-Id: Ic8c502767ec6c3d3b1f5e84df60638bd2fc6be75
> Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2339102
> Auto-Submit: Peter Marshall <petermarshall@chromium.org>
> Commit-Queue: Tobias Tebbi <tebbi@chromium.org>
> Reviewed-by: Tobias Tebbi <tebbi@chromium.org>
> Cr-Commit-Position: refs/heads/master@{#69247}
> ```
>    
> Refs: https://github.com/v8/v8/commit/beebee4f80ff2eb91187ef1e8fa00b8ff82a20b


> test: add cpu-profiler-crash test
>     
> This test is added as it usually crashes without applying the v8 patch:
> https://github.com/v8/v8/commit/beebee4f80ff2eb91187ef1e8fa00b8ff82a20b3