### PR TITLE
lib: add JSDoc typings for util

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -74,7 +74,7 @@ const {
 let internalDeepEqual;
 
 /**
- * @param {any} arg 
+ * @param {any} arg
  * @returns {arg is boolean}
  */
 function isBoolean(arg) {
@@ -82,7 +82,7 @@ function isBoolean(arg) {
 }
 
 /**
- * @param {any} arg 
+ * @param {any} arg
  * @returns {arg is null}
  */
 function isNull(arg) {
@@ -90,7 +90,7 @@ function isNull(arg) {
 }
 
 /**
- * @param {any} arg 
+ * @param {any} arg
  * @returns {arg is (null | undefined)}
  */
 function isNullOrUndefined(arg) {
@@ -98,7 +98,7 @@ function isNullOrUndefined(arg) {
 }
 
 /**
- * @param {any} arg 
+ * @param {any} arg
  * @returns {arg is number}
  */
 function isNumber(arg) {
@@ -106,7 +106,7 @@ function isNumber(arg) {
 }
 
 /**
- * @param {any} arg 
+ * @param {any} arg
  * @returns {arg is string}
  */
 function isString(arg) {
@@ -114,7 +114,7 @@ function isString(arg) {
 }
 
 /**
- * @param {any} arg 
+ * @param {any} arg
  * @returns {arg is symbol}
  */
 function isSymbol(arg) {
@@ -122,7 +122,7 @@ function isSymbol(arg) {
 }
 
 /**
- * @param {any} arg 
+ * @param {any} arg
  * @returns {arg is undefined}
  */
 function isUndefined(arg) {
@@ -130,7 +130,7 @@ function isUndefined(arg) {
 }
 
 /**
- * @param {any} arg 
+ * @param {any} arg
  * @returns {boolean}
  */
 function isObject(arg) {
@@ -146,7 +146,7 @@ function isError(e) {
 }
 
 /**
- * @param {any} arg 
+ * @param {any} arg
  * @returns {arg is Function}
  */
 function isFunction(arg) {
@@ -154,7 +154,7 @@ function isFunction(arg) {
 }
 
 /**
- * @param {any} arg 
+ * @param {any} arg
  * @returns {arg is (null | boolean | string | number | symbol)}
  */
 function isPrimitive(arg) {
@@ -163,7 +163,7 @@ function isPrimitive(arg) {
 }
 
 /**
- * @param {number} n 
+ * @param {number} n
  * @returns {string}
  */
 function pad(n) {
@@ -266,7 +266,10 @@ const callbackifyOnRejected = hideStackFrames((reason, cb) => {
 /**
  * @template {(...args: any[]) => Promise<any>} T
  * @param {T} original
- * @returns {T extends (...args: infer TArgs) => Promise<infer TReturn> ? ((...params: [...TArgs, ((err: Error, ret: TReturn) => any)]) => void) : never}
+ * @returns {T extends (...args: infer TArgs) => Promise<infer TReturn> ?
+ *   ((...params: [...TArgs, ((err: Error, ret: TReturn) => any)]) => void) :
+ *   never
+ * }
  */
 function callbackify(original) {
   if (typeof original !== 'function') {

--- a/lib/util.js
+++ b/lib/util.js
@@ -155,7 +155,7 @@ function isFunction(arg) {
 
 /**
  * @param {any} arg
- * @returns {arg is (null | boolean | string | number | symbol)}
+ * @returns {arg is (boolean | null | number | string | symbol | undefined)}
  */
 function isPrimitive(arg) {
   return arg === null ||

--- a/lib/util.js
+++ b/lib/util.js
@@ -131,7 +131,7 @@ function isUndefined(arg) {
 
 /**
  * @param {any} arg
- * @returns {boolean}
+ * @returns {a is NonNullable<object>}
  */
 function isObject(arg) {
   return arg !== null && typeof arg === 'object';

--- a/lib/util.js
+++ b/lib/util.js
@@ -73,51 +73,99 @@ const {
 
 let internalDeepEqual;
 
+/**
+ * @param {any} arg 
+ * @returns {arg is boolean}
+ */
 function isBoolean(arg) {
   return typeof arg === 'boolean';
 }
 
+/**
+ * @param {any} arg 
+ * @returns {arg is null}
+ */
 function isNull(arg) {
   return arg === null;
 }
 
+/**
+ * @param {any} arg 
+ * @returns {arg is (null | undefined)}
+ */
 function isNullOrUndefined(arg) {
   return arg === null || arg === undefined;
 }
 
+/**
+ * @param {any} arg 
+ * @returns {arg is number}
+ */
 function isNumber(arg) {
   return typeof arg === 'number';
 }
 
+/**
+ * @param {any} arg 
+ * @returns {arg is string}
+ */
 function isString(arg) {
   return typeof arg === 'string';
 }
 
+/**
+ * @param {any} arg 
+ * @returns {arg is symbol}
+ */
 function isSymbol(arg) {
   return typeof arg === 'symbol';
 }
 
+/**
+ * @param {any} arg 
+ * @returns {arg is undefined}
+ */
 function isUndefined(arg) {
   return arg === undefined;
 }
 
+/**
+ * @param {any} arg 
+ * @returns {boolean}
+ */
 function isObject(arg) {
   return arg !== null && typeof arg === 'object';
 }
 
+/**
+ * @param {any} e
+ * @returns {arg is Error}
+ */
 function isError(e) {
   return ObjectPrototypeToString(e) === '[object Error]' || e instanceof Error;
 }
 
+/**
+ * @param {any} arg 
+ * @returns {arg is Function}
+ */
 function isFunction(arg) {
   return typeof arg === 'function';
 }
 
+/**
+ * @param {any} arg 
+ * @returns {arg is (null | boolean | string | number | symbol)}
+ */
 function isPrimitive(arg) {
   return arg === null ||
          (typeof arg !== 'object' && typeof arg !== 'function');
 }
 
+/**
+ * @param {number} n 
+ * @returns {string}
+ */
 function pad(n) {
   return StringPrototypePadStart(n.toString(), 2, '0');
 }
@@ -125,7 +173,9 @@ function pad(n) {
 const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep',
                 'Oct', 'Nov', 'Dec'];
 
-// 26 Feb 16:19:34
+/**
+ * @returns {string}  26 Feb 16:19:34
+ */
 function timestamp() {
   const d = new Date();
   const t = ArrayPrototypeJoin([
@@ -137,7 +187,10 @@ function timestamp() {
 }
 
 let console;
-// Log is just a thin wrapper to console.log that prepends a timestamp
+/**
+ * Log is just a thin wrapper to console.log that prepends a timestamp
+ * @type {(...args: any[]) => void}
+ */
 function log(...args) {
   if (!console) {
     console = require('internal/console/global');
@@ -154,9 +207,9 @@ function log(...args) {
  * functions as prototype setup using normal JavaScript does not work as
  * expected during bootstrapping (see mirror.js in r114903).
  *
- * @param {function} ctor Constructor function which needs to inherit the
+ * @param {Function} ctor Constructor function which needs to inherit the
  *     prototype.
- * @param {function} superCtor Constructor function to inherit prototype from.
+ * @param {Function} superCtor Constructor function to inherit prototype from.
  * @throws {TypeError} Will error if either constructor is null, or if
  *     the super constructor lacks a prototype.
  */
@@ -180,6 +233,13 @@ function inherits(ctor, superCtor) {
   ObjectSetPrototypeOf(ctor.prototype, superCtor.prototype);
 }
 
+/**
+ * @template T
+ * @template S
+ * @param {T} target
+ * @param {S} source
+ * @returns {S extends null ? T : (T & S)}
+ */
 function _extend(target, source) {
   // Don't do anything if source isn't an object
   if (source === null || typeof source !== 'object') return target;
@@ -203,6 +263,11 @@ const callbackifyOnRejected = hideStackFrames((reason, cb) => {
   return cb(reason);
 });
 
+/**
+ * @template {(...args: any[]) => Promise<any>} T
+ * @param {T} original
+ * @returns {T extends (...args: infer TArgs) => Promise<infer TReturn> ? ((...params: [...TArgs, ((err: Error, ret: TReturn) => any)]) => void) : never}
+ */
 function callbackify(original) {
   if (typeof original !== 'function') {
     throw new ERR_INVALID_ARG_TYPE('original', 'Function', original);
@@ -237,6 +302,10 @@ function callbackify(original) {
   return callbackified;
 }
 
+/**
+ * @param {number} err
+ * @returns {string}
+ */
 function getSystemErrorName(err) {
   validateNumber(err, 'err');
   if (err >= 0 || !NumberIsSafeInteger(err)) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -74,6 +74,7 @@ const {
 let internalDeepEqual;
 
 /**
+ * @deprecated since v4.0.0
  * @param {any} arg
  * @returns {arg is boolean}
  */
@@ -82,6 +83,7 @@ function isBoolean(arg) {
 }
 
 /**
+ * @deprecated since v4.0.0
  * @param {any} arg
  * @returns {arg is null}
  */
@@ -90,6 +92,7 @@ function isNull(arg) {
 }
 
 /**
+ * @deprecated since v4.0.0
  * @param {any} arg
  * @returns {arg is (null | undefined)}
  */
@@ -98,6 +101,7 @@ function isNullOrUndefined(arg) {
 }
 
 /**
+ * @deprecated since v4.0.0
  * @param {any} arg
  * @returns {arg is number}
  */
@@ -114,6 +118,7 @@ function isString(arg) {
 }
 
 /**
+ * @deprecated since v4.0.0
  * @param {any} arg
  * @returns {arg is symbol}
  */
@@ -122,6 +127,7 @@ function isSymbol(arg) {
 }
 
 /**
+ * @deprecated since v4.0.0
  * @param {any} arg
  * @returns {arg is undefined}
  */
@@ -130,6 +136,7 @@ function isUndefined(arg) {
 }
 
 /**
+ * @deprecated since v4.0.0
  * @param {any} arg
  * @returns {a is NonNullable<object>}
  */
@@ -138,6 +145,7 @@ function isObject(arg) {
 }
 
 /**
+ * @deprecated since v4.0.0
  * @param {any} e
  * @returns {arg is Error}
  */
@@ -146,6 +154,7 @@ function isError(e) {
 }
 
 /**
+ * @deprecated since v4.0.0
  * @param {any} arg
  * @returns {arg is Function}
  */
@@ -154,6 +163,7 @@ function isFunction(arg) {
 }
 
 /**
+ * @deprecated since v4.0.0
  * @param {any} arg
  * @returns {arg is (boolean | null | number | string | symbol | undefined)}
  */
@@ -189,6 +199,7 @@ function timestamp() {
 let console;
 /**
  * Log is just a thin wrapper to console.log that prepends a timestamp
+ * @deprecated since v6.0.0
  * @type {(...args: any[]) => void}
  */
 function log(...args) {
@@ -234,6 +245,7 @@ function inherits(ctor, superCtor) {
 }
 
 /**
+ * @deprecated since v6.0.0
  * @template T
  * @template S
  * @param {T} target


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Ref: https://github.com/nodejs/node/pull/38182
Ref: https://twitter.com/bradleymeck/status/1380643627211354115

Added JSDoc typings to `lib/util`. Most of the typings are pretty simple and direct, all the `isThing` methods have been typed using [type predicates](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates).

`callbackify` is a bit complex, for this I used the new [Leading Rest elements in tuple types](https://devblogs.microsoft.com/typescript/announcing-typescript-4-2/#non-trailing-rests) to infer types.

### Before:

<img width="714" alt="image" src="https://user-images.githubusercontent.com/31949290/114418526-39ca6380-9bd0-11eb-9d8d-7e4700aa5a2f.png">

### After:

<img width="839" alt="image" src="https://user-images.githubusercontent.com/31949290/114415417-49947880-9bcd-11eb-85af-8c3e48657600.png">


There are still some errors with `checkJs` enabled that I'm not sure how to fix since we are mutating the original type:

<img width="794" alt="image" src="https://user-images.githubusercontent.com/31949290/114420905-62535d00-9bd2-11eb-859a-39668b6ee0a1.png">

