### PR TITLE
node-api: make reference weak parameter an indirect link to references

### DIFF
--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -418,7 +418,8 @@ class Reference : public RefBase {
       return;
     }
     _persistent.SetWeak(
-        _secondPassParameter, FinalizeCallback, v8::WeakCallbackType::kParameter);
+        _secondPassParameter, FinalizeCallback,
+        v8::WeakCallbackType::kParameter);
     *_secondPassParameter = this;
   }
 
@@ -455,7 +456,6 @@ class Reference : public RefBase {
   // of a parameter within the Reference object itself. This is what
   // is stored in _secondPassParameter and it is alocated in the
   // constructor for the Reference.
-  SecondPassCallParameterRef* _secondPassParameter;
   static void SecondPassCallback(
       const v8::WeakCallbackInfo<SecondPassCallParameterRef>& data) {
     SecondPassCallParameterRef* parameter = data.GetParameter();
@@ -469,6 +469,7 @@ class Reference : public RefBase {
   }
 
   v8impl::Persistent<v8::Value> _persistent;
+  SecondPassCallParameterRef* _secondPassParameter;
 };
 
 enum UnwrapAction {


### PR DESCRIPTION
As the cancellation of second pass callbacks are not reachable from the current
v8 API, and the second pass callbacks are scheduled with NodePlatform's task
runner, we have to ensure that the weak parameter holds indirect access to the
v8impl::Reference object so that the object can be destroyed on addon env
teardown before the whole node env is able to shutdown.

There aren't any means to request garbage collection with asynchronous second
pass callbacks at node.js teardown (force gc would trigger second pass callbacks
synchronously). And on the main branch, it is not allowed to calling into JavaScript 
during environment teardown. So this PR can not be stably tested.

Refs: https://github.com/nodejs/node/pull/37802#discussion_r604722450