### PR TITLE
timers: remove redundant unref calls

### DIFF
--- a/lib/timers/promises.js
+++ b/lib/timers/promises.js
@@ -61,8 +61,7 @@ function setTimeout(after, value, options = {}) {
   }
   let oncancel;
   const ret = new Promise((resolve, reject) => {
-    const timeout = new Timeout(resolve, after, args, false, true);
-    if (!ref) timeout.unref();
+    const timeout = new Timeout(resolve, after, args, false, ref);
     insert(timeout, timeout._idleTimeout);
     if (signal) {
       oncancel = FunctionPrototypeBind(cancelListenerHandler,
@@ -141,8 +140,7 @@ async function* setInterval(after, value, options = {}) {
         callback();
         callback = undefined;
       }
-    }, after, undefined, true, true);
-    if (!ref) interval.unref();
+    }, after, undefined, true, ref);
     insert(interval, interval._idleTimeout);
     if (signal) {
       onCancel = () => {


### PR DESCRIPTION
Remove redundant calls to `Timeout.unref()` by passing the
`ref: boolean` parameter of `timers/promises#setTimeout` and
`timers/promises#setInterval` directly to `Timeout` constructor's
`isRefed` parameter.

Note: possible expansion of this PR is to apply the same `isRefed`
parameter from `Timeout` to `Immediate` to prevent the same redundant
`Immediate.unref()` call in `timers/promises#setImmediate`.