### PR TITLE
tools: update gitignore for CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,6 +139,15 @@ tools/*/*.i.tmp
 # === Rules for Windows vcbuild.bat ===
 /temp-vcbuild
 
+# === Rules for CMake ===
+cmake-build-debug/
+CMakeCache.txt
+CMakeFiles
+CTestTestfile.cmake
+cmake_install.cmake
+install_manifest.txt
+*.cbp
+
 # === Global Rules ===
 # Keep last to avoid being excluded
 *.pyc


### PR DESCRIPTION
I have using Clion for developing Node.js for a long time. But it's quite annoying I keep the redundant files I don't have to commit. So just ignore them (please free my pain 😃 ).

Currently things look like this:
![image](https://user-images.githubusercontent.com/3759816/111585798-cf095080-87fa-11eb-9fed-eeaf6772a001.png)
