### PR TITLE
bootstrap: mksnapshot should show JS error summaries

### DIFF
--- a/tools/snapshot/snapshot_builder.cc
+++ b/tools/snapshot/snapshot_builder.cc
@@ -107,7 +107,6 @@ std::string SnapshotBuilder::Generate(
                                    per_process::v8_platform.Platform(),
                                    args,
                                    exec_args);
-      // fprintf(stderr, "BOOTSTRAPPING1\n\n\n");
 
       HandleScope scope(isolate);
       creator.SetDefaultContext(Context::New(isolate));

--- a/tools/snapshot/snapshot_builder.cc
+++ b/tools/snapshot/snapshot_builder.cc
@@ -111,7 +111,6 @@ std::string SnapshotBuilder::Generate(
       HandleScope scope(isolate);
       creator.SetDefaultContext(Context::New(isolate));
       isolate_data_indexes = main_instance->isolate_data()->Serialize(&creator);
-      // fprintf(stderr, "BOOTSTRAPPING2\n\n\n");
 
       TryCatch bootstrapCatch(isolate);
       Local<Context> context = NewContext(isolate);

--- a/tools/snapshot/snapshot_builder.cc
+++ b/tools/snapshot/snapshot_builder.cc
@@ -15,11 +15,11 @@ using v8::Context;
 using v8::HandleScope;
 using v8::Isolate;
 using v8::Local;
+using v8::Object;
 using v8::SnapshotCreator;
 using v8::StartupData;
-using v8::TryCatch;
-using v8::Object;
 using v8::String;
+using v8::TryCatch;
 using v8::Value;
 
 template <typename T>

--- a/tools/snapshot/snapshot_builder.cc
+++ b/tools/snapshot/snapshot_builder.cc
@@ -83,7 +83,10 @@ std::string SnapshotBuilder::Generate(
     const std::vector<std::string> args,
     const std::vector<std::string> exec_args) {
   Isolate* isolate = Isolate::Allocate();
-  isolate->SetCaptureStackTraceForUncaughtExceptions(true, 10, v8::StackTrace::StackTraceOptions::kDetailed);
+  isolate->SetCaptureStackTraceForUncaughtExceptions(
+    true,
+    10,
+    v8::StackTrace::StackTraceOptions::kDetailed);
   per_process::v8_platform.Platform()->RegisterIsolate(isolate,
                                                        uv_default_loop());
   std::unique_ptr<NodeMainInstance> main_instance;
@@ -118,25 +121,23 @@ std::string SnapshotBuilder::Generate(
             .ToLocalChecked();
         Local<Value> stack = obj->Get(
             context,
-            FIXED_ONE_BYTE_STRING(isolate, "stack")
-          ).ToLocalChecked();
+            FIXED_ONE_BYTE_STRING(isolate, "stack")).ToLocalChecked();
         if (stack->IsUndefined()) {
           Local<String> str = obj->Get(
               context,
-              FIXED_ONE_BYTE_STRING(isolate, "name")
-            ).ToLocalChecked()->ToString(context).ToLocalChecked();
+              FIXED_ONE_BYTE_STRING(isolate, "name"))
+            .ToLocalChecked()->ToString(context).ToLocalChecked();
           str = String::Concat(
             isolate,
             str,
             FIXED_ONE_BYTE_STRING(isolate, ": "));
           stack = String::Concat(
             isolate,
-            str, 
+            str,
             obj->Get(
                 context,
-                FIXED_ONE_BYTE_STRING(isolate, "message")
-              ).ToLocalChecked()->ToString(context).ToLocalChecked()
-          );
+                FIXED_ONE_BYTE_STRING(isolate, "message"))
+              .ToLocalChecked()->ToString(context).ToLocalChecked());
         }
         v8::String::Utf8Value utf8_value(isolate, stack);
         if (*utf8_value != nullptr) {


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This came up while trying to debug some stuff going on in the snapshot, makes debugging a lot easier. IDK if we want to do something other than use `abort()` here.