### PR TITLE
test: account for pending deprecations in esm test

### DIFF
--- a/test/es-module/test-esm-local-deprecations.mjs
+++ b/test/es-module/test-esm-local-deprecations.mjs
@@ -1,4 +1,4 @@
-import { mustCall } from '../common/index.mjs';
+import '../common/index.mjs';
 import assert from 'assert';
 import fixtures from '../common/fixtures.js';
 import { pathToFileURL } from 'url';
@@ -9,15 +9,20 @@ const selfDeprecatedFolders =
 const deprecatedFoldersIgnore =
     fixtures.path('/es-modules/deprecated-folders-ignore/main.js');
 
-let curWarning = 0;
 const expectedWarnings = [
   '"./" in the "exports" field',
   '"#self/" in the "imports" field'
 ];
 
-process.addListener('warning', mustCall((warning) => {
-  assert(warning.stack.includes(expectedWarnings[curWarning++]), warning.stack);
-}, expectedWarnings.length));
+process.addListener('warning', (warning) => {
+  if (warning.stack.includes(expectedWarnings[0])) {
+    expectedWarnings.shift();
+  }
+});
+
+process.on('exit', () => {
+  assert.deepStrictEqual(expectedWarnings, []);
+});
 
 (async () => {
   await import(pathToFileURL(selfDeprecatedFolders));


### PR DESCRIPTION
test-esm-local-deprecations fails if NODE_PENDING_DEPRECATION is set
because the test expects exactly the warnings it expects and no other
warnings. Modify the test to still expect its errors in the order it
expects them, but to ignore errors it does not expect.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
