### PR TITLE
fs: code style for fs/promises

### DIFF
--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -174,7 +174,7 @@ class FileHandle extends EventEmitterMixin(JSTransferable) {
     return fsCall(writeFile, this, data, options);
   }
 
-  close = () => {
+  close() {
     if (this[kFd] === -1) {
       return PromiseResolve();
     }


### PR DESCRIPTION
I think that the 
```javascript
close = () => {...}
```  
should be changed to 
```javascript
close() {...}
```

to make all method declarations of this class in a uniform style