### PR TITLE
test: improve coverage for `question` in readline

### DIFF
--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -905,6 +905,18 @@ for (let i = 0; i < 12; i++) {
     rli.close();
   }
 
+  // Calling the question multiple times
+  {
+    const [rli] = getInterface({ terminal });
+    rli.question('foo?', common.mustCall((answer) => {
+      assert.strictEqual(answer, 'baz');
+    }));
+    rli.question('bar?', common.mustNotCall(() => {
+    }));
+    rli.write('baz\n');
+    rli.close();
+  }
+
   // Calling the promisified question
   {
     const [rli] = getInterface({ terminal });


### PR DESCRIPTION
Improve test coverage for `Interface.question`.

It indicates that only the first `callback` is effective when `question` is calling multiple times.

Ref: https://coverage.nodejs.org/coverage-dc43066ee9a37655/lib/readline.js.html#L443
