### PR TITLE
test: fix test-tls-no-sslv3 for OpenSSL 3

### DIFF
--- a/test/parallel/test-tls-no-sslv3.js
+++ b/test/parallel/test-tls-no-sslv3.js
@@ -38,7 +38,7 @@ server.listen(0, '127.0.0.1', function() {
 server.on('tlsClientError', (err) => errors.push(err));
 
 process.on('exit', function() {
-  if (/unknown option -ssl3/.test(stderr)) {
+  if (/[Uu]nknown option:? -ssl3/.test(stderr)) {
     common.printSkipMessage('`openssl s_client -ssl3` not supported.');
   } else {
     assert.strictEqual(errors.length, 1);


### PR DESCRIPTION
OpenSSL 3 has changed the format of the error message for an unknown
option to the CLI. Update the test to allow for the older and newer
message formats.

Refs: https://github.com/openssl/openssl/pull/10774

Example message from an OpenSSL 1.1.1 CLI:
```
$ openssl s_client -ssl3
s_client: Option unknown option -ssl3
s_client: Use -help for summary.
$
```
OpenSSL 3.0.0 alpha13:
```
$ openssl s_client -ssl3
openssl s_client: Unknown option: -ssl3
openssl s_client: Use -help for summary.
$
```
cc @danbev 

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
