### PR TITLE
tools: add the bootstrapped _depot_tools dir to the PATH (for V8 tests)

### DIFF
--- a/tools/make-v8.sh
+++ b/tools/make-v8.sh
@@ -5,9 +5,6 @@ set -xe
 BUILD_ARCH_TYPE=$1
 V8_BUILD_OPTIONS=$2
 
-NODE_REPO_DIR="$(cd "$(dirname "$(dirname "$0")" )" && pwd)"
-DEPOT_TOOLS_DIR="$NODE_REPO_DIR"/deps/v8/_depot_tools
-
 cd deps/v8 || exit
 find . -type d -name .git -print0 | xargs -0 rm -rf
 tools/node/fetch_deps.py .
@@ -39,6 +36,7 @@ if [ "$ARCH" = "s390x" ] || [ "$ARCH" = "ppc64le" ]; then
   gn gen -v "out.gn/$BUILD_ARCH_TYPE" --args="is_component_build=false is_debug=false use_goma=false goma_dir=\"None\" use_custom_libcxx=false v8_target_cpu=\"$TARGET_ARCH\" target_cpu=\"$TARGET_ARCH\" v8_enable_backtrace=true"
   ninja -v -C "out.gn/$BUILD_ARCH_TYPE" d8 cctest inspector-test
 else
+  DEPOT_TOOLS_DIR="$(cd _depot_tools && pwd)"
   # shellcheck disable=SC2086
   PATH="$DEPOT_TOOLS_DIR":$PATH tools/dev/v8gen.py "$BUILD_ARCH_TYPE" --no-goma $V8_BUILD_OPTIONS
   PATH="$DEPOT_TOOLS_DIR":$PATH ninja -C "out.gn/$BUILD_ARCH_TYPE/" d8 cctest inspector-test

--- a/tools/make-v8.sh
+++ b/tools/make-v8.sh
@@ -40,6 +40,6 @@ if [ "$ARCH" = "s390x" ] || [ "$ARCH" = "ppc64le" ]; then
   ninja -v -C "out.gn/$BUILD_ARCH_TYPE" d8 cctest inspector-test
 else
   # shellcheck disable=SC2086
-  PATH=~/_depot_tools:"$DEPOT_TOOLS_DIR":$PATH tools/dev/v8gen.py "$BUILD_ARCH_TYPE" --no-goma $V8_BUILD_OPTIONS
-  PATH=~/_depot_tools:"$DEPOT_TOOLS_DIR":$PATH ninja -C "out.gn/$BUILD_ARCH_TYPE/" d8 cctest inspector-test
+  PATH="$DEPOT_TOOLS_DIR":$PATH tools/dev/v8gen.py "$BUILD_ARCH_TYPE" --no-goma $V8_BUILD_OPTIONS
+  PATH="$DEPOT_TOOLS_DIR":$PATH ninja -C "out.gn/$BUILD_ARCH_TYPE/" d8 cctest inspector-test
 fi

--- a/tools/make-v8.sh
+++ b/tools/make-v8.sh
@@ -5,6 +5,9 @@ set -xe
 BUILD_ARCH_TYPE=$1
 V8_BUILD_OPTIONS=$2
 
+NODE_REPO_DIR="$(cd "$(dirname "$(dirname "$0")" )" && pwd)"
+DEPOT_TOOLS_DIR="$NODE_REPO_DIR"/deps/v8/_depot_tools
+
 cd deps/v8 || exit
 find . -type d -name .git -print0 | xargs -0 rm -rf
 tools/node/fetch_deps.py .
@@ -37,6 +40,6 @@ if [ "$ARCH" = "s390x" ] || [ "$ARCH" = "ppc64le" ]; then
   ninja -v -C "out.gn/$BUILD_ARCH_TYPE" d8 cctest inspector-test
 else
   # shellcheck disable=SC2086
