### PR TITLE
src: make v8_initialized have thread_local storage

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -148,7 +148,7 @@ unsigned int reverted_cve = 0;
 // util.h
 // Tells whether the per-process V8::Initialize() is called and
 // if it is safe to call v8::Isolate::GetCurrent().
-bool v8_initialized = false;
+thread_local bool v8_initialized = false;
 
 // node_internals.h
 // process-relative uptime base in nanoseconds, initialized in node::Start()

--- a/src/node_errors.cc
+++ b/src/node_errors.cc
@@ -424,13 +424,11 @@ void OnFatalError(const char* location, const char* message) {
     FPrintF(stderr, "FATAL ERROR: %s\n", message);
   }
 
-  Isolate* isolate = Isolate::GetCurrent();
-  // TODO(legendecas): investigate failures on triggering node-report with
-  // nullptr isolates.
-  if (isolate == nullptr) {
+  if (!per_process::v8_initialized) {
     fflush(stderr);
     ABORT();
   }
+  Isolate* isolate = Isolate::GetCurrent();
   Environment* env = Environment::GetCurrent(isolate);
   bool report_on_fatalerror;
   {

--- a/src/util.h
+++ b/src/util.h
@@ -92,7 +92,7 @@ inline T MultiplyWithOverflowCheck(T a, T b);
 namespace per_process {
 // Tells whether the per-process V8::Initialize() is called and
 // if it is safe to call v8::Isolate::GetCurrent().
-extern bool v8_initialized;
+thread_local extern bool v8_initialized;
 }  // namespace per_process
 
 // Used by the allocation functions when allocation fails.


### PR DESCRIPTION
This commit makes `v8_initialized` have thread_local storate
to allow it to be checked from different threads.

The motivation for this is that currently
`test/node-api/test_fatal/test_threads.js` fails for a Debug build with
the following error:
```console
#
# Fatal error in ../deps/v8/src/execution/isolate.h, line 579
# Debug check failed: (isolate) != nullptr.
#
#
#
#FailureMessage Object: 0x7f055effca10
 1: 0x101e3f8 node::DumpBacktrace(_IO_FILE*) [/node/out/Debug/node]
 2: 0x11c31ed  [/node/out/Debug/node]
 3: 0x11c320d  [/node/out/Debug/node]
 4: 0x2ba4448 V8_Fatal(char const*, int, char const*, ...) [/node/out/Debug/node]
 5: 0x2ba4473  [/node/out/Debug/node]
 6: 0x139e049 v8::internal::Isolate::Current() [/node/out/Debug/node]
 7: 0x11025ee node::OnFatalError(char const*, char const*) [/node/out/Debug/node]
 8: 0x1102564 node::FatalError(char const*, char const*) [/node/out/Debug/node]
 9: 0x10add1d napi_open_callback_scope [/node/out/Debug/node]
10: 0x7f05664211dc  [/node/test/node-api/test_fatal/build/Debug/test_fatal.node]
11: 0x7f056608e4e2  [/usr/lib64/libpthread.so.0]
12: 0x7f0565fbd6c3 clone [/usr/lib64/libc.so.6]

node:assert:412
    throw err;
    ^

AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:

  assert.ok(p.status === 134 || p.signal === 'SIGABRT')

    at Object.<anonymous> (/node/test/node-api/test_fatal/test_threads.js:21:8)
    at Module._compile (node:internal/modules/cjs/loader:1109:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1138:10)
    at Module.load (node:internal/modules/cjs/loader:989:32)
    at Function.Module._load (node:internal/modules/cjs/loader:829:14)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:79:12)
    at node:internal/main/run_main_module:17:47 {
  generatedMessage: true,
  code: 'ERR_ASSERTION',
  actual: false,
  expected: true,
  operator: '=='
}
```
This is caused by a call to `Isolate::GetCurrent()` when the calling
thread has not initialized V8. With this change it is possible to
check that the current thread has initialized V8 and if not avoid
calling `Isolate::GetCurrent()`.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
