### PR TITLE
dgram: extract cluster lazy loading method to make it testable

### DIFF
--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -85,7 +85,11 @@ const RECV_BUFFER = true;
 const SEND_BUFFER = false;
 
 // Lazily loaded
-let cluster = null;
+let _cluster = null;
+function lazyLoadCluster() {
+  if (!_cluster) _cluster = require('cluster');
+  return _cluster;
+}
 
 const errnoException = errors.errnoException;
 const exceptionWithHostPort = errors.exceptionWithHostPort;
@@ -200,8 +204,7 @@ function bufferSize(self, size, buffer) {
 
 // Query primary process to get the server handle and utilize it.
 function bindServerHandle(self, options, errCb) {
-  if (!cluster)
-    cluster = require('cluster');
+  const cluster = lazyLoadCluster();
 
   const state = self[kStateSymbol];
   cluster._getServer(self, options, (err, handle) => {
@@ -262,8 +265,7 @@ Socket.prototype.bind = function(port_, address_ /* , callback */) {
     const exclusive = !!port.exclusive;
     const state = this[kStateSymbol];
 
-    if (!cluster)
-      cluster = require('cluster');
+    const cluster = lazyLoadCluster();
 
     if (cluster.isWorker && !exclusive) {
       bindServerHandle(this, {
@@ -325,8 +327,7 @@ Socket.prototype.bind = function(port_, address_ /* , callback */) {
       return;
     }
 
-    if (!cluster)
-      cluster = require('cluster');
+    const cluster = lazyLoadCluster();
 
     let flags = 0;
     if (state.reuseAddr)


### PR DESCRIPTION
~~There is no need to ensure `cluster` loaded in `bindServerHandle` because
it's already loaded before calling it.~~

~~This PR makes `cluster` as an argument to remind developers that `cluster`
needs to be loaded before calling this function.~~

Update:
The lazy load parts in `bindServerHandle` is unreachable because `cluster` has been loaded before calling it. Extract it to a seperated method to make the code testable.

Refs:
https://coverage.nodejs.org/coverage-26e318a321a872bc/lib/dgram.js.html#L202
