### PR TITLE
build: move OPENSSL_API_COMPAT to else clause

### DIFF
--- a/node.gypi
+++ b/node.gypi
@@ -326,9 +326,6 @@
             # For tests
             './deps/openssl/openssl.gyp:openssl-cli',
           ],
-          # Set 1.0.0 as the API compability level to avoid the
-          # deprecation warnings when using OpenSSL 3.0.
-	        'defines': ['OPENSSL_API_COMPAT=0x10000000L'],
           'conditions': [
             # -force_load or --whole-archive are not applicable for
             # the static library
@@ -364,6 +361,10 @@
               ],
             }],
           ]
+        }, {
+          # Set 1.0.0 as the API compability level to avoid the
+          # deprecation warnings when using OpenSSL 3.0.
+          'defines': [ 'OPENSSL_API_COMPAT=0x10000000L', ]
         }],
         [ 'openssl_quic=="true" and node_shared_ngtcp2=="false"', {
           'dependencies': [ './deps/ngtcp2/ngtcp2.gyp:ngtcp2' ]


### PR DESCRIPTION
Currently there are a number of deprecation warnings generated when
linking with OpenSSL 3.0, for example:
```console
In file included from ../src/crypto/crypto_scrypt.h:6,
                 from ../src/crypto/crypto_scrypt.cc:1:
../src/crypto/crypto_util.h:64:37: warning:
‘void RSA_free(RSA*)’ is deprecated: Since OpenSSL 3.0
[-Wdeprecated-declarations]
   64 | using RSAPointer = DeleteFnPtr<RSA, RSA_free>;

```
The reason for this is that I had placed the macro `OPENSSL_API_COMPAT`
inside of the node_shared_openssl="false" clause, but that was a
mistake and this macro should have gone into the else clause instead.


