### PR TITLE
lib: implement AbortSignal.abort()

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -315,6 +315,7 @@ module.exports = {
   },
   globals: {
     AbortController: 'readable',
+    AbortSignal: 'readable',
     Atomics: 'readable',
     BigInt: 'readable',
     BigInt64Array: 'readable',

--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -67,6 +67,15 @@ added: v15.0.0
 The `AbortSignal` is used to notify observers when the
 `abortController.abort()` method is called.
 
+#### Static method: `AbortSignal.abort()`
+<!-- YAML
+added: REPLACEME
+-->
+
+* Returns: {AbortSignal}
+
+Returns a new already aborted `AbortSignal`.
+
 #### Event: `'abort'`
 <!-- YAML
 added: v15.0.0

--- a/lib/internal/abort_controller.js
+++ b/lib/internal/abort_controller.js
@@ -50,6 +50,10 @@ class AbortSignal extends EventTarget {
       aborted: this.aborted
     }, depth, options);
   }
+
+  static abort() {
+    return createAbortSignal(true);
+  }
 }
 
 ObjectDefineProperties(AbortSignal.prototype, {
@@ -65,10 +69,10 @@ ObjectDefineProperty(AbortSignal.prototype, SymbolToStringTag, {
 
 defineEventHandler(AbortSignal.prototype, 'abort');
 
-function createAbortSignal() {
+function createAbortSignal(aborted = false) {
   const signal = new EventTarget();
   ObjectSetPrototypeOf(signal, AbortSignal.prototype);
-  signal[kAborted] = false;
+  signal[kAborted] = aborted;
   return signal;
 }
 

--- a/test/fixtures/wpt/README.md
+++ b/test/fixtures/wpt/README.md
@@ -12,7 +12,7 @@ Last update:
 
 - common: https://github.com/web-platform-tests/wpt/tree/bb97a68974/common
 - console: https://github.com/web-platform-tests/wpt/tree/3b1f72e99a/console
-- dom/abort: https://github.com/web-platform-tests/wpt/tree/625e1310ce/dom/abort
+- dom/abort: https://github.com/web-platform-tests/wpt/tree/1728d198c9/dom/abort
 - encoding: https://github.com/web-platform-tests/wpt/tree/35f70910d3/encoding
 - FileAPI: https://github.com/web-platform-tests/wpt/tree/3b279420d4/FileAPI
 - hr-time: https://github.com/web-platform-tests/wpt/tree/9910784394/hr-time

--- a/test/fixtures/wpt/dom/abort/event.any.js
+++ b/test/fixtures/wpt/dom/abort/event.any.js
@@ -64,4 +64,9 @@ test(t => {
   controller.abort();
 }, "the abort event should have the right properties");
 
+test(t => {
+  const signal = AbortSignal.abort();
+  assert_true(signal.aborted);
+}, "the AbortSignal.abort() static returns an already aborted signal");
+
 done();

--- a/test/fixtures/wpt/versions.json
+++ b/test/fixtures/wpt/versions.json
@@ -8,7 +8,7 @@
     "path": "console"
   },
   "dom/abort": {
-    "commit": "625e1310ce19e9dde25b01f9eda0452c6ec274da",
+    "commit": "1728d198c92834d92f7f399ef35e7823d5bfa0e4",
     "path": "dom/abort"
   },
   "encoding": {

--- a/test/parallel/test-abortcontroller.js
+++ b/test/parallel/test-abortcontroller.js
@@ -67,3 +67,8 @@ const { ok, strictEqual, throws } = require('assert');
   strictEqual(toString(ac), '[object AbortController]');
   strictEqual(toString(ac.signal), '[object AbortSignal]');
 }
+
+{
+  const signal = AbortSignal.abort();
+  ok(signal.aborted);
+}


### PR DESCRIPTION
Implementation of `AbortSignal.abort()` to create an already aborted `AbortSignal`

Refs: https://github.com/whatwg/dom/pull/960

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
