### PR TITLE
build: allow `make doc-only` without python installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -772,9 +772,11 @@ docclean:
 	$(RM) -r out/doc
 	$(RM) "$(VERSIONS_DATA)"
 
-RAWVER=$(shell $(PYTHON) tools/getnodeversion.py)
-VERSION=v$(RAWVER)
-CHANGELOG=doc/changelogs/CHANGELOG_V$(firstword $(subst ., ,$(RAWVER))).md
+RAWVER_MAJOR := $(shell sed -n 's:^\#define NODE_MAJOR_VERSION ::p' src/node_version.h)
+RAWVER_MINOR := $(shell sed -n 's:^\#define NODE_MINOR_VERSION ::p' src/node_version.h)
+RAWVER_PATCH := $(shell sed -n 's:^\#define NODE_PATCH_VERSION ::p' src/node_version.h)
+VERSION := v$(RAWVER_MAJOR).$(RAWVER_MINOR).$(RAWVER_PATCH)
+CHANGELOG := doc/changelogs/CHANGELOG_V$(RAWVER_MAJOR).md
 
 # For nightly builds, you must set DISTTYPE to "nightly", "next-nightly" or
 # "custom". For the nightly and next-nightly case, you need to set DATESTRING


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This is a minor and in a way silly PR. It replaces a call to python script for extracting version numbers from `node_version.h` with 3 calls to sed in Makefile.

I happened to run `make doc-only` without python available. There were some "python not found" error messages, but the make proceeded and eventually produced the documentation. The only issue with it was that version number was missing in the title: "Node.js v documentation".

I'm aware python is a build dependency for node. I just thought if `doc-only` does not fail to build the docs without python, it might as well include the version number.
