### PR TITLE
lib: enforce using `primordials.globalThis` instead of `global`

### DIFF
--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -29,6 +29,8 @@ rules:
     - error
     - name: globalThis
       message: "Use `const { globalThis } = primordials;` instead of the global."
+    - name: global
+      message: "Use `const { globalThis } = primordials;` instead of `global`."
   # Custom rules in tools/eslint-rules
   node-core/lowercase-name-for-primitive: error
   node-core/non-ascii-character: error

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -49,6 +49,7 @@ const {
   ReflectGet,
   ReflectSet,
   SymbolToStringTag,
+  globalThis,
 } = primordials;
 const config = internalBinding('config');
 const { deprecate } = require('internal/util');
@@ -189,61 +190,62 @@ if (!config.noBrowserGlobals) {
   // Override global console from the one provided by the VM
   // to the one implemented by Node.js
   // https://console.spec.whatwg.org/#console-namespace
-  exposeNamespace(global, 'console', createGlobalConsole(global.console));
+  exposeNamespace(globalThis, 'console',
+                  createGlobalConsole(globalThis.console));
 
   const { URL, URLSearchParams } = require('internal/url');
   // https://url.spec.whatwg.org/#url
-  exposeInterface(global, 'URL', URL);
+  exposeInterface(globalThis, 'URL', URL);
   // https://url.spec.whatwg.org/#urlsearchparams
-  exposeInterface(global, 'URLSearchParams', URLSearchParams);
+  exposeInterface(globalThis, 'URLSearchParams', URLSearchParams);
 
   const {
     TextEncoder, TextDecoder
   } = require('internal/encoding');
   // https://encoding.spec.whatwg.org/#textencoder
-  exposeInterface(global, 'TextEncoder', TextEncoder);
+  exposeInterface(globalThis, 'TextEncoder', TextEncoder);
   // https://encoding.spec.whatwg.org/#textdecoder
-  exposeInterface(global, 'TextDecoder', TextDecoder);
+  exposeInterface(globalThis, 'TextDecoder', TextDecoder);
 
   const {
     AbortController,
     AbortSignal,
   } = require('internal/abort_controller');
-  exposeInterface(global, 'AbortController', AbortController);
-  exposeInterface(global, 'AbortSignal', AbortSignal);
+  exposeInterface(globalThis, 'AbortController', AbortController);
+  exposeInterface(globalThis, 'AbortSignal', AbortSignal);
 
   const {
     EventTarget,
     Event,
   } = require('internal/event_target');
-  exposeInterface(global, 'EventTarget', EventTarget);
-  exposeInterface(global, 'Event', Event);
+  exposeInterface(globalThis, 'EventTarget', EventTarget);
+  exposeInterface(globalThis, 'Event', Event);
   const {
     MessageChannel,
     MessagePort,
     MessageEvent,
   } = require('internal/worker/io');
-  exposeInterface(global, 'MessageChannel', MessageChannel);
-  exposeInterface(global, 'MessagePort', MessagePort);
-  exposeInterface(global, 'MessageEvent', MessageEvent);
+  exposeInterface(globalThis, 'MessageChannel', MessageChannel);
+  exposeInterface(globalThis, 'MessagePort', MessagePort);
+  exposeInterface(globalThis, 'MessageEvent', MessageEvent);
 
   // https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope
   const timers = require('timers');
-  defineOperation(global, 'clearInterval', timers.clearInterval);
-  defineOperation(global, 'clearTimeout', timers.clearTimeout);
-  defineOperation(global, 'setInterval', timers.setInterval);
-  defineOperation(global, 'setTimeout', timers.setTimeout);
+  defineOperation(globalThis, 'clearInterval', timers.clearInterval);
+  defineOperation(globalThis, 'clearTimeout', timers.clearTimeout);
+  defineOperation(globalThis, 'setInterval', timers.setInterval);
+  defineOperation(globalThis, 'setTimeout', timers.setTimeout);
 
-  defineOperation(global, 'queueMicrotask', queueMicrotask);
+  defineOperation(globalThis, 'queueMicrotask', queueMicrotask);
 
-  defineLazyGlobal(global, 'performance', () => {
+  defineLazyGlobal(globalThis, 'performance', () => {
     const { performance } = require('perf_hooks');
     return performance;
   });
 
   // Non-standard extensions:
-  defineOperation(global, 'clearImmediate', timers.clearImmediate);
-  defineOperation(global, 'setImmediate', timers.setImmediate);
+  defineOperation(globalThis, 'clearImmediate', timers.clearImmediate);
+  defineOperation(globalThis, 'setImmediate', timers.setImmediate);
 }
 
 // Set the per-Environment callback that will be called
@@ -388,7 +390,7 @@ function setupProcessObject() {
     value: 'process'
   });
   // Make process globally available to users by putting it on the global proxy
-  ObjectDefineProperty(global, 'process', {
+  ObjectDefineProperty(globalThis, 'process', {
     value: process,
     enumerable: false,
     writable: true,
@@ -397,7 +399,7 @@ function setupProcessObject() {
 }
 
 function setupGlobalProxy() {
-  ObjectDefineProperty(global, SymbolToStringTag, {
+  ObjectDefineProperty(globalThis, SymbolToStringTag, {
     value: 'global',
     writable: false,
     enumerable: false,
@@ -418,7 +420,7 @@ function setupBuffer() {
   delete bufferBinding.setBufferPrototype;
   delete bufferBinding.zeroFill;
 
-  ObjectDefineProperties(global, {
+  ObjectDefineProperties(globalThis, {
     'Buffer': {
       value: Buffer,
       enumerable: false,

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -6,6 +6,7 @@ const {
   SafeMap,
   SafeWeakMap,
   StringPrototypeStartsWith,
+  globalThis,
 } = primordials;
 
 const {
@@ -302,7 +303,7 @@ function initializeDeprecations() {
   // deprecation path for these in ES Modules.
   // See https://github.com/nodejs/node/pull/26334.
   let _process = process;
-  ObjectDefineProperty(global, 'process', {
+  ObjectDefineProperty(globalThis, 'process', {
     get() {
       return _process;
     },
@@ -314,7 +315,7 @@ function initializeDeprecations() {
   });
 
   let _Buffer = Buffer;
-  ObjectDefineProperty(global, 'Buffer', {
+  ObjectDefineProperty(globalThis, 'Buffer', {
     get() {
       return _Buffer;
     },

--- a/lib/internal/main/eval_string.js
+++ b/lib/internal/main/eval_string.js
@@ -4,6 +4,10 @@
 // `--interactive`.
 
 const {
+  globalThis,
+} = primordials;
+
+const {
   prepareMainThreadExecution
 } = require('internal/bootstrap/pre_execution');
 const { evalModule, evalScript } = require('internal/process/execution');
@@ -12,7 +16,7 @@ const { addBuiltinLibsToObject } = require('internal/modules/cjs/helpers');
 const { getOptionValue } = require('internal/options');
 
 prepareMainThreadExecution();
-addBuiltinLibsToObject(global);
+addBuiltinLibsToObject(globalThis);
 markBootstrapComplete();
 
 const source = getOptionValue('--eval');

--- a/lib/internal/per_context/primordials.js
+++ b/lib/internal/per_context/primordials.js
@@ -155,6 +155,7 @@ function copyPrototype(src, dest, prefix) {
   'Math',
   'Reflect',
 ].forEach((name) => {
+  // eslint-disable-next-line no-restricted-globals
   copyPropsRenamed(global[name], primordials, name);
 });
 
@@ -198,6 +199,7 @@ function copyPrototype(src, dest, prefix) {
   'WeakRef',
   'WeakSet',
 ].forEach((name) => {
+  // eslint-disable-next-line no-restricted-globals
   const original = global[name];
   primordials[name] = original;
   copyPropsRenamed(original, primordials, name);
@@ -210,6 +212,7 @@ function copyPrototype(src, dest, prefix) {
 [
   'Promise',
 ].forEach((name) => {
+  // eslint-disable-next-line no-restricted-globals
   const original = global[name];
   primordials[name] = original;
   copyPropsRenamedBound(original, primordials, name);

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -74,6 +74,7 @@ const {
   TypedArrayPrototypeGetLength,
   TypedArrayPrototypeGetSymbolToStringTag,
   Uint8Array,
+  globalThis,
   uncurryThis,
 } = primordials;
 
@@ -144,7 +145,7 @@ let hexSlice;
 
 const builtInObjects = new SafeSet(
   ArrayPrototypeFilter(
-    ObjectGetOwnPropertyNames(global),
+    ObjectGetOwnPropertyNames(globalThis),
     (e) => RegExpPrototypeTest(/^[A-Z][a-zA-Z0-9]+$/, e)
   )
 );

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -98,6 +98,7 @@ const {
   Symbol,
   SyntaxError,
   SyntaxErrorPrototype,
+  globalThis,
 } = primordials;
 
 const {
@@ -1009,7 +1010,7 @@ REPLServer.prototype.close = function close() {
 REPLServer.prototype.createContext = function() {
   let context;
   if (this.useGlobal) {
-    context = global;
+    context = globalThis;
   } else {
     sendInspectorCommand((session) => {
       session.post('Runtime.enable');
@@ -1021,11 +1022,11 @@ REPLServer.prototype.createContext = function() {
     }, () => {
       context = vm.createContext();
     });
-    ArrayPrototypeForEach(ObjectGetOwnPropertyNames(global), (name) => {
+    ArrayPrototypeForEach(ObjectGetOwnPropertyNames(globalThis), (name) => {
       // Only set properties that do not already exist as a global builtin.
       if (!globalBuiltins.has(name)) {
         ObjectDefineProperty(context, name,
-                             ObjectGetOwnPropertyDescriptor(global, name));
+                             ObjectGetOwnPropertyDescriptor(globalThis, name));
       }
     });
     context.global = context;


### PR DESCRIPTION
`global.global` may be overwritten in user-land, it's probably safer not to rely on it.

```
$ echo 'Reflect.defineProperty(globalThis, "global", { get() {throw new Error} })' > pre.js
$ node -r ./pre.js
Welcome to Node.js v15.12.0.
Type ".help" for more information.
/Users/duhamean/Documents/node/f.js:2
  get() {throw new Error}
               ^

Error
    at get (…/pre.js:1:61)
    at REPLServer.createContext (node:repl:1011:5)
    at REPLServer.resetContext (node:repl:1059:23)
    at new REPLServer (node:repl:720:8)
    at Object.start (node:repl:982:10)
    at Object.createRepl [as createInternalRepl] (node:internal/repl:51:21)
    at node:internal/main/repl:41:13
    at Object.loadESM (node:internal/process/esm_loader:68:11)
```
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
