### PR TITLE
tools: relax max-len lint rule for template strings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -141,6 +141,7 @@ module.exports = {
       code: 80,
       ignorePattern: '^// Flags:',
       ignoreRegExpLiterals: true,
+      ignoreTemplateLiterals: true,
       ignoreUrls: true,
       tabWidth: 2,
     }],

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -1551,8 +1551,9 @@ function formatMap(value, ctx, ignored, recurseTimes) {
   const output = [];
   ctx.indentationLvl += 2;
   for (const { 0: k, 1: v } of value) {
-    output.push(`${formatValue(ctx, k, recurseTimes)} => ` +
-                formatValue(ctx, v, recurseTimes));
+    output.push(
+      `${formatValue(ctx, k, recurseTimes)} => ${formatValue(ctx, v, recurseTimes)}`
+    );
   }
   ctx.indentationLvl -= 2;
   return output;
@@ -1593,8 +1594,8 @@ function formatMapIterInner(ctx, recurseTimes, entries, state) {
   if (state === kWeak) {
     for (; i < maxLength; i++) {
       const pos = i * 2;
-      output[i] = `${formatValue(ctx, entries[pos], recurseTimes)}` +
-        ` => ${formatValue(ctx, entries[pos + 1], recurseTimes)}`;
+      output[i] =
+        `${formatValue(ctx, entries[pos], recurseTimes)} => ${formatValue(ctx, entries[pos + 1], recurseTimes)}`;
     }
     // Sort all entries to have a halfway reliable output (if more entries than
     // retrieved ones exist, we can not reliably return the same output) if the

--- a/tools/doc/apilinks.js
+++ b/tools/doc/apilinks.js
@@ -62,8 +62,8 @@ inputs.forEach((file) => {
   const program = ast.body;
 
   // Build link
-  const link = `https://github.com/${repo}/blob/${tag}/` +
-    path.relative('.', file).replace(/\\/g, '/');
+  const link =
+    `https://github.com/${repo}/blob/${tag}/${path.relative('.', file).replace(/\\/g, '/')}`;
 
   // Scan for exports.
   const exported = { constructors: [], identifiers: [] };

--- a/tools/doc/checkLinks.js
+++ b/tools/doc/checkLinks.js
@@ -63,10 +63,9 @@ function checkFile(path) {
       if (previousDefinitionLabel &&
           previousDefinitionLabel > node.label) {
         const { line, column } = node.position.start;
-        console.error((process.env.GITHUB_ACTIONS ?
-          `::error file=${path},line=${line},col=${column}::` : '') +
-          `Unordered reference at ${path}:${line}:${column} (` +
-          `"${node.label}" should be before "${previousDefinitionLabel}")`
+        console.error(
+          (process.env.GITHUB_ACTIONS ? `::error file=${path},line=${line},col=${column}::` : '') +
+          `Unordered reference at ${path}:${line}:${column} ("${node.label}" should be before "${previousDefinitionLabel}")`
         );
         process.exitCode = 1;
       }

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -169,12 +169,10 @@ function linkManPages(text) {
       const displayAs = `<code>${name}(${number}${optionalCharacter})</code>`;
 
       if (BSD_ONLY_SYSCALLS.has(name)) {
-        return `${beginning}<a href="https://www.freebsd.org/cgi/man.cgi` +
-          `?query=${name}&sektion=${number}">${displayAs}</a>`;
+        return `${beginning}<a href="https://www.freebsd.org/cgi/man.cgi?query=${name}&sektion=${number}">${displayAs}</a>`;
       }
 
-      return `${beginning}<a href="http://man7.org/linux/man-pages/man${number}` +
-        `/${name}.${number}${optionalCharacter}.html">${displayAs}</a>`;
+      return `${beginning}<a href="http://man7.org/linux/man-pages/man${number}/${name}.${number}${optionalCharacter}.html">${displayAs}</a>`;
     });
 }
 
@@ -212,17 +210,14 @@ function preprocessElements({ filename }) {
       } else if (node.type === 'code') {
         if (!node.lang) {
           console.warn(
-            `No language set in ${filename}, ` +
-            `line ${node.position.start.line}`);
+            `No language set in ${filename}, line ${node.position.start.line}`
+          );
         }
         const className = isJSFlavorSnippet(node) ?
           `language-js ${node.lang}` :
           `language-${node.lang}`;
         const highlighted =
-          `<code class='${className}'>` +
-          (getLanguage(node.lang || '') ?
-            highlight(node.lang, node.value) : node).value +
-          '</code>';
+          `<code class='${className}'>${(getLanguage(node.lang || '') ? highlight(node.lang, node.value) : node).value}</code>`;
         node.type = 'html';
 
         if (isJSFlavorSnippet(node)) {
@@ -356,8 +351,7 @@ function parseYAML(text) {
 
     result += '</table>\n</details>\n';
   } else {
-    result += `${added.description}${deprecated.description}` +
-              `${removed.description}\n`;
+    result += `${added.description}${deprecated.description}${removed.description}\n`;
   }
 
   if (meta.napiVersion) {
@@ -420,15 +414,14 @@ function buildToc({ filename, apilinks }) {
       const hasStability = node.stability !== undefined;
       toc += ' '.repeat((depth - 1) * 2) +
         (hasStability ? `* <span class="stability_${node.stability}">` : '* ') +
-        `<a href="#${isDeprecationHeading ? node.data.hProperties.id : id}">` +
-        `${headingText}</a>${hasStability ? '</span>' : ''}\n`;
+        `<a href="#${isDeprecationHeading ? node.data.hProperties.id : id}">${headingText}</a>${hasStability ? '</span>' : ''}\n`;
 
       let anchor =
          `<span><a class="mark" href="#${id}" id="${id}">#</a></span>`;
 
       if (realFilename === 'errors' && headingText.startsWith('ERR_')) {
-        anchor += `<span><a class="mark" href="#${headingText}" ` +
-                  `id="${headingText}">#</a></span>`;
+        anchor +=
+          `<span><a class="mark" href="#${headingText}" id="${headingText}">#</a></span>`;
       }
 
       const api = headingText.replace(/^.*:\s+/, '').replace(/\(.*/, '');
@@ -478,8 +471,7 @@ function altDocs(filename, docCreated, versions) {
     `${host}/docs/latest-v${versionNum}/api/${filename}.html`;
 
   const wrapInListItem = (version) =>
-    `<li><a href="${getHref(version.num)}">${version.num}` +
-    `${version.lts ? ' <b>LTS</b>' : ''}</a></li>`;
+    `<li><a href="${getHref(version.num)}">${version.num}${version.lts ? ' <b>LTS</b>' : ''}</a></li>`;
 
   function isDocInVersion(version) {
     const [versionMajor, versionMinor] = version.num.split('.').map(Number);

--- a/tools/doc/json.js
+++ b/tools/doc/json.js
@@ -458,7 +458,6 @@ const callWithParams = r`\([^)]*\)`;
 
 const maybeExtends = `(?: +extends +${maybeAncestors}${classId})?`;
 
-/* eslint-disable max-len */
 const headingExpressions = [
   { type: 'event', re: RegExp(
     `${eventPrefix}${maybeBacktick}${maybeQuote}(${notQuotes})${maybeQuote}${maybeBacktick}$`, 'i') },
@@ -478,7 +477,6 @@ const headingExpressions = [
   { type: 'property', re: RegExp(
     `^${maybeClassPropertyPrefix}${maybeBacktick}${ancestors}(${id})${maybeBacktick}$`, 'i') },
 ];
-/* eslint-enable max-len */
 
 function newSection(header, file) {
   const text = textJoin(header.children, file);

--- a/tools/lint-sh.js
+++ b/tools/lint-sh.js
@@ -138,8 +138,7 @@ async function checkFiles(...files) {
     const data = JSON.parse(stdout);
     for (const { file, line, column, message } of data) {
       console.error(
-        `::error file=${file},line=${line},col=${column}::` +
-          `${file}:${line}:${column}: ${message}`
+        `::error file=${file},line=${line},col=${column}::${file}:${line}:${column}: ${message}`
       );
     }
   }


### PR DESCRIPTION
Splitting template strings across multiple lines can make them harder to
read.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
