### PR TITLE
tools: remove repeated lines in macos firewall script

### DIFF
--- a/tools/macos-firewall.sh
+++ b/tools/macos-firewall.sh
@@ -27,8 +27,6 @@ then
   # linked to either out/Debug/node or out/Release/node depending on the
   # BUILDTYPE.
   $SFW --remove "$NODE_DEBUG"
-  $SFW --remove "$NODE_DEBUG"
-  $SFW --remove "$NODE_RELEASE"
   $SFW --remove "$NODE_RELEASE"
   $SFW --remove "$NODE_LINK"
   $SFW --remove "$CCTEST_DEBUG"


### PR DESCRIPTION
I don't think the comment about duplicates is about the repeating lines here. I *think* it's about the way the blocks repeat the same commands? If I'm wrong about that, I guess the comment needs updating so I don't open this pull request again in six months. :-D

