### PR TITLE
test: refactor code to use AbortSignal.abort()

### DIFF
--- a/test/parallel/test-child-process-exec-abortcontroller-promisified.js
+++ b/test/parallel/test-child-process-exec-abortcontroller-promisified.js
@@ -37,9 +37,7 @@ const waitCommand = common.isLinux ?
 }
 
 {
-  const ac = new AbortController();
-  const { signal } = ac;
-  ac.abort();
+  const signal = AbortSignal.abort(); // Abort in advance
   const promise = execPromisifed(waitCommand, { signal });
 
   assert.rejects(promise, /AbortError/, 'pre aborted signal failed')

--- a/test/parallel/test-child-process-execFile-promisified-abortController.js
+++ b/test/parallel/test-child-process-execFile-promisified-abortController.js
@@ -29,9 +29,7 @@ const invalidArgTypeError = {
 
 {
   // Verify that the signal option works properly when already aborted
-  const ac = new AbortController();
-  const { signal } = ac;
-  ac.abort();
+  const signal = AbortSignal.abort();
 
   assert.rejects(
     promisified(process.execPath, [echoFixture, 0], { signal }),

--- a/test/parallel/test-child-process-execfile.js
+++ b/test/parallel/test-child-process-execfile.js
@@ -69,9 +69,7 @@ const execOpts = { encoding: 'utf8', shell: true };
 
 {
   // Verify that does not spawn a child if already aborted
-  const ac = new AbortController();
-  const { signal } = ac;
-  ac.abort();
+  const signal = AbortSignal.abort();
 
   const check = common.mustCall((err) => {
     assert.strictEqual(err.code, 'ABORT_ERR');

--- a/test/parallel/test-child-process-fork-abort-signal.js
+++ b/test/parallel/test-child-process-fork-abort-signal.js
@@ -23,9 +23,7 @@ const { fork } = require('child_process');
 }
 {
   // Test passing an already aborted signal to a forked child_process
-  const ac = new AbortController();
-  const { signal } = ac;
-  ac.abort();
+  const signal = AbortSignal.abort();
   const cp = fork(fixtures.path('child-process-stay-alive-forever.js'), {
     signal
   });
@@ -40,9 +38,7 @@ const { fork } = require('child_process');
 
 {
   // Test passing a different kill signal
-  const ac = new AbortController();
-  const { signal } = ac;
-  ac.abort();
+  const signal = AbortSignal.abort();
   const cp = fork(fixtures.path('child-process-stay-alive-forever.js'), {
     signal,
     killSignal: 'SIGKILL',

--- a/test/parallel/test-child-process-spawn-controller.js
+++ b/test/parallel/test-child-process-spawn-controller.js
@@ -29,10 +29,7 @@ const aliveScript = fixtures.path('child-process-stay-alive-forever.js');
 
 {
   // Verify that passing an already-aborted signal works.
-  const controller = new AbortController();
-  const { signal } = controller;
-
-  controller.abort();
+  const signal = AbortSignal.abort();
 
   const cp = spawn(process.execPath, [aliveScript], {
     signal,

--- a/test/parallel/test-dgram-close-signal.js
+++ b/test/parallel/test-dgram-close-signal.js
@@ -25,9 +25,7 @@ const dgram = require('dgram');
 
 {
   // Test close with pre-aborted signal.
-  const controller = new AbortController();
-  controller.abort();
-  const { signal } = controller;
+  const signal = AbortSignal.abort();
   const server = dgram.createSocket({ type: 'udp4', signal });
   server.on('close', common.mustCall());
 }

--- a/test/parallel/test-event-on-async-iterator.js
+++ b/test/parallel/test-event-on-async-iterator.js
@@ -248,28 +248,26 @@ async function nodeEventTarget() {
 
 async function abortableOnBefore() {
   const ee = new EventEmitter();
-  const ac = new AbortController();
-  ac.abort();
+  const abortedSignal = AbortSignal.abort();
   [1, {}, null, false, 'hi'].forEach((signal) => {
     assert.throws(() => on(ee, 'foo', { signal }), {
       code: 'ERR_INVALID_ARG_TYPE'
     });
   });
-  assert.throws(() => on(ee, 'foo', { signal: ac.signal }), {
+  assert.throws(() => on(ee, 'foo', { signal: abortedSignal }), {
     name: 'AbortError'
   });
 }
 
 async function eventTargetAbortableOnBefore() {
   const et = new EventTarget();
-  const ac = new AbortController();
-  ac.abort();
+  const abortedSignal = AbortSignal.abort();
   [1, {}, null, false, 'hi'].forEach((signal) => {
     assert.throws(() => on(et, 'foo', { signal }), {
       code: 'ERR_INVALID_ARG_TYPE'
     });
   });
-  assert.throws(() => on(et, 'foo', { signal: ac.signal }), {
+  assert.throws(() => on(et, 'foo', { signal: abortedSignal }), {
     name: 'AbortError'
   });
 }

--- a/test/parallel/test-events-once.js
+++ b/test/parallel/test-events-once.js
@@ -133,9 +133,8 @@ async function prioritizesEventEmitter() {
 
 async function abortSignalBefore() {
   const ee = new EventEmitter();
-  const ac = new AbortController();
   ee.on('error', common.mustNotCall());
-  ac.abort();
+  const abortedSignal = AbortSignal.abort();
 
   await Promise.all([1, {}, 'hi', null, false].map((signal) => {
     return rejects(once(ee, 'foo', { signal }), {
@@ -143,7 +142,7 @@ async function abortSignalBefore() {
     });
   }));
 
-  return rejects(once(ee, 'foo', { signal: ac.signal }), {
+  return rejects(once(ee, 'foo', { signal: abortedSignal }), {
     name: 'AbortError'
   });
 }
@@ -184,8 +183,7 @@ async function abortSignalRemoveListener() {
 
 async function eventTargetAbortSignalBefore() {
   const et = new EventTarget();
-  const ac = new AbortController();
-  ac.abort();
+  const abortedSignal = AbortSignal.abort();
 
   await Promise.all([1, {}, 'hi', null, false].map((signal) => {
     return rejects(once(et, 'foo', { signal }), {
@@ -193,7 +191,7 @@ async function eventTargetAbortSignalBefore() {
     });
   }));
 
-  return rejects(once(et, 'foo', { signal: ac.signal }), {
+  return rejects(once(et, 'foo', { signal: abortedSignal }), {
     name: 'AbortError'
   });
 }

--- a/test/parallel/test-fs-promises-file-handle-readFile.js
+++ b/test/parallel/test-fs-promises-file-handle-readFile.js
@@ -58,9 +58,7 @@ async function doReadAndCancel() {
     const fileHandle = await open(filePathForHandle, 'w+');
     const buffer = Buffer.from('Dogs running'.repeat(10000), 'utf8');
     fs.writeFileSync(filePathForHandle, buffer);
-    const controller = new AbortController();
-    const { signal } = controller;
-    controller.abort();
+    const signal = AbortSignal.abort();
     await assert.rejects(readFile(fileHandle, { signal }), {
       name: 'AbortError'
     });

--- a/test/parallel/test-fs-promises-readfile.js
+++ b/test/parallel/test-fs-promises-readfile.js
@@ -43,9 +43,7 @@ async function validateReadFileProc() {
 }
 
 function validateReadFileAbortLogicBefore() {
-  const controller = new AbortController();
-  const signal = controller.signal;
-  controller.abort();
+  const signal = AbortSignal.abort();
   assert.rejects(readFile(fn, { signal }), {
     name: 'AbortError'
   });

--- a/test/parallel/test-fs-readfile.js
+++ b/test/parallel/test-fs-readfile.js
@@ -54,9 +54,7 @@ for (const e of fileInfo) {
 }
 {
   // Test cancellation, before
-  const controller = new AbortController();
-  const signal = controller.signal;
-  controller.abort();
+  const signal = AbortSignal.abort();
   fs.readFile(fileInfo[0].name, { signal }, common.mustCall((err, buf) => {
     assert.strictEqual(err.name, 'AbortError');
   }));

--- a/test/parallel/test-fs-watch-abort-signal.js
+++ b/test/parallel/test-fs-watch-abort-signal.js
@@ -24,9 +24,7 @@ const fixtures = require('../common/fixtures');
 {
   // Signal aborted before creating the watcher
   const file = fixtures.path('empty.js');
-  const ac = new AbortController();
-  const { signal } = ac;
-  ac.abort();
+  const signal = AbortSignal.abort();
   const watcher = fs.watch(file, { signal });
   watcher.once('close', common.mustCall());
 }

--- a/test/parallel/test-net-server-listen-options-signal.js
+++ b/test/parallel/test-net-server-listen-options-signal.js
@@ -26,8 +26,7 @@ const net = require('net');
 {
   // Test close with pre-aborted signal.
   const server = net.createServer();
-  const controller = new AbortController();
-  controller.abort();
+  const signal = AbortSignal.abort();
   server.on('close', common.mustCall());
-  server.listen({ port: 0, signal: controller.signal });
+  server.listen({ port: 0, signal });
 }

--- a/test/parallel/test-stream-pipeline.js
+++ b/test/parallel/test-stream-pipeline.js
@@ -487,9 +487,7 @@ const net = require('net');
   // Check pre-aborted signal
   const pipelinePromise = promisify(pipeline);
   async function run() {
-    const ac = new AbortController();
-    const { signal } = ac;
-    ac.abort();
+    const signal = AbortSignal.abort();
     async function* producer() {
       yield '5';
       await Promise.resolve();

--- a/test/parallel/test-stream-writable-destroy.js
+++ b/test/parallel/test-stream-writable-destroy.js
@@ -448,11 +448,10 @@ const assert = require('assert');
 }
 
 {
-  const ac = new AbortController();
-  ac.abort();
+  const signal = AbortSignal.abort();
 
   const write = new Writable({
-    signal: ac.signal,
+    signal,
     write(chunk, enc, cb) { cb(); }
   });
 

--- a/test/parallel/test-timers-promisified.js
+++ b/test/parallel/test-timers-promisified.js
@@ -98,9 +98,7 @@ process.on('multipleResolves', common.mustNotCall());
 }
 
 {
-  const ac = new AbortController();
-  const signal = ac.signal;
-  ac.abort(); // Abort in advance
+  const signal = AbortSignal.abort(); // Abort in advance
   assert.rejects(setPromiseTimeout(10, undefined, { signal }), /AbortError/)
     .then(common.mustCall());
 }
@@ -114,17 +112,13 @@ process.on('multipleResolves', common.mustNotCall());
 }
 
 {
-  const ac = new AbortController();
-  const signal = ac.signal;
-  ac.abort(); // Abort in advance
+  const signal = AbortSignal.abort(); // Abort in advance
   assert.rejects(setPromiseImmediate(10, { signal }), /AbortError/)
     .then(common.mustCall());
 }
 
 {
-  const ac = new AbortController();
-  const { signal } = ac;
-  ac.abort(); // Abort in advance
+  const signal = AbortSignal.abort(); // Abort in advance
 
   const iterable = setInterval(1, undefined, { signal });
   const iterator = iterable[Symbol.asyncIterator]();


### PR DESCRIPTION
As discussed with @benjamingr, I refactored all code that used pre-aborted signals to the new API `AbortSignal.abort()` by @jasnell.

Refs: whatwg/dom#960

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
