### PR TITLE
src: refactor to use THROW_* argument based snprintf

### DIFF
--- a/src/crypto/crypto_cipher.cc
+++ b/src/crypto/crypto_cipher.cc
@@ -511,10 +511,10 @@ bool CipherBase::InitAuthenticated(
   if (mode == EVP_CIPH_GCM_MODE) {
     if (auth_tag_len != kNoAuthTagLength) {
       if (!IsValidGCMTagLength(auth_tag_len)) {
-        char msg[50];
-        snprintf(msg, sizeof(msg),
-            "Invalid authentication tag length: %u", auth_tag_len);
-        THROW_ERR_CRYPTO_INVALID_AUTH_TAG(env(), msg);
+        THROW_ERR_CRYPTO_INVALID_AUTH_TAG(
+          env(),
+          "Invalid authentication tag length: %u",
+          auth_tag_len);
         return false;
       }
 
@@ -523,9 +523,8 @@ bool CipherBase::InitAuthenticated(
     }
   } else {
     if (auth_tag_len == kNoAuthTagLength) {
-      char msg[128];
-      snprintf(msg, sizeof(msg), "authTagLength required for %s", cipher_type);
-      THROW_ERR_CRYPTO_INVALID_AUTH_TAG(env(), msg);
+      THROW_ERR_CRYPTO_INVALID_AUTH_TAG(
+        env(), "authTagLength required for %s", cipher_type);
       return false;
     }
 
@@ -633,10 +632,8 @@ void CipherBase::SetAuthTag(const FunctionCallbackInfo<Value>& args) {
   }
 
   if (!is_valid) {
-    char msg[50];
-    snprintf(msg, sizeof(msg),
-        "Invalid authentication tag length: %u", tag_len);
-    return THROW_ERR_CRYPTO_INVALID_AUTH_TAG(env, msg);
+    return THROW_ERR_CRYPTO_INVALID_AUTH_TAG(
+      env, "Invalid authentication tag length: %u", tag_len);
   }
 
   cipher->auth_tag_len_ = tag_len;

--- a/src/crypto/crypto_dsa.cc
+++ b/src/crypto/crypto_dsa.cc
@@ -84,9 +84,7 @@ Maybe<bool> DsaKeyGenTraits::AdditionalConfig(
   params->params.modulus_bits = args[*offset].As<Uint32>()->Value();
   params->params.divisor_bits = args[*offset + 1].As<Int32>()->Value();
   if (params->params.divisor_bits < -1) {
-    char msg[1024];
-    snprintf(msg, sizeof(msg), "invalid value for divisor_bits");
-    THROW_ERR_OUT_OF_RANGE(env, msg);
+    THROW_ERR_OUT_OF_RANGE(env, "invalid value for divisor_bits");
     return Nothing<bool>();
   }
 

--- a/src/crypto/crypto_hash.cc
+++ b/src/crypto/crypto_hash.cc
@@ -233,9 +233,7 @@ Maybe<bool> HashTraits::AdditionalConfig(
   Utf8Value digest(env->isolate(), args[offset]);
   params->digest = EVP_get_digestbyname(*digest);
   if (UNLIKELY(params->digest == nullptr)) {
-    char msg[1024];
-    snprintf(msg, sizeof(msg), "Invalid digest: %s", *digest);
-    THROW_ERR_CRYPTO_INVALID_DIGEST(env);
+    THROW_ERR_CRYPTO_INVALID_DIGEST(env, "Invalid digest: %s", *digest);
     return Nothing<bool>();
   }
 

--- a/src/crypto/crypto_keys.cc
+++ b/src/crypto/crypto_keys.cc
@@ -515,9 +515,7 @@ std::shared_ptr<KeyObjectData> ImportJWKAsymmetricKey(
     return ImportJWKEcKey(env, jwk, args, offset);
   }
 
-  char msg[1024];
-  snprintf(msg, sizeof(msg), "%s is not a supported JWK key type", kty);
-  THROW_ERR_CRYPTO_INVALID_JWK(env, msg);
+  THROW_ERR_CRYPTO_INVALID_JWK(env, "%s is not a supported JWK key type", kty);
   return std::shared_ptr<KeyObjectData>();
 }
 

--- a/src/crypto/crypto_rsa.cc
+++ b/src/crypto/crypto_rsa.cc
@@ -138,9 +138,7 @@ Maybe<bool> RsaKeyGenTraits::AdditionalConfig(
       Utf8Value digest(env->isolate(), args[*offset]);
       params->params.md = EVP_get_digestbyname(*digest);
       if (params->params.md == nullptr) {
-        char msg[1024];
-        snprintf(msg, sizeof(msg), "md specifies an invalid digest");
-        THROW_ERR_CRYPTO_INVALID_DIGEST(env, msg);
+        THROW_ERR_CRYPTO_INVALID_DIGEST(env, "md specifies an invalid digest");
         return Nothing<bool>();
       }
     }
@@ -150,9 +148,8 @@ Maybe<bool> RsaKeyGenTraits::AdditionalConfig(
       Utf8Value digest(env->isolate(), args[*offset + 1]);
       params->params.mgf1_md = EVP_get_digestbyname(*digest);
       if (params->params.mgf1_md == nullptr) {
-        char msg[1024];
-        snprintf(msg, sizeof(msg), "mgf1_md specifies an invalid digest");
-        THROW_ERR_CRYPTO_INVALID_DIGEST(env, msg);
+        THROW_ERR_CRYPTO_INVALID_DIGEST(env,
+          "mgf1_md specifies an invalid digest");
         return Nothing<bool>();
       }
     }
@@ -161,9 +158,9 @@ Maybe<bool> RsaKeyGenTraits::AdditionalConfig(
       CHECK(args[*offset + 2]->IsInt32());
       params->params.saltlen = args[*offset + 2].As<Int32>()->Value();
       if (params->params.saltlen < 0) {
-        char msg[1024];
-        snprintf(msg, sizeof(msg), "salt length is out of range");
-        THROW_ERR_OUT_OF_RANGE(env, msg);
+        THROW_ERR_OUT_OF_RANGE(
+          env,
+          "salt length is out of range");
         return Nothing<bool>();
       }
     }

--- a/src/crypto/crypto_scrypt.cc
+++ b/src/crypto/crypto_scrypt.cc
@@ -111,9 +111,7 @@ Maybe<bool> ScryptTraits::AdditionalConfig(
 
   params->length = args[offset + 6].As<Int32>()->Value();
   if (params->length < 0) {
-    char msg[1024];
-    snprintf(msg, sizeof(msg), "length must be <= %d", INT_MAX);
-    THROW_ERR_OUT_OF_RANGE(env, msg);
+    THROW_ERR_OUT_OF_RANGE(env, "length must be <= %d", INT_MAX);
     return Nothing<bool>();
   }
 
@@ -151,4 +149,3 @@ bool ScryptTraits::DeriveBits(
 
 }  // namespace crypto
 }  // namespace node
-


### PR DESCRIPTION
Similar to #38354 this refactors various `src/node_errors.cc`-based errors to use the argument based snprintf rather than explicitly building the message upfront.