### PR TITLE
deps: V8: cherry-pick 1648e050cade

### DIFF
--- a/deps/v8/src/torque/torque-parser.cc
+++ b/deps/v8/src/torque/torque-parser.cc
@@ -1836,14 +1836,15 @@ base::Optional<ParseResult> MakeNumberLiteralExpression(
 #if defined(V8_OS_SOLARIS)
     // stod() on Solaris does not currently support hex strings. Use strtol()
     // specifically for hex literals until stod() support is available.
-    if (number.find("0x") || number.find("0X")) {
-      value = static_cast<double>(strtol(number.c_str(), nullptr, 0));
-    } else {
+    if (number.find("0x") == std::string::npos &&
+        number.find("0X") == std::string::npos) {
       value = std::stod(number);
+    } else {
+      value = static_cast<double>(strtol(number.c_str(), nullptr, 0));
     }
 #else
     value = std::stod(number);
-#endif // !defined(V8_OS_SOLARIS)
+#endif  // !defined(V8_OS_SOLARIS)
   } catch (const std::out_of_range&) {
     Error("double literal out-of-range").Throw();
   }


### PR DESCRIPTION
Original commit message:

    torque: workaround stod() limitations on Solaris

    std::stod() on Solaris does not currently handle hex strings.
    This commit provides a workaround based on strtol() until proper
    stod() support is available.

    This was encountered while updating Node.js to V8 8.8. For more
    details see the following comment:

    https://github.com/nodejs/node/pull/36139#issuecomment-740131942

    Change-Id: I16ed80a817f6d9105e7153b10824b1fee8520432
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2692746
    Reviewed-by: Michael Stanton <mvstanton@chromium.org>
    Commit-Queue: Michael Stanton <mvstanton@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#73255}

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
