### PR TITLE
tools: make GH Actions workflows work if default branch is not master

### DIFF
--- a/.github/workflows/build-tarball.yml
+++ b/.github/workflows/build-tarball.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - main
       - v[0-9]+.x-staging
       - v[0-9]+.x
 

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - main
       - canary
       - v[0-9]+.x-staging
       - v[0-9]+.x

--- a/.github/workflows/commit-queue.yml
+++ b/.github/workflows/commit-queue.yml
@@ -28,7 +28,7 @@ jobs:
           # See https://github.com/nodejs/node-core-utils/pull/486
           fetch-depth: 0
           # A personal token is required because pushing with GITHUB_TOKEN will
-          # prevent commits from running CI after they land on master. It needs
+          # prevent commits from running CI after they land. It needs
           # to be set here because `checkout` configures GitHub authentication
           # for push as well.
           token: ${{ secrets.GH_USER_TOKEN }}
@@ -63,15 +63,13 @@ jobs:
           owner: ${{ env.OWNER }}
           repo: ${{ env.REPOSITORY }}
           # Commit queue is only enabled for the default branch on the repository
-          # TODO(mmarchini): get the default branch programmatically instead of
-          # assuming `master`
-          base_ref: "master"
+          base_ref: ${{ github.repository.default_branch }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure node-core-utils
         run: |
-          ncu-config set branch master
+          ncu-config set branch ${{ github.repository.default_branch }}
           ncu-config set upstream origin
           ncu-config set username "${{ secrets.GH_USER_NAME }}"
           ncu-config set token "${{ secrets.GH_USER_TOKEN }}"

--- a/.github/workflows/coverage-linux.yml
+++ b/.github/workflows/coverage-linux.yml
@@ -10,6 +10,7 @@ on:
   push:
     branches:
       - master
+      - main
     paths-ignore:
       - 'doc/**'
       - 'deps/**'

--- a/.github/workflows/coverage-windows.yml
+++ b/.github/workflows/coverage-windows.yml
@@ -10,6 +10,7 @@ on:
   push:
     branches:
       - master
+      - main
     paths-ignore:
       - 'doc/**'
       - 'deps/**'

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - main
       - v[0-9]+.x-staging
       - v[0-9]+.x
 

--- a/.github/workflows/misc.yml
+++ b/.github/workflows/misc.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - main
       - v[0-9]+.x-staging
       - v[0-9]+.x
 

--- a/.github/workflows/notify-force-push.yml
+++ b/.github/workflows/notify-force-push.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - master
+      - main
 
 name: Notify on Force Push
 jobs:
@@ -17,7 +18,7 @@ jobs:
         SLACK_ICON: https://github.com/nodejs.png?size=48
         SLACK_TITLE: '${{ github.actor }} force-pushed to ${{ github.ref }}'
         SLACK_MESSAGE: |
-          A commit was force-pushed to <https://github.com/${{ github.repository }}/tree/master|${{ github.repository }}@master> by <https://github.com/${{ github.actor }}|${{ github.actor }}>
+          A commit was force-pushed to <https://github.com/${{ github.repository }}/tree/${{ github.repository.default_branch }}|${{ github.repository }}@${{ github.repository.default_branch }}> by <https://github.com/${{ github.actor }}|${{ github.actor }}>
 
           Before: <https://github.com/${{ github.repository }}/commit/${{ github.event.before }}|${{ github.event.before }}>
           After: <https://github.com/${{ github.repository }}/commit/${{ github.event.after }}|${{ github.event.after }}>

--- a/.github/workflows/test-asan.yml
+++ b/.github/workflows/test-asan.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - main
       - canary
       - v[0-9]+.x-staging
       - v[0-9]+.x

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - main
       - canary
       - v[0-9]+.x-staging
       - v[0-9]+.x

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - master
+      - main
       - canary
       - v[0-9]+.x-staging
       - v[0-9]+.x


### PR DESCRIPTION
The workflows should be able to work whether the default branch is named `master` or `main`. This should ease the transition if/when we switch to `main` in the future.
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
