### PR TITLE
test: update OpenSSL 3.x expected error message

### DIFF
--- a/test/parallel/test-crypto-dh.js
+++ b/test/parallel/test-crypto-dh.js
@@ -188,7 +188,7 @@ if (common.hasOpenSSL3) {
 assert.throws(() => {
   dh3.computeSecret('');
 }, { message: common.hasOpenSSL3 ?
-  'error:02800066:Diffie-Hellman routines::invalid public key' :
+  'error:02800080:Diffie-Hellman routines::invalid secret' :
   'Supplied key is too small' });
 
 // Create a shared using a DH group.


### PR DESCRIPTION
This commit updates an expected error message which has changed in
OpenSSl 3.x. OpenSSL 3.0 is still under development but once there is a
relase we should not be seeing test failure like this.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
