### PR TITLE
crypto: reconcile oneshot sign/verify sync and async implementations

### DIFF
--- a/benchmark/crypto/oneshot-sign-verify.js
+++ b/benchmark/crypto/oneshot-sign-verify.js
@@ -1,0 +1,141 @@
+'use strict';
+
+const common = require('../common.js');
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+const fixtures_keydir = path.resolve(__dirname, '../../test/fixtures/keys/');
+const keyFixtures = {
+  publicKey: fs.readFileSync(`${fixtures_keydir}/ec_p256_public.pem`)
+    .toString(),
+  privateKey: fs.readFileSync(`${fixtures_keydir}/ec_p256_private.pem`)
+    .toString()
+};
+
+const data = crypto.randomBytes(256);
+
+let pems;
+let keyObjects;
+
+function getKeyObject({ privateKey, publicKey }) {
+  return {
+    privateKey: crypto.createPrivateKey(privateKey),
+    publicKey: crypto.createPublicKey(publicKey)
+  };
+}
+
+const bench = common.createBenchmark(main, {
+  mode: ['sync', 'async-serial', 'async-parallel'],
+  keyFormat: ['pem', 'keyObject', 'pem.unique', 'keyObject.unique'],
+  n: [1e3],
+});
+
+function measureSync(n, privateKey, publicKey, keys) {
+  bench.start();
+  for (let i = 0; i < n; ++i) {
+    crypto.verify(
+      'sha256',
+      data,
+      { key: publicKey || keys[i].publicKey, dsaEncoding: 'ieee-p1363' },
+      crypto.sign(
+        'sha256',
+        data,
+        { key: privateKey || keys[i].privateKey, dsaEncoding: 'ieee-p1363' }));
+  }
+  bench.end(n);
+}
+
+function measureAsyncSerial(n, privateKey, publicKey, keys) {
+  let remaining = n;
+  function done() {
+    if (--remaining === 0)
+      bench.end(n);
+    else
+      one();
+  }
+
+  function one() {
+    crypto.sign(
+      'sha256',
+      data,
+      {
+        key: privateKey || keys[n - remaining].privateKey,
+        dsaEncoding: 'ieee-p1363'
+      },
+      (err, signature) => {
+        crypto.verify(
+          'sha256',
+          data,
+          {
+            key: publicKey || keys[n - remaining].publicKey,
+            dsaEncoding: 'ieee-p1363'
+          },
+          signature,
+          done);
+      });
+  }
+  bench.start();
+  one();
+}
+
+function measureAsyncParallel(n, privateKey, publicKey, keys) {
+  let remaining = n;
+  function done() {
+    if (--remaining === 0)
+      bench.end(n);
+  }
+  bench.start();
+  for (let i = 0; i < n; ++i) {
+    crypto.sign(
+      'sha256',
+      data,
+      { key: privateKey || keys[i].privateKey, dsaEncoding: 'ieee-p1363' },
+      (err, signature) => {
+        crypto.verify(
+          'sha256',
+          data,
+          { key: publicKey || keys[i].publicKey, dsaEncoding: 'ieee-p1363' },
+          signature,
+          done);
+      });
+  }
+}
+
+function main({ n, mode, keyFormat }) {
+  pems ||= [...Buffer.alloc(n)].map(() => ({
+    privateKey: keyFixtures.privateKey,
+    publicKey: keyFixtures.publicKey
+  }));
+  keyObjects ||= pems.map(getKeyObject);
+
+  let privateKey, publicKey, keys;
+
+  switch (keyFormat) {
+    case 'keyObject':
+      ({ publicKey, privateKey } = keyObjects[0]);
+      break;
+    case 'pem':
+      ({ publicKey, privateKey } = pems[0]);
+      break;
+    case 'pem.unique':
+      keys = pems;
+      break;
+    case 'keyObject.unique':
+      keys = keyObjects;
+      break;
+    default:
+      throw new Error('not implemented');
+  }
+
+  switch (mode) {
+    case 'sync':
+      measureSync(n, privateKey, publicKey, keys);
+      break;
+    case 'async-serial':
+      measureAsyncSerial(n, privateKey, publicKey, keys);
+      break;
+    case 'async-parallel':
+      measureAsyncParallel(n, privateKey, publicKey, keys);
+      break;
+  }
+}

