### PR TITLE
worker: avoid potential deadlock on NearHeapLimit

### DIFF
--- a/src/node_worker.h
+++ b/src/node_worker.h
@@ -70,7 +70,7 @@ class Worker : public AsyncWrap {
   static void LoopStartTime(const v8::FunctionCallbackInfo<v8::Value>& args);
 
  private:
-  void CreateEnvMessagePort(Environment* env);
+  bool CreateEnvMessagePort(Environment* env);
   static size_t NearHeapLimit(void* data, size_t current_heap_limit,
                               size_t initial_heap_limit);
 

--- a/test/parallel/test-worker-nearheaplimit-deadlock.js
+++ b/test/parallel/test-worker-nearheaplimit-deadlock.js
@@ -1,0 +1,22 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { Worker } = require('worker_threads');
+
+// Do not use isMainThread so that this test itself can be run inside a Worker.
+if (!process.env.HAS_STARTED_WORKER) {
+  process.env.HAS_STARTED_WORKER = 1;
+  const opts = {
+    resourceLimits: {
+      maxYoungGenerationSizeMb: 0,
+      maxOldGenerationSizeMb: 0
+    }
+  };
+
+  const worker = new Worker(__filename, opts);
+  worker.on('error', common.mustCall((err) => {
+    assert.strictEqual(err.code, 'ERR_WORKER_OUT_OF_MEMORY');
+  }));
+} else {
+  setInterval(() => {}, 1);
+}


### PR DESCRIPTION
It can happen that the `NearHeapLimit` callback is called while calling
the `oninit()` function on `MessagePort` construction causing a deadlock
when the `Worker::Exit()` method is called, as the `mutex_` was already
held on the `CreateEnvMessagePort()` method. To fix it, just use the
`mutex_` to protect the `child_port_data_` variable and avoid holding it
when creating the `MessagePort`.
Also, return early from `Worker::Run()` if the worker message port
could not be created.

Fixes: https://github.com/nodejs/node/issues/38208.

A couple of things I'd like to point out:
- I've only been able to reproduce the issue from the original report in the `v12.x` branch, but I think that potentially it could happen on newer branches too.
- I've implemented this solution on the assumption that the mutex is only needed to protect `child_port_data_` based on this [comment](https://github.com/nodejs/node/blob/master/src/node_worker.h#L87), if that's not the case, it won't work. Another option I've tried that also works was using a recursive mutex, but I don't know if that solution would be acceptable.