### PR TITLE
lib: runtime deprecate access to process.binding('v8')

### DIFF
--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -108,6 +108,7 @@ const internalBindingAllowlist = new SafeSet([
 
 const runtimeDeprecatedList = new SafeSet([
   'async_wrap',
+  'v8',
 ]);
 
 // Set up process.binding() and process._linkedBinding().


### PR DESCRIPTION
The only useful functions are already exposed via public APIs. There's no reason for user code to access the binding.

Signed-off-by: James M Snell <jasnell@gmail.com>
