### PR TITLE
lib: harden lint checks for globals

### DIFF
--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -31,8 +31,8 @@ rules:
       message: "Use `const { AbortController } = require('internal/abort_controller');` instead of the global."
     - name: AbortSignal
       message: "Use `const { AbortSignal } = require('internal/abort_controller');` instead of the global."
-      # Atomics is not available in primordials because it's behind
-      # --no-harmony-atomics CLI flag.
+      # Atomics is not available in primordials because it can be
+      # disabled with --no-harmony-atomics CLI flag.
     - name: Atomics
       message: "Use `const { Atomics } = globalThis;` instead of the global."
     - name: Buffer
@@ -41,8 +41,8 @@ rules:
       message: "Use `const { Event } = require('internal/event_target');` instead of the global."
     - name: EventTarget
       message: "Use `const { EventTarget } = require('internal/event_target');` instead of the global."
-      # Intl is not available in primordials because it's behind
-      # --without-intl build flag.
+      # Intl is not available in primordials because it can be
+      # disabled with --without-intl build flag.
     - name: Intl
       message: "Use `const { Intl } = globalThis;` instead of the global."
     - name: MessageChannel
@@ -51,8 +51,8 @@ rules:
       message: "Use `const { MessageEvent } = require('internal/worker/io');` instead of the global."
     - name: MessagePort
       message: "Use `const { MessagePort } = require('internal/worker/io');` instead of the global."
-      # SharedArrayBuffer is not available in primordials because it's behind
-      # --no-harmony-sharedarraybuffer CLI flag.
+      # SharedArrayBuffer is not available in primordials because it can be
+      # disabled with --no-harmony-sharedarraybuffer CLI flag.
     - name: SharedArrayBuffer
       message: "Use `const { SharedArrayBuffer } = globalThis;` instead of the global."
     - name: TextDecoder
@@ -63,8 +63,8 @@ rules:
       message: "Use `const { URL } = require('internal/url');` instead of the global."
     - name: URLSearchParams
       message: "Use `const { URLSearchParams } = require('internal/url');` instead of the global."
-      # WebAssembly is not available in primordials because it's behind
-      # --no-harmony-sharedarraybuffer CLI flag.
+      # WebAssembly is not available in primordials because it can be
+      # disabled with --jitless CLI flag.
     - name: WebAssembly
       message: "Use `const { WebAssembly } = globalThis;` instead of the global."
     - name: atob

--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -27,16 +27,65 @@ rules:
       message: "Use 'overrideStackTrace' from 'lib/internal/errors.js' instead of 'Error.prepareStackTrace'."
   no-restricted-globals:
     - error
-    - name: globalThis
-      message: "Use `const { globalThis } = primordials;` instead of the global."
+    - name: AbortController
+      message: "Use `const { AbortController } = require('internal/abort_controller');` instead of the global."
+    - name: AbortSignal
+      message: "Use `const { AbortSignal } = require('internal/abort_controller');` instead of the global."
+      # Atomics is not available in primordials because it's behind
+      # --no-harmony-atomics CLI flag.
+    - name: Atomics
+      message: "Use `const { Atomics } = globalThis;` instead of the global."
+    - name: Buffer
+      message: "Use `const { Buffer } = require('buffer');` instead of the global."
+    - name: Event
+      message: "Use `const { Event } = require('internal/event_target');` instead of the global."
+    - name: EventTarget
+      message: "Use `const { EventTarget } = require('internal/event_target');` instead of the global."
+      # Intl is not available in primordials because it's behind
+      # --without-intl build flag.
+    - name: Intl
+      message: "Use `const { Intl } = globalThis;` instead of the global."
+    - name: MessageChannel
+      message: "Use `const { MessageChannel } = require('internal/worker/io');` instead of the global."
+    - name: MessageEvent
+      message: "Use `const { MessageEvent } = require('internal/worker/io');` instead of the global."
+    - name: MessagePort
+      message: "Use `const { MessagePort } = require('internal/worker/io');` instead of the global."
+      # SharedArrayBuffer is not available in primordials because it's behind
+      # --no-harmony-sharedarraybuffer CLI flag.
+    - name: SharedArrayBuffer
+      message: "Use `const { SharedArrayBuffer } = globalThis;` instead of the global."
+    - name: TextDecoder
+      message: "Use `const { TextDecoder } = require('internal/encoding');` instead of the global."
+    - name: TextEncoder
+      message: "Use `const { TextEncoder } = require('internal/encoding');` instead of the global."
+    - name: URL
+      message: "Use `const { URL } = require('internal/url');` instead of the global."
+    - name: URLSearchParams
+      message: "Use `const { URLSearchParams } = require('internal/url');` instead of the global."
+      # WebAssembly is not available in primordials because it's behind
+      # --no-harmony-sharedarraybuffer CLI flag.
+    - name: WebAssembly
+      message: "Use `const { WebAssembly } = globalThis;` instead of the global."
+    - name: atob
+      message: "Use `const { atob } = require('buffer');` instead of the global."
+    - name: btoa
+      message: "Use `const { btoa } = require('buffer');` instead of the global."
     - name: global
       message: "Use `const { globalThis } = primordials;` instead of `global`."
