### PR TITLE
module: clarify CJS global-like variables not defined error message

### DIFF
--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -4,18 +4,21 @@ const {
   ArrayPrototypeJoin,
   ArrayPrototypeMap,
   ArrayPrototypePush,
+  ArrayPrototypeSome,
   FunctionPrototype,
   ObjectSetPrototypeOf,
   PromiseAll,
   PromiseResolve,
   PromisePrototypeCatch,
   ReflectApply,
+  RegExpPrototypeTest,
   SafeArrayIterator,
   SafeSet,
   StringPrototypeIncludes,
   StringPrototypeMatch,
   StringPrototypeReplace,
   StringPrototypeSplit,
+  StringPrototypeStartsWith,
 } = primordials;
 
 const { ModuleWrap } = internalBinding('module_wrap');
@@ -27,6 +30,19 @@ const resolvedPromise = PromiseResolve();
 const noop = FunctionPrototype;
 
 let hasPausedEntry = false;
+
+const CJSGlobalLike = [
+  'require',
+  'module',
+  'exports',
+  '__filename',
+  '__dirname',
+];
+const isCommonJSGlobalLikeNotDefinedError = (errorMessage) =>
+  ArrayPrototypeSome(
+    CJSGlobalLike,
+    (globalLike) => errorMessage === `${globalLike} is not defined`
+  );
 
 /* A ModuleJob tracks the loading of a single Module, and the ModuleJobs of
  * its dependencies, over time. */
@@ -155,7 +171,32 @@ class ModuleJob {
     await this.instantiate();
     const timeout = -1;
     const breakOnSigint = false;
-    await this.module.evaluate(timeout, breakOnSigint);
+    try {
+      await this.module.evaluate(timeout, breakOnSigint);
+    } catch (e) {
+      if (e?.name === 'ReferenceError' &&
+          isCommonJSGlobalLikeNotDefinedError(e.message)) {
+        e.message += ' in ES module scope';
+
+        if (StringPrototypeStartsWith(e.message, 'require ')) {
+          e.message += ', you can use import instead';
+        }
+
+        const packageConfig =
+          StringPrototypeStartsWith(this.module.url, 'file://') &&
+            RegExpPrototypeTest(/\.js(\?[^#]*)?(#.*)?$/, this.module.url) &&
+            require('internal/modules/esm/resolve')
+              .getPackageScopeConfig(this.module.url);
+        if (packageConfig.type === 'module') {
+          e.message +=
+            '\nThis file is being treated as an ES module because it has a ' +
+            `'.js' file extension and '${packageConfig.pjsonPath}' contains ` +
+            '"type": "module". To treat it as a CommonJS script, rename it ' +
+            'to use the \'.cjs\' file extension.';
+        }
+      }
+      throw e;
+    }
     return { module: this.module };
   }
 }

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -893,6 +893,7 @@ module.exports = {
   DEFAULT_CONDITIONS,
   defaultResolve,
   encodedSepRegEx,
+  getPackageScopeConfig,
   getPackageType,
   packageExportsResolve,
   packageImportsResolve

--- a/test/es-module/test-esm-undefined-cjs-global-like-variables.js
+++ b/test/es-module/test-esm-undefined-cjs-global-like-variables.js
@@ -1,0 +1,42 @@
+'use strict';
+const common = require('../common');
+const fixtures = require('../common/fixtures');
+const assert = require('assert');
+const { pathToFileURL } = require('url');
+
+assert.rejects(
+  import('data:text/javascript,require;'),
+  /require is not defined in ES module scope, you can use import instead$/
+).then(common.mustCall());
+assert.rejects(
+  import('data:text/javascript,exports={};'),
+  /exports is not defined in ES module scope$/
+).then(common.mustCall());
+
+assert.rejects(
+  import('data:text/javascript,require_custom;'),
+  /^(?!in ES module scope)(?!use import instead).*$/
+).then(common.mustCall());
+
+const pkgUrl = pathToFileURL(fixtures.path('/es-modules/package-type-module/'));
+assert.rejects(
+  import(new URL('./cjs.js', pkgUrl)),
+  /use the '\.cjs' file extension/
+).then(common.mustCall());
+assert.rejects(
+  import(new URL('./cjs.js#target', pkgUrl)),
+  /use the '\.cjs' file extension/
+).then(common.mustCall());
+assert.rejects(
+  import(new URL('./cjs.js?foo=bar', pkgUrl)),
+  /use the '\.cjs' file extension/
+).then(common.mustCall());
+assert.rejects(
+  import(new URL('./cjs.js?foo=bar#target', pkgUrl)),
+  /use the '\.cjs' file extension/
+).then(common.mustCall());
+
+assert.rejects(
+  import('data:text/javascript,require;//.js'),
+  /^(?!use the '\.cjs' file extension).*$/
+).then(common.mustCall());


### PR DESCRIPTION
Error message on Node.js v15.x:
```
ReferenceError: require is not defined
      at data:text/javascript,require;:1:1
      at ModuleJob.run (node:internal/modules/esm/module_job:154:23)
      at async Loader.import (node:internal/modules/esm/loader:166:24)
      at async importModuleDynamicallyWrapper (node:internal/vm/module:437:15)
      at async waitForActual (node:assert:736:5)
      at async Function.rejects (node:assert:845:25)
```

Error message with this PR:
```
ReferenceError: require is not defined in ES module scope, you can use import instead
      at data:text/javascript,require;:1:1
      at ModuleJob.run (node:internal/modules/esm/module_job:155:25)
      at async Loader.import (node:internal/modules/esm/loader:166:24)
      at async importModuleDynamicallyWrapper (node:internal/vm/module:437:15)
      at async waitForActual (node:assert:736:5)
      at async Function.rejects (node:assert:845:25)
```
@nodejs/modules I'm not sure we should keep the `.cjs` advice because it doesn't always apply – sometimes there are no files (E.G.: `data:` URL), and this behaviour could be overridden by a custom loader. On the other hand, for a user stumbling over this issue, the suggestion could be helpful. wdyt?

Fixes: https://github.com/nodejs/node/issues/33741

~In the issue, it's also been discussed to add a message explaining why the file was parsed as ESM rather than CJS, but I couldn't find how to do that.~
EDIT: When the module is a file with `.js` extension, the following error message is shown:
```
ReferenceError: require is not defined in ES module scope, you can use import instead
This file is being treated as an ES module because it has a '.js' file extension and '/…/package.json' contains "type": "module". To treat it as a CommonJS script, rename it to use the '.cjs' file extension.
```
