### PR TITLE
build: default PYTHON to python3 in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 -include config.mk
 
 BUILDTYPE ?= Release
-PYTHON ?= python
+PYTHON ?= python3
 DESTDIR ?=
 SIGN ?=
 PREFIX ?= /usr/local


### PR DESCRIPTION
So that direct calls to `make` which spawn the configure script do not use Python 2.
