### PR TITLE
node-api: define version 8

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -689,6 +689,7 @@ For more details, review the [Object lifetime management][].
 added:
   - v14.8.0
   - v12.19.0
+napiVersion: 8
 -->
 
 A 128-bit value stored as two unsigned 64-bit integers. It serves as a UUID
@@ -1703,6 +1704,7 @@ with `napi_add_env_cleanup_hook`, otherwise the process will abort.
 added:
   - v14.8.0
   - v12.19.0
+napiVersion: 8
 changes:
   - version:
     - v14.10.0
@@ -1710,8 +1712,6 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/34819
     description: Changed signature of the `hook` callback.
 -->
-
-> Stability: 1 - Experimental
 
 ```c
 NAPI_EXTERN napi_status napi_add_async_cleanup_hook(
@@ -1753,8 +1753,6 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/34819
     description: Removed `env` parameter.
 -->
-
-> Stability: 1 - Experimental
 
 ```c
 NAPI_EXTERN napi_status napi_remove_async_cleanup_hook(
@@ -4213,9 +4211,8 @@ specification).
 added:
   - v14.14.0
   - v12.20.0
+napiVersion: 8
 -->
-
-> Stability: 1 - Experimental
 
 ```c
 napi_status napi_object_freeze(napi_env env,
@@ -4240,9 +4237,8 @@ ECMA-262 specification.
 added:
   - v14.14.0
   - v12.20.0
+napiVersion: 8
 -->
-
-> Stability: 1 - Experimental
 
 ```c
 napi_status napi_object_seal(napi_env env,
@@ -4905,9 +4901,8 @@ JavaScript object becomes garbage-collected.
 added:
   - v14.8.0
   - v12.19.0
+napiVersion: 8
 -->
-
-> Stability: 1 - Experimental
 
 ```c
 napi_status napi_type_tag_object(napi_env env,
@@ -4934,9 +4929,8 @@ If the object already has an associated type tag, this API will return
 added:
   - v14.8.0
   - v12.19.0
+napiVersion: 8
 -->
-
-> Stability: 1 - Experimental
 
 ```c
 napi_status napi_check_object_type_tag(napi_env env,

--- a/src/js_native_api.h
+++ b/src/js_native_api.h
@@ -17,7 +17,7 @@
 // functions available in a new version of N-API that is not yet ported in all
 // LTS versions, they can set NAPI_VERSION knowing that they have specifically
 // depended on that version.
-#define NAPI_VERSION 7
+#define NAPI_VERSION 8
 #endif
 #endif
 
@@ -539,7 +539,7 @@ NAPI_EXTERN napi_status napi_is_detached_arraybuffer(napi_env env,
                                                      bool* result);
 #endif  // NAPI_VERSION >= 7
 
-#ifdef NAPI_EXPERIMENTAL
+#if NAPI_VERSION >= 8
 // Type tagging
 NAPI_EXTERN napi_status napi_type_tag_object(napi_env env,
                                              napi_value value,
@@ -554,7 +554,7 @@ NAPI_EXTERN napi_status napi_object_freeze(napi_env env,
                                            napi_value object);
 NAPI_EXTERN napi_status napi_object_seal(napi_env env,
                                          napi_value object);
-#endif  // NAPI_EXPERIMENTAL
+#endif  // NAPI_VERSION >= 8
 
 EXTERN_C_END
 

--- a/src/js_native_api_types.h
+++ b/src/js_native_api_types.h
@@ -31,7 +31,7 @@ typedef enum {
   // from instance properties. Ignored by napi_define_properties.
   napi_static = 1 << 10,
 
-#ifdef NAPI_EXPERIMENTAL
+#if NAPI_VERSION >= 8
   // Default for class methods.
   napi_default_method = napi_writable | napi_configurable,
 
@@ -39,7 +39,7 @@ typedef enum {
   napi_default_jsproperty = napi_writable |
                             napi_enumerable |
                             napi_configurable,
-#endif  // NAPI_EXPERIMENTAL
+#endif  // NAPI_VERSION >= 8
 } napi_property_attributes;
 
 typedef enum {
@@ -150,11 +150,11 @@ typedef enum {
 } napi_key_conversion;
 #endif  // NAPI_VERSION >= 6
 
-#ifdef NAPI_EXPERIMENTAL
+#if NAPI_VERSION >= 8
 typedef struct {
   uint64_t lower;
   uint64_t upper;
 } napi_type_tag;
-#endif  // NAPI_EXPERIMENTAL
+#endif  // NAPI_VERSION >= 8
 
 #endif  // SRC_JS_NATIVE_API_TYPES_H_

--- a/src/node_api.h
+++ b/src/node_api.h
@@ -250,7 +250,7 @@ napi_ref_threadsafe_function(napi_env env, napi_threadsafe_function func);
 
 #endif  // NAPI_VERSION >= 4
 
-#ifdef NAPI_EXPERIMENTAL
+#if NAPI_VERSION >= 8
 
 NAPI_EXTERN napi_status napi_add_async_cleanup_hook(
     napi_env env,
@@ -260,6 +260,10 @@ NAPI_EXTERN napi_status napi_add_async_cleanup_hook(
 
 NAPI_EXTERN napi_status napi_remove_async_cleanup_hook(
     napi_async_cleanup_hook_handle remove_handle);
+
+#endif  // NAPI_VERSION >= 8
+
+#ifdef NAPI_EXPERIMENTAL
 
 NAPI_EXTERN napi_status
 node_api_get_module_file_name(napi_env env, const char** result);

--- a/src/node_api_types.h
+++ b/src/node_api_types.h
@@ -41,10 +41,10 @@ typedef struct {
   const char* release;
 } napi_node_version;
 
-#ifdef NAPI_EXPERIMENTAL
+#if NAPI_VERSION >= 8
 typedef struct napi_async_cleanup_hook_handle__* napi_async_cleanup_hook_handle;
 typedef void (*napi_async_cleanup_hook)(napi_async_cleanup_hook_handle handle,
                                         void* data);
-#endif  // NAPI_EXPERIMENTAL
+#endif  // NAPI_VERSION >= 8
 
 #endif  // SRC_NODE_API_TYPES_H_

--- a/src/node_version.h
+++ b/src/node_version.h
@@ -93,6 +93,6 @@
 
 // The NAPI_VERSION provided by this version of the runtime. This is the version
 // which the Node binary being built supports.
-#define NAPI_VERSION  7
+#define NAPI_VERSION  8
 
 #endif  // SRC_NODE_VERSION_H_

--- a/test/js-native-api/test_general/test.js
+++ b/test/js-native-api/test_general/test.js
@@ -33,7 +33,7 @@ assert.notStrictEqual(test_general.testGetPrototype(baseObject),
                       test_general.testGetPrototype(extendedObject));
 
 // Test version management functions
-assert.strictEqual(test_general.testGetVersion(), 7);
+assert.strictEqual(test_general.testGetVersion(), 8);
 
 [
   123,

--- a/test/js-native-api/test_object/test_object.c
+++ b/test/js-native-api/test_object/test_object.c
@@ -1,4 +1,3 @@
-#define NAPI_EXPERIMENTAL
 #include <js_native_api.h>
 #include "../common.h"
 #include <string.h>

--- a/test/node-api/test_async_cleanup_hook/binding.c
+++ b/test/node-api/test_async_cleanup_hook/binding.c
@@ -1,4 +1,3 @@
-#define NAPI_EXPERIMENTAL
 #include "node_api.h"
 #include "assert.h"
 #include "uv.h"


### PR DESCRIPTION
Mark as stable the APIs that define Node-API version 8.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
