### PR TITLE
tools: fix compiler warning in inspector_protocol

### DIFF
--- a/tools/inspector_protocol/encoding/encoding.cc
+++ b/tools/inspector_protocol/encoding/encoding.cc
@@ -833,8 +833,9 @@ void CBORTokenizer::ReadNextToken(bool enter_envelope) {
           // inspector_protocol, it's not a CBOR limitation), so we check
           // against the signed max, so that the allowable values are
           // 0, 1, 2, ... 2^31 - 1.
-          if (!success || std::numeric_limits<int32_t>::max() <
-                              token_start_internal_value_) {
+          if (!success ||
+                static_cast<int64_t>(std::numeric_limits<int32_t>::max()) <
+                  static_cast<int64_t>(token_start_internal_value_)) {
             SetError(Error::CBOR_INVALID_INT32);
             return;
           }

--- a/tools/inspector_protocol/lib/encoding_cpp.template
+++ b/tools/inspector_protocol/lib/encoding_cpp.template
@@ -840,8 +840,9 @@ void CBORTokenizer::ReadNextToken(bool enter_envelope) {
           // inspector_protocol, it's not a CBOR limitation), so we check
           // against the signed max, so that the allowable values are
           // 0, 1, 2, ... 2^31 - 1.
-          if (!success || std::numeric_limits<int32_t>::max() <
-                              token_start_internal_value_) {
+          if (!success ||
+                static_cast<int64_t>(std::numeric_limits<int32_t>::max()) <
+                  static_cast<int64_t>(token_start_internal_value_)) {
             SetError(Error::CBOR_INVALID_INT32);
             return;
           }


### PR DESCRIPTION
```
error: comparison of integer expressions of different signedness:
‘int’ and ‘uint64_t’ {aka ‘long unsigned int’} [-Werror=sign-compare]
 2562 |           if (!success || std::numeric_limits<int32_t>::max() <
      |                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
 2563 |                               token_start_internal_value_) {
      |                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
