### PR TITLE
src: skip test_fatal/test_threads for Debug builds

### DIFF
--- a/test/node-api/test_fatal/test_threads.js
+++ b/test/node-api/test_fatal/test_threads.js
@@ -4,6 +4,10 @@ const assert = require('assert');
 const child_process = require('child_process');
 const test_fatal = require(`./build/${common.buildType}/test_fatal`);
 
+if (common.buildType === 'Debug')
+  common.skip('as this will currently fail with a Debug check ' +
+              'in v8::Isolate::GetCurrent()');
+
 // Test in a child process because the test code will trigger a fatal error
 // that crashes the process.
 if (process.argv[2] === 'child') {


### PR DESCRIPTION
Currently `test/node-api/test_fatal/test_threads.js` fails for a Debug
build with the following error:
```console
#
# Fatal error in ../deps/v8/src/execution/isolate.h, line 579
# Debug check failed: (isolate) != nullptr.
#
#
#
#FailureMessage Object: 0x7f055effca10
 1: 0x101e3f8 node::DumpBacktrace(_IO_FILE*) [/node/out/Debug/node]
 2: 0x11c31ed  [/node/out/Debug/node]
 3: 0x11c320d  [/node/out/Debug/node]
 4: 0x2ba4448 V8_Fatal(char const*, int, char const*, ...) [/node/out/Debug/node]
 5: 0x2ba4473  [/node/out/Debug/node]
 6: 0x139e049 v8::internal::Isolate::Current() [/node/out/Debug/node]
 7: 0x11025ee node::OnFatalError(char const*, char const*) [/node/out/Debug/node]
 8: 0x1102564 node::FatalError(char const*, char const*) [/node/out/Debug/node]
 9: 0x10add1d napi_open_callback_scope [/node/out/Debug/node]
10: 0x7f05664211dc  [/node/test/node-api/test_fatal/build/Debug/test_fatal.node]
11: 0x7f056608e4e2  [/usr/lib64/libpthread.so.0]
12: 0x7f0565fbd6c3 clone [/usr/lib64/libc.so.6]

node:assert:412
    throw err;
    ^

AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:

  assert.ok(p.status === 134 || p.signal === 'SIGABRT')

    at Object.<anonymous> (/node/test/node-api/test_fatal/test_threads.js:21:8)
    at Module._compile (node:internal/modules/cjs/loader:1109:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1138:10)
    at Module.load (node:internal/modules/cjs/loader:989:32)
    at Function.Module._load (node:internal/modules/cjs/loader:829:14)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:79:12)
    at node:internal/main/run_main_module:17:47 {
  generatedMessage: true,
  code: 'ERR_ASSERTION',
  actual: false,
  expected: true,
  operator: '=='
}
```

This is caused by a call to `Isolate::GetCurrent()` when the calling
thread has not initialized V8. We are working suggestion to add a method
to V8 which allows a check/get without any checks but in the mean time
this change should allow debug builds to pass the test suit.

Refs: https://chromium-review.googlesource.com/c/v8/v8/+/2910630