### PR TITLE
doc: fix asyncLocalStorage.run() description

### DIFF
--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -1124,8 +1124,9 @@ added:
 * `...args` {any}
 
 Runs a function synchronously within a context and returns its
-return value. The store is not accessible outside of the callback function or
-the asynchronous operations created within the callback.
+return value. The store is not accessible outside of the callback function.
+The store is accessible to any asynchronous operations created within the
+callback.
 
 The optional `args` are passed to the callback function.
 
@@ -1139,6 +1140,9 @@ const store = { id: 2 };
 try {
   asyncLocalStorage.run(store, () => {
     asyncLocalStorage.getStore(); // Returns the store object
+    setTimeout(() => {
+      asyncLocalStorage.getStore(); // Returns the store object
+    }, 200);
     throw new Error();
   });
 } catch (e) {


### PR DESCRIPTION
From the docs [here](https://nodejs.org/docs/latest-v15.x/api/async_hooks.html#async_hooks_asynclocalstorage_run_store_callback_args)

> This methods runs a function synchronously outside of a context and return its return value. The store is not accessible within the callback function **or the asynchronous operations created within the callback.**

The description that store is not available when asynchronous operation is created within the callback is not accurate.

This PR add a `setTimeout()` within the example and update the description.

Fixes: https://github.com/nodejs/node/issues/38022

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
