### PR TITLE
node-api: correctly return pending exception status on napi_new_instance

### DIFF
--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -2660,7 +2660,7 @@ napi_status napi_new_instance(napi_env env,
   auto maybe = ctor->NewInstance(context, argc,
     reinterpret_cast<v8::Local<v8::Value>*>(const_cast<napi_value*>(argv)));
 
-  CHECK_MAYBE_EMPTY(env, maybe, napi_generic_failure);
+  CHECK_MAYBE_EMPTY(env, maybe, napi_pending_exception);
 
   *result = v8impl::JsValueFromV8LocalValue(maybe.ToLocalChecked());
   return GET_RETURN_STATUS(env);

--- a/test/js-native-api/test_exception/test.js
+++ b/test/js-native-api/test_exception/test.js
@@ -48,11 +48,58 @@ const test_exception = (function() {
                      ` thrown, but ${returnedError} was passed`);
 }
 
+
+{
+  const throwTheError = class { constructor() { throw theError; } };
+
+  // Test that the native side successfully captures the exception
+  let returnedError = test_exception.constructReturnException(throwTheError);
+  assert.strictEqual(returnedError, theError);
+
+  // Test that the native side passes the exception through
+  assert.throws(
+    () => { test_exception.constructAllowException(throwTheError); },
+    (err) => err === theError
+  );
+
+  // Test that the exception thrown above was marked as pending
+  // before it was handled on the JS side
+  const exception_pending = test_exception.wasPending();
+  assert.strictEqual(exception_pending, true,
+                     'Exception not pending as expected,' +
+                     ` .wasPending() returned ${exception_pending}`);
+
+  // Test that the native side does not capture a non-existing exception
+  returnedError = test_exception.constructReturnException(common.mustCall());
+  assert.strictEqual(returnedError, undefined,
+                     'Returned error should be undefined when no exception is' +
+                     ` thrown, but ${returnedError} was passed`);
+}
+
 {
   // Test that no exception appears that was not thrown by us
   let caughtError;
   try {
     test_exception.allowException(common.mustCall());
+  } catch (anError) {
+    caughtError = anError;
+  }
+  assert.strictEqual(caughtError, undefined,
+                     'No exception originated on the native side, but' +
+                     ` ${caughtError} was passed`);
+
+  // Test that the exception state remains clear when no exception is thrown
+  const exception_pending = test_exception.wasPending();
+  assert.strictEqual(exception_pending, false,
+                     'Exception state did not remain clear as expected,' +
+                     ` .wasPending() returned ${exception_pending}`);
+}
+
+{
+  // Test that no exception appears that was not thrown by us
+  let caughtError;
+  try {
+    test_exception.constructAllowException(common.mustCall());
   } catch (anError) {
     caughtError = anError;
   }

--- a/test/js-native-api/test_exception/test_exception.c
+++ b/test/js-native-api/test_exception/test_exception.c
@@ -22,6 +22,22 @@ static napi_value returnException(napi_env env, napi_callback_info info) {
   return NULL;
 }
 
+static napi_value constructReturnException(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args[1];
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+
+  napi_value result;
+  napi_status status = napi_new_instance(env, args[0], 0, 0, &result);
+  if (status == napi_pending_exception) {
+    napi_value ex;
+    NODE_API_CALL(env, napi_get_and_clear_last_exception(env, &ex));
+    return ex;
+  }
+
+  return NULL;
+}
+
 static napi_value allowException(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
@@ -32,6 +48,19 @@ static napi_value allowException(napi_env env, napi_callback_info info) {
 
   napi_value result;
   napi_call_function(env, global, args[0], 0, 0, &result);
+  // Ignore status and check napi_is_exception_pending() instead.
+
+  NODE_API_CALL(env, napi_is_exception_pending(env, &exceptionWasPending));
+  return NULL;
+}
+
+static napi_value constructAllowException(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args[1];
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+
+  napi_value result;
+  napi_new_instance(env, args[0], 0, 0, &result);
   // Ignore status and check napi_is_exception_pending() instead.
 
   NODE_API_CALL(env, napi_is_exception_pending(env, &exceptionWasPending));
@@ -64,6 +93,8 @@ napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
     DECLARE_NODE_API_PROPERTY("returnException", returnException),
     DECLARE_NODE_API_PROPERTY("allowException", allowException),
+    DECLARE_NODE_API_PROPERTY("constructReturnException", constructReturnException),
+    DECLARE_NODE_API_PROPERTY("constructAllowException", constructAllowException),
     DECLARE_NODE_API_PROPERTY("wasPending", wasPending),
     DECLARE_NODE_API_PROPERTY("createExternal", createExternal),
   };


### PR DESCRIPTION
When there are any JavaScript exceptions pending,
`napi_pending_exception` should be returned.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Related: https://github.com/nodejs/node-addon-api/issues/1000