### PR TITLE
doc: fix typo in buffer.md

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -350,7 +350,7 @@ added: v15.7.0
 * `type` {string} The content-type for the new `Blob`
 
 Creates and returns a new `Blob` containing a subset of this `Blob` objects
-data. The original `Blob` is not alterered.
+data. The original `Blob` is not altered.
 
 ### `blob.text()`
 <!-- YAML


### PR DESCRIPTION
I found a typo in buffer documentation :

alterered -> altered