### PR TITLE
tools: set arch in Distribution.xml

### DIFF
--- a/tools/macos-installer/productbuild/distribution.xml.tmpl
+++ b/tools/macos-installer/productbuild/distribution.xml.tmpl
@@ -6,7 +6,7 @@
     <background alignment="topleft" file="osx_installer_logo.png"/>
     <pkg-ref id="org.nodejs.node.pkg" auth="root"/>
     <pkg-ref id="org.nodejs.npm.pkg" auth="root"/>
-    <options customize="allow" require-scripts="false"/>
+    <options customize="allow" require-scripts="false" hostArchitectures="x86_64,arm64"/>
     <license file="license.rtf"/>
     <choices-outline>
       <line choice="org.nodejs.node.pkg" />


### PR DESCRIPTION
refs: https://github.com/nodejs/node/pull/37678#issuecomment-821179247

We overwrite the Distrbution.xml file inside the pkg which means
the pkg cannot be opened on apple silicon without rosetta
as it defaults to x86_64

