### PR TITLE
fs: const variables for createDeferredPromise

### DIFF
--- a/lib/internal/fs/watchers.js
+++ b/lib/internal/fs/watchers.js
@@ -319,7 +319,7 @@ async function* watch(filename, options = {}) {
     throw new AbortError();
 
   const handle = new FSEvent();
-  let { promise, resolve, reject } = createDeferredPromise();
+  const { promise, resolve, reject } = createDeferredPromise();
   const oncancel = () => {
     handle.close();
     reject(new AbortError());


### PR DESCRIPTION
Since the value is never changed, we can use `const` declaration instead of `let`.