### PR TITLE
lib: make primordials Promise static methods safe

### DIFF
--- a/lib/internal/inspector/inspect_repl.js
+++ b/lib/internal/inspector/inspect_repl.js
@@ -49,7 +49,6 @@ const {
   ObjectKeys,
   ObjectValues,
   Promise,
-  PromiseAll,
   PromisePrototypeCatch,
   PromisePrototypeThen,
   PromiseResolve,
@@ -57,8 +56,8 @@ const {
   ReflectOwnKeys,
   RegExpPrototypeSymbolMatch,
   RegExpPrototypeSymbolReplace,
-  SafeArrayIterator,
   SafeMap,
+  SafePromiseAll,
   String,
   StringFromCharCode,
   StringPrototypeEndsWith,
@@ -493,8 +492,8 @@ function createRepl(inspector) {
     }
 
     loadScopes() {
-      return PromiseAll(
-        new SafeArrayIterator(ArrayPrototypeMap(
+      return SafePromiseAll(
+        ArrayPrototypeMap(
           ArrayPrototypeFilter(
             this.scopeChain,
             (scope) => scope.type !== 'global'
@@ -507,7 +506,6 @@ function createRepl(inspector) {
             });
             return new ScopeSnapshot(scope, result);
           })
-        )
       );
     }
 
@@ -635,8 +633,8 @@ function createRepl(inspector) {
                             (error) => `<${error.message}>`);
     const lastIndex = watchedExpressions.length - 1;
 
-    const values = await PromiseAll(new SafeArrayIterator(
-      ArrayPrototypeMap(watchedExpressions, inspectValue)));
+    const values = await SafePromiseAll(ArrayPrototypeMap(watchedExpressions,
+                                                          inspectValue));
     const lines = ArrayPrototypeMap(watchedExpressions, (expr, idx) => {
       const prefix = `${leftPad(idx, ' ', lastIndex)}: ${expr} =`;
       const value = inspect(values[idx], { colors: true });
@@ -839,7 +837,7 @@ function createRepl(inspector) {
                                       location.lineNumber + 1));
     if (!newBreakpoints.length) return PromiseResolve();
     return PromisePrototypeThen(
-      PromiseAll(new SafeArrayIterator(newBreakpoints)),
+      SafePromiseAll(newBreakpoints),
       (results) => {
         print(`${results.length} breakpoints restored.`);
       });
@@ -875,8 +873,7 @@ function createRepl(inspector) {
 
     inspector.suspendReplWhile(() =>
       PromisePrototypeThen(
-        PromiseAll(new SafeArrayIterator(
-          [formatWatchers(true), selectedFrame.list(2)])),
+        SafePromiseAll([formatWatchers(true), selectedFrame.list(2)]),
         ({ 0: watcherList, 1: context }) => {
           const breakContext = watcherList ?
             `${watcherList}\n${inspect(context)}` :

--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -7,12 +7,11 @@ const {
   ArrayPrototypeSome,
   FunctionPrototype,
   ObjectSetPrototypeOf,
-  PromiseAll,
   PromiseResolve,
   PromisePrototypeCatch,
   ReflectApply,
   RegExpPrototypeTest,
-  SafeArrayIterator,
+  SafePromiseAll,
   SafeSet,
   StringPrototypeIncludes,
   StringPrototypeMatch,
@@ -77,9 +76,9 @@ class ModuleJob {
       });
 
       if (promises !== undefined)
-        await PromiseAll(new SafeArrayIterator(promises));
+        await SafePromiseAll(promises);
 
-      return PromiseAll(new SafeArrayIterator(dependencyJobs));
+      return SafePromiseAll(dependencyJobs);
     };
     // Promise for the list of all dependencyJobs.
     this.linked = link();
@@ -107,8 +106,8 @@ class ModuleJob {
       }
       jobsInGraph.add(moduleJob);
       const dependencyJobs = await moduleJob.linked;
-      return PromiseAll(new SafeArrayIterator(
-        ArrayPrototypeMap(dependencyJobs, addJobsToDependencyGraph)));
+      return SafePromiseAll(
+        ArrayPrototypeMap(dependencyJobs, addJobsToDependencyGraph));
     };
     await addJobsToDependencyGraph(this);
 

--- a/lib/internal/per_context/primordials.js
+++ b/lib/internal/per_context/primordials.js
@@ -248,6 +248,7 @@ function copyPrototype(src, dest, prefix) {
 
 const {
   ArrayPrototypeForEach,
+  ArrayPrototypeMap,
   FinalizationRegistry,
   FunctionPrototypeCall,
   Map,
@@ -414,6 +415,60 @@ primordials.SafePromisePrototypeFinally = (thisPromise, onFinally) =>
       .finally(onFinally)
       .then(a, b)
   );
+
+const arrayToSafePromiseIterable = (promises) =>
+  new primordials.SafeArrayIterator(
+    ArrayPrototypeMap(
+      promises,
+      (promise) =>
+        new SafePromise((a, b) => PromisePrototypeThen(promise, a, b))
+    )
+  );
+
+/**
+ * @param {Promise<any>[]} promises
+ * @returns {Promise<any[]>}
+ */
+primordials.SafePromiseAll = (promises) =>
+  // Wrapping on a new Promise is necessary to not expose the SafePromise
+  // prototype to user-land.
+  new Promise((a, b) =>
+    SafePromise.all(arrayToSafePromiseIterable(promises)).then(a, b)
+  );
+
+/**
+ * @param {Promise<any>[]} promises
+ * @returns {Promise<object>}
+ */
+primordials.SafePromiseAllSettled = (promises) =>
+  // Wrapping on a new Promise is necessary to not expose the SafePromise
+  // prototype to user-land.
+  new Promise((a, b) =>
+    SafePromise.allSettled(arrayToSafePromiseIterable(promises)).then(a, b)
+  );
+
+/**
+ * @param {Promise<any>[]} promises
+ * @returns {Promise<any>}
+ */
+primordials.SafePromiseAny = (promises) =>
+  // Wrapping on a new Promise is necessary to not expose the SafePromise
+  // prototype to user-land.
+  new Promise((a, b) =>
+    SafePromise.any(arrayToSafePromiseIterable(promises)).then(a, b)
+  );
+
+/**
+ * @param {Promise<any>[]} promises
+ * @returns {Promise<any>}
+ */
+primordials.SafePromiseRace = (promises) =>
+  // Wrapping on a new Promise is necessary to not expose the SafePromise
+  // prototype to user-land.
+  new Promise((a, b) =>
+    SafePromise.race(arrayToSafePromiseIterable(promises)).then(a, b)
+  );
+
 
 ObjectSetPrototypeOf(primordials, null);
 ObjectFreeze(primordials);

--- a/lib/internal/vm/module.js
+++ b/lib/internal/vm/module.js
@@ -10,8 +10,8 @@ const {
   ObjectDefineProperty,
   ObjectGetPrototypeOf,
   ObjectSetPrototypeOf,
-  PromiseAll,
   ReflectApply,
+  SafePromiseAll,
   SafeWeakMap,
   Symbol,
   SymbolToStringTag,
@@ -329,7 +329,7 @@ class SourceTextModule extends Module {
 
       try {
         if (promises !== undefined) {
-          await PromiseAll(promises);
+          await SafePromiseAll(promises);
         }
       } catch (e) {
         this.#error = e;

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -74,11 +74,11 @@ const {
   ObjectKeys,
   ObjectSetPrototypeOf,
   Promise,
-  PromiseRace,
   ReflectApply,
   RegExp,
   RegExpPrototypeExec,
   RegExpPrototypeTest,
+  SafePromiseRace,
   SafeSet,
   SafeWeakSet,
   StringPrototypeCharAt,
@@ -561,7 +561,7 @@ function REPLServer(prompt,
             };
             prioritizedSigintQueue.add(sigintListener);
           });
-          promise = PromiseRace([promise, interrupt]);
+          promise = SafePromiseRace([promise, interrupt]);
         }
 
         (async () => {

--- a/test/parallel/test-primordials-promise.js
+++ b/test/parallel/test-primordials-promise.js
@@ -7,9 +7,18 @@ const assert = require('assert');
 const {
   PromisePrototypeCatch,
   PromisePrototypeThen,
+  SafePromiseAll,
+  SafePromiseAllSettled,
+  SafePromiseAny,
   SafePromisePrototypeFinally,
+  SafePromiseRace,
 } = require('internal/test/binding').primordials;
 
+Array.prototype[Symbol.iterator] = common.mustNotCall();
+Promise.all = common.mustNotCall();
+Promise.allSettled = common.mustNotCall();
+Promise.any = common.mustNotCall();
+Promise.race = common.mustNotCall();
 Promise.prototype.catch = common.mustNotCall();
 Promise.prototype.finally = common.mustNotCall();
 Promise.prototype.then = common.mustNotCall();
@@ -17,6 +26,11 @@ Promise.prototype.then = common.mustNotCall();
 assertIsPromise(PromisePrototypeCatch(Promise.reject(), common.mustCall()));
 assertIsPromise(PromisePrototypeThen(test(), common.mustCall()));
 assertIsPromise(SafePromisePrototypeFinally(test(), common.mustCall()));
+
+assertIsPromise(SafePromiseAll([test()]));
+assertIsPromise(SafePromiseAllSettled([test()]));
+assertIsPromise(SafePromiseAny([test()]));
+assertIsPromise(SafePromiseRace([test()]));
 
 async function test() {
   const catchFn = common.mustCall();


### PR DESCRIPTION
Promise static methods that iterate over the provided argument (`%Promise.all%`, `%Promise.any%`, ...) look up the `then` property over each promise to support promise subclassing. This PR is introducing `SafePromiseAll`, `SafePromiseAny`, etc. that take a array, safely iterate over it, and wrap each promise in a `SafePromise` whose prototype is accessible from userland.
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
