### PR TITLE
benchmark: use `process.hrtime.bigint()`

### DIFF
--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -12,7 +12,7 @@ class Benchmark {
     this._ended = false;
 
     // Holds process.hrtime value
-    this._time = [0, 0];
+    this._time = 0n;
 
     // Use the file name as the name of the benchmark
     this.name = require.main.filename.slice(__dirname.length + 1);
@@ -218,12 +218,12 @@ class Benchmark {
       throw new Error('Called start more than once in a single benchmark');
     }
     this._started = true;
-    this._time = process.hrtime();
+    this._time = process.hrtime.bigint();
   }
 
   end(operations) {
     // Get elapsed time now and do error checking later for accuracy.
-    const elapsed = process.hrtime(this._time);
+    const time = process.hrtime.bigint();
 
     if (!this._started) {
       throw new Error('called end without start');
@@ -237,16 +237,19 @@ class Benchmark {
     if (!process.env.NODEJS_BENCHMARK_ZERO_ALLOWED && operations <= 0) {
       throw new Error('called end() with operation count <= 0');
     }
-    if (elapsed[0] === 0 && elapsed[1] === 0) {
+
+    this._ended = true;
+
+    if (time === this._time) {
       if (!process.env.NODEJS_BENCHMARK_ZERO_ALLOWED)
         throw new Error('insufficient clock precision for short benchmark');
       // Avoid dividing by zero
-      elapsed[1] = 1;
+      this.report(operations && Number.MAX_VALUE, 0n);
+      return;
     }
 
-    this._ended = true;
-    const time = elapsed[0] + elapsed[1] / 1e9;
-    const rate = operations / time;
+    const elapsed = time - this._time;
+    const rate = operations / (Number(elapsed) / 1e9);
     this.report(rate, elapsed);
   }
 
@@ -255,10 +258,19 @@ class Benchmark {
       name: this.name,
       conf: this.config,
       rate,
-      time: elapsed[0] + elapsed[1] / 1e9,
+      time: nanoSecondsToString(elapsed),
       type: 'report',
     });
   }
+}
+
+function nanoSecondsToString(bigint) {
+  const str = bigint.toString();
+  const decimalPointIndex = str.length - 9;
+  if (decimalPointIndex < 0) {
+    return `0.${'0'.repeat(-decimalPointIndex)}${str}`;
+  }
+  return `${str.slice(0, decimalPointIndex)}.${str.slice(decimalPointIndex)}`;
 }
 
 function formatResult(data) {


### PR DESCRIPTION
Using `BigInt` may result in better precision than the legacy `process.hrtime()` we are currently using (as long as the run completes in less than 100 days :)).

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
