### PR TITLE
test: fix flaky inspector-cli tests when breakpoints are restored

### DIFF
--- a/test/common/inspector-cli.js
+++ b/test/common/inspector-cli.js
@@ -23,7 +23,10 @@ function startCLI(args, flags = [], spawnOpts = {}) {
     if (this === child.stderr) {
       stderrOutput += chunk;
     }
-    outputBuffer.push(chunk);
+    // TODO(trott): Figure out why the "breakpoints restored." message appears
+    // in unpredictable places especially on AIX in CI. We shouldn't be
+    // excluding it, but it gets in the way of the output checking for tests.
+    outputBuffer.push(chunk.replace(/\n*\d+ breakpoints restored\.\n*/mg, ''));
   }
 
   function getOutput() {

--- a/test/inspector-cli/test-inspector-cli-pid.js
+++ b/test/inspector-cli/test-inspector-cli-pid.js
@@ -40,16 +40,7 @@ function launchTarget(...args) {
     })
     .then(() => cli.command('sb("alive.js", 3)'))
     .then(() => cli.waitFor(/break/))
-    // TODO: There is a known issue on AIX and some other operating systems
-    // where the breakpoints aren't properly resolved yet when we reach this
-    // point. Eventually that should be figured out but for now we don't
-    // want to fail builds because of it.
-    // What it should be:
-    //
-    // .then(() => cli.waitForPrompt())
-    //
-    // What we're diong for now:
-    .then(() => cli.waitFor(/>\s+(?:\n1 breakpoints restored\.)?$/))
+    .then(() => cli.waitForPrompt())
     .then(() => {
       assert.match(
         cli.output,


### PR DESCRIPTION
Sometimes, there isn't a newine in the AIX output that already has a
comment indicating it needs investigation.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
