### PR TITLE
test: set locale for datetime-change-notify test

### DIFF
--- a/test/parallel/test-datetime-change-notify.js
+++ b/test/parallel/test-datetime-change-notify.js
@@ -11,14 +11,27 @@ if (!isMainThread)
 
 const assert = require('assert');
 
-process.env.TZ = 'Etc/UTC';
-assert.match(new Date().toString(), /GMT\+0000/);
+const cases = [
+  {
+    timeZone: 'Etc/UTC',
+    expected: /Coordinated Universal Time/,
+  },
+  {
+    timeZone: 'America/New_York',
+    expected: /Eastern (Standard|Daylight) Time/,
+  },
+  {
+    timeZone: 'America/Los_Angeles',
+    expected: /Pacific (Standard|Daylight) Time/,
+  },
+  {
+    timeZone: 'Europe/Dublin',
+    expected: /Irish/,
+  },
+];
 
-process.env.TZ = 'America/New_York';
-assert.match(new Date().toString(), /Eastern (Standard|Daylight) Time/);
-
-process.env.TZ = 'America/Los_Angeles';
-assert.match(new Date().toString(), /Pacific (Standard|Daylight) Time/);
-
-process.env.TZ = 'Europe/Dublin';
-assert.match(new Date().toString(), /Irish/);
+for (const { timeZone, expected } of cases) {
+  process.env.TZ = timeZone;
+  const date = new Date().toLocaleString('en-US', { timeZoneName: 'long' });
+  assert.match(date, expected);
+}


### PR DESCRIPTION
The time zone output by `toString()` will change with user's language, use `toLocaleString()` to set the time zone.

This test will fail on a computer with the language set to Chinese.

Example:

use `toString()`

```js
new Date().toString() 
// output: Thu May 20 2021 05:18:38 GMT+0000 (协调世界时)
```

use `toLocaleString()`

```js
new Date().toLocaleString('en-US', { timeZoneName: 'long' }); 
// output: date 5/20/2021, 5:24:25 AM Coordinated Universal Time
```

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
