### PR TITLE
deps: v8 backport 9689b17687b

### DIFF
--- a/deps/v8/src/diagnostics/objects-printer.cc
+++ b/deps/v8/src/diagnostics/objects-printer.cc
@@ -1621,6 +1621,7 @@ void SourceTextModule::SourceTextModulePrint(std::ostream& os) {  // NOLINT
   os << "\n - requested_modules: " << Brief(requested_modules());
   os << "\n - script: " << Brief(script());
   os << "\n - import_meta: " << Brief(import_meta());
+  os << "\n - cycle_root: " << Brief(cycle_root());
   os << "\n";
 }
 

--- a/deps/v8/src/heap/factory.cc
+++ b/deps/v8/src/heap/factory.cc
@@ -2485,6 +2485,7 @@ Handle<SourceTextModule> Factory::NewSourceTextModule(
   module->set_flags(0);
   module->set_async(IsAsyncModule(code->kind()));
   module->set_async_evaluating(false);
+  module->set_cycle_root(roots.the_hole_value());
   module->set_async_parent_modules(*async_parent_modules);
   module->set_pending_async_dependencies(0);
   return module;

--- a/deps/v8/src/objects/module-inl.h
+++ b/deps/v8/src/objects/module-inl.h
@@ -111,6 +111,14 @@ class UnorderedModuleSet
             ZoneAllocator<Handle<Module>>(zone)) {}
 };
 
+Handle<SourceTextModule> SourceTextModule::GetCycleRoot(
+    Isolate* isolate) const {
+  CHECK_GE(status(), kEvaluated);
+  DCHECK(!cycle_root().IsTheHole(isolate));
+  Handle<SourceTextModule> root(SourceTextModule::cast(cycle_root()), isolate);
+  return root;
+}
+
 void SourceTextModule::AddAsyncParentModule(Isolate* isolate,
                                             Handle<SourceTextModule> module,
                                             Handle<SourceTextModule> parent) {

--- a/deps/v8/src/objects/source-text-module.h
+++ b/deps/v8/src/objects/source-text-module.h
@@ -78,6 +78,9 @@ class SourceTextModule
                                           Handle<SourceTextModule> module,
                                           Handle<SourceTextModule> parent);
 
+  // Get the non-hole cycle root. Only valid when status >= kEvaluated.
+  inline Handle<SourceTextModule> GetCycleRoot(Isolate* isolate) const;
+
   // Returns a SourceTextModule, the
   // ith parent in depth first traversal order of a given async child.
   inline Handle<SourceTextModule> GetAsyncParentModule(Isolate* isolate,
@@ -162,10 +165,6 @@ class SourceTextModule
   static V8_WARN_UNUSED_RESULT bool MaybeTransitionComponent(
       Isolate* isolate, Handle<SourceTextModule> module,
       ZoneForwardList<Handle<SourceTextModule>>* stack, Status new_status);
-
-  // Implementation of spec GetAsyncCycleRoot.
-  static V8_WARN_UNUSED_RESULT Handle<SourceTextModule> GetAsyncCycleRoot(
-      Isolate* isolate, Handle<SourceTextModule> module);
 
   // Implementation of spec ExecuteModule is broken up into
   // InnerExecuteAsyncModule for asynchronous modules and ExecuteModule

--- a/deps/v8/src/objects/source-text-module.tq
+++ b/deps/v8/src/objects/source-text-module.tq
@@ -29,6 +29,11 @@ extern class SourceTextModule extends Module {
   // a JSObject afterwards.
   import_meta: TheHole|JSObject;
 
+  // The first visited module of a cycle. For modules not in a cycle, this is
+  // the module itself. It's the hole before the module state transitions to
+  // kEvaluated.
+  cycle_root: SourceTextModule|TheHole;
+
   async_parent_modules: ArrayList;
   top_level_capability: JSPromise|Undefined;
 

--- a/deps/v8/test/mjsunit/harmony/modules-import-rqstd-order-async-cycle.mjs
+++ b/deps/v8/test/mjsunit/harmony/modules-import-rqstd-order-async-cycle.mjs
@@ -1,0 +1,12 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-top-level-await
+
+import "modules-skip-async-cycle-start.mjs"
+
+assertEquals(globalThis.test_order, [
+  '2', 'async before', 'async after', '1',
+  '3', 'start',
+]);

--- a/deps/v8/test/mjsunit/harmony/modules-skip-async-cycle-1.mjs
+++ b/deps/v8/test/mjsunit/harmony/modules-skip-async-cycle-1.mjs
@@ -1,0 +1,14 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-top-level-await
+
+import "modules-skip-async-cycle-2.mjs";
+import "modules-skip-async-cycle-leaf.mjs";
+
+if (globalThis.test_order === undefined) {
+  globalThis.test_order = [];
+}
+globalThis.test_order.push('1');
+

--- a/deps/v8/test/mjsunit/harmony/modules-skip-async-cycle-2.mjs
+++ b/deps/v8/test/mjsunit/harmony/modules-skip-async-cycle-2.mjs
@@ -1,0 +1,12 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-top-level-await
+
+import "modules-skip-async-cycle-1.mjs";
+
+if (globalThis.test_order === undefined) {
+  globalThis.test_order = [];
+}
+globalThis.test_order.push('2');

--- a/deps/v8/test/mjsunit/harmony/modules-skip-async-cycle-3.mjs
+++ b/deps/v8/test/mjsunit/harmony/modules-skip-async-cycle-3.mjs
@@ -1,0 +1,12 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-top-level-await
+
+import "modules-skip-async-cycle-2.mjs";
+
+if (globalThis.test_order === undefined) {
+  globalThis.test_order = [];
+}
+globalThis.test_order.push('3');

--- a/deps/v8/test/mjsunit/harmony/modules-skip-async-cycle-leaf.mjs
+++ b/deps/v8/test/mjsunit/harmony/modules-skip-async-cycle-leaf.mjs
@@ -1,0 +1,13 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-top-level-await
+
+if (globalThis.test_order === undefined) {
+  globalThis.test_order = [];
+}
+
+globalThis.test_order.push('async before');
+await 0;
+globalThis.test_order.push('async after');

--- a/deps/v8/test/mjsunit/harmony/modules-skip-async-cycle-start.mjs
+++ b/deps/v8/test/mjsunit/harmony/modules-skip-async-cycle-start.mjs
@@ -1,0 +1,13 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-top-level-await
+
+import "modules-skip-async-cycle-1.mjs";
+import "modules-skip-async-cycle-3.mjs";
+
+if (globalThis.test_order === undefined) {
+  globalThis.test_order = [];
+}
+globalThis.test_order.push('start');


### PR DESCRIPTION
Original commit from https://chromium-review.googlesource.com/c/v8/v8/+/2667772, fixing a TLA execution ordering spec bug:

```
[top-level-await] Implement spec fix for cycle root detection

There is a bug in the top-level await spec draft such that async
strongly connected components are not always evaluated before their
depending modules.

See https://github.com/tc39/proposal-top-level-await/pull/161 for full
discussion and spec fix.

Bug: v8:11376
Change-Id: I88bf06afb2e9a5d8d0b757de8276f1d1242a875e
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2667772
Reviewed-by: Adam Klein <adamk@chromium.org>
Reviewed-by: Camillo Bruni <cbruni@chromium.org>
Commit-Queue: Shu-yu Guo <syg@chromium.org>
Cr-Commit-Position: refs/heads/master@{#72508}
```