--- a/lib/internal/crypto/dsa.js
+++ b/lib/internal/crypto/dsa.js
@@ -251,12 +251,15 @@ function dsaSignVerify(key, data, algorithm, signature) {
     kCryptoJobAsync,
     signature === undefined ? kSignJobModeSign : kSignJobModeVerify,
     key[kKeyObject][kHandle],
+    undefined,
+    undefined,
+    undefined,
     data,
     normalizeHashName(key.algorithm.hash.name),
     undefined,  // Salt-length is not used in DSA
     undefined,  // Padding is not used in DSA
-    signature,
-    kSigEncDER));
+    kSigEncDER,
+    signature));
 }
 
 module.exports = {

--- a/lib/internal/crypto/ec.js
+++ b/lib/internal/crypto/ec.js
@@ -467,12 +467,15 @@ function ecdsaSignVerify(key, data, { name, hash }, signature) {
     kCryptoJobAsync,
     mode,
     key[kKeyObject][kHandle],
+    undefined,
+    undefined,
+    undefined,
     data,
     hashname,
     undefined,  // Salt length, not used with ECDSA
     undefined,  // PSS Padding, not used with ECDSA
-    signature,
-    kSigEncP1363));
+    kSigEncP1363,
+    signature));
 }
 
 module.exports = {

--- a/lib/internal/crypto/rsa.js
+++ b/lib/internal/crypto/rsa.js
@@ -356,10 +356,14 @@ function rsaSignVerify(key, data, { saltLength }, signature) {
     kCryptoJobAsync,
     signature === undefined ? kSignJobModeSign : kSignJobModeVerify,
     key[kKeyObject][kHandle],
+    undefined,
+    undefined,
+    undefined,
     data,
     normalizeHashName(key.algorithm.hash.name),
     saltLength,
     padding,
+    undefined,
     signature));
 }
 

