### PR TITLE
fs: stop fixing EPERM on Windows

### DIFF
--- a/lib/internal/fs/rimraf.js
+++ b/lib/internal/fs/rimraf.js
@@ -1,9 +1,4 @@
-// This file is a modified version of the rimraf module on npm. It has been
-// modified in the following ways:
-// - Use of the assert module has been replaced with core's error system.
-// - All code related to the glob dependency has been removed.
-// - Bring your own custom fs module is not currently supported.
-// - Some basic code cleanup.
+// This file is a modified version of the rimraf module on npm.
 'use strict';
 
 const {
@@ -15,16 +10,12 @@ const {
 const { Buffer } = require('buffer');
 const fs = require('fs');
 const {
-  chmod,
-  chmodSync,
   lstat,
   lstatSync,
   readdir,
   readdirSync,
   rmdir,
   rmdirSync,
-  stat,
-  statSync,
   unlink,
   unlinkSync
 } = fs;
@@ -34,9 +25,6 @@ const { sleep } = require('internal/util');
 const notEmptyErrorCodes = new SafeSet(['ENOTEMPTY', 'EEXIST', 'EPERM']);
 const retryErrorCodes = new SafeSet(
   ['EBUSY', 'EMFILE', 'ENFILE', 'ENOTEMPTY', 'EPERM']);
-const isWindows = process.platform === 'win32';
-const epermHandler = isWindows ? fixWinEPERM : _rmdir;
-const epermHandlerSync = isWindows ? fixWinEPERMSync : _rmdirSync;
 const readdirEncoding = 'buffer';
 const separator = Buffer.from(sep);
 
@@ -69,10 +57,6 @@ function _rimraf(path, options, callback) {
     if (err) {
       if (err.code === 'ENOENT')
         return callback(null);
-
-      // Windows can EPERM on stat.
-      if (isWindows && err.code === 'EPERM')
-        return fixWinEPERM(path, options, err, callback);
     } else if (stats.isDirectory()) {
       return _rmdir(path, options, err, callback);
     }
@@ -81,32 +65,11 @@ function _rimraf(path, options, callback) {
       if (err) {
         if (err.code === 'ENOENT')
           return callback(null);
-        if (err.code === 'EISDIR')
+        if (err.code === 'EISDIR' || err.code === 'EPERM')
           return _rmdir(path, options, err, callback);
-        if (err.code === 'EPERM') {
-          return epermHandler(path, options, err, callback);
-        }
       }
 
       return callback(err);
-    });
-  });
-}
-
-
-function fixWinEPERM(path, options, originalErr, callback) {
-  chmod(path, 0o666, (err) => {
-    if (err)
-      return callback(err.code === 'ENOENT' ? null : originalErr);
-
-    stat(path, (err, stats) => {
-      if (err)
-        return callback(err.code === 'ENOENT' ? null : originalErr);
-
-      if (stats.isDirectory())
-        _rmdir(path, options, originalErr, callback);
-      else
-        unlink(path, callback);
     });
   });
 }
@@ -181,10 +144,6 @@ function rimrafSync(path, options) {
   } catch (err) {
     if (err.code === 'ENOENT')
       return;
-
-    // Windows can EPERM on stat.
-    if (isWindows && err.code === 'EPERM')
-      fixWinEPERMSync(path, options, err);
   }
 
   try {
@@ -194,14 +153,11 @@ function rimrafSync(path, options) {
     else
       _unlinkSync(path, options);
   } catch (err) {
-    if (err.code === 'ENOENT')
-      return;
-    if (err.code === 'EPERM')
-      return epermHandlerSync(path, options, err);
-    if (err.code !== 'EISDIR')
-      throw err;
+    if (err.code === 'EISDIR' || err.code === 'EPERM')
+      return _rmdirSync(path, options, err);
 
-    _rmdirSync(path, options, err);
+    if (err.code !== 'ENOENT')
+      throw err;
   }
 }
 
@@ -277,33 +233,6 @@ function _rmdirSync(path, options, originalErr) {
 
     throw originalErr || err;
   }
