### PR TITLE
test: add ancestor package.json checks for tmpdir

### DIFF
--- a/test/common/README.md
+++ b/test/common/README.md
@@ -370,10 +370,12 @@ const { spawn } = require('child_process');
 spawn(...common.pwdCommand, { stdio: ['pipe'] });
 ```
 
-### `requireNoPackageJSONAbove()`
+### `requireNoPackageJSONAbove([dir])`
 
-Throws an `AssertionError` if a `package.json` file is in any ancestor
-directory. Such files may interfere with proper test functionality.
+* `dir` [&lt;string>][] default = \_\_dirname
+
+Throws an `AssertionError` if a `package.json` file exists in any ancestor
+directory above `dir`. Such files may interfere with proper test functionality.
 
 ### `runWithInvalidFD(func)`
 

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -708,8 +708,8 @@ function gcUntil(name, condition) {
   });
 }
 
-function requireNoPackageJSONAbove() {
-  let possiblePackage = path.join(__dirname, '..', 'package.json');
+function requireNoPackageJSONAbove(dir = __dirname) {
+  let possiblePackage = path.join(dir, '..', 'package.json');
   let lastPackage = null;
   while (possiblePackage !== lastPackage) {
     if (fs.existsSync(possiblePackage)) {

--- a/test/pummel/test-policy-integrity.js
+++ b/test/pummel/test-policy-integrity.js
@@ -76,6 +76,7 @@ function newTestId() {
   return nextTestId++;
 }
 tmpdir.refresh();
+common.requireNoPackageJSONAbove(tmpdir.path);
 
 let spawned = 0;
 const toSpawn = [];


### PR DESCRIPTION
Policy tests can fail if a `package.json` exists in any of the parent
directories above the test. The existing checks are done for the
ancestors of the test directory but some tests execute from the tmpdir.

Refs: https://github.com/nodejs/node/issues/38088
Refs: https://github.com/nodejs/node/issues/35600
Refs: https://github.com/nodejs/node/pull/35633

cc @bmeck 

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
