### PR TITLE
stream: add AbortSignal support to promisified pipeline

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1719,7 +1719,11 @@ pipeline(
 );
 ```
 
-The `pipeline` API provides promise version:
+The `pipeline` API provides a promise version, which can also
+receive an options argument as the last parameter with a
+`signal` {AbortSignal} property. When the signal is aborted,
+`destroy` will be called on the underlying pipeline, with an
+`AbortError`.
 
 ```js
 const { pipeline } = require('stream/promises');
@@ -1734,6 +1738,30 @@ async function run() {
 }
 
 run().catch(console.error);
+```
+
+To use an `AbortSignal`, pass it inside an options object,
+as the last argument:
+
+```js
+const { pipeline } = require('stream/promises');
+
+async function run() {
+  const ac = new AbortController();
+  const options = {
+    signal: ac.signal,
+  };
+
+  setTimeout(() => ac.abort(), 1);
+  await pipeline(
+    fs.createReadStream('archive.tar'),
+    zlib.createGzip(),
+    fs.createWriteStream('archive.tar.gz'),
+    options,
+  );
+}
+
+run().catch(console.error); // AbortError
 ```
 
 The `pipeline` API also supports async generators:

--- a/lib/stream/promises.js
+++ b/lib/stream/promises.js
@@ -1,22 +1,65 @@
 'use strict';
 
 const {
+  ArrayPrototypePop,
   Promise,
+  SymbolAsyncIterator,
+  SymbolIterator,
 } = primordials;
+
+const {
+  addAbortSignalNoValidate,
+} = require('internal/streams/add-abort-signal');
+
+const {
+  validateAbortSignal,
+} = require('internal/validators');
 
 let pl;
 let eos;
 
+function isReadable(obj) {
+  return !!(obj && typeof obj.pipe === 'function');
+}
+
+function isWritable(obj) {
+  return !!(obj && typeof obj.write === 'function');
+}
+
+function isStream(obj) {
+  return isReadable(obj) || isWritable(obj);
+}
+
+function isIterable(obj, isAsync) {
+  if (!obj) return false;
+  if (isAsync === true) return typeof obj[SymbolAsyncIterator] === 'function';
+  if (isAsync === false) return typeof obj[SymbolIterator] === 'function';
+  return typeof obj[SymbolAsyncIterator] === 'function' ||
+    typeof obj[SymbolIterator] === 'function';
+}
+
 function pipeline(...streams) {
   if (!pl) pl = require('internal/streams/pipeline');
   return new Promise((resolve, reject) => {
-    pl(...streams, (err, value) => {
+    let signal;
+    const lastArg = streams[streams.length - 1];
+    if (lastArg && typeof lastArg === 'object' &&
+        !isStream(lastArg) && !isIterable(lastArg)) {
+      const options = ArrayPrototypePop(streams);
+      signal = options.signal;
+      validateAbortSignal(signal, 'options.signal');
+    }
+
+    const pipe = pl(...streams, (err, value) => {
       if (err) {
         reject(err);
       } else {
         resolve(value);
       }
     });
+    if (signal) {
+      addAbortSignalNoValidate(signal, pipe);
+    }
   });
 }
 


### PR DESCRIPTION
This PR adds support for AbortSignal to promisified pipeline (in `stream/promises`)

This resolves #37321. 

As an aside, this wouldn't be hard to actually push it into pipeline itself and support it in the regular version, however it's already pretty simple to just call `addAbortSignal` from `stream` on the received pipeline.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x]  commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
