### PR TITLE
domain: improve DEP0097 warning

### DIFF
--- a/lib/domain.js
+++ b/lib/domain.js
@@ -456,7 +456,7 @@ EventEmitter.init = function() {
 };
 
 const eventEmit = EventEmitter.prototype.emit;
-EventEmitter.prototype.emit = function(...args) {
+EventEmitter.prototype.emit = function emit(...args) {
   const domain = this.domain;
 
   const type = args[0];

--- a/lib/domain.js
+++ b/lib/domain.js
@@ -130,7 +130,7 @@ function emitMakeCallbackDeprecation({ target, method }) {
       'Using a domain property in MakeCallback is deprecated. Use the ' +
       'async_context variant of MakeCallback or the AsyncResource class ' +
       'instead. ' +
-      `(Triggered by calling ${method?.name ?? '<anonymous>'} ` +
+      `(Triggered by calling ${method?.name || '<anonymous>'} ` +
       `on ${target?.constructor?.name}.)`,
       'DeprecationWarning', 'DEP0097');
     sendMakeCallbackDeprecation = true;

--- a/test/parallel/test-domain-dep0097.js
+++ b/test/parallel/test-domain-dep0097.js
@@ -1,0 +1,17 @@
+'use strict';
+const common = require('../common');
+
+common.skipIfInspectorDisabled();
+
+const assert = require('assert');
+const domain = require('domain');
+const inspector = require('inspector');
+
+process.on('warning', common.mustCall((warning) => {
+  assert.strictEqual(warning.code, 'DEP0097');
+  assert.match(warning.message, /Triggered by calling <anonymous> on process/);
+}));
+
+domain.create().run(() => {
+  inspector.open();
+});

--- a/test/parallel/test-domain-dep0097.js
+++ b/test/parallel/test-domain-dep0097.js
@@ -9,7 +9,7 @@ const inspector = require('inspector');
 
 process.on('warning', common.mustCall((warning) => {
   assert.strictEqual(warning.code, 'DEP0097');
-  assert.match(warning.message, /Triggered by calling <anonymous> on process/);
+  assert.match(warning.message, /Triggered by calling emit on process/);
 }));
 
 domain.create().run(() => {


### PR DESCRIPTION
There are two issues here:

1. Anonymous functions, whose `name` is the empty string were not being displayed properly. This is addressed by the first commit.
2. The `domain` module monkey patches `EventEmitter.prototype.emit()`, but that function's name was not being inferred. This is addressed by the second commit.