### PR TITLE
crypto: reduce range of size to int max

### DIFF
--- a/lib/internal/crypto/random.js
+++ b/lib/internal/crypto/random.js
@@ -57,8 +57,8 @@ const {
 
 const { FastBuffer } = require('internal/buffer');
 
-const kMaxUint32 = 2 ** 32 - 1;
-const kMaxPossibleLength = MathMin(kMaxLength, kMaxUint32);
+const kMaxInt32 = 2 ** 31 - 1;
+const kMaxPossibleLength = MathMin(kMaxLength, kMaxInt32);
 
 function assertOffset(offset, elementSize, length) {
   validateNumber(offset, 'offset');

--- a/test/parallel/test-crypto-random.js
+++ b/test/parallel/test-crypto-random.js
@@ -32,8 +32,8 @@ const cryptop = require('crypto').webcrypto;
 const { kMaxLength } = require('buffer');
 const { inspect } = require('util');
 
-const kMaxUint32 = Math.pow(2, 32) - 1;
-const kMaxPossibleLength = Math.min(kMaxLength, kMaxUint32);
+const kMaxInt32 = 2 ** 31 - 1;
+const kMaxPossibleLength = Math.min(kMaxLength, kMaxInt32);
 
 common.expectWarning('DeprecationWarning',
                      'crypto.pseudoRandomBytes is deprecated.', 'DEP0115');
@@ -51,7 +51,7 @@ common.expectWarning('DeprecationWarning',
       assert.throws(() => f(value, common.mustNotCall()), errObj);
     });
 
-    [-1, NaN, 2 ** 32].forEach((value) => {
+    [-1, NaN, 2 ** 32, 2 ** 31].forEach((value) => {
       const errObj = {
         code: 'ERR_OUT_OF_RANGE',
         name: 'RangeError',


### PR DESCRIPTION
## Background

A bump of max length of Buffer to `2 ** 32 - 1`(https://bugs.chromium.org/p/v8/issues/detail?id=4153#c66) breaks validation of `size`argument of `randomBytes`. When passing a over-large `size` like `2 * 31)`, it causes abort in v14 as described in #38090.

## Impact of the PR

For v15, the overlarge size is catched in C++ code, and an Error will throw currently:

```
Welcome to Node.js v15.12.0.
Type ".help" for more information.
> crypto.randomBytes(2147483648)
Uncaught RangeError: buffer is too large
    at randomFillSync (node:internal/crypto/random:128:15)
    at Object.randomBytes (node:internal/crypto/random:96:5) {
  code: 'ERR_OUT_OF_RANGE'
```

After the PR, an JS-level Error will throw:

```
> crypto.randomBytes(2147483648)
Uncaught:
RangeError [ERR_OUT_OF_RANGE]: The value of "size" is out of range. It must be >= 0 && <= 2147483647. Received 2147483648
    at new NodeError (node:internal/errors:349:5)
    at assertSize (node:internal/crypto/random:80:11)
    at Object.randomBytes (node:internal/crypto/random:93:10)
    at REPL1:1:8
    at Script.runInThisContext (node:vm:131:12)
    at REPLServer.defaultEval (node:repl:522:29)
    at bound (node:domain:416:15)
    at REPLServer.runBound [as eval] (node:domain:427:12)
    at REPLServer.onLine (node:repl:844:10)
    at REPLServer.emit (node:events:381:22) {
  code: 'ERR_OUT_OF_RANGE'
}
```

For v14, executing `crypto.randomBytes(2147483648)` will abort immediately

```
Welcome to Node.js v14.16.0.
Type ".help" for more information.
>  crypto.randomBytes(2147483648)
[1]    96221 segmentation fault  node
```

If this PR is backported successfully, it will throw the same Error described above instead of abort.

Refs: #38090