### PR TITLE
crypto: fix generateKeyPair type checks

### DIFF
--- a/lib/internal/crypto/keygen.js
+++ b/lib/internal/crypto/keygen.js
@@ -195,7 +195,7 @@ function createJob(mode, type, options) {
         throw new ERR_INVALID_ARG_VALUE('options.hash', hash);
       if (mgf1Hash !== undefined && typeof mgf1Hash !== 'string')
         throw new ERR_INVALID_ARG_VALUE('options.mgf1Hash', mgf1Hash);
-      if (saltLength !== undefined && !isInt32(saltLength))
+      if (saltLength !== undefined && (!isInt32(saltLength) || saltLength < 0))
         throw new ERR_INVALID_ARG_VALUE('options.saltLength', saltLength);
 
       return new RsaKeyPairGenJob(
@@ -218,7 +218,7 @@ function createJob(mode, type, options) {
       let { divisorLength } = options;
       if (divisorLength == null) {
         divisorLength = -1;
-      } else if (!isInt32(divisorLength)) {
+      } else if (!isInt32(divisorLength) || divisorLength < 0) {
         throw new ERR_INVALID_ARG_VALUE('options.divisorLength', divisorLength);
       }
 
@@ -293,7 +293,7 @@ function createJob(mode, type, options) {
         if (!isArrayBufferView(prime))
           throw new ERR_INVALID_ARG_VALUE('options.prime', prime);
       } else if (primeLength != null) {
-        if (!isInt32(primeLength))
+        if (!isInt32(primeLength) || primeLength < 0)
           throw new ERR_INVALID_ARG_VALUE('options.primeLength', primeLength);
       } else {
         throw new ERR_MISSING_OPTION(
@@ -301,7 +301,7 @@ function createJob(mode, type, options) {
       }
 
       if (generator != null) {
-        if (!isInt32(generator))
+        if (!isInt32(generator) || generator < 0)
           throw new ERR_INVALID_ARG_VALUE('options.generator', generator);
       }
       return new DhKeyPairGenJob(

--- a/lib/internal/crypto/keygen.js
+++ b/lib/internal/crypto/keygen.js
@@ -40,6 +40,7 @@ const {
 const { customPromisifyArgs } = require('internal/util');
 
 const {
+  isInt32,
   isUint32,
   validateCallback,
   validateString,
@@ -194,7 +195,7 @@ function createJob(mode, type, options) {
         throw new ERR_INVALID_ARG_VALUE('options.hash', hash);
       if (mgf1Hash !== undefined && typeof mgf1Hash !== 'string')
         throw new ERR_INVALID_ARG_VALUE('options.mgf1Hash', mgf1Hash);
-      if (saltLength !== undefined && !isUint32(saltLength))
+      if (saltLength !== undefined && !isInt32(saltLength))
         throw new ERR_INVALID_ARG_VALUE('options.saltLength', saltLength);
 
       return new RsaKeyPairGenJob(
@@ -217,7 +218,7 @@ function createJob(mode, type, options) {
       let { divisorLength } = options;
       if (divisorLength == null) {
         divisorLength = -1;
-      } else if (!isUint32(divisorLength)) {
+      } else if (!isInt32(divisorLength)) {
         throw new ERR_INVALID_ARG_VALUE('options.divisorLength', divisorLength);
       }
 
@@ -292,7 +293,7 @@ function createJob(mode, type, options) {
         if (!isArrayBufferView(prime))
           throw new ERR_INVALID_ARG_VALUE('options.prime', prime);
       } else if (primeLength != null) {
-        if (!isUint32(primeLength))
+        if (!isInt32(primeLength))
           throw new ERR_INVALID_ARG_VALUE('options.primeLength', primeLength);
       } else {
         throw new ERR_MISSING_OPTION(
@@ -300,7 +301,7 @@ function createJob(mode, type, options) {
       }
 
       if (generator != null) {
-        if (!isUint32(generator))
+        if (!isInt32(generator))
           throw new ERR_INVALID_ARG_VALUE('options.generator', generator);
       }
       return new DhKeyPairGenJob(

--- a/test/parallel/test-crypto-keygen.js
+++ b/test/parallel/test-crypto-keygen.js
@@ -958,7 +958,7 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
   }
 
   // Test invalid divisor lengths.
-  for (const divisorLength of ['a', true, {}, [], 4096.1, 2147483648]) {
+  for (const divisorLength of ['a', true, {}, [], 4096.1, 2147483648, -1]) {
     assert.throws(() => generateKeyPair('dsa', {
       modulusLength: 2048,
       divisorLength
@@ -1094,6 +1094,17 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
 
   assert.throws(() => {
     generateKeyPair('dh', {
+      primeLength: -1
+    }, common.mustNotCall());
+  }, {
+    name: 'TypeError',
+    code: 'ERR_INVALID_ARG_VALUE',
+    message: "The property 'options.primeLength' is invalid. " +
+             'Received -1',
+  });
+
+  assert.throws(() => {
+    generateKeyPair('dh', {
       primeLength: 2,
       generator: 2147483648,
     }, common.mustNotCall());
@@ -1102,6 +1113,18 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     code: 'ERR_INVALID_ARG_VALUE',
     message: "The property 'options.generator' is invalid. " +
              'Received 2147483648',
+  });
+
+  assert.throws(() => {
+    generateKeyPair('dh', {
+      primeLength: 2,
+      generator: -1,
+    }, common.mustNotCall());
+  }, {
+    name: 'TypeError',
+    code: 'ERR_INVALID_ARG_VALUE',
+    message: "The property 'options.generator' is invalid. " +
+             'Received -1',
   });
 
   // Test incompatible options.
@@ -1178,6 +1201,20 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     code: 'ERR_INVALID_ARG_VALUE',
     message: "The property 'options.saltLength' is invalid. " +
              'Received 2147483648'
+  });
+
+  assert.throws(() => {
+    generateKeyPair('rsa-pss', {
+      modulusLength: 512,
+      saltLength: -1,
+      hash: 'sha256',
+      mgf1Hash: 'sha256'
+    }, common.mustNotCall());
+  }, {
+    name: 'TypeError',
+    code: 'ERR_INVALID_ARG_VALUE',
+    message: "The property 'options.saltLength' is invalid. " +
+             'Received -1'
   });
 
   // Invalid private key type.

--- a/test/parallel/test-crypto-keygen.js
+++ b/test/parallel/test-crypto-keygen.js
@@ -958,7 +958,7 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
   }
 
   // Test invalid divisor lengths.
-  for (const divisorLength of ['a', true, {}, [], 4096.1]) {
+  for (const divisorLength of ['a', true, {}, [], 4096.1, 2147483648]) {
     assert.throws(() => generateKeyPair('dsa', {
       modulusLength: 2048,
       divisorLength
@@ -1081,6 +1081,29 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     message: 'Unknown DH group'
   });
 
+  assert.throws(() => {
+    generateKeyPair('dh', {
+      primeLength: 2147483648
+    }, common.mustNotCall());
+  }, {
+    name: 'TypeError',
+    code: 'ERR_INVALID_ARG_VALUE',
+    message: "The property 'options.primeLength' is invalid. " +
+             'Received 2147483648',
+  });
+
+  assert.throws(() => {
+    generateKeyPair('dh', {
+      primeLength: 2,
+      generator: 2147483648,
+    }, common.mustNotCall());
+  }, {
+    name: 'TypeError',
+    code: 'ERR_INVALID_ARG_VALUE',
+    message: "The property 'options.generator' is invalid. " +
+             'Received 2147483648',
+  });
+
   // Test incompatible options.
   const allOpts = {
     group: 'modp5',
@@ -1141,6 +1164,21 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
         `Received ${inspect(hashValue)}`
     });
   }
+
+  // too long salt length
+  assert.throws(() => {
+    generateKeyPair('rsa-pss', {
+      modulusLength: 512,
+      saltLength: 2147483648,
+      hash: 'sha256',
+      mgf1Hash: 'sha256'
+    }, common.mustNotCall());
+  }, {
+    name: 'TypeError',
+    code: 'ERR_INVALID_ARG_VALUE',
+    message: "The property 'options.saltLength' is invalid. " +
+             'Received 2147483648'
+  });
 
   // Invalid private key type.
   for (const type of ['foo', 'spki']) {


### PR DESCRIPTION
There were a few mismatches between the type checks in `keygen` and the types in the c++ code, which could cause a crash.

I've  changed saltLength (rsa-pss), divisorLength (dsa), primeLength (dh) and generator (dh) checks in `keygen` to int32 from uint32, to align with the c++ code.

fixes: https://github.com/nodejs/node/issues/38358