### PR TITLE
test: remove common.hasQuic

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -59,8 +59,6 @@ const hasCrypto = Boolean(process.versions.openssl) &&
 const hasOpenSSL3 = hasCrypto &&
     require('crypto').constants.OPENSSL_VERSION_NUMBER >= 805306368;
 
-const hasQuic = hasCrypto && !!process.config.variables.openssl_quic;
-
 // Check for flags. Skip this for workers (both, the `cluster` module and
 // `worker_threads`) and child processes.
 // If the binary was built without-ssl then the crypto flags are
@@ -756,7 +754,6 @@ const common = {
   hasIntl,
   hasCrypto,
   hasOpenSSL3,
-  hasQuic,
   hasMultiLocalhost,
   invalidArgTypeHelper,
   isAIX,

--- a/test/parallel/test-process-versions.js
+++ b/test/parallel/test-process-versions.js
@@ -19,11 +19,6 @@ if (common.hasCrypto) {
   expected_keys.push('openssl');
 }
 
-if (common.hasQuic) {
-  expected_keys.push('ngtcp2');
-  expected_keys.push('nghttp3');
-}
-
 if (common.hasIntl) {
   expected_keys.push('icu');
   expected_keys.push('cldr');


### PR DESCRIPTION
Remove common.hasQuic. It's a remnant from the initial QUIC
implementation which was removed.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
