### PR TITLE
worker: fix exit code for error thrown in uncaughtException handler

### DIFF
--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -215,7 +215,7 @@ function workerOnGlobalUncaughtException(error, fromPromise) {
   if (!process._exiting) {
     try {
       process._exiting = true;
-      process.exitCode = handlerThrew ? 7 : 1;
+      process.exitCode = 1;
       if (!handlerThrew) {
         process.emit('exit', process.exitCode);
       }

--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -199,15 +199,27 @@ port.on('message', (message) => {
 function workerOnGlobalUncaughtException(error, fromPromise) {
   debug(`[${threadId}] gets uncaught exception`);
   let handled = false;
+  let handlerThrew = false;
   try {
     handled = onGlobalUncaughtException(error, fromPromise);
   } catch (e) {
     error = e;
+    handlerThrew = true;
   }
   debug(`[${threadId}] uncaught exception handled = ${handled}`);
 
   if (handled) {
     return true;
+  }
+
+  if (!process._exiting) {
+    try {
+      process._exiting = true;
+      process.exitCode = handlerThrew ? 7 : 1;
+      if (!handlerThrew) {
+        process.emit('exit', process.exitCode);
+      }
+    } catch {}
   }
 
   let serialized;

--- a/test/fixtures/process-exit-code-cases.js
+++ b/test/fixtures/process-exit-code-cases.js
@@ -2,124 +2,126 @@
 
 const assert = require('assert');
 
-const cases = [];
-module.exports = cases;
+function getTestCases(isWorker = false) {
+  const cases = [];
+  function exitsOnExitCodeSet() {
+    process.exitCode = 42;
+    process.on('exit', (code) => {
+      assert.strictEqual(process.exitCode, 42);
+      assert.strictEqual(code, 42);
+    });
+  }
+  cases.push({ func: exitsOnExitCodeSet, result: 42 });
 
-function exitsOnExitCodeSet() {
-  process.exitCode = 42;
-  process.on('exit', (code) => {
-    assert.strictEqual(process.exitCode, 42);
-    assert.strictEqual(code, 42);
-  });
-}
-cases.push({ func: exitsOnExitCodeSet, result: 42 });
-
-function changesCodeViaExit() {
-  process.exitCode = 99;
-  process.on('exit', (code) => {
-    assert.strictEqual(process.exitCode, 42);
-    assert.strictEqual(code, 42);
-  });
-  process.exit(42);
-}
-cases.push({ func: changesCodeViaExit, result: 42 });
-
-function changesCodeZeroExit() {
-  process.exitCode = 99;
-  process.on('exit', (code) => {
-    assert.strictEqual(process.exitCode, 0);
-    assert.strictEqual(code, 0);
-  });
-  process.exit(0);
-}
-cases.push({ func: changesCodeZeroExit, result: 0 });
-
-function exitWithOneOnUncaught() {
-  process.exitCode = 99;
-  process.on('exit', (code) => {
-    // cannot use assert because it will be uncaughtException -> 1 exit code
-    // that will render this test useless
-    if (code !== 1 || process.exitCode !== 1) {
-      console.log('wrong code! expected 1 for uncaughtException');
-      process.exit(99);
-    }
-  });
-  throw new Error('ok');
-}
-cases.push({
-  func: exitWithOneOnUncaught,
-  result: 1,
-  error: /^Error: ok$/,
-});
-
-function changeCodeInsideExit() {
-  process.exitCode = 95;
-  process.on('exit', (code) => {
-    assert.strictEqual(process.exitCode, 95);
-    assert.strictEqual(code, 95);
+  function changesCodeViaExit() {
     process.exitCode = 99;
-  });
-}
-cases.push({ func: changeCodeInsideExit, result: 99 });
+    process.on('exit', (code) => {
+      assert.strictEqual(process.exitCode, 42);
+      assert.strictEqual(code, 42);
+    });
+    process.exit(42);
+  }
+  cases.push({ func: changesCodeViaExit, result: 42 });
 
-function zeroExitWithUncaughtHandler() {
-  process.on('exit', (code) => {
-    assert.strictEqual(process.exitCode, 0);
-    assert.strictEqual(code, 0);
-  });
-  process.on('uncaughtException', () => {});
-  throw new Error('ok');
-}
-cases.push({ func: zeroExitWithUncaughtHandler, result: 0 });
+  function changesCodeZeroExit() {
+    process.exitCode = 99;
+    process.on('exit', (code) => {
+      assert.strictEqual(process.exitCode, 0);
+      assert.strictEqual(code, 0);
+    });
+    process.exit(0);
+  }
+  cases.push({ func: changesCodeZeroExit, result: 0 });
 
-function changeCodeInUncaughtHandler() {
-  process.on('exit', (code) => {
-    assert.strictEqual(process.exitCode, 97);
-    assert.strictEqual(code, 97);
+  function exitWithOneOnUncaught() {
+    process.exitCode = 99;
+    process.on('exit', (code) => {
+      // cannot use assert because it will be uncaughtException -> 1 exit code
+      // that will render this test useless
+      if (code !== 1 || process.exitCode !== 1) {
+        console.log('wrong code! expected 1 for uncaughtException');
+        process.exit(99);
+      }
+    });
+    throw new Error('ok');
+  }
+  cases.push({
+    func: exitWithOneOnUncaught,
+    result: 1,
+    error: /^Error: ok$/,
   });
-  process.on('uncaughtException', () => {
-    process.exitCode = 97;
-  });
-  throw new Error('ok');
-}
-cases.push({ func: changeCodeInUncaughtHandler, result: 97 });
 
-function changeCodeInExitWithUncaught() {
-  process.on('exit', (code) => {
-    assert.strictEqual(process.exitCode, 1);
-    assert.strictEqual(code, 1);
-    process.exitCode = 98;
-  });
-  throw new Error('ok');
-}
-cases.push({
-  func: changeCodeInExitWithUncaught,
-  result: 98,
-  error: /^Error: ok$/,
-});
+  function changeCodeInsideExit() {
+    process.exitCode = 95;
+    process.on('exit', (code) => {
+      assert.strictEqual(process.exitCode, 95);
+      assert.strictEqual(code, 95);
+      process.exitCode = 99;
+    });
+  }
+  cases.push({ func: changeCodeInsideExit, result: 99 });
 
-function exitWithZeroInExitWithUncaught() {
-  process.on('exit', (code) => {
-    assert.strictEqual(process.exitCode, 1);
-    assert.strictEqual(code, 1);
-    process.exitCode = 0;
-  });
-  throw new Error('ok');
-}
-cases.push({
-  func: exitWithZeroInExitWithUncaught,
-  result: 0,
-  error: /^Error: ok$/,
-});
+  function zeroExitWithUncaughtHandler() {
+    process.on('exit', (code) => {
+      assert.strictEqual(process.exitCode, 0);
+      assert.strictEqual(code, 0);
+    });
+    process.on('uncaughtException', () => { });
+    throw new Error('ok');
+  }
+  cases.push({ func: zeroExitWithUncaughtHandler, result: 0 });
 
-function exitWithThrowInUncaughtHandler() {
-  process.on('uncaughtException', () => {
-    throw new Error('ok')
+  function changeCodeInUncaughtHandler() {
+    process.on('exit', (code) => {
+      assert.strictEqual(process.exitCode, 97);
+      assert.strictEqual(code, 97);
+    });
+    process.on('uncaughtException', () => {
+      process.exitCode = 97;
+    });
+    throw new Error('ok');
+  }
+  cases.push({ func: changeCodeInUncaughtHandler, result: 97 });
+
+  function changeCodeInExitWithUncaught() {
+    process.on('exit', (code) => {
+      assert.strictEqual(process.exitCode, 1);
+      assert.strictEqual(code, 1);
+      process.exitCode = 98;
+    });
+    throw new Error('ok');
+  }
+  cases.push({
+    func: changeCodeInExitWithUncaught,
+    result: 98,
+    error: /^Error: ok$/,
   });
-  throw new Error('bad');
+
+  function exitWithZeroInExitWithUncaught() {
+    process.on('exit', (code) => {
+      assert.strictEqual(process.exitCode, 1);
+      assert.strictEqual(code, 1);
+      process.exitCode = 0;
+    });
+    throw new Error('ok');
+  }
+  cases.push({
+    func: exitWithZeroInExitWithUncaught,
+    result: 0,
+    error: /^Error: ok$/,
+  });
+
+  function exitWithThrowInUncaughtHandler() {
+    process.on('uncaughtException', () => {
+      throw new Error('ok')
+    });
+    throw new Error('bad');
+  }
+  cases.push({
+    func: exitWithThrowInUncaughtHandler,
+    result: isWorker ? 1 : 7,
+    error: /^Error: ok$/,
+  });
+  return cases;
 }
-cases.push({
-  func: exitWithThrowInUncaughtHandler,
-  result: 1,
-  error: /^Error: ok$/,
-});
+exports.getTestCases = getTestCases;

--- a/test/fixtures/process-exit-code-cases.js
+++ b/test/fixtures/process-exit-code-cases.js
@@ -111,3 +111,15 @@ cases.push({
   result: 0,
   error: /^Error: ok$/,
 });
+
+function exitWithThrowInUncaughtHandler() {
+  process.on('uncaughtException', () => {
+    throw new Error('ok')
+  });
+  throw new Error('bad');
+}
+cases.push({
+  func: exitWithThrowInUncaughtHandler,
+  result: 7,
+  error: /^Error: ok$/,
+});

--- a/test/fixtures/process-exit-code-cases.js
+++ b/test/fixtures/process-exit-code-cases.js
@@ -120,6 +120,6 @@ function exitWithThrowInUncaughtHandler() {
 }
 cases.push({
   func: exitWithThrowInUncaughtHandler,
-  result: 7,
+  result: 1,
   error: /^Error: ok$/,
 });

--- a/test/parallel/test-process-exit-code.js
+++ b/test/parallel/test-process-exit-code.js
@@ -24,7 +24,8 @@ require('../common');
 const assert = require('assert');
 const debug = require('util').debuglog('test');
 
-const testCases = require('../fixtures/process-exit-code-cases');
+const { getTestCases } = require('../fixtures/process-exit-code-cases');
+const testCases = getTestCases(false);
 
 if (!process.argv[2]) {
   parent();

--- a/test/parallel/test-worker-exit-code.js
+++ b/test/parallel/test-worker-exit-code.js
@@ -8,7 +8,8 @@ const assert = require('assert');
 const worker = require('worker_threads');
 const { Worker, parentPort } = worker;
 
-const testCases = require('../fixtures/process-exit-code-cases');
+const { getTestCases } = require('../fixtures/process-exit-code-cases');
+const testCases = getTestCases(true);
 
 // Do not use isMainThread so that this test itself can be run inside a Worker.
 if (!process.env.HAS_STARTED_WORKER) {


### PR DESCRIPTION
When an `uncaughtException` handler itself throws in a worker, the worker exits with an error code of 0 instead of ~7~ 1, which happens because the worker thread global handler catches the error, and exitCode stays 0.

My fix only emits `exit` for "regular" unhandled exceptions (which shouldn't actually reach that code anyway, as it should set `_exiting` correctly in the "inner" handler) to emulate the same behaviour that happens in non-workers, where `exit` is not emitted when an error is thrown from a handler.

The `process._exiting` logic was essentially taken from here: https://github.com/nodejs/node/blob/master/lib/internal/process/execution.js#L167

Fixes: https://github.com/nodejs/node/issues/37996