### PR TITLE
doc: add parentheses to function and move reference

### DIFF
--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -638,7 +638,7 @@ will not terminate until it receives `EOF` (<kbd>Ctrl</kbd>+<kbd>D</kbd> on
 Linux/macOS, <kbd>Ctrl</kbd>+<kbd>Z</kbd> followed by <kbd>Return</kbd> on
 Windows).
 If you want your application to exit without waiting for user input, you can
-[`unref`][] the standard input stream:
+[`unref()`][] the standard input stream:
 
 ```js
 process.stdin.unref();
@@ -978,5 +978,5 @@ const { createInterface } = require('readline');
 [`process.stdin`]: process.md#process_process_stdin
 [`process.stdout`]: process.md#process_process_stdout
 [`rl.close()`]: #readline_rl_close
+[`unref()`]: net.md#net_socket_unref
 [reading files]: #readline_example_read_file_stream_line_by_line
-[`unref`]: net.md#net_socket_unref


### PR DESCRIPTION
Add parentheses as `unref()` is a function. Move it to the correct
lexically-sorted location in the reference list.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
