### PR TITLE
lib: fix typo in lib/internal/crypto/random.js

### DIFF
--- a/lib/internal/crypto/random.js
+++ b/lib/internal/crypto/random.js
@@ -155,7 +155,7 @@ function randomFill(buf, offset, size, callback) {
   if (typeof offset === 'function') {
     callback = offset;
     offset = 0;
-    size = buf.bytesLength;
+    size = buf.byteLength;
   } else if (typeof size === 'function') {
     callback = size;
     size = buf.byteLength - offset;


### PR DESCRIPTION
I found a typo :  "bytesLength" -> "byteLength"

