### PR TITLE
net: net.BlockList updates and add net.SocketAddress

### DIFF
--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -69,7 +69,7 @@ IP subnets.
 added: v15.0.0
 -->
 
-* `address` {string} An IPv4 or IPv6 address.
+* `address` {string|net.SocketAddress} An IPv4 or IPv6 address.
 * `type` {string} Either `'ipv4'` or `'ipv6'`. **Default:** `'ipv4'`.
 
 Adds a rule to block the given IP address.
@@ -79,8 +79,9 @@ Adds a rule to block the given IP address.
 added: v15.0.0
 -->
 
-* `start` {string} The starting IPv4 or IPv6 address in the range.
-* `end` {string} The ending IPv4 or IPv6 address in the range.
+* `start` {string|net.SocketAddress} The starting IPv4 or IPv6 address in the
+  range.
+* `end` {string|net.SocketAddress} The ending IPv4 or IPv6 address in the range.
 * `type` {string} Either `'ipv4'` or `'ipv6'`. **Default:** `'ipv4'`.
 
 Adds a rule to block a range of IP addresses from `start` (inclusive) to
@@ -91,7 +92,7 @@ Adds a rule to block a range of IP addresses from `start` (inclusive) to
 added: v15.0.0
 -->
 
-* `net` {string} The network IPv4 or IPv6 address.
+* `net` {string|net.SocketAddress} The network IPv4 or IPv6 address.
 * `prefix` {number} The number of CIDR prefix bits. For IPv4, this
   must be a value between `0` and `32`. For IPv6, this must be between
   `0` and `128`.
@@ -104,7 +105,7 @@ Adds a rule to block a range of IP addresses specified as a subnet mask.
 added: v15.0.0
 -->
 
-* `address` {string} The IP address to check
+* `address` {string|net.SocketAddress} The IP address to check
 * `type` {string} Either `'ipv4'` or `'ipv6'`. **Default:** `'ipv4'`.
 * Returns: {boolean}
 

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -135,6 +135,51 @@ added: v15.0.0
 
 The list of rules added to the blocklist.
 
+## Class: `net.SocketAddress`
+<!-- YAML
+added: REPLACEME
+-->
+### `new net.SocketAddress([options])`
+<!-- YAML
+added: REPLACEME
+-->
+
+* `options` {Object}
+  * `address` {string} The network address as either an IPv4 or IPv6 string.
+    **Default**: `'127.0.0.1'` if `family` is `'ipv4'`; `'::'` if `family` is
+    `'ipv6'`.
+  * `family` {string} One of either `'ipv4'` or 'ipv6'`. **Default**: `'ipv4'`.
+  * `flowlabel` {number} An IPv6 flow-label used only if `family` is `'ipv6'`.
+  * `port` {number} An IP port.
+
+### `socketaddress.address`
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type {string}
+
+### `socketaddress.family`
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type {string} Either `'ipv4'` or `'ipv6'`.
+
+### `socketaddress.flowlabel`
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type {number}
+
+### `socketaddress.port`
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type {number}
+
 ## Class: `net.Server`
 <!-- YAML
 added: v0.1.90

--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -527,6 +527,9 @@ are part of the channel.
 <!-- YAML
 added: v10.5.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/37917
+    description: Add 'BlockList' to the list of cloneable types.
   - version: v15.9.0
     pr-url: https://github.com/nodejs/node/pull/37155
     description: Add 'Histogram' types to the list of cloneable types.
@@ -569,6 +572,7 @@ In particular, the significant differences to `JSON` are:
   * {Histogram}s,
   * {KeyObject}s,
   * {MessagePort}s,
+  * {net.BlockList}s,
   * {X509Certificate}s.
 
 ```js

--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -573,6 +573,7 @@ In particular, the significant differences to `JSON` are:
   * {KeyObject}s,
   * {MessagePort}s,
   * {net.BlockList}s,
