### PR TITLE
Policy scope fix

### DIFF
--- a/lib/internal/policy/manifest.js
+++ b/lib/internal/policy/manifest.js
@@ -41,6 +41,8 @@ const shouldAbortOnUncaughtException =
   getOptionValue('--abort-on-uncaught-exception');
 const { abort, exit, _rawDebug } = process;
 
+const TERMINATE = () => null;
+
 // From https://url.spec.whatwg.org/#special-scheme
 const SPECIAL_SCHEMES = new SafeSet([
   'file:',
@@ -76,7 +78,7 @@ function REACTION_LOG(error) {
 
 class Manifest {
   /**
-   * @type {Map<string, DependencyMapper>}
+   * @type {Map<string | null | undefined, DependencyMapper>}
    *
    * Used to compare a resource to the content body at the resource.
    * `true` is used to signify that all integrities are allowed, otherwise,
@@ -139,6 +141,8 @@ class Manifest {
    */
   constructor(obj, manifestURL) {
     const scopes = this.#scopeDependencies;
+    scopes.set(null, TERMINATE);
+    scopes.set(undefined, TERMINATE);
     const integrities = this.#resourceIntegrities;
     const dependencies = this.#resourceDependencies;
     let reaction = REACTION_THROW;
@@ -205,18 +209,20 @@ class Manifest {
       return (toSpecifier, conditions) => {
         if (toSpecifier in dependencyMap !== true) {
           if (cascade === true) {
-            let scopeHREF;
+            /** @type {string | null} */
+            let scopeHREF = resourceHREF;
             if (typeof parentDeps === 'undefined') {
               do {
-                scopeHREF = this.#findScopeHREF(resourceHREF);
+                scopeHREF = this.#findScopeHREF(scopeHREF);
+                if (scopeHREF === resourceHREF) {
+                  scopeHREF = null;
+                }
+                if (scopes.has(scopeHREF)) {
+                  break;
+                }
               } while (
-                scopeHREF !== null &&
-                scopes.has(scopeHREF) !== true
+                scopeHREF !== null
               );
-            }
-            if (scopeHREF === null) {
-              parentDeps = () => null;
-            } else {
               parentDeps = scopes.get(scopeHREF);
             }
             return parentDeps(toSpecifier);

--- a/lib/internal/policy/manifest.js
+++ b/lib/internal/policy/manifest.js
@@ -41,7 +41,7 @@ const shouldAbortOnUncaughtException =
   getOptionValue('--abort-on-uncaught-exception');
 const { abort, exit, _rawDebug } = process;
 
-const TERMINATE = () => null;
+const kTerminate = () => null;
 
 // From https://url.spec.whatwg.org/#special-scheme
 const SPECIAL_SCHEMES = new SafeSet([

--- a/lib/internal/policy/manifest.js
+++ b/lib/internal/policy/manifest.js
@@ -141,8 +141,8 @@ class Manifest {
    */
   constructor(obj, manifestURL) {
     const scopes = this.#scopeDependencies;
-    scopes.set(null, TERMINATE);
-    scopes.set(undefined, TERMINATE);
+    scopes.set(null, kTerminate);
+    scopes.set(undefined, kTerminate);
     const integrities = this.#resourceIntegrities;
     const dependencies = this.#resourceDependencies;
     let reaction = REACTION_THROW;
@@ -423,7 +423,7 @@ class Manifest {
       protocol = currentURL.protocol;
     }
     // Only a few schemes are hierarchical
-    if (SPECIAL_SCHEMES.has(currentURL.protocol)) {
+    if (kSpecialSchemes.has(currentURL.protocol)) {
       // Make first '..' act like '.'
       if (!StringPrototypeEndsWith(currentURL.pathname, '/')) {
         currentURL.pathname += '/';

--- a/lib/internal/policy/manifest.js
+++ b/lib/internal/policy/manifest.js
@@ -44,7 +44,7 @@ const { abort, exit, _rawDebug } = process;
 const kTerminate = () => null;
 
 // From https://url.spec.whatwg.org/#special-scheme
-const SPECIAL_SCHEMES = new SafeSet([
+const kSpecialSchemes = new SafeSet([
   'file:',
   'ftp:',
   'http:',

--- a/test/fixtures/policy/dependencies/dependencies-scopes-and-resources-policy.json
+++ b/test/fixtures/policy/dependencies/dependencies-scopes-and-resources-policy.json
@@ -1,0 +1,14 @@
+{
+  "resources": {
+    "../multi-deps.js": {
+      "integrity": true,
+      "cascade": true
+    }
+  },
+  "scopes": {
+    "../": {
+      "integrity": true,
+      "dependencies": true
+    }
+  }
+}

--- a/test/fixtures/policy/multi-deps.js
+++ b/test/fixtures/policy/multi-deps.js
@@ -1,0 +1,3 @@
+'use strict';
+require('fs');
+require('process');

--- a/test/parallel/test-policy-scopes.js
+++ b/test/parallel/test-policy-scopes.js
@@ -10,12 +10,26 @@ const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const { spawnSync } = require('child_process');
 
-const dep = fixtures.path('policy', 'main.mjs');
 {
+  const dep = fixtures.path('policy', 'main.mjs');
   const depPolicy = fixtures.path(
     'policy',
     'dependencies',
     'dependencies-scopes-policy.json');
+  const { status } = spawnSync(
+    process.execPath,
+    [
+      '--experimental-policy', depPolicy, dep,
+    ]
+  );
+  assert.strictEqual(status, 0);
+}
+{
+  const dep = fixtures.path('policy', 'multi-deps.js');
+  const depPolicy = fixtures.path(
+    'policy',
+    'dependencies',
+    'dependencies-scopes-and-resources-policy.json');
   const { status } = spawnSync(
     process.execPath,
     [


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This fixes a case where repeated scope lookup for modules with multiple dependencies would fail and the manifest would look up the dependency redirector of the referrer rather than the scope. This was found in stress testing of https://github.com/bmeck/local-fs-https-imports . The reason it didn't appear to have a test before is likely that code coverage was unaffected.