### PR TITLE
debugger: refactor to use internal modules

### DIFF
--- a/lib/internal/inspector/inspect_repl.js
+++ b/lib/internal/inspector/inspect_repl.js
@@ -28,11 +28,12 @@
 const FS = require('fs');
 const Path = require('path');
 const Repl = require('repl');
-const util = require('util');
 const vm = require('vm');
-const fileURLToPath = require('url').fileURLToPath;
+const { fileURLToPath } = require('internal/url');
 
-const debuglog = util.debuglog('inspect');
+const { customInspectSymbol } = require('internal/util');
+const { inspect: utilInspect } = require('internal/util/inspect');
+const debuglog = require('internal/util/debuglog').debuglog('inspect');
 
 const SHORTCUTS = {
   cont: 'c',
@@ -170,12 +171,12 @@ class RemoteObject {
     }
   }
 
-  [util.inspect.custom](depth, opts) {
+  [customInspectSymbol](depth, opts) {
     function formatProperty(prop) {
       switch (prop.type) {
         case 'string':
         case 'undefined':
-          return util.inspect(prop.value, opts);
+          return utilInspect(prop.value, opts);
 
         case 'number':
         case 'boolean':
@@ -184,7 +185,7 @@ class RemoteObject {
         case 'object':
         case 'symbol':
           if (prop.subtype === 'date') {
-            return util.inspect(new Date(prop.value), opts);
+            return utilInspect(new Date(prop.value), opts);
           }
           if (prop.subtype === 'array') {
             return opts.stylize(prop.value, 'special');
@@ -200,7 +201,7 @@ class RemoteObject {
       case 'number':
       case 'string':
       case 'undefined':
-        return util.inspect(this.value, opts);
+        return utilInspect(this.value, opts);
 
       case 'symbol':
         return opts.stylize(this.description, 'special');
@@ -214,10 +215,10 @@ class RemoteObject {
       case 'object':
         switch (this.subtype) {
           case 'date':
-            return util.inspect(new Date(this.description), opts);
+            return utilInspect(new Date(this.description), opts);
 
           case 'null':
-            return util.inspect(null, opts);
+            return utilInspect(null, opts);
 
           case 'regexp':
             return opts.stylize(this.description, 'regexp');
@@ -265,11 +266,11 @@ class ScopeSnapshot {
     this.completionGroup = properties.map((prop) => prop.name);
   }
 
-  [util.inspect.custom](depth, opts) {
+  [customInspectSymbol](depth, opts) {
     const type = `${this.type[0].toUpperCase()}${this.type.slice(1)}`;
     const name = this.name ? `<${this.name}>` : '';
     const prefix = `${type}${name} `;
-    return util.inspect(this.properties, opts)
+    return utilInspect(this.properties, opts)
       .replace(/^Map /, prefix);
   }
 }
@@ -318,7 +319,7 @@ function createRepl(inspector) {
 
   const INSPECT_OPTIONS = { colors: inspector.stdout.isTTY };
   function inspect(value) {
-    return util.inspect(value, INSPECT_OPTIONS);
+    return utilInspect(value, INSPECT_OPTIONS);
   }
 
   function print(value, addNewline = true) {
@@ -358,7 +359,7 @@ function createRepl(inspector) {
   function listScripts(displayNatives = false) {
     print(formatScripts(displayNatives));
   }
-  listScripts[util.inspect.custom] = function listWithoutInternal() {
+  listScripts[customInspectSymbol] = function listWithoutInternal() {
     return formatScripts();
   };
 
@@ -374,7 +375,7 @@ function createRepl(inspector) {
       return p;
     }
 
-    [util.inspect.custom](depth, { stylize }) {
+    [customInspectSymbol](depth, { stylize }) {
       const { startTime, endTime } = this.data;
       const MU = String.fromChar(956);
       return stylize(`[Profile ${endTime - startTime}${MU}s]`, 'special');
@@ -395,7 +396,7 @@ function createRepl(inspector) {
       this.delta = delta;
     }
 
-    [util.inspect.custom](depth, options) {
+    [customInspectSymbol](depth, options) {
       const { scriptId, lineNumber, columnNumber, delta, scriptSource } = this;
       const start = Math.max(1, lineNumber - delta + 1);
       const end = lineNumber + delta + 1;
@@ -461,7 +462,7 @@ function createRepl(inspector) {
   }
 
   class Backtrace extends Array {
-    [util.inspect.custom]() {
+    [customInspectSymbol]() {
       return this.map((callFrame, idx) => {
         const {
           location: { scriptId, lineNumber, columnNumber },


### PR DESCRIPTION
This avoids loading the entirety of `node:util` and `node:url` and their dependencies while only a subset is actually used by this module.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
