### PR TITLE
test: fixup failing test/internet/test-dns.js

### DIFF
--- a/test/internet/test-dns.js
+++ b/test/internet/test-dns.js
@@ -91,7 +91,7 @@ TEST(async function test_resolve4_ttl(done) {
       assert.strictEqual(typeof item, 'object');
       assert.strictEqual(typeof item.ttl, 'number');
       assert.strictEqual(typeof item.address, 'string');
-      assert.ok(item.ttl > 0);
+      assert.ok(item.ttl >= 0);
       assert.ok(isIPv4(item.address));
     }
   }
@@ -119,7 +119,7 @@ TEST(async function test_resolve6_ttl(done) {
       assert.strictEqual(typeof item, 'object');
       assert.strictEqual(typeof item.ttl, 'number');
       assert.strictEqual(typeof item.address, 'string');
-      assert.ok(item.ttl > 0);
+      assert.ok(item.ttl >= 0);
       assert.ok(isIPv6(item.address));
     }
   }


### PR DESCRIPTION
The `ttl` for the `nodejs.org` DNS record is returning `0` currently. The test checks for `> 0`, causing the test to fail.

Signed-off-by: James M Snell <jasnell@gmail.com>


