### PR TITLE
test: fix flaky test-webcrypto-encrypt-decrypt-aes

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -27,8 +27,6 @@ test-worker-memory: PASS,FLAKY
 test-worker-message-port-transfer-terminate: PASS,FLAKY
 
 [$system==linux]
-# https://github.com/nodejs/node/issues/35586
-test-webcrypto-encrypt-decrypt-aes: PASS,FLAKY
 
 [$system==macos]
 

--- a/test/parallel/test-webcrypto-encrypt-decrypt-aes.js
+++ b/test/parallel/test-webcrypto-encrypt-decrypt-aes.js
@@ -96,10 +96,12 @@ async function testDecrypt({ keyBuffer, algorithm, result }) {
     const variations = [];
 
     passing.forEach((vector) => {
-      variations.push(testEncrypt(vector));
-      variations.push(testEncryptNoEncrypt(vector));
-      variations.push(testEncryptNoDecrypt(vector));
-      variations.push(testEncryptWrongAlg(vector, 'AES-CTR'));
+      variations.push(testEncrypt(Object.assign({}, vector)));
+      variations.push(testEncryptNoEncrypt(Object.assign({}, vector)));
+      variations.push(testEncryptNoDecrypt(Object.assign({}, vector)));
+      variations.push(
+        testEncryptWrongAlg(Object.assign({}, vector), 'AES-CTR')
+      );
     });
 
     failing.forEach((vector) => {


### PR DESCRIPTION
Use Object.assign() to make shallow copies of the object passed to the
test functions. The test functions are passed to Promise.all() so
execution order is not guaranteed. So using the same object in all of
them is a race condition where one test can have side effects in
another.

Fixes: https://github.com/nodejs/node/issues/35586

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
