### PR TITLE
lib: refactor to use validateAsyncCallback

### DIFF
--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -14,13 +14,13 @@ const {
 } = primordials;
 
 const {
-  ERR_ASYNC_CALLBACK,
   ERR_ASYNC_TYPE,
   ERR_INVALID_ASYNC_ID
 } = require('internal/errors').codes;
 const {
   validateFunction,
   validateString,
+  validateAsyncCallback,
 } = require('internal/validators');
 const internal_async_hooks = require('internal/async_hooks');
 
@@ -66,16 +66,11 @@ const {
 
 class AsyncHook {
   constructor({ init, before, after, destroy, promiseResolve }) {
-    if (init !== undefined && typeof init !== 'function')
-      throw new ERR_ASYNC_CALLBACK('hook.init');
-    if (before !== undefined && typeof before !== 'function')
-      throw new ERR_ASYNC_CALLBACK('hook.before');
-    if (after !== undefined && typeof after !== 'function')
-      throw new ERR_ASYNC_CALLBACK('hook.after');
-    if (destroy !== undefined && typeof destroy !== 'function')
-      throw new ERR_ASYNC_CALLBACK('hook.destroy');
-    if (promiseResolve !== undefined && typeof promiseResolve !== 'function')
-      throw new ERR_ASYNC_CALLBACK('hook.promiseResolve');
+    validateAsyncCallback(init, 'hook.init');
+    validateAsyncCallback(before, 'hook.before');
+    validateAsyncCallback(after, 'hook.after');
+    validateAsyncCallback(destroy, 'hook.destroy');
+    validateAsyncCallback(promiseResolve, 'hook.promiseResolve');
 
     this[init_symbol] = init;
     this[before_symbol] = before;

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -241,7 +241,7 @@ const validateFunction = hideStackFrames((value, name) => {
 });
 
 const validateAsyncCallback = hideStackFrames((value, name) => {
-  if (typeof value !== 'function')
+  if (value != undefined && typeof value !== 'function')
     throw new ERR_ASYNC_CALLBACK(name);
 });
 

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -24,6 +24,7 @@ const {
     ERR_OUT_OF_RANGE,
     ERR_UNKNOWN_SIGNAL,
     ERR_INVALID_CALLBACK,
+    ERR_ASYNC_CALLBACK,
   }
 } = require('internal/errors');
 const { normalizeEncoding } = require('internal/util');
@@ -239,6 +240,11 @@ const validateFunction = hideStackFrames((value, name) => {
     throw new ERR_INVALID_ARG_TYPE(name, 'Function', value);
 });
 
+const validateAsyncCallback = hideStackFrames((value, name) => {
+  if (typeof value !== 'function')
+    throw new ERR_ASYNC_CALLBACK(name);
+});
+
 module.exports = {
   isInt32,
   isUint32,
@@ -259,4 +265,5 @@ module.exports = {
   validateUint32,
   validateCallback,
   validateAbortSignal,
+  validateAsyncCallback
 };

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -241,7 +241,7 @@ const validateFunction = hideStackFrames((value, name) => {
 });
 
 const validateAsyncCallback = hideStackFrames((value, name) => {
-  if (value != undefined && typeof value !== 'function')
+  if (value !== undefined && typeof value !== 'function')
     throw new ERR_ASYNC_CALLBACK(name);
 });
 


### PR DESCRIPTION
We can refactor the constructor of AsyncHook class to make it more concise