### PR TITLE
worker_threads: fix spawning from preload scripts

### DIFF
--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -1127,6 +1127,17 @@ Calling `unref()` on a worker allows the thread to exit if this is the only
 active handle in the event system. If the worker is already `unref()`ed calling
 `unref()` again has no effect.
 
+## Notes
+
+### Launching worker threads from preload scripts
+
+Take care when launching worker threads from preload scripts (scripts loaded
+and run using the `-r` command line flag). Unless the `execArgv` option is
+explicitly set, new Worker threads automatically inherit the command line flags
+from the running process and will preload the same preload scripts as the main
+thread. If the preload script unconditionally launches a worker thread, every
+thread spawned will spawn another until the application crashes.
+
 [Addons worker support]: addons.md#addons_worker_support
 [ECMAScript module loader]: esm.md#esm_data_imports
 [HTML structured clone algorithm]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm

--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -121,10 +121,6 @@ port.on('message', (message) => {
     initializeCJSLoader();
     initializeESMLoader();
 
-    const CJSLoader = require('internal/modules/cjs/loader');
-    assert(!CJSLoader.hasLoadedAnyUserCJSModule);
-    loadPreloadModules();
-    initializeFrozenIntrinsics();
     if (argv !== undefined) {
       process.argv = ArrayPrototypeConcat(process.argv, argv);
     }
@@ -146,6 +142,11 @@ port.on('message', (message) => {
       return cachedCwd;
     };
     workerIo.sharedCwdCounter = cwdCounter;
+
+    const CJSLoader = require('internal/modules/cjs/loader');
+    assert(!CJSLoader.hasLoadedAnyUserCJSModule);
+    loadPreloadModules();
+    initializeFrozenIntrinsics();
 
     if (!hasStdin)
       process.stdin.push(null);

--- a/test/fixtures/worker-preload.js
+++ b/test/fixtures/worker-preload.js
@@ -1,0 +1,9 @@
+const {
+  Worker,
+  workerData,
+  threadId
+} = require('worker_threads');
+
+if (threadId < 2) {
+  new Worker('1 + 1', { eval: true });
+}

--- a/test/parallel/test-preload-worker.js
+++ b/test/parallel/test-preload-worker.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const common = require('../common');
+const fixtures = require('../common/fixtures');
+const worker = fixtures.path('worker-preload.js');
+const { exec } = require('child_process');
+const kNodeBinary = process.argv[0];
+
+
+exec(`"${kNodeBinary}" -r "${worker}" -pe "1+1"`, common.mustSucceed());


### PR DESCRIPTION
Fix spawning nested worker threads from preload scripts and
warn about doing so.

Signed-off-by: James M Snell <jasnell@gmail.com>
Fixes: https://github.com/nodejs/node/issues/36531

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
