### PR TITLE
child_process: check for closed pipes after creating socket

### DIFF
--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -447,6 +447,10 @@ ChildProcess.prototype.spawn = function(options) {
       stream.socket = createSocket(this.pid !== 0 ?
         stream.handle : null, i > 0);
 
+      // Trigger an empty read to check for a closed pipe
+      // or the close event will go undetected until next write
+      stream.socket.read(0);
+
       if (i > 0 && this.pid !== 0) {
         this._closesNeeded++;
         stream.socket.on('close', () => {

--- a/test/parallel/test-child-process-spawn-close-stdin.js
+++ b/test/parallel/test-child-process-spawn-close-stdin.js
@@ -1,0 +1,19 @@
+'use strict';
+// Refs: https://github.com/nodejs/node/issues/25131
+const common = require('../common');
+const cp = require('child_process');
+const fs = require('fs');
+
+if (process.argv[2] === 'child') {
+  fs.closeSync(0);
+} else {
+  const child = cp.spawn(process.execPath, [__filename, 'child'], {
+    stdio: ['pipe', 'inherit', 'inherit']
+  });
+
+  child.stdin.on('close', common.mustCall(() => {
+    process.exit(0);
+  }));
+
+  child.on('close', common.mustNotCall(() => {}));
+}


### PR DESCRIPTION
After the socket is created, this PR now triggers an empty read to make sure we catch stdio events like closing the stdin file descriptor. Otherwise those events will go undetected until the next stream write.

Fixes: https://github.com/nodejs/node/issues/25131

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
