### PR TITLE
path: fix POSIX path.resolve() perf regression

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -23,7 +23,6 @@
 
 const {
   FunctionPrototypeBind,
-  RegExp,
   StringPrototypeCharCodeAt,
   StringPrototypeIndexOf,
   StringPrototypeLastIndexOf,
@@ -47,6 +46,8 @@ const {
   validateObject,
   validateString,
 } = require('internal/validators');
+
+const platformIsWin32 = (process.platform === 'win32');
 
 function isPathSeparator(code) {
   return code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH;
@@ -1011,6 +1012,21 @@ const win32 = {
   posix: null
 };
 
+const posixCwd = (() => {
+  if (platformIsWin32) {
+    // Converts Windows' backslash path separators to POSIX forward slashes
+    // and truncates any drive indicator
+    const regexp = /\\/g;
+    return () => {
+      const cwd = StringPrototypeReplace(process.cwd(), regexp, '/');
+      return StringPrototypeSlice(cwd, StringPrototypeIndexOf(cwd, '/'));
+    };
+  }
+
+  // We're already on POSIX, no need for any transformations
+  return () => process.cwd();
+})();
+
 const posix = {
   // path.resolve([from ...], to)
   resolve(...args) {
@@ -1018,17 +1034,7 @@ const posix = {
     let resolvedAbsolute = false;
 
     for (let i = args.length - 1; i >= -1 && !resolvedAbsolute; i--) {
-      let path;
-      if (i >= 0) {
-        path = args[i];
-      } else {
-        const _ = StringPrototypeReplace(
-          process.cwd(),
-          new RegExp(`\\${module.exports.sep}`, 'g'),
-          posix.sep
-        );
-        path = StringPrototypeSlice(_, StringPrototypeIndexOf(_, posix.sep));
-      }
+      const path = i >= 0 ? args[i] : posixCwd();
 
       validateString(path, 'path');
 
@@ -1431,4 +1437,4 @@ posix.posix = win32.posix = posix;
 win32._makeLong = win32.toNamespacedPath;
 posix._makeLong = posix.toNamespacedPath;
 
-module.exports = process.platform === 'win32' ? win32 : posix;
+module.exports = platformIsWin32 ? win32 : posix;


### PR DESCRIPTION
b0d5e036d8677633d82032deac055ad716a55531 introduced an unnecessary performance regression when using `path.resolve()` on POSIX systems. This commit both removes that regression in that situation and reduces the performance hit when `path.posix.resolve()` is used directly/indirectly on Windows systems.

The following benchmark results come from a Linux system:

After b0d5e036d8677633d82032deac055ad716a55531:

```
                                                                           confidence improvement accuracy (*)   (**)  (***)
path/resolve-posix.jsn=1000000 paths=''                                          ***    -54.27 %       ±0.94% ±1.26% ±1.65%
path/resolve-posix.jsn=1000000 paths='|'                                         ***    -54.97 %       ±1.07% ±1.43% ±1.86%
path/resolve-posix.jsn=1000000 paths='a/b/c/|../../..'                           ***    -34.18 %       ±0.86% ±1.15% ±1.50%
path/resolve-posix.jsn=1000000 paths='foo/bar|/tmp/file/|..|a/../subfile'        ***      8.11 %       ±1.55% ±2.07% ±2.71%
```

After the new implementation (basically caching the regexp):

```
                                                                           confidence improvement accuracy (*)   (**)  (***)
path/resolve-posix.jsn=1000000 paths=''                                          ***    -12.13 %       ±1.60% ±2.13% ±2.78%
path/resolve-posix.jsn=1000000 paths='|'                                         ***    -11.08 %       ±1.37% ±1.82% ±2.37%
path/resolve-posix.jsn=1000000 paths='a/b/c/|../../..'                           ***     -6.80 %       ±1.05% ±1.40% ±1.83%
path/resolve-posix.jsn=1000000 paths='foo/bar|/tmp/file/|..|a/../subfile'        ***      7.86 %       ±1.40% ±1.87% ±2.44%
```

After avoiding the transformations from b0d5e036d8677633d82032deac055ad716a55531 for POSIX systems (I'm not sure why there is a performance *increase* in this case, as I would have expected zero or close to zero change, but that's V8 for you):

```
                                                                           confidence improvement accuracy (*)   (**)  (***)
path/resolve-posix.jsn=1000000 paths=''                                          ***      9.13 %       ±1.16% ±1.54% ±2.01%
path/resolve-posix.jsn=1000000 paths='|'                                         ***      8.69 %       ±1.13% ±1.51% ±1.97%
path/resolve-posix.jsn=1000000 paths='a/b/c/|../../..'                           ***      4.82 %       ±0.91% ±1.21% ±1.58%
path/resolve-posix.jsn=1000000 paths='foo/bar|/tmp/file/|..|a/../subfile'        ***      8.62 %       ±1.24% ±1.66% ±2.17%
```

/cc @Trott @mcollina 