### PR TITLE
http2: add specific error code for custom frames

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1364,6 +1364,15 @@ When setting the priority for an HTTP/2 stream, the stream may be marked as
 a dependency for a parent stream. This error code is used when an attempt is
 made to mark a stream and dependent of itself.
 
+<a id="ERR_HTTP2_TOO_MANY_INVALID_FRAMES"></a>
+### `ERR_HTTP2_TOO_MANY_INVALID_FRAMES`
+<!--
+added: REPLACEME
+-->
+
+The limit of acceptable invalid HTTP/2 protocol frames sent by the peer,
+as specified through the `maxSessionInvalidFrames` option, has been exceeded.
+
 <a id="ERR_HTTP2_TRAILERS_ALREADY_SENT"></a>
 ### `ERR_HTTP2_TRAILERS_ALREADY_SENT`
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -992,6 +992,7 @@ E('ERR_HTTP2_STREAM_CANCEL', function(error) {
 E('ERR_HTTP2_STREAM_ERROR', 'Stream closed with error code %s', Error);
 E('ERR_HTTP2_STREAM_SELF_DEPENDENCY',
   'A stream cannot depend on itself', Error);
+E('ERR_HTTP2_TOO_MANY_INVALID_FRAMES', 'Too many invalid HTTP/2 frames', Error);
 E('ERR_HTTP2_TRAILERS_ALREADY_SENT',
   'Trailing headers have already been sent', Error);
 E('ERR_HTTP2_TRAILERS_NOT_READY',

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -778,9 +778,9 @@ const setAndValidatePriorityOptions = hideStackFrames((options) => {
 
 // When an error occurs internally at the binding level, immediately
 // destroy the session.
-function onSessionInternalError(code) {
+function onSessionInternalError(integerCode, customErrorCode) {
   if (this[kOwner] !== undefined)
-    this[kOwner].destroy(new NghttpError(code));
+    this[kOwner].destroy(new NghttpError(integerCode, customErrorCode));
 }
 
 function settingsCallback(cb, ack, duration) {

--- a/lib/internal/http2/util.js
+++ b/lib/internal/http2/util.js
@@ -29,6 +29,7 @@ const {
     ERR_INVALID_HTTP_TOKEN
   },
   addCodeToName,
+  getMessage,
   hideStackFrames
 } = require('internal/errors');
 
@@ -543,11 +544,13 @@ function mapToHeaders(map,
 }
 
 class NghttpError extends Error {
-  constructor(ret) {
-    super(binding.nghttp2ErrorString(ret));
-    this.code = 'ERR_HTTP2_ERROR';
-    this.errno = ret;
-    addCodeToName(this, super.name, 'ERR_HTTP2_ERROR');
+  constructor(integerCode, customErrorCode) {
+    super(customErrorCode ?
+      getMessage(customErrorCode, [], null) :
+      binding.nghttp2ErrorString(integerCode));
+    this.code = customErrorCode || 'ERR_HTTP2_ERROR';
+    this.errno = integerCode;
+    addCodeToName(this, super.name, this.code);
   }
 
   toString() {

--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -662,8 +662,9 @@ class Http2Session : public AsyncWrap,
   // Indicates whether there currently exist outgoing buffers for this stream.
   bool HasWritesOnSocketForStream(Http2Stream* stream);
 
-  // Write data from stream_buf_ to the session
-  ssize_t ConsumeHTTP2Data();
+  // Write data from stream_buf_ to the session.
+  // This will call the error callback if an error occurs.
+  void ConsumeHTTP2Data();
 
   void MemoryInfo(MemoryTracker* tracker) const override;
   SET_MEMORY_INFO_NAME(Http2Session)
@@ -898,6 +899,9 @@ class Http2Session : public AsyncWrap,
   v8::Global<v8::ArrayBuffer> stream_buf_ab_;
   AllocatedBuffer stream_buf_allocation_;
   size_t stream_buf_offset_ = 0;
+  // Custom error code for errors that originated inside one of the callbacks
+  // called by nghttp2_session_mem_recv.
+  const char* custom_recv_error_code_ = nullptr;
 
   size_t max_outstanding_pings_ = kDefaultMaxPings;
   std::queue<BaseObjectPtr<Http2Ping>> outstanding_pings_;

--- a/test/parallel/test-http2-empty-frame-without-eof.js
+++ b/test/parallel/test-http2-empty-frame-without-eof.js
@@ -26,8 +26,12 @@ async function main() {
       stream.on('error', common.mustNotCall());
       client.on('error', common.mustNotCall());
     } else {
-      stream.on('error', common.mustCall());
-      client.on('error', common.mustCall());
+      const expected = {
+        code: 'ERR_HTTP2_TOO_MANY_INVALID_FRAMES',
+        message: 'Too many invalid HTTP/2 frames'
+      };
+      stream.on('error', common.expectsError(expected));
+      client.on('error', common.expectsError(expected));
     }
     stream.resume();
     await once(stream, 'end');


### PR DESCRIPTION
As suggested in https://github.com/nodejs/node/issues/37849#issuecomment-805049586
improve the error presented when encountering a large number of
invalid frames by giving this situation a specific error code (which we
should have had from the beginning).

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
