### PR TITLE
util: add util/errors

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1517,6 +1517,13 @@ Invalid characters were detected in headers.
 A cursor on a given stream cannot be moved to a specified row without a
 specified column.
 
+<a id="ERR_INVALID_ERROR_MESSAGE"></a>
+### `ERR_INVALID_ERROR_MESSAGE`
+
+When using the `util/errors` module to create a new `Error` with a
+code, the message defined for the error code must be either a string
+or a function.
+
 <a id="ERR_INVALID_FD"></a>
 ### `ERR_INVALID_FD`
 
@@ -1795,6 +1802,12 @@ strict compliance with the API specification (which in some cases may accept
 `func(undefined)` but not `func()`). In most native Node.js APIs,
 `func(undefined)` and `func()` are treated identically, and the
 [`ERR_INVALID_ARG_TYPE`][] error code may be used instead.
+
+<a id="ERR_MISSING_ERROR_MESSAGE"></a>
+### `ERR_MISSING_ERROR_MESSAGE`
+
+When using the `util/errors` module to create a new `Error` with a
+code, the messages map must contain a definition for the given code.
 
 <a id="ERR_MISSING_OPTION"></a>
 ### `ERR_MISSING_OPTION`

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1304,6 +1304,110 @@ const { read, written } = encoder.encodeInto(src, dest);
 
 The encoding supported by the `TextEncoder` instance. Always set to `'utf-8'`.
 
+## `util/errors`
+<!-- YAML
+added: REPLACEME
+-->
+
+The `util/errors` module provides access to additional utilities related
+to the Node.js custom error types.
+
+```mjs
+import {
+  AbortError,
+  DOMException,
+  makeErrorWithCode
+} from 'util/errors';
+```
+
+```cjs
+const {
+  AbortError,
+  DOMException,
+  makeErrorWithCode
+} = require('util/errors');
+```
+
+### Class: `AbortError`
+<!-- YAML
+added: REPLACEME
+-->
+
+The `AbortError` is used with the {AbortController} and is thrown
+when an {AbortSignal} is triggered.
+
+```mjs
+import { AbortError } from 'util/errors';
+
+throw new AbortError();
+```
+
+```cjs
+const { AbortError } = require('util/errors');
+
+throw new AbortError();
+```
+
+### Class: `DOMException`
+<!-- YAML
+added: REPLACEME
+-->
+
+The `DOMException` class is an implementation of the standard
+[HTML `DOMException`][].
+
+#### `new DOMException([message[, name]])`
+<!-- YAML
+added: REPLACEME
+-->
+
+* `message` {string}
+* `name` {string}
+
+### `makeErrorWithCode(code[, options])`
+<!-- YAML
+added: REPLACEME
+-->
+
+* `code` {string}
+* `options` {Object}
+  * `Base` {Function} The base {Error} class for the generated error.
+    **Defaults**: {Error}.
+  * `messages` {Map} A map containing the error message definitions for
+    the codes.
+
+The `makeErrorWithCode()` function generates and returns a Function that
+can be used to generate Node.js-style {Error} objects with `code`
+properties. It is the same underlying mechanism that Node.js uses to
+define it's own internal errors.
+
+The `messages` option is a `Map` whose entries map a `code` to either a
+`string` or a `Function`. The string may contain formatting tags that
+are replaced when the error is created. The function must return a string
+generated from the provided arguments.
+
+```js
+const messages = new Map([
+  ['FOO', 'hello %s'],
+  ['BAR', (name) => `hello ${name}`],
+]);
+
+const FOO = makeErrorWithCode('FOO', { messages });
+
+throw new FOO('world');  // message: hello world
+```
+
+```js
+const messages = new Map([
+  ['FOO', 'hello %s'],
+  ['BAR', (name) => `hello ${name}`],
+]);
+
+const BAR = makeErrorWithCode('BAR', { messages, Base: TypeError });
+
+throw new BAR('world');  // message: hello world
+```
+
 ## `util.types`
 <!-- YAML
 added: v10.0.0
@@ -2474,6 +2578,7 @@ util.log('Timestamped message.');
 [Custom inspection functions on objects]: #util_custom_inspection_functions_on_objects
 [Custom promisified functions]: #util_custom_promisified_functions
 [Customizing `util.inspect` colors]: #util_customizing_util_inspect_colors
