### PR TITLE
test: improve clarity of test-async-local-storage-enable-disable.js \…

### DIFF
--- a/test/async-hooks/test-async-local-storage-enable-disable.js
+++ b/test/async-hooks/test-async-local-storage-enable-disable.js
@@ -24,8 +24,8 @@ asyncLocalStorage.run(new Map(), () => {
 
     process.nextTick(() => {
       assert.strictEqual(asyncLocalStorage.getStore(), undefined);
-      asyncLocalStorage.run(new Map(), () => {
-        assert.notStrictEqual(asyncLocalStorage.getStore(), undefined);
+      asyncLocalStorage.run(new Map().set('bar', 'foo'), () => {
+        assert.strictEqual(asyncLocalStorage.getStore().get('bar'), 'foo');
       });
     });
   });


### PR DESCRIPTION
The last als.run() will reactivate the als, hence the test should test for getting the object, not` undefined`

Based on the [Nodejs documentation](https://nodejs.org/api/async_hooks.html#async_hooks_asynclocalstorage_disable)

> Disables the instance of AsyncLocalStorage. All subsequent calls to asyncLocalStorage.getStore() will return undefined until asyncLocalStorage.run() or asyncLocalStorage.enterWith() is called 

The original test is doing
```Javascript
asyncLocalStorage.run(new Map(), () => {
        assert.notStrictEqual(asyncLocalStorage.getStore(), undefined);
```
The `asyncLocalStorage.getStore()` will return a `Map`, however, the test will pass as it is not strict.

As this is within a `run()`, we should test for `asyncLocalStorage` to return the `store` instead.

This will demonstrate a clearer purpose of the test.

