### PR TITLE
test: fix flaky test-zlib-unused-weak.js

### DIFF
--- a/test/parallel/test-zlib-unused-weak.js
+++ b/test/parallel/test-zlib-unused-weak.js
@@ -6,6 +6,7 @@ const zlib = require('zlib');
 
 // Tests that native zlib handles start out their life as weak handles.
 
+global.gc();
 const before = process.memoryUsage().external;
 for (let i = 0; i < 100; ++i)
   zlib.createGzip();


### PR DESCRIPTION
Failed test: https://ci.nodejs.org/job/node-test-commit-linux/nodes=alpine-last-latest-x64/40825/testReport/junit/(root)/test/parallel_test_zlib_unused_weak/

```
AssertionError [ERR_ASSERTION]: Expected after-GC delta -29156 to be less than 5 % of before-GC delta -9751
```

I think the delta should be positive. Calling `gc()` before `zlib.createGzip()` should make it more stable.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
