### PR TITLE
test: address deprecation warning in test

### DIFF
--- a/test/pummel/test-fs-largefile.js
+++ b/test/pummel/test-fs-largefile.js
@@ -34,7 +34,7 @@ const fd = fs.openSync(filepath, 'w+');
 const offset = 5 * 1024 * 1024 * 1024; // 5GB
 const message = 'Large File';
 
-fs.truncateSync(fd, offset);
+fs.ftruncateSync(fd, offset);
 assert.strictEqual(fs.statSync(filepath).size, offset);
 const writeBuf = Buffer.from(message);
 fs.writeSync(fd, writeBuf, 0, writeBuf.length, offset);


### PR DESCRIPTION
fs.truncateSync() with fd is deprecated. Use fs.ftruncateSync().