-}
-
-
-function fixWinEPERMSync(path, options, originalErr) {
-  try {
-    chmodSync(path, 0o666);
-  } catch (err) {
-    if (err.code === 'ENOENT')
-      return;
-
-    throw originalErr;
-  }
-
-  let stats;
-
-  try {
-    stats = statSync(path, { throwIfNoEntry: false });
-  } catch {
-    throw originalErr;
-  }
-
-  if (stats === undefined) return;
-
-  if (stats.isDirectory())
-    _rmdirSync(path, options, originalErr);
-  else
-    _unlinkSync(path, options);
 }
 
 

--- a/test/common/tmpdir.js
+++ b/test/common/tmpdir.js
@@ -10,16 +10,11 @@ function rmSync(pathname) {
   const maxRetries = 10;
 
   for (let retryNumber = 0; retryNumber < maxRetries; ++retryNumber) {
-    err = null;
-
     try {
       fs.rmSync(pathname, { maxRetries: 3, recursive: true, force: true });
+      return;
     } catch (_err) {
       err = _err;
-    }
-
-    if (err === null) {
-      return;
     }
 
     const errPath = err.path;
@@ -33,11 +28,7 @@ function rmSync(pathname) {
     }
   }
 
-  if (err === null) {
-    return;
-  }
-
-  throw err;
+  if (err) throw err;
 }
 
 const testRoot = process.env.NODE_TEST_DIR ?

--- a/test/common/tmpdir.js
+++ b/test/common/tmpdir.js
@@ -28,15 +28,8 @@ function rmSync(pathname) {
     if (errCode === 'EACCES' || errCode === 'EPERM') {
       const surroundingDir = path.join(errPath, '..');
 
-      try {
-        fs.chmodSync(surroundingDir, 0o777);
-      } catch {
-      }
-
-      try {
-        fs.chmodSync(errPath, 0o777);
-      } catch {
-      }
+      try { fs.chmodSync(surroundingDir, 0o777); } catch {}
+      try { fs.chmodSync(errPath, 0o777); } catch {}
     }
   }
 

--- a/test/common/tmpdir.js
+++ b/test/common/tmpdir.js
@@ -6,7 +6,45 @@ const path = require('path');
 const { isMainThread } = require('worker_threads');
 
 function rmSync(pathname) {
-  fs.rmSync(pathname, { maxRetries: 3, recursive: true, force: true });
+  let err = null;
+  const maxRetries = 10;
+
+  for (let retryNumber = 0; retryNumber < maxRetries; ++retryNumber) {
+    err = null;
+
+    try {
+      fs.rmSync(pathname, { maxRetries: 3, recursive: true, force: true });
+    } catch (_err) {
+      err = _err;
+    }
+
+    if (err === null) {
+      return;
+    }
+
+    const errPath = err.path;
+    const errCode = err.code;
+
+    if (errCode === 'EACCES' || errCode === 'EPERM') {
+      const surroundingDir = path.join(errPath, '..');
+
+      try {
+        fs.chmodSync(surroundingDir, 0o777);
+      } catch {
+      }
+
+      try {
+        fs.chmodSync(errPath, 0o777);
+      } catch {
+      }
+    }
+  }
+
+  if (err === null) {
+    return;
+  }
+
+  throw err;
 }
 
 const testRoot = process.env.NODE_TEST_DIR ?
@@ -31,6 +69,28 @@ function refresh() {
   }
 }
 
