### PR TITLE
doc: use **Default:** more consistently

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -207,8 +207,8 @@ added:
   - v12.19.0
 -->
 
-* `fn` {Function} **Default** A no-op function.
-* `exact` {number} **Default** `1`.
+* `fn` {Function} **Default:** A no-op function.
+* `exact` {number} **Default:** `1`.
 * Returns: {Function} that wraps `fn`.
 
 The wrapper function is expected to be called exactly `exact` times. If the

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -307,7 +307,7 @@ added: v15.7.0
   any mix of such objects, that will be stored within the `Blob`.
 * `options` {Object}
   * `encoding` {string} The character encoding to use for string sources.
-    **Default**: `'utf8'`.
+    **Default:** `'utf8'`.
   * `type` {string} The Blob content-type. The intent is for `type` to convey
     the MIME media type of the data, however no validation of the type format
     is performed.

--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -423,7 +423,7 @@ added: v0.9.12
 -->
 
 * `signal` {string} Name of the kill signal to send to the worker
-  process. **Default**: `'SIGTERM'`
+  process. **Default:** `'SIGTERM'`
 
 This function will kill the worker. In the primary, it does this
 by disconnecting the `worker.process`, and once disconnected, killing

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1741,11 +1741,11 @@ added: v15.6.0
 
 * `email` {string}
 * `options` {Object}
-  * `subject` {string} `'always'` or `'never'`. **Defaults**: `'always'`.
-  * `wildcards` {boolean} **Defaults**: `true`.
-  * `partialWildcards` {boolean} **Defaults**: `true`.
-  * `multiLabelWildcards` {boolean} **Defaults**: `false`.
-  * `singleLabelSubdomains` {boolean} **Defaults**: `false`.
+  * `subject` {string} `'always'` or `'never'`. **Default:** `'always'`.
+  * `wildcards` {boolean} **Default:** `true`.
+  * `partialWildcards` {boolean} **Default:** `true`.
+  * `multiLabelWildcards` {boolean} **Default:** `false`.
+  * `singleLabelSubdomains` {boolean} **Default:** `false`.
 * Returns: {string|undefined} Returns `email` if the certificate matches,
   `undefined` if it does not.
 
@@ -1758,11 +1758,11 @@ added: v15.6.0
 
 * `name` {string}
 * `options` {Object}
-  * `subject` {string} `'always'` or `'never'`. **Defaults**: `'always'`.
-  * `wildcards` {boolean} **Defaults**: `true`.
-  * `partialWildcards` {boolean} **Defaults**: `true`.
-  * `multiLabelWildcards` {boolean} **Defaults**: `false`.
-  * `singleLabelSubdomains` {boolean} **Defaults**: `false`.
+  * `subject` {string} `'always'` or `'never'`. **Default:** `'always'`.
+  * `wildcards` {boolean} **Default:** `true`.
+  * `partialWildcards` {boolean} **Default:** `true`.
+  * `multiLabelWildcards` {boolean} **Default:** `false`.
+  * `singleLabelSubdomains` {boolean} **Default:** `false`.
 * Returns: {string|undefined} Returns `name` if the certificate matches,
   `undefined` if it does not.
 
@@ -1775,11 +1775,11 @@ added: v15.6.0
 
 * `ip` {string}
 * `options` {Object}
-  * `subject` {string} `'always'` or `'never'`. **Defaults**: `'always'`.
-  * `wildcards` {boolean} **Defaults**: `true`.
-  * `partialWildcards` {boolean} **Defaults**: `true`.
-  * `multiLabelWildcards` {boolean} **Defaults**: `false`.
-  * `singleLabelSubdomains` {boolean} **Defaults**: `false`.
+  * `subject` {string} `'always'` or `'never'`. **Default:** `'always'`.
+  * `wildcards` {boolean} **Default:** `true`.
+  * `partialWildcards` {boolean} **Default:** `true`.
+  * `multiLabelWildcards` {boolean} **Default:** `false`.
+  * `singleLabelSubdomains` {boolean} **Default:** `false`.
 * Returns: {string|undefined} Returns `ip` if the certificate matches,
   `undefined` if it does not.
 
