### PR TITLE
doc: update setTimeout examples

### DIFF
--- a/doc/api/domain.md
+++ b/doc/api/domain.md
@@ -133,9 +133,7 @@ if (cluster.isPrimary) {
 
       try {
         // Make sure we close down within 30 seconds
-        const killtimer = setTimeout(() => {
-          process.exit(1);
-        }, 30000);
+        const killtimer = setTimeout(process.exit, 30000, 1);
         // But don't keep the process open just for that!
         killtimer.unref();
 
@@ -423,12 +421,10 @@ d.on('error', (er) => {
 });
 d.run(() => {
   process.nextTick(() => {
-    setTimeout(() => { // Simulating some various async stuff
-      fs.open('non-existent file', 'r', (er, fd) => {
-        if (er) throw er;
-        // proceed...
-      });
-    }, 100);
+    setTimeout(fs.open, 100, 'non-existent file', 'r', (er, fd) => {
+      if (er) throw er;
+      // proceed...
+    });
   });
 });
 ```

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -97,9 +97,7 @@ In the following example, for instance, the timeout will never occur:
 
 ```js
 process.on('exit', (code) => {
-  setTimeout(() => {
-    console.log('This will not run');
-  }, 0);
+  setTimeout(console.log, 0, 'This will not run');
 });
 ```
 
@@ -259,9 +257,7 @@ process.on('uncaughtException', (err, origin) => {
   );
 });
 
-setTimeout(() => {
-  console.log('This will still run.');
-}, 500);
+setTimeout(console.log, 500, 'This will still run.');
 
 // Intentionally cause an exception, but don't catch it.
 nonexistentFunc();


### PR DESCRIPTION
Uses the arg passing feature of `setTimeout` in examples where possible, e.g. 
```js
setTimeout(console.log, 0, 'foo');
```
instead of
```js
setTimeout(() => {
  console.log('foo');
}, 0);
```