+  * {net.SocketAddress}es,
   * {X509Certificate}s.
 
 ```js

--- a/lib/internal/blocklist.js
+++ b/lib/internal/blocklist.js
@@ -8,13 +8,16 @@ const {
 
 const {
   BlockList: BlockListHandle,
-  AF_INET,
-  AF_INET6,
 } = internalBinding('block_list');
 
 const {
   customInspectSymbol: kInspect,
 } = require('internal/util');
+
+const {
+  SocketAddress,
+  kHandle: kSocketAddressHandle,
+} = require('internal/socketaddress');
 
 const {
   JSTransferable,
@@ -55,56 +58,76 @@ class BlockList extends JSTransferable {
   }
 
   addAddress(address, family = 'ipv4') {
-    validateString(address, 'address');
-    validateString(family, 'family');
-    family = family.toLowerCase();
-    if (family !== 'ipv4' && family !== 'ipv6')
-      throw new ERR_INVALID_ARG_VALUE('family', family);
-    const type = family === 'ipv4' ? AF_INET : AF_INET6;
-    this[kHandle].addAddress(address, type);
+    if (!SocketAddress.isSocketAddress(address)) {
+      validateString(address, 'address');
+      validateString(family, 'family');
+      address = new SocketAddress({
+        address,
+        family,
+      });
+    }
+    this[kHandle].addAddress(address[kSocketAddressHandle]);
   }
 
   addRange(start, end, family = 'ipv4') {
-    validateString(start, 'start');
-    validateString(end, 'end');
-    validateString(family, 'family');
-    family = family.toLowerCase();
-    if (family !== 'ipv4' && family !== 'ipv6')
-      throw new ERR_INVALID_ARG_VALUE('family', family);
-    const type = family === 'ipv4' ? AF_INET : AF_INET6;
-    const ret = this[kHandle].addRange(start, end, type);
+    if (!SocketAddress.isSocketAddress(start)) {
+      validateString(start, 'start');
+      validateString(family, 'family');
+      start = new SocketAddress({
+        address: start,
+        family,
+      });
+    }
+    if (!SocketAddress.isSocketAddress(end)) {
+      validateString(end, 'end');
+      validateString(family, 'family');
+      end = new SocketAddress({
+        address: end,
+        family,
+      });
+    }
+    const ret = this[kHandle].addRange(
+      start[kSocketAddressHandle],
+      end[kSocketAddressHandle]);
     if (ret === false)
       throw new ERR_INVALID_ARG_VALUE('start', start, 'must come before end');
   }
 
   addSubnet(network, prefix, family = 'ipv4') {
-    validateString(network, 'network');
-    validateString(family, 'family');
-    family = family.toLowerCase();
-    let type;
-    switch (family) {
+    if (!SocketAddress.isSocketAddress(network)) {
+      validateString(network, 'network');
+      validateString(family, 'family');
+      network = new SocketAddress({
+        address: network,
+        family,
+      });
+    }
+    switch (network.family) {
       case 'ipv4':
-        type = AF_INET;
         validateInt32(prefix, 'prefix', 0, 32);
         break;
       case 'ipv6':
-        type = AF_INET6;
         validateInt32(prefix, 'prefix', 0, 128);
         break;
-      default:
-        throw new ERR_INVALID_ARG_VALUE('family', family);
     }
-    this[kHandle].addSubnet(network, type, prefix);
+    this[kHandle].addSubnet(network[kSocketAddressHandle], prefix);
   }
 
   check(address, family = 'ipv4') {
-    validateString(address, 'address');
-    validateString(family, 'family');
-    family = family.toLowerCase();
-    if (family !== 'ipv4' && family !== 'ipv6')
-      throw new ERR_INVALID_ARG_VALUE('family', family);
-    const type = family === 'ipv4' ? AF_INET : AF_INET6;
-    return Boolean(this[kHandle].check(address, type));
+    if (!SocketAddress.isSocketAddress(address)) {
+      validateString(address, 'address');
+      validateString(family, 'family');
+      try {
+        address = new SocketAddress({
+          address,
+          family,
+        });
+      } catch {
+        // Ignore the error. If it's not a valid address, return false.
+        return false;
+      }
+    }
+    return Boolean(this[kHandle].check(address[kSocketAddressHandle]));
   }
 
   get rules() {

--- a/lib/internal/blocklist.js
+++ b/lib/internal/blocklist.js
@@ -2,6 +2,7 @@
 
 const {
   Boolean,
+  ObjectSetPrototypeOf,
   Symbol
 } = primordials;
 
@@ -14,26 +15,28 @@ const {
 const {
   customInspectSymbol: kInspect,
 } = require('internal/util');
+
+const {
+  JSTransferable,
+  kClone,
+  kDeserialize,
+} = require('internal/worker/js_transferable');
+
 const { inspect } = require('internal/util/inspect');
 
 const kHandle = Symbol('kHandle');
 const { owner_symbol } = internalBinding('symbols');
 
 const {
-  ERR_INVALID_ARG_TYPE,
   ERR_INVALID_ARG_VALUE,
 } = require('internal/errors').codes;
 
 const { validateInt32, validateString } = require('internal/validators');
 
-class BlockList {
-  constructor(handle = new BlockListHandle()) {
-    // The handle argument is an intentionally undocumented
-    // internal API. User code will not be able to create
-    // a BlockListHandle object directly.
-    if (!(handle instanceof BlockListHandle))
-      throw new ERR_INVALID_ARG_TYPE('handle', 'BlockListHandle', handle);
-    this[kHandle] = handle;
+class BlockList extends JSTransferable {
+  constructor() {
+    super();
+    this[kHandle] = new BlockListHandle();
     this[kHandle][owner_symbol] = this;
   }
 
@@ -107,6 +110,34 @@ class BlockList {
   get rules() {
     return this[kHandle].getRules();
   }
+
+  [kClone]() {
+    const handle = this[kHandle];
+    return {
+      data: { handle },
+      deserializeInfo: 'internal/blocklist:InternalBlockList',
+    };
+  }
+
+  [kDeserialize]({ handle }) {
+    this[kHandle] = handle;
+    this[kHandle][owner_symbol] = this;
+  }
 }
 
-module.exports = BlockList;
+class InternalBlockList extends JSTransferable {
+  constructor(handle) {
+    super();
+    this[kHandle] = handle;
+    if (handle !== undefined)
+      handle[owner_symbol] = this;
+  }
+}
+
+InternalBlockList.prototype.constructor = BlockList.prototype.constructor;
+ObjectSetPrototypeOf(InternalBlockList.prototype, BlockList.prototype);
+
+module.exports = {
+  BlockList,
+  InternalBlockList,
+};

--- a/lib/internal/socketaddress.js
+++ b/lib/internal/socketaddress.js
@@ -47,14 +47,16 @@ class SocketAddress extends JSTransferable {
   constructor(options = {}) {
     super();
     validateObject(options, 'options');
+    let { family = 'ipv4' } = options;
     const {
-      family = 'ipv4',
       address = (family === 'ipv4' ? '127.0.0.1' : '::'),
       port = 0,
       flowlabel = 0,
     } = options;
 
     let type;
+    if (typeof family?.toLowerCase === 'function')
+      family = family.toLowerCase();
     switch (family) {
       case 'ipv4':
         type = AF_INET;
@@ -63,7 +65,7 @@ class SocketAddress extends JSTransferable {
         type = AF_INET6;
         break;
       default:
-        throw new ERR_INVALID_ARG_VALUE('options.family', family);
+        throw new ERR_INVALID_ARG_VALUE('options.family', options.family);
     }
 
     validateString(address, 'options.address');
@@ -150,4 +152,5 @@ ObjectSetPrototypeOf(InternalSocketAddress.prototype, SocketAddress.prototype);
 module.exports = {
   SocketAddress,
   InternalSocketAddress,
+  kHandle,
 };

--- a/lib/internal/socketaddress.js
+++ b/lib/internal/socketaddress.js
@@ -1,0 +1,153 @@
+'use strict';
+
+const {
+  ObjectSetPrototypeOf,
+  Symbol,
+} = primordials;
+
+const {
+  SocketAddress: _SocketAddress,
+  AF_INET,
+  AF_INET6,
+} = internalBinding('block_list');
+
+const {
+  validateObject,
+  validateString,
+  validatePort,
+  validateUint32,
+} = require('internal/validators');
+
+const {
+  codes: {
+    ERR_INVALID_ARG_VALUE,
+  },
+} = require('internal/errors');
+
+const {
+  customInspectSymbol: kInspect,
+} = require('internal/util');
+
+const { inspect } = require('internal/util/inspect');
+
+const {
+  JSTransferable,
+  kClone,
+  kDeserialize,
+} = require('internal/worker/js_transferable');
+
+const kHandle = Symbol('kHandle');
+const kDetail = Symbol('kDetail');
+
+class SocketAddress extends JSTransferable {
+  static isSocketAddress(value) {
+    return value?.[kHandle] !== undefined;
+  }
+
+  constructor(options = {}) {
+    super();
+    validateObject(options, 'options');
+    const {
+      family = 'ipv4',
+      address = (family === 'ipv4' ? '127.0.0.1' : '::'),
+      port = 0,
+      flowlabel = 0,
+    } = options;
+
+    let type;
+    switch (family) {
+      case 'ipv4':
+        type = AF_INET;
+        break;
+      case 'ipv6':
+        type = AF_INET6;
+        break;
+      default:
+        throw new ERR_INVALID_ARG_VALUE('options.family', family);
+    }
+
+    validateString(address, 'options.address');
+    validatePort(port, 'options.port');
+    validateUint32(flowlabel, 'options.flowlabel', false);
+
+    this[kHandle] = new _SocketAddress(address, port, type, flowlabel);
+    this[kDetail] = this[kHandle].detail({
+      address: undefined,
+      port: undefined,
+      family: undefined,
+      flowlabel: undefined,
+    });
+  }
+
+  get address() {
+    return this[kDetail].address;
+  }
+
+  get port() {
+    return this[kDetail].port;
+  }
+
+  get family() {
+    return this[kDetail].family === AF_INET ? 'ipv4' : 'ipv6';
+  }
+
+  get flowlabel() {
+    // The flow label can be changed internally.
+    return this[kHandle].flowlabel();
+  }
+
+  [kInspect](depth, options) {
+    if (depth < 0)
+      return this;
+
+    const opts = {
+      ...options,
+      depth: options.depth == null ? null : options.depth - 1
+    };
+
+    return `SocketAddress ${inspect(this.toJSON(), opts)}`;
+  }
+
+  [kClone]() {
+    const handle = this[kHandle];
+    return {
+      data: { handle },
+      deserializeInfo: 'internal/socketaddress:InternalSocketAddress',
+    };
+  }
+
+  [kDeserialize]({ handle }) {
+    this[kHandle] = handle;
+    this[kDetail] = handle.detail({
+      address: undefined,
+      port: undefined,
+      family: undefined,
+      flowlabel: undefined,
+    });
+  }
+
+  toJSON() {
+    return {
+      address: this.address,
+      port: this.port,
+      family: this.family,
+      flowlabel: this.flowlabel,
+    };
+  }
+}
+
+class InternalSocketAddress extends JSTransferable {
+  constructor(handle) {
+    super();
+    this[kHandle] = handle;
+  }
+}
+
+InternalSocketAddress.prototype.constructor =
+  SocketAddress.prototype.construtor;
+ObjectSetPrototypeOf(InternalSocketAddress.prototype, SocketAddress.prototype);
+
+module.exports = {
+  SocketAddress,
+  InternalSocketAddress,
+};

--- a/lib/net.js
+++ b/lib/net.js
@@ -1760,8 +1760,7 @@ module.exports = {
   _normalizeArgs: normalizeArgs,
   _setSimultaneousAccepts,
   get BlockList() {
-    if (BlockList === undefined)
-      BlockList = require('internal/blocklist');
+    BlockList ??= require('internal/blocklist').BlockList;
     return BlockList;
   },
   connect,

--- a/lib/net.js
+++ b/lib/net.js
@@ -122,6 +122,7 @@ const {
 let cluster;
 let dns;
 let BlockList;
+let SocketAddress;
 
 const { clearTimeout } = require('timers');
 const { kTimeout } = require('internal/timers');
@@ -1762,6 +1763,10 @@ module.exports = {
   get BlockList() {
     BlockList ??= require('internal/blocklist').BlockList;
     return BlockList;
+  },
+  get SocketAddress() {
+    SocketAddress ??= require('internal/socketaddress').SocketAddress;
+    return SocketAddress;
   },
   connect,
   createConnection: connect,

--- a/node.gyp
+++ b/node.gyp
@@ -220,6 +220,7 @@
       'lib/internal/repl/await.js',
       'lib/internal/repl/history.js',
       'lib/internal/repl/utils.js',
+      'lib/internal/socketaddress.js',
       'lib/internal/socket_list.js',
       'lib/internal/source_map/prepare_stack_trace.js',
       'lib/internal/source_map/source_map.js',

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -1026,15 +1026,18 @@ inline void Environment::SetInstanceMethod(v8::Local<v8::FunctionTemplate> that,
 inline void Environment::SetConstructorFunction(
     v8::Local<v8::Object> that,
     const char* name,
-    v8::Local<v8::FunctionTemplate> tmpl) {
-  SetConstructorFunction(that, OneByteString(isolate(), name), tmpl);
+    v8::Local<v8::FunctionTemplate> tmpl,
+    SetConstructorFunctionFlag flag) {
+  SetConstructorFunction(that, OneByteString(isolate(), name), tmpl, flag);
 }
 
 inline void Environment::SetConstructorFunction(
     v8::Local<v8::Object> that,
     v8::Local<v8::String> name,
-    v8::Local<v8::FunctionTemplate> tmpl) {
-  tmpl->SetClassName(name);
+    v8::Local<v8::FunctionTemplate> tmpl,
+    SetConstructorFunctionFlag flag) {
+  if (LIKELY(flag == SetConstructorFunctionFlag::SET_CLASS_NAME))
+    tmpl->SetClassName(name);
   that->Set(
       context(),
       name,

--- a/src/env.h
+++ b/src/env.h
@@ -258,6 +258,7 @@ constexpr size_t kFsStatsBufferLength =
   V(fingerprint256_string, "fingerprint256")                                   \
   V(fingerprint_string, "fingerprint")                                         \
   V(flags_string, "flags")                                                     \
+  V(flowlabel_string, "flowlabel")                                             \
   V(fragment_string, "fragment")                                               \
   V(frames_received_string, "framesReceived")                                  \
   V(frames_sent_string, "framesSent")                                          \
@@ -475,6 +476,7 @@ constexpr size_t kFsStatsBufferLength =
   V(script_context_constructor_template, v8::FunctionTemplate)                 \
   V(secure_context_constructor_template, v8::FunctionTemplate)                 \
   V(shutdown_wrap_template, v8::ObjectTemplate)                                \
+  V(socketaddress_constructor_template, v8::FunctionTemplate)                  \
   V(streambaseoutputstream_constructor_template, v8::ObjectTemplate)           \
   V(qlogoutputstream_constructor_template, v8::ObjectTemplate)                 \
   V(tcp_constructor_template, v8::FunctionTemplate)                            \

--- a/src/env.h
+++ b/src/env.h
@@ -452,7 +452,7 @@ constexpr size_t kFsStatsBufferLength =
   V(base_object_ctor_template, v8::FunctionTemplate)                           \
   V(binding_data_ctor_template, v8::FunctionTemplate)                          \
   V(blob_constructor_template, v8::FunctionTemplate)                           \
-  V(blocklist_instance_template, v8::ObjectTemplate)                           \
+  V(blocklist_constructor_template, v8::FunctionTemplate)                      \
   V(compiled_fn_entry_template, v8::ObjectTemplate)                            \
   V(dir_instance_template, v8::ObjectTemplate)                                 \
   V(fd_constructor_template, v8::ObjectTemplate)                               \
@@ -1237,13 +1237,22 @@ class Environment : public MemoryRetainer {
                                          const char* name,
                                          v8::FunctionCallback callback);
 
+  enum class SetConstructorFunctionFlag {
+    NONE,
+    SET_CLASS_NAME,
+  };
+
   inline void SetConstructorFunction(v8::Local<v8::Object> that,
                           const char* name,
-                          v8::Local<v8::FunctionTemplate> tmpl);
+                          v8::Local<v8::FunctionTemplate> tmpl,
+                          SetConstructorFunctionFlag flag =
+                              SetConstructorFunctionFlag::SET_CLASS_NAME);
 
   inline void SetConstructorFunction(v8::Local<v8::Object> that,
                           v8::Local<v8::String> name,
-                          v8::Local<v8::FunctionTemplate> tmpl);
+                          v8::Local<v8::FunctionTemplate> tmpl,
+                          SetConstructorFunctionFlag flag =
+                              SetConstructorFunctionFlag::SET_CLASS_NAME);
 
   void AtExit(void (*cb)(void* arg), void* arg);
   void RunAtExitCallbacks();

--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -56,6 +56,7 @@ void OnFatalError(const char* location, const char* message);
   V(ERR_CRYPTO_JOB_INIT_FAILED, Error)                                         \
   V(ERR_DLOPEN_FAILED, Error)                                                  \
   V(ERR_EXECUTION_ENVIRONMENT_NOT_AVAILABLE, Error)                            \
+  V(ERR_INVALID_ADDRESS, Error)                                                \
   V(ERR_INVALID_ARG_VALUE, TypeError)                                          \
   V(ERR_OSSL_EVP_INVALID_DIGEST, Error)                                        \
   V(ERR_INVALID_ARG_TYPE, TypeError)                                           \
@@ -143,6 +144,7 @@ ERRORS_WITH_CODE(V)
   V(ERR_DLOPEN_FAILED, "DLOpen failed")                                        \
   V(ERR_EXECUTION_ENVIRONMENT_NOT_AVAILABLE,                                   \
     "Context not associated with Node.js environment")                         \
+  V(ERR_INVALID_ADDRESS, "Invalid socket address")                             \
   V(ERR_INVALID_MODULE, "No such module")                                      \
   V(ERR_INVALID_THIS, "Value of \"this\" is the wrong type")                   \
   V(ERR_INVALID_TRANSFER_OBJECT, "Found invalid object in transferList")       \

--- a/src/node_sockaddr.cc
+++ b/src/node_sockaddr.cc
@@ -390,6 +390,7 @@ SocketAddressBlockList::SocketAddressBlockList(
 
 void SocketAddressBlockList::AddSocketAddress(
     const SocketAddress& address) {
+  Mutex::ScopedLock lock(mutex_);
   std::unique_ptr<Rule> rule =
       std::make_unique<SocketAddressRule>(address);
   rules_.emplace_front(std::move(rule));
@@ -398,6 +399,7 @@ void SocketAddressBlockList::AddSocketAddress(
 
 void SocketAddressBlockList::RemoveSocketAddress(
     const SocketAddress& address) {
+  Mutex::ScopedLock lock(mutex_);
   auto it = address_rules_.find(address);
   if (it != std::end(address_rules_)) {
     rules_.erase(it->second);
@@ -408,6 +410,7 @@ void SocketAddressBlockList::RemoveSocketAddress(
 void SocketAddressBlockList::AddSocketAddressRange(
     const SocketAddress& start,
     const SocketAddress& end) {
+  Mutex::ScopedLock lock(mutex_);
   std::unique_ptr<Rule> rule =
       std::make_unique<SocketAddressRangeRule>(start, end);
   rules_.emplace_front(std::move(rule));
@@ -416,12 +419,14 @@ void SocketAddressBlockList::AddSocketAddressRange(
 void SocketAddressBlockList::AddSocketAddressMask(
     const SocketAddress& network,
     int prefix) {
+  Mutex::ScopedLock lock(mutex_);
   std::unique_ptr<Rule> rule =
       std::make_unique<SocketAddressMaskRule>(network, prefix);
   rules_.emplace_front(std::move(rule));
 }
 
 bool SocketAddressBlockList::Apply(const SocketAddress& address) {
+  Mutex::ScopedLock lock(mutex_);
   for (const auto& rule : rules_) {
     if (rule->Apply(address))
       return true;
@@ -488,14 +493,25 @@ std::string SocketAddressBlockList::SocketAddressMaskRule::ToString() {
 }
 
 MaybeLocal<Array> SocketAddressBlockList::ListRules(Environment* env) {
+  Mutex::ScopedLock lock(mutex_);
   std::vector<Local<Value>> rules;
+  if (!ListRules(env, &rules))
+    return MaybeLocal<Array>();
+  return Array::New(env->isolate(), rules.data(), rules.size());
+}
+
+bool SocketAddressBlockList::ListRules(
+    Environment* env,
+    std::vector<v8::Local<v8::Value>>* rules) {
+  if (parent_ && !parent_->ListRules(env, rules))
+    return false;
   for (const auto& rule : rules_) {
     Local<Value> str;
     if (!rule->ToV8String(env).ToLocal(&str))
-      return MaybeLocal<Array>();
-    rules.push_back(str);
+      return false;
+    rules->push_back(str);
   }
-  return Array::New(env->isolate(), rules.data(), rules.size());
+  return true;
 }
 
 void SocketAddressBlockList::MemoryInfo(node::MemoryTracker* tracker) const {
@@ -519,20 +535,42 @@ void SocketAddressBlockList::SocketAddressMaskRule::MemoryInfo(
 }
 
 SocketAddressBlockListWrap::SocketAddressBlockListWrap(
-    Environment* env, Local<Object> wrap)
-    : BaseObject(env, wrap) {
+    Environment* env,
+    Local<Object> wrap,
+    std::shared_ptr<SocketAddressBlockList> blocklist)
+    : BaseObject(env, wrap),
+      blocklist_(std::move(blocklist)) {
   MakeWeak();
 }
 
 BaseObjectPtr<SocketAddressBlockListWrap> SocketAddressBlockListWrap::New(
     Environment* env) {
   Local<Object> obj;
-  if (!env->blocklist_instance_template()
+  if (!env->blocklist_constructor_template()
+          ->InstanceTemplate()
           ->NewInstance(env->context()).ToLocal(&obj)) {
-    return {};
+    return BaseObjectPtr<SocketAddressBlockListWrap>();
   }
   BaseObjectPtr<SocketAddressBlockListWrap> wrap =
-      MakeDetachedBaseObject<SocketAddressBlockListWrap>(env, obj);
+      MakeBaseObject<SocketAddressBlockListWrap>(env, obj);
+  CHECK(wrap);
+  return wrap;
+}
+
+BaseObjectPtr<SocketAddressBlockListWrap> SocketAddressBlockListWrap::New(
+    Environment* env,
+    std::shared_ptr<SocketAddressBlockList> blocklist) {
+  Local<Object> obj;
+  if (!env->blocklist_constructor_template()
+          ->InstanceTemplate()
+          ->NewInstance(env->context()).ToLocal(&obj)) {
+    return BaseObjectPtr<SocketAddressBlockListWrap>();
+  }
+  BaseObjectPtr<SocketAddressBlockListWrap> wrap =
+      MakeBaseObject<SocketAddressBlockListWrap>(
+          env,
+          obj,
+          std::move(blocklist));
   CHECK(wrap);
   return wrap;
 }
@@ -562,7 +600,7 @@ void SocketAddressBlockListWrap::AddAddress(
   if (!SocketAddress::ToSockAddr(family, *value, 0, &address))
     return;
 
-  wrap->AddSocketAddress(
+  wrap->blocklist_->AddSocketAddress(
       SocketAddress(reinterpret_cast<const sockaddr*>(&address)));
 
   args.GetReturnValue().Set(true);
@@ -597,7 +635,7 @@ void SocketAddressBlockListWrap::AddRange(
   if (start_addr > end_addr)
     return args.GetReturnValue().Set(false);
 
-  wrap->AddSocketAddressRange(start_addr, end_addr);
+  wrap->blocklist_->AddSocketAddressRange(start_addr, end_addr);
 
   args.GetReturnValue().Set(true);
 }
@@ -628,7 +666,7 @@ void SocketAddressBlockListWrap::AddSubnet(
   CHECK_IMPLIES(family == AF_INET6, prefix <= 128);
   CHECK_GE(prefix, 0);
 
-  wrap->AddSocketAddressMask(
+  wrap->blocklist_->AddSocketAddressMask(
       SocketAddress(reinterpret_cast<const sockaddr*>(&address)),
       prefix);
 
@@ -654,7 +692,8 @@ void SocketAddressBlockListWrap::Check(
     return;
 
   args.GetReturnValue().Set(
-      wrap->Apply(SocketAddress(reinterpret_cast<const sockaddr*>(&address))));
+      wrap->blocklist_->Apply(
+          SocketAddress(reinterpret_cast<const sockaddr*>(&address))));
 }
 
 void SocketAddressBlockListWrap::GetRules(
@@ -663,8 +702,41 @@ void SocketAddressBlockListWrap::GetRules(
   SocketAddressBlockListWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
   Local<Array> rules;
-  if (wrap->ListRules(env).ToLocal(&rules))
+  if (wrap->blocklist_->ListRules(env).ToLocal(&rules))
     args.GetReturnValue().Set(rules);
+}
+
+void SocketAddressBlockListWrap::MemoryInfo(MemoryTracker* tracker) const {
+  blocklist_->MemoryInfo(tracker);
+}
+
+std::unique_ptr<worker::TransferData>
+SocketAddressBlockListWrap::CloneForMessaging() const {
+  return std::make_unique<TransferData>(this);
+}
+
+bool SocketAddressBlockListWrap::HasInstance(
+    Environment* env,
+    Local<Value> value) {
+  return GetConstructorTemplate(env)->HasInstance(value);
+}
+
+Local<FunctionTemplate> SocketAddressBlockListWrap::GetConstructorTemplate(
+    Environment* env) {
+  Local<FunctionTemplate> tmpl = env->blocklist_constructor_template();
+  if (tmpl.IsEmpty()) {
+    tmpl = env->NewFunctionTemplate(SocketAddressBlockListWrap::New);
+    tmpl->SetClassName(FIXED_ONE_BYTE_STRING(env->isolate(), "BlockList"));
+    tmpl->Inherit(BaseObject::GetConstructorTemplate(env));
+    tmpl->InstanceTemplate()->SetInternalFieldCount(kInternalFieldCount);
+    env->SetProtoMethod(tmpl, "addAddress", AddAddress);
+    env->SetProtoMethod(tmpl, "addRange", AddRange);
+    env->SetProtoMethod(tmpl, "addSubnet", AddSubnet);
+    env->SetProtoMethod(tmpl, "check", Check);
+    env->SetProtoMethod(tmpl, "getRules", GetRules);
+    env->set_blocklist_constructor_template(tmpl);
+  }
+  return tmpl;
 }
 
 void SocketAddressBlockListWrap::Initialize(
@@ -674,21 +746,26 @@ void SocketAddressBlockListWrap::Initialize(
     void* priv) {
   Environment* env = Environment::GetCurrent(context);
 
-  Local<FunctionTemplate> t =
-      env->NewFunctionTemplate(SocketAddressBlockListWrap::New);
-  t->InstanceTemplate()->SetInternalFieldCount(BaseObject::kInternalFieldCount);
-
-  env->SetProtoMethod(t, "addAddress", SocketAddressBlockListWrap::AddAddress);
-  env->SetProtoMethod(t, "addRange", SocketAddressBlockListWrap::AddRange);
-  env->SetProtoMethod(t, "addSubnet", SocketAddressBlockListWrap::AddSubnet);
-  env->SetProtoMethod(t, "check", SocketAddressBlockListWrap::Check);
-  env->SetProtoMethod(t, "getRules", SocketAddressBlockListWrap::GetRules);
-
-  env->set_blocklist_instance_template(t->InstanceTemplate());
-  env->SetConstructorFunction(target, "BlockList", t);
+  env->SetConstructorFunction(
+      target,
+      "BlockList",
+      GetConstructorTemplate(env),
+      Environment::SetConstructorFunctionFlag::NONE);
 
   NODE_DEFINE_CONSTANT(target, AF_INET);
   NODE_DEFINE_CONSTANT(target, AF_INET6);
+}
+
+BaseObjectPtr<BaseObject> SocketAddressBlockListWrap::TransferData::Deserialize(
+    Environment* env,
+    Local<Context> context,
+    std::unique_ptr<worker::TransferData> self) {
+  return New(env, std::move(blocklist_));
+}
+
+void SocketAddressBlockListWrap::TransferData::MemoryInfo(
+    MemoryTracker* tracker) const {
+  blocklist_->MemoryInfo(tracker);
 }
 
 }  // namespace node

--- a/src/node_sockaddr.h
+++ b/src/node_sockaddr.h
@@ -168,6 +168,10 @@ class SocketAddressBase : public BaseObject {
     v8::Local<v8::Object> wrap,
     std::shared_ptr<SocketAddress> address);
 
+  inline const std::shared_ptr<SocketAddress>& address() const {
+    return address_;
+  }
+
   void MemoryInfo(MemoryTracker* tracker) const override;
   SET_MEMORY_INFO_NAME(SocketAddressBase);
   SET_SELF_SIZE(SocketAddressBase);
@@ -246,38 +250,36 @@ class SocketAddressBlockList : public MemoryRetainer {
       std::shared_ptr<SocketAddressBlockList> parent = {});
   ~SocketAddressBlockList() = default;
 
-  void AddSocketAddress(
-      const SocketAddress& address);
+  void AddSocketAddress(const std::shared_ptr<SocketAddress>& address);
 
-  void RemoveSocketAddress(
-      const SocketAddress& address);
+  void RemoveSocketAddress(const std::shared_ptr<SocketAddress>& address);
 
   void AddSocketAddressRange(
-      const SocketAddress& start,
-      const SocketAddress& end);
+      const std::shared_ptr<SocketAddress>& start,
+      const std::shared_ptr<SocketAddress>& end);
 
   void AddSocketAddressMask(
-      const SocketAddress& address,
+      const std::shared_ptr<SocketAddress>& address,
       int prefix);
 
-  bool Apply(const SocketAddress& address);
+  bool Apply(const std::shared_ptr<SocketAddress>& address);
 
   size_t size() const { return rules_.size(); }
 
   v8::MaybeLocal<v8::Array> ListRules(Environment* env);
 
   struct Rule : public MemoryRetainer {
-    virtual bool Apply(const SocketAddress& address) = 0;
+    virtual bool Apply(const std::shared_ptr<SocketAddress>& address) = 0;
     inline v8::MaybeLocal<v8::Value> ToV8String(Environment* env);
     virtual std::string ToString() = 0;
   };
 
   struct SocketAddressRule final : Rule {
-    SocketAddress address;
+    std::shared_ptr<SocketAddress> address;
 
-    explicit SocketAddressRule(const SocketAddress& address);
+    explicit SocketAddressRule(const std::shared_ptr<SocketAddress>& address);
 
-    bool Apply(const SocketAddress& address) override;
+    bool Apply(const std::shared_ptr<SocketAddress>& address) override;
     std::string ToString() override;
 
     void MemoryInfo(node::MemoryTracker* tracker) const override;
@@ -286,14 +288,14 @@ class SocketAddressBlockList : public MemoryRetainer {
   };
 
   struct SocketAddressRangeRule final : Rule {
-    SocketAddress start;
-    SocketAddress end;
+    std::shared_ptr<SocketAddress> start;
+    std::shared_ptr<SocketAddress> end;
 
     SocketAddressRangeRule(
-        const SocketAddress& start,
-        const SocketAddress& end);
+        const std::shared_ptr<SocketAddress>& start,
+        const std::shared_ptr<SocketAddress>& end);
 
-    bool Apply(const SocketAddress& address) override;
+    bool Apply(const std::shared_ptr<SocketAddress>& address) override;
     std::string ToString() override;
 
     void MemoryInfo(node::MemoryTracker* tracker) const override;
@@ -302,14 +304,14 @@ class SocketAddressBlockList : public MemoryRetainer {
   };
 
   struct SocketAddressMaskRule final : Rule {
-    SocketAddress network;
+    std::shared_ptr<SocketAddress> network;
     int prefix;
 
     SocketAddressMaskRule(
-        const SocketAddress& address,
+        const std::shared_ptr<SocketAddress>& address,
         int prefix);
 
-    bool Apply(const SocketAddress& address) override;
+    bool Apply(const std::shared_ptr<SocketAddress>& address) override;
     std::string ToString() override;
 
     void MemoryInfo(node::MemoryTracker* tracker) const override;

--- a/test/cctest/test_sockaddr.cc
+++ b/test/cctest/test_sockaddr.cc
@@ -197,8 +197,12 @@ TEST(SocketAddressBlockList, Simple) {
   sockaddr_storage storage[2];
   SocketAddress::ToSockAddr(AF_INET, "10.0.0.1", 0, &storage[0]);
   SocketAddress::ToSockAddr(AF_INET, "10.0.0.2", 0, &storage[1]);
-  SocketAddress addr1(reinterpret_cast<const sockaddr*>(&storage[0]));
-  SocketAddress addr2(reinterpret_cast<const sockaddr*>(&storage[1]));
+  std::shared_ptr<SocketAddress> addr1 =
+      std::make_shared<SocketAddress>(
+          reinterpret_cast<const sockaddr*>(&storage[0]));
+  std::shared_ptr<SocketAddress> addr2 =
+      std::make_shared<SocketAddress>(
+          reinterpret_cast<const sockaddr*>(&storage[1]));
 
   bl.AddSocketAddress(addr1);
   bl.AddSocketAddress(addr2);

--- a/test/parallel/test-blocklist-clone.js
+++ b/test/parallel/test-blocklist-clone.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const common = require('../common');
+
+const {
+  BlockList,
+} = require('net');
+
+const {
+  ok,
+  notStrictEqual,
+} = require('assert');
+
+const blocklist = new BlockList();
+blocklist.addAddress('123.123.123.123');
+
+const mc = new MessageChannel();
+
+mc.port1.onmessage = common.mustCall(({ data }) => {
+  notStrictEqual(data, blocklist);
+  ok(data.check('123.123.123.123'));
+  ok(!data.check('123.123.123.124'));
+
+  data.addAddress('123.123.123.124');
+  ok(blocklist.check('123.123.123.124'));
+  ok(data.check('123.123.123.124'));
+
+  mc.port1.close();
+});
+
+mc.port2.postMessage(blocklist);

--- a/test/parallel/test-blocklist.js
+++ b/test/parallel/test-blocklist.js
@@ -138,10 +138,6 @@ const util = require('util');
 }
 
 {
-  assert.throws(() => new BlockList('NOT BLOCK LIST HANDLE'), /ERR_INVALID_ARG_TYPE/);
-}
-
-{
   const blockList = new BlockList();
   assert.throws(() => blockList.addRange('1.1.1.2', '1.1.1.1'), /ERR_INVALID_ARG_VALUE/);
 }

--- a/test/parallel/test-blocklist.js
+++ b/test/parallel/test-blocklist.js
@@ -2,7 +2,10 @@
 
 require('../common');
 
-const { BlockList } = require('net');
+const {
+  BlockList,
+  SocketAddress,
+} = require('net');
 const assert = require('assert');
 const util = require('util');
 
@@ -67,8 +70,61 @@ const util = require('util');
 
 {
   const blockList = new BlockList();
+  const sa1 = new SocketAddress({ address: '1.1.1.1' });
+  const sa2 = new SocketAddress({
+    address: '8592:757c:efae:4e45:fb5d:d62a:0d00:8e17',
+    family: 'ipv6'
+  });
+  const sa3 = new SocketAddress({ address: '1.1.1.2' });
+
+  blockList.addAddress(sa1);
+  blockList.addAddress(sa2);
+  blockList.addAddress('::ffff:1.1.1.2', 'ipv6');
+
+  assert(blockList.check('1.1.1.1'));
+  assert(blockList.check(sa1));
+  assert(!blockList.check('1.1.1.1', 'ipv6'));
+  assert(!blockList.check('8592:757c:efae:4e45:fb5d:d62a:0d00:8e17'));
+  assert(blockList.check('8592:757c:efae:4e45:fb5d:d62a:0d00:8e17', 'ipv6'));
+  assert(blockList.check(sa2));
+
+  assert(blockList.check('::ffff:1.1.1.1', 'ipv6'));
+  assert(blockList.check('::ffff:1.1.1.1', 'IPV6'));
+
+  assert(blockList.check('1.1.1.2'));
+  assert(blockList.check(sa3));
+
+  assert(!blockList.check('1.2.3.4'));
+  assert(!blockList.check('::1', 'ipv6'));
+}
+
+{
+  const blockList = new BlockList();
   blockList.addRange('1.1.1.1', '1.1.1.10');
   blockList.addRange('::1', '::f', 'ipv6');
+
+  assert(!blockList.check('1.1.1.0'));
+  for (let n = 1; n <= 10; n++)
+    assert(blockList.check(`1.1.1.${n}`));
+  assert(!blockList.check('1.1.1.11'));
+
+  assert(!blockList.check('::0', 'ipv6'));
+  for (let n = 0x1; n <= 0xf; n++) {
+    assert(blockList.check(`::${n.toString(16)}`, 'ipv6'),
+           `::${n.toString(16)} check failed`);
+  }
+  assert(!blockList.check('::10', 'ipv6'));
+}
+
+{
+  const blockList = new BlockList();
+  const sa1 = new SocketAddress({ address: '1.1.1.1' });
+  const sa2 = new SocketAddress({ address: '1.1.1.10' });
+  const sa3 = new SocketAddress({ address: '::1', family: 'ipv6' });
+  const sa4 = new SocketAddress({ address: '::f', family: 'ipv6' });
+
+  blockList.addRange(sa1, sa2);
+  blockList.addRange(sa3, sa4);
 
   assert(!blockList.check('1.1.1.0'));
   for (let n = 1; n <= 10; n++)
@@ -100,6 +156,23 @@ const util = require('util');
 
 {
   const blockList = new BlockList();
+  const sa1 = new SocketAddress({ address: '1.1.1.0' });
+  const sa2 = new SocketAddress({ address: '1.1.1.1' });
+  blockList.addSubnet(sa1, 16);
+  blockList.addSubnet('8592:757c:efae:4e45::', 64, 'ipv6');
+
+  assert(blockList.check('1.1.0.1'));
+  assert(blockList.check(sa2));
+  assert(!blockList.check('1.2.0.1'));
+  assert(blockList.check('::ffff:1.1.0.1', 'ipv6'));
+
+  assert(blockList.check('8592:757c:efae:4e45:f::', 'ipv6'));
+  assert(blockList.check('8592:757c:efae:4e45::f', 'ipv6'));
+  assert(!blockList.check('8592:757c:efae:4f45::f', 'ipv6'));
+}
+
+{
+  const blockList = new BlockList();
   blockList.addAddress('1.1.1.1');
   blockList.addRange('10.0.0.1', '10.0.0.10');
   blockList.addSubnet('8592:757c:efae:4e45::', 64, 'IpV6'); // Case insensitive
@@ -110,7 +183,6 @@ const util = require('util');
     'Address: IPv4 1.1.1.1'
   ];
   assert.deepStrictEqual(blockList.rules, rulesCheck);
-  console.log(blockList);
 
   assert(blockList.check('1.1.1.1'));
   assert(blockList.check('10.0.0.5'));
@@ -145,23 +217,27 @@ const util = require('util');
 {
   const blockList = new BlockList();
   assert.throws(() => blockList.addSubnet(1), /ERR_INVALID_ARG_TYPE/);
-  assert.throws(() => blockList.addSubnet('', ''), /ERR_INVALID_ARG_TYPE/);
-  assert.throws(() => blockList.addSubnet('', NaN), /ERR_OUT_OF_RANGE/);
+  assert.throws(() => blockList.addSubnet('1.1.1.1', ''),
+                /ERR_INVALID_ARG_TYPE/);
+  assert.throws(() => blockList.addSubnet('1.1.1.1', NaN), /ERR_OUT_OF_RANGE/);
   assert.throws(() => blockList.addSubnet('', 1, 1), /ERR_INVALID_ARG_TYPE/);
   assert.throws(() => blockList.addSubnet('', 1, ''), /ERR_INVALID_ARG_VALUE/);
 
-  assert.throws(() => blockList.addSubnet('', -1, 'ipv4'), /ERR_OUT_OF_RANGE/);
-  assert.throws(() => blockList.addSubnet('', 33, 'ipv4'), /ERR_OUT_OF_RANGE/);
+  assert.throws(() => blockList.addSubnet('1.1.1.1', -1, 'ipv4'),
+                /ERR_OUT_OF_RANGE/);
+  assert.throws(() => blockList.addSubnet('1.1.1.1', 33, 'ipv4'),
+                /ERR_OUT_OF_RANGE/);
 
-  assert.throws(() => blockList.addSubnet('', -1, 'ipv6'), /ERR_OUT_OF_RANGE/);
-  assert.throws(() => blockList.addSubnet('', 129, 'ipv6'), /ERR_OUT_OF_RANGE/);
+  assert.throws(() => blockList.addSubnet('::', -1, 'ipv6'),
+                /ERR_OUT_OF_RANGE/);
+  assert.throws(() => blockList.addSubnet('::', 129, 'ipv6'),
+                /ERR_OUT_OF_RANGE/);
 }
 
 {
   const blockList = new BlockList();
   assert.throws(() => blockList.check(1), /ERR_INVALID_ARG_TYPE/);
   assert.throws(() => blockList.check('', 1), /ERR_INVALID_ARG_TYPE/);
-  assert.throws(() => blockList.check('', ''), /ERR_INVALID_ARG_VALUE/);
 }
 
 {

--- a/test/parallel/test-socketaddress.js
+++ b/test/parallel/test-socketaddress.js
@@ -1,0 +1,110 @@
+'use strict';
+
+const common = require('../common');
+const {
+  ok,
+  strictEqual,
+  throws,
+} = require('assert');
+const {
+  SocketAddress,
+} = require('net');
+
+{
+  const sa = new SocketAddress();
+  strictEqual(sa.address, '127.0.0.1');
+  strictEqual(sa.port, 0);
+  strictEqual(sa.family, 'ipv4');
+  strictEqual(sa.flowlabel, 0);
+
+  const mc = new MessageChannel();
+  mc.port1.onmessage = common.mustCall(({ data }) => {
+    ok(SocketAddress.isSocketAddress(data));
+
+    strictEqual(data.address, '127.0.0.1');
+    strictEqual(data.port, 0);
+    strictEqual(data.family, 'ipv4');
+    strictEqual(data.flowlabel, 0);
+
+    mc.port1.close();
+  });
+  mc.port2.postMessage(sa);
+}
+
+{
+  const sa = new SocketAddress({});
+  strictEqual(sa.address, '127.0.0.1');
+  strictEqual(sa.port, 0);
+  strictEqual(sa.family, 'ipv4');
+  strictEqual(sa.flowlabel, 0);
+}
+
+{
+  const sa = new SocketAddress({
+    address: '123.123.123.123',
+  });
+  strictEqual(sa.address, '123.123.123.123');
+  strictEqual(sa.port, 0);
+  strictEqual(sa.family, 'ipv4');
+  strictEqual(sa.flowlabel, 0);
+}
+
+{
+  const sa = new SocketAddress({
+    address: '123.123.123.123',
+    port: 80
+  });
+  strictEqual(sa.address, '123.123.123.123');
+  strictEqual(sa.port, 80);
+  strictEqual(sa.family, 'ipv4');
+  strictEqual(sa.flowlabel, 0);
+}
+
+{
+  const sa = new SocketAddress({
+    family: 'ipv6'
+  });
+  strictEqual(sa.address, '::');
+  strictEqual(sa.port, 0);
+  strictEqual(sa.family, 'ipv6');
+  strictEqual(sa.flowlabel, 0);
+}
+
+{
+  const sa = new SocketAddress({
+    family: 'ipv6',
+    flowlabel: 1,
+  });
+  strictEqual(sa.address, '::');
+  strictEqual(sa.port, 0);
+  strictEqual(sa.family, 'ipv6');
+  strictEqual(sa.flowlabel, 1);
+}
+
+[1, false, 'hello'].forEach((i) => {
+  throws(() => new SocketAddress(i), {
+    code: 'ERR_INVALID_ARG_TYPE'
+  });
+});
+
+[1, false, {}, [], 'test'].forEach((family) => {
+  throws(() => new SocketAddress({ family }), {
+    code: 'ERR_INVALID_ARG_VALUE'
+  });
+});
+
+[1, false, {}, []].forEach((address) => {
+  throws(() => new SocketAddress({ address }), {
+    code: 'ERR_INVALID_ARG_TYPE'
+  });
+});
+
+[-1, false, {}, []].forEach((port) => {
+  throws(() => new SocketAddress({ port }), {
+    code: 'ERR_SOCKET_BAD_PORT'
+  });
+});
+
+throws(() => new SocketAddress({ flowlabel: -1 }), {
+  code: 'ERR_OUT_OF_RANGE'
+});

--- a/tools/doc/type-parser.js
+++ b/tools/doc/type-parser.js
@@ -175,6 +175,7 @@ const customTypesMap = {
   'net.BlockList': 'net.html#net_class_net_blocklist',
   'net.Server': 'net.html#net_class_net_server',
   'net.Socket': 'net.html#net_class_net_socket',
+  'net.SocketAddress': 'net.html#net_class_net_socketaddress',
 
   'NodeEventTarget':
     'events.html#events_class_nodeeventtarget',


### PR DESCRIPTION
This does three things:

1. Makes `net.BlockList` shareable over `MessagePort` / worker threads. The backend data is shared by all clones.
2. Introduces a new `net.SocketAddress` class that wraps the internal `node::SocketAddress` utility, allowing those to be created and used multiple times and avoiding copy operations.
3. Modifies `net.BlockList` to accept `net.SocketAddress` instances.

This work is in preparation for both the upcoming revised QUIC implementation and explorations into a permission system for Node.js