### PR TITLE
test: skip some console tests on dumb terminal

### DIFF
--- a/test/parallel/test-repl-mode.js
+++ b/test/parallel/test-repl-mode.js
@@ -1,8 +1,10 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const Stream = require('stream');
 const repl = require('repl');
+
+common.skipIfDumbTerminal();
 
 const tests = [
   testSloppyMode,

--- a/test/parallel/test-repl-strict-mode-previews.js
+++ b/test/parallel/test-repl-strict-mode-previews.js
@@ -5,6 +5,7 @@
 const common = require('../common');
 
 common.skipIfInspectorDisabled();
+common.skipIfDumbTerminal();
 
 if (process.argv[2] === 'child') {
   const stream = require('stream');


### PR DESCRIPTION
This adds two more tests to be skipped on systems with only a
dumb terminal. See PR #33165 for details.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
