### PR TITLE
lib: add brand checks to AbortController and AbortSignal

### DIFF
--- a/lib/internal/abort_controller.js
+++ b/lib/internal/abort_controller.js
@@ -41,7 +41,7 @@ function customInspect(self, obj, depth, options) {
 }
 
 function validateAbortSignal(obj) {
-  if (obj == null || obj[kAborted] === undefined)
+  if (obj?.[kAborted] === undefined)
     throw new ERR_INVALID_THIS('AbortSignal');
 }
 
@@ -102,7 +102,7 @@ function abortSignal(signal) {
 const kSignal = Symbol('signal');
 
 function validateAbortController(obj) {
-  if (obj == null || obj[kSignal] === undefined)
+  if (obj?.[kSignal] === undefined)
     throw new ERR_INVALID_THIS('AbortController');
 }
 

--- a/lib/internal/abort_controller.js
+++ b/lib/internal/abort_controller.js
@@ -24,8 +24,10 @@ const {
 } = require('internal/util');
 const { inspect } = require('internal/util/inspect');
 const {
-  ERR_INVALID_THIS
-} = require('internal/errors').codes;
+  codes: {
+    ERR_INVALID_THIS,
+  }
+} = require('internal/errors');
 
 const kAborted = Symbol('kAborted');
 

--- a/lib/internal/abort_controller.js
+++ b/lib/internal/abort_controller.js
@@ -23,6 +23,9 @@ const {
   customInspectSymbol,
 } = require('internal/util');
 const { inspect } = require('internal/util/inspect');
+const {
+  ERR_INVALID_THIS
+} = require('internal/errors').codes;
 
 const kAborted = Symbol('kAborted');
 
@@ -37,13 +40,21 @@ function customInspect(self, obj, depth, options) {
   return `${self.constructor.name} ${inspect(obj, opts)}`;
 }
 
+function validateAbortSignal(obj) {
+  if (obj == null || obj[kAborted] === undefined)
+    throw new ERR_INVALID_THIS('AbortSignal');
+}
+
 class AbortSignal extends EventTarget {
   constructor() {
     // eslint-disable-next-line no-restricted-syntax
     throw new TypeError('Illegal constructor');
   }
 
-  get aborted() { return !!this[kAborted]; }
+  get aborted() {
+    validateAbortSignal(this);
+    return !!this[kAborted];
+  }
 
   [customInspectSymbol](depth, options) {
     return customInspect(this, {
@@ -89,13 +100,26 @@ function abortSignal(signal) {
 // initializers for now:
 // https://bugs.chromium.org/p/v8/issues/detail?id=10704
 const kSignal = Symbol('signal');
+
+function validateAbortController(obj) {
+  if (obj == null || obj[kSignal] === undefined)
+    throw new ERR_INVALID_THIS('AbortController');
+}
+
 class AbortController {
   constructor() {
     this[kSignal] = createAbortSignal();
   }
 
-  get signal() { return this[kSignal]; }
-  abort() { abortSignal(this[kSignal]); }
+  get signal() {
+    validateAbortController(this);
+    return this[kSignal];
+  }
+
+  abort() {
+    validateAbortController(this);
+    abortSignal(this[kSignal]);
+  }
 
   [customInspectSymbol](depth, options) {
     return customInspect(this, {

--- a/test/parallel/test-abortcontroller.js
+++ b/test/parallel/test-abortcontroller.js
@@ -87,6 +87,7 @@ const { ok, strictEqual, throws } = require('assert');
 
   const badAbortControllers = [
     null,
+    undefined,
     0,
     NaN,
     true,
@@ -117,6 +118,7 @@ const { ok, strictEqual, throws } = require('assert');
 
   const badAbortSignals = [
     null,
+    undefined,
     0,
     NaN,
     true,

--- a/test/parallel/test-abortcontroller.js
+++ b/test/parallel/test-abortcontroller.js
@@ -72,3 +72,63 @@ const { ok, strictEqual, throws } = require('assert');
   const signal = AbortSignal.abort();
   ok(signal.aborted);
 }
+
+{
+  // Test that AbortController properties and methods
+  // validate the receiver object
+  const acSignalGet = Object.getOwnPropertyDescriptor(
+    AbortController.prototype,
+    'signal'
+  ).get;
+  const acAbort = AbortController.prototype.abort;
+
+  const goodController = new AbortController();
+  ok(acSignalGet.call(goodController));
+  acAbort.call(goodController);
+
+  const badAbortControllers = [
+    null,
+    0,
+    NaN,
+    true,
+    'AbortController',
+    Object.create(AbortController.prototype)
+  ];
+  for (const badController of badAbortControllers) {
+    throws(
+      () => acSignalGet.call(badController),
+      { code: 'ERR_INVALID_THIS', name: 'TypeError' }
+    );
+    throws(
+      () => acAbort.call(badController),
+      { code: 'ERR_INVALID_THIS', name: 'TypeError' }
+    );
+  }
+}
+
+{
+  // Test that AbortSignal properties
+  // validate the receiver object
+  const signalAbortedGet = Object.getOwnPropertyDescriptor(
+    AbortSignal.prototype,
+    'aborted'
+  ).get;
+
+  const goodSignal = new AbortController().signal;
+  strictEqual(signalAbortedGet.call(goodSignal), false);
+
+  const badAbortSignals = [
+    null,
+    0,
+    NaN,
+    true,
+    'AbortSignal',
+    Object.create(AbortSignal.prototype)
+  ];
+  for (const badSignal of badAbortSignals) {
+    throws(
+      () => signalAbortedGet.call(badSignal),
+      { code: 'ERR_INVALID_THIS', name: 'TypeError' }
+    );
+  }
+}

--- a/test/parallel/test-abortcontroller.js
+++ b/test/parallel/test-abortcontroller.js
@@ -74,8 +74,7 @@ const { ok, strictEqual, throws } = require('assert');
 }
 
 {
-  // Test that AbortController properties and methods
-  // validate the receiver object
+  // Test that AbortController properties and methods validate the receiver
   const acSignalGet = Object.getOwnPropertyDescriptor(
     AbortController.prototype,
     'signal'
@@ -107,8 +106,7 @@ const { ok, strictEqual, throws } = require('assert');
 }
 
 {
-  // Test that AbortSignal properties
-  // validate the receiver object
+  // Test that AbortSignal properties validate the receiver
   const signalAbortedGet = Object.getOwnPropertyDescriptor(
     AbortSignal.prototype,
     'aborted'


### PR DESCRIPTION
Web IDL specifies that both [attributes](https://heycam.github.io/webidl/#dfn-attribute-getter) and [operations](https://heycam.github.io/webidl/#dfn-create-operation-function) of IDL interfaces should throw a `TypeError` if `this` does not implement the interface. These brand checks were missing for `AbortController` and `AbortSignal` (as noticed [here](https://github.com/nodejs/whatwg-stream/pull/3#discussion_r591943417)), so I added them.

Unfortunately, this is not straightforward to test. WPT has [an IDL test for this](https://github.com/web-platform-tests/wpt/blob/96c7f0b57b704c94a7535d58009500ea94c02995/dom/idlharness.any.js#L19-L20), but it's bunched up together with other IDL tests for `EventTarget`, `Event` and `CustomEvent`. Node supports the first two but not the last one, so the test would still fail. 😕 Suggestions are welcome!