### PR TITLE
tools: remove max-len ESLint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -95,7 +95,6 @@ module.exports = {
       line: {
         // Ignore all lines that have less characters than 20 and all lines that
         // start with something that looks like a variable name or code.
-        // eslint-disable-next-line max-len
         ignorePattern: '.{0,20}$|[a-z]+ ?[0-9A-Z_.(/=:[#-]|std|http|ssh|ftp|(let|var|const) [a-z_A-Z0-9]+ =|[b-z] |[a-z]*[0-9].* ',
         ignoreInlineComments: true,
         ignoreConsecutiveComments: true,
@@ -137,13 +136,6 @@ module.exports = {
     'key-spacing': ['error', { mode: 'strict' }],
     'keyword-spacing': 'error',
     'linebreak-style': ['error', 'unix'],
-    'max-len': ['error', {
-      code: 80,
-      ignorePattern: '^// Flags:',
-      ignoreRegExpLiterals: true,
-      ignoreUrls: true,
-      tabWidth: 2,
-    }],
     'new-parens': 'error',
     'no-async-promise-executor': 'error',
     'no-class-assign': 'error',
@@ -185,7 +177,6 @@ module.exports = {
     'no-proto': 'error',
     'no-redeclare': ['error', { 'builtinGlobals': false }],
     'no-restricted-modules': ['error', 'sys'],
-    /* eslint-disable max-len */
     'no-restricted-properties': [
       'error',
       {
@@ -238,7 +229,6 @@ module.exports = {
         message: 'Use Number.isNaN() instead of the global isNaN() function.',
       },
     ],
-    /* eslint-enable max-len */
     'no-return-await': 'error',
     'no-self-assign': 'error',
     'no-self-compare': 'error',

--- a/test/parallel/test-http2-binding.js
+++ b/test/parallel/test-http2-binding.js
@@ -107,7 +107,7 @@ const expectedHeaderNames = {
   HTTP2_HEADER_ACCEPT_LANGUAGE: 'accept-language',
   HTTP2_HEADER_ACCEPT_RANGES: 'accept-ranges',
   HTTP2_HEADER_ACCEPT: 'accept',
-  HTTP2_HEADER_ACCESS_CONTROL_ALLOW_CREDENTIALS: 'access-control-allow-credentials', // eslint-disable-line max-len
+  HTTP2_HEADER_ACCESS_CONTROL_ALLOW_CREDENTIALS: 'access-control-allow-credentials',
   HTTP2_HEADER_ACCESS_CONTROL_ALLOW_HEADERS: 'access-control-allow-headers',
   HTTP2_HEADER_ACCESS_CONTROL_ALLOW_METHODS: 'access-control-allow-methods',
   HTTP2_HEADER_ACCESS_CONTROL_ALLOW_ORIGIN: 'access-control-allow-origin',

--- a/test/parallel/test-policy-integrity-flag.js
+++ b/test/parallel/test-policy-integrity-flag.js
@@ -21,12 +21,10 @@ const emptySRI = `sha512-${emptyHash.digest('base64')}`;
 const policyHash = crypto.createHash('sha512');
 policyHash.update(fs.readFileSync(depPolicy));
 
-/* eslint-disable max-len */
 // When using \n only
 const nixPolicySRI = 'sha512-u/nXI6UacK5fKDC2bopcgnuQY4JXJKlK3dESO3GIKKxwogVHjJqpF9rgk7Zw+TJXIc96xBUWKHuUgOzic8/4tQ==';
 // When \n is turned into \r\n
 const windowsPolicySRI = 'sha512-OeyCPRo4OZMosHyquZXDHpuU1F4KzG9UHFnn12FMaHsvqFUt3TFZ+7wmZE7ThZ5rsQWkUjc9ZH0knGZ2e8BYPQ==';
-/* eslint-enable max-len */
 
 const depPolicySRI = `${nixPolicySRI} ${windowsPolicySRI}`;
 {

--- a/test/parallel/test-readline-keys.js
+++ b/test/parallel/test-readline-keys.js
@@ -136,7 +136,6 @@ addTest('a\x1baA\x1bA', [
 ]);
 
 // xterm/gnome ESC [ letter (with modifiers)
-/* eslint-disable max-len */
 addTest('\x1b[2P\x1b[3P\x1b[4P\x1b[5P\x1b[6P\x1b[7P\x1b[8P\x1b[3Q\x1b[8Q\x1b[3R\x1b[8R\x1b[3S\x1b[8S', [
   { name: 'f1', sequence: '\x1b[2P', code: '[P', shift: true, meta: false, ctrl: false },
   { name: 'f1', sequence: '\x1b[3P', code: '[P', shift: false, meta: true, ctrl: false },
@@ -152,7 +151,6 @@ addTest('\x1b[2P\x1b[3P\x1b[4P\x1b[5P\x1b[6P\x1b[7P\x1b[8P\x1b[3Q\x1b[8Q\x1b[3R\
   { name: 'f4', sequence: '\x1b[3S', code: '[S', meta: true },
   { name: 'f4', sequence: '\x1b[8S', code: '[S', shift: true, meta: true, ctrl: true },
 ]);
-/* eslint-enable max-len */
 
 // xterm/gnome ESC O letter
 addTest('\x1bOP\x1bOQ\x1bOR\x1bOS', [
@@ -250,7 +248,6 @@ addTest('\x1b[A\x1b[B\x1b[2A\x1b[2B', [
 ]);
 
 // `rxvt` keys with modifiers.
-// eslint-disable-next-line max-len
 addTest('\x1b[20~\x1b[2$\x1b[2^\x1b[3$\x1b[3^\x1b[5$\x1b[5^\x1b[6$\x1b[6^\x1b[7$\x1b[7^\x1b[8$\x1b[8^', [
   { name: 'f9', sequence: '\x1b[20~', code: '[20~' },
   { name: 'insert', sequence: '\x1b[2$', code: '[2$', shift: true },

--- a/test/parallel/test-url-parse-format.js
+++ b/test/parallel/test-url-parse-format.js
@@ -844,7 +844,7 @@ const parseTests = {
     hostname: 'a.b',
     hash: null,
     pathname: '/%09bc%0Adr%0Def%20g%22hq%27j%3Ckl%3E',
-    path: '/%09bc%0Adr%0Def%20g%22hq%27j%3Ckl%3E?mn%5Cop%5Eq=r%6099%7Bst%7Cuv%7Dwz', // eslint-disable-line max-len
+    path: '/%09bc%0Adr%0Def%20g%22hq%27j%3Ckl%3E?mn%5Cop%5Eq=r%6099%7Bst%7Cuv%7Dwz',
     search: '?mn%5Cop%5Eq=r%6099%7Bst%7Cuv%7Dwz',
     query: 'mn%5Cop%5Eq=r%6099%7Bst%7Cuv%7Dwz',
     href: 'http://a.b/%09bc%0Adr%0Def%20g%22hq%27j%3Ckl%3E?mn%5Cop%5Eq=r%6099%7Bst%7Cuv%7Dwz'

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -2610,7 +2610,6 @@ assert.strictEqual(
 
   expected = [
     '[',
-    /* eslint-disable max-len */
     '   \u001b[33m0\u001b[39m,  \u001b[33m1\u001b[39m,  \u001b[33m2\u001b[39m,  \u001b[33m3\u001b[39m,',
     '   \u001b[33m4\u001b[39m,  \u001b[33m5\u001b[39m,  \u001b[33m6\u001b[39m,  \u001b[33m7\u001b[39m,',
     '   \u001b[33m8\u001b[39m,  \u001b[33m9\u001b[39m, \u001b[33m10\u001b[39m, \u001b[33m11\u001b[39m,',
@@ -2626,7 +2625,6 @@ assert.strictEqual(
     '  \u001b[33m48\u001b[39m, \u001b[33m49\u001b[39m, \u001b[33m50\u001b[39m, \u001b[33m51\u001b[39m,',
     '  \u001b[33m52\u001b[39m, \u001b[33m53\u001b[39m, \u001b[33m54\u001b[39m, \u001b[33m55\u001b[39m,',
     '  \u001b[33m56\u001b[39m, \u001b[33m57\u001b[39m, \u001b[33m58\u001b[39m, \u001b[33m59\u001b[39m',
-    /* eslint-enable max-len */
     ']',
   ].join('\n');
 
@@ -3067,7 +3065,7 @@ assert.strictEqual(
     '[GeneratorFunction: generator] {\n' +
     '  [length]: 0,\n' +
     "  [name]: 'generator',\n" +
-    "  [prototype]: Object [Generator] { [Symbol(Symbol.toStringTag)]: 'Generator' },\n" + // eslint-disable-line max-len
+    "  [prototype]: Object [Generator] { [Symbol(Symbol.toStringTag)]: 'Generator' },\n" +
     "  [Symbol(Symbol.toStringTag)]: 'GeneratorFunction'\n" +
     '}'
   );

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -499,7 +499,6 @@ function altDocs(filename, docCreated, versions) {
   ` : '';
 }
 
-// eslint-disable-next-line max-len
 const githubLogo = '<span class="github_icon"><svg height="16" width="16" viewBox="0 0 16.1 16.1" fill="currentColor"><path d="M8 0a8 8 0 0 0-2.5 15.6c.4 0 .5-.2.5-.4v-1.5c-2 .4-2.5-.5-2.7-1 0-.1-.5-.9-.8-1-.3-.2-.7-.6 0-.6.6 0 1 .6 1.2.8.7 1.2 1.9 1 2.4.7 0-.5.2-.9.5-1-1.8-.3-3.7-1-3.7-4 0-.9.3-1.6.8-2.2 0-.2-.3-1 .1-2 0 0 .7-.3 2.2.7a7.4 7.4 0 0 1 4 0c1.5-1 2.2-.8 2.2-.8.5 1.1.2 2 .1 2.1.5.6.8 1.3.8 2.2 0 3-1.9 3.7-3.6 4 .3.2.5.7.5 1.4v2.2c0 .2.1.5.5.4A8 8 0 0 0 16 8a8 8 0 0 0-8-8z"/></svg></span>';
 function editOnGitHub(filename) {
   return `<li class="edit_on_github"><a href="https://github.com/nodejs/node/edit/master/doc/api/${filename}.md">${githubLogo}Edit on GitHub</a></li>`;

--- a/tools/doc/json.js
+++ b/tools/doc/json.js
@@ -458,7 +458,6 @@ const callWithParams = r`\([^)]*\)`;
 
 const maybeExtends = `(?: +extends +${maybeAncestors}${classId})?`;
 
-/* eslint-disable max-len */
 const headingExpressions = [
   { type: 'event', re: RegExp(
     `${eventPrefix}${maybeBacktick}${maybeQuote}(${notQuotes})${maybeQuote}${maybeBacktick}$`, 'i') },
@@ -478,7 +477,6 @@ const headingExpressions = [
   { type: 'property', re: RegExp(
     `^${maybeClassPropertyPrefix}${maybeBacktick}${ancestors}(${id})${maybeBacktick}$`, 'i') },
 ];
-/* eslint-enable max-len */
 
 function newSection(header, file) {
   const text = textJoin(header.children, file);


### PR DESCRIPTION
The max-len rule often hampers readability rather than enhancing it. Few
developers are inconvenienced by lines longer than 80 characters. Let's
remove it.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
