### PR TITLE
deps: replace custom flatten method with build-in Array.flat

### DIFF
--- a/deps/v8/tools/tracing/proto-converter/proto-to-json.ts
+++ b/deps/v8/tools/tracing/proto-converter/proto-to-json.ts
@@ -24,9 +24,6 @@ import { Root } from 'protobufjs';
 // JSON fields it will include/exclude based on the data present in the trace
 // event.
 
-// TODO(petermarshall): Replace with Array#flat once it lands in Node.js.
-const flatten = <T>(a: T[], b: T[]) => { a.push(...b); return a; }
-
 // Convert a string representing an int or uint (64 bit) to a Number or throw
 // if the value won't fit.
 function parseIntOrThrow(int: string) {
@@ -124,7 +121,7 @@ async function main() {
           }, {})
         };
       }))
-      .reduce(flatten, [])
+      .flat()
   };
   await fs.promises.writeFile(process.argv[4], JSON.stringify(output, null, 2));
 }


### PR DESCRIPTION
cleaning up code from custom method by using a built-in method Array.flat() which will no only clean up code but also make it more readable by developers