### PR TITLE
doc: mark Node.js 10 as End-of-Life

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Select a Node.js version below to view the changelog history:
 * [Node.js 13](doc/changelogs/CHANGELOG_V13.md) End-of-Life
 * [Node.js 12](doc/changelogs/CHANGELOG_V12.md) Long Term Support
 * [Node.js 11](doc/changelogs/CHANGELOG_V11.md) End-of-Life
-* [Node.js 10](doc/changelogs/CHANGELOG_V10.md) Long Term Support
+* [Node.js 10](doc/changelogs/CHANGELOG_V10.md) End-of-Life
 * [Node.js 9](doc/changelogs/CHANGELOG_V9.md) End-of-Life
 * [Node.js 8](doc/changelogs/CHANGELOG_V8.md) End-of-Life
 * [Node.js 7](doc/changelogs/CHANGELOG_V7.md) End-of-Life
@@ -30,7 +30,6 @@ release.
   <th title="Current"><a href="doc/changelogs/CHANGELOG_V15.md">15</a><sup>Current</sup></th>
   <th title="LTS Until 2023-04"><a href="doc/changelogs/CHANGELOG_V14.md">14</a><sup>LTS</sup></th>
   <th title="LTS Until 2022-04"><a href="doc/changelogs/CHANGELOG_V12.md">12</a><sup>LTS</sup></th>
-  <th title="LTS Until 2021-04"><a href="doc/changelogs/CHANGELOG_V10.md">10</a><sup>LTS</sup></th>
 </tr>
 <tr>
     <td valign="top">
@@ -124,50 +123,6 @@ release.
 <a href="doc/changelogs/CHANGELOG_V12.md#12.2.0">12.2.0</a><br/>
 <a href="doc/changelogs/CHANGELOG_V12.md#12.1.0">12.1.0</a><br/>
 <a href="doc/changelogs/CHANGELOG_V12.md#12.0.0">12.0.0</a><br/>
-    </td>
-    <td valign="top">
-<b><a href="doc/changelogs/CHANGELOG_V10.md#10.24.1">10.24.1</a></b><br/>
-<a href="doc/changelogs/CHANGELOG_V10.md#10.24.0">10.24.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V10.md#10.23.3">10.23.3</a><br/>
-<a href="doc/changelogs/CHANGELOG_V10.md#10.23.2">10.23.2</a><br/>
-<a href="doc/changelogs/CHANGELOG_V10.md#10.23.1">10.23.1</a><br/>
-<a href="doc/changelogs/CHANGELOG_V10.md#10.23.0">10.23.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V10.md#10.22.1">10.22.1</a><br/>
-<a href="doc/changelogs/CHANGELOG_V10.md#10.22.0">10.22.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V10.md#10.21.0">10.21.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V10.md#10.20.1">10.20.1</a><br/>
-<a href="doc/changelogs/CHANGELOG_V10.md#10.20.0">10.20.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V10.md#10.19.0">10.19.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V10.md#10.18.1">10.18.1</a><br/>
-<a href="doc/changelogs/CHANGELOG_V10.md#10.18.0">10.18.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V10.md#10.17.0">10.17.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V10.md#10.16.3">10.16.3</a><br/>
-<a href="doc/changelogs/CHANGELOG_V10.md#10.16.2">10.16.2</a><br/>
-<a href="doc/changelogs/CHANGELOG_V10.md#10.16.1">10.16.1</a><br/>
-<a href="doc/changelogs/CHANGELOG_V10.md#10.16.0">10.16.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V10.md#10.15.3">10.15.3</a><br/>
-<a href="doc/changelogs/CHANGELOG_V10.md#10.15.2">10.15.2</a><br/>
-<a href="doc/changelogs/CHANGELOG_V10.md#10.15.1">10.15.1</a><br/>
-<a href="doc/changelogs/CHANGELOG_V10.md#10.15.0">10.15.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V10.md#10.14.2">10.14.2</a><br/>
-<a href="doc/changelogs/CHANGELOG_V10.md#10.14.1">10.14.1</a><br/>
-<a href="doc/changelogs/CHANGELOG_V10.md#10.14.0">10.14.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V10.md#10.13.0">10.13.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V10.md#10.12.0">10.12.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V10.md#10.11.0">10.11.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V10.md#10.10.0">10.10.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V10.md#10.9.0">10.9.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V10.md#10.8.0">10.8.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V10.md#10.7.0">10.7.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V10.md#10.6.0">10.6.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V10.md#10.5.0">10.5.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V10.md#10.4.1">10.4.1</a><br/>
-<a href="doc/changelogs/CHANGELOG_V10.md#10.4.0">10.4.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V10.md#10.3.0">10.3.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V10.md#10.2.1">10.2.1</a><br/>
-<a href="doc/changelogs/CHANGELOG_V10.md#10.2.0">10.2.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V10.md#10.1.0">10.1.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V10.md#10.0.0">10.0.0</a><br/>
     </td>
 </tr>
 </table>


### PR DESCRIPTION
Node.js 10 is out of support after today (2021-04-30).

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
