### PR TITLE
test: improve error reporting in test-child-process-pipe-dataflow

### DIFF
--- a/test/parallel/test-child-process-pipe-dataflow.js
+++ b/test/parallel/test-child-process-pipe-dataflow.js
@@ -66,8 +66,8 @@ const MB = KB * KB;
     wcBuf += data;
   }));
 
-  wc.on('close', common.mustCall(() => {
+  process.on('exit', () => {
     // Grep always adds one extra byte at the end.
     assert.strictEqual(wcBuf.trim(), (MB + 1).toString());
-  }));
+  });
 }


### PR DESCRIPTION
When the test fails, it usually ends up failing on the assertion that
`wc` did not find as many bytes as it expected. That may not be
helpful if it is caused by a failure earlier in the command
pipeline ( cat | grep | wc ). Move the byte check to
`process.on('exit')` so that other error handlers that report the
existence of errors run first.

Refs: https://github.com/nodejs/node/issues/25988

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
