### PR TITLE
deps: upgrade npm to 7.6.2

### DIFF
--- a/deps/npm/AUTHORS
+++ b/deps/npm/AUTHORS
@@ -757,3 +757,4 @@ kumavis <aaron@kumavis.me>
 Christof Lemke <christoflemke@github.com>
 Nathan Shively-Sanders <293473+sandersn@users.noreply.github.com>
 Bjørn Johansen <bjjohans@microsoft.com>
+Fraqe <f@fraqe.ca>

--- a/deps/npm/CHANGELOG.md
+++ b/deps/npm/CHANGELOG.md
@@ -1,3 +1,33 @@
+## v7.6.2 (2021-03-09)
+
+### BUG FIXES
+
+* [`e0a3a5218`](https://github.com/npm/cli/commit/e0a3a5218cac7ca5850930aaaad8a939ddf75d4d)
+  [#2831](https://github.com/npm/cli/issues/2831)
+  Fix cb() never called in search with --json option
+  ([@fraqe](https://github.com/fraqe))
+* [`85a8694dd`](https://github.com/npm/cli/commit/85a8694dd9b4a924a474ba75261914511a216868)
+  [#2795](https://github.com/npm/cli/issues/2795)
+  fix(npm.output): make output go through npm.output
+  ([@wraithgar](https://github.com/wraithgar))
+* [`9fe0df5b5`](https://github.com/npm/cli/commit/9fe0df5b5d7606e5841288d9931be6c04767c9ca)
+  [#2821](https://github.com/npm/cli/issues/2821)
+  fix(usage): clean up usage declarations
+  ([@wraithgar](https://github.com/wraithgar))
+
+### DEPENDENCIES
+
+* [`7f470b5c2`](https://github.com/npm/cli/commit/7f470b5c25d544e36d97b28e28ae20dfa1d4ab31)
+  `@npmcli/arborist@2.2.7`
+    * fix(install): Do not revert a file: dep to version on bare name re-install
+* [`e9b7fc275`](https://github.com/npm/cli/commit/e9b7fc275a0bdf8f00dbcf5dd2283675776fc459)
+  `libnpmdiff@2.0.4`
+    * fix(diff): Gracefully handle packages with prepare script
+* [`c7314aa62`](https://github.com/npm/cli/commit/c7314aa62195b7f0d8886776692e8a2c892413ed)
+  `byte-size@7.0.1`
+* [`864f48d43`](https://github.com/npm/cli/commit/864f48d4327269f521161cf89888ea2b6db5fdab)
+  `pacote@11.3.0`
+
 ## v7.6.1 (2021-03-04)
 
 ### BUG FIXES

--- a/deps/npm/docs/output/commands/npm-ls.html
+++ b/deps/npm/docs/output/commands/npm-ls.html
@@ -159,7 +159,7 @@ tree at all, use <a href="../commands/npm-explain.html"><code>npm explain</code>
 the results to only the paths to the packages named.  Note that nested
 packages will <em>also</em> show the paths to the specified packages.  For
 example, running <code>npm ls promzard</code> in npm’s source tree will show:</p>
-<pre lang="bash"><code>npm@7.6.1 /path/to/npm
+<pre lang="bash"><code>npm@7.6.2 /path/to/npm
 └─┬ init-package-json@0.0.4
   └── promzard@0.1.5
 </code></pre>

--- a/deps/npm/docs/output/commands/npm.html
+++ b/deps/npm/docs/output/commands/npm.html
@@ -148,7 +148,7 @@ npm command-line interface
 <pre lang="bash"><code>npm &lt;command&gt; [args]
 </code></pre>
 <h3 id="version">Version</h3>
-<p>7.6.1</p>
+<p>7.6.2</p>
 <h3 id="description">Description</h3>
 <p>npm is the package manager for the Node JavaScript platform.  It puts
 modules in place so that node can find them, and manages dependency

--- a/deps/npm/lib/adduser.js
+++ b/deps/npm/lib/adduser.js
@@ -1,7 +1,6 @@
 const log = require('npmlog')
-const output = require('./utils/output.js')
-const usageUtil = require('./utils/usage.js')
 const replaceInfo = require('./utils/replace-info.js')
+const BaseCommand = require('./base-command.js')
 const authTypes = {
   legacy: require('./auth/legacy.js'),
   oauth: require('./auth/oauth.js'),
@@ -9,17 +8,13 @@ const authTypes = {
   sso: require('./auth/sso.js'),
 }
 
-class AddUser {
-  constructor (npm) {
-    this.npm = npm
+class AddUser extends BaseCommand {
+  static get name () {
+    return 'adduser'
   }
 
-  /* istanbul ignore next - see test/lib/load-all-commands.js */
-  get usage () {
-    return usageUtil(
-      'adduser',
-      'npm adduser [--registry=url] [--scope=@orgname] [--always-auth]'
-    )
+  static get usage () {
+    return ['[--registry=url] [--scope=@orgname] [--always-auth]']
   }
 
   exec (args, cb) {
@@ -49,7 +44,7 @@ class AddUser {
       scope,
     })
 
-    output(message)
+    this.npm.output(message)
   }
 
   getRegistry ({ scope, registry }) {

--- a/deps/npm/lib/audit.js
+++ b/deps/npm/lib/audit.js
@@ -1,23 +1,21 @@
 const Arborist = require('@npmcli/arborist')
 const auditReport = require('npm-audit-report')
-const output = require('./utils/output.js')
 const reifyFinish = require('./utils/reify-finish.js')
 const auditError = require('./utils/audit-error.js')
-const usageUtil = require('./utils/usage.js')
+const BaseCommand = require('./base-command.js')
 
-class Audit {
-  constructor (npm) {
-    this.npm = npm
+class Audit extends BaseCommand {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'audit'
   }
 
   /* istanbul ignore next - see test/lib/load-all-commands.js */
-  get usage () {
-    return usageUtil(
-      'audit',
-      'npm audit [--json] [--production]' +
-      '\nnpm audit fix ' +
-      '[--force|--package-lock-only|--dry-run|--production|--only=(dev|prod)]'
-    )
+  static get usage () {
+    return [
+      '[--json] [--production]',
+      'fix [--force|--package-lock-only|--dry-run|--production|--only=(dev|prod)]',
+    ]
   }
 
   async completion (opts) {
@@ -57,7 +55,7 @@ class Audit {
         reporter,
       })
       process.exitCode = process.exitCode || result.exitCode
-      output(result.report)
+      this.npm.output(result.report)
     }
   }
 }

--- a/deps/npm/lib/base-command.js
+++ b/deps/npm/lib/base-command.js
@@ -1,0 +1,38 @@
+// Base class for npm.commands[cmd]
+const usageUtil = require('./utils/usage.js')
+
+class BaseCommand {
+  constructor (npm) {
+    this.npm = npm
+  }
+
+  get usage () {
+    let usage = `npm ${this.constructor.name}\n\n`
+    if (this.constructor.description)
+      usage = `${usage}${this.constructor.description}\n\n`
+
+    usage = `${usage}Usage:\n`
+    if (!this.constructor.usage)
+      usage = `${usage}npm ${this.constructor.name}`
+    else
+      usage = `${usage}${this.constructor.usage.map(u => `npm ${this.constructor.name} ${u}`).join('\n')}`
+
+    // Mostly this just appends aliases, this could be more clear
+    usage = usageUtil(this.constructor.name, usage)
+    usage = `${usage}\n\nRun "npm ${this.constructor.name} help" for more info`
+    return usage
+  }
+
+  usageError (msg) {
+    if (!msg) {
+      return Object.assign(new Error(`\nUsage: ${this.usage}`), {
+        code: 'EUSAGE',
+      })
+    }
+
+    return Object.assign(new Error(`\nUsage: ${msg}\n\n${this.usage}`), {
+      code: 'EUSAGE',
+    })
+  }
+}
+module.exports = BaseCommand

--- a/deps/npm/lib/bin.js
+++ b/deps/npm/lib/bin.js
@@ -1,15 +1,13 @@
-const output = require('./utils/output.js')
 const envPath = require('./utils/path.js')
-const usageUtil = require('./utils/usage.js')
+const BaseCommand = require('./base-command.js')
 
-class Bin {
-  constructor (npm) {
-    this.npm = npm
+class Bin extends BaseCommand {
+  static get name () {
+    return 'bin'
   }
 
-  /* istanbul ignore next - see test/lib/load-all-commands.js */
-  get usage () {
-    return usageUtil('bin', 'npm bin [-g]')
+  static get usage () {
+    return ['[-g]']
   }
 
   exec (args, cb) {
@@ -18,7 +16,7 @@ class Bin {
 
   async bin (args) {
     const b = this.npm.bin
-    output(b)
+    this.npm.output(b)
     if (this.npm.flatOptions.global && !envPath.includes(b))
       console.error('(not in PATH env variable)')
   }

--- a/deps/npm/lib/bugs.js
+++ b/deps/npm/lib/bugs.js
@@ -1,17 +1,16 @@
 const log = require('npmlog')
 const pacote = require('pacote')
 const openUrl = require('./utils/open-url.js')
-const usageUtil = require('./utils/usage.js')
 const hostedFromMani = require('./utils/hosted-git-info-from-manifest.js')
+const BaseCommand = require('./base-command.js')
 
-class Bugs {
-  constructor (npm) {
-    this.npm = npm
+class Bugs extends BaseCommand {
+  static get name () {
+    return 'bugs'
   }
 
-  /* istanbul ignore next - see test/lib/load-all-commands.js */
-  get usage () {
-    return usageUtil('bugs', 'npm bugs [<pkgname>]')
+  static get usage () {
+    return ['[<pkgname>]']
   }
 
   exec (args, cb) {

--- a/deps/npm/lib/cache.js
+++ b/deps/npm/lib/cache.js
@@ -1,27 +1,28 @@
 const cacache = require('cacache')
 const { promisify } = require('util')
 const log = require('npmlog')
-const output = require('./utils/output.js')
 const pacote = require('pacote')
 const path = require('path')
 const rimraf = promisify(require('rimraf'))
+const BaseCommand = require('./base-command.js')
 
-const usageUtil = require('./utils/usage.js')
-class Cache {
-  constructor (npm) {
-    this.npm = npm
+class Cache extends BaseCommand {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'cache'
   }
 
-  get usage () {
-    return usageUtil('cache',
-      'npm cache add <tarball file>' +
-      '\nnpm cache add <folder>' +
-      '\nnpm cache add <tarball url>' +
-      '\nnpm cache add <git url>' +
-      '\nnpm cache add <name>@<version>' +
-      '\nnpm cache clean' +
-      '\nnpm cache verify'
-    )
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get usage () {
+    return [
+      'add <tarball file>',
+      'add <folder>',
+      'add <tarball url>',
+      'add <git url>',
+      'add <name>@<version>',
+      'clean',
+      'verify',
+    ]
   }
 
   async completion (opts) {
@@ -116,13 +117,13 @@ with --force.`)
       ? `~${cache.substr(process.env.HOME.length)}`
       : cache
     const stats = await cacache.verify(cache)
-    output(`Cache verified and compressed (${prefix})`)
-    output(`Content verified: ${stats.verifiedContent} (${stats.keptSize} bytes)`)
-    stats.badContentCount && output(`Corrupted content removed: ${stats.badContentCount}`)
-    stats.reclaimedCount && output(`Content garbage-collected: ${stats.reclaimedCount} (${stats.reclaimedSize} bytes)`)
-    stats.missingContent && output(`Missing content: ${stats.missingContent}`)
-    output(`Index entries: ${stats.totalEntries}`)
-    output(`Finished in ${stats.runTime.total / 1000}s`)
+    this.npm.output(`Cache verified and compressed (${prefix})`)
+    this.npm.output(`Content verified: ${stats.verifiedContent} (${stats.keptSize} bytes)`)
+    stats.badContentCount && this.npm.output(`Corrupted content removed: ${stats.badContentCount}`)
+    stats.reclaimedCount && this.npm.output(`Content garbage-collected: ${stats.reclaimedCount} (${stats.reclaimedSize} bytes)`)
+    stats.missingContent && this.npm.output(`Missing content: ${stats.missingContent}`)
+    this.npm.output(`Index entries: ${stats.totalEntries}`)
+    this.npm.output(`Finished in ${stats.runTime.total / 1000}s`)
   }
 }
 

--- a/deps/npm/lib/ci.js
+++ b/deps/npm/lib/ci.js
@@ -7,7 +7,6 @@ const fs = require('fs')
 const readdir = util.promisify(fs.readdir)
 
 const log = require('npmlog')
-const usageUtil = require('./utils/usage.js')
 
 const removeNodeModules = async where => {
   const rimrafOpts = { glob: false }
@@ -18,15 +17,12 @@ const removeNodeModules = async where => {
   await Promise.all(entries.map(f => rimraf(`${path}/${f}`, rimrafOpts)))
   process.emit('timeEnd', 'npm-ci:rm')
 }
+const BaseCommand = require('./base-command.js')
 
-class CI {
-  constructor (npm) {
-    this.npm = npm
-  }
-
+class CI extends BaseCommand {
   /* istanbul ignore next - see test/lib/load-all-commands.js */
-  get usage () {
-    return usageUtil('ci', 'npm ci')
+  static get name () {
+    return 'ci'
   }
 
   exec (args, cb) {

--- a/deps/npm/lib/completion.js
+++ b/deps/npm/lib/completion.js
@@ -39,20 +39,20 @@ const configNames = Object.keys(types)
 const shorthandNames = Object.keys(shorthands)
 const allConfs = configNames.concat(shorthandNames)
 const isWindowsShell = require('./utils/is-windows-shell.js')
-const output = require('./utils/output.js')
 const fileExists = require('./utils/file-exists.js')
 
-const usageUtil = require('./utils/usage.js')
 const { promisify } = require('util')
+const BaseCommand = require('./base-command.js')
 
-class Completion {
-  constructor (npm) {
-    this.npm = npm
+class Completion extends BaseCommand {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'completion'
   }
 
   /* istanbul ignore next - see test/lib/load-all-commands.js */
-  get usage () {
-    return usageUtil('completion', 'source <(npm completion)')
+  static get description () {
+    return 'npm command completion script. save to ~/.bashrc or ~/.zshrc'
   }
 
   // completion for the completion command
@@ -131,14 +131,14 @@ class Completion {
 
     if (partialWords.slice(0, -1).indexOf('--') === -1) {
       if (word.charAt(0) === '-')
-        return wrap(opts, configCompl(opts))
+        return this.wrap(opts, configCompl(opts))
 
       if (words[w - 1] &&
         words[w - 1].charAt(0) === '-' &&
         !isFlag(words[w - 1])) {
         // awaiting a value for a non-bool config.
         // don't even try to do this for now
-        return wrap(opts, configValueCompl(opts))
+        return this.wrap(opts, configValueCompl(opts))
       }
     }
 
@@ -152,7 +152,7 @@ class Completion {
     // check if there's a command already.
     const cmd = parsed.argv.remain[1]
     if (!cmd)
-      return wrap(opts, cmdCompl(opts))
+      return this.wrap(opts, cmdCompl(opts))
 
     Object.keys(parsed).forEach(k => this.npm.config.set(k, parsed[k]))
 
@@ -162,8 +162,28 @@ class Completion {
     const impl = this.npm.commands[cmd]
     if (impl && impl.completion) {
       const comps = await impl.completion(opts)
-      return wrap(opts, comps)
+      return this.wrap(opts, comps)
     }
+  }
+
+  // The command should respond with an array.  Loop over that,
+  // wrapping quotes around any that have spaces, and writing
+  // them to stdout.
+  // If any of the items are arrays, then join them with a space.
+  // Ie, returning ['a', 'b c', ['d', 'e']] would allow it to expand
+  // to: 'a', 'b c', or 'd' 'e'
+  wrap (opts, compls) {
+    if (!Array.isArray(compls))
+      compls = compls ? [compls] : []
+
+    compls = compls.map(c =>
+      Array.isArray(c) ? c.map(escape).join(' ') : escape(c))
+
+    if (opts.partialWord)
+      compls = compls.filter(c => c.startsWith(opts.partialWord))
+
+    if (compls.length > 0)
+      this.npm.output(compls.join('\n'))
   }
 }
 
@@ -213,26 +233,6 @@ const unescape = w => w.charAt(0) === '\'' ? w.replace(/^'|'$/g, '')
 
 const escape = w => !/\s+/.test(w) ? w
   : '\'' + w + '\''
-
-// The command should respond with an array.  Loop over that,
-// wrapping quotes around any that have spaces, and writing
-// them to stdout.
-// If any of the items are arrays, then join them with a space.
-// Ie, returning ['a', 'b c', ['d', 'e']] would allow it to expand
-// to: 'a', 'b c', or 'd' 'e'
-const wrap = (opts, compls) => {
-  if (!Array.isArray(compls))
-    compls = compls ? [compls] : []
-
-  compls = compls.map(c =>
-    Array.isArray(c) ? c.map(escape).join(' ') : escape(c))
-
-  if (opts.partialWord)
-    compls = compls.filter(c => c.startsWith(opts.partialWord))
-
-  if (compls.length > 0)
-    output(compls.join('\n'))
-}
 
 // the current word has a dash.  Return the config names,
 // with the same number of dashes as the current word has.

--- a/deps/npm/lib/config.js
+++ b/deps/npm/lib/config.js
@@ -1,6 +1,4 @@
 const { defaults, types } = require('./utils/config.js')
-const usageUtil = require('./utils/usage.js')
-const output = require('./utils/output.js')
 
 const mkdirp = require('mkdirp-infer-owner')
 const { dirname } = require('path')
@@ -29,22 +27,22 @@ const keyValues = args => {
 
 const publicVar = k => !/^(\/\/[^:]+:)?_/.test(k)
 
-class Config {
-  constructor (npm) {
-    this.npm = npm
+const BaseCommand = require('./base-command.js')
+class Config extends BaseCommand {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'config'
   }
 
-  get usage () {
-    return usageUtil(
-      'config',
-      'npm config set <key>=<value> [<key>=<value> ...]' +
-      '\nnpm config get [<key> [<key> ...]]' +
-      '\nnpm config delete <key> [<key> ...]' +
-      '\nnpm config list [--json]' +
-      '\nnpm config edit' +
-      '\nnpm set <key>=<value> [<key>=<value> ...]' +
-      '\nnpm get [<key> [<key> ...]]'
-    )
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get usage () {
+    return [
+      'set <key>=<value> [<key>=<value> ...]',
+      'get [<key> [<key> ...]]',
+      'delete <key> [<key> ...]',
+      'list [--json]',
+      'edit',
+    ]
   }
 
   async completion (opts) {
@@ -142,7 +140,7 @@ class Config {
       const pref = keys.length > 1 ? `${key}=` : ''
       out.push(pref + this.npm.config.get(key))
     }
-    output(out.join('\n'))
+    this.npm.output(out.join('\n'))
   }
 
   async del (keys) {
@@ -241,7 +239,7 @@ ${defData}
       )
     }
 
-    output(msg.join('\n').trim())
+    this.npm.output(msg.join('\n').trim())
   }
 
   async listJson () {
@@ -252,11 +250,7 @@ ${defData}
 
       publicConf[key] = this.npm.config.get(key)
     }
-    output(JSON.stringify(publicConf, null, 2))
-  }
-
-  usageError () {
-    return Object.assign(new Error(this.usage), { code: 'EUSAGE' })
+    this.npm.output(JSON.stringify(publicConf, null, 2))
   }
 }
 

--- a/deps/npm/lib/dedupe.js
+++ b/deps/npm/lib/dedupe.js
@@ -1,16 +1,13 @@
 // dedupe duplicated packages, or find them in the tree
 const Arborist = require('@npmcli/arborist')
-const usageUtil = require('./utils/usage.js')
 const reifyFinish = require('./utils/reify-finish.js')
 
-class Dedupe {
-  constructor (npm) {
-    this.npm = npm
-  }
+const BaseCommand = require('./base-command.js')
 
+class Dedupe extends BaseCommand {
   /* istanbul ignore next - see test/lib/load-all-commands.js */
-  get usage () {
-    return usageUtil('dedupe', 'npm dedupe')
+  static get name () {
+    return 'dedupe'
   }
 
   exec (args, cb) {

--- a/deps/npm/lib/deprecate.js
+++ b/deps/npm/lib/deprecate.js
@@ -4,18 +4,17 @@ const npa = require('npm-package-arg')
 const semver = require('semver')
 const getIdentity = require('./utils/get-identity.js')
 const libaccess = require('libnpmaccess')
-const usageUtil = require('./utils/usage.js')
+const BaseCommand = require('./base-command.js')
 
-class Deprecate {
-  constructor (npm) {
-    this.npm = npm
+class Deprecate extends BaseCommand {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'deprecate'
   }
 
-  get usage () {
-    return usageUtil(
-      'deprecate',
-      'npm deprecate <pkg>[@<version>] <message>'
-    )
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get usage () {
+    return ['<pkg>[@<version>] <message>']
   }
 
   async completion (opts) {
@@ -70,12 +69,6 @@ class Deprecate {
       body: packument,
       ignoreBody: true,
     }))
-  }
-
-  usageError () {
-    return Object.assign(new Error(`\nUsage: ${this.usage}`), {
-      code: 'EUSAGE',
-    })
   }
 }
 

--- a/deps/npm/lib/diff.js
+++ b/deps/npm/lib/diff.js
@@ -8,24 +8,24 @@ const npmlog = require('npmlog')
 const pacote = require('pacote')
 const pickManifest = require('npm-pick-manifest')
 
-const usageUtil = require('./utils/usage.js')
-const output = require('./utils/output.js')
 const readLocalPkg = require('./utils/read-local-package.js')
+const BaseCommand = require('./base-command.js')
 
-class Diff {
-  constructor (npm) {
-    this.npm = npm
+class Diff extends BaseCommand {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'diff'
   }
 
-  get usage () {
-    return usageUtil(
-      'diff',
-      'npm diff [...<paths>]' +
-      '\nnpm diff --diff=<pkg-name> [...<paths>]' +
-      '\nnpm diff --diff=<version-a> [--diff=<version-b>] [...<paths>]' +
-      '\nnpm diff --diff=<spec-a> [--diff=<spec-b>] [...<paths>]' +
-      '\nnpm diff [--diff-ignore-all-space] [--diff-name-only] [...<paths>] [...<paths>]'
-    )
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get usage () {
+    return [
+      '[...<paths>]',
+      '--diff=<pkg-name> [...<paths>]',
+      '--diff=<version-a> [--diff=<version-b>] [...<paths>]',
+      '--diff=<spec-a> [--diff=<spec-b>] [...<paths>]',
+      '[--diff-ignore-all-space] [--diff-name-only] [...<paths>] [...<paths>]',
+    ]
   }
 
   get where () {
@@ -55,7 +55,7 @@ class Diff {
       diffFiles: args,
       where: this.where,
     })
-    return output(res)
+    return this.npm.output(res)
   }
 
   async retrieveSpecs ([a, b]) {

--- a/deps/npm/lib/dist-tag.js
+++ b/deps/npm/lib/dist-tag.js
@@ -3,23 +3,23 @@ const npa = require('npm-package-arg')
 const regFetch = require('npm-registry-fetch')
 const semver = require('semver')
 
-const output = require('./utils/output.js')
 const otplease = require('./utils/otplease.js')
 const readLocalPkgName = require('./utils/read-local-package.js')
-const usageUtil = require('./utils/usage.js')
+const BaseCommand = require('./base-command.js')
 
-class DistTag {
-  constructor (npm) {
-    this.npm = npm
+class DistTag extends BaseCommand {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'dist-tag'
   }
 
-  get usage () {
-    return usageUtil(
-      'dist-tag',
-      'npm dist-tag add <pkg>@<version> [<tag>]' +
-      '\nnpm dist-tag rm <pkg> <tag>' +
-      '\nnpm dist-tag ls [<pkg>]'
-    )
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get usage () {
+    return [
+      'add <pkg>@<version> [<tag>]',
+      'rm <pkg> <tag>',
+      'ls [<pkg>]',
+    ]
   }
 
   async completion (opts) {
@@ -91,7 +91,7 @@ class DistTag {
       spec,
     }
     await otplease(reqOpts, reqOpts => regFetch(url, reqOpts))
-    output(`+${t}: ${spec.name}@${version}`)
+    this.npm.output(`+${t}: ${spec.name}@${version}`)
   }
 
   async remove (spec, tag, opts) {
@@ -116,7 +116,7 @@ class DistTag {
       spec,
     }
     await otplease(reqOpts, reqOpts => regFetch(url, reqOpts))
-    output(`-${tag}: ${spec.name}@${version}`)
+    this.npm.output(`-${tag}: ${spec.name}@${version}`)
   }
 
   async list (spec, opts) {
@@ -133,7 +133,7 @@ class DistTag {
       const tags = await this.fetchTags(spec, opts)
       const msg =
         Object.keys(tags).map(k => `${k}: ${tags[k]}`).sort().join('\n')
-      output(msg)
+      this.npm.output(msg)
       return tags
     } catch (err) {
       log.error('dist-tag ls', "Couldn't get dist-tag data for", spec)

--- a/deps/npm/lib/doctor.js
+++ b/deps/npm/lib/doctor.js
@@ -10,9 +10,7 @@ const semver = require('semver')
 const { promisify } = require('util')
 const ansiTrim = require('./utils/ansi-trim.js')
 const isWindows = require('./utils/is-windows.js')
-const output = require('./utils/output.js')
 const ping = require('./utils/ping.js')
-const usageUtil = require('./utils/usage.js')
 const { defaults: { registry: defaultRegistry } } = require('./utils/config.js')
 const lstat = promisify(fs.lstat)
 const readdir = promisify(fs.readdir)
@@ -32,14 +30,11 @@ const maskLabel = mask => {
   return label.join(', ')
 }
 
-class Doctor {
-  constructor (npm) {
-    this.npm = npm
-  }
-
+const BaseCommand = require('./base-command.js')
+class Doctor extends BaseCommand {
   /* istanbul ignore next - see test/lib/load-all-commands.js */
-  get usage () {
-    return usageUtil('doctor', 'npm doctor')
+  static get name () {
+    return 'doctor'
   }
 
   exec (args, cb) {
@@ -111,7 +106,7 @@ class Doctor {
     const silent = this.npm.log.levels[this.npm.log.level] >
       this.npm.log.levels.error
     if (!silent) {
-      output(table(outTable, tableOpts))
+      this.npm.output(table(outTable, tableOpts))
       if (!allOk)
         console.error('')
     }

--- a/deps/npm/lib/edit.js
+++ b/deps/npm/lib/edit.js
@@ -4,18 +4,19 @@
 const { resolve } = require('path')
 const fs = require('graceful-fs')
 const { spawn } = require('child_process')
-const usageUtil = require('./utils/usage.js')
 const splitPackageNames = require('./utils/split-package-names.js')
 const completion = require('./utils/completion/installed-shallow.js')
+const BaseCommand = require('./base-command.js')
 
-class Edit {
-  constructor (npm) {
-    this.npm = npm
+class Edit extends BaseCommand {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'edit'
   }
 
   /* istanbul ignore next - see test/lib/load-all-commands.js */
-  get usage () {
-    return usageUtil('edit', 'npm edit <pkg>[/<subpkg>...]')
+  static get usage () {
+    return ['<pkg>[/<subpkg>...]']
   }
 
   /* istanbul ignore next - see test/lib/load-all-commands.js */

--- a/deps/npm/lib/exec.js
+++ b/deps/npm/lib/exec.js
@@ -1,5 +1,3 @@
-const output = require('./utils/output.js')
-const usageUtil = require('./utils/usage.js')
 const { promisify } = require('util')
 const read = promisify(require('read'))
 const mkdirp = require('mkdirp-infer-owner')
@@ -13,6 +11,7 @@ const pacote = require('pacote')
 const npa = require('npm-package-arg')
 const fileExists = require('./utils/file-exists.js')
 const PATH = require('./utils/path.js')
+const BaseCommand = require('./base-command.js')
 
 // it's like this:
 //
@@ -39,31 +38,25 @@ const PATH = require('./utils/path.js')
 // runScript({ pkg, event: 'npx', ... })
 // process.env.npm_lifecycle_event = 'npx'
 
-class Exec {
-  constructor (npm) {
-    this.npm = npm
+class Exec extends BaseCommand {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'exec'
   }
 
-  get usage () {
-    return usageUtil('exec',
-      'Run a command from a local or remote npm package.\n\n' +
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get description () {
+    return 'Run a command from a local or remote npm package.'
+  }
 
-      'npm exec -- <pkg>[@<version>] [args...]\n' +
-      'npm exec --package=<pkg>[@<version>] -- <cmd> [args...]\n' +
-      'npm exec -c \'<cmd> [args...]\'\n' +
-      'npm exec --package=foo -c \'<cmd> [args...]\'\n' +
-      '\n' +
-      'npx <pkg>[@<specifier>] [args...]\n' +
-      'npx -p <pkg>[@<specifier>] <cmd> [args...]\n' +
-      'npx -c \'<cmd> [args...]\'\n' +
-      'npx -p <pkg>[@<specifier>] -c \'<cmd> [args...]\'' +
-      '\n' +
-      'Run without --call or positional args to open interactive subshell\n',
-
-      '\n--package=<pkg> (may be specified multiple times)\n' +
-      '-p is a shorthand for --package only when using npx executable\n' +
-      '-c <cmd> --call=<cmd> (may not be mixed with positional arguments)'
-    )
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get usage () {
+    return [
+      '-- <pkg>[@<version>] [args...]',
+      '--package=<pkg>[@<version>] -- <cmd> [args...]',
+      '-c \'<cmd> [args...]\'',
+      '--package=foo -c \'<cmd> [args...]\'',
+    ]
   }
 
   exec (args, cb) {
@@ -224,7 +217,7 @@ class Exec {
         if (process.stdin.isTTY) {
           if (ciDetect())
             return this.npm.log.warn('exec', 'Interactive mode disabled in CI environment')
-          output(`\nEntering npm script environment\nType 'exit' or ^D when finished\n`)
+          this.npm.output(`\nEntering npm script environment\nType 'exit' or ^D when finished\n`)
         }
       }
       return await runScript({

--- a/deps/npm/lib/explain.js
+++ b/deps/npm/lib/explain.js
@@ -1,21 +1,21 @@
-const usageUtil = require('./utils/usage.js')
 const { explainNode } = require('./utils/explain-dep.js')
 const completion = require('./utils/completion/installed-deep.js')
-const output = require('./utils/output.js')
 const Arborist = require('@npmcli/arborist')
 const npa = require('npm-package-arg')
 const semver = require('semver')
 const { relative, resolve } = require('path')
 const validName = require('validate-npm-package-name')
+const BaseCommand = require('./base-command.js')
 
-class Explain {
-  constructor (npm) {
-    this.npm = npm
+class Explain extends BaseCommand {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'explain'
   }
 
   /* istanbul ignore next - see test/lib/load-all-commands.js */
-  get usage () {
-    return usageUtil('explain', 'npm explain <folder | specifier>')
+  static get usage () {
+    return ['<folder | specifier>']
   }
 
   /* istanbul ignore next - see test/lib/load-all-commands.js */
@@ -59,9 +59,9 @@ class Explain {
     }
 
     if (this.npm.flatOptions.json)
-      output(JSON.stringify(expls, null, 2))
+      this.npm.output(JSON.stringify(expls, null, 2))
     else {
-      output(expls.map(expl => {
+      this.npm.output(expls.map(expl => {
         return explainNode(expl, Infinity, this.npm.color)
       }).join('\n\n'))
     }

--- a/deps/npm/lib/explore.js
+++ b/deps/npm/lib/explore.js
@@ -5,17 +5,17 @@ const rpj = require('read-package-json-fast')
 const runScript = require('@npmcli/run-script')
 const { join, resolve, relative } = require('path')
 const completion = require('./utils/completion/installed-shallow.js')
-const output = require('./utils/output.js')
-const usageUtil = require('./utils/usage.js')
+const BaseCommand = require('./base-command.js')
 
-class Explore {
-  constructor (npm) {
-    this.npm = npm
+class Explore extends BaseCommand {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'explore'
   }
 
   /* istanbul ignore next - see test/lib/load-all-commands.js */
-  get usage () {
-    return usageUtil('explore', 'npm explore <pkg> [ -- <command>]')
+  static get usage () {
+    return ['<pkg> [ -- <command>]']
   }
 
   /* istanbul ignore next - see test/lib/load-all-commands.js */
@@ -54,7 +54,7 @@ class Explore {
     }
 
     if (!args.length)
-      output(`\nExploring ${path}\nType 'exit' or ^D when finished\n`)
+      this.npm.output(`\nExploring ${path}\nType 'exit' or ^D when finished\n`)
     this.npm.log.disableProgress()
     try {
       return await runScript({

--- a/deps/npm/lib/find-dupes.js
+++ b/deps/npm/lib/find-dupes.js
@@ -1,14 +1,10 @@
 // dedupe duplicated packages, or find them in the tree
-const usageUtil = require('./utils/usage.js')
+const BaseCommand = require('./base-command.js')
 
-class FindDupes {
-  constructor (npm) {
-    this.npm = npm
-  }
-
+class FindDupes extends BaseCommand {
   /* istanbul ignore next - see test/lib/load-all-commands.js */
-  get usage () {
-    return usageUtil('find-dupes', 'npm find-dupes')
+  static get name () {
+    return 'find-dupes'
   }
 
   exec (args, cb) {

--- a/deps/npm/lib/fund.js
+++ b/deps/npm/lib/fund.js
@@ -12,27 +12,24 @@ const {
 } = require('libnpmfund')
 
 const completion = require('./utils/completion/installed-deep.js')
-const output = require('./utils/output.js')
 const openUrl = require('./utils/open-url.js')
-const usageUtil = require('./utils/usage.js')
 
 const getPrintableName = ({ name, version }) => {
   const printableVersion = version ? `@${version}` : ''
   return `${name}${printableVersion}`
 }
 
-class Fund {
-  constructor (npm) {
-    this.npm = npm
+const BaseCommand = require('./base-command.js')
+
+class Fund extends BaseCommand {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'fund'
   }
 
   /* istanbul ignore next - see test/lib/load-all-commands.js */
-  get usage () {
-    return usageUtil(
-      'fund',
-      'npm fund',
-      'npm fund [--json] [--browser] [--unicode] [[<@scope>/]<pkg> [--which=<fundingSourceNumber>]'
-    )
+  static get usage () {
+    return ['[--json] [--browser] [--unicode] [[<@scope>/]<pkg> [--which=<fundingSourceNumber>]']
   }
 
   /* istanbul ignore next - see test/lib/load-all-commands.js */
@@ -85,7 +82,7 @@ class Fund {
       ? this.printJSON
       : this.printHuman
 
-    output(
+    this.npm.output(
       print(
         getFundingInfo(tree),
         opts
@@ -206,9 +203,9 @@ class Fund {
       validSources.forEach(({ type, url }, i) => {
         const typePrefix = type ? `${type} funding` : 'Funding'
         const msg = `${typePrefix} available at the following URL`
-        output(`${i + 1}: ${msg}: ${url}`)
+        this.npm.output(`${i + 1}: ${msg}: ${url}`)
       })
-      output('Run `npm fund [<@scope>/]<pkg> --which=1`, for example, to open the first funding URL listed in that package')
+      this.npm.output('Run `npm fund [<@scope>/]<pkg> --which=1`, for example, to open the first funding URL listed in that package')
     } else {
       const noFundingError = new Error(`No valid funding method available for: ${spec}`)
       noFundingError.code = 'ENOFUND'

--- a/deps/npm/lib/get.js
+++ b/deps/npm/lib/get.js
@@ -1,16 +1,14 @@
-const usageUtil = require('./utils/usage.js')
+const BaseCommand = require('./base-command.js')
 
-class Get {
-  constructor (npm) {
-    this.npm = npm
+class Get extends BaseCommand {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'get'
   }
 
   /* istanbul ignore next - see test/lib/load-all-commands.js */
-  get usage () {
-    return usageUtil(
-      'get',
-      'npm get [<key> ...] (See `npm config`)'
-    )
+  static get usage () {
+    return ['[<key> ...] (See `npm config`)']
   }
 
   /* istanbul ignore next - see test/lib/load-all-commands.js */

--- a/deps/npm/lib/help-search.js
+++ b/deps/npm/lib/help-search.js
@@ -1,22 +1,23 @@
 const fs = require('fs')
 const path = require('path')
 const color = require('ansicolors')
-const output = require('./utils/output.js')
-const usageUtil = require('./utils/usage.js')
 const npmUsage = require('./utils/npm-usage.js')
 const { promisify } = require('util')
 const glob = promisify(require('glob'))
 const readFile = promisify(fs.readFile)
 const didYouMean = require('./utils/did-you-mean.js')
 const { cmdList } = require('./utils/cmd-list.js')
+const BaseCommand = require('./base-command.js')
 
-class HelpSearch {
-  constructor (npm) {
-    this.npm = npm
+class HelpSearch extends BaseCommand {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'help-search'
   }
 
-  get usage () {
-    return usageUtil('help-search', 'npm help-search <text>')
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get usage () {
+    return ['<text>']
   }
 
   exec (args, cb) {
@@ -44,8 +45,8 @@ class HelpSearch {
     if (!formatted.trim())
       npmUsage(this.npm, false)
     else {
-      output(formatted)
-      output(didYouMean(args[0], cmdList))
+      this.npm.output(formatted)
+      this.npm.output(didYouMean(args[0], cmdList))
     }
   }
 

--- a/deps/npm/lib/help.js
+++ b/deps/npm/lib/help.js
@@ -4,18 +4,18 @@ const path = require('path')
 const log = require('npmlog')
 const openUrl = require('./utils/open-url.js')
 const glob = require('glob')
-const output = require('./utils/output.js')
 
-const usage = require('./utils/usage.js')
+const BaseCommand = require('./base-command.js')
 
-class Help {
-  constructor (npm) {
-    this.npm = npm
+class Help extends BaseCommand {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'help'
   }
 
   /* istanbul ignore next - see test/lib/load-all-commands.js */
-  get usage () {
-    return usage('help', 'npm help <term> [<terms..>]')
+  static get usage () {
+    return ['<term> [<terms..>]']
   }
 
   async completion (opts) {
@@ -70,7 +70,7 @@ class Help {
       this.npm.commands[section].usage) {
       this.npm.config.set('loglevel', 'silent')
       log.level = 'silent'
-      output(this.npm.commands[section].usage)
+      this.npm.output(this.npm.commands[section].usage)
       return
     }
 

--- a/deps/npm/lib/hook.js
+++ b/deps/npm/lib/hook.js
@@ -1,22 +1,21 @@
 const hookApi = require('libnpmhook')
-const output = require('./utils/output.js')
 const otplease = require('./utils/otplease.js')
 const relativeDate = require('tiny-relative-date')
 const Table = require('cli-table3')
-const usageUtil = require('./utils/usage.js')
 
-class Hook {
-  constructor (npm) {
-    this.npm = npm
+const BaseCommand = require('./base-command.js')
+class Hook extends BaseCommand {
+  static get name () {
+    return 'hook'
   }
 
-  get usage () {
-    return usageUtil('hook', [
-      'npm hook add <pkg> <url> <secret> [--type=<type>]',
-      'npm hook ls [pkg]',
-      'npm hook rm <id>',
-      'npm hook update <id> <url> <secret>',
-    ].join('\n'))
+  static get usage () {
+    return [
+      'add <pkg> <url> <secret> [--type=<type>]',
+      'ls [pkg]',
+      'rm <id>',
+      'update <id> <url> <secret>',
+    ]
   }
 
   exec (args, cb) {
@@ -44,12 +43,12 @@ class Hook {
   async add (pkg, uri, secret, opts) {
     const hook = await hookApi.add(pkg, uri, secret, opts)
     if (opts.json)
-      output(JSON.stringify(hook, null, 2))
+      this.npm.output(JSON.stringify(hook, null, 2))
     else if (opts.parseable) {
-      output(Object.keys(hook).join('\t'))
-      output(Object.keys(hook).map(k => hook[k]).join('\t'))
+      this.npm.output(Object.keys(hook).join('\t'))
+      this.npm.output(Object.keys(hook).map(k => hook[k]).join('\t'))
     } else if (!opts.silent && opts.loglevel !== 'silent') {
-      output(`+ ${this.hookName(hook)} ${
+      this.npm.output(`+ ${this.hookName(hook)} ${
         opts.unicode ? ' ➜ ' : ' -> '
       } ${hook.endpoint}`)
     }
@@ -58,19 +57,19 @@ class Hook {
   async ls (pkg, opts) {
     const hooks = await hookApi.ls({ ...opts, package: pkg })
     if (opts.json)
-      output(JSON.stringify(hooks, null, 2))
+      this.npm.output(JSON.stringify(hooks, null, 2))
     else if (opts.parseable) {
-      output(Object.keys(hooks[0]).join('\t'))
+      this.npm.output(Object.keys(hooks[0]).join('\t'))
       hooks.forEach(hook => {
-        output(Object.keys(hook).map(k => hook[k]).join('\t'))
+        this.npm.output(Object.keys(hook).map(k => hook[k]).join('\t'))
       })
     } else if (!hooks.length)
-      output("You don't have any hooks configured yet.")
+      this.npm.output("You don't have any hooks configured yet.")
     else if (!opts.silent && opts.loglevel !== 'silent') {
       if (hooks.length === 1)
-        output('You have one hook configured.')
+        this.npm.output('You have one hook configured.')
       else
-        output(`You have ${hooks.length} hooks configured.`)
+        this.npm.output(`You have ${hooks.length} hooks configured.`)
 
       const table = new Table({ head: ['id', 'target', 'endpoint'] })
       hooks.forEach((hook) => {
@@ -90,19 +89,19 @@ class Hook {
         } else
           table.push([{ colSpan: 2, content: 'never triggered' }])
       })
-      output(table.toString())
+      this.npm.output(table.toString())
     }
   }
 
   async rm (id, opts) {
     const hook = await hookApi.rm(id, opts)
     if (opts.json)
-      output(JSON.stringify(hook, null, 2))
+      this.npm.output(JSON.stringify(hook, null, 2))
     else if (opts.parseable) {
-      output(Object.keys(hook).join('\t'))
-      output(Object.keys(hook).map(k => hook[k]).join('\t'))
+      this.npm.output(Object.keys(hook).join('\t'))
+      this.npm.output(Object.keys(hook).map(k => hook[k]).join('\t'))
     } else if (!opts.silent && opts.loglevel !== 'silent') {
-      output(`- ${this.hookName(hook)} ${
+      this.npm.output(`- ${this.hookName(hook)} ${
         opts.unicode ? ' ✘ ' : ' X '
       } ${hook.endpoint}`)
     }
@@ -111,12 +110,12 @@ class Hook {
   async update (id, uri, secret, opts) {
     const hook = await hookApi.update(id, uri, secret, opts)
     if (opts.json)
-      output(JSON.stringify(hook, null, 2))
+      this.npm.output(JSON.stringify(hook, null, 2))
     else if (opts.parseable) {
-      output(Object.keys(hook).join('\t'))
-      output(Object.keys(hook).map(k => hook[k]).join('\t'))
+      this.npm.output(Object.keys(hook).join('\t'))
+      this.npm.output(Object.keys(hook).map(k => hook[k]).join('\t'))
     } else if (!opts.silent && opts.loglevel !== 'silent') {
-      output(`+ ${this.hookName(hook)} ${
+      this.npm.output(`+ ${this.hookName(hook)} ${
         opts.unicode ? ' ➜ ' : ' -> '
       } ${hook.endpoint}`)
     }

--- a/deps/npm/lib/init.js
+++ b/deps/npm/lib/init.js
@@ -1,22 +1,21 @@
 const initJson = require('init-package-json')
 const npa = require('npm-package-arg')
 
-const usageUtil = require('./utils/usage.js')
-const output = require('./utils/output.js')
+const BaseCommand = require('./base-command.js')
 
-class Init {
-  constructor (npm) {
-    this.npm = npm
+class Init extends BaseCommand {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'init'
   }
 
   /* istanbul ignore next - see test/lib/load-all-commands.js */
-  get usage () {
-    return usageUtil(
-      'init',
-      '\nnpm init [--force|-f|--yes|-y|--scope]' +
-      '\nnpm init <@scope> (same as `npx <@scope>/create`)' +
-      '\nnpm init [<@scope>/]<name> (same as `npx [<@scope>/]create-<name>`)'
-    )
+  static get usage () {
+    return [
+      '[--force|-f|--yes|-y|--scope]',
+      '<@scope> (same as `npx <@scope>/create`)',
+      '[<@scope>/]<name> (same as `npx [<@scope>/]create-<name>`)',
+    ]
   }
 
   exec (args, cb) {
@@ -61,7 +60,7 @@ class Init {
     this.npm.log.disableProgress()
     const initFile = this.npm.config.get('init-module')
     if (!this.npm.flatOptions.yes && !this.npm.flatOptions.force) {
-      output([
+      this.npm.output([
         'This utility will walk you through creating a package.json file.',
         'It only covers the most common items, and tries to guess sensible defaults.',
         '',

--- a/deps/npm/lib/install-ci-test.js
+++ b/deps/npm/lib/install-ci-test.js
@@ -1,19 +1,12 @@
 // npm install-ci-test
 // Runs `npm ci` and then runs `npm test`
 
-const usageUtil = require('./utils/usage.js')
+const CI = require('./ci.js')
 
-class InstallCITest {
-  constructor (npm) {
-    this.npm = npm
-  }
-
-  get usage () {
-    return usageUtil(
-      'install-ci-test',
-      'npm install-ci-test [args]' +
-      '\nSame args as `npm ci`'
-    )
+class InstallCITest extends CI {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'install-ci-test'
   }
 
   exec (args, cb) {

--- a/deps/npm/lib/install-test.js
+++ b/deps/npm/lib/install-test.js
@@ -1,23 +1,12 @@
 // npm install-test
 // Runs `npm install` and then runs `npm test`
 
-const usageUtil = require('./utils/usage.js')
+const Install = require('./install.js')
 
-class InstallTest {
-  constructor (npm) {
-    this.npm = npm
-  }
-
-  get usage () {
-    return usageUtil(
-      'install-test',
-      'npm install-test [args]' +
-      '\nSame args as `npm install`'
-    )
-  }
-
-  async completion (opts) {
-    return this.npm.commands.install.completion(opts)
+class InstallTest extends Install {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'install-test'
   }
 
   exec (args, cb) {

--- a/deps/npm/lib/install.js
+++ b/deps/npm/lib/install.js
@@ -3,35 +3,33 @@
 const fs = require('fs')
 const util = require('util')
 const readdir = util.promisify(fs.readdir)
-const usageUtil = require('./utils/usage.js')
 const reifyFinish = require('./utils/reify-finish.js')
 const log = require('npmlog')
 const { resolve, join } = require('path')
 const Arborist = require('@npmcli/arborist')
 const runScript = require('@npmcli/run-script')
 
-class Install {
-  constructor (npm) {
-    this.npm = npm
+const BaseCommand = require('./base-command.js')
+class Install extends BaseCommand {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'install'
   }
 
   /* istanbul ignore next - see test/lib/load-all-commands.js */
-  get usage () {
-    return usageUtil(
-      'install',
-      'npm install (with no args, in package dir)' +
-      '\nnpm install [<@scope>/]<pkg>' +
-      '\nnpm install [<@scope>/]<pkg>@<tag>' +
-      '\nnpm install [<@scope>/]<pkg>@<version>' +
-      '\nnpm install [<@scope>/]<pkg>@<version range>' +
-      '\nnpm install <alias>@npm:<name>' +
-      '\nnpm install <folder>' +
-      '\nnpm install <tarball file>' +
-      '\nnpm install <tarball url>' +
-      '\nnpm install <git:// url>' +
-      '\nnpm install <github username>/<github project>',
-      '[--save-prod|--save-dev|--save-optional|--save-peer] [--save-exact] [--no-save]'
-    )
+  static get usage () {
+    return [
+      '[<@scope>/]<pkg>',
+      '[<@scope>/]<pkg>@<tag>',
+      '[<@scope>/]<pkg>@<version>',
+      '[<@scope>/]<pkg>@<version range>',
+      '<alias>@npm:<name>',
+      '<folder>',
+      '<tarball file>',
+      '<tarball url>',
+      '<git:// url>',
+      '<github username>/<github project> [--save-prod|--save-dev|--save-optional|--save-peer] [--save-exact] [--no-save]',
+    ]
   }
 
   async completion (opts) {

--- a/deps/npm/lib/link.js
+++ b/deps/npm/lib/link.js
@@ -8,21 +8,21 @@ const npa = require('npm-package-arg')
 const rpj = require('read-package-json-fast')
 const semver = require('semver')
 
-const usageUtil = require('./utils/usage.js')
 const reifyFinish = require('./utils/reify-finish.js')
 
-class Link {
-  constructor (npm) {
-    this.npm = npm
+const BaseCommand = require('./base-command.js')
+class Link extends BaseCommand {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'link'
   }
 
   /* istanbul ignore next - see test/lib/load-all-commands.js */
-  get usage () {
-    return usageUtil(
-      'link',
-      'npm link (in package dir)' +
-      '\nnpm link [<@scope>/]<pkg>[@<version>]'
-    )
+  static get usage () {
+    return [
+      '(in package dir)',
+      '[<@scope>/]<pkg>[@<version>]',
+    ]
   }
 
   async completion (opts) {

--- a/deps/npm/lib/ll.js
+++ b/deps/npm/lib/ll.js
@@ -1,13 +1,14 @@
 const LS = require('./ls.js')
-const usageUtil = require('./utils/usage.js')
 
 class LL extends LS {
   /* istanbul ignore next - see test/lib/load-all-commands.js */
-  get usage () {
-    return usageUtil(
-      'll',
-      'npm ll [[<@scope>/]<pkg> ...]'
-    )
+  static get name () {
+    return 'll'
+  }
+
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get usage () {
+    return ['[[<@scope>/]<pkg> ...]']
   }
 
   exec (args, cb) {

--- a/deps/npm/lib/logout.js
+++ b/deps/npm/lib/logout.js
@@ -1,19 +1,17 @@
 const log = require('npmlog')
 const getAuth = require('npm-registry-fetch/auth.js')
 const npmFetch = require('npm-registry-fetch')
-const usageUtil = require('./utils/usage.js')
+const BaseCommand = require('./base-command.js')
 
-class Logout {
-  constructor (npm) {
-    this.npm = npm
+class Logout extends BaseCommand {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'logout'
   }
 
   /* istanbul ignore next - see test/lib/load-all-commands.js */
-  get usage () {
-    return usageUtil(
-      'logout',
-      'npm logout [--registry=<url>] [--scope=<@scope>]'
-    )
+  static get usage () {
+    return ['[--registry=<url>] [--scope=<@scope>]']
   }
 
   exec (args, cb) {

--- a/deps/npm/lib/ls.js
+++ b/deps/npm/lib/ls.js
@@ -7,9 +7,7 @@ const Arborist = require('@npmcli/arborist')
 const { breadth } = require('treeverse')
 const npa = require('npm-package-arg')
 
-const usageUtil = require('./utils/usage.js')
 const completion = require('./utils/completion/installed-deep.js')
-const output = require('./utils/output.js')
 
 const _depth = Symbol('depth')
 const _dedupe = Symbol('dedupe')
@@ -22,18 +20,17 @@ const _parent = Symbol('parent')
 const _problems = Symbol('problems')
 const _required = Symbol('required')
 const _type = Symbol('type')
+const BaseCommand = require('./base-command.js')
 
-class LS {
-  constructor (npm) {
-    this.npm = npm
+class LS extends BaseCommand {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'ls'
   }
 
   /* istanbul ignore next - see test/lib/load-all-commands.js */
-  get usage () {
-    return usageUtil(
-      'ls',
-      'npm ls [[<@scope>/]<pkg> ...]'
-    )
+  static get usage () {
+    return ['npm ls [[<@scope>/]<pkg> ...]']
   }
 
   /* istanbul ignore next - see test/lib/load-all-commands.js */
@@ -147,7 +144,7 @@ class LS {
     const [rootError] = tree.errors.filter(e =>
       e.code === 'EJSONPARSE' && e.path === resolve(path, 'package.json'))
 
-    output(
+    this.npm.output(
       json
         ? jsonOutput({ path, problems, result, rootError, seenItems })
         : parseable

--- a/deps/npm/lib/npm.js
+++ b/deps/npm/lib/npm.js
@@ -282,6 +282,13 @@ const npm = module.exports = new class extends EventEmitter {
     }
     return resolve(this.config.get('tmp'), this[_tmpFolder])
   }
+
+  // output to stdout in a progress bar compatible way
+  output (...msg) {
+    this.log.clearProgress()
+    console.log(...msg)
+    this.log.showProgress()
+  }
 }()
 
 // now load everything required by the class methods

--- a/deps/npm/lib/org.js
+++ b/deps/npm/lib/org.js
@@ -1,21 +1,21 @@
 const liborg = require('libnpmorg')
-const usageUtil = require('./utils/usage.js')
-const output = require('./utils/output.js')
 const otplease = require('./utils/otplease.js')
 const Table = require('cli-table3')
+const BaseCommand = require('./base-command.js')
 
-class Org {
-  constructor (npm) {
-    this.npm = npm
+class Org extends BaseCommand {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'org'
   }
 
-  get usage () {
-    return usageUtil(
-      'org',
-      'npm org set orgname username [developer | admin | owner]\n' +
-      'npm org rm orgname username\n' +
-      'npm org ls orgname [<username>]'
-    )
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get usage () {
+    return [
+      'set orgname username [developer | admin | owner]',
+      'rm orgname username',
+      'ls orgname [<username>]',
+    ]
   }
 
   async completion (opts) {
@@ -72,17 +72,17 @@ class Org {
 
     return liborg.set(org, user, role, opts).then(memDeets => {
       if (opts.json)
-        output(JSON.stringify(memDeets, null, 2))
+        this.npm.output(JSON.stringify(memDeets, null, 2))
       else if (opts.parseable) {
-        output(['org', 'orgsize', 'user', 'role'].join('\t'))
-        output([
+        this.npm.output(['org', 'orgsize', 'user', 'role'].join('\t'))
+        this.npm.output([
           memDeets.org.name,
           memDeets.org.size,
           memDeets.user,
           memDeets.role,
         ].join('\t'))
       } else if (!opts.silent && opts.loglevel !== 'silent')
-        output(`Added ${memDeets.user} as ${memDeets.role} to ${memDeets.org.name}. You now have ${memDeets.org.size} member${memDeets.org.size === 1 ? '' : 's'} in this org.`)
+        this.npm.output(`Added ${memDeets.user} as ${memDeets.role} to ${memDeets.org.name}. You now have ${memDeets.org.size} member${memDeets.org.size === 1 ? '' : 's'} in this org.`)
 
       return memDeets
     })
@@ -102,17 +102,17 @@ class Org {
       org = org.replace(/^[~@]?/, '')
       const userCount = Object.keys(roster).length
       if (opts.json) {
-        output(JSON.stringify({
+        this.npm.output(JSON.stringify({
           user,
           org,
           userCount,
           deleted: true,
         }))
       } else if (opts.parseable) {
-        output(['user', 'org', 'userCount', 'deleted'].join('\t'))
-        output([user, org, userCount, true].join('\t'))
+        this.npm.output(['user', 'org', 'userCount', 'deleted'].join('\t'))
+        this.npm.output([user, org, userCount, true].join('\t'))
       } else if (!opts.silent && opts.loglevel !== 'silent')
-        output(`Successfully removed ${user} from ${org}. You now have ${userCount} member${userCount === 1 ? '' : 's'} in this org.`)
+        this.npm.output(`Successfully removed ${user} from ${org}. You now have ${userCount} member${userCount === 1 ? '' : 's'} in this org.`)
     })
   }
 
@@ -129,18 +129,18 @@ class Org {
         roster = newRoster
       }
       if (opts.json)
-        output(JSON.stringify(roster, null, 2))
+        this.npm.output(JSON.stringify(roster, null, 2))
       else if (opts.parseable) {
-        output(['user', 'role'].join('\t'))
+        this.npm.output(['user', 'role'].join('\t'))
         Object.keys(roster).forEach(user => {
-          output([user, roster[user]].join('\t'))
+          this.npm.output([user, roster[user]].join('\t'))
         })
       } else if (!opts.silent && opts.loglevel !== 'silent') {
         const table = new Table({ head: ['user', 'role'] })
         Object.keys(roster).sort().forEach(user => {
           table.push([user, roster[user]])
         })
-        output(table.toString())
+        this.npm.output(table.toString())
       }
     })
   }

--- a/deps/npm/lib/outdated.js
+++ b/deps/npm/lib/outdated.js
@@ -9,20 +9,18 @@ const pickManifest = require('npm-pick-manifest')
 
 const Arborist = require('@npmcli/arborist')
 
-const output = require('./utils/output.js')
-const usageUtil = require('./utils/usage.js')
 const ansiTrim = require('./utils/ansi-trim.js')
+const BaseCommand = require('./base-command.js')
 
-class Outdated {
-  constructor (npm) {
-    this.npm = npm
+class Outdated extends BaseCommand {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'outdated'
   }
 
   /* istanbul ignore next - see test/lib/load-all-commands.js */
-  get usage () {
-    return usageUtil('outdated',
-      'npm outdated [[<@scope>/]<pkg> ...]'
-    )
+  static get usage () {
+    return ['[[<@scope>/]<pkg> ...]']
   }
 
   exec (args, cb) {
@@ -75,9 +73,9 @@ class Outdated {
 
     // display results
     if (this.opts.json)
-      output(this.makeJSON(outdated))
+      this.npm.output(this.makeJSON(outdated))
     else if (this.opts.parseable)
-      output(this.makeParseable(outdated))
+      this.npm.output(this.makeParseable(outdated))
     else {
       const outList = outdated.map(x => this.makePretty(x))
       const outHead = ['Package',
@@ -99,7 +97,7 @@ class Outdated {
         align: ['l', 'r', 'r', 'r', 'l'],
         stringLength: s => ansiTrim(s).length,
       }
-      output(table(outTable, tableOpts))
+      this.npm.output(table(outTable, tableOpts))
     }
   }
 

--- a/deps/npm/lib/owner.js
+++ b/deps/npm/lib/owner.js
@@ -3,27 +3,23 @@ const npa = require('npm-package-arg')
 const npmFetch = require('npm-registry-fetch')
 const pacote = require('pacote')
 
-const output = require('./utils/output.js')
 const otplease = require('./utils/otplease.js')
 const readLocalPkg = require('./utils/read-local-package.js')
-const usageUtil = require('./utils/usage.js')
+const BaseCommand = require('./base-command.js')
 
-class Owner {
-  constructor (npm) {
-    this.npm = npm
+class Owner extends BaseCommand {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'owner'
   }
 
-  get usage () {
-    return usageUtil(
-      'owner',
-      'npm owner add <user> [<@scope>/]<pkg>' +
-      '\nnpm owner rm <user> [<@scope>/]<pkg>' +
-      '\nnpm owner ls [<@scope>/]<pkg>'
-    )
-  }
-
-  get usageError () {
-    return Object.assign(new Error(this.usage), { code: 'EUSAGE' })
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get usage () {
+    return [
+      'add <user> [<@scope>/]<pkg>',
+      'rm <user> [<@scope>/]<pkg>',
+      'ls [<@scope>/]<pkg>',
+    ]
   }
 
   async completion (opts) {
@@ -70,7 +66,7 @@ class Owner {
       case 'remove':
         return this.rm(args[0], args[1], opts)
       default:
-        throw this.usageError
+        throw this.usageError()
     }
   }
 
@@ -78,7 +74,7 @@ class Owner {
     if (!pkg) {
       const pkgName = await readLocalPkg(this.npm)
       if (!pkgName)
-        throw this.usageError
+        throw this.usageError()
 
       pkg = pkgName
     }
@@ -89,9 +85,9 @@ class Owner {
       const packumentOpts = { ...opts, fullMetadata: true }
       const { maintainers } = await pacote.packument(spec, packumentOpts)
       if (!maintainers || !maintainers.length)
-        output('no admin found')
+        this.npm.output('no admin found')
       else
-        output(maintainers.map(o => `${o.name} <${o.email}>`).join('\n'))
+        this.npm.output(maintainers.map(o => `${o.name} <${o.email}>`).join('\n'))
 
       return maintainers
     } catch (err) {
@@ -102,138 +98,141 @@ class Owner {
 
   async add (user, pkg, opts) {
     if (!user)
-      throw this.usageError
+      throw this.usageError()
 
     if (!pkg) {
       const pkgName = await readLocalPkg(this.npm)
       if (!pkgName)
-        throw this.usageError
+        throw this.usageError()
 
       pkg = pkgName
     }
     log.verbose('owner add', '%s to %s', user, pkg)
 
     const spec = npa(pkg)
-    return putOwners(spec, user, opts, validateAddOwner)
+    return this.putOwners(spec, user, opts,
+      (newOwner, owners) => this.validateAddOwner(newOwner, owners))
   }
 
   async rm (user, pkg, opts) {
     if (!user)
-      throw this.usageError
+      throw this.usageError()
 
     if (!pkg) {
       const pkgName = await readLocalPkg(this.npm)
       if (!pkgName)
-        throw this.usageError
+        throw this.usageError()
 
       pkg = pkgName
     }
     log.verbose('owner rm', '%s from %s', user, pkg)
 
     const spec = npa(pkg)
-    return putOwners(spec, user, opts, validateRmOwner)
+    return this.putOwners(spec, user, opts,
+      (rmOwner, owners) => this.validateRmOwner(rmOwner, owners))
+  }
+
+  async putOwners (spec, user, opts, validation) {
+    const uri = `/-/user/org.couchdb.user:${encodeURIComponent(user)}`
+    let u = ''
+
+    try {
+      u = await npmFetch.json(uri, opts)
+    } catch (err) {
+      log.error('owner mutate', `Error getting user data for ${user}`)
+      throw err
+    }
+
+    if (user && (!u || !u.name || u.error)) {
+      throw Object.assign(
+        new Error(
+          "Couldn't get user data for " + user + ': ' + JSON.stringify(u)
+        ),
+        { code: 'EOWNERUSER' }
+      )
+    }
+
+    // normalize user data
+    u = { name: u.name, email: u.email }
+
+    const data = await pacote.packument(spec, { ...opts, fullMetadata: true })
+
+    // save the number of maintainers before validation for comparison
+    const before = data.maintainers ? data.maintainers.length : 0
+
+    const m = validation(u, data.maintainers)
+    if (!m)
+      return // invalid owners
+
+    const body = {
+      _id: data._id,
+      _rev: data._rev,
+      maintainers: m,
+    }
+    const dataPath = `/${spec.escapedName}/-rev/${encodeURIComponent(data._rev)}`
+    const res = await otplease(opts, opts => {
+      return npmFetch.json(dataPath, {
+        ...opts,
+        method: 'PUT',
+        body,
+        spec,
+      })
+    })
+
+    if (!res.error) {
+      if (m.length < before)
+        this.npm.output(`- ${user} (${spec.name})`)
+      else
+        this.npm.output(`+ ${user} (${spec.name})`)
+    } else {
+      throw Object.assign(
+        new Error('Failed to update package: ' + JSON.stringify(res)),
+        { code: 'EOWNERMUTATE' }
+      )
+    }
+    return res
+  }
+
+  validateAddOwner (newOwner, owners) {
+    owners = owners || []
+    for (const o of owners) {
+      if (o.name === newOwner.name) {
+        log.info(
+          'owner add',
+          'Already a package owner: ' + o.name + ' <' + o.email + '>'
+        )
+        return false
+      }
+    }
+    return [
+      ...owners,
+      newOwner,
+    ]
+  }
+
+  validateRmOwner (rmOwner, owners) {
+    let found = false
+    const m = owners.filter(function (o) {
+      var match = (o.name === rmOwner.name)
+      found = found || match
+      return !match
+    })
+
+    if (!found) {
+      log.info('owner rm', 'Not a package owner: ' + rmOwner.name)
+      return false
+    }
+
+    if (!m.length) {
+      throw Object.assign(
+        new Error(
+          'Cannot remove all owners of a package. Add someone else first.'
+        ),
+        { code: 'EOWNERRM' }
+      )
+    }
+
+    return m
   }
 }
 module.exports = Owner
-
-const validateAddOwner = (newOwner, owners) => {
-  owners = owners || []
-  for (const o of owners) {
-    if (o.name === newOwner.name) {
-      log.info(
-        'owner add',
-        'Already a package owner: ' + o.name + ' <' + o.email + '>'
-      )
-      return false
-    }
-  }
-  return [
-    ...owners,
-    newOwner,
-  ]
-}
-
-const validateRmOwner = (rmOwner, owners) => {
-  let found = false
-  const m = owners.filter(function (o) {
-    var match = (o.name === rmOwner.name)
-    found = found || match
-    return !match
-  })
-
-  if (!found) {
-    log.info('owner rm', 'Not a package owner: ' + rmOwner.name)
-    return false
-  }
-
-  if (!m.length) {
-    throw Object.assign(
-      new Error(
-        'Cannot remove all owners of a package. Add someone else first.'
-      ),
-      { code: 'EOWNERRM' }
-    )
-  }
-
-  return m
-}
-
-const putOwners = async (spec, user, opts, validation) => {
-  const uri = `/-/user/org.couchdb.user:${encodeURIComponent(user)}`
-  let u = ''
-
-  try {
-    u = await npmFetch.json(uri, opts)
-  } catch (err) {
-    log.error('owner mutate', `Error getting user data for ${user}`)
-    throw err
-  }
-
-  if (user && (!u || !u.name || u.error)) {
-    throw Object.assign(
-      new Error(
-        "Couldn't get user data for " + user + ': ' + JSON.stringify(u)
-      ),
-      { code: 'EOWNERUSER' }
-    )
-  }
-
-  // normalize user data
-  u = { name: u.name, email: u.email }
-
-  const data = await pacote.packument(spec, { ...opts, fullMetadata: true })
-
-  // save the number of maintainers before validation for comparison
-  const before = data.maintainers ? data.maintainers.length : 0
-
-  const m = validation(u, data.maintainers)
-  if (!m)
-    return // invalid owners
-
-  const body = {
-    _id: data._id,
-    _rev: data._rev,
-    maintainers: m,
-  }
-  const dataPath = `/${spec.escapedName}/-rev/${encodeURIComponent(data._rev)}`
-  const res = await otplease(opts, opts =>
-    npmFetch.json(dataPath, {
-      ...opts,
-      method: 'PUT',
-      body,
-      spec,
-    }))
-
-  if (!res.error) {
-    if (m.length < before)
-      output(`- ${user} (${spec.name})`)
-    else
-      output(`+ ${user} (${spec.name})`)
-  } else {
-    throw Object.assign(
-      new Error('Failed to update package: ' + JSON.stringify(res)),
-      { code: 'EOWNERMUTATE' }
-    )
-  }
-  return res
-}

--- a/deps/npm/lib/pack.js
+++ b/deps/npm/lib/pack.js
@@ -7,18 +7,18 @@ const npa = require('npm-package-arg')
 const { getContents, logTar } = require('./utils/tar.js')
 
 const writeFile = util.promisify(require('fs').writeFile)
-const output = require('./utils/output.js')
 
-const usageUtil = require('./utils/usage.js')
+const BaseCommand = require('./base-command.js')
 
-class Pack {
-  constructor (npm) {
-    this.npm = npm
+class Pack extends BaseCommand {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'pack'
   }
 
   /* istanbul ignore next - see test/lib/load-all-commands.js */
-  get usage () {
-    return usageUtil('pack', 'npm pack [[<@scope>/]<pkg>...] [--dry-run]')
+  static get usage () {
+    return ['[[<@scope>/]<pkg>...] [--dry-run]']
   }
 
   exec (args, cb) {
@@ -49,7 +49,7 @@ class Pack {
 
     for (const tar of tarballs) {
       logTar(tar, { log, unicode })
-      output(tar.filename.replace(/^@/, '').replace(/\//, '-'))
+      this.npm.output(tar.filename.replace(/^@/, '').replace(/\//, '-'))
     }
   }
 }

--- a/deps/npm/lib/ping.js
+++ b/deps/npm/lib/ping.js
@@ -1,16 +1,16 @@
 const log = require('npmlog')
-const output = require('./utils/output.js')
-const usageUtil = require('./utils/usage.js')
 const pingUtil = require('./utils/ping.js')
+const BaseCommand = require('./base-command.js')
 
-class Ping {
-  constructor (npm) {
-    this.npm = npm
+class Ping extends BaseCommand {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'ping'
   }
 
   /* istanbul ignore next - see test/lib/load-all-commands.js */
-  get usage () {
-    return usageUtil('ping', 'npm ping\nping registry')
+  static get description () {
+    return 'ping registry'
   }
 
   exec (args, cb) {
@@ -24,7 +24,7 @@ class Ping {
     const time = Date.now() - start
     log.notice('PONG', `${time / 1000}ms`)
     if (this.npm.flatOptions.json) {
-      output(JSON.stringify({
+      this.npm.output(JSON.stringify({
         registry: this.npm.flatOptions.registry,
         time,
         details,

--- a/deps/npm/lib/prefix.js
+++ b/deps/npm/lib/prefix.js
@@ -1,14 +1,14 @@
-const output = require('./utils/output.js')
-const usageUtil = require('./utils/usage.js')
+const BaseCommand = require('./base-command.js')
 
-class Prefix {
-  constructor (npm) {
-    this.npm = npm
+class Prefix extends BaseCommand {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'prefix'
   }
 
   /* istanbul ignore next - see test/lib/load-all-commands.js */
-  get usage () {
-    return usageUtil('prefix', 'npm prefix [-g]')
+  static get usage () {
+    return ['[-g]']
   }
 
   exec (args, cb) {
@@ -16,7 +16,7 @@ class Prefix {
   }
 
   async prefix (args) {
-    return output(this.npm.prefix)
+    return this.npm.output(this.npm.prefix)
   }
 }
 module.exports = Prefix

--- a/deps/npm/lib/prune.js
+++ b/deps/npm/lib/prune.js
@@ -1,18 +1,17 @@
 // prune extraneous packages
 const Arborist = require('@npmcli/arborist')
-const usageUtil = require('./utils/usage.js')
 const reifyFinish = require('./utils/reify-finish.js')
 
-class Prune {
-  constructor (npm) {
-    this.npm = npm
+const BaseCommand = require('./base-command.js')
+class Prune extends BaseCommand {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'prune'
   }
 
   /* istanbul ignore next - see test/lib/load-all-commands.js */
-  get usage () {
-    return usageUtil('prune',
-      'npm prune [[<@scope>/]<pkg>...] [--production]'
-    )
+  static get usage () {
+    return ['[[<@scope>/]<pkg>...] [--production]']
   }
 
   exec (args, cb) {

--- a/deps/npm/lib/publish.js
+++ b/deps/npm/lib/publish.js
@@ -9,9 +9,7 @@ const npa = require('npm-package-arg')
 const npmFetch = require('npm-registry-fetch')
 
 const { flatten } = require('./utils/flat-options.js')
-const output = require('./utils/output.js')
 const otplease = require('./utils/otplease.js')
-const usageUtil = require('./utils/usage.js')
 const { getContents, logTar } = require('./utils/tar.js')
 
 // this is the only case in the CLI where we use the old full slow
@@ -19,16 +17,18 @@ const { getContents, logTar } = require('./utils/tar.js')
 // defaults and metadata, like git sha's and default scripts and all that.
 const readJson = util.promisify(require('read-package-json'))
 
-class Publish {
-  constructor (npm) {
-    this.npm = npm
+const BaseCommand = require('./base-command.js')
+class Publish extends BaseCommand {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'publish'
   }
 
-  get usage () {
-    return usageUtil('publish',
-      'npm publish [<folder>] [--tag <tag>] [--access <public|restricted>] [--dry-run]' +
-      '\n\nPublishes \'.\' if no argument supplied' +
-      '\nSets tag `latest` if no --tag specified')
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get usage () {
+    return [
+      '[<folder>] [--tag <tag>] [--access <public|restricted>] [--dry-run]',
+    ]
   }
 
   exec (args, cb) {
@@ -115,9 +115,9 @@ class Publish {
 
     const silent = log.level === 'silent'
     if (!silent && json)
-      output(JSON.stringify(pkgContents, null, 2))
+      this.npm.output(JSON.stringify(pkgContents, null, 2))
     else if (!silent)
-      output(`+ ${pkgContents.id}`)
+      this.npm.output(`+ ${pkgContents.id}`)
 
     return pkgContents
   }

--- a/deps/npm/lib/rebuild.js
+++ b/deps/npm/lib/rebuild.js
@@ -2,18 +2,18 @@ const { resolve } = require('path')
 const Arborist = require('@npmcli/arborist')
 const npa = require('npm-package-arg')
 const semver = require('semver')
-const usageUtil = require('./utils/usage.js')
-const output = require('./utils/output.js')
 const completion = require('./utils/completion/installed-deep.js')
 
-class Rebuild {
-  constructor (npm) {
-    this.npm = npm
+const BaseCommand = require('./base-command.js')
+class Rebuild extends BaseCommand {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'rebuild'
   }
 
   /* istanbul ignore next - see test/lib/load-all-commands.js */
-  get usage () {
-    return usageUtil('rebuild', 'npm rebuild [[<@scope>/]<name>[@<version>] ...]')
+  static get usage () {
+    return ['[[<@scope>/]<name>[@<version>] ...]']
   }
 
   /* istanbul ignore next - see test/lib/load-all-commands.js */
@@ -52,7 +52,7 @@ class Rebuild {
     } else
       await arb.rebuild()
 
-    output('rebuilt dependencies successfully')
+    this.npm.output('rebuilt dependencies successfully')
   }
 
   isNode (specs, node) {

--- a/deps/npm/lib/repo.js
+++ b/deps/npm/lib/repo.js
@@ -4,16 +4,17 @@ const { URL } = require('url')
 
 const hostedFromMani = require('./utils/hosted-git-info-from-manifest.js')
 const openUrl = require('./utils/open-url.js')
-const usageUtil = require('./utils/usage.js')
 
-class Repo {
-  constructor (npm) {
-    this.npm = npm
+const BaseCommand = require('./base-command.js')
+class Repo extends BaseCommand {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'repo'
   }
 
   /* istanbul ignore next - see test/lib/load-all-commands.js */
-  get usage () {
-    return usageUtil('repo', 'npm repo [<pkgname> [<pkgname> ...]]')
+  static get usage () {
+    return ['[<pkgname> [<pkgname> ...]]']
   }
 
   exec (args, cb) {

--- a/deps/npm/lib/restart.js
+++ b/deps/npm/lib/restart.js
@@ -2,8 +2,9 @@ const LifecycleCmd = require('./utils/lifecycle-cmd.js')
 
 // This ends up calling run-script(['restart', ...args])
 class Restart extends LifecycleCmd {
-  constructor (npm) {
-    super(npm, 'restart')
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'restart'
   }
 }
 module.exports = Restart

--- a/deps/npm/lib/root.js
+++ b/deps/npm/lib/root.js
@@ -1,14 +1,13 @@
-const output = require('./utils/output.js')
-const usageUtil = require('./utils/usage.js')
-
-class Root {
-  constructor (npm) {
-    this.npm = npm
+const BaseCommand = require('./base-command.js')
+class Root extends BaseCommand {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'root'
   }
 
   /* istanbul ignore next - see test/lib/load-all-commands.js */
-  get usage () {
-    return usageUtil('root', 'npm root [-g]')
+  static get usage () {
+    return ['[-g]']
   }
 
   exec (args, cb) {
@@ -16,7 +15,7 @@ class Root {
   }
 
   async root () {
-    output(this.npm.dir)
+    this.npm.output(this.npm.dir)
   }
 }
 module.exports = Root

--- a/deps/npm/lib/run-script.js
+++ b/deps/npm/lib/run-script.js
@@ -2,9 +2,7 @@ const runScript = require('@npmcli/run-script')
 const { isServerPackage } = runScript
 const readJson = require('read-package-json-fast')
 const { resolve } = require('path')
-const output = require('./utils/output.js')
 const log = require('npmlog')
-const usageUtil = require('./utils/usage.js')
 const didYouMean = require('./utils/did-you-mean.js')
 const isWindowsShell = require('./utils/is-windows-shell.js')
 
@@ -19,17 +17,16 @@ const cmdList = [
   'version',
 ].reduce((l, p) => l.concat(['pre' + p, p, 'post' + p]), [])
 
-class RunScript {
-  constructor (npm) {
-    this.npm = npm
+const BaseCommand = require('./base-command.js')
+class RunScript extends BaseCommand {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'run-script'
   }
 
   /* istanbul ignore next - see test/lib/load-all-commands.js */
-  get usage () {
-    return usageUtil(
-      'run-script',
-      'npm run-script <command> [-- <args>]'
-    )
+  static get usage () {
+    return ['<command> [-- <args>]']
   }
 
   async completion (opts) {
@@ -117,13 +114,13 @@ class RunScript {
       return allScripts
 
     if (this.npm.flatOptions.json) {
-      output(JSON.stringify(scripts, null, 2))
+      this.npm.output(JSON.stringify(scripts, null, 2))
       return allScripts
     }
 
     if (this.npm.flatOptions.parseable) {
       for (const [script, cmd] of Object.entries(scripts))
-        output(`${script}:${cmd}`)
+        this.npm.output(`${script}:${cmd}`)
 
       return allScripts
     }
@@ -138,18 +135,18 @@ class RunScript {
     }
 
     if (cmds.length)
-      output(`Lifecycle scripts included in ${name}:`)
+      this.npm.output(`Lifecycle scripts included in ${name}:`)
 
     for (const script of cmds)
-      output(prefix + script + indent + scripts[script])
+      this.npm.output(prefix + script + indent + scripts[script])
 
     if (!cmds.length && runScripts.length)
-      output(`Scripts available in ${name} via \`npm run-script\`:`)
+      this.npm.output(`Scripts available in ${name} via \`npm run-script\`:`)
     else if (runScripts.length)
-      output('\navailable via `npm run-script`:')
+      this.npm.output('\navailable via `npm run-script`:')
 
     for (const script of runScripts)
-      output(prefix + script + indent + scripts[script])
+      this.npm.output(prefix + script + indent + scripts[script])
 
     return allScripts
   }

--- a/deps/npm/lib/search.js
+++ b/deps/npm/lib/search.js
@@ -5,8 +5,6 @@ const log = require('npmlog')
 
 const formatPackageStream = require('./search/format-package-stream.js')
 const packageFilter = require('./search/package-filter.js')
-const output = require('./utils/output.js')
-const usageUtil = require('./utils/usage.js')
 
 function prepareIncludes (args) {
   return args
@@ -26,17 +24,16 @@ function prepareExcludes (searchexclude) {
     .filter(s => s)
 }
 
-class Search {
-  constructor (npm) {
-    this.npm = npm
+const BaseCommand = require('./base-command.js')
+class Search extends BaseCommand {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'search'
   }
 
   /* istanbul ignore next - see test/lib/load-all-commands.js */
-  get usage () {
-    return usageUtil(
-      'search',
-      'npm search [-l|--long] [--json] [--parseable] [--no-description] [search terms ...]'
-    )
+  static get usage () {
+    return ['[-l|--long] [--json] [--parseable] [--no-description] [search terms ...]']
   }
 
   exec (args, cb) {
@@ -83,12 +80,12 @@ class Search {
     p.on('data', chunk => {
       if (!anyOutput)
         anyOutput = true
-      output(chunk.toString('utf8'))
+      this.npm.output(chunk.toString('utf8'))
     })
 
     await p.promise()
     if (!anyOutput && !opts.json && !opts.parseable)
-      output('No matches found for ' + (args.map(JSON.stringify).join(' ')))
+      this.npm.output('No matches found for ' + (args.map(JSON.stringify).join(' ')))
 
     log.silly('search', 'search completed')
     log.clearProgress()

--- a/deps/npm/lib/search/format-package-stream.js
+++ b/deps/npm/lib/search/format-package-stream.js
@@ -43,6 +43,7 @@ class JSONOutputStream extends Minipass {
 
   end () {
     super.write(this._didFirst ? ']\n' : '\n]\n')
+    super.end()
   }
 }
 

--- a/deps/npm/lib/set-script.js
+++ b/deps/npm/lib/set-script.js
@@ -1,17 +1,18 @@
 const log = require('npmlog')
-const usageUtil = require('./utils/usage.js')
 const fs = require('fs')
 const parseJSON = require('json-parse-even-better-errors')
 const rpj = require('read-package-json-fast')
 
-class SetScript {
-  constructor (npm) {
-    this.npm = npm
+const BaseCommand = require('./base-command.js')
+class SetScript extends BaseCommand {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'set-script'
   }
 
   /* istanbul ignore next - see test/lib/load-all-commands.js */
-  get usage () {
-    return usageUtil('set-script', 'npm set-script [<script>] [<command>]')
+  static get usage () {
+    return ['[<script>] [<command>]']
   }
 
   exec (args, cb) {

--- a/deps/npm/lib/set.js
+++ b/deps/npm/lib/set.js
@@ -1,15 +1,14 @@
-const usageUtil = require('./utils/usage.js')
+const BaseCommand = require('./base-command.js')
 
-class Set {
-  constructor (npm) {
-    this.npm = npm
+class Set extends BaseCommand {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'set'
   }
 
-  get usage () {
-    return usageUtil(
-      'set',
-      'npm set <key>=<value> [<key>=<value> ...] (See `npm config`)'
-    )
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get usage () {
+    return ['<key>=<value> [<key>=<value> ...] (See `npm config`)']
   }
 
   /* istanbul ignore next - see test/lib/load-all-commands.js */

--- a/deps/npm/lib/shrinkwrap.js
+++ b/deps/npm/lib/shrinkwrap.js
@@ -5,16 +5,11 @@ const { unlink } = fs.promises || { unlink: util.promisify(fs.unlink) }
 const Arborist = require('@npmcli/arborist')
 const log = require('npmlog')
 
-const usageUtil = require('./utils/usage.js')
-
-class Shrinkwrap {
-  constructor (npm) {
-    this.npm = npm
-  }
-
+const BaseCommand = require('./base-command.js')
+class Shrinkwrap extends BaseCommand {
   /* istanbul ignore next - see test/lib/load-all-commands.js */
-  get usage () {
-    return usageUtil('shrinkwrap', 'npm shrinkwrap')
+  static get name () {
+    return 'shrinkwrap'
   }
 
   exec (args, cb) {

--- a/deps/npm/lib/star.js
+++ b/deps/npm/lib/star.js
@@ -2,21 +2,18 @@ const fetch = require('npm-registry-fetch')
 const log = require('npmlog')
 const npa = require('npm-package-arg')
 
-const output = require('./utils/output.js')
-const usageUtil = require('./utils/usage.js')
 const getIdentity = require('./utils/get-identity')
 
-class Star {
-  constructor (npm) {
-    this.npm = npm
+const BaseCommand = require('./base-command.js')
+class Star extends BaseCommand {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'star'
   }
 
-  get usage () {
-    return usageUtil(
-      'star',
-      'npm star [<pkg>...]\n' +
-      'npm unstar [<pkg>...]'
-    )
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get usage () {
+    return ['[<pkg>...]']
   }
 
   exec (args, cb) {
@@ -73,7 +70,7 @@ class Star {
         body,
       })
 
-      output(show + ' ' + pkg.name)
+      this.npm.output(show + ' ' + pkg.name)
       log.verbose('star', data)
       return data
     }

--- a/deps/npm/lib/stars.js
+++ b/deps/npm/lib/stars.js
@@ -1,18 +1,18 @@
 const log = require('npmlog')
 const fetch = require('npm-registry-fetch')
 
-const output = require('./utils/output.js')
 const getIdentity = require('./utils/get-identity.js')
-const usageUtil = require('./utils/usage.js')
 
-class Stars {
-  constructor (npm) {
-    this.npm = npm
+const BaseCommand = require('./base-command.js')
+class Stars extends BaseCommand {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'stars'
   }
 
   /* istanbul ignore next - see test/lib/load-all-commands.js */
-  get usage () {
-    return usageUtil('stars', 'npm stars [<user>]')
+  static get usage () {
+    return ['[<user>]']
   }
 
   exec (args, cb) {
@@ -36,7 +36,7 @@ class Stars {
       log.warn('stars', 'user has not starred any packages')
 
     for (const row of rows)
-      output(row.value)
+      this.npm.output(row.value)
   }
 }
 module.exports = Stars

--- a/deps/npm/lib/start.js
+++ b/deps/npm/lib/start.js
@@ -2,8 +2,9 @@ const LifecycleCmd = require('./utils/lifecycle-cmd.js')
 
 // This ends up calling run-script(['start', ...args])
 class Start extends LifecycleCmd {
-  constructor (npm) {
-    super(npm, 'start')
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'start'
   }
 }
 module.exports = Start

--- a/deps/npm/lib/stop.js
+++ b/deps/npm/lib/stop.js
@@ -2,8 +2,9 @@ const LifecycleCmd = require('./utils/lifecycle-cmd.js')
 
 // This ends up calling run-script(['stop', ...args])
 class Stop extends LifecycleCmd {
-  constructor (npm) {
-    super(npm, 'stop')
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'stop'
   }
 }
 module.exports = Stop

--- a/deps/npm/lib/team.js
+++ b/deps/npm/lib/team.js
@@ -1,24 +1,24 @@
 const columns = require('cli-columns')
 const libteam = require('libnpmteam')
 
-const output = require('./utils/output.js')
 const otplease = require('./utils/otplease.js')
-const usageUtil = require('./utils/usage.js')
 
-class Team {
-  constructor (npm) {
-    this.npm = npm
+const BaseCommand = require('./base-command.js')
+class Team extends BaseCommand {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'team'
   }
 
-  get usage () {
-    return usageUtil(
-      'team',
-      'npm team create <scope:team> [--otp <otpcode>]\n' +
-      'npm team destroy <scope:team> [--otp <otpcode>]\n' +
-      'npm team add <scope:team> <user> [--otp <otpcode>]\n' +
-      'npm team rm <scope:team> <user> [--otp <otpcode>]\n' +
-      'npm team ls <scope>|<scope:team>\n'
-    )
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get usage () {
+    return [
+      'create <scope:team> [--otp <otpcode>]',
+      'destroy <scope:team> [--otp <otpcode>]',
+      'add <scope:team> <user> [--otp <otpcode>]',
+      'rm <scope:team> <user> [--otp <otpcode>]',
+      'ls <scope>|<scope:team>',
+    ]
   }
 
   async completion (opts) {
@@ -66,82 +66,82 @@ class Team {
   async create (entity, opts) {
     await libteam.create(entity, opts)
     if (opts.json) {
-      output(JSON.stringify({
+      this.npm.output(JSON.stringify({
         created: true,
         team: entity,
       }))
     } else if (opts.parseable)
-      output(`${entity}\tcreated`)
+      this.npm.output(`${entity}\tcreated`)
     else if (!opts.silent && opts.loglevel !== 'silent')
-      output(`+@${entity}`)
+      this.npm.output(`+@${entity}`)
   }
 
   async destroy (entity, opts) {
     await libteam.destroy(entity, opts)
     if (opts.json) {
-      output(JSON.stringify({
+      this.npm.output(JSON.stringify({
         deleted: true,
         team: entity,
       }))
     } else if (opts.parseable)
-      output(`${entity}\tdeleted`)
+      this.npm.output(`${entity}\tdeleted`)
     else if (!opts.silent && opts.loglevel !== 'silent')
-      output(`-@${entity}`)
+      this.npm.output(`-@${entity}`)
   }
 
   async add (entity, user, opts) {
     await libteam.add(user, entity, opts)
     if (opts.json) {
-      output(JSON.stringify({
+      this.npm.output(JSON.stringify({
         added: true,
         team: entity,
         user,
       }))
     } else if (opts.parseable)
-      output(`${user}\t${entity}\tadded`)
+      this.npm.output(`${user}\t${entity}\tadded`)
     else if (!opts.silent && opts.loglevel !== 'silent')
-      output(`${user} added to @${entity}`)
+      this.npm.output(`${user} added to @${entity}`)
   }
 
   async rm (entity, user, opts) {
     await libteam.rm(user, entity, opts)
     if (opts.json) {
-      output(JSON.stringify({
+      this.npm.output(JSON.stringify({
         removed: true,
         team: entity,
         user,
       }))
     } else if (opts.parseable)
-      output(`${user}\t${entity}\tremoved`)
+      this.npm.output(`${user}\t${entity}\tremoved`)
     else if (!opts.silent && opts.loglevel !== 'silent')
-      output(`${user} removed from @${entity}`)
+      this.npm.output(`${user} removed from @${entity}`)
   }
 
   async listUsers (entity, opts) {
     const users = (await libteam.lsUsers(entity, opts)).sort()
     if (opts.json)
-      output(JSON.stringify(users, null, 2))
+      this.npm.output(JSON.stringify(users, null, 2))
     else if (opts.parseable)
-      output(users.join('\n'))
+      this.npm.output(users.join('\n'))
     else if (!opts.silent && opts.loglevel !== 'silent') {
       const plural = users.length === 1 ? '' : 's'
       const more = users.length === 0 ? '' : ':\n'
-      output(`\n@${entity} has ${users.length} user${plural}${more}`)
-      output(columns(users, { padding: 1 }))
+      this.npm.output(`\n@${entity} has ${users.length} user${plural}${more}`)
+      this.npm.output(columns(users, { padding: 1 }))
     }
   }
 
   async listTeams (entity, opts) {
     const teams = (await libteam.lsTeams(entity, opts)).sort()
     if (opts.json)
-      output(JSON.stringify(teams, null, 2))
+      this.npm.output(JSON.stringify(teams, null, 2))
     else if (opts.parseable)
-      output(teams.join('\n'))
+      this.npm.output(teams.join('\n'))
     else if (!opts.silent && opts.loglevel !== 'silent') {
       const plural = teams.length === 1 ? '' : 's'
       const more = teams.length === 0 ? '' : ':\n'
-      output(`\n@${entity} has ${teams.length} team${plural}${more}`)
-      output(columns(teams.map(t => `@${t}`), { padding: 1 }))
+      this.npm.output(`\n@${entity} has ${teams.length} team${plural}${more}`)
+      this.npm.output(columns(teams.map(t => `@${t}`), { padding: 1 }))
     }
   }
 }

--- a/deps/npm/lib/test.js
+++ b/deps/npm/lib/test.js
@@ -2,8 +2,9 @@ const LifecycleCmd = require('./utils/lifecycle-cmd.js')
 
 // This ends up calling run-script(['test', ...args])
 class Test extends LifecycleCmd {
-  constructor (npm) {
-    super(npm, 'test')
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'test'
   }
 
   exec (args, cb) {

--- a/deps/npm/lib/uninstall.js
+++ b/deps/npm/lib/uninstall.js
@@ -2,20 +2,19 @@ const { resolve } = require('path')
 const Arborist = require('@npmcli/arborist')
 const rpj = require('read-package-json-fast')
 
-const usageUtil = require('./utils/usage.js')
 const reifyFinish = require('./utils/reify-finish.js')
 const completion = require('./utils/completion/installed-shallow.js')
 
-class Uninstall {
-  constructor (npm) {
-    this.npm = npm
+const BaseCommand = require('./base-command.js')
+class Uninstall extends BaseCommand {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'uninstall'
   }
 
-  get usage () {
-    return usageUtil(
-      'uninstall',
-      'npm uninstall [<@scope>/]<pkg>[@<version>]... [-S|--save|--no-save]'
-    )
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get usage () {
+    return ['[<@scope>/]<pkg>[@<version>]... [-S|--save|--no-save]']
   }
 
   /* istanbul ignore next - see test/lib/load-all-commands.js */

--- a/deps/npm/lib/unpublish.js
+++ b/deps/npm/lib/unpublish.js
@@ -7,18 +7,19 @@ const npmFetch = require('npm-registry-fetch')
 const libunpub = require('libnpmpublish').unpublish
 const readJson = util.promisify(require('read-package-json'))
 
-const usageUtil = require('./utils/usage.js')
-const output = require('./utils/output.js')
 const otplease = require('./utils/otplease.js')
 const getIdentity = require('./utils/get-identity.js')
 
-class Unpublish {
-  constructor (npm) {
-    this.npm = npm
+const BaseCommand = require('./base-command.js')
+class Unpublish extends BaseCommand {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'unpublish'
   }
 
-  get usage () {
-    return usageUtil('unpublish', 'npm unpublish [<@scope>/]<pkg>[@<version>]')
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get usage () {
+    return ['[<@scope>/]<pkg>[@<version>]']
   }
 
   async completion (args) {
@@ -107,7 +108,7 @@ class Unpublish {
     }
 
     if (!silent && loglevel !== 'silent')
-      output(`- ${pkgName}${pkgVersion}`)
+      this.npm.output(`- ${pkgName}${pkgVersion}`)
   }
 }
 module.exports = Unpublish

--- a/deps/npm/lib/unstar.js
+++ b/deps/npm/lib/unstar.js
@@ -1,6 +1,11 @@
 const Star = require('./star.js')
 
 class Unstar extends Star {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'unstar'
+  }
+
   exec (args, cb) {
     this.npm.config.set('star.unstar', true)
     super.exec(args, cb)

--- a/deps/npm/lib/update.js
+++ b/deps/npm/lib/update.js
@@ -3,21 +3,19 @@ const path = require('path')
 const Arborist = require('@npmcli/arborist')
 const log = require('npmlog')
 
-const usageUtil = require('./utils/usage.js')
 const reifyFinish = require('./utils/reify-finish.js')
 const completion = require('./utils/completion/installed-deep.js')
 
-class Update {
-  constructor (npm) {
-    this.npm = npm
+const BaseCommand = require('./base-command.js')
+class Update extends BaseCommand {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'update'
   }
 
   /* istanbul ignore next - see test/lib/load-all-commands.js */
-  get usage () {
-    return usageUtil(
-      'update',
-      'npm update [-g] [<pkg>...]'
-    )
+  static get usage () {
+    return ['[-g] [<pkg>...]']
   }
 
   /* istanbul ignore next - see test/lib/load-all-commands.js */

--- a/deps/npm/lib/utils/audit-error.js
+++ b/deps/npm/lib/utils/audit-error.js
@@ -3,7 +3,6 @@
 // prints a JSON version of the error if it's --json
 // returns 'true' if there was an error, false otherwise
 
-const output = require('./output.js')
 const auditError = (npm, report) => {
   if (!report || !report.error)
     return false
@@ -18,7 +17,7 @@ const auditError = (npm, report) => {
   const { body: errBody } = error
   const body = Buffer.isBuffer(errBody) ? errBody.toString() : errBody
   if (npm.flatOptions.json) {
-    output(JSON.stringify({
+    npm.output(JSON.stringify({
       message: error.message,
       method: error.method,
       uri: error.uri,
@@ -27,7 +26,7 @@ const auditError = (npm, report) => {
       body,
     }, null, 2))
   } else
-    output(body)
+    npm.output(body)
 
   throw 'audit endpoint returned an error'
 }

--- a/deps/npm/lib/utils/lifecycle-cmd.js
+++ b/deps/npm/lib/utils/lifecycle-cmd.js
@@ -1,19 +1,14 @@
 // The implementation of commands that are just "run a script"
 // restart, start, stop, test
-const usageUtil = require('./usage.js')
 
-class LifecycleCmd {
-  constructor (npm, stage) {
-    this.npm = npm
-    this.stage = stage
-  }
-
-  get usage () {
-    return usageUtil(this.stage, `npm ${this.stage} [-- <args>]`)
+const BaseCommand = require('../base-command.js')
+class LifecycleCmd extends BaseCommand {
+  static get usage () {
+    return ['[-- <args>]']
   }
 
   exec (args, cb) {
-    this.npm.commands['run-script']([this.stage, ...args], cb)
+    this.npm.commands['run-script']([this.constructor.name, ...args], cb)
   }
 }
 module.exports = LifecycleCmd

--- a/deps/npm/lib/utils/npm-usage.js
+++ b/deps/npm/lib/utils/npm-usage.js
@@ -1,6 +1,5 @@
 const didYouMean = require('./did-you-mean.js')
 const { dirname } = require('path')
-const output = require('./output.js')
 const { cmdList } = require('./cmd-list')
 
 module.exports = (npm, valid = true) => {
@@ -8,7 +7,7 @@ module.exports = (npm, valid = true) => {
   const usesBrowser = npm.config.get('viewer') === 'browser'
     ? ' (in a browser)' : ''
   npm.log.level = 'silent'
-  output(`
+  npm.output(`
 Usage: npm <command>
 
 npm install        install all the dependencies in your project
@@ -34,7 +33,7 @@ npm@${npm.version} ${dirname(dirname(__dirname))}
 `)
 
   if (npm.argv.length >= 1)
-    output(didYouMean(npm.argv[0], cmdList))
+    npm.output(didYouMean(npm.argv[0], cmdList))
 
   if (!valid)
     process.exitCode = 1

--- a/deps/npm/lib/utils/open-url.js
+++ b/deps/npm/lib/utils/open-url.js
@@ -1,4 +1,3 @@
-const output = require('./output.js')
 const opener = require('opener')
 
 const { URL } = require('url')
@@ -16,7 +15,7 @@ const open = async (npm, url, errMsg) => {
       }, null, 2)
       : `${errMsg}:\n  ${url}\n`
 
-    output(alternateMsg)
+    npm.output(alternateMsg)
   }
 
   if (browser === false) {

--- a/deps/npm/lib/utils/output.js
+++ b/deps/npm/lib/utils/output.js
@@ -1,7 +1,0 @@
-const log = require('npmlog')
-// output to stdout in a progress bar compatible way
-module.exports = (...msg) => {
-  log.clearProgress()
-  console.log(...msg)
-  log.showProgress()
-}

--- a/deps/npm/lib/utils/reify-output.js
+++ b/deps/npm/lib/utils/reify-output.js
@@ -10,7 +10,6 @@
 //   run `npm audit fix` to fix them, or `npm audit` for details
 
 const log = require('npmlog')
-const output = require('./output.js')
 const { depth } = require('treeverse')
 const ms = require('ms')
 const auditReport = require('npm-audit-report')
@@ -72,10 +71,10 @@ const reifyOutput = (npm, arb) => {
       summary.audit = npm.command === 'audit' ? auditReport
         : auditReport.toJSON().metadata
     }
-    output(JSON.stringify(summary, 0, 2))
+    npm.output(JSON.stringify(summary, 0, 2))
   } else {
     packagesChangedMessage(npm, summary)
-    packagesFundingMessage(summary)
+    packagesFundingMessage(npm, summary)
     printAuditReport(npm, auditReport)
   }
 }
@@ -98,7 +97,7 @@ const printAuditReport = (npm, report) => {
     auditLevel,
   })
   process.exitCode = process.exitCode || res.exitCode
-  output('\n' + res.report)
+  npm.output('\n' + res.report)
 }
 
 const packagesChangedMessage = (npm, { added, removed, changed, audited }) => {
@@ -136,18 +135,18 @@ const packagesChangedMessage = (npm, { added, removed, changed, audited }) => {
     msg.push(`audited ${audited} package${audited === 1 ? '' : 's'}`)
 
   msg.push(` in ${ms(Date.now() - npm.started)}`)
-  output(msg.join(''))
+  npm.output(msg.join(''))
 }
 
-const packagesFundingMessage = ({ funding }) => {
+const packagesFundingMessage = (npm, { funding }) => {
   if (!funding)
     return
 
-  output('')
+  npm.output('')
   const pkg = funding === 1 ? 'package' : 'packages'
   const is = funding === 1 ? 'is' : 'are'
-  output(`${funding} ${pkg} ${is} looking for funding`)
-  output('  run `npm fund` for details')
+  npm.output(`${funding} ${pkg} ${is} looking for funding`)
+  npm.output('  run `npm fund` for details')
 }
 
 module.exports = reifyOutput

--- a/deps/npm/lib/version.js
+++ b/deps/npm/lib/version.js
@@ -1,21 +1,15 @@
 const libversion = require('libnpmversion')
-const output = require('./utils/output.js')
-const usageUtil = require('./utils/usage.js')
 
-class Version {
-  constructor (npm) {
-    this.npm = npm
+const BaseCommand = require('./base-command.js')
+class Version extends BaseCommand {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'version'
   }
 
-  get usage () {
-    return usageUtil(
-      'version',
-      'npm version [<newversion> | major | minor | patch | premajor | preminor | prepatch | prerelease [--preid=<prerelease-id>] | from-git]\n' +
-      '(run in package dir)\n\n' +
-      `'npm -v' or 'npm --version' to print npm version (${this.npm.version})\n` +
-      `'npm view <pkg> version' to view a package's published version\n` +
-      `'npm ls' to inspect current package/dependency versions\n`
-    )
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get usage () {
+    return ['[<newversion> | major | minor | patch | premajor | preminor | prepatch | prerelease [--preid=<prerelease-id>] | from-git]']
   }
 
   async completion (opts) {
@@ -56,7 +50,7 @@ class Version {
       ...this.npm.flatOptions,
       path: this.npm.prefix,
     })
-    return output(`${prefix}${version}`)
+    return this.npm.output(`${prefix}${version}`)
   }
 
   async list () {
@@ -78,9 +72,9 @@ class Version {
       results[key] = version
 
     if (this.npm.flatOptions.json)
-      output(JSON.stringify(results, null, 2))
+      this.npm.output(JSON.stringify(results, null, 2))
     else
-      output(results)
+      this.npm.output(results)
   }
 }
 module.exports = Version

--- a/deps/npm/lib/view.js
+++ b/deps/npm/lib/view.js
@@ -14,22 +14,19 @@ const style = require('ansistyles')
 const { inspect, promisify } = require('util')
 const { packument } = require('pacote')
 
-const usageUtil = require('./utils/usage.js')
-
 const readFile = promisify(fs.readFile)
 const readJson = async file => jsonParse(await readFile(file, 'utf8'))
 
-class View {
-  constructor (npm) {
-    this.npm = npm
+const BaseCommand = require('./base-command.js')
+class View extends BaseCommand {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'view'
   }
 
   /* istanbul ignore next - see test/lib/load-all-commands.js */
-  get usage () {
-    return usageUtil(
-      'view',
-      'npm view [<@scope>/]<pkg>[@<version>] [<field>[.subfield]...]'
-    )
+  static get usage () {
+    return ['[<@scope>/]<pkg>[@<version>] [<field>[.subfield]...]']
   }
 
   async completion (opts) {

--- a/deps/npm/lib/whoami.js
+++ b/deps/npm/lib/whoami.js
@@ -1,19 +1,20 @@
-const output = require('./utils/output.js')
 const getIdentity = require('./utils/get-identity.js')
-const usageUtil = require('./utils/usage.js')
 
-class Whoami {
-  constructor (npm) {
-    this.npm = npm
+const BaseCommand = require('./base-command.js')
+class Whoami extends BaseCommand {
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get name () {
+    return 'whoami'
   }
 
   /* istanbul ignore next - see test/lib/load-all-commands.js */
-  get usage () {
-    return usageUtil(
-      'whoami',
-      'npm whoami [--registry <registry>]\n' +
-      '(just prints username according to given registry)'
-    )
+  static get description () {
+    return 'prints username according to given registry'
+  }
+
+  /* istanbul ignore next - see test/lib/load-all-commands.js */
+  static get usage () {
+    return ['[--registry <registry>]']
   }
 
   exec (args, cb) {
@@ -23,7 +24,7 @@ class Whoami {
   async whoami (args) {
     const opts = this.npm.flatOptions
     const username = await getIdentity(this.npm, opts)
-    output(opts.json ? JSON.stringify(username) : username)
+    this.npm.output(opts.json ? JSON.stringify(username) : username)
   }
 }
 module.exports = Whoami

--- a/deps/npm/man/man1/npm-ls.1
+++ b/deps/npm/man/man1/npm-ls.1
@@ -26,7 +26,7 @@ example, running \fBnpm ls promzard\fP in npm's source tree will show:
 .P
 .RS 2
 .nf
-npm@7\.6\.1 /path/to/npm
+npm@7\.6\.2 /path/to/npm
 └─┬ init\-package\-json@0\.0\.4
   └── promzard@0\.1\.5
 .fi

--- a/deps/npm/man/man1/npm.1
+++ b/deps/npm/man/man1/npm.1
@@ -10,7 +10,7 @@ npm <command> [args]
 .RE
 .SS Version
 .P
-7\.6\.1
+7\.6\.2
 .SS Description
 .P
 npm is the package manager for the Node JavaScript platform\.  It puts

--- a/deps/npm/node_modules/@npmcli/arborist/lib/arborist/build-ideal-tree.js
+++ b/deps/npm/node_modules/@npmcli/arborist/lib/arborist/build-ideal-tree.js
@@ -431,11 +431,13 @@ module.exports = cls => class IdealTreeBuilder extends cls {
     // ie, doing `foo@bar` we just return foo
     // but if it's a url or git, we don't know the name until we
     // fetch it and look in its manifest.
-    return Promise.all(add.map(rawSpec =>
-      this[_retrieveSpecName](npa(rawSpec))
+    return Promise.all(add.map(rawSpec => {
+      // We do NOT provide the path here, because user-additions need
+      // to be resolved relative to the CWD the user is in.
+      return this[_retrieveSpecName](npa(rawSpec))
         .then(add => this[_updateFilePath](add))
         .then(add => this[_followSymlinkPath](add))
-    )).then(add => {
+    })).then(add => {
       this[_resolvedAdd] = add
       // now add is a list of spec objects with names.
       // find a home for each of them!

--- a/deps/npm/node_modules/@npmcli/arborist/package.json
+++ b/deps/npm/node_modules/@npmcli/arborist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@npmcli/arborist",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "description": "Manage node_modules trees",
   "dependencies": {
     "@npmcli/installed-package-contents": "^1.0.7",

--- a/deps/npm/node_modules/byte-size/LICENSE
+++ b/deps/npm/node_modules/byte-size/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014-20 Lloyd Brookes <75pound@gmail.com>
+Copyright (c) 2014-21 Lloyd Brookes <75pound@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/deps/npm/node_modules/byte-size/README.hbs
+++ b/deps/npm/node_modules/byte-size/README.hbs
@@ -159,6 +159,6 @@ Old browser (adds `window.byteSize`):
 
 * * *
 
-&copy; 2014-20 Lloyd Brookes \<75pound@gmail.com\>.
+&copy; 2014-21 Lloyd Brookes \<75pound@gmail.com\>.
 
 Isomorphic test suite by [test-runner](https://github.com/test-runner-js/test-runner) and [web-runner](https://github.com/test-runner-js/web-runner). Documented by [jsdoc-to-markdown](https://github.com/jsdoc2md/jsdoc-to-markdown).

--- a/deps/npm/node_modules/byte-size/README.md
+++ b/deps/npm/node_modules/byte-size/README.md
@@ -193,6 +193,6 @@ Old browser (adds `window.byteSize`):
 
 * * *
 
-&copy; 2014-20 Lloyd Brookes \<75pound@gmail.com\>.
+&copy; 2014-21 Lloyd Brookes \<75pound@gmail.com\>.
 
 Isomorphic test suite by [test-runner](https://github.com/test-runner-js/test-runner) and [web-runner](https://github.com/test-runner-js/web-runner). Documented by [jsdoc-to-markdown](https://github.com/jsdoc2md/jsdoc-to-markdown).

--- a/deps/npm/node_modules/byte-size/dist/index.js
+++ b/deps/npm/node_modules/byte-size/dist/index.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
   typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
   typeof define === 'function' && define.amd ? define(factory) :
-  (global = global || self, global.byteSize = factory());
+  (global = typeof globalThis !== 'undefined' ? globalThis : global || self, global.byteSize = factory());
 }(this, (function () { 'use strict';
 
   /**

--- a/deps/npm/node_modules/byte-size/package.json
+++ b/deps/npm/node_modules/byte-size/package.json
@@ -8,7 +8,7 @@
       "url": "http://repejota.com"
     }
   ],
-  "version": "7.0.0",
+  "version": "7.0.1",
   "main": "dist/index.js",
   "license": "MIT",
   "engines": {
@@ -39,12 +39,12 @@
     "dist": "rollup -f umd -n byteSize -o dist/index.js index.mjs"
   },
   "devDependencies": {
-    "@test-runner/web": "^0.3.4",
+    "@test-runner/web": "^0.3.5",
     "coveralls": "^3.1.0",
     "esm-runner": "^0.3.4",
     "isomorphic-assert": "^0.1.1",
-    "jsdoc-to-markdown": "^5.0.3",
-    "rollup": "^2.10.9",
+    "jsdoc-to-markdown": "^7.0.0",
+    "rollup": "^2.40.0",
     "test-object-model": "^0.6.1"
   },
   "standard": {

--- a/deps/npm/node_modules/libnpmdiff/README.md
+++ b/deps/npm/node_modules/libnpmdiff/README.md
@@ -86,7 +86,7 @@ Fetches the registry tarballs and compare files between a spec `a` and spec `b`.
 - `diffSrcPrefix <String>`: Prefix to be used in the filenames from `a`. Defaults to `a/`.
 - `diffDstPrefix <String>`: Prefix to be used in the filenames from `b`. Defaults to `b/`.
 - `diffText <Boolean>`: Should treat all files as text and try to print diff for binary files. Defaults to `false`.
-- ...`cache`, `registry` and other common options accepted by [pacote](https://github.com/npm/pacote#options)
+- ...`cache`, `registry`, `where` and other common options accepted by [pacote](https://github.com/npm/pacote#options)
 
 Returns a `Promise` that fullfils with a `String` containing the resulting patch diffs.
 

--- a/deps/npm/node_modules/libnpmdiff/index.js
+++ b/deps/npm/node_modules/libnpmdiff/index.js
@@ -1,6 +1,7 @@
 const pacote = require('pacote')
 
 const formatDiff = require('./lib/format-diff.js')
+const getTarball = require('./lib/tarball.js')
 const untar = require('./lib/untar.js')
 
 const argsError = () =>
@@ -25,8 +26,8 @@ const diff = async (specs, opts = {}) => {
 
   // fetches tarball using pacote
   const [a, b] = await Promise.all([
-    pacote.tarball(aManifest._resolved, opts),
-    pacote.tarball(bManifest._resolved, opts),
+    getTarball(aManifest, opts),
+    getTarball(bManifest, opts),
   ])
 
   // read all files

--- a/deps/npm/node_modules/libnpmdiff/lib/tarball.js
+++ b/deps/npm/node_modules/libnpmdiff/lib/tarball.js
@@ -1,0 +1,33 @@
+const { relative } = require('path')
+
+const npa = require('npm-package-arg')
+const pkgContents = require('@npmcli/installed-package-contents')
+const pacote = require('pacote')
+const { tarCreateOptions } = pacote.DirFetcher
+const tar = require('tar')
+
+// returns a simplified tarball when reading files from node_modules folder,
+// thus avoiding running the prepare scripts and the extra logic from packlist
+const nodeModulesTarball = (manifest, opts) =>
+  pkgContents({ path: manifest._resolved, depth: 1 })
+    .then(files =>
+      files.map(file => relative(manifest._resolved, file))
+    )
+    .then(files =>
+      tar.c(tarCreateOptions(manifest), files).concat()
+    )
+
+const tarball = (manifest, opts) => {
+  const resolved = manifest._resolved
+  const where = opts.where || process.cwd()
+
+  const fromNodeModules = npa(resolved).type === 'directory'
+    && /node_modules[\\/](@[^\\/]+\/)?[^\\/]+[\\/]?$/.test(relative(where, resolved))
+
+  if (fromNodeModules)
+    return nodeModulesTarball(manifest, opts)
+
+  return pacote.tarball(manifest._resolved, opts)
+}
+
+module.exports = tarball

--- a/deps/npm/node_modules/libnpmdiff/package.json
+++ b/deps/npm/node_modules/libnpmdiff/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libnpmdiff",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "The registry diff",
   "repository": "https://github.com/npm/libnpmdiff",
   "files": [
@@ -55,10 +55,12 @@
   },
   "dependencies": {
     "@npmcli/disparity-colors": "^1.0.1",
+    "@npmcli/installed-package-contents": "^1.0.7",
     "binary-extensions": "^2.2.0",
     "diff": "^5.0.0",
     "minimatch": "^3.0.4",
-    "pacote": "^11.2.3",
+    "npm-package-arg": "^8.1.1",
+    "pacote": "^11.3.0",
     "tar": "^6.1.0"
   }
 }

--- a/deps/npm/node_modules/pacote/README.md
+++ b/deps/npm/node_modules/pacote/README.md
@@ -168,6 +168,18 @@ resolved, and other properties, as they are determined.
   times (even just to validate the cache) for a given packument, since it
   is unlikely to change in the span of a single command.
 
+
+### Advanced API
+
+Each different type of fetcher is exposed for more advanced usage such as
+using helper methods from this classes:
+
+* `DirFetcher`
+* `FileFetcher`
+* `GitFetcher`
+* `RegistryFetcher`
+* `RemoteFetcher`
+
 ## Extracted File Modes
 
 Files are extracted with a mode matching the following formula:

--- a/deps/npm/node_modules/pacote/lib/index.js
+++ b/deps/npm/node_modules/pacote/lib/index.js
@@ -1,5 +1,16 @@
 const { get } = require('./fetcher.js')
+const GitFetcher = require('./git.js')
+const RegistryFetcher = require('./registry.js')
+const FileFetcher = require('./file.js')
+const DirFetcher = require('./dir.js')
+const RemoteFetcher = require('./remote.js')
+
 module.exports = {
+  GitFetcher,
+  RegistryFetcher,
+  FileFetcher,
+  DirFetcher,
+  RemoteFetcher,
   resolve: (spec, opts) => get(spec, opts).resolve(),
   extract: (spec, dest, opts) => get(spec, opts).extract(dest),
   manifest: (spec, opts) => get(spec, opts).manifest(),

--- a/deps/npm/node_modules/pacote/lib/util/tar-create-options.js
+++ b/deps/npm/node_modules/pacote/lib/util/tar-create-options.js
@@ -1,0 +1,24 @@
+const isPackageBin = require('./is-package-bin.js')
+
+const tarCreateOptions = manifest => ({
+  cwd: manifest._resolved,
+  prefix: 'package/',
+  portable: true,
+  gzip: true,
+
+  // ensure that package bins are always executable
+  // Note that npm-packlist is already filtering out
+  // anything that is not a regular file, ignored by
+  // .npmignore or package.json "files", etc.
+  filter: (path, stat) => {
+    if (isPackageBin(manifest, path))
+      stat.mode |= 0o111
+    return true
+  },
+
+  // Provide a specific date in the 1980s for the benefit of zip,
+  // which is confounded by files dated at the Unix epoch 0.
+  mtime: new Date('1985-10-26T08:15:00.000Z'),
+})
+
+module.exports = tarCreateOptions

--- a/deps/npm/node_modules/pacote/package.json
+++ b/deps/npm/node_modules/pacote/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pacote",
-  "version": "11.2.7",
+  "version": "11.3.0",
   "description": "JavaScript package downloader",
   "author": "Isaac Z. Schlueter <i@izs.me> (https://izs.me)",
   "bin": {

--- a/deps/npm/package.json
+++ b/deps/npm/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.6.1",
+  "version": "7.6.2",
   "name": "npm",
   "description": "a package manager for JavaScript",
   "keywords": [
@@ -42,7 +42,7 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@npmcli/arborist": "^2.2.6",
+    "@npmcli/arborist": "^2.2.7",
     "@npmcli/ci-detect": "^1.2.0",
     "@npmcli/config": "^1.2.9",
     "@npmcli/run-script": "^1.8.3",
@@ -50,7 +50,7 @@
     "ansicolors": "~0.3.2",
     "ansistyles": "~0.1.3",
     "archy": "~1.0.0",
-    "byte-size": "^7.0.0",
+    "byte-size": "^7.0.1",
     "cacache": "^15.0.5",
     "chalk": "^4.1.0",
     "chownr": "^2.0.0",
@@ -66,7 +66,7 @@
     "json-parse-even-better-errors": "^2.3.1",
     "leven": "^3.1.0",
     "libnpmaccess": "^4.0.1",
-    "libnpmdiff": "^2.0.3",
+    "libnpmdiff": "^2.0.4",
     "libnpmfund": "^1.0.2",
     "libnpmhook": "^6.0.1",
     "libnpmorg": "^2.0.1",
@@ -91,7 +91,7 @@
     "npm-user-validate": "^1.0.1",
     "npmlog": "~4.1.2",
     "opener": "^1.5.2",
-    "pacote": "^11.2.7",
+    "pacote": "^11.3.0",
     "parse-conflict-json": "^1.1.1",
     "qrcode-terminal": "^0.12.0",
     "read": "~1.0.7",

--- a/deps/npm/tap-snapshots/test-lib-dist-tag.js-TAP.test.js
+++ b/deps/npm/tap-snapshots/test-lib-dist-tag.js-TAP.test.js
@@ -6,19 +6,29 @@
  */
 'use strict'
 exports[`test/lib/dist-tag.js TAP add missing args > should exit usage error message 1`] = `
+npm dist-tag
+
+Usage:
 npm dist-tag add <pkg>@<version> [<tag>]
 npm dist-tag rm <pkg> <tag>
 npm dist-tag ls [<pkg>]
 
 alias: dist-tags
+
+Run "npm dist-tag help" for more info
 `
 
 exports[`test/lib/dist-tag.js TAP add missing pkg name > should exit usage error message 1`] = `
+npm dist-tag
+
+Usage:
 npm dist-tag add <pkg>@<version> [<tag>]
 npm dist-tag rm <pkg> <tag>
 npm dist-tag ls [<pkg>]
 
 alias: dist-tags
+
+Run "npm dist-tag help" for more info
 `
 
 exports[`test/lib/dist-tag.js TAP add new tag > should return success msg 1`] = `
@@ -31,11 +41,16 @@ dist-tag add 1.0.0 to @scoped/another@7.7.7
 `
 
 exports[`test/lib/dist-tag.js TAP borked cmd usage > should show usage error 1`] = `
+npm dist-tag
+
+Usage:
 npm dist-tag add <pkg>@<version> [<tag>]
 npm dist-tag rm <pkg> <tag>
 npm dist-tag ls [<pkg>]
 
 alias: dist-tags
+
+Run "npm dist-tag help" for more info
 `
 
 exports[`test/lib/dist-tag.js TAP ls in current package > should list available tags for current package 1`] = `
@@ -45,11 +60,16 @@ latest: 1.0.0
 `
 
 exports[`test/lib/dist-tag.js TAP ls on missing name in current package > should throw usage error message 1`] = `
+npm dist-tag
+
+Usage:
 npm dist-tag add <pkg>@<version> [<tag>]
 npm dist-tag rm <pkg> <tag>
 npm dist-tag ls [<pkg>]
 
 alias: dist-tags
+
+Run "npm dist-tag help" for more info
 `
 
 exports[`test/lib/dist-tag.js TAP ls on missing package > should log no dist-tag found msg 1`] = `
@@ -89,11 +109,16 @@ exports[`test/lib/dist-tag.js TAP remove existing tag > should return success ms
 `
 
 exports[`test/lib/dist-tag.js TAP remove missing pkg name > should exit usage error message 1`] = `
+npm dist-tag
+
+Usage:
 npm dist-tag add <pkg>@<version> [<tag>]
 npm dist-tag rm <pkg> <tag>
 npm dist-tag ls [<pkg>]
 
 alias: dist-tags
+
+Run "npm dist-tag help" for more info
 `
 
 exports[`test/lib/dist-tag.js TAP remove non-existing tag > should log error msg 1`] = `

--- a/deps/npm/tap-snapshots/test-lib-profile.js-TAP.test.js
+++ b/deps/npm/tap-snapshots/test-lib-profile.js-TAP.test.js
@@ -9,7 +9,11 @@ exports[`test/lib/profile.js TAP enable-2fa from token and set otp, retries on p
 Scan into your authenticator app:
 qrcode
  Or enter code:
-12342FA successfully enabled. Below are your recovery codes, please print these out.You will need these to recover access to your account if you lose your authentication device.	123456	789101
+1234
+2FA successfully enabled. Below are your recovery codes, please print these out.
+You will need these to recover access to your account if you lose your authentication device.
+	123456
+	789101
 `
 
 exports[`test/lib/profile.js TAP profile get <key> --parseable > should output parseable result value 1`] = `
@@ -29,7 +33,17 @@ foo	foo@github.com (verified)	https://github.com/npm
 `
 
 exports[`test/lib/profile.js TAP profile get no args --parseable > should output all profile info as parseable result 1`] = `
-tfa	auth-and-writesname	fooemail	foo@github.comemail_verified	truecreated	2015-02-26T01:26:37.384Zupdated	2020-08-12T16:19:35.326Zfullname	Foo Barhomepage	https://github.comfreenode	foobartwitter	https://twitter.com/npmjsgithub	https://github.com/npm
+tfa	auth-and-writes
+name	foo
+email	foo@github.com
+email_verified	true
+created	2015-02-26T01:26:37.384Z
+updated	2020-08-12T16:19:35.326Z
+fullname	Foo Bar
+homepage	https://github.com
+freenode	foobar
+twitter	https://twitter.com/npmjs
+github	https://github.com/npm
 `
 
 exports[`test/lib/profile.js TAP profile get no args default output > should output table with contents 1`] = `

--- a/deps/npm/tap-snapshots/test-lib-publish.js-TAP.test.js
+++ b/deps/npm/tap-snapshots/test-lib-publish.js-TAP.test.js
@@ -6,8 +6,10 @@
  */
 'use strict'
 exports[`test/lib/publish.js TAP shows usage with wrong set of arguments > should print usage 1`] = `
+npm publish
+
+Usage:
 npm publish [<folder>] [--tag <tag>] [--access <public|restricted>] [--dry-run]
 
-Publishes '.' if no argument supplied
-Sets tag \`latest\` if no --tag specified
+Run "npm publish help" for more info
 `

--- a/deps/npm/tap-snapshots/test-lib-utils-npm-usage.js-TAP.test.js
+++ b/deps/npm/tap-snapshots/test-lib-utils-npm-usage.js-TAP.test.js
@@ -207,7 +207,10 @@ npm help npm       more involved overview
 
 All commands:
 
-    access          npm access public [<package>]
+    access          npm access
+
+                    Usage:
+                    npm access public [<package>]
                     npm access restricted [<package>]
                     npm access grant <read-only|read-write> <scope:team> [<package>]
                     npm access revoke <scope:team> [<package>]
@@ -217,20 +220,45 @@ All commands:
                     npm access ls-collaborators [<package> [<user>]]
                     npm access edit [<package>]
 
-    adduser         npm adduser [--registry=url] [--scope=@orgname] [--always-auth]
+                    Run "npm access help" for more info
+
+    adduser         npm adduser
+
+                    Usage:
+                    npm adduser [--registry=url] [--scope=@orgname] [--always-auth]
 
                     aliases: login, add-user
 
-    audit           npm audit [--json] [--production]
+                    Run "npm adduser help" for more info
+
+    audit           npm audit
+
+                    Usage:
+                    npm audit [--json] [--production]
                     npm audit fix [--force|--package-lock-only|--dry-run|--production|--only=(dev|prod)]
 
-    bin             npm bin [-g]
+                    Run "npm audit help" for more info
 
-    bugs            npm bugs [<pkgname>]
+    bin             npm bin
+
+                    Usage:
+                    npm bin [-g]
+
+                    Run "npm bin help" for more info
+
+    bugs            npm bugs
+
+                    Usage:
+                    npm bugs [<pkgname>]
 
                     alias: issues
 
-    cache           npm cache add <tarball file>
+                    Run "npm bugs help" for more info
+
+    cache           npm cache
+
+                    Usage:
+                    npm cache add <tarball file>
                     npm cache add <folder>
                     npm cache add <tarball url>
                     npm cache add <git url>
@@ -238,39 +266,76 @@ All commands:
                     npm cache clean
                     npm cache verify
 
+                    Run "npm cache help" for more info
+
     ci              npm ci
+
+                    Usage:
+                    npm ci
 
                     aliases: clean-install, ic, install-clean, isntall-clean
 
-    completion      source <(npm completion)
+                    Run "npm ci help" for more info
 
-    config          npm config set <key>=<value> [<key>=<value> ...]
+    completion      npm completion
+
+                    npm command completion script. save to ~/.bashrc or ~/.zshrc
+
+                    Usage:
+                    npm completion
+
+                    Run "npm completion help" for more info
+
+    config          npm config
+
+                    Usage:
+                    npm config set <key>=<value> [<key>=<value> ...]
                     npm config get [<key> [<key> ...]]
                     npm config delete <key> [<key> ...]
                     npm config list [--json]
                     npm config edit
-                    npm set <key>=<value> [<key>=<value> ...]
-                    npm get [<key> [<key> ...]]
 
                     alias: c
 
+                    Run "npm config help" for more info
+
     dedupe          npm dedupe
+
+                    Usage:
+                    npm dedupe
 
                     alias: ddp
 
-    deprecate       npm deprecate <pkg>[@<version>] <message>
+                    Run "npm dedupe help" for more info
 
-    diff            npm diff [...<paths>]
+    deprecate       npm deprecate
+
+                    Usage:
+                    npm deprecate <pkg>[@<version>] <message>
+
+                    Run "npm deprecate help" for more info
+
+    diff            npm diff
+
+                    Usage:
+                    npm diff [...<paths>]
                     npm diff --diff=<pkg-name> [...<paths>]
                     npm diff --diff=<version-a> [--diff=<version-b>] [...<paths>]
                     npm diff --diff=<spec-a> [--diff=<spec-b>] [...<paths>]
                     npm diff [--diff-ignore-all-space] [--diff-name-only] [...<paths>] [...<paths>]
 
-    dist-tag        npm dist-tag add <pkg>@<version> [<tag>]
+                    Run "npm diff help" for more info
+
+    dist-tag        npm dist-tag
+
+                    Usage:
+                    npm dist-tag add <pkg>@<version> [<tag>]
                     npm dist-tag rm <pkg> <tag>
                     npm dist-tag ls [<pkg>]
 
                     alias: dist-tags
+
+                    Run "npm dist-tag help" for more info
 
     docs            npm docs [<pkgname> [<pkgname> ...]]
 
@@ -278,59 +343,102 @@ All commands:
 
     doctor          npm doctor
 
-    edit            npm edit <pkg>[/<subpkg>...]
+                    Usage:
+                    npm doctor
 
-    exec            Run a command from a local or remote npm package.
+                    Run "npm doctor help" for more info
 
+    edit            npm edit
+
+                    Usage:
+                    npm edit <pkg>[/<subpkg>...]
+
+                    Run "npm edit help" for more info
+
+    exec            npm exec
+
+                    Run a command from a local or remote npm package.
+
+                    Usage:
                     npm exec -- <pkg>[@<version>] [args...]
                     npm exec --package=<pkg>[@<version>] -- <cmd> [args...]
                     npm exec -c '<cmd> [args...]'
                     npm exec --package=foo -c '<cmd> [args...]'
 
-                    npx <pkg>[@<specifier>] [args...]
-                    npx -p <pkg>[@<specifier>] <cmd> [args...]
-                    npx -c '<cmd> [args...]'
-                    npx -p <pkg>[@<specifier>] -c '<cmd> [args...]'
-                    Run without --call or positional args to open interactive subshell
-
-
                     alias: x
-                    common options:
-                    --package=<pkg> (may be specified multiple times)
-                    -p is a shorthand for --package only when using npx executable
-                    -c <cmd> --call=<cmd> (may not be mixed with positional arguments)
 
-    explain         npm explain <folder | specifier>
+                    Run "npm exec help" for more info
+
+    explain         npm explain
+
+                    Usage:
+                    npm explain <folder | specifier>
 
                     alias: why
 
-    explore         npm explore <pkg> [ -- <command>]
+                    Run "npm explain help" for more info
+
+    explore         npm explore
+
+                    Usage:
+                    npm explore <pkg> [ -- <command>]
+
+                    Run "npm explore help" for more info
 
     find-dupes      npm find-dupes
 
+                    Usage:
+                    npm find-dupes
+
+                    Run "npm find-dupes help" for more info
+
     fund            npm fund
 
-                    common options: npm fund [--json] [--browser] [--unicode] [[<@scope>/]<pkg> [--which=<fundingSourceNumber>]
+                    Usage:
+                    npm fund [--json] [--browser] [--unicode] [[<@scope>/]<pkg> [--which=<fundingSourceNumber>]
 
-    get             npm get [<key> ...] (See \`npm config\`)
+                    Run "npm fund help" for more info
 
-    help            npm help <term> [<terms..>]
+    get             npm get
+
+                    Usage:
+                    npm get [<key> ...] (See \`npm config\`)
+
+                    Run "npm get help" for more info
+
+    help            npm help
+
+                    Usage:
+                    npm help <term> [<terms..>]
 
                     alias: hlep
 
-    hook            npm hook add <pkg> <url> <secret> [--type=<type>]
+                    Run "npm help help" for more info
+
+    hook            npm hook
+
+                    Usage:
+                    npm hook add <pkg> <url> <secret> [--type=<type>]
                     npm hook ls [pkg]
                     npm hook rm <id>
                     npm hook update <id> <url> <secret>
 
-    init
+                    Run "npm hook help" for more info
+
+    init            npm init
+
+                    Usage:
                     npm init [--force|-f|--yes|-y|--scope]
                     npm init <@scope> (same as \`npx <@scope>/create\`)
                     npm init [<@scope>/]<name> (same as \`npx [<@scope>/]create-<name>\`)
 
                     aliases: create, innit
 
-    install         npm install (with no args, in package dir)
+                    Run "npm init help" for more info
+
+    install         npm install
+
+                    Usage:
                     npm install [<@scope>/]<pkg>
                     npm install [<@scope>/]<pkg>@<tag>
                     npm install [<@scope>/]<pkg>@<version>
@@ -340,151 +448,343 @@ All commands:
                     npm install <tarball file>
                     npm install <tarball url>
                     npm install <git:// url>
-                    npm install <github username>/<github project>
+                    npm install <github username>/<github project> [--save-prod|--save-dev|--save-optional|--save-peer] [--save-exact] [--no-save]
 
                     aliases: i, in, ins, inst, insta, instal, isnt, isnta, isntal, add
-                    common options: [--save-prod|--save-dev|--save-optional|--save-peer] [--save-exact] [--no-save]
 
-    install-ci-test npm install-ci-test [args]
-                    Same args as \`npm ci\`
+                    Run "npm install help" for more info
+
+    install-ci-test npm install-ci-test
+
+                    Usage:
+                    npm install-ci-test
 
                     alias: cit
 
-    install-test    npm install-test [args]
-                    Same args as \`npm install\`
+                    Run "npm install-ci-test help" for more info
+
+    install-test    npm install-test
+
+                    Usage:
+                    npm install-test [<@scope>/]<pkg>
+                    npm install-test [<@scope>/]<pkg>@<tag>
+                    npm install-test [<@scope>/]<pkg>@<version>
+                    npm install-test [<@scope>/]<pkg>@<version range>
+                    npm install-test <alias>@npm:<name>
+                    npm install-test <folder>
+                    npm install-test <tarball file>
+                    npm install-test <tarball url>
+                    npm install-test <git:// url>
+                    npm install-test <github username>/<github project> [--save-prod|--save-dev|--save-optional|--save-peer] [--save-exact] [--no-save]
 
                     alias: it
 
-    link            npm link (in package dir)
+                    Run "npm install-test help" for more info
+
+    link            npm link
+
+                    Usage:
+                    npm link (in package dir)
                     npm link [<@scope>/]<pkg>[@<version>]
 
                     alias: ln
 
-    ll              npm ll [[<@scope>/]<pkg> ...]
+                    Run "npm link help" for more info
+
+    ll              npm ll
+
+                    Usage:
+                    npm ll [[<@scope>/]<pkg> ...]
 
                     alias: la
 
-    login           npm adduser [--registry=url] [--scope=@orgname] [--always-auth]
+                    Run "npm ll help" for more info
+
+    login           npm adduser
+
+                    Usage:
+                    npm adduser [--registry=url] [--scope=@orgname] [--always-auth]
 
                     aliases: login, add-user
 
-    logout          npm logout [--registry=<url>] [--scope=<@scope>]
+                    Run "npm adduser help" for more info
 
-    ls              npm ls [[<@scope>/]<pkg> ...]
+    logout          npm logout
+
+                    Usage:
+                    npm logout [--registry=<url>] [--scope=<@scope>]
+
+                    Run "npm logout help" for more info
+
+    ls              npm ls
+
+                    Usage:
+                    npm ls npm ls [[<@scope>/]<pkg> ...]
 
                     alias: list
 
-    org             npm org set orgname username [developer | admin | owner]
+                    Run "npm ls help" for more info
+
+    org             npm org
+
+                    Usage:
+                    npm org set orgname username [developer | admin | owner]
                     npm org rm orgname username
                     npm org ls orgname [<username>]
 
                     alias: ogr
 
-    outdated        npm outdated [[<@scope>/]<pkg> ...]
+                    Run "npm org help" for more info
 
-    owner           npm owner add <user> [<@scope>/]<pkg>
+    outdated        npm outdated
+
+                    Usage:
+                    npm outdated [[<@scope>/]<pkg> ...]
+
+                    Run "npm outdated help" for more info
+
+    owner           npm owner
+
+                    Usage:
+                    npm owner add <user> [<@scope>/]<pkg>
                     npm owner rm <user> [<@scope>/]<pkg>
                     npm owner ls [<@scope>/]<pkg>
 
                     alias: author
 
-    pack            npm pack [[<@scope>/]<pkg>...] [--dry-run]
+                    Run "npm owner help" for more info
+
+    pack            npm pack
+
+                    Usage:
+                    npm pack [[<@scope>/]<pkg>...] [--dry-run]
+
+                    Run "npm pack help" for more info
 
     ping            npm ping
+
                     ping registry
 
-    prefix          npm prefix [-g]
+                    Usage:
+                    npm ping
 
-    profile         npm profile enable-2fa [auth-only|auth-and-writes]
+                    Run "npm ping help" for more info
 
+    prefix          npm prefix
 
-                    common options: npm profile disable-2fa
+                    Usage:
+                    npm prefix [-g]
 
+                    Run "npm prefix help" for more info
 
-    prune           npm prune [[<@scope>/]<pkg>...] [--production]
+    profile         npm profile
 
-    publish         npm publish [<folder>] [--tag <tag>] [--access <public|restricted>] [--dry-run]
+                    Usage:
+                    npm profile enable-2fa [auth-only|auth-and-writes]
+                    npm profile disable-2fa
+                    npm profile get [<key>]
+                    npm profile set <key> <value>
 
-                    Publishes '.' if no argument supplied
-                    Sets tag \`latest\` if no --tag specified
+                    Run "npm profile help" for more info
 
-    rebuild         npm rebuild [[<@scope>/]<name>[@<version>] ...]
+    prune           npm prune
+
+                    Usage:
+                    npm prune [[<@scope>/]<pkg>...] [--production]
+
+                    Run "npm prune help" for more info
+
+    publish         npm publish
+
+                    Usage:
+                    npm publish [<folder>] [--tag <tag>] [--access <public|restricted>] [--dry-run]
+
+                    Run "npm publish help" for more info
+
+    rebuild         npm rebuild
+
+                    Usage:
+                    npm rebuild [[<@scope>/]<name>[@<version>] ...]
 
                     alias: rb
 
-    repo            npm repo [<pkgname> [<pkgname> ...]]
+                    Run "npm rebuild help" for more info
 
-    restart         npm restart [-- <args>]
+    repo            npm repo
 
-    root            npm root [-g]
+                    Usage:
+                    npm repo [<pkgname> [<pkgname> ...]]
 
-    run-script      npm run-script <command> [-- <args>]
+                    Run "npm repo help" for more info
+
+    restart         npm restart
+
+                    Usage:
+                    npm restart [-- <args>]
+
+                    Run "npm restart help" for more info
+
+    root            npm root
+
+                    Usage:
+                    npm root [-g]
+
+                    Run "npm root help" for more info
+
+    run-script      npm run-script
+
+                    Usage:
+                    npm run-script <command> [-- <args>]
 
                     aliases: run, rum, urn
 
-    search          npm search [-l|--long] [--json] [--parseable] [--no-description] [search terms ...]
+                    Run "npm run-script help" for more info
+
+    search          npm search
+
+                    Usage:
+                    npm search [-l|--long] [--json] [--parseable] [--no-description] [search terms ...]
 
                     aliases: s, se, find
 
-    set             npm set <key>=<value> [<key>=<value> ...] (See \`npm config\`)
+                    Run "npm search help" for more info
 
-    set-script      npm set-script [<script>] [<command>]
+    set             npm set
+
+                    Usage:
+                    npm set <key>=<value> [<key>=<value> ...] (See \`npm config\`)
+
+                    Run "npm set help" for more info
+
+    set-script      npm set-script
+
+                    Usage:
+                    npm set-script [<script>] [<command>]
+
+                    Run "npm set-script help" for more info
 
     shrinkwrap      npm shrinkwrap
 
-    star            npm star [<pkg>...]
-                    npm unstar [<pkg>...]
+                    Usage:
+                    npm shrinkwrap
 
-    stars           npm stars [<user>]
+                    Run "npm shrinkwrap help" for more info
 
-    start           npm start [-- <args>]
+    star            npm star
 
-    stop            npm stop [-- <args>]
+                    Usage:
+                    npm star [<pkg>...]
 
-    team            npm team create <scope:team> [--otp <otpcode>]
+                    Run "npm star help" for more info
+
+    stars           npm stars
+
+                    Usage:
+                    npm stars [<user>]
+
+                    Run "npm stars help" for more info
+
+    start           npm start
+
+                    Usage:
+                    npm start [-- <args>]
+
+                    Run "npm start help" for more info
+
+    stop            npm stop
+
+                    Usage:
+                    npm stop [-- <args>]
+
+                    Run "npm stop help" for more info
+
+    team            npm team
+
+                    Usage:
+                    npm team create <scope:team> [--otp <otpcode>]
                     npm team destroy <scope:team> [--otp <otpcode>]
                     npm team add <scope:team> <user> [--otp <otpcode>]
                     npm team rm <scope:team> <user> [--otp <otpcode>]
                     npm team ls <scope>|<scope:team>
 
+                    Run "npm team help" for more info
 
-    test            npm test [-- <args>]
+    test            npm test
+
+                    Usage:
+                    npm test [-- <args>]
 
                     aliases: tst, t
 
-    token           npm token list
+                    Run "npm test help" for more info
+
+    token           npm token
+
+                    Usage:
+                    npm token list
                     npm token revoke <id|token>
                     npm token create [--read-only] [--cidr=list]
 
-    uninstall       npm uninstall [<@scope>/]<pkg>[@<version>]... [-S|--save|--no-save]
+                    Run "npm token help" for more info
+
+    uninstall       npm uninstall
+
+                    Usage:
+                    npm uninstall [<@scope>/]<pkg>[@<version>]... [-S|--save|--no-save]
 
                     aliases: un, unlink, remove, rm, r
 
-    unpublish       npm unpublish [<@scope>/]<pkg>[@<version>]
+                    Run "npm uninstall help" for more info
 
-    unstar          npm star [<pkg>...]
+    unpublish       npm unpublish
+
+                    Usage:
+                    npm unpublish [<@scope>/]<pkg>[@<version>]
+
+                    Run "npm unpublish help" for more info
+
+    unstar          npm unstar
+
+                    Usage:
                     npm unstar [<pkg>...]
 
-    update          npm update [-g] [<pkg>...]
+                    Run "npm unstar help" for more info
+
+    update          npm update
+
+                    Usage:
+                    npm update [-g] [<pkg>...]
 
                     aliases: up, upgrade, udpate
 
-    version         npm version [<newversion> | major | minor | patch | premajor | preminor | prepatch | prerelease [--preid=<prerelease-id>] | from-git]
-                    (run in package dir)
+                    Run "npm update help" for more info
 
-                    'npm -v' or 'npm --version' to print npm version ({VERSION})
-                    'npm view <pkg> version' to view a package's published version
-                    'npm ls' to inspect current package/dependency versions
+    version         npm version
 
+                    Usage:
+                    npm version [<newversion> | major | minor | patch | premajor | preminor | prepatch | prerelease [--preid=<prerelease-id>] | from-git]
 
                     alias: verison
 
-    view            npm view [<@scope>/]<pkg>[@<version>] [<field>[.subfield]...]
+                    Run "npm version help" for more info
+
+    view            npm view
+
+                    Usage:
+                    npm view [<@scope>/]<pkg>[@<version>] [<field>[.subfield]...]
 
                     aliases: v, info, show
 
-    whoami          npm whoami [--registry <registry>]
-                    (just prints username according to given registry)
+                    Run "npm view help" for more info
+
+    whoami          npm whoami
+
+                    prints username according to given registry
+
+                    Usage:
+                    npm whoami [--registry <registry>]
+
+                    Run "npm whoami help" for more info
 
 Specify configs in the ini-formatted file:
     /some/config/file/.npmrc

--- a/deps/npm/test/lib/access.js
+++ b/deps/npm/test/lib/access.js
@@ -3,6 +3,10 @@ const requireInject = require('require-inject')
 
 const Access = require('../../lib/access.js')
 
+const npm = {
+  output: () => null,
+}
+
 test('completion', t => {
   const access = new Access({ flatOptions: {} })
   const testComp = (argv, expect) => {
@@ -37,7 +41,7 @@ test('completion', t => {
 test('subcommand required', t => {
   const access = new Access({ flatOptions: {} })
   access.exec([], (err) => {
-    t.equal(err, '\nUsage: Subcommand is required.\n\n' + access.usage)
+    t.match(err, access.usageError('Subcommand is required.'))
     t.end()
   })
 })
@@ -457,9 +461,8 @@ test('npm access ls-packages with no team', (t) => {
       },
     },
     '../../lib/utils/get-identity.js': () => Promise.resolve('foo'),
-    '../../lib/utils/output.js': () => null,
   })
-  const access = new Access({})
+  const access = new Access(npm)
   access.exec([
     'ls-packages',
   ], (err) => {
@@ -477,9 +480,8 @@ test('access ls-packages on team', (t) => {
         return {}
       },
     },
-    '../../lib/utils/output.js': () => null,
   })
-  const access = new Access({})
+  const access = new Access(npm)
   access.exec([
     'ls-packages',
     'myorg:myteam',
@@ -503,9 +505,8 @@ test('access ls-collaborators on current', (t) => {
         return {}
       },
     },
-    '../../lib/utils/output.js': () => null,
   })
-  const access = new Access({ prefix })
+  const access = new Access({ prefix, ...npm })
   access.exec([
     'ls-collaborators',
   ], (err) => {
@@ -523,9 +524,8 @@ test('access ls-collaborators on spec', (t) => {
         return {}
       },
     },
-    '../../lib/utils/output.js': () => null,
   })
-  const access = new Access({})
+  const access = new Access(npm)
   access.exec([
     'ls-collaborators',
     'yargs',

--- a/deps/npm/test/lib/adduser.js
+++ b/deps/npm/test/lib/adduser.js
@@ -61,6 +61,9 @@ const npm = {
     },
     setCredentialsByURI,
   },
+  output: msg => {
+    result = msg
+  },
 }
 
 const AddUser = requireInject('../../lib/adduser.js', {
@@ -70,14 +73,15 @@ const AddUser = requireInject('../../lib/adduser.js', {
       registryOutput = msg
     },
   },
-  '../../lib/utils/output.js': msg => {
-    result = msg
-  },
   '../../lib/auth/legacy.js': authDummy,
 })
 
 const adduser = new AddUser(npm)
 
+test('usage', (t) => {
+  t.match(adduser.usage, 'adduser', 'usage has command name in it')
+  t.end()
+})
 test('simple login', (t) => {
   adduser.exec([], (err) => {
     t.ifError(err, 'npm adduser')

--- a/deps/npm/test/lib/audit.js
+++ b/deps/npm/test/lib/audit.js
@@ -14,6 +14,9 @@ t.test('should audit using Arborist', t => {
     flatOptions: {
       json: false,
     },
+    output: () => {
+      OUTPUT_CALLED = true
+    },
   }
   const Audit = requireInject('../../lib/audit.js', {
     'npm-audit-report': () => {
@@ -36,9 +39,6 @@ t.test('should audit using Arborist', t => {
         throw new Error('got wrong object passed to reify-output')
 
       REIFY_FINISH_CALLED = true
-    },
-    '../../lib/utils/output.js': () => {
-      OUTPUT_CALLED = true
     },
   })
 
@@ -70,6 +70,7 @@ t.test('should audit - json', t => {
     flatOptions: {
       json: true,
     },
+    output: () => {},
   }
 
   const Audit = requireInject('../../lib/audit.js', {
@@ -83,7 +84,6 @@ t.test('should audit - json', t => {
       }
     },
     '../../lib/utils/reify-output.js': () => {},
-    '../../lib/utils/output.js': () => {},
   })
   const audit = new Audit(npm)
 
@@ -106,6 +106,9 @@ t.test('report endpoint error', t => {
         },
         log: {
           warn: (...warning) => LOGS.push(warning),
+        },
+        output: (...msg) => {
+          OUTPUT.push(msg)
         },
       }
       const Audit = requireInject('../../lib/audit.js', {
@@ -130,9 +133,6 @@ t.test('report endpoint error', t => {
           }
         },
         '../../lib/utils/reify-output.js': () => {},
-        '../../lib/utils/output.js': (...msg) => {
-          OUTPUT.push(msg)
-        },
       })
       const audit = new Audit(npm)
 

--- a/deps/npm/test/lib/bin.js
+++ b/deps/npm/test/lib/bin.js
@@ -2,16 +2,20 @@ const { test } = require('tap')
 const requireInject = require('require-inject')
 
 test('bin', (t) => {
-  t.plan(3)
+  t.plan(4)
   const dir = '/bin/dir'
 
-  const Bin = requireInject('../../lib/bin.js', {
-    '../../lib/utils/output.js': (output) => {
+  const Bin = require('../../lib/bin.js')
+
+  const npm = {
+    bin: dir,
+    flatOptions: { global: false },
+    output: (output) => {
       t.equal(output, dir, 'prints the correct directory')
     },
-  })
-
-  const bin = new Bin({ bin: dir, flatOptions: { global: false } })
+  }
+  const bin = new Bin(npm)
+  t.match(bin.usage, 'bin', 'usage has command name in it')
 
   bin.exec([], (err) => {
     t.ifError(err, 'npm bin')
@@ -33,12 +37,16 @@ test('bin -g', (t) => {
 
   const Bin = requireInject('../../lib/bin.js', {
     '../../lib/utils/path.js': [dir],
-    '../../lib/utils/output.js': (output) => {
-      t.equal(output, dir, 'prints the correct directory')
-    },
   })
 
-  const bin = new Bin({ bin: dir, flatOptions: { global: true } })
+  const npm = {
+    bin: dir,
+    flatOptions: { global: true },
+    output: (output) => {
+      t.equal(output, dir, 'prints the correct directory')
+    },
+  }
+  const bin = new Bin(npm)
 
   bin.exec([], (err) => {
     t.ifError(err, 'npm bin')
@@ -60,11 +68,15 @@ test('bin -g (not in path)', (t) => {
 
   const Bin = requireInject('../../lib/bin.js', {
     '../../lib/utils/path.js': ['/not/my/dir'],
-    '../../lib/utils/output.js': (output) => {
+  })
+  const npm = {
+    bin: dir,
+    flatOptions: { global: true },
+    output: (output) => {
       t.equal(output, dir, 'prints the correct directory')
     },
-  })
-  const bin = new Bin({ bin: dir, flatOptions: { global: true } })
+  }
+  const bin = new Bin(npm)
 
   bin.exec([], (err) => {
     t.ifError(err, 'npm bin')

--- a/deps/npm/test/lib/bugs.js
+++ b/deps/npm/test/lib/bugs.js
@@ -55,6 +55,11 @@ const Bugs = requireInject('../../lib/bugs.js', {
 
 const bugs = new Bugs({ flatOptions: {} })
 
+t.test('usage', (t) => {
+  t.match(bugs.usage, 'bugs', 'usage has command name in it')
+  t.end()
+})
+
 t.test('open bugs urls', t => {
   const expect = {
     nobugs: 'https://www.npmjs.com/package/nobugs',

--- a/deps/npm/test/lib/cache.js
+++ b/deps/npm/test/lib/cache.js
@@ -8,9 +8,14 @@ const flatOptions = {
   force: false,
 }
 
+let outputOutput = []
+
 const npm = {
   flatOptions,
   cache: '/fake/path',
+  output: (msg) => {
+    outputOutput.push(msg)
+  },
 }
 
 let rimrafPath = ''
@@ -41,11 +46,6 @@ const pacote = {
   },
 }
 
-let outputOutput = []
-const output = (msg) => {
-  outputOutput.push(msg)
-}
-
 const cacacheVerifyStats = {
   keptSize: 100,
   verifiedContent: 1,
@@ -63,7 +63,6 @@ const Cache = requireInject('../../lib/cache.js', {
   npmlog,
   pacote,
   rimraf,
-  '../../lib/utils/output.js': output,
   '../../lib/utils/usage.js': usageUtil,
 })
 
@@ -71,7 +70,7 @@ const cache = new Cache(npm)
 
 t.test('cache no args', t => {
   cache.exec([], err => {
-    t.equal(err.message, 'usage instructions', 'should throw usage instructions')
+    t.match(err.message, 'usage instructions', 'should throw usage instructions')
     t.end()
   })
 })

--- a/deps/npm/test/lib/completion.js
+++ b/deps/npm/test/lib/completion.js
@@ -46,6 +46,9 @@ const npm = {
       },
     },
   },
+  output: (line) => {
+    output.push(line)
+  },
 }
 
 const cmdList = {
@@ -80,9 +83,6 @@ const Completion = requireInject('../../lib/completion.js', {
   '../../lib/utils/config.js': config,
   '../../lib/utils/deref-command.js': deref,
   '../../lib/utils/is-windows-shell.js': false,
-  '../../lib/utils/output.js': (line) => {
-    output.push(line)
-  },
 })
 const completion = new Completion(npm)
 

--- a/deps/npm/test/lib/config.js
+++ b/deps/npm/test/lib/config.js
@@ -62,15 +62,15 @@ const npm = {
       return true
     },
   },
+  output: msg => {
+    result = msg
+  },
 }
 
 const usageUtil = () => 'usage instructions'
 
 const mocks = {
   '../../lib/utils/config.js': { defaults, types },
-  '../../lib/utils/output.js': msg => {
-    result = msg
-  },
   '../../lib/utils/usage.js': usageUtil,
 }
 
@@ -180,12 +180,7 @@ t.test('config list --json', t => {
 
 t.test('config delete no args', t => {
   config.exec(['delete'], (err) => {
-    t.equal(
-      err.message,
-      'usage instructions',
-      'should throw usage error'
-    )
-    t.equal(err.code, 'EUSAGE', 'should throw expected error code')
+    t.match(err, { message: '\nUsage: usage instructions' })
     t.end()
   })
 })
@@ -265,11 +260,7 @@ t.test('config delete key --global', t => {
 
 t.test('config set no args', t => {
   config.exec(['set'], (err) => {
-    t.equal(
-      err.message,
-      'usage instructions',
-      'should throw usage error'
-    )
+    t.match(err, { message: '\nUsage: usage instructions' })
     t.end()
   })
 })

--- a/deps/npm/test/lib/deprecate.js
+++ b/deps/npm/test/lib/deprecate.js
@@ -60,14 +60,14 @@ test('completion', async t => {
 
 test('no args', t => {
   deprecate.exec([], (err) => {
-    t.match(err, /Usage: npm deprecate/, 'logs usage')
+    t.match(err, 'Usage:', 'logs usage')
     t.end()
   })
 })
 
 test('only one arg', t => {
   deprecate.exec(['foo'], (err) => {
-    t.match(err, /Usage: npm deprecate/, 'logs usage')
+    t.match(err, 'Usage:', 'logs usage')
     t.end()
   })
 })

--- a/deps/npm/test/lib/diff.js
+++ b/deps/npm/test/lib/diff.js
@@ -23,12 +23,12 @@ const npm = {
   get prefix () {
     return this.flatOptions.prefix
   },
+  output: noop,
 }
 const mocks = {
   npmlog: { info: noop, verbose: noop },
   libnpmdiff: (...args) => libnpmdiff(...args),
   'npm-registry-fetch': async () => ({}),
-  '../../lib/utils/output.js': noop,
   '../../lib/utils/read-local-package.js': async () => rlp(),
   '../../lib/utils/usage.js': () => 'usage instructions',
 }

--- a/deps/npm/test/lib/dist-tag.js
+++ b/deps/npm/test/lib/dist-tag.js
@@ -58,9 +58,6 @@ const DistTag = requireInject('../../lib/dist-tag.js', {
   get 'npm-registry-fetch' () {
     return npmRegistryFetchMock
   },
-  '../../lib/utils/output.js': msg => {
-    result = msg
-  },
 })
 
 const distTag = new DistTag({
@@ -69,6 +66,9 @@ const distTag = new DistTag({
     get (key) {
       return _flatOptions[key]
     },
+  },
+  output: msg => {
+    result = msg
   },
 })
 

--- a/deps/npm/test/lib/doctor.js
+++ b/deps/npm/test/lib/doctor.js
@@ -104,6 +104,9 @@ const npm = {
     },
   },
   version: '7.1.0',
+  output: (data) => {
+    output.push(data)
+  },
 }
 
 let latestNpm = npm.version
@@ -123,9 +126,6 @@ const cacache = {
 const Doctor = requireInject('../../lib/doctor.js', {
   '../../lib/utils/is-windows.js': false,
   '../../lib/utils/ping.js': ping,
-  '../../lib/utils/output.js': (data) => {
-    output.push(data)
-  },
   cacache,
   pacote,
   'make-fetch-happen': fetch,
@@ -285,9 +285,6 @@ test('node versions', t => {
         const WinDoctor = requireInject('../../lib/doctor.js', {
           '../../lib/utils/is-windows.js': true,
           '../../lib/utils/ping.js': ping,
-          '../../lib/utils/output.js': (data) => {
-            output.push(data)
-          },
           cacache,
           pacote,
           'make-fetch-happen': fetch,
@@ -566,9 +563,6 @@ test('node versions', t => {
         const Doctor = requireInject('../../lib/doctor.js', {
           '../../lib/utils/is-windows.js': false,
           '../../lib/utils/ping.js': ping,
-          '../../lib/utils/output.js': (data) => {
-            output.push(data)
-          },
           cacache,
           pacote,
           'make-fetch-happen': fetch,

--- a/deps/npm/test/lib/exec.js
+++ b/deps/npm/test/lib/exec.js
@@ -55,6 +55,7 @@ const npm = {
       LOG_WARN.push(args)
     },
   },
+  output,
 }
 
 const RUN_SCRIPTS = []
@@ -93,7 +94,6 @@ const mocks = {
   pacote,
   read,
   'mkdirp-infer-owner': mkdirp,
-  '../../lib/utils/output.js': output,
 }
 const Exec = requireInject('../../lib/exec.js', mocks)
 const exec = new Exec(npm)

--- a/deps/npm/test/lib/explain.js
+++ b/deps/npm/test/lib/explain.js
@@ -4,15 +4,15 @@ const npm = {
   prefix: null,
   color: true,
   flatOptions: {},
+  output: (...args) => {
+    OUTPUT.push(args)
+  },
 }
 const { resolve } = require('path')
 
 const OUTPUT = []
 
 const Explain = requireInject('../../lib/explain.js', {
-  '../../lib/utils/output.js': (...args) => {
-    OUTPUT.push(args)
-  },
 
   // keep the snapshots pared down a bit, since this has its own tests.
   '../../lib/utils/explain-dep.js': {

--- a/deps/npm/test/lib/explore.js
+++ b/deps/npm/test/lib/explore.js
@@ -55,9 +55,6 @@ const getExplore = (windows) => {
     },
     'read-package-json-fast': mockRPJ,
     '@npmcli/run-script': mockRunScript,
-    '../../lib/utils/output.js': out => {
-      output.push(out)
-    },
   })
   const npm = {
     dir: windows ? 'c:\\npm\\dir' : '/npm/dir',
@@ -68,6 +65,9 @@ const getExplore = (windows) => {
     },
     flatOptions: {
       shell: 'shell-command',
+    },
+    output: out => {
+      output.push(out)
     },
   }
   return new Explore(npm)
@@ -338,7 +338,7 @@ t.test('usage if no pkg provided', t => {
   for (const args of noPkg) {
     t.test(JSON.stringify(args), t => {
       posixExplore.exec(args, er => {
-        t.equal(er, 'npm explore <pkg> [ -- <command>]')
+        t.match(er, 'Usage:')
         t.strictSame({
           ERROR_HANDLER_CALLED: null,
           RPJ_CALLED,

--- a/deps/npm/test/lib/fund.js
+++ b/deps/npm/test/lib/fund.js
@@ -202,9 +202,6 @@ const openUrl = async (npm, url, msg) => {
 }
 const Fund = requireInject('../../lib/fund.js', {
   '../../lib/utils/open-url.js': openUrl,
-  '../../lib/utils/output.js': msg => {
-    result += msg + '\n'
-  },
   pacote: {
     manifest: (arg) => arg.name === 'ntl'
       ? Promise.resolve({
@@ -217,6 +214,9 @@ const fund = new Fund({
   flatOptions: _flatOptions,
   get prefix () {
     return _flatOptions.prefix
+  },
+  output: msg => {
+    result += msg + '\n'
   },
 })
 

--- a/deps/npm/test/lib/help-search.js
+++ b/deps/npm/test/lib/help-search.js
@@ -21,6 +21,7 @@ const npm = {
       return cb(npmHelpErr)
     },
   },
+  output,
 }
 
 let npmUsageArg = null
@@ -45,7 +46,6 @@ const glob = (p, cb) =>
 
 const HelpSearch = requireInject('../../lib/help-search.js', {
   '../../lib/utils/npm-usage.js': npmUsage,
-  '../../lib/utils/output.js': output,
   glob,
 })
 const helpSearch = new HelpSearch(npm)

--- a/deps/npm/test/lib/help.js
+++ b/deps/npm/test/lib/help.js
@@ -14,6 +14,7 @@ const npmConfig = {
 }
 
 let helpSearchArgs = null
+const OUTPUT = []
 const npm = {
   config: {
     get: (key) => npmConfig[key],
@@ -34,11 +35,9 @@ const npm = {
     },
   },
   deref: (cmd) => {},
-}
-
-const OUTPUT = []
-const output = (msg) => {
-  OUTPUT.push(msg)
+  output: msg => {
+    OUTPUT.push(msg)
+  },
 }
 
 const globDefaults = [
@@ -74,7 +73,6 @@ const openUrl = async (npm, url, msg) => {
 const Help = requireInject('../../lib/help.js', {
   '../../lib/utils/npm-usage.js': npmUsage,
   '../../lib/utils/open-url.js': openUrl,
-  '../../lib/utils/output.js': output,
   child_process: {
     spawn,
   },

--- a/deps/npm/test/lib/hook.js
+++ b/deps/npm/test/lib/hook.js
@@ -1,6 +1,7 @@
 const { test } = require('tap')
 const requireInject = require('require-inject')
 
+const output = []
 const npm = {
   flatOptions: {
     json: false,
@@ -8,6 +9,9 @@ const npm = {
     silent: false,
     loglevel: 'info',
     unicode: false,
+  },
+  output: (msg) => {
+    output.push(msg)
   },
 }
 
@@ -51,12 +55,8 @@ const libnpmhook = {
   },
 }
 
-const output = []
 const Hook = requireInject('../../lib/hook.js', {
   '../../lib/utils/otplease.js': async (opts, fn) => fn(opts),
-  '../../lib/utils/output.js': (msg) => {
-    output.push(msg)
-  },
   libnpmhook,
 })
 const hook = new Hook(npm)

--- a/deps/npm/test/lib/init.js
+++ b/deps/npm/test/lib/init.js
@@ -14,13 +14,13 @@ const npm = {
   config: { set () {} },
   flatOptions: {},
   log: npmLog,
+  output: (...msg) => {
+    result += msg.join('\n')
+  },
 }
 const mocks = {
   'init-package-json': (dir, initFile, config, cb) => cb(null, 'data'),
   '../../lib/utils/usage.js': () => 'usage instructions',
-  '../../lib/utils/output.js': (...msg) => {
-    result += msg.join('\n')
-  },
 }
 const Init = requireInject('../../lib/init.js', mocks)
 const init = new Init(npm)

--- a/deps/npm/test/lib/load-all-commands.js
+++ b/deps/npm/test/lib/load-all-commands.js
@@ -1,6 +1,6 @@
 // Thanks to nyc not working properly with proxies this
-// doesn't affect coverage. but it does ensure that every command
-// has a usage, and if it has completion it is a function
+// doesn't affect coverage. but it does ensure that every command has a usage
+// that contains its name, and if it has completion it is a function
 const npm = require('../../lib/npm.js')
 const t = require('tap')
 const { cmdList } = require('../../lib/utils/cmd-list.js')

--- a/deps/npm/test/lib/ls.js
+++ b/deps/npm/test/lib/ls.js
@@ -1,8 +1,6 @@
-const { resolve } = require('path')
-
 const t = require('tap')
-const requireInject = require('require-inject')
 
+const { resolve } = require('path')
 const { utimesSync } = require('fs')
 const touchHiddenPackageLock = prefix => {
   const later = new Date(Date.now() + 10000)
@@ -106,11 +104,7 @@ const _flatOptions = {
   },
   production: false,
 }
-const LS = requireInject('../../lib/ls.js', {
-  '../../lib/utils/output.js': msg => {
-    result = msg
-  },
-})
+const LS = require('../../lib/ls.js')
 const ls = new LS({
   flatOptions: _flatOptions,
   limit: {
@@ -126,6 +120,9 @@ const ls = new LS({
     get (key) {
       return _flatOptions[key]
     },
+  },
+  output: msg => {
+    result = msg
   },
 })
 

--- a/deps/npm/test/lib/npm.js
+++ b/deps/npm/test/lib/npm.js
@@ -357,7 +357,7 @@ t.test('loading as main will load the cli', t => {
   p.on('close', (code, signal) => {
     t.equal(code, 0)
     t.equal(signal, null)
-    t.equal(Buffer.concat(out).toString().trim(), ls.usage)
+    t.match(Buffer.concat(out).toString(), ls.usage)
     t.end()
   })
 })

--- a/deps/npm/test/lib/org.js
+++ b/deps/npm/test/lib/org.js
@@ -2,6 +2,7 @@ const { test } = require('tap')
 const requireInject = require('require-inject')
 const ansiTrim = require('../../lib/utils/ansi-trim.js')
 
+const output = []
 const npm = {
   flatOptions: {
     json: false,
@@ -9,9 +10,10 @@ const npm = {
     silent: false,
     loglevel: 'info',
   },
+  output: (msg) => {
+    output.push(msg)
+  },
 }
-
-const output = []
 
 let orgSize = 1
 let orgSetArgs = null
@@ -41,9 +43,6 @@ const libnpmorg = {
 
 const Org = requireInject('../../lib/org.js', {
   '../../lib/utils/otplease.js': async (opts, fn) => fn(opts),
-  '../../lib/utils/output.js': (msg) => {
-    output.push(msg)
-  },
   libnpmorg,
 })
 const org = new Org(npm)

--- a/deps/npm/test/lib/outdated.js
+++ b/deps/npm/test/lib/outdated.js
@@ -68,17 +68,8 @@ const packument = spec => {
 }
 
 let logs
-const cleanLogs = (done) => {
-  logs = ''
-  const fn = (...args) => {
-    logs += '\n'
-    args.map(el => {
-      logs += el
-      return logs
-    })
-  }
-  console.log = fn
-  done()
+const output = (msg) => {
+  logs = `${logs}\n${msg}`
 }
 
 const globalDir = t.testdir({
@@ -102,10 +93,14 @@ const outdated = (dir, opts) => {
     prefix: dir,
     globalDir: `${globalDir}/node_modules`,
     flatOptions: opts,
+    output,
   })
 }
 
-t.beforeEach(cleanLogs)
+t.beforeEach((done) => {
+  logs = ''
+  done()
+})
 
 const redactCwd = (path) => {
   const normalizePath = p => p

--- a/deps/npm/test/lib/owner.js
+++ b/deps/npm/test/lib/owner.js
@@ -6,7 +6,12 @@ let readLocalPkgResponse = null
 
 const noop = () => null
 
-const npm = { flatOptions: {} }
+const npm = {
+  flatOptions: {},
+  output: (msg) => {
+    result = result ? `${result}\n${msg}` : msg
+  },
+}
 const npmFetch = { json: noop }
 const npmlog = { error: noop, info: noop, verbose: noop }
 const pacote = { packument: noop }
@@ -15,9 +20,6 @@ const mocks = {
   npmlog,
   'npm-registry-fetch': npmFetch,
   pacote,
-  '../../lib/utils/output.js': (...msg) => {
-    result += msg.join('\n')
-  },
   '../../lib/utils/otplease.js': async (opts, fn) => fn({ otp: '123456', opts }),
   '../../lib/utils/read-local-package.js': async () => readLocalPkgResponse,
   '../../lib/utils/usage.js': () => 'usage instructions',
@@ -40,11 +42,7 @@ t.test('owner no args', t => {
   })
 
   owner.exec([], err => {
-    t.equal(
-      err.message,
-      'usage instructions',
-      'should throw usage instructions'
-    )
+    t.match(err, /usage instructions/, 'should not error out on empty locations')
     t.end()
   })
 })
@@ -87,11 +85,7 @@ t.test('owner ls no args no cwd package', t => {
   })
 
   owner.exec(['ls'], err => {
-    t.equal(
-      err.message,
-      'usage instructions',
-      'should throw usage instructions if no cwd package available'
-    )
+    t.match(err, /usage instructions/, 'should throw usage instructions if no cwd package available')
     t.end()
   })
 })
@@ -467,11 +461,7 @@ t.test('owner add no user', t => {
   })
 
   owner.exec(['add'], err => {
-    t.equal(
-      err.message,
-      'usage instructions',
-      'should throw usage instructions if no user provided'
-    )
+    t.match(err, /usage instructions/, 'should throw usage instructions if user provided')
     t.end()
   })
 })
@@ -483,11 +473,7 @@ t.test('owner add <user> no cwd package', t => {
   })
 
   owner.exec(['add', 'foo'], err => {
-    t.equal(
-      err.message,
-      'usage instructions',
-      'should throw usage instructions if no user provided'
-    )
+    t.match(err, /usage instructions/, 'should throw usage instructions if no user provided')
     t.end()
   })
 })
@@ -674,11 +660,7 @@ t.test('owner rm no user', t => {
   })
 
   owner.exec(['rm'], err => {
-    t.equal(
-      err.message,
-      'usage instructions',
-      'should throw usage instructions if no user provided to rm'
-    )
+    t.match(err, /usage instructions/, 'should throw usage instructions if no user provided to rm')
     t.end()
   })
 })
@@ -690,11 +672,7 @@ t.test('owner rm <user> no cwd package', t => {
   })
 
   owner.exec(['rm', 'foo'], err => {
-    t.equal(
-      err.message,
-      'usage instructions',
-      'should throw usage instructions if no user provided to rm'
-    )
+    t.match(err, /usage instructions/, 'should throw usage instructions if no user provided to rm')
     t.end()
   })
 })

--- a/deps/npm/test/lib/pack.js
+++ b/deps/npm/test/lib/pack.js
@@ -18,7 +18,6 @@ t.afterEach(cb => {
 
 t.test('should pack current directory with no arguments', (t) => {
   const Pack = requireInject('../../lib/pack.js', {
-    '../../lib/utils/output.js': output,
     libnpmpack,
     npmlog: {
       notice: () => {},
@@ -32,6 +31,7 @@ t.test('should pack current directory with no arguments', (t) => {
       json: false,
       dryRun: false,
     },
+    output,
   })
 
   pack.exec([], er => {
@@ -53,7 +53,6 @@ t.test('should pack given directory', (t) => {
   })
 
   const Pack = requireInject('../../lib/pack.js', {
-    '../../lib/utils/output.js': output,
     libnpmpack,
     npmlog: {
       notice: () => {},
@@ -67,6 +66,7 @@ t.test('should pack given directory', (t) => {
       json: true,
       dryRun: true,
     },
+    output,
   })
 
   pack.exec([testDir], er => {
@@ -88,7 +88,6 @@ t.test('should pack given directory for scoped package', (t) => {
   })
 
   const Pack = requireInject('../../lib/pack.js', {
-    '../../lib/utils/output.js': output,
     libnpmpack,
     npmlog: {
       notice: () => {},
@@ -102,6 +101,7 @@ t.test('should pack given directory for scoped package', (t) => {
       json: true,
       dryRun: true,
     },
+    output,
   })
 
   return pack.exec([testDir], er => {
@@ -116,7 +116,6 @@ t.test('should pack given directory for scoped package', (t) => {
 
 t.test('should log pack contents', (t) => {
   const Pack = requireInject('../../lib/pack.js', {
-    '../../lib/utils/output.js': output,
     '../../lib/utils/tar.js': {
       ...require('../../lib/utils/tar.js'),
       logTar: () => {
@@ -136,6 +135,7 @@ t.test('should log pack contents', (t) => {
       json: false,
       dryRun: false,
     },
+    output,
   })
 
   pack.exec([], er => {

--- a/deps/npm/test/lib/ping.js
+++ b/deps/npm/test/lib/ping.js
@@ -81,12 +81,6 @@ test('pings and returns json', (t) => {
       t.equal(spec, flatOptions, 'passes flatOptions')
       return details
     },
-    '../../lib/utils/output.js': function (spec) {
-      const parsed = JSON.parse(spec)
-      t.equal(parsed.registry, flatOptions.registry, 'returns the correct registry url')
-      t.match(parsed.details, details, 'prints returned details')
-      t.type(parsed.time, 'number', 'returns time as a number')
-    },
     npmlog: {
       notice: (type, spec) => {
         ++noticeCalls
@@ -100,7 +94,15 @@ test('pings and returns json', (t) => {
       },
     },
   })
-  const ping = new Ping({ flatOptions })
+  const ping = new Ping({
+    flatOptions,
+    output: function (spec) {
+      const parsed = JSON.parse(spec)
+      t.equal(parsed.registry, flatOptions.registry, 'returns the correct registry url')
+      t.match(parsed.details, details, 'prints returned details')
+      t.type(parsed.time, 'number', 'returns time as a number')
+    },
+  })
 
   ping.exec([], (err) => {
     t.equal(noticeCalls, 2, 'should have logged 2 lines')

--- a/deps/npm/test/lib/prefix.js
+++ b/deps/npm/test/lib/prefix.js
@@ -1,16 +1,16 @@
-const { test } = require('tap')
-const requireInject = require('require-inject')
+const t = require('tap')
 
-test('prefix', (t) => {
+t.test('prefix', (t) => {
   t.plan(3)
   const dir = '/prefix/dir'
 
-  const Prefix = requireInject('../../lib/prefix.js', {
-    '../../lib/utils/output.js': (output) => {
+  const Prefix = require('../../lib/prefix.js')
+  const prefix = new Prefix({
+    prefix: dir,
+    output: (output) => {
       t.equal(output, dir, 'prints the correct directory')
     },
   })
-  const prefix = new Prefix({ prefix: dir })
 
   prefix.exec([], (err) => {
     t.ifError(err, 'npm prefix')

--- a/deps/npm/test/lib/profile.js
+++ b/deps/npm/test/lib/profile.js
@@ -8,7 +8,13 @@ const flatOptions = {
   parseable: false,
   registry: 'https://registry.npmjs.org/',
 }
-const npm = { config: {}, flatOptions: { ...flatOptions }}
+const npm = {
+  config: {},
+  flatOptions: { ...flatOptions },
+  output: (...msg) => {
+    result = result ? `${result}\n${msg.join('\n')}` : msg.join('\n')
+  },
+}
 const mocks = {
   ansistyles: { bright: a => a },
   npmlog: {
@@ -31,9 +37,6 @@ const mocks = {
           .map(i => i.join(': ')))
         .join('\n')
     }
-  },
-  '../../lib/utils/output.js': (...msg) => {
-    result += msg.join('\n')
   },
   '../../lib/utils/pulse-till-done.js': {
     withPromise: async a => a,

--- a/deps/npm/test/lib/publish.js
+++ b/deps/npm/test/lib/publish.js
@@ -134,9 +134,6 @@ t.test('if loglevel=info and json, should not output package contents', (t) => {
 
   log.level = 'info'
   const Publish = requireInject('../../lib/publish.js', {
-    '../../lib/utils/output.js': () => {
-      t.pass('output is called')
-    },
     '../../lib/utils/tar.js': {
       getContents: () => ({
         id: 'someid',
@@ -162,6 +159,9 @@ t.test('if loglevel=info and json, should not output package contents', (t) => {
         return { token: 'some.registry.token' }
       },
     },
+    output: () => {
+      t.pass('output is called')
+    },
   })
 
   publish.exec([testDir], (er) => {
@@ -184,9 +184,6 @@ t.test('if loglevel=silent and dry-run, should not output package contents or pu
 
   log.level = 'silent'
   const Publish = requireInject('../../lib/publish.js', {
-    '../../lib/utils/output.js': () => {
-      throw new Error('should not output in dry run mode')
-    },
     '../../lib/utils/tar.js': {
       getContents: () => ({
         id: 'someid',
@@ -210,6 +207,9 @@ t.test('if loglevel=silent and dry-run, should not output package contents or pu
       getCredentialsByURI: () => {
         throw new Error('should not call getCredentialsByURI in dry run')
       },
+    },
+    output: () => {
+      throw new Error('should not output in dry run mode')
     },
   })
 
@@ -241,9 +241,6 @@ t.test('if loglevel=info and dry-run, should not publish, should log package con
         t.pass('logTar is called')
       },
     },
-    '../../lib/utils/output.js': () => {
-      t.pass('output fn is called')
-    },
     libnpmpublish: {
       publish: () => {
         throw new Error('should not call libnpmpublish in dry run')
@@ -258,7 +255,11 @@ t.test('if loglevel=info and dry-run, should not publish, should log package con
       ...config,
       getCredentialsByURI: () => {
         throw new Error('should not call getCredentialsByURI in dry run')
-      }},
+      },
+    },
+    output: () => {
+      t.pass('output fn is called')
+    },
   })
 
   publish.exec([testDir], (er) => {

--- a/deps/npm/test/lib/rebuild.js
+++ b/deps/npm/test/lib/rebuild.js
@@ -1,7 +1,6 @@
 const fs = require('fs')
 const { resolve } = require('path')
 const t = require('tap')
-const requireInject = require('require-inject')
 
 let result = ''
 
@@ -11,15 +10,11 @@ const npm = {
     global: false,
   },
   prefix: '',
-}
-const mocks = {
-  '../../lib/utils/output.js': (...msg) => {
+  output: (...msg) => {
     result += msg.join('\n')
   },
-  '../../lib/utils/usage.js': () => 'usage instructions',
 }
-
-const Rebuild = requireInject('../../lib/rebuild.js', mocks)
+const Rebuild = require('../../lib/rebuild.js')
 const rebuild = new Rebuild(npm)
 
 t.afterEach(cb => {

--- a/deps/npm/test/lib/restart.js
+++ b/deps/npm/test/lib/restart.js
@@ -10,7 +10,6 @@ const npm = {
 }
 const Restart = require('../../lib/restart.js')
 const restart = new Restart(npm)
-t.equal(restart.usage, 'npm restart [-- <args>]')
 restart.exec(['foo'], () => {
   t.match(runArgs, ['restart', 'foo'])
   t.end()

--- a/deps/npm/test/lib/root.js
+++ b/deps/npm/test/lib/root.js
@@ -1,16 +1,16 @@
-const { test } = require('tap')
-const requireInject = require('require-inject')
+const t = require('tap')
 
-test('root', (t) => {
+t.test('root', (t) => {
   t.plan(3)
   const dir = '/root/dir'
 
-  const Root = requireInject('../../lib/root.js', {
-    '../../lib/utils/output.js': (output) => {
+  const Root = require('../../lib/root.js')
+  const root = new Root({
+    dir,
+    output: (output) => {
       t.equal(output, dir, 'prints the correct directory')
     },
   })
-  const root = new Root({ dir })
 
   root.exec([], (err) => {
     t.ifError(err, 'npm root')

--- a/deps/npm/test/lib/run-script.js
+++ b/deps/npm/test/lib/run-script.js
@@ -18,6 +18,7 @@ const npm = {
       npm.config.settings[k] = v
     },
   },
+  output: (...msg) => output.push(msg),
 }
 
 const output = []
@@ -40,7 +41,6 @@ const getRS = windows => {
     }),
     npmlog,
     '../../lib/utils/is-windows-shell.js': windows,
-    '../../lib/utils/output.js': (...msg) => output.push(msg),
   })
   return new RunScript(npm)
 }

--- a/deps/npm/test/lib/star.js
+++ b/deps/npm/test/lib/star.js
@@ -4,15 +4,18 @@ const t = require('tap')
 let result = ''
 
 const noop = () => null
-const npm = { config: { get () {} }, flatOptions: { unicode: false } }
+const npm = {
+  config: { get () {} },
+  flatOptions: { unicode: false },
+  output: (...msg) => {
+    result += msg.join('\n')
+  },
+}
 const npmFetch = { json: noop }
 const npmlog = { error: noop, info: noop, verbose: noop }
 const mocks = {
   npmlog,
   'npm-registry-fetch': npmFetch,
-  '../../lib/utils/output.js': (...msg) => {
-    result += msg.join('\n')
-  },
   '../../lib/utils/get-identity.js': async () => 'foo',
   '../../lib/utils/usage.js': () => 'usage instructions',
 }

--- a/deps/npm/test/lib/stars.js
+++ b/deps/npm/test/lib/stars.js
@@ -4,15 +4,18 @@ const t = require('tap')
 let result = ''
 
 const noop = () => null
-const npm = { config: { get () {} }, flatOptions: {} }
+const npm = {
+  config: { get () {} },
+  flatOptions: {},
+  output: (...msg) => {
+    result = [result, ...msg].join('\n')
+  },
+}
 const npmFetch = { json: noop }
 const npmlog = { warn: noop }
 const mocks = {
   npmlog,
   'npm-registry-fetch': npmFetch,
-  '../../lib/utils/output.js': (...msg) => {
-    result = [result, ...msg].join('\n')
-  },
   '../../lib/utils/get-identity.js': async () => 'foo',
   '../../lib/utils/usage.js': () => 'usage instructions',
 }

--- a/deps/npm/test/lib/start.js
+++ b/deps/npm/test/lib/start.js
@@ -10,7 +10,6 @@ const npm = {
 }
 const Start = require('../../lib/start.js')
 const start = new Start(npm)
-t.equal(start.usage, 'npm start [-- <args>]')
 start.exec(['foo'], () => {
   t.match(runArgs, ['start', 'foo'])
   t.end()

--- a/deps/npm/test/lib/stop.js
+++ b/deps/npm/test/lib/stop.js
@@ -10,7 +10,6 @@ const npm = {
 }
 const Stop = require('../../lib/stop.js')
 const stop = new Stop(npm)
-t.equal(stop.usage, 'npm stop [-- <args>]')
 stop.exec(['foo'], () => {
   t.match(runArgs, ['stop', 'foo'])
   t.end()

--- a/deps/npm/test/lib/team.js
+++ b/deps/npm/test/lib/team.js
@@ -10,13 +10,15 @@ const libnpmteam = {
   async lsUsers () {},
   async rm () {},
 }
-const npm = { flatOptions: {} }
+const npm = {
+  flatOptions: {},
+  output: (...msg) => {
+    result += msg.join('\n')
+  },
+}
 const mocks = {
   libnpmteam,
   'cli-columns': a => a.join(' '),
-  '../../lib/utils/output.js': (...msg) => {
-    result += msg.join('\n')
-  },
   '../../lib/utils/otplease.js': async (opts, fn) => fn(opts),
   '../../lib/utils/usage.js': () => 'usage instructions',
 }

--- a/deps/npm/test/lib/token.js
+++ b/deps/npm/test/lib/token.js
@@ -7,9 +7,11 @@ const mocks = {
   log: {},
   readUserInfo: {},
 }
+const npm = {
+  output: (...args) => mocks.output(...args),
+}
 
 const Token = requireInject('../../lib/token.js', {
-  '../../lib/utils/output.js': (...args) => mocks.output(...args),
   '../../lib/utils/otplease.js': (opts, fn) => {
     return Promise.resolve().then(() => fn(opts))
   },
@@ -17,11 +19,14 @@ const Token = requireInject('../../lib/token.js', {
   'npm-profile': mocks.profile,
   npmlog: mocks.log,
 })
-const token = new Token({})
+
+const token = new Token(npm)
 
 const tokenWithMocks = (mockRequests) => {
   for (const mod in mockRequests) {
-    if (mod !== 'npm') {
+    if (mod === 'npm')
+      mockRequests.npm = { ...npm, ...mockRequests.npm }
+    else {
       if (typeof mockRequests[mod] === 'function')
         mocks[mod] = mockRequests[mod]
       else {
@@ -44,7 +49,7 @@ const tokenWithMocks = (mockRequests) => {
     }
   }
 
-  const token = new Token(mockRequests.npm || {})
+  const token = new Token(mockRequests.npm || npm)
   return [token, reset]
 }
 

--- a/deps/npm/test/lib/unpublish.js
+++ b/deps/npm/test/lib/unpublish.js
@@ -10,6 +10,9 @@ const npm = {
     silent: false,
     loglevel: 'silly',
   },
+  output: (...msg) => {
+    result += msg.join('\n')
+  },
 }
 const mocks = {
   npmlog: { silly () {}, verbose () {} },
@@ -18,9 +21,6 @@ const mocks = {
   'npm-package-arg': noop,
   'npm-registry-fetch': { json: noop },
   'read-package-json': cb => cb(),
-  '../../lib/utils/output.js': (...msg) => {
-    result += msg.join('\n')
-  },
   '../../lib/utils/otplease.js': async (opts, fn) => fn(opts),
   '../../lib/utils/usage.js': () => 'usage instructions',
   '../../lib/utils/get-identity.js': async () => 'foo',

--- a/deps/npm/test/lib/utils/audit-error.js
+++ b/deps/npm/test/lib/utils/audit-error.js
@@ -1,20 +1,18 @@
 const t = require('tap')
-const requireInject = require('require-inject')
 
 const LOGS = []
+const OUTPUT = []
+const output = (...msg) => OUTPUT.push(msg)
+const auditError = require('../../../lib/utils/audit-error.js')
+
 const npm = {
   command: null,
   flatOptions: {},
   log: {
     warn: (...msg) => LOGS.push(msg),
   },
+  output,
 }
-const OUTPUT = []
-const output = (...msg) => OUTPUT.push(msg)
-const auditError = requireInject('../../../lib/utils/audit-error.js', {
-  '../../../lib/utils/output.js': output,
-})
-
 t.afterEach(cb => {
   npm.flatOptions = {}
   OUTPUT.length = 0

--- a/deps/npm/test/lib/utils/lifecycle-cmd.js
+++ b/deps/npm/test/lib/utils/lifecycle-cmd.js
@@ -10,7 +10,12 @@ const npm = {
   },
 }
 t.test('create a lifecycle command', t => {
-  const cmd = new LifecycleCmd(npm, 'test-stage')
+  class TestStage extends LifecycleCmd {
+    static get name () {
+      return 'test-stage'
+    }
+  }
+  const cmd = new TestStage(npm)
   t.match(cmd.usage, /test-stage/)
   cmd.exec(['some', 'args'], (er, result) => {
     t.same(runArgs, ['test-stage', 'some', 'args'])

--- a/deps/npm/test/lib/utils/npm-usage.js
+++ b/deps/npm/test/lib/utils/npm-usage.js
@@ -3,10 +3,10 @@ const t = require('tap')
 const OUTPUT = []
 const output = (...msg) => OUTPUT.push(msg)
 const requireInject = require('require-inject')
-const usage = requireInject('../../../lib/utils/npm-usage.js', {
-  '../../../lib/utils/output.js': output,
-})
+const usage = require('../../../lib/utils/npm-usage.js')
+
 const npm = requireInject('../../../lib/npm.js')
+npm.output = output
 
 t.test('usage', t => {
   t.afterEach((cb) => {

--- a/deps/npm/test/lib/utils/open-url.js
+++ b/deps/npm/test/lib/utils/open-url.js
@@ -1,6 +1,8 @@
 const { test } = require('tap')
 const requireInject = require('require-inject')
 
+const OUTPUT = []
+const output = (...args) => OUTPUT.push(args)
 const npm = {
   _config: {
     json: false,
@@ -12,10 +14,8 @@ const npm = {
       npm._config[k] = v
     },
   },
+  output,
 }
-
-const OUTPUT = []
-const output = (...args) => OUTPUT.push(args)
 
 let openerUrl = null
 let openerOpts = null
@@ -27,7 +27,6 @@ const opener = (url, opts, cb) => {
 }
 
 const openUrl = requireInject('../../../lib/utils/open-url.js', {
-  '../../../lib/utils/output.js': output,
   opener,
 })
 

--- a/deps/npm/test/lib/utils/output.js
+++ b/deps/npm/test/lib/utils/output.js
@@ -1,8 +1,0 @@
-const t = require('tap')
-const logs = []
-console.log = (...msg) => logs.push(msg)
-const output = require('../../../lib/utils/output.js')
-output('hello', 'world')
-output('hello')
-output('world')
-t.strictSame(logs, [['hello', 'world'], ['hello'], ['world']])

--- a/deps/npm/test/lib/utils/reify-output.js
+++ b/deps/npm/test/lib/utils/reify-output.js
@@ -1,5 +1,4 @@
 const t = require('tap')
-const requireInject = require('require-inject')
 
 const log = require('npmlog')
 log.level = 'warn'
@@ -13,22 +12,13 @@ const npm = {
   started: Date.now(),
   flatOptions: settings,
 }
-const getReifyOutput = tester =>
-  requireInject(
-    '../../../lib/utils/reify-output.js',
-    {
-      '../../../lib/utils/output.js': tester,
-    }
-  )
-
+const reifyOutput = require('../../../lib/utils/reify-output.js')
 t.test('missing info', (t) => {
   t.plan(1)
-  const reifyOutput = getReifyOutput(
-    out => t.doesNotHave(
-      out,
-      'looking for funding',
-      'should not print fund message if missing info'
-    )
+  npm.output = out => t.doesNotHave(
+    out,
+    'looking for funding',
+    'should not print fund message if missing info'
   )
 
   reifyOutput(npm, {
@@ -43,12 +33,10 @@ t.test('missing info', (t) => {
 
 t.test('even more missing info', t => {
   t.plan(1)
-  const reifyOutput = getReifyOutput(
-    out => t.doesNotHave(
-      out,
-      'looking for funding',
-      'should not print fund message if missing info'
-    )
+  npm.output = out => t.doesNotHave(
+    out,
+    'looking for funding',
+    'should not print fund message if missing info'
   )
 
   reifyOutput(npm, {
@@ -60,17 +48,15 @@ t.test('even more missing info', t => {
 
 t.test('single package', (t) => {
   t.plan(1)
-  const reifyOutput = getReifyOutput(
-    out => {
-      if (out.endsWith('looking for funding')) {
-        t.match(
-          out,
-          '1 package is looking for funding',
-          'should print single package message'
-        )
-      }
+  npm.output = out => {
+    if (out.endsWith('looking for funding')) {
+      t.match(
+        out,
+        '1 package is looking for funding',
+        'should print single package message'
+      )
     }
-  )
+  }
 
   reifyOutput(npm, {
     // a report with an error is the same as no report at all, if
@@ -110,12 +96,10 @@ t.test('no message when funding config is false', (t) => {
     settings.fund = true
   })
   settings.fund = false
-  const reifyOutput = getReifyOutput(
-    out => {
-      if (out.endsWith('looking for funding'))
-        t.fail('should not print funding info', { actual: out })
-    }
-  )
+  npm.output = out => {
+    if (out.endsWith('looking for funding'))
+      t.fail('should not print funding info', { actual: out })
+  }
 
   reifyOutput(npm, {
     actualTree: {
@@ -147,17 +131,15 @@ t.test('no message when funding config is false', (t) => {
 
 t.test('print appropriate message for many packages', (t) => {
   t.plan(1)
-  const reifyOutput = getReifyOutput(
-    out => {
-      if (out.endsWith('looking for funding')) {
-        t.match(
-          out,
-          '3 packages are looking for funding',
-          'should print single package message'
-        )
-      }
+  npm.output = out => {
+    if (out.endsWith('looking for funding')) {
+      t.match(
+        out,
+        '3 packages are looking for funding',
+        'should print single package message'
+      )
     }
-  )
+  }
 
   reifyOutput(npm, {
     actualTree: {
@@ -206,9 +188,9 @@ t.test('print appropriate message for many packages', (t) => {
 })
 
 t.test('no output when silent', t => {
-  const reifyOutput = getReifyOutput(out => {
+  npm.output = out => {
     t.fail('should not get output when silent', { actual: out })
-  })
+  }
   t.teardown(() => log.level = 'warn')
   log.level = 'silent'
   reifyOutput(npm, {
@@ -235,9 +217,9 @@ t.test('no output when silent', t => {
 
 t.test('packages changed message', t => {
   const output = []
-  const reifyOutput = getReifyOutput(out => {
+  npm.output = out => {
     output.push(out)
-  })
+  }
 
   // return a test function that builds up the mock and snapshots output
   const testCase = (t, added, removed, changed, audited, json, command) => {
@@ -311,9 +293,7 @@ t.test('packages changed message', t => {
 t.test('added packages should be looked up within returned tree', t => {
   t.test('has added pkg in inventory', t => {
     t.plan(1)
-    const reifyOutput = getReifyOutput(
-      out => t.matchSnapshot(out)
-    )
+    npm.output = out => t.matchSnapshot(out)
 
     reifyOutput(npm, {
       actualTree: {
@@ -332,9 +312,7 @@ t.test('added packages should be looked up within returned tree', t => {
 
   t.test('missing added pkg in inventory', t => {
     t.plan(1)
-    const reifyOutput = getReifyOutput(
-      out => t.matchSnapshot(out)
-    )
+    npm.output = out => t.matchSnapshot(out)
 
     reifyOutput(npm, {
       actualTree: {

--- a/deps/npm/test/lib/version.js
+++ b/deps/npm/test/lib/version.js
@@ -11,14 +11,13 @@ const npm = {
   },
   prefix: '',
   version: '1.0.0',
-}
-const mocks = {
-  libnpmversion: noop,
-  '../../lib/utils/output.js': (...msg) => {
+  output: (...msg) => {
     for (const m of msg)
       result.push(m)
   },
-  '../../lib/utils/usage.js': () => 'usage instructions',
+}
+const mocks = {
+  libnpmversion: noop,
 }
 
 const Version = requireInject('../../lib/version.js', mocks)
@@ -65,7 +64,7 @@ t.test('too many args', t => {
   version.exec(['foo', 'bar'], err => {
     t.match(
       err,
-      'usage instructions',
+      'npm version',
       'should throw usage instructions error'
     )
 

--- a/deps/npm/test/lib/whoami.js
+++ b/deps/npm/test/lib/whoami.js
@@ -5,11 +5,13 @@ test('whoami', (t) => {
   t.plan(3)
   const Whoami = requireInject('../../lib/whoami.js', {
     '../../lib/utils/get-identity.js': () => Promise.resolve('foo'),
-    '../../lib/utils/output.js': (output) => {
+  })
+  const whoami = new Whoami({
+    flatOptions: {},
+    output: (output) => {
       t.equal(output, 'foo', 'should output the username')
     },
   })
-  const whoami = new Whoami({ flatOptions: {} })
 
   whoami.exec([], (err) => {
     t.ifError(err, 'npm whoami')
@@ -21,11 +23,13 @@ test('whoami json', (t) => {
   t.plan(3)
   const Whoami = requireInject('../../lib/whoami.js', {
     '../../lib/utils/get-identity.js': () => Promise.resolve('foo'),
-    '../../lib/utils/output.js': (output) => {
+  })
+  const whoami = new Whoami({
+    flatOptions: { json: true },
+    output: (output) => {
       t.equal(output, '"foo"', 'should output the username as json')
     },
   })
-  const whoami = new Whoami({ flatOptions: { json: true } })
 
   whoami.exec([], (err) => {
     t.ifError(err, 'npm whoami')


### PR DESCRIPTION
## v7.6.2 (2021-03-09)

### BUG FIXES

* [`e0a3a5218`](https://github.com/npm/cli/commit/e0a3a5218cac7ca5850930aaaad8a939ddf75d4d) [#2831](https://github.com/npm/cli/issues/2831) Fix cb() never called in search with --json option ([@fraqe](https://github.com/fraqe))
* [`85a8694dd`](https://github.com/npm/cli/commit/85a8694dd9b4a924a474ba75261914511a216868) [#2795](https://github.com/npm/cli/issues/2795) fix(npm.output): make output go through npm.output ([@wraithgar](https://github.com/wraithgar))
* [`9fe0df5b5`](https://github.com/npm/cli/commit/9fe0df5b5d7606e5841288d9931be6c04767c9ca) [#2821](https://github.com/npm/cli/issues/2821) fix(usage): clean up usage declarations ([@wraithgar](https://github.com/wraithgar))

### DEPENDENCIES

* [`7f470b5c2`](https://github.com/npm/cli/commit/7f470b5c25d544e36d97b28e28ae20dfa1d4ab31) `@npmcli/arborist@2.2.7`
    * fix(install): Do not revert a file: dep to version on bare name re-install
* [`e9b7fc275`](https://github.com/npm/cli/commit/e9b7fc275a0bdf8f00dbcf5dd2283675776fc459) `libnpmdiff@2.0.4`
    * fix(diff): Gracefully handle packages with prepare script
* [`c7314aa62`](https://github.com/npm/cli/commit/c7314aa62195b7f0d8886776692e8a2c892413ed) `byte-size@7.0.1`
* [`864f48d43`](https://github.com/npm/cli/commit/864f48d4327269f521161cf89888ea2b6db5fdab) `pacote@11.3.0`