### PR TITLE
src: set PromiseHooks by Environment

### DIFF
--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -454,8 +454,8 @@ static void EnablePromiseHook(const FunctionCallbackInfo<Value>& args) {
 
 static void SetPromiseHooks(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
-  Local<Context> ctx = env->context();
-  ctx->SetPromiseHooks(
+
+  env->async_hooks()->SetJSPromiseHooks(
     args[0]->IsFunction() ? args[0].As<Function>() : Local<Function>(),
     args[1]->IsFunction() ? args[1].As<Function>() : Local<Function>(),
     args[2]->IsFunction() ? args[2].As<Function>() : Local<Function>(),

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -95,6 +95,20 @@ v8::Local<v8::Object> AsyncHooks::native_execution_async_resource(size_t i) {
   return PersistentToLocal::Strong(native_execution_async_resources_[i]);
 }
 
+inline void AsyncHooks::SetJSPromiseHooks(v8::Local<v8::Function> init,
+                                          v8::Local<v8::Function> before,
+                                          v8::Local<v8::Function> after,
+                                          v8::Local<v8::Function> resolve) {
+  js_promise_hooks_[0].Reset(env()->isolate(), init);
+  js_promise_hooks_[1].Reset(env()->isolate(), before);
+  js_promise_hooks_[2].Reset(env()->isolate(), after);
+  js_promise_hooks_[3].Reset(env()->isolate(), resolve);
+  for (auto it = contexts_.begin(); it != contexts_.end(); it++) {
+    PersistentToLocal::Strong(*it)
+        ->SetPromiseHooks(init, before, after, resolve);
+  }
+}
+
 inline v8::Local<v8::String> AsyncHooks::provider_string(int idx) {
   return env()->isolate_data()->async_wrap_provider(idx);
 }
@@ -217,6 +231,37 @@ void AsyncHooks::clear_async_id_stack() {
   fields_[kStackLength] = 0;
 }
 
+inline void AsyncHooks::AddContext(v8::Local<v8::Context> ctx) {
+  ctx->SetPromiseHooks(
+    js_promise_hooks_[0].IsEmpty() ?
+      v8::Local<v8::Function>() :
+      PersistentToLocal::Strong(js_promise_hooks_[0]),
+    js_promise_hooks_[1].IsEmpty() ?
+      v8::Local<v8::Function>() :
+      PersistentToLocal::Strong(js_promise_hooks_[1]),
+    js_promise_hooks_[2].IsEmpty() ?
+      v8::Local<v8::Function>() :
+      PersistentToLocal::Strong(js_promise_hooks_[2]),
+    js_promise_hooks_[3].IsEmpty() ?
+      v8::Local<v8::Function>() :
+      PersistentToLocal::Strong(js_promise_hooks_[3]));
+
+  size_t id = contexts_.size();
+  contexts_.resize(id + 1);
+  contexts_[id].Reset(env()->isolate(), ctx);
+}
+
+inline void AsyncHooks::RemoveContext(v8::Local<v8::Context> ctx) {
+  for (auto it = contexts_.begin(); it != contexts_.end(); it++) {
+    v8::Local<v8::Context> saved_context = PersistentToLocal::Strong(*it);
+    if (saved_context == ctx) {
+      it->Reset();
+      contexts_.erase(it);
+      break;
+    }
+  }
+}
+
 // The DefaultTriggerAsyncIdScope(AsyncWrap*) constructor is defined in
 // async_wrap-inl.h to avoid a circular dependency.
 
@@ -304,6 +349,8 @@ inline void Environment::AssignToContext(v8::Local<v8::Context> context,
 #if HAVE_INSPECTOR
   inspector_agent()->ContextCreated(context, info);
 #endif  // HAVE_INSPECTOR
+
+  this->async_hooks()->AddContext(context);
 }
 
 inline Environment* Environment::GetCurrent(v8::Isolate* isolate) {

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -100,13 +100,9 @@ inline void AsyncHooks::SetJSPromiseHooks(v8::Local<v8::Function> init,
                                           v8::Local<v8::Function> after,
                                           v8::Local<v8::Function> resolve) {
   js_promise_hooks_[0].Reset(env()->isolate(), init);
-  if (!init.IsEmpty()) js_promise_hooks_[0].SetWeak();
   js_promise_hooks_[1].Reset(env()->isolate(), before);
-  if (!before.IsEmpty()) js_promise_hooks_[1].SetWeak();
   js_promise_hooks_[2].Reset(env()->isolate(), after);
-  if (!after.IsEmpty()) js_promise_hooks_[2].SetWeak();
   js_promise_hooks_[3].Reset(env()->isolate(), resolve);
-  if (!resolve.IsEmpty()) js_promise_hooks_[3].SetWeak();
   for (auto it = contexts_.begin(); it != contexts_.end(); it++) {
     PersistentToLocal::Weak(env()->isolate(), *it)
         ->SetPromiseHooks(init, before, after, resolve);
@@ -236,20 +232,19 @@ void AsyncHooks::clear_async_id_stack() {
 }
 
 inline void AsyncHooks::AddContext(v8::Local<v8::Context> ctx) {
-  v8::Isolate * isolate = ctx->GetIsolate();
   ctx->SetPromiseHooks(
     js_promise_hooks_[0].IsEmpty() ?
       v8::Local<v8::Function>() :
-      PersistentToLocal::Weak(isolate, js_promise_hooks_[0]),
+      PersistentToLocal::Strong(js_promise_hooks_[0]),
     js_promise_hooks_[1].IsEmpty() ?
       v8::Local<v8::Function>() :
-      PersistentToLocal::Weak(isolate, js_promise_hooks_[1]),
+      PersistentToLocal::Strong(js_promise_hooks_[1]),
     js_promise_hooks_[2].IsEmpty() ?
       v8::Local<v8::Function>() :
-      PersistentToLocal::Weak(isolate, js_promise_hooks_[2]),
+      PersistentToLocal::Strong(js_promise_hooks_[2]),
     js_promise_hooks_[3].IsEmpty() ?
       v8::Local<v8::Function>() :
-      PersistentToLocal::Weak(isolate, js_promise_hooks_[3]));
+      PersistentToLocal::Strong(js_promise_hooks_[3]));
 
   size_t id = contexts_.size();
   contexts_.resize(id + 1);

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -104,7 +104,7 @@ inline void AsyncHooks::SetJSPromiseHooks(v8::Local<v8::Function> init,
   js_promise_hooks_[2].Reset(env()->isolate(), after);
   js_promise_hooks_[3].Reset(env()->isolate(), resolve);
   for (auto it = contexts_.begin(); it != contexts_.end(); it++) {
-    PersistentToLocal::Strong(*it)
+    PersistentToLocal::Weak(env()->isolate(), *it)
         ->SetPromiseHooks(init, before, after, resolve);
   }
 }
@@ -249,6 +249,7 @@ inline void AsyncHooks::AddContext(v8::Local<v8::Context> ctx) {
   size_t id = contexts_.size();
   contexts_.resize(id + 1);
   contexts_[id].Reset(env()->isolate(), ctx);
+  contexts_[id].SetWeak();
 }
 
 inline void AsyncHooks::RemoveContext(v8::Local<v8::Context> ctx) {

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -253,8 +253,11 @@ inline void AsyncHooks::AddContext(v8::Local<v8::Context> ctx) {
 }
 
 inline void AsyncHooks::RemoveContext(v8::Local<v8::Context> ctx) {
+  v8::Isolate* isolate = env()->isolate();
+  v8::HandleScope handle_scope(isolate);
   for (auto it = contexts_.begin(); it != contexts_.end(); it++) {
-    v8::Local<v8::Context> saved_context = PersistentToLocal::Strong(*it);
+    v8::Local<v8::Context> saved_context =
+      PersistentToLocal::Weak(env()->isolate(), *it);
     if (saved_context == ctx) {
       it->Reset();
       contexts_.erase(it);

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -100,9 +100,13 @@ inline void AsyncHooks::SetJSPromiseHooks(v8::Local<v8::Function> init,
                                           v8::Local<v8::Function> after,
                                           v8::Local<v8::Function> resolve) {
   js_promise_hooks_[0].Reset(env()->isolate(), init);
+  if (!init.IsEmpty()) js_promise_hooks_[0].SetWeak();
   js_promise_hooks_[1].Reset(env()->isolate(), before);
+  if (!before.IsEmpty()) js_promise_hooks_[1].SetWeak();
   js_promise_hooks_[2].Reset(env()->isolate(), after);
+  if (!after.IsEmpty()) js_promise_hooks_[2].SetWeak();
   js_promise_hooks_[3].Reset(env()->isolate(), resolve);
+  if (!resolve.IsEmpty()) js_promise_hooks_[3].SetWeak();
   for (auto it = contexts_.begin(); it != contexts_.end(); it++) {
     PersistentToLocal::Weak(env()->isolate(), *it)
         ->SetPromiseHooks(init, before, after, resolve);
@@ -232,19 +236,20 @@ void AsyncHooks::clear_async_id_stack() {
 }
 
 inline void AsyncHooks::AddContext(v8::Local<v8::Context> ctx) {
+  v8::Isolate * isolate = ctx->GetIsolate();
   ctx->SetPromiseHooks(
     js_promise_hooks_[0].IsEmpty() ?
       v8::Local<v8::Function>() :
-      PersistentToLocal::Strong(js_promise_hooks_[0]),
+      PersistentToLocal::Weak(isolate, js_promise_hooks_[0]),
     js_promise_hooks_[1].IsEmpty() ?
       v8::Local<v8::Function>() :
-      PersistentToLocal::Strong(js_promise_hooks_[1]),
+      PersistentToLocal::Weak(isolate, js_promise_hooks_[1]),
     js_promise_hooks_[2].IsEmpty() ?
       v8::Local<v8::Function>() :
-      PersistentToLocal::Strong(js_promise_hooks_[2]),
+      PersistentToLocal::Weak(isolate, js_promise_hooks_[2]),
     js_promise_hooks_[3].IsEmpty() ?
       v8::Local<v8::Function>() :
-      PersistentToLocal::Strong(js_promise_hooks_[3]));
+      PersistentToLocal::Weak(isolate, js_promise_hooks_[3]));
 
   size_t id = contexts_.size();
   contexts_.resize(id + 1);

--- a/src/env.cc
+++ b/src/env.cc
@@ -1164,10 +1164,7 @@ void AsyncHooks::MemoryInfo(MemoryTracker* tracker) const {
   tracker->TrackField("async_ids_stack", async_ids_stack_);
   tracker->TrackField("fields", fields_);
   tracker->TrackField("async_id_fields", async_id_fields_);
-  tracker->TrackFieldWithSize(
-      "contexts", contexts_.size() * sizeof(v8::Global<Context>));
-  tracker->TrackFieldWithSize(
-      "js_promise_hooks", 4 * sizeof(v8::Global<Function>));
+  tracker->TrackField("js_promise_hooks", js_promise_hooks_);
 }
 
 void AsyncHooks::grow_async_ids_stack() {

--- a/src/env.cc
+++ b/src/env.cc
@@ -1164,6 +1164,10 @@ void AsyncHooks::MemoryInfo(MemoryTracker* tracker) const {
   tracker->TrackField("async_ids_stack", async_ids_stack_);
   tracker->TrackField("fields", fields_);
   tracker->TrackField("async_id_fields", async_id_fields_);
+  tracker->TrackFieldWithSize(
+      "contexts", contexts_.size() * sizeof(v8::Global<Context>));
+  tracker->TrackFieldWithSize(
+      "js_promise_hooks", 4 * sizeof(v8::Global<Function>));
 }
 
 void AsyncHooks::grow_async_ids_stack() {

--- a/src/env.cc
+++ b/src/env.cc
@@ -1156,6 +1156,12 @@ AsyncHooks::SerializeInfo AsyncHooks::Serialize(Local<Context> context,
         context,
         native_execution_async_resources_[i].Get(context->GetIsolate()));
   }
+  CHECK_EQ(contexts_.size(), 1);
+  CHECK_EQ(contexts_[0], env()->context());
+  CHECK(js_promise_hooks_[0].IsEmpty());
+  CHECK(js_promise_hooks_[1].IsEmpty());
+  CHECK(js_promise_hooks_[2].IsEmpty());
+  CHECK(js_promise_hooks_[3].IsEmpty());
 
   return info;
 }

--- a/src/env.h
+++ b/src/env.h
@@ -701,6 +701,11 @@ class AsyncHooks : public MemoryRetainer {
   // The `js_execution_async_resources` array contains the value in that case.
   inline v8::Local<v8::Object> native_execution_async_resource(size_t index);
 
+  inline void SetJSPromiseHooks(v8::Local<v8::Function> init,
+                                v8::Local<v8::Function> before,
+                                v8::Local<v8::Function> after,
+                                v8::Local<v8::Function> resolve);
+
   inline v8::Local<v8::String> provider_string(int idx);
 
   inline void no_force_checks();
@@ -710,6 +715,10 @@ class AsyncHooks : public MemoryRetainer {
       v8::Local<v8::Object> execution_async_resource_);
   inline bool pop_async_context(double async_id);
   inline void clear_async_id_stack();  // Used in fatal exceptions.
+
+  inline void AddContext(v8::Local<v8::Context> ctx);
+  inline void RemoveContext(v8::Local<v8::Context> ctx);
+
 
   AsyncHooks(const AsyncHooks&) = delete;
   AsyncHooks& operator=(const AsyncHooks&) = delete;
@@ -770,6 +779,10 @@ class AsyncHooks : public MemoryRetainer {
 
   // Non-empty during deserialization
   const SerializeInfo* info_ = nullptr;
+
+  std::vector<v8::Global<v8::Context>> contexts_;
+
+  v8::Global<v8::Function> js_promise_hooks_[4];
 };
 
 class ImmediateInfo : public MemoryRetainer {

--- a/src/env.h
+++ b/src/env.h
@@ -781,7 +781,7 @@ class AsyncHooks : public MemoryRetainer {
 
   std::vector<v8::Global<v8::Context>> contexts_;
 
-  v8::Global<v8::Function> js_promise_hooks_[4];
+  std::array<v8::Global<v8::Function>, 4> js_promise_hooks_;
 };
 
 class ImmediateInfo : public MemoryRetainer {

--- a/src/env.h
+++ b/src/env.h
@@ -719,7 +719,6 @@ class AsyncHooks : public MemoryRetainer {
   inline void AddContext(v8::Local<v8::Context> ctx);
   inline void RemoveContext(v8::Local<v8::Context> ctx);
 
-
   AsyncHooks(const AsyncHooks&) = delete;
   AsyncHooks& operator=(const AsyncHooks&) = delete;
   AsyncHooks(AsyncHooks&&) = delete;

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -128,7 +128,8 @@ ContextifyContext::ContextifyContext(
 ContextifyContext::~ContextifyContext() {
   env()->RemoveCleanupHook(CleanupHook, this);
 
-  env()->async_hooks()->RemoveContext(PersistentToLocal::Strong(context_));
+  env()->async_hooks()
+    ->RemoveContext(PersistentToLocal::Weak(env()->isolate(), context_));
 }
 
 

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -127,6 +127,8 @@ ContextifyContext::ContextifyContext(
 
 ContextifyContext::~ContextifyContext() {
   env()->RemoveCleanupHook(CleanupHook, this);
+
+  env()->async_hooks()->RemoveContext(PersistentToLocal::Strong(context_));
 }
 
 

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -30,6 +30,7 @@
 #include "node_internals.h"
 #include "node_watchdog.h"
 #include "util-inl.h"
+#include "v8.h"
 
 namespace node {
 namespace contextify {
@@ -127,9 +128,11 @@ ContextifyContext::ContextifyContext(
 
 ContextifyContext::~ContextifyContext() {
   env()->RemoveCleanupHook(CleanupHook, this);
+  Isolate* isolate = env()->isolate();
+  HandleScope scope(isolate);
 
   env()->async_hooks()
-    ->RemoveContext(PersistentToLocal::Weak(env()->isolate(), context_));
+    ->RemoveContext(PersistentToLocal::Weak(isolate, context_));
 }
 
 

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -30,7 +30,6 @@
 #include "node_internals.h"
 #include "node_watchdog.h"
 #include "util-inl.h"
-#include "v8.h"
 
 namespace node {
 namespace contextify {

--- a/test/parallel/test-async-local-storage-contexts.js
+++ b/test/parallel/test-async-local-storage-contexts.js
@@ -1,0 +1,35 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const vm = require('vm');
+const { AsyncLocalStorage } = require('async_hooks');
+
+// Regression test for https://github.com/nodejs/node/issues/38781
+
+const context = vm.createContext({
+  AsyncLocalStorage,
+  assert
+});
+
+vm.runInContext(`
+  const storage = new AsyncLocalStorage()
+  async function test() {
+    return storage.run({ test: 'vm' }, async () => {
+      assert.strictEqual(storage.getStore().test, 'vm');
+      await 42;
+      assert.strictEqual(storage.getStore().test, 'vm');
+    });
+  }
+  test()
+`, context);
+
+const storage = new AsyncLocalStorage();
+async function test() {
+  return storage.run({ test: 'main context' }, async () => {
+    assert.strictEqual(storage.getStore().test, 'main context');
+    await 42;
+    assert.strictEqual(storage.getStore().test, 'main context');
+  });
+}
+test();


### PR DESCRIPTION
The new JS PromiseHooks introduced in the referenced PR are per
v8::Context. This meant that code depending on them, such as
AsyncLocalStorage, wouldn't behave correctly across vm.Context
instances.

PromiseHooks are now synchronized across the main Context and any
Context created via vm.Context.

Refs: https://github.com/nodejs/node/pull/36394
Fixes: https://github.com/nodejs/node/issues/38781
Signed-off-by: Bryan English <bryan@bryanenglish.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
