### PR TITLE
docs: workload name corrected as per the latest VS Installer

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -563,7 +563,7 @@ to run it again before invoking `make -j4`.
 * [Python 3.9](https://www.microsoft.com/en-us/p/python-39/9p7qfqmjrfp7)
 * The "Desktop development with C++" workload from
   [Visual Studio 2019](https://visualstudio.microsoft.com/downloads/) or
-  the "Visual C++ build tools" workload from the
+  the "C++ build tools" workload from the
   [Build Tools](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2019),
   with the default optional components
 * Basic Unix tools required for some tests,


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
The windows local machine setup guide suggests installing the prerequisites "Visual C++ build tools" workload from the visual studio build tool installer. But, there is not workload named "Visual C++ build tools" in the current installer. Instead, maybe the Microsoft team renamed that to just "C++ build tools" in the workload list.
Correcting the workload name as per the current installer list. 

Reference:

![WorkloadNameCorrectionRef](https://user-images.githubusercontent.com/26359740/116791550-ce8df600-aad8-11eb-8f97-84618e9452d0.gif)
