### PR TITLE
test: fix flaky test-dns and test-dns-lookup

### DIFF
--- a/test/common/internet.js
+++ b/test/common/internet.js
@@ -22,6 +22,9 @@ const addresses = {
   INVALID_HOST: 'something.invalid',
   // A host with MX records registered
   MX_HOST: 'nodejs.org',
+  // On some systems, .invalid returns a server failure/try again rather than
+  // record not found. Use this to guarantee record not found.
+  NOT_FOUND: 'come.on.fhqwhgads',
   // A host with SRV records registered
   SRV_HOST: '_jabber._tcp.google.com',
   // A host with PTR records registered

--- a/test/internet/test-dns-lookup.js
+++ b/test/internet/test-dns-lookup.js
@@ -8,30 +8,30 @@ const { addresses } = require('../common/internet');
 const assert = require('assert');
 
 assert.rejects(
-  dnsPromises.lookup(addresses.INVALID_HOST, {
+  dnsPromises.lookup(addresses.NOT_FOUND, {
     hints: 0,
     family: 0,
     all: false
   }),
   {
     code: 'ENOTFOUND',
-    message: `getaddrinfo ENOTFOUND ${addresses.INVALID_HOST}`
+    message: `getaddrinfo ENOTFOUND ${addresses.NOT_FOUND}`
   }
 );
 
 assert.rejects(
-  dnsPromises.lookup(addresses.INVALID_HOST, {
+  dnsPromises.lookup(addresses.NOT_FOUND, {
     hints: 0,
     family: 0,
     all: true
   }),
   {
     code: 'ENOTFOUND',
-    message: `getaddrinfo ENOTFOUND ${addresses.INVALID_HOST}`
+    message: `getaddrinfo ENOTFOUND ${addresses.NOT_FOUND}`
   }
 );
 
-dns.lookup(addresses.INVALID_HOST, {
+dns.lookup(addresses.NOT_FOUND, {
   hints: 0,
   family: 0,
   all: true
@@ -39,8 +39,8 @@ dns.lookup(addresses.INVALID_HOST, {
   assert.strictEqual(error.code, 'ENOTFOUND');
   assert.strictEqual(
     error.message,
-    `getaddrinfo ENOTFOUND ${addresses.INVALID_HOST}`
+    `getaddrinfo ENOTFOUND ${addresses.NOT_FOUND}`
   );
   assert.strictEqual(error.syscall, 'getaddrinfo');
-  assert.strictEqual(error.hostname, addresses.INVALID_HOST);
+  assert.strictEqual(error.hostname, addresses.NOT_FOUND);
 }));

--- a/test/internet/test-dns.js
+++ b/test/internet/test-dns.js
@@ -163,13 +163,13 @@ TEST(async function test_resolveMx(done) {
 });
 
 TEST(function test_resolveMx_failure(done) {
-  dnsPromises.resolveMx(addresses.INVALID_HOST)
+  dnsPromises.resolveMx(addresses.NOT_FOUND)
     .then(common.mustNotCall())
     .catch(common.mustCall((err) => {
       assert.strictEqual(err.code, 'ENOTFOUND');
     }));
 
-  const req = dns.resolveMx(addresses.INVALID_HOST, function(err, result) {
+  const req = dns.resolveMx(addresses.NOT_FOUND, function(err, result) {
     assert.ok(err instanceof Error);
     assert.strictEqual(err.code, 'ENOTFOUND');
 
@@ -203,13 +203,13 @@ TEST(async function test_resolveNs(done) {
 });
 
 TEST(function test_resolveNs_failure(done) {
-  dnsPromises.resolveNs(addresses.INVALID_HOST)
+  dnsPromises.resolveNs(addresses.NOT_FOUND)
     .then(common.mustNotCall())
     .catch(common.mustCall((err) => {
       assert.strictEqual(err.code, 'ENOTFOUND');
     }));
 
-  const req = dns.resolveNs(addresses.INVALID_HOST, function(err, result) {
+  const req = dns.resolveNs(addresses.NOT_FOUND, function(err, result) {
     assert.ok(err instanceof Error);
     assert.strictEqual(err.code, 'ENOTFOUND');
 
@@ -247,13 +247,13 @@ TEST(async function test_resolveSrv(done) {
 });
 
 TEST(function test_resolveSrv_failure(done) {
-  dnsPromises.resolveSrv(addresses.INVALID_HOST)
+  dnsPromises.resolveSrv(addresses.NOT_FOUND)
     .then(common.mustNotCall())
     .catch(common.mustCall((err) => {
       assert.strictEqual(err.code, 'ENOTFOUND');
     }));
 
-  const req = dns.resolveSrv(addresses.INVALID_HOST, function(err, result) {
+  const req = dns.resolveSrv(addresses.NOT_FOUND, function(err, result) {
     assert.ok(err instanceof Error);
     assert.strictEqual(err.code, 'ENOTFOUND');
 
@@ -287,13 +287,13 @@ TEST(async function test_resolvePtr(done) {
 });
 
 TEST(function test_resolvePtr_failure(done) {
-  dnsPromises.resolvePtr(addresses.INVALID_HOST)
+  dnsPromises.resolvePtr(addresses.NOT_FOUND)
     .then(common.mustNotCall())
     .catch(common.mustCall((err) => {
       assert.strictEqual(err.code, 'ENOTFOUND');
     }));
 
-  const req = dns.resolvePtr(addresses.INVALID_HOST, function(err, result) {
+  const req = dns.resolvePtr(addresses.NOT_FOUND, function(err, result) {
     assert.ok(err instanceof Error);
     assert.strictEqual(err.code, 'ENOTFOUND');
 
@@ -332,13 +332,13 @@ TEST(async function test_resolveNaptr(done) {
 });
 
 TEST(function test_resolveNaptr_failure(done) {
-  dnsPromises.resolveNaptr(addresses.INVALID_HOST)
+  dnsPromises.resolveNaptr(addresses.NOT_FOUND)
     .then(common.mustNotCall())
     .catch(common.mustCall((err) => {
       assert.strictEqual(err.code, 'ENOTFOUND');
     }));
 
-  const req = dns.resolveNaptr(addresses.INVALID_HOST, function(err, result) {
+  const req = dns.resolveNaptr(addresses.NOT_FOUND, function(err, result) {
     assert.ok(err instanceof Error);
     assert.strictEqual(err.code, 'ENOTFOUND');
 
@@ -381,13 +381,13 @@ TEST(async function test_resolveSoa(done) {
 });
 
 TEST(function test_resolveSoa_failure(done) {
-  dnsPromises.resolveSoa(addresses.INVALID_HOST)
+  dnsPromises.resolveSoa(addresses.NOT_FOUND)
     .then(common.mustNotCall())
     .catch(common.mustCall((err) => {
       assert.strictEqual(err.code, 'ENOTFOUND');
     }));
 
-  const req = dns.resolveSoa(addresses.INVALID_HOST, function(err, result) {
+  const req = dns.resolveSoa(addresses.NOT_FOUND, function(err, result) {
     assert.ok(err instanceof Error);
     assert.strictEqual(err.code, 'ENOTFOUND');
 
@@ -421,13 +421,13 @@ TEST(async function test_resolveCaa(done) {
 });
 
 TEST(function test_resolveCaa_failure(done) {
-  dnsPromises.resolveTxt(addresses.INVALID_HOST)
+  dnsPromises.resolveTxt(addresses.NOT_FOUND)
     .then(common.mustNotCall())
     .catch(common.mustCall((err) => {
       assert.strictEqual(err.code, 'ENOTFOUND');
     }));
 
-  const req = dns.resolveCaa(addresses.INVALID_HOST, function(err, result) {
+  const req = dns.resolveCaa(addresses.NOT_FOUND, function(err, result) {
     assert.ok(err instanceof Error);
     assert.strictEqual(err.code, 'ENOTFOUND');
 
@@ -461,13 +461,13 @@ TEST(async function test_resolveCname(done) {
 });
 
 TEST(function test_resolveCname_failure(done) {
-  dnsPromises.resolveCname(addresses.INVALID_HOST)
+  dnsPromises.resolveCname(addresses.NOT_FOUND)
     .then(common.mustNotCall())
     .catch(common.mustCall((err) => {
       assert.strictEqual(err.code, 'ENOTFOUND');
     }));
 
-  const req = dns.resolveCname(addresses.INVALID_HOST, function(err, result) {
+  const req = dns.resolveCname(addresses.NOT_FOUND, function(err, result) {
     assert.ok(err instanceof Error);
     assert.strictEqual(err.code, 'ENOTFOUND');
 
@@ -499,13 +499,13 @@ TEST(async function test_resolveTxt(done) {
 });
 
 TEST(function test_resolveTxt_failure(done) {
-  dnsPromises.resolveTxt(addresses.INVALID_HOST)
+  dnsPromises.resolveTxt(addresses.NOT_FOUND)
     .then(common.mustNotCall())
     .catch(common.mustCall((err) => {
       assert.strictEqual(err.code, 'ENOTFOUND');
     }));
 
-  const req = dns.resolveTxt(addresses.INVALID_HOST, function(err, result) {
+  const req = dns.resolveTxt(addresses.NOT_FOUND, function(err, result) {
     assert.ok(err instanceof Error);
     assert.strictEqual(err.code, 'ENOTFOUND');
 
@@ -519,16 +519,16 @@ TEST(function test_resolveTxt_failure(done) {
 
 
 TEST(function test_lookup_failure(done) {
-  dnsPromises.lookup(addresses.INVALID_HOST, 4)
+  dnsPromises.lookup(addresses.NOT_FOUND, 4)
     .then(common.mustNotCall())
     .catch(common.expectsError({ code: dns.NOTFOUND }));
 
-  const req = dns.lookup(addresses.INVALID_HOST, 4, (err) => {
+  const req = dns.lookup(addresses.NOT_FOUND, 4, (err) => {
     assert.ok(err instanceof Error);
     assert.strictEqual(err.code, dns.NOTFOUND);
     assert.strictEqual(err.code, 'ENOTFOUND');
     assert.ok(!/ENOENT/.test(err.message));
-    assert.ok(err.message.includes(addresses.INVALID_HOST));
+    assert.ok(err.message.includes(addresses.NOT_FOUND));
 
     done();
   });
@@ -672,18 +672,18 @@ TEST(function test_reverse_failure(done) {
 
 
 TEST(function test_lookup_failure(done) {
-  dnsPromises.lookup(addresses.INVALID_HOST)
+  dnsPromises.lookup(addresses.NOT_FOUND)
     .then(common.mustNotCall())
     .catch(common.expectsError({
       code: 'ENOTFOUND',
-      hostname: addresses.INVALID_HOST
+      hostname: addresses.NOT_FOUND
     }));
 
-  const req = dns.lookup(addresses.INVALID_HOST, (err) => {
+  const req = dns.lookup(addresses.NOT_FOUND, (err) => {
     assert(err instanceof Error);
     assert.strictEqual(err.code, 'ENOTFOUND');  // Silly error code...
-    assert.strictEqual(err.hostname, addresses.INVALID_HOST);
-    assert.ok(err.message.includes(addresses.INVALID_HOST));
+    assert.strictEqual(err.hostname, addresses.NOT_FOUND);
+    assert.ok(err.message.includes(addresses.NOT_FOUND));
 
     done();
   });
@@ -693,7 +693,7 @@ TEST(function test_lookup_failure(done) {
 
 
 TEST(function test_resolve_failure(done) {
-  const req = dns.resolve4(addresses.INVALID_HOST, (err) => {
+  const req = dns.resolve4(addresses.NOT_FOUND, (err) => {
     assert(err instanceof Error);
 
     switch (err.code) {
@@ -705,8 +705,8 @@ TEST(function test_resolve_failure(done) {
         break;
     }
 
-    assert.strictEqual(err.hostname, addresses.INVALID_HOST);
-    assert.ok(err.message.includes(addresses.INVALID_HOST));
+    assert.strictEqual(err.hostname, addresses.NOT_FOUND);
+    assert.ok(err.message.includes(addresses.NOT_FOUND));
 
     done();
   });


### PR DESCRIPTION
Ubuntu 16.04 is going to be unsupported after April 2021. Switching
Node.js CI to Ubuntu 18.04 for the internet tests resulted in failures
in test-dns and test-dns-lookup because it returns server failure/try
again on .invalid domain. Add a hostname for testing that will return
record not found.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
