### PR TITLE
src: make BaseObject::is_snapshotable virtual

### DIFF
--- a/src/base_object.h
+++ b/src/base_object.h
@@ -158,8 +158,7 @@ class BaseObject : public MemoryRetainer {
 
   virtual inline void OnGCCollect();
 
-  bool is_snapshotable() const { return is_snapshotable_; }
-  void set_is_snapshotable(bool val) { is_snapshotable_ = val; }
+  virtual inline bool is_snapshotable() const { return false; }
 
  private:
   v8::Local<v8::Object> WrappedObject() const override;
@@ -209,7 +208,6 @@ class BaseObject : public MemoryRetainer {
 
   Environment* env_;
   PointerData* pointer_data_ = nullptr;
-  bool is_snapshotable_ = false;
 };
 
 // Global alias for FromJSObject() to avoid churn.

--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -16,7 +16,6 @@ SnapshotableObject::SnapshotableObject(Environment* env,
                                        Local<Object> wrap,
                                        EmbedderObjectType type)
     : BaseObject(env, wrap), type_(type) {
-  set_is_snapshotable(true);
 }
 
 const char* SnapshotableObject::GetTypeNameChars() const {

--- a/src/node_snapshotable.h
+++ b/src/node_snapshotable.h
@@ -90,6 +90,7 @@ class SnapshotableObject : public BaseObject {
   virtual void PrepareForSerialization(v8::Local<v8::Context> context,
                                        v8::SnapshotCreator* creator) = 0;
   virtual InternalFieldInfo* Serialize(int index) = 0;
+  bool is_snapshotable() const override { return true; }
   // We'll make sure that the type is set in the constructor
   EmbedderObjectType type() { return type_; }
 


### PR DESCRIPTION
Use a virtual function in order to save space (8 bytes per instance
on 64-bit platforms) and in order to be consistent with the other
methods on BaseObject.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
