### PR TITLE
test: fix flaky test-webcrypto-encrypt-decrypt-aes

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -27,8 +27,6 @@ test-worker-memory: PASS,FLAKY
 test-worker-message-port-transfer-terminate: PASS,FLAKY
 
 [$system==linux]
-# https://github.com/nodejs/node/issues/35586
-test-webcrypto-encrypt-decrypt-aes: PASS,FLAKY
 
 [$system==macos]
 

--- a/test/parallel/test-webcrypto-encrypt-decrypt-aes.js
+++ b/test/parallel/test-webcrypto-encrypt-decrypt-aes.js
@@ -9,6 +9,9 @@ const assert = require('assert');
 const { getRandomValues, subtle } = require('crypto').webcrypto;
 
 async function testEncrypt({ keyBuffer, algorithm, plaintext, result }) {
+  // using a copy of plaintext to prevent tampering of the original
+  plaintext = Buffer.from(plaintext);
+
   const key = await subtle.importKey(
     'raw',
     keyBuffer,
@@ -23,8 +26,10 @@ async function testEncrypt({ keyBuffer, algorithm, plaintext, result }) {
     Buffer.from(output).toString('hex'),
     Buffer.from(result).toString('hex'));
 
-  const check = await subtle.decrypt(algorithm, key, output);
-  output[0] = 255 - output[0];
+  // converting the returned ArrayBuffer into a Buffer right away,
+  // so that the next line works
+  const check = Buffer.from(await subtle.decrypt(algorithm, key, output));
+  check[0] = 255 - check[0];
 
   assert.strictEqual(
     Buffer.from(check).toString('hex'),

--- a/test/parallel/test-webcrypto-encrypt-decrypt-aes.js
+++ b/test/parallel/test-webcrypto-encrypt-decrypt-aes.js
@@ -9,7 +9,7 @@ const assert = require('assert');
 const { getRandomValues, subtle } = require('crypto').webcrypto;
 
 async function testEncrypt({ keyBuffer, algorithm, plaintext, result }) {
-  // using a copy of plaintext to prevent tampering of the original
+  // Using a copy of plaintext to prevent tampering of the original
   plaintext = Buffer.from(plaintext);
 
   const key = await subtle.importKey(
@@ -26,7 +26,7 @@ async function testEncrypt({ keyBuffer, algorithm, plaintext, result }) {
     Buffer.from(output).toString('hex'),
     Buffer.from(result).toString('hex'));
 
-  // converting the returned ArrayBuffer into a Buffer right away,
+  // Converting the returned ArrayBuffer into a Buffer right away,
   // so that the next line works
   const check = Buffer.from(await subtle.decrypt(algorithm, key, output));
   check[0] = 255 - check[0];


### PR DESCRIPTION
* Use a copy of `plaintext` to prevent tampering of the original
* Since `subtle.decrypt` returns a `Promise` containing an `ArrayBuffer` and
  `ArrayBuffer`s cannot be modified directly, create a `Buffer` from it
  right away so that the modification in the next line works as intended

Fixes: https://github.com/nodejs/node/issues/35586

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