+function logErrorInfo(err) {
+  console.error('Can\'t clean tmpdir:', tmpPath);
+
+  const files = fs.readdirSync(tmpPath);
+  console.error('Files blocking:', files);
+
+  if (files.some((f) => f.startsWith('.nfs'))) {
+    // Warn about NFS "silly rename"
+    console.error('Note: ".nfs*" might be files that were open and ' +
+                  'unlinked but not closed.');
+    console.error('See http://nfs.sourceforge.net/#faq_d2 for details.');
+  }
+
+  console.error();
+
+  // Additionally logging err, just in case throwing err gets overshadowed by
+  // an error from a test failure.
+  console.error(err);
+
+  throw err;
+}
+
 function onexit() {
   // Change directory to avoid possible EBUSY
   if (isMainThread)
@@ -38,21 +98,8 @@ function onexit() {
 
   try {
     rmSync(tmpPath);
-  } catch (e) {
-    console.error('Can\'t clean tmpdir:', tmpPath);
-
-    const files = fs.readdirSync(tmpPath);
-    console.error('Files blocking:', files);
-
-    if (files.some((f) => f.startsWith('.nfs'))) {
-      // Warn about NFS "silly rename"
-      console.error('Note: ".nfs*" might be files that were open and ' +
-                    'unlinked but not closed.');
-      console.error('See http://nfs.sourceforge.net/#faq_d2 for details.');
-    }
-
-    console.error();
-    throw e;
+  } catch (err) {
+    logErrorInfo(err);
   }
 }
 

--- a/test/common/tmpdir.js
+++ b/test/common/tmpdir.js
@@ -28,7 +28,7 @@ function rmSync(pathname) {
     }
   }
 
-  if (err !== null) throw err;
+  throw err;
 }
 
 const testRoot = process.env.NODE_TEST_DIR ?

--- a/test/common/tmpdir.js
+++ b/test/common/tmpdir.js
@@ -28,7 +28,7 @@ function rmSync(pathname) {
     }
   }
 
-  if (err) throw err;
+  if (err !== null) throw err;
 }
 
 const testRoot = process.env.NODE_TEST_DIR ?

--- a/test/common/tmpdir.js
+++ b/test/common/tmpdir.js
@@ -82,8 +82,6 @@ function logErrorInfo(err) {
     console.error('See http://nfs.sourceforge.net/#faq_d2 for details.');
   }
 
-  console.error();
-
   // Additionally logging err, just in case throwing err gets overshadowed by
   // an error from a test failure.
   console.error(err);

--- a/test/common/tmpdir.js
+++ b/test/common/tmpdir.js
@@ -73,11 +73,13 @@ function onexit() {
       console.error('See http://nfs.sourceforge.net/#faq_d2 for details.');
     }
 
-    // Additionally logging err, just in case throwing err gets overshadowed by
-    // an error from a test failure.
+    // Manually logging err instead of throwing it, so that it doesn't get
+    // overshadowed by an error from a test failure.
     console.error(err);
 
-    throw err;
+    // Setting the process exit code to a non-zero exit code, so that this gets
+    // marked as `not ok` during a CI run.
+    process.exitCode ||= 1;
   }
 }
 

--- a/test/common/tmpdir.js
+++ b/test/common/tmpdir.js
@@ -53,26 +53,6 @@ function refresh() {
   }
 }
 
-function logErrorInfo(err) {
-  console.error('Can\'t clean tmpdir:', tmpPath);
-
-  const files = fs.readdirSync(tmpPath);
-  console.error('Files blocking:', files);
-
-  if (files.some((f) => f.startsWith('.nfs'))) {
-    // Warn about NFS "silly rename"
-    console.error('Note: ".nfs*" might be files that were open and ' +
-                  'unlinked but not closed.');
-    console.error('See http://nfs.sourceforge.net/#faq_d2 for details.');
-  }
-
-  // Additionally logging err, just in case throwing err gets overshadowed by
-  // an error from a test failure.
-  console.error(err);
-
-  throw err;
-}
-
 function onexit() {
   // Change directory to avoid possible EBUSY
   if (isMainThread)
@@ -81,7 +61,23 @@ function onexit() {
   try {
     rmSync(tmpPath);
   } catch (err) {
-    logErrorInfo(err);
+    console.error('Can\'t clean tmpdir:', tmpPath);
+
+    const files = fs.readdirSync(tmpPath);
+    console.error('Files blocking:', files);
+
+    if (files.some((f) => f.startsWith('.nfs'))) {
+      // Warn about NFS "silly rename"
+      console.error('Note: ".nfs*" might be files that were open and ' +
+                    'unlinked but not closed.');
+      console.error('See http://nfs.sourceforge.net/#faq_d2 for details.');
+    }
+
+    // Additionally logging err, just in case throwing err gets overshadowed by
+    // an error from a test failure.
+    console.error(err);
+
+    throw err;
   }
 }
 

--- a/test/common/tmpdir.js
+++ b/test/common/tmpdir.js
@@ -79,7 +79,9 @@ function onexit() {
 
     // Setting the process exit code to a non-zero exit code, so that this gets
     // marked as `not ok` during a CI run.
-    process.exitCode ||= 1;
+    if (!process.exitCode) {
+      process.exitCode = 1;
+    }
   }
 }
 

