### PR TITLE
stream: allow empty string as first stream of pipeline

### DIFF
--- a/lib/internal/streams/utils.js
+++ b/lib/internal/streams/utils.js
@@ -20,7 +20,7 @@ function isStream(obj) {
 }
 
 function isIterable(obj, isAsync) {
-  if (!obj && typeof obj !== 'string') return false;
+  if (obj == null) return false;
   if (isAsync === true) return typeof obj[SymbolAsyncIterator] === 'function';
   if (isAsync === false) return typeof obj[SymbolIterator] === 'function';
   return typeof obj[SymbolAsyncIterator] === 'function' ||

--- a/lib/internal/streams/utils.js
+++ b/lib/internal/streams/utils.js
@@ -20,7 +20,7 @@ function isStream(obj) {
 }
 
 function isIterable(obj, isAsync) {
-  if (!obj) return false;
+  if (!obj && typeof obj !== 'string') return false;
   if (isAsync === true) return typeof obj[SymbolAsyncIterator] === 'function';
   if (isAsync === false) return typeof obj[SymbolIterator] === 'function';
   return typeof obj[SymbolAsyncIterator] === 'function' ||

--- a/test/parallel/test-stream-pipeline-with-empty-string.js
+++ b/test/parallel/test-stream-pipeline-with-empty-string.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const common = require('../common');
+const {
+  pipeline,
+  PassThrough
+} = require('stream');
+
+
+async function runTest() {
+  await pipeline(
+    '',
+    new PassThrough({ objectMode: true }),
+    common.mustCall(() => { })
+  );
+}
+
+runTest().then(common.mustCall(() => {}));


### PR DESCRIPTION
Empty string `''` should be allowed as first stream of `pipeline` per [doc](https://nodejs.org/api/stream.html#stream_stream_pipeline_source_transforms_destination_callback) as `Iterable`.

Fixes: https://github.com/nodejs/node/issues/38721
