### PR TITLE
Add IBM i to supported platform list

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -117,6 +117,7 @@ platforms. This is true regardless of entries in the table below.
 | macOS            | arm64            | >= 11                           | Experimental |                                   |
 | SmartOS          | x64              | >= 18                           | Tier 2       |                                   |
 | AIX              | ppc64be >=power7 | >= 7.2 TL04                     | Tier 2       |                                   |
+| IBM i            | ppc64be >=power7 | >= 7.3                          | Tier 2       |                                   |
 | FreeBSD          | x64              | >= 11                           | Experimental | Downgraded as of Node.js 12  <sup>[7](#fn7)</sup>     |
 
 <em id="fn1">1</em>: GCC 8 is not provided on the base platform. Users will


### PR DESCRIPTION
Justification for adding IBM i to the supported platform list: 
- IBM i is part of the [Nightly CI builds](https://ci.nodejs.org/job/node-test-commit-ibmi/nodes=ibmi72-ppc64/)
- IBM offers [premium support](http://ibm.biz/ibmi-oss-support) for Node.js on IBM i
- Node.js is [readily available via yum](https://nodejs.org/en/download/package-manager/#ibm-i) for IBM i users.
- There are @nodejs/platform-ibmi and @libuv/ibmi platform teams that can be engaged on any submitted issues
- Node.js has been quite successful on the platform, (Thanks, @mhdawson for the shout out [here](https://www.youtube.com/watch?v=t3MR6v_YKyA&feature=youtu.be&t=795)!)
- Node.js on IBM i is awesome 