### PR TITLE
test: fix flaky test-net-timeout

### DIFF
--- a/test/pummel/test-net-timeout.js
+++ b/test/pummel/test-net-timeout.js
@@ -45,7 +45,6 @@ const echo_server = net.createServer((socket) => {
   });
 
   socket.on('data', (d) => {
-    console.log(d);
     socket.write(d);
   });
 
@@ -105,7 +104,4 @@ process.on('exit', () => {
   console.log(`diff = ${diff}`);
 
   assert.ok(timeout < diff);
-
-  // Allow for 800 milliseconds more
-  assert.ok(diff < timeout + 800);
 });


### PR DESCRIPTION
The check for an 800ms window makes assumptions about a setTimeout()
not running late etc. Remove it.

Refs: https://github.com/nodejs/node/pull/34289

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
