### PR TITLE
doc: add distinctive color for code elements inside links

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -13,7 +13,7 @@
   --red3: #ca5010;
   --green1: #43853d;
   --green2: #5a8147;
-  --green3: #454545;
+  --green3: #64de64;
   --green4: #99cc7d;
   --green5: #84ba64;
   --gray1: #707070;
@@ -49,6 +49,9 @@
 .dark-mode tt {
   color: var(--grey-smoke);
   background-color: var(--highlight-background-color);
+}
+.dark-mode a code {
+  color: var(--green3);
 }
 
 /*--------------------- Layout and Typography ----------------------------*/
@@ -605,7 +608,8 @@ a code {
   margin-bottom: 0;
 }
 
-#column2 ul li a {
+#column2 ul li a,
+#column2 ul li a code {
   color: var(--color-text-nav);
   border-radius: 0;
 }


### PR DESCRIPTION
Currently it's hard to understand when a `<code>` element is a link or not when using dark-mode.

Before:
![image](https://user-images.githubusercontent.com/14309773/112730898-72addb80-8f34-11eb-8f9f-3b2f71b49297.png)

After:
![links are now shown in green](https://user-images.githubusercontent.com/14309773/112730885-5c078480-8f34-11eb-9e68-e8cb028e9f65.png)


<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
