### PR TITLE
tools: use LDFLAGS_host for host toolset

### DIFF
--- a/tools/gyp/pylib/gyp/generator/ninja.py
+++ b/tools/gyp/pylib/gyp/generator/ninja.py
@@ -1427,7 +1427,11 @@ class NinjaWriter(object):
         is_executable = spec["type"] == "executable"
         # The ldflags config key is not used on mac or win. On those platforms
         # linker flags are set via xcode_settings and msvs_settings, respectively.
-        env_ldflags = os.environ.get("LDFLAGS", "").split()
+        if self.toolset == "target":
+            env_ldflags = os.environ.get("LDFLAGS", "").split()
+        elif self.toolset == "host":
+            env_ldflags = os.environ.get("LDFLAGS_host", "").split()
+
         if self.flavor == "mac":
             ldflags = self.xcode_settings.GetLdflags(
                 config_name,


### PR DESCRIPTION
This makes the behaviour similar to that of CFLAGS_host

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
