### PR TITLE
doc: align module resolve algorithm with implementation

### DIFF
--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -197,13 +197,14 @@ LOAD_NODE_MODULES(X, START)
 NODE_MODULES_PATHS(START)
 1. let PARTS = path split(START)
 2. let I = count of PARTS - 1
-3. let DIRS = [GLOBAL_FOLDERS]
+3. let DIRS = []
 4. while I >= 0,
    a. if PARTS[I] = "node_modules" CONTINUE
    b. DIR = path join(PARTS[0 .. I] + "node_modules")
    c. DIRS = DIRS + DIR
    d. let I = I - 1
-5. return DIRS
+5. DIRS = DIRS.concat(GLOBAL_FOLDERS)
+6. return DIRS
 
 LOAD_PACKAGE_IMPORTS(X, DIR)
 1. Find the closest package scope SCOPE to DIR.

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -201,10 +201,9 @@ NODE_MODULES_PATHS(START)
 4. while I >= 0,
    a. if PARTS[I] = "node_modules" CONTINUE
    b. DIR = path join(PARTS[0 .. I] + "node_modules")
-   c. DIRS = DIRS + DIR
+   c. DIRS = DIR + DIRS
    d. let I = I - 1
-5. DIRS = DIRS.concat(GLOBAL_FOLDERS)
-6. return DIRS
+5. return DIRS.concat(GLOBAL_FOLDERS)
 
 LOAD_PACKAGE_IMPORTS(X, DIR)
 1. Find the closest package scope SCOPE to DIR.

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -203,7 +203,7 @@ NODE_MODULES_PATHS(START)
    b. DIR = path join(PARTS[0 .. I] + "node_modules")
    c. DIRS = DIR + DIRS
    d. let I = I - 1
-5. return DIRS.concat(GLOBAL_FOLDERS)
+5. return DIRS + GLOBAL_FOLDERS
 
 LOAD_PACKAGE_IMPORTS(X, DIR)
 1. Find the closest package scope SCOPE to DIR.


### PR DESCRIPTION
In docs, it reads like `GLOBAL_FOLDERS` takes precedence over `node_module`, but in implementation, `GLOBAL_FOLDERS` is appended to the last of paths to resolve. It should take lowest priority.

https://github.com/nodejs/node/blob/f1cbaea74b432a49af61293e005f8d7e7f56325c/lib/internal/modules/cjs/loader.js#L678

Fixes: https://github.com/nodejs/node/issues/38128
