### PR TITLE
src: fix more MSVC warnings

### DIFF
--- a/src/base64-inl.h
+++ b/src/base64-inl.h
@@ -23,6 +23,11 @@ inline uint32_t ReadUint32BE(const unsigned char* p) {
          static_cast<uint32_t>(p[3]);
 }
 
+#ifdef _MSC_VER
+#pragma warning(push)
+// MSVC C4003: not enough actual parameters for macro 'identifier'
+#pragma warning(disable : 4003)
+#endif
 
 template <typename TypeName>
 bool base64_decode_group_slow(char* const dst, const size_t dstlen,
@@ -50,6 +55,9 @@ bool base64_decode_group_slow(char* const dst, const size_t dstlen,
   return true;  // Continue decoding.
 }
 
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 template <typename TypeName>
 size_t base64_decode_fast(char* const dst, const size_t dstlen,

--- a/src/base64-inl.h
+++ b/src/base64-inl.h
@@ -30,21 +30,17 @@ bool base64_decode_group_slow(char* const dst, const size_t dstlen,
                               size_t* const i, size_t* const k) {
   uint8_t hi;
   uint8_t lo;
-#define V(expr)                                                               \
-  for (;;) {                                                                  \
-    const uint8_t c = src[*i];                                                \
-    lo = unbase64(c);                                                         \
-    *i += 1;                                                                  \
-    if (lo < 64)                                                              \
-      break;  /* Legal character. */                                          \
-    if (c == '=' || *i >= srclen)                                             \
-      return false;  /* Stop decoding. */                                     \
-  }                                                                           \
-  expr;                                                                       \
-  if (*i >= srclen)                                                           \
-    return false;                                                             \
-  if (*k >= dstlen)                                                           \
-    return false;                                                             \
+#define V(expr)                                                                \
+  for (;;) {                                                                   \
+    const uint8_t c = static_cast<uint8_t>(src[*i]);                           \
+    lo = unbase64(c);                                                          \
+    *i += 1;                                                                   \
+    if (lo < 64) break;                         /* Legal character. */         \
+    if (c == '=' || *i >= srclen) return false; /* Stop decoding. */           \
+  }                                                                            \
+  expr;                                                                        \
+  if (*i >= srclen) return false;                                              \
+  if (*k >= dstlen) return false;                                              \
   hi = lo;
   V(/* Nothing. */);
   V(dst[(*k)++] = ((hi & 0x3F) << 2) | ((lo & 0x30) >> 4));
@@ -66,10 +62,10 @@ size_t base64_decode_fast(char* const dst, const size_t dstlen,
   size_t k = 0;
   while (i < max_i && k < max_k) {
     const unsigned char txt[] = {
-      static_cast<unsigned char>(unbase64(src[i + 0])),
-      static_cast<unsigned char>(unbase64(src[i + 1])),
-      static_cast<unsigned char>(unbase64(src[i + 2])),
-      static_cast<unsigned char>(unbase64(src[i + 3])),
+        static_cast<unsigned char>(unbase64(static_cast<uint8_t>(src[i + 0]))),
+        static_cast<unsigned char>(unbase64(static_cast<uint8_t>(src[i + 1]))),
+        static_cast<unsigned char>(unbase64(static_cast<uint8_t>(src[i + 2]))),
+        static_cast<unsigned char>(unbase64(static_cast<uint8_t>(src[i + 3]))),
     };
 
     const uint32_t v = ReadUint32BE(txt);

--- a/src/crypto/crypto_dsa.cc
+++ b/src/crypto/crypto_dsa.cc
@@ -146,14 +146,18 @@ Maybe<bool> GetDsaKeyDetail(
   size_t modulus_length = BN_num_bytes(p) * CHAR_BIT;
   size_t divisor_length = BN_num_bytes(q) * CHAR_BIT;
 
-  if (target->Set(
-          env->context(),
-          env->modulus_length_string(),
-          Number::New(env->isolate(), modulus_length)).IsNothing() ||
-      target->Set(
-          env->context(),
-          env->divisor_length_string(),
-          Number::New(env->isolate(), divisor_length)).IsNothing()) {
+  if (target
+          ->Set(
+              env->context(),
+              env->modulus_length_string(),
+              Number::New(env->isolate(), static_cast<double>(modulus_length)))
+          .IsNothing() ||
+      target
+          ->Set(
+              env->context(),
+              env->divisor_length_string(),
+              Number::New(env->isolate(), static_cast<double>(divisor_length)))
+          .IsNothing()) {
     return Nothing<bool>();
   }
 

--- a/src/crypto/crypto_keygen.cc
+++ b/src/crypto/crypto_keygen.cc
@@ -66,7 +66,8 @@ Maybe<bool> SecretKeyGenTraits::AdditionalConfig(
     SecretKeyGenConfig* params) {
   Environment* env = Environment::GetCurrent(args);
   CHECK(args[*offset]->IsUint32());
-  params->length = std::trunc(args[*offset].As<Uint32>()->Value() / CHAR_BIT);
+  params->length = static_cast<size_t>(
+      std::trunc(args[*offset].As<Uint32>()->Value() / CHAR_BIT));
   if (params->length > INT_MAX) {
     const std::string msg{
       SPrintF("length must be less than or equal to %s bits",

--- a/src/crypto/crypto_keys.cc
+++ b/src/crypto/crypto_keys.cc
@@ -529,10 +529,9 @@ Maybe<bool> GetSecretKeyDetail(
   // converted to bits.
 
   size_t length = key->GetSymmetricKeySize() * CHAR_BIT;
-  return target->Set(
-      env->context(),
-      env->length_string(),
-      Number::New(env->isolate(), length));
+  return target->Set(env->context(),
+                     env->length_string(),
+                     Number::New(env->isolate(), static_cast<double>(length)));
 }
 
 Maybe<bool> GetAsymmetricKeyDetail(

--- a/src/crypto/crypto_rsa.cc
+++ b/src/crypto/crypto_rsa.cc
@@ -532,10 +532,12 @@ Maybe<bool> GetRsaKeyDetail(
 
   size_t modulus_length = BN_num_bytes(n) * CHAR_BIT;
 
-  if (target->Set(
-          env->context(),
-          env->modulus_length_string(),
-          Number::New(env->isolate(), modulus_length)).IsNothing()) {
+  if (target
+          ->Set(
+              env->context(),
+              env->modulus_length_string(),
+              Number::New(env->isolate(), static_cast<double>(modulus_length)))
+          .IsNothing()) {
     return Nothing<bool>();
   }
 

--- a/src/inspector/worker_inspector.h
+++ b/src/inspector/worker_inspector.h
@@ -53,12 +53,13 @@ struct WorkerInfo {
 
 class ParentInspectorHandle {
  public:
-  ParentInspectorHandle(int id, const std::string& url,
+  ParentInspectorHandle(uint64_t id,
+                        const std::string& url,
                         std::shared_ptr<MainThreadHandle> parent_thread,
                         bool wait_for_connect);
   ~ParentInspectorHandle();
   std::unique_ptr<ParentInspectorHandle> NewParentInspectorHandle(
-      int thread_id, const std::string& url) {
+      uint64_t thread_id, const std::string& url) {
     return std::make_unique<ParentInspectorHandle>(thread_id,
                                                    url,
                                                    parent_thread_,
@@ -75,7 +76,7 @@ class ParentInspectorHandle {
       bool prevent_shutdown);
 
  private:
-  int id_;
+  uint64_t id_;
   std::string url_;
   std::shared_ptr<MainThreadHandle> parent_thread_;
   bool wait_;
@@ -87,9 +88,9 @@ class WorkerManager : public std::enable_shared_from_this<WorkerManager> {
                          : thread_(thread) {}
 
   std::unique_ptr<ParentInspectorHandle> NewParentHandle(
-      int thread_id, const std::string& url);
-  void WorkerStarted(int session_id, const WorkerInfo& info, bool waiting);
-  void WorkerFinished(int session_id);
+      uint64_t thread_id, const std::string& url);
+  void WorkerStarted(uint64_t session_id, const WorkerInfo& info, bool waiting);
+  void WorkerFinished(uint64_t session_id);
   std::unique_ptr<WorkerManagerEventHandle> SetAutoAttach(
       std::unique_ptr<WorkerDelegate> attach_delegate);
   void SetWaitOnStartForDelegate(int id, bool wait);
@@ -100,7 +101,7 @@ class WorkerManager : public std::enable_shared_from_this<WorkerManager> {
 
  private:
   std::shared_ptr<MainThreadHandle> thread_;
-  std::unordered_map<int, WorkerInfo> children_;
+  std::unordered_map<uint64_t, WorkerInfo> children_;
   std::unordered_map<int, std::unique_ptr<WorkerDelegate>> delegates_;
   // If any one needs it, workers stop for all
   std::unordered_set<int> delegates_waiting_on_start_;

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -527,7 +527,7 @@ class NodeInspectorClient : public V8InspectorClient {
         timers_.emplace(std::piecewise_construct, std::make_tuple(data),
                         std::make_tuple(env_, [=]() { callback(data); }));
     CHECK(result.second);
-    uint64_t interval = 1000 * interval_s;
+    uint64_t interval = static_cast<uint64_t>(1000 * interval_s);
     result.first->second.Update(interval, interval);
   }
 
@@ -917,7 +917,7 @@ void Agent::SetParentHandle(
 }
 
 std::unique_ptr<ParentInspectorHandle> Agent::GetParentHandle(
-    int thread_id, const std::string& url) {
+    uint64_t thread_id, const std::string& url) {
   if (!parent_handle_) {
     return client_->getWorkerManager()->NewParentHandle(thread_id, url);
   } else {

--- a/src/inspector_agent.h
+++ b/src/inspector_agent.h
@@ -84,7 +84,7 @@ class Agent {
 
   void SetParentHandle(std::unique_ptr<ParentInspectorHandle> parent_handle);
   std::unique_ptr<ParentInspectorHandle> GetParentHandle(
-      int thread_id, const std::string& url);
+      uint64_t thread_id, const std::string& url);
 
   // Called to create inspector sessions that can be used from the same thread.
   // The inspector responds by using the delegate to send messages back.

--- a/src/node_revert.h
+++ b/src/node_revert.h
@@ -28,6 +28,12 @@ namespace per_process {
 extern unsigned int reverted_cve;
 }
 
+#ifdef _MSC_VER
+#pragma warning(push)
+// MSVC C4065: switch statement contains 'default' but no 'case' labels
+#pragma warning(disable : 4065)
+#endif
+
 inline const char* RevertMessage(const reversion cve) {
 #define V(code, label, msg) case SECURITY_REVERT_##code: return label ": " msg;
   switch (cve) {
@@ -37,6 +43,10 @@ inline const char* RevertMessage(const reversion cve) {
   }
 #undef V
 }
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 inline void Revert(const reversion cve) {
   per_process::reverted_cve |= 1 << cve;

--- a/src/node_serdes.cc
+++ b/src/node_serdes.cc
@@ -443,7 +443,7 @@ void DeserializerContext::ReadRawBytes(
   CHECK_GE(position, ctx->data_);
   CHECK_LE(position + length, ctx->data_ + ctx->length_);
 
-  const uint32_t offset = position - ctx->data_;
+  const uint32_t offset = static_cast<uint32_t>(position - ctx->data_);
   CHECK_EQ(ctx->data_ + offset, position);
 
   args.GetReturnValue().Set(offset);

--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -896,7 +896,7 @@ void URLHost::ParseIPv6Host(const char* input, size_t length) {
   }
 
   if (compress_pointer != nullptr) {
-    unsigned swaps = piece_pointer - compress_pointer;
+    int64_t swaps = piece_pointer - compress_pointer;
     piece_pointer = buffer_end - 1;
     while (piece_pointer != &value_.ipv6[0] && swaps > 0) {
       uint16_t temp = *piece_pointer;
@@ -963,7 +963,7 @@ void URLHost::ParseIPv4Host(const char* input, size_t length, bool* is_ipv4) {
 
   while (pointer <= end) {
     const char ch = pointer < end ? pointer[0] : kEOL;
-    int remaining = end - pointer - 1;
+    int64_t remaining = end - pointer - 1;
     if (ch == '.' || ch == kEOL) {
       if (++parts > static_cast<int>(arraysize(numbers)))
         return;
@@ -996,10 +996,11 @@ void URLHost::ParseIPv4Host(const char* input, size_t length, bool* is_ipv4) {
   }
 
   type_ = HostType::H_IPV4;
-  val = numbers[parts - 1];
+  val = static_cast<uint32_t>(numbers[parts - 1]);
   for (int n = 0; n < parts - 1; n++) {
     double b = 3 - n;
-    val += numbers[n] * pow(256, b);
+    val +=
+        static_cast<uint32_t>(numbers[n]) * static_cast<uint32_t>(pow(256, b));
   }
 
   value_.ipv4 = val;

--- a/src/node_wasi.cc
+++ b/src/node_wasi.cc
@@ -279,7 +279,8 @@ void WASI::ArgsGet(const FunctionCallbackInfo<Value>& args) {
 
   if (err == UVWASI_ESUCCESS) {
     for (size_t i = 0; i < wasi->uvw_.argc; i++) {
-      uint32_t offset = argv_buf_offset + (argv[i] - argv[0]);
+      uint32_t offset =
+          static_cast<uint32_t>(argv_buf_offset + (argv[i] - argv[0]));
       uvwasi_serdes_write_uint32_t(memory,
                                    argv_offset +
                                    (i * UVWASI_SERDES_SIZE_uint32_t),
@@ -410,7 +411,8 @@ void WASI::EnvironGet(const FunctionCallbackInfo<Value>& args) {
 
   if (err == UVWASI_ESUCCESS) {
     for (size_t i = 0; i < wasi->uvw_.envc; i++) {
-      uint32_t offset = environ_buf_offset + (environment[i] - environment[0]);
+      uint32_t offset = static_cast<uint32_t>(
+          environ_buf_offset + (environment[i] - environment[0]));
 
       uvwasi_serdes_write_uint32_t(memory,
                                    environ_offset +

--- a/src/node_win32_etw_provider-inl.h
+++ b/src/node_win32_etw_provider-inl.h
@@ -111,13 +111,14 @@ extern int events_enabled;
                              dataDescriptors);                                \
   CHECK_EQ(status, ERROR_SUCCESS);
 
-#define ETW_WRITE_EMPTY_EVENT(eventDescriptor)                                \
-  DWORD status = event_write(node_provider,                                   \
-                             &eventDescriptor,                                \
-                             0,                                               \
-                             NULL);  // NOLINT (readability/null_usage)       \
+// NOLINTNEXTLINE (readability/null_usage)
+#define NULL_NOLINT NULL
+
+#define ETW_WRITE_EMPTY_EVENT(eventDescriptor)                                 \
+  DWORD status = event_write(node_provider, &eventDescriptor, 0, NULL_NOLINT); \
   CHECK_EQ(status, ERROR_SUCCESS);
 
+#undef NULL_NOLINT
 
 void NODE_HTTP_SERVER_REQUEST(node_dtrace_http_server_request_t* req,
     node_dtrace_connection_t* conn, const char* remote, int port,

--- a/src/node_win32_etw_provider-inl.h
+++ b/src/node_win32_etw_provider-inl.h
@@ -118,8 +118,6 @@ extern int events_enabled;
   DWORD status = event_write(node_provider, &eventDescriptor, 0, NULL_NOLINT); \
   CHECK_EQ(status, ERROR_SUCCESS);
 
-#undef NULL_NOLINT
-
 void NODE_HTTP_SERVER_REQUEST(node_dtrace_http_server_request_t* req,
     node_dtrace_connection_t* conn, const char* remote, int port,
     const char* method, const char* url, int fd) {
@@ -271,6 +269,8 @@ void NODE_V8SYMBOL_ADD(LPCSTR symbol,
   }
 }
 #undef SETSYMBUF
+
+#undef NULL_NOLINT
 
 
 bool NODE_HTTP_SERVER_REQUEST_ENABLED() { return events_enabled > 0; }

--- a/src/signal_wrap.cc
+++ b/src/signal_wrap.cc
@@ -153,7 +153,7 @@ class SignalWrap : public HandleWrap {
 
 void DecreaseSignalHandlerCount(int signum) {
   Mutex::ScopedLock lock(handled_signals_mutex);
-  int new_handler_count = --handled_signals[signum];
+  int64_t new_handler_count = --handled_signals[signum];
   CHECK_GE(new_handler_count, 0);
   if (new_handler_count == 0)
     handled_signals.erase(signum);

--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -337,7 +337,7 @@ MaybeLocal<Value> StreamBase::CallJSOnreadMethod(ssize_t nread,
     }
   }
 
-  env->stream_base_state()[kReadBytesOrError] = nread;
+  env->stream_base_state()[kReadBytesOrError] = static_cast<int32_t>(nread);
   env->stream_base_state()[kArrayBufferOffset] = offset;
 
   Local<Value> argv[] = {

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -250,8 +250,8 @@ static size_t hex_decode(char* buf,
                          const size_t srcLen) {
   size_t i;
   for (i = 0; i < len && i * 2 + 1 < srcLen; ++i) {
-    unsigned a = unhex(src[i * 2 + 0]);
-    unsigned b = unhex(src[i * 2 + 1]);
+    unsigned a = unhex(static_cast<uint8_t>(src[i * 2 + 0]));
+    unsigned b = unhex(static_cast<uint8_t>(src[i * 2 + 1]));
     if (!~a || !~b)
       return i;
     buf[i] = (a << 4) | b;

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -531,7 +531,7 @@ void UDPWrap::DoSend(const FunctionCallbackInfo<Value>& args, int family) {
     wrap->current_send_has_callback_ =
         sendto ? args[5]->IsTrue() : args[3]->IsTrue();
 
-    err = wrap->Send(*bufs, count, addr);
+    err = static_cast<int>(wrap->Send(*bufs, count, addr));
 
     wrap->current_send_req_wrap_.Clear();
     wrap->current_send_has_callback_ = false;
@@ -705,11 +705,10 @@ void UDPWrap::OnRecv(ssize_t nread,
   Context::Scope context_scope(env->context());
 
   Local<Value> argv[] = {
-    Integer::New(env->isolate(), nread),
-    object(),
-    Undefined(env->isolate()),
-    Undefined(env->isolate())
-  };
+      Integer::New(env->isolate(), static_cast<int32_t>(nread)),
+      object(),
+      Undefined(env->isolate()),
+      Undefined(env->isolate())};
 
   if (nread < 0) {
     MakeCallback(env->onmessage_string(), arraysize(argv), argv);


### PR DESCRIPTION
commit c0a92899a8b90271d92241118c1dd1fd65acf840

    src: avoid implicit type conversions (take 2)

    This fixes more C4244 MSVC warnings in the code base.

    Refs: https://github.com/nodejs/node/pull/37149

commit 6e89d7364c03f6398f2a3f8cdc9b49a17776ddf1

    src: disable unfixable MSVC warnings

    The following warnings are disabled:
    - C4065 in node_revert.h: there are no security reversions on the master
      branch.
    - C4003 in base64-inl.h: a macro is used four times, only once without
      parameters.

commit 4f94dbc7db6b31ed14b76d0adf1e1e67ed632ede

    src: fix ETW_WRITE_EMPTY_EVENT macro

    A comment was written before the last line, hiding a check.