### PR TITLE
doc,tools: allow stability table to be updated

### DIFF
--- a/doc/api/documentation.md
+++ b/doc/api/documentation.md
@@ -50,7 +50,8 @@ modifications occur. To avoid surprises, use of an Experimental feature may need
 a command-line flag. Experimental features may also emit a [warning][].
 
 ## Stability overview
-<!-- STABILITY_OVERVIEW_SLOT -->
+<!-- STABILITY_OVERVIEW_SLOT_BEGIN -->
+<!-- STABILITY_OVERVIEW_SLOT_END -->
 
 ## JSON output
 <!-- YAML


### PR DESCRIPTION
Keep markers for the stability table so that it can be updated on
subsequent runs of the doc tooling. Only overwrite the files if
they have been changed.

Fixes: https://github.com/nodejs/node/issues/37886
cc @nodejs/documentation @danbev 

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
