### PR TITLE
crypto: use BoringSSL compatible errors

### DIFF
--- a/src/crypto/crypto_dh.cc
+++ b/src/crypto/crypto_dh.cc
@@ -120,11 +120,13 @@ void DiffieHellman::MemoryInfo(MemoryTracker* tracker) const {
 bool DiffieHellman::Init(const char* p, int p_len, int g) {
   dh_.reset(DH_new());
   if (p_len <= 0) {
-    BNerr(BN_F_BN_GENERATE_PRIME_EX, BN_R_BITS_TOO_SMALL);
+    ERR_put_error(ERR_LIB_BN, BN_F_BN_GENERATE_PRIME_EX,
+      BN_R_BITS_TOO_SMALL, __FILE__, __LINE__);
     return false;
   }
   if (g <= 1) {
-    DHerr(DH_F_DH_BUILTIN_GENPARAMS, DH_R_BAD_GENERATOR);
+    ERR_put_error(ERR_LIB_DH, DH_F_DH_BUILTIN_GENPARAMS,
+      DH_R_BAD_GENERATOR, __FILE__, __LINE__);
     return false;
   }
   BIGNUM* bn_p =
@@ -142,18 +144,21 @@ bool DiffieHellman::Init(const char* p, int p_len, int g) {
 bool DiffieHellman::Init(const char* p, int p_len, const char* g, int g_len) {
   dh_.reset(DH_new());
   if (p_len <= 0) {
-    BNerr(BN_F_BN_GENERATE_PRIME_EX, BN_R_BITS_TOO_SMALL);
+    ERR_put_error(ERR_LIB_BN, BN_F_BN_GENERATE_PRIME_EX,
+      BN_R_BITS_TOO_SMALL, __FILE__, __LINE__);
     return false;
   }
   if (g_len <= 0) {
-    DHerr(DH_F_DH_BUILTIN_GENPARAMS, DH_R_BAD_GENERATOR);
+    ERR_put_error(ERR_LIB_DH, DH_F_DH_BUILTIN_GENPARAMS,
+      DH_R_BAD_GENERATOR, __FILE__, __LINE__);
     return false;
   }
   BIGNUM* bn_g =
       BN_bin2bn(reinterpret_cast<const unsigned char*>(g), g_len, nullptr);
   if (BN_is_zero(bn_g) || BN_is_one(bn_g)) {
     BN_free(bn_g);
-    DHerr(DH_F_DH_BUILTIN_GENPARAMS, DH_R_BAD_GENERATOR);
+    ERR_put_error(ERR_LIB_DH, DH_F_DH_BUILTIN_GENPARAMS,
+      DH_R_BAD_GENERATOR, __FILE__, __LINE__);
     return false;
   }
   BIGNUM* bn_p =


### PR DESCRIPTION
This PR migrates OpenSSL-specific error messages (`BNerr` & `Dherr`) to the underlying error calls, which BoringSSL is also capable of invoking. Electron is currently patching these out, and we'd prefer not to. 

Another consideration we might perhaps make, however, is instead just throwing more prototypical Node.js errors - curious what y'all think.
