### PR TITLE
doc: add legacy status

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2172,12 +2172,15 @@ future release.
 ### DEP0116: Legacy URL API
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/37784
+    description: Deprecation revoked. Status changed to "Legacy".
   - version: v11.0.0
     pr-url: https://github.com/nodejs/node/pull/22715
     description: Documentation-only deprecation.
 -->
 
-Type: Documentation-only
+Type: Deprecation revoked
 
 The [Legacy URL API][] is deprecated. This includes [`url.format()`][],
 [`url.parse()`][], [`url.resolve()`][], and the [legacy `urlObject`][]. Please

--- a/doc/api/documentation.md
+++ b/doc/api/documentation.md
@@ -37,6 +37,12 @@ The stability indices are as follows:
 > Stability: 2 - Stable. Compatibility with the npm ecosystem is a high
 > priority.
 
+<!-- separator -->
+
+> Stability: 3 - Legacy. The feature is no longer recommended for use. While it
+likely will not be removed, and is still covered by semantic-versioning
+guarantees, use of the feature should be avoided.
+
 Use caution when making use of Experimental features, particularly within
 modules. Users may not be aware that experimental features are being used.
 Bugs or behavior changes may surprise users when Experimental API

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -1075,18 +1075,29 @@ console.log(urlToHttpOptions(myUrl));
 
 ## Legacy URL API
 <!-- YAML
-deprecated: v11.0.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/37784
+    description: Deprecation revoked. Status changed to "Legacy".
+  - version: v11.0.0
+    pr-url: https://github.com/nodejs/node/pull/22715
+    description: This API is deprecated.
 -->
+
+> Stability: 3 - Legacy: Use the WHATWG URL API instead.
 
 ### Legacy `urlObject`
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/37784
+    description: Deprecation revoked. Status changed to "Legacy".
   - version: v11.0.0
     pr-url: https://github.com/nodejs/node/pull/22715
     description: The Legacy URL API is deprecated. Use the WHATWG URL API.
 -->
 
-> Stability: 0 - Deprecated: Use the WHATWG URL API instead.
+> Stability: 3 - Legacy: Use the WHATWG URL API instead.
 
 The legacy `urlObject` (`require('url').Url`) is created and returned by the
 `url.parse()` function.
@@ -1192,6 +1203,9 @@ forward-slash characters (`/`) are required following the colon in the
 <!-- YAML
 added: v0.1.25
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/37784
+    description: Deprecation revoked. Status changed to "Legacy".
   - version: v11.0.0
     pr-url: https://github.com/nodejs/node/pull/22715
     description: The Legacy URL API is deprecated. Use the WHATWG URL API.
@@ -1203,7 +1217,7 @@ changes:
                  times.
 -->
 
-> Stability: 0 - Deprecated: Use the WHATWG URL API instead.
+> Stability: 3 - Legacy: Use the WHATWG URL API instead.
 
 * `urlObject` {Object|string} A URL object (as returned by `url.parse()` or
   constructed otherwise). If a string, it is converted to an object by passing
@@ -1285,6 +1299,9 @@ The formatting process operates as follows:
 <!-- YAML
 added: v0.1.25
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/37784
+    description: Deprecation revoked. Status changed to "Legacy".
   - version: v11.14.0
     pr-url: https://github.com/nodejs/node/pull/26941
     description: The `pathname` property on the returned URL object is now `/`
@@ -1299,7 +1316,7 @@ changes:
                  when no query string is present.
 -->
 
-> Stability: 0 - Deprecated: Use the WHATWG URL API instead.
+> Stability: 3 - Legacy: Use the WHATWG URL API instead.
 
 * `urlString` {string} The URL string to parse.
 * `parseQueryString` {boolean} If `true`, the `query` property will always
@@ -1329,6 +1346,9 @@ incorrect handling of usernames and passwords have been identified.
 <!-- YAML
 added: v0.1.25
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/37784
+    description: Deprecation revoked. Status changed to "Legacy".
   - version: v11.0.0
     pr-url: https://github.com/nodejs/node/pull/22715
     description: The Legacy URL API is deprecated. Use the WHATWG URL API.
@@ -1347,7 +1367,7 @@ changes:
                  contains a hostname.
 -->
 
-> Stability: 0 - Deprecated: Use the WHATWG URL API instead.
+> Stability: 3 - Legacy: Use the WHATWG URL API instead.
 
 * `from` {string} The Base URL being resolved against.
 * `to` {string} The HREF URL being resolved.

--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -4,6 +4,7 @@
   --black1: #090c15;
   --black2: #2c3437;
   --black3: #0d111d;
+  --blue1: #00f;
   --white: #ffffff;
   --white-smoke: #f2f2f2;
   --grey-smoke: #e9edf0;
@@ -263,6 +264,10 @@ ol.version-picker li:last-child a {
   background-color: var(--green2);
 }
 
+.api_stability_3 {
+  background-color: var(--blue1);
+}
+
 .module_stability {
   vertical-align: middle;
 }
@@ -372,7 +377,7 @@ dd + dt.pre {
 #apicontent {
   padding-top: 1rem;
 }
-  
+
 #apicontent section {
   content-visibility: auto;
   contain-intrinsic-size: 1px 5000px;


### PR DESCRIPTION
Adds a new "Legacy" option to the stability index. The idea here is to give us another alternative to deprecating. Legacy code is still subject to semver rules but is specifically called out as legacy and to be avoided.

Marks the legacy URL parser as legacy, removing deprecated.

/cc @nodejs/tsc @addaleax @ljharb 