### PR TITLE
worker: add support for platformData

### DIFF
--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -61,6 +61,38 @@ Worker threads inherit non-process-specific options by default. Refer to
 [`Worker constructor options`][] to know how to customize worker thread options,
 specifically `argv` and `execArgv` options.
 
+## `worker.getEnvironmentData(key)`
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+* `key` {any} Any arbitrary, cloneable JavaScript value that can be used as a
+  {Map} key.
+* Returns: {any}
+
+Within a worker thread, `worker.getEnvironmentData()` returns a clone
+of data passed to the spawning thread's `worker.setEnvironmentData()`.
+Every new `Worker` receives its own copy of the environment data
+automatically.
+
+```js
+const {
+  Worker,
+  isMainThread,
+  setEnvironmentData,
+  getEnvironmentData,
+} = require('worker_threads');
+
+if (isMainThread) {
+  setEnvironmentData('Hello', 'World!');
+  const worker = new Worker(__filename);
+} else {
+  console.log(getEnvironmentData('Hello'));  // Prints 'World!'.
+}
+```
+
 ## `worker.isMainThread`
 <!-- YAML
 added: v10.5.0
@@ -245,6 +277,23 @@ new Worker('process.env.SET_IN_WORKER = "foo"', { eval: true, env: SHARE_ENV })
     console.log(process.env.SET_IN_WORKER);  // Prints 'foo'.
   });
 ```
+
+## `worker.setEnvironmentData(key[, value])`
+<!--YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+* `key` {any} Any arbitrary, cloneable JavaScript value that can be used as a
+  {Map} key.
+* `value` {any} Any arbitrary, cloneable JavaScript value that will be cloned
+  and passed automatically to all new `Worker` instances. If `value` is passed
+  as `undefined`, any previously set value for the `key` will be deleted.
+
+The `worker.setEnvironmentData()` API sets the content of
+`worker.getEnvironmentData()` in the current thread and all new `Worker`
+instances spawned from the current context.
 
 ## `worker.threadId`
 <!-- YAML

--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -105,6 +105,7 @@ port.on('message', (message) => {
       filename,
       doEval,
       workerData,
+      environmentData,
       publicPort,
       manifestSrc,
       manifestURL,
@@ -126,6 +127,8 @@ port.on('message', (message) => {
     }
     publicWorker.parentPort = publicPort;
     publicWorker.workerData = workerData;
+
+    require('internal/worker').assignEnvironmentData(environmentData);
 
     // The counter is only passed to the workers created by the main thread, not
     // to workers created by other workers.

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -18,6 +18,7 @@ const {
   ReflectApply,
   RegExpPrototypeTest,
   SafeArrayIterator,
+  SafeMap,
   String,
   Symbol,
   SymbolFor,
@@ -90,6 +91,8 @@ let debug = require('internal/util/debuglog').debuglog('worker', (fn) => {
 
 let cwdCounter;
 
+const environmentData = new SafeMap();
+
 if (isMainThread) {
   cwdCounter = new Uint32Array(new SharedArrayBuffer(4));
   const originalChdir = process.chdir;
@@ -97,6 +100,24 @@ if (isMainThread) {
     Atomics.add(cwdCounter, 0, 1);
     originalChdir(path);
   };
+}
+
+function setEnvironmentData(key, value) {
+  if (value === undefined)
+    environmentData.delete(key);
+  else
+    environmentData.set(key, value);
+}
+
+function getEnvironmentData(key) {
+  return environmentData.get(key);
+}
+
+function assignEnvironmentData(data) {
+  if (data === undefined) return;
+  data.forEach((value, key) => {
+    environmentData.set(key, value);
+  });
 }
 
 class Worker extends EventEmitter {
@@ -228,6 +249,7 @@ class Worker extends EventEmitter {
       doEval,
       cwdCounter: cwdCounter || workerIo.sharedCwdCounter,
       workerData: options.workerData,
+      environmentData,
       publicPort: port2,
       manifestURL: getOptionValue('--experimental-policy') ?
         require('internal/process/policy').url :
@@ -493,6 +515,9 @@ module.exports = {
   SHARE_ENV,
   resourceLimits:
     !isMainThread ? makeResourceLimits(resourceLimitsRaw) : {},
+  setEnvironmentData,
+  getEnvironmentData,
+  assignEnvironmentData,
   threadId,
   Worker,
 };

--- a/lib/worker_threads.js
+++ b/lib/worker_threads.js
@@ -4,6 +4,8 @@ const {
   isMainThread,
   SHARE_ENV,
   resourceLimits,
+  setEnvironmentData,
+  getEnvironmentData,
   threadId,
   Worker
 } = require('internal/worker');
@@ -34,4 +36,6 @@ module.exports = {
   parentPort: null,
   workerData: null,
   BroadcastChannel,
+  setEnvironmentData,
+  getEnvironmentData,
 };

--- a/test/parallel/test-worker-environmentdata.js
+++ b/test/parallel/test-worker-environmentdata.js
@@ -3,7 +3,6 @@
 require('../common');
 const {
   Worker,
-  isMainThread,
   getEnvironmentData,
   setEnvironmentData,
   threadId,
@@ -14,7 +13,8 @@ const {
   strictEqual,
 } = require('assert');
 
-if (isMainThread) {
+if (!process.env.HAS_STARTED_WORKER) {
+  process.env.HAS_STARTED_WORKER = 1;
   setEnvironmentData('foo', 'bar');
   setEnvironmentData('hello', { value: 'world' });
   setEnvironmentData(1, 2);
@@ -28,6 +28,6 @@ if (isMainThread) {
   strictEqual(getEnvironmentData(1), undefined);
 
   // Recurse to make sure the environment data is inherited
-  if (threadId === 1)
+  if (threadId <= 2)
     new Worker(__filename);
 }

--- a/test/parallel/test-worker-environmentdata.js
+++ b/test/parallel/test-worker-environmentdata.js
@@ -1,0 +1,33 @@
+'use strict';
+
+require('../common');
+const {
+  Worker,
+  isMainThread,
+  getEnvironmentData,
+  setEnvironmentData,
+  threadId,
+} = require('worker_threads');
+
+const {
+  deepStrictEqual,
+  strictEqual,
+} = require('assert');
+
+if (isMainThread) {
+  setEnvironmentData('foo', 'bar');
+  setEnvironmentData('hello', { value: 'world' });
+  setEnvironmentData(1, 2);
+  strictEqual(getEnvironmentData(1), 2);
+  setEnvironmentData(1); // Delete it, key won't show up in the worker.
+  new Worker(__filename);
+  setEnvironmentData('hello');  // Delete it. Has no impact on the worker.
+} else {
+  strictEqual(getEnvironmentData('foo'), 'bar');
+  deepStrictEqual(getEnvironmentData('hello'), { value: 'world' });
+  strictEqual(getEnvironmentData(1), undefined);
+
+  // Recurse to make sure the environment data is inherited
+  if (threadId === 1)
+    new Worker(__filename);
+}


### PR DESCRIPTION
The `worker.platformData` and `worker.setPlatformData()` APIs allow an arbitrary, cloneable JavaScript value to be set and passed to all new Worker instances spawned from the current context. It is similar to `workerData` except that `platformData` is set independently of the `new Worker()` constructor, and the value is passed automatically to all new Workers.

This is a *partial* fix of https://github.com/nodejs/node/issues/30992
but does not implement a complete fix.

Signed-off-by: James M Snell <jasnell@gmail.com>

/cc @addaleax @coreyfarrell 