@@ -2023,7 +2023,7 @@ added: v15.8.0
     is used that yields a false positive rate of at most 2<sup>-64</sup> for
     random input. Care must be used when selecting a number of checks. Refer
     to the OpenSSL documentation for the [`BN_is_prime_ex`][] function `nchecks`
-    options for more details. **Defaults**: `0`
+    options for more details. **Default:** `0`
 * `callback` {Function}
   * `err` {Error} Set to an {Error} object if an error occurred during check.
   * `result` {boolean} `true` if the candidate is a prime with an error
@@ -2045,7 +2045,7 @@ added: v15.8.0
     is used that yields a false positive rate of at most 2<sup>-64</sup> for
     random input. Care must be used when selecting a number of checks. Refer
     to the OpenSSL documentation for the [`BN_is_prime_ex`][] function `nchecks`
-    options for more details. **Defaults**: `0`
+    options for more details. **Default:** `0`
 * Returns: {boolean} `true` if the candidate is a prime with an error
   probability less than `0.25 ** options.checks`.
 
@@ -2799,7 +2799,7 @@ added: v15.8.0
 * `options` {Object}
   * `add` {ArrayBuffer|SharedArrayBuffer|TypedArray|Buffer|DataView|bigint}
   * `rem` {ArrayBuffer|SharedArrayBuffer|TypedArray|Buffer|DataView|bigint}
-  * `safe` {boolean} **Defaults**: `false`.
+  * `safe` {boolean} **Default:** `false`.
   * `bigint` {boolean} When `true`, the generated prime is returned
     as a `bigint`.
 * `callback` {Function}
@@ -2841,7 +2841,7 @@ added: v15.8.0
 * `options` {Object}
   * `add` {ArrayBuffer|SharedArrayBuffer|TypedArray|Buffer|DataView|bigint}
   * `rem` {ArrayBuffer|SharedArrayBuffer|TypedArray|Buffer|DataView|bigint}
-  * `safe` {boolean} **Defaults**: `false`.
+  * `safe` {boolean} **Default:** `false`.
   * `bigint` {boolean} When `true`, the generated prime is returned
     as a `bigint`.
 * Returns: {ArrayBuffer|bigint}
@@ -3583,7 +3583,7 @@ added:
   - v12.19.0
 -->
 
-* `min` {integer} Start of random range (inclusive). **Default**: `0`.
+* `min` {integer} Start of random range (inclusive). **Default:** `0`.
 * `max` {integer} End of random range (exclusive).
 * `callback` {Function} `function(err, n) {}`.
 
@@ -3626,7 +3626,7 @@ added: v15.6.0
     Node.js generates and caches enough
     random data to generate up to 128 random UUIDs. To generate a UUID
     without using the cache, set `disableEntropyCache` to `true`.
-    **Defaults**: `false`.
+    **Default:** `false`.
 * Returns: {string}
 
 Generates a random [RFC 4122][] Version 4 UUID.

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -70,7 +70,7 @@ added: v15.0.0
 -->
 
 * `address` {string} An IPv4 or IPv6 address.
-* `type` {string} Either `'ipv4'` or `'ipv6'`. **Default**: `'ipv4'`.
+* `type` {string} Either `'ipv4'` or `'ipv6'`. **Default:** `'ipv4'`.
 
 Adds a rule to block the given IP address.
 
@@ -81,7 +81,7 @@ added: v15.0.0
 
 * `start` {string} The starting IPv4 or IPv6 address in the range.
 * `end` {string} The ending IPv4 or IPv6 address in the range.
-* `type` {string} Either `'ipv4'` or `'ipv6'`. **Default**: `'ipv4'`.
+* `type` {string} Either `'ipv4'` or `'ipv6'`. **Default:** `'ipv4'`.
 
 Adds a rule to block a range of IP addresses from `start` (inclusive) to
 `end` (inclusive).
