### PR TITLE
lib: add JSDoc typings for assert

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -122,6 +122,14 @@ function innerFail(obj) {
   throw new AssertionError(obj);
 }
 
+/**
+ * @param {any} actual
+ * @param {any} expected
+ * @param {string | Error} [message]
+ * @param {string} [operator]
+ * @param {Function} [stackStartFn]
+ * @returns {void}
+ */
 function fail(actual, expected, message, operator, stackStartFn) {
   const argsLen = arguments.length;
 
@@ -403,14 +411,24 @@ function innerOk(fn, argLen, value, message) {
   }
 }
 
-// Pure assertion tests whether a value is truthy, as determined
-// by !!value.
+/**
+ * Pure assertion tests whether a value is truthy, as determined
+ * by !!value.
+ * @param {...any} args
+ * @returns {void}
+ */
 function ok(...args) {
   innerOk(ok, args.length, ...args);
 }
 assert.ok = ok;
 
-// The equality assertion tests shallow, coercive equality with ==.
+/**
+ * The equality assertion tests shallow, coercive equality with ==.
+ * @param {any} actual
+ * @param {any} expected
+ * @param {string | Error} [message]
+ * @returns {void}
+ */
 /* eslint-disable no-restricted-properties */
 assert.equal = function equal(actual, expected, message) {
   if (arguments.length < 2) {
@@ -428,8 +446,14 @@ assert.equal = function equal(actual, expected, message) {
   }
 };
 
-// The non-equality assertion tests for whether two objects are not
-// equal with !=.
+/**
+ * The non-equality assertion tests for whether two objects are not
+ * equal with !=.
+ * @param {any} actual
+ * @param {any} expected
+ * @param {string | Error} [message]
+ * @returns {void}
+ */
 assert.notEqual = function notEqual(actual, expected, message) {
   if (arguments.length < 2) {
     throw new ERR_MISSING_ARGS('actual', 'expected');
@@ -446,7 +470,13 @@ assert.notEqual = function notEqual(actual, expected, message) {
   }
 };
 
-// The equivalence assertion tests a deep equality relation.
+/**
+ * The deep equivalence assertion tests a deep equality relation.
+ * @param {any} actual
+ * @param {any} expected
+ * @param {string | Error} [message]
+ * @returns {void}
+ */
 assert.deepEqual = function deepEqual(actual, expected, message) {
   if (arguments.length < 2) {
     throw new ERR_MISSING_ARGS('actual', 'expected');
@@ -463,7 +493,13 @@ assert.deepEqual = function deepEqual(actual, expected, message) {
   }
 };
 
-// The non-equivalence assertion tests for any deep inequality.
+/**
+ * The deep non-equivalence assertion tests for any deep inequality.
+ * @param {any} actual
+ * @param {any} expected
+ * @param {string | Error} [message]
+ * @returns {void}
+ */
 assert.notDeepEqual = function notDeepEqual(actual, expected, message) {
   if (arguments.length < 2) {
     throw new ERR_MISSING_ARGS('actual', 'expected');
@@ -481,6 +517,13 @@ assert.notDeepEqual = function notDeepEqual(actual, expected, message) {
 };
 /* eslint-enable */
 
+/**
+ * The deep strict equivalence assertion tests a deep strict equality relation.
+ * @param {any} actual
+ * @param {any} expected
+ * @param {string | Error} [message]
+ * @returns {void}
+ */
 assert.deepStrictEqual = function deepStrictEqual(actual, expected, message) {
   if (arguments.length < 2) {
     throw new ERR_MISSING_ARGS('actual', 'expected');
@@ -497,6 +540,14 @@ assert.deepStrictEqual = function deepStrictEqual(actual, expected, message) {
   }
 };
 
+/**
+ * The deep strict non-equivalence assertion tests for any deep strict
+ * inequality.
+ * @param {any} actual
+ * @param {any} expected
+ * @param {string | Error} [message]
+ * @returns {void}
+ */
 assert.notDeepStrictEqual = notDeepStrictEqual;
 function notDeepStrictEqual(actual, expected, message) {
   if (arguments.length < 2) {
@@ -514,6 +565,13 @@ function notDeepStrictEqual(actual, expected, message) {
   }
 }
 
+/**
+ * The strict equivalence assertion tests a strict equality relation.
+ * @param {any} actual
+ * @param {any} expected
+ * @param {string | Error} [message]
+ * @returns {void}
+ */
 assert.strictEqual = function strictEqual(actual, expected, message) {
   if (arguments.length < 2) {
     throw new ERR_MISSING_ARGS('actual', 'expected');
@@ -529,6 +587,13 @@ assert.strictEqual = function strictEqual(actual, expected, message) {
   }
 };
 
+/**
+ * The strict non-equivalence assertion tests for any strict inequality.
+ * @param {any} actual
+ * @param {any} expected
+ * @param {string | Error} [message]
+ * @returns {void}
+ */
 assert.notStrictEqual = function notStrictEqual(actual, expected, message) {
   if (arguments.length < 2) {
     throw new ERR_MISSING_ARGS('actual', 'expected');
@@ -837,22 +902,51 @@ function expectsNoError(stackStartFn, actual, error, message) {
   throw actual;
 }
 
+/**
+ * Expects the function `promiseFn` to throw an error.
+ * @param {Function} promiseFn
+ * @param {...any} [args]
+ * @returns {void}
+ */
 assert.throws = function throws(promiseFn, ...args) {
   expectsError(throws, getActual(promiseFn), ...args);
 };
 
+/**
+ * Expects `promiseFn` function or its value to reject.
+ * @param {Function} promiseFn
+ * @param {...any} [args]
+ * @returns {void}
+ */
 assert.rejects = async function rejects(promiseFn, ...args) {
   expectsError(rejects, await waitForActual(promiseFn), ...args);
 };
 
+/**
+ * Asserts that the function `fn` does not throw an error.
+ * @param {Function} fn
+ * @param {...any} [args]
+ * @returns {void}
+ */
 assert.doesNotThrow = function doesNotThrow(fn, ...args) {
   expectsNoError(doesNotThrow, getActual(fn), ...args);
 };
 
+/**
+ * Expects `fn` or its value to not reject.
+ * @param {Function} fn
+ * @param {...any} [args]
+ * @returns {void}
+ */
 assert.doesNotReject = async function doesNotReject(fn, ...args) {
   expectsNoError(doesNotReject, await waitForActual(fn), ...args);
 };
 
+/**
+ * Throws `value` if the value of not `null` or `undefined`.
+ * @param {any} err
+ * @returns {void}
+ */
 assert.ifError = function ifError(err) {
   if (err !== null && err !== undefined) {
     let message = 'ifError got unwanted exception: ';
@@ -937,24 +1031,44 @@ function internalMatch(string, regexp, message, fn) {
   }
 }
 
+/**
+ * Expects the `string` input to match the regular expression.
+ * @param {string} string
+ * @param {RegExp} regexp
+ * @param {string | Error} [message]
+ * @returns {void}
+ */
 assert.match = function match(string, regexp, message) {
   internalMatch(string, regexp, message, match);
 };
 
+/**
+ * Expects the `string` input not to match the regular expression.
+ * @param {string} string
+ * @param {RegExp} regexp
+ * @param {string | Error} [message]
+ * @returns {void}
+ */
 assert.doesNotMatch = function doesNotMatch(string, regexp, message) {
   internalMatch(string, regexp, message, doesNotMatch);
 };
 
 assert.CallTracker = CallTracker;
 
-// Expose a strict only variant of assert
+/**
+ * Expose a strict only variant of assert.
+ * @param {...any} args
+ * @returns {void}
+ */
 function strict(...args) {
   innerOk(strict, args.length, ...args);
 }
+
 assert.strict = ObjectAssign(strict, assert, {
   equal: assert.strictEqual,
   deepEqual: assert.deepStrictEqual,
   notEqual: assert.notStrictEqual,
   notDeepEqual: assert.notDeepStrictEqual
 });
+
 assert.strict.strict = assert.strict;

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -904,7 +904,7 @@ function expectsNoError(stackStartFn, actual, error, message) {
 
 /**
  * Expects the function `promiseFn` to throw an error.
- * @param {Function} promiseFn
+ * @param {() => any} promiseFn
  * @param {...any} [args]
  * @returns {void}
  */

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -518,7 +518,8 @@ assert.notDeepEqual = function notDeepEqual(actual, expected, message) {
 /* eslint-enable */
 
 /**
- * The deep strict equivalence assertion tests a deep strict equality relation.
+ * The deep strict equivalence assertion tests a deep strict equality
+ * relation.
  * @param {any} actual
  * @param {any} expected
  * @param {string | Error} [message]

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -916,7 +916,7 @@ assert.throws = function throws(promiseFn, ...args) {
  * Expects `promiseFn` function or its value to reject.
  * @param {() => Promise<any>} promiseFn
  * @param {...any} [args]
- * @returns {void}
+ * @returns {Promise<void>}
  */
 assert.rejects = async function rejects(promiseFn, ...args) {
   expectsError(rejects, await waitForActual(promiseFn), ...args);
@@ -936,7 +936,7 @@ assert.doesNotThrow = function doesNotThrow(fn, ...args) {
  * Expects `fn` or its value to not reject.
  * @param {() => Promise<any>} fn
  * @param {...any} [args]
- * @returns {void}
+ * @returns {Promise<void>}
  */
 assert.doesNotReject = async function doesNotReject(fn, ...args) {
   expectsNoError(doesNotReject, await waitForActual(fn), ...args);

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -914,7 +914,7 @@ assert.throws = function throws(promiseFn, ...args) {
 
 /**
  * Expects `promiseFn` function or its value to reject.
- * @param {Function} promiseFn
+ * @param {() => Promise<any>} promiseFn
  * @param {...any} [args]
  * @returns {void}
  */
@@ -924,7 +924,7 @@ assert.rejects = async function rejects(promiseFn, ...args) {
 
 /**
  * Asserts that the function `fn` does not throw an error.
- * @param {Function} fn
+ * @param {() => any} fn
  * @param {...any} [args]
  * @returns {void}
  */
@@ -934,7 +934,7 @@ assert.doesNotThrow = function doesNotThrow(fn, ...args) {
 
 /**
  * Expects `fn` or its value to not reject.
- * @param {Function} fn
+ * @param {() => Promise<any>} fn
  * @param {...any} [args]
  * @returns {void}
  */

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -943,7 +943,7 @@ assert.doesNotReject = async function doesNotReject(fn, ...args) {
 };
 
 /**
- * Throws `value` if the value of not `null` or `undefined`.
+ * Throws `value` if the value is not `null` or `undefined`.
  * @param {any} err
  * @returns {void}
  */

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -128,7 +128,7 @@ function innerFail(obj) {
  * @param {string | Error} [message]
  * @param {string} [operator]
  * @param {Function} [stackStartFn]
- * @returns {void}
+ * @returns {never}
  */
 function fail(actual, expected, message, operator, stackStartFn) {
   const argsLen = arguments.length;


### PR DESCRIPTION
Added JSDoc typings for the assert lib.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
