### PR TITLE
typings: add JSDoc typings for events

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -71,6 +71,11 @@ const kMaxEventTargetListeners = Symbol('events.maxEventTargetListeners');
 const kMaxEventTargetListenersWarned =
   Symbol('events.maxEventTargetListenersWarned');
 
+/**
+ * Creates a new `EventEmitter` instance.
+ * @param {{ captureRejections?: boolean; }} [opts]
+ * @returns {EventEmitter}
+ */
 function EventEmitter(opts) {
   EventEmitter.init.call(this, opts);
 }
@@ -151,6 +156,12 @@ ObjectDefineProperties(EventEmitter, {
   }
 });
 
+/**
+ * Sets the max listeners.
+ * @param {number} n
+ * @param {EventTarget[] | EventEmitter[]} [evenTargets]
+ * @returns {void}
+ */
 EventEmitter.setMaxListeners =
   function(n = defaultMaxListeners, ...eventTargets) {
     if (typeof n !== 'number' || n < 0 || NumberIsNaN(n))
@@ -245,8 +256,11 @@ function emitUnhandledRejectionOrErr(ee, err, type, args) {
   }
 }
 
-// Obviously not all Emitters should be limited to 10. This function allows
-// that to be increased. Set to zero for unlimited.
+/**
+ * Increases the max listeners of the event emitter.
+ * @param {number} n
+ * @returns {EventEmitter}
+ */
 EventEmitter.prototype.setMaxListeners = function setMaxListeners(n) {
   if (typeof n !== 'number' || n < 0 || NumberIsNaN(n)) {
     throw new ERR_OUT_OF_RANGE('n', 'a non-negative number', n);
@@ -261,6 +275,10 @@ function _getMaxListeners(that) {
   return that._maxListeners;
 }
 
+/**
+ * Returns the current max listener value for the event emitter.
+ * @returns {number}
+ */
 EventEmitter.prototype.getMaxListeners = function getMaxListeners() {
   return _getMaxListeners(this);
 };
@@ -311,6 +329,13 @@ function enhanceStackTrace(err, own) {
   return err.stack + sep + ownStack.join('\n');
 }
 
+/**
+ * Synchronously calls each of the listeners registered
+ * for the event.
+ * @param {string | symbol} type
+ * @param {...any} [args]
+ * @returns {boolean}
+ */
 EventEmitter.prototype.emit = function emit(type, ...args) {
   let doError = (type === 'error');
 
@@ -452,12 +477,25 @@ function _addListener(target, type, listener, prepend) {
   return target;
 }
 
+/**
+ * Adds a listener to the event emitter.
+ * @param {string | symbol} type
+ * @param {Function} listener
+ * @returns {EventEmitter}
+ */
 EventEmitter.prototype.addListener = function addListener(type, listener) {
   return _addListener(this, type, listener, false);
 };
 
 EventEmitter.prototype.on = EventEmitter.prototype.addListener;
 
+/**
+ * Adds the `listener` function to the beginning of
+ * the listeners array.
+ * @param {string | symbol} type
+ * @param {Function} listener
+ * @returns {EventEmitter}
+ */
 EventEmitter.prototype.prependListener =
     function prependListener(type, listener) {
       return _addListener(this, type, listener, true);
@@ -481,6 +519,12 @@ function _onceWrap(target, type, listener) {
   return wrapped;
 }
 
+/**
+ * Adds a one-time `listener` function to the event emitter.
+ * @param {string | symbol} type
+ * @param {Function} listener
+ * @returns {EventEmitter}
+ */
 EventEmitter.prototype.once = function once(type, listener) {
   checkListener(listener);
 
@@ -488,6 +532,13 @@ EventEmitter.prototype.once = function once(type, listener) {
   return this;
 };
 
+/**
+ * Adds a one-time `listener` function to the beginning of
+ * the listeners array.
+ * @param {string | symbol} type
+ * @param {Function} listener
+ * @returns {EventEmitter}
+ */
 EventEmitter.prototype.prependOnceListener =
     function prependOnceListener(type, listener) {
       checkListener(listener);
@@ -496,7 +547,12 @@ EventEmitter.prototype.prependOnceListener =
       return this;
     };
 
-// Emits a 'removeListener' event if and only if the listener was removed.
+/**
+ * Removes the specified `listener` from the listeners array.
+ * @param {string | symbol} type
+ * @param {Function} listener
+ * @returns {EventEmitter}
+ */
 EventEmitter.prototype.removeListener =
     function removeListener(type, listener) {
       checkListener(listener);
@@ -550,6 +606,13 @@ EventEmitter.prototype.removeListener =
 
 EventEmitter.prototype.off = EventEmitter.prototype.removeListener;
 
+/**
+ * Removes all listeners from the event emitter. (Only
+ * removes listeners for a specific event name if specified
+ * as `type`).
+ * @param {string | symbol} [type]
+ * @returns {EventEmitter}
+ */
 EventEmitter.prototype.removeAllListeners =
     function removeAllListeners(type) {
       const events = this._events;
@@ -613,14 +676,33 @@ function _listeners(target, type, unwrap) {
     unwrapListeners(evlistener) : arrayClone(evlistener);
 }
 
+/**
+ * Returns a copy of the array of listeners for the event name
+ * specified as `type`.
+ * @param {string | symbol} type
+ * @returns {Function[]}
+ */
 EventEmitter.prototype.listeners = function listeners(type) {
   return _listeners(this, type, true);
 };
 
+/**
+ * Returns a copy of the array of listeners and wrappers for
+ * the event name specified as `type`.
+ * @param {string | symbol} type
+ * @returns {Function[]}
+ */
 EventEmitter.prototype.rawListeners = function rawListeners(type) {
   return _listeners(this, type, false);
 };
 
+/**
+ * Returns the number of listeners listening to the event name
+ * specified as `type`.
+ * @param {EventEmitter} emitter
+ * @param {string | symbol} type
+ * @returns {number}
+ */
 EventEmitter.listenerCount = function(emitter, type) {
   if (typeof emitter.listenerCount === 'function') {
     return emitter.listenerCount(type);
@@ -629,6 +711,13 @@ EventEmitter.listenerCount = function(emitter, type) {
 };
 
 EventEmitter.prototype.listenerCount = listenerCount;
+
+/**
+ * Returns the number of listeners listening to event name
+ * specified as `type`.
+ * @param {string | symbol} type
+ * @returns {number}
+ */
 function listenerCount(type) {
   const events = this._events;
 
@@ -645,6 +734,11 @@ function listenerCount(type) {
   return 0;
 }
 
+/**
+ * Returns an array listing the events for which
+ * the emitter has registered listeners.
+ * @returns {any[]}
+ */
 EventEmitter.prototype.eventNames = function eventNames() {
   return this._eventsCount > 0 ? ReflectOwnKeys(this._events) : [];
 };
@@ -672,6 +766,13 @@ function unwrapListeners(arr) {
   return ret;
 }
 
+/**
+ * Returns a copy of the array of listeners for the event name
+ * specified as `type`.
+ * @param {EventEmitter | EventTarget} emitterOrTarget
+ * @param {string | symbol} type
+ * @returns {Function[]}
+ */
 function getEventListeners(emitterOrTarget, type) {
   // First check if EventEmitter
   if (typeof emitterOrTarget.listeners === 'function') {
@@ -696,6 +797,14 @@ function getEventListeners(emitterOrTarget, type) {
                                  emitterOrTarget);
 }
 
+/**
+ * Creates a `Promise` that is fulfilled when the emitter
+ * emits the given event.
+ * @param {EventEmitter} emitter
+ * @param {string} name
+ * @param {{ signal: AbortSignal; }} [options]
+ * @returns {Promise}
+ */
 async function once(emitter, name, options = {}) {
   const signal = options?.signal;
   validateAbortSignal(signal, 'options.signal');
@@ -767,6 +876,13 @@ function eventTargetAgnosticAddListener(emitter, name, listener, flags) {
   }
 }
 
+/**
+ * Returns an `AsyncIterator` that iterates `event` events.
+ * @param {EventEmitter} emitter
+ * @param {string | symbol} event
+ * @param {{ signal: AbortSignal; }} [options]
+ * @returns {AsyncIterator}
+ */
 function on(emitter, event, options) {
   const signal = options?.signal;
   validateAbortSignal(signal, 'options.signal');

--- a/lib/events.js
+++ b/lib/events.js
@@ -159,7 +159,7 @@ ObjectDefineProperties(EventEmitter, {
 /**
  * Sets the max listeners.
  * @param {number} n
- * @param {EventTarget[] | EventEmitter[]} [evenTargets]
+ * @param {EventTarget[] | EventEmitter[]} [eventTargets]
  * @returns {void}
  */
 EventEmitter.setMaxListeners =
@@ -699,6 +699,7 @@ EventEmitter.prototype.rawListeners = function rawListeners(type) {
 /**
  * Returns the number of listeners listening to the event name
  * specified as `type`.
+ * @deprecated since v3.2.0
  * @param {EventEmitter} emitter
  * @param {string | symbol} type
  * @returns {number}


### PR DESCRIPTION
Added JSDoc typings for the `events` lib module.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
