### PR TITLE
lib: refactor to use missing primordials

### DIFF
--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -1,8 +1,12 @@
 'use strict';
 
 const {
+  ArrayPrototypePop,
   ArrayPrototypeSlice,
+  ArrayPrototypeUnshift,
   ErrorCaptureStackTrace,
+  FunctionPrototypeApply,
+  FunctionPrototypeBind,
   ObjectPrototypeHasOwnProperty,
   ObjectDefineProperty,
   Symbol,
@@ -124,16 +128,16 @@ function callbackTrampoline(asyncId, resource, cb, ...args) {
 
   let result;
   if (asyncId === 0 && typeof domain_cb === 'function') {
-    args.unshift(cb);
-    result = domain_cb.apply(this, args);
+    ArrayPrototypeUnshift(args, cb);
+    result = FunctionPrototypeApply(domain_cb, this, args);
   } else {
-    result = cb.apply(this, args);
+    result = FunctionPrototypeApply(cb, this, args);
   }
 
   if (asyncId !== 0 && hasHooks(kAfter))
     emitAfterNative(asyncId);
 
-  execution_async_resources.pop();
+  ArrayPrototypePop(execution_async_resources);
   return result;
 }
 
@@ -251,7 +255,7 @@ function emitHook(symbol, asyncId) {
 }
 
 function emitHookFactory(symbol, name) {
-  const fn = emitHook.bind(undefined, symbol);
+  const fn = FunctionPrototypeBind(emitHook, undefined, symbol);
 
   // Set the name property of the function as it looks good in the stack trace.
   ObjectDefineProperty(fn, 'name', {
@@ -421,14 +425,14 @@ function clearDefaultTriggerAsyncId() {
 
 function defaultTriggerAsyncIdScope(triggerAsyncId, block, ...args) {
   if (triggerAsyncId === undefined)
-    return block.apply(null, args);
+    return FunctionPrototypeApply(block, null, args);
   // CHECK(NumberIsSafeInteger(triggerAsyncId))
   // CHECK(triggerAsyncId > 0)
   const oldDefaultTriggerAsyncId = async_id_fields[kDefaultTriggerAsyncId];
   async_id_fields[kDefaultTriggerAsyncId] = triggerAsyncId;
 
   try {
-    return block.apply(null, args);
+    return FunctionPrototypeApply(block, null, args);
   } finally {
     async_id_fields[kDefaultTriggerAsyncId] = oldDefaultTriggerAsyncId;
   }
@@ -529,7 +533,7 @@ function popAsyncContext(asyncId) {
   const offset = stackLength - 1;
   async_id_fields[kExecutionAsyncId] = async_wrap.async_ids_stack[2 * offset];
   async_id_fields[kTriggerAsyncId] = async_wrap.async_ids_stack[2 * offset + 1];
-  execution_async_resources.pop();
+  ArrayPrototypePop(execution_async_resources);
   async_hook_fields[kStackLength] = offset;
   return offset > 0;
 }


### PR DESCRIPTION
The `async_hooks` internal module is not using some of the primordials, we should use primordials whenever possible for consistency.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
