### PR TITLE
deps: upgrade npm to 7.7.5

### DIFF
--- a/deps/npm/.npmignore
+++ b/deps/npm/.npmignore
@@ -39,3 +39,7 @@ docs/template.html
 Session.vim
 .nyc_output
 /.editorconfig
+
+# don't ship smoke tests
+smoke-tests/
+tap-snapshots/smoke-tests-index.js-TAP.test.js

--- a/deps/npm/AUTHORS
+++ b/deps/npm/AUTHORS
@@ -767,3 +767,4 @@ Eric Chow <eric.zjp.chow@gmail.com>
 kbayrhammer <klaus.bayrhammer@redbull.com>
 James Chen-Smith <jameschensmith@gmail.com>
 Yash Singh <saiansh2525@gmail.com>
+Danielle Church <dani.church@gmail.com>

--- a/deps/npm/CHANGELOG.md
+++ b/deps/npm/CHANGELOG.md
@@ -1,3 +1,31 @@
+## v7.7.5 (2021-03-25)
+
+### BUG FIXES
+
+* [`95ba87622`](https://github.com/npm/cli/commit/95ba87622e00d68270eda9e071b19737718fca16)
+  [#2949](https://github.com/npm/cli/issues/2949)
+  fix handling manual indexes in `npm help`
+  ([@dmchurch](https://github.com/dmchurch))
+* [`59cf37962`](https://github.com/npm/cli/commit/59cf37962a2286e0f7d3bd37fa9c8bc3bac94218)
+  [#2958](https://github.com/npm/cli/issues/2958)
+  always set `npm.command` to canonical command name
+  ([@isaacs](https://github.com/isaacs))
+* [`1415b4bde`](https://github.com/npm/cli/commit/1415b4bdeeaabb6e0ba12b6b1b0cc56502bd64ab)
+  [#2964](https://github.com/npm/cli/issues/2964)
+  fix(config): properly translate user-agent
+  ([@wraithgar](https://github.com/wraithgar))
+* [`59271936d`](https://github.com/npm/cli/commit/59271936d90fbd6956a41967119f578c0ba63db9)
+  [#2965](https://github.com/npm/cli/issues/2965)
+  fix(config): tie save-exact/save-prefix together
+  ([@wraithgar](https://github.com/wraithgar))
+
+### TESTS
+
+* [`97b415287`](https://github.com/npm/cli/commit/97b41528739460b2e9e72e09000aded412418cb2)
+  [#2959](https://github.com/npm/cli/issues/2959)
+  add smoke tests
+  ([@ruyadorno](https://github.com/ruyadorno))
+
 ## v7.7.4 (2021-03-24)
 
 ### BUG FIXES

--- a/deps/npm/docs/output/commands/npm-ls.html
+++ b/deps/npm/docs/output/commands/npm-ls.html
@@ -159,7 +159,7 @@ tree at all, use <a href="../commands/npm-explain.html"><code>npm explain</code>
 the results to only the paths to the packages named.  Note that nested
 packages will <em>also</em> show the paths to the specified packages.  For
 example, running <code>npm ls promzard</code> in npm’s source tree will show:</p>
-<pre lang="bash"><code>npm@7.7.4 /path/to/npm
+<pre lang="bash"><code>npm@7.7.5 /path/to/npm
 └─┬ init-package-json@0.0.4
   └── promzard@0.1.5
 </code></pre>

--- a/deps/npm/docs/output/commands/npm.html
+++ b/deps/npm/docs/output/commands/npm.html
@@ -148,7 +148,7 @@ npm command-line interface
 <pre lang="bash"><code>npm &lt;command&gt; [args]
 </code></pre>
 <h3 id="version">Version</h3>
-<p>7.7.4</p>
+<p>7.7.5</p>
 <h3 id="description">Description</h3>
 <p>npm is the package manager for the Node JavaScript platform.  It puts
 modules in place so that node can find them, and manages dependency

--- a/deps/npm/lib/help.js
+++ b/deps/npm/lib/help.js
@@ -9,7 +9,7 @@ const BaseCommand = require('./base-command.js')
 // Strips out the number from foo.7 or foo.7. or foo.7.tgz
 // We don't currently compress our man pages but if we ever did this would
 // seemlessly continue supporting it
-const manNumberRegex = /\.(\d+)(\..*)?$/
+const manNumberRegex = /\.(\d+)(\.[^/\\]*)?$/
 
 class Help extends BaseCommand {
   /* istanbul ignore next - see test/lib/load-all-commands.js */

--- a/deps/npm/lib/npm.js
+++ b/deps/npm/lib/npm.js
@@ -25,7 +25,7 @@ const proxyCmds = new Proxy({}, {
       // old way of doing things, until we can make breaking changes to the
       // npm.commands[x] api
       target[actual] = new Proxy(
-        (args, cb) => npm[_runCmd](cmd, impl, args, cb),
+        (args, cb) => npm[_runCmd](actual, impl, args, cb),
         {
           get: (target, attr, receiver) => {
             return Reflect.get(impl, attr, receiver)

--- a/deps/npm/lib/utils/config/definitions.js
+++ b/deps/npm/lib/utils/config/definitions.js
@@ -1526,7 +1526,10 @@ define('save-exact', {
     Dependencies saved to package.json will be configured with an exact
     version rather than using npm's default semver range operator.
   `,
-  flatten,
+  flatten (key, obj, flatOptions) {
+    // just call the save-prefix flattener, it reads from obj['save-exact']
+    definitions['save-prefix'].flatten('save-prefix', obj, flatOptions)
+  },
 })
 
 define('save-optional', {
@@ -1595,6 +1598,7 @@ define('save-prefix', {
   `,
   flatten (key, obj, flatOptions) {
     flatOptions.savePrefix = obj['save-exact'] ? '' : obj['save-prefix']
+    obj['save-prefix'] = flatOptions.savePrefix
   },
 })
 
@@ -1970,6 +1974,11 @@ define('user-agent', {
         .replace(/\{arch\}/gi, process.arch)
         .replace(/\{ci\}/gi, ciName ? `ci/${ciName}` : '')
         .trim()
+    // user-agent is a unique kind of config item that gets set from a template
+    // and ends up translated.  Because of this, the normal "should we set this
+    // to process.env also doesn't work
+    obj[key] = flatOptions.userAgent
+    process.env.npm_config_user_agent = flatOptions.userAgent
   },
 })
 

--- a/deps/npm/man/man1/npm-ls.1
+++ b/deps/npm/man/man1/npm-ls.1
@@ -26,7 +26,7 @@ example, running \fBnpm ls promzard\fP in npm's source tree will show:
 .P
 .RS 2
 .nf
-npm@7\.7\.4 /path/to/npm
+npm@7\.7\.5 /path/to/npm
 └─┬ init\-package\-json@0\.0\.4
   └── promzard@0\.1\.5
 .fi

--- a/deps/npm/man/man1/npm.1
+++ b/deps/npm/man/man1/npm.1
@@ -10,7 +10,7 @@ npm <command> [args]
 .RE
 .SS Version
 .P
-7\.7\.4
+7\.7\.5
 .SS Description
 .P
 npm is the package manager for the Node JavaScript platform\.  It puts

--- a/deps/npm/package.json
+++ b/deps/npm/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.7.4",
+  "version": "7.7.5",
   "name": "npm",
   "description": "a package manager for JavaScript",
   "keywords": [
@@ -207,7 +207,8 @@
     "lint": "npm run eslint -- test/lib test/bin \"lib/**/*.js\"",
     "lintfix": "npm run lint -- --fix",
     "prelint": "rimraf test/npm_cache*",
-    "resetdeps": "bash scripts/resetdeps.sh"
+    "resetdeps": "bash scripts/resetdeps.sh",
+    "smoke-tests": "tap smoke-tests/index.js"
   },
   "//": [
     "XXX temporarily only run unit tests while v7 beta is in progress",

--- a/deps/npm/tap-snapshots/smoke-tests-index.js-TAP.test.js
+++ b/deps/npm/tap-snapshots/smoke-tests-index.js-TAP.test.js
@@ -1,0 +1,649 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`smoke-tests/index.js TAP npm diff > should have expected diff output 1`] = `
+diff --git a/package.json b/package.json
+index v1.0.4..v1.1.1 100644
+--- a/package.json
++++ b/package.json
+@@ -1,15 +1,21 @@
+ {
+   "name": "abbrev",
+-  "version": "1.0.4",
++  "version": "1.1.1",
+   "description": "Like ruby's abbrev module, but in js",
+   "author": "Isaac Z. Schlueter <i@izs.me>",
+-  "main": "./lib/abbrev.js",
++  "main": "abbrev.js",
+   "scripts": {
+-    "test": "node lib/abbrev.js"
++    "test": "tap test.js --100",
++    "preversion": "npm test",
++    "postversion": "npm publish",
++    "postpublish": "git push origin --all; git push origin --tags"
+   },
+   "repository": "http://github.com/isaacs/abbrev-js",
+-  "license": {
+-    "type": "MIT",
+-    "url": "https://github.com/isaacs/abbrev-js/raw/master/LICENSE"
+-  }
++  "license": "ISC",
++  "devDependencies": {
++    "tap": "^10.1"
++  },
++  "files": [
++    "abbrev.js"
++  ]
+ }
+diff --git a/LICENSE b/LICENSE
+index v1.0.4..v1.1.1 100644
+--- a/LICENSE
++++ b/LICENSE
+@@ -1,4 +1,27 @@
+-Copyright 2009, 2010, 2011 Isaac Z. Schlueter.
++This software is dual-licensed under the ISC and MIT licenses.
++You may use this software under EITHER of the following licenses.
++
++----------
++
++The ISC License
++
++Copyright (c) Isaac Z. Schlueter and Contributors
++
++Permission to use, copy, modify, and/or distribute this software for any
++purpose with or without fee is hereby granted, provided that the above
++copyright notice and this permission notice appear in all copies.
++
++THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
++WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
++MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
++ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
++WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
++ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
++IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
++
++----------
++
++Copyright Isaac Z. Schlueter and Contributors
+ All rights reserved.
+
+ Permission is hereby granted, free of charge, to any person
+diff --git a/lib/abbrev.js b/lib/abbrev.js
+deleted file mode 100644
+index v1.0.4..v1.1.1
+--- a/lib/abbrev.js
++++ b/lib/abbrev.js
+@@ -1,111 +0,0 @@
+-
+-module.exports = exports = abbrev.abbrev = abbrev
+-
+-abbrev.monkeyPatch = monkeyPatch
+-
+-function monkeyPatch () {
+-  Object.defineProperty(Array.prototype, 'abbrev', {
+-    value: function () { return abbrev(this) },
+-    enumerable: false, configurable: true, writable: true
+-  })
+-
+-  Object.defineProperty(Object.prototype, 'abbrev', {
+-    value: function () { return abbrev(Object.keys(this)) },
+-    enumerable: false, configurable: true, writable: true
+-  })
+-}
+-
+-function abbrev (list) {
+-  if (arguments.length !== 1 || !Array.isArray(list)) {
+-    list = Array.prototype.slice.call(arguments, 0)
+-  }
+-  for (var i = 0, l = list.length, args = [] ; i < l ; i ++) {
+-    args[i] = typeof list[i] === "string" ? list[i] : String(list[i])
+-  }
+-
+-  // sort them lexicographically, so that they're next to their nearest kin
+-  args = args.sort(lexSort)
+-
+-  // walk through each, seeing how much it has in common with the next and previous
+-  var abbrevs = {}
+-    , prev = ""
+-  for (var i = 0, l = args.length ; i < l ; i ++) {
+-    var current = args[i]
+-      , next = args[i + 1] || ""
+-      , nextMatches = true
+-      , prevMatches = true
+-    if (current === next) continue
+-    for (var j = 0, cl = current.length ; j < cl ; j ++) {
+-      var curChar = current.charAt(j)
+-      nextMatches = nextMatches && curChar === next.charAt(j)
+-      prevMatches = prevMatches && curChar === prev.charAt(j)
+-      if (!nextMatches && !prevMatches) {
+-        j ++
+-        break
+-      }
+-    }
+-    prev = current
+-    if (j === cl) {
+-      abbrevs[current] = current
+-      continue
+-    }
+-    for (var a = current.substr(0, j) ; j <= cl ; j ++) {
+-      abbrevs[a] = current
+-      a += current.charAt(j)
+-    }
+-  }
+-  return abbrevs
+-}
+-
+-function lexSort (a, b) {
+-  return a === b ? 0 : a > b ? 1 : -1
+-}
+-
+-
+-// tests
+-if (module === require.main) {
+-
+-var assert = require("assert")
+-var util = require("util")
+-
+-console.log("running tests")
+-function test (list, expect) {
+-  var actual = abbrev(list)
+-  assert.deepEqual(actual, expect,
+-    "abbrev("+util.inspect(list)+") === " + util.inspect(expect) + "/n"+
+-    "actual: "+util.inspect(actual))
+-  actual = abbrev.apply(exports, list)
+-  assert.deepEqual(abbrev.apply(exports, list), expect,
+-    "abbrev("+list.map(JSON.stringify).join(",")+") === " + util.inspect(expect) + "/n"+
+-    "actual: "+util.inspect(actual))
+-}
+-
+-test([ "ruby", "ruby", "rules", "rules", "rules" ],
+-{ rub: 'ruby'
+-, ruby: 'ruby'
+-, rul: 'rules'
+-, rule: 'rules'
+-, rules: 'rules'
+-})
+-test(["fool", "foom", "pool", "pope"],
+-{ fool: 'fool'
+-, foom: 'foom'
+-, poo: 'pool'
+-, pool: 'pool'
+-, pop: 'pope'
+-, pope: 'pope'
+-})
+-test(["a", "ab", "abc", "abcd", "abcde", "acde"],
+-{ a: 'a'
+-, ab: 'ab'
+-, abc: 'abc'
+-, abcd: 'abcd'
+-, abcde: 'abcde'
+-, ac: 'acde'
+-, acd: 'acde'
+-, acde: 'acde'
+-})
+-
+-console.log("pass")
+-
+-}
+/ No newline at end of file
+diff --git a/abbrev.js b/abbrev.js
+new file mode 100644
+index v1.0.4..v1.1.1
+--- a/abbrev.js
++++ b/abbrev.js
+@@ -0,0 +1,61 @@
++module.exports = exports = abbrev.abbrev = abbrev
++
++abbrev.monkeyPatch = monkeyPatch
++
++function monkeyPatch () {
++  Object.defineProperty(Array.prototype, 'abbrev', {
++    value: function () { return abbrev(this) },
++    enumerable: false, configurable: true, writable: true
++  })
++
++  Object.defineProperty(Object.prototype, 'abbrev', {
++    value: function () { return abbrev(Object.keys(this)) },
++    enumerable: false, configurable: true, writable: true
++  })
++}
++
++function abbrev (list) {
++  if (arguments.length !== 1 || !Array.isArray(list)) {
++    list = Array.prototype.slice.call(arguments, 0)
++  }
++  for (var i = 0, l = list.length, args = [] ; i < l ; i ++) {
++    args[i] = typeof list[i] === "string" ? list[i] : String(list[i])
++  }
++
++  // sort them lexicographically, so that they're next to their nearest kin
++  args = args.sort(lexSort)
++
++  // walk through each, seeing how much it has in common with the next and previous
++  var abbrevs = {}
++    , prev = ""
++  for (var i = 0, l = args.length ; i < l ; i ++) {
++    var current = args[i]
++      , next = args[i + 1] || ""
++      , nextMatches = true
++      , prevMatches = true
++    if (current === next) continue
++    for (var j = 0, cl = current.length ; j < cl ; j ++) {
++      var curChar = current.charAt(j)
++      nextMatches = nextMatches && curChar === next.charAt(j)
++      prevMatches = prevMatches && curChar === prev.charAt(j)
++      if (!nextMatches && !prevMatches) {
++        j ++
++        break
++      }
++    }
++    prev = current
++    if (j === cl) {
++      abbrevs[current] = current
++      continue
++    }
++    for (var a = current.substr(0, j) ; j <= cl ; j ++) {
++      abbrevs[a] = current
++      a += current.charAt(j)
++    }
++  }
++  return abbrevs
++}
++
++function lexSort (a, b) {
++  return a === b ? 0 : a > b ? 1 : -1
++}
+
+`
+
+exports[`smoke-tests/index.js TAP npm explain > should have expected explain output 1`] = `
+abbrev@1.0.4
+node_modules/abbrev
+  abbrev@"^1.0.4" from the root project
+
+`
+
+exports[`smoke-tests/index.js TAP npm fund > should have expected fund output 1`] = `
+project@1.0.0
+\`-- https://github.com/sponsors/isaacs
+    \`-- promise-all-reject-late@1.0.1
+
+
+`
+
+exports[`smoke-tests/index.js TAP npm init > should have successful npm init result 1`] = `
+Wrote to {CWD}/smoke-tests/index/project/package.json:
+
+{
+  "name": "project",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo /"Error: no test specified/" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}
+
+
+
+`
+
+exports[`smoke-tests/index.js TAP npm install dev dep > should have expected dev dep added lockfile result 1`] = `
+{
+  "name": "project",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^1.0.4"
+      },
+      "devDependencies": {
+        "promise-all-reject-late": "^1.0.1"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.4.tgz",
+      "integrity": "sha1-vVWuXkE7oXIu5Mq6H26hBBSlns0="
+    },
+    "node_modules/promise-all-reject-late": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise-all-reject-late/-/promise-all-reject-late-1.0.1.tgz",
+      "integrity": "sha512-vuf0Lf0lOxyQREH7GDIOUMLS7kz+gs8i6B+Yi8dC68a2sychGrHTJYghMBD6k7eUcH0H5P73EckCA48xijWqXw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    }
+  },
+  "dependencies": {
+    "abbrev": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.4.tgz",
+      "integrity": "sha1-vVWuXkE7oXIu5Mq6H26hBBSlns0="
+    },
+    "promise-all-reject-late": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise-all-reject-late/-/promise-all-reject-late-1.0.1.tgz",
+      "integrity": "sha512-vuf0Lf0lOxyQREH7GDIOUMLS7kz+gs8i6B+Yi8dC68a2sychGrHTJYghMBD6k7eUcH0H5P73EckCA48xijWqXw==",
+      "dev": true
+    }
+  }
+}
+
+`
+
+exports[`smoke-tests/index.js TAP npm install dev dep > should have expected dev dep added package.json result 1`] = `
+{
+  "name": "project",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo /"Error: no test specified/" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "abbrev": "^1.0.4"
+  },
+  "devDependencies": {
+    "promise-all-reject-late": "^1.0.1"
+  }
+}
+
+`
+
+exports[`smoke-tests/index.js TAP npm install dev dep > should have expected dev dep added reify output 1`] = `
+
+added 1 package
+
+1 package is looking for funding
+  run \`npm fund\` for details
+
+`
+
+exports[`smoke-tests/index.js TAP npm install prodDep@version > should have expected install reify output 1`] = `
+
+added 1 package
+
+`
+
+exports[`smoke-tests/index.js TAP npm install prodDep@version > should have expected lockfile result 1`] = `
+{
+  "name": "project",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^1.0.4"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.4.tgz",
+      "integrity": "sha1-vVWuXkE7oXIu5Mq6H26hBBSlns0="
+    }
+  },
+  "dependencies": {
+    "abbrev": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.4.tgz",
+      "integrity": "sha1-vVWuXkE7oXIu5Mq6H26hBBSlns0="
+    }
+  }
+}
+
+`
+
+exports[`smoke-tests/index.js TAP npm install prodDep@version > should have expected package.json result 1`] = `
+{
+  "name": "project",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo /"Error: no test specified/" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "abbrev": "^1.0.4"
+  }
+}
+
+`
+
+exports[`smoke-tests/index.js TAP npm ls > should have expected ls output 1`] = `
+project@1.0.0 {CWD}/smoke-tests/index/project
++-- abbrev@1.0.4
+\`-- promise-all-reject-late@1.0.1
+
+
+`
+
+exports[`smoke-tests/index.js TAP npm outdated > should have expected outdated output 1`] = `
+Package  Current  Wanted  Latest  Location             Depended by
+abbrev     1.0.4   1.1.1   1.1.1  node_modules/abbrev  project
+
+`
+
+exports[`smoke-tests/index.js TAP npm prefix > should have expected prefix output 1`] = `
+{CWD}/smoke-tests/index/project
+
+`
+
+exports[`smoke-tests/index.js TAP npm run-script > should have expected run-script output 1`] = `
+
+> project@1.0.0 hello
+> echo Hello
+
+Hello
+
+`
+
+exports[`smoke-tests/index.js TAP npm set-script > should have expected script added package.json result 1`] = `
+{
+  "name": "project",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo /"Error: no test specified/" && exit 1",
+    "hello": "echo Hello"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "abbrev": "^1.0.4"
+  },
+  "devDependencies": {
+    "promise-all-reject-late": "^1.0.1"
+  }
+}
+
+`
+
+exports[`smoke-tests/index.js TAP npm set-script > should have expected set-script output 1`] = `
+
+`
+
+exports[`smoke-tests/index.js TAP npm uninstall > should have expected uninstall lockfile result 1`] = `
+{
+  "name": "project",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^1.0.4"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    }
+  },
+  "dependencies": {
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    }
+  }
+}
+
+`
+
+exports[`smoke-tests/index.js TAP npm uninstall > should have expected uninstall package.json result 1`] = `
+{
+  "name": "project",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo /"Error: no test specified/" && exit 1",
+    "hello": "echo Hello"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "abbrev": "^1.0.4"
+  }
+}
+
+`
+
+exports[`smoke-tests/index.js TAP npm uninstall > should have expected uninstall reify output 1`] = `
+
+removed 1 package
+
+`
+
+exports[`smoke-tests/index.js TAP npm update dep > should have expected update lockfile result 1`] = `
+{
+  "name": "project",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^1.0.4"
+      },
+      "devDependencies": {
+        "promise-all-reject-late": "^1.0.1"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
+    "node_modules/promise-all-reject-late": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise-all-reject-late/-/promise-all-reject-late-1.0.1.tgz",
+      "integrity": "sha512-vuf0Lf0lOxyQREH7GDIOUMLS7kz+gs8i6B+Yi8dC68a2sychGrHTJYghMBD6k7eUcH0H5P73EckCA48xijWqXw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    }
+  },
+  "dependencies": {
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
+    "promise-all-reject-late": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise-all-reject-late/-/promise-all-reject-late-1.0.1.tgz",
+      "integrity": "sha512-vuf0Lf0lOxyQREH7GDIOUMLS7kz+gs8i6B+Yi8dC68a2sychGrHTJYghMBD6k7eUcH0H5P73EckCA48xijWqXw==",
+      "dev": true
+    }
+  }
+}
+
+`
+
+exports[`smoke-tests/index.js TAP npm update dep > should have expected update package.json result 1`] = `
+{
+  "name": "project",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo /"Error: no test specified/" && exit 1",
+    "hello": "echo Hello"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "abbrev": "^1.0.4"
+  },
+  "devDependencies": {
+    "promise-all-reject-late": "^1.0.1"
+  }
+}
+
+`
+
+exports[`smoke-tests/index.js TAP npm update dep > should have expected update reify output 1`] = `
+
+changed 1 package
+
+1 package is looking for funding
+  run \`npm fund\` for details
+
+`
+
+exports[`smoke-tests/index.js TAP npm view > should have expected view output 1`] = `
+
+[4m[1m[32mabbrev[39m@[32m1.0.4[39m[22m[24m | [32mMIT[39m | deps: [32mnone[39m | versions: [33m8[39m
+Like ruby's abbrev module, but in js
+[36mhttps://github.com/isaacs/abbrev-js#readme[39m
+
+dist
+.tarball: [36mhttps://registry.npmjs.org/abbrev/-/abbrev-1.0.4.tgz[39m
+.shasum: [33mbd55ae5e413ba1722ee4caba1f6ea10414a59ecd[39m
+
+maintainers:
+- [33mnlf[39m <[36mquitlahok@gmail.com[39m>
+- [33mruyadorno[39m <[36mruyadorno@hotmail.com[39m>
+- [33mdarcyclarke[39m <[36mdarcy@darcyclarke.me[39m>
+- [33madam_baldwin[39m <[36mevilpacket@gmail.com[39m>
+- [33misaacs[39m <[36mi@izs.me[39m>
+
+dist-tags:
+[1m[32mlatest[39m[22m: 1.1.1
+
+published [33mover a year ago[39m by [33misaacs[39m <[36mi@izs.me[39m>
+
+`

--- a/deps/npm/test/lib/help.js
+++ b/deps/npm/test/lib/help.js
@@ -340,3 +340,26 @@ test('npm help - man viewer propagates errors', t => {
     t.end()
   })
 })
+
+test('npm help with complex installation path finds proper help file', t => {
+  npmConfig.viewer = 'browser'
+  globResult = [
+    'C:/Program Files/node-v14.15.5-win-x64/node_modules/npm/man/man1/npm-install.1',
+    // glob always returns forward slashes, even on Windows
+  ]
+
+  t.teardown(() => {
+    npmConfig.viewer = undefined
+    globResult = globDefaults
+    spawnBin = null
+    spawnArgs = null
+  })
+
+  return help.exec(['1', 'install'], (err) => {
+    if (err)
+      throw err
+
+    t.match(openUrlArg, /commands(\/|\\)npm-install.html$/, 'attempts to open the correct url')
+    t.end()
+  })
+})

--- a/deps/npm/test/lib/npm.js
+++ b/deps/npm/test/lib/npm.js
@@ -15,7 +15,7 @@ for (const env of Object.keys(process.env).filter(e => /^npm_/.test(e))) {
         'should match "npm test" or "npm run test"'
       )
     } else
-      t.match(process.env[env], /^(run)|(run-script)|(exec)$/)
+      t.match(process.env[env], /^(run-script|exec)$/)
   }
   delete process.env[env]
 }
@@ -411,9 +411,14 @@ t.test('npm.load', t => {
     npm.localPrefix = dir
 
     await new Promise((res, rej) => {
-      npm.commands['run-script']([], er => {
+      // verify that calling the command with a short name still sets
+      // the npm.command property to the full canonical name of the cmd.
+      npm.command = null
+      npm.commands.run([], er => {
         if (er)
           rej(er)
+
+        t.equal(npm.command, 'run-script', 'npm.command set to canonical name')
 
         t.match(
           consoleLogs,

--- a/deps/npm/test/lib/utils/config/definitions.js
+++ b/deps/npm/test/lib/utils/config/definitions.js
@@ -733,10 +733,16 @@ t.test('user-agent', t => {
     `${process.platform} ${process.arch}`
   definitions['user-agent'].flatten('user-agent', obj, flat)
   t.equal(flat.userAgent, expectNoCI)
+  t.equal(process.env.npm_config_user_agent, flat.userAgent, 'npm_user_config environment is set')
+  t.equal(obj['user-agent'], flat.userAgent, 'config user-agent template is translated')
+
   obj['ci-name'] = 'foo'
+  obj['user-agent'] = definitions['user-agent'].default
   const expectCI = `${expectNoCI} ci/foo`
   definitions['user-agent'].flatten('user-agent', obj, flat)
   t.equal(flat.userAgent, expectCI)
+  t.equal(process.env.npm_config_user_agent, flat.userAgent, 'npm_user_config environment is set')
+  t.equal(obj['user-agent'], flat.userAgent, 'config user-agent template is translated')
   t.end()
 })
 
@@ -751,6 +757,21 @@ t.test('save-prefix', t => {
   t.strictSame(flat, { savePrefix: '' })
   definitions['save-prefix']
     .flatten('save-prefix', { ...obj, 'save-exact': false }, flat)
+  t.strictSame(flat, { savePrefix: '~1.2.3' })
+  t.end()
+})
+
+t.test('save-exact', t => {
+  const obj = {
+    'save-exact': true,
+    'save-prefix': '~1.2.3',
+  }
+  const flat = {}
+  definitions['save-exact']
+    .flatten('save-exact', { ...obj, 'save-exact': true }, flat)
+  t.strictSame(flat, { savePrefix: '' })
+  definitions['save-exact']
+    .flatten('save-exact', { ...obj, 'save-exact': false }, flat)
   t.strictSame(flat, { savePrefix: '~1.2.3' })
   t.end()
 })

--- a/deps/npm/test/lib/utils/config/flatten.js
+++ b/deps/npm/test/lib/utils/config/flatten.js
@@ -17,7 +17,6 @@ const obj = {
 const flat = flatten(obj)
 t.strictSame(flat, {
   saveType: 'dev',
-  saveExact: true,
   savePrefix: '',
   '@foobar:registry': 'https://foo.bar.com/',
   '//foo.bar.com:_authToken': 'foobarbazquuxasdf',
@@ -30,7 +29,6 @@ t.strictSame(flat, {
 process.env.NODE = '/usr/local/bin/node.exe'
 flatten({ 'save-dev': false }, flat)
 t.strictSame(flat, {
-  saveExact: true,
   savePrefix: '',
   '@foobar:registry': 'https://foo.bar.com/',
   '//foo.bar.com:_authToken': 'foobarbazquuxasdf',


### PR DESCRIPTION
## v7.7.5 (2021-03-25)

### BUG FIXES

* [`95ba87622`](https://github.com/npm/cli/commit/95ba87622e00d68270eda9e071b19737718fca16) [#2949](https://github.com/npm/cli/issues/2949) fix handling manual indexes in `npm help` ([@dmchurch](https://github.com/dmchurch))
* [`59cf37962`](https://github.com/npm/cli/commit/59cf37962a2286e0f7d3bd37fa9c8bc3bac94218) [#2958](https://github.com/npm/cli/issues/2958) always set `npm.command` to canonical command name ([@isaacs](https://github.com/isaacs))
* [`1415b4bde`](https://github.com/npm/cli/commit/1415b4bdeeaabb6e0ba12b6b1b0cc56502bd64ab) [#2964](https://github.com/npm/cli/issues/2964) fix(config): properly translate user-agent ([@wraithgar](https://github.com/wraithgar))
* [`59271936d`](https://github.com/npm/cli/commit/59271936d90fbd6956a41967119f578c0ba63db9) [#2965](https://github.com/npm/cli/issues/2965) fix(config): tie save-exact/save-prefix together ([@wraithgar](https://github.com/wraithgar))

### TESTS

* [`97b415287`](https://github.com/npm/cli/commit/97b41528739460b2e9e72e09000aded412418cb2) [#2959](https://github.com/npm/cli/issues/2959) add smoke tests ([@ruyadorno](https://github.com/ruyadorno))

