### PR TITLE
buffer: remove unreachable code

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -242,10 +242,7 @@ function _copyActual(source, target, targetStart, sourceStart, sourceEnd) {
     sourceEnd = sourceStart + target.length - targetStart;
 
   let nb = sourceEnd - sourceStart;
-  const targetLen = target.length - targetStart;
   const sourceLen = source.length - sourceStart;
-  if (nb > targetLen)
-    nb = targetLen;
   if (nb > sourceLen)
     nb = sourceLen;
 


### PR DESCRIPTION
The condition `nb > targetLen` is always `false` because of line 241-242 