### PR TITLE
lib: remove redundant branch in  async_hooks

### DIFF
--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -4,7 +4,7 @@ const {
   ArrayPrototypePop,
   ArrayPrototypeSlice,
   ArrayPrototypeUnshift,
-  ErrorCaptureStackTrace,
+
   FunctionPrototypeBind,
   ObjectPrototypeHasOwnProperty,
   ObjectDefineProperty,
@@ -158,14 +158,7 @@ function executionAsyncResource() {
 
 // Used to fatally abort the process if a callback throws.
 function fatalError(e) {
-  if (typeof e.stack === 'string') {
-    process._rawDebug(e.stack);
-  } else {
-    const o = { message: e };
-    ErrorCaptureStackTrace(o, fatalError);
-    process._rawDebug(o.stack);
-  }
-
+  process._rawDebug(e.stack);
   const { getOptionValue } = require('internal/options');
   if (getOptionValue('--abort-on-uncaught-exception')) {
     process.abort();


### PR DESCRIPTION
The if-else is check if e.stack is string
according to Node.js docs, e.stack is always
a string, so there is no need for this check

Refs: https://github.com/nodejs/node/issues/38077

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