@@ -95,7 +95,7 @@ added: v15.0.0
 * `prefix` {number} The number of CIDR prefix bits. For IPv4, this
   must be a value between `0` and `32`. For IPv6, this must be between
   `0` and `128`.
-* `type` {string} Either `'ipv4'` or `'ipv6'`. **Default**: `'ipv4'`.
+* `type` {string} Either `'ipv4'` or `'ipv6'`. **Default:** `'ipv4'`.
 
 Adds a rule to block a range of IP addresses specified as a subnet mask.
 
@@ -105,7 +105,7 @@ added: v15.0.0
 -->
 
 * `address` {string} The IP address to check
-* `type` {string} Either `'ipv4'` or `'ipv6'`. **Default**: `'ipv4'`.
+* `type` {string} Either `'ipv4'` or `'ipv6'`. **Default:** `'ipv4'`.
 * Returns: {boolean}
 
 Returns `true` if the given IP address matches any of the rules added to the

--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -149,7 +149,7 @@ added: v10.10.0
 -->
 
 * `pid` {integer} The process ID to retrieve scheduling priority for.
-  **Default** `0`.
+  **Default:** `0`.
 * Returns: {integer}
 
 Returns the scheduling priority for the process specified by `pid`. If `pid` is
@@ -300,7 +300,7 @@ added: v10.10.0
 -->
 
 * `pid` {integer} The process ID to set scheduling priority for.
-  **Default** `0`.
+  **Default:** `0`.
 * `priority` {integer} The scheduling priority to assign to the process.
 
 Attempts to set the scheduling priority for the process specified by `pid`. If

--- a/doc/api/perf_hooks.md
+++ b/doc/api/perf_hooks.md
@@ -660,11 +660,11 @@ added: REPLACEME
 
 * `options` {Object}
   * `min` {number|bigint} The minimum recordable value. Must be an integer
-    value greater than 0. **Defaults**: `1`.
+    value greater than 0. **Default:** `1`.
   * `max` {number|bigint} The maximum recordable value. Must be an integer
-    value greater than `min`. **Defaults**: `Number.MAX_SAFE_INTEGER`.
+    value greater than `min`. **Default:** `Number.MAX_SAFE_INTEGER`.
   * `figures` {number} The number of accuracy digits. Must be a number between
-    `1` and `5`. **Defaults**: `3`.
+    `1` and `5`. **Default:** `3`.
 * Returns {RecordableHistogram}
 
 Returns a {RecordableHistogram}.

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1597,13 +1597,13 @@ changes:
 * `stream` {Stream} A readable and/or writable stream.
 * `options` {Object}
   * `error` {boolean} If set to `false`, then a call to `emit('error', err)` is
-    not treated as finished. **Default**: `true`.
+    not treated as finished. **Default:** `true`.
   * `readable` {boolean} When set to `false`, the callback will be called when
     the stream ends even though the stream might still be readable.
-    **Default**: `true`.
+    **Default:** `true`.
   * `writable` {boolean} When set to `false`, the callback will be called when
     the stream ends even though the stream might still be writable.
-    **Default**: `true`.
+    **Default:** `true`.
 * `callback` {Function} A callback function that takes an optional error
   argument.
 * Returns: {Function} A cleanup function which removes all registered

--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -197,7 +197,7 @@ added: v0.0.1
 
 * `callback` {Function} The function to call when the timer elapses.
 * `delay` {number} The number of milliseconds to wait before calling the
-  `callback`. **Default**: `1`.
+  `callback`. **Default:** `1`.
 * `...args` {any} Optional arguments to pass when the `callback` is called.
 * Returns: {Timeout} for use with [`clearInterval()`][]
 
@@ -215,7 +215,7 @@ added: v0.0.1
 
 * `callback` {Function} The function to call when the timer elapses.
 * `delay` {number} The number of milliseconds to wait before calling the
