### PR TITLE
deps: V8: cherry-pick 501482cbc704

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.8',
+    'v8_embedder_string': '-node.9',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/objects/value-serializer.cc
+++ b/deps/v8/src/objects/value-serializer.cc
@@ -1190,7 +1190,8 @@ Maybe<T> ValueDeserializer::ReadZigZag() {
 
 Maybe<double> ValueDeserializer::ReadDouble() {
   // Warning: this uses host endianness.
-  if (position_ > end_ - sizeof(double)) return Nothing<double>();
+  if (sizeof(double) > static_cast<unsigned>(end_ - position_))
+    return Nothing<double>();
   double value;
   base::Memcpy(&value, position_, sizeof(double));
   position_ += sizeof(double);

--- a/test/parallel/test-v8-serdes.js
+++ b/test/parallel/test-v8-serdes.js
@@ -236,3 +236,10 @@ const hostObject = new (internalBinding('js_stream').JSStream)();
     /^TypeError: buffer must be a TypedArray or a DataView$/,
   );
 }
+
+{
+  // Regression test for https://github.com/nodejs/node/issues/37978
+  assert.throws(() => {
+    new v8.Deserializer(new v8.Serializer().releaseBuffer()).readDouble();
+  }, /ReadDouble\(\) failed/);
+}


### PR DESCRIPTION
Original commit message:

    Fix ValueDeserializer::ReadDouble() bounds check

    If end_ is smaller than sizeof(double), the result would wrap
    around, and lead to an invalid memory access.

    Refs: https://github.com/nodejs/node/issues/37978
    Change-Id: Ibc8ddcb0c090358789a6a02f550538f91d431c1d
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2801353
    Reviewed-by: Marja Hölttä <marja@chromium.org>
    Commit-Queue: Marja Hölttä <marja@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#73800}

Refs: https://github.com/v8/v8/commit/501482cbc704
Fixes: https://github.com/nodejs/node/issues/37978
