### PR TITLE
test: clear obsolete FLAKY entries

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -8,8 +8,6 @@ prefix parallel
 
 [$system==win32]
 # https://github.com/nodejs/node/issues/20750
-test-http2-pipe: PASS,FLAKY
-# https://github.com/nodejs/node/issues/20750
 test-stream-pipeline-http2: PASS,FLAKY
 # https://github.com/nodejs/node/issues/24497
 test-timers-immediate-queue: PASS,FLAKY

--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -7,8 +7,6 @@ prefix parallel
 [true] # This section applies to all platforms
 
 [$system==win32]
-# https://github.com/nodejs/node/issues/20750
-test-stream-pipeline-http2: PASS,FLAKY
 # https://github.com/nodejs/node/issues/24497
 test-timers-immediate-queue: PASS,FLAKY
 # https://github.com/nodejs/node/issues/23277


### PR DESCRIPTION
test-stream-pipeline-http2 and test-http2-pipe haven't failed for a long time.

Closes: https://github.com/nodejs/node/issues/20750