### PR TITLE
src: report idle time correctly

### DIFF
--- a/src/env.h
+++ b/src/env.h
@@ -1064,6 +1064,8 @@ class Environment : public MemoryRetainer {
   inline void AssignToContext(v8::Local<v8::Context> context,
                               const ContextInfo& info);
 
+  void StartProfilerIdleNotifier();
+
   inline v8::Isolate* isolate() const;
   inline uv_loop_t* event_loop() const;
   inline void TryLoadAddon(
@@ -1414,6 +1416,8 @@ class Environment : public MemoryRetainer {
   uv_timer_t timer_handle_;
   uv_check_t immediate_check_handle_;
   uv_idle_t immediate_idle_handle_;
+  uv_prepare_t idle_prepare_handle_;
+  uv_check_t idle_check_handle_;
   uv_async_t task_queues_async_;
   int64_t task_queues_async_refs_ = 0;
 

--- a/test/parallel/test-inspector-has-idle.js
+++ b/test/parallel/test-inspector-has-idle.js
@@ -1,0 +1,43 @@
+'use strict';
+const common = require('../common');
+
+common.skipIfInspectorDisabled();
+
+const assert = require('assert');
+const { Session } = require('inspector');
+const { promisify } = require('util');
+
+const sleep = promisify(setTimeout);
+
+async function test() {
+  const inspector = new Session();
+  inspector.connect();
+
+  inspector.post('Profiler.enable');
+  inspector.post('Profiler.start');
+
+  await sleep(1000);
+
+  const { profile } = await new Promise((resolve, reject) => {
+    inspector.post('Profiler.stop', (err, params) => {
+      if (err) return reject(err);
+      resolve(params);
+    });
+  });
+
+  let hasIdle = false;
+  for (const node of profile.nodes) {
+    if (node.callFrame.functionName === '(idle)') {
+      hasIdle = true;
+      break;
+    }
+  }
+  assert(hasIdle);
+
+  inspector.post('Profiler.disable');
+  inspector.disconnect();
+}
+
+test().then(common.mustCall(() => {
+  console.log('Done!');
+}));


### PR DESCRIPTION
With this change, the V8 profiler will attribute any time between prepare and check cycles, except any entrances to `InternalCallbackScope`, to be "idle" time. All callbacks, microtasks, and timers will be marked as not idle. The one exception is native modules which don't use the `MakeCallback` helper, but those are already broken anyway for async context tracking so we should just encourage broken modules to be fixed.

This functionality previously existed, but was removed in #34010 due to not correctly attributing callbacks in the I/O phase of the event loop. This change restores that code and with some additional changes to `InternalCallbackScope` to correctly report idle status during callback scopes. Also relevant is #33138.

cc @nodejs/diagnostics 