### PR TITLE
doc: fix typo in assert.md

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -1951,7 +1951,7 @@ assert.rejects(
 ```
 
 ```cjs
-const asssert = require('assert/strict');
+const assert = require('assert/strict');
 
 assert.rejects(
   Promise.reject(new Error('Wrong value')),


### PR DESCRIPTION
I found a typo in assert documentation :

"asssert" ->  "assert"
