### PR TITLE
repl: fix Ctrl+C on top level await

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -74,8 +74,6 @@ const {
   ObjectKeys,
   ObjectSetPrototypeOf,
   Promise,
-  PromisePrototypeFinally,
-  PromisePrototypeThen,
   PromiseRace,
   ReflectApply,
   RegExp,
@@ -566,21 +564,24 @@ function REPLServer(prompt,
           promise = PromiseRace([promise, interrupt]);
         }
 
-        PromisePrototypeFinally(PromisePrototypeThen(promise, (result) => {
-          finishExecution(null, result);
-        }, (err) => {
-          if (err && process.domain) {
-            debug('not recoverable, send to domain');
-            process.domain.emit('error', err);
-            process.domain.exit();
-            return;
+        (async () => {
+          try {
+            const result = await promise;
+            finishExecution(null, result);
+          } catch (err) {
+            if (err && process.domain) {
+              debug('not recoverable, send to domain');
+              process.domain.emit('error', err);
+              process.domain.exit();
+              return;
+            }
+            finishExecution(err);
+          } finally {
+            // Remove prioritized SIGINT listener if it was not called.
+            prioritizedSigintQueue.delete(sigintListener);
+            unpause();
           }
-          finishExecution(err);
-        }), () => {
-          // Remove prioritized SIGINT listener if it was not called.
-          prioritizedSigintQueue.delete(sigintListener);
-          unpause();
-        });
+        })();
       }
     }
 
@@ -768,7 +769,9 @@ function REPLServer(prompt,
   const prioritizedSigintQueue = new SafeSet();
   self.on('SIGINT', function onSigInt() {
     if (prioritizedSigintQueue.size > 0) {
-      ArrayPrototypeForEach(prioritizedSigintQueue, (task) => task());
+      for (const task of prioritizedSigintQueue) {
+        task();
+      }
       return;
     }
 

--- a/test/parallel/test-repl-top-level-await.js
+++ b/test/parallel/test-repl-top-level-await.js
@@ -164,18 +164,12 @@ async function ordinaryTests() {
 }
 
 async function ctrlCTest() {
-  putIn.run([
-    `const timeout = (msecs) => new Promise((resolve) => {
-       setTimeout(resolve, msecs).unref();
-     });`,
-  ]);
-
   console.log('Testing Ctrl+C');
   assert.deepStrictEqual(await runAndWait([
-    'await timeout(100000)',
+    'await new Promise(() => {})',
     { ctrl: true, name: 'c' },
   ]), [
-    'await timeout(100000)\r',
+    'await new Promise(() => {})\r',
     'Uncaught:',
     '[Error [ERR_SCRIPT_EXECUTION_INTERRUPTED]: ' +
       'Script execution was interrupted by `SIGINT`] {',
@@ -190,4 +184,4 @@ async function main() {
   await ctrlCTest();
 }
 
-main();
+main().then(common.mustCall());


### PR DESCRIPTION
On Node.js v16.x, there is no way to cancel a top-level await call but to kill the program or wait for the promise to settle. I think that's a somewhat recent regression as this is not the case in Node.js v14.x.
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
