### PR TITLE
doc: optimize HTML rendering

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -372,6 +372,11 @@ dd + dt.pre {
 #apicontent {
   padding-top: 1rem;
 }
+  
+#apicontent section {
+  content-visibility: auto;
+  contain-intrinsic-size: 1px 5000px;
+}
 
 #apicontent .line {
   width: calc(50% - 1rem);

--- a/tools/doc/allhtml.js
+++ b/tools/doc/allhtml.js
@@ -36,8 +36,8 @@ for (const link of toc.match(/<a.*?>/g)) {
   contents += data.slice(0, match.index)
     .replace(/[\s\S]*?id="toc"[^>]*>\s*<\w+>.*?<\/\w+>\s*(<ul>\s*)?/, '');
 
-  apicontent += data.slice(match.index + match[0].length)
-    .replace(/<!-- API END -->[\s\S]*/, '')
+  apicontent += '<section>' + data.slice(match.index + match[0].length)
+    .replace(/<!-- API END -->[\s\S]*/, '</section>')
     .replace(/<a href="(\w[^#"]*)#/g, (match, href) => {
       return htmlFiles.includes(href) ? '<a href="#' : match;
     })

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -66,6 +66,18 @@ const gtocHTML = unified()
 const templatePath = path.join(docPath, 'template.html');
 const template = fs.readFileSync(templatePath, 'utf8');
 
+function wrapSections(content) {
+  let firstTime = true;
+  return content.toString()
+    .replace(/<h2/g, (heading) => {
+      if (firstTime) {
+        firstTime = false;
+        return '<section>' + heading;
+      }
+      return '</section><section>' + heading;
+    }) + (firstTime ? '' : '</section>');
+}
+
 function toHTML({ input, content, filename, nodeVersion, versions }) {
   filename = path.basename(filename, '.md');
 
@@ -79,7 +91,7 @@ function toHTML({ input, content, filename, nodeVersion, versions }) {
                      .replace('__GTOC__', gtocHTML.replace(
                        `class="nav-${id}"`, `class="nav-${id} active"`))
                      .replace('__EDIT_ON_GITHUB__', editOnGitHub(filename))
-                     .replace('__CONTENT__', content.toString());
+                     .replace('__CONTENT__', wrapSections(content));
 
   const docCreated = input.match(
     /<!--\s*introduced_in\s*=\s*v([0-9]+)\.([0-9]+)\.[0-9]+\s*-->/);


### PR DESCRIPTION
Defer rendering sections of docs until they are displayed on the user's screen.

Rendering+painting time of `all.html` on master is `~1min` on my machine:
![screenshot of Chrome DevTools Performance tab, rendering time is 53089 ms, painting time is 3491 ms](https://user-images.githubusercontent.com/14309773/107432736-ae2d4b80-6b28-11eb-8540-3d7fc2d9298b.png)


Rendering+painting time of `all.html` on this branch is `~1s` on my machine:
![screenshot of Chrome DevTools Performance tab 937 ms, painting time is 51 ms](https://user-images.githubusercontent.com/14309773/107432467-4c6ce180-6b28-11eb-8f4a-b1fa24b594db.png)

This feature is only available for Chromium browsers using version 85+ (https://caniuse.com/?search=content%20visibility), and won't change much for other browsers.


<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
