### PR TITLE
test: clarify usage of tmpdir.refresh()

### DIFF
--- a/test/common/README.md
+++ b/test/common/README.md
@@ -945,12 +945,17 @@ The realpath of the testing temporary directory.
 
 Deletes and recreates the testing temporary directory.
 
-The first time `refresh()` runs,  it adds a listener to process `'exit'` that
+The first time `refresh()` runs, it adds a listener to process `'exit'` that
 cleans the temporary directory. Thus, every file under `tmpdir.path` needs to
 be closed before the test completes. A good way to do this is to add a
 listener to process `'beforeExit'`. If a file needs to be left open until
 Node.js completes, use a child process and call `refresh()` only in the
 parent.
+
+It is usually only necessary to call `refresh()` once in a test file.
+Avoid calling it more than once in an asynchronous context as one call
+might refresh the temporary directory of a different context, causing
+the test to fail somewhat mysteriously.
 
 ## UDP pair helper
 


### PR DESCRIPTION
This emphasizes that `tmpdir.refresh()` must be called only once in each
test file when needed.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
