### PR TITLE
doc: fix typo in lib/internal/modules/esm/module_job.js

### DIFF
--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -120,7 +120,7 @@ class ModuleJob {
           const importStatement = splitStack[1];
           // TODO(@ctavan): The original error stack only provides the single
           // line which causes the error. For multi-line import statements we
-          // cannot generate an equivalent object descructuring assignment by
+          // cannot generate an equivalent object destructuring assignment by
           // just parsing the error stack.
           const oneLineNamedImports = StringPrototypeMatch(importStatement, /{.*}/);
           const destructuringAssignment = oneLineNamedImports &&


### PR DESCRIPTION
'destructuring' spelled as 'descructuring'