### PR TITLE
child_process: fix spawn and fork AbortSignal behavior

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -351,6 +351,9 @@ controller.abort();
 <!-- YAML
 added: v0.5.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/37325
+    description: killSignal for AbortSignal was added.
   - version: v15.6.0
     pr-url: https://github.com/nodejs/node/pull/36603
     description: AbortSignal support was added.
@@ -383,6 +386,8 @@ changes:
     messages between processes. Possible values are `'json'` and `'advanced'`.
     See [Advanced serialization][] for more details. **Default:** `'json'`.
   * `signal` {AbortSignal} Allows closing the subprocess using an AbortSignal.
+  * `killSignal` {string} The signal value to be used when the spawned
+    process will be killed by the abort signal. **Default:** `'SIGTERM'`.
   * `silent` {boolean} If `true`, stdin, stdout, and stderr of the child will be
     piped to the parent, otherwise they will be inherited from the parent, see
     the `'pipe'` and `'inherit'` options for [`child_process.spawn()`][]'s
@@ -431,6 +436,9 @@ The `signal` option works exactly the same way it does in
 <!-- YAML
 added: v0.1.90
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/37325
+    description: killSignal for AbortSignal was added.
   - version: v15.5.0
     pr-url: https://github.com/nodejs/node/pull/36432
     description: AbortSignal support was added.
@@ -477,6 +485,8 @@ changes:
   * `windowsHide` {boolean} Hide the subprocess console window that would
     normally be created on Windows systems. **Default:** `false`.
   * `signal` {AbortSignal} allows aborting the execFile using an AbortSignal.
+  * `killSignal` {string} The signal value to be used when the spawned
+    process will be killed by the abort signal. **Default:** `'SIGTERM'`.
 
 * Returns: {ChildProcess}
 

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -585,6 +585,18 @@ function normalizeSpawnArguments(file, args, options) {
   };
 }
 
+function abortChildProcess(child, killSignal) {
+  if (!child)
+    return;
+  try {
+    if (child.kill(killSignal)) {
+      child.emit('error', new AbortError());
+    }
+  } catch (err) {
+    child.emit('error', err);
+  }
+}
+
 
 function spawn(file, args, options) {
   const child = new ChildProcess();
@@ -594,21 +606,19 @@ function spawn(file, args, options) {
     const signal = options.signal;
     // Validate signal, if present
     validateAbortSignal(signal, 'options.signal');
-
+    const killSignal = sanitizeKillSignal(options.killSignal);
     // Do nothing and throw if already aborted
     if (signal.aborted) {
       onAbortListener();
     } else {
       signal.addEventListener('abort', onAbortListener, { once: true });
-      child.once('close',
+      child.once('exit',
                  () => signal.removeEventListener('abort', onAbortListener));
     }
 
     function onAbortListener() {
       process.nextTick(() => {
-        child?.kill?.(options.killSignal);
-
-        child.emit('error', new AbortError());
+        abortChildProcess(child, killSignal);
       });
     }
   }
@@ -764,19 +774,18 @@ function spawnWithSignal(file, args, options) {
   }
   const child = spawn(file, args, opts);
 
-  if (options && options.signal) {
+  if (options?.signal) {
+    const killSignal = sanitizeKillSignal(options.killSignal);
+
     function kill() {
-      if (child._handle) {
-        child._handle.kill(options.killSignal || 'SIGTERM');
-        child.emit('error', new AbortError());
-      }
+      abortChildProcess(child, killSignal);
     }
     if (options.signal.aborted) {
       process.nextTick(kill);
     } else {
-      options.signal.addEventListener('abort', kill);
+      options.signal.addEventListener('abort', kill, { once: true });
       const remove = () => options.signal.removeEventListener('abort', kill);
-      child.once('close', remove);
+      child.once('exit', remove);
     }
   }
   return child;

--- a/test/parallel/test-child-process-exec-abortcontroller-promisified.js
+++ b/test/parallel/test-child-process-exec-abortcontroller-promisified.js
@@ -4,48 +4,47 @@ const assert = require('assert');
 const exec = require('child_process').exec;
 const { promisify } = require('util');
 
-let pwdcommand, dir;
 const execPromisifed = promisify(exec);
 const invalidArgTypeError = {
   code: 'ERR_INVALID_ARG_TYPE',
   name: 'TypeError'
 };
 
-
+let waitCommand = '';
 if (common.isWindows) {
-  pwdcommand = 'echo %cd%';
-  dir = 'c:\\windows';
+  waitCommand = 'TIMEOUT 120';
 } else {
-  pwdcommand = 'pwd';
-  dir = '/dev';
+  waitCommand = 'sleep 2m';
 }
-
 
 {
   const ac = new AbortController();
   const signal = ac.signal;
-  const promise = execPromisifed(pwdcommand, { cwd: dir, signal });
-  assert.rejects(promise, /AbortError/).then(common.mustCall());
+  const promise = execPromisifed(waitCommand, { signal });
+  assert.rejects(promise, /AbortError/, 'post aborted sync signal failed')
+        .then(common.mustCall());
   ac.abort();
 }
 
 {
   assert.throws(() => {
-    execPromisifed(pwdcommand, { cwd: dir, signal: {} });
+    execPromisifed(waitCommand, { signal: {} });
   }, invalidArgTypeError);
 }
 
 {
   function signal() {}
   assert.throws(() => {
-    execPromisifed(pwdcommand, { cwd: dir, signal });
+    execPromisifed(waitCommand, { signal });
   }, invalidArgTypeError);
 }
 
 {
   const ac = new AbortController();
-  const signal = (ac.abort(), ac.signal);
-  const promise = execPromisifed(pwdcommand, { cwd: dir, signal });
+  const { signal } = ac;
+  ac.abort();
+  const promise = execPromisifed(waitCommand, { signal });
 
-  assert.rejects(promise, /AbortError/).then(common.mustCall());
+  assert.rejects(promise, /AbortError/, 'pre aborted signal failed')
+        .then(common.mustCall());
 }


### PR DESCRIPTION
This PR fixes a few errors with AbortSignal and spawn/fork.

I've changed the AbortSignal to get removed on 'exit', instead of 'close' which I _think_ is more correct. This fixed a bug in fork (see added test in the fork tests) where an AbortError could be emitted even though the process was already exited.

In spawn, the 'abort' event didn't kill the process (see #37273), which is now fixed. For both spawn and fork, I've also changed it to emit AbortError only when `kill` returns true.

I've also added killSignal to the documentation, as it was already used by the AbortSignal code, but was undocumented. So I've added `sanitize` as well (and tests for the killSignal).

Fixes #37273 .