-  `callback`. **Default**: `1`.
+  `callback`. **Default:** `1`.
 * `...args` {any} Optional arguments to pass when the `callback` is called.
 * Returns: {Timeout} for use with [`clearTimeout()`][]
 
@@ -341,12 +341,12 @@ added: v15.0.0
 -->
 
 * `delay` {number} The number of milliseconds to wait before resolving the
-  `Promise`. **Default**: `1`.
+  `Promise`. **Default:** `1`.
 * `value` {any} A value with which the `Promise` is resolved.
 * `options` {Object}
   * `ref` {boolean} Set to `false` to indicate that the scheduled `Timeout`
     should not require the Node.js event loop to remain active.
-    **Default**: `true`.
+    **Default:** `true`.
   * `signal` {AbortSignal} An optional `AbortSignal` that can be used to
     cancel the scheduled `Timeout`.
 
@@ -359,7 +359,7 @@ added: v15.0.0
 * `options` {Object}
   * `ref` {boolean} Set to `false` to indicate that the scheduled `Immediate`
     should not require the Node.js event loop to remain active.
-    **Default**: `true`.
+    **Default:** `true`.
   * `signal` {AbortSignal} An optional `AbortSignal` that can be used to
     cancel the scheduled `Immediate`.
 
@@ -371,13 +371,13 @@ added: REPLACEME
 Returns an async iterator that generates values in an interval of `delay` ms.
 
 * `delay` {number} The number of milliseconds to wait between iterations.
-   **Default**: `1`.
+   **Default:** `1`.
 * `value` {any} A value with which the iterator returns.
 * `options` {Object}
   * `ref` {boolean} Set to `false` to indicate that the scheduled `Timeout`
     between iterations should not require the Node.js event loop to
     remain active.
-    **Default**: `true`.
+    **Default:** `true`.
   * `signal` {AbortSignal} An optional `AbortSignal` that can be used to
     cancel the scheduled `Timeout` between operations.
 

--- a/doc/api/webcrypto.md
+++ b/doc/api/webcrypto.md
@@ -985,7 +985,7 @@ added: v15.0.0
 
 * Type: {number} The size in bits of the generated authentication tag.
   This values must be one of `32`, `64`, `96`, `104`, `112`, `120`, or
-  `128`. **Default**: `128`.
+  `128`. **Default:** `128`.
 
 ### Class: `AesImportParams`
 <!-- YAML
@@ -1746,21 +1746,21 @@ added: v15.0.0
 -->
 
 * Type: {number} The CPU/memory cost parameter. Must e a power of two
-  greater than 1. **Default** `16384`.
+  greater than 1. **Default:** `16384`.
 
 ##### `nodeScryptParams.p`
 <!-- YAML
 added: v15.0.0
 -->
 
-* Type: {number} Parallelization parameter. **Default** `1`.
+* Type: {number} Parallelization parameter. **Default:** `1`.
 
 ##### `nodeScryptParams.r`
 <!-- YAML
 added: v15.0.0
 -->
 
-* Type: {number} Block size parameter. **Default**: `8`.
+* Type: {number} Block size parameter. **Default:** `8`.
 
 ##### `nodeScryptParams.salt`
 <!-- YAML

--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -862,7 +862,7 @@ changes:
     [`fs.close()`][], and closes them when the Worker exits, similar to other
     resources like network sockets or file descriptors managed through
     the [`FileHandle`][] API. This option is automatically inherited by all
-    nested `Worker`s. **Default**: `true`.
+    nested `Worker`s. **Default:** `true`.
   * `transferList` {Object[]} If one or more `MessagePort`-like objects
     are passed in `workerData`, a `transferList` is required for those
     items or [`ERR_MISSING_MESSAGE_PORT_IN_TRANSFER_LIST`][] is thrown.


### PR DESCRIPTION
It seems that `**Default:**` was unofficially decided on as the way to specify default values. This commit updates the API documentation to use this format more consistently.