### PR TITLE
http,http2: add abort signal to server requests

### DIFF
--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -38,6 +38,7 @@ const kHeaders = Symbol('kHeaders');
 const kHeadersCount = Symbol('kHeadersCount');
 const kTrailers = Symbol('kTrailers');
 const kTrailersCount = Symbol('kTrailersCount');
+const kAbortController = Symbol('kAbortController');
 
 function readStart(socket) {
   if (socket && !socket._paused && socket.readable)
@@ -77,6 +78,7 @@ function IncomingMessage(socket) {
   this.rawTrailers = [];
 
   this.aborted = false;
+  this[kAbortController] = null;
 
   this.upgrade = null;
 
@@ -141,6 +143,22 @@ ObjectDefineProperty(IncomingMessage.prototype, 'trailers', {
   },
   set: function(val) {
     this[kTrailers] = val;
+  }
+});
+
+ObjectDefineProperty(IncomingMessage.prototype, 'signal', {
+  get: function() {
+    if (!this[kAbortController]) {
+      this[kAbortController] = new AbortController();
+      if (this.aborted) {
+        this[kAbortController].abort();
+      } else {
+        this.on('aborted', () => {
+          this[kAbortController].abort();
+        });
+      }
+    }
+    return this[kAbortController].signal;
   }
 });
 

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -153,7 +153,7 @@ ObjectDefineProperty(IncomingMessage.prototype, 'signal', {
       if (this.aborted) {
         this[kAbortController].abort();
       } else {
-        this.on('aborted', () => {
+        this.once('aborted', () => {
           this[kAbortController].abort();
         });
       }

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -438,7 +438,7 @@ class Http2ServerRequest extends Readable {
       if (this[kAborted]) {
         this[kAbortController].abort();
       } else {
-        this.on('aborted', () => {
+        this.once('aborted', () => {
           this[kAbortController].abort();
         });
       }

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -74,6 +74,7 @@ const kTrailers = Symbol('trailers');
 const kRawTrailers = Symbol('rawTrailers');
 const kSetHeader = Symbol('setHeader');
 const kAborted = Symbol('aborted');
+const kAbortController = Symbol('abortController');
 
 let statusMessageWarned = false;
 let statusConnectionHeaderWarned = false;
@@ -322,6 +323,7 @@ class Http2ServerRequest extends Readable {
     this[kRawTrailers] = [];
     this[kStream] = stream;
     this[kAborted] = false;
+    this[kAbortController] = null;
     stream[kProxySocket] = null;
     stream[kRequest] = this;
 
@@ -428,6 +430,20 @@ class Http2ServerRequest extends Readable {
 
   set url(url) {
     this[kHeaders][HTTP2_HEADER_PATH] = url;
+  }
+
+  get signal() {
+    if (!this[kAbortController]) {
+      this[kAbortController] = new AbortController();
+      if (this[kAborted]) {
+        this[kAbortController].abort();
+      } else {
+        this.on('aborted', () => {
+          this[kAbortController].abort();
+        });
+      }
+    }
+    return this[kAbortController].signal;
   }
 
   setTimeout(msecs, callback) {


### PR DESCRIPTION
Add support for getting a signal from http/http2 server requests which is aborted when the requests themselves are aborted.

fixes: https://github.com/nodejs/node/issues/37661

I think that this feature makes sense, and is similar to what [Fetch](https://fetch.spec.whatwg.org/#request-signal) has.  I haven't added tests or changed docs yet, as I'd like to see if there's support for this feature. If other people think this is a good idea - I'll happily contribute tests and docs for this as well.