### PR TITLE
build: add GitHub Action for coverage with --without-intl

### DIFF
--- a/.github/workflows/coverage-linux-without-intl.yml
+++ b/.github/workflows/coverage-linux-without-intl.yml
@@ -1,0 +1,69 @@
+name: Coverage Linux (without intl)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - '**.md'
+      - benchmark/**
+      - deps/**
+      - doc/**
+      - .github/**
+      - '!.github/workflows/coverage-linux-without-intl.yml'
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+      - benchmark/**
+      - deps/**
+      - doc/**
+      - .github/**
+      - '!.github/workflows/coverage-linux-without-intl.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  PYTHON_VERSION: '3.11'
+  FLAKY_TESTS: keep_retrying
+
+permissions:
+  contents: read
+
+jobs:
+  coverage-linux-without-intl:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Environment Information
+        run: npx envinfo
+      - name: Install gcovr
+        run: pip install gcovr==4.2
+      - name: Build
+        run: make build-ci -j2 V=1 CONFIG_FLAGS="--error-on-warn --coverage --without-intl"
+      # TODO(bcoe): fix the couple tests that fail with the inspector enabled.
+      # The cause is most likely coverage's use of the inspector.
+      - name: Test
+        run: NODE_V8_COVERAGE=coverage/tmp make test-cov -j2 V=1 TEST_CI_ARGS="-p dots --measure-flakiness 9" || exit 0
+      - name: Report JS
+        run: npx c8 report --check-coverage
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
+      - name: Report C++
+        run: cd out && gcovr --gcov-exclude='.*\b(deps|usr|out|obj|cctest|embedding)\b' -v -r Release/obj.target --xml -o ../coverage/coverage-cxx.xml --root=$(cd ../ && pwd)
+      # Clean temporary output from gcov and c8, so that it's not uploaded:
+      - name: Clean tmp
+        run: rm -rf coverage/tmp && rm -rf out
+      - name: Upload
+        uses: codecov/codecov-action@v3
+        with:
+          directory: ./coverage

--- a/configure.py
+++ b/configure.py
@@ -571,7 +571,7 @@ intl_optgroup.add_argument('--without-intl',
     action='store_const',
     dest='with_intl',
     const='none',
-    help='Disable Intl, same as --with-intl=none (disables inspector)')
+    help='Disable Intl, same as --with-intl=none')
 
 intl_optgroup.add_argument('--with-icu-path',
     action='store',
@@ -1924,7 +1924,6 @@ def configure_intl(o):
 
 def configure_inspector(o):
   disable_inspector = (options.without_inspector or
-                       options.with_intl in (None, 'none') or
                        options.without_ssl)
   o['variables']['v8_enable_inspector'] = 0 if disable_inspector else 1
 


### PR DESCRIPTION
There are parts of the code base that require a build without intl to be
covered. So add a coverage job to build --without-intl.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
