### PR TITLE
[v12.x] src: move CHECK in AddIsolateFinishedCallback

### DIFF
--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -359,10 +359,10 @@ void NodePlatform::AddIsolateFinishedCallback(Isolate* isolate,
   Mutex::ScopedLock lock(per_isolate_mutex_);
   auto it = per_isolate_.find(isolate);
   if (it == per_isolate_.end()) {
-    CHECK(it->second);
     cb(data);
     return;
   }
+  CHECK(it->second);
   it->second->AddShutdownCallback(cb, data);
 }
 


### PR DESCRIPTION
`CHECK(it->second)` asserts that we have `PerIsolatePlatformData`
in the `per_isolate_` map, and not just a key with empty value. When
`it == per_isolate_.end()`, however, it means that we don't have the
isolate and the `CHECK(it->second)` is guaranteed to fail then!