### PR TITLE
http: refactor to remove redundant argument of _deferToConnect

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -818,7 +818,7 @@ function onSocketNT(req, socket, err) {
 }
 
 ClientRequest.prototype._deferToConnect = _deferToConnect;
-function _deferToConnect(method, arguments_, cb) {
+function _deferToConnect(method, arguments_) {
   // This function is for calls that need to happen once the socket is
   // assigned to this request and writable. It's an important promisy
   // thing for all the socket calls that happen either now
@@ -828,9 +828,6 @@ function _deferToConnect(method, arguments_, cb) {
   const callSocketMethod = () => {
     if (method)
       ReflectApply(this.socket[method], this.socket, arguments_);
-
-    if (typeof cb === 'function')
-      cb();
   };
 
   const onSocket = () => {


### PR DESCRIPTION
Since it's considered a private method, I guess it's safe to remove this unused argument.

All references are here:

https://github.com/nodejs/node/blob/52e4fb5b23157222d85b9275f7ccdfa88fe88d0f/lib/_http_client.js#L879-L886
