### PR TITLE
test: add OpenSSL 3.0 checks

### DIFF
--- a/test/parallel/test-crypto-keygen.js
+++ b/test/parallel/test-crypto-keygen.js
@@ -389,20 +389,20 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
 {
   // Test async DSA key object generation.
   generateKeyPair('dsa', {
-    modulusLength: 512,
+    modulusLength: common.hasOpenSSL3 ? 2048 : 512,
     divisorLength: 256
   }, common.mustSucceed((publicKey, privateKey) => {
     assert.strictEqual(publicKey.type, 'public');
     assert.strictEqual(publicKey.asymmetricKeyType, 'dsa');
     assert.deepStrictEqual(publicKey.asymmetricKeyDetails, {
-      modulusLength: 512,
+      modulusLength: common.hasOpenSSL3 ? 2048 : 512,
       divisorLength: 256
     });
 
     assert.strictEqual(privateKey.type, 'private');
     assert.strictEqual(privateKey.asymmetricKeyType, 'dsa');
     assert.deepStrictEqual(privateKey.asymmetricKeyDetails, {
-      modulusLength: 512,
+      modulusLength: common.hasOpenSSL3 ? 2048 : 512,
       divisorLength: 256
     });
   }));

--- a/test/parallel/test-tls-passphrase.js
+++ b/test/parallel/test-tls-passphrase.js
@@ -224,7 +224,7 @@ server.listen(0, common.mustCall(function() {
 })).unref();
 
 const errMessagePassword = common.hasOpenSSL3 ?
-  /processing error/ : /bad decrypt/;
+  /Error: PEM_read_bio_PrivateKey/ : /bad decrypt/;
 
 // Missing passphrase
 assert.throws(function() {
@@ -254,7 +254,8 @@ assert.throws(function() {
   });
 }, errMessagePassword);
 
-const errMessageDecrypt = /bad decrypt/;
+const errMessageDecrypt = common.hasOpenSSL3 ?
+  /Error: PEM_read_bio_PrivateKey/ : /bad decrypt/;
 
 // Invalid passphrase
 assert.throws(function() {


### PR DESCRIPTION
These commits add OpenSSL 3.0 checks to test-crypto-keygen.js and test-tls-passphase.js.

There is currently a build [request](https://github.com/nodejs/build/issues/2584) to add a CI job so hopefully these failures will be reported automatically in the near future.