### PR TITLE
doc: remove dependencyspecifiers frozen remark

### DIFF
--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -556,8 +556,7 @@ const contextifiedObject = vm.createContext({
 
 * {string[]}
 
-The specifiers of all dependencies of this module. The returned array is frozen
-to disallow any changes to it.
+The specifiers of all dependencies of this module.
 
 Corresponds to the `[[RequestedModules]]` field of [Cyclic Module Record][]s in
 the ECMAScript specification.


### PR DESCRIPTION
returned module.dependencySpecifiers array is not frozen. it is Object.isFrozen -> false and indexes are mutable. tested on a SourceTextModule instance.

Maybe freezing was the intention and this is a bug but it might be a misplacement because module.namespace is actually frozen -as expected- but with no such remark.