### PR TITLE
doc: add nodejs-sec email template

### DIFF
--- a/doc/guides/security-release-process.md
+++ b/doc/guides/security-release-process.md
@@ -38,6 +38,12 @@ information described.
   * Described in the pre/post announcements
 
 * [ ] Pre-release announcement [email][]: ***LINK TO EMAIL***
+  ```
+  Security updates for all active release lines, Month Year
+
+  The Node.js project will release new versions of all supported release lines on or shortly after Day of week, Month Day of Month, Year
+  For more information see: https://nodejs.org/en/blog/vulnerability/month-year-security-releases/
+  ```
   (Get access from existing manager: Ben Noordhuis, Rod Vagg, Michael Dawson)
 
 * [ ] Pre-release announcement to nodejs.org blog: ***LINK TO BLOG***
@@ -64,6 +70,12 @@ information described.
 * [ ] [Unlock CI](https://github.com/nodejs/build/blob/HEAD/doc/jenkins-guide.md#after-the-release)
 
 * [ ] Post-release announcement in reply [email][]: ***LINK TO EMAIL***
+  ```
+  Security updates for all active release lines, Month Year
+
+  The Node.js project has now released new versions of all supported release lines.
+  For more information see: https://nodejs.org/en/blog/vulnerability/month-year-security-releases/
+  ```
 
 * [ ] Post-release announcement to Nodejs.org blog: ***LINK TO BLOG POST***
   * (Re-PR the pre-approved branch from nodejs-private/nodejs.org-private to

--- a/doc/guides/security-release-process.md
+++ b/doc/guides/security-release-process.md
@@ -38,7 +38,7 @@ information described.
   * Described in the pre/post announcements
 
 * [ ] Pre-release announcement [email][]: ***LINK TO EMAIL***
-  ```
+  ```text
   Security updates for all active release lines, Month Year
 
   The Node.js project will release new versions of all supported release lines on or shortly after Day of week, Month Day of Month, Year
@@ -70,7 +70,7 @@ information described.
 * [ ] [Unlock CI](https://github.com/nodejs/build/blob/HEAD/doc/jenkins-guide.md#after-the-release)
 
 * [ ] Post-release announcement in reply [email][]: ***LINK TO EMAIL***
-  ```
+  ```text
   Security updates for all active release lines, Month Year
 
   The Node.js project has now released new versions of all supported release lines.


### PR DESCRIPTION
This commit adds a suggestion for a template to be used as part of the
security release process. One step of this process is to create an email
to nodejs-sec group and currently would contain a copy and pasted
version of what is published on nodejs.org. This suggestion is to
instead use a link to the blog post.

Refs: https://github.com/nodejs/node/issues/38143

