### PR TITLE
deps: V8: cherry-pick 373f4ae739ee

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.15',
+    'v8_embedder_string': '-node.16',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/torque/utils.cc
+++ b/deps/v8/src/torque/utils.cc
@@ -317,13 +317,15 @@ void ReplaceFileContentsIfDifferent(const std::string& file_path,
                                     const std::string& contents) {
   std::ifstream old_contents_stream(file_path.c_str());
   std::string old_contents;
+  bool file_exists = false;
   if (old_contents_stream.good()) {
+    file_exists = true;
     std::istreambuf_iterator<char> eos;
     old_contents =
         std::string(std::istreambuf_iterator<char>(old_contents_stream), eos);
     old_contents_stream.close();
   }
-  if (old_contents.length() == 0 || old_contents != contents) {
+  if (!file_exists || old_contents != contents) {
     std::ofstream new_contents_stream;
     new_contents_stream.open(file_path.c_str());
     new_contents_stream << contents;


### PR DESCRIPTION
Original commit message:

    [torque] Don't replace unmodified empty files

    To improve incremental builds.

    Bug: v8:7793
    Change-Id: I6990a97e058d22d34acd1f609167cd30ca7518ad
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2596789
    Reviewed-by: Nico Hartmann <nicohartmann@chromium.org>
    Commit-Queue: Seth Brenith <seth.brenith@microsoft.com>
    Cr-Commit-Position: refs/heads/master@{#72053}
Refs: https://github.com/v8/v8/commit/373f4ae739eeae0e4d2224b15002be35f1470312

Fixes: https://github.com/nodejs/node/issues/37368
Refs: https://github.com/nodejs/node/pull/36139#issuecomment-780739135

Some of the `.inc` files written by torque are empty, i.e. they are
zero length. Actions in gyp generated makefiles are always run, and
torque would always write out zero length files which meant their 
timestamps were newer than any previously compiled object file. 

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
