### PR TITLE
test: fix wasi/test-return-on-exit on 32-bit systems

### DIFF
--- a/test/wasi/test-return-on-exit.js
+++ b/test/wasi/test-return-on-exit.js
@@ -21,7 +21,8 @@ const buffer = fs.readFileSync(modulePath);
   // Verify that if a WASI application throws an exception, Node rethrows it
   // properly.
   const wasi = new WASI({ returnOnExit: true });
-  wasi.wasiImport.proc_exit = () => { throw new Error('test error'); };
+  const patchedExit = () => { throw new Error('test error'); };
+  wasi.wasiImport.proc_exit = patchedExit.bind(wasi.wasiImport);
   const importObject = { wasi_snapshot_preview1: wasi.wasiImport };
   const { instance } = await WebAssembly.instantiate(buffer, importObject);
 

--- a/test/wasi/wasi.status
+++ b/test/wasi/wasi.status
@@ -5,7 +5,3 @@ prefix wasi
 # sample-test                        : PASS,FLAKY
 
 [true] # This section applies to all platforms
-
-[$system==win32]
-# https://github.com/nodejs/node/pull/36139
-test-return-on-exit: PASS,FLAKY


### PR DESCRIPTION
Let's see if this works...

Starting with the V8 8.8 update, this test has been regularly crashing with an out of memory error on 32-bit Windows. The issue has been narrowed down to a function not being bound. This seems like a V8 bug, but at least it seems that we can work around it.

Fixes: https://github.com/nodejs/node/issues/37374
