### PR TITLE
build: add missing torque output sources

### DIFF
--- a/tools/v8_gypfiles/v8.gyp
+++ b/tools/v8_gypfiles/v8.gyp
@@ -166,6 +166,9 @@
           '<(SHARED_INTERMEDIATE_DIR)/torque-generated/class-verifiers.h',
           '<(SHARED_INTERMEDIATE_DIR)/torque-generated/factory.cc',
           '<(SHARED_INTERMEDIATE_DIR)/torque-generated/objects-printer.cc',
+          '<@(torque_outputs_inl_inc)',
+          '<@(torque_outputs_cc)',
+          '<@(torque_outputs_inc)',
         ],
         'include_dirs': [
           '<(SHARED_INTERMEDIATE_DIR)',


### PR DESCRIPTION
The `torque_generated_definitions` target is missing some torque
generated files in its sources list when compared to the equivalent
target in V8's BUILD.gn.

Fixes: https://github.com/nodejs/node/issues/38571

Syncs our gyp file with 
https://github.com/nodejs/node/blob/e46c680bf2b211bbd52cf959ca17ee98c7f657f5/deps/v8/BUILD.gn#L1618-L1625

cc @john-yan @nodejs/v8-update 
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
