### PR TITLE
perf: add toJSON to performance class

### DIFF
--- a/doc/api/perf_hooks.md
+++ b/doc/api/perf_hooks.md
@@ -261,6 +261,14 @@ If the wrapped function returns a promise, a finally handler will be attached
 to the promise and the duration will be reported once the finally handler is
 invoked.
 
+### `performance.toJSON()`
+<!-- YAML
+added: REPLACEME
+-->
+
+An object which is JSON representation of the `performance` object. It
+is similar to [`window.performance.toJSON`][] in browsers.
+
 ## Class: `PerformanceEntry`
 <!-- YAML
 added: v8.5.0
@@ -1025,4 +1033,5 @@ require('some-module');
 [`child_process.spawnSync()`]: child_process.md#child_process_child_process_spawnsync_command_args_options
 [`process.hrtime()`]: process.md#process_process_hrtime_time
 [`timeOrigin`]: https://w3c.github.io/hr-time/#dom-performance-timeorigin
+[`window.performance.toJSON`]: https://developer.mozilla.org/en-US/docs/Web/API/Performance/toJSON
 [`window.performance`]: https://developer.mozilla.org/en-US/docs/Web/API/Window/performance

--- a/lib/perf_hooks.js
+++ b/lib/perf_hooks.js
@@ -59,6 +59,15 @@ class Performance extends EventTarget {
       timeOrigin: this.timeOrigin,
     }, opts)}`;
   }
+
+}
+
+function toJSON() {
+  return {
+    nodeTiming: this.nodeTiming,
+    timeOrigin: this.timeOrigin,
+    eventLoopUtilization: this.eventLoopUtilization()
+  };
 }
 
 class InternalPerformance extends EventTarget {}
@@ -105,6 +114,11 @@ ObjectDefineProperties(Performance.prototype, {
     configurable: true,
     enumerable: true,
     value: timeOriginTimestamp,
+  },
+  toJSON: {
+    configurable: true,
+    enumerable: true,
+    value: toJSON,
   }
 });
 

--- a/test/parallel/test-tojson-perf_hooks.js
+++ b/test/parallel/test-tojson-perf_hooks.js
@@ -1,0 +1,14 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const { performance } = require('perf_hooks');
+
+// Test toJSON for performance object
+{
+  assert.strictEqual(typeof performance.toJSON, 'function');
+  const jsonObject = performance.toJSON();
+  assert.strictEqual(typeof jsonObject, 'object');
+  assert.strictEqual(jsonObject.timeOrigin, performance.timeOrigin);
+  assert.strictEqual(typeof jsonObject.nodeTiming, 'object');
+}


### PR DESCRIPTION
Added toJSON method to the InternalPerformance class as per the
convention followed in other performance classes and per the spec:
https://www.w3.org/TR/hr-time/#tojson-method

Fixes: #37623
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->