### PR TITLE
test: update parallel/test-crypto-keygen for OpenSSL 3

### DIFF
--- a/test/parallel/test-crypto-keygen.js
+++ b/test/parallel/test-crypto-keygen.js
@@ -1325,6 +1325,8 @@ if (!common.hasOpenSSL3) {
       if (!getCurves().includes(namedCurve))
         continue;
 
+      const expectedErrorCode =
+        common.hasOpenSSL3 ? 'ERR_OSSL_MISSING_OID' : 'ERR_OSSL_EC_MISSING_OID';
       const params = {
         namedCurve,
         publicKeyEncoding: {
@@ -1336,11 +1338,11 @@ if (!common.hasOpenSSL3) {
       assert.throws(() => {
         generateKeyPairSync('ec', params);
       }, {
-        code: 'ERR_OSSL_EC_MISSING_OID'
+        code: expectedErrorCode
       });
 
       generateKeyPair('ec', params, common.mustCall((err) => {
-        assert.strictEqual(err.code, 'ERR_OSSL_EC_MISSING_OID');
+        assert.strictEqual(err.code, expectedErrorCode);
       }));
     }
   }


### PR DESCRIPTION
OpenSSL 3 returns a different error code.

We've just enabled testing against a dynamically linked OpenSSL 3 (https://github.com/nodejs/build/issues/2584) -- we did have a clean run on a copy of the job last week but that was before the test was recently changed in https://github.com/nodejs/node/pull/37076.

cc @nodejs/crypto 

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
