### PR TITLE
test: os, replace custom flatten method with built-in Array.flat

### DIFF
--- a/test/parallel/test-os.js
+++ b/test/parallel/test-os.js
@@ -39,10 +39,6 @@ const is = {
   }
 };
 
-const flatten = (arr) =>
-  arr.reduce((acc, c) =>
-    acc.concat(Array.isArray(c) ? flatten(c) : c), []);
-
 process.env.TMPDIR = '/tmpdir';
 process.env.TMP = '/tmp';
 process.env.TEMP = '/temp';
@@ -174,7 +170,8 @@ const netmaskToCIDRSuffixMap = new Map(Object.entries({
   'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff': 128
 }));
 
-flatten(Object.values(interfaces))
+Object.values(interfaces).flat(Infinity)
+
   .map((v) => ({ v, mask: netmaskToCIDRSuffixMap.get(v.netmask) }))
   .forEach(({ v, mask }) => {
     assert.ok('cidr' in v, `"cidr" prop not found in ${inspect(v)}`);

--- a/test/parallel/test-os.js
+++ b/test/parallel/test-os.js
@@ -171,7 +171,6 @@ const netmaskToCIDRSuffixMap = new Map(Object.entries({
 }));
 
 Object.values(interfaces).flat(Infinity)
-
   .map((v) => ({ v, mask: netmaskToCIDRSuffixMap.get(v.netmask) }))
   .forEach(({ v, mask }) => {
     assert.ok('cidr' in v, `"cidr" prop not found in ${inspect(v)}`);

--- a/test/parallel/test-os.js
+++ b/test/parallel/test-os.js
@@ -170,7 +170,8 @@ const netmaskToCIDRSuffixMap = new Map(Object.entries({
   'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff': 128
 }));
 
-Object.values(interfaces).flat(Infinity)
+Object.values(interfaces)
+  .flat(Infinity)
   .map((v) => ({ v, mask: netmaskToCIDRSuffixMap.get(v.netmask) }))
   .forEach(({ v, mask }) => {
     assert.ok('cidr' in v, `"cidr" prop not found in ${inspect(v)}`);


### PR DESCRIPTION
I would like to improve the test coverage code (test-os.js) as it's uses untested custom function (flatten) to use built-in method Array.flat()

