### PR TITLE
repl: fix error message printing

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -651,7 +651,7 @@ function REPLServer(prompt,
         errStack = self.writer(e);
 
         // Remove one line error braces to keep the old style in place.
-        if (errStack[errStack.length - 1] === ']') {
+        if (errStack[0] === '[' && errStack[errStack.length - 1] === ']') {
           errStack = StringPrototypeSlice(errStack, 1, -1);
         }
       }

--- a/test/parallel/test-repl-pretty-stack-custom-writer.js
+++ b/test/parallel/test-repl-pretty-stack-custom-writer.js
@@ -17,7 +17,7 @@ const repl = require('repl');
     useColors: false
   });
 
-  r.write(`throw new Error("foo[a]")\n`);
+  r.write('throw new Error("foo[a]")\n');
   r.close();
   assert.strictEqual(output.read().toString(), 'Uncaught Error: foo[a]\n');
 }

--- a/test/parallel/test-repl-pretty-stack-custom-writer.js
+++ b/test/parallel/test-repl-pretty-stack-custom-writer.js
@@ -1,0 +1,23 @@
+'use strict';
+require('../common');
+const { PassThrough } = require('stream');
+const assert = require('assert');
+const repl = require('repl');
+
+{
+  const input = new PassThrough();
+  const output = new PassThrough();
+
+  const r = repl.start({
+    prompt: '',
+    input,
+    output,
+    writer: String,
+    terminal: false,
+    useColors: false
+  });
+
+  r.write(`throw new Error("foo[a]")\n`);
+  r.close();
+  assert.strictEqual(output.read().toString(), 'Uncaught Error: foo[a]\n');
+}


### PR DESCRIPTION
The REPL implementation would strip away the first and last character
of a formatted error message if it ended with `]` (but with the
obviously missing check for a starting `]`), leading to things like
`Uncaught rror: foo[a` being printed for input like `Error: foo[a]`.

Refs: https://github.com/nodejs/node/pull/22436

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
