### PR TITLE
doc: document that module.evaluate fulfills as undefined

### DIFF
--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -587,7 +587,7 @@ in the ECMAScript specification.
     [`Error`][]. Existing handlers for the event that have been attached via
     `process.on('SIGINT')` are disabled during script execution, but continue to
     work after that. **Default:** `false`.
-* Returns: {Promise}
+* Returns: {Promise} Fulfills with `undefined` upon success.
 
 Evaluate the module.
 


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/37453
Signed-off-by: James M Snell <jasnell@gmail.com>
