### PR TITLE
worker: add addPreload API

### DIFF
--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -3,6 +3,7 @@
 /* global SharedArrayBuffer */
 
 const {
+  ArrayFrom,
   ArrayIsArray,
   ArrayPrototypeForEach,
   ArrayPrototypeMap,
@@ -19,6 +20,7 @@ const {
   RegExpPrototypeTest,
   SafeArrayIterator,
   SafeMap,
+  SafeSet,
   String,
   Symbol,
   SymbolFor,
@@ -58,7 +60,10 @@ const {
 } = workerIo;
 const { deserializeError } = require('internal/error_serdes');
 const { fileURLToPath, isURLInstance, pathToFileURL } = require('internal/url');
-const { validateArray } = require('internal/validators');
+const {
+  validateArray,
+  validateString,
+} = require('internal/validators');
 
 const {
   ownsProcessState,
@@ -92,6 +97,7 @@ let debug = require('internal/util/debuglog').debuglog('worker', (fn) => {
 let cwdCounter;
 
 const environmentData = new SafeMap();
+const preloads = new SafeSet();
 
 if (isMainThread) {
   cwdCounter = new Uint32Array(new SharedArrayBuffer(4));
@@ -118,6 +124,11 @@ function assignEnvironmentData(data) {
   data.forEach((value, key) => {
     environmentData.set(key, value);
   });
+}
+
+function addPreload(module) {
+  validateString(module, 'module');
+  preloads.add(module);
 }
 
 class Worker extends EventEmitter {
@@ -196,7 +207,8 @@ class Worker extends EventEmitter {
                                    env === process.env ? null : env,
                                    options.execArgv,
                                    parseResourceLimits(options.resourceLimits),
-                                   !!(options.trackUnmanagedFds ?? true));
+                                   !!(options.trackUnmanagedFds ?? true),
+                                   ArrayFrom(preloads));
     if (this[kHandle].invalidExecArgv) {
       throw new ERR_WORKER_INVALID_EXEC_ARGV(this[kHandle].invalidExecArgv);
     }
@@ -518,6 +530,7 @@ module.exports = {
   setEnvironmentData,
   getEnvironmentData,
   assignEnvironmentData,
+  addPreload,
   threadId,
   Worker,
 };

--- a/lib/worker_threads.js
+++ b/lib/worker_threads.js
@@ -6,6 +6,7 @@ const {
   resourceLimits,
   setEnvironmentData,
   getEnvironmentData,
+  addPreload,
   threadId,
   Worker
 } = require('internal/worker');
@@ -38,4 +39,5 @@ module.exports = {
   BroadcastChannel,
   setEnvironmentData,
   getEnvironmentData,
+  addPreload,
 };


### PR DESCRIPTION
Adds a `worker_threads.addPreload(module)` API to allow injecting
preload modules for all new workers without modifying `new Worker()`
calls.

```js
const { Worker, addPreload } = require('worker_threads');

addPreload('./foo.js');

new Worker('console.log(process.execArgv)', { eval: true });
```

This is currently a draft to solicit feedback on the API. /cc @coreyfarrell @addaleax @gireeshpunathil 

This works by injecting the `-r {module}` into the execArgv and appending to the environment options. This ensures that the modules are inherited.

There are a couple of questions that need answering:

1. Should injected preload modules run *before* or *after* preload modules explicitly listed in execArgv?
2. Should there be a way of removing preload modules added with `addPreload()`, and should that have any impact on those added explicitly via `execArgv`?

Signed-off-by: James M Snell <jasnell@gmail.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
