### PR TITLE
child_process: retain reference to data with advanced serialization

### DIFF
--- a/lib/internal/child_process/serialization.js
+++ b/lib/internal/child_process/serialization.js
@@ -12,6 +12,7 @@ const { StringDecoder } = require('string_decoder');
 const v8 = require('v8');
 const { isArrayBufferView } = require('internal/util/types');
 const assert = require('internal/assert');
+const { streamBaseState, kLastWriteWasAsync } = internalBinding('stream_wrap');
 
 const kMessageBuffer = Symbol('kMessageBuffer');
 const kJSONBuffer = Symbol('kJSONBuffer');
@@ -82,10 +83,16 @@ const advanced = {
     const serializedMessage = ser.releaseBuffer();
     const sizeBuffer = Buffer.allocUnsafe(4);
     sizeBuffer.writeUInt32BE(serializedMessage.length);
-    return channel.writeBuffer(req, Buffer.concat([
+
+    const buffer = Buffer.concat([
       sizeBuffer,
       serializedMessage,
-    ]), handle);
+    ]);
+    const result = channel.writeBuffer(req, buffer, handle);
+    // Mirror what stream_base_commons.js does for Buffer retention.
+    if (streamBaseState[kLastWriteWasAsync])
+      req.buffer = buffer;
+    return result;
   },
 };
 

--- a/test/parallel/test-child-process-advanced-serialization-largebuffer.js
+++ b/test/parallel/test-child-process-advanced-serialization-largebuffer.js
@@ -1,0 +1,27 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const child_process = require('child_process');
+
+// Regression test for https://github.com/nodejs/node/issues/34797
+const eightMB = 8 * 1024 * 1024;
+
+if (process.argv[2] === 'child') {
+  for (let i = 0; i < 4; i++) {
+    process.send(new Uint8Array(eightMB).fill(i));
+  }
+} else {
+  const child = child_process.spawn(process.execPath, [__filename, 'child'], {
+    stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
+    serialization: 'advanced'
+  });
+  const received = [];
+  child.on('message', common.mustCall((chunk) => {
+    assert.deepStrictEqual(chunk, new Uint8Array(eightMB).fill(chunk[0]));
+
+    received.push(chunk[0]);
+    if (received.length === 4) {
+      assert.deepStrictEqual(received, [0, 1, 2, 3]);
+    }
+  }, 4));
+}


### PR DESCRIPTION
Do the same thing we do for other streams, and retain a reference to
the Buffer that was sent over IPC while the write request is active,
so that it doesn’t get garbage collected while the data is still in
flight.

(This is a good example of why it’s a bad idea that we’re not re-using
the general streams implementation for IPC and instead maintain
separate usage of the low-level I/O primitives.)

Fixes: https://github.com/nodejs/node/issues/34797

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
