### PR TITLE
repl: document top level await limitation with const/let

### DIFF
--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -233,6 +233,23 @@ undefined
 undefined
 ```
 
+One known limitation of using the `await` keyword in the REPL is that
+it will invalidate the lexical scoping of the `const` and `let`
+keywords.
+
+For example:
+
+```console
+> const m = await Promise.resolve(123)
+undefined
+> m
+123
+> const m = await Promise.resolve(234)
+undefined
+> m
+234
+```
+
 ### Reverse-i-search
 <!-- YAML
 added:


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/17669
Signed-off-by: James M Snell <jasnell@gmail.com>

