### PR TITLE
fs: fix writeFile AbortSignal does not close file

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -342,6 +342,11 @@ function readFile(path, options, callback) {
     return;
   }
 
+  if (options.signal?.aborted) {
+    callback(lazyDOMException('The operation was aborted', 'AbortError'));
+    return;
+  }
+
   const flagsNumber = stringToFlags(options.flag);
   path = getValidatedPath(path);
 
@@ -1453,7 +1458,13 @@ function lutimesSync(path, atime, mtime) {
 
 function writeAll(fd, isUserFd, buffer, offset, length, signal, callback) {
   if (signal?.aborted) {
-    callback(lazyDOMException('The operation was aborted', 'AbortError'));
+    if (isUserFd) {
+      callback(lazyDOMException('The operation was aborted', 'AbortError'));
+    } else {
+      fs.close(fd, function() {
+        callback(lazyDOMException('The operation was aborted', 'AbortError'));
+      });
+    }
     return;
   }
   // write(fd, buffer, offset, length, position, callback)


### PR DESCRIPTION
This PR fixes an issue where the callback-style writeFile does not close the fd when the AbortSignal is aborted
(readFile handles this correctly).

I've also "optimized" the read-path to not open the file if the signal is aborted before the file is even opened.

(this PR is different than my other PR, which fixed an issue in promisified writeFile)

- [] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [] tests and/or benchmarks are included
- [] documentation is changed or added
- [x]  commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)