### PR TITLE
doc: how to expose primordials when using --expose-internals

### DIFF
--- a/doc/guides/writing-tests.md
+++ b/doc/guides/writing-tests.md
@@ -286,6 +286,15 @@ const assert = require('assert');
 const freelist = require('internal/freelist');
 ```
 
+In specific scenarios it may be useful to get a hold of `primordials` or
+`internalBinding()`. You can do so using
+
+```console
+node --expose-internals -r internal/test/binding lib/fs.js
+```
+
+This only works if you preload `internal/test/binding` by command line flag.
+
 ### Assertions
 
 When writing assertions, prefer the strict versions:


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This exposes `primordials` as a global property when using `--expose-internals`.

This allows efforts like https://github.com/nodejs/node/pull/21128 to follow general core robustness using `primordials` while potentially being developed outside of the core repo itself. Without such a repo using `primordials` it would not be easy to vendor in while maintaining such rigor without various duplications.

The `--expose-internals` flag is not currently documented in the main docs and I didn't add a note about this because of that.