### PR TITLE
fs: allow no-params fsPromises fileHandle read

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -285,7 +285,7 @@ Reads data from the file and stores that in the given buffer.
 If the file is not modified concurrently, the end-of-file is reached when the
 number of bytes read is zero.
 
-#### `filehandle.read(options)`
+#### `filehandle.read([options])`
 <!-- YAML
 added:
  - v13.11.0

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -400,6 +400,9 @@ async function open(path, flags, mode) {
 async function read(handle, bufferOrOptions, offset, length, position) {
   let buffer = bufferOrOptions;
   if (!isArrayBufferView(buffer)) {
+    if (bufferOrOptions === undefined) {
+      bufferOrOptions = {};
+    }
     if (bufferOrOptions.buffer) {
       buffer = bufferOrOptions.buffer;
       validateBuffer(buffer);

--- a/test/parallel/test-fs-promises-file-handle-read.js
+++ b/test/parallel/test-fs-promises-file-handle-read.js
@@ -61,6 +61,13 @@ async function validateLargeRead(options) {
   assert.strictEqual(readHandle.bytesRead, 0);
 }
 
+async function validateReadNoParams() {
+  const filePath = fixtures.path('x.txt');
+  const fileHandle = await open(filePath, 'r');
+  // Should not throw
+  await fileHandle.read();
+}
+
 
 (async function() {
   tmpdir.refresh();
@@ -70,4 +77,5 @@ async function validateLargeRead(options) {
   await validateRead('', 'read-empty-file-conf', { useConf: true });
   await validateLargeRead({ useConf: false });
   await validateLargeRead({ useConf: true });
+  await validateReadNoParams();
 })().then(common.mustCall());


### PR DESCRIPTION
Currently, `fileHandle.read()` throws a `TypeError`, but `fs.read(fd, cb)` works. This PR makes `fileHandle.read()` work the same as `fs.read(fd, cb)`.