### PR TITLE
src: set SSL_OP_ALLOW_CLIENT_RENEGOTIATION

### DIFF
--- a/src/crypto/crypto_context.cc
+++ b/src/crypto/crypto_context.cc
@@ -474,6 +474,9 @@ void SecureContext::Init(const FunctionCallbackInfo<Value>& args) {
   // SSLv3 is disabled because it's susceptible to downgrade attacks (POODLE.)
   SSL_CTX_set_options(sc->ctx_.get(), SSL_OP_NO_SSLv2);
   SSL_CTX_set_options(sc->ctx_.get(), SSL_OP_NO_SSLv3);
+#if OPENSSL_VERSION_MAJOR >= 3
+  SSL_CTX_set_options(sc->ctx_.get(), SSL_OP_ALLOW_CLIENT_RENEGOTIATION);
+#endif
 
   // Enable automatic cert chaining. This is enabled by default in OpenSSL, but
   // disabled by default in BoringSSL. Enable it explicitly to make the


### PR DESCRIPTION
This commit sets SSL_OP_ALLOW_CLIENT_RENEGOTIATION for OpenSSL 3.0 as
this option is not set by default as it was in  previous versions.

Without this option set there are a few tests that fail when linked
against OpenSSl 3.0.0-alpha-17, for example test-https-client-renegotiation-limit.js.

I'm not sure we should be setting this for OpenSSL 3.0 or not, but I'll take
a closer look at the implications. If nothing else this would allow
for us to update to alpha-17 in the mean time.
