### PR TITLE
doc: revise CI text in collaborator guide

### DIFF
--- a/doc/guides/collaborator-guide.md
+++ b/doc/guides/collaborator-guide.md
@@ -210,11 +210,11 @@ the comment anyway to avoid any doubt.
 All fixes must have a test case which demonstrates the defect. The test should
 fail before the change, and pass after the change.
 
-Do not land any pull requests without a passing (green or yellow) CI run.
-A green GitHub Actions CI result is required. A passing
-[Jenkins CI](https://ci.nodejs.org/) is also required if PR contains changes
-that will affect the `node` binary. This is critical as GitHub Actions CI does
-not cover all the environments supported by Node.js.
+Do not land any pull requests without the necessary passing CI runs.
+A passing (green) GitHub Actions CI result is required. A passing (green or
+yellow) [Jenkins CI](https://ci.nodejs.org/) is also required if the pull
+request contains changes that will affect the `node` binary. This is because
+GitHub Actions CI does not cover all the environments supported by Node.js.
 
 <details>
 <summary>Changes that affect the `node` binary</summary>
@@ -295,7 +295,7 @@ in the form:
 To specify the branch this way, `refs/heads/BRANCH` is used
 (e.g. for `master` -> `refs/heads/master`).
 For pull requests, it will look like `refs/pull/PR_NUMBER/head`
-(e.g. for PR#42 -> `refs/pull/42/head`).
+(e.g. for pull request #42 -> `refs/pull/42/head`).
 * `REBASE_ONTO`: Change that to `origin/master` so the pull request gets rebased
 onto master. This can especially be important for pull requests that have been
 open a while.


### PR DESCRIPTION
Minor clarifications to text. For example, this moves the "(green or
yellow)" parenthetical closer to the text to which it applies. (It
applies only to Jenkins CI.)

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
