### PR TITLE
test: ignore WPT worker errors after tests finished

### DIFF
--- a/test/common/wpt.js
+++ b/test/common/wpt.js
@@ -389,6 +389,11 @@ class WPTRunner {
       });
 
       worker.on('error', (err) => {
+        if (!this.inProgress.has(testFileName)) {
+          // The test is already finished. Ignore errors that occur after it.
+          // This can happen normally, for example in timers tests.
+          return;
+        }
         this.fail(
           testFileName,
           {

--- a/test/wpt/status/html/webappapis/timers.json
+++ b/test/wpt/status/html/webappapis/timers.json
@@ -1,14 +1,1 @@
-{
-  "negative-settimeout.any.js": {
-    "fail": "assert_unreached: Reached unreachable code"
-  },
-  "type-long-setinterval.any.js": {
-    "fail": "assert_unreached: Reached unreachable code"
-  },
-  "type-long-settimeout.any.js": {
-    "fail": "assert_unreached: Reached unreachable code"
-  },
-  "negative-setinterval.any.js": {
-    "fail": "assert_unreached: Reached unreachable code"
-  }
-}
+{}


### PR DESCRIPTION
This can happen normally, for example in timers tests.
