### PR TITLE
test: validate no debug info for http2

### DIFF
--- a/test/parallel/test-http2-clean-output.js
+++ b/test/parallel/test-http2-clean-output.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const {
+  hasCrypto,
+  mustCall,
+  skip
+} = require('../common');
+if (!hasCrypto)
+  skip('missing crypto');
+
+const {
+  strictEqual
+} = require('assert');
+const {
+  createServer,
+  connect
+} = require('http2');
+const {
+  spawnSync
+} = require('child_process');
+
+// Validate that there is no unexpected output when
+// using http2
+if (process.argv[2] !== 'child') {
+  const {
+    stdout, stderr, status
+  } = spawnSync(process.execPath, [__filename, 'child'], { encoding: 'utf8' });
+  strictEqual(stderr, '');
+  strictEqual(stdout, '');
+  strictEqual(status, 0);
+} else {
+  const server = createServer();
+  server.listen(0, mustCall(() => {
+    const client = connect(`http://localhost:${server.address().port}`);
+    client.on('connect', mustCall(() => {
+      client.close();
+      server.close();
+    }));
+  }));
+}


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/31763

This test would have helped us catch the noisy output
from http2 earlier. Currently none of the tests
fail if there is unexpected debug output.

Signed-off-by: Michael Dawson <mdawson@devrus.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
