### PR TITLE
lib: inline `Array` operations in `FreeList` methods

### DIFF
--- a/lib/internal/freelist.js
+++ b/lib/internal/freelist.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const {
+  ObjectSetPrototypeOf,
   ReflectApply,
 } = primordials;
 
@@ -9,18 +10,29 @@ class FreeList {
     this.name = name;
     this.ctor = ctor;
     this.max = max;
-    this.list = [];
+    this.list = ObjectSetPrototypeOf([], null);
   }
 
   alloc() {
-    return this.list.length > 0 ?
-      this.list.pop() :
-      ReflectApply(this.ctor, this, arguments);
+    const { list } = this;
+    const { length } = list;
+
+    if (length > 0) {
+      const lastIndex = length - 1;
+      const result = list[lastIndex];
+      list.length = lastIndex;
+      return result;
+    }
+
+    return ReflectApply(this.ctor, this, arguments);
   }
 
   free(obj) {
-    if (this.list.length < this.max) {
-      this.list.push(obj);
+    const { list } = this;
+    const { length } = list;
+
+    if (length < this.max) {
+      list[length] = obj;
       return true;
     }
     return false;


### PR DESCRIPTION
This inlines a simplified behaviour of <code>[%Array.prototype.pop%](https://tc39.es/ecma262/#sec-array.prototype.pop)</code> and <code>[%Array.prototype.push%](https://tc39.es/ecma262/#sec-array.prototype.push)</code> in `FreeList`’s methods and sets the prototype of the `list` to `null` so that [OrdinarySetWithOwnDescriptor](https://tc39.es/ecma262/#sec-ordinarysetwithowndescriptor) doesn’t walk up the prototype chain.

This avoids depending on user code not mutating `%Array.prototype%.pop` and `%Array.prototype%.push`.

---

**Refs:** <https://github.com/nodejs/node/pull/36565>
**Refs:** <https://github.com/nodejs/node/pull/36600>

> If I had to guess, I’d say **V8** is doing some inlining shenanigans when it detects a `push` or `pop` method on an ordinary array with `%Array.prototype%` in its `[[Prototype]]` internal slot.

---

/cc @aduh95 @Lxxyx 

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
