### PR TITLE
events: only add listener if AbortSignal not aborted

### DIFF
--- a/lib/internal/abort_controller.js
+++ b/lib/internal/abort_controller.js
@@ -17,7 +17,8 @@ const {
   defineEventHandler,
   EventTarget,
   Event,
-  kTrustEvent
+  kCanAddEvent,
+  kTrustEvent,
 } = require('internal/event_target');
 const {
   customInspectSymbol,
@@ -41,6 +42,10 @@ class AbortSignal extends EventTarget {
   constructor() {
     // eslint-disable-next-line no-restricted-syntax
     throw new TypeError('Illegal constructor');
+  }
+
+  [kCanAddEvent](type) {
+    return type === 'abort' ? !this.aborted : true;
   }
 
   get aborted() { return !!this[kAborted]; }

--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -44,6 +44,7 @@ const {
   kMaxEventTargetListenersWarned,
 } = EventEmitter;
 
+const kCanAddEvent = Symbol('kCanAddEvent');
 const kEvents = Symbol('kEvents');
 const kStop = Symbol('kStop');
 const kTarget = Symbol('kTarget');
@@ -278,6 +279,13 @@ class EventTarget {
     initEventTarget(this);
   }
 
+  // Subclasses can override to control whether new event handlers
+  // of the given type can be added. If this returns false, the
+  // request to add the handler is silently ignored.
+  [kCanAddEvent](type) {
+    return true;
+  }
+
   [kNewListener](size, type, listener, once, capture, passive) {
     if (this[kMaxEventTargetListeners] > 0 &&
         size > this[kMaxEventTargetListeners] &&
@@ -326,6 +334,9 @@ class EventTarget {
       return;
     }
     type = String(type);
+
+    if (!this[kCanAddEvent](type))
+      return;
 
     if (signal) {
       if (signal.aborted) {
@@ -708,6 +719,7 @@ module.exports = {
   defineEventHandler,
   initEventTarget,
   initNodeEventTarget,
+  kCanAddEvent,
   kCreateEvent,
   kNewListener,
   kTrustEvent,

--- a/test/parallel/test-abortcontroller.js
+++ b/test/parallel/test-abortcontroller.js
@@ -4,6 +4,7 @@
 const common = require('../common');
 
 const { ok, strictEqual, throws } = require('assert');
+const { getEventListeners } = require('events');
 
 {
   // Tests that abort is fired with the correct event type on AbortControllers
@@ -66,4 +67,12 @@ const { ok, strictEqual, throws } = require('assert');
   const ac = new AbortController();
   strictEqual(toString(ac), '[object AbortController]');
   strictEqual(toString(ac.signal), '[object AbortSignal]');
+}
+
+{
+  const ac = new AbortController();
+  ac.signal.addEventListener('abort', () => {});  // Intentionally ignored
+  ac.abort();
+  ac.signal.addEventListener('abort', () => {});  // Intentionally ignored
+  strictEqual(getEventListeners(ac.signal, 'abort').length, 1);
 }


### PR DESCRIPTION
If the `AbortSignal` is already aborted, then there's no
sense in registering the handler. The spec even says not ~~to
do so~~ to retain "abort algorithms" if the `aborted flag` is set.

Signed-off-by: James M Snell <jasnell@gmail.com>

/cc @benjamingr 