### PR TITLE
doc: standardize on pseudorandom

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -3605,7 +3605,7 @@ added: v15.8.0
   * `err` {Error}
   * `prime` {ArrayBuffer|bigint}
 
-Generates a pseudo-random prime of `size` bits.
+Generates a pseudorandom prime of `size` bits.
 
 If `options.safe` is `true`, the prime will be a safe prime -- that is,
 `(prime - 1) / 2` will also be a prime.
@@ -3645,7 +3645,7 @@ added: v15.8.0
     as a `bigint`.
 * Returns: {ArrayBuffer|bigint}
 
-Generates a pseudo-random prime of `size` bits.
+Generates a pseudorandom prime of `size` bits.
 
 If `options.safe` is `true`, the prime will be a safe prime -- that is,
 `(prime - 1) / 2` will also be a prime.
@@ -4316,7 +4316,7 @@ changes:
   * `buf` {Buffer}
 * Returns: {Buffer} if the `callback` function is not provided.
 
-Generates cryptographically strong pseudo-random data. The `size` argument
+Generates cryptographically strong pseudorandom data. The `size` argument
 is a number indicating the number of bytes to generate.
 
 If a `callback` function is provided, the bytes are generated asynchronously
@@ -5116,10 +5116,10 @@ When passing strings to cryptographic APIs, consider the following factors.
 
 * Not all byte sequences are valid UTF-8 strings. Therefore, when a byte
   sequence of length `n` is derived from a string, its entropy is generally
-  lower than the entropy of a random or pseudo-random `n` byte sequence.
+  lower than the entropy of a random or pseudorandom `n` byte sequence.
   For example, no UTF-8 string will result in the byte sequence `c0 af`. Secret
-  keys should almost exclusively be random or pseudo-random byte sequences.
-* Similarly, when converting random or pseudo-random byte sequences to UTF-8
+  keys should almost exclusively be random or pseudorandom byte sequences.
+* Similarly, when converting random or pseudorandom byte sequences to UTF-8
   strings, subsequences that do not represent valid code points may be replaced
   by the Unicode replacement character (`U+FFFD`). The byte representation of
   the resulting Unicode string may, therefore, not be equal to the byte sequence
@@ -5134,7 +5134,7 @@ When passing strings to cryptographic APIs, consider the following factors.
   ```
 
   The outputs of ciphers, hash functions, signature algorithms, and key
-  derivation functions are pseudo-random byte sequences and should not be
+  derivation functions are pseudorandom byte sequences and should not be
   used as Unicode strings.
 * When strings are obtained from user input, some Unicode characters can be
   represented in multiple equivalent ways that result in different byte

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -1772,7 +1772,7 @@ changes:
     **Default:** none, see `minVersion`.
   * `sessionIdContext` {string} Opaque identifier used by servers to ensure
     session state is not shared between applications. Unused by clients.
-  * `ticketKeys`: {Buffer} 48-bytes of cryptographically strong pseudo-random
+  * `ticketKeys`: {Buffer} 48-bytes of cryptographically strong pseudorandom
     data. See [Session Resumption][] for more information.
   * `sessionTimeout` {number} The number of seconds after which a TLS session
     created by the server will no longer be resumable. See
@@ -1915,7 +1915,7 @@ changes:
     If `callback` is called with a falsy `ctx` argument, the default secure
     context of the server will be used. If `SNICallback` wasn't provided the
     default callback with high-level API will be used (see below).
-  * `ticketKeys`: {Buffer} 48-bytes of cryptographically strong pseudo-random
+  * `ticketKeys`: {Buffer} 48-bytes of cryptographically strong pseudorandom
     data. See [Session Resumption][] for more information.
   * `pskCallback` {Function}
     * socket: {tls.TLSSocket} the server [`tls.TLSSocket`][] instance for

--- a/doc/api/webcrypto.md
+++ b/doc/api/webcrypto.md
@@ -1175,7 +1175,7 @@ added: v15.0.0
 * Type: {ArrayBuffer|TypedArray|DataView|Buffer}
 
 The salt value significantly improves the strength of the HKDF algorithm.
-It should be random or pseudo-random and should be the same length as the
+It should be random or pseudorandom and should be the same length as the
 output of the digest function (for instance, if using `'SHA-256'` as the
 digest, the salt should be 256-bits of random data).
 
@@ -1327,7 +1327,7 @@ added: v15.0.0
 
 * Type: {ArrayBuffer|TypedArray|DataView|Buffer}
 
-Should be at least 16 random or pseudo-random bytes.
+Should be at least 16 random or pseudorandom bytes.
 
 ### Class: `RsaHashedImportParams`
 <!-- YAML


### PR DESCRIPTION
Our docs use both _pseudo-random_ and _pseudorandom_. Standardize on _pseudorandom_.

Which spelling to use is not covered in our doc style guide. It says to refer to Microsoft's style guide for things not covered. Microsoft's style guide similarly does not indicate which spelling to use. It refers to the American Heritage Dictionary for things it doesn't cover. American Heritage Dictionary contains an entry for _pseudorandom_ and does not appear to mention _pseudo-random_. (Anecdotally, _pseudorandom_ seems to be the most common spelling in recent documents and _pseudo-random tends to show up in older documents.)

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
