### PR TITLE
readline: fix pre-aborted AbortSignal question handling

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -59,6 +59,7 @@ const {
   StringPrototypeStartsWith,
   StringPrototypeTrim,
   Promise,
+  PromiseReject,
   Symbol,
   SymbolAsyncIterator,
   SafeStringIterator,
@@ -400,12 +401,13 @@ Interface.prototype.question = function(query, options, cb) {
 Interface.prototype.question[promisify.custom] = function(query, options) {
   options = typeof options === 'object' && options !== null ? options : {};
 
-  return new Promise((resolve, reject) => {
-    if (options.signal?.aborted) {
-      throw new AbortError();
-    }
+  if (options.signal && options.signal.aborted) {
+    return PromiseReject(new AbortError());
+  }
 
+  return new Promise((resolve, reject) => {
     this.question(query, options, resolve);
+
     if (options.signal) {
       options.signal.addEventListener('abort', () => {
         reject(new AbortError());

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -376,6 +376,10 @@ Interface.prototype.question = function(query, options, cb) {
   options = typeof options === 'object' && options !== null ? options : {};
 
   if (options.signal) {
+    if (options.signal.aborted) {
+      return;
+    }
+
     options.signal.addEventListener('abort', () => {
       this[kQuestionCancel]();
     }, { once: true });
@@ -397,8 +401,11 @@ Interface.prototype.question[promisify.custom] = function(query, options) {
   options = typeof options === 'object' && options !== null ? options : {};
 
   return new Promise((resolve, reject) => {
-    this.question(query, options, resolve);
+    if (options.signal?.aborted) {
+      throw new AbortError();
+    }
 
+    this.question(query, options, resolve);
     if (options.signal) {
       options.signal.addEventListener('abort', () => {
         reject(new AbortError());

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -968,6 +968,31 @@ for (let i = 0; i < 12; i++) {
     rli.close();
   }
 
+  // pre-aborted signal
+  {
+    const signal = AbortSignal.abort();
+    const [rli] = getInterface({ terminal });
+    rli.pause();
+    rli.on('resume', common.mustNotCall());
+    rli.question('hello?', { signal }, common.mustNotCall());
+    rli.close();
+  }
+
+  // pre-aborted signal promisified question
+  {
+    const signal = AbortSignal.abort();
+    const [rli] = getInterface({ terminal });
+    const question = util.promisify(rli.question).bind(rli);
+    rli.on('resume', common.mustNotCall());
+    rli.pause();
+    question('hello?', { signal })
+    .then(common.mustNotCall())
+    .catch(common.mustCall((error) => {
+      assert.strictEqual(error.name, 'AbortError');
+    }));
+    rli.close();
+  }
+
   // Can create a new readline Interface with a null output argument
   {
     const [rli, fi] = getInterface({ output: null, terminal });


### PR DESCRIPTION
`question` in `readline` was missing pre-aborted AbortSignal handling. I'm not sure if the behaviour for the callback version is confusing or not (if the signal is already aborted, just return and do nothing) - so thoughts are welcome.
