### PR TITLE
lib: add support for JSTransferable as a mixin

### DIFF
--- a/lib/internal/test/transfer.js
+++ b/lib/internal/test/transfer.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const {
+  makeTransferable,
+  kClone,
+  kDeserialize,
+} = require('internal/worker/js_transferable');
+
+process.emitWarning(
+  'These APIs are for internal testing only. Do not use them.',
+  'internal/test/transfer');
+
+// Used as part of parallel/test-messaging-maketransferable.
+// This has to exist within the lib/internal/ path in order
+// for deserialization to work.
+
+class E {
+  constructor(b) {
+    this.b = b;
+  }
+}
+
+class F extends E {
+  constructor(b) {
+    super(b);
+    /* eslint-disable-next-line no-constructor-return */
+    return makeTransferable(this);
+  }
+
+  [kClone]() {
+    return {
+      data: { b: this.b },
+      deserializeInfo: 'internal/test/transfer:F'
+    };
+  }
+
+  [kDeserialize]({ b }) {
+    this.b = b;
+  }
+}
+
+module.exports = { E, F };

--- a/lib/internal/worker/js_transferable.js
+++ b/lib/internal/worker/js_transferable.js
@@ -1,6 +1,11 @@
 'use strict';
 const {
   Error,
+  ObjectDefineProperties,
+  ObjectGetOwnPropertyDescriptors,
+  ObjectGetPrototypeOf,
+  ObjectSetPrototypeOf,
+  ReflectConstruct,
   StringPrototypeSplit,
 } = primordials;
 const {
@@ -22,21 +27,30 @@ function setup() {
     const { 0: module, 1: ctor } = StringPrototypeSplit(deserializeInfo, ':');
     const Ctor = require(module)[ctor];
     if (typeof Ctor !== 'function' ||
-        !(Ctor.prototype instanceof JSTransferable)) {
+        typeof Ctor.prototype[messaging_deserialize_symbol] !== 'function') {
       // Not one of the official errors because one should not be able to get
       // here without messing with Node.js internals.
       // eslint-disable-next-line no-restricted-syntax
       throw new Error(`Unknown deserialize spec ${deserializeInfo}`);
     }
+
     return new Ctor();
   });
 }
 
+function makeTransferable(obj) {
+  const inst = ReflectConstruct(JSTransferable, [], obj.constructor);
+  ObjectDefineProperties(inst, ObjectGetOwnPropertyDescriptors(obj));
+  ObjectSetPrototypeOf(inst, ObjectGetPrototypeOf(obj));
+  return inst;
+}
+
 module.exports = {
+  makeTransferable,
   setup,
   JSTransferable,
   kClone: messaging_clone_symbol,
   kDeserialize: messaging_deserialize_symbol,
   kTransfer: messaging_transfer_symbol,
-  kTransferList: messaging_transfer_list_symbol
+  kTransferList: messaging_transfer_list_symbol,
 };

--- a/node.gyp
+++ b/node.gyp
@@ -229,6 +229,7 @@
       'lib/internal/source_map/source_map.js',
       'lib/internal/source_map/source_map_cache.js',
       'lib/internal/test/binding.js',
+      'lib/internal/test/transfer.js',
       'lib/internal/timers.js',
       'lib/internal/tls.js',
       'lib/internal/trace_events_async_hooks.js',

--- a/test/parallel/test-messaging-maketransferable.js
+++ b/test/parallel/test-messaging-maketransferable.js
@@ -1,0 +1,27 @@
+// Flags: --expose-internals
+'use strict';
+
+const common = require('../common');
+
+const assert = require('assert');
+const {
+  JSTransferable,
+} = require('internal/worker/js_transferable');
+const { E, F } = require('internal/test/transfer');
+
+// Tests that F is transferable even tho it does not directly,
+// observably extend the JSTransferable class.
+
+const mc = new MessageChannel();
+
+mc.port1.onmessageerror = common.mustNotCall();
+
+mc.port1.onmessage = common.mustCall(({ data }) => {
+  assert(!(data instanceof JSTransferable));
+  assert(data instanceof F);
+  assert(data instanceof E);
+  assert.strictEqual(data.b, 1);
+  mc.port1.close();
+});
+
+mc.port2.postMessage(new F(1));


### PR DESCRIPTION
@addaleax ... Very interested in what you think on this... the use case is that I want to define internal classes that are both transferable *and* extend `NodeEventTarget` but without forcing all `NodeEventTarget` instances to be cloneable or incur the cost of extending `JSTransferable`. Because we can't use multiple inheritance this uses `JSTransferable` as a kind of mixin.

This is not a public facing API. It is inteded for internal use only for now.

---

Adds a new `makeTransferable()` utility that can construct a
`JSTransferable` object that does not directly extend the
`JSTransferable` JavaScript class.

Because JavaScript does not support multiple inheritance, it is
not possible (without help) to implement a class that extends
both `JSTransferable` and, for instance, `EventTarget` without
incurring a significant additional complexity and performance
cost by making all `EventTarget` instances extend `JSTransferable`...

That is, we *don't* want:

```js
class EventTarget extends JSTransferable { ... }
```

The `makeTransferable()` allows us to create objects that are
backed internally by `JSTransferable` without having to actually
extend it by leveraging the magic of `Reflect.construct()`.

```js
const {
  JSTransferable,
  kClone,
  kDeserialize,
  makeTransferable,
} = require('internal/worker/js_transferable');

class E {
  constructor(b) {
    this.b = b;
  }
}

class F extends E {
  constructor(b) {
    super(b);
    return makeTransferable(this);
  }

  [kClone]() { /** ... **/ }
  [kDeserialize]() { /** ... **/ }
}

const f = new F();

f instanceof F;  // true
f instanceof E;  // true
f instanceof JSTransferable;  // false

const mc = new MessageChannel();
mc.port1.onmessage = ({ data }) => {
  data instanceof F;  // true
  data instanceof E;  // true
  data instanceof JSTransferable;  // false
};
mc.port2.postMessage(f);  // works!
```

The additional `internal/test/transfer.js` file is required for the
test because successfully deserializing transferable classes requires
that they be located in `lib/internal` for now.

Signed-off-by: James M Snell <jasnell@gmail.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
