### PR TITLE
typings: add typing for string decoder

### DIFF
--- a/lib/string_decoder.js
+++ b/lib/string_decoder.js
@@ -54,7 +54,8 @@ const kNativeDecoder = Symbol('kNativeDecoder');
 /**
  *
  * @param {string} enc
- * @returns {"utf8" | "utf16le" | "hex" | "ascii" | "base64" | "latin1" | "base64url"}
+ * @returns {"utf8" | "utf16le" | "hex" | "ascii"
+ *           | "base64" | "latin1" | "base64url"}
  */
 function normalizeEncoding(enc) {
   const nenc = internalUtil.normalizeEncoding(enc);

--- a/lib/string_decoder.js
+++ b/lib/string_decoder.js
@@ -51,6 +51,11 @@ const kNativeDecoder = Symbol('kNativeDecoder');
 
 // Do not cache `Buffer.isEncoding` when checking encoding names as some
 // modules monkey-patch it to support additional encodings
+/**
+ *
+ * @param {string} enc
+ * @returns {"utf8" | "utf16le" | "hex" | "ascii" | "base64" | "latin1" | "base64url"}
+ */
 function normalizeEncoding(enc) {
   const nenc = internalUtil.normalizeEncoding(enc);
   if (nenc === undefined) {
@@ -68,12 +73,21 @@ for (let i = 0; i < encodings.length; ++i)
 // StringDecoder provides an interface for efficiently splitting a series of
 // buffers into a series of JS strings without breaking apart multi-byte
 // characters.
+/**
+ *
+ * @param {string} encoding
+ */
 function StringDecoder(encoding) {
   this.encoding = normalizeEncoding(encoding);
   this[kNativeDecoder] = Buffer.alloc(kSize);
   this[kNativeDecoder][kEncodingField] = encodingsMap[this.encoding];
 }
 
+/**
+ *
+ * @param {string | Buffer | TypedArray | DataView} buf
+ * @returns {string}
+ */
 StringDecoder.prototype.write = function write(buf) {
   if (typeof buf === 'string')
     return buf;
@@ -84,6 +98,11 @@ StringDecoder.prototype.write = function write(buf) {
   return decode(this[kNativeDecoder], buf);
 };
 
+/**
+ *
+ * @param {string | Buffer | TypedArray | DataView} buf
+ * @returns {string}
+ */
 StringDecoder.prototype.end = function end(buf) {
   let ret = '';
   if (buf !== undefined)
@@ -94,6 +113,12 @@ StringDecoder.prototype.end = function end(buf) {
 };
 
 /* Everything below this line is undocumented legacy stuff. */
+/**
+ *
+ * @param {string | Buffer | TypedArray | DataView} buf
+ * @param {number} offset
+ * @returns {string}
+ */
 StringDecoder.prototype.text = function text(buf, offset) {
   this[kNativeDecoder][kMissingBytes] = 0;
   this[kNativeDecoder][kBufferedBytes] = 0;

--- a/lib/string_decoder.js
+++ b/lib/string_decoder.js
@@ -78,7 +78,7 @@ for (let i = 0; i < encodings.length; ++i)
  * buffers into a series of JS strings without breaking apart multi-byte
  * characters.
  *
- * @param {string} encoding
+ * @param {string} [encoding=utf-8]
  */
 function StringDecoder(encoding) {
   this.encoding = normalizeEncoding(encoding);
@@ -109,7 +109,7 @@ StringDecoder.prototype.write = function write(buf) {
  * After end() is called, the stringDecoder object can be reused for new
  * input.
  *
- * @param {string | Buffer | TypedArray | DataView} buf
+ * @param {string | Buffer | TypedArray | DataView} [buf]
  * @returns {string}
  */
 StringDecoder.prototype.end = function end(buf) {

--- a/lib/string_decoder.js
+++ b/lib/string_decoder.js
@@ -52,10 +52,12 @@ const kNativeDecoder = Symbol('kNativeDecoder');
 // Do not cache `Buffer.isEncoding` when checking encoding names as some
 // modules monkey-patch it to support additional encodings
 /**
+ * Normalize encoding notation
  *
  * @param {string} enc
  * @returns {"utf8" | "utf16le" | "hex" | "ascii"
  *           | "base64" | "latin1" | "base64url"}
+ * @throws {TypeError} Throws an error when encoding is invalid
  */
 function normalizeEncoding(enc) {
   const nenc = internalUtil.normalizeEncoding(enc);
@@ -71,10 +73,10 @@ const encodingsMap = {};
 for (let i = 0; i < encodings.length; ++i)
   encodingsMap[encodings[i]] = i;
 
-// StringDecoder provides an interface for efficiently splitting a series of
-// buffers into a series of JS strings without breaking apart multi-byte
-// characters.
 /**
+ * StringDecoder provides an interface for efficiently splitting a series of
+ * buffers into a series of JS strings without breaking apart multi-byte
+ * characters.
  *
  * @param {string} encoding
  */
@@ -85,9 +87,12 @@ function StringDecoder(encoding) {
 }
 
 /**
+ * Returns a decoded string, omitting any incomplete multi-bytes
+ * characters at the end of the Buffer, or TypedArray, or DataView
  *
  * @param {string | Buffer | TypedArray | DataView} buf
  * @returns {string}
+ * @throws {TypeError} Throws when buf is not in one of supported types
  */
 StringDecoder.prototype.write = function write(buf) {
   if (typeof buf === 'string')
@@ -100,6 +105,9 @@ StringDecoder.prototype.write = function write(buf) {
 };
 
 /**
+ * Returns any remaining input stored in the internal buffer as a string.
+ * After end() is called, the stringDecoder object can be reused for new
+ * input.
  *
  * @param {string | Buffer | TypedArray | DataView} buf
  * @returns {string}


### PR DESCRIPTION
This PR adds some JSDoc typings for internal/string_decoder.

Screenshots from my VS code:

`normalizeEncoding`
![Screen Shot 2021-04-13 at 23 35 26](https://user-images.githubusercontent.com/6264033/114579933-f1cf3d80-9cb0-11eb-94b4-e461da30aefb.png)

`StringDecoder`
![Screen Shot 2021-04-13 at 23 36 31](https://user-images.githubusercontent.com/6264033/114580037-162b1a00-9cb1-11eb-8872-04fa0d9fbe2c.png)

`StringDecoder.prototype.write`
![Screen Shot 2021-04-13 at 23 37 00](https://user-images.githubusercontent.com/6264033/114580101-27742680-9cb1-11eb-9eb1-c23b77c1397d.png)

`StringDecoder.prototype.end`
![Screen Shot 2021-04-13 at 23 38 24](https://user-images.githubusercontent.com/6264033/114580343-59858880-9cb1-11eb-91cb-c090aba79a06.png)


`StringDecoder.prototype.text`
![Screen Shot 2021-04-13 at 23 37 34](https://user-images.githubusercontent.com/6264033/114580205-3c50ba00-9cb1-11eb-8c55-60df65cfe633.png)

