### PR TITLE
build: remove dependency on `distutils.spawn`

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -246,8 +246,6 @@ Installation via Linux package manager can be achieved with:
 
 FreeBSD and OpenBSD users may also need to install `libexecinfo`.
 
-Python 3 users may also need to install `python3-distutils`.
-
 #### macOS prerequisites
 
 * Xcode Command Line Tools >= 11 for macOS
@@ -270,11 +268,6 @@ To build Node.js:
 $ ./configure
 $ make -j4
 ```
-
-If you run into a `No module named 'distutils.spawn'` error when executing
-`./configure`, please try `python3 -m pip install --upgrade setuptools` or
-`sudo apt install python3-distutils -y`.
-For more information, see <https://github.com/nodejs/node/issues/30189>.
 
 The `-j4` option will cause `make` to run 4 simultaneous compilation jobs which
 may reduce build time. For more information, see the

--- a/configure
+++ b/configure
@@ -15,7 +15,10 @@ exec python "$0" "$@"
 del _
 
 import sys
-from distutils.spawn import find_executable
+try:
+  from shutil import which
+except ImportError:
+  from distutils.spawn import find_executable as which
 
 print('Node.js configure: Found Python {}.{}.{}...'.format(*sys.version_info))
 acceptable_pythons = ((3, 9), (3, 8), (3, 7), (3, 6))
@@ -25,7 +28,7 @@ else:
   python_cmds = ['python{}.{}'.format(*vers) for vers in acceptable_pythons]
   sys.stderr.write('Please use {}.\n'.format(' or '.join(python_cmds)))
   for python_cmd in python_cmds:
-      python_cmd_path = find_executable(python_cmd)
+      python_cmd_path = which(python_cmd)
       if python_cmd_path and 'pyenv/shims' not in python_cmd_path:
         sys.stderr.write('\t{} {}\n'.format(python_cmd_path, ' '.join(sys.argv[:1])))
   sys.exit(1)

--- a/configure.py
+++ b/configure.py
@@ -14,7 +14,7 @@ import shutil
 import bz2
 import io
 
-from distutils.spawn import find_executable as which
+from shutil import which
 from distutils.version import StrictVersion
 
 # If not run from node/, cd to node/.


### PR DESCRIPTION
Debian based packages of Python 3 do not include `distutils.spawn` and
require an additional apt package to be installed (`python3-distutils`).
Replace use of `distutils.spawn` with `shutil.which`, available in all
versions of Python currently allowed by our configure scripts.

For the `configure` script only, fall back to `distutils.spawn` to allow
friendlier error messages when run on older unsupported versions of
Python (e.g. 2.7).

`configure.py` also uses `distutils.version` -- this appears to be
available in Debian packaged Python 3 without installing
`python3-distutils` so has been left as-is.

Refs: https://github.com/nodejs/node/issues/30189
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
