### PR TITLE
Revert "timers: refactor to use optional chaining"

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -171,7 +171,7 @@ ObjectDefineProperty(setTimeout, customPromisify, {
 });
 
 function clearTimeout(timer) {
-  if (timer?._onTimeout) {
+  if (timer && timer._onTimeout) {
     timer._onTimeout = null;
     unenroll(timer);
     return;

--- a/lib/timers/promises.js
+++ b/lib/timers/promises.js
@@ -53,7 +53,10 @@ function setTimeout(after, value, options = {}) {
         'boolean',
         ref));
   }
-  if (signal?.aborted) {
+  // TODO(@jasnell): If a decision is made that this cannot be backported
+  // to 12.x, then this can be converted to use optional chaining to
+  // simplify the check.
+  if (signal && signal.aborted) {
     return PromiseReject(new AbortError());
   }
   let oncancel;
@@ -95,7 +98,10 @@ function setImmediate(value, options = {}) {
         'boolean',
         ref));
   }
-  if (signal?.aborted) {
+  // TODO(@jasnell): If a decision is made that this cannot be backported
+  // to 12.x, then this can be converted to use optional chaining to
+  // simplify the check.
+  if (signal && signal.aborted) {
     return PromiseReject(new AbortError());
   }
   let oncancel;


### PR DESCRIPTION
This reverts commit d8f535b0259db91124a14b689cb2514977de6045.

As part of https://github.com/nodejs/node/issues/37937, I tracked down a regression introduced by https://github.com/nodejs/node/pull/36767.

With optional chaining:

![Screenshot 2021-04-15 at 12 07 40](https://user-images.githubusercontent.com/52195/114853121-c26d1d80-9de3-11eb-8bf7-1ce694c7e41e.png)

Without optional chanining:

![Screenshot 2021-04-15 at 12 07 51](https://user-images.githubusercontent.com/52195/114853117-c13bf080-9de3-11eb-8af0-5a68fed56604.png)

This sits in the hot path for HTTP.

---

I will recommend caution in adopting optional chaining in other areas of the Node.js.