### PR TITLE
http2: make res.req a normal property

### DIFF
--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -480,6 +480,7 @@ class Http2ServerResponse extends Stream {
     stream[kProxySocket] = null;
     stream[kResponse] = this;
     this.writable = true;
+    this.req = stream[kRequest];
     stream.on('drain', onStreamDrain);
     stream.on('aborted', onStreamAbortedResponse);
     stream.on('close', onStreamCloseResponse);
@@ -527,10 +528,6 @@ class Http2ServerResponse extends Stream {
 
   get headersSent() {
     return this[kStream].headersSent;
-  }
-
-  get req() {
-    return this[kStream][kRequest];
   }
 
   get sendDate() {

--- a/test/parallel/test-http2-compat-serverresponse.js
+++ b/test/parallel/test-http2-compat-serverresponse.js
@@ -14,6 +14,9 @@ server.listen(0, common.mustCall(function() {
   server.once('request', common.mustCall(function(request, response) {
     assert.strictEqual(response.req, request);
 
+    // Verify that writing to response.req is allowed.
+    response.req = null;
+
     response.on('finish', common.mustCall(function() {
       process.nextTick(() => {
         server.close();


### PR DESCRIPTION
The change in https://github.com/nodejs/node/pull/36505 broke userland code that already wrote to `res.req`. This commit updates the `res.req` getter in the http2 compat layer to be a normal property.

Fixes: https://github.com/nodejs/node/issues/37705
