### PR TITLE
lib: add typings for fileURLToPath

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -1317,9 +1317,9 @@ const forwardSlashRegEx = /\//g;
 
 /**
  * @param {URL} url
+ * @returns {string}
  */
 function getPathFromURLWin32(url) {
-  url.pathname
   const hostname = url.hostname;
   let pathname = url.pathname;
   for (let n = 0; n < pathname.length; n++) {
@@ -1374,6 +1374,7 @@ function getPathFromURLPosix(url) {
 
 /**
  * @param {string | URL} path 
+ * @returns {string}
  */
 function fileURLToPath(path) {
   if (typeof path === 'string')

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -857,6 +857,9 @@ class URL {
           FunctionPrototypeBind(onParsePortComplete, this));
   }
 
+  /**
+   * @returns {string}
+   */
   get pathname() {
     const ctx = this[context];
     if (this[cannotBeBase])
@@ -1312,7 +1315,11 @@ function urlToHttpOptions(url) {
 
 const forwardSlashRegEx = /\//g;
 
+/**
+ * @param {URL} url
+ */
 function getPathFromURLWin32(url) {
+  url.pathname
   const hostname = url.hostname;
   let pathname = url.pathname;
   for (let n = 0; n < pathname.length; n++) {
@@ -1365,6 +1372,9 @@ function getPathFromURLPosix(url) {
   return decodeURIComponent(pathname);
 }
 
+/**
+ * @param {string | URL} path 
+ */
 function fileURLToPath(path) {
   if (typeof path === 'string')
     path = new URL(path);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
   ],
   "compilerOptions": {
     "allowJs": true,
-    "checkJs": false,
+    "checkJs": true,
     "noEmit": true,
     "lib": ["ESNext"],
     "target": "ESNext",


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This types `internal/url.js` `fileURLToPath`.

It actually adds a typings to 3 locations:

* `getPathFromURLWin32` to specify the parameter it takes
* `URL.prototype.pathname` to make inference work on the return type of `getPathFromURLWin32`
* `fileURLToPath` to specify the parameters it takes

I did not actually specify the return types *while doing my initial check* of these since that would be determined by the implementation details and specifying the return value might not match the implementation. Due to the desire to keep checks turned off by default due to the overall lack of typings at this point in the project. Be sure to enable checks by changing :

https://github.com/nodejs/node/blob/40ace4739646baf19b7f64ca56e6f1659a58393e/tsconfig.json#L10

`checkJs` to `true` in `node/tsconfig.json` and being sure to restart any TS Server you might have running in your IDE to perform checks.

After enabling checks I set the expected return types and then validated that there were no errors before changing `checkJs` back to `false` and pushing out the PR.

There are no tests for such typings, but you can show proof of your work by attaching simple images which could then be validated by a reviewer:

* before
<img width="439" alt="Screen Shot 2021-04-09 at 20 47 59" src="https://user-images.githubusercontent.com/234659/114254449-02ac4600-9975-11eb-89e7-61dc33fb652a.png">

*after
<img width="569" alt="Screen Shot 2021-04-09 at 20 47 39" src="https://user-images.githubusercontent.com/234659/114254459-0c35ae00-9975-11eb-9b1e-e07477ea85d0.png">
