### PR TITLE
fs: introduce `filehandle.stream`

### DIFF
--- a/benchmark/fs/bench-stream-via-pipeline.js
+++ b/benchmark/fs/bench-stream-via-pipeline.js
@@ -1,0 +1,67 @@
+'use strict';
+const common = require('../common.js');
+const tmpdir = require('../../test/common/tmpdir');
+const path = require('path');
+const fsp = require('fs/promises');
+const fs = require('fs');
+const stream = require('stream');
+
+const KB = 2 ** 10;
+const MB = 2 ** 20;
+
+const configs = {
+  n: [100],
+  fileSize: [
+    1 * KB,
+    1 * MB,
+    10 * MB,
+  ],
+};
+
+tmpdir.refresh();
+const sourceRoot = path.resolve(tmpdir.path, 'source');
+const destRoot = path.resolve(tmpdir.path, 'dest');
+
+const bench = common.createBenchmark(main, configs);
+
+async function main(conf) {
+  const { fileSize } = conf;
+  // prepare temp files
+  const content = 'a'.repeat(fileSize);
+
+  const sourceName = `${sourceRoot}-${fileSize}`;
+  const destName = `${destRoot}-${fileSize}`;
+
+  const testFixtures = await Promise.all(
+    new Array(conf.n).fill(null).map((_, i) => prepareFixture(i))
+  );
+
+  bench.start();
+
+  await Promise.all(
+    testFixtures.map(
+      (testFixture) => {
+        return new Promise((resolve) => {
+          stream.pipeline(testFixture[0], testFixture[1], () => {
+            resolve();
+          });
+        });
+      })
+  );
+  bench.end(conf.n);
+
+  await Promise.all(testFixtures.map((_, i) => {
+    return cleanUp(i);
+  }));
+
+  async function prepareFixture(i) {
+    await fsp.writeFile(`${sourceName}-${i}`, content);
+    const destStream = fs.createWriteStream(`${destName}-${i}`);
+    const sourceStream = fs.createReadStream(`${sourceName}-${i}`);
+    return [sourceStream, destStream];
+  }
+
+  async function cleanUp(i) {
+    await Promise.all([fsp.unlink(`${sourceName}-${i}`), fsp.unlink(`${destName}-${i}`)]);
+  }
+}

--- a/benchmark/fs/bench-stream-via-pipeline.js
+++ b/benchmark/fs/bench-stream-via-pipeline.js
@@ -54,7 +54,7 @@ async function main(conf) {
     return [sourceStream, destStream];
   }
 
-  async function cleanUp(_, i) {
-    await Promise.all([fsp.unlink(`${sourceName}-${i}`), fsp.unlink(`${destName}-${i}`)]);
+  function cleanUp(_, i) {
+    return [fsp.unlink(`${sourceName}-${i}`), fsp.unlink(`${destName}-${i}`)];
   }
 }

--- a/benchmark/fs/bench-stream.js
+++ b/benchmark/fs/bench-stream.js
@@ -1,0 +1,59 @@
+'use strict';
+const common = require('../common.js');
+const tmpdir = require('../../test/common/tmpdir');
+const path = require('path');
+const fsp = require('fs/promises');
+const fs = require('fs');
+
+
+const KB = 2 ** 10;
+const MB = 2 ** 20;
+
+const configs = {
+  n: [100],
+  fileSize: [
+    1 * KB,
+    1 * MB,
+    10 * MB,
+  ],
+};
+
+tmpdir.refresh();
+const sourceRoot = path.resolve(tmpdir.path, 'source');
+const destRoot = path.resolve(tmpdir.path, 'dest');
+
+const bench = common.createBenchmark(main, configs);
+
+async function main(conf) {
+  const { fileSize } = conf;
+  const content = 'a'.repeat(fileSize);
+  const sourceName = `${sourceRoot}-${fileSize}`;
+  const destName = `${destRoot}-${fileSize}`;
+
+  const testFixtures = await Promise.all(
+    new Array(conf.n).fill(null).map((_, i) => prepareFixture(i))
+  );
+
+  bench.start();
+  await Promise.all(
+    testFixtures.map(
+      (testFixture) => testFixture[0].stream(testFixture[1])
+    )
+  );
+  bench.end(conf.n);
+
+  await Promise.all(testFixtures.map((_, i) => {
+    return cleanUp(i);
+  }));
+
+  async function prepareFixture(i) {
+    await fsp.writeFile(`${sourceName}-${i}`, content);
+    const destStream = fs.createWriteStream(`${destName}-${i}`);
+    const sourceHandle = await fsp.open(`${sourceName}-${i}`);
+    return [sourceHandle, destStream];
+  }
+
+  async function cleanUp(i) {
+    await Promise.all([fsp.unlink(`${sourceName}-${i}`), fsp.unlink(`${destName}-${i}`)]);
+  }
+}

