### PR TITLE
doc: clarify that fs.Dir async iterator closes automatically

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -5138,9 +5138,6 @@ Subsequent reads will result in errors.
 A promise is returned that will be resolved after the resource has been
 closed.
 
-When using the async iterator, the {fs.Dir} object will be automatically
-closed after the iterator exits.
-
 #### `dir.close(callback)`
 <!-- YAML
 added: v12.12.0

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -901,6 +901,9 @@ try {
 }
 ```
 
+When using the async iterator, the {fs.Dir} object will be automatically
+closed after the iterator exits.
+
 ### `fsPromises.readdir(path[, options])`
 <!-- YAML
 added: v10.0.0
@@ -5119,6 +5122,9 @@ try {
 }
 ```
 
+When using the async iterator, the {fs.Dir} object will be automatically
+closed after the iterator exits.
+
 #### `dir.close()`
 <!-- YAML
 added: v12.12.0
@@ -5131,6 +5137,9 @@ Subsequent reads will result in errors.
 
 A promise is returned that will be resolved after the resource has been
 closed.
+
+When using the async iterator, the {fs.Dir} object will be automatically
+closed after the iterator exits.
 
 #### `dir.close(callback)`
 <!-- YAML


### PR DESCRIPTION
Signed-off-by: James M Snell <jasnell@gmail.com>
Fixes: https://github.com/nodejs/node/issues/35148