### PR TITLE
crypto: add optional callback to crypto.sign and crypto.verify

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -3822,10 +3822,13 @@ added: v10.0.0
 Enables the FIPS compliant crypto provider in a FIPS-enabled Node.js build.
 Throws an error if FIPS mode is not available.
 
-### `crypto.sign(algorithm, data, key)`
+### `crypto.sign(algorithm, data, key[, callback])`
 <!-- YAML
 added: v12.0.0
 changes:
+  - version: REPLACEME
+    pr-url: TODO
+    description: Optional callback argument added.
   - version:
      - v13.2.0
      - v12.16.0
@@ -3837,7 +3840,10 @@ changes:
 * `algorithm` {string | null | undefined}
 * `data` {ArrayBuffer|Buffer|TypedArray|DataView}
 * `key` {Object|string|ArrayBuffer|Buffer|TypedArray|DataView|KeyObject|CryptoKey}
-* Returns: {Buffer}
+* `callback` {Function}
+  * `err` {Error}
+  * `signature` {Buffer}
+* Returns: {Buffer} if the `callback` function is not provided.
 <!--lint enable maximum-line-length remark-lint-->
 
 Calculates and returns the signature for `data` using the given private key and
@@ -3863,6 +3869,8 @@ additional properties can be passed:
   `crypto.constants.RSA_PSS_SALTLEN_DIGEST` sets the salt length to the digest
   size, `crypto.constants.RSA_PSS_SALTLEN_MAX_SIGN` (default) sets it to the
   maximum permissible value.
+
+If the `callback` function is provided this function uses libuv's threadpool.
 
 ### `crypto.timingSafeEqual(a, b)`
 <!-- YAML
@@ -3894,10 +3902,13 @@ Use of `crypto.timingSafeEqual` does not guarantee that the *surrounding* code
 is timing-safe. Care should be taken to ensure that the surrounding code does
 not introduce timing vulnerabilities.
 
-### `crypto.verify(algorithm, data, key, signature)`
+### `crypto.verify(algorithm, data, key, signature[, callback])`
 <!-- YAML
 added: v12.0.0
 changes:
+  - version: REPLACEME
+    pr-url: TODO
+    description: Optional callback argument added.
   - version: v15.0.0
     pr-url: https://github.com/nodejs/node/pull/35093
     description: The data, key, and signature arguments can also be ArrayBuffer.
@@ -3913,7 +3924,12 @@ changes:
 * `data` {ArrayBuffer| Buffer|TypedArray|DataView}
 * `key` {Object|string|ArrayBuffer|Buffer|TypedArray|DataView|KeyObject|CryptoKey}
 * `signature` {ArrayBuffer|Buffer|TypedArray|DataView}
-* Returns: {boolean}
+* `callback` {Function}
+  * `err` {Error}
+  * `result` {boolean}
+* Returns: {boolean} `true` or `false` depending on the validity of the
+  signature for the data and public key if the `callback` function is not
+  provided.
 <!--lint enable maximum-line-length remark-lint-->
 
 Verifies the given signature for `data` using the given key and algorithm. If
@@ -3944,6 +3960,8 @@ The `signature` argument is the previously calculated signature for the `data`.
 
 Because public keys can be derived from private keys, a private key or a public
 key may be passed for `key`.
+
+If the `callback` function is provided this function uses libuv's threadpool.
 
 ### `crypto.webcrypto`
 <!-- YAML

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -3827,7 +3827,7 @@ Throws an error if FIPS mode is not available.
 added: v12.0.0
 changes:
   - version: REPLACEME
-    pr-url: TODO
+    pr-url: https://github.com/nodejs/node/pull/37500
     description: Optional callback argument added.
   - version:
      - v13.2.0
@@ -3907,7 +3907,7 @@ not introduce timing vulnerabilities.
 added: v12.0.0
 changes:
   - version: REPLACEME
-    pr-url: TODO
+    pr-url: https://github.com/nodejs/node/pull/37500
     description: Optional callback argument added.
   - version: v15.0.0
     pr-url: https://github.com/nodejs/node/pull/35093

--- a/lib/internal/crypto/dsa.js
+++ b/lib/internal/crypto/dsa.js
@@ -254,6 +254,7 @@ function dsaSignVerify(key, data, algorithm, signature) {
     normalizeHashName(key.algorithm.hash.name),
     undefined,  // Salt-length is not used in DSA
     undefined,  // Padding is not used in DSA
+    kSigEncDER, // TODO(@jasnell): revise the inconsistency with WebCrypto's EC
     signature));
 }
 

--- a/lib/internal/crypto/dsa.js
+++ b/lib/internal/crypto/dsa.js
@@ -10,6 +10,7 @@ const {
   KeyObjectHandle,
   SignJob,
   kCryptoJobAsync,
+  kSigEncDER,
   kKeyTypePrivate,
   kSignJobModeSign,
   kSignJobModeVerify,
@@ -254,8 +255,8 @@ function dsaSignVerify(key, data, algorithm, signature) {
     normalizeHashName(key.algorithm.hash.name),
     undefined,  // Salt-length is not used in DSA
     undefined,  // Padding is not used in DSA
-    kSigEncDER, // TODO(@jasnell): revise the inconsistency with WebCrypto's EC
-    signature));
+    signature,
+    kSigEncDER));
 }
 
 module.exports = {

--- a/lib/internal/crypto/ec.js
+++ b/lib/internal/crypto/ec.js
@@ -17,6 +17,7 @@ const {
   kKeyTypePublic,
   kSignJobModeSign,
   kSignJobModeVerify,
+  kSigEncP1363,
 } = internalBinding('crypto');
 
 const {
@@ -470,6 +471,7 @@ function ecdsaSignVerify(key, data, { name, hash }, signature) {
     hashname,
     undefined,  // Salt length, not used with ECDSA
     undefined,  // PSS Padding, not used with ECDSA
+    kSigEncP1363,
     signature));
 }
 

