### PR TITLE
readline: add AbortSignal support to interface

### DIFF
--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -544,6 +544,9 @@ the current position of the cursor down.
 <!-- YAML
 added: v0.1.98
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/37932
+    description: The `signal` option is supported now.
   - version: v15.8.0
     pr-url: https://github.com/nodejs/node/pull/33662
     description: The `history` option is supported now.
@@ -601,6 +604,8 @@ changes:
     **Default:** `500`.
   * `tabSize` {integer} The number of spaces a tab is equal to (minimum 1).
     **Default:** `8`.
+  * `signal` {AbortSignal} Allows closing the interface using an AbortSignal.
+    Aborting the signal will internally call `close` on the interface.
 * Returns: {readline.Interface}
 
 The `readline.createInterface()` method creates a new `readline.Interface`

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -74,6 +74,7 @@ const {
   ERR_INVALID_CURSOR_POS,
 } = codes;
 const {
+  validateAbortSignal,
   validateArray,
   validateCallback,
   validateString,
@@ -150,7 +151,7 @@ function Interface(input, output, completer, terminal) {
   let removeHistoryDuplicates = false;
   let crlfDelay;
   let prompt = '> ';
-
+  let signal;
   if (input && input.input) {
     // An options object was given
     output = input.output;
@@ -158,6 +159,7 @@ function Interface(input, output, completer, terminal) {
     terminal = input.terminal;
     history = input.history;
     historySize = input.historySize;
+    signal = input.signal;
     if (input.tabSize !== undefined) {
       validateUint32(input.tabSize, 'tabSize', true);
       this.tabSize = input.tabSize;
@@ -176,6 +178,11 @@ function Interface(input, output, completer, terminal) {
         );
       }
     }
+
+    if (signal) {
+      validateAbortSignal(signal, 'options.signal');
+    }
+
     crlfDelay = input.crlfDelay;
     input = input.input;
   }
@@ -318,6 +325,16 @@ function Interface(input, output, completer, terminal) {
       output.on('resize', onresize);
 
     self.once('close', onSelfCloseWithTerminal);
+  }
+
+  if (signal) {
+    const onAborted = () => self.close();
+    if (signal.aborted) {
+      process.nextTick(onAborted);
+    } else {
+      signal.addEventListener('abort', onAborted, { once: true });
+      self.once('close', () => signal.removeEventListener('abort', onAborted));
+    }
   }
 
   // Current line


### PR DESCRIPTION
Add abort signal support to `Interface`/`createInterface` in `readline`. The AbortSignal calls close internally when aborted.