### PR TITLE
THP ELF assembly: Add .note.GNU-stack section

### DIFF
--- a/src/large_pages/node_text_start.S
+++ b/src/large_pages/node_text_start.S
@@ -1,8 +1,8 @@
+#if defined(__ELF__)
+.section .note.GNU-stack,"",@progbits
+#endif
 .text
 .align 0x2000
 .global __node_text_start
 .hidden __node_text_start
-#if defined(__ELF__)
-.section .note.GNU-stack,"",@progbits
-#endif
 __node_text_start:

--- a/src/large_pages/node_text_start.S
+++ b/src/large_pages/node_text_start.S
@@ -2,4 +2,7 @@
 .align 0x2000
 .global __node_text_start
 .hidden __node_text_start
+#if defined(__ELF__)
+.section .note.GNU-stack,"",@progbits
+#endif
 __node_text_start:


### PR DESCRIPTION
This indicates to GNU binutils that it can unset the executable stack flag on the binary that it is building.

Refs: https://github.com/nodejs/node/issues/17933

cc @gabrielschulhof @bnoordhuis (from the `git` shortlog in this part of the codebase)
cc @danbev (as discussed, for review)

Two developer notes to aid review:

- Some other examples on the web instruct to use `%progbits` with a percentage symbol.  The approach here uses `@progbits` instead, which is the form documented in the [`binutils` documentation here](https://sourceware.org/binutils/docs-2.36/as/Section.html#Section).
- The conditional block does not check for a Linux-based build environment; this is intentional since `node` is a cross-platform binary and I believe this section could be relevant for other platforms.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.