### PR TITLE
buffer,errors: add missing n literal in range error string

### DIFF
--- a/lib/internal/buffer.js
+++ b/lib/internal/buffer.js
@@ -63,8 +63,8 @@ function checkInt(value, min, max, buf, offset, byteLength) {
       if (min === 0 || min === 0n) {
         range = `>= 0${n} and < 2${n} ** ${(byteLength + 1) * 8}${n}`;
       } else {
-        range = `>= -(2${n} ** ${(byteLength + 1) * 8 - 1}${n}) and < 2 ** ` +
-                `${(byteLength + 1) * 8 - 1}${n}`;
+        range = `>= -(2${n} ** ${(byteLength + 1) * 8 - 1}${n}) and ` +
+                `< 2${n} ** ${(byteLength + 1) * 8 - 1}${n}`;
       }
     } else {
       range = `>= ${min}${n} and <= ${max}${n}`;


### PR DESCRIPTION
<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This adds the missing `n` literal for `BigInt` range errors in buffers.

Here's an example from the REPL with arrows pointing at where the `n` literal is missing.

```bash
> const buffer = Buffer.alloc(1024)
undefined
> buffer.writeBigInt64BE(2n ** 64n)
Uncaught:
RangeError [ERR_OUT_OF_RANGE]: The value of "value" is out of range. It must be >= -(2n ** 63n) and < 2 ** 63n. Received 18_446_744_073_709_551_616n
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>^
    at checkInt (internal/buffer.js:67:11)
    at writeBigU_Int64BE (internal/buffer.js:600:3)
    at Buffer.writeBigInt64BE (internal/buffer.js:631:10)
    at repl:1:8
    at Script.runInThisContext (vm.js:132:18)
    at REPLServer.defaultEval (repl.js:472:29)
    at bound (domain.js:430:14)
    at REPLServer.runBound [as eval] (domain.js:443:12)
    at REPLServer.onLine (repl.js:794:10)
    at REPLServer.emit (events.js:326:22) {
  code: 'ERR_OUT_OF_RANGE'
}
```
