### PR TITLE
build: allow LTO with Clang 3.9.1+

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -164,17 +164,28 @@
           'v8_enable_handle_zapping': 0,
           'pgo_generate': ' -fprofile-generate ',
           'pgo_use': ' -fprofile-use -fprofile-correction ',
-          'lto': ' -flto=4 -fuse-linker-plugin -ffat-lto-objects ',
           'conditions': [
             ['node_shared != "true"', {
               'MSVC_runtimeType': 0    # MultiThreaded (/MT)
             }, {
               'MSVC_runtimeType': 2   # MultiThreadedDLL (/MD)
             }],
+            ['llvm_version=="0.0"', {
+              'lto': ' -flto=4 -fuse-linker-plugin -ffat-lto-objects ', # GCC
+            }, {
+              'lto': ' -flto ', # Clang
+            }],
           ],
         },
         'cflags': [ '-O3' ],
         'conditions': [
+          ['enable_lto=="true"', {
+            'cflags': ['<(lto)'],
+            'ldflags': ['<(lto)'],
+            'xcode_settings': {
+              'LLVM_LTO': 'YES',
+            },
+          }],
           ['OS=="linux"', {
             'conditions': [
               ['node_section_ordering_info!=""', {
@@ -205,10 +216,6 @@
               ['enable_pgo_use=="true"', {
                 'cflags': ['<(pgo_use)'],
                 'ldflags': ['<(pgo_use)'],
-              },],
-              ['enable_lto=="true"', {
-                'cflags': ['<(lto)'],
-                'ldflags': ['<(lto)'],
               },],
             ],
           },],


### PR DESCRIPTION
Bug: #38568

Test: manual,

- arm64-apple-darwin20.5.0 / Apple clang version 12.0.5 (clang-1205.0.22.9)
- x86_64-pc-linux-gnu / Ubuntu clang version 13.0.0-++20210520052624+48780527dd68-1\~exp1\~20210520153429.417

```sh
export AR=llvm-ar RANLIB=llvm-ranlib CC=clang CXX=clang++ (not needed on macOS)
./configure --enable-lto
make -j32
```

Note: LTO is very memory consuming, and 16GB (the largest we have for arm64 mac) is not enough. Things are A LOT slower when there is no enough memory. Don't panic, have patience and it will finish. 

Signed-off-by: Jesse Chan <jc@linux.com>