### PR TITLE
http: add http.ClientRequest.getRawHeaderNames()

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -1347,6 +1347,7 @@ The `http` module `OutgoingMessage.prototype._headers` and
 the public methods (e.g. `OutgoingMessage.prototype.getHeader()`,
 `OutgoingMessage.prototype.getHeaders()`,
 `OutgoingMessage.prototype.getHeaderNames()`,
+`OutgoingMessage.prototype.getRawHeaderNames()`,
 `OutgoingMessage.prototype.hasHeader()`,
 `OutgoingMessage.prototype.removeHeader()`,
 `OutgoingMessage.prototype.setHeader()`) for working with outgoing headers.

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -777,6 +777,24 @@ const cookie = request.getHeader('Cookie');
 // 'cookie' is of type string[]
 ```
 
+### `request.getRawHeaderNames()`
+<!-- YAML
+added: REPLACEME
+-->
+
+* Returns: {string[]}
+
+Returns an array containing the unique names of the current outgoing raw
+headers. Header names are returned with their exact casing being set.
+
+```js
+request.setHeader('Foo', 'bar');
+request.setHeader('Set-Cookie', ['foo=bar', 'bar=baz']);
+
+const headerNames = request.getRawHeaderNames();
+// headerNames === ['Foo', 'Set-Cookie']
+```
+
 ### `request.maxHeadersCount`
 
 * {number} **Default:** `2000`

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -22,6 +22,7 @@
 'use strict';
 
 const {
+  Array,
   ArrayIsArray,
   ArrayPrototypeForEach,
   ArrayPrototypeJoin,
@@ -36,6 +37,7 @@ const {
   ObjectCreate,
   ObjectDefineProperty,
   ObjectKeys,
+  ObjectValues,
   ObjectPrototypeHasOwnProperty,
   ObjectSetPrototypeOf,
   RegExpPrototypeTest,
@@ -653,6 +655,23 @@ OutgoingMessage.prototype.getHeader = function getHeader(name) {
 // Returns an array of the names of the current outgoing headers.
 OutgoingMessage.prototype.getHeaderNames = function getHeaderNames() {
   return this[kOutHeaders] !== null ? ObjectKeys(this[kOutHeaders]) : [];
+};
+
+
+// Returns an array of the names of the current outgoing raw headers.
+OutgoingMessage.prototype.getRawHeaderNames = function getRawHeaderNames() {
+  const headersMap = this[kOutHeaders];
+  if (headersMap === null) return [];
+
+  const values = ObjectValues(headersMap);
+  const headers = Array(values.length);
+  // Retain for(;;) loop for performance reasons
+  // Refs: https://github.com/nodejs/node/pull/30958
+  for (let i = 0, l = values.length; i < l; i++) {
+    headers[i] = values[i][0];
+  }
+
+  return headers;
 };
 
 

--- a/test/parallel/test-http-mutable-headers.js
+++ b/test/parallel/test-http-mutable-headers.js
@@ -108,6 +108,10 @@ const s = http.createServer(common.mustCall((req, res) => {
                              ['x-test-header', 'x-test-header2',
                               'set-cookie', 'x-test-array-header']);
 
+      assert.deepStrictEqual(res.getRawHeaderNames(),
+                             ['x-test-header', 'X-TEST-HEADER2',
+                              'set-cookie', 'x-test-array-header']);
+
       assert.strictEqual(res.hasHeader('x-test-header2'), true);
       assert.strictEqual(res.hasHeader('X-TEST-HEADER2'), true);
       assert.strictEqual(res.hasHeader('X-Test-Header2'), true);
@@ -171,7 +175,10 @@ function nextTest() {
 
   let bufferedResponse = '';
 
-  http.get({ port: s.address().port }, common.mustCall((response) => {
+  const req = http.get({
+    port: s.address().port,
+    headers: { 'X-foo': 'bar' }
+  }, common.mustCall((response) => {
     switch (test) {
       case 'headers':
         assert.strictEqual(response.statusCode, 201);
@@ -214,4 +221,10 @@ function nextTest() {
       common.mustCall(nextTest)();
     }));
   }));
+
+  assert.deepStrictEqual(req.getHeaderNames(),
+                         ['x-foo', 'host']);
+
+  assert.deepStrictEqual(req.getRawHeaderNames(),
+                         ['X-foo', 'Host']);
 }


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/37641

As discussed here https://github.com/nodejs/node/issues/37641#issuecomment-792927966 I'm submitting a patch to expose the raw header names being sent with the request.

~~I didn't updated the documentation because I'm not sure about the process for deprecating things since [DEP0066](https://nodejs.org/api/deprecations.html#deprecations_dep0066_outgoingmessage_prototype_headers_outgoingmessage_prototype_headernames) was introduced in v12 and this is v15.~~