### PR TITLE
webcrypto: graduate from experimental, expose via `crypto` 

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -3836,6 +3836,18 @@ const {
 console.log(getHashes()); // ['DSA', 'DSA-SHA', 'DSA-SHA1', ...]
 ```
 
+### `crypto.getRandomValues(typedArray)`
+<!-- YAML
+added: REPLACEME
+-->
+
+* `typedArray` {Buffer|TypedArray|DataView|ArrayBuffer}
+* Returns: {Buffer|TypedArray|DataView|ArrayBuffer} Returns `typedArray`.
+
+Alias for `crypto.webcrypto.getRandomValues(typedArray)`
+
+See [`webcrypto.getRandomValues()`][] for details.
+
 ### `crypto.hkdf(digest, key, salt, info, keylen, callback)`
 <!-- YAML
 added: v15.0.0
@@ -5002,6 +5014,13 @@ additional properties can be passed:
 
 If the `callback` function is provided this function uses libuv's threadpool.
 
+### `crypto.subtle`
+<!-- YAML
+added: REPLACEME
+-->
+
+Alias for [`webcrypto.subtle`][].
+
 ### `crypto.timingSafeEqual(a, b)`
 <!-- YAML
 added: v6.6.0
@@ -5724,6 +5743,8 @@ See the [list of SSL OP Flags][] for details.
 [`util.promisify()`]: util.md#util_util_promisify_original
 [`verify.update()`]: #crypto_verify_update_data_inputencoding
 [`verify.verify()`]: #crypto_verify_verify_object_signature_signatureencoding
+[`webcrypto.getRandomValues()`]: webcrypto.md#webcrypto_crypto_getrandomvalues_typedarray
+[`webcrypto.subtle`]: webcrypto.md#webcrypto_crypto_subtle
 [certificate object]: tls.md#tls_certificate_object
 [encoding]: buffer.md#buffer_buffers_and_character_encodings
 [initialization vector]: https://en.wikipedia.org/wiki/Initialization_vector

--- a/doc/api/webcrypto.md
+++ b/doc/api/webcrypto.md
@@ -2,7 +2,7 @@
 
 <!-- introduced_in=v15.0.0 -->
 
-> Stability: 1 - Experimental
+> Stability: 2 - Stable
 
 Node.js provides an implementation of the standard [Web Crypto API][].
 

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -287,6 +287,18 @@ ObjectDefineProperties(module.exports, {
     get() { return lazyRequire('internal/crypto/webcrypto'); }
   },
 
+  subtle: {
+    configurable: true,
+    enumerable: false,
+    get() { return this.webcrypto.subtle; },
+  },
+
+  getRandomValues: {
+    configurable: true,
+    enumerable: false,
+    get() { return this.webcrypto.getRandomValues; },
+  },
+
   // Aliases for randomBytes are deprecated.
   // The ecosystem needs those to exist for backwards compatibility.
   prng: {

--- a/test/parallel/test-webcrypto.js
+++ b/test/parallel/test-webcrypto.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const common = require('../common');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const { strictEqual } = require('assert');
+const {
+  webcrypto,
+  subtle,
+  getRandomValues,
+} = require('crypto');
+
+strictEqual(subtle, webcrypto.subtle);
+strictEqual(getRandomValues, webcrypto.getRandomValues);


### PR DESCRIPTION
In the browser, the `crypto` global exposes `subtle` and
`getRandomValues` as properties. In the Node.js impl, those
require an additional indirection via `crypto.webcrypto.*`.
This commit exposes aliases to promote cross-environment
isomorphism.

Note: In the browser, the `CryptoKey` object is also exposed
as a global. I decided not to do that here because it requires
a larger change to the internal `node_crypto` binding because
of the need to register external references. That can be done
in a separate PR but it's a much lower priority.

This also graduates WebCrypto from experimental status.

Signed-off-by: James M Snell <jasnell@gmail.com>