### PR TITLE
src: remove KeyObjectData::CreateSecret overload

### DIFF
--- a/src/crypto/crypto_keys.cc
+++ b/src/crypto/crypto_keys.cc
@@ -837,11 +837,6 @@ void KeyObjectData::MemoryInfo(MemoryTracker* tracker) const {
   }
 }
 
-std::shared_ptr<KeyObjectData> KeyObjectData::CreateSecret(
-    const ArrayBufferOrViewContents<char>& buf) {
-  return CreateSecret(buf.ToCopy());
-}
-
 std::shared_ptr<KeyObjectData> KeyObjectData::CreateSecret(ByteSource key) {
   CHECK(key);
   return std::shared_ptr<KeyObjectData>(new KeyObjectData(std::move(key)));

--- a/src/crypto/crypto_keys.h
+++ b/src/crypto/crypto_keys.h
@@ -134,9 +134,6 @@ class ManagedEVPPKey : public MemoryRetainer {
 // Objects of this class can safely be shared among threads.
 class KeyObjectData : public MemoryRetainer {
  public:
-  static std::shared_ptr<KeyObjectData> CreateSecret(
-      const ArrayBufferOrViewContents<char>& buf);
-
   static std::shared_ptr<KeyObjectData> CreateSecret(ByteSource key);
 
   static std::shared_ptr<KeyObjectData> CreateAsymmetric(


### PR DESCRIPTION
This function is unused and there is not much potential for using it in the current codebase.

This is the only invocation of `CreateSecret` that could use this overload instead of calling `ToCopy`, and it seems appropriate to explicitly call `ToCopy` here.

https://github.com/nodejs/node/blob/f562ec64e8e3d602fb5035c079c97fff59c395cd/src/crypto/crypto_keys.cc#L946-L950

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
