### PR TITLE
stream: fix highwatermark threshold and add the missing error

### DIFF
--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -62,6 +62,7 @@ const {
   codes: {
     ERR_INVALID_ARG_TYPE,
     ERR_METHOD_NOT_IMPLEMENTED,
+    ERR_OUT_OF_RANGE,
     ERR_STREAM_PUSH_AFTER_EOF,
     ERR_STREAM_UNSHIFT_AFTER_END_EVENT,
   }
@@ -363,9 +364,8 @@ Readable.prototype.setEncoding = function(enc) {
 // Don't raise the hwm > 1GB.
 const MAX_HWM = 0x40000000;
 function computeNewHighWaterMark(n) {
-  if (n >= MAX_HWM) {
-    // TODO(ronag): Throw ERR_VALUE_OUT_OF_RANGE.
-    n = MAX_HWM;
+  if (n > MAX_HWM) {
+    throw new ERR_OUT_OF_RANGE('size', '<= 1GiB', n);
   } else {
     // Get the next highest power of 2 to prevent increasing hwm excessively in
     // tiny amounts.

--- a/test/parallel/test-streams-highwatermark.js
+++ b/test/parallel/test-streams-highwatermark.js
@@ -70,3 +70,18 @@ const { inspect } = require('util');
     assert.strictEqual(readable._readableState.highWaterMark, Number(size));
   });
 }
+
+{
+  // Test highwatermark limit
+  const hwm = 0x40000000 + 1;
+  const readable = stream.Readable({
+    read() {},
+  });
+
+  assert.throws(() => readable.read(hwm), common.expectsError({
+    code: 'ERR_OUT_OF_RANGE',
+    message: 'The value of "size" is out of range.' +
+             ' It must be <= 1GiB. Received ' +
+             hwm,
+  }));
+}


### PR DESCRIPTION
1. Fix highwatermark threshold: `< 1GiB` -> `<= 1GiB`, [doc here](https://nodejs.org/api/stream.html#stream_readable_read_size)
2. Add the missing error: Size out of range

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
