### PR TITLE
module: improve support of data: URLs

### DIFF
--- a/lib/internal/modules/esm/get_source.js
+++ b/lib/internal/modules/esm/get_source.js
@@ -2,6 +2,7 @@
 
 const {
   RegExpPrototypeExec,
+  decodeURIComponent,
 } = primordials;
 const { getOptionValue } = require('internal/options');
 // Do not eagerly grab .manifest, it may be in TDZ
@@ -32,7 +33,7 @@ async function defaultGetSource(url, { format } = {}, defaultGetSource) {
       throw new ERR_INVALID_URL(url);
     }
     const { 1: base64, 2: body } = match;
-    source = Buffer.from(body, base64 ? 'base64' : 'utf8');
+    source = Buffer.from(decodeURIComponent(body), base64 ? 'base64' : 'utf8');
   } else {
     throw new ERR_INVALID_URL_SCHEME(['file', 'data']);
   }

--- a/test/es-module/test-esm-data-urls.js
+++ b/test/es-module/test-esm-data-urls.js
@@ -102,4 +102,9 @@ function createBase64URL(mime, body) {
       assert.strictEqual(e.code, 'ERR_INVALID_RETURN_PROPERTY_VALUE');
     }
   }
+  {
+    const plainESMURL = 'data:text/javascript,export%20default%202';
+    const module = await import(plainESMURL);
+    assert.strictEqual(module.default, 2);
+  }
 })().then(common.mustCall());


### PR DESCRIPTION
Add support for loading modules using percent-encoded URLs.

This makes Node.js implementation closer to the browsers' one. On the browser the following snippet prints `Hello, World!` to the console:

```js
import("data:text/javascript,console.log%28%27Hello%2C%20World%21%27%29%3B");
```

On Node.js, it thorws an error: `SyntaxError: Invalid or unexpected token`. This PR fixes that.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
