### PR TITLE
module: make module.parent truthy when loaded from ESM

### DIFF
--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -912,16 +912,23 @@ added: v0.1.16
 deprecated:
   - v14.6.0
   - v12.19.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: When the module is loaded by something that is not a CommonJS
+                 module, the value of `module.parent` is truthy. On previous
+                 versions, it is `undefined`.
 -->
 
 > Stability: 0 - Deprecated: Please use [`require.main`][] and
 > [`module.children`][] instead.
 
-* {module | null | undefined}
+* {module | null | Object}
 
 The module that first required this one, or `null` if the current module is the
-entry point of the current process, or `undefined` if the module was loaded by
-something that is not a CommonJS module (E.G.: REPL or `import`).
+entry point of the current process, or an instance of an add-hoc `UnknownModule`
+class if the module was loaded by something that is not a CommonJS module (E.G.:
+REPL or `import`).
 
 ### `module.path`
 <!-- YAML

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -241,7 +241,13 @@ ObjectDefineProperty(Module.prototype, 'isPreloading', isPreloadingDesc);
 ObjectDefineProperty(NativeModule.prototype, 'isPreloading', isPreloadingDesc);
 
 function getModuleParent() {
-  return moduleParentCache.get(this);
+  const parent = moduleParentCache.get(this);
+  if (parent === undefined) {
+    const parent = new (class UnknownModule {})();
+    moduleParentCache.set(this, parent);
+    return parent;
+  }
+  return parent;
 }
 
 function setModuleParent(value) {

--- a/test/fixtures/cjs-module-parent.js
+++ b/test/fixtures/cjs-module-parent.js
@@ -1,0 +1,5 @@
+'use strict';
+const assert = require('assert');
+
+// Accessing module.parent should not be falsy.
+assert.ok(module.parent)

--- a/test/parallel/test-module-parent-deprecation-no-warning-for-cjs-users.js
+++ b/test/parallel/test-module-parent-deprecation-no-warning-for-cjs-users.js
@@ -1,0 +1,7 @@
+'use strict';
+
+require('../common');
+const fixtures = require('../common/fixtures');
+
+// Accessing module.parent from a child module should not raise a warning.
+require(fixtures.path('cjs-module-parent.js'));

--- a/test/parallel/test-module-parent-deprecation-warning-for-esm-users.mjs
+++ b/test/parallel/test-module-parent-deprecation-warning-for-esm-users.mjs
@@ -1,0 +1,7 @@
+import { mustCall } from '../common/index.mjs';
+import fixtures from '../common/fixtures.js';
+
+// Accessing module.parent from a child module should raise a deprecation
+// warning when imported from ESM.
+import(fixtures.path('cjs-module-parent.js'))
+    .then(mustCall());


### PR DESCRIPTION
This is to ensure backward compatibility of CJS modules checking the
boolean value of `module.parent` to test if the module is the entry
point of the current process.

Currently, `module.parent` provides a way for CJS users to get which CJS modules required the current module first. This feature – not very useful by itself – is also (wrongly) used to make assumption about the program entry point. Some packages wrap their test code inside a `if(!module.parent)` condition, assuming that a falsy value means the module is run from CLI. The issue with this pattern is that the assumption doesn't work as soon as the module interacts with ESM or REPL.

The issue I'd like to address is when a dependency is using the `if(!module.parent)` pattern to run its tests, and the test code gets executed for ESM users without their knowledge; those tests that may have side effects and make the end user code fail without obvious reason.
The current behavior where `module.parent` is `undefined` therefore falsy impacts end users trying to migrate from CJS to ESM, not the package author using such pattern in one of their abandoned project. This PR switches to a dummy object which makes it truthy.

Refs: https://github.com/nodejs/node/pull/33534

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
