### PR TITLE
buffer: add @@toStringTag to Blob

### DIFF
--- a/lib/internal/blob.js
+++ b/lib/internal/blob.js
@@ -2,12 +2,14 @@
 
 const {
   ArrayFrom,
+  ObjectDefineProperty,
   ObjectSetPrototypeOf,
   PromiseResolve,
   RegExpPrototypeTest,
   StringPrototypeToLowerCase,
   Symbol,
   SymbolIterator,
+  SymbolToStringTag,
   Uint8Array,
 } = primordials;
 
@@ -216,6 +218,11 @@ class Blob extends JSTransferable {
     return dec.decode(await this.arrayBuffer());
   }
 }
+
+ObjectDefineProperty(Blob.prototype, SymbolToStringTag, {
+  configurable: true,
+  value: 'Blob',
+});
 
 InternalBlob.prototype.constructor = Blob;
 ObjectSetPrototypeOf(

--- a/test/parallel/test-blob.js
+++ b/test/parallel/test-blob.js
@@ -184,3 +184,14 @@ assert.throws(() => new Blob(['test', 1]), {
   const b = new Blob(['hello'], { type: '\x01' });
   assert.strictEqual(b.type, '');
 }
+
+{
+  const descriptor =
+      Object.getOwnPropertyDescriptor(Blob.prototype, Symbol.toStringTag);
+  assert.deepStrictEqual(descriptor, {
+    configurable: true,
+    enumerable: false,
+    value: 'Blob',
+    writable: false
+  });
+}


### PR DESCRIPTION
This commit adds the `toStringTag` to the `Blob` class to match the behavior of Chrome and Firefox.

Fixes: https://github.com/nodejs/node/issues/37337