### PR TITLE
dgram: remove unreachable connectState assign

### DIFF
--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -186,9 +186,6 @@ function replaceHandle(self, newHandle) {
   // Replace the existing handle by the handle we got from primary.
   oldHandle.close();
   state.handle = newHandle;
-  // Check if the udp handle was connected and set the state accordingly
-  if (isConnected(self))
-    state.connectState = CONNECT_STATE_CONNECTED;
 }
 
 function bufferSize(self, size, buffer) {
@@ -291,10 +288,6 @@ Socket.prototype.bind = function(port_, address_ /* , callback */) {
 
     if (err)
       throw errnoException(err, 'open');
-
-    // Check if the udp handle was connected and set the state accordingly
-    if (isConnected(this))
-      state.connectState = CONNECT_STATE_CONNECTED;
 
     startListening(this);
     return this;
@@ -552,16 +545,6 @@ function clearQueue() {
   for (const queueEntry of queue)
     queueEntry();
 }
-
-function isConnected(self) {
-  try {
-    self.remoteAddress();
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 
 // valid combinations
 // For connectionless sockets


### PR DESCRIPTION
`isConnected()` returns `true` implies that `remoteAddress()` doesn't throw an error. The implementation of `remoteAddress` is as follows:

https://github.com/nodejs/node/blob/29f1b609ba5d12d3903379bb72ff5aa6e6225568/lib/dgram.js#L770-L775

It also implies that `state.connectState === CONNECT_STATE_CONNECTED`.

So it seems not necessary to assign it again.