### PR TITLE
src: avoid deferred gc/cleanup for Buffer.from

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -315,7 +315,7 @@ MaybeLocal<Object> New(Isolate* isolate,
 
     actual = StringBytes::Write(
         isolate,
-        reinterpret_cast<char*>(store->Data()),
+        static_cast<char*>(store->Data()),
         length,
         string,
         enc);

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -303,28 +303,36 @@ MaybeLocal<Object> New(Isolate* isolate,
   if (!StringBytes::Size(isolate, string, enc).To(&length))
     return Local<Object>();
   size_t actual = 0;
-  char* data = nullptr;
+  std::unique_ptr<BackingStore> store;
 
   if (length > 0) {
-    data = UncheckedMalloc(length);
+    store = ArrayBuffer::NewBackingStore(isolate, length);
 
-    if (data == nullptr) {
+    if (UNLIKELY(!store)) {
       THROW_ERR_MEMORY_ALLOCATION_FAILED(isolate);
       return Local<Object>();
     }
 
-    actual = StringBytes::Write(isolate, data, length, string, enc);
+    actual = StringBytes::Write(
+        isolate,
+        reinterpret_cast<char*>(store->Data()),
+        length,
+        string,
+        enc);
     CHECK(actual <= length);
 
-    if (actual == 0) {
-      free(data);
-      data = nullptr;
-    } else if (actual < length) {
-      data = node::Realloc(data, actual);
+    if (LIKELY(actual > 0)) {
+      if (actual < length)
+        store = BackingStore::Reallocate(isolate, std::move(store), actual);
+      Local<ArrayBuffer> buf = ArrayBuffer::New(isolate, std::move(store));
+      Local<Object> obj;
+      if (UNLIKELY(!New(isolate, buf, 0, actual).ToLocal(&obj)))
+        return MaybeLocal<Object>();
+      return scope.Escape(obj);
     }
   }
 
-  return scope.EscapeMaybe(New(isolate, data, actual));
+  return scope.EscapeMaybe(New(isolate, 0));
 }
 
 


### PR DESCRIPTION
/cc @addaleax @Daninet

Previously, the code path would allocated a tracked `ArrayBuffer` that defers cleanup and deallocation of the underlying data with a native `SetImmediate`. Avoid the unnecessary deferral by just allocating a `BackingStore` directly and writing into it.

This should be considered an alternative to #38336

Fixes: https://github.com/nodejs/node/issues/38300
Refs: https://github.com/nodejs/node/pull/38336

