### PR TITLE
util: inspect __proto__ key as written in object literal

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -1718,6 +1718,8 @@ function formatProperty(ctx, value, recurseTimes, key, type, desc,
       strEscapeSequencesReplacer, escapeFn
     );
     name = `[${ctx.stylize(tmp, 'symbol')}]`;
+  } else if (key === '__proto__') {
+    name = "['__proto__']";
   } else if (desc.enumerable === false) {
     const tmp = StringPrototypeReplace(key,
                                        strEscapeSequencesReplacer, escapeFn);

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -3095,3 +3095,10 @@ assert.strictEqual(
     ']'
   );
 }
+
+{
+  assert.strictEqual(
+    util.inspect({ ['__proto__']: { a: 1 } }),
+    "{ ['__proto__']: { a: 1 } }"
+  );
+}


### PR DESCRIPTION
Since util.inspect() gives object-literal-like output, handle the
special `__proto__` key in the way that it would be handled in object
literals.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
