### PR TITLE
doc: fix typos in lib/internal/bootstrap/pre_execution.js

### DIFF
--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -236,9 +236,9 @@ function setupInspectorHooks() {
   }
 }
 
-// In general deprecations are intialized wherever the APIs are implemented,
+// In general deprecations are initialized wherever the APIs are implemented,
 // this is used to deprecate APIs implemented in C++ where the deprecation
-// utitlities are not easily accessible.
+// utilities are not easily accessible.
 function initializeDeprecations() {
   const { deprecate } = require('internal/util');
   const pendingDeprecation = getOptionValue('--pending-deprecation');


### PR DESCRIPTION
'initialized' spelled as 'intialized'
'utilities' spelled as 'utitlities'