### PR TITLE
process: add range validation to debugPort

### DIFF
--- a/src/node_process_object.cc
+++ b/src/node_process_object.cc
@@ -1,4 +1,5 @@
 #include "env-inl.h"
+#include "node_errors.h"
 #include "node_external_reference.h"
 #include "node_internals.h"
 #include "node_metadata.h"
@@ -60,6 +61,13 @@ static void DebugPortSetter(Local<Name> property,
                             const PropertyCallbackInfo<void>& info) {
   Environment* env = Environment::GetCurrent(info);
   int32_t port = value->Int32Value(env->context()).FromMaybe(0);
+
+  if ((port != 0 && port < 1024) || port > 65535) {
+    return THROW_ERR_OUT_OF_RANGE(
+      env,
+      "process.debugPort must be 0 or in range 1024 to 65535");
+  }
+
   ExclusiveAccess<HostPort>::Scoped host_port(env->inspector_host_port());
   host_port->set_port(static_cast<int>(port));
 }

--- a/test/parallel/test-set-process-debug-port.js
+++ b/test/parallel/test-set-process-debug-port.js
@@ -1,0 +1,60 @@
+'use strict';
+const common = require('../common');
+
+common.skipIfInspectorDisabled();
+common.skipIfWorker();
+
+const assert = require('assert');
+const kMinPort = 1024;
+const kMaxPort = 65535;
+
+function check(value, expected) {
+  process.debugPort = value;
+  assert.strictEqual(process.debugPort, expected);
+}
+
+// Expected usage with numbers.
+check(0, 0);
+check(kMinPort, kMinPort);
+check(kMinPort + 1, kMinPort + 1);
+check(kMaxPort - 1, kMaxPort - 1);
+check(kMaxPort, kMaxPort);
+
+// Numeric strings coerce.
+check('0', 0);
+check(`${kMinPort}`, kMinPort);
+check(`${kMinPort + 1}`, kMinPort + 1);
+check(`${kMaxPort - 1}`, kMaxPort - 1);
+check(`${kMaxPort}`, kMaxPort);
+
+// Most other values are coerced to 0.
+check('', 0);
+check(false, 0);
+check(NaN, 0);
+check(Infinity, 0);
+check(-Infinity, 0);
+check(function() {}, 0);
+check({}, 0);
+check([], 0);
+
+// Symbols do not coerce.
+assert.throws(() => {
+  process.debugPort = Symbol();
+}, /^TypeError: Cannot convert a Symbol value to a number$/);
+
+// Verify port bounds checking.
+[
+  true,
+  -1,
+  1,
+  kMinPort - 1,
+  kMaxPort + 1,
+  '-1',
+  '1',
+  `${kMinPort - 1}`,
+  `${kMaxPort + 1}`,
+].forEach((value) => {
+  assert.throws(() => {
+    process.debugPort = value;
+  }, /^RangeError: process\.debugPort must be 0 or in range 1024 to 65535$/);
+});


### PR DESCRIPTION
This commit adds validation to the `process.debugPort` setter.

Fixes: https://github.com/nodejs/node/issues/38037