### PR TITLE
doc: remove generated from dsaEncoding description

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1548,7 +1548,7 @@ If `privateKey` is not a [`KeyObject`][], this function behaves as if
 object, the following additional properties can be passed:
 
 * `dsaEncoding` {string} For DSA and ECDSA, this option specifies the
-  format of the generated signature. It can be one of the following:
+  format of the signature. It can be one of the following:
   * `'der'` (default): DER-encoded ASN.1 signature structure encoding `(r, s)`.
   * `'ieee-p1363'`: Signature format `r || s` as proposed in IEEE-P1363.
 * `padding` {integer} Optional padding value for RSA, one of the following:
@@ -1672,7 +1672,7 @@ If `object` is not a [`KeyObject`][], this function behaves as if
 object, the following additional properties can be passed:
 
 * `dsaEncoding` {string} For DSA and ECDSA, this option specifies the
-  format of the generated signature. It can be one of the following:
+  format of the signature. It can be one of the following:
   * `'der'` (default): DER-encoded ASN.1 signature structure encoding `(r, s)`.
   * `'ieee-p1363'`: Signature format `r || s` as proposed in IEEE-P1363.
 * `padding` {integer} Optional padding value for RSA, one of the following:
@@ -3840,7 +3840,7 @@ passed to [`crypto.createPrivateKey()`][]. If it is an object, the following
 additional properties can be passed:
 
 * `dsaEncoding` {string} For DSA and ECDSA, this option specifies the
-  format of the generated signature. It can be one of the following:
+  format of the signature. It can be one of the following:
   * `'der'` (default): DER-encoded ASN.1 signature structure encoding `(r, s)`.
   * `'ieee-p1363'`: Signature format `r || s` as proposed in IEEE-P1363.
 * `padding` {integer} Optional padding value for RSA, one of the following:
@@ -3916,7 +3916,7 @@ passed to [`crypto.createPublicKey()`][]. If it is an object, the following
 additional properties can be passed:
 
 * `dsaEncoding` {string} For DSA and ECDSA, this option specifies the
-  format of the generated signature. It can be one of the following:
+  format of the signature. It can be one of the following:
   * `'der'` (default): DER-encoded ASN.1 signature structure encoding `(r, s)`.
   * `'ieee-p1363'`: Signature format `r || s` as proposed in IEEE-P1363.
 * `padding` {integer} Optional padding value for RSA, one of the following:

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1548,7 +1548,7 @@ If `privateKey` is not a [`KeyObject`][], this function behaves as if
 object, the following additional properties can be passed:
 
 * `dsaEncoding` {string} For DSA and ECDSA, this option specifies the
-  format of the signature. It can be one of the following:
+  format of the generated signature. It can be one of the following:
   * `'der'` (default): DER-encoded ASN.1 signature structure encoding `(r, s)`.
   * `'ieee-p1363'`: Signature format `r || s` as proposed in IEEE-P1363.
 * `padding` {integer} Optional padding value for RSA, one of the following:
@@ -3840,7 +3840,7 @@ passed to [`crypto.createPrivateKey()`][]. If it is an object, the following
 additional properties can be passed:
 
 * `dsaEncoding` {string} For DSA and ECDSA, this option specifies the
-  format of the signature. It can be one of the following:
+  format of the generated signature. It can be one of the following:
   * `'der'` (default): DER-encoded ASN.1 signature structure encoding `(r, s)`.
   * `'ieee-p1363'`: Signature format `r || s` as proposed in IEEE-P1363.
 * `padding` {integer} Optional padding value for RSA, one of the following:


### PR DESCRIPTION
remove term `generated` from `dsaEncoding` parameter's description - the parameter is used to specify the format of the signature, function dictates the signature 'action'

Fixes: https://github.com/nodejs/node/issues/37454

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