--- a/lib/internal/crypto/sig.js
+++ b/lib/internal/crypto/sig.js
@@ -24,9 +24,8 @@ const {
   Sign: _Sign,
   SignJob,
   Verify: _Verify,
-  signOneShot: _signOneShot,
-  verifyOneShot: _verifyOneShot,
   kCryptoJobAsync,
+  kCryptoJobSync,
   kSigEncDER,
   kSigEncP1363,
   kSignJobModeSign,
@@ -40,10 +39,6 @@ const {
 } = require('internal/crypto/util');
 
 const {
-  createPrivateKey,
-  createPublicKey,
-  isCryptoKey,
-  isKeyObject,
   preparePrivateKey,
   preparePublicOrPrivateKey,
 } = require('internal/crypto/keys');
@@ -162,37 +157,33 @@ function signOneShot(algorithm, data, key, callback) {
   // Options specific to (EC)DSA
   const dsaSigEnc = getDSASignatureEncoding(key);
 
-  if (!callback) {
-    const {
-      data: keyData,
-      format: keyFormat,
-      type: keyType,
-      passphrase: keyPassphrase
-    } = preparePrivateKey(key);
-
-    return _signOneShot(keyData, keyFormat, keyType, keyPassphrase, data,
-                        algorithm, rsaPadding, pssSaltLength, dsaSigEnc);
-  }
-
-  let keyData;
-  if (isKeyObject(key) || isCryptoKey(key)) {
-    ({ data: keyData } = preparePrivateKey(key));
-  } else if (isKeyObject(key.key) || isCryptoKey(key.key)) {
-    ({ data: keyData } = preparePrivateKey(key.key));
-  } else {
-    keyData = createPrivateKey(key)[kHandle];
-  }
+  const {
+    data: keyData,
+    format: keyFormat,
+    type: keyType,
+    passphrase: keyPassphrase
+  } = preparePrivateKey(key);
 
   const job = new SignJob(
-    kCryptoJobAsync,
+    callback ? kCryptoJobAsync : kCryptoJobSync,
     kSignJobModeSign,
     keyData,
+    keyFormat,
+    keyType,
+    keyPassphrase,
     data,
     algorithm,
     pssSaltLength,
     rsaPadding,
-    undefined,
     dsaSigEnc);
+
+  if (!callback) {
+    const { 0: err, 1: signature } = job.run();
+    if (err !== undefined)
+      throw err;
+
+    return Buffer.from(signature);
+  }
 
   job.ondone = (error, signature) => {
     if (error) return FunctionPrototypeCall(callback, job, error);
@@ -272,38 +263,34 @@ function verifyOneShot(algorithm, data, key, signature, callback) {
     );
   }
 
-  if (!callback) {
-    const {
-      data: keyData,
-      format: keyFormat,
-      type: keyType,
-      passphrase: keyPassphrase
-    } = preparePublicOrPrivateKey(key);
-
-    return _verifyOneShot(keyData, keyFormat, keyType, keyPassphrase,
-                          signature, data, algorithm, rsaPadding,
-                          pssSaltLength, dsaSigEnc);
-  }
-
-  let keyData;
-  if (isKeyObject(key) || isCryptoKey(key)) {
-    ({ data: keyData } = preparePublicOrPrivateKey(key));
-  } else if (key != null && (isKeyObject(key.key) || isCryptoKey(key.key))) {
-    ({ data: keyData } = preparePublicOrPrivateKey(key.key));
-  } else {
-    keyData = createPublicKey(key)[kHandle];
-  }
+  const {
+    data: keyData,
+    format: keyFormat,
+    type: keyType,
+    passphrase: keyPassphrase
+  } = preparePublicOrPrivateKey(key);
 
   const job = new SignJob(
-    kCryptoJobAsync,
+    callback ? kCryptoJobAsync : kCryptoJobSync,
     kSignJobModeVerify,
     keyData,
+    keyFormat,
+    keyType,
+    keyPassphrase,
     data,
     algorithm,
     pssSaltLength,
     rsaPadding,
-    signature,
-    dsaSigEnc);
+    dsaSigEnc,
+    signature);
+
+  if (!callback) {
+    const { 0: err, 1: result } = job.run();
+    if (err !== undefined)
+      throw err;
+
+    return result;
+  }
 
   job.ondone = (error, result) => {
     if (error) return FunctionPrototypeCall(callback, job, error);

--- a/src/crypto/crypto_sig.h
+++ b/src/crypto/crypto_sig.h
@@ -111,7 +111,7 @@ struct SignConfiguration final : public MemoryRetainer {
 
   CryptoJobMode job_mode;
   Mode mode;
-  std::shared_ptr<KeyObjectData> key;
+  ManagedEVPPKey key;
   ByteSource data;
   ByteSource signature;
   const EVP_MD* digest = nullptr;

--- a/test/parallel/test-crypto-sign-verify.js
+++ b/test/parallel/test-crypto-sign-verify.js
@@ -528,11 +528,15 @@ assert.throws(
     // Test invalid signature lengths.
     for (const i of [-2, -1, 1, 2, 4, 8]) {
       sig = crypto.randomBytes(length + i);
-      assert.throws(() => {
-        crypto.verify('sha1', data, opts, sig);
-      }, {
-        message: 'Malformed signature'
-      });
+      let result;
+      try {
+        result = crypto.verify('sha1', data, opts, sig);
+      } catch (err) {
+        assert.match(err.message, /asn1 encoding/);
+        assert.strictEqual(err.library, 'asn1 encoding routines');
+        continue;
+      }
+      assert.strictEqual(result, false);
     }
   }
 


### PR DESCRIPTION
This reconciles the crypto.sign and crypto.verify C++ implementation when running with or without a callback.