### PR TITLE
doc: clarify when child process 'spawn' event is *not* emitted

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -1162,6 +1162,8 @@ added: v15.1.0
 -->
 
 The `'spawn'` event is emitted once the child process has spawned successfully.
+If the child process does not spawn successfully, the `'spawn'` event is not
+emitted and the `'error'` event is emitted instead.
 
 If emitted, the `'spawn'` event comes before all other events and before any
 data is received via `stdout` or `stderr`.


### PR DESCRIPTION
Making this clarification in response to a comment on GitHub:
https://github.com/nodejs/node/issues/35288#issuecomment-802811813