### PR TITLE
child_process: cleanup AbortSignal code duplication

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -605,23 +605,6 @@ function spawn(file, args, options) {
   const killSignal = sanitizeKillSignal(options.killSignal);
   const child = new ChildProcess();
 
-  if (options.signal) {
-    const signal = options.signal;
-    if (signal.aborted) {
-      onAbortListener();
-    } else {
-      signal.addEventListener('abort', onAbortListener, { once: true });
-      child.once('exit',
-                 () => signal.removeEventListener('abort', onAbortListener));
-    }
-
-    function onAbortListener() {
-      process.nextTick(() => {
-        abortChildProcess(child, killSignal);
-      });
-    }
-  }
-
   debug('spawn', options);
   child.spawn(options);
 
@@ -643,6 +626,23 @@ function spawn(file, args, options) {
         timeoutId = null;
       }
     });
+  }
+
+  if (options.signal) {
+    const signal = options.signal;
+    if (signal.aborted) {
+      process.nextTick(() => {
+        onAbortListener();
+      });
+    } else {
+      signal.addEventListener('abort', onAbortListener, { once: true });
+      child.once('exit',
+                 () => signal.removeEventListener('abort', onAbortListener));
+    }
+
+    function onAbortListener() {
+      abortChildProcess(child, killSignal);
+    }
   }
 
   return child;
@@ -778,37 +778,6 @@ function sanitizeKillSignal(killSignal) {
   }
 }
 
-// This level of indirection is here because the other child_process methods
-// call spawn internally but should use different cancellation logic.
-function spawnWithSignal(file, args, options) {
-  // Remove signal from options to spawn
-  // to avoid double emitting of AbortError
-  const opts = options && typeof options === 'object' && ('signal' in options) ?
-    { ...options, signal: undefined } :
-    options;
-
-  if (options?.signal) {
-    // Validate signal, if present
-    validateAbortSignal(options.signal, 'options.signal');
-  }
-  const child = spawn(file, args, opts);
-
-  if (options?.signal) {
-    const killSignal = sanitizeKillSignal(options.killSignal);
-
-    function kill() {
-      abortChildProcess(child, killSignal);
-    }
-    if (options.signal.aborted) {
-      process.nextTick(kill);
-    } else {
-      options.signal.addEventListener('abort', kill, { once: true });
-      const remove = () => options.signal.removeEventListener('abort', kill);
-      child.once('exit', remove);
-    }
-  }
-  return child;
-}
 module.exports = {
   _forkChild,
   ChildProcess,
@@ -817,6 +786,6 @@ module.exports = {
   execFileSync,
   execSync,
   fork,
-  spawn: spawnWithSignal,
+  spawn,
   spawnSync
 };

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -631,9 +631,7 @@ function spawn(file, args, options) {
   if (options.signal) {
     const signal = options.signal;
     if (signal.aborted) {
-      process.nextTick(() => {
-        onAbortListener();
-      });
+      process.nextTick(onAbortListener);
     } else {
       signal.addEventListener('abort', onAbortListener, { once: true });
       child.once('exit',


### PR DESCRIPTION
This PR cleans-up AbortSignal code duplication between fork/exec and spawn (which seem to share the same essential implementation). Removed `spawnWithSignal`, and all logic is now in `spawn`. 

This PR does have two behaviour changes:
- Some timing changes for `fork/execFile`, where before for `fork/execFile` an abort caused an abort in next-tick, while now it'll call `abort` in the same tick (a pre-aborted signal still aborts in next-tick as before). The behaviour for `spawn` is unchanged.
- I've moved signal registration to after `child.spawn()` is called, so that if `child.spawn()` throws, the signal won't keep a reference to the "bad" child-process.