### PR TITLE
doc: update `buffer.constants.MAX_LENGTH`

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -3415,7 +3415,13 @@ added: v8.2.0
 * {integer} The largest size allowed for a single `Buffer` instance.
 
 On 32-bit architectures, this value currently is 2<sup>30</sup> - 1 (~1GB).
-On 64-bit architectures, this value currently is 2<sup>31</sup> - 1 (~2GB).
+On 64-bit architectures, this value currently is
+
+* for v12: 2<sup>31</sup> - 1 (~2GB)
+* for v14: 2<sup>32</sup> - 1 (~4GB)
+* for v15: 2<sup>32</sup>(~4GB)
+
+It reflects [`v8::TypedArray::kMaxLength`][] under the hood.
 
 This value is also available as [`buffer.kMaxLength`][].
 
@@ -3589,3 +3595,4 @@ introducing security vulnerabilities into an application.
 [binary strings]: https://developer.mozilla.org/en-US/docs/Web/API/DOMString/Binary
 [endianness]: https://en.wikipedia.org/wiki/Endianness
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols
+[`v8::TypedArray::kMaxLength`]: https://v8.github.io/api/head/classv8_1_1TypedArray.html#a54a48f4373da0850663c4393d843b9b0

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -3410,16 +3410,24 @@ added: v8.2.0
 #### `buffer.constants.MAX_LENGTH`
 <!-- YAML
 added: v8.2.0
+changes:
+  - version: v15.0.0
+    pr-url: https://github.com/nodejs/node/pull/35415
+    description: Value is changed to 2<sup>32</sup> (~4GB) on 64-bit
+      architectures.
+  - version: v14.0.0
+    pr-url: https://github.com/nodejs/node/pull/32116
+    description: Value is changed to 2<sup>32</sup> - 1 (~4GB) on 64-bit
+      architectures.
 -->
 
 * {integer} The largest size allowed for a single `Buffer` instance.
 
 On 32-bit architectures, this value currently is 2<sup>30</sup> - 1 (~1GB).
-On 64-bit architectures, this value currently is
 
-* for v12: 2<sup>31</sup> - 1 (~2GB)
-* for v14: 2<sup>32</sup> - 1 (~4GB)
-* for v15: 2<sup>32</sup>(~4GB)
+On 64-bit architectures, this value varies from Node.js version to version.
+It is at least 2<sup>31</sup> - 1 (~2GB) and currently is 2<sup>32</sup>
+(~4GB). See history for detail.
 
 It reflects [`v8::TypedArray::kMaxLength`][] under the hood.
 

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -3413,21 +3413,19 @@ added: v8.2.0
 changes:
   - version: v15.0.0
     pr-url: https://github.com/nodejs/node/pull/35415
-    description: Value is changed to 2<sup>32</sup> (~4GB) on 64-bit
+    description: Value is changed to 2<sup>32</sup> on 64-bit
       architectures.
   - version: v14.0.0
     pr-url: https://github.com/nodejs/node/pull/32116
-    description: Value is changed to 2<sup>32</sup> - 1 (~4GB) on 64-bit
-      architectures.
+    description: Value is changed from 2<sup>31</sup> - 1 to
+      2<sup>32</sup> - 1 on 64-bit architectures.
 -->
 
 * {integer} The largest size allowed for a single `Buffer` instance.
 
 On 32-bit architectures, this value currently is 2<sup>30</sup> - 1 (~1GB).
 
-On 64-bit architectures, this value varies from Node.js version to version.
-It is at least 2<sup>31</sup> - 1 (~2GB) and currently is 2<sup>32</sup>
-(~4GB). See history for detail.
+On 64-bit architectures, this value currently is 2<sup>32</sup> (~4GB).
 
 It reflects [`v8::TypedArray::kMaxLength`][] under the hood.
 

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -3591,8 +3591,8 @@ introducing security vulnerabilities into an application.
 [`buffer.constants.MAX_STRING_LENGTH`]: #buffer_buffer_constants_max_string_length
 [`buffer.kMaxLength`]: #buffer_buffer_kmaxlength
 [`util.inspect()`]: util.md#util_util_inspect_object_options
+[`v8::TypedArray::kMaxLength`]: https://v8.github.io/api/head/classv8_1_1TypedArray.html#a54a48f4373da0850663c4393d843b9b0
 [base64url]: https://tools.ietf.org/html/rfc4648#section-5
 [binary strings]: https://developer.mozilla.org/en-US/docs/Web/API/DOMString/Binary
 [endianness]: https://en.wikipedia.org/wiki/Endianness
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols
-[`v8::TypedArray::kMaxLength`]: https://v8.github.io/api/head/classv8_1_1TypedArray.html#a54a48f4373da0850663c4393d843b9b0


### PR DESCRIPTION
This PR
1. updates `buffer.constants.MAX_LENGTH` for different Node.js versions in 64-bit platform;
2. adds a link to `v8::TypedArray::kMaxLength` as an informative note.

Fixes: https://github.com/nodejs/node/issues/38093