### PR TITLE
lib: runtime deprecate access to process.binding('async_wrap')

### DIFF
--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -105,6 +105,10 @@ const internalBindingAllowlist = new SafeSet([
   'zlib',
 ]);
 
+const runtimeDeprecatedList = new SafeSet([
+  'async_wrap',
+]);
+
 // Set up process.binding() and process._linkedBinding().
 {
   const bindingObj = ObjectCreate(null);
@@ -114,6 +118,13 @@ const internalBindingAllowlist = new SafeSet([
     // Deprecated specific process.binding() modules, but not all, allow
     // selective fallback to internalBinding for the deprecated ones.
     if (internalBindingAllowlist.has(module)) {
+      if (runtimeDeprecatedList.has(module)) {
+        runtimeDeprecatedList.delete(module);
+        process.emitWarning(
+          `Access to process.binding('${module}') is deprecated.`,
+          'DeprecationWarning',
+        'DEP0111');
+      }
       return internalBinding(module);
     }
     // eslint-disable-next-line no-restricted-syntax

--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -123,7 +123,7 @@ const runtimeDeprecatedList = new SafeSet([
         process.emitWarning(
           `Access to process.binding('${module}') is deprecated.`,
           'DeprecationWarning',
-        'DEP0111');
+          'DEP0111');
       }
       return internalBinding(module);
     }


### PR DESCRIPTION
* Runtime deprecates access to `process.binding('async_wrap')`
* ~~Exports `async_hooks.Providers` as a convenience~~
* Makes some other cleanups to the requires since I was in here poking around anyway.

/cc @addaleax @nodejs/tsc

Signed-off-by: James M Snell <jasnell@gmail.com>
Fixes: https://github.com/nodejs/node/issues/37575
Refs: https://github.com/nodejs/node/pull/37485#pullrequestreview-600060802

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
