### PR TITLE
doc: advise against using randomFill on floats

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -4454,16 +4454,12 @@ const a = new Uint32Array(10);
 console.log(Buffer.from(randomFillSync(a).buffer,
                         a.byteOffset, a.byteLength).toString('hex'));
 
-const b = new Float64Array(10);
+const b = new DataView(new ArrayBuffer(10));
 console.log(Buffer.from(randomFillSync(b).buffer,
                         b.byteOffset, b.byteLength).toString('hex'));
 
-const c = new DataView(new ArrayBuffer(10));
-console.log(Buffer.from(randomFillSync(c).buffer,
-                        c.byteOffset, c.byteLength).toString('hex'));
-
-const d = new ArrayBuffer(10);
-console.log(Buffer.from(randomFillSync(d)).toString('hex'));
+const c = new ArrayBuffer(10);
+console.log(Buffer.from(randomFillSync(c)).toString('hex'));
 ```
 
 ```cjs
@@ -4475,16 +4471,12 @@ const a = new Uint32Array(10);
 console.log(Buffer.from(randomFillSync(a).buffer,
                         a.byteOffset, a.byteLength).toString('hex'));
 
-const b = new Float64Array(10);
+const b = new DataView(new ArrayBuffer(10));
 console.log(Buffer.from(randomFillSync(b).buffer,
                         b.byteOffset, b.byteLength).toString('hex'));
 
-const c = new DataView(new ArrayBuffer(10));
-console.log(Buffer.from(randomFillSync(c).buffer,
-                        c.byteOffset, c.byteLength).toString('hex'));
-
-const d = new ArrayBuffer(10);
-console.log(Buffer.from(randomFillSync(d)).toString('hex'));
+const c = new ArrayBuffer(10);
+console.log(Buffer.from(randomFillSync(c)).toString('hex'));
 ```
 
 ### `crypto.randomFill(buffer[, offset][, size], callback)`
@@ -4560,6 +4552,12 @@ randomFill(buf, 5, 5, (err, buf) => {
 Any `ArrayBuffer`, `TypedArray`, or `DataView` instance may be passed as
 `buffer`.
 
+While this includes instances of `Float32Array` and `Float64Array`, this
+function should not be used to generate random floating-point numbers. The
+result may contain `+Infinity`, `-Infinity`, and `NaN`, and even if the array
+contains finite numbers only, they are not drawn from a uniform random
+distribution and have no meaningful lower or upper bounds.
+
 ```mjs
 const {
   randomFill,
@@ -4572,22 +4570,15 @@ randomFill(a, (err, buf) => {
     .toString('hex'));
 });
 
-const b = new Float64Array(10);
+const b = new DataView(new ArrayBuffer(10));
 randomFill(b, (err, buf) => {
   if (err) throw err;
   console.log(Buffer.from(buf.buffer, buf.byteOffset, buf.byteLength)
     .toString('hex'));
 });
 
-const c = new DataView(new ArrayBuffer(10));
+const c = new ArrayBuffer(10);
 randomFill(c, (err, buf) => {
-  if (err) throw err;
-  console.log(Buffer.from(buf.buffer, buf.byteOffset, buf.byteLength)
-    .toString('hex'));
-});
-
-const d = new ArrayBuffer(10);
-randomFill(d, (err, buf) => {
   if (err) throw err;
   console.log(Buffer.from(buf).toString('hex'));
 });
@@ -4605,22 +4596,15 @@ randomFill(a, (err, buf) => {
     .toString('hex'));
 });
 
-const b = new Float64Array(10);
+const b = new DataView(new ArrayBuffer(10));
 randomFill(b, (err, buf) => {
   if (err) throw err;
   console.log(Buffer.from(buf.buffer, buf.byteOffset, buf.byteLength)
     .toString('hex'));
 });
 
-const c = new DataView(new ArrayBuffer(10));
+const c = new ArrayBuffer(10);
 randomFill(c, (err, buf) => {
-  if (err) throw err;
-  console.log(Buffer.from(buf.buffer, buf.byteOffset, buf.byteLength)
-    .toString('hex'));
-});
-
-const d = new ArrayBuffer(10);
-randomFill(d, (err, buf) => {
   if (err) throw err;
   console.log(Buffer.from(buf).toString('hex'));
 });


### PR DESCRIPTION
The docs not only allow using `randomFill` on `Float32Array` and `Float64Array`, but they also include examples of doing that. There are virtually no valid use cases for this, and it can cause incorrect behavior due to the extremely low, but non-negligible, chance of producing `NaN`, `+Infinity`, and `-Infinity` in the `TypedArray`.

Refs: https://github.com/nodejs/node/issues/38137

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
