### PR TITLE
lib: use primordial for noop

### DIFF
--- a/lib/internal/bootstrap/switches/is_main_thread.js
+++ b/lib/internal/bootstrap/switches/is_main_thread.js
@@ -1,6 +1,9 @@
 'use strict';
 
-const { ObjectDefineProperty } = primordials;
+const {
+  FunctionPrototype,
+  ObjectDefineProperty
+} = primordials;
 const rawMethods = internalBinding('process_methods');
 
 // TODO(joyeecheung): deprecate and remove these underscore methods
@@ -10,8 +13,8 @@ process._debugEnd = rawMethods._debugEnd;
 // See the discussion in https://github.com/nodejs/node/issues/19009 and
 // https://github.com/nodejs/node/pull/34010 for why these are no-ops.
 // Five word summary: they were broken beyond repair.
-process._startProfilerIdleNotifier = () => {};
-process._stopProfilerIdleNotifier = () => {};
+process._startProfilerIdleNotifier = FunctionPrototype;
+process._stopProfilerIdleNotifier = FunctionPrototype;
 
 function defineStream(name, getter) {
   ObjectDefineProperty(process, name, {


### PR DESCRIPTION
Most of the internal modules use the `FunctionPrototype` primordial for no-op functions, we could use them here for consistency.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
