### PR TITLE
test: fixup flaky test-performance-function-async test

### DIFF
--- a/test/parallel/test-performance-function-async.js
+++ b/test/parallel/test-performance-function-async.js
@@ -26,7 +26,6 @@ async function doIt() {
 const obs = new PerformanceObserver(common.mustCall((list) => {
   const entry = list.getEntries()[0];
   assert.strictEqual(entry.name, 'doIt');
-  assert(entry.duration > 100);
   assert(check);
   obs.disconnect();
 }));


### PR DESCRIPTION
The time assertion was inaccurate. Just remove it as it's not strictly necessary. Recommend fast track.

![image](https://user-images.githubusercontent.com/439929/108894330-ffc4e400-75c6-11eb-8214-33c6522a8f4f.png)

