### PR TITLE
tools: fix type mismatch in test runner

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -375,7 +375,10 @@ class TapProgressIndicator(SimpleProgressIndicator):
 
       if output.diagnostic:
         self.severity = 'ok'
-        self.traceback = output.diagnostic
+        if isinstance(output.diagnostic, list):
+          self.traceback = '\n'.join(output.diagnostic)
+        else:
+          self.traceback = output.diagnostic
 
 
     duration = output.test.duration


### PR DESCRIPTION
`output.diagnostic` is a list that is appended to on SmartOS when retrying a test due to `ECONNREFUSED`. 
https://github.com/nodejs/node/blob/2853b76e202e2549a8c02ed9f46621abcb76f392/tools/test.py#L612
https://github.com/nodejs/node/blob/2853b76e202e2549a8c02ed9f46621abcb76f392/tools/test.py#L197-L204

The test runner checks if `output.diagnostic` is truthy and, if so, assigns its value to `self.traceback`. 
https://github.com/nodejs/node/blob/2853b76e202e2549a8c02ed9f46621abcb76f392/tools/test.py#L376-L378

However `self.traceback` is supposed to be a string, and `_printDiagnostic()` in the `TapProgressIndicator` attempts to call `splitlines()` on it, which fails if it is a list with:
```
AttributeError: 'list' object has no attribute 'splitlines'
```
https://github.com/nodejs/node/blob/2853b76e202e2549a8c02ed9f46621abcb76f392/tools/test.py#L318-L324

Seen in https://ci.nodejs.org/job/node-test-commit-smartos/nodes=smartos18-64/38562/console
```
23:20:25 ok 2976 pummel/test-net-connect-econnrefused
23:20:33   ---
23:20:33   duration_ms: 8.617
23:20:33   severity: ok
23:20:33   stack: |-
23:20:33 Traceback (most recent call last):
23:20:33   File "tools/test.py", line 1753, in <module>
23:20:33     sys.exit(Main())
23:20:33   File "tools/test.py", line 1729, in Main
23:20:33     if RunTestCases(cases_to_run, options.progress, options.j, options.flaky_tests):
23:20:33   File "tools/test.py", line 951, in RunTestCases
23:20:33     return progress.Run(tasks)
23:20:33   File "tools/test.py", line 160, in Run
23:20:33     self.RunSingle(False, 0)
23:20:33   File "tools/test.py", line 221, in RunSingle
23:20:33     self.HasRun(output)
23:20:33   File "tools/test.py", line 395, in HasRun
23:20:33     self._printDiagnostic()
23:20:33   File "tools/test.py", line 323, in _printDiagnostic
23:20:33     for l in self.traceback.splitlines():
23:20:33 AttributeError: 'list' object has no attribute 'splitlines'
23:20:33 make[1]: *** [Makefile:516: test-ci] Error 1
```

cc @nodejs/python 

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
