### PR TITLE
stream: add a non-destroying iterator to Readable

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1528,7 +1528,7 @@ added: REPLACEME
 * Returns: {AsyncIterator} to consume the stream.
 
 The iterator created by this method gives users the option to cancel the
-destruction the stream if the `for await...of` loop is exited by `return`,
+destruction of the stream if the `for await...of` loop is exited by `return`,
 `break` or `throw`, or if the iterator should destroy the stream if the stream
 emitted an error during iteration.
 

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1518,6 +1518,8 @@ has less then 64KB of data because no `highWaterMark` option is provided to
 added: REPLACEME
 -->
 
+> Stability: 1 - Experimental
+
 * `options` {Object}
   * `destroyOnReturn` {boolean} When set to `false`, calling `return` on the
     async iterator, or exiting a `for await...of` iteration using a `break`,

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1547,7 +1547,7 @@ async function printIterator(readable) {
     console.log(chunk); // Will print 2 and then 3
   }
 
-  console.log(readable.destroyed); // true, stream was totally consumed
+  console.log(readable.destroyed); // True, stream was totally consumed
 }
 
 async function printSymbolAsyncIterator(readable) {

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1506,12 +1506,66 @@ async function print(readable) {
 print(fs.createReadStream('file')).catch(console.error);
 ```
 
-If the loop terminates with a `break` or a `throw`, the stream will be
-destroyed. In other terms, iterating over a stream will consume the stream
+If the loop terminates with a `break`, `return` or a `throw`, the stream will
+be destroyed. In other terms, iterating over a stream will consume the stream
 fully. The stream will be read in chunks of size equal to the `highWaterMark`
 option. In the code example above, data will be in a single chunk if the file
 has less then 64KB of data because no `highWaterMark` option is provided to
 [`fs.createReadStream()`][].
+
+##### `readable.iterator([options])`
+<!-- YAML
+added: REPLACEME
+-->
+
+* `options` {Object}
+  * `destroyOnReturn` {boolean} When set to `false`, calling `return` on the
+    async iterator, or exiting a `for await...of` iteration using a `break`,
+    `return` or `throw` will not destroy the stream. **Default:** `true`.
+  * `destroyOnError` {boolean} When set to `false`, if the stream emits an
+    error while it's being iterated, the iterator will not destroy the stream.
+    **Default:** `true`.
+* Returns: {AsyncIterator} to consume the stream.
+
+The iterator created by this method gives users the option to cancel the
+destruction the stream if the `for await...of` loop is exited by `return`,
+`break` or `throw`, or if the iterator should destroy the stream if the stream
+emitted an error during iteration.
+
+```js
+const { Readable } = require('stream');
+
+async function printIterator(readable) {
+  for await (const chunk of readable.iterator({ destroyOnReturn: false })) {
+    console.log(chunk); // 1
+    break;
+  }
+
+  console.log(readable.destroyed); // false
+
+  for await (const chunk of readable.iterator({ destroyOnReturn: false })) {
+    console.log(chunk); // Will print 2 and then 3
+  }
+
+  console.log(readable.destroyed); // true, stream was totally consumed
+}
+
+async function printSymbolAsyncIterator(readable) {
+  for await (const chunk of readable) {
+    console.log(chunk); // 1
+    break;
+  }
+
+  console.log(readable.destroyed); // true
+}
+
+async function showBoth() {
+  await printIterator(Readable.from([1, 2, 3]));
+  await printSymbolAsyncIterator(Readable.from([1, 2, 3]));
+}
+
+showBoth();
+```
 
 ### Duplex and transform streams
 

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1506,7 +1506,7 @@ async function print(readable) {
 print(fs.createReadStream('file')).catch(console.error);
 ```
 
-If the loop terminates with a `break`, `return` or a `throw`, the stream will
+If the loop terminates with a `break`, `return`, or a `throw`, the stream will
 be destroyed. In other terms, iterating over a stream will consume the stream
 fully. The stream will be read in chunks of size equal to the `highWaterMark`
 option. In the code example above, data will be in a single chunk if the file
@@ -1521,7 +1521,7 @@ added: REPLACEME
 * `options` {Object}
   * `destroyOnReturn` {boolean} When set to `false`, calling `return` on the
     async iterator, or exiting a `for await...of` iteration using a `break`,
-    `return` or `throw` will not destroy the stream. **Default:** `true`.
+    `return`, or `throw` will not destroy the stream. **Default:** `true`.
   * `destroyOnError` {boolean} When set to `false`, if the stream emits an
     error while it's being iterated, the iterator will not destroy the stream.
     **Default:** `true`.
@@ -1529,7 +1529,7 @@ added: REPLACEME
 
 The iterator created by this method gives users the option to cancel the
 destruction of the stream if the `for await...of` loop is exited by `return`,
-`break` or `throw`, or if the iterator should destroy the stream if the stream
+`break`, or `throw`, or if the iterator should destroy the stream if the stream
 emitted an error during iteration.
 
 ```js

--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -1065,7 +1065,7 @@ Readable.prototype[SymbolAsyncIterator] = function() {
   return streamToAsyncIterator(this);
 };
 
-Readable.prototype.iterator = function (options = {
+Readable.prototype.iterator = function(options = {
   destroyOnReturn: true,
   destroyOnError: true,
 }) {

--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -1062,8 +1062,17 @@ Readable.prototype.wrap = function(stream) {
 };
 
 Readable.prototype[SymbolAsyncIterator] = function() {
-  let stream = this;
+  return streamToAsyncIterator(this);
+};
 
+Readable.prototype.iterator = function (options = {
+  destroyOnReturn: true,
+  destroyOnError: true,
+}) {
+  return streamToAsyncIterator(this, options);
+};
+
+function streamToAsyncIterator(stream, options) {
   if (typeof stream.read !== 'function') {
     // v1 stream
     const src = stream;
@@ -1076,13 +1085,18 @@ Readable.prototype[SymbolAsyncIterator] = function() {
     }).wrap(src);
   }
 
-  const iter = createAsyncIterator(stream);
+  const iter = createAsyncIterator(stream, options);
   iter.stream = stream;
   return iter;
-};
+}
 
-async function* createAsyncIterator(stream) {
+async function* createAsyncIterator(stream, options) {
   let callback = nop;
+
+  const {
+    destroyOnReturn = true,
+    destroyOnError = true,
+  } = (options ?? {});
 
   function next(resolve) {
     if (this === stream) {
@@ -1116,6 +1130,7 @@ async function* createAsyncIterator(stream) {
       next.call(this);
     });
 
+  let errorThrown = false;
   try {
     while (true) {
       const chunk = stream.destroyed ? null : stream.read();
@@ -1132,12 +1147,17 @@ async function* createAsyncIterator(stream) {
       }
     }
   } catch (err) {
-    destroyImpl.destroyer(stream, err);
+    if (destroyOnError) {
+      destroyImpl.destroyer(stream, err);
+    }
+    errorThrown = true;
     throw err;
   } finally {
-    if (state.autoDestroy || !endEmitted) {
-      // TODO(ronag): ERR_PREMATURE_CLOSE?
-      destroyImpl.destroyer(stream, null);
+    if (!errorThrown && destroyOnReturn) {
+      if (state.autoDestroy || !endEmitted) {
+        // TODO(ronag): ERR_PREMATURE_CLOSE?
+        destroyImpl.destroyer(stream, null);
+      }
     }
   }
 }

--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -62,6 +62,7 @@ const {
   ERR_METHOD_NOT_IMPLEMENTED,
   ERR_STREAM_UNSHIFT_AFTER_END_EVENT
 } = require('internal/errors').codes;
+const { validateObject } = require('internal/validators');
 
 const kPaused = Symbol('kPaused');
 
@@ -1065,10 +1066,10 @@ Readable.prototype[SymbolAsyncIterator] = function() {
   return streamToAsyncIterator(this);
 };
 
-Readable.prototype.iterator = function(options = {
-  destroyOnReturn: true,
-  destroyOnError: true,
-}) {
+Readable.prototype.iterator = function(options) {
+  if (options !== undefined) {
+    validateObject(options, 'options');
+  }
   return streamToAsyncIterator(this, options);
 };
 
@@ -1093,10 +1094,11 @@ function streamToAsyncIterator(stream, options) {
 async function* createAsyncIterator(stream, options) {
   let callback = nop;
 
-  const {
-    destroyOnReturn = true,
-    destroyOnError = true,
-  } = (options ?? {});
+  const opts = {
+    destroyOnReturn: true,
+    destroyOnError: true,
+    ...options,
+  };
 
   function next(resolve) {
     if (this === stream) {
@@ -1147,13 +1149,13 @@ async function* createAsyncIterator(stream, options) {
       }
     }
   } catch (err) {
-    if (destroyOnError) {
+    if (opts.destroyOnError) {
       destroyImpl.destroyer(stream, err);
     }
     errorThrown = true;
     throw err;
   } finally {
-    if (!errorThrown && destroyOnReturn) {
+    if (!errorThrown && opts.destroyOnReturn) {
       if (state.autoDestroy || !endEmitted) {
         // TODO(ronag): ERR_PREMATURE_CLOSE?
         destroyImpl.destroyer(stream, null);

--- a/test/parallel/test-stream-readable-async-iterators.js
+++ b/test/parallel/test-stream-readable-async-iterators.js
@@ -793,6 +793,20 @@ async function tests() {
 
     assert.ok(readable.destroyed);
   })().then(common.mustCall());
+
+  // Check non-object options.
+  {
+    const readable = createReadable();
+    assert.throws(
+      () => readable.iterator(42),
+      {
+        code: 'ERR_INVALID_ARG_TYPE',
+        name: 'TypeError',
+        message: 'The "options" argument must be of type object. Received ' +
+                 'type number (42)',
+      }
+    );
+  }
 }
 
 {

--- a/test/parallel/test-stream-readable-async-iterators.js
+++ b/test/parallel/test-stream-readable-async-iterators.js
@@ -693,6 +693,108 @@ async function tests() {
   });
 }
 
+// AsyncIterator non-destroying iterator
+{
+  function createReadable() {
+    return Readable.from((async function* () {
+      await Promise.resolve();
+      yield 5;
+      await Promise.resolve();
+      yield 7;
+      await Promise.resolve();
+    })());
+  }
+
+  function createErrorReadable() {
+    const opts = { read() { throw new Error('inner'); } };
+    return new Readable(opts);
+  }
+
+  // Check default destroys on return
+  (async function() {
+    const readable = createReadable();
+    for await (const chunk of readable.iterator()) {
+      assert.strictEqual(chunk, 5);
+      break;
+    }
+
+    assert.ok(readable.destroyed);
+  })().then(common.mustCall());
+
+  // Check explicit destroying on return
+  (async function() {
+    const readable = createReadable();
+    for await (const chunk of readable.iterator({ destroyOnReturn: true })) {
+      assert.strictEqual(chunk, 5);
+      break;
+    }
+
+    assert.ok(readable.destroyed);
+  })().then(common.mustCall());
+
+  // Check default destroys on error
+  (async function() {
+    const readable = createErrorReadable();
+    try {
+      // eslint-disable-next-line no-unused-vars
+      for await (const chunk of readable) { }
+      assert.fail('should have thrown');
+    } catch (err) {
+      assert.strictEqual(err.message, 'inner');
+    }
+
+    assert.ok(readable.destroyed);
+  })().then(common.mustCall());
+
+  // Check explicit destroys on error
+  (async function() {
+    const readable = createErrorReadable();
+    const opts = { destroyOnError: true, destroyOnReturn: false };
+    try {
+      // eslint-disable-next-line no-unused-vars
+      for await (const chunk of readable.iterator(opts)) { }
+      assert.fail('should have thrown');
+    } catch (err) {
+      assert.strictEqual(err.message, 'inner');
+    }
+
+    assert.ok(readable.destroyed);
+  })().then(common.mustCall());
+
+  // Check explicit non-destroy with return true
+  (async function() {
+    const readable = createErrorReadable();
+    const opts = { destroyOnError: false, destroyOnReturn: true };
+    try {
+      // eslint-disable-next-line no-unused-vars
+      for await (const chunk of readable.iterator(opts)) { }
+      assert.fail('should have thrown');
+    } catch (err) {
+      assert.strictEqual(err.message, 'inner');
+    }
+
+    assert.ok(!readable.destroyed);
+  })().then(common.mustCall());
+
+  // Check explicit non-destroy with return true
+  (async function() {
+    const readable = createReadable();
+    const opts = { destroyOnReturn: false };
+    for await (const chunk of readable.iterator(opts)) {
+      assert.strictEqual(chunk, 5);
+      break;
+    }
+
+    assert.ok(!readable.destroyed);
+
+    for await (const chunk of readable.iterator(opts)) {
+      assert.strictEqual(chunk, 7);
+    }
+
+    assert.ok(readable.destroyed);
+  })().then(common.mustCall());
+}
+
 {
   let _req;
   const server = http.createServer((request, response) => {


### PR DESCRIPTION
Add a non-destroying async iterator to Readable.

fixes: https://github.com/nodejs/node/issues/38491

@nodejs/streams 

A few things that I think might need attention:
1.  The API itself. Is a new method needed and is the naming OK, or should options be added to Symbol.asyncIterator?
2. Should the new method receive different defaults than Symbol.asyncIterator?
3. Maybe unrelated to this PR, should the `createAsyncIterator` method remove the listeners that it adds after the iteration ends? Currently it does not, but this was done when it essentially always destroyed the stream. Now it does not (although, it would be a bit problematic with Error, as it emits an error next-tick if an error was thrown). I'm not sure if it's that bad, as the listeners are mostly noops anyway. 