### PR TITLE
fix: replace deprecated listenerCount method

### DIFF
--- a/lib/domain.js
+++ b/lib/domain.js
@@ -255,7 +255,7 @@ Domain.prototype._errorHandler = function(er) {
     // as this would throw an error, make the process exit, and thus
     // prevent the process 'uncaughtException' event from being emitted
     // if a listener is set.
-    if (EventEmitter.listenerCount(this, 'error') > 0) {
+    if (this.listenerCount('error') > 0) {
       // Clear the uncaughtExceptionCaptureCallback so that we know that, since
       // the top-level domain is not active anymore, it would be ok to abort on
       // an uncaught exception at this point


### PR DESCRIPTION
As announced in the doc:

We should avoid using `events.listenerCount(emitter, eventName)`, because it is deprecated:
https://nodejs.org/api/events.html#events_events_listenercount_emitter_eventname
Instead, we should use `emitter.listenerCount(eventName)`
https://nodejs.org/api/events.html#events_emitter_listenercount_eventname