### PR TITLE
[v14.x backport] lib: make safe primordials safe to iterate

### DIFF
--- a/lib/internal/per_context/primordials.js
+++ b/lib/internal/per_context/primordials.js
@@ -91,9 +91,52 @@ function copyPrototype(src, dest, prefix) {
   }
 }
 
+const createSafeIterator = (factory, next) => {
+  class SafeIterator {
+    constructor(iterable) {
+      this._iterator = factory(iterable);
+    }
+    next() {
+      return next(this._iterator);
+    }
+    [Symbol.iterator]() {
+      return this;
+    }
+  }
+  Object.setPrototypeOf(SafeIterator.prototype, null);
+  Object.freeze(SafeIterator.prototype);
+  Object.freeze(SafeIterator);
+  return SafeIterator;
+};
+
 function makeSafe(unsafe, safe) {
-  copyProps(unsafe.prototype, safe.prototype);
+  if (Symbol.iterator in unsafe.prototype) {
+    const dummy = new unsafe();
+    let next; // We can reuse the same `next` method.
+
+    for (const key of Reflect.ownKeys(unsafe.prototype)) {
+      if (!Reflect.getOwnPropertyDescriptor(safe.prototype, key)) {
+        const desc = Reflect.getOwnPropertyDescriptor(unsafe.prototype, key);
+        if (
+          typeof desc.value === 'function' &&
+          desc.value.length === 0 &&
+          Symbol.iterator in (desc.value.call(dummy) ?? {})
+        ) {
+          const createIterator = uncurryThis(desc.value);
+          if (next == null) next = uncurryThis(createIterator(dummy).next);
+          const SafeIterator = createSafeIterator(createIterator, next);
+          desc.value = function() {
+            return new SafeIterator(this);
+          };
+        }
+        Reflect.defineProperty(safe.prototype, key, desc);
+      }
+    }
+  } else {
+    copyProps(unsafe.prototype, safe.prototype);
+  }
   copyProps(unsafe, safe);
+
   Object.setPrototypeOf(safe.prototype, null);
   Object.freeze(safe.prototype);
   Object.freeze(safe);

--- a/lib/internal/source_map/source_map_cache.js
+++ b/lib/internal/source_map/source_map_cache.js
@@ -7,16 +7,11 @@ const {
   ObjectKeys,
   ObjectGetOwnPropertyDescriptor,
   ObjectPrototypeHasOwnProperty,
-  Map,
-  MapPrototypeEntries,
   RegExpPrototypeTest,
   SafeMap,
   StringPrototypeMatch,
   StringPrototypeSplit,
-  uncurryThis,
 } = primordials;
-
-const MapIteratorNext = uncurryThis(MapPrototypeEntries(new Map()).next);
 
 function ObjectGetValueSafe(obj, key) {
   const desc = ObjectGetOwnPropertyDescriptor(obj, key);
@@ -195,11 +190,7 @@ function rekeySourceMap(cjsModuleInstance, newInstance) {
 function sourceMapCacheToObject() {
   const obj = ObjectCreate(null);
 
-  const it = MapPrototypeEntries(esmSourceMapCache);
-  let entry;
-  while (!(entry = MapIteratorNext(it)).done) {
-    const k = entry.value[0];
-    const v = entry.value[1];
+  for (const { 0: k, 1: v } of esmSourceMapCache) {
     obj[k] = v;
   }
 

--- a/lib/internal/worker/io.js
+++ b/lib/internal/worker/io.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const {
+  ArrayPrototypeForEach,
   ArrayPrototypeMap,
   ArrayPrototypePush,
   FunctionPrototypeCall,
@@ -259,8 +260,7 @@ class WritableWorkerStdio extends Writable {
   [kStdioWantsMoreDataCallback]() {
     const cbs = this[kWritableCallbacks];
     this[kWritableCallbacks] = [];
-    for (const cb of cbs)
-      cb();
+    ArrayPrototypeForEach(cbs, (cb) => cb());
     if ((this[kPort][kWaitingStreams] -= cbs.length) === 0)
       this[kPort].unref();
   }

--- a/test/parallel/test-worker-terminate-source-map.js
+++ b/test/parallel/test-worker-terminate-source-map.js
@@ -27,16 +27,19 @@ const { callCount } = workerData;
 function increaseCallCount() { callCount[0]++; }
 
 // Increase the call count when a forbidden method is called.
-Object.getPrototypeOf((new Map()).entries()).next = increaseCallCount;
-Map.prototype.entries = increaseCallCount;
-Object.keys = increaseCallCount;
-Object.create = increaseCallCount;
-Object.hasOwnProperty = increaseCallCount;
 for (const property of ['_cache', 'lineLengths', 'url']) {
   Object.defineProperty(Object.prototype, property, {
     get: increaseCallCount,
     set: increaseCallCount
   });
 }
+Object.getPrototypeOf([][Symbol.iterator]()).next = increaseCallCount;
+Object.getPrototypeOf((new Map()).entries()).next = increaseCallCount;
+Array.prototype[Symbol.iterator] = increaseCallCount;
+Map.prototype[Symbol.iterator] = increaseCallCount;
+Map.prototype.entries = increaseCallCount;
+Object.keys = increaseCallCount;
+Object.create = increaseCallCount;
+Object.hasOwnProperty = increaseCallCount;
 
 parentPort.postMessage('done');


### PR DESCRIPTION
Backport PR to remove the logical nullish assignment operator (not supported until V8 8.5).

PR-URL: https://github.com/nodejs/node/pull/36391
Reviewed-By: Michaël Zasso <targos@protonmail.com>
Reviewed-By: James M Snell <jasnell@gmail.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
