### PR TITLE
lib: add `globalThis` to primordials

### DIFF
--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -25,6 +25,10 @@ rules:
       message: "Please use `require('internal/errors').hideStackFrames()` instead."
     - selector: "AssignmentExpression:matches([left.name='prepareStackTrace'], [left.property.name='prepareStackTrace'])"
       message: "Use 'overrideStackTrace' from 'lib/internal/errors.js' instead of 'Error.prepareStackTrace'."
+  no-restricted-globals:
+    - error
+    - name: globalThis
+      message: "Use `const { globalThis } = primordials;` instead of the global."
   # Custom rules in tools/eslint-rules
   node-core/lowercase-name-for-primitive: error
   node-core/non-ascii-character: error

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -9,6 +9,7 @@ const {
   RegExpPrototypeExec,
   SafeWeakMap,
   StringPrototypeStartsWith,
+  globalThis,
 } = primordials;
 
 const {

--- a/lib/internal/per_context/primordials.js
+++ b/lib/internal/per_context/primordials.js
@@ -131,6 +131,14 @@ function copyPrototype(src, dest, prefix) {
   }
 }
 
+// Create copies of configurable value properties of the global object
+[
+  'globalThis',
+].forEach((name) => {
+  // eslint-disable-next-line no-restricted-globals
+  primordials[name] = globalThis[name];
+});
+
 // Create copies of URI handling functions
 [
   decodeURI,

--- a/lib/internal/process/execution.js
+++ b/lib/internal/process/execution.js
@@ -1,5 +1,9 @@
 'use strict';
 
+const {
+  globalThis,
+} = primordials;
+
 const path = require('path');
 
 const {

--- a/lib/internal/test/binding.js
+++ b/lib/internal/test/binding.js
@@ -1,5 +1,9 @@
 'use strict';
 
+const {
+  globalThis,
+} = primordials;
+
 process.emitWarning(
   'These APIs are for internal testing only. Do not use them.',
   'internal/test/binding');

--- a/lib/internal/v8_prof_polyfill.js
+++ b/lib/internal/v8_prof_polyfill.js
@@ -72,6 +72,7 @@ function read(fileName) {
 }
 const quit = process.exit;
 // Polyfill "readline()".
+// eslint-disable-next-line no-restricted-globals
 const logFile = globalThis.arguments[globalThis.arguments.length - 1];
 try {
   fs.accessSync(logFile);
@@ -161,6 +162,7 @@ function macCppfiltNm(out) {
   });
 }
 
+// eslint-disable-next-line no-restricted-globals
 Object.assign(globalThis, {
   os,
   print,


### PR DESCRIPTION
This is useful to avoid throwing exception if `globalThis` is being overwritten in userland:

```console
> node -e 'globalThis.globalThis = null;new Error().stack'
node:internal/process/execution:92
    globalThis.module = origModule;
                      ^

TypeError: Cannot set property 'module' of null
    at evalScript (node:internal/process/execution:92:23)
    at node:internal/main/eval_string:23:3
```

I'm using `no-restricted-globals` instead of `node-core/prefer-primordials` to generate better error messages.
```
lib/internal/process/execution.js
  58:22  error  Use `const { globalThisModule } = primordials;` instead of the global      node-core/prefer-primordials
  75:3   error  Use `const { globalThis__filename } = primordials;` instead of the global  node-core/prefer-primordials
  92:5   error  Use `const { globalThisModule } = primordials;` instead of the global      node-core/prefer-primordials
```
```
lib/internal/process/execution.js
  58:22  error  Unexpected use of 'globalThis'. Use `const { globalThis } = primordials;` instead of the global  no-restricted-globals
  75:3   error  Unexpected use of 'globalThis'. Use `const { globalThis } = primordials;` instead of the global  no-restricted-globals
  92:5   error  Unexpected use of 'globalThis'. Use `const { globalThis } = primordials;` instead of the global  no-restricted-globals
```
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
