### PR TITLE
doc: use sentence-style capitlaztion in template header

### DIFF
--- a/doc/template.html
+++ b/doc/template.html
@@ -24,7 +24,7 @@
     <div id="column1" data-id="__ID__" class="interior">
       <header>
         <div class="header-container">
-          <h1>Node.js __VERSION__ Documentation</h1>
+          <h1>Node.js __VERSION__ documentation</h1>
           <button class="theme-toggle-btn" id="theme-toggle-btn" title="Toggle dark mode/light mode" aria-label="Toggle dark mode/light mode" hidden>
             <svg xmlns="http://www.w3.org/2000/svg" class="icon dark-icon" height="24" width="24">
               <path fill="none" d="M0 0h24v24H0z" />


### PR DESCRIPTION
Make the level one header for all the HTML documents use consistent
capitalization style as the documentation itself.

## Without this change:
> ![image](https://user-images.githubusercontent.com/718899/111870571-bad06b00-8942-11eb-991c-8b1db53af5a4.png)


## With this change::
> ![image](https://user-images.githubusercontent.com/718899/111870506-675e1d00-8942-11eb-94a4-5742183b13a4.png)
