### PR TITLE
benchmark: output JSON-compatible numbers

### DIFF
--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -267,7 +267,7 @@ class Benchmark {
 function nanoSecondsToString(bigint) {
   const str = bigint.toString();
   const decimalPointIndex = str.length - 9;
-  if (decimalPointIndex < 0) {
+  if (decimalPointIndex <= 0) {
     return `0.${'0'.repeat(-decimalPointIndex)}${str}`;
   }
   return `${str.slice(0, decimalPointIndex)}.${str.slice(decimalPointIndex)}`;


### PR DESCRIPTION
This is to simplify the implementation of a JavaScript version of the
compare.R script.

See https://github.com/targos/node-benchmark-compare

You can try it with:
```console
npm i -g node-benchmark-compare
node-benchmark-compare result.csv
```

I verified that the script gives the exact same numbers as the R script.