### PR TITLE
[v16.x] deps: V8: Add Power10 to the supported list and enable related features

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.11',
+    'v8_embedder_string': '-node.12',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/base/cpu.cc
+++ b/deps/v8/src/base/cpu.cc
@@ -31,6 +31,9 @@
 #ifndef POWER_9
 #define POWER_9 0x20000
 #endif
+#ifndef POWER_10
+#define POWER_10 0x40000
+#endif
 #endif
 #if V8_OS_POSIX
 #include <unistd.h>  // sysconf()
@@ -780,7 +783,10 @@ CPU::CPU()
 
   part_ = -1;
   if (auxv_cpu_type) {
-    if (strcmp(auxv_cpu_type, "power9") == 0) {
+    if (strcmp(auxv_cpu_type, "power10") == 0) {
+      part_ = PPC_POWER10;
+    }
+    else if (strcmp(auxv_cpu_type, "power9") == 0) {
       part_ = PPC_POWER9;
     } else if (strcmp(auxv_cpu_type, "power8") == 0) {
       part_ = PPC_POWER8;
@@ -801,6 +807,8 @@ CPU::CPU()
 
 #elif V8_OS_AIX
   switch (_system_configuration.implementation) {
+    case POWER_10:
+      part_ = PPC_POWER10;
     case POWER_9:
       part_ = PPC_POWER9;
       break;

--- a/deps/v8/src/base/cpu.h
+++ b/deps/v8/src/base/cpu.h
@@ -70,6 +70,7 @@ class V8_BASE_EXPORT CPU final {
     PPC_POWER7,
     PPC_POWER8,
     PPC_POWER9,
+    PPC_POWER10,
     PPC_G4,
     PPC_G5,
     PPC_PA6T

--- a/deps/v8/src/codegen/ppc/assembler-ppc.cc
+++ b/deps/v8/src/codegen/ppc/assembler-ppc.cc
@@ -67,24 +67,28 @@ void CpuFeatures::ProbeImpl(bool cross_compile) {
 #ifndef USE_SIMULATOR
   // Probe for additional features at runtime.
   base::CPU cpu;
-  if (cpu.part() == base::CPU::PPC_POWER9) {
+  if (cpu.part() == base::CPU::PPC_POWER9 ||
+      cpu.part() == base::CPU::PPC_POWER10) {
     supported_ |= (1u << MODULO);
   }
 #if V8_TARGET_ARCH_PPC64
   if (cpu.part() == base::CPU::PPC_POWER8 ||
-      cpu.part() == base::CPU::PPC_POWER9) {
+      cpu.part() == base::CPU::PPC_POWER9 ||
+      cpu.part() == base::CPU::PPC_POWER10) {
     supported_ |= (1u << FPR_GPR_MOV);
   }
 #endif
   if (cpu.part() == base::CPU::PPC_POWER6 ||
       cpu.part() == base::CPU::PPC_POWER7 ||
       cpu.part() == base::CPU::PPC_POWER8 ||
-      cpu.part() == base::CPU::PPC_POWER9) {
+      cpu.part() == base::CPU::PPC_POWER9 ||
+      cpu.part() == base::CPU::PPC_POWER10) {
     supported_ |= (1u << LWSYNC);
   }
   if (cpu.part() == base::CPU::PPC_POWER7 ||
       cpu.part() == base::CPU::PPC_POWER8 ||
-      cpu.part() == base::CPU::PPC_POWER9) {
+      cpu.part() == base::CPU::PPC_POWER9 ||
+      cpu.part() == base::CPU::PPC_POWER10) {
     supported_ |= (1u << ISELECT);
     supported_ |= (1u << VSX);
   }


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
Please note that enum values are slightly different from V8 upstream, i.e `PPC_POWER10` instead of `kPPCPower10`.
We also have SIMD enabled upstream which will not be backported here.

Refs: https://github.com/v8/v8/commit/530080c44af254646a3cc3f364aac26b1b5ac10c