### PR TITLE
crypto: add internal error codes

### DIFF
--- a/src/crypto/crypto_cipher.h
+++ b/src/crypto/crypto_cipher.h
@@ -227,18 +227,18 @@ class CipherJob final : public CryptoJob<CipherTraits> {
       // Success!
       return;
     }
-    CryptoErrorVector* errors = CryptoJob<CipherTraits>::errors();
+    CryptoErrorStore* errors = CryptoJob<CipherTraits>::errors();
     errors->Capture();
-    if (errors->empty()) {
+    if (errors->Empty()) {
       switch (status) {
         case WebCryptoCipherStatus::OK:
           UNREACHABLE();
           break;
         case WebCryptoCipherStatus::INVALID_KEY_TYPE:
-          errors->emplace_back("Invalid key type.");
+          errors->Insert(NodeCryptoError::INVALID_KEY_TYPE);
           break;
         case WebCryptoCipherStatus::FAILED:
-          errors->emplace_back("Cipher job failed.");
+          errors->Insert(NodeCryptoError::CIPHER_JOB_FAILED);
           break;
       }
     }
@@ -248,17 +248,17 @@ class CipherJob final : public CryptoJob<CipherTraits> {
       v8::Local<v8::Value>* err,
       v8::Local<v8::Value>* result) override {
     Environment* env = AsyncWrap::env();
-    CryptoErrorVector* errors = CryptoJob<CipherTraits>::errors();
+    CryptoErrorStore* errors = CryptoJob<CipherTraits>::errors();
     if (out_.size() > 0) {
-      CHECK(errors->empty());
+      CHECK(errors->Empty());
       *err = v8::Undefined(env->isolate());
       *result = out_.ToArrayBuffer(env);
       return v8::Just(!result->IsEmpty());
     }
 
-    if (errors->empty())
+    if (errors->Empty())
       errors->Capture();
-    CHECK(!errors->empty());
+    CHECK(!errors->Empty());
     *result = v8::Undefined(env->isolate());
     return v8::Just(errors->ToException(env).ToLocal(err));
   }

--- a/src/crypto/crypto_context.cc
+++ b/src/crypto/crypto_context.cc
@@ -551,7 +551,7 @@ void SecureContext::SetEngineKey(const FunctionCallbackInfo<Value>& args) {
 
   CHECK_EQ(args.Length(), 2);
 
-  CryptoErrorVector errors;
+  CryptoErrorStore errors;
   Utf8Value engine_id(env->isolate(), args[1]);
   EnginePointer engine = LoadEngineById(*engine_id, &errors);
   if (!engine) {
@@ -987,7 +987,7 @@ void SecureContext::SetClientCertEngine(
   // support multiple calls to SetClientCertEngine.
   CHECK(!sc->client_cert_engine_provided_);
 
-  CryptoErrorVector errors;
+  CryptoErrorStore errors;
   const Utf8Value engine_id(env->isolate(), args[0]);
   EnginePointer engine = LoadEngineById(*engine_id, &errors);
   if (!engine) {

--- a/src/crypto/crypto_keygen.h
+++ b/src/crypto/crypto_keygen.h
@@ -82,10 +82,10 @@ class KeyGenJob final : public CryptoJob<KeyGenTraits> {
         // Success!
         break;
       case KeyGenJobStatus::FAILED: {
-        CryptoErrorVector* errors = CryptoJob<KeyGenTraits>::errors();
+        CryptoErrorStore* errors = CryptoJob<KeyGenTraits>::errors();
         errors->Capture();
-        if (errors->empty())
-          errors->push_back(std::string("Key generation job failed"));
+        if (errors->Empty())
+          errors->Insert(NodeCryptoError::KEY_GENERATION_JOB_FAILED);
       }
     }
   }
@@ -94,7 +94,7 @@ class KeyGenJob final : public CryptoJob<KeyGenTraits> {
       v8::Local<v8::Value>* err,
       v8::Local<v8::Value>* result) override {
     Environment* env = AsyncWrap::env();
-    CryptoErrorVector* errors = CryptoJob<KeyGenTraits>::errors();
+    CryptoErrorStore* errors = CryptoJob<KeyGenTraits>::errors();
     AdditionalParams* params = CryptoJob<KeyGenTraits>::params();
     if (status_ == KeyGenJobStatus::OK &&
         LIKELY(!KeyGenTraits::EncodeKey(env, params, result).IsNothing())) {
@@ -102,9 +102,9 @@ class KeyGenJob final : public CryptoJob<KeyGenTraits> {
       return v8::Just(true);
     }
 
-    if (errors->empty())
+    if (errors->Empty())
       errors->Capture();
-    CHECK(!errors->empty());
+    CHECK(!errors->Empty());
     *result = Undefined(env->isolate());
     return v8::Just(errors->ToException(env).ToLocal(err));
   }

--- a/src/crypto/crypto_keys.h
+++ b/src/crypto/crypto_keys.h
@@ -347,18 +347,18 @@ class KeyExportJob final : public CryptoJob<KeyExportTraits> {
       // Success!
       return;
     }
-    CryptoErrorVector* errors = CryptoJob<KeyExportTraits>::errors();
+    CryptoErrorStore* errors = CryptoJob<KeyExportTraits>::errors();
     errors->Capture();
-    if (errors->empty()) {
+    if (errors->Empty()) {
       switch (status) {
         case WebCryptoKeyExportStatus::OK:
           UNREACHABLE();
           break;
         case WebCryptoKeyExportStatus::INVALID_KEY_TYPE:
-          errors->emplace_back("Invalid key type.");
+          errors->Insert(NodeCryptoError::INVALID_KEY_TYPE);
           break;
         case WebCryptoKeyExportStatus::FAILED:
-          errors->emplace_back("Cipher job failed.");
+          errors->Insert(NodeCryptoError::CIPHER_JOB_FAILED);
           break;
       }
     }
@@ -368,17 +368,17 @@ class KeyExportJob final : public CryptoJob<KeyExportTraits> {
       v8::Local<v8::Value>* err,
       v8::Local<v8::Value>* result) override {
     Environment* env = AsyncWrap::env();
-    CryptoErrorVector* errors = CryptoJob<KeyExportTraits>::errors();
+    CryptoErrorStore* errors = CryptoJob<KeyExportTraits>::errors();
     if (out_.size() > 0) {
-      CHECK(errors->empty());
+      CHECK(errors->Empty());
       *err = v8::Undefined(env->isolate());
       *result = out_.ToArrayBuffer(env);
       return v8::Just(!result->IsEmpty());
     }
 
-    if (errors->empty())
+    if (errors->Empty())
       errors->Capture();
-    CHECK(!errors->empty());
+    CHECK(!errors->Empty());
     *result = v8::Undefined(env->isolate());
     return v8::Just(errors->ToException(env).ToLocal(err));
   }


### PR DESCRIPTION
According to addaleax's comment here: https://github.com/nodejs/node/pull/37555#pullrequestreview-601086451
> Maybe we could also expand `CryptoErrorVector` in the future to forward error codes, rather than just plain strings, so that the errors become more programatically accessible?