### PR TITLE
lib: fix typo in lib/_tls_common.js

### DIFF
--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -364,7 +364,7 @@ exports.createSecureContext = function createSecureContext(options) {
     if (ticketKeys.byteLength !== 48) {
       throw new ERR_INVALID_ARG_VALUE(
         'options.ticketKeys',
-        ticketKeys.byteLenth,
+        ticketKeys.byteLength,
         'must be exactly 48 bytes');
     }
     c.context.setTicketKeys(ticketKeys);


### PR DESCRIPTION
I found a typo :  "byteLenth" -> "byteLength"