### PR TITLE
lib: fix typo in lib/internal/bootstrap/loaders.js

### DIFF
--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -4,7 +4,7 @@
 // lib/internal/modules/esm/* (ES Modules).
 //
 // This file is compiled and run by node.cc before bootstrap/node.js
-// was called, therefore the loaders are bootstraped before we start to
+// was called, therefore the loaders are bootstrapped before we start to
 // actually bootstrap Node.js. It creates the following objects:
 //
 // C++ binding loaders:


### PR DESCRIPTION
'bootstrapped' spelled as 'bootstraped'