### PR TITLE
Possible mistake on line no. 21, isPrimary()

### DIFF
--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -18,7 +18,7 @@ const cluster = require('cluster');
 const http = require('http');
 const numCPUs = require('os').cpus().length;
 
-if (cluster.isPrimary) {
+if (cluster.isMaster) {
   console.log(`Primary ${process.pid} is running`);
 
   // Fork workers.


### PR DESCRIPTION
isPrimary() returns 'undefined' because the property seems to not exist, but using the property isMaster() returns the value properly and the example code works fine.

Thanks! if you come across this, and please revert if this is a mistake from my end.