### PR TITLE
crypto: fix header name

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -970,7 +970,7 @@
             'src/crypto/crypto_tls.h',
             'src/crypto/crypto_clienthello.h',
             'src/crypto/crypto_context.h',
-            'src/crypto/crypto_ecdh.h',
+            'src/crypto/crypto_ec.h',
             'src/crypto/crypto_hkdf.h',
             'src/crypto/crypto_pbkdf2.h',
             'src/crypto/crypto_sig.h',


### PR DESCRIPTION
cc @nodejs/crypto 

File is renamed in https://github.com/nodejs/node/pull/37048. Now is useless.