### PR TITLE
test: remove references to unsupported AIX versions

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -420,9 +420,6 @@ added: v10.0.0
 Change the file system timestamps of the object referenced by the {FileHandle}
 then resolves the promise with no arguments upon success.
 
-This function does not work on AIX versions before 7.1, it will reject the
-promise with an error using code `UV_ENOSYS`.
-
 #### `filehandle.write(buffer[, offset[, length[, position]]])`
 <!-- YAML
 added: v10.0.0
@@ -2336,9 +2333,6 @@ changes:
 
 Change the file system timestamps of the object referenced by the supplied file
 descriptor. See [`fs.utimes()`][].
-
-This function does not work on AIX versions before 7.1, it will return the
-error `UV_ENOSYS`.
 
 ### `fs.lchmod(path, mode, callback)`
 <!-- YAML

--- a/test/parallel/test-trace-events-fs-sync.js
+++ b/test/parallel/test-trace-events-fs-sync.js
@@ -124,13 +124,6 @@ for (const tr in tests) {
                               '--trace-event-categories', 'node.fs.sync',
                               '-e', tests[tr] ],
                             { cwd: tmpdir.path, encoding: 'utf8' });
-  // Some AIX versions don't support futimes or utimes, so skip.
-  if (common.isAIX && proc.status !== 0 && tr === 'fs.sync.futimes') {
-    continue;
-  }
-  if (common.isAIX && proc.status !== 0 && tr === 'fs.sync.utimes') {
-    continue;
-  }
 
   // Make sure the operation is successful.
   // Don't use assert with a custom message here. Otherwise the


### PR DESCRIPTION
The `filehandle.utimes()` and `fs.futimes()` APIs work on all versions
of AIX that are supported by this version of Node.js.

cc @nodejs/platform-aix 

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
