### PR TITLE
fs: use default stack size for fsevents pthread on macOS 10.15+

### DIFF
--- a/deps/uv/src/unix/fsevents.c
+++ b/deps/uv/src/unix/fsevents.c
@@ -649,9 +649,15 @@ static int uv__fsevents_loop_init(uv_loop_t* loop) {
   if (pthread_attr_init(attr))
     attr = NULL;
 
+  /**
+   * macOS 10.15 FSEvents uses alloca() stack allocations, requiring a larger
+   * stack size. Leave this as the default 512KB size in that case.
+   */
+  #if MAC_OS_X_VERSION_MAX_ALLOWED < 101500
   if (attr != NULL)
     if (pthread_attr_setstacksize(attr, 4 * PTHREAD_STACK_MIN))
       abort();
+  #endif
 
   loop->cf_state = state;
 


### PR DESCRIPTION
This fixes `SIGBUS` crashes on macOS 10.15 due to FSEvents code attempting to allocate large arrays on the stack.

The existing size (`4 * PTHREAD_STACK_MIN` or 32KB) causes a stack overflow when more than ~1000 events are received at once. See https://github.com/nodejs/node/issues/37697#issuecomment-797146408 for a more detailed explanation. Removing the manual `pthread_attr_setstacksize` call here [defaults to a stack size of 512KB](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Multithreading/CreatingThreads/CreatingThreads.html#//apple_ref/doc/uid/10000057i-CH15-SW7).

A similar issue appeared in the past when Apple updated their FSEvents code on OS X 10.9 . https://github.com/joyent/libuv/pull/964

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
