### PR TITLE
process: upgrade process.binding to runtime deprecation

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2084,6 +2084,9 @@ The `produceCachedData` option is deprecated. Use
 ### DEP0111: `process.binding()`
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: Upgraded to a runtime deprecation.
   - version: v11.12.0
     pr-url: https://github.com/nodejs/node/pull/26500
     description: Added support for `--pending-deprecation`.
@@ -2092,7 +2095,7 @@ changes:
     description: Documentation-only deprecation.
 -->
 
-Type: Documentation-only (supports [`--pending-deprecation`][])
+Type: Runtime
 
 `process.binding()` is for use by Node.js internal code only.
 

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -288,11 +288,11 @@ function initializeDeprecations() {
     });
   }
 
-  if (pendingDeprecation) {
-    process.binding = deprecate(process.binding,
-                                'process.binding() is deprecated. ' +
-                                'Please use public APIs instead.', 'DEP0111');
+  process.binding = deprecate(process.binding,
+                              'process.binding() is deprecated. ' +
+                              'Please use public APIs instead.', 'DEP0111');
 
+  if (pendingDeprecation) {
     process._tickCallback = deprecate(process._tickCallback,
                                       'process._tickCallback() is deprecated',
                                       'DEP0134');


### PR DESCRIPTION
@nodejs/tsc ... this one still may be controversial but I figured I'd give it a shot.

`process.binding()` has always been problematic and has been deprecated since the 11.x timeframe. We have fully migrated to `internalBinding()` internally but there are still a few stragglers in the ecosystem that have not let go of their hold on our internal bindings. It's time to start nudging them harder out of the nest.

Fixes: https://github.com/nodejs/node/issues/30884