### PR TITLE
repl: display prompt once after error callback

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -889,8 +889,11 @@ function REPLServer(prompt,
         self.output.write(self.writer(ret) + '\n');
       }
 
-      // Display prompt again
-      self.displayPrompt();
+      // Display prompt again (unless we already did by emitting the 'error'
+      // event on the domain instance).
+      if (!e) {
+        self.displayPrompt();
+      }
     }
   });
 

--- a/test/parallel/test-repl-uncaught-exception-evalcallback.js
+++ b/test/parallel/test-repl-uncaught-exception-evalcallback.js
@@ -1,0 +1,23 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const repl = require('repl');
+const { PassThrough } = require('stream');
+const input = new PassThrough();
+const output = new PassThrough();
+
+const r = repl.start({
+  input, output,
+  eval: common.mustCall((code, context, filename, cb) => {
+    r.setPrompt('prompt! ');
+    cb(new Error('err'));
+  })
+});
+
+input.end('foo\n');
+
+// The output includes exactly one post-error prompt.
+const out = output.read().toString();
+assert.match(out, /prompt!/);
+assert.doesNotMatch(out, /prompt![\S\s]*prompt!/);
+output.on('data', common.mustNotCall());


### PR DESCRIPTION
Do not call `.displayPrompt()` twice after the `eval` callback
resulted in an error.

(This does not affect the default eval because it doesn’t use
the callback if an error occurs.)

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
