### PR TITLE
lib: refactor Timeout, ImmediateList, TimersList to class

### DIFF
--- a/lib/internal/timers.js
+++ b/lib/internal/timers.js
@@ -136,9 +136,6 @@ let timerListId = NumberMIN_SAFE_INTEGER;
 
 const kRefed = Symbol('refed');
 
-// Create a single linked list instance only once at startup
-const immediateQueue = new ImmediateList();
-
 let nextExpiry = Infinity;
 let refCount = 0;
 
@@ -161,140 +158,148 @@ function initAsyncResource(resource, type) {
   if (initHooksExist())
     emitInit(asyncId, type, triggerAsyncId, resource);
 }
-
-// Timer constructor function.
-// The entire prototype is defined in lib/timers.js
-function Timeout(callback, after, args, isRepeat, isRefed) {
-  after *= 1; // Coalesce to number or NaN
-  if (!(after >= 1 && after <= TIMEOUT_MAX)) {
-    if (after > TIMEOUT_MAX) {
-      process.emitWarning(`${after} does not fit into` +
-                          ' a 32-bit signed integer.' +
-                          '\nTimeout duration was set to 1.',
-                          'TimeoutOverflowWarning');
+class Timeout {
+  // Timer constructor function.
+  // The entire prototype is defined in lib/timers.js
+  constructor(callback, after, args, isRepeat, isRefed) {
+    after *= 1; // Coalesce to number or NaN
+    if (!(after >= 1 && after <= TIMEOUT_MAX)) {
+      if (after > TIMEOUT_MAX) {
+        process.emitWarning(`${after} does not fit into` +
+                            ' a 32-bit signed integer.' +
+                            '\nTimeout duration was set to 1.',
+                            'TimeoutOverflowWarning');
+      }
+      after = 1; // Schedule on next tick, follows browser behavior
     }
-    after = 1; // Schedule on next tick, follows browser behavior
-  }
 
-  this._idleTimeout = after;
-  this._idlePrev = this;
-  this._idleNext = this;
-  this._idleStart = null;
-  // This must be set to null first to avoid function tracking
-  // on the hidden class, revisit in V8 versions after 6.2
-  this._onTimeout = null;
-  this._onTimeout = callback;
-  this._timerArgs = args;
-  this._repeat = isRepeat ? after : null;
-  this._destroyed = false;
+    this._idleTimeout = after;
+    this._idlePrev = this;
+    this._idleNext = this;
+    this._idleStart = null;
+    // This must be set to null first to avoid function tracking
+    // on the hidden class, revisit in V8 versions after 6.2
+    this._onTimeout = null;
+    this._onTimeout = callback;
+    this._timerArgs = args;
+    this._repeat = isRepeat ? after : null;
+    this._destroyed = false;
 
-  if (isRefed)
-    incRefCount();
-  this[kRefed] = isRefed;
-  this[kHasPrimitive] = false;
-
-  initAsyncResource(this, 'Timeout');
-}
-
-// Make sure the linked list only shows the minimal necessary information.
-Timeout.prototype[inspect.custom] = function(_, options) {
-  return inspect(this, {
-    ...options,
-    // Only inspect one level.
-    depth: 0,
-    // It should not recurse.
-    customInspect: false
-  });
-};
-
-Timeout.prototype.refresh = function() {
-  if (this[kRefed])
-    active(this);
-  else
-    unrefActive(this);
-
-  return this;
-};
-
-Timeout.prototype.unref = function() {
-  if (this[kRefed]) {
-    this[kRefed] = false;
-    if (!this._destroyed)
-      decRefCount();
-  }
-  return this;
-};
-
-Timeout.prototype.ref = function() {
-  if (!this[kRefed]) {
-    this[kRefed] = true;
-    if (!this._destroyed)
+    if (isRefed)
       incRefCount();
+    this[kRefed] = isRefed;
+    this[kHasPrimitive] = false;
+
+    initAsyncResource(this, 'Timeout');
   }
-  return this;
-};
 
-Timeout.prototype.hasRef = function() {
-  return this[kRefed];
-};
+  // Make sure the linked list only shows the minimal necessary information.
+  [inspect.custom](_, options) {
+    return inspect(this, {
+      ...options,
+      // Only inspect one level.
+      depth: 0,
+      // It should not recurse.
+      customInspect: false
+    });
+  }
 
-function TimersList(expiry, msecs) {
-  this._idleNext = this; // Create the list with the linkedlist properties to
-  this._idlePrev = this; // Prevent any unnecessary hidden class changes.
-  this.expiry = expiry;
-  this.id = timerListId++;
-  this.msecs = msecs;
-  this.priorityQueuePosition = null;
+  refresh() {
+    if (this[kRefed])
+      active(this);
+    else
+      unrefActive(this);
+
+    return this;
+  }
+
+  unref() {
+    if (this[kRefed]) {
+      this[kRefed] = false;
+      if (!this._destroyed)
+        decRefCount();
+    }
+    return this;
+  }
+
+  ref() {
+    if (!this[kRefed]) {
+      this[kRefed] = true;
+      if (!this._destroyed)
+        incRefCount();
+    }
+    return this;
+  }
+
+  hasRef() {
+    return this[kRefed];
+  }
 }
 
-// Make sure the linked list only shows the minimal necessary information.
-TimersList.prototype[inspect.custom] = function(_, options) {
-  return inspect(this, {
-    ...options,
-    // Only inspect one level.
-    depth: 0,
-    // It should not recurse.
-    customInspect: false
-  });
-};
+class TimersList {
+  constructor(expiry, msecs) {
+    this._idleNext = this; // Create the list with the linkedlist properties to
+    this._idlePrev = this; // Prevent any unnecessary hidden class changes.
+    this.expiry = expiry;
+    this.id = timerListId++;
+    this.msecs = msecs;
+    this.priorityQueuePosition = null;
+  }
+
+  // Make sure the linked list only shows the minimal necessary information.
+  [inspect.custom](_, options) {
+    return inspect(this, {
+      ...options,
+      // Only inspect one level.
+      depth: 0,
+      // It should not recurse.
+      customInspect: false
+    });
+  }
+}
 
 // A linked list for storing `setImmediate()` requests
-function ImmediateList() {
-  this.head = null;
-  this.tail = null;
+class ImmediateList {
+  constructor() {
+    this.head = null;
+    this.tail = null;
+  }
+
+  // Appends an item to the end of the linked list, adjusting the current tail's
+  // next pointer and the item's previous pointer where applicable
+  append(item) {
+    if (this.tail !== null) {
+      this.tail._idleNext = item;
+      item._idlePrev = this.tail;
+    } else {
+      this.head = item;
+    }
+    this.tail = item;
+  }
+
+  // Removes an item from the linked list, adjusting the pointers of adjacent
+  // items and the linked list's head or tail pointers as necessary
+  remove(item) {
+    if (item._idleNext) {
+      item._idleNext._idlePrev = item._idlePrev;
+    }
+
+    if (item._idlePrev) {
+      item._idlePrev._idleNext = item._idleNext;
+    }
+
+    if (item === this.head)
+      this.head = item._idleNext;
+    if (item === this.tail)
+      this.tail = item._idlePrev;
+
+    item._idleNext = null;
+    item._idlePrev = null;
+  }
 }
 
-// Appends an item to the end of the linked list, adjusting the current tail's
-// next pointer and the item's previous pointer where applicable
-ImmediateList.prototype.append = function(item) {
-  if (this.tail !== null) {
-    this.tail._idleNext = item;
-    item._idlePrev = this.tail;
-  } else {
-    this.head = item;
-  }
-  this.tail = item;
-};
-
-// Removes an item from the linked list, adjusting the pointers of adjacent
-// items and the linked list's head or tail pointers as necessary
-ImmediateList.prototype.remove = function(item) {
-  if (item._idleNext) {
-    item._idleNext._idlePrev = item._idlePrev;
-  }
-
-  if (item._idlePrev) {
-    item._idlePrev._idleNext = item._idleNext;
-  }
-
-  if (item === this.head)
-    this.head = item._idleNext;
-  if (item === this.tail)
-    this.tail = item._idlePrev;
-
-  item._idleNext = null;
-  item._idlePrev = null;
-};
+// Create a single linked list instance only once at startup
+const immediateQueue = new ImmediateList();
 
 function incRefCount() {
   if (refCount++ === 0)


### PR DESCRIPTION
The prototype is old-style, refactor it to the ES6-class.

Special Note:
Line 139-140 was moved to Line 301-302 because class doesn't support `hoisting`

```js
// Create a single linked list instance only once at startup	
const immediateQueue = new ImmediateList();
```