### PR TITLE
test: skip test-hash-seed on armv6 and armv7

### DIFF
--- a/test/pummel/test-hash-seed.js
+++ b/test/pummel/test-hash-seed.js
@@ -2,6 +2,11 @@
 
 // Check that spawn child doesn't create duplicated entries
 const common = require('../common');
+
+if ((process.config.variables.arm_version === '6') ||
+    (process.config.variables.arm_version === '7'))
+  common.skip('Too slow for armv6 and armv7 bots');
+
 const kRepetitions = 2;
 const assert = require('assert');
 const fixtures = require('../common/fixtures');


### PR DESCRIPTION
The test is too slow to run on the Raspberry Pi bots. (It takes over 900
seconds to run on Pi 3 bots and even more than that on Pi 2 bots.) Skip
it on armv6 and armv7.

Refs: https://github.com/nodejs/node/pull/34289

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
