### PR TITLE
errors: remove input from ERR_INVALID_URL message

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1265,7 +1265,9 @@ E('ERR_INVALID_TUPLE', '%s must be an iterable %s tuple', TypeError);
 E('ERR_INVALID_URI', 'URI malformed', URIError);
 E('ERR_INVALID_URL', function(input) {
   this.input = input;
-  return `Invalid URL: ${input}`;
+  // Don't include URL in message.
+  // (See https://github.com/nodejs/node/pull/38614)
+  return 'Invalid URL';
 }, TypeError);
 E('ERR_INVALID_URL_SCHEME',
   (expected) => {

--- a/test/es-module/test-esm-loader-invalid-url.mjs
+++ b/test/es-module/test-esm-loader-invalid-url.mjs
@@ -3,8 +3,12 @@ import { expectsError, mustCall } from '../common/index.mjs';
 import assert from 'assert';
 
 import('../fixtures/es-modules/test-esm-ok.mjs')
-.then(assert.fail, expectsError({
-  code: 'ERR_INVALID_URL',
-  message: 'Invalid URL: ../fixtures/es-modules/test-esm-ok.mjs'
-}))
+.then(assert.fail, (error) => {
+  expectsError({
+    code: 'ERR_INVALID_URL',
+    message: 'Invalid URL'
+  })(error);
+
+  assert.strictEqual(error.input, '../fixtures/es-modules/test-esm-ok.mjs');
+})
 .then(mustCall());

--- a/test/parallel/test-whatwg-url-custom-parsing.js
+++ b/test/parallel/test-whatwg-url-custom-parsing.js
@@ -55,11 +55,8 @@ for (const test of failureTests) {
     () => new URL(test.input, test.base),
     (error) => {
       assert.throws(() => { throw error; }, expectedError);
-
-      // The input could be processed, so we don't do strict matching here
-      let match;
-      assert(match = (`${error}`).match(/Invalid URL: (.*)$/));
-      assert.strictEqual(error.input, match[1]);
+      assert.strictEqual(`${error}`, 'TypeError [ERR_INVALID_URL]: Invalid URL');
+      assert.strictEqual(error.message, 'Invalid URL');
       return true;
     });
 }


### PR DESCRIPTION
The dynamic part in the message, if any, should be the reason explaining why the url is invalid and not the url it self.

Migrating from `url.parse()` to `new URL()` you may start to see `ERR_INVALID_URL` errors in logs and http responses where the message contains the full input url. I decided to propose this change after discovering a secret being exposed. It will produce more compact errors but it may also help avoid user error like this to become a common attack surface during migration to whatwg.

`ERR_INVALID_URL` also seems to stand out from the other more compact errors found in `errors.js` so I hope this change is welcome.

What do you guys think?
