### PR TITLE
module: Unflag JSON modules

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -222,13 +222,6 @@ added:
 
 Enable experimental `import.meta.resolve()` support.
 
-### `--experimental-json-modules`
-<!-- YAML
-added: v12.9.0
--->
-
-Enable experimental JSON support for the ES Module loader.
-
 ### `--experimental-loader=module`
 <!-- YAML
 added: v9.0.0

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -5,6 +5,9 @@
 <!-- YAML
 added: v8.5.0
 changes:
+  - version: REPLACEME
+    pr-url: https://githubcom/nodejs/node/pull/00000
+    description: Loading JSON modules no longer requires a command-line flag.
   - version:
     - v15.3.0
     pr-url: https://github.com/nodejs/node/pull/35781
@@ -422,21 +425,6 @@ These CommonJS variables are not available in ES modules.
 `__filename` and `__dirname` use cases can be replicated via
 [`import.meta.url`][].
 
-#### No JSON Module Loading
-
-JSON imports are still experimental and only supported via the
-`--experimental-json-modules` flag.
-
-Local JSON files can be loaded relative to `import.meta.url` with `fs` directly:
-
-<!-- eslint-skip -->
-```js
-import { readFile } from 'fs/promises';
-const json = JSON.parse(await readFile(new URL('./dat.json', import.meta.url)));
-```
-
-Alterantively `module.createRequire()` can be used.
-
 #### No Native Module Loading
 
 Native modules are not currently supported with ES module imports.
@@ -471,35 +459,35 @@ separate cache.
 <i id="esm_experimental_json_modules"></i>
 
 ## JSON modules
+<!--YAML
+added: v12.9.0
+changes:
+  - version: REPLACEME
+    pr-url: https://githubcom/nodejs/node/pull/00000
+    description: Loading JSON modules no longer requires a command-line flag.
+-->
 
 > Stability: 1 - Experimental
 
-Currently importing JSON modules are only supported in the `commonjs` mode
-and are loaded using the CJS loader. [WHATWG JSON modules specification][] are
-still being standardized, and are experimentally supported by including the
-additional flag `--experimental-json-modules` when running Node.js.
-
-When the `--experimental-json-modules` flag is included, both the
-`commonjs` and `module` mode use the new experimental JSON
-loader. The imported JSON only exposes a `default`. There is no
+The imported JSON only exposes a `default` export. There is no
 support for named exports. A cache entry is created in the CommonJS
 cache to avoid duplication. The same object is returned in
 CommonJS if the JSON module has already been imported from the
 same path.
 
-Assuming an `index.mjs` with
-
-<!-- eslint-skip -->
-```js
+```js esm
 import packageConfig from './package.json';
+const { version, name } = packageConfig;
+
+console.log(version);
 ```
 
-The `--experimental-json-modules` flag is needed for the module
-to work.
+```js cjs
+(async () => {
+  const { default: { version, name } } = await import('./package.json');
 
-```bash
-node index.mjs # fails
-node --experimental-json-modules index.mjs # works
+  console.log(version);
+})().catch(console.error);
 ```
 
 <i id="esm_experimental_wasm_modules"></i>

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -460,7 +460,7 @@ separate cache.
 
 ## JSON modules
 <!--YAML
-added: v12.9.0
+added: v12.0.0
 changes:
   - version: REPLACEME
     pr-url: https://githubcom/nodejs/node/pull/00000

--- a/lib/internal/modules/esm/get_format.js
+++ b/lib/internal/modules/esm/get_format.js
@@ -6,7 +6,6 @@ const {
 const { extname } = require('path');
 const { getOptionValue } = require('internal/options');
 
-const experimentalJsonModules = getOptionValue('--experimental-json-modules');
 const experimentalSpecifierResolution =
   getOptionValue('--experimental-specifier-resolution');
 const experimentalWasmModules = getOptionValue('--experimental-wasm-modules');
@@ -18,7 +17,8 @@ const extensionFormatMap = {
   '__proto__': null,
   '.cjs': 'commonjs',
   '.js': 'module',
-  '.mjs': 'module'
+  '.mjs': 'module',
+  '.json': 'json',
 };
 
 const legacyExtensionFormatMap = {
@@ -33,9 +33,6 @@ const legacyExtensionFormatMap = {
 if (experimentalWasmModules)
   extensionFormatMap['.wasm'] = legacyExtensionFormatMap['.wasm'] = 'wasm';
 
-if (experimentalJsonModules)
-  extensionFormatMap['.json'] = legacyExtensionFormatMap['.json'] = 'json';
-
 function defaultGetFormat(url, context, defaultGetFormatUnused) {
   if (StringPrototypeStartsWith(url, 'node:')) {
     return { format: 'builtin' };
@@ -49,7 +46,7 @@ function defaultGetFormat(url, context, defaultGetFormatUnused) {
     const format = ({
       '__proto__': null,
       'text/javascript': 'module',
-      'application/json': experimentalJsonModules ? 'json' : null,
+      'application/json': 'json',
       'application/wasm': experimentalWasmModules ? 'wasm' : null
     })[mime] || null;
     return { format };

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -303,8 +303,7 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             kAllowedInEnvironment);
   AddOption("--experimental-abortcontroller", "",
             NoOp{}, kAllowedInEnvironment);
-  AddOption("--experimental-json-modules",
-            "experimental JSON interop support for the ES Module loader",
+  AddOption("--experimental-json-modules", "",
             &EnvironmentOptions::experimental_json_modules,
             kAllowedInEnvironment);
   AddOption("--experimental-loader",

--- a/test/es-module/test-esm-non-js.js
+++ b/test/es-module/test-esm-non-js.js
@@ -1,21 +1,15 @@
 'use strict';
 
 const common = require('../common');
-const { spawn } = require('child_process');
+const fixtures = require('../common/fixtures');
+
 const assert = require('assert');
+const { pathToFileURL } = require('url');
+const { Worker } = require('worker_threads');
 
-const entry = require.resolve('./test-esm-json.mjs');
-
-// Verify non-js extensions fail for ESM
-const child = spawn(process.execPath, [entry]);
-
-let stderr = '';
-child.stderr.setEncoding('utf8');
-child.stderr.on('data', (data) => {
-  stderr += data;
-});
-child.on('close', common.mustCall((code, signal) => {
-  assert.strictEqual(code, 1);
-  assert.strictEqual(signal, null);
-  assert.ok(stderr.indexOf('ERR_UNKNOWN_FILE_EXTENSION') !== -1);
+new Worker(new URL(
+  'data:text/javascript,' +
+  `import ${JSON.stringify(pathToFileURL(fixtures.path('altdocs.md')))};`
+)).on('error', common.mustCall((err) => {
+  assert.strictEqual(err.code, 'ERR_UNKNOWN_FILE_EXTENSION');
 }));


### PR DESCRIPTION
[JSON modules TC39 proposal](https://github.com/tc39/proposal-json-modules) has reached stage 3, this PR removes the experimental flag to use the feature. This PR doesn't implement https://github.com/tc39/proposal-import-assertions (which is still flagged in upstream V8); it should be backportable to LTS Release Lines.

//cc @nodejs/modules

Fixes: https://github.com/nodejs/node/issues/37141

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
