### PR TITLE
doc: document new TCP_KEEPCNT and TCP_KEEPINTVL socket option defaults

### DIFF
--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -1007,7 +1007,9 @@ Set the encoding for the socket as a [Readable Stream][]. See
 <!-- YAML
 added: v0.1.92
 changes:
-  - version: v12.17.0
+  - version:
+    - v13.12.0
+    - v12.17.0
     pr-url: https://github.com/nodejs/node/pull/32204
     description: New defaults for `TCP_KEEPCNT` and `TCP_KEEPINTVL` socket options were added.
 -->

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -1006,6 +1006,10 @@ Set the encoding for the socket as a [Readable Stream][]. See
 ### `socket.setKeepAlive([enable][, initialDelay])`
 <!-- YAML
 added: v0.1.92
+changes:
+  - version: v12.17.0
+    pr-url: https://github.com/nodejs/node/pull/32204
+    description: New defaults for `TCP_KEEPCNT` and `TCP_KEEPINTVL` socket options were added.
 -->
 
 * `enable` {boolean} **Default:** `false`
@@ -1019,6 +1023,12 @@ Set `initialDelay` (in milliseconds) to set the delay between the last
 data packet received and the first keepalive probe. Setting `0` for
 `initialDelay` will leave the value unchanged from the default
 (or previous) setting.
+
+Enabling the keep-alive functionality will set the following socket options:
+* `SO_KEEPALIVE=1`
+* `TCP_KEEPIDLE=initialDelay`
+* `TCP_KEEPCNT=10`
+* `TCP_KEEPINTVL=1`
 
 ### `socket.setNoDelay([noDelay])`
 <!-- YAML


### PR DESCRIPTION
PR https://github.com/nodejs/node/pull/32204 introduced new defaults for the TCP keep-alive socket options (see [`deps/uv/src/unix/tcp.c`](https://github.com/nodejs/node/pull/32204/files#diff-0b61736929a04948679e92c530a2d1363b46e725cd41c00589ae0205480ae4fa)):
- `TCP_KEEPCNT` now defaults to `10` on all platforms
- `TCP_KEEPINTVL` now defaults to `1` on all platforms

Previously, `TCP_KEEPCNT` and `TCP_KEEPINTVL` were not set explicitly and OS-default values were used.

This affects Node.js releases v14.0.0 and above, v12.17.0 and above (but not v10).

Fixes: https://github.com/nodejs/node/issues/38298
Refs: https://github.com/nodejs/node/pull/32204

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
