### PR TITLE
doc: update CI requirements for landing pull requests

### DIFF
--- a/doc/guides/collaborator-guide.md
+++ b/doc/guides/collaborator-guide.md
@@ -13,8 +13,8 @@
   * [Consensus seeking](#consensus-seeking)
   * [Waiting for approvals](#waiting-for-approvals)
   * [Testing and CI](#testing-and-ci)
-    * [Useful CI jobs](#useful-ci-jobs)
-    * [Starting a CI job](#starting-a-ci-job)
+    * [Useful Jenkins CI jobs](#useful-jenkins-ci-jobs)
+    * [Starting a Jenkins CI job](#starting-a-jenkins-ci-job)
   * [Internal vs. public API](#internal-vs-public-api)
   * [Breaking changes](#breaking-changes)
     * [Breaking changes and deprecations](#breaking-changes-and-deprecations)
@@ -209,21 +209,56 @@ the comment anyway to avoid any doubt.
 All fixes must have a test case which demonstrates the defect. The test should
 fail before the change, and pass after the change.
 
-All pull requests must pass continuous integration tests. Code changes must pass
-on [project CI server](https://ci.nodejs.org/). Pull requests that only change
-documentation and comments can use GitHub Actions results.
-
 Do not land any pull requests without a passing (green or yellow) CI run.
-For documentation-only changes, GitHub Actions CI is sufficient.
-For all other code changes, Jenkins CI must pass as well. If there are
-Jenkins CI failures unrelated to the change in the pull request, try "Resume
-Build". It is in the left navigation of the relevant `node-test-pull-request`
-job. It will preserve all the green results from the current job but re-run
-everything else. Start a fresh CI if more than seven days have elapsed since
-the original failing CI as the compiled binaries for the Windows and ARM
-platforms are only kept for seven days.
+A green GitHub Actions CI result is required. A passing
+[Jenkins CI](https://ci.nodejs.org/) is also required if PR contains changes
+that will affect the `node` binary. This is critical as GitHub Actions CI does
+not cover all the environments supported by Node.js.
 
-#### Useful CI jobs
+<details>
+<summary>Changes that affect the `node` binary</summary>
+
+Changes in the following folders (except comment-only changes) are guaranteed to
+affect the `node` binary:
+
+* `deps/`
+* `lib/`
+* `src/`
+* `test/`
+* `tools/code_cache/`
+* `tools/gyp/`
+* `tools/icu/`
+* `tools/inspector-protocol/`
+* `tools/msvs/`
+* `tools/snapshot/`
+* `tools/v8_gypfiles/`
+
+There are some other files that touch the build chain. Changes in the following
+files also qualify as affecting the `node` binary:
+
+* `tools/*.py`
+* `tools/build-addons.js`
+* `*.gyp`
+* `*.gypi`
+* `configure`
+* `configure.py`
+* `Makefile`
+* `vcbuilt.bat`
+
+</details>
+
+If there are GitHub Actions CI failures unrelated to the change in the pull
+request, try "Re-run all jobs". It's under the "🔄 Re-run jobs" button, on the
+right-hand side of "Checks" tab.
+
+If there are Jenkins CI failures unrelated to the change in the pull request,
+try "Resume Build". It is in the left navigation of the relevant
+`node-test-pull-request` job. It will preserve all the green results from the
+current job but re-run everything else. Start a fresh CI if more than seven days
+have elapsed since the original failing CI as the compiled binaries for the
+Windows and ARM platforms are only kept for seven days.
+
+#### Useful Jenkins CI jobs
 
 * [`node-test-pull-request`](https://ci.nodejs.org/job/node-test-pull-request/)
 is the CI job to test pull requests. It runs the `build-ci` and `test-ci`
@@ -248,7 +283,7 @@ not used in other CI test runs (such as tests in the `internet` or `pummel`
 directories). It can also make sure tests pass when provided with a flag not
 used in other CI test runs (such as `--worker`).
 
-#### Starting a CI job
+#### Starting a Jenkins CI job
 
 From the CI Job page, click "Build with Parameters" on the left side.
 


### PR DESCRIPTION
The current text contain repetitions and inconsistencies. Also, I think there are some cases where Jenkins CI doesn't have any added value (linter changes, adding GH actions scripts, doc generation tool updates, etc.) but it's still required today. 

This PR suggests to list folders where the full Jenkins CI is actually needed. For changes outside of those critical folders, I think GH actions results would report all the relevant mistakes already.

/cc @nodejs/tsc 

_If this change is accepted, I can work on a PR to reflect this change on `node-core-utils`._

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
