### PR TITLE
fs: fix pre-aborted writeFile AbortSignal file leak

### DIFF
--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -66,6 +66,7 @@ const {
 const { opendir } = require('internal/fs/dir');
 const {
   parseFileMode,
+  validateAbortSignal,
   validateBoolean,
   validateBuffer,
   validateInteger,
@@ -668,14 +669,17 @@ async function writeFile(path, data, options) {
     data = Buffer.from(data, options.encoding || 'utf8');
   }
 
+  validateAbortSignal(options.signal);
   if (path instanceof FileHandle)
     return writeFileHandle(path, data, options.signal);
 
-  const fd = await open(path, flag, options.mode);
   if (options.signal?.aborted) {
     throw lazyDOMException('The operation was aborted', 'AbortError');
   }
-  return PromisePrototypeFinally(writeFileHandle(fd, data), fd.close);
+
+  const fd = await open(path, flag, options.mode);
+  const { signal } = options;
+  return PromisePrototypeFinally(writeFileHandle(fd, data, signal), fd.close);
 }
 
 async function appendFile(path, data, options) {
@@ -691,6 +695,10 @@ async function readFile(path, options) {
 
   if (path instanceof FileHandle)
     return readFileHandle(path, options);
+
+  if (options.signal?.aborted) {
+    throw lazyDOMException('The operation was aborted', 'AbortError');
+  }
 
   const fd = await open(path, flag, 0o666);
   return PromisePrototypeFinally(readFileHandle(fd, options), fd.close);


### PR DESCRIPTION
This fixes an issue in `promises.writeFile` where a file is opened, and not closed if the abort signal is aborted before/during the file was opened. 

A minor thing is that `fd.close` can still throw, I'm not sure if it's an issue or not.

In addition I also added validation for the AbortSignal, and a check where if the signal was _already_ aborted, the file won't be opened at all.

- [] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x]  commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)