### PR TITLE
doc: clarify DiffieHellmanGroup class docs

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1114,8 +1114,10 @@ module):
 added: v0.7.5
 -->
 
-The `DiffieHellmanGroup` class takes a well-known modp group as its argument but
-otherwise works the same as `DiffieHellman`.
+The `DiffieHellmanGroup` class takes a well-known modp group as its argument.
+Works the same as `DiffieHellman`, except that it does not allow changing its
+keys after creation - i.e. does not implement `setPublicKey` or `setPrivateKey`
+methods.
 
 ```mjs
 const { createDiffieHellmanGroup } = await import('crypto');

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1115,9 +1115,9 @@ added: v0.7.5
 -->
 
 The `DiffieHellmanGroup` class takes a well-known modp group as its argument.
-Works the same as `DiffieHellman`, except that it does not allow changing its
-keys after creation - i.e. does not implement `setPublicKey` or `setPrivateKey`
-methods.
+It works the same as `DiffieHellman`, except that it does not allow changing
+its keys after creation. In other words, it does not implement `setPublicKey()`
+or `setPrivateKey()` methods.
 
 ```mjs
 const { createDiffieHellmanGroup } = await import('crypto');


### PR DESCRIPTION
Make it clearer in the docs that DiffieHellmanGroup does not support changing the keys after creation (it's already mentioned in the docs - but only in the documentation for the `getDiffieHellman` method).
