### PR TITLE
fs: add aggregate errors to fsPromises to avoid error swallowing

### DIFF
--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -10,6 +10,7 @@ const {
   PromisePrototypeFinally,
   PromisePrototypeThen,
   PromiseResolve,
+  PromiseReject,
   SafeArrayIterator,
   Symbol,
   Uint8Array,
@@ -33,6 +34,7 @@ const {
     ERR_METHOD_NOT_IMPLEMENTED,
   },
   AbortError,
+  aggregateTwoErrors,
 } = require('internal/errors');
 const { isArrayBufferView } = require('internal/util/types');
 const { rimrafPromises } = require('internal/fs/rimraf');
@@ -248,6 +250,19 @@ class FileHandle extends EventEmitterMixin(JSTransferable) {
       );
     }
   }
+}
+
+async function handleFdClose(fileOpPromise, closeFunc) {
+  return PromisePrototypeThen(
+    fileOpPromise,
+    (result) => PromisePrototypeThen(closeFunc(), () => result),
+    (opError) =>
+      PromisePrototypeThen(
+        closeFunc(),
+        () => PromiseReject(opError),
+        (closeError) => PromiseReject(aggregateTwoErrors(closeError, opError))
+      )
+  );
 }
 
 async function fsCall(fn, handle, ...args) {
@@ -501,7 +516,7 @@ async function rename(oldPath, newPath) {
 
 async function truncate(path, len = 0) {
   const fd = await open(path, 'r+');
-  return PromisePrototypeFinally(ftruncate(fd, len), fd.close);
+  return handleFdClose(ftruncate(fd, len), fd.close);
 }
 
 async function ftruncate(handle, len = 0) {
@@ -632,7 +647,7 @@ async function lchmod(path, mode) {
     throw new ERR_METHOD_NOT_IMPLEMENTED('lchmod()');
 
   const fd = await open(path, O_WRONLY | O_SYMLINK);
-  return PromisePrototypeFinally(fchmod(fd, mode), fd.close);
+  return handleFdClose(fchmod(fd, mode), fd.close);
 }
 
 async function lchown(path, uid, gid) {
@@ -711,7 +726,7 @@ async function writeFile(path, data, options) {
   checkAborted(options.signal);
 
   const fd = await open(path, flag, options.mode);
-  return PromisePrototypeFinally(
+  return handleFdClose(
     writeFileHandle(fd, data, options.signal, options.encoding), fd.close);
 }
 
@@ -736,7 +751,7 @@ async function readFile(path, options) {
   checkAborted(options.signal);
 
   const fd = await open(path, flag, 0o666);
-  return PromisePrototypeFinally(readFileHandle(fd, options), fd.close);
+  return handleFdClose(readFileHandle(fd, options), fd.close);
 }
 
 module.exports = {

--- a/test/parallel/test-fs-promises-file-handle-aggregate-errors.js
+++ b/test/parallel/test-fs-promises-file-handle-aggregate-errors.js
@@ -50,12 +50,13 @@ async function checkAggregateError(op) {
       }
     });
 
-    await op(filePath).catch(common.mustCall((err) => {
-      assert.strictEqual(err.constructor.name, 'AggregateError');
+    await assert.rejects(op(filePath), common.mustCall((err) => {
+      assert.strictEqual(err.name, 'AggregateError');
       assert.strictEqual(err.code, 123);
       assert.strictEqual(err.errors.length, 2);
       assert.strictEqual(err.errors[0].message, 'INTERNAL_ERROR');
       assert.strictEqual(err.errors[1].message, 'CLOSE_ERROR');
+      return true;
     }));
   } finally {
     Object.defineProperty(FileHandle.prototype, 'fd', originalFd);

--- a/test/parallel/test-fs-promises-file-handle-aggregate-errors.js
+++ b/test/parallel/test-fs-promises-file-handle-aggregate-errors.js
@@ -1,0 +1,72 @@
+'use strict';
+// Flags: --expose-internals
+
+const common = require('../common');
+const tmpdir = require('../common/tmpdir');
+
+// The following tests validate aggregate errors are thrown correctly
+// when both an operation and close throw.
+
+const fs = require('fs');
+const path = require('path');
+const {
+  readFile,
+  writeFile,
+  truncate,
+  lchmod,
+} = fs.promises;
+const {
+  FileHandle,
+} = require('internal/fs/promises');
+
+const assert = require('assert');
+const originalFd = Object.getOwnPropertyDescriptor(FileHandle.prototype, 'fd');
+
+let count = 0;
+async function createFile() {
+  const filePath = path.join(tmpdir.path, `aggregate_errors_${++count}.txt`);
+  await writeFile(filePath, 'content');
+  return filePath;
+}
+
+async function checkAggregateError(op) {
+  try {
+    const filePath = await createFile();
+    Object.defineProperty(FileHandle.prototype, 'fd', {
+      get: function() {
+        // Close is set by using a setter,
+        // so it needs to be set on the instance.
+        const originalClose = this.close;
+        this.close = async () => {
+          // close the file
+          await originalClose.call(this);
+          const closeError = new Error('CLOSE_ERROR');
+          closeError.code = 456;
+          throw closeError;
+        };
+        const opError = new Error('INTERNAL_ERROR');
+        opError.code = 123;
+        throw opError;
+      }
+    });
+
+    await op(filePath).catch(common.mustCall((err) => {
+      assert.strictEqual(err.constructor.name, 'AggregateError');
+      assert.strictEqual(err.code, 123);
+      assert.strictEqual(err.errors.length, 2);
+      assert.strictEqual(err.errors[0].message, 'INTERNAL_ERROR');
+      assert.strictEqual(err.errors[1].message, 'CLOSE_ERROR');
+    }));
+  } finally {
+    Object.defineProperty(FileHandle.prototype, 'fd', originalFd);
+  }
+}
+(async function() {
+  tmpdir.refresh();
+  await checkAggregateError((filePath) => truncate(filePath));
+  await checkAggregateError((filePath) => readFile(filePath));
+  await checkAggregateError((filePath) => writeFile(filePath, '123'));
+  if (common.isOSX) {
+    await checkAggregateError((filePath) => lchmod(filePath, 0o777));
+  }
+})().then(common.mustCall());

--- a/test/parallel/test-fs-promises-file-handle-aggregate-errors.js
+++ b/test/parallel/test-fs-promises-file-handle-aggregate-errors.js
@@ -7,14 +7,13 @@ const tmpdir = require('../common/tmpdir');
 // The following tests validate aggregate errors are thrown correctly
 // when both an operation and close throw.
 
-const fs = require('fs');
 const path = require('path');
 const {
   readFile,
   writeFile,
   truncate,
   lchmod,
-} = fs.promises;
+} = require('fs/promises');
 const {
   FileHandle,
 } = require('internal/fs/promises');

--- a/test/parallel/test-fs-promises-file-handle-close-errors.js
+++ b/test/parallel/test-fs-promises-file-handle-close-errors.js
@@ -1,0 +1,68 @@
+'use strict';
+// Flags: --expose-internals
+
+const common = require('../common');
+const tmpdir = require('../common/tmpdir');
+
+// The following tests validate aggregate errors are thrown correctly
+// when both an operation and close throw.
+
+const fs = require('fs');
+const path = require('path');
+const {
+  readFile,
+  writeFile,
+  truncate,
+  lchmod,
+} = fs.promises;
+const {
+  FileHandle,
+} = require('internal/fs/promises');
+
+const assert = require('assert');
+const originalFd = Object.getOwnPropertyDescriptor(FileHandle.prototype, 'fd');
+
+let count = 0;
+async function createFile() {
+  const filePath = path.join(tmpdir.path, `close_errors_${++count}.txt`);
+  await writeFile(filePath, 'content');
+  return filePath;
+}
+
+async function checkAggregateError(op) {
+  try {
+    const filePath = await createFile();
+    Object.defineProperty(FileHandle.prototype, 'fd', {
+      get: function() {
+        // Close is set by using a setter,
+        // so it needs to be set on the instance.
+        const originalClose = this.close;
+        this.close = async () => {
+          // close the file
+          await originalClose.call(this);
+          const closeError = new Error('CLOSE_ERROR');
+          closeError.code = 456;
+          throw closeError;
+        };
+        return originalFd.get.call(this);
+      }
+    });
+
+    await op(filePath).catch(common.mustCall((err) => {
+      assert.strictEqual(err.constructor.name, 'Error');
+      assert.strictEqual(err.message, 'CLOSE_ERROR');
+      assert.strictEqual(err.code, 456);
+    }));
+  } finally {
+    Object.defineProperty(FileHandle.prototype, 'fd', originalFd);
+  }
+}
+(async function() {
+  tmpdir.refresh();
+  await checkAggregateError((filePath) => truncate(filePath));
+  await checkAggregateError((filePath) => readFile(filePath));
+  await checkAggregateError((filePath) => writeFile(filePath, '123'));
+  if (common.isOSX) {
+    await checkAggregateError((filePath) => lchmod(filePath, 0o777));
+  }
+})().then(common.mustCall());

--- a/test/parallel/test-fs-promises-file-handle-close-errors.js
+++ b/test/parallel/test-fs-promises-file-handle-close-errors.js
@@ -7,14 +7,13 @@ const tmpdir = require('../common/tmpdir');
 // The following tests validate aggregate errors are thrown correctly
 // when both an operation and close throw.
 
-const fs = require('fs');
 const path = require('path');
 const {
   readFile,
   writeFile,
   truncate,
   lchmod,
-} = fs.promises;
+} = require('fs/promises');
 const {
   FileHandle,
 } = require('internal/fs/promises');

--- a/test/parallel/test-fs-promises-file-handle-op-errors.js
+++ b/test/parallel/test-fs-promises-file-handle-op-errors.js
@@ -7,14 +7,13 @@ const tmpdir = require('../common/tmpdir');
 // The following tests validate aggregate errors are thrown correctly
 // when both an operation and close throw.
 
-const fs = require('fs');
 const path = require('path');
 const {
   readFile,
   writeFile,
   truncate,
   lchmod,
-} = fs.promises;
+} = require('fs/promises');
 const {
   FileHandle,
 } = require('internal/fs/promises');

--- a/test/parallel/test-fs-promises-file-handle-op-errors.js
+++ b/test/parallel/test-fs-promises-file-handle-op-errors.js
@@ -1,0 +1,66 @@
+'use strict';
+// Flags: --expose-internals
+
+const common = require('../common');
+const tmpdir = require('../common/tmpdir');
+
+// The following tests validate aggregate errors are thrown correctly
+// when both an operation and close throw.
+
+const fs = require('fs');
+const path = require('path');
+const {
+  readFile,
+  writeFile,
+  truncate,
+  lchmod,
+} = fs.promises;
+const {
+  FileHandle,
+} = require('internal/fs/promises');
+
+const assert = require('assert');
+const originalFd = Object.getOwnPropertyDescriptor(FileHandle.prototype, 'fd');
+
+let count = 0;
+async function createFile() {
+  const filePath = path.join(tmpdir.path, `op_errors_${++count}.txt`);
+  await writeFile(filePath, 'content');
+  return filePath;
+}
+
+async function checkAggregateError(op) {
+  try {
+    const filePath = await createFile();
+    Object.defineProperty(FileHandle.prototype, 'fd', {
+      get: function() {
+        // Close is set by using a setter,
+        // so it needs to be set on the instance.
+        const originalClose = this.close;
+        this.close = common.mustCall(function(...args) {
+          return originalClose.apply(this, args);
+        });
+        const opError = new Error('INTERNAL_ERROR');
+        opError.code = 123;
+        throw opError;
+      }
+    });
+
+    await op(filePath).catch(common.mustCall((err) => {
+      assert.strictEqual(err.constructor.name, 'Error');
+      assert.strictEqual(err.message, 'INTERNAL_ERROR');
+      assert.strictEqual(err.code, 123);
+    }));
+  } finally {
+    Object.defineProperty(FileHandle.prototype, 'fd', originalFd);
+  }
+}
+(async function() {
+  tmpdir.refresh();
+  await checkAggregateError((filePath) => truncate(filePath));
+  await checkAggregateError((filePath) => readFile(filePath));
+  await checkAggregateError((filePath) => writeFile(filePath, '123'));
+  if (common.isOSX) {
+    await checkAggregateError((filePath) => lchmod(filePath, 0o777));
+  }
+})().then(common.mustCall());


### PR DESCRIPTION
Add `AggregateError` support to fsPromises, instead of swallowing errors if `fd.close` throws and the operation threw as well. This PR adds this to truncate, lchmod, writeFile and readFile. Currently, before this PR, if `fd.close` and the operation both throw - you would only get the `close` error.

This is similar to what was done before in fs in https://github.com/nodejs/node/pull/37460.