### PR TITLE
test: stream.finished detects a destroyed IncomingMessage

### DIFF
--- a/test/parallel/test-stream-finished.js
+++ b/test/parallel/test-stream-finished.js
@@ -570,6 +570,22 @@ testClosed((opts) => new Writable({ write() {}, ...opts }));
   });
 }
 
+{
+  const server = http.createServer((req, res) => {
+    req.on('close', () => {
+      finished(req, common.mustCall(() => {
+        server.close();
+      }));
+    });
+    req.destroy();
+  }).listen(0, function() {
+    http.request({
+      method: 'GET',
+      port: this.address().port
+    }).end().on('error', common.mustCall());
+  });
+}
+
 
 {
   const w = new Writable({

--- a/test/parallel/test-stream-finished.js
+++ b/test/parallel/test-stream-finished.js
@@ -553,14 +553,14 @@ testClosed((opts) => new Writable({ write() {}, ...opts }));
 }
 
 {
-  const server = http.createServer((req, res) => {
-    res.on('close', () => {
+  const server = http.createServer(common.mustCall((req, res) => {
+    res.on('close', common.mustCall(() => {
       finished(res, common.mustCall(() => {
         server.close();
       }));
-    });
+    }));
     res.end();
-  })
+  }))
   .listen(0, function() {
     http.request({
       method: 'GET',
@@ -571,14 +571,14 @@ testClosed((opts) => new Writable({ write() {}, ...opts }));
 }
 
 {
-  const server = http.createServer((req, res) => {
-    req.on('close', () => {
+  const server = http.createServer(common.mustCall((req, res) => {
+    req.on('close', common.mustCall(() => {
       finished(req, common.mustCall(() => {
         server.close();
       }));
-    });
+    }));
     req.destroy();
-  }).listen(0, function() {
+  })).listen(0, function() {
     http.request({
       method: 'GET',
       port: this.address().port


### PR DESCRIPTION
Add a test to verify that `stream.finished` works correctly on `IncomingMessage`, as it looks like it didn't work on Node 15, but now works on Node 16.

The test that I added does not pass on Node 15, but passes on Node 16.

refs: https://github.com/nodejs/node/issues/38657