### PR TITLE
tools: remove fixer for non-ascii-character ESLint custom rule

### DIFF
--- a/test/parallel/test-eslint-non-ascii-character.js
+++ b/test/parallel/test-eslint-non-ascii-character.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+common.skipIfEslintMissing();
+
+const RuleTester = require('../../tools/node_modules/eslint').RuleTester;
+const rule = require('../../tools/eslint-rules/non-ascii-character');
+
+new RuleTester().run('non-ascii-characters', rule, {
+  valid: [
+    {
+      code: 'console.log("fhqwhgads")',
+      options: []
+    },
+  ],
+  invalid: [
+    {
+      code: 'console.log("μ")',
+      options: [],
+      errors: [{ message: "Non-ASCII character 'μ' detected." }],
+    },
+  ]
+});

--- a/tools/eslint-rules/non-ascii-character.js
+++ b/tools/eslint-rules/non-ascii-character.js
@@ -46,20 +46,10 @@ module.exports = (context) => {
       node,
       message,
       loc: sourceCode.getLocFromIndex(offendingCharacterPosition),
-      fix: (fixer) => {
-        return fixer.replaceText(
-          node,
-          suggestion ? `${suggestion}` : ''
-        );
-      }
     });
   };
 
   return {
     Program: (node) => reportIfError(node, context.getSourceCode())
   };
-};
-
-module.exports.meta = {
-  fixable: 'code'
 };


### PR DESCRIPTION
The fixer for non-ascii-character does not typidally do the right thing. It
removes the entire node, not the offending character. I discovered this
when it removed the entire contents of a file and I wasn't sure which
auto-fix rule was doing it.

This commit adds a minimal test for the rule. The tests require that
auto-fix results be supplied, so if someone wants to re-add auto-fixing
to the rule, we'll have tests that it does the right thing.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
