### PR TITLE
doc: fix typo in stream docs

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -2197,7 +2197,7 @@ user programs.
 #### `writable._writev(chunks, callback)`
 
 * `chunks` {Object[]} The data to be written. The value is an array of {Object}
-  that each represent a discreet chunk of data to write. The properties of
+  that each represent a discrete chunk of data to write. The properties of
   these objects are:
   * `chunk` {Buffer|string} A buffer instance or string containing the data to
     be written. The `chunk` will be a string if the `Writable` was created with


### PR DESCRIPTION
🙂 