### PR TITLE
lib: add JSDoc to os module functions

### DIFF
--- a/lib/os.js
+++ b/lib/os.js
@@ -107,7 +107,7 @@ const kEndianness = isBigEndian ? 'BE' : 'LE';
 const avgValues = new Float64Array(3);
 
 /**
- * @returns {number[]}
+ * @returns {[number, number, number]}
  */
 function loadavg() {
   getLoadAvg(avgValues);
@@ -245,7 +245,7 @@ function getCIDR(address, netmask, family) {
 }
 
 /**
- * @returns {Object.<string, Array<{
+ * @returns {Record<string, Array<{
  *  address: string
  *  netmask: string
  *  family: 'IPv4' | 'IPv6'

--- a/lib/os.js
+++ b/lib/os.js
@@ -80,8 +80,17 @@ const {
 const getHomeDirectory = getCheckedFunction(_getHomeDirectory);
 const getHostname = getCheckedFunction(_getHostname);
 const getInterfaceAddresses = getCheckedFunction(_getInterfaceAddresses);
+/**
+ * @returns {string}
+ */
 const getOSRelease = () => release;
+/**
+ * @returns {string}
+ */
 const getOSType = () => type;
+/**
+ * @returns {string}
+ */
 const getOSVersion = () => version;
 
 getFreeMem[SymbolToPrimitive] = () => getFreeMem();
@@ -97,11 +106,30 @@ const kEndianness = isBigEndian ? 'BE' : 'LE';
 
 const avgValues = new Float64Array(3);
 
+/**
+ * @returns {number[]}
+ */
 function loadavg() {
   getLoadAvg(avgValues);
   return [avgValues[0], avgValues[1], avgValues[2]];
 }
 
+/**
+ * Returns an array of objects containing information about each
+ * logical CPU core.
+ *
+ * @returns {Array<{
+ *  model: string
+ *  speed: number
+ *  times: {
+ *    user: number
+ *    nice: number
+ *    sys: number
+ *    idle: number
+ *    irq: number
+ *  }
+ * }>}
+ */
 function cpus() {
   // [] is a bugfix for a regression introduced in 51cea61
   const data = getCPUs() || [];
@@ -123,16 +151,25 @@ function cpus() {
   return result;
 }
 
+/**
+ * @returns {string}
+ */
 function arch() {
   return process.arch;
 }
 arch[SymbolToPrimitive] = () => process.arch;
 
+/**
+ * @returns {string}
+ */
 function platform() {
   return process.platform;
 }
 platform[SymbolToPrimitive] = () => process.platform;
 
+/**
+ * @returns {string}
+ */
 function tmpdir() {
   var path;
   if (isWindows) {
@@ -155,6 +192,9 @@ function tmpdir() {
 }
 tmpdir[SymbolToPrimitive] = () => tmpdir();
 
+/**
+ * @returns {'BE' | 'LE'}
+ */
 function endianness() {
   return kEndianness;
 }
@@ -204,6 +244,17 @@ function getCIDR(address, netmask, family) {
   return `${address}/${ones}`;
 }
 
+/**
+ * @returns {Object.<string, Array<{
+ *  address: string
+ *  netmask: string
+ *  family: 'IPv4' | 'IPv6'
+ *  mac: string
+ *  internal: boolean
+ *  scopeid: number
+ *  cidr: string | null
+ * }>>}
+ */
 function networkInterfaces() {
   const data = getInterfaceAddresses();
   const result = {};
@@ -234,6 +285,9 @@ function networkInterfaces() {
   return result;
 }
 
+/**
+ * @returns {void}
+ */
 function setPriority(pid, priority) {
   if (priority === undefined) {
     priority = pid;
@@ -249,6 +303,9 @@ function setPriority(pid, priority) {
     throw new ERR_SYSTEM_ERROR(ctx);
 }
 
+/**
+ * @returns {number}
+ */
 function getPriority(pid) {
   if (pid === undefined)
     pid = 0;
@@ -264,6 +321,18 @@ function getPriority(pid) {
   return priority;
 }
 
+/**
+ * @param {{ encoding?: string }} options If `encoding` is set to `'buffer'`,
+ * the `username`, `shell`, and `homedir` values will be `Buffer` instances.
+ * Default: `'utf8'`
+ * @returns {{
+ *   uid: number
+ *   gid: number
+ *   username: string
+ *   homedir: string
+ *   shell: string | null
+ * }}
+ */
 function userInfo(options) {
   if (typeof options !== 'object')
     options = null;

--- a/lib/os.js
+++ b/lib/os.js
@@ -286,6 +286,8 @@ function networkInterfaces() {
 }
 
 /**
+ * @param {number} pid
+ * @param {number} priority
  * @returns {void}
  */
 function setPriority(pid, priority) {
@@ -304,6 +306,7 @@ function setPriority(pid, priority) {
 }
 
 /**
+ * @param {number} pid
  * @returns {number}
  */
 function getPriority(pid) {


### PR DESCRIPTION
Inspired by @bmeck: https://twitter.com/bradleymeck/status/1380643627211354115

I only pulled in actual docs if it seemed relevant, but can add more. It seemed redundant to copy the docs wholesale, but I can!

I also wasn't sure what the preferred style for types was with regards to `x[]` vs `Array<x>`, so I went with the recommended [array-simple](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/array-type.md#array-simple) mode of `typescript-eslint`.

Some screenshots:

![](https://cdn.zappy.app/b78444bfec3a670eaf4f1b18f0cb232d.png)

![](https://cdn.zappy.app/1e218b1afff3c5a52769a48abad614ea.png)

![](https://cdn.zappy.app/b792570cd60202c3de7dc67f2342f29d.png)