### PR TITLE
doc: clarify child_process close event

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -1065,11 +1065,11 @@ added: v0.7.7
 * `code` {number} The exit code if the child exited on its own.
 * `signal` {string} The signal by which the child process was terminated.
 
-The `'close'` event is emitted after a process has ended _and_ the stdio streams
-of a child process have been closed. This is distinct from the [`'exit'`][] event,
-since multiple processes might share the same stdio streams. The `'close'` event
-will always emit after [`'exit'`][] was already emitted, or [`'error'`][] if the
-child failed to spawn.
+The `'close'` event is emitted after a process has ended _and_ the stdio
+streams of a child process have been closed. This is distinct from the
+[`'exit'`][] event, since multiple processes might share the same stdio
+streams. The `'close'` event will always emit after [`'exit'`][] was
+already emitted, or [`'error'`][] if the child failed to spawn.
 
 ```js
 const { spawn } = require('child_process');

--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -1065,9 +1065,11 @@ added: v0.7.7
 * `code` {number} The exit code if the child exited on its own.
 * `signal` {string} The signal by which the child process was terminated.
 
-The `'close'` event is emitted when the stdio streams of a child process have
-been closed. This is distinct from the [`'exit'`][] event, since multiple
-processes might share the same stdio streams.
+The `'close'` event is emitted after a process has ended _and_ the stdio streams
+of a child process have been closed. This is distinct from the [`'exit'`][] event,
+since multiple processes might share the same stdio streams. The `'close'` event
+will always emit after [`'exit'`][] was already emitted, or [`'error'`][] if the
+child failed to spawn.
 
 ```js
 const { spawn } = require('child_process');


### PR DESCRIPTION
Clarify the 'close' event description in the child_process docs.

This event is a bit confusing, as the documentation did not state that:

- It's supposed to get emitted after "exit" was already emitted.
- It _also_ emits when the `child_process` has failed to spawn (and thus, `exit` will never be emitted). Another detail, that I did not add to the docs, is that in this case the exit code passed to the closed handler is _negative_. Should this be mentioned?

fixes: #37998