### PR TITLE
perf_hooks: add histogram option to timerify

### DIFF
--- a/doc/api/perf_hooks.md
+++ b/doc/api/perf_hooks.md
@@ -215,7 +215,7 @@ which the current `node` process began, measured in Unix time.
 added: v8.5.0
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/00000
+    pr-url: https://github.com/nodejs/node/pull/37475
     description: Added the histogram option.
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/37136

--- a/doc/api/perf_hooks.md
+++ b/doc/api/perf_hooks.md
@@ -210,10 +210,13 @@ added: v8.5.0
 The [`timeOrigin`][] specifies the high resolution millisecond timestamp at
 which the current `node` process began, measured in Unix time.
 
-### `performance.timerify(fn)`
+### `performance.timerify(fn[, options])`
 <!-- YAML
 added: v8.5.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: Added the histogram option.
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/37136
     description: Re-implemented to use pure-JavaScript and the ability
@@ -221,6 +224,10 @@ changes:
 -->
 
 * `fn` {Function}
+* `options` {Object}
+  * `histogram` {RecordableHistogram} A histogram object created using
+    `perf_hooks.createHistogram()` that will record runtime durations in
+    nanoseconds.
 
 _This property is an extension by Node.js. It is not available in Web browsers._
 

--- a/lib/internal/histogram.js
+++ b/lib/internal/histogram.js
@@ -42,6 +42,10 @@ const {
   JSTransferable,
 } = require('internal/worker/js_transferable');
 
+function isHistogram(object) {
+  return object?.[kHandle] !== undefined;
+}
+
 class Histogram extends JSTransferable {
   constructor(internal) {
     super();
@@ -193,6 +197,7 @@ module.exports = {
   RecordableHistogram,
   InternalHistogram,
   InternalRecordableHistogram,
+  isHistogram,
   kDestroy,
   kHandle,
   createHistogram,

--- a/lib/internal/perf/timerify.js
+++ b/lib/internal/perf/timerify.js
@@ -3,6 +3,7 @@
 const {
   FunctionPrototypeBind,
   ObjectDefineProperties,
+  MathCeil,
   ReflectApply,
   ReflectConstruct,
   Symbol,
@@ -12,6 +13,14 @@ const {
   InternalPerformanceEntry,
   now,
 } = require('internal/perf/perf');
+
+const {
+  validateObject
+} = require('internal/validators');
+
+const {
+  isHistogram
+} = require('internal/histogram');
 
 const {
   isConstructor,
@@ -29,8 +38,10 @@ const {
 
 const kTimerified = Symbol('kTimerified');
 
-function processComplete(name, start, args) {
+function processComplete(name, start, args, histogram) {
   const duration = now() - start;
+  if (histogram !== undefined)
+    histogram.record(MathCeil(duration * 1e6));
   const entry =
     new InternalPerformanceEntry(
       name,
@@ -45,9 +56,22 @@ function processComplete(name, start, args) {
   enqueue(entry);
 }
 
-function timerify(fn) {
+function timerify(fn, options = {}) {
   if (typeof fn !== 'function')
     throw new ERR_INVALID_ARG_TYPE('fn', 'function', fn);
+
+  validateObject(options, 'options');
+  const {
+    histogram
+  } = options;
+
+  if (histogram !== undefined &&
+      (!isHistogram(histogram) || typeof histogram.record !== 'function')) {
+    throw new ERR_INVALID_ARG_TYPE(
+      'options.histogram',
+      'RecordableHistogram',
+      histogram);
+  }
 
   if (fn[kTimerified]) return fn[kTimerified];
 
@@ -65,9 +89,10 @@ function timerify(fn) {
           result,
           fn.name,
           start,
-          args));
+          args,
+          histogram));
     }
-    processComplete(fn.name, start, args);
+    processComplete(fn.name, start, args, histogram);
     return result;
   }
 


### PR DESCRIPTION
Allows setting a `Histogram` object option on timerify to
record function execution times over time.

e.g.

```js
const {
  createHistogram,
  performance,
} = require('perf_hooks');

function foo() { /** ... **/ }

const histogram = createHistogram();
const tfoo = performance.timerify(foo, { histogram });

tfoo(); // execute tfoo a bunch.

console.log(histogram.max);  // max sampled execution time for foo()
```

Signed-off-by: James M Snell <jasnell@gmail.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
