### PR TITLE
lib: cache `process.binding(…)` wrappers

### DIFF
--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -136,13 +136,18 @@ const legacyWrapperList = new SafeSet([
           'DEP0111');
       }
       if (legacyWrapperList.has(module)) {
-        return nativeModuleRequire('internal/legacy/processbinding')[module]();
+        return bindingObj[module] ??=
+          nativeModuleRequire('internal/legacy/processbinding')[module]();
       }
       return internalBinding(module);
     }
     // eslint-disable-next-line no-restricted-syntax
     throw new Error(`No such module: ${module}`);
   };
+}
+
+{
+  const bindingObj = ObjectCreate(null);
 
   process._linkedBinding = function _linkedBinding(module) {
     module = String(module);

--- a/lib/internal/legacy/processbinding.js
+++ b/lib/internal/legacy/processbinding.js
@@ -2,14 +2,13 @@
 const {
   ArrayPrototypeFilter,
   ArrayPrototypeIncludes,
-  ArrayPrototypeMap,
   ObjectFromEntries,
   ObjectEntries,
   SafeArrayIterator,
 } = primordials;
 const types = require('internal/util/types');
 
-const factories = {
+module.exports = {
   util() {
     return ObjectFromEntries(new SafeArrayIterator(ArrayPrototypeFilter(
       ObjectEntries(types),
@@ -35,17 +34,3 @@ const factories = {
       })));
   }
 };
-
-module.exports = ObjectFromEntries(
-  new SafeArrayIterator(
-    ArrayPrototypeMap(ObjectEntries(factories), ({ 0: key, 1: factory }) => {
-      let result;
-      return [key, () => {
-        if (!result) {
-          result = factory();
-        }
-        return result;
-      }];
-    }),
-  ),
-);

--- a/lib/internal/legacy/processbinding.js
+++ b/lib/internal/legacy/processbinding.js
@@ -2,13 +2,14 @@
 const {
   ArrayPrototypeFilter,
   ArrayPrototypeIncludes,
+  ArrayPrototypeMap,
   ObjectFromEntries,
   ObjectEntries,
   SafeArrayIterator,
 } = primordials;
-const { types } = require('util');
+const types = require('internal/util/types');
 
-module.exports = {
+const factories = {
   util() {
     return ObjectFromEntries(new SafeArrayIterator(ArrayPrototypeFilter(
       ObjectEntries(types),
@@ -34,3 +35,17 @@ module.exports = {
       })));
   }
 };
+
+module.exports = ObjectFromEntries(
+  new SafeArrayIterator(
+    ArrayPrototypeMap(ObjectEntries(factories), ({ 0: key, 1: factory }) => {
+      let result;
+      return [key, () => {
+        if (!result) {
+          result = factory();
+        }
+        return result;
+      }];
+    }),
+  ),
+);

--- a/test/parallel/test-process-binding-util.js
+++ b/test/parallel/test-process-binding-util.js
@@ -28,3 +28,5 @@ assert.deepStrictEqual(
 for (const k of Object.keys(utilBinding)) {
   assert.strictEqual(utilBinding[k], util.types[k]);
 }
+
+assert.strictEqual(utilBinding, process.binding('util'));


### PR DESCRIPTION
Currently, `process.binding("util") === process.binding("util")` is `true`, this ensures that with <https://github.com/nodejs/node/pull/37819>, `process.binding("util") === process.binding("util")` remains `true`.

---

**Refs:** <https://github.com/nodejs/node/pull/37819>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
