### PR TITLE
benchmark: fix http elapsed time

### DIFF
--- a/benchmark/_http-benchmarkers.js
+++ b/benchmark/_http-benchmarkers.js
@@ -222,7 +222,7 @@ exports.run = function(options, callback) {
     return;
   }
 
-  const benchmarker_start = process.hrtime();
+  const benchmarker_start = process.hrtime.bigint();
 
   const child = benchmarker.create(options);
 
@@ -233,7 +233,7 @@ exports.run = function(options, callback) {
   child.stdout.on('data', (chunk) => stdout += chunk);
 
   child.once('close', (code) => {
-    const elapsed = process.hrtime(benchmarker_start);
+    const benchmark_end = process.hrtime.bigint();
     if (code) {
       let error_message = `${options.benchmarker} failed with ${code}.`;
       if (stdout !== '') {
@@ -250,6 +250,7 @@ exports.run = function(options, callback) {
       return;
     }
 
+    const elapsed = benchmark_end - benchmarker_start;
     callback(null, code, options.benchmarker, result, elapsed);
   });
 


### PR DESCRIPTION
Since commit 4e9ad206e22, elapsed time is expected to be a BigInt instead of an array. This make the R script fails such as in https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/1026/.

Refs: https://github.com/nodejs/node/pull/38369

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
