### PR TITLE
doc: add more commands for cherry-picking and changelog to release docs

### DIFF
--- a/doc/guides/releases.md
+++ b/doc/guides/releases.md
@@ -175,10 +175,10 @@ duplicate or not.
 For a list of commits that could be landed in a patch release on v1.x:
 
 ```console
-$ branch-diff v1.x-staging master --exclude-label=semver-major,semver-minor,dont-land-on-v1.x,backport-requested-v1.x --filter-release --format=simple
+$ branch-diff v1.x-staging master --exclude-label=semver-major,semver-minor,dont-land-on-v1.x,backport-requested-v1.x,backport-blocked-v1.x --filter-release --format=simple
 ```
 
-Previous release commits and version bumps do not need to be
+Previously released commits and version bumps do not need to be
 cherry-picked.
 
 Carefully review the list of commits:
@@ -187,8 +187,16 @@ Carefully review the list of commits:
 * Checking semver status - Commits labeled as `semver-minor` or `semver-major`
 should only be cherry-picked when appropriate for the type of release being
 made.
-* If you think it's risky so should wait for a while, add the `baking-for-lts`
-tag.
+* If you think it's risky and the change should wait for a while, add the
+`baking-for-lts` tag.
+
+When you are ready to cherry-pick commits, you can automate with the following
+command. (For semver-minor releases, make sure to remove the `semver-minor` tag
+from `exclude-label`.)
+
+```console
+$ branch-diff v1.x-staging master --exclude-label=semver-major,semver-minor,dont-land-on-v1.x,backport-requested-v1.x,backport-blocked-v1.x --filter-release --format=sha --reverse | xargs git cherry-pick
+```
 
 When cherry-picking commits, if there are simple conflicts you can resolve
 them. Otherwise, add the `backport-requested-vN.x` label to the original PR
@@ -196,8 +204,13 @@ and post a comment stating that it does not land cleanly and will require a
 backport PR. You can refer the owner of the PR to the "[Backporting to Release
  Lines](https://github.com/nodejs/node/blob/HEAD/doc/guides/backporting-to-release-lines.md)" guide.
 
-If commits were cherry-picked in this step, check that the test still pass and
-push to the staging branch to keep it up-to-date.
+If commits were cherry-picked in this step, check that the test still pass.
+
+```console
+$ make test
+```
+
+Then, push to the staging branch to keep it up-to-date.
 
 ```console
 $ git push upstream v1.x-staging
@@ -274,8 +287,10 @@ in the repository was not on the current branch you may have to supply a
 `--start-ref` argument:
 
 ```console
-$ changelog-maker --group --start-ref v1.2.2
+$ changelog-maker --group --filter-release --start-ref v1.2.2
 ```
+
+`--filter-release` will remove the release commit from the previous release.
 
 #### Step 2: Update the appropriate doc/changelogs/CHANGELOG_*.md file
 


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
This adds a few command-specific steps to the release docs.