### PR TITLE
perf_hooks: use `process.hrtime.bigint()`

### DIFF
--- a/lib/internal/perf/now.js
+++ b/lib/internal/perf/now.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const {
+  Number,
+} = primordials;
+
+const {
+  timeOriginBigInt,
+} = internalBinding('performance');
+
+const ns2ms = 10n ** 6n;
+module.exports = function now() {
+  const time = process.hrtime.bigint() - timeOriginBigInt;
+  return Number(time / ns2ms) + Number(time % ns2ms) / 1e6;
+};

--- a/lib/internal/perf/perf.js
+++ b/lib/internal/perf/perf.js
@@ -6,9 +6,7 @@ const {
   TypeError,
 } = primordials;
 
-const {
-  timeOrigin,
-} = internalBinding('performance');
+const now = require('internal/perf/now');
 
 const {
   customInspectSymbol: kInspect,
@@ -23,10 +21,6 @@ const kDuration = Symbol('kDuration');
 const kDetail = Symbol('kDetail');
 const kReadOnlyAttributes = Symbol('kReadOnlyAttributes');
 
-function now() {
-  const hr = process.hrtime();
-  return (hr[0] * 1000 + hr[1] / 1e6) - timeOrigin;
-}
 
 function isPerformanceEntry(obj) {
   return obj?.[kName] !== undefined;

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -29,7 +29,7 @@ const {
 const EventEmitter = require('events');
 const assert = require('internal/assert');
 const path = require('path');
-const { timeOrigin } = internalBinding('performance');
+const now = require('internal/perf/now');
 
 const errorCodes = require('internal/errors').codes;
 const {
@@ -501,12 +501,6 @@ function eventLoopUtilization(util1, util2) {
   const active_delta = active - util1.active;
   const utilization = active_delta / (idle_delta + active_delta);
   return { idle: idle_delta, active: active_delta, utilization };
-}
-
-// Duplicate code from performance.now() so don't need to require perf_hooks.
-function now() {
-  const hr = process.hrtime();
-  return (hr[0] * 1000 + hr[1] / 1e6) - timeOrigin;
 }
 
 module.exports = {

--- a/node.gyp
+++ b/node.gyp
@@ -196,6 +196,7 @@
       'lib/internal/options.js',
       'lib/internal/perf/perf.js',
       'lib/internal/perf/nodetiming.js',
+      'lib/internal/perf/now.js',
       'lib/internal/perf/usertiming.js',
       'lib/internal/perf/observe.js',
       'lib/internal/perf/event_loop_delay.js',

--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -13,6 +13,7 @@
 namespace node {
 namespace performance {
 
+using v8::BigInt;
 using v8::Context;
 using v8::DontDelete;
 using v8::Function;
@@ -347,6 +348,10 @@ void Initialize(Local<Object> target,
   target->DefineOwnProperty(context,
                             FIXED_ONE_BYTE_STRING(isolate, "timeOrigin"),
                             Number::New(isolate, timeOrigin / 1e6),
+                            attr).ToChecked();
+  target->DefineOwnProperty(context,
+                            FIXED_ONE_BYTE_STRING(isolate, "timeOriginBigInt"),
+                            BigInt::New(isolate, timeOrigin),
                             attr).ToChecked();
 
   target->DefineOwnProperty(


### PR DESCRIPTION
Putting `now` in a separate module so we can re-use it for the worker implementation.

This might be actually slower than the legacy implementation: https://jsben.ch/NQjs4
Opening to run more benchmark to see if that's noticable.
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