--- a/benchmark/fs/bench-stream.js
+++ b/benchmark/fs/bench-stream.js
@@ -31,7 +31,7 @@ async function main(conf) {
   const destName = `${destRoot}-${fileSize}`;
 
   const testFixtures = await Promise.all(
-    new Array(conf.n).fill(null).map((_, i) => prepareFixture(i))
+    Array.from({ length: conf.n }, prepareFixture)
   );
 
   bench.start();
@@ -42,18 +42,16 @@ async function main(conf) {
   );
   bench.end(conf.n);
 
-  await Promise.all(testFixtures.map((_, i) => {
-    return cleanUp(i);
-  }));
+  await Promise.all(testFixtures.flatMap(cleanUp));
 
-  async function prepareFixture(i) {
+  async function prepareFixture(_, i) {
     await fsp.writeFile(`${sourceName}-${i}`, content);
     const destStream = fs.createWriteStream(`${destName}-${i}`);
     const sourceHandle = await fsp.open(`${sourceName}-${i}`);
     return [sourceHandle, destStream];
   }
 
-  async function cleanUp(i) {
+  async function cleanUp(_, i) {
     await Promise.all([fsp.unlink(`${sourceName}-${i}`), fsp.unlink(`${destName}-${i}`)]);
   }
 }

--- a/benchmark/fs/bench-stream.js
+++ b/benchmark/fs/bench-stream.js
@@ -51,7 +51,7 @@ async function main(conf) {
     return [sourceHandle, destStream];
   }
 
-  async function cleanUp(_, i) {
-    await Promise.all([fsp.unlink(`${sourceName}-${i}`), fsp.unlink(`${destName}-${i}`)]);
+  function cleanUp(_, i) {
+    return [fsp.unlink(`${sourceName}-${i}`), fsp.unlink(`${destName}-${i}`)];
   }
 }

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -368,6 +368,24 @@ changes:
     {fs.Stats} object should be `bigint`. **Default:** `false`.
 * Returns: {Promise} Fulfills with an {fs.Stats} for the file.
 
+#### `filehandle.stream(dst, [options])`
+<!-- YAML
+added: REPLACEME
+-->
+* dst {stream.Writable} Option
+* `options` {Object}
+  * `start` {integer} Optional, the position where stream starts from.
+    **Default:** `0`
+  * `end` {integer} Optional, the position where stream ends.
+    If it isn't provided. Stream will terminate at the EOF.
+  * `signal` {AbortSignal} Optional, signal of `AbortController`
+
+Push all contents of the file designated by `filehandle` to a writable
+stream `dst`.
+
+It is similar to `stream.pipe`, but it has better performance than
+`stream.pipe` on piping file.
+
 #### `filehandle.sync()`
 <!-- YAML
 added: v10.0.0

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -374,9 +374,9 @@ added: REPLACEME
 -->
 * dst {stream.Writable} Option
 * `options` {Object}
-  * `start` {integer} Optional, the position where stream starts from.
-    **Default:** `0`
-  * `end` {integer} Optional, the position where stream ends.
+  * `start` {integer} Optional, the position where stream starts from
+    (inclusive). **Default:** `0`
+  * `end` {integer} Optional, the position where stream ends (inclusive)
     If it isn't provided. Stream will terminate at the EOF.
   * `signal` {AbortSignal} Optional, signal of `AbortController`
 

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -375,7 +375,7 @@ added: REPLACEME
 * dst {stream.Writable} Option
 * `options` {Object}
   * `start` {integer} Optional, the position where stream starts from
-    (inclusive). **Default:** `0`
+    (inclusive). **Default:** Current Position of `filehandle`
   * `end` {integer} Optional, the position where stream ends (inclusive)
     If it isn't provided. Stream will terminate at the EOF.
   * `signal` {AbortSignal} Optional, signal of `AbortController`

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -31,6 +31,8 @@ const {
     ERR_INVALID_ARG_TYPE,
     ERR_INVALID_ARG_VALUE,
     ERR_METHOD_NOT_IMPLEMENTED,
+    ERR_STREAM_PREMATURE_CLOSE,
+    ERR_OUT_OF_RANGE
   },
   AbortError,
 } = require('internal/errors');
@@ -96,6 +98,8 @@ const {
 const getDirectoryEntriesPromise = promisify(getDirents);
 const validateRmOptionsPromise = promisify(validateRmOptions);
 
+let EE;
+
 class FileHandle extends EventEmitterMixin(JSTransferable) {
   /**
    * @param {InternalFSBinding.FileHandle | undefined} filehandle
@@ -131,6 +135,10 @@ class FileHandle extends EventEmitterMixin(JSTransferable) {
 
   datasync() {
     return fsCall(fdatasync, this);
+  }
+
+  stream(dst, options = {}) {
+    return fsCall(stream, this, dst, options);
   }
 
   sync() {
@@ -737,6 +745,70 @@ async function readFile(path, options) {
 
   const fd = await open(path, flag, 0o666);
   return PromisePrototypeFinally(readFileHandle(fd, options), fd.close);
+}
+
+async function stream(handle, dest, options) {
+  checkAborted(options.signal);
+  if (!EE) {
+    EE = require('events');
+  }
+  const BUFFER_SIZE = 128 * 2 ** 10;
+  const {
+    start = 0,
+    end,
+  } = options;
+
+  if (start && typeof start !== 'number') {
+    throw new ERR_INVALID_ARG_TYPE('start', 'number', start);
+  }
+  if (end && typeof end !== 'number') {
+    throw new ERR_INVALID_ARG_TYPE('end', 'number', end);
+  }
+  if (start < 0) {
+    throw new ERR_OUT_OF_RANGE('start', 'greater than 0', start);
+  }
+  if (end < 0) {
+    throw new ERR_OUT_OF_RANGE('end', 'greater than 0', end);
+  }
+  if (end && start > end) {
+    throw new ERR_OUT_OF_RANGE('start', `less than end ${end}`, start);
+  }
+
+  let currPos = start;
+  const allocatedBuffer = Buffer.allocUnsafe(
+    end ? MathMin(end - currPos, BUFFER_SIZE) : BUFFER_SIZE
+  );
+
+  while (true) {
+    if (end && currPos >= end) {
+      break;
+    }
+
+    checkAborted(options.signal);
+    if (dest.writableNeedDrain) {
+      await EE.once(dest, 'drain');
+    }
+
+    const { buffer, bytesRead } = await handle.read(
+      allocatedBuffer,
+      0,
+      allocatedBuffer.byteLength,
+      currPos
+    );
+
+    if (dest.destroyed) {
+      // Is that writable stream destroyed before is right?
+      throw new ERR_STREAM_PREMATURE_CLOSE();
+    }
+
+    // Nothing to read
+    if (bytesRead === 0) {
+      break;
+    }
+
+    dest.write(buffer.slice(0, bytesRead));
+    currPos += bytesRead;
+  }
 }
 
 module.exports = {

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -797,11 +797,9 @@ async function stream(handle, dest, options) {
     );
 
     if (dest.destroyed) {
-      // Is that writable stream destroyed before is right?
       throw new ERR_STREAM_PREMATURE_CLOSE();
     }
 
-    // Nothing to read
     if (bytesRead === 0) {
       break;
     }

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -747,7 +747,8 @@ async function readFile(path, options) {
   return PromisePrototypeFinally(readFileHandle(fd, options), fd.close);
 }
 
-async function stream(handle, dest, options) {
+async function stream(handle, dest, options = {}) {
+  validateAbortSignal(options.signal);
   checkAborted(options.signal);
   if (!EE) {
     EE = require('events');

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -32,7 +32,6 @@ const {
     ERR_INVALID_ARG_VALUE,
     ERR_METHOD_NOT_IMPLEMENTED,
     ERR_STREAM_PREMATURE_CLOSE,
-    ERR_OUT_OF_RANGE
   },
   AbortError,
 } = require('internal/errors');
@@ -759,26 +758,17 @@ async function stream(handle, dest, options = {}) {
     end,
   } = options;
 
-  if (start && typeof start !== 'number') {
-    throw new ERR_INVALID_ARG_TYPE('start', 'number', start);
+  if (start) {
+    validateInteger(start, 'start', 0);
   }
-  if (end && typeof end !== 'number') {
-    throw new ERR_INVALID_ARG_TYPE('end', 'number', end);
-  }
-  if (start < 0) {
-    throw new ERR_OUT_OF_RANGE('start', 'greater than 0', start);
-  }
-  if (end < 0) {
-    throw new ERR_OUT_OF_RANGE('end', 'greater than 0', end);
-  }
-  if (end && start > end) {
-    throw new ERR_OUT_OF_RANGE('start', `less than end ${end}`, start);
+  if (end) {
+    validateInteger(end, 'end', start);
   }
 
   let currPos = start;
 
   while (true) {
-    if (end && currPos >= end) {
+    if (end && currPos > end) {
       break;
     }
 
@@ -788,7 +778,7 @@ async function stream(handle, dest, options = {}) {
     }
 
     let buffer = Buffer.allocUnsafe(
-      end ? MathMin(end - currPos, BUFFER_SIZE) : BUFFER_SIZE
+      end ? MathMin(end + 1 - currPos, BUFFER_SIZE) : BUFFER_SIZE
     );
 
     const { bytesRead } = await handle.read(

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -73,6 +73,7 @@ const {
   validateBuffer,
   validateEncoding,
   validateInteger,
+  validateObject,
 } = require('internal/validators');
 const pathModule = require('path');
 const { promisify } = require('internal/util');
@@ -746,10 +747,8 @@ async function readFile(path, options) {
   return PromisePrototypeFinally(readFileHandle(fd, options), fd.close);
 }
 
-async function stream(handle, dest, options) {
-  if (!options) {
-    options = {};
-  }
+async function stream(handle, dest, options = {}) {
+  validateObject(options, 'options');
 
   if (!isWritable(dest)) {
     throw new ERR_INVALID_ARG_TYPE('dest', 'Writable', dest);
@@ -766,10 +765,10 @@ async function stream(handle, dest, options) {
     end,
   } = options;
 
-  if (start) {
+  if (start !== undefined) {
     validateInteger(start, 'start', 0);
   }
-  if (end) {
+  if (end !== undefined) {
     validateInteger(end, 'end', start);
   }
 

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -775,9 +775,6 @@ async function stream(handle, dest, options) {
   }
 
   let currPos = start;
-  const allocatedBuffer = Buffer.allocUnsafe(
-    end ? MathMin(end - currPos, BUFFER_SIZE) : BUFFER_SIZE
-  );
 
   while (true) {
     if (end && currPos >= end) {
@@ -789,10 +786,14 @@ async function stream(handle, dest, options) {
       await EE.once(dest, 'drain');
     }
 
-    const { buffer, bytesRead } = await handle.read(
-      allocatedBuffer,
+    let buffer = Buffer.allocUnsafe(
+      end ? MathMin(end - currPos, BUFFER_SIZE) : BUFFER_SIZE
+    );
+
+    const { bytesRead } = await handle.read(
+      buffer,
       0,
-      allocatedBuffer.byteLength,
+      buffer.byteLength,
       currPos
     );
 
@@ -804,7 +805,14 @@ async function stream(handle, dest, options) {
       break;
     }
 
-    dest.write(buffer.slice(0, bytesRead));
+    if (bytesRead !== buffer.length) {
+      // Shrink to fit bytes read
+      const copy = Buffer.allocUnsafeSlow(bytesRead);
+      buffer.copy(copy, 0, 0, bytesRead);
+      buffer = copy;
+    }
+
+    dest.write(buffer);
     currPos += bytesRead;
   }
 }

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -78,7 +78,7 @@ const pathModule = require('path');
 const { promisify } = require('internal/util');
 const { EventEmitterMixin } = require('internal/event_target');
 const { watch } = require('internal/fs/watchers');
-const { isIterable } = require('internal/streams/utils');
+const { isIterable, isWritable } = require('internal/streams/utils');
 
 const kHandle = Symbol('kHandle');
 const kFd = Symbol('kFd');
@@ -746,7 +746,15 @@ async function readFile(path, options) {
   return PromisePrototypeFinally(readFileHandle(fd, options), fd.close);
 }
 
-async function stream(handle, dest, options = {}) {
+async function stream(handle, dest, options) {
+  if (!options) {
+    options = {};
+  }
+
+  if (!isWritable(dest)) {
+    throw new ERR_INVALID_ARG_TYPE('dest', 'Writable', dest);
+  }
+
   validateAbortSignal(options.signal);
   checkAborted(options.signal);
   if (!EE) {

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -781,6 +781,7 @@ async function stream(handle, dest, options = {}) {
 
     checkAborted(options.signal);
     if (dest.writableNeedDrain) {
+      if (dest.destroyed) return;
       await EE.once(dest, 'drain');
     }
 
@@ -810,7 +811,10 @@ async function stream(handle, dest, options = {}) {
       buffer = copy;
     }
 
-    dest.write(buffer);
+    if (!dest.write(buffer)) {
+      if (dest.destroyed) return;
+      await EE.once(dest, 'drain');
+    }
     currPos += bytesRead;
   }
 }

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -754,7 +754,7 @@ async function stream(handle, dest, options = {}) {
   }
   const BUFFER_SIZE = 128 * 2 ** 10;
   const {
-    start = 0,
+    start = handle[kHandle].bytesRead,
     end,
   } = options;
 

--- a/lib/internal/streams/utils.js
+++ b/lib/internal/streams/utils.js
@@ -31,4 +31,5 @@ module.exports = {
   isIterable,
   isReadable,
   isStream,
+  isWritable
 };

--- a/test/parallel/test-fs-promises-stream.js
+++ b/test/parallel/test-fs-promises-stream.js
@@ -42,12 +42,10 @@ async function testStreamWithStart() {
   assert.deepStrictEqual(
     destContent.toString().length,
     content.slice(1).length,
-    'length of copied text is not match with the origin'
   );
   assert.deepStrictEqual(
     destContent.toString(),
     content.slice(1),
-    'content of copied text is not match with the origin'
   );
 }
 
@@ -61,12 +59,10 @@ async function testStreamWithEnd() {
   assert.deepStrictEqual(
     destContent.toString().length,
     content.slice(0, 1).length,
-    'length of copied text is not match with the origin'
   );
   assert.deepStrictEqual(
     destContent.toString(),
     content.slice(0, 1),
-    'content of copied text is not match with the origin'
   );
 }
 
@@ -80,12 +76,10 @@ async function testStreamWithStartAndEnd() {
   assert.deepStrictEqual(
     destContent.toString().length,
     content.slice(1, 5).length,
-    'length of copied text is not match with the origin'
   );
   assert.deepStrictEqual(
     destContent.toString(),
     content.slice(1, 5),
-    'content of copied text is not match with the origin'
   );
 }
 

--- a/test/parallel/test-fs-promises-stream.js
+++ b/test/parallel/test-fs-promises-stream.js
@@ -1,0 +1,187 @@
+'use strict';
+
+const common = require('../common');
+const fs = require('fs');
+const fsp = require('fs/promises');
+const tmpdir = require('../common/tmpdir');
+const assert = require('assert');
+const path = require('path');
+
+tmpdir.refresh();
+
+const content = '01'.repeat(5);
+const sourceTemplate = path.resolve(tmpdir.path, 'source');
+const destTemplate = path.resolve(tmpdir.path, 'dest');
+
+// prepare fixture
+
+async function createFixture(fixture) {
+  const source = `${sourceTemplate}-${fixture}`;
+  const dest = `${destTemplate}-${fixture}`;
+  await fsp.writeFile(source, content);
+  return [source, dest];
+}
+
+async function testStreamWithoutOption() {
+  const [sourceName, destName] = await createFixture('no-options');
+  const dest = fs.createWriteStream(destName);
+  const handler = await fsp.open(sourceName);
+  await handler.stream(dest);
+
+  const destContent = await fsp.readFile(destName);
+  assert.deepStrictEqual(destContent.toString(), content);
+}
+
+async function testStreamWithStart() {
+  const [sourceName, destName] = await createFixture('with-start');
+  const dest = fs.createWriteStream(destName);
+  const handler = await fsp.open(sourceName);
+  await handler.stream(dest, { start: 1 });
+  const destContent = await fsp.readFile(destName);
+
+  assert.deepStrictEqual(
+    destContent.toString().length,
+    content.slice(1).length,
+    'length of copied text is not match with the origin'
+  );
+  assert.deepStrictEqual(
+    destContent.toString(),
+    content.slice(1),
+    'content of copied text is not match with the origin'
+  );
+}
+
+async function testStreamWithEnd() {
+  const [sourceName, destName] = await createFixture('with-end');
+  const dest = fs.createWriteStream(destName);
+  const handler = await fsp.open(sourceName);
+  await handler.stream(dest, { end: 1 });
+  const destContent = await fsp.readFile(destName);
+
+  assert.deepStrictEqual(
+    destContent.toString().length,
+    content.slice(0, 1).length,
+    'length of copied text is not match with the origin'
+  );
+  assert.deepStrictEqual(
+    destContent.toString(),
+    content.slice(0, 1),
+    'content of copied text is not match with the origin'
+  );
+}
+
+async function testStreamWithStartAndEnd() {
+  const [sourceName, destName] = await createFixture('with-start-and-end');
+  const dest = fs.createWriteStream(destName);
+  const handler = await fsp.open(sourceName);
+  await handler.stream(dest, { start: 1, end: 5 });
+  const destContent = await fsp.readFile(destName);
+
+  assert.deepStrictEqual(
+    destContent.toString().length,
+    content.slice(1, 5).length,
+    'length of copied text is not match with the origin'
+  );
+  assert.deepStrictEqual(
+    destContent.toString(),
+    content.slice(1, 5),
+    'content of copied text is not match with the origin'
+  );
+}
+
+async function testAbortController() {
+  const [sourceName, destName] = await createFixture('abort-controller');
+  const dest = fs.createWriteStream(destName);
+  const handler = await fsp.open(sourceName);
+
+  const abortController = new AbortController();
+  process.nextTick(() => {
+    abortController.abort();
+  });
+
+  assert.rejects(handler.stream(dest, { signal: abortController.signal }), {
+    name: 'AbortError'
+  });
+}
+
+async function testPrematureClose() {
+  const [sourceName, destName] = await createFixture('premature-close');
+  const dest = fs.createWriteStream(destName);
+  const handler = await fsp.open(sourceName);
+
+  dest.on('close', common.mustCall(() => {
+    assert.rejects(handler.stream(dest), {
+      code: 'ERR_STREAM_PREMATURE_CLOSE'
+    });
+  }));
+  dest.destroy();
+}
+
+
+async function testArgumentValidation(options, expectedError) {
+  const [sourceName, destName] = await createFixture('options');
+  const dest = fs.createWriteStream(destName);
+  const handler = await fsp.open(sourceName);
+
+  assert.rejects(handler.stream(dest, options), expectedError);
+}
+
+
+(async () => {
+  await testStreamWithoutOption();
+  await testStreamWithStart();
+  await testStreamWithEnd();
+  await testStreamWithStartAndEnd();
+  await testAbortController();
+  await testPrematureClose();
+
+  const negativeStart = [{
+    start: -1
+  }, {
+    code: 'ERR_OUT_OF_RANGE',
+    message: 'The value of "start" is out of range. ' +
+      'It must be greater than 0. Received -1'
+  }];
+
+  const negativeEnd = [{
+    end: -1
+  }, {
+    code: 'ERR_OUT_OF_RANGE',
+    message: 'The value of "end" is out of range. ' +
+      'It must be greater than 0. Received -1'
+  }];
+
+  const nonNumberStart = [{
+    start: 'nonNumber'
+  }, {
+    code: 'ERR_INVALID_ARG_TYPE',
+    message: 'The "start" argument must be of type number. ' +
+      'Received type string (\'nonNumber\')'
+  }];
+
+  const nonNumberEnd = [{
+    end: 'nonNumber'
+  }, {
+    code: 'ERR_INVALID_ARG_TYPE',
+    message: 'The "end" argument must be of type number. ' +
+      'Received type string (\'nonNumber\')'
+  }];
+
+  const startGreaterThanEnd = [{
+    start: 4,
+    end: 2
+  }, {
+    code: 'ERR_OUT_OF_RANGE',
+    message: 'The value of "start" is out of range. ' +
+      'It must be less than end 2. Received 4'
+  }];
+  await Promise.all(
+    [
+      negativeStart,
+      negativeEnd,
+      nonNumberStart,
+      nonNumberEnd,
+      startGreaterThanEnd,
+    ].map((args) => testArgumentValidation(...args))
+  );
+})().then(common.mustCall());

--- a/test/parallel/test-fs-promises-stream.js
+++ b/test/parallel/test-fs-promises-stream.js
@@ -58,11 +58,11 @@ async function testStreamWithEnd() {
 
   assert.deepStrictEqual(
     destContent.toString().length,
-    content.slice(0, 1).length,
+    content.slice(0, 2).length,
   );
   assert.deepStrictEqual(
     destContent.toString(),
-    content.slice(0, 1),
+    content.slice(0, 2),
   );
 }
 
@@ -75,11 +75,11 @@ async function testStreamWithStartAndEnd() {
 
   assert.deepStrictEqual(
     destContent.toString().length,
-    content.slice(1, 5).length,
+    content.slice(1, 6).length,
   );
   assert.deepStrictEqual(
     destContent.toString(),
-    content.slice(1, 5),
+    content.slice(1, 6),
   );
 }
 
@@ -134,7 +134,7 @@ async function testArgumentValidation(options, expectedError) {
   }, {
     code: 'ERR_OUT_OF_RANGE',
     message: 'The value of "start" is out of range. ' +
-      'It must be greater than 0. Received -1'
+      'It must be >= 0 && <= 9007199254740991. Received -1'
   }];
 
   const negativeEnd = [{
@@ -142,7 +142,7 @@ async function testArgumentValidation(options, expectedError) {
   }, {
     code: 'ERR_OUT_OF_RANGE',
     message: 'The value of "end" is out of range. ' +
-      'It must be greater than 0. Received -1'
+      'It must be >= 0 && <= 9007199254740991. Received -1'
   }];
 
   const nonNumberStart = [{
@@ -166,8 +166,8 @@ async function testArgumentValidation(options, expectedError) {
     end: 2
   }, {
     code: 'ERR_OUT_OF_RANGE',
-    message: 'The value of "start" is out of range. ' +
-      'It must be less than end 2. Received 4'
+    message: 'The value of "end" is out of range. ' +
+      'It must be >= 4 && <= 9007199254740991. Received 2'
   }];
   await Promise.all(
     [


### PR DESCRIPTION
This PR introduces a new API `stream` on `filehandle`, which has better performance over `stream.pipe` on file operation.

## Benchmark

I conducted two benchmarking experiments about copying files by two different way, `stream.pipe` and `filehandle.stream`. For benchmarking code see `benchmark/fs/bench-stream-via-pipeline.js` and `benchmark/fs/bench-stream.js`. The result is showed as following.

| File Size  |  Copy by`stream.pipe` (Q1)  |  Copy by `filehandle.stream` (Q2)  | Improvement (Q2/Q1) |
| ------------- | ------------- |-----|-----|
| 1 KB | 2,882.30  | 11,102.54 | 3.85 |
| 1 MB  | 786.42  | 1,656.13 | 2.11|
| 10 MB | 68.30 | 73.16 | 1.07 |

<details>
<summary>Raw Result</summary>

```
➜  node git:(feature/add-stream-to-file-handle) out/Release/node benchmark/fs/bench-stream-via-pipeline.js
fs/bench-stream-via-pipeline.js fileSize=1024 n=100: 2,882.297241630011
fs/bench-stream-via-pipeline.js fileSize=1048576 n=100: 786.4203946112839
fs/bench-stream-via-pipeline.js fileSize=10485760 n=100: 68.301593019569
➜  node git:(feature/add-stream-to-file-handle) out/Release/node benchmark/fs/bench-stream.js
fs/bench-stream.js fileSize=1024 n=100: 11,102.539950269502
fs/bench-stream.js fileSize=1048576 n=100: 1,656.1340954553295
fs/bench-stream.js fileSize=10485760 n=100: 73.16234942556548
```

</details>

It shows good performance over small-size file (~1KB), and comparable performance over large-size file (~10MB).

cc @ronag

Fixes: https://github.com/nodejs/node/issues/38350

