### PR TITLE
cli: `-C` alias for `--conditions` flag

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1754,7 +1754,6 @@ $ node --max-old-space-size=1536 index.js
 ```
 
 [Chrome DevTools Protocol]: https://chromedevtools.github.io/devtools-protocol/
-[conditional exports]: packages.md#packages_conditional_exports
 [ECMAScript Module loader]: esm.md#esm_loaders
 [REPL]: repl.md
 [ScriptCoverage]: https://chromedevtools.github.io/devtools-protocol/tot/Profiler#type-ScriptCoverage
@@ -1773,6 +1772,7 @@ $ node --max-old-space-size=1536 index.js
 [`tls.DEFAULT_MIN_VERSION`]: tls.md#tls_tls_default_min_version
 [`unhandledRejection`]: process.md#process_event_unhandledrejection
 [`worker_threads.threadId`]: worker_threads.md#worker_threads_worker_threadid
+[conditional exports]: packages.md#packages_conditional_exports
 [context-aware]: addons.md#addons_context_aware_addons
 [customizing ESM specifier resolution]: esm.md#esm_customizing_esm_specifier_resolution_algorithm
 [debugger]: debugger.md

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -80,7 +80,7 @@ $ node --completion-bash > node_bash_completion
 $ source node_bash_completion
 ```
 
-### `-m`, `--conditions=condition`
+### `-m=condition`, `--conditions=condition`
 <!-- YAML
 added:
   - v14.9.0
@@ -89,13 +89,19 @@ added:
 
 > Stability: 1 - Experimental
 
-Enable experimental support for custom conditional exports resolution
+Enable experimental support for custom [conditional exports][] resolution
 conditions.
 
 Any number of custom string condition names are permitted.
 
 The default Node.js conditions of `"node"`, `"default"`, `"import"`, and
 `"require"` will always apply as defined.
+
+For example, to run a module with "development" resolutions:
+
+```console
+$ node -m=development app.js
+```
 
 ### `--cpu-prof`
 <!-- YAML
@@ -1748,6 +1754,7 @@ $ node --max-old-space-size=1536 index.js
 ```
 
 [Chrome DevTools Protocol]: https://chromedevtools.github.io/devtools-protocol/
+[Conditional exports]: packages.md#packages_conditional_exports
 [ECMAScript Module loader]: esm.md#esm_loaders
 [REPL]: repl.md
 [ScriptCoverage]: https://chromedevtools.github.io/devtools-protocol/tot/Profiler#type-ScriptCoverage

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1754,7 +1754,7 @@ $ node --max-old-space-size=1536 index.js
 ```
 
 [Chrome DevTools Protocol]: https://chromedevtools.github.io/devtools-protocol/
-[Conditional exports]: packages.md#packages_conditional_exports
+[conditional exports]: packages.md#packages_conditional_exports
 [ECMAScript Module loader]: esm.md#esm_loaders
 [REPL]: repl.md
 [ScriptCoverage]: https://chromedevtools.github.io/devtools-protocol/tot/Profiler#type-ScriptCoverage

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -80,7 +80,7 @@ $ node --completion-bash > node_bash_completion
 $ source node_bash_completion
 ```
 
-### `--conditions=condition`
+### `-m`, `--conditions=condition`
 <!-- YAML
 added:
   - v14.9.0

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -80,7 +80,7 @@ $ node --completion-bash > node_bash_completion
 $ source node_bash_completion
 ```
 
-### `-m=condition`, `--conditions=condition`
+### `-C=condition`, `--conditions=condition`
 <!-- YAML
 added:
   - v14.9.0
@@ -100,7 +100,7 @@ The default Node.js conditions of `"node"`, `"default"`, `"import"`, and
 For example, to run a module with "development" resolutions:
 
 ```console
-$ node -m=development app.js
+$ node -C=development app.js
 ```
 
 ### `--cpu-prof`
@@ -1376,7 +1376,7 @@ node --require "./a.js" --require "./b.js"
 
 Node.js options that are allowed are:
 <!-- node-options-node start -->
-* `--conditions`
+* `--conditions`, `-C`
 * `--diagnostic-dir`
 * `--disable-proto`
 * `--enable-fips`

--- a/doc/node.1
+++ b/doc/node.1
@@ -78,7 +78,7 @@ Aborting instead of exiting causes a core file to be generated for analysis.
 .It Fl -completion-bash
 Print source-able bash completion script for Node.js.
 .
-.It Fl -conditions Ar string
+.It Fl m , Fl -conditions Ar string
 Use custom conditional exports conditions.
 .Ar string
 .

--- a/doc/node.1
+++ b/doc/node.1
@@ -78,7 +78,7 @@ Aborting instead of exiting causes a core file to be generated for analysis.
 .It Fl -completion-bash
 Print source-able bash completion script for Node.js.
 .
-.It Fl m , Fl -conditions Ar string
+.It Fl C , Fl -conditions Ar string
 Use custom conditional exports conditions.
 .Ar string
 .

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -292,6 +292,7 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "additional user conditions for conditional exports and imports",
             &EnvironmentOptions::conditions,
             kAllowedInEnvironment);
+  AddAlias("-m", "--conditions");
   AddOption("--diagnostic-dir",
             "set dir for all output files"
             " (default: current working directory)",

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -292,7 +292,7 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "additional user conditions for conditional exports and imports",
             &EnvironmentOptions::conditions,
             kAllowedInEnvironment);
-  AddAlias("-m", "--conditions");
+  AddAlias("-C", "--conditions");
   AddOption("--diagnostic-dir",
             "set dir for all output files"
             " (default: current working directory)",

--- a/test/es-module/test-esm-custom-exports.mjs
+++ b/test/es-module/test-esm-custom-exports.mjs
@@ -1,4 +1,4 @@
-// Flags: --conditions=custom-condition --conditions another
+// Flags: --conditions=custom-condition -m another
 import { mustCall } from '../common/index.mjs';
 import { strictEqual } from 'assert';
 import { requireFixture, importFixture } from '../fixtures/pkgexports.mjs';

--- a/test/es-module/test-esm-custom-exports.mjs
+++ b/test/es-module/test-esm-custom-exports.mjs
@@ -1,4 +1,4 @@
-// Flags: --conditions=custom-condition -m another
+// Flags: --conditions=custom-condition -C another
 import { mustCall } from '../common/index.mjs';
 import { strictEqual } from 'assert';
 import { requireFixture, importFixture } from '../fixtures/pkgexports.mjs';

--- a/test/parallel/test-process-env-allowed-flags.js
+++ b/test/parallel/test-process-env-allowed-flags.js
@@ -51,7 +51,7 @@ const assert = require('assert');
 // Assert all "canonical" flags begin with dash(es)
 {
   process.allowedNodeEnvironmentFlags.forEach((flag) => {
-    assert(/^--?[a-z0-9._-]+$/.test(flag),
+    assert(/^--?[a-zA-Z0-9._-]+$/.test(flag),
            `Unexpected format for flag ${flag}`);
   });
 }


### PR DESCRIPTION
Use cases like `--conditions=development` should be easy to type, so having an alias allows for a much easier `node -C=development app.js` command and makes this workflow feel more natural, especially since we haven't otherwise given precedence to development / production modes.

`-c` and `-e` are both already taken so `-C` is used instead, per discussion below.

I've also added an example and reference to the CLI documentation.

@nodejs/modules 