--- a/lib/internal/crypto/ec.js
+++ b/lib/internal/crypto/ec.js
@@ -471,8 +471,8 @@ function ecdsaSignVerify(key, data, { name, hash }, signature) {
     hashname,
     undefined,  // Salt length, not used with ECDSA
     undefined,  // PSS Padding, not used with ECDSA
-    kSigEncP1363,
-    signature));
+    signature,
+    kSigEncP1363));
 }
 
 module.exports = {

--- a/lib/internal/crypto/rsa.js
+++ b/lib/internal/crypto/rsa.js
@@ -30,6 +30,7 @@ const {
 } = require('internal/errors');
 
 const {
+  validateInt32,
   validateUint32,
 } = require('internal/validators');
 
@@ -342,7 +343,7 @@ function rsaSignVerify(key, data, { saltLength }, signature) {
     // TODO(@jasnell): Validate maximum size of saltLength
     // based on the key size:
     //   Math.ceil((keySizeInBits - 1)/8) - digestSizeInBytes - 2
-    validateUint32(saltLength, 'algorithm.saltLength');
+    validateInt32(saltLength, 'algorithm.saltLength', -2);
   }
 
   const mode = signature === undefined ? kSignJobModeSign : kSignJobModeVerify;

--- a/lib/internal/crypto/rsa.js
+++ b/lib/internal/crypto/rsa.js
@@ -359,7 +359,6 @@ function rsaSignVerify(key, data, { saltLength }, signature) {
     normalizeHashName(key.algorithm.hash.name),
     saltLength,
     padding,
-    undefined, // EC(DSA) Signature Encoding is not used in RSA
     signature));
 }
 

--- a/lib/internal/crypto/rsa.js
+++ b/lib/internal/crypto/rsa.js
@@ -359,6 +359,7 @@ function rsaSignVerify(key, data, { saltLength }, signature) {
     normalizeHashName(key.algorithm.hash.name),
     saltLength,
     padding,
+    undefined, // EC(DSA) Signature Encoding is not used in RSA
     signature));
 }
 

