### PR TITLE
http2: fix hanging of `Http2ServerResponse`'s `end` method with no data

### DIFF
--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -755,7 +755,9 @@ class Http2ServerResponse extends Stream {
     }
 
     if (chunk !== null && chunk !== undefined)
-      this.write(chunk, encoding);
+      chunk = '';
+
+    this.write(chunk, encoding);
 
     state.headRequest = stream.headRequest;
     state.ending = true;


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/38258

