### PR TITLE
fix: vm trigger defineProperty setter twice

### DIFF
--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -444,6 +444,7 @@ void ContextifyContext::PropertySetterCallback(
   }
 
   USE(ctx->sandbox()->Set(context, property, value));
+  args.GetReturnValue().Set(value);
 }
 
 // static
@@ -516,6 +517,7 @@ void ContextifyContext::PropertyDefinerCallback(
         desc.has_set() ? desc.set() : Undefined(isolate).As<Value>());
 
     define_prop_on_sandbox(&desc_for_sandbox);
+    args.GetReturnValue().Set(sandbox);
   } else {
     Local<Value> value =
         desc.has_value() ? desc.value() : Undefined(isolate).As<Value>();
@@ -527,6 +529,7 @@ void ContextifyContext::PropertyDefinerCallback(
       PropertyDescriptor desc_for_sandbox(value);
       define_prop_on_sandbox(&desc_for_sandbox);
     }
+    args.GetReturnValue().Set(sandbox);
   }
 }
 

--- a/test/known_issues/test-vm-defineProperty-setter.js
+++ b/test/known_issues/test-vm-defineProperty-setter.js
@@ -1,0 +1,25 @@
+// Refs:https://github.com/nodejs/node/pull/38557
+
+const assert = require('assert');
+const vm = require('vm')
+const context = {
+    console,
+    setter: 0,
+    assert,
+}
+vm.createContext(context)
+vm.runInContext(`
+  var global = (function() {return this})()
+  Object.defineProperty(this, "test", {
+    get: function get() {
+        
+    },
+    set: function set(newValue) {
+      global.setter++
+      assert.strictEqual(global === this, false);
+    }
+  })
+  this.test = 1
+`, context)
+
+assert.strictEqual(context.setter, 1);


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->


input:

```javascript
const vm = require('vm')
const context = {
    console,
}
vm.createContext(context)
vm.runInContext(`
  var global = (function() {return this})()
  Object.defineProperty(this, "test", {
    get: function get() {
        
    },
    set: function set(newValue) {
      console.log('setter global === this', global === this, Date.now())
    }
  })
  this.test = 1
`, context)
```

output:

```log
setter global === this false 1620221534399
setter global === this true 1620221534411
```

As the above shows, `Object.defineProperty` `set` will trigger twice.

Because `set` property is defined in `sandbox` and `global` object,
and `set` is trigger in `sandbox` and `global` object.
Define `set` twice and trigger `set` twice shold be prevent：

![image](https://user-images.githubusercontent.com/10678931/117150309-9a714880-adea-11eb-88c4-0cca63756dc8.png)




