### PR TITLE
os: add os.devNull

### DIFF
--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -122,6 +122,18 @@ The properties included on each object include:
 `nice` values are POSIX-only. On Windows, the `nice` values of all processors
 are always 0.
 
+## `os.devNull`
+<!-- YAML
+added: REPLACEME
+-->
+
+* {string}
+
+The platform-specific file path of the null device.
+
+* `\\.\nul` on Windows
+* `/dev/null` on POSIX
+
 ## `os.endianness()`
 <!-- YAML
 added: v0.9.4

--- a/lib/os.js
+++ b/lib/os.js
@@ -382,5 +382,12 @@ ObjectDefineProperties(module.exports, {
     enumerable: true,
     writable: false,
     value: isWindows ? '\r\n' : '\n'
+  },
+
+  devNull: {
+    configurable: true,
+    enumerable: true,
+    writable: false,
+    value: isWindows ? '\\\\.\\nul' : '/dev/null'
   }
 });

--- a/test/parallel/test-os.js
+++ b/test/parallel/test-os.js
@@ -259,3 +259,10 @@ if (!common.isIBMi) {
 
 is.number(+os.freemem, 'freemem');
 is.number(os.freemem(), 'freemem');
+
+const devNull = os.devNull;
+if (common.isWindows) {
+  assert.strictEqual(devNull, '\\\\.\\nul');
+} else {
+  assert.strictEqual(devNull, '/dev/null');
+}


### PR DESCRIPTION
Provides the platform-specific file path of the null device.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
