### PR TITLE
dgram: close and release handle in time

### DIFF
--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -180,7 +180,6 @@ function replaceHandle(self, newHandle) {
 
   // Replace the existing handle by the handle we got from primary.
   oldHandle.close();
-  oldHandle = null;
   state.handle = newHandle;
   // Check if the udp handle was connected and set the state accordingly
   if (isConnected(self))

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -170,7 +170,7 @@ function startListening(socket) {
 
 function replaceHandle(self, newHandle) {
   const state = self[kStateSymbol];
-  let oldHandle = state.handle;
+  const oldHandle = state.handle;
 
   // Set up the handle that we got from primary.
   newHandle.lookup = oldHandle.lookup;

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -170,7 +170,7 @@ function startListening(socket) {
 
 function replaceHandle(self, newHandle) {
   const state = self[kStateSymbol];
-  const oldHandle = state.handle;
+  let oldHandle = state.handle;
 
   // Set up the handle that we got from primary.
   newHandle.lookup = oldHandle.lookup;
@@ -180,6 +180,7 @@ function replaceHandle(self, newHandle) {
 
   // Replace the existing handle by the handle we got from primary.
   oldHandle.close();
+  oldHandle = null;
   state.handle = newHandle;
   // Check if the udp handle was connected and set the state accordingly
   if (isConnected(self))
@@ -356,7 +357,8 @@ Socket.prototype.bind = function(port_, address_ /* , callback */) {
         const ex = exceptionWithHostPort(err, 'bind', ip, port);
         state.bindState = BIND_STATE_UNBOUND;
         this.emit('error', ex);
-        // Todo: close?
+        state.handle.close();
+        state.handle = null;
         return;
       }
 


### PR DESCRIPTION
1. For 'lookup' function, when there's an error thrown out, 'state.handle' should be closed and released in time, because we don't need a useless handle when error is thrown out.
2. For 'replaceHandle', release the old handle in time.