### PR TITLE
test: reduce memory usage of test-worker-stdio

### DIFF
--- a/test/parallel/test-worker-stdio.js
+++ b/test/parallel/test-worker-stdio.js
@@ -27,7 +27,7 @@ if (isMainThread) {
   const passed = new BufferingWritable();
 
   const w = new Worker(__filename, { stdin: true, stdout: true });
-  const source = fs.createReadStream(process.execPath);
+  const source = fs.createReadStream(process.execPath, { end: 1_000_000 });
   source.pipe(w.stdin);
   source.pipe(original);
   w.stdout.pipe(passed);


### PR DESCRIPTION
On systems with limited memory and that are compiled with debugging
information, this particular test is causing OOM condition
especially as it is run in parallel. Even when run with a stripped
binary as an input, the test consumes upward of 250M RSS. By
limiting the input stream to the 1M, the stream is still buffering
but memory consumption is similar to other parallel tests.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
