### PR TITLE
readline: initialize _questionCallback during construction

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -242,6 +242,8 @@ function Interface(input, output, completer, terminal) {
   this.removeHistoryDuplicates = !!removeHistoryDuplicates;
   this.crlfDelay = crlfDelay ?
     MathMax(kMincrlfDelay, crlfDelay) : kMincrlfDelay;
+  this._questionCallback = null;
+
   // Check arity, 2 - for async, 1 for sync
   if (typeof completer === 'function') {
     this.completer = completer.length === 2 ?


### PR DESCRIPTION
`_questionCallback` is used in `Interface`, but it is not initialized in constrctor. 

This PR makes `_questionCallback` initialized properly to improve the readability.