### PR TITLE
test: fix test to allow quictls fork of OpenSSL 3

### DIFF
--- a/test/parallel/test-process-versions.js
+++ b/test/parallel/test-process-versions.js
@@ -54,7 +54,7 @@ if (common.hasCrypto) {
     // The following also matches a development version of OpenSSL 3.x which
     // can be in the format '3.0.0-alpha4-dev'. This can be handy when building
     // and linking against the main development branch of OpenSSL.
-    /^\d+\.\d+\.\d+(-[-a-z0-9]+)?$/ :
+    /^\d+\.\d+\.\d+(?:[-+][a-z0-9]+)*$/ :
     /^\d+\.\d+\.\d+[a-z]?(\+quic)?(-fips)?$/;
   assert(versionRegex.test(process.versions.openssl));
 }


### PR DESCRIPTION
The quictls fork of OpenSSL identifies itself with a `+quic` suffix
in its version string. This was previously rejected by the version
string check as the `+` was not an allowed character.

Refs: https://github.com/nodejs/node/commit/7ac626505d2f6f2e603bd7c9ddb356c893bbbe55

Discovered while testing https://github.com/nodejs/build/pull/2613.
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
