### PR TITLE
vm: unnecessary variable

### DIFF
--- a/lib/vm.js
+++ b/lib/vm.js
@@ -142,8 +142,8 @@ class Script extends ContextifyScript {
   }
 
   runInNewContext(contextObject, options) {
-    return this.runInContext(createContext(contextObject, 
-                                           getContextOptions(options)), 
+    return this.runInContext(createContext(contextObject,
+                                           getContextOptions(options)),
                              options);
   }
 }

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -142,8 +142,9 @@ class Script extends ContextifyScript {
   }
 
   runInNewContext(contextObject, options) {
-    const context = createContext(contextObject, getContextOptions(options));
-    return this.runInContext(context, options);
+    return this.runInContext(createContext(contextObject, 
+                                           getContextOptions(options)), 
+                             options);
   }
 }
 


### PR DESCRIPTION
Can't we just pass this directly to the method? Since its not used multiple times in the same scope.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
