### PR TITLE
build: sync generation of `v8_build_config.json`

### DIFF
--- a/tools/v8_gypfiles/v8.gyp
+++ b/tools/v8_gypfiles/v8.gyp
@@ -1509,6 +1509,7 @@
           'variables': {
             'v8_dump_build_config_args': [
               '<(PRODUCT_DIR)/v8_build_config.json',
+              'current_cpu=<(v8_current_cpu)',
               'dcheck_always_on=<(dcheck_always_on)',
               'is_android=<(is_android)',
               'is_asan=<(asan)',
@@ -1517,20 +1518,30 @@
               'is_component_build=<(component)',
               'is_debug=<(CONFIGURATION_NAME)',
               # Not available in gyp.
+              'is_full_debug=0',
+              # Not available in gyp.
               'is_gcov_coverage=0',
               'is_msan=<(msan)',
               'is_tsan=<(tsan)',
               # Not available in gyp.
               'is_ubsan_vptr=0',
               'target_cpu=<(target_arch)',
+              'v8_current_cpu=<(v8_current_cpu)',
+              # Not available in gyp.
+              'v8_enable_atomic_marking_state=0',
+              # Not available in gyp.
+              'v8_enable_atomic_object_field_writes=0',
+              # Not available in gyp.
+              'v8_enable_concurrent_marking=0',
               'v8_enable_i18n_support=<(v8_enable_i18n_support)',
               'v8_enable_verify_predictable=<(v8_enable_verify_predictable)',
-              'v8_target_cpu=<(v8_target_arch)',
-              'v8_use_siphash=<(v8_use_siphash)',
               'v8_enable_verify_csa=<(v8_enable_verify_csa)',
               'v8_enable_lite_mode=<(v8_enable_lite_mode)',
               'v8_enable_pointer_compression=<(v8_enable_pointer_compression)',
               'v8_enable_webassembly=<(v8_enable_webassembly)',
+              # Not available in gyp.
+              'v8_control_flow_integrity=0',
+              'v8_target_cpu=<(v8_target_arch)',
             ]
           },
           'conditions': [


### PR DESCRIPTION
The contents of the `v8_build_config.json` file generated when
configured with `--enable-d8` is missing entries which prevent V8's
test runner from using the built `d8` binary. Sync the keys written
into the file with those generated in V8's [`deps/v8/BUILD.gn`](https://github.com/nodejs/node/blob/6d04cc684952ccbaa4a0cad36752a0f2bbaaa048/deps/v8/BUILD.gn#L1812-L1846) file.

Prior to this patch V8's test runner would fail to parse `v8_build_config.json`
as it was missing `v8_control_flow_integrity`:
```
$ python2 deps/v8/tools/run-tests.py --outdir ../../out/Release --progress=dots --timeout=120 mjsunit debugger message preparser
Traceback (most recent call last):
  File "/home/rlau/sandbox/github/node/deps/v8/tools/testrunner/base_runner.py", line 283, in execute
    self._load_build_config(options)
  File "/home/rlau/sandbox/github/node/deps/v8/tools/testrunner/base_runner.py", line 428, in _load_build_config
    self.build_config = _do_load_build_config(outdir, options.verbose)
  File "/home/rlau/sandbox/github/node/deps/v8/tools/testrunner/base_runner.py", line 253, in _do_load_build_config
    return BuildConfig(build_config_json)
  File "/home/rlau/sandbox/github/node/deps/v8/tools/testrunner/base_runner.py", line 173, in __init__
    self.control_flow_integrity = build_config['v8_control_flow_integrity']
KeyError: 'v8_control_flow_integrity'
```
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
