### PR TITLE
doc: remove extraneous dash from flag prefix

### DIFF
--- a/doc/node.1
+++ b/doc/node.1
@@ -454,7 +454,7 @@ Print stack traces for process warnings (including deprecations).
 .It Fl -track-heap-objects
 Track heap object allocations for heap snapshots.
 .
-.It Fl --unhandled-rejections=mode
+.It Fl -unhandled-rejections=mode
 Define the behavior for unhandled rejections. Can be one of `strict` (raise an error), `warn` (enforce warnings) or `none` (silence warnings).
 .
 .It Fl -use-bundled-ca , Fl -use-openssl-ca


### PR DESCRIPTION
When rendered by `man node`, all flags have a dash prepended to them.
Prior to this change, the man page would incorrectly read
`---unhandled-rejections=mode`

The three dashes is invalid syntax and rejected by the `node` command.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
