### PR TITLE
docs: add command flag to import.meta.resolve

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -283,6 +283,9 @@ const buffer = readFileSync(new URL('./data.proto', import.meta.url));
 
 > Stability: 1 - Experimental
 
+*This feature is only available with the `--experimental-import-meta-resolve` command
+flag enabled.*
+
 * `specifier` {string} The module specifier to resolve relative to `parent`.
 * `parent` {string|URL} The absolute parent module URL to resolve from. If none
   is specified, the value of `import.meta.url` is used as the default.

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -283,8 +283,8 @@ const buffer = readFileSync(new URL('./data.proto', import.meta.url));
 
 > Stability: 1 - Experimental
 
-*This feature is only available with the `--experimental-import-meta-resolve`
-command flag enabled.*
+This feature is only available with the `--experimental-import-meta-resolve`
+command flag enabled.
 
 * `specifier` {string} The module specifier to resolve relative to `parent`.
 * `parent` {string|URL} The absolute parent module URL to resolve from. If none

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -283,8 +283,8 @@ const buffer = readFileSync(new URL('./data.proto', import.meta.url));
 
 > Stability: 1 - Experimental
 
-*This feature is only available with the `--experimental-import-meta-resolve` command
-flag enabled.*
+*This feature is only available with the `--experimental-import-meta-resolve`
+command flag enabled.*
 
 * `specifier` {string} The module specifier to resolve relative to `parent`.
 * `parent` {string|URL} The absolute parent module URL to resolve from. If none


### PR DESCRIPTION
import.meta.resolve is only available under --experimental-import-meta-resolve cli flag.

Source:
https://github.com/nodejs/node/blob/e46c680bf2b211bbd52cf959ca17ee98c7f657f5/lib/internal/modules/esm/translators.js#L132

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
