### PR TITLE
deps: V8: cherry-pick 0c8b6e415c30

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.24',
+    'v8_embedder_string': '-node.25',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/base/platform/platform-posix.cc
+++ b/deps/v8/src/base/platform/platform-posix.cc
@@ -415,6 +415,16 @@ bool OS::SetPermissions(void* address, size_t size, MemoryPermission access) {
 
   int prot = GetProtectionFromMemoryPermission(access);
   int ret = mprotect(address, size, prot);
+
+  // MacOS 11.2 on Apple Silicon refuses to switch permissions from
+  // rwx to none. Just use madvise instead.
+#if defined(V8_OS_MACOSX)
+  if (ret != 0 && access == OS::MemoryPermission::kNoAccess) {
+    ret = madvise(address, size, MADV_FREE_REUSABLE);
+    return ret == 0;
+  }
+#endif
+
   if (ret == 0 && access == OS::MemoryPermission::kNoAccess) {
     // This is advisory; ignore errors and continue execution.
     USE(DiscardSystemPages(address, size));

--- a/deps/v8/src/heap/remembered-set-inl.h~HEAD
+++ b/deps/v8/src/heap/remembered-set-inl.h~HEAD
@@ -1,0 +1,57 @@
+// Copyright 2016 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef V8_HEAP_REMEMBERED_SET_INL_H_
+#define V8_HEAP_REMEMBERED_SET_INL_H_
+
+#include "src/common/ptr-compr-inl.h"
+#include "src/heap/remembered-set.h"
+
+namespace v8 {
+namespace internal {
+
+template <typename Callback>
+SlotCallbackResult UpdateTypedSlotHelper::UpdateTypedSlot(Heap* heap,
+                                                          SlotType slot_type,
+                                                          Address addr,
+                                                          Callback callback) {
+  switch (slot_type) {
+    case CODE_TARGET_SLOT: {
+      RelocInfo rinfo(addr, RelocInfo::CODE_TARGET, 0, Code());
+      return UpdateCodeTarget(&rinfo, callback);
+    }
+    case CODE_ENTRY_SLOT: {
+      return UpdateCodeEntry(addr, callback);
+    }
+    case COMPRESSED_EMBEDDED_OBJECT_SLOT: {
+      RelocInfo rinfo(addr, RelocInfo::COMPRESSED_EMBEDDED_OBJECT, 0, Code());
+      return UpdateEmbeddedPointer(heap, &rinfo, callback);
+    }
+    case FULL_EMBEDDED_OBJECT_SLOT: {
+      RelocInfo rinfo(addr, RelocInfo::FULL_EMBEDDED_OBJECT, 0, Code());
+      return UpdateEmbeddedPointer(heap, &rinfo, callback);
+    }
+    case COMPRESSED_OBJECT_SLOT: {
+      HeapObject old_target = HeapObject::cast(Object(
+          DecompressTaggedAny(heap->isolate(), base::Memory<Tagged_t>(addr))));
+      HeapObject new_target = old_target;
+      SlotCallbackResult result = callback(FullMaybeObjectSlot(&new_target));
+      DCHECK(!HasWeakHeapObjectTag(new_target));
+      if (new_target != old_target) {
+        base::Memory<Tagged_t>(addr) = CompressTagged(new_target.ptr());
+      }
+      return result;
+    }
+    case FULL_OBJECT_SLOT: {
+      return callback(FullMaybeObjectSlot(addr));
+    }
+    case CLEARED_SLOT:
+      break;
+  }
+  UNREACHABLE();
+}
+
+}  // namespace internal
+}  // namespace v8
+#endif  // V8_HEAP_REMEMBERED_SET_INL_H_


### PR DESCRIPTION
Original commit message:

    [mac][wasm] Work around MacOS 11.2 code page decommit failures

    MacOS 11.2 refuses to set "no access" permissions on memory that
    we previously used for JIT-compiled code. It is still unclear
    whether this is WAI on the part of the kernel. In the meantime,
    as a workaround, we use madvise(..., MADV_FREE_REUSABLE) instead
    of mprotect(..., NONE) when discarding code pages. This is inspired
    by what Chromium's gin platform does.

    Fixed: v8:11389
    Change-Id: I866586932573b4253002436ae5eee4e0411c45fc
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2679688
    Commit-Queue: Jakob Kummerow <jkummerow@chromium.org>
    Commit-Queue: Michael Lippautz <mlippautz@chromium.org>
    Auto-Submit: Jakob Kummerow <jkummerow@chromium.org>
    Reviewed-by: Michael Lippautz <mlippautz@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#72559}

Refs: https://github.com/v8/v8/commit/0c8b6e415c3020a987d2287f1543d629cd993535

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
