### PR TITLE
lib: runtime deprecated access to process.binding('util')

### DIFF
--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -108,6 +108,7 @@ const internalBindingAllowlist = new SafeSet([
 
 const runtimeDeprecatedList = new SafeSet([
   'async_wrap',
+  'util',
 ]);
 
 // Set up process.binding() and process._linkedBinding().


### PR DESCRIPTION
The various `isType()` functions exposed by process.binding('util')
are already available via `util.types`, and the rest really aren't
safe for external use. Deprecate access with the intent of removing
access in the near future.

/cc @ljharb since I know lodash still references this for Node.js version < 10 (for those users still on < 10.x this deprecation message will never print anyway).

and @addaleax whom I know has opinions on this stuff ;-)

Signed-off-by: James M Snell <jasnell@gmail.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
