### PR TITLE
tools: remove redundant v8 config

### DIFF
--- a/tools/v8_gypfiles/features.gypi
+++ b/tools/v8_gypfiles/features.gypi
@@ -123,9 +123,6 @@
     'v8_enable_pointer_compression%': 0,
     'v8_enable_31bit_smis_on_64bit_arch%': 0,
 
-    # Reverse JS arguments order in the stack (sets -dV8_REVERSE_JSARGS).
-    'v8_enable_reverse_jsargs%': 0,
-
     # Sets -dOBJECT_PRINT.
     'v8_enable_object_print%': 0,
 
@@ -307,9 +304,6 @@
         'defines': ['V8_IMMINENT_DEPRECATION_WARNINGS',],
       },{
         'defines!': ['V8_IMMINENT_DEPRECATION_WARNINGS',],
-      }],
-      ['v8_enable_reverse_jsargs==1', {
-        'defines': ['V8_REVERSE_JSARGS',],
       }],
       ['v8_enable_i18n_support==1', {
         'defines': ['V8_INTL_SUPPORT',],


### PR DESCRIPTION
This is removed in v8 8.8 https://github.com/v8/v8/commit/50ddb12d2c3ca29c0f906efe78c4299fdf6ef490#diff-d7acea6210a7cc323c71038bc347fc751c62b8f13566c9dcdbc212328c8efa44

cc @nodejs/v8 