### PR TITLE
http: fix double AbortSignal registration

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -288,14 +288,20 @@ function ClientRequest(input, options, cb) {
                       options.headers);
   }
 
+  let optsWithoutSignal = options;
+  if (optsWithoutSignal.signal) {
+    optsWithoutSignal = ObjectAssign({}, options);
+    delete optsWithoutSignal.signal;
+  }
+
   // initiate connection
   if (this.agent) {
-    this.agent.addRequest(this, options);
+    this.agent.addRequest(this, optsWithoutSignal);
   } else {
     // No agent, default to Connection:close.
     this._last = true;
     this.shouldKeepAlive = false;
-    if (typeof options.createConnection === 'function') {
+    if (typeof optsWithoutSignal.createConnection === 'function') {
       const oncreate = once((err, socket) => {
         if (err) {
           process.nextTick(() => emitError(this, err));
@@ -305,7 +311,8 @@ function ClientRequest(input, options, cb) {
       });
 
       try {
-        const newSocket = options.createConnection(options, oncreate);
+        const newSocket = optsWithoutSignal.createConnection(optsWithoutSignal,
+                                                             oncreate);
         if (newSocket) {
           oncreate(null, newSocket);
         }
@@ -313,8 +320,8 @@ function ClientRequest(input, options, cb) {
         oncreate(err);
       }
     } else {
-      debug('CLIENT use net.createConnection', options);
-      this.onSocket(net.createConnection(options));
+      debug('CLIENT use net.createConnection', optsWithoutSignal);
+      this.onSocket(net.createConnection(optsWithoutSignal));
     }
   }
 }

--- a/test/parallel/test-http-agent-abort-controller.js
+++ b/test/parallel/test-http-agent-abort-controller.js
@@ -1,0 +1,73 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+const Agent = http.Agent;
+const { getEventListeners, once } = require('events');
+const agent = new Agent();
+const server = http.createServer();
+
+server.listen(0, common.mustCall(async () => {
+  const port = server.address().port;
+  const host = 'localhost';
+  const options = {
+    port: port,
+    host: host,
+    _agentKey: agent.getName({ port, host })
+  };
+
+  async function postCreateConnection() {
+    const ac = new AbortController();
+    const { signal } = ac;
+    const connection = agent.createConnection({ ...options, signal });
+    assert.strictEqual(getEventListeners(signal, 'abort').length, 1);
+    ac.abort();
+    const [err] = await once(connection, 'error');
+    assert.strictEqual(err?.name, 'AbortError');
+  }
+
+  async function preCreateConnection() {
+    const ac = new AbortController();
+    const { signal } = ac;
+    ac.abort();
+    const connection = agent.createConnection({ ...options, signal });
+    const [err] = await once(connection, 'error');
+    assert.strictEqual(err?.name, 'AbortError');
+  }
+
+  async function agentAsParam() {
+    const ac = new AbortController();
+    const { signal } = ac;
+    const request = http.get({
+      port: server.address().port,
+      path: '/hello',
+      agent: agent,
+      signal,
+    });
+    assert.strictEqual(getEventListeners(signal, 'abort').length, 1);
+    ac.abort();
+    const [err] = await once(request, 'error');
+    assert.strictEqual(err?.name, 'AbortError');
+  }
+
+  async function agentAsParamPreAbort() {
+    const ac = new AbortController();
+    const { signal } = ac;
+    ac.abort();
+    const request = http.get({
+      port: server.address().port,
+      path: '/hello',
+      agent: agent,
+      signal,
+    });
+    assert.strictEqual(getEventListeners(signal, 'abort').length, 0);
+    const [err] = await once(request, 'error');
+    assert.strictEqual(err?.name, 'AbortError');
+  }
+
+  await postCreateConnection();
+  await preCreateConnection();
+  await agentAsParam();
+  await agentAsParamPreAbort();
+  server.close();
+}));

--- a/test/parallel/test-https-abortcontroller.js
+++ b/test/parallel/test-https-abortcontroller.js
@@ -7,7 +7,7 @@ if (!common.hasCrypto)
 const fixtures = require('../common/fixtures');
 const https = require('https');
 const assert = require('assert');
-const { once } = require('events');
+const { once, getEventListeners } = require('events');
 
 const options = {
   key: fixtures.readKey('agent1-key.pem'),
@@ -29,6 +29,7 @@ const options = {
       rejectUnauthorized: false,
       signal: ac.signal,
     });
+    assert.strictEqual(getEventListeners(ac.signal, 'abort').length, 1);
     process.nextTick(() => ac.abort());
     const [ err ] = await once(req, 'error');
     assert.strictEqual(err.name, 'AbortError');


### PR DESCRIPTION
It looks like https://github.com/nodejs/node/pull/36431 added support for AbortSignal to `net.createConnection` and `net.connect` (will add tests/docs in a separate PR). This caused "double registration" to the AbortSignal. This PR fixes the issue by removing the signal from the internal calls to `net`.

Also added tests for http.agent

@benjamingr 