### PR TITLE
doc: document null target pattern

### DIFF
--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -383,6 +383,26 @@ treating the right hand side target pattern as a `**` glob against the list of
 files within the package. Because `node_modules` paths are forbidden in exports
 targets, this expansion is dependent on only the files of the package itself.
 
+To exclude private subfolders from patterns, `null` targets can be used:
+
+```json
+// ./node_modules/es-module-package/package.json
+{
+  "exports": {
+    "./features/*": "./src/features/*.js",
+    "./features/private-internal/*": null
+  }
+}
+```
+
+```js
+import featureInternal from 'es-module-package/features/private-internal/m';
+// Throws: ERR_PACKAGE_PATH_NOT_EXPORTED
+
+import featureX from 'es-module-package/features/x';
+// Loads ./node_modules/es-module-package/src/features/x.js
+```
+
 ### Subpath folder mappings
 <!-- YAML
 changes:

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -358,6 +358,9 @@ For these use cases, subpath export patterns can be used instead:
 }
 ```
 
+**`*` matches expose nested subpaths as it is a string replacement syntax 
+only.**
+
 The left hand matching pattern must always end in `*`. All instances of `*` on
 the right hand side will then be replaced with this value, including if it
 contains any `/` separators.

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -358,7 +358,7 @@ For these use cases, subpath export patterns can be used instead:
 }
 ```
 
-**`*` matches expose nested subpaths as it is a string replacement syntax 
+**`*` maps expose nested subpaths as it is a string replacement syntax
 only.**
 
 The left hand matching pattern must always end in `*`. All instances of `*` on


### PR DESCRIPTION
We don't currently document `null` targets in package "exports", which provide a useful _exclude_ functionality when used in subpath patterns. This extends the subpath patterns docs with a short description and example of this behaviour.

@nodejs/modules 