### PR TITLE
module: improve error message for invalid data URL

### DIFF
--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -6,12 +6,14 @@ require('internal/modules/cjs/loader');
 const {
   FunctionPrototypeBind,
   ObjectSetPrototypeOf,
+  RegExpPrototypeExec,
   SafeWeakMap,
   StringPrototypeStartsWith,
 } = primordials;
 
 const {
   ERR_INVALID_ARG_VALUE,
+  ERR_INVALID_MODULE_SPECIFIER,
   ERR_INVALID_RETURN_PROPERTY,
   ERR_INVALID_RETURN_PROPERTY_VALUE,
   ERR_INVALID_RETURN_VALUE,
@@ -107,6 +109,15 @@ class Loader {
     }
 
     const { format } = getFormatResponse;
+    if (format === null) {
+      const dataUrl = RegExpPrototypeExec(
+        /^data:([^/]+\/[^;,]+)(?:[^,]*?)(;base64)?,/,
+        url,
+      );
+      throw new ERR_INVALID_MODULE_SPECIFIER(
+        url,
+        dataUrl ? `has an unsupported MIME type "${dataUrl[1]}"` : '');
+    }
     if (typeof format !== 'string') {
       throw new ERR_INVALID_RETURN_PROPERTY_VALUE(
         'string', 'loader getFormat', 'format', format);

--- a/test/es-module/test-esm-data-urls.js
+++ b/test/es-module/test-esm-data-urls.js
@@ -99,7 +99,7 @@ function createBase64URL(mime, body) {
       await import(plainESMURL);
       common.mustNotCall()();
     } catch (e) {
-      assert.strictEqual(e.code, 'ERR_INVALID_RETURN_PROPERTY_VALUE');
+      assert.strictEqual(e.code, 'ERR_INVALID_MODULE_SPECIFIER');
     }
   }
   {

--- a/test/es-module/test-esm-invalid-data-urls.js
+++ b/test/es-module/test-esm-invalid-data-urls.js
@@ -1,0 +1,24 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+
+(async () => {
+  await assert.rejects(import('data:text/plain,export default0'), {
+    code: 'ERR_INVALID_MODULE_SPECIFIER',
+    message:
+      'Invalid module "data:text/plain,export default0" has an unsupported ' +
+      'MIME type "text/plain"',
+  });
+  await assert.rejects(import('data:text/plain;base64,'), {
+    code: 'ERR_INVALID_MODULE_SPECIFIER',
+    message:
+      'Invalid module "data:text/plain;base64," has an unsupported ' +
+      'MIME type "text/plain"',
+  });
+  await assert.rejects(import('data:application/json,[]'), {
+    code: 'ERR_INVALID_MODULE_SPECIFIER',
+    message:
+      'Invalid module "data:application/json,[]" has an unsupported ' +
+      'MIME type "application/json"',
+  });
+})().then(common.mustCall());


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/37647

Changes the error message when importing module with an unknown/unsupported MIME type from:

```
TypeError [ERR_INVALID_RETURN_PROPERTY_VALUE]: Expected string to be returned for the "format" from the "loader getFormat" function but got type object.
```

to

```
TypeError [ERR_INVALID_MODULE_SPECIFIER]: Invalid module "data:application/json,[]" has an unsupported MIME type "application/json"
```

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