--- a/lib/internal/crypto/sig.js
+++ b/lib/internal/crypto/sig.js
@@ -177,6 +177,8 @@ function signOneShot(algorithm, data, key, callback) {
   let keyData;
   if (isKeyObject(key) || isCryptoKey(key)) {
     ({ data: keyData } = preparePrivateKey(key));
+  } else if (key != null && (isKeyObject(key.key) || isCryptoKey(key.key))) {
+    ({ data: keyData } = preparePrivateKey(key.key));
   } else {
     keyData = createPrivateKey(key)[kHandle];
   }
@@ -285,6 +287,8 @@ function verifyOneShot(algorithm, data, key, signature, callback) {
   let keyData;
   if (isKeyObject(key) || isCryptoKey(key)) {
     ({ data: keyData } = preparePublicOrPrivateKey(key));
+  } else if (key != null && (isKeyObject(key.key) || isCryptoKey(key.key))) {
+    ({ data: keyData } = preparePublicOrPrivateKey(key.key));
   } else {
     keyData = createPublicKey(key)[kHandle];
   }

--- a/lib/internal/crypto/sig.js
+++ b/lib/internal/crypto/sig.js
@@ -184,8 +184,7 @@ function signOneShot(algorithm, data, key, callback) {
   }
 
   // TODO: add dsaSigEnc to SignJob
-  // TODO: recognize pssSaltLength constants RSA_PSS_SALTLEN_DIGEST,
-  // RSA_PSS_SALTLEN_MAX_SIGN, and RSA_PSS_SALTLEN_AUTO
+  // TODO: recognize pssSaltLength RSA_PSS_SALTLEN_* constants in SignJob
   const job = new SignJob(
     kCryptoJobAsync,
     kSignJobModeSign,
@@ -297,8 +296,7 @@ function verifyOneShot(algorithm, data, key, signature, callback) {
   }
 
   // TODO: add dsaSigEnc to SignJob
-  // TODO: recognize pssSaltLength constants RSA_PSS_SALTLEN_DIGEST,
-  // RSA_PSS_SALTLEN_MAX_SIGN, and RSA_PSS_SALTLEN_AUTO
+  // TODO: recognize pssSaltLength RSA_PSS_SALTLEN_* constants in SignJob
   const job = new SignJob(
     kCryptoJobAsync,
     kSignJobModeVerify,

--- a/lib/internal/crypto/sig.js
+++ b/lib/internal/crypto/sig.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const {
+  FunctionPrototypeCall,
   ObjectSetPrototypeOf,
   ReflectApply,
 } = primordials;
@@ -14,17 +15,22 @@ const {
 } = require('internal/errors');
 
 const {
+  validateCallback,
   validateEncoding,
   validateString,
 } = require('internal/validators');
 
 const {
   Sign: _Sign,
+  SignJob,
   Verify: _Verify,
   signOneShot: _signOneShot,
   verifyOneShot: _verifyOneShot,
+  kCryptoJobAsync,
   kSigEncDER,
   kSigEncP1363,
+  kSignJobModeSign,
+  kSignJobModeVerify,
 } = internalBinding('crypto');
 
 const {
@@ -34,11 +40,17 @@ const {
 } = require('internal/crypto/util');
 
 const {
-  preparePublicOrPrivateKey,
+  createPrivateKey,
+  createPublicKey,
+  isCryptoKey,
+  isKeyObject,
   preparePrivateKey,
+  preparePublicOrPrivateKey,
 } = require('internal/crypto/keys');
 
 const { Writable } = require('stream');
+
+const { Buffer } = require('buffer');
 
 const {
   isArrayBufferView,
@@ -131,21 +143,17 @@ Sign.prototype.sign = function sign(options, encoding) {
   return ret;
 };
 
-function signOneShot(algorithm, data, key) {
+function signOneShot(algorithm, data, key, callback) {
   if (algorithm != null)
     validateString(algorithm, 'algorithm');
+
+  if (callback !== undefined)
+    validateCallback(callback);
 
   data = getArrayBufferOrView(data, 'data');
 
   if (!key)
     throw new ERR_CRYPTO_SIGN_KEY_REQUIRED();
-
-  const {
-    data: keyData,
-    format: keyFormat,
-    type: keyType,
-    passphrase: keyPassphrase
-  } = preparePrivateKey(key);
 
   // Options specific to RSA
   const rsaPadding = getPadding(key);
@@ -154,8 +162,40 @@ function signOneShot(algorithm, data, key) {
   // Options specific to (EC)DSA
   const dsaSigEnc = getDSASignatureEncoding(key);
 
-  return _signOneShot(keyData, keyFormat, keyType, keyPassphrase, data,
-                      algorithm, rsaPadding, pssSaltLength, dsaSigEnc);
+  if (!callback) {
+    const {
+      data: keyData,
+      format: keyFormat,
+      type: keyType,
+      passphrase: keyPassphrase
+    } = preparePrivateKey(key);
+
+    return _signOneShot(keyData, keyFormat, keyType, keyPassphrase, data,
+                        algorithm, rsaPadding, pssSaltLength, dsaSigEnc);
+  }
+
+  let keyData;
+  if (isKeyObject(key) || isCryptoKey(key)) {
+    ({ data: keyData } = preparePrivateKey(key));
+  } else {
+    keyData = createPrivateKey(key)[kHandle];
+  }
+
+  // TODO: add dsaSigEnc to SignJob
+  const job = new SignJob(
+    kCryptoJobAsync,
+    kSignJobModeSign,
+    keyData,
+    data,
+    algorithm,
+    pssSaltLength,
+    rsaPadding);
+
+  job.ondone = (error, signature) => {
+    if (error) return FunctionPrototypeCall(callback, job, error);
+    FunctionPrototypeCall(callback, job, null, Buffer.from(signature));
+  };
+  job.run();
 }
 
 function Verify(algorithm, options) {
@@ -197,9 +237,12 @@ Verify.prototype.verify = function verify(options, signature, sigEncoding) {
                               rsaPadding, pssSaltLength, dsaSigEnc);
 };
 
-function verifyOneShot(algorithm, data, key, signature) {
+function verifyOneShot(algorithm, data, key, signature, callback) {
   if (algorithm != null)
     validateString(algorithm, 'algorithm');
+
+  if (callback !== undefined)
+    validateCallback(callback);
 
   data = getArrayBufferOrView(data, 'data');
 
@@ -210,13 +253,6 @@ function verifyOneShot(algorithm, data, key, signature) {
       data
     );
   }
-
-  const {
-    data: keyData,
-    format: keyFormat,
-    type: keyType,
-    passphrase: keyPassphrase
-  } = preparePublicOrPrivateKey(key);
 
   // Options specific to RSA
   const rsaPadding = getPadding(key);
@@ -233,8 +269,42 @@ function verifyOneShot(algorithm, data, key, signature) {
     );
   }
 
-  return _verifyOneShot(keyData, keyFormat, keyType, keyPassphrase, signature,
-                        data, algorithm, rsaPadding, pssSaltLength, dsaSigEnc);
+  if (!callback) {
+    const {
+      data: keyData,
+      format: keyFormat,
+      type: keyType,
+      passphrase: keyPassphrase
+    } = preparePublicOrPrivateKey(key);
+
+    return _verifyOneShot(keyData, keyFormat, keyType, keyPassphrase,
+                          signature, data, algorithm, rsaPadding,
+                          pssSaltLength, dsaSigEnc);
+  }
+
+  let keyData;
+  if (isKeyObject(key) || isCryptoKey(key)) {
+    ({ data: keyData } = preparePublicOrPrivateKey(key));
+  } else {
+    keyData = createPublicKey(key)[kHandle];
+  }
+
+  // TODO: add dsaSigEnc to SignJob
+  const job = new SignJob(
+    kCryptoJobAsync,
+    kSignJobModeVerify,
+    keyData,
+    data,
+    algorithm,
+    pssSaltLength,
+    rsaPadding,
+    signature);
+
+  job.ondone = (error, result) => {
+    if (error) return FunctionPrototypeCall(callback, job, error);
+    FunctionPrototypeCall(callback, job, null, result);
+  };
+  job.run();
 }
 
 module.exports = {

--- a/lib/internal/crypto/sig.js
+++ b/lib/internal/crypto/sig.js
@@ -184,6 +184,8 @@ function signOneShot(algorithm, data, key, callback) {
   }
 
   // TODO: add dsaSigEnc to SignJob
+  // TODO: recognize pssSaltLength constants RSA_PSS_SALTLEN_DIGEST,
+  // RSA_PSS_SALTLEN_MAX_SIGN, and RSA_PSS_SALTLEN_AUTO
   const job = new SignJob(
     kCryptoJobAsync,
     kSignJobModeSign,
@@ -294,6 +296,8 @@ function verifyOneShot(algorithm, data, key, signature, callback) {
   }
 
   // TODO: add dsaSigEnc to SignJob
+  // TODO: recognize pssSaltLength constants RSA_PSS_SALTLEN_DIGEST,
+  // RSA_PSS_SALTLEN_MAX_SIGN, and RSA_PSS_SALTLEN_AUTO
   const job = new SignJob(
     kCryptoJobAsync,
     kSignJobModeVerify,

--- a/lib/internal/crypto/sig.js
+++ b/lib/internal/crypto/sig.js
@@ -183,7 +183,6 @@ function signOneShot(algorithm, data, key, callback) {
     keyData = createPrivateKey(key)[kHandle];
   }
 
-  // TODO: add dsaSigEnc to SignJob
   // TODO: recognize pssSaltLength RSA_PSS_SALTLEN_* constants in SignJob
   const job = new SignJob(
     kCryptoJobAsync,
@@ -193,6 +192,7 @@ function signOneShot(algorithm, data, key, callback) {
     algorithm,
     pssSaltLength,
     rsaPadding,
+    undefined,
     dsaSigEnc);
 
   job.ondone = (error, signature) => {
@@ -295,7 +295,6 @@ function verifyOneShot(algorithm, data, key, signature, callback) {
     keyData = createPublicKey(key)[kHandle];
   }
 
-  // TODO: add dsaSigEnc to SignJob
   // TODO: recognize pssSaltLength RSA_PSS_SALTLEN_* constants in SignJob
   const job = new SignJob(
     kCryptoJobAsync,
@@ -305,8 +304,8 @@ function verifyOneShot(algorithm, data, key, signature, callback) {
     algorithm,
     pssSaltLength,
     rsaPadding,
-    dsaSigEnc,
-    signature);
+    signature,
+    dsaSigEnc);
 
   job.ondone = (error, result) => {
     if (error) return FunctionPrototypeCall(callback, job, error);

--- a/lib/internal/crypto/sig.js
+++ b/lib/internal/crypto/sig.js
@@ -183,7 +183,6 @@ function signOneShot(algorithm, data, key, callback) {
     keyData = createPrivateKey(key)[kHandle];
   }
 
-  // TODO: recognize pssSaltLength RSA_PSS_SALTLEN_* constants in SignJob
   const job = new SignJob(
     kCryptoJobAsync,
     kSignJobModeSign,
@@ -295,7 +294,6 @@ function verifyOneShot(algorithm, data, key, signature, callback) {
     keyData = createPublicKey(key)[kHandle];
   }
 
-  // TODO: recognize pssSaltLength RSA_PSS_SALTLEN_* constants in SignJob
   const job = new SignJob(
     kCryptoJobAsync,
     kSignJobModeVerify,

--- a/lib/internal/crypto/sig.js
+++ b/lib/internal/crypto/sig.js
@@ -193,7 +193,8 @@ function signOneShot(algorithm, data, key, callback) {
     data,
     algorithm,
     pssSaltLength,
-    rsaPadding);
+    rsaPadding,
+    dsaSigEnc);
 
   job.ondone = (error, signature) => {
     if (error) return FunctionPrototypeCall(callback, job, error);
@@ -306,6 +307,7 @@ function verifyOneShot(algorithm, data, key, signature, callback) {
     algorithm,
     pssSaltLength,
     rsaPadding,
+    dsaSigEnc,
     signature);
 
   job.ondone = (error, result) => {

--- a/src/crypto/crypto_ec.cc
+++ b/src/crypto/crypto_ec.cc
@@ -926,62 +926,114 @@ size_t GroupOrderSize(ManagedEVPPKey key) {
   return BN_num_bytes(order.get());
 }
 
+// TODO(@jasnell): Reconcile with ConvertSignatureToP1363 in crypto_sig.cc
+// TODO(@jasnell): Move out of crypto_ec since this is also doing DSA now also
 ByteSource ConvertToWebCryptoSignature(
-    ManagedEVPPKey key,
+    const ManagedEVPPKey& key,
     const ByteSource& signature) {
   const unsigned char* data =
       reinterpret_cast<const unsigned char*>(signature.get());
-  EcdsaSigPointer ecsig(d2i_ECDSA_SIG(nullptr, &data, signature.size()));
 
-  if (!ecsig)
-    return ByteSource();
-
-  size_t order_size_bytes = GroupOrderSize(key);
-  char* outdata = MallocOpenSSL<char>(order_size_bytes * 2);
-  ByteSource out = ByteSource::Allocated(outdata, order_size_bytes * 2);
-  unsigned char* ptr = reinterpret_cast<unsigned char*>(outdata);
-
+  ECDSASigPointer ecsig;
+  DsaSigPointer dsasig;
   const BIGNUM* pr;
   const BIGNUM* ps;
-  ECDSA_SIG_get0(ecsig.get(), &pr, &ps);
+  size_t len = 0;
 
-  if (!BN_bn2binpad(pr, ptr, order_size_bytes) ||
-      !BN_bn2binpad(ps, ptr + order_size_bytes, order_size_bytes)) {
+  switch (EVP_PKEY_id(key.get())) {
+    case EVP_PKEY_EC: {
+      ecsig = ECDSASigPointer(d2i_ECDSA_SIG(nullptr, &data, signature.size()));
+
+      if (!ecsig)
+        return ByteSource();
+
+      len = GroupOrderSize(key);
+
+      ECDSA_SIG_get0(ecsig.get(), &pr, &ps);
+      break;
+    }
+    case EVP_PKEY_DSA: {
+      dsasig = DsaSigPointer(d2i_DSA_SIG(nullptr, &data, signature.size()));
+
+      if (!dsasig)
+        return ByteSource();
+
+      DSA_SIG_get0(dsasig.get(), &pr, &ps);
+      len = BN_num_bytes(pr);
+    }
+  }
+
+  CHECK_GT(len, 0);
+
+  char* outdata = MallocOpenSSL<char>(len * 2);
+  ByteSource out = ByteSource::Allocated(outdata, len * 2);
+  unsigned char* ptr = reinterpret_cast<unsigned char*>(outdata);
+
+  if (!BN_bn2binpad(pr, ptr, len) || !BN_bn2binpad(ps, ptr + len, len)) {
     return ByteSource();
   }
   return out;
 }
 
+// TODO(@jasnell): Reconcile with ConvertSignatureToDER in crypto_sig.cc
+// TODO(@jasnell): Move out of crypto_ec since this is also doing DSA now also
 ByteSource ConvertFromWebCryptoSignature(
-    ManagedEVPPKey key,
+    const ManagedEVPPKey& key,
     const ByteSource& signature) {
-  size_t order_size_bytes = GroupOrderSize(key);
-
-  // If the size of the signature is incorrect, verification
-  // will fail.
-  if (signature.size() != 2 * order_size_bytes)
-    return ByteSource();  // Empty!
-
-  EcdsaSigPointer ecsig(ECDSA_SIG_new());
-  if (!ecsig)
-    return ByteSource();
-
   BignumPointer r(BN_new());
   BignumPointer s(BN_new());
-
   const unsigned char* sig = signature.data<unsigned char>();
 
-  if (!BN_bin2bn(sig, order_size_bytes, r.get()) ||
-      !BN_bin2bn(sig + order_size_bytes, order_size_bytes, s.get()) ||
-      !ECDSA_SIG_set0(ecsig.get(), r.release(), s.release())) {
-    return ByteSource();
-  }
+  switch (EVP_PKEY_id(key.get())) {
+    case EVP_PKEY_EC: {
+      size_t order_size_bytes = GroupOrderSize(key);
 
-  int size = i2d_ECDSA_SIG(ecsig.get(), nullptr);
-  char* data = MallocOpenSSL<char>(size);
-  unsigned char* ptr = reinterpret_cast<unsigned char*>(data);
-  CHECK_EQ(i2d_ECDSA_SIG(ecsig.get(), &ptr), size);
-  return ByteSource::Allocated(data, size);
+      // If the size of the signature is incorrect, verification
+      // will fail.
+      if (signature.size() != 2 * order_size_bytes)
+        return ByteSource();  // Empty!
+
+      ECDSASigPointer ecsig(ECDSA_SIG_new());
+      if (!ecsig)
+        return ByteSource();
+
+      if (!BN_bin2bn(sig, order_size_bytes, r.get()) ||
+          !BN_bin2bn(sig + order_size_bytes, order_size_bytes, s.get()) ||
+          !ECDSA_SIG_set0(ecsig.get(), r.release(), s.release())) {
+        return ByteSource();
+      }
+
+      int size = i2d_ECDSA_SIG(ecsig.get(), nullptr);
+      char* data = MallocOpenSSL<char>(size);
+      unsigned char* ptr = reinterpret_cast<unsigned char*>(data);
+      CHECK_EQ(i2d_ECDSA_SIG(ecsig.get(), &ptr), size);
+      return ByteSource::Allocated(data, size);
+    }
+    case EVP_PKEY_DSA: {
+      size_t len = signature.size() / 2;
+
+      if (signature.size() != 2 * len)
+        return ByteSource();
+
+      DsaSigPointer dsasig(DSA_SIG_new());
+      if (!dsasig)
+        return ByteSource();
+
+      if (!BN_bin2bn(sig, len, r.get()) ||
+          !BN_bin2bn(sig + len, len, s.get()) ||
+          !DSA_SIG_set0(dsasig.get(), r.release(), s.release())) {
+        return ByteSource();
+      }
+
+      int size = i2d_DSA_SIG(dsasig.get(), nullptr);
+      char* data = MallocOpenSSL<char>(size);
+      unsigned char* ptr = reinterpret_cast<unsigned char*>(data);
+      CHECK_EQ(i2d_DSA_SIG(dsasig.get(), &ptr), size);
+      return ByteSource::Allocated(data, size);
+    }
+    default:
+      UNREACHABLE();
+  }
 }
 
 }  // namespace crypto

--- a/src/crypto/crypto_ec.h
+++ b/src/crypto/crypto_ec.h
@@ -164,11 +164,11 @@ v8::Maybe<bool> GetEcKeyDetail(
     v8::Local<v8::Object> target);
 
 ByteSource ConvertToWebCryptoSignature(
-  ManagedEVPPKey key,
+  const ManagedEVPPKey& key,
   const ByteSource& signature);
 
 ByteSource ConvertFromWebCryptoSignature(
-    ManagedEVPPKey key,
+    const ManagedEVPPKey& key,
     const ByteSource& signature);
 
 }  // namespace crypto

--- a/src/crypto/crypto_sig.cc
+++ b/src/crypto/crypto_sig.cc
@@ -744,9 +744,9 @@ Maybe<bool> SignTraits::AdditionalConfig(
     }
   }
 
-  if (args[offset + 4]->IsUint32()) {  // Salt length
+  if (args[offset + 4]->IsInt32()) {  // Salt length
     params->flags |= SignConfiguration::kHasSaltLength;
-    params->salt_length = args[offset + 4].As<Uint32>()->Value();
+    params->salt_length = args[offset + 4].As<Int32>()->Value();
   }
   if (args[offset + 5]->IsUint32()) {  // Padding
     params->flags |= SignConfiguration::kHasPadding;

--- a/src/crypto/crypto_sig.h
+++ b/src/crypto/crypto_sig.h
@@ -15,7 +15,8 @@ namespace crypto {
 static const unsigned int kNoDsaSignature = static_cast<unsigned int>(-1);
 
 enum DSASigEnc {
-  kSigEncDER, kSigEncP1363
+  kSigEncDER,
+  kSigEncP1363
 };
 
 class SignBase : public BaseObject {
@@ -117,6 +118,7 @@ struct SignConfiguration final : public MemoryRetainer {
   int flags = SignConfiguration::kHasNone;
   int padding = 0;
   int salt_length = 0;
+  DSASigEnc dsa_encoding = kSigEncDER;
 
   SignConfiguration() = default;
 

--- a/src/crypto/crypto_util.h
+++ b/src/crypto/crypto_util.h
@@ -75,7 +75,7 @@ using HMACCtxPointer = DeleteFnPtr<HMAC_CTX, HMAC_CTX_free>;
 using CipherCtxPointer = DeleteFnPtr<EVP_CIPHER_CTX, EVP_CIPHER_CTX_free>;
 using RsaPointer = DeleteFnPtr<RSA, RSA_free>;
 using DsaPointer = DeleteFnPtr<DSA, DSA_free>;
-using EcdsaSigPointer = DeleteFnPtr<ECDSA_SIG, ECDSA_SIG_free>;
+using DsaSigPointer = DeleteFnPtr<DSA_SIG, DSA_SIG_free>;
 
 // Our custom implementation of the certificate verify callback
 // used when establishing a TLS handshake. Because we cannot perform

--- a/test/parallel/test-crypto-async-sign-verify.js
+++ b/test/parallel/test-crypto-async-sign-verify.js
@@ -98,11 +98,11 @@ test('ec_secp256k1_public.pem', 'ec_secp256k1_private.pem', 'sha384', false,
      { dsaEncoding: 'ieee-p1363' });
 
 // DSA w/ der signature encoding
-test('dsa_public_1025.pem', 'dsa_private_1025.pem', 'sha256',
+test('dsa_public.pem', 'dsa_private.pem', 'sha256',
      false);
-test('dsa_public_1025.pem', 'dsa_private_1025.pem', 'sha256',
+test('dsa_public.pem', 'dsa_private.pem', 'sha256',
      false, { dsaEncoding: 'der' });
 
 // DSA w/ ieee-p1363 signature encoding
-test('dsa_public_1025.pem', 'dsa_private_1025.pem', 'sha256', false,
+test('dsa_public.pem', 'dsa_private.pem', 'sha256', false,
      { dsaEncoding: 'ieee-p1363' });

--- a/test/parallel/test-crypto-async-sign-verify.js
+++ b/test/parallel/test-crypto-async-sign-verify.js
@@ -7,7 +7,7 @@ const assert = require('assert');
 const crypto = require('crypto');
 const fixtures = require('../common/fixtures');
 
-async function test(
+function test(
   publicFixture,
   privateFixture,
   algorithm,
@@ -61,40 +61,38 @@ async function test(
   }
 }
 
-Promise.all([
-  // RSA w/ default padding
-  test('rsa_public.pem', 'rsa_private.pem', 'sha256', true),
-  test('rsa_public.pem', 'rsa_private.pem', 'sha256', true,
-       { padding: crypto.constants.RSA_PKCS1_PADDING }),
+// RSA w/ default padding
+test('rsa_public.pem', 'rsa_private.pem', 'sha256', true),
+test('rsa_public.pem', 'rsa_private.pem', 'sha256', true,
+     { padding: crypto.constants.RSA_PKCS1_PADDING });
 
-  // RSA w/ PSS_PADDING and default saltLength
-  test('rsa_public.pem', 'rsa_private.pem', 'sha256', false,
-       { padding: crypto.constants.RSA_PKCS1_PSS_PADDING }),
-  test('rsa_public.pem', 'rsa_private.pem', 'sha256', false,
-       {
-         padding: crypto.constants.RSA_PKCS1_PSS_PADDING,
-         saltLength: crypto.constants.RSA_PSS_SALTLEN_MAX_SIGN
-       }),
+// RSA w/ PSS_PADDING and default saltLength
+test('rsa_public.pem', 'rsa_private.pem', 'sha256', false,
+     { padding: crypto.constants.RSA_PKCS1_PSS_PADDING });
+test('rsa_public.pem', 'rsa_private.pem', 'sha256', false,
+     {
+       padding: crypto.constants.RSA_PKCS1_PSS_PADDING,
+       saltLength: crypto.constants.RSA_PSS_SALTLEN_MAX_SIGN
+     });
 
-  // RSA w/ PSS_PADDING and PSS_SALTLEN_DIGEST
-  test('rsa_public.pem', 'rsa_private.pem', 'sha256', false,
-       {
-         padding: crypto.constants.RSA_PKCS1_PSS_PADDING,
-         saltLength: crypto.constants.RSA_PSS_SALTLEN_DIGEST
-       }),
+// RSA w/ PSS_PADDING and PSS_SALTLEN_DIGEST
+test('rsa_public.pem', 'rsa_private.pem', 'sha256', false,
+     {
+       padding: crypto.constants.RSA_PKCS1_PSS_PADDING,
+       saltLength: crypto.constants.RSA_PSS_SALTLEN_DIGEST
+     });
 
-  // ED25519
-  test('ed25519_public.pem', 'ed25519_private.pem', undefined, true),
-  // ED448
-  test('ed448_public.pem', 'ed448_private.pem', undefined, true),
+// ED25519
+test('ed25519_public.pem', 'ed25519_private.pem', undefined, true),
+// ED448
+test('ed448_public.pem', 'ed448_private.pem', undefined, true),
 
-  // ECDSA w/ der signature encoding
-  test('ec_secp256k1_public.pem', 'ec_secp256k1_private.pem', 'sha384',
-       false),
-  test('ec_secp256k1_public.pem', 'ec_secp256k1_private.pem', 'sha384',
-       false, { dsaEncoding: 'der' }),
+// ECDSA w/ der signature encoding
+test('ec_secp256k1_public.pem', 'ec_secp256k1_private.pem', 'sha384',
+     false),
+test('ec_secp256k1_public.pem', 'ec_secp256k1_private.pem', 'sha384',
+     false, { dsaEncoding: 'der' });
 
-  // ECDSA w/ ieee-p1363 signature encoding
-  test('ec_secp256k1_public.pem', 'ec_secp256k1_private.pem', 'sha384', false,
-       { dsaEncoding: 'ieee-p1363' }),
-]).then(common.mustCall());
+// ECDSA w/ ieee-p1363 signature encoding
+test('ec_secp256k1_public.pem', 'ec_secp256k1_private.pem', 'sha384', false,
+     { dsaEncoding: 'ieee-p1363' });

--- a/test/parallel/test-crypto-async-sign-verify.js
+++ b/test/parallel/test-crypto-async-sign-verify.js
@@ -39,12 +39,12 @@ function test(
   }
 
   const data = Buffer.from('Hello world');
-  const signature = crypto.sign(algorithm, data, privateKey);
+  const expected = crypto.sign(algorithm, data, privateKey);
 
   for (const key of [privatePem, privateKey, privateDer]) {
     crypto.sign(algorithm, data, key, common.mustSucceed((actual) => {
       if (deterministic) {
-        assert.deepStrictEqual(actual, signature);
+        assert.deepStrictEqual(actual, expected);
       }
 
       assert.strictEqual(
@@ -53,7 +53,7 @@ function test(
   }
 
   for (const key of [publicPem, publicKey, publicDer]) {
-    crypto.verify(algorithm, data, key, signature, common.mustSucceed(
+    crypto.verify(algorithm, data, key, expected, common.mustSucceed(
       (verified) => assert.strictEqual(verified, true)));
 
     crypto.verify(algorithm, data, key, Buffer.from(''), common.mustSucceed(
@@ -62,7 +62,7 @@ function test(
 }
 
 // RSA w/ default padding
-test('rsa_public.pem', 'rsa_private.pem', 'sha256', true),
+test('rsa_public.pem', 'rsa_private.pem', 'sha256', true);
 test('rsa_public.pem', 'rsa_private.pem', 'sha256', true,
      { padding: crypto.constants.RSA_PKCS1_PADDING });
 
@@ -76,23 +76,33 @@ test('rsa_public.pem', 'rsa_private.pem', 'sha256', false,
      });
 
 // RSA w/ PSS_PADDING and PSS_SALTLEN_DIGEST
-test('rsa_public.pem', 'rsa_private.pem', 'sha256', false,
-     {
-       padding: crypto.constants.RSA_PKCS1_PSS_PADDING,
-       saltLength: crypto.constants.RSA_PSS_SALTLEN_DIGEST
-     });
+// test('rsa_public.pem', 'rsa_private.pem', 'sha256', false,
+//      {
+//        padding: crypto.constants.RSA_PKCS1_PSS_PADDING,
+//        saltLength: crypto.constants.RSA_PSS_SALTLEN_DIGEST
+//      });
 
 // ED25519
-test('ed25519_public.pem', 'ed25519_private.pem', undefined, true),
+test('ed25519_public.pem', 'ed25519_private.pem', undefined, true);
 // ED448
-test('ed448_public.pem', 'ed448_private.pem', undefined, true),
+test('ed448_public.pem', 'ed448_private.pem', undefined, true);
 
 // ECDSA w/ der signature encoding
 test('ec_secp256k1_public.pem', 'ec_secp256k1_private.pem', 'sha384',
-     false),
+     false);
 test('ec_secp256k1_public.pem', 'ec_secp256k1_private.pem', 'sha384',
      false, { dsaEncoding: 'der' });
 
 // ECDSA w/ ieee-p1363 signature encoding
 test('ec_secp256k1_public.pem', 'ec_secp256k1_private.pem', 'sha384', false,
+     { dsaEncoding: 'ieee-p1363' });
+
+// DSA w/ der signature encoding
+test('dsa_public_1025.pem', 'dsa_private_1025.pem', 'sha256',
+     false);
+test('dsa_public_1025.pem', 'dsa_private_1025.pem', 'sha256',
+     false, { dsaEncoding: 'der' });
+
+// DSA w/ ieee-p1363 signature encoding
+test('dsa_public_1025.pem', 'dsa_private_1025.pem', 'sha256', false,
      { dsaEncoding: 'ieee-p1363' });

--- a/test/parallel/test-crypto-async-sign-verify.js
+++ b/test/parallel/test-crypto-async-sign-verify.js
@@ -1,0 +1,101 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const crypto = require('crypto');
+const fixtures = require('../common/fixtures');
+
+async function test(
+  publicFixture,
+  privateFixture,
+  algorithm,
+  deterministic,
+  options
+) {
+  let publicPem = fixtures.readKey(publicFixture);
+  let privatePem = fixtures.readKey(privateFixture);
+  let privateKey = crypto.createPrivateKey(privatePem);
+  let publicKey = crypto.createPublicKey(publicPem);
+  const privateDer = {
+    key: privateKey.export({ format: 'der', type: 'pkcs8' }),
+    format: 'der',
+    type: 'pkcs8',
+    ...options
+  };
+  const publicDer = {
+    key: publicKey.export({ format: 'der', type: 'spki' }),
+    format: 'der',
+    type: 'spki',
+    ...options
+  };
+
+  if (options) {
+    publicPem = { ...options, key: publicPem };
+    privatePem = { ...options, key: privatePem };
+    privateKey = { ...options, key: privateKey };
+    publicKey = { ...options, key: publicKey };
+  }
+
+  const data = Buffer.from('Hello world');
+  const signature = crypto.sign(algorithm, data, privateKey);
+
+  for (const key of [privatePem, privateKey, privateDer]) {
+    crypto.sign(algorithm, data, key, common.mustSucceed((actual) => {
+      if (deterministic) {
+        assert.deepStrictEqual(actual, signature);
+      } else {
+        assert.strictEqual(
+          crypto.verify(algorithm, data, key, signature), true);
+      }
+    }));
+  }
+
+  for (const key of [publicPem, publicKey, publicDer]) {
+    crypto.verify(algorithm, data, key, signature, common.mustSucceed(
+      (actual) => assert.strictEqual(actual, true)));
+
+    crypto.verify(algorithm, data, key, Buffer.from(''), common.mustSucceed(
+      (actual) => assert.strictEqual(actual, false)));
+  }
+}
+
+Promise.all([
+  // RSA w/ default padding
+  test('rsa_public.pem', 'rsa_private.pem', 'sha256', true),
+  test('rsa_public.pem', 'rsa_private.pem', 'sha256', true,
+       { padding: crypto.constants.RSA_PKCS1_PADDING }),
+
+  // RSA w/ PSS_PADDING and default saltLength
+  test('rsa_public.pem', 'rsa_private.pem', 'sha256', false,
+       { padding: crypto.constants.RSA_PKCS1_PSS_PADDING }),
+  test('rsa_public.pem', 'rsa_private.pem', 'sha256', false,
+       {
+         padding: crypto.constants.RSA_PKCS1_PSS_PADDING,
+         saltLength: crypto.constants.RSA_PSS_SALTLEN_MAX_SIGN
+       }),
+
+  // RSA w/ PSS_PADDING and PSS_SALTLEN_DIGEST
+  test('rsa_public.pem', 'rsa_private.pem', 'sha256', false,
+       {
+         padding: crypto.constants.RSA_PKCS1_PSS_PADDING,
+         saltLength: crypto.constants.RSA_PSS_SALTLEN_DIGEST
+       }),
+
+  // ED25519
+  test('ed25519_public.pem', 'ed25519_private.pem', undefined, true),
+  // ED448
+  test('ed448_public.pem', 'ed448_private.pem', undefined, true),
+
+  // TODO: add dsaSigEnc to SignJob
+  // ECDSA w/ der signature encoding
+  // test('ec_secp256k1_public.pem', 'ec_secp256k1_private.pem', 'sha384',
+  //      false),
+  // test('ec_secp256k1_public.pem', 'ec_secp256k1_private.pem', 'sha384',
+  //      false, { dsaEncoding: 'der' }),
+
+  // ECDSA w/ ieee-p1363 signature encoding
+  test('ec_secp256k1_public.pem', 'ec_secp256k1_private.pem', 'sha384', false,
+       { dsaEncoding: 'ieee-p1363' }),
+]).then(common.mustCall());

--- a/test/parallel/test-crypto-async-sign-verify.js
+++ b/test/parallel/test-crypto-async-sign-verify.js
@@ -45,19 +45,19 @@ async function test(
     crypto.sign(algorithm, data, key, common.mustSucceed((actual) => {
       if (deterministic) {
         assert.deepStrictEqual(actual, signature);
-      } else {
-        assert.strictEqual(
-          crypto.verify(algorithm, data, key, signature), true);
       }
+
+      assert.strictEqual(
+        crypto.verify(algorithm, data, key, actual), true);
     }));
   }
 
   for (const key of [publicPem, publicKey, publicDer]) {
     crypto.verify(algorithm, data, key, signature, common.mustSucceed(
-      (actual) => assert.strictEqual(actual, true)));
+      (verified) => assert.strictEqual(verified, true)));
 
     crypto.verify(algorithm, data, key, Buffer.from(''), common.mustSucceed(
-      (actual) => assert.strictEqual(actual, false)));
+      (verified) => assert.strictEqual(verified, false)));
   }
 }
 
@@ -88,12 +88,11 @@ Promise.all([
   // ED448
   test('ed448_public.pem', 'ed448_private.pem', undefined, true),
 
-  // TODO: add dsaSigEnc to SignJob
   // ECDSA w/ der signature encoding
-  // test('ec_secp256k1_public.pem', 'ec_secp256k1_private.pem', 'sha384',
-  //      false),
-  // test('ec_secp256k1_public.pem', 'ec_secp256k1_private.pem', 'sha384',
-  //      false, { dsaEncoding: 'der' }),
+  test('ec_secp256k1_public.pem', 'ec_secp256k1_private.pem', 'sha384',
+       false),
+  test('ec_secp256k1_public.pem', 'ec_secp256k1_private.pem', 'sha384',
+       false, { dsaEncoding: 'der' }),
 
   // ECDSA w/ ieee-p1363 signature encoding
   test('ec_secp256k1_public.pem', 'ec_secp256k1_private.pem', 'sha384', false,

--- a/test/parallel/test-crypto-async-sign-verify.js
+++ b/test/parallel/test-crypto-async-sign-verify.js
@@ -76,11 +76,11 @@ test('rsa_public.pem', 'rsa_private.pem', 'sha256', false,
      });
 
 // RSA w/ PSS_PADDING and PSS_SALTLEN_DIGEST
-// test('rsa_public.pem', 'rsa_private.pem', 'sha256', false,
-//      {
-//        padding: crypto.constants.RSA_PKCS1_PSS_PADDING,
-//        saltLength: crypto.constants.RSA_PSS_SALTLEN_DIGEST
-//      });
+test('rsa_public.pem', 'rsa_private.pem', 'sha256', false,
+     {
+       padding: crypto.constants.RSA_PKCS1_PSS_PADDING,
+       saltLength: crypto.constants.RSA_PSS_SALTLEN_DIGEST
+     });
 
 // ED25519
 test('ed25519_public.pem', 'ed25519_private.pem', undefined, true);


### PR DESCRIPTION
As discussed in #37218 this begins adding callbacks for one-shot `crypto` module operations to allow for execution using libuv's threadpool, rather than introducing a new module.

Starting off with
- `crypto.sign(algorithm, data, key[, callback])`
- `crypto.verify(algorithm, data, key, signature[, callback])`