### PR TITLE
build: include minimal V8 headers in distribution

### DIFF
--- a/tools/install.py
+++ b/tools/install.py
@@ -157,12 +157,17 @@ def files(action):
   headers(action)
 
 def headers(action):
-  def ignore_inspector_headers(files_arg, dest):
-    inspector_headers = [
-      'deps/v8/include/v8-inspector.h',
-      'deps/v8/include/v8-inspector-protocol.h'
+  def wanted_v8_headers(files_arg, dest):
+    v8_headers = [
+      'deps/v8/include/cppgc/common.h',
+      'deps/v8/include/v8.h',
+      'deps/v8/include/v8-internal.h',
+      'deps/v8/include/v8-platform.h',
+      'deps/v8/include/v8-profiler.h',
+      'deps/v8/include/v8-version.h',
+      'deps/v8/include/v8config.h',
     ]
-    files_arg = [name for name in files_arg if name not in inspector_headers]
+    files_arg = [name for name in files_arg if name in v8_headers]
     action(files_arg, dest)
 
   action([
@@ -182,7 +187,7 @@ def headers(action):
   if sys.platform.startswith('aix'):
     action(['out/Release/node.exp'], 'include/node/')
 
-  subdir_files('deps/v8/include', 'include/node/', ignore_inspector_headers)
+  subdir_files('deps/v8/include', 'include/node/', wanted_v8_headers)
 
   if 'false' == variables.get('node_shared_libuv'):
     subdir_files('deps/uv/include', 'include/node/', action)


### PR DESCRIPTION
    build: include minimal V8 headers in distribution

    Because Node.js currently distributes all V8 headers, it is not clear
    which ones are part of our API and ABI compatibility contract. V8 may
    add, remove, or change headers at any time, preventing us sometimes
    from updating because the change could affect addons which may depend
    on them. Moreover, the `cppgc` library, included in V8, is exposed
    even though it is still in active development and doesn't have a
    stable API.
    Node.js should choose exactly which headers are exposed and part of
    our native API, so that it's easier to reason about changes during V8
    updates and to prevent us from automatically increasing the API
    surface when new headers are added by V8.
    Instead of specifically excluding v8-inspector, only include `v8.h`,
    `v8-platform.h` (used in `node.h`) and `v8-profiler.h`.