### PR TITLE
doc: change color of doctag on night mode

### DIFF
--- a/doc/api_assets/hljs.css
+++ b/doc/api_assets/hljs.css
@@ -36,7 +36,8 @@
 }
 
 .dark-mode .hljs-keyword,
-.dark-mode .hljs-attribute {
+.dark-mode .hljs-attribute,
+.dark-mode .hljs-doctag {
   color: #66d9ef;
 }
 


### PR DESCRIPTION
Demo:

![Screen Shot 2021-05-12 at 19 57 00](https://user-images.githubusercontent.com/6264033/117971562-a6b25400-b35c-11eb-97bb-cee1fd5a1a80.png)


Fixes: https://github.com/nodejs/node/issues/38641