### PR TITLE
src: remove extra semi after member fn

### DIFF
--- a/src/cares_wrap.h
+++ b/src/cares_wrap.h
@@ -141,8 +141,8 @@ struct NodeAresTask final : public MemoryRetainer {
   uv_poll_t poll_watcher;
 
   inline void MemoryInfo(MemoryTracker* trakcer) const override;
-  SET_MEMORY_INFO_NAME(NodeAresTask);
-  SET_SELF_SIZE(NodeAresTask);
+  SET_MEMORY_INFO_NAME(NodeAresTask)
+  SET_SELF_SIZE(NodeAresTask)
 
   struct Hash {
     inline size_t operator()(NodeAresTask* a) const {

--- a/src/timer_wrap.h
+++ b/src/timer_wrap.h
@@ -32,7 +32,7 @@ class TimerWrap final : public MemoryRetainer {
   void Ref();
   void Unref();
 
-  SET_NO_MEMORY_INFO();
+  SET_NO_MEMORY_INFO()
   SET_MEMORY_INFO_NAME(TimerWrap)
   SET_SELF_SIZE(TimerWrap)
 


### PR DESCRIPTION
Added in https://github.com/nodejs/node/pull/34186 and https://github.com/nodejs/node/pull/38172 - causes build failures in Electron.

```
In file included from ../../third_party/electron_node/src/inspector_agent.cc:18:
../../third_party/electron_node/src/timer_wrap.h:35:23: error: extra ';' after member function definition [-Werror,-Wextra-semi]
  SET_NO_MEMORY_INFO();
                      ^
1 error generated.
[740/12750] CXX obj/cc/cc/layer_tree_host_impl.o
```

```
In file included from ../../third_party/electron_node/src/cares_wrap.cc:25:
../../third_party/electron_node/src/cares_wrap.h:144:37: error: extra ';' after member function definition [-Werror,-Wextra-semi]
  SET_MEMORY_INFO_NAME(NodeAresTask);
                                    ^
../../third_party/electron_node/src/cares_wrap.h:145:30: error: extra ';' after member function definition [-Werror,-Wextra-semi]
  SET_SELF_SIZE(NodeAresTask);
                             ^
2 errors generated.
```

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->