### PR TITLE
perf_hooks: fix PerformanceObserver 'gc' crash

### DIFF
--- a/lib/internal/perf/observe.js
+++ b/lib/internal/perf/observe.js
@@ -72,6 +72,8 @@ const kDeprecationMessage =
 const kTypeSingle = 0;
 const kTypeMultiple = 1;
 
+let gcTrackingInstalled = false;
+
 const kSupportedEntryTypes = ObjectFreeze([
   'function',
   'gc',
@@ -124,8 +126,11 @@ function maybeIncrementObserverCount(type) {
 
   if (observerType !== undefined) {
     observerCounts[observerType]++;
-    if (observerType === NODE_PERFORMANCE_ENTRY_TYPE_GC)
+    if (!gcTrackingInstalled &&
+        observerType === NODE_PERFORMANCE_ENTRY_TYPE_GC) {
       installGarbageCollectionTracking();
+      gcTrackingInstalled = true;
+    }
   }
 }
 

--- a/test/parallel/test-performanceobserver-gc.js
+++ b/test/parallel/test-performanceobserver-gc.js
@@ -1,0 +1,17 @@
+'use strict';
+
+require('../common');
+
+// Verifies that setting up two observers to listen
+// to gc performance does not crash.
+
+const {
+  PerformanceObserver,
+} = require('perf_hooks');
+
+// We don't actually care if the callback is ever invoked in this test
+const obs = new PerformanceObserver(() => {});
+const obs2 = new PerformanceObserver(() => {});
+
+obs.observe({ type: 'gc' });
+obs2.observe({ type: 'gc' });


### PR DESCRIPTION
Signed-off-by: James M Snell <jasnell@gmail.com>
Fixes: https://github.com/nodejs/node/issues/38412

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
