### PR TITLE
timers: fix arbitrary object clearImmediate errors

### DIFF
--- a/lib/internal/timers.js
+++ b/lib/internal/timers.js
@@ -279,11 +279,11 @@ ImmediateList.prototype.append = function(item) {
 // Removes an item from the linked list, adjusting the pointers of adjacent
 // items and the linked list's head or tail pointers as necessary
 ImmediateList.prototype.remove = function(item) {
-  if (item._idleNext !== null) {
+  if (item._idleNext) {
     item._idleNext._idlePrev = item._idlePrev;
   }
 
-  if (item._idlePrev !== null) {
+  if (item._idlePrev) {
     item._idlePrev._idleNext = item._idleNext;
   }
 

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -283,7 +283,7 @@ function clearImmediate(immediate) {
     toggleImmediateRef(false);
   immediate[kRefed] = null;
 
-  if (destroyHooksExist()) {
+  if (destroyHooksExist() && immediate[async_id_symbol] !== undefined) {
     emitDestroy(immediate[async_id_symbol]);
   }
 

--- a/test/parallel/test-repl-clear-immediate-crash.js
+++ b/test/parallel/test-repl-clear-immediate-crash.js
@@ -1,0 +1,12 @@
+'use strict';
+const common = require('../common');
+const child_process = require('child_process');
+const assert = require('assert');
+
+// Regression test for https://github.com/nodejs/node/issues/37806:
+const proc = child_process.spawn(process.execPath, ['-i']);
+proc.on('error', common.mustNotCall());
+proc.on('exit', common.mustCall((code) => {
+  assert.strictEqual(code, 0);
+}));
+proc.stdin.write('clearImmediate({});\n.exit\n');

--- a/test/parallel/test-timers-clear-object-does-not-throw-error.js
+++ b/test/parallel/test-timers-clear-object-does-not-throw-error.js
@@ -1,0 +1,8 @@
+'use strict';
+require('../common');
+
+// This test makes sure clearing timers with
+// objects doesn't throw
+clearImmediate({});
+clearTimeout({});
+clearInterval({});


### PR DESCRIPTION
Fix errors that are caused by invoking clearImmediate with arbitrary objects. (e.g. `clearImmediate({})`)

- Fix in `timers.js` fixes the REPL crash.
- Fix in `internal/timers.js` fixes another error that gets thrown.

Both of the above already exist in the `clearTimeout` path.

Fixes: https://github.com/nodejs/node/issues/37806