### PR TITLE
test,doc: fix https agent minVersion/maxVersion test and docs

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -1738,12 +1738,12 @@ changes:
     private key in different ways.
   * `maxVersion` {string} Optionally set the maximum TLS version to allow. One
     of `'TLSv1.3'`, `'TLSv1.2'`, `'TLSv1.1'`, or `'TLSv1'`. Cannot be specified
-    along with the `secureProtocol` option, use one or the other.
+    along with the `secureProtocol` option; use one or the other.
     **Default:** [`tls.DEFAULT_MAX_VERSION`][].
   * `minVersion` {string} Optionally set the minimum TLS version to allow. One
     of `'TLSv1.3'`, `'TLSv1.2'`, `'TLSv1.1'`, or `'TLSv1'`. Cannot be specified
-    along with the `secureProtocol` option, use one or the other. It is not
-    recommended to use less than TLSv1.2, but it may be required for
+    along with the `secureProtocol` option; use one or the other. Avoid
+    setting to less than TLSv1.2, but it may be required for
     interoperability.
     **Default:** [`tls.DEFAULT_MIN_VERSION`][].
   * `passphrase` {string} Shared passphrase used for a single private key and/or

--- a/test/parallel/test-https-agent-additional-options.js
+++ b/test/parallel/test-https-agent-additional-options.js
@@ -63,8 +63,8 @@ function variations(iter, port, cb) {
         server.close();
       } else {
         // Save `value` for check the next time.
-        value = next.value.val;
         const [key, val] = next.value;
+        value = val;
         https.get({ ...getBaseOptions(port), [key]: val },
                   variations(iter, port, cb));
       }

--- a/test/parallel/test-https-agent-additional-options.js
+++ b/test/parallel/test-https-agent-additional-options.js
@@ -36,6 +36,8 @@ const updatedValues = new Map([
   ['dhparam', fixtures.readKey('dh2048.pem')],
   ['ecdhCurve', 'secp384r1'],
   ['honorCipherOrder', true],
+  ['minVersion', 'TLSv1.1'],
+  ['maxVersion', 'TLSv1.3'],
   ['secureOptions', crypto.constants.SSL_OP_CIPHER_SERVER_PREFERENCE],
   ['secureProtocol', 'TLSv1_1_method'],
   ['sessionIdContext', 'sessionIdContext'],


### PR DESCRIPTION
    test: fix test-https-agent-additional-options.js
    
    `value` was always being assigned to an `undefined` property of an
    Array. Thus, the assertions that depended on `value` being defined were
    never being checked. Assign `value` the correct...er...value.
---
    test add tests for missing https agent options
    
    Add test that minVersion and maxVersion options are accepted. This
    should complete coverage for lib/https.js.
    
    Refs: https://codecov.io/gh/nodejs/node/src/ec0dcd720e10831b3e783b415c5dc011ed5be2f8/lib/https.js
---
    doc: revise TLS minVersion/maxVersion text
    
    Minor changes mostly to improve compliance with our style guide.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
