### PR TITLE
async_hooks,doc: cache process.stdout.fd outside init

### DIFF
--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -271,11 +271,16 @@ created, while `triggerAsyncId` shows *why* a resource was created.
 The following is a simple demonstration of `triggerAsyncId`:
 
 ```js
+const async_hooks = require('async_hooks');
+const fs = require('fs');
+
+const { fd } = process.stdout;
+
 async_hooks.createHook({
   init(asyncId, type, triggerAsyncId) {
     const eid = async_hooks.executionAsyncId();
     fs.writeSync(
-      1,
+      fd,
       `${type}(${asyncId}): trigger: ${triggerAsyncId} execution: ${eid}\n`);
   }
 }).enable();
@@ -322,29 +327,34 @@ callback to `listen()` will look like. The output formatting is slightly more
 elaborate to make calling context easier to see.
 
 ```js
+const async_hooks = require('async_hooks');
+const fs = require('fs');
+
+const { fd } = process.stdout;
+
 let indent = 0;
 async_hooks.createHook({
   init(asyncId, type, triggerAsyncId) {
     const eid = async_hooks.executionAsyncId();
     const indentStr = ' '.repeat(indent);
     fs.writeSync(
-      1,
+      fd,
       `${indentStr}${type}(${asyncId}):` +
       ` trigger: ${triggerAsyncId} execution: ${eid}\n`);
   },
   before(asyncId) {
     const indentStr = ' '.repeat(indent);
-    fs.writeSync(process.stdout.fd, `${indentStr}before:  ${asyncId}\n`);
+    fs.writeSync(fd, `${indentStr}before:  ${asyncId}\n`);
     indent += 2;
   },
   after(asyncId) {
     indent -= 2;
     const indentStr = ' '.repeat(indent);
-    fs.writeSync(process.stdout.fd, `${indentStr}after:  ${asyncId}\n`);
+    fs.writeSync(fd, `${indentStr}after:  ${asyncId}\n`);
   },
   destroy(asyncId) {
     const indentStr = ' '.repeat(indent);
-    fs.writeSync(process.stdout.fd, `${indentStr}destroy:  ${asyncId}\n`);
+    fs.writeSync(fd, `${indentStr}destroy:  ${asyncId}\n`);
   },
 }).enable();
 

--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -275,7 +275,7 @@ async_hooks.createHook({
   init(asyncId, type, triggerAsyncId) {
     const eid = async_hooks.executionAsyncId();
     fs.writeSync(
-      process.stdout.fd,
+      1,
       `${type}(${asyncId}): trigger: ${triggerAsyncId} execution: ${eid}\n`);
   }
 }).enable();
@@ -328,7 +328,7 @@ async_hooks.createHook({
     const eid = async_hooks.executionAsyncId();
     const indentStr = ' '.repeat(indent);
     fs.writeSync(
-      process.stdout.fd,
+      1,
       `${indentStr}${type}(${asyncId}):` +
       ` trigger: ${triggerAsyncId} execution: ${eid}\n`);
   },

--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -271,9 +271,6 @@ created, while `triggerAsyncId` shows *why* a resource was created.
 The following is a simple demonstration of `triggerAsyncId`:
 
 ```js
-const async_hooks = require('async_hooks');
-const fs = require('fs');
-
 const { fd } = process.stdout;
 
 async_hooks.createHook({
@@ -285,7 +282,7 @@ async_hooks.createHook({
   }
 }).enable();
 
-require('net').createServer((conn) => {}).listen(8080);
+net.createServer((conn) => {}).listen(8080);
 ```
 
 Output when hitting the server with `nc localhost 8080`:
@@ -327,9 +324,6 @@ callback to `listen()` will look like. The output formatting is slightly more
 elaborate to make calling context easier to see.
 
 ```js
-const async_hooks = require('async_hooks');
-const fs = require('fs');
-
 const { fd } = process.stdout;
 
 let indent = 0;
@@ -358,7 +352,7 @@ async_hooks.createHook({
   },
 }).enable();
 
-require('net').createServer(() => {}).listen(8080, () => {
+net.createServer(() => {}).listen(8080, () => {
   // Let's wait 10ms before logging the server started.
   setTimeout(() => {
     console.log('>>>', async_hooks.executionAsyncId());


### PR DESCRIPTION
This stops "RangeError: Maximum call stack size exceeded".

<details>

```console
❯ node -v
v15.2.0
❯ node --trace-uncaught before.js
node:internal/async_hooks:204
    fatalError(e);
    ^

RangeError: Maximum call stack size exceeded
Thrown at:
    at emitInitNative (node:internal/async_hooks:204:5)
    at WriteStream (node:tty:91:15)
    at createWritableStdioStream (node:internal/bootstrap/switches/is_main_thread:47:16)
    at getStdout (node:internal/bootstrap/switches/is_main_thread:122:12)
    at init (/home/raisinten/Desktop/universe/temp/project/before.js:8:15)
    at emitInitNative (node:internal/async_hooks:197:43)
    at WriteStream (node:tty:91:15)
    at createWritableStdioStream (node:internal/bootstrap/switches/is_main_thread:47:16)
    at getStdout (node:internal/bootstrap/switches/is_main_thread:122:12)
    at init (/home/raisinten/Desktop/universe/temp/project/before.js:8:15)
❯ echo $?
7
❯ node --trace-uncaught after.js
TCPSERVERWRAP(2): trigger: 1 execution: 1
TickObject(3): trigger: 2 execution: 1
^C
```

</details>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
