### PR TITLE
doc: note the system requirements for V8 tests

### DIFF
--- a/doc/guides/maintaining-V8.md
+++ b/doc/guides/maintaining-V8.md
@@ -229,7 +229,7 @@ to be cherry-picked in the Node.js repository and V8-CI must test the change.
   * Run the Node.js [V8 CI][] in addition to the [Node.js CI][].
     The CI uses the `test-v8` target in the `Makefile`, which uses
     `tools/make-v8.sh` to reconstruct a git tree in the `deps/v8` directory to
-    run V8 tests.
+    run V8 tests<sup>2</sup>.
 
 The [`git-node`][] tool can be used to simplify this task. Run
 `git node v8 backport <sha>` to cherry-pick a commit.
@@ -413,6 +413,11 @@ This would require some tooling to:
 
 <sup>1</sup>Node.js 0.12 and older are intentionally omitted from this document
 as their support has ended.
+
+<sup>2</sup>At the moment the V8 tests still require Python 2. To run these
+tests locally, you can run `/path/to/python2 ./configure.py` before running
+`make test-v8`, in the root of this repository. On macOS, this also requires
+a full Xcode install, not just the "command line tools" for Xcode.
 
 [ChromiumReleaseCalendar]: https://www.chromium.org/developers/calendar
 [Node.js CI]: https://ci.nodejs.org/job/node-test-pull-request/

--- a/doc/guides/maintaining-V8.md
+++ b/doc/guides/maintaining-V8.md
@@ -414,10 +414,10 @@ This would require some tooling to:
 <sup>1</sup>Node.js 0.12 and older are intentionally omitted from this document
 as their support has ended.
 
-<sup>2</sup>At the moment the V8 tests still require Python 2. To run these
-tests locally, you can run `/path/to/python2 ./configure.py` before running
-`make test-v8`, in the root of this repository. On macOS, this also requires
-a full Xcode install, not just the "command line tools" for Xcode.
+<sup>2</sup>The V8 tests still require Python 2. To run these tests locally,
+you can run `PYTHON2 ./configure.py` before running `make test-v8`, in the root
+of this repository. On macOS, this also requires a full Xcode install,
+not just the "command line tools" for Xcode.
 
 [ChromiumReleaseCalendar]: https://www.chromium.org/developers/calendar
 [Node.js CI]: https://ci.nodejs.org/job/node-test-pull-request/


### PR DESCRIPTION
The `test-v8` Makefile target still requires Python 2, and it requires a full Xcode install on macOS, due to its use of `xcodebuild` at some points.

Refs: https://github.com/nodejs/node/pull/36691#issuecomment-820868219

_(Note for reviewers, a related PR: The `test-v8` Makefile target also requires `ninja`, but I think it doesn't really **need to** require `ninja`. It actually downloads `ninja` as part of Google's `depot_tools`, but (apparently by mistake) does not put those on the PATH. See my other PR to put this copy of `ninja` on the PATH: https://github.com/nodejs/node/pull/38299. I didn't add `ninja` as a requirement in this documentation, since I hope my PR https://github.com/nodejs/node/pull/38299  will make that requirement go away.)_

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
