### PR TITLE
fix: incorrect timers-promisified test case

### DIFF
--- a/test/parallel/test-timers-promisified.js
+++ b/test/parallel/test-timers-promisified.js
@@ -393,10 +393,11 @@ process.on('multipleResolves', common.mustNotCall());
   let pre = false;
   let post = false;
 
+  const time_unit = common.platformTimeout(50);
   Promise.all([
     setPromiseTimeout(1).then(() => pre = true),
     new Promise((res) => {
-      const iterable = timerPromises.setInterval(200);
+      const iterable = timerPromises.setInterval(time_unit * 2);
       const iterator = iterable[Symbol.asyncIterator]();
 
       iterator.next().then(() => {
@@ -408,6 +409,6 @@ process.on('multipleResolves', common.mustNotCall());
         return iterator.return();
       }).then(res);
     }),
-    setPromiseTimeout(300).then(() => post = true)
+    setPromiseTimeout(time_unit * 3).then(() => post = true)
   ]).then(common.mustCall());
 }

--- a/test/parallel/test-timers-promisified.js
+++ b/test/parallel/test-timers-promisified.js
@@ -399,7 +399,7 @@ process.on('multipleResolves', common.mustNotCall());
       const iterable = timerPromises.setInterval(200);
       const iterator = iterable[Symbol.asyncIterator]();
 
-      iterator.next().then(common.mustCall(() => {
+      iterator.next().then(() => {
         assert.ok(pre, 'interval ran too early');
         assert.ok(!post, 'interval ran too late');
         return iterator.next();

--- a/test/parallel/test-timers-promisified.js
+++ b/test/parallel/test-timers-promisified.js
@@ -394,9 +394,9 @@ process.on('multipleResolves', common.mustNotCall());
   let post = false;
 
   Promise.all([
-    setPromiseTimeout(10).then(() => pre = true),
+    setPromiseTimeout(100).then(() => pre = true),
     new Promise((res) => {
-      const iterable = setInterval(() => {}, 20);
+      const iterable = setInterval(() => {}, 200);
       const iterator = iterable[Symbol.asyncIterator]();
 
       iterator.next().then(common.mustCall(() => {
@@ -409,6 +409,6 @@ process.on('multipleResolves', common.mustNotCall());
         return iterator.return();
       }));
     }),
-    setPromiseTimeout(30).then(() => post = true)
-  ]);
+    setPromiseTimeout(300).then(() => post = true)
+  ]).then(common.mustCall());
 }

--- a/test/parallel/test-timers-promisified.js
+++ b/test/parallel/test-timers-promisified.js
@@ -403,7 +403,7 @@ process.on('multipleResolves', common.mustNotCall());
         assert.ok(pre, 'interval ran too early');
         assert.ok(!post, 'interval ran too late');
         return iterator.next();
-      })).then(common.mustCall(() => {
+      }).then(() => {
         assert.ok(post, 'second interval ran too early');
         return iterator.return();
       }).then(res);

--- a/test/parallel/test-timers-promisified.js
+++ b/test/parallel/test-timers-promisified.js
@@ -393,7 +393,7 @@ process.on('multipleResolves', common.mustNotCall());
   let pre = false;
   let post = false;
 
-  const time_unit = common.platformTimeout(50);
+  const time_unit = 50;
   Promise.all([
     setPromiseTimeout(1).then(() => pre = true),
     new Promise((res) => {

--- a/test/parallel/test-timers-promisified.js
+++ b/test/parallel/test-timers-promisified.js
@@ -405,9 +405,8 @@ process.on('multipleResolves', common.mustNotCall());
         return iterator.next();
       })).then(common.mustCall(() => {
         assert.ok(post, 'second interval ran too early');
-        res();
         return iterator.return();
-      }));
+      }).then(res);
     }),
     setPromiseTimeout(300).then(() => post = true)
   ]).then(common.mustCall());

--- a/test/parallel/test-timers-promisified.js
+++ b/test/parallel/test-timers-promisified.js
@@ -394,9 +394,9 @@ process.on('multipleResolves', common.mustNotCall());
   let post = false;
 
   Promise.all([
-    setPromiseTimeout(100).then(() => pre = true),
+    setPromiseTimeout(1).then(() => pre = true),
     new Promise((res) => {
-      const iterable = setInterval(() => {}, 200);
+      const iterable = timerPromises.setInterval(() => {}, 200);
       const iterator = iterable[Symbol.asyncIterator]();
 
       iterator.next().then(common.mustCall(() => {

--- a/test/parallel/test-timers-promisified.js
+++ b/test/parallel/test-timers-promisified.js
@@ -396,7 +396,7 @@ process.on('multipleResolves', common.mustNotCall());
   Promise.all([
     setPromiseTimeout(1).then(() => pre = true),
     new Promise((res) => {
-      const iterable = timerPromises.setInterval(() => {}, 200);
+      const iterable = timerPromises.setInterval(200);
       const iterator = iterable[Symbol.asyncIterator]();
 
       iterator.next().then(common.mustCall(() => {

--- a/test/parallel/test-timers-promisified.js
+++ b/test/parallel/test-timers-promisified.js
@@ -395,7 +395,7 @@ process.on('multipleResolves', common.mustNotCall());
 
   Promise.all([
     setPromiseTimeout(10).then(() => pre = true),
-    new Promise(res => {
+    new Promise((res) => {
       const iterable = setInterval(() => {}, 20);
       const iterator = iterable[Symbol.asyncIterator]();
 


### PR DESCRIPTION
This test case is incorrect, and it caused too many unit-test failures

https://ci.nodejs.org/job/node-test-commit-linuxone/nodes=rhel7-s390x/25697/testReport/
https://ci.nodejs.org/job/node-test-commit-linuxone/nodes=rhel7-s390x/25708/testReport/
...

You can see it in this page: https://ci.nodejs.org/job/node-test-commit-linuxone/nodes=rhel7-s390x/
This is probably caused by a wrong time-sequence execution order. I'm trying to work on this.

### Analysis
```js
  setPromiseTimeout(1).then(() => pre = true);  // L1
  const iterable = setInterval(() => {}, 2); // L2
  //...
  iterator.next().then(...); // L3
  setPromiseTimeout(3).then(() => post = true); // L4
```

Assume we execute this code at time 0
Time=0, FinishExecute=L1, callback L1 is queued to execute at Time=1
Time=1, FinishExecute=L2, callback L2 is queued to execute at Time=3, 5, 7, ...
Time=2, FinishExecute=L3
Time=11, FinishExecute=L4, callback L3 is queued to execute at Time=14

In this case, this unit test will throw an error `'second interval ran too early'`, but it is OK.

### My solution
First, the timeout is 10, 20, 30 to tolerate the time for code-execution
Second, use the `Promise.all` to wait for these three promises

I think it would work.

Fixes: https://github.com/nodejs/node/issues/37395