### PR TITLE
src: Use %progbits instead of @progbits

### DIFF
--- a/src/large_pages/node_text_start.S
+++ b/src/large_pages/node_text_start.S
@@ -1,5 +1,5 @@
 #if defined(__ELF__)
-.section .note.GNU-stack,"",@progbits
+.section .note.GNU-stack,"",%progbits
 #endif
 .text
 .align 0x2000


### PR DESCRIPTION
While @progbits is preferred for most architectures, there are some
(notably 32-bit ARM) for which it does not. %progbits is effective
everywhere.

See https://bugzilla.redhat.com/show_bug.cgi?id=1950528 for more
details.

Related: https://github.com/nodejs/node/issues/17933
Related: https://github.com/nodejs/node/pull/37688

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