+    - name: globalThis
+      message: "Use `const { globalThis } = primordials;` instead of the global."
+    - name: performance
+      message: "Use `const { performance } = require('perf_hooks');` instead of the global."
+    - name: queueMicrotask
+      message: "Use `const { queueMicrotask } = require('internal/process/task_queues');` instead of the global."
   # Custom rules in tools/eslint-rules
   node-core/lowercase-name-for-primitive: error
   node-core/non-ascii-character: error
   node-core/no-array-destructuring: error
   node-core/prefer-primordials:
     - error
+    - name: AggregateError
     - name: Array
     - name: ArrayBuffer
     - name: BigInt
@@ -76,6 +125,7 @@ rules:
       into: Number
     - name: parseInt
       into: Number
+    - name: Proxy
     - name: Promise
     - name: RangeError
     - name: ReferenceError

--- a/lib/internal/blob.js
+++ b/lib/internal/blob.js
@@ -20,6 +20,8 @@ const {
   FixedSizeBlobCopyJob,
 } = internalBinding('buffer');
 
+const { TextDecoder } = require('internal/encoding');
+
 const {
   JSTransferable,
   kClone,

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -46,6 +46,7 @@ const {
   ObjectGetPrototypeOf,
   ObjectPreventExtensions,
   ObjectSetPrototypeOf,
+  Proxy,
   ReflectGet,
   ReflectSet,
   SymbolToStringTag,

--- a/lib/internal/crypto/webcrypto.js
+++ b/lib/internal/crypto/webcrypto.js
@@ -26,7 +26,7 @@ const {
   validateString,
 } = require('internal/validators');
 
-const { TextDecoder } = require('internal/encoding');
+const { TextDecoder, TextEncoder } = require('internal/encoding');
 
 const {
   codes: {

--- a/lib/internal/freeze_intrinsics.js
+++ b/lib/internal/freeze_intrinsics.js
@@ -19,7 +19,7 @@
 // https://github.com/google/caja/blob/master/src/com/google/caja/ses/repairES5.js
 // https://github.com/tc39/proposal-ses/blob/e5271cc42a257a05dcae2fd94713ed2f46c08620/shim/src/freeze.js
 
-/* global WebAssembly, SharedArrayBuffer, console */
+/* global console */
 'use strict';
 
 const {
@@ -78,6 +78,7 @@ const {
   ObjectPrototypeHasOwnProperty,
   Promise,
   PromisePrototype,
+  Proxy,
   RangeError,
   RangeErrorPrototype,
   ReferenceError,
@@ -123,6 +124,13 @@ const {
   encodeURIComponent,
   globalThis,
 } = primordials;
+
+const {
+  Atomics,
+  Intl,
+  SharedArrayBuffer,
+  WebAssembly
+} = globalThis;
 
 module.exports = function() {
   const {

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -9,6 +9,7 @@ const {
   ObjectCreate,
   ObjectKeys,
   ObjectPrototypeHasOwnProperty,
+  Proxy,
   ReflectApply,
   ReflectGetPrototypeOf,
   StringPrototypeIncludes,

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -18,6 +18,7 @@ const {
   ObjectPrototypeHasOwnProperty,
   Promise,
   PromisePrototypeCatch,
+  Proxy,
   ReflectApply,
   ReflectGet,
   ReflectGetPrototypeOf,

--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -9,6 +9,7 @@ const {
   ArrayPrototypeSplice,
   ObjectDefineProperty,
   PromisePrototypeCatch,
+  globalThis: { Atomics },
 } = primordials;
 
 const {

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -45,6 +45,7 @@ const {
   ObjectPrototype,
   ObjectPrototypeHasOwnProperty,
   ObjectSetPrototypeOf,
+  Proxy,
   ReflectApply,
   ReflectSet,
   RegExpPrototypeTest,

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -1,7 +1,5 @@
 'use strict';
 
-/* global WebAssembly */
-
 const {
   ArrayPrototypeForEach,
   ArrayPrototypeMap,
@@ -21,6 +19,7 @@ const {
   StringPrototypeSplit,
   StringPrototypeStartsWith,
   SyntaxErrorPrototype,
+  globalThis: { WebAssembly },
 } = primordials;
 
 let _TYPES = null;
@@ -63,6 +62,7 @@ const experimentalImportMetaResolve =
     getOptionValue('--experimental-import-meta-resolve');
 const asyncESM = require('internal/process/esm_loader');
 const { emitWarningSync } = require('internal/process/warning');
+const { TextDecoder } = require('internal/encoding');
 
 let cjsParse;
 async function initCJSParse() {

--- a/lib/internal/per_context/primordials.js
+++ b/lib/internal/per_context/primordials.js
@@ -137,6 +137,7 @@ function copyPrototype(src, dest, prefix) {
 
 // Create copies of configurable value properties of the global object
 [
+  'Proxy',
   'globalThis',
 ].forEach((name) => {
   // eslint-disable-next-line no-restricted-globals
@@ -157,6 +158,7 @@ function copyPrototype(src, dest, prefix) {
 [
   'JSON',
   'Math',
+  'Proxy',
   'Reflect',
 ].forEach((name) => {
   // eslint-disable-next-line no-restricted-globals

--- a/lib/internal/v8_prof_polyfill.js
+++ b/lib/internal/v8_prof_polyfill.js
@@ -28,7 +28,7 @@
 'use strict';
 
 /* eslint-disable node-core/prefer-primordials */
-/* global Buffer, console */
+/* global console */
 
 module.exports = { versionCheck };
 
@@ -40,6 +40,7 @@ if (module.id === 'internal/v8_prof_polyfill') return;
 // Node polyfill
 const fs = require('fs');
 const cp = require('child_process');
+const { Buffer } = require('buffer');
 const os = {
   system: function(name, args) {
     if (process.platform === 'linux' && name === 'nm') {

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -1,7 +1,5 @@
 'use strict';
 
-/* global SharedArrayBuffer */
-
 const {
   ArrayIsArray,
   ArrayPrototypeForEach,
@@ -24,6 +22,7 @@ const {
   SymbolFor,
   TypedArrayPrototypeFill,
   Uint32Array,
+  globalThis: { Atomics, SharedArrayBuffer },
 } = primordials;
 
 const EventEmitter = require('events');

--- a/lib/internal/worker/io.js
+++ b/lib/internal/worker/io.js
@@ -41,6 +41,7 @@ const {
 const { Readable, Writable } = require('stream');
 const {
   Event,
+  EventTarget,
   NodeEventTarget,
   defineEventHandler,
   initNodeEventTarget,


### PR DESCRIPTION
In most cases we want to avoid relying of looking up the global scope to access an API, which could be mutated from userland.
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
