### PR TITLE
doc: apply sentence-consistently in C++ style guide

### DIFF
--- a/doc/guides/cpp-style-guide.md
+++ b/doc/guides/cpp-style-guide.md
@@ -1,11 +1,11 @@
-# C++ Style Guide
+# C++ style guide
 
 See also the [C++ codebase README](../../src/README.md) for C++ idioms in the
 Node.js codebase not related to stylistic issues.
 
-## Table of Contents
+## Table of contents
 
-* [Guides and References](#guides-and-references)
+* [Guides and references](#guides-and-references)
 * [Formatting](#formatting)
   * [Left-leaning (C++ style) asterisks for pointer declarations](#left-leaning-c-style-asterisks-for-pointer-declarations)
   * [C++ style comments](#c-style-comments)
@@ -18,11 +18,11 @@ Node.js codebase not related to stylistic issues.
   * [`snake_case_` for private class fields](#snake_case_-for-private-class-fields)
   * [`snake_case` for C-like structs](#snake_case-for-c-like-structs)
   * [Space after `template`](#space-after-template)
-* [Memory Management](#memory-management)
+* [Memory management](#memory-management)
   * [Memory allocation](#memory-allocation)
   * [Use `nullptr` instead of `NULL` or `0`](#use-nullptr-instead-of-null-or-0)
   * [Use explicit pointer comparisons](#use-explicit-pointer-comparisons)
-  * [Ownership and Smart Pointers](#ownership-and-smart-pointers)
+  * [Ownership and smart pointers](#ownership-and-smart-pointers)
   * [Avoid non-const references](#avoid-non-const-references)
   * [Use AliasedBuffers to manipulate TypedArrays](#use-aliasedbuffers-to-manipulate-typedarrays)
 * [Others](#others)
@@ -32,7 +32,7 @@ Node.js codebase not related to stylistic issues.
   * [Avoid throwing JavaScript errors in C++ methods](#avoid-throwing-javascript-errors-in-c)
     * [Avoid throwing JavaScript errors in nested C++ methods](#avoid-throwing-javascript-errors-in-nested-c-methods)
 
-## Guides and References
+## Guides and references
 
 The Node.js C++ codebase strives to be consistent in its use of language
 features and idioms, as well as have some specific guidelines for the use of
@@ -191,7 +191,7 @@ class FancyContainer {
 }
 ```
 
-## Memory Management
+## Memory management
 
 ### Memory allocation
 
@@ -208,7 +208,7 @@ Use explicit comparisons to `nullptr` when testing pointers, i.e.
 `if (foo == nullptr)` instead of `if (foo)` and
 `foo != nullptr` instead of `!foo`.
 
-### Ownership and Smart Pointers
+### Ownership and smart pointers
 
 * [R.20][]: Use `std::unique_ptr` or `std::shared_ptr` to represent ownership
 * [R.21][]: Prefer `unique_ptr` over `shared_ptr` unless you need to share


### PR DESCRIPTION
Use sentence case for headers consistently. This makes the document
internally consistent and also aligns it with our docs generally and the
style guide we use for docs.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
