### PR TITLE
test: add undefined fatalException exit code test case

### DIFF
--- a/test/fixtures/process-exit-code-cases.js
+++ b/test/fixtures/process-exit-code-cases.js
@@ -122,6 +122,15 @@ function getTestCases(isWorker = false) {
     result: isWorker ? 1 : 7,
     error: /^Error: ok$/,
   });
+
+  function exitWithUndefinedFatalException() {
+    process._fatalException = undefined;
+    throw new Error('ok');
+  }
+  cases.push({
+    func: exitWithUndefinedFatalException,
+    result: 6,
+  });
   return cases;
 }
 exports.getTestCases = getTestCases;


### PR DESCRIPTION
This PR adds a test that checks the exit code when `_fatalException` is `undefined`. This change actually creates two tests - one for process exit code and one for worker exit codes.

This case is _extremely_ obscure, and probably unrealistic - [but there's some explicit code](https://github.com/nodejs/node/blob/master/src/node_errors.cc#L953) in `node_errors.cc` that checks this case, so I've added a test for it.