+[HTML `DOMException`]: https://developer.mozilla.org/en-US/docs/Web/API/DOMException
 [Internationalization]: intl.md
 [Module Namespace Object]: https://tc39.github.io/ecma262/#sec-module-namespace-exotic-objects
 [WHATWG Encoding Standard]: https://encoding.spec.whatwg.org/

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -233,7 +233,7 @@ class SystemError extends Error {
     super();
     // Reset the limit and setting the name property.
     if (isErrorStackTraceLimitWritable()) Error.stackTraceLimit = limit;
-    const prefix = getMessage(key, [], this);
+    const prefix = getMessage(key, [], this, messages);
     let message = `${prefix}: ${context.syscall} returned ` +
                   `${context.code} (${context.message})`;
 
@@ -338,14 +338,18 @@ function makeSystemErrorWithCode(key) {
   };
 }
 
-function makeNodeErrorWithCode(Base, key) {
+function makeErrorWithCode(key, options = {}) {
+  const {
+    Base,
+    messages,
+  } = options;
   return function NodeError(...args) {
     const limit = Error.stackTraceLimit;
     if (isErrorStackTraceLimitWritable()) Error.stackTraceLimit = 0;
     const error = new Base();
     // Reset the limit and setting the name property.
     if (isErrorStackTraceLimitWritable()) Error.stackTraceLimit = limit;
-    const message = getMessage(key, args, error);
+    const message = getMessage(key, args, error, messages);
     ObjectDefineProperty(error, 'message', {
       value: message,
       enumerable: false,
@@ -364,6 +368,10 @@ function makeNodeErrorWithCode(Base, key) {
     error.code = key;
     return error;
   };
+}
+
+function makeNodeErrorWithCode(Base, key) {
+  return makeErrorWithCode(key, { Base, messages });
 }
 
 /**
@@ -399,8 +407,8 @@ function E(sym, val, def, ...otherClasses) {
   codes[sym] = def;
 }
 
-function getMessage(key, args, self) {
-  const msg = messages.get(key);
+function getMessage(key, args, self, msgs = messages) {
+  const msg = msgs.get(key);
 
   if (assert === undefined) assert = require('internal/assert');
 
@@ -808,6 +816,7 @@ module.exports = {
   uvExceptionWithHostPort,
   SystemError,
   AbortError,
+  makeErrorWithCode,
   // This is exported only to facilitate testing.
   E,
   kNoOverride,
@@ -1190,6 +1199,9 @@ E('ERR_INVALID_CHAR',
   }, TypeError);
 E('ERR_INVALID_CURSOR_POS',
   'Cannot set cursor row without setting its column', TypeError);
+E('ERR_INVALID_ERROR_MESSAGE', (code) => {
+  return `Message for code '${code}' must be a string or Function`;
+}, TypeError);
 E('ERR_INVALID_FD',
   '"fd" must be a positive integer: %s', RangeError);
 E('ERR_INVALID_FD_TYPE', 'Unsupported fd type: %s', TypeError);
@@ -1339,6 +1351,9 @@ E('ERR_MISSING_ARGS',
     }
     return `${msg} must be specified`;
   }, TypeError);
+E('ERR_MISSING_ERROR_MESSAGE', (code) => {
+  return `Message for code '${code}' is not defined`;
+}, TypeError);
 E('ERR_MISSING_OPTION', '%s is required', TypeError);
 E('ERR_MODULE_NOT_FOUND', (path, base, type = 'package') => {
   return `Cannot find ${type} '${path}' imported from ${base}`;

--- a/lib/util/errors.js
+++ b/lib/util/errors.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const {
+  Error,
+  SafeMap,
+} = primordials;
+
+const {
+  AbortError,
+  codes: {
+    ERR_INVALID_ARG_TYPE,
+    ERR_INVALID_ERROR_MESSAGE,
+    ERR_MISSING_ERROR_MESSAGE,
+  },
+  makeErrorWithCode: _makeErrorWithCode,
+} = require('internal/errors');
+
+const {
+  DOMException,
+} = internalBinding('messaging');
+
+const {
+  validateFunction,
+  validateObject,
+  validateString,
+} = require('internal/validators');
+
+const {
+  isMap,
+} = require('util/types');
+
+function makeErrorWithCode(code, options = {}) {
+  validateString(code, 'code');
+  validateObject(options, 'options');
+  const {
+    Base = Error,
+    messages = new SafeMap(),
+  } = options;
+  validateFunction(Base, 'options.Base');
+  if (!isMap(messages)) {
+    throw new ERR_INVALID_ARG_TYPE(
+      'options.messages',
+      'Map',
+      messages);
+  }
+  const message = messages.get(code);
+  if (message === undefined) {
+    throw new ERR_MISSING_ERROR_MESSAGE(code);
+  }
+  if (typeof message !== 'function' &&
+      typeof message !== 'string') {
+    throw new ERR_INVALID_ERROR_MESSAGE(code);
+  }
+  return _makeErrorWithCode(code, { Base, messages });
+}
+
+module.exports = {
+  makeErrorWithCode,
+  AbortError,
+  DOMException,
+};

--- a/node.gyp
+++ b/node.gyp
@@ -97,6 +97,7 @@
       'lib/tty.js',
       'lib/url.js',
       'lib/util.js',
+      'lib/util/errors.js',
       'lib/util/types.js',
       'lib/v8.js',
       'lib/vm.js',

--- a/test/parallel/test-util-errors.js
+++ b/test/parallel/test-util-errors.js
@@ -1,0 +1,113 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+
+const errors = require('util/errors');
+const {
+  makeErrorWithCode,
+  AbortError,
+  DOMException,
+} = errors;
+
+{
+  const messages = new Map([
+    ['FOO', 'bar %s'],
+    ['BAZ', (name) => `${name}`],
+    ['ABC', 1],
+  ]);
+
+  const E = makeErrorWithCode('FOO', { messages });
+  const e = new E('hello');
+  assert.strictEqual(e.message, 'bar hello');
+  assert.strictEqual(e.code, 'FOO');
+  assert(e instanceof Error);
+
+  // Asserts because the message requires arguments that are not given
+  assert.throws(() => new E(), {
+    code: 'ERR_INTERNAL_ASSERTION',
+  });
+
+  const E2 = makeErrorWithCode('BAZ', { Base: TypeError, messages });
+  const e2 = new E2('hello');
+  assert.strictEqual(e2.message, 'hello');
+  assert.strictEqual(e2.code, 'BAZ');
+  assert(e2 instanceof TypeError);
+
+  assert.throws(() => makeErrorWithCode('ABC', { messages }), {
+    code: 'ERR_INVALID_ERROR_MESSAGE',
+  });
+
+  assert.throws(() => makeErrorWithCode('ABC'), {
+    code: 'ERR_MISSING_ERROR_MESSAGE',
+  });
+
+  assert.throws(() => makeErrorWithCode('XYZ', { messages }), {
+    code: 'ERR_MISSING_ERROR_MESSAGE',
+  });
+
+  assert.throws(() => makeErrorWithCode(1), {
+    code: 'ERR_INVALID_ARG_TYPE',
+  });
+
+  assert.throws(() => makeErrorWithCode('Test', 1), {
+    code: 'ERR_INVALID_ARG_TYPE',
+  });
+
+  assert.throws(() => makeErrorWithCode('Test', { Base: 1 }), {
+    code: 'ERR_INVALID_ARG_TYPE',
+  });
+
+  assert.throws(() => makeErrorWithCode('Test', { messages: 'hello' }), {
+    code: 'ERR_INVALID_ARG_TYPE',
+  });
+}
+
+{
+  const err = new AbortError();
+  assert.strictEqual(err.name, 'AbortError');
+  assert.strictEqual(err.code, 'ABORT_ERR');
+}
+
+{
+  const kDomExceptions = {
+    'IndexSizeError': 1,
+    'HierarchyRequestError': 3,
+    'WrongDocumentError': 4,
+    'InvalidCharacterError': 5,
+    'NoModificationAllowedError': 7,
+    'NotFoundError': 8,
+    'NotSupportedError': 9,
+    'InUseAttributeError': 10,
+    'InvalidStateError': 11,
+    'SyntaxError': 12,
+    'InvalidModificationError': 13,
+    'NamespaceError': 14,
+    'InvalidAccessError': 15,
+    'TypeMismatchError': 17,
+    'SecurityError': 18,
+    'NetworkError': 19,
+    'AbortError': 20,
+    'URLMismatchError': 21,
+    'QuotaExceededError': 22,
+    'TimeoutError': 23,
+    'InvalidNodeTypeError': 24,
+    'DataCloneError': 25,
+    'EncodingError': 0,
+    'NotReadableError': 0,
+    'UnknownError': 0,
+    'ConstraintError': 0,
+    'DataError': 0,
+    'TransactionInactiveError': 0,
+    'ReadOnlyError': 0,
+    'VersionError': 0,
+    'OperationError': 0,
+    'NotAllowedError': 0,
+  };
+
+  Object.keys(kDomExceptions).forEach((i) => {
+    const e = new DOMException('message', i);
+    assert.strictEqual(e.name, i);
+    assert.strictEqual(e.code, kDomExceptions[i]);
+  });
+}


### PR DESCRIPTION
Exports a subset of `internal/errors` as `require('util/errors')`.

The reason for `util/errors` is because there is already a `errors`
module on npm that has a non-trivial number of downloads per week.
Unfortunately that makes it `semver-major`

Signed-off-by: James M Snell <jasnell@gmail.com>
Fixes: https://github.com/nodejs/node/issues/38361
Fixes: https://github.com/nodejs/node/issues/14554