### PR TITLE
perf_hooks: make performance a global

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -331,5 +331,6 @@ module.exports = {
     globalThis: 'readable',
     btoa: 'readable',
     atob: 'readable',
+    performance: 'readable',
   },
 };

--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -279,6 +279,10 @@ The `MessagePort` class. See [`MessagePort`][] for more details.
 
 This variable may appear to be global but is not. See [`module`][].
 
+## `performance`
+
+The [`perf_hooks.performance`][] object.
+
 ## `process`
 <!-- YAML
 added: v0.1.7
@@ -428,6 +432,7 @@ The object that acts as the namespace for all W3C
 [`console`]: console.md
 [`exports`]: modules.md#modules_exports
 [`module`]: modules.md#modules_module
+[`perf_hooks.performance`]: perf_hooks.md#perf_hooks_perf_hooks_performance
 [`process.nextTick()`]: process.md#process_process_nexttick_callback_args
 [`process` object]: process.md#process_process
 [`require()`]: modules.md#modules_require_id

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -236,6 +236,11 @@ if (!config.noBrowserGlobals) {
 
   defineOperation(global, 'queueMicrotask', queueMicrotask);
 
+  defineLazyGlobal(global, 'performance', () => {
+    const { performance } = require('perf_hooks');
+    return performance;
+  });
+
   // Non-standard extensions:
   defineOperation(global, 'clearImmediate', timers.clearImmediate);
   defineOperation(global, 'setImmediate', timers.setImmediate);
@@ -479,5 +484,23 @@ function defineOperation(target, name, method) {
     enumerable: true,
     configurable: true,
     value: method
+  });
+}
+
+function defineLazyGlobal(target, name, loader) {
+  let value;
+  let overridden = false;
+  ObjectDefineProperty(target, name, {
+    enumerable: true,
+    configurable: true,
+    get() {
+      if (value === undefined && !overridden)
+        value = loader();
+      return value;
+    },
+    set(val) {
+      value = val;
+      overridden = true;
+    }
   });
 }

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -287,6 +287,10 @@ if (global.gc) {
   knownGlobals.push(global.gc);
 }
 
+if (global.performance) {
+  knownGlobals.push(global.performance);
+}
+
 function allowGlobals(...allowlist) {
   knownGlobals = knownGlobals.concat(allowlist);
 }

--- a/test/parallel/test-global.js
+++ b/test/parallel/test-global.js
@@ -47,6 +47,7 @@ builtinModules.forEach((moduleName) => {
     'clearImmediate',
     'clearInterval',
     'clearTimeout',
+    'performance',
     'setImmediate',
     'setInterval',
     'setTimeout'

--- a/test/parallel/test-performance-global.js
+++ b/test/parallel/test-performance-global.js
@@ -1,0 +1,18 @@
+'use strict';
+/* eslint-disable no-global-assign */
+
+require('../common');
+
+const perf_hooks = require('perf_hooks');
+const {
+  strictEqual
+} = require('assert');
+
+const perf = performance;
+strictEqual(globalThis.performance, perf_hooks.performance);
+performance = undefined;
+strictEqual(globalThis.performance, undefined);
+strictEqual(typeof perf_hooks.performance.now, 'function');
+
+// Restore the value of performance for the known globals check
+performance = perf;

--- a/test/wpt/test-hr-time.js
+++ b/test/wpt/test-hr-time.js
@@ -9,8 +9,7 @@ runner.setInitScript(`
   const { Blob } = require('buffer');
   global.Blob = Blob;
 
-  const { performance, PerformanceObserver } = require('perf_hooks');
-  global.performance = performance;
+  const { PerformanceObserver } = require('perf_hooks');
   global.PerformanceObserver = PerformanceObserver;
 `);
 


### PR DESCRIPTION
Expose `perf_hooks.performance` as a global