### PR TITLE
src: indent long help text properly

### DIFF
--- a/lib/internal/main/print_help.js
+++ b/lib/internal/main/print_help.js
@@ -152,8 +152,8 @@ function format(
     else
       text += StringPrototypeRepeat(' ', firstColumn - displayName.length);
 
-    text += indent(StringPrototypeTrimLeft(fold(displayHelpText, secondColumn),
-                                           firstColumn)) + '\n';
+    text += StringPrototypeTrimLeft(
+      indent(fold(displayHelpText, secondColumn), firstColumn)) + '\n';
   }
 
   if (maxFirstColumnUsed < firstColumn - 4) {

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -729,7 +729,7 @@ PerProcessOptionsParser::PerProcessOptionsParser(
   AddOption("--icu-data-dir",
             "set ICU data load path to dir (overrides NODE_ICU_DATA)"
 #ifndef NODE_HAVE_SMALL_ICU
-            " (note: linked-in ICU data is present)\n"
+            " (note: linked-in ICU data is present)"
 #endif
             ,
             &PerProcessOptions::icu_data_dir,


### PR DESCRIPTION
The previous code passed an ignored argument to StringPrototypeTrimLeft, and
tried to trim a string that didn't start with whitespace. The trim makes more
sense after the indentation has been added. Now wrapped lines actually show up
with the rest of the help text.

This was a regression introduced in #36140.

Before:

```
  --frozen-intrinsics                    experimental frozen intrinsics support
  --heap-prof                            Start the V8 heap profiler on start up, and write the
  heap profile to disk before exit. If --heap-prof-dir is
  not specified, write the profile to the current working
  directory.
  --heap-prof-dir=...                    Directory where the V8 heap profiles generated by
  --heap-prof will be placed.
```

After:
```
  --frozen-intrinsics                    experimental frozen intrinsics support
  --heap-prof                            Start the V8 heap profiler on start up, and write the
                                         heap profile to disk before exit. If --heap-prof-dir is
                                         not specified, write the profile to the current working
                                         directory.
  --heap-prof-dir=...                    Directory where the V8 heap profiles generated by
                                         --heap-prof will be placed.
```

Doing this made an uncharacteristic trailing newline in the `--icu-data-dir`
help text more obvious, so I removed that.
