### PR TITLE
lib: fix typo in lib/internal/crypto/certificate.js

### DIFF
--- a/lib/internal/crypto/certificate.js
+++ b/lib/internal/crypto/certificate.js
@@ -11,7 +11,7 @@ const {
 } = require('internal/crypto/util');
 
 // The functions contained in this file cover the SPKAC format
-// (also refered to as Netscape SPKI). A general description of
+// (also referred to as Netscape SPKI). A general description of
 // the format can be found at https://en.wikipedia.org/wiki/SPKAC
 
 function verifySpkac(spkac, encoding) {


### PR DESCRIPTION
'referred' spelled as 'refered'