### PR TITLE
[v14.x] doc: drop import.meta.resolve parent arg URL type

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -271,6 +271,11 @@ const buffer = readFileSync(new URL('./data.proto', import.meta.url));
 ```
 
 ### `import.meta.resolve(specifier[, parent])`
+<!--
+added:
+  - v13.9.0
+  - v12.16.2
+-->
 
 > Stability: 1 - Experimental
 
@@ -278,7 +283,7 @@ This feature is only available with the `--experimental-import-meta-resolve`
 command flag enabled.
 
 * `specifier` {string} The module specifier to resolve relative to `parent`.
-* `parent` {string|URL} The absolute parent module URL to resolve from. If none
+* `parent` {string} The absolute parent module URL to resolve from. If none
   is specified, the value of `import.meta.url` is used as the default.
 * Returns: {Promise}
 


### PR DESCRIPTION
I could not find any version of Node.js which accepts a parent argument of type `URL`.  For example, on Node.js 16.1.0, `index.mjs` with content:

```js
import.meta.resolve('./index.mjs', new URL(import.meta.url));
```

produces:

    node:internal/process/promises:246
              triggerUncaughtException(err, true /* fromPromise */);
              ^

    TypeError [ERR_INVALID_ARG_TYPE]: The "parentURL" argument must be of type string. Received an instance of URL
        at new NodeError (node:internal/errors:363:5)
        at validateString (node:internal/validators:119:11)
        at Loader.resolve (node:internal/modules/esm/loader:87:7)
        at Object.resolve (node:internal/modules/esm/translators:122:26)
        at file:///path/to/index.mjs:1:13
        at ModuleJob.run (node:internal/modules/esm/module_job:175:25)
        at async Loader.import (node:internal/modules/esm/loader:178:24)
        at async Object.loadESM (node:internal/process/esm_loader:68:5) {
      code: 'ERR_INVALID_ARG_TYPE'
    }

Therefore, update the docs to drop the URL type for this argument.

Thanks for considering,
Kevin

cc: @guybedford, since you are the author of these docs and an expert in all things import.