### PR TITLE
crypto: fix webcrypto derive(Bits|Key) resolve values and docs

### DIFF
--- a/doc/api/webcrypto.md
+++ b/doc/api/webcrypto.md
@@ -275,7 +275,7 @@ async function pbkdf2Key(pass, salt, iterations = 1000, length = 256) {
     ec.encode(pass),
     'PBKDF2',
     false,
-    ['deriveBits']);
+    ['deriveKey']);
   const key = await subtle.deriveKey({
     name: 'PBKDF2',
     hash: 'SHA-512',
@@ -536,7 +536,7 @@ added: v15.0.0
 * `derivedKeyAlgorithm`: {HmacKeyGenParams|AesKeyGenParams}
 * `extractable`: {boolean}
 * `keyUsages`: {string[]} See [Key usages][].
-* Returns: {Promise} containing {ArrayBuffer}
+* Returns: {Promise} containing {CryptoKey}
 <!--lint enable maximum-line-length remark-lint-->
 
 Using the method and parameters specified in `algorithm`, and the keying

--- a/lib/internal/crypto/pbkdf2.js
+++ b/lib/internal/crypto/pbkdf2.js
@@ -122,7 +122,7 @@ async function pbkdf2DeriveBits(algorithm, baseKey, length) {
   return new Promise((resolve, reject) => {
     pbkdf2(raw, salt, iterations, byteLength, hash, (err, result) => {
       if (err) return reject(err);
-      resolve(result);
+      resolve(result.buffer);
     });
   });
 }

--- a/lib/internal/crypto/scrypt.js
+++ b/lib/internal/crypto/scrypt.js
@@ -167,7 +167,7 @@ async function scryptDeriveBits(algorithm, baseKey, length) {
   return new Promise((resolve, reject) => {
     scrypt(raw, salt, byteLength, { N, r, p, maxmem }, (err, result) => {
       if (err) return reject(err);
-      resolve(result);
+      resolve(result.buffer);
     });
   });
 }

--- a/test/parallel/test-webcrypto-derivebits-ecdh.js
+++ b/test/parallel/test-webcrypto-derivebits-ecdh.js
@@ -98,6 +98,7 @@ async function prepareKeys() {
           public: publicKey
         }, privateKey, 8 * size);
 
+        assert(bits instanceof ArrayBuffer);
         assert.strictEqual(Buffer.from(bits).toString('hex'), result);
       }
 

--- a/test/parallel/test-webcrypto-derivebits-hkdf.js
+++ b/test/parallel/test-webcrypto-derivebits-hkdf.js
@@ -237,6 +237,7 @@ async function testDeriveBits(
     baseKeys[size],
     256);
 
+  assert(bits instanceof ArrayBuffer);
   assert.strictEqual(
     Buffer.from(bits).toString('hex'),
     kDerivations[size][saltSize][hash][infoSize]);

--- a/test/parallel/test-webcrypto-derivebits-node-dh.js
+++ b/test/parallel/test-webcrypto-derivebits-node-dh.js
@@ -112,6 +112,7 @@ async function prepareKeys() {
       public: publicKey
     }, privateKey, null);
 
+    assert(bits instanceof ArrayBuffer);
     assert.strictEqual(Buffer.from(bits).toString('hex'), result);
   }
 

--- a/test/parallel/test-webcrypto-derivebits-pbkdf2.js
+++ b/test/parallel/test-webcrypto-derivebits-pbkdf2.js
@@ -421,6 +421,7 @@ async function testDeriveBits(
 
   const bits = await subtle.deriveBits(algorithm, baseKeys[size], 256);
 
+  assert(bits instanceof ArrayBuffer);
   assert.strictEqual(
     Buffer.from(bits).toString('hex'),
     kDerivations[size][saltSize][hash][iterations]);

--- a/test/parallel/test-webcrypto-derivebits.js
+++ b/test/parallel/test-webcrypto-derivebits.js
@@ -31,6 +31,8 @@ const { internalBinding } = require('internal/test/binding');
       }, alice.privateKey, 128),
     ]);
 
+    assert(secret1 instanceof ArrayBuffer);
+    assert(secret2 instanceof ArrayBuffer);
     assert.deepStrictEqual(secret1, secret2);
   }
 
@@ -114,6 +116,7 @@ if (typeof internalBinding('crypto').ScryptJob === 'function') {
       name: 'NODE-SCRYPT',
       salt: ec.encode(salt),
     }, key, length);
+    assert(secret instanceof ArrayBuffer);
     assert.strictEqual(Buffer.from(secret).toString('hex'), expected);
   }
 


### PR DESCRIPTION
Couple of issues discovered in #38115 addressed by this PR

- `PBKDF2` deriveBits resolve value type
- `NODE-SCRYPT` deriveBits resolve value type
- docs: `subtle.deriveKey` resolve value type
- docs: `### Deriving bits and keys` example does not work with `deriveBits`
- test: assert deriveBits resolve with ArrayBuffer

ad resolve value types see [SubtleCrypto interface definition](https://www.w3.org/TR/WebCryptoAPI/#dfn-SubtleCrypto).