### PR TITLE
tools: use bundled npm in update scripts

### DIFF
--- a/tools/update-babel-eslint.sh
+++ b/tools/update-babel-eslint.sh
@@ -2,8 +2,6 @@
 
 # Shell script to update babel-eslint in the source tree to the latest release.
 
-# Depends on npm, npx, and node being in $PATH.
-
 # This script must be be in the tools directory when it runs because it uses
 # $0 to determine directories to work in.
 
@@ -11,15 +9,20 @@ cd "$( dirname "${0}" )" || exit
 rm -rf node_modules/@babel
 mkdir babel-eslint-tmp
 cd babel-eslint-tmp || exit
-npm init --yes
 
-npm install --global-style --no-bin-links --production --no-package-lock @babel/core @babel/eslint-parser@latest @babel/plugin-syntax-class-properties@latest @babel/plugin-syntax-top-level-await@latest
+ROOT="$PWD/../.."
+[ -z "$NODE" ] && NODE="$ROOT/out/Release/node"
+[ -x "$NODE" ] || NODE=`command -v node`
+NPM="$ROOT/deps/npm"
+
+"$NODE" "$NPM" init --yes
+"$NODE" "$NPM" install --global-style --no-bin-links --production --no-package-lock @babel/core @babel/eslint-parser@latest @babel/plugin-syntax-class-properties@latest @babel/plugin-syntax-top-level-await@latest
 
 # Use dmn to remove some unneeded files.
-npx dmn@2.2.2 -f clean
+"$NODE" "$NPM" exec -- dmn@2.2.2 -f clean
 # Use removeNPMAbsolutePaths to remove unused data in package.json.
 # This avoids churn as absolute paths can change from one dev to another.
-npx removeNPMAbsolutePaths@1.0.4 .
+"$NODE" "$NPM" exec -- removeNPMAbsolutePaths@1.0.4 .
 
 cd ..
 mv babel-eslint-tmp/node_modules/@babel node_modules/@babel

--- a/tools/update-eslint.sh
+++ b/tools/update-eslint.sh
@@ -2,8 +2,6 @@
 
 # Shell script to update ESLint in the source tree to the latest release.
 
-# Depends on npm, npx, and node being in $PATH.
-
 # This script must be in the tools directory when it runs because it uses the
 # script source file path to determine directories to work in.
 
@@ -12,16 +10,22 @@ rm -rf node_modules/eslint node_modules/eslint-plugin-markdown
 (
     mkdir eslint-tmp
     cd eslint-tmp || exit
-    npm init --yes
 
-    npm install --global-style --no-bin-links --production --no-package-lock eslint@latest
-    npm install --global-style --no-bin-links --production --no-package-lock eslint-plugin-markdown@latest
+    ROOT="$PWD/../.."
+    [ -z "$NODE" ] && NODE="$ROOT/out/Release/node"
+    [ -x "$NODE" ] || NODE=`command -v node`
+    NPM="$ROOT/deps/npm"
+
+    "$NODE" "$NPM" init --yes
+
+    "$NODE" "$NPM" install --global-style --no-bin-links --production --no-package-lock eslint@latest
+    "$NODE" "$NPM" install --global-style --no-bin-links --production --no-package-lock eslint-plugin-markdown@latest
 
     # Use dmn to remove some unneeded files.
-    npx dmn@2.2.2 -f clean
+    "$NODE" "$NPM" exec -- dmn@2.2.2 -f clean
     # Use removeNPMAbsolutePaths to remove unused data in package.json.
     # This avoids churn as absolute paths can change from one dev to another.
-    npx removeNPMAbsolutePaths@1.0.4 .
+    "$NODE" "$NPM" exec -- removeNPMAbsolutePaths@1.0.4 .
 )
 
 mv eslint-tmp/node_modules/eslint node_modules/eslint


### PR DESCRIPTION
The scripts `./tools/update-babel-eslint.sh` and
`./tools/update-eslint.sh` are relying on the version of `npm` found in
the local-defined `$PATH` env.

This changeset proposes to modify these scripts to run the version of
npm bundled in the current branch (found at `./deps/npm`) - in order to:

  1. Standardize the version of npm that should be use to install these
deps, avoids the pitfall of having an inadverted user run these
scripts with an unsupported/incompatible npm version.
  2. Given that npm7 has a different install algorithm than npm6 that
takes into account and install peer dependencies, it might be a safer
choice to ensure what version of npm should be use during this
transitional period in which users might still have npm6 by default in
their local system.
  3. Avoids the possible extra churn of having different resulting files
    being shuffled around between installs due to usage of a disparate
    version of the npm cli.

cc @lpinca @Trott @richardlau 

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
