### PR TITLE
src,node-api: fatal errors should not assume a current isolate may exist

### DIFF
--- a/src/node_errors.cc
+++ b/src/node_errors.cc
@@ -425,6 +425,12 @@ void OnFatalError(const char* location, const char* message) {
   }
 
   Isolate* isolate = Isolate::GetCurrent();
+  // TODO(legendecas): investigate failures on triggering node-report with
+  // nullptr isolates.
+  if (isolate == nullptr) {
+    fflush(stderr);
+    ABORT();
+  }
   Environment* env = Environment::GetCurrent(isolate);
   bool report_on_fatalerror;
   {

--- a/test/node-api/test_fatal/test.js
+++ b/test/node-api/test_fatal/test.js
@@ -16,3 +16,4 @@ const p = child_process.spawnSync(
 assert.ifError(p.error);
 assert.ok(p.stderr.toString().includes(
   'FATAL ERROR: test_fatal::Test fatal message'));
+assert.ok(p.status === 134 || p.signal === 'SIGABRT');

--- a/test/node-api/test_fatal/test_fatal.c
+++ b/test/node-api/test_fatal/test_fatal.c
@@ -1,9 +1,29 @@
+// For the purpose of this test we use libuv's threading library. When deciding
+// on a threading library for a new project it bears remembering that in the
+// future libuv may introduce API changes which may render it non-ABI-stable,
+// which, in turn, may affect the ABI stability of the project despite its use
+// of N-API.
+#include <uv.h>
 #include <node_api.h>
 #include "../../js-native-api/common.h"
+
+static uv_thread_t uv_thread;
+
+static void work_thread(void* data) {
+  napi_fatal_error("work_thread", NAPI_AUTO_LENGTH,
+      "foobar", NAPI_AUTO_LENGTH);
+}
 
 static napi_value Test(napi_env env, napi_callback_info info) {
   napi_fatal_error("test_fatal::Test", NAPI_AUTO_LENGTH,
                    "fatal message", NAPI_AUTO_LENGTH);
+  return NULL;
+}
+
+static napi_value TestThread(napi_env env, napi_callback_info info) {
+  NODE_API_ASSERT(env,
+      (uv_thread_create(&uv_thread, work_thread, NULL) == 0),
+      "Thread creation");
   return NULL;
 }
 
@@ -16,6 +36,7 @@ static napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor properties[] = {
     DECLARE_NODE_API_PROPERTY("Test", Test),
     DECLARE_NODE_API_PROPERTY("TestStringLength", TestStringLength),
+    DECLARE_NODE_API_PROPERTY("TestThread", TestThread),
   };
 
   NODE_API_CALL(env, napi_define_properties(

--- a/test/node-api/test_fatal/test_threads.js
+++ b/test/node-api/test_fatal/test_threads.js
@@ -7,13 +7,14 @@ const test_fatal = require(`./build/${common.buildType}/test_fatal`);
 // Test in a child process because the test code will trigger a fatal error
 // that crashes the process.
 if (process.argv[2] === 'child') {
-  test_fatal.TestStringLength();
-  return;
+  test_fatal.TestThread();
+  // Busy loop to allow the work thread to abort.
+  while (true) {}
 }
 
 const p = child_process.spawnSync(
-  process.execPath, [ '--napi-modules', __filename, 'child' ]);
+  process.execPath, [ __filename, 'child' ]);
 assert.ifError(p.error);
 assert.ok(p.stderr.toString().includes(
-  'FATAL ERROR: test_fatal::Test fatal message'));
+  'FATAL ERROR: work_thread foobar'));
 assert.ok(p.status === 134 || p.signal === 'SIGABRT');


### PR DESCRIPTION
Fixes a segment fault on `Environment::GetCurrent(isolate)` on fatal error.

napi_fatal_error and node [watchdog](https://github.com/nodejs/node/blob/master/src/node_watchdog.cc#L47) triggers fatal error but rather
running on a thread that holds no current isolate.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
