### PR TITLE
[v14.x backport] fs: improve fsPromises readFile performance

### DIFF
--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -4,12 +4,12 @@
 // See https://github.com/libuv/libuv/pull/1501.
 const kIoMaxLength = 2 ** 31 - 1;
 
-// Note: This is different from kReadFileBufferLength used for non-promisified
-// fs.readFile.
-const kReadFileMaxChunkSize = 2 ** 14;
+const kReadFileBufferLength = 512 * 1024;
+const kReadFileUnknownBufferLength = 64 * 1024;
 const kWriteFileMaxChunkSize = 2 ** 14;
 
 const {
+  ArrayPrototypePush,
   Error,
   MathMax,
   MathMin,
@@ -272,21 +272,43 @@ async function readFileHandle(filehandle, options) {
   if (size > kIoMaxLength)
     throw new ERR_FS_FILE_TOO_LARGE(size);
 
-  const chunks = [];
-  const chunkSize = size === 0 ?
-    kReadFileMaxChunkSize :
-    MathMin(size, kReadFileMaxChunkSize);
   let endOfFile = false;
+  let totalRead = 0;
+  const noSize = size === 0;
+  const buffers = [];
+  const fullBuffer = noSize ? undefined : Buffer.allocUnsafeSlow(size);
   do {
-    const buf = Buffer.alloc(chunkSize);
-    const { bytesRead, buffer } =
-      await read(filehandle, buf, 0, chunkSize, -1);
-    endOfFile = bytesRead === 0;
-    if (bytesRead > 0)
-      chunks.push(buffer.slice(0, bytesRead));
+    let buffer;
+    let offset;
+    let length;
+    if (noSize) {
+      buffer = Buffer.allocUnsafeSlow(kReadFileUnknownBufferLength);
+      offset = 0;
+      length = kReadFileUnknownBufferLength;
+    } else {
+      buffer = fullBuffer;
+      offset = totalRead;
+      length = MathMin(size - totalRead, kReadFileBufferLength);
+    }
+
+    const bytesRead = (await binding.read(filehandle.fd, buffer, offset,
+                                          length, -1, kUsePromises)) || 0;
+    totalRead += bytesRead;
+    endOfFile = bytesRead === 0 || totalRead === size;
+    if (noSize && bytesRead > 0) {
+      const isBufferFull = bytesRead === kReadFileUnknownBufferLength;
+      const chunkBuffer = isBufferFull ? buffer : buffer.slice(0, bytesRead);
+      ArrayPrototypePush(buffers, chunkBuffer);
+    }
   } while (!endOfFile);
 
-  const result = Buffer.concat(chunks);
+  let result;
+  if (size > 0) {
+    result = totalRead === size ? fullBuffer : fullBuffer.slice(0, totalRead);
+  } else {
+    result = buffers.length === 1 ? buffers[0] : Buffer.concat(buffers,
+                                                               totalRead);
+  }
 
   return options.encoding ? result.toString(options.encoding) : result;
 }


### PR DESCRIPTION
Improve the fsPromises readFile performance
by allocating only one buffer, when size is known,
increase the size of the readbuffer chunks,
and dont read more data if size bytes have been read

refs: https://github.com/nodejs/node/issues/37583

PR-URL: https://github.com/nodejs/node/pull/37608

I only cherry-picked the changes to `fs/promises.js` (first commit) but didn't backport the benchmark (second commit). If that's needed, I'll be happy to do it as well. This PR also incorporates the changes of https://github.com/nodejs/node/pull/37127, so I'm not sure if that PR should be backported before this one.