### PR TITLE
fs: fix async iterator partial writes with writeFile

### DIFF
--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -300,13 +300,12 @@ async function writeFileHandle(filehandle, data, signal, encoding) {
         isArrayBufferView(buf) ? buf : Buffer.from(buf, encoding || 'utf8');
       let remaining = toWrite.byteLength;
       while (remaining > 0) {
-        checkAborted(signal);
         const writeSize = MathMin(kWriteFileMaxChunkSize, remaining);
         const { bytesWritten } = await write(
           filehandle, toWrite, toWrite.byteLength - remaining, writeSize);
         remaining -= bytesWritten;
+        checkAborted(signal);
       }
-      checkAborted(signal);
     }
     return;
   }

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -296,9 +296,16 @@ async function writeFileHandle(filehandle, data, signal, encoding) {
   if (isCustomIterable(data)) {
     for await (const buf of data) {
       checkAborted(signal);
-      await write(
-        filehandle, buf, undefined,
-        isArrayBufferView(buf) ? buf.byteLength : encoding);
+      const toWrite =
+        isArrayBufferView(buf) ? buf : Buffer.from(buf, encoding || 'utf8');
+      let remaining = toWrite.byteLength;
+      while (remaining > 0) {
+        checkAborted(signal);
+        const writeSize = MathMin(kWriteFileMaxChunkSize, remaining);
+        const { bytesWritten } = await write(
+          filehandle, toWrite, toWrite.byteLength - remaining, writeSize);
+        remaining -= bytesWritten;
+      }
       checkAborted(signal);
     }
     return;

--- a/test/parallel/test-fs-promises-writefile.js
+++ b/test/parallel/test-fs-promises-writefile.js
@@ -25,6 +25,14 @@ const iterable = {
     yield 'c';
   }
 };
+
+const veryLargeBuffer = {
+  expected: 'dogs running'.repeat(512 * 1024),
+  *[Symbol.iterator]() {
+    yield Buffer.from('dogs running'.repeat(512 * 1024), 'utf8');
+  }
+};
+
 function iterableWith(value) {
   return {
     *[Symbol.iterator]() {
@@ -106,6 +114,12 @@ async function doWriteAsyncIterable() {
   assert.deepStrictEqual(data, asyncIterable.expected);
 }
 
+async function doWriteAsyncLargeIterable() {
+  await fsPromises.writeFile(dest, veryLargeBuffer);
+  const data = fs.readFileSync(dest, 'utf-8');
+  assert.deepStrictEqual(data, veryLargeBuffer.expected);
+}
+
 async function doWriteInvalidValues() {
   await Promise.all(
     [42, 42n, {}, Symbol('42'), true, undefined, null, NaN].map((value) =>
@@ -158,5 +172,6 @@ async function doReadWithEncoding() {
   await doWriteIterableWithEncoding();
   await doWriteBufferIterable();
   await doWriteAsyncIterable();
+  await doWriteAsyncLargeIterable();
   await doWriteInvalidValues();
 })().then(common.mustCall());


### PR DESCRIPTION
Fix an issue where chunks might be partially written when using `writeFile` with an async iterator.

When writing a chunk it might only be partially written, as `write` is called without checking that everything was written - this fixes the issue. I've also added chunking to make the async iterator write match the regular write. There's a minor behaviour change, where previously strings would change to buffers in the `c++` layer, however that made checking if the buffer was completely written extremely difficult, so I've moved it to the JS side (which is what happens in the non-iterator path as well).
