### PR TITLE
lib: fix typo in lib/internal/http2/core.js

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1280,7 +1280,7 @@ class Http2Session extends EventEmitter {
   }
 
   // Sets the local window size (local endpoints's window size)
-  // Returns 0 if sucess or throw an exception if NGHTTP2_ERR_NOMEM
+  // Returns 0 if success or throw an exception if NGHTTP2_ERR_NOMEM
   // if the window allocation fails
   setLocalWindowSize(windowSize) {
     if (this.destroyed)


### PR DESCRIPTION
'success' spelled as 'sucess'