### PR TITLE
doc: fix legacy stability indicator display

### DIFF
--- a/doc/api/documentation.md
+++ b/doc/api/documentation.md
@@ -40,8 +40,8 @@ The stability indices are as follows:
 <!-- separator -->
 
 > Stability: 3 - Legacy. The feature is no longer recommended for use. While it
-likely will not be removed, and is still covered by semantic-versioning
-guarantees, use of the feature should be avoided.
+> likely will not be removed, and is still covered by semantic-versioning
+> guarantees, use of the feature should be avoided.
 
 Use caution when making use of Experimental features, particularly within
 modules. Users may not be aware that experimental features are being used.


### PR DESCRIPTION
Now:

![image](https://user-images.githubusercontent.com/718899/111871096-ab065600-8945-11eb-8d84-3cdcc112a194.png)


With this change:

![image](https://user-images.githubusercontent.com/718899/111871107-b5285480-8945-11eb-9700-eb6964896920.png)
