### PR TITLE
doc: sending http request to localhost to avoid https redirect

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -2758,7 +2758,7 @@ http.get('http://localhost:8000/', (res) => {
 
 // Create a local server to receive data from
 const server = http.createServer((req, res) => {
-  res.writeHead(200, { 'content-type': 'application/json' });
+  res.writeHead(200, { 'Content-Type': 'application/json' });
   res.end(JSON.stringify({
     data: 'Hello World!'
   }));

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -2720,7 +2720,7 @@ The `callback` is invoked with a single argument that is an instance of
 JSON fetching example:
 
 ```js
-http.get('http://nodejs.org/dist/index.json', (res) => {
+http.get('http://localhost:8000/', (res) => {
   const { statusCode } = res;
   const contentType = res.headers['content-type'];
 
@@ -2755,6 +2755,16 @@ http.get('http://nodejs.org/dist/index.json', (res) => {
 }).on('error', (e) => {
   console.error(`Got error: ${e.message}`);
 });
+
+// Create a local server to receive data from
+const server = http.createServer((req, res) => {
+  res.writeHead(200, { 'content-type': 'application/json' });
+  res.end(`{
+    'data': 'hello world'
+  }`);
+});
+
+server.listen(8000);
 ```
 
 ## `http.globalAgent`

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -2759,9 +2759,9 @@ http.get('http://localhost:8000/', (res) => {
 // Create a local server to receive data from
 const server = http.createServer((req, res) => {
   res.writeHead(200, { 'content-type': 'application/json' });
-  res.end(`{
-    'data': 'hello world'
-  }`);
+  res.end(JSON.stringify({
+    data: 'Hello World!'
+  }));
 });
 
 server.listen(8000);


### PR DESCRIPTION
In the JSON fetching example, http.get request is being sent to an http url that redirects to https. This causes the http.get request to fail. To avoid redirect errors, a local http server is set up that returns a json response.

Fixes: https://github.com/nodejs/node/issues/37907

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
