### PR TITLE
doc: remove superfluous await from fsPromises.readdir example

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -932,7 +932,7 @@ import { readdir } from 'fs/promises';
 
 try {
   const files = await readdir(path);
-  for await (const file of files)
+  for (const file of files)
     console.log(file);
 } catch (err) {
   console.error(err);


### PR DESCRIPTION
The `await` operator in the example, iterating over the returned array
of filenames is not necessary, since the returned array is either
consisting of `string`s or of `fs.Dirent` objects, neither providing
an asyncIterator.

Refs: https://github.com/nodejs/help/issues/3317

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
