### PR TITLE
lib: add requestAnimationFrame global

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -331,5 +331,7 @@ module.exports = {
     globalThis: 'readable',
     btoa: 'readable',
     atob: 'readable',
+    requestAnimationFrame: 'readable',
+    cancelAnimationFrame: 'readable',
   },
 };

--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -164,6 +164,29 @@ added: REPLACEME
 
 Global alias for [`buffer.btoa()`][].
 
+## `cancelAnimationFrame(immediateObject)`
+<!-- YAML
+added: REPLACEME
+-->
+
+<!--type=global-->
+
+> Stability: 3 - Legacy: Use clearImmediate() instead.
+
+* `immediateObject` {Object} The return value of `requestAnimationFrame()`
+  identifying the request being canceled.
+
+```js
+const req = requestAnimationFrame((ts) => {
+  console.log(`called at ${ts}`);
+});
+
+cancelAnimationFrame(req);
+```
+
+In Node.js, `cancelAnimationFrame()` is an alias for `clearImmediate()`.
+Code specifically targeting Node.js should use `clearImmediate()` instead.
+
 ## `clearImmediate(immediateObject)`
 <!-- YAML
 added: v0.9.1
@@ -328,6 +351,33 @@ DataHandler.prototype.load = async function load(key) {
   this.emit('load', data);
 };
 ```
+
+## `requestAnimationFrame(callback)`
+<!-- YAML
+added: REPLACEME
+-->
+
+<!--type=global-->
+
+> Stability: 3 - Legacy: Use the setImmediate() instead.
+
+* `callback` {Function}
+* Returns {Object}
+
+Registers a function with `setImmediate()` that is invoked with a single
+argument set to the value of `perf_hooks.performance.now()`.
+
+```js
+requestAnimationFrame((ts) => {
+  console.log(`called at ${ts}`);
+});
+```
+
+Node.js does not implement the same timing and event loop frame semantics
+as Web Browsers and does not include any notion of rendering or "animation".
+The `requestAnimationFrame()` method should be considered a close approximation
+to enable cross-environment portable JavaScript code to be written. Code
+specifically targeting Node.js should use `setImmediate()` instead.
 
 ## `require()`
 

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -239,6 +239,20 @@ if (!config.noBrowserGlobals) {
   // Non-standard extensions:
   defineOperation(global, 'clearImmediate', timers.clearImmediate);
   defineOperation(global, 'setImmediate', timers.setImmediate);
+
+  function requestAnimationFrame(callback) {
+    const { performance } = require('perf_hooks');
+    const {
+      codes: {
+        ERR_INVALID_ARG_TYPE,
+      },
+    } = require('internal/errors');
+    if (typeof callback !== 'function')
+      throw new ERR_INVALID_ARG_TYPE('callback', 'Function', callback);
+    return timers.setImmediate(() => callback(performance.now()));
+  }
+  defineOperation(global, 'requestAnimationFrame', requestAnimationFrame);
+  defineOperation(global, 'cancelAnimationFrame', timers.clearImmediate);
 }
 
 // Set the per-Environment callback that will be called

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -261,6 +261,8 @@ function platformTimeout(ms) {
   return ms; // ARMv8+
 }
 
+const requestAnimationFrame = globalThis.requestAnimationFrame;
+
 let knownGlobals = [
   atob,
   btoa,
@@ -268,6 +270,7 @@ let knownGlobals = [
   clearInterval,
   clearTimeout,
   global,
+  requestAnimationFrame,
   setImmediate,
   setInterval,
   setTimeout,

--- a/test/parallel/test-requestanimationframe.js
+++ b/test/parallel/test-requestanimationframe.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const common = require('../common');
+const { strictEqual } = require('assert');
+
+let called = false;
+
+requestAnimationFrame(common.mustCall((ts) => {
+  called = true;
+  strictEqual(typeof ts, 'number');
+}));
+
+strictEqual(called, false);
+
+const req = requestAnimationFrame(common.mustNotCall());
+cancelAnimationFrame(req);


### PR DESCRIPTION
Adds the browser API `requestAnimationFrame()` as an isomorphic
wrapper around `setImmediate()`. Marked Legacy with a clear
indication that code targeting Node.js should use `setImmediate()`
instead.

Signed-off-by: James M Snell <jasnell@gmail.com>

/cc @mcollina 

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
