### PR TITLE
[v15.x backport] perf_hooks: make Performance extend EventTarget

### DIFF
--- a/lib/perf_hooks.js
+++ b/lib/perf_hooks.js
@@ -54,6 +54,9 @@ const {
   NODE_PERFORMANCE_MILESTONE_ENVIRONMENT
 } = constants;
 
+const {
+  EventTarget,
+} = require('internal/event_target');
 const L = require('internal/linkedlist');
 const kInspect = require('internal/util').customInspectSymbol;
 
@@ -418,8 +421,9 @@ class PerformanceObserver {
   }
 }
 
-class Performance {
+class Performance extends EventTarget {
   constructor() {
+    super();
     this[kIndex] = {
       [kMarks]: new SafeSet()
     };

--- a/test/wpt/status/hr-time.json
+++ b/test/wpt/status/hr-time.json
@@ -1,7 +1,4 @@
 {
-  "basic.any.js": {
-    "fail": "self.performance.addEventListener is not a function"
-  },
   "idlharness.any.js": {
     "skip": "TODO: update IDL parser"
   },


### PR DESCRIPTION
Backport of https://github.com/nodejs/node/pull/37621

