### PR TITLE
debugger: cherry-pick remaining commits for node-inspect

### DIFF
--- a/lib/internal/inspector/_inspect.js
+++ b/lib/internal/inspector/_inspect.js
@@ -340,6 +340,7 @@ function startInspect(argv = process.argv.slice(2),
 
     console.error(`Usage: ${invokedAs} script.js`);
     console.error(`       ${invokedAs} <host>:<port>`);
+    console.error(`       ${invokedAs} --port=<port>`);
     console.error(`       ${invokedAs} -p <pid>`);
     process.exit(1);
   }

--- a/lib/internal/inspector/inspect_repl.js
+++ b/lib/internal/inspector/inspect_repl.js
@@ -1027,7 +1027,7 @@ function createRepl(inspector) {
 
         repl.setPrompt('> ');
 
-        print('Press Ctrl + C to leave debug repl');
+        print('Press Ctrl+C to leave debug repl');
         repl.displayPrompt();
       },
 
@@ -1096,7 +1096,7 @@ function createRepl(inspector) {
     repl.on('reset', initializeContext);
 
     repl.defineCommand('interrupt', () => {
-      // We want this for testing purposes where sending CTRL-C can be tricky.
+      // We want this for testing purposes where sending Ctrl+C can be tricky.
       repl.emit('SIGINT');
     });
 

--- a/lib/internal/inspector/inspect_repl.js
+++ b/lib/internal/inspector/inspect_repl.js
@@ -581,7 +581,7 @@ function createRepl(inspector) {
         const lines = watchedExpressions
           .map((expr, idx) => {
             const prefix = `${leftPad(idx, ' ', lastIndex)}: ${expr} =`;
-            const value = inspect(values[idx], { colors: true });
+            const value = inspect(values[idx]);
             if (value.indexOf('\n') === -1) {
               return `${prefix} ${value}`;
             }

--- a/test/inspector-cli/test-inspector-cli-exec.js
+++ b/test/inspector-cli/test-inspector-cli-exec.js
@@ -31,7 +31,7 @@ const assert = require('assert');
     .then(() => {
       assert.match(
         cli.output,
-        /Press Ctrl \+ C to leave debug repl\n+> /,
+        /Press Ctrl\+C to leave debug repl\n+> /,
         'shows hint for how to leave repl');
       assert.doesNotMatch(cli.output, /debug>/, 'changes the repl style');
     })


### PR DESCRIPTION
The move of node-inspect from deps to core did not include three relevant commits that landed in the node-inspect repository after the last node-inspect release. This pull request includes them.