### PR TITLE
test: use .test domain for not found address

### DIFF
--- a/test/common/internet.js
+++ b/test/common/internet.js
@@ -24,7 +24,7 @@ const addresses = {
   MX_HOST: 'nodejs.org',
   // On some systems, .invalid returns a server failure/try again rather than
   // record not found. Use this to guarantee record not found.
-  NOT_FOUND: 'come.on.fhqwhgads',
+  NOT_FOUND: 'come.on.fhqwhgads.test',
   // A host with SRV records registered
   SRV_HOST: '_jabber._tcp.google.com',
   // A host with PTR records registered


### PR DESCRIPTION
While it is extremely unlikely that `.fhqwhgads` will become a valid
domain, we should, where possible, use one of the reserved domains for
testing.

Refs: https://tools.ietf.org/html/rfc2606
Refs: https://github.com/nodejs/node/pull/38282

cc @Trott 

```
iojs@test-digitalocean-ubuntu1804-x64-1:~/build/workspace/node-test-commit-custom-suites-freestyle$ ./node 
Welcome to Node.js v16.0.0-pre.
Type ".help" for more information.
> const opts = { hints: 0, family: 0, all: false }
undefined
>  dns.promises.lookup('something.invalid', opts)
Promise { <pending> }
> Uncaught Error: getaddrinfo EAI_AGAIN something.invalid
    at __node_internal_captureLargerStackTrace (node:internal/errors:456:5)
    at __node_internal_ (node:internal/errors:678:10)
    at GetAddrInfoReqWrap.onlookup [as oncomplete] (node:internal/dns/promises:42:17)
    at GetAddrInfoReqWrap.callbackTrampoline (node:internal/async_hooks:135:14) {
  errno: -3001,
  code: 'EAI_AGAIN',
  syscall: 'getaddrinfo',
  hostname: 'something.invalid'
}
>  dns.promises.lookup('something.invalid.test', opts)
Promise { <pending> }
> Uncaught Error: getaddrinfo ENOTFOUND something.invalid.test
    at __node_internal_captureLargerStackTrace (node:internal/errors:456:5)
    at __node_internal_ (node:internal/errors:678:10)
    at GetAddrInfoReqWrap.onlookup [as oncomplete] (node:internal/dns/promises:42:17)
    at GetAddrInfoReqWrap.callbackTrampoline (node:internal/async_hooks:135:14) {
  errno: -3008,
  code: 'ENOTFOUND',
  syscall: 'getaddrinfo',
  hostname: 'something.invalid.test'
}
>  dns.promises.lookup('something.invalid.example', opts)
Promise { <pending> }
> Uncaught Error: getaddrinfo ENOTFOUND something.invalid.example
    at __node_internal_captureLargerStackTrace (node:internal/errors:456:5)
    at __node_internal_ (node:internal/errors:678:10)
    at GetAddrInfoReqWrap.onlookup [as oncomplete] (node:internal/dns/promises:42:17)
    at GetAddrInfoReqWrap.callbackTrampoline (node:internal/async_hooks:135:14) {
  errno: -3008,
  code: 'ENOTFOUND',
  syscall: 'getaddrinfo',
  hostname: 'something.invalid.example'
}
> dns.promises.resolveMx('something.invalid')
Promise { <pending> }
> Uncaught Error: queryMx ESERVFAIL something.invalid
    at __node_internal_captureLargerStackTrace (node:internal/errors:456:5)
    at __node_internal_ (node:internal/errors:678:10)
    at QueryReqWrap.onresolve [as oncomplete] (node:internal/dns/promises:169:17)
    at QueryReqWrap.callbackTrampoline (node:internal/async_hooks:135:14) {
  errno: undefined,
  code: 'ESERVFAIL',
  syscall: 'queryMx',
  hostname: 'something.invalid'
}
> dns.promises.resolveMx('something.test')
Promise { <pending> }
> Uncaught Error: queryMx ENOTFOUND something.test
    at __node_internal_captureLargerStackTrace (node:internal/errors:456:5)
    at __node_internal_ (node:internal/errors:678:10)
    at QueryReqWrap.onresolve [as oncomplete] (node:internal/dns/promises:169:17)
    at QueryReqWrap.callbackTrampoline (node:internal/async_hooks:135:14) {
  errno: undefined,
  code: 'ENOTFOUND',
  syscall: 'queryMx',
  hostname: 'something.test'
}
> dns.promises.resolveMx('something.example')
Promise { <pending> }
> #Uncaught Error: queryMx ENOTFOUND something.example
    at __node_internal_captureLargerStackTrace (node:internal/errors:456:5)
    at __node_internal_ (node:internal/errors:678:10)
    at QueryReqWrap.onresolve [as oncomplete] (node:internal/dns/promises:169:17)
    at QueryReqWrap.callbackTrampoline (node:internal/async_hooks:135:14) {
  errno: undefined,
  code: 'ENOTFOUND',
  syscall: 'queryMx',
  hostname: 'something.example'
}
>
```

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
