### PR TITLE
test: pass functions directly

### DIFF
--- a/test/js-native-api/test_error/test.js
+++ b/test/js-native-api/test_error/test.js
@@ -70,21 +70,21 @@ assert.throws(() => {
   ));
 
 assert.throws(
-  () => test_error.throwErrorCode(),
+  test_error.throwErrorCode,
   {
     code: 'ERR_TEST_CODE',
     message: 'Error [error]'
   });
 
 assert.throws(
-  () => test_error.throwRangeErrorCode(),
+  test_error.throwRangeErrorCode,
   {
     code: 'ERR_TEST_CODE',
     message: 'RangeError [range error]'
   });
 
 assert.throws(
-  () => test_error.throwTypeErrorCode(),
+  test_error.throwTypeErrorCode,
   {
     code: 'ERR_TEST_CODE',
     message: 'TypeError [type error]'

--- a/test/js-native-api/test_string/test.js
+++ b/test/js-native-api/test_string/test.js
@@ -70,16 +70,10 @@ assert.strictEqual(test_string.TestUtf16Insufficient(str6), str6.slice(0, 3));
 assert.strictEqual(test_string.Utf16Length(str6), 5);
 assert.strictEqual(test_string.Utf8Length(str6), 14);
 
-assert.throws(() => {
-  test_string.TestLargeUtf8();
-}, /^Error: Invalid argument$/);
+assert.throws(test_string.TestLargeUtf8, /^Error: Invalid argument$/);
 
-assert.throws(() => {
-  test_string.TestLargeLatin1();
-}, /^Error: Invalid argument$/);
+assert.throws(test_string.TestLargeLatin1, /^Error: Invalid argument$/);
 
-assert.throws(() => {
-  test_string.TestLargeUtf16();
-}, /^Error: Invalid argument$/);
+assert.throws(test_string.TestLargeUtf16, /^Error: Invalid argument$/);
 
 test_string.TestMemoryCorruption(' '.repeat(64 * 1024));


### PR DESCRIPTION
It would be better to pass the functions that doesn't require a parameter directly instead of nesting it inside another function.
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
