### PR TITLE
test: split promisified timers test for coverage purposes

### DIFF
--- a/test/parallel/test-timers-immediate-promisified.js
+++ b/test/parallel/test-timers-immediate-promisified.js
@@ -1,0 +1,99 @@
+// Flags: --no-warnings --expose-internals
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const timers = require('timers');
+const { promisify } = require('util');
+const child_process = require('child_process');
+
+// TODO(benjamingr) - refactor to use getEventListeners when #35991 lands
+const { NodeEventTarget } = require('internal/event_target');
+
+const timerPromises = require('timers/promises');
+
+const setPromiseImmediate = promisify(timers.setImmediate);
+const exec = promisify(child_process.exec);
+
+assert.strictEqual(setPromiseImmediate, timerPromises.setImmediate);
+
+process.on('multipleResolves', common.mustNotCall());
+
+{
+  const promise = setPromiseImmediate();
+  promise.then(common.mustCall((value) => {
+    assert.strictEqual(value, undefined);
+  }));
+}
+
+{
+  const promise = setPromiseImmediate('foobar');
+  promise.then(common.mustCall((value) => {
+    assert.strictEqual(value, 'foobar');
+  }));
+}
+
+{
+  const ac = new AbortController();
+  const signal = ac.signal;
+  assert.rejects(setPromiseImmediate(10, { signal }), /AbortError/)
+    .then(common.mustCall());
+  ac.abort();
+}
+
+{
+  const signal = AbortSignal.abort(); // Abort in advance
+  assert.rejects(setPromiseImmediate(10, { signal }), /AbortError/)
+    .then(common.mustCall());
+}
+
+{
+  // Check that aborting after resolve will not reject.
+  const ac = new AbortController();
+  const signal = ac.signal;
+  setPromiseImmediate(10, { signal })
+    .then(common.mustCall(() => { ac.abort(); }))
+    .then(common.mustCall());
+}
+
+{
+  // Check that timer adding signals does not leak handlers
+  const signal = new NodeEventTarget();
+  signal.aborted = false;
+  setPromiseImmediate(0, { signal }).finally(common.mustCall(() => {
+    assert.strictEqual(signal.listenerCount('abort'), 0);
+  }));
+}
+
+{
+  Promise.all(
+    [1, '', false, Infinity].map(
+      (i) => assert.rejects(setPromiseImmediate(10, i), {
+        code: 'ERR_INVALID_ARG_TYPE'
+      })
+    )
+  ).then(common.mustCall());
+
+  Promise.all(
+    [1, '', false, Infinity, null, {}].map(
+      (signal) => assert.rejects(setPromiseImmediate(10, { signal }), {
+        code: 'ERR_INVALID_ARG_TYPE'
+      })
+    )
+  ).then(common.mustCall());
+
+  Promise.all(
+    [1, '', Infinity, null, {}].map(
+      (ref) => assert.rejects(setPromiseImmediate(10, { ref }), {
+        code: 'ERR_INVALID_ARG_TYPE'
+      })
+    )
+  ).then(common.mustCall());
+}
+
+{
+  exec(`${process.execPath} -pe "const assert = require('assert');` +
+    'require(\'timers/promises\').setImmediate(null, { ref: false }).' +
+    'then(assert.fail)"').then(common.mustCall(({ stderr }) => {
+    assert.strictEqual(stderr, '');
+  }));
+}

--- a/test/parallel/test-timers-timeout-promisified.js
+++ b/test/parallel/test-timers-timeout-promisified.js
@@ -1,0 +1,99 @@
+// Flags: --no-warnings --expose-internals
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const timers = require('timers');
+const { promisify } = require('util');
+const child_process = require('child_process');
+
+// TODO(benjamingr) - refactor to use getEventListeners when #35991 lands
+const { NodeEventTarget } = require('internal/event_target');
+
+const timerPromises = require('timers/promises');
+
+const setPromiseTimeout = promisify(timers.setTimeout);
+const exec = promisify(child_process.exec);
+
+assert.strictEqual(setPromiseTimeout, timerPromises.setTimeout);
+
+process.on('multipleResolves', common.mustNotCall());
+
+{
+  const promise = setPromiseTimeout(1);
+  promise.then(common.mustCall((value) => {
+    assert.strictEqual(value, undefined);
+  }));
+}
+
+{
+  const promise = setPromiseTimeout(1, 'foobar');
+  promise.then(common.mustCall((value) => {
+    assert.strictEqual(value, 'foobar');
+  }));
+}
+
+{
+  const ac = new AbortController();
+  const signal = ac.signal;
+  assert.rejects(setPromiseTimeout(10, undefined, { signal }), /AbortError/)
+    .then(common.mustCall());
+  ac.abort();
+}
+
+{
+  const signal = AbortSignal.abort(); // Abort in advance
+  assert.rejects(setPromiseTimeout(10, undefined, { signal }), /AbortError/)
+    .then(common.mustCall());
+}
+
+{
+  // Check that aborting after resolve will not reject.
+  const ac = new AbortController();
+  const signal = ac.signal;
+  setPromiseTimeout(10, undefined, { signal })
+    .then(common.mustCall(() => { ac.abort(); }))
+    .then(common.mustCall());
+}
+
+{
+  // Check that timer adding signals does not leak handlers
+  const signal = new NodeEventTarget();
+  signal.aborted = false;
+  setPromiseTimeout(0, null, { signal }).finally(common.mustCall(() => {
+    assert.strictEqual(signal.listenerCount('abort'), 0);
+  }));
+}
+
+{
+  Promise.all(
+    [1, '', false, Infinity].map(
+      (i) => assert.rejects(setPromiseTimeout(10, null, i), {
+        code: 'ERR_INVALID_ARG_TYPE'
+      })
+    )
+  ).then(common.mustCall());
+
+  Promise.all(
+    [1, '', false, Infinity, null, {}].map(
+      (signal) => assert.rejects(setPromiseTimeout(10, null, { signal }), {
+        code: 'ERR_INVALID_ARG_TYPE'
+      })
+    )
+  ).then(common.mustCall());
+
+  Promise.all(
+    [1, '', Infinity, null, {}].map(
+      (ref) => assert.rejects(setPromiseTimeout(10, null, { ref }), {
+        code: 'ERR_INVALID_ARG_TYPE'
+      })
+    )
+  ).then(common.mustCall());
+}
+
+{
+  exec(`${process.execPath} -pe "const assert = require('assert');` +
+    'require(\'timers/promises\').setTimeout(1000, null, { ref: false }).' +
+    'then(assert.fail)"').then(common.mustCall(({ stderr }) => {
+    assert.strictEqual(stderr, '');
+  }));
+}


### PR DESCRIPTION
Because of lazy loading, running promisified timers tests for setTimeout
and setImmediate from the same file means that there is a piece of code
that doesn't get covered. Split into separate files to cover everything.

Refs: https://coverage.nodejs.org/coverage-290c158018ac0277/lib/timers.js.html#L269

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
