### PR TITLE
tools: update markdown linter rules

### DIFF
--- a/tools/lint-md.js
+++ b/tools/lint-md.js
@@ -49667,6 +49667,11 @@ function validateMeta(node, file, meta) {
 
 function validateYAMLComments(tree, file) {
   unistUtilVisit(tree, "html", function visitor(node) {
+    if (node.value.startsWith("<!--YAML\n"))
+      file.message(
+        "Expected `<!-- YAML`, found `<!--YAML`. Please add a space",
+        node
+      );
     if (!node.value.startsWith("<!-- YAML\n")) return;
     try {
       const meta = jsYaml$2.load("#" + node.value.slice(0, -"-->".length));

--- a/tools/node-lint-md-cli-rollup/package-lock.json
+++ b/tools/node-lint-md-cli-rollup/package-lock.json
@@ -2111,9 +2111,9 @@
       }
     },
     "node_modules/remark-preset-lint-node": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/remark-preset-lint-node/-/remark-preset-lint-node-2.1.1.tgz",
-      "integrity": "sha512-3Cv4kDVaC8V0XsiK/ntdpOEztOx0v8L9DczQ3KRIN7QwyPS3Gjaq2DJ7wNglXVK4z7PekcND0mXK78eLduhwwA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/remark-preset-lint-node/-/remark-preset-lint-node-2.2.0.tgz",
+      "integrity": "sha512-85wnJs7HyQlY3Ae5HRxPjJx5cFBvAAOSfSpmyNVb6Fs9HYoR9ipimAxWfl2M1gYVT2rBrod8Jzu415dOMukzOw==",
       "dependencies": {
         "js-yaml": "^4.0.0",
         "remark-lint": "^8.0.0",
@@ -4226,9 +4226,9 @@
       }
     },
     "remark-preset-lint-node": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/remark-preset-lint-node/-/remark-preset-lint-node-2.1.1.tgz",
-      "integrity": "sha512-3Cv4kDVaC8V0XsiK/ntdpOEztOx0v8L9DczQ3KRIN7QwyPS3Gjaq2DJ7wNglXVK4z7PekcND0mXK78eLduhwwA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/remark-preset-lint-node/-/remark-preset-lint-node-2.2.0.tgz",
+      "integrity": "sha512-85wnJs7HyQlY3Ae5HRxPjJx5cFBvAAOSfSpmyNVb6Fs9HYoR9ipimAxWfl2M1gYVT2rBrod8Jzu415dOMukzOw==",
       "requires": {
         "js-yaml": "^4.0.0",
         "remark-lint": "^8.0.0",


### PR DESCRIPTION
Update remark-preset-lint-node to 2.2.0 which includes improved YAML
comment linting for our markdown files.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
