### PR TITLE
src: remove unused guards around node-api reference

### DIFF
--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -627,9 +627,6 @@ v8::Local<v8::Value> Reference::Get() {
 }
 
 void Reference::Finalize(bool is_env_teardown) {
-  if (is_env_teardown) env_teardown_finalize_started_ = true;
-  if (!is_env_teardown && env_teardown_finalize_started_) return;
-
   // During env teardown, `~napi_env()` alone is responsible for finalizing.
   // Thus, we don't want any stray gc passes to trigger a second call to
   // `RefBase::Finalize()`. ClearWeak will ensure that even if the

--- a/src/js_native_api_v8.h
+++ b/src/js_native_api_v8.h
@@ -433,7 +433,6 @@ class Reference : public RefBase {
   static void SecondPassCallback(
       const v8::WeakCallbackInfo<SecondPassCallParameterRef>& data);
 
-  bool env_teardown_finalize_started_ = false;
   v8impl::Persistent<v8::Value> _persistent;
   SecondPassCallParameterRef* _secondPassParameter;
   bool _secondPassScheduled;


### PR DESCRIPTION
This is roughly a revert on https://github.com/nodejs/node/pull/38250 while we have a formal fix around the use-after-free issue on `v8impl::Reference` with https://github.com/nodejs/node/pull/38000 landed.

As https://github.com/nodejs/node/pull/38250 was alleviating the problem but the root cause is unfortunately not fixed, we may remove the code to prevent future confusion.