### PR TITLE
util: refactor to use primordials in debuglog

### DIFF
--- a/lib/internal/util/debuglog.js
+++ b/lib/internal/util/debuglog.js
@@ -5,8 +5,10 @@ const {
   ObjectCreate,
   ObjectDefineProperty,
   RegExp,
+  RegExpPrototypeSymbolReplace,
   RegExpPrototypeTest,
   SafeArrayIterator,
+  StringPrototypeReplace,
   StringPrototypeToLowerCase,
   StringPrototypeToUpperCase,
 } = primordials;
@@ -24,10 +26,10 @@ let testEnabled;
 function initializeDebugEnv(debugEnv) {
   debugImpls = ObjectCreate(null);
   if (debugEnv) {
-    debugEnv = debugEnv.replace(/[|\\{}()[\]^$+?.]/g, '\\$&')
-      .replace(/\*/g, '.*')
-      .replace(/,/g, '$|^')
-      .toUpperCase();
+    debugEnv = RegExpPrototypeSymbolReplace(/[|\\{}()[\]^$+?.]/g, debugEnv, '\\$&');
+    debugEnv = StringPrototypeReplace(debugEnv, /\*/g, '.*');
+    debugEnv = StringPrototypeReplace(debugEnv, /,/g, '$|^');
+    debugEnv = StringPrototypeToUpperCase(debugEnv);
     debugEnvRegex = new RegExp(`^${debugEnv}$`, 'i');
   }
   testEnabled = FunctionPrototypeBind(RegExpPrototypeTest, null, debugEnvRegex);


### PR DESCRIPTION
Replace code that's vulnerable to Prototype Pollution with Primordials.