### PR TITLE
doc: add arguments for stream event of Http2Server and Http2SecureServer

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1824,7 +1824,7 @@ added: v8.4.0
 The `'stream'` event is emitted when a `'stream'` event has been emitted by
 an `Http2Session` associated with the server.
 
-See also [`Http2Session`'s `stream` event][].
+See also [`Http2Session`'s `'stream'` event][].
 
 ```js
 const http2 = require('http2');
@@ -2020,7 +2020,7 @@ added: v8.4.0
 The `'stream'` event is emitted when a `'stream'` event has been emitted by
 an `Http2Session` associated with the server.
 
-See also [`Http2Session`'s `stream` event][].
+See also [`Http2Session`'s `'stream'` event][].
 
 ```js
 const http2 = require('http2');
@@ -3854,7 +3854,7 @@ you need to implement any fall-back behaviour yourself.
 [`Http2ServerRequest`]: #http2_class_http2_http2serverrequest
 [`Http2ServerResponse`]: #http2_class_http2_http2serverresponse
 [`Http2Session` and Sockets]: #http2_http2session_and_sockets
-[`Http2Session`'s `stream` event]: #http2_event_stream
+[`Http2Session`'s `'stream'` event]: #http2_event_stream
 [`Http2Stream`]: #http2_class_http2stream
 [`ServerHttp2Stream`]: #http2_class_serverhttp2stream
 [`TypeError`]: errors.md#errors_class_typeerror

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1815,8 +1815,16 @@ an `Http2Session` object associated with the `Http2Server`.
 added: v8.4.0
 -->
 
+* `stream` {Http2Stream} A reference to the stream
+* `headers` {HTTP/2 Headers Object} An object describing the headers
+* `flags` {number} The associated numeric flags
+* `rawHeaders` {Array} An array containing the raw header names followed by
+  their respective values.
+
 The `'stream'` event is emitted when a `'stream'` event has been emitted by
 an `Http2Session` associated with the server.
+
+See also [`Http2Session`'s `stream` event][].
 
 ```js
 const http2 = require('http2');
@@ -2003,8 +2011,16 @@ an `Http2Session` object associated with the `Http2SecureServer`.
 added: v8.4.0
 -->
 
+* `stream` {Http2Stream} A reference to the stream
+* `headers` {HTTP/2 Headers Object} An object describing the headers
+* `flags` {number} The associated numeric flags
+* `rawHeaders` {Array} An array containing the raw header names followed by
+  their respective values.
+
 The `'stream'` event is emitted when a `'stream'` event has been emitted by
 an `Http2Session` associated with the server.
+
+See also [`Http2Session`'s `stream` event][].
 
 ```js
 const http2 = require('http2');
@@ -3838,6 +3854,7 @@ you need to implement any fall-back behaviour yourself.
 [`Http2ServerRequest`]: #http2_class_http2_http2serverrequest
 [`Http2ServerResponse`]: #http2_class_http2_http2serverresponse
 [`Http2Session` and Sockets]: #http2_http2session_and_sockets
+[`Http2Session`'s `stream` event]: #http2_event_stream
 [`Http2Stream`]: #http2_class_http2stream
 [`ServerHttp2Stream`]: #http2_class_serverhttp2stream
 [`TypeError`]: errors.md#errors_class_typeerror


### PR DESCRIPTION
This PR adds arguments of the callback of `stream` event for both `Http2Server` and `Http2SecureServer`.