### PR TITLE
test: add extra space in pseudo-tty test failure output

### DIFF
--- a/test/pseudo-tty/testcfg.py
+++ b/test/pseudo-tty/testcfg.py
@@ -70,7 +70,7 @@ class TTYTestCase(test.TestCase):
     raw_lines = (output.stdout + output.stderr).split('\n')
     outlines = [ s.rstrip() for s in raw_lines if not self.IgnoreLine(s) ]
     if len(outlines) != len(patterns):
-      print("length differs.")
+      print(" length differs.")
       print("expect=%d" % len(patterns))
       print("actual=%d" % len(outlines))
       print("patterns:")
@@ -82,7 +82,7 @@ class TTYTestCase(test.TestCase):
       return True
     for i in range(len(patterns)):
       if not re.match(patterns[i], outlines[i]):
-        print("match failed")
+        print(" match failed")
         print("line=%d" % i)
         print("expect=%s" % patterns[i])
         print("actual=%s" % outlines[i])


### PR DESCRIPTION
It adds a extra space between test suite name and the failure reason when a test in pseduo-tty fails. It imporoves the readablity of failure message.

Considering test case

```js
// test/pesudo-tty/test-of-course-it-will-fail-line.js
'use strict'

process.stdout.write("no, no")
```

and expected output

```
of course, it fails intentionally
I have two line

```

Before the change, the test failure is shown as 

```
Before
[00:00|%   0|+   0|-   0]: release test-of-course-it-will-fail-linelength differs.
expect=2
actual=1
patterns:
pattern = ^of\ course\,\ it\ fails\ intentionally$
pattern = ^I\ have\ two\ line$
outlines:
outline = no, no
=== release test-of-course-it-will-fail-line ===                   
Path: pseudo-tty/test-of-course-it-will-fail-line
no, no
Command: /System/Library/Frameworks/Python.framework/Versions/2.7/Resources/Python.app/Contents/MacOS/Python /Users/qingyudeng/projects/node/test/pseudo-tty/pty_helper.py out/Release/node /Users/qingyudeng/projects/node/test/pseudo-tty/test-of-course-it-will-fail-line.js
[00:00|% 100|+   0|-   1]: Done  
```

After the change, it will be shown as

```
[00:00|%   0|+   0|-   0]: release test-of-course-it-will-fail-line length differs.
expect=2
actual=1
patterns:
pattern = ^of\ course\,\ it\ fails\ intentionally$
pattern = ^I\ have\ two\ line$
outlines:
outline = no, no
=== release test-of-course-it-will-fail-line ===                   
Path: pseudo-tty/test-of-course-it-will-fail-line
no, no
Command: /System/Library/Frameworks/Python.framework/Versions/2.7/Resources/Python.app/Contents/MacOS/Python /Users/qingyudeng/projects/node/test/pseudo-tty/pty_helper.py out/Release/node /Users/qingyudeng/projects/node/test/pseudo-tty/test-of-course-it-will-fail-line.js
[00:00|% 100|+   0|-   1]: Done  
```

Also, it happens when `match failure` occurs

Before
```
[00:00|%   0|+   0|-   0]: release test-of-course-it-will-failmatch failed
line=0
expect=^of\ course\,\ it\ fails\ intentionally$
actual=no, no
=== release test-of-course-it-will-fail ===                   
Path: pseudo-tty/test-of-course-it-will-fail
no, no
Command: /System/Library/Frameworks/Python.framework/Versions/2.7/Resources/Python.app/Contents/MacOS/Python /Users/qingyudeng/projects/node/test/pseudo-tty/pty_helper.py out/Release/node /Users/qingyudeng/projects/node/test/pseudo-tty/test-of-course-it-will-fail.js
```

After
```
[00:00|%   0|+   0|-   0]: release test-of-course-it-will-fail match failed
line=0
expect=^of\ course\,\ it\ fails\ intentionally$
actual=no, no
=== release test-of-course-it-will-fail ===                   
Path: pseudo-tty/test-of-course-it-will-fail
no, no
Command: /System/Library/Frameworks/Python.framework/Versions/2.7/Resources/Python.app/Contents/MacOS/Python /Users/qingyudeng/projects/node/test/pseudo-tty/pty_helper.py out/Release/node /Users/qingyudeng/projects/node/test/pseudo-tty/test-of-course-it-will-fail.js
[00:00|% 100|+   0|-   1]: Done  
```