### PR TITLE
vm: fix link with invalid graph

### DIFF
--- a/lib/internal/vm/module.js
+++ b/lib/internal/vm/module.js
@@ -255,6 +255,7 @@ const kNoError = Symbol('kNoError');
 class SourceTextModule extends Module {
   #error = kNoError;
   #statusOverride;
+  #waitingLinkPromises;
 
   constructor(sourceText, options = {}) {
     validateString(sourceText, 'sourceText');
@@ -308,31 +309,37 @@ class SourceTextModule extends Module {
     this[kLink] = async (linker) => {
       this.#statusOverride = 'linking';
 
-      const promises = this[kWrap].link(async (identifier) => {
-        const module = await linker(identifier, this);
-        if (module[kWrap] === undefined) {
-          throw new ERR_VM_MODULE_NOT_MODULE();
-        }
-        if (module.context !== this.context) {
-          throw new ERR_VM_MODULE_DIFFERENT_CONTEXT();
-        }
-        if (module.status === 'errored') {
-          throw new ERR_VM_MODULE_LINKING_ERRORED();
-        }
-        if (module.status === 'unlinked') {
-          await module[kLink](linker);
-        }
-        return module[kWrap];
-      });
-
       try {
+        const promises = this[kWrap].link(async (identifier) => {
+          const module = await linker(identifier, this);
+          if (module[kWrap] === undefined) {
+            throw new ERR_VM_MODULE_NOT_MODULE();
+          }
+          if (module.context !== this.context) {
+            throw new ERR_VM_MODULE_DIFFERENT_CONTEXT();
+          }
+          if (module.status === 'errored') {
+            throw new ERR_VM_MODULE_LINKING_ERRORED();
+          }
+          if (module.status === 'unlinked') {
+            await module[kLink](linker);
+          }
+          if (module.status === 'linking') {
+            await module.#waitingLinkPromises;
+          }
+          return module[kWrap];
+        });
+
         if (promises !== undefined) {
-          await PromiseAll(promises);
+          assert(this.#waitingLinkPromises === undefined);
+          this.#waitingLinkPromises = PromiseAll(promises);
         }
+        await this.#waitingLinkPromises;
       } catch (e) {
         this.#error = e;
         throw e;
       } finally {
+        this.#waitingLinkPromises = undefined;
         this.#statusOverride = undefined;
       }
     };

--- a/test/parallel/test-vm-module-link-37426.js
+++ b/test/parallel/test-vm-module-link-37426.js
@@ -1,0 +1,23 @@
+// Flags: --experimental-vm-modules
+
+'use strict';
+
+const common = require('../common');
+const { SourceTextModule, SyntheticModule } = require('vm');
+
+const tm = new SourceTextModule('import "a"');
+
+tm
+  .link(async () => {
+    const tm2 = new SourceTextModule('import "b"');
+    tm2.link(async () => {
+      const sm = new SyntheticModule([], () => {});
+      await sm.link(() => {});
+      await sm.evaluate();
+      return sm;
+    }).then(() => tm2.evaluate());
+    return tm2;
+  })
+  .then(() => tm.evaluate())
+  .then(common.mustCall())
+  .catch(common.mustNotCall());


### PR DESCRIPTION
This fixes an annoying bug where the entry module would link before its
dependencies were linked. This is fixed by forcing modules to wait for
all dependency linker promises to resolve.

Fixes: https://github.com/nodejs/node/issues/37426

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
