### PR TITLE
test: deflake test-fs-read-optional-params

### DIFF
--- a/test/parallel/test-fs-read-optional-params.js
+++ b/test/parallel/test-fs-read-optional-params.js
@@ -11,14 +11,14 @@ const expected = Buffer.from('xyz\n');
 const defaultBufferAsync = Buffer.alloc(16384);
 const bufferAsOption = Buffer.allocUnsafe(expected.length);
 
-// Test passing in an empty options object
-fs.read(fd, { position: 0 }, common.mustCall((err, bytesRead, buffer) => {
+// Test not passing in any options object
+fs.read(fd, common.mustCall((err, bytesRead, buffer) => {
   assert.strictEqual(bytesRead, expected.length);
   assert.deepStrictEqual(defaultBufferAsync.length, buffer.length);
 }));
 
-// Test not passing in any options object
-fs.read(fd, common.mustCall((err, bytesRead, buffer) => {
+// Test passing in an empty options object
+fs.read(fd, { position: 0 }, common.mustCall((err, bytesRead, buffer) => {
   assert.strictEqual(bytesRead, expected.length);
   assert.deepStrictEqual(defaultBufferAsync.length, buffer.length);
 }));


### PR DESCRIPTION
If `fs.read()` is called without specifying the `position` option, data
will be read from the current file position. There is another concurrent
`fs.read()` call before the test for no options object which might
invalidate the test expectations.

Run the test for no options object first.

Fixes: https://github.com/nodejs/node/issues/37946

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