-  PATH=~/_depot_tools:$PATH tools/dev/v8gen.py "$BUILD_ARCH_TYPE" --no-goma $V8_BUILD_OPTIONS
-  PATH=~/_depot_tools:$PATH ninja -C "out.gn/$BUILD_ARCH_TYPE/" d8 cctest inspector-test
+  PATH=~/_depot_tools:"$DEPOT_TOOLS_DIR":$PATH tools/dev/v8gen.py "$BUILD_ARCH_TYPE" --no-goma $V8_BUILD_OPTIONS
+  PATH=~/_depot_tools:"$DEPOT_TOOLS_DIR":$PATH ninja -C "out.gn/$BUILD_ARCH_TYPE/" d8 cctest inspector-test
 fi


### PR DESCRIPTION
**Short summary:**

This script needs to execute a copy of `ninja` in order to complete.

The script downloads Google's `depot_tools` early on. (`depot_tools` includes a copy of the `ninja` binary.) I propose to add those to the PATH, so that running `ninja` later in the script succeeds for users at home running this outside of CI.

**Background, context, more details:**

The `make-v8.sh` script (used by the `test-v8` Makefile target) implicitly requires a separate copy of `ninja` on the PATH, even though it bootstraps a copy of `ninja` for you (that it proceeds to not use).

This Pull Request adds the `_depot_tools` dir bootstrapped during this script to the `PATH`, *before* `ninja` is executed, taking advantage of the fact that `_depot_tools` conveniently includes a copy of `ninja`. This makes for one less system requirement to be able to finish the `test-v8` Makefile target.

(I am not sure why this script chooses to add `~/_depot_tools` to the PATH, as at least oiutside of CI on my personal machine, that directory never exists on my machine during the entire `test-v8` Makefile target from beginning to end. But I interpret that as evidence that `depot_tools` is already meant to be on the PATH in some form or other.)

<details>

I was looking into documenting the system requirements needed to finish the `test-v8` Makefile target. _(I wanted to document that this is now the only part of this repository (that I know of) that [still requires Python  2](https://github.com/nodejs/node/pull/36691#issuecomment-820868219) after https://github.com/nodejs/node/pull/36691, given that some Python scripts in the upstream `depot_tools` and `v8` repositories still aren't Python 3 compatible)._

When I was testing that Makefile target locally, I noticed something a bit strange (to my eyes) about an implicit `ninja` requirement:

- The `test-v8` Makefile target implicitly [expects `ninja` on the PATH in order to complete](https://github.com/nodejs/node/blob/v15.14.0/tools/make-v8.sh#L41)
- The `test-v8` Makefile target ends up [bootstrapping](https://github.com/nodejs/node/blob/v15.14.0/tools/make-v8.sh#L10) [a copy of](https://github.com/nodejs/node/blob/v15.14.0/deps/v8/tools/node/fetch_deps.py#L72-L73) [`depot_tools`](https://github.com/nodejs/node/blob/v15.14.0/deps/v8/tools/node/node_common.py#L19-L43) before that, at `deps/v8/_depot_tools`
  - This includes a copy of `ninja`
- A seemingly arbitrary path `~/_depot_tools` _is_ [added to the PATH](https://github.com/nodejs/node/blob/v15.14.0/tools/make-v8.sh#L40-L41), but this isn't ensured to exist/isn't bootstrapped by the `test-v8` Makefile target
  -  (To my eyes, this path is arbitrary/maybe not useful, since it would be sheer coincidence if the user has `depot_tools` there, but I left it in case CI needs it... It should now be fully redundant as of this PR, so I think the script could probably skip adding that location to the `PATH`. Unless CI needs a custom `depot_tools` there with modifications? It works for me locally with upstream `depot_tools`, so I can't think of why that would be needed.)
- The `deps/v8/_depot_tools` which was just bootstrapped is _not_ put on the PATH
  - I feel like it should be? This gives us `ninja`, and we went out of our way to get it, so I think we should take advantage.

It feels like the bootstrapped `_depot_tools` is supposed to be on the PATH so we can use its copy of `ninja` 
to complete the rest of building V8. Rather than documenting this quirky and redundant (maybe accidental) `ninja` requirement, I thought I'd have a go at making it unnecessary to manually ensure `ninja` is on the PATH, by using the copy that was just bootstrapped.

</details>

An alternative might be simply directly executing the `deps/v8/_depot_tools/ninja` binary without altering the PATH whatsoever. ~~But I haven't yet tested whether that works.~~ Works for me, not sure whether it works just as well in CI.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
