### PR TITLE
src: allow CAP_NET_BIND_SERVICE in SafeGetenv

### DIFF
--- a/src/node_credentials.cc
+++ b/src/node_credentials.cc
@@ -48,10 +48,14 @@ bool HasOnly(int capability) {
     getpid()};
 
 
-  if (syscall(SYS_capget, &cap_header_data, &cap_data[0]) != 0) {
+  if (syscall(SYS_capget, &cap_header_data, &cap_data) != 0) {
     return false;
   }
-  return cap_data[0].effective ==
+  if (capability < 32) {
+    return cap_data[0].permitted ==
+        static_cast<unsigned int>(CAP_TO_MASK(capability));
+  }
+  return cap_data[1].permitted ==
       static_cast<unsigned int>(CAP_TO_MASK(capability));
 }
 #endif

--- a/src/node_credentials.cc
+++ b/src/node_credentials.cc
@@ -11,6 +11,10 @@
 #if !defined(_MSC_VER)
 #include <unistd.h>  // setuid, getuid
 #endif
+#ifdef __linux__
+#include <linux/capability.h>
+#include <sys/syscall.h>
+#endif  // __linux__
 
 namespace node {
 
@@ -33,11 +37,38 @@ bool linux_at_secure = false;
 
 namespace credentials {
 
-// Look up environment variable unless running as setuid root.
+#if defined(__linux__)
+// Returns true if the current process only has the passed-in capability.
+bool HasOnly(int capability) {
+  DCHECK(cap_valid(capability));
+
+  struct __user_cap_data_struct cap_data[2];
+  struct __user_cap_header_struct cap_header_data = {
+    _LINUX_CAPABILITY_VERSION_3,
+    getpid()};
+
+
+  if (syscall(SYS_capget, &cap_header_data, &cap_data[0]) != 0) {
+    return false;
+  }
+  return cap_data[0].effective ==
+      static_cast<unsigned int>(CAP_TO_MASK(capability));
+}
+#endif
+
+// Look up the environment variable and allow the lookup if the current
+// process only has the capability CAP_NET_BIND_SERVICE set. If the current
+// process does not have any capabilities set and the process is running as
+// setuid root then lookup will not be allowed.
 bool SafeGetenv(const char* key, std::string* text, Environment* env) {
 #if !defined(__CloudABI__) && !defined(_WIN32)
+#if defined(__linux__)
+  if ((!HasOnly(CAP_NET_BIND_SERVICE) && per_process::linux_at_secure) ||
+      getuid() != geteuid() || getgid() != getegid())
+#else
   if (per_process::linux_at_secure || getuid() != geteuid() ||
       getgid() != getegid())
+#endif
     goto fail;
 #endif
 


### PR DESCRIPTION
This commit updates SafeGetenv to check if the current process has the
effective capability `cap_net_bind_service` set, and if so allows
environment variables to be read.
    
The motivation for this change is a use-case where Node is run in a
container, and the is a requirement to be able to listen to ports
below 1024. This is done by setting the capability of
`cap_net_bind_service`. In addition there is a need to set the
environment variable `NODE_EXTRA_CA_CERTS`. But currently this
environment variable will not be read when the capability has been set
on the executable.

----
### Manual tests
#### No caps or setuid                                                             
```console                                                                      
$ env NODE_EXTRA_CA_CERTS="something" out/Release/node -p 'process.versions.node'
Warning: Ignoring extra certs from `something`, load failed: error:02001002:system library:fopen:No such file or directory
17.0.0-pre                                                                   
```                                                                             
Environment variables should be readable, hence the warning.                    
                                                                                
                                                                                
#### With multiple caps                                                            
```console                                                                      
$ sudo setcap cap_net_broadcast,cap_net_bind_service+p out/Release/node        
$ env NODE_EXTRA_CA_CERTS="something" out/Release/node -p 'process.versions.node'
17.0.0-pre                                                                      
```                                                                             
Environment variables are not readable (no warning).                            
                                                                                
#### With only cap_net_bind_service cap                                             
```console                                                                      
$ sudo setcap cap_net_bind_service+p out/Release/node                          
$ env NODE_EXTRA_CA_CERTS="something" out/Release/node -p 'process.versions.node'
Warning: Ignoring extra certs from `something`, load failed: error:02001002:system library:fopen:No such file or directory
17.0.0-pre                                                                      
```     
Environment variables should be readable, hence the warning.                    
                                                                        
                                                                                
#### With setuid with no caps                                                       
```console                                                                      
$ sudo setcap -r out/Release/node                                               
$ getcap out/Release/node                                                       
$ su -                                                                          
[root@localhost ~]# cd /home/danielbevenius/work/nodejs/node                    
[root@localhost node]# chown root:root out/Release/node                         
[root@localhost node]# chmod u+s out/Release/node                               
[root@localhost node]# exit                                                     
$ ls -l out/Release/node                                                        
-rwsrwxr-x. 1 root root 78713256 Mar 29 11:04 out/Release/node                  
$ env NODE_EXTRA_CA_CERTS="something" out/Release/node -p 'process.versions.node'
17.0.0-pre                                                                      
```                                                                             
Environment variables are not readable (no warning).                            
                                                                                
#### With setuid with multiple caps                                                 
```console                                                                      
$ sudo setcap cap_net_broadcast,cap_net_bind_service+p out/Release/node        
$ env NODE_EXTRA_CA_CERTS="something" out/Release/node -p 'process.versions.node'
17.0.0-pre                                                                      
```                                                                             
Environment variables are not readable (no warning).                            
                                                                                
#### With setuid and only cap_net_bind_service cap                                
```console                                                                      
$ sudo setcap cap_net_bind_service+ep out/Release/node                          
$ env NODE_EXTRA_CA_CERTS="something" out/Release/node -p 'process.versions.node'
17.0.0-pre                                                                      
```                                                                             
Environment variables are not readable (no warning).