### PR TITLE
crypto: fix Hash and Cipher abort on end

### DIFF
--- a/lib/internal/crypto/cipher.js
+++ b/lib/internal/crypto/cipher.js
@@ -154,8 +154,16 @@ ObjectSetPrototypeOf(Cipher.prototype, LazyTransform.prototype);
 ObjectSetPrototypeOf(Cipher, LazyTransform);
 
 Cipher.prototype._transform = function _transform(chunk, encoding, callback) {
-  this.push(this[kHandle].update(chunk, encoding));
-  callback();
+  let error = null;
+  try {
+    if (typeof chunk === 'string') {
+      validateEncoding(chunk, encoding);
+    }
+    this.push(this[kHandle].update(chunk, encoding));
+  } catch (err) {
+    error = err;
+  }
+  callback(error);
 };
 
 Cipher.prototype._flush = function _flush(callback) {

--- a/lib/internal/crypto/hash.js
+++ b/lib/internal/crypto/hash.js
@@ -83,8 +83,13 @@ Hash.prototype.copy = function copy(options) {
 };
 
 Hash.prototype._transform = function _transform(chunk, encoding, callback) {
-  this[kHandle].update(chunk, encoding);
-  callback();
+  let error = null;
+  try {
+    this.update(chunk, encoding);
+  } catch (err) {
+    error = err;
+  }
+  callback(error);
 };
 
 Hash.prototype._flush = function _flush(callback) {

--- a/test/parallel/test-crypto-binary-default.js
+++ b/test/parallel/test-crypto-binary-default.js
@@ -579,6 +579,31 @@ assert.throws(
     name: 'TypeError'
   });
 
+{
+  const hash = crypto.createHash('sha1');
+  hash.on('error', common.mustCall((err) => {
+    assert.strictEqual(err.code, 'ERR_INVALID_ARG_VALUE');
+    assert.strictEqual(err.name, 'TypeError');
+  }));
+  hash.end('str', 'hex', common.mustCall((err) => {
+    assert.ok(err instanceof Error, 'err should be an error');
+    assert.strictEqual(err.code, 'ERR_STREAM_DESTROYED');
+    assert.strictEqual(err.name, 'Error');
+  }));
+}
+
+{
+  const decipher = crypto.createDecipher('des-ede3-cbc', '');
+  decipher.on('error', common.mustCall((err) => {
+    assert.strictEqual(err.code, 'ERR_INVALID_ARG_VALUE');
+    assert.strictEqual(err.name, 'TypeError');
+  }));
+  decipher.end('str', 'hex', common.mustCall((err) => {
+    assert.ok(err instanceof Error, 'err should be an error');
+    assert.strictEqual(err.code, 'ERR_STREAM_DESTROYED');
+    assert.strictEqual(err.name, 'Error');
+  }));
+}
 
 // Test Diffie-Hellman with two parties sharing a secret,
 // using various encodings as we go along


### PR DESCRIPTION
Fix `Hash` and `Cipher` aborting when using `end` with `hex` and specific lengths of chunks. The issue was caused because there was missing validation on the written content from the `end` method. Note that this actually affects quite a few things in Crypto. This affects decipher/cipher (both deprecated) but also decipheriv/cipheriv as well as Hash and Hmac.

I wasn't sure if this should throw in `_transform` or create an error and provide it to the callback, but according to the stream docs providing an error to the callback is what's expected - so I would love to get some input on my fix, and if it makes sense.

Fixes: https://github.com/nodejs/node/issues/38015