### PR TITLE
tools: disable LTO for "v8_cppgc_shared" target

### DIFF
--- a/tools/v8_gypfiles/v8.gyp
+++ b/tools/v8_gypfiles/v8.gyp
@@ -1378,6 +1378,9 @@
           '<(V8_ROOT)/src/heap/base/worklist.h',
         ],
         'conditions': [
+          ['enable_lto=="true"', {
+            'cflags_cc': [ '-fno-lto' ],
+          }],
           ['clang or OS!="win"', {
             'conditions': [
               ['_toolset == "host" and host_arch == "x64" or _toolset == "target" and target_arch=="x64"', {


### PR DESCRIPTION
"PushAllRegistersAndIterateStack" is implemented in assembly and
called from "stack.cc" via 'extern "C"'. [1]

However, LTO does not work well with symbol usage from assembly. [2]

This change workarounds the issue by disabling LTO for the target.

With GCC 10 and "./configure --enable-lto", compilation succeeds
after this change.

[1] v8/v8@c10863153
[2] https://gcc.gnu.org/wiki/LinkTimeOptimizationFAQ#Symbol_usage_from_assembly_language

Refs: #35957
Refs: #38335
Signed-off-by: Jesse Chan <jc@linux.com>