### PR TITLE
punycode: add pending deprecation

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -832,7 +832,7 @@ The [`require.extensions`][] property is deprecated.
 <!-- YAML
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/35092
+    pr-url: https://github.com/nodejs/node/pull/38444
     description: Added support for `--pending-deprecation`.
   - version: v7.0.0
     pr-url: https://github.com/nodejs/node/pull/7941

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -831,12 +831,15 @@ The [`require.extensions`][] property is deprecated.
 ### DEP0040: `punycode` module
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/35092
+    description: Added support for `--pending-deprecation`.
   - version: v7.0.0
     pr-url: https://github.com/nodejs/node/pull/7941
     description: Documentation-only deprecation.
 -->
 
-Type: Documentation-only
+Type: Documentation-only (supports [`--pending-deprecation`][])
 
 The [`punycode`][] module is deprecated. Please use a userland alternative
 instead.

--- a/lib/punycode.js
+++ b/lib/punycode.js
@@ -1,5 +1,15 @@
 'use strict';
 
+const { getOptionValue } = require('internal/options');
+if (getOptionValue('--pending-deprecation')){
+	process.emitWarning(
+		'The `punycode` module is deprecated. Please use a userland ' +
+		'alternative instead.',
+		'DeprecationWarning',
+		'DEP0040',
+	);
+}
+
 /** Highest positive signed 32-bit float value */
 const maxInt = 2147483647; // aka. 0x7FFFFFFF or 2^31-1
 

--- a/test/message/core_line_numbers.out
+++ b/test/message/core_line_numbers.out
@@ -1,9 +1,9 @@
-node:punycode:42
+node:punycode:52
 	throw new RangeError(errors[type]);
 	^
 
 RangeError: Invalid input
-    at error (node:punycode:42:8)
+    at error (node:punycode:52:8)
     at Object.decode (node:punycode:*:*)
     at Object.<anonymous> (*test*message*core_line_numbers.js:*:*)
     at Module._compile (node:internal/modules/cjs/loader:*:*)

--- a/test/parallel/test-punycode.js
+++ b/test/parallel/test-punycode.js
@@ -1,3 +1,5 @@
+// Flags: --pending-deprecation
+
 // Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -20,7 +22,13 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+const common = require('../common');
+
+const punycodeWarning =
+  'The `punycode` module is deprecated. Please use a userland alternative ' +
+  'instead.';
+common.expectWarning('DeprecationWarning', punycodeWarning, 'DEP0040');
+
 const punycode = require('punycode');
 const assert = require('assert');
 


### PR DESCRIPTION
Revival of https://github.com/nodejs/node/pull/35092: now that https://github.com/nodejs/node/pull/35091 is in Node.js v16.x, this module is unused in the codebase. I think we should move forward with this deprecation.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
