### PR TITLE
node-api: fix shutdown crashes

### DIFF
--- a/src/js_native_api_v8.h
+++ b/src/js_native_api_v8.h
@@ -124,22 +124,22 @@ struct napi_env__ {
 
 // This class is used to keep a napi_env live in a way that
 // is exception safe versus calling Ref/Unref directly
-class LiveEnv {
+class EnvRefHolder {
  public:
-  explicit LiveEnv(napi_env env) : _env(env) {
+  explicit EnvRefHolder(napi_env env) : _env(env) {
       _env->Ref();
   }
 
-  explicit LiveEnv(const LiveEnv& other): _env(other.env()) {
+  explicit EnvRefHolder(const EnvRefHolder& other): _env(other.env()) {
     _env->Ref();
   }
 
-  LiveEnv(LiveEnv&& other) {
+  EnvRefHolder(EnvRefHolder&& other) {
     _env = other._env;
     other._env = nullptr;
   }
 
-  ~LiveEnv() {
+  ~EnvRefHolder() {
     if (_env != nullptr) {
       _env->Unref();
     }

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -39,9 +39,9 @@ struct node_napi_env__ : public napi_env__ {
 
   void CallFinalizer(napi_finalize cb, void* data, void* hint) override {
     // we need to keep the env live until the finalizer has been run
-    // LiveEnv provides an exception safe wrapper to Ref and then
+    // EnvRefHolder provides an exception safe wrapper to Ref and then
     // Unref once the lamba is freed
-    LiveEnv liveEnv(static_cast<napi_env>(this));
+    EnvRefHolder liveEnv(static_cast<napi_env>(this));
     node_env()->SetImmediate([=, liveEnv = std::move(liveEnv)]
         (node::Environment* node_env) {
       napi_env env = liveEnv.env();

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -48,7 +48,7 @@ struct node_napi_env__ : public napi_env__ {
           env->CallIntoModule([&](napi_env env) {
             cb(env, data, hint);
           });
-	}
+        }
         env->Unref();
       });
     } else {
@@ -89,10 +89,10 @@ class BufferFinalizer : private Finalizer {
         if (finalizer->_finalize_callback == nullptr) {
           finalizer->_env->Unref();
           return;
-	}
+        }
 
-	{
-	  v8::HandleScope handle_scope(finalizer->_env->isolate);
+        {
+          v8::HandleScope handle_scope(finalizer->_env->isolate);
           v8::Context::Scope context_scope(finalizer->_env->context());
 
           finalizer->_env->CallIntoModule([&](napi_env env) {
@@ -101,7 +101,7 @@ class BufferFinalizer : private Finalizer {
                 finalizer->_finalize_data,
                 finalizer->_finalize_hint);
           });
-	}
+        }
         finalizer->_env->Unref();
       });
     } else {


### PR DESCRIPTION
Refs: https://github.com/nodejs/node-addon-api/issues/906

Ensure that finalization is not defered during shutdown.
The env for the addon is deleted immediately after
iterating the list of finalizers to be run. Defering
causes crashes as the finalization uses the already
deleted env.

Signed-off-by: Michael Dawson <mdawson@devrus.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
