### PR TITLE
crypto: check ed/x webcrypto key import algorithm names

### DIFF
--- a/doc/api/webcrypto.md
+++ b/doc/api/webcrypto.md
@@ -1697,8 +1697,8 @@ added: v15.8.0
 
 * Type: {boolean}
 
-The `public` parameter is used to specify that the key is to be interpreted
-as a public key.
+The `public` parameter is used to specify that the `'raw'` format key is to be
+interpreted as a public key. **Default:** `false`.
 
 ### `NODE-SCRYPT` Algorithm
 <!-- YAML

--- a/lib/internal/crypto/ec.js
+++ b/lib/internal/crypto/ec.js
@@ -253,10 +253,6 @@ async function ecImportKey(
     namedCurve,
     'algorithm.namedCurve',
     ObjectKeys(kNamedCurveAliases));
-  // Only used for NODE-EDnnnn key variants to distinguish between
-  // importing a raw public key or raw private key.
-  if (algorithm.public !== undefined)
-    validateBoolean(algorithm.public, 'algorithm.public');
   let keyObject;
   const usagesSet = new SafeSet(keyUsages);
   let checkNamedCurve = true;
@@ -266,6 +262,24 @@ async function ecImportKey(
         throw new ERR_INVALID_ARG_TYPE('keyData', 'KeyObject', keyData);
       if (keyData.type === 'secret')
         throw lazyDOMException('Invalid key type', 'InvalidAccessException');
+
+      switch (namedCurve) {
+        case 'NODE-X25519':
+          // Fall through
+        case 'NODE-X448':
+          checkNamedCurve = false;
+          if (algorithm.name !== 'ECDH')
+            throw lazyDOMException('Invalid algorithm name.', 'DataError');
+          break;
+        case 'NODE-ED25519':
+          // Fall through
+        case 'NODE-ED448':
+          checkNamedCurve = false;
+          if (algorithm.name !== namedCurve)
+            throw lazyDOMException('Invalid algorithm name.', 'DataError');
+          break;
+      }
+
       verifyAcceptableEcKeyUse(name, keyData.type, usagesSet);
       keyObject = keyData;
       break;
@@ -296,8 +310,24 @@ async function ecImportKey(
         case 'OKP': {
           checkNamedCurve = false;
           const isPublic = keyData.d === undefined;
-          const type =
-            namedCurve === 'NODE-X25519' || 'NODE-X448' ? 'ECDH' : 'ECDSA';
+
+          let type;
+          switch (namedCurve) {
+            case 'NODE-ED25519':
+              // Fall through
+            case 'NODE-ED448':
+              type = `NODE-${keyData.crv.toUpperCase()}`;
+              break;
+            case 'NODE-X25519':
+              // Fall through
+            case 'NODE-X448':
+              type = 'ECDH';
+              break;
+          }
+
+          if (algorithm.name !== type)
+            throw lazyDOMException('Invalid algorithm name.', 'DataError');
+
           verifyAcceptableEcKeyUse(
             type,
             isPublic ? 'public' : 'private',
@@ -364,8 +394,12 @@ async function ecImportKey(
           // Fall through
         case 'NODE-X448':
           checkNamedCurve = false;
+          if (algorithm.public !== undefined)
+            validateBoolean(algorithm.public, 'algorithm.public');
+          if (algorithm.name !== 'ECDH')
+            throw lazyDOMException('Invalid algorithm name.', 'DataError');
           verifyAcceptableEcKeyUse(
-            'ECDH',
+            algorithm.name,
             algorithm.public === true ? 'public' : 'private',
             usagesSet);
           keyObject = createECRawKey(namedCurve, keyData, algorithm.public);
@@ -374,8 +408,12 @@ async function ecImportKey(
           // Fall through
         case 'NODE-ED448':
           checkNamedCurve = false;
+          if (algorithm.public !== undefined)
+            validateBoolean(algorithm.public, 'algorithm.public');
+          if (algorithm.name !== namedCurve)
+            throw lazyDOMException('Invalid algorithm name.', 'DataError');
           verifyAcceptableEcKeyUse(
-            'ECDSA',
+            algorithm.name,
             algorithm.public === true ? 'public' : 'private',
             usagesSet);
           keyObject = createECRawKey(namedCurve, keyData, algorithm.public);


### PR DESCRIPTION
This fixes a couple things in the `webcrypto` experimental module

- makes sure Ed* keys algorithms are `NODE-ED*`
- makes sure X* keys algorithms are `ECDH`
- doc change to clarify the `nodeEdKeyImportParams.public` parameter is only used with the `raw` format.

Previously you couldn't import these using the `node.keyObject` format at all despite the support matrix saying so.