### PR TITLE
stream: move duplicated code to an internal module

### DIFF
--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -11,7 +11,6 @@ const {
   FunctionPrototypeCall,
   ReflectApply,
   SymbolAsyncIterator,
-  SymbolIterator,
 } = primordials;
 
 let eos;
@@ -26,6 +25,12 @@ const {
 } = require('internal/errors').codes;
 
 const { validateCallback } = require('internal/validators');
+
+const {
+  isIterable,
+  isReadable,
+  isStream,
+} = require('internal/streams/utils');
 
 let EE;
 let PassThrough;
@@ -80,26 +85,6 @@ function popCallback(streams) {
   // checking for length === 0 as well.
   validateCallback(streams[streams.length - 1]);
   return ArrayPrototypePop(streams);
-}
-
-function isReadable(obj) {
-  return !!(obj && typeof obj.pipe === 'function');
-}
-
-function isWritable(obj) {
-  return !!(obj && typeof obj.write === 'function');
-}
-
-function isStream(obj) {
-  return isReadable(obj) || isWritable(obj);
-}
-
-function isIterable(obj, isAsync) {
-  if (!obj) return false;
-  if (isAsync === true) return typeof obj[SymbolAsyncIterator] === 'function';
-  if (isAsync === false) return typeof obj[SymbolIterator] === 'function';
-  return typeof obj[SymbolAsyncIterator] === 'function' ||
-    typeof obj[SymbolIterator] === 'function';
 }
 
 function makeAsyncIterable(val) {

--- a/lib/internal/streams/utils.js
+++ b/lib/internal/streams/utils.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const {
+  SymbolAsyncIterator,
+  SymbolIterator,
+} = primordials;
+
+function isReadable(obj) {
+  return !!(obj && typeof obj.pipe === 'function');
+}
+
+function isWritable(obj) {
+  return !!(obj && typeof obj.write === 'function');
+}
+
+function isStream(obj) {
+  return isReadable(obj) || isWritable(obj);
+}
+
+function isIterable(obj, isAsync) {
+  if (!obj) return false;
+  if (isAsync === true) return typeof obj[SymbolAsyncIterator] === 'function';
+  if (isAsync === false) return typeof obj[SymbolIterator] === 'function';
+  return typeof obj[SymbolAsyncIterator] === 'function' ||
+    typeof obj[SymbolIterator] === 'function';
+}
+
+module.exports = {
+  isIterable,
+  isReadable,
+  isStream,
+};

--- a/lib/stream/promises.js
+++ b/lib/stream/promises.js
@@ -3,8 +3,6 @@
 const {
   ArrayPrototypePop,
   Promise,
-  SymbolAsyncIterator,
-  SymbolIterator,
 } = primordials;
 
 const {
@@ -15,28 +13,13 @@ const {
   validateAbortSignal,
 } = require('internal/validators');
 
+const {
+  isIterable,
+  isStream,
+} = require('internal/streams/utils');
+
 let pl;
 let eos;
-
-function isReadable(obj) {
-  return !!(obj && typeof obj.pipe === 'function');
-}
-
-function isWritable(obj) {
-  return !!(obj && typeof obj.write === 'function');
-}
-
-function isStream(obj) {
-  return isReadable(obj) || isWritable(obj);
-}
-
-function isIterable(obj, isAsync) {
-  if (!obj) return false;
-  if (isAsync === true) return typeof obj[SymbolAsyncIterator] === 'function';
-  if (isAsync === false) return typeof obj[SymbolIterator] === 'function';
-  return typeof obj[SymbolAsyncIterator] === 'function' ||
-    typeof obj[SymbolIterator] === 'function';
-}
 
 function pipeline(...streams) {
   if (!pl) pl = require('internal/streams/pipeline');

--- a/node.gyp
+++ b/node.gyp
@@ -263,6 +263,7 @@
       'lib/internal/streams/state.js',
       'lib/internal/streams/pipeline.js',
       'lib/internal/streams/end-of-stream.js',
+      'lib/internal/streams/utils.js',
       'deps/v8/tools/splaytree.js',
       'deps/v8/tools/codemap.js',
       'deps/v8/tools/consarray.js',

--- a/test/parallel/test-bootstrap-modules.js
+++ b/test/parallel/test-bootstrap-modules.js
@@ -98,6 +98,7 @@ const expectedModules = new Set([
   'NativeModule internal/streams/readable',
   'NativeModule internal/streams/state',
   'NativeModule internal/streams/transform',
+  'NativeModule internal/streams/utils',
   'NativeModule internal/streams/writable',
   'NativeModule internal/timers',
   'NativeModule internal/url',


### PR DESCRIPTION
~isIterable() is called in one place with only one argument, so the
second argument and associated logic for it can be removed.~

Create a utils module for isIterable(), isReadable(), and isStream().


<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
