### PR TITLE
errors: remove experimental from --enable-source-maps

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -194,12 +194,15 @@ Enable FIPS-compliant crypto at startup. (Requires Node.js to be built with
 added: v12.12.0
 -->
 
-> Stability: 1 - Experimental
+Enable [Source Map v3][] support for stack traces.
 
-Enable experimental Source Map v3 support for stack traces.
+When using a transpiler, such as TypeScript, strack traces thrown by an
+application reference the transpiled code, not the original source position.
+`--enable-source-maps` enables caching of [Source Maps][] and makes a best
+effort to report stack traces relative to the original source file.
 
-Currently, overriding `Error.prepareStackTrace` is ignored when the
-`--enable-source-maps` flag is set.
+Overriding `Error.prepareStackTrace` prevents `--enable-source-maps` from
+modifiying the stack trace.
 
 ### `--experimental-abortcontroller`
 <!-- YAML
@@ -1699,6 +1702,8 @@ $ node --max-old-space-size=1536 index.js
 [`NODE_OPTIONS`]: #cli_node_options_options
 [`SlowBuffer`]: buffer.md#buffer_class_slowbuffer
 [`process.setUncaughtExceptionCaptureCallback()`]: process.md#process_process_setuncaughtexceptioncapturecallback_fn
+[Source Maps]: https://sourcemaps.info/spec.html
+[Source Map v3]: https://sourcemaps.info/spec.html
 [`tls.DEFAULT_MAX_VERSION`]: tls.md#tls_tls_default_max_version
 [`tls.DEFAULT_MIN_VERSION`]: tls.md#tls_tls_default_min_version
 [`unhandledRejection`]: process.md#process_event_unhandledrejection

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -198,7 +198,7 @@ changes:
     description: remove note about experimental status.
 -->
 
-Enable [Source Map v3][] support for stack traces.
+Enable [Source Map v3][Source Map] support for stack traces.
 
 When using a transpiler, such as TypeScript, strack traces thrown by an
 application reference the transpiled code, not the original source position.
@@ -1697,7 +1697,6 @@ $ node --max-old-space-size=1536 index.js
 [REPL]: repl.md
 [ScriptCoverage]: https://chromedevtools.github.io/devtools-protocol/tot/Profiler#type-ScriptCoverage
 [Source Map]: https://sourcemaps.info/spec.html
-[Source Map v3]: https://sourcemaps.info/spec.html
 [Subresource Integrity]: https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity
 [V8 JavaScript code coverage]: https://v8project.blogspot.com/2017/12/javascript-code-coverage.html
 [`--openssl-config`]: #cli_openssl_config_file

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -195,7 +195,7 @@ added: v12.12.0
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/37362
-    description: remove note about experimental status.
+    description: This API is no longer experimental.
 -->
 
 Enable [Source Map v3][Source Map] support for stack traces.

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -202,7 +202,7 @@ Enable [Source Map v3][] support for stack traces.
 
 When using a transpiler, such as TypeScript, strack traces thrown by an
 application reference the transpiled code, not the original source position.
-`--enable-source-maps` enables caching of [Source Maps][] and makes a best
+`--enable-source-maps` enables caching of Source Maps and makes a best
 effort to report stack traces relative to the original source file.
 
 Overriding `Error.prepareStackTrace` prevents `--enable-source-maps` from
@@ -1697,6 +1697,7 @@ $ node --max-old-space-size=1536 index.js
 [REPL]: repl.md
 [ScriptCoverage]: https://chromedevtools.github.io/devtools-protocol/tot/Profiler#type-ScriptCoverage
 [Source Map]: https://sourcemaps.info/spec.html
+[Source Map v3]: https://sourcemaps.info/spec.html
 [Subresource Integrity]: https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity
 [V8 JavaScript code coverage]: https://v8project.blogspot.com/2017/12/javascript-code-coverage.html
 [`--openssl-config`]: #cli_openssl_config_file
@@ -1705,8 +1706,6 @@ $ node --max-old-space-size=1536 index.js
 [`CRYPTO_secure_malloc_init`]: https://www.openssl.org/docs/man1.1.0/man3/CRYPTO_secure_malloc_init.html
 [`NODE_OPTIONS`]: #cli_node_options_options
 [`SlowBuffer`]: buffer.md#buffer_class_slowbuffer
-[Source Map v3]: https://sourcemaps.info/spec.html
-[Source Maps]: https://sourcemaps.info/spec.html
 [`process.setUncaughtExceptionCaptureCallback()`]: process.md#process_process_setuncaughtexceptioncapturecallback_fn
 [`tls.DEFAULT_MAX_VERSION`]: tls.md#tls_tls_default_max_version
 [`tls.DEFAULT_MIN_VERSION`]: tls.md#tls_tls_default_min_version

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -192,6 +192,10 @@ Enable FIPS-compliant crypto at startup. (Requires Node.js to be built with
 ### `--enable-source-maps`
 <!-- YAML
 added: v12.12.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/37362
+    description: remove note about experimental status.
 -->
 
 Enable [Source Map v3][] support for stack traces.

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1705,9 +1705,9 @@ $ node --max-old-space-size=1536 index.js
 [`CRYPTO_secure_malloc_init`]: https://www.openssl.org/docs/man1.1.0/man3/CRYPTO_secure_malloc_init.html
 [`NODE_OPTIONS`]: #cli_node_options_options
 [`SlowBuffer`]: buffer.md#buffer_class_slowbuffer
-[`process.setUncaughtExceptionCaptureCallback()`]: process.md#process_process_setuncaughtexceptioncapturecallback_fn
-[Source Maps]: https://sourcemaps.info/spec.html
 [Source Map v3]: https://sourcemaps.info/spec.html
+[Source Maps]: https://sourcemaps.info/spec.html
+[`process.setUncaughtExceptionCaptureCallback()`]: process.md#process_process_setuncaughtexceptioncapturecallback_fn
 [`tls.DEFAULT_MAX_VERSION`]: tls.md#tls_tls_default_max_version
 [`tls.DEFAULT_MIN_VERSION`]: tls.md#tls_tls_default_min_version
 [`unhandledRejection`]: process.md#process_event_unhandledrejection


### PR DESCRIPTION
`--enable-source-maps` has been a feature since `v12.12.0` and is at a point where I would be comfortable calling the functionality stable.

Why I think this is a good call:

* there are [hundreds of folks](https://github.com/search?q=%22--enable-source-maps%22&type=code) setting the flag already on GitHub -- dropping the experimental should drive even more adoption.
* I believe we've addressed most major outstanding bugs -- there's room for improvements, i.e., [adding tests for worker threads](https://github.com/nodejs/node/issues/34898), [making them work in a REPL](https://github.com/nodejs/node/issues/29865), but I think this work is additive.
* #37252 addresses the concerns I had around our stack trace format not aligning with standards work that's happening.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

CC: @ljharb 
