### PR TITLE
tls: fix session and keylog add listener segfault

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -689,7 +689,9 @@ TLSSocket.prototype._init = function(socket, wrap) {
     if (event !== 'keylog')
       return;
 
-    ssl.enableKeylogCallback();
+    // Guard against enableKeylogCallback after destroy
+    if (!this._handle) return;
+    this._handle.enableKeylogCallback();
 
     // Remove this listener since it's no longer needed.
     this.removeListener('newListener', keylogNewListener);
@@ -733,7 +735,9 @@ TLSSocket.prototype._init = function(socket, wrap) {
       if (event !== 'session')
         return;
 
-      ssl.enableSessionCallbacks();
+      // Guard against enableSessionCallbacks after destroy
+      if (!this._handle) return;
+      this._handle.enableSessionCallbacks();
 
       // Remove this listener since it's no longer needed.
       this.removeListener('newListener', newListener);

--- a/test/parallel/test-tls-tlswrap-segfault-2.js
+++ b/test/parallel/test-tls-tlswrap-segfault-2.js
@@ -1,0 +1,24 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+// This test ensures that Node.js doesn't incur a segfault while
+// adding session or keylog listeners after destroy.
+// https://github.com/nodejs/node/issues/38133
+// https://github.com/nodejs/node/issues/38135
+
+const tls = require('tls');
+const tlsSocketKeyLog = tls.connect('cause-error');
+tlsSocketKeyLog.on('error', () => {
+  setTimeout(() => {
+    tlsSocketKeyLog.on('keylog', () => { });
+  }, 10);
+});
+
+const tlsSocketSession = tls.connect('cause-error-2');
+tlsSocketSession.on('error', (e) => {
+  setTimeout(() => {
+    tlsSocketSession.on('keylog', () => { });
+  }, 10);
+});

--- a/test/parallel/test-tls-tlswrap-segfault-2.js
+++ b/test/parallel/test-tls-tlswrap-segfault-2.js
@@ -10,15 +10,13 @@ if (!common.hasCrypto)
 
 const tls = require('tls');
 const tlsSocketKeyLog = tls.connect('cause-error');
-tlsSocketKeyLog.on('error', () => {
-  setTimeout(() => {
-    tlsSocketKeyLog.on('keylog', () => { });
-  }, 10);
-});
+tlsSocketKeyLog.on('error', common.mustCall());
+tlsSocketKeyLog.on('close', common.mustCall(() => {
+  tlsSocketKeyLog.on('keylog', common.mustNotCall());
+}));
 
 const tlsSocketSession = tls.connect('cause-error-2');
-tlsSocketSession.on('error', (e) => {
-  setTimeout(() => {
-    tlsSocketSession.on('session', () => { });
-  }, 10);
-});
+tlsSocketSession.on('error', common.mustCall());
+tlsSocketSession.on('close', common.mustCall(() => {
+  tlsSocketSession.on('session', common.mustNotCall());
+}));

--- a/test/parallel/test-tls-tlswrap-segfault-2.js
+++ b/test/parallel/test-tls-tlswrap-segfault-2.js
@@ -19,6 +19,6 @@ tlsSocketKeyLog.on('error', () => {
 const tlsSocketSession = tls.connect('cause-error-2');
 tlsSocketSession.on('error', (e) => {
   setTimeout(() => {
-    tlsSocketSession.on('keylog', () => { });
+    tlsSocketSession.on('session', () => { });
   }, 10);
 });


### PR DESCRIPTION
Fix an issue where adding a `session` or `keylog` listener on a tlsSocket after it was destroyed causes a segfault.

fixes: https://github.com/nodejs/node/issues/38133
fixes: https://github.com/nodejs/node/issues/38135