### PR TITLE
fs: use createDeferredPromise() in promises.watch()

### DIFF
--- a/lib/internal/fs/watchers.js
+++ b/lib/internal/fs/watchers.js
@@ -4,7 +4,6 @@ const {
   FunctionPrototypeCall,
   ObjectDefineProperty,
   ObjectSetPrototypeOf,
-  Promise,
   Symbol,
 } = primordials;
 
@@ -15,6 +14,7 @@ const {
     ERR_INVALID_ARG_VALUE,
   },
 } = require('internal/errors');
+const { createDeferredPromise } = require('internal/util');
 
 const {
   kFsStatsFieldsNumber,
@@ -319,21 +319,14 @@ async function* watch(filename, options = {}) {
     throw new AbortError();
 
   const handle = new FSEvent();
-  let res;
-  let rej;
+  let { promise, resolve, reject } = createDeferredPromise();
   const oncancel = () => {
     handle.close();
-    rej(new AbortError());
+    reject(new AbortError());
   };
 
   try {
     signal?.addEventListener('abort', oncancel, { once: true });
-
-    let promise = new Promise((resolve, reject) => {
-      res = resolve;
-      rej = reject;
-    });
-
     handle.onchange = (status, eventType, filename) => {
       if (status < 0) {
         const error = uvException({
@@ -343,11 +336,11 @@ async function* watch(filename, options = {}) {
         });
         error.filename = filename;
         handle.close();
-        rej(error);
+        reject(error);
         return;
       }
 
-      res({ eventType, filename });
+      resolve({ eventType, filename });
     };
 
     const err = handle.start(path, persistent, recursive, encoding);
@@ -366,10 +359,7 @@ async function* watch(filename, options = {}) {
 
     while (!signal?.aborted) {
       yield await promise;
-      promise = new Promise((resolve, reject) => {
-        res = resolve;
-        rej = reject;
-      });
+      ({ promise, resolve, reject } = createDeferredPromise());
     }
     throw new AbortError();
   } finally {


### PR DESCRIPTION
This commit updates `fsPromises.watch()` to use the `createDeferredPromise()` utility.