### PR TITLE
typings: add JSDoc typings for child_process

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -87,6 +87,28 @@ const {
 
 const MAX_BUFFER = 1024 * 1024;
 
+/**
+ * Spawns a new Node.js process + fork.
+ * @param {string} modulePath
+ * @param {string[]} [args]
+ * @param {{
+ *   cwd?: string;
+ *   detached?: boolean;
+ *   env?: Object;
+ *   execPath?: string;
+ *   execArgv?: string[];
+ *   gid?: number;
+ *   serialization?: string;
+ *   signal?: AbortSignal;
+ *   killSignal?: string | number;
+ *   silent?: boolean;
+ *   stdio?: Array | string;
+ *   uid?: number;
+ *   windowsVerbatimArguments?: boolean;
+ *   timeout?: number;
+ *   }} [options]
+ * @returns {ChildProcess}
+ */
 function fork(modulePath /* , args, options */) {
   validateString(modulePath, 'modulePath');
 
@@ -174,7 +196,29 @@ function normalizeExecArgs(command, options, callback) {
   };
 }
 
-
+/**
+ * Spawns a shell executing the given command.
+ * @param {string} command
+ * @param {{
+ *   cmd?: string;
+ *   env?: Object;
+ *   encoding?: string;
+ *   shell?: string;
+ *   signal?: AbortSignal;
+ *   timeout?: number;
+ *   maxBuffer?: number;
+ *   killSignal?: string | number;
+ *   uid?: number;
+ *   gid?: number;
+ *   windowsHide?: boolean;
+ *   }} [options]
+ * @param {(
+ *   error?: Error,
+ *   stdout?: string | Buffer,
+ *   stderr?: string | Buffer
+ *   ) => any} [callback]
+ * @returns {ChildProcess}
+ */
 function exec(command, options, callback) {
   const opts = normalizeExecArgs(command, options, callback);
   return module.exports.execFile(opts.file,
@@ -205,6 +249,31 @@ ObjectDefineProperty(exec, promisify.custom, {
   value: customPromiseExecFunction(exec)
 });
 
+/**
+ * Spawns the specified file as a shell.
+ * @param {string} file
+ * @param {string[]} [args]
+ * @param {{
+ *   cwd?: string;
+ *   env?: Object;
+ *   encoding?: string;
+ *   timeout?: number;
+ *   maxBuffer?: number;
+ *   killSignal?: string | number;
+ *   uid?: number;
+ *   gid?: number;
+ *   windowsHide?: boolean;
+ *   windowsVerbatimArguments?: boolean;
+ *   shell?: boolean | string;
+ *   signal?: AbortSignal;
+ *   }} [options]
+ * @param {(
+ *   error?: Error,
+ *   stdout?: string | Buffer,
+ *   stderr?: string | Buffer
+ *   ) => any} [callback]
+ * @returns {ChildProcess}
+ */
 function execFile(file /* , args, options, callback */) {
   let args = [];
   let callback;
@@ -597,7 +666,28 @@ function abortChildProcess(child, killSignal) {
   }
 }
 
-
+/**
+ * Spawns a new process using the given `file`.
+ * @param {string} file
+ * @param {string[]} [args]
+ * @param {{
+ *   cwd?: string;
+ *   env?: Object;
+ *   argv0?: string;
+ *   stdio?: Array | string;
+ *   detached?: boolean;
+ *   uid?: number;
+ *   gid?: number;
+ *   serialization?: string;
+ *   shell?: boolean | string;
+ *   windowsVerbatimArguments?: boolean;
+ *   windowsHide?: boolean;
+ *   signal?: AbortSignal;
+ *   timeout?: number;
+ *   killSignal?: string | number;
+ *   }} [options]
+ * @returns {ChildProcess}
+ */
 function spawn(file, args, options) {
   options = normalizeSpawnArguments(file, args, options);
   validateTimeout(options.timeout);
@@ -646,6 +736,36 @@ function spawn(file, args, options) {
   return child;
 }
 
+/**
+ * Spawns a new process synchronously using the given `file`.
+ * @param {string} file
+ * @param {string[]} [args]
+ * @param {{
+ *   cwd?: string;
+ *   input?: string | Buffer | TypedArray | DataView;
+ *   argv0?: string;
+ *   stdio?: string | Array;
+ *   env?: Object;
+ *   uid?: number;
+ *   gid?: number;
+ *   timeout?: number;
+ *   killSignal?: string | number;
+ *   maxBuffer?: number;
+ *   encoding?: string;
+ *   shell?: boolean | string;
+ *   windowsVerbatimArguments?: boolean;
+ *   windowsHide?: boolean;
+ *   }} [options]
+ * @returns {{
+ *   pid: number;
+ *   output: Array;
+ *   stdout: Buffer | string;
+ *   stderr: Buffer | string;
+ *   status: number | null;
+ *   signal: string | null;
+ *   error: Error;
+ *   }}
+ */
 function spawnSync(file, args, options) {
   options = {
     maxBuffer: MAX_BUFFER,
@@ -712,7 +832,26 @@ function checkExecSyncError(ret, args, cmd) {
   return err;
 }
 
-
+/**
+ * Spawns a file as a shell synchronously.
+ * @param {string} command
+ * @param {string[]} [args]
+ * @param {{
+ *   cwd?: string;
+ *   input?: string | Buffer | TypedArray | DataView;
+ *   stdio?: string | Array;
+ *   env?: Object;
+ *   uid?: number;
+ *   gid?: number;
+ *   timeout?: number;
+ *   killSignal?: string | number;
+ *   maxBuffer?: number;
+ *   encoding?: string;
+ *   windowsHide?: boolean;
+ *   shell?: boolean | string;
+ *   }} [options]
+ * @returns {Buffer | string}
+ */
 function execFileSync(command, args, options) {
   options = normalizeSpawnArguments(command, args, options);
 
@@ -731,7 +870,25 @@ function execFileSync(command, args, options) {
   return ret.stdout;
 }
 
-
+/**
+ * Spawns a shell executing the given `command` synchronously.
+ * @param {string} command
+ * @param {{
+ *   cwd?: string;
+ *   input?: string | Buffer | TypedArray | DataView;
+ *   stdio?: string | Array;
+ *   env?: Object;
+ *   shell?: string;
+ *   uid?: number;
+ *   gid?: number;
+ *   timeout?: number;
+ *   killSignal?: string | number;
+ *   maxBuffer?: number;
+ *   encoding?: string;
+ *   windowsHide?: boolean;
+ *   }} [options]
+ * @returns {Buffer | string}
+ */
 function execSync(command, options) {
   const opts = normalizeExecArgs(command, options, null);
   const inheritStderr = !opts.options.stdio;


### PR DESCRIPTION
Added JSDoc typings for the `child_process` lib module.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
