### PR TITLE
fs: use assert in fsCall argument checking 

### DIFF
--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -267,7 +267,7 @@ async function handleFdClose(fileOpPromise, closeFunc) {
 }
 
 async function fsCall(fn, handle, ...args) {
-  assert(handle instanceof FileHandle,
+  assert(handle[kRefs] !== undefined,
          'handle must be an instance of FileHandle');
 
   if (handle.fd === -1) {

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -80,6 +80,7 @@ const { promisify } = require('internal/util');
 const { EventEmitterMixin } = require('internal/event_target');
 const { watch } = require('internal/fs/watchers');
 const { isIterable } = require('internal/streams/utils');
+const assert = require('internal/assert');
 
 const kHandle = Symbol('kHandle');
 const kFd = Symbol('kFd');
@@ -266,9 +267,8 @@ async function handleFdClose(fileOpPromise, closeFunc) {
 }
 
 async function fsCall(fn, handle, ...args) {
-  if (handle[kRefs] === undefined) {
-    throw new ERR_INVALID_ARG_TYPE('filehandle', 'FileHandle', handle);
-  }
+  assert(handle instanceof FileHandle,
+         'handle must be an instance of FileHandle');
 
   if (handle.fd === -1) {
     // eslint-disable-next-line no-restricted-syntax

--- a/test/parallel/test-fs-promises.js
+++ b/test/parallel/test-fs-promises.js
@@ -452,6 +452,16 @@ async function getHandle(dest) {
       assert.strictEqual(ret.bytesWritten, 2);
       await handle.close();
     }
+
+    // Test prototype methods calling with contexts other than FileHandle
+    {
+      const handle = await getHandle(dest);
+      assert.rejects(() => handle.stat.call({}), {
+        code: 'ERR_INTERNAL_ASSERTION',
+        message: /handle must be an instance of FileHandle/
+      });
+      await handle.close();
+    }
   }
 
   doTest().then(common.mustCall());


### PR DESCRIPTION
~~It seems to be a piece of dead code and could be safely removed~~

~~1. The `fsCall` function is only used within the `FileHandle` prototype methods~~
~~2. The second argument of every call is `this`, which ensures it's an instance of `FileHandle`~~

Updated, see https://github.com/nodejs/node/pull/38519#issuecomment-833336669

Refs: https://coverage.nodejs.org/coverage-68e6673224365120/lib/internal/fs/promises.js.html#L268