### PR TITLE
doc: document ctor of ReadStream and WriteStream in tty

### DIFF
--- a/doc/api/tty.md
+++ b/doc/api/tty.md
@@ -56,7 +56,7 @@ changes:
   see `options` of [`net.Socket` constructor][].
 * Returns {tty.ReadStream}
 
-Creates a ReadStream for `fd` associated with a TTY.
+Creates a `ReadStream` for `fd` associated with a TTY.
 
 ### `readStream.isRaw`
 <!-- YAML
@@ -111,7 +111,7 @@ added: v0.5.8
 * `fd` {number} A file descriptor associated with a TTY.
 * Returns {tty.WriteStream}
 
-Creates a WriteStream for `fd` associated with a TTY.
+Creates a `WriteStream` for `fd` associated with a TTY.
 
 ### Event: `'resize'`
 <!-- YAML

--- a/doc/api/tty.md
+++ b/doc/api/tty.md
@@ -43,6 +43,21 @@ Represents the readable side of a TTY. In normal circumstances
 [`process.stdin`][] will be the only `tty.ReadStream` instance in a Node.js
 process and there should be no reason to create additional instances.
 
+### `new tty.ReadStream(fd[, options])`
+<!-- YAML
+added: v0.5.8
+changes:
+  - version: v0.9.4
+    description: The `options` argument is supported.
+-->
+
+* `fd` {number} A file descriptor associated with a TTY.
+* `options` {Object} Options passed to parent `net.Socket`,
+  see `options` of [`net.Socket` constructor][].
+* Returns {tty.ReadStream}
+
+Creates a ReadStream for `fd` associated with a TTY.
+
 ### `readStream.isRaw`
 <!-- YAML
 added: v0.7.7
@@ -87,6 +102,16 @@ Represents the writable side of a TTY. In normal circumstances,
 [`process.stdout`][] and [`process.stderr`][] will be the only
 `tty.WriteStream` instances created for a Node.js process and there
 should be no reason to create additional instances.
+
+### `new tty.WriteStream(fd)`
+<!-- YAML
+added: v0.5.8
+-->
+
+* `fd` {number} A file descriptor associated with a TTY.
+* Returns {tty.WriteStream}
+
+Creates a WriteStream for `fd` associated with a TTY.
 
 ### Event: `'resize'`
 <!-- YAML
@@ -293,6 +318,7 @@ The `tty.isatty()` method returns `true` if the given `fd` is associated with
 a TTY and `false` if it is not, including whenever `fd` is not a non-negative
 integer.
 
+[`net.Socket` constructor]: net.md#net_new_net_socket_options
 [`process.stderr`]: process.md#process_process_stderr
 [`process.stdin`]: process.md#process_process_stdin
 [`process.stdout`]: process.md#process_process_stdout

--- a/tools/doc/type-parser.js
+++ b/tools/doc/type-parser.js
@@ -214,6 +214,9 @@ const customTypesMap = {
 
   'Tracing': 'tracing.html#tracing_tracing_object',
 
+  'tty.ReadStream': 'tty.html#tty_class_tty_readstream',
+  'tty.WriteStream': 'tty.html#tty_class_tty_writestream',
+
   'URL': 'url.html#url_the_whatwg_url_api',
   'URLSearchParams': 'url.html#url_class_urlsearchparams',
 


### PR DESCRIPTION
Add documents for constructors of both `tty.ReadStream` and `tty.WriteStream`.

Fixes: https://github.com/nodejs/node/issues/37780
