### PR TITLE
doc: indicate that abort tests do not generate core files

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -15,7 +15,7 @@ For the tests to run on Windows, be sure to clone Node.js source code with the
 
 | Directory        | Runs on CI | Purpose         |
 | ---------------- | ---------- | --------------- |
-| `abort`          | Yes        | Tests for when the `--abort-on-uncaught-exception` flag is used. |
+| `abort`          | Yes        | Tests that use `--abort-on-uncaught-exception` and other situations where we want to test something but avoid generating a core file. |
 | `addons`         | Yes        | Tests for [addon](https://nodejs.org/api/addons.html) functionality along with some tests that require an addon. |
 | `async-hooks`    | Yes       | Tests for [async_hooks](https://nodejs.org/api/async_hooks.html) functionality. |
 | `benchmark`      | Yes       | Test minimal functionality of benchmarks. |


### PR DESCRIPTION
The key thing about the tests in `test/abort` is that tests in that
directory do not generate core files (thanks to testcfg.py). Make a note
of that in the test README.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
