### PR TITLE
lib: fix and improve os JSDoc typings

### DIFF
--- a/lib/os.js
+++ b/lib/os.js
@@ -286,7 +286,7 @@ function networkInterfaces() {
 }
 
 /**
- * @param {number} pid
+ * @param {number} [pid=0]
  * @param {number} priority
  * @returns {void}
  */
@@ -306,7 +306,7 @@ function setPriority(pid, priority) {
 }
 
 /**
- * @param {number} pid
+ * @param {number} [pid=0]
  * @returns {number}
  */
 function getPriority(pid) {
@@ -325,9 +325,9 @@ function getPriority(pid) {
 }
 
 /**
- * @param {{ encoding?: string }} options If `encoding` is set to `'buffer'`,
- * the `username`, `shell`, and `homedir` values will be `Buffer` instances.
- * Default: `'utf8'`
+ * @param {{ encoding?: string }} [options=utf8] If `encoding` is set to
+ * `'buffer'`, the `username`, `shell`, and `homedir` values will
+ * be `Buffer` instances.
  * @returns {{
  *   uid: number
  *   gid: number


### PR DESCRIPTION
We add JSDoc comments in lib files to help core developers. I feel it would be important for core developers to know whether a param is optional and what it's default value is. 

This PR makes the following changes in lib/os.js:
- marked optional params as such
- assigned default values using JSDoc conventions.