### PR TITLE
buffer: expose btoa and atob as globals

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -329,5 +329,7 @@ module.exports = {
     TextDecoder: 'readable',
     queueMicrotask: 'readable',
     globalThis: 'readable',
+    btoa: 'readable',
+    atob: 'readable',
   },
 };

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -3282,6 +3282,8 @@ accessed using `require('buffer')`.
 added: REPLACEME
 -->
 
+> Stability: 3 - Legacy. Use `Buffer.from(data, 'base64')` instead.
+
 * `data` {any} The Base64-encoded input string.
 
 Decodes a string of Base64-encoded data into bytes, and encodes those bytes
@@ -3300,6 +3302,8 @@ and binary data should be performed using `Buffer.from(str, 'base64')` and
 <!-- YAML
 added: REPLACEME
 -->
+
+> Stability: 3 - Legacy. Use `buf.toString('base64')` instead.
 
 * `data` {any} An ASCII (Latin1) string.
 

--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -146,6 +146,24 @@ This variable may appear to be global but is not. See [`__dirname`][].
 
 This variable may appear to be global but is not. See [`__filename`][].
 
+## `atob(data)`
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 3 - Legacy. Use `Buffer.from(data, 'base64')` instead.
+
+Global alias for [`buffer.atob()`][].
+
+## `btoa(data)`
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 3 - Legacy. Use `buf.toString('base64')` instead.
+
+Global alias for [`buffer.btoa()`][].
+
 ## `clearImmediate(immediateObject)`
 <!-- YAML
 added: v0.9.1
@@ -402,6 +420,8 @@ The object that acts as the namespace for all W3C
 [`URL`]: url.md#url_class_url
 [`__dirname`]: modules.md#modules_dirname
 [`__filename`]: modules.md#modules_filename
+[`buffer.atob()`]: buffer.md#buffer_buffer_atob_data
+[`buffer.btoa()`]: buffer.md#buffer_buffer_btoa_data
 [`clearImmediate`]: timers.md#timers_clearimmediate_immediate
 [`clearInterval`]: timers.md#timers_clearinterval_timeout
 [`clearTimeout`]: timers.md#timers_cleartimeout_timeout

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -42,6 +42,7 @@ const {
   FunctionPrototypeCall,
   JSONParse,
   ObjectDefineProperty,
+  ObjectDefineProperties,
   ObjectGetPrototypeOf,
   ObjectPreventExtensions,
   ObjectSetPrototypeOf,
@@ -400,7 +401,11 @@ function setupGlobalProxy() {
 }
 
 function setupBuffer() {
-  const { Buffer } = require('buffer');
+  const {
+    Buffer,
+    atob,
+    btoa,
+  } = require('buffer');
   const bufferBinding = internalBinding('buffer');
 
   // Only after this point can C++ use Buffer::New()
@@ -408,11 +413,25 @@ function setupBuffer() {
   delete bufferBinding.setBufferPrototype;
   delete bufferBinding.zeroFill;
 
-  ObjectDefineProperty(global, 'Buffer', {
-    value: Buffer,
-    enumerable: false,
-    writable: true,
-    configurable: true
+  ObjectDefineProperties(global, {
+    'Buffer': {
+      value: Buffer,
+      enumerable: false,
+      writable: true,
+      configurable: true,
+    },
+    'atob': {
+      value: atob,
+      enumerable: false,
+      writable: true,
+      configurable: true,
+    },
+    'btoa': {
+      value: btoa,
+      enumerable: false,
+      writable: true,
+      configurable: true,
+    },
   });
 }
 

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -38,6 +38,11 @@ const bits = ['arm64', 'mips', 'mipsel', 'ppc64', 's390x', 'x64']
   .includes(process.arch) ? 64 : 32;
 const hasIntl = !!process.config.variables.v8_enable_i18n_support;
 
+const {
+  atob,
+  btoa
+} = require('buffer');
+
 // Some tests assume a umask of 0o022 so set that up front. Tests that need a
 // different umask will set it themselves.
 //
@@ -257,6 +262,8 @@ function platformTimeout(ms) {
 }
 
 let knownGlobals = [
+  atob,
+  btoa,
   clearImmediate,
   clearInterval,
   clearTimeout,

--- a/test/parallel/test-btoa-atob-global.js
+++ b/test/parallel/test-btoa-atob-global.js
@@ -1,0 +1,9 @@
+'use strict';
+
+require('../common');
+
+const { strictEqual } = require('assert');
+const buffer = require('buffer');
+
+strictEqual(globalThis.atob, buffer.atob);
+strictEqual(globalThis.btoa, buffer.btoa);


### PR DESCRIPTION
Requires https://github.com/nodejs/node/pull/37529 to land first. The first two commits are from that other PR

Exposes the `atob()` and `btoa()` functions introduced in #37529 as globals as they are in the browsers and other platforms.

/cc @ljharb 

