### PR TITLE
doc: fix typo in buffer.md - should be uint16array

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -205,7 +205,7 @@ console.log(uint32array);
 
 ```js
 const buf = Buffer.from('hello', 'utf16le');
-const uint16arr = new Uint16Array(
+const uint16array = new Uint16Array(
   buf.buffer,
   buf.byteOffset,
   buf.length / Uint16Array.BYTES_PER_ELEMENT);


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

There is a typo inside `doc/api/buffer.md`, currently the code snippets look like this:
```js
const buf = Buffer.from('hello', 'utf16le');
const uint16arr = new Uint16Array(
  buf.buffer,
  buf.byteOffset,
  buf.length / Uint16Array.BYTES_PER_ELEMENT);

console.log(uint16array);

// Prints: Uint16Array(5) [ 104, 101, 108, 108, 111 ]
```

But this snippets doesn't work as we've got this error:
```sh
console.log(uint16array);
            ^

ReferenceError: uint16array is not defined
    at Object.<anonymous> (/home/divlo/Documents/testing/test/app.js:7:13)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:72:12)
    at internal/main/run_main_module.js:17:47
 ```
 
 To fix it, we need to change `uint16arr` to `uint16array`, with that change it effectively prints to stdout : `Uint16Array(5) [ 104, 101, 108, 108, 111 ]`. :+1: 