### PR TITLE
doc: add Ayase-252 to triagers

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,6 +591,8 @@ maintaining the Node.js project.
 
 ### Triagers
 
+* [Ayase-252](https://github.com/Ayase-252) -
+**Qingyu Deng** &lt;i@ayase-lab.com&gt;
 * [marsonya](https://github.com/marsonya) -
 **Akhil Marsonya** &lt;akhil.marsonya27@gmail.com&gt; (he/him)
 * [PoojaDurgad](https://github.com/PoojaDurgad) -


### PR DESCRIPTION
 I would like apply for a Triager role following procedure in [Triaging a Bug Report](https://github.com/nodejs/node/blob/master/doc/guides/contributing/issues.md#triaging-a-bug-report) section.

## The motivation for becoming a triager

I believe that the best way to master a tech is practicing as much as possible. and, I think that becoming a triager can provide different perspectives on Node.js. Moreover, reading code with goal may improve my understanding on the Node.js codebase further.

Also, I benifit a lot from Node.js and its ecosystem also as a web developer. Triaging could be a great way to make contribution to the community.

## Agreement on CoC

I have read the [Code of Conduct](https://github.com/nodejs/admin/blob/HEAD/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct), and understood and will adhere the CoC.