### PR TITLE
net: make readyState to be closed if socket is not opened

### DIFF
--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -1115,6 +1115,10 @@ information.
 ### `socket.readyState`
 <!-- YAML
 added: v0.5.0
+changes:
+  - version: REPLACEME
+    pr-url: REPLACEME
+    description: When stream is not opened, reading it will be `closed`.
 -->
 
 * {string}
@@ -1125,6 +1129,8 @@ This property represents the state of the connection as a string.
 * If the stream is readable and writable, it is `open`.
 * If the stream is readable and not writable, it is `readOnly`.
 * If the stream is not readable and writable, it is `writeOnly`.
+* If the stream is not opened or is neither readable nor writable, it is
+  `closed`.
 
 ## `net.connect()`
 

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -1118,19 +1118,19 @@ added: v0.5.0
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/38249
-    description: When stream is not opened, reading it will be `closed`.
+    description: When socket is not opened, reading it will be `closed`.
 -->
 
 * {string}
 
 This property represents the state of the connection as a string.
 
-* If the stream is connecting `socket.readyState` is `opening`.
-* If the stream is readable and writable, it is `open`.
-* If the stream is readable and not writable, it is `readOnly`.
-* If the stream is not readable and writable, it is `writeOnly`.
-* If the stream is not opened or is neither readable nor writable, it is
-  `closed`.
+* If the socket is connecting `socket.readyState` is `opening`.
+* If the socket is readable and writable, it is `open`.
+* If the socket is readable and not writable, it is `readOnly`.
+* If the socket is not readable and writable, it is `writeOnly`.
+* If the socket is not connecting, connected or is otherwise neither
+  readable nor writable, it is `closed`.
 
 ## `net.connect()`
 

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -1118,7 +1118,8 @@ added: v0.5.0
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/38249
-    description: When socket is not opened, reading it will be `closed`.
+    description: When socket is not connecting, connected or is otherwise
+      neither readable nor writable, it is `closed`.
 -->
 
 * {string}

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -1117,7 +1117,7 @@ information.
 added: v0.5.0
 changes:
   - version: REPLACEME
-    pr-url: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/38249
     description: When stream is not opened, reading it will be `closed`.
 -->
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -536,8 +536,8 @@ ObjectDefineProperty(Socket.prototype, 'readyState', {
   get: function() {
     if (this.connecting) {
       return 'opening';
-    } else if(this.pending) {
-      return "closed";
+    } else if (this.pending) {
+      return 'closed';
     } else if (this.readable && this.writable) {
       return 'open';
     } else if (this.readable && !this.writable) {

--- a/lib/net.js
+++ b/lib/net.js
@@ -536,6 +536,8 @@ ObjectDefineProperty(Socket.prototype, 'readyState', {
   get: function() {
     if (this.connecting) {
       return 'opening';
+    } else if(this.pending) {
+      return "closed";
     } else if (this.readable && this.writable) {
       return 'open';
     } else if (this.readable && !this.writable) {

--- a/test/parallel/test-net-connect-buffer.js
+++ b/test/parallel/test-net-connect-buffer.js
@@ -45,6 +45,7 @@ tcp.listen(0, common.mustCall(function() {
 
   let connected = false;
   assert.strictEqual(socket.pending, true);
+  assert.strictEqual(socket.readyState, 'closed');
   socket.connect(this.address().port, common.mustCall(() => connected = true));
 
   assert.strictEqual(socket.pending, true);


### PR DESCRIPTION
This PR sets `Socket.readyState` to `closed`, when socket is not opened (still `pending` but not `connecting`). 

Currently, `Socket.readyState` is `open` before socket is connected to a peer. It can be somehow confusing for users.

Fixes: https://github.com/nodejs/node/issues/38247