### PR TITLE
test,http: check that http server is robust from handler abuse

### DIFF
--- a/test/parallel/test-http-req-close-robust-from-tampering.js
+++ b/test/parallel/test-http-req-close-robust-from-tampering.js
@@ -1,0 +1,26 @@
+'use strict';
+const common = require('../common');
+const { createServer } = require('http');
+const { connect } = require('net');
+
+// Make sure that calling the semi-private close() handlers manually doesn't
+// cause an error.
+
+const server = createServer(common.mustCall((req, res) => {
+  req.client._events.close.forEach((fn) => { fn.bind(req)(); });
+}));
+
+server.unref();
+
+server.listen(0, common.mustCall(() => {
+  const client = connect(server.address().port);
+
+  const req = [
+    'POST / HTTP/1.1',
+    'Content-Length: 11',
+    '',
+    'hello world',
+  ].join('\r\n');
+
+  client.end(req);
+}));


### PR DESCRIPTION
The only way I could find to complete coverage for _http_common.js is to
use semi-private (exposed but probably shouldn't be) handlers to get the
state into something weird. With the if-condition being checked (see
Refs) commented out, I get this result from this test:

```
node:_http_common:140
  if (len > 0 && !stream._dumped) {
                         ^

TypeError: Cannot read property '_dumped' of null
    at HTTPParser.parserOnBody (node:_http_common:140:26)
```

With the check in place, the test passes without an error. Seems like
quite the edge case, but I'm going to assume it's there for a reason.

Refs: https://coverage.nodejs.org/coverage-b560645d6b0a4bed/lib/_http_common.js.html#L137

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
