### PR TITLE
worker: do not look up context twice in PostMessage

### DIFF
--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -840,11 +840,11 @@ BaseObjectPtr<BaseObject> MessagePortData::Deserialize(
 }
 
 Maybe<bool> MessagePort::PostMessage(Environment* env,
+                                     Local<Context> context,
                                      Local<Value> message_v,
                                      const TransferList& transfer_v) {
   Isolate* isolate = env->isolate();
   Local<Object> obj = object(isolate);
-  Local<Context> context = obj->GetCreationContext().ToLocalChecked();
 
   std::shared_ptr<Message> msg = std::make_shared<Message>();
 
@@ -986,7 +986,7 @@ void MessagePort::PostMessage(const FunctionCallbackInfo<Value>& args) {
     return;
   }
 
-  Maybe<bool> res = port->PostMessage(env, args[0], transfer_list);
+  Maybe<bool> res = port->PostMessage(env, context, args[0], transfer_list);
   if (res.IsJust())
     args.GetReturnValue().Set(res.FromJust());
 }

--- a/src/node_messaging.h
+++ b/src/node_messaging.h
@@ -242,6 +242,7 @@ class MessagePort : public HandleWrap {
   // If this port is closed, or if there is no sibling, this message is
   // serialized with transfers, then silently discarded.
   v8::Maybe<bool> PostMessage(Environment* env,
+                              v8::Local<v8::Context> context,
                               v8::Local<v8::Value> message,
                               const TransferList& transfer);
 


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/38780#issuecomment-846548949

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