--- a/test/parallel/test-fs-rm.js
+++ b/test/parallel/test-fs-rm.js
@@ -286,12 +286,12 @@ function removeAsync(dir) {
   // IBMi has a different access permission mechanism
   // This test should not be run as `root`
   if (!common.isIBMi && (common.isWindows || process.getuid() !== 0)) {
-    // On Windows, we are allowed to access and modify the contents of a
-    // read-only folder.
+    // Check that deleting a file that cannot be accessed using rmsync throws:
+    // https://github.com/nodejs/node/issues/38683
     {
-      // Check that deleting a file that cannot be accessed using rmsync throws:
-      // https://github.com/nodejs/node/issues/38683
       function isValidState(exists, err) {
+        // On Windows, we are allowed to access and modify the contents of a
+        // read-only folder.
         return common.isWindows ?
                (exists === false && err === null)) :
                (exists === true && err?.code === 'EACCES'));
@@ -358,12 +358,12 @@ function removeAsync(dir) {
       }
     }
 
-    // On Windows, we are not allowed to delete a read-only directory.
+    // Check endless recursion.
+    // https://github.com/nodejs/node/issues/34580
     {
-      // Check endless recursion.
-      // https://github.com/nodejs/node/issues/34580
       function isValidState(exists, err) {
-        // TODO(RaisinTen): Replace the error code with 'EACCES' if this lands:
+        // On Windows, we are not allowed to delete a read-only folder yet.
+        // TODO(RaisinTen): Remove Windows special-casing if this lands:
         // https://github.com/libuv/libuv/pull/3193
         return common.isWindows ?
                (exists === true && err?.code === 'EPERM') :

--- a/test/parallel/test-fs-rm.js
+++ b/test/parallel/test-fs-rm.js
@@ -334,8 +334,8 @@ function removeAsync(dir) {
         fs.chmodSync(dirname, 0o444);
 
         fs.rm(filePath, { force: true }, common.mustCall((err) => {
-        try { fs.chmodSync(dirname, 0o777); } catch {}
-        try { fs.chmodSync(filePath, 0o777); } catch {}
+          try { fs.chmodSync(dirname, 0o777); } catch {}
+          try { fs.chmodSync(filePath, 0o777); } catch {}
 
           if (!isValidState(fs.existsSync(filePath), err)) {
             throw err;
@@ -398,8 +398,8 @@ function removeAsync(dir) {
         fs.chmodSync(middle, 0o555);
 
         fs.rm(root, { recursive: true }, common.mustCall((err) => {
-        try { fs.chmodSync(middle, 0o777); } catch {}
-        try { fs.chmodSync(leaf, 0o777); } catch {}
+          try { fs.chmodSync(middle, 0o777); } catch {}
+          try { fs.chmodSync(leaf, 0o777); } catch {}
 
           if (!isValidState(fs.existsSync(root), err)) {
             throw err;

--- a/test/parallel/test-fs-rm.js
+++ b/test/parallel/test-fs-rm.js
@@ -286,6 +286,13 @@ function removeAsync(dir) {
   // IBMi has a different access permission mechanism
   // This test should not be run as `root`
   if (!common.isIBMi && (common.isWindows || process.getuid() !== 0)) {
+    class InvalidStateError extends Error {
+      constructor(err) {
+        super('Invalid state');
+        this.cause = err;
+      }
+    }
+
     // Check that deleting a file that cannot be accessed using rmsync throws:
     // https://github.com/nodejs/node/issues/38683
     {
@@ -319,9 +326,7 @@ function removeAsync(dir) {
         try { fs.chmodSync(filePath, 0o777); } catch {}
 
         if (!isValidState(fs.existsSync(filePath), err)) {
-          const e = new Error('Invalid state');
-          e.cause = err;
-          throw e;
+          throw new InvalidStateError(err);
         }
       }
 
@@ -340,9 +345,7 @@ function removeAsync(dir) {
           try { fs.chmodSync(filePath, 0o777); } catch {}
 
           if (!isValidState(fs.existsSync(filePath), err)) {
-            const e = new Error('Invalid state');
-            e.cause = err;
-            throw e;
+            throw new InvalidStateError(err);
           }
         }));
       }
@@ -384,9 +387,7 @@ function removeAsync(dir) {
         try { fs.chmodSync(leaf, 0o777); } catch {}
 
         if (!isValidState(fs.existsSync(root), err)) {
-          const e = new Error('Invalid state');
-          e.cause = err;
-          throw e;
+          throw new InvalidStateError(err);
         }
       }
 
@@ -408,9 +409,7 @@ function removeAsync(dir) {
           try { fs.chmodSync(leaf, 0o777); } catch {}
 
           if (!isValidState(fs.existsSync(root), err)) {
-            const e = new Error('Invalid state');
-            e.cause = err;
-            throw e;
+            throw new InvalidStateError(err);
           }
         }));
       }

--- a/test/parallel/test-fs-rm.js
+++ b/test/parallel/test-fs-rm.js
@@ -351,9 +351,8 @@ function removeAsync(dir) {
         // On Windows, we are not allowed to delete a read-only folder yet.
         // TODO(RaisinTen): Remove Windows special-casing if this lands:
         // https://github.com/libuv/libuv/pull/3193
-        return common.isWindows ?
-          (exists === true && err?.code === 'EPERM') :
-          (exists === true && err?.code === 'EACCES');
+        return exists === true &&
+               err?.code === common.isWindows ? 'EPERM' : 'EACCES';
       }
 
       {

--- a/test/parallel/test-fs-rm.js
+++ b/test/parallel/test-fs-rm.js
@@ -315,15 +315,8 @@ function removeAsync(dir) {
           err = _err;
         }
 
-        try {
-          fs.chmodSync(dirname, 0o777);
-        } catch {
-        }
-
-        try {
-          fs.chmodSync(filePath, 0o777);
-        } catch {
-        }
+        try { fs.chmodSync(dirname, 0o777); } catch {}
+        try { fs.chmodSync(filePath, 0o777); } catch {}
 
         if (!isValidState(fs.existsSync(filePath), err)) {
           throw err;
@@ -341,15 +334,8 @@ function removeAsync(dir) {
         fs.chmodSync(dirname, 0o444);
 
         fs.rm(filePath, { force: true }, common.mustCall((err) => {
-          try {
-            fs.chmodSync(dirname, 0o777);
-          } catch {
-          }
-
-          try {
-            fs.chmodSync(filePath, 0o777);
-          } catch {
-          }
+        try { fs.chmodSync(dirname, 0o777); } catch {}
+        try { fs.chmodSync(filePath, 0o777); } catch {}
 
           if (!isValidState(fs.existsSync(filePath), err)) {
             throw err;
@@ -391,15 +377,8 @@ function removeAsync(dir) {
           err = _err;
         }
 
-        try {
-          fs.chmodSync(middle, 0o777);
-        } catch {
-        }
-
-        try {
-          fs.chmodSync(leaf, 0o777);
-        } catch {
-        }
+        try { fs.chmodSync(middle, 0o777); } catch {}
+        try { fs.chmodSync(leaf, 0o777); } catch {}
 
         if (!isValidState(fs.existsSync(root), err)) {
           throw err;
@@ -420,15 +399,8 @@ function removeAsync(dir) {
         fs.chmodSync(middle, 0o555);
 
         fs.rm(root, { recursive: true }, common.mustCall((err) => {
-          try {
-            fs.chmodSync(middle, 0o777);
-          } catch {
-          }
-
-          try {
-            fs.chmodSync(leaf, 0o777);
-          } catch {
-          }
+        try { fs.chmodSync(middle, 0o777); } catch {}
+        try { fs.chmodSync(leaf, 0o777); } catch {}
 
           if (!isValidState(fs.existsSync(root), err)) {
             throw err;

--- a/test/parallel/test-fs-rm.js
+++ b/test/parallel/test-fs-rm.js
@@ -293,8 +293,8 @@ function removeAsync(dir) {
         // On Windows, we are allowed to access and modify the contents of a
         // read-only folder.
         return common.isWindows ?
-               (exists === false && err === null)) :
-               (exists === true && err?.code === 'EACCES'));
+               (exists === false && err === null) :
+               (exists === true && err?.code === 'EACCES');
       }
 
       {

--- a/test/parallel/test-fs-rm.js
+++ b/test/parallel/test-fs-rm.js
@@ -319,7 +319,9 @@ function removeAsync(dir) {
         try { fs.chmodSync(filePath, 0o777); } catch {}
 
         if (!isValidState(fs.existsSync(filePath), err)) {
-          throw err;
+          const e = new Error('Invalid state');
+          e.cause = err;
+          throw e;
         }
       }
 
@@ -338,7 +340,9 @@ function removeAsync(dir) {
           try { fs.chmodSync(filePath, 0o777); } catch {}
 
           if (!isValidState(fs.existsSync(filePath), err)) {
-            throw err;
+            const e = new Error('Invalid state');
+            e.cause = err;
+            throw e;
           }
         }));
       }
@@ -380,7 +384,9 @@ function removeAsync(dir) {
         try { fs.chmodSync(leaf, 0o777); } catch {}
 
         if (!isValidState(fs.existsSync(root), err)) {
-          throw err;
+          const e = new Error('Invalid state');
+          e.cause = err;
+          throw e;
         }
       }
 
@@ -402,7 +408,9 @@ function removeAsync(dir) {
           try { fs.chmodSync(leaf, 0o777); } catch {}
 
           if (!isValidState(fs.existsSync(root), err)) {
-            throw err;
+            const e = new Error('Invalid state');
+            e.cause = err;
+            throw e;
           }
         }));
       }

--- a/test/parallel/test-fs-rm.js
+++ b/test/parallel/test-fs-rm.js
@@ -293,8 +293,8 @@ function removeAsync(dir) {
         // On Windows, we are allowed to access and modify the contents of a
         // read-only folder.
         return common.isWindows ?
-               (exists === false && err === null) :
-               (exists === true && err?.code === 'EACCES');
+          (exists === false && err === null) :
+          (exists === true && err?.code === 'EACCES');
       }
 
       {
@@ -366,8 +366,8 @@ function removeAsync(dir) {
         // TODO(RaisinTen): Remove Windows special-casing if this lands:
         // https://github.com/libuv/libuv/pull/3193
         return common.isWindows ?
-               (exists === true && err?.code === 'EPERM') :
-               (exists === true && err?.code === 'EACCES');
+          (exists === true && err?.code === 'EPERM') :
+          (exists === true && err?.code === 'EACCES');
       }
 
       {


### PR DESCRIPTION
Originally, when `rimraf` faced an `EPERM` on Windows, it would try to
change the file permissions of the entry and attempt to remove it
again. However, `rm -rf` doesn't change any file permissions, so `rimraf`
shouldn't either.

This change also updates `test/common/tmpdir.js` to repeatedly try
changing the file permissions of its contents to `0o777` when an `EACCES` or
an `EPERM` is faced while attempting to remove them.

Signed-off-by: Darshan Sen <raisinten@gmail.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
