### PR TITLE
event: remove return value on addEventListener

### DIFF
--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -329,7 +329,7 @@ class EventTarget {
 
     if (signal) {
       if (signal.aborted) {
-        return false;
+        return;
       }
       // TODO(benjamingr) make this weak somehow? ideally the signal would
       // not prevent the event target from GC.

--- a/test/parallel/test-eventtarget-whatwg-signal.js
+++ b/test/parallel/test-eventtarget-whatwg-signal.js
@@ -25,7 +25,11 @@ const {
   controller.abort();
   et.dispatchEvent(new Event('test'));
   strictEqual(count, 2, 'Aborting on the controller removes the listener');
-  et.addEventListener('test', handler, { signal: controller.signal });
+  // See: https://github.com/nodejs/node/pull/37696 , adding an event listener
+  // should always return undefined.
+  strictEqual(
+    et.addEventListener('test', handler, { signal: controller.signal }),
+    undefined);
   et.dispatchEvent(new Event('test'));
   strictEqual(count, 2, 'Passing an aborted signal never adds the handler');
 }


### PR DESCRIPTION
The `addEventListener()` should not return a value.

Signed-off-by: James M Snell <jasnell@gmail.com>

/cc @benjamingr 