### PR TITLE
test: remove unneeded m flag on regular expressions

### DIFF
--- a/test/js-native-api/test_exception/testFinalizerException.js
+++ b/test/js-native-api/test_exception/testFinalizerException.js
@@ -29,4 +29,4 @@ const child = spawnSync(process.execPath, [
   '--expose-gc', __filename, 'child',
 ]);
 assert.strictEqual(child.signal, null);
-assert.match(child.stderr.toString(), /Error during Finalize/m);
+assert.match(child.stderr.toString(), /Error during Finalize/);

--- a/test/parallel/test-readline-async-iterators.js
+++ b/test/parallel/test-readline-async-iterators.js
@@ -39,7 +39,7 @@ async function testSimple() {
       expectedLines.pop();
     }
     assert.deepStrictEqual(iteratedLines, expectedLines);
-    assert.strictEqual(iteratedLines.join(''), fileContent.replace(/\n/gm, ''));
+    assert.strictEqual(iteratedLines.join(''), fileContent.replace(/\n/g, ''));
   }
 }
 

--- a/test/report/test-report-uv-handles.js
+++ b/test/report/test-report-uv-handles.js
@@ -97,14 +97,14 @@ if (process.argv[2] === 'child') {
 
     // Test libuv handle key order
     {
-      const get_libuv = /"libuv":\s\[([\s\S]*?)\]/gm;
-      const get_handle_inner = /{([\s\S]*?),*?}/gm;
+      const get_libuv = /"libuv":\s\[([\s\S]*?)\]/g;
+      const get_handle_inner = /{([\s\S]*?),*?}/g;
       const libuv_handles_str = get_libuv.exec(stdout)[1];
       const libuv_handles_array = libuv_handles_str.match(get_handle_inner);
       for (const i of libuv_handles_array) {
         // Exclude nested structure
         if (i.includes('type')) {
-          const handle_keys = i.match(/(".*"):/gm);
+          const handle_keys = i.match(/(".*"):/g);
           assert(handle_keys[0], 'type');
           assert(handle_keys[1], 'is_active');
         }


### PR DESCRIPTION
The m flag has no effect on regular expressions that don't match the
start or the end of a line.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
