### PR TITLE
Update abort signal in fs promise api example

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -985,7 +985,7 @@ try {
 
   // Abort the request before the promise settles.
   controller.abort();
-  
+
   await promise;
 } catch (err) {
   // When a request is aborted - err is an AbortError
@@ -1002,7 +1002,7 @@ Any specified {FileHandle} has to support reading.
 <!-- YAML
 added: v10.0.0
 -->
-
+  
 * `path` {string|Buffer|URL}
 * `options` {string|Object}
   * `encoding` {string} **Default:** `'utf8'`
@@ -1323,7 +1323,7 @@ try {
 
   // Abort the request before the promise settles.
   controller.abort();
-  
+
   await promise;
 } catch (err) {
   // When a request is aborted - err is an AbortError

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -980,12 +980,15 @@ import { readFile } from 'fs/promises';
 
 try {
   const controller = new AbortController();
-  const signal = controller.signal;
-  readFile(fileName, { signal });
+  const { signal } = controller;
+  const promise = readFile(fileName, { signal });
 
-  // Abort the request
+  // Abort the request before the promise settled
   controller.abort();
+  
+  await promise;
 } catch (err) {
+  // When a request is aborted - err is an AbortError
   console.error(err);
 }
 ```
@@ -1316,8 +1319,12 @@ try {
   const controller = new AbortController();
   const { signal } = controller;
   const data = new Uint8Array(Buffer.from('Hello Node.js'));
-  writeFile('message.txt', data, { signal });
+  const promise = writeFile('message.txt', data, { signal });
+
+  // Abort the request before the promise settled
   controller.abort();
+  
+  await promise;
 } catch (err) {
   // When a request is aborted - err is an AbortError
   console.error(err);

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1321,7 +1321,7 @@ try {
   const data = new Uint8Array(Buffer.from('Hello Node.js'));
   const promise = writeFile('message.txt', data, { signal });
 
-  // Abort the request before the promise settled
+  // Abort the request before the promise settles.
   controller.abort();
   
   await promise;

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -983,7 +983,7 @@ try {
   const { signal } = controller;
   const promise = readFile(fileName, { signal });
 
-  // Abort the request before the promise settled
+  // Abort the request before the promise settles.
   controller.abort();
   
   await promise;

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1002,7 +1002,6 @@ Any specified {FileHandle} has to support reading.
 <!-- YAML
 added: v10.0.0
 -->
-  
 * `path` {string|Buffer|URL}
 * `options` {string|Object}
   * `encoding` {string} **Default:** `'utf8'`


### PR DESCRIPTION
Without `await`ing the promise the try-catch block would never catch this error. IMO this was misleading.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
