### PR TITLE
doc: clarify the parameter byteOffset for lastIndexOf method of Buffer

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1405,9 +1405,9 @@ changes:
 -->
 
 * `value` {string|Buffer|Uint8Array|integer} What to search for.
-* `byteOffset` {integer} Where to begin searching in `buf`. If negative, then
-  offset is calculated from the end of `buf`. **Default:**
-  `buf.length - 1`.
+* `byteOffset` {integer} The index of the last byte in `buf` to be considered
+  as the beginning of a match. If negative, then offset is calculated
+  from the end of `buf`. **Default:** `buf.length - 1`.
 * `encoding` {string} If `value` is a string, this is the encoding used to
   determine the binary representation of the string that will be searched for in
   `buf`. **Default:** `'utf8'`.


### PR DESCRIPTION
I suggest to clarify the parameter `byteOffset` for the `lastIndexOf` method of `Buffer`. 

Currently, the doc says : 
"Where to begin searching in buf"

But in my opinion, it's not just. The parameter is more : 
"the index of the last byte in buf to be considered as the beginning of a match."

What do you think about that ?