### PR TITLE
crypto: forbid NODE-ED25519 and NODE-ED448 "raw" key export

### DIFF
--- a/lib/internal/crypto/webcrypto.js
+++ b/lib/internal/crypto/webcrypto.js
@@ -288,8 +288,11 @@ async function exportKeyRaw(key) {
     case 'NODE-ED25519':
       // Fall through
     case 'NODE-ED448':
-      return lazyRequire('internal/crypto/ec')
-        .ecExportKey(key, kWebCryptoKeyFormatRaw);
+      if (key.type === 'public') {
+        return lazyRequire('internal/crypto/ec')
+          .ecExportKey(key, kWebCryptoKeyFormatRaw);
+      }
+      break;
     case 'ECDSA':
       // Fall through
     case 'ECDH':

--- a/test/parallel/test-webcrypto-ed25519-ed448.js
+++ b/test/parallel/test-webcrypto-ed25519-ed448.js
@@ -268,15 +268,12 @@ async function test2(namedCurve) {
         true, ['verify']),
     ]);
 
-    const [
-      rawKey1,
-      rawKey2,
-    ] = await Promise.all([
-      subtle.exportKey('raw', privateKey),
-      subtle.exportKey('raw', publicKey),
-    ]);
-    assert.deepStrictEqual(Buffer.from(rawKey1), vector.privateKey);
-    assert.deepStrictEqual(Buffer.from(rawKey2), vector.publicKey);
+    const rawPublicKey = await subtle.exportKey('raw', publicKey);
+    assert.deepStrictEqual(Buffer.from(rawPublicKey), vector.publicKey);
+
+    assert.rejects(subtle.exportKey('raw', privateKey), {
+      message: new RegExp(`Unable to export a raw ${namedCurve} private key`)
+    }).then(common.mustCall());
 
     const sig = await subtle.sign(
       { name: namedCurve },


### PR DESCRIPTION
closes #38655

Similar to ECDH and ECDSA "raw" export is not allowed for private keys.

This is a breaking change but webcrypto is still an experimental module.

cc @nodejs/crypto 