### PR TITLE
buffer: refactor `byteLength` to remove outdated optimizations

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -738,17 +738,16 @@ function byteLength(string, encoding) {
   }
 
   const len = string.length;
-  const mustMatch = (arguments.length > 2 && arguments[2] === true);
-  if (!mustMatch && len === 0)
+  if (len === 0)
     return 0;
 
-  if (!encoding)
-    return (mustMatch ? -1 : byteLengthUtf8(string));
-
-  const ops = getEncodingOps(encoding);
-  if (ops === undefined)
-    return (mustMatch ? -1 : byteLengthUtf8(string));
-  return ops.byteLength(string);
+  if (encoding) {
+    const ops = getEncodingOps(encoding);
+    if (ops) {
+      return ops.byteLength(string);
+    }
+  }
+  return byteLengthUtf8(string);
 }
 
 Buffer.byteLength = byteLength;

--- a/test/parallel/test-buffer-bytelength.js
+++ b/test/parallel/test-buffer-bytelength.js
@@ -23,8 +23,6 @@ const vm = require('vm');
   );
 });
 
-assert.strictEqual(Buffer.byteLength('', undefined, true), -1);
-
 assert(ArrayBuffer.isView(new Buffer(10)));
 assert(ArrayBuffer.isView(new SlowBuffer(10)));
 assert(ArrayBuffer.isView(Buffer.alloc(10)));


### PR DESCRIPTION
The third argument `mustMatch` is now outdated, so remove it.

Fixes: https://github.com/nodejs/node/issues/38536
