### PR TITLE
v8: add date/time change notification

### DIFF
--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -199,6 +199,16 @@ being non-zero indicates a potential memory leak.
 }
 ```
 
+## `v8.notifyDateTimeConfigurationChange()`
+<!-- YAML
+added: REPLACEME
+-->
+
+Triggers a notification to V8 that the time zone, daylight savings time,
+or other date/time configuration parameters for the system have changed,
+causing V8 to clear any cached configuration it is currently holding on
+to.
+
 ## `v8.setFlagsFromString(flags)`
 <!-- YAML
 added: v1.0.0

--- a/lib/v8.js
+++ b/lib/v8.js
@@ -82,6 +82,7 @@ const {
   updateHeapStatisticsBuffer,
   updateHeapSpaceStatisticsBuffer,
   updateHeapCodeStatisticsBuffer,
+  notifyDateTimeConfigurationChange,
 
   // Properties for heap statistics buffer extraction.
   kTotalHeapSizeIndex,
@@ -273,6 +274,7 @@ module.exports = {
   getHeapStatistics,
   getHeapSpaceStatistics,
   getHeapCodeStatistics,
+  notifyDateTimeConfigurationChange,
   setFlagsFromString,
   Serializer,
   Deserializer,

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -197,6 +197,13 @@ void SetFlagsFromString(const FunctionCallbackInfo<Value>& args) {
   V8::SetFlagsFromString(*flags, static_cast<size_t>(flags.length()));
 }
 
+void NotifyDateTimeConfigurationChange(
+    const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  env->isolate()->DateTimeConfigurationChangeNotification(
+      Isolate::TimeZoneDetection::kRedetect);
+}
+
 void Initialize(Local<Object> target,
                 Local<Value> unused,
                 Local<Context> context,
@@ -235,6 +242,10 @@ void Initialize(Local<Object> target,
                  "updateHeapSpaceStatisticsBuffer",
                  UpdateHeapSpaceStatisticsBuffer);
 
+  env->SetMethod(target,
+                 "notifyDateTimeConfigurationChange",
+                 NotifyDateTimeConfigurationChange);
+
 #define V(i, _, name)                                                          \
   target                                                                       \
       ->Set(env->context(),                                                    \
@@ -257,6 +268,7 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(UpdateHeapCodeStatisticsBuffer);
   registry->Register(UpdateHeapSpaceStatisticsBuffer);
   registry->Register(SetFlagsFromString);
+  registry->Register(NotifyDateTimeConfigurationChange);
 }
 
 }  // namespace v8_utils

--- a/test/parallel/test-datetime-change-notify.js
+++ b/test/parallel/test-datetime-change-notify.js
@@ -1,0 +1,16 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+
+const {
+  notifyDateTimeConfigurationChange,
+} = require('v8');
+
+process.env.TZ = 'UTC';
+notifyDateTimeConfigurationChange();
+assert.match(new Date().toString(), /GMT\+0000/);
+
+process.env.TZ = 'EST';
+notifyDateTimeConfigurationChange();
+assert.match(new Date().toString(), /GMT-05:00/);


### PR DESCRIPTION
This is an *attempt* at providing a workable solution for #4230 ....

V8 caches the timezone details. On windows, when `process.env.TZ` is changed, V8 is not picking up the changes. This PR introduces an API that can be used to tell V8 to clear it's cached timezone parameters. ~~Whether this is going to work or not, I'm not yet sure as I'm having difficulty building on windows locally at the moment. We'll see what the CI has to say~~

Fixes: https://github.com/nodejs/node/issues/4230
Signed-off-by: James M Snell <jasnell@gmail.com>

