### PR TITLE
stream: pipeline should accept Buffer as a valid first argument

### DIFF
--- a/lib/internal/streams/utils.js
+++ b/lib/internal/streams/utils.js
@@ -6,11 +6,13 @@ const {
 } = primordials;
 
 function isReadable(obj) {
-  return !!(obj && typeof obj.pipe === 'function');
+  return !!(obj && typeof obj.pipe === 'function' &&
+            typeof obj.on === 'function');
 }
 
 function isWritable(obj) {
-  return !!(obj && typeof obj.write === 'function');
+  return !!(obj && typeof obj.write === 'function' &&
+            typeof obj.on === 'function');
 }
 
 function isStream(obj) {

--- a/test/parallel/test-stream-pipeline.js
+++ b/test/parallel/test-stream-pipeline.js
@@ -1339,3 +1339,19 @@ const net = require('net');
     assert.strictEqual(res, '123');
   }));
 }
+
+{
+  const content = 'abc';
+  pipeline(Buffer.from(content), PassThrough({ objectMode: true }),
+           common.mustSucceed(() => {}));
+
+  let res = '';
+  pipeline(Buffer.from(content), async function*(previous) {
+    for await (const val of previous) {
+      res += String.fromCharCode(val);
+      yield val;
+    }
+  }, common.mustSucceed(() => {
+    assert.strictEqual(res, content);
+  }));
+}


### PR DESCRIPTION
Change `isStream` to also check existence of `on`, so it won't mistake Buffers as Writable.

fixes: https://github.com/nodejs/node/issues/37731
