### PR TITLE
src: allow embedder-provided PageAllocator in NodePlatform

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -465,7 +465,8 @@ MultiIsolatePlatform* CreatePlatform(
 MultiIsolatePlatform* CreatePlatform(
     int thread_pool_size,
     v8::TracingController* tracing_controller) {
-  return MultiIsolatePlatform::Create(thread_pool_size, tracing_controller)
+  return MultiIsolatePlatform::Create(thread_pool_size,
+                                      tracing_controller)
       .release();
 }
 
@@ -475,8 +476,11 @@ void FreePlatform(MultiIsolatePlatform* platform) {
 
 std::unique_ptr<MultiIsolatePlatform> MultiIsolatePlatform::Create(
     int thread_pool_size,
-    v8::TracingController* tracing_controller) {
-  return std::make_unique<NodePlatform>(thread_pool_size, tracing_controller);
+    v8::TracingController* tracing_controller,
+    v8::PageAllocator* page_allocator) {
+  return std::make_unique<NodePlatform>(thread_pool_size,
+                                        tracing_controller,
+                                        page_allocator);
 }
 
 MaybeLocal<Object> GetPerContextExports(Local<Context> context) {

--- a/src/node.h
+++ b/src/node.h
@@ -310,7 +310,8 @@ class NODE_EXTERN MultiIsolatePlatform : public v8::Platform {
 
   static std::unique_ptr<MultiIsolatePlatform> Create(
       int thread_pool_size,
-      v8::TracingController* tracing_controller = nullptr);
+      v8::TracingController* tracing_controller = nullptr,
+      v8::PageAllocator* page_allocator = nullptr);
 };
 
 enum IsolateSettingsFlags {

--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -324,12 +324,17 @@ void PerIsolatePlatformData::DecreaseHandleCount() {
 }
 
 NodePlatform::NodePlatform(int thread_pool_size,
-                           v8::TracingController* tracing_controller) {
+                           v8::TracingController* tracing_controller,
+                           v8::PageAllocator* page_allocator) {
   if (tracing_controller != nullptr) {
     tracing_controller_ = tracing_controller;
   } else {
     tracing_controller_ = new v8::TracingController();
   }
+
+  // V8 will default to its built in allocator if none is provided.
+  page_allocator_ = page_allocator;
+
   // TODO(addaleax): It's a bit icky that we use global state here, but we can't
   // really do anything about it unless V8 starts exposing a way to access the
   // current v8::Platform instance.
@@ -548,6 +553,10 @@ Platform::StackTracePrinter NodePlatform::GetStackTracePrinter() {
     DumpBacktrace(stderr);
     fflush(stderr);
   };
+}
+
+v8::PageAllocator* NodePlatform::GetPageAllocator() {
+  return page_allocator_;
 }
 
 template <class T>

--- a/src/node_platform.h
+++ b/src/node_platform.h
@@ -138,7 +138,8 @@ class WorkerThreadsTaskRunner {
 class NodePlatform : public MultiIsolatePlatform {
  public:
   NodePlatform(int thread_pool_size,
-               v8::TracingController* tracing_controller);
+               v8::TracingController* tracing_controller,
+               v8::PageAllocator* page_allocator = nullptr);
   ~NodePlatform() override;
 
   void DrainTasks(v8::Isolate* isolate) override;
@@ -170,6 +171,7 @@ class NodePlatform : public MultiIsolatePlatform {
       v8::Isolate* isolate) override;
 
   Platform::StackTracePrinter GetStackTracePrinter() override;
+  v8::PageAllocator* GetPageAllocator() override;
 
  private:
   IsolatePlatformDelegate* ForIsolate(v8::Isolate* isolate);
@@ -181,6 +183,7 @@ class NodePlatform : public MultiIsolatePlatform {
   std::unordered_map<v8::Isolate*, DelegatePair> per_isolate_;
 
   v8::TracingController* tracing_controller_;
+  v8::PageAllocator* page_allocator_;
   std::shared_ptr<WorkerThreadsTaskRunner> worker_thread_task_runner_;
   bool has_shut_down_ = false;
 };


### PR DESCRIPTION
For certain embedder use cases there are more complex memory allocation requirements that the default V8 page allocator does not handle. For example, using MAP_JIT when running under a hardened runtime environment on macOS. This allows embedders like Electron to provide their own allocator that does handle these cases.

See: https://github.com/electron/electron/pull/26331

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
