### PR TITLE
process: add `'worker'` event

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -457,6 +457,15 @@ of the custom deprecation.
 The `*-deprecation` command-line flags only affect warnings that use the name
 `'DeprecationWarning'`.
 
+### Event: `'worker'`
+<!-- YAML
+added: REPLACEME
+-->
+
+* `worker` {Worker} The {Worker} that was created.
+
+The `'worker'` event is emitted after a new {Worker} thread has been created.
+
 #### Emitting custom warnings
 
 See the [`process.emitWarning()`][process_emit_warning] method for issuing

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -266,6 +266,8 @@ class Worker extends EventEmitter {
     };
     // Actually start the new thread now that everything is in place.
     this[kHandle].startThread();
+
+    process.nextTick(() => process.emit('worker', this));
   }
 
   [kOnExit](code, customErr, customErrReason) {

--- a/test/parallel/test-worker-event.js
+++ b/test/parallel/test-worker-event.js
@@ -4,10 +4,11 @@ const common = require('../common');
 const assert = require('assert');
 const {
   Worker,
+  threadId: parentThreadId,
 } = require('worker_threads');
 
 process.on('worker', common.mustCall(({ threadId }) => {
-  assert.strictEqual(threadId, 1);
+  assert.strictEqual(threadId, parentThreadId + 1);
 }));
 
 new Worker('', { eval: true });

--- a/test/parallel/test-worker-event.js
+++ b/test/parallel/test-worker-event.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const {
+  Worker,
+} = require('worker_threads');
+
+process.on('worker', common.mustCall(({ threadId }) => {
+  assert.strictEqual(threadId, 1);
+}));
+
+new Worker('', { eval: true });

--- a/tools/doc/type-parser.js
+++ b/tools/doc/type-parser.js
@@ -223,6 +223,7 @@ const customTypesMap = {
   'vm.SourceTextModule': 'vm.html#vm_class_vm_sourcetextmodule',
 
   'MessagePort': 'worker_threads.html#worker_threads_class_messageport',
+  'Worker': 'worker_threads.html#worker_threads_class_worker',
 
   'X509Certificate': 'crypto.html#crypto_class_x509certificate',
 


### PR DESCRIPTION
Provides a new `process.on('worker', (worker) => {})` event that
is triggered by the creation of a new `worker_thread.Worker`.
The use case is to allow hooks to be installed for monitoring
workers without having to modify the call sites around those.

Signed-off-by: James M Snell <jasnell@gmail.com>

