### PR TITLE
src: fix minor typo in trace_event.h

### DIFF
--- a/src/tracing/trace_event.h
+++ b/src/tracing/trace_event.h
@@ -460,13 +460,13 @@ static inline uint64_t AddTraceEventImpl(
     const char* scope, uint64_t id, uint64_t bind_id, int32_t num_args,
     const char** arg_names, const uint8_t* arg_types,
     const uint64_t* arg_values, unsigned int flags) {
-  std::unique_ptr<v8::ConvertableToTraceFormat> arg_convertibles[2];
+  std::unique_ptr<v8::ConvertableToTraceFormat> arg_convertables[2];
   if (num_args > 0 && arg_types[0] == TRACE_VALUE_TYPE_CONVERTABLE) {
-    arg_convertibles[0].reset(reinterpret_cast<v8::ConvertableToTraceFormat*>(
+    arg_convertables[0].reset(reinterpret_cast<v8::ConvertableToTraceFormat*>(
         static_cast<intptr_t>(arg_values[0])));
   }
   if (num_args > 1 && arg_types[1] == TRACE_VALUE_TYPE_CONVERTABLE) {
-    arg_convertibles[1].reset(reinterpret_cast<v8::ConvertableToTraceFormat*>(
+    arg_convertables[1].reset(reinterpret_cast<v8::ConvertableToTraceFormat*>(
         static_cast<intptr_t>(arg_values[1])));
   }
   // DCHECK(num_args, 2);
@@ -475,7 +475,7 @@ static inline uint64_t AddTraceEventImpl(
   if (controller == nullptr) return 0;
   return controller->AddTraceEvent(phase, category_group_enabled, name, scope, id,
                                    bind_id, num_args, arg_names, arg_types,
-                                   arg_values, arg_convertibles, flags);
+                                   arg_values, arg_convertables, flags);
 }
 
 static V8_INLINE uint64_t AddTraceEventWithTimestampImpl(
@@ -505,13 +505,13 @@ static V8_INLINE void AddMetadataEventImpl(
     const uint8_t* category_group_enabled, const char* name, int32_t num_args,
     const char** arg_names, const uint8_t* arg_types,
     const uint64_t* arg_values, unsigned int flags) {
-  std::unique_ptr<v8::ConvertableToTraceFormat> arg_convertibles[2];
+  std::unique_ptr<v8::ConvertableToTraceFormat> arg_convertables[2];
   if (num_args > 0 && arg_types[0] == TRACE_VALUE_TYPE_CONVERTABLE) {
-    arg_convertibles[0].reset(reinterpret_cast<v8::ConvertableToTraceFormat*>(
+    arg_convertables[0].reset(reinterpret_cast<v8::ConvertableToTraceFormat*>(
         static_cast<intptr_t>(arg_values[0])));
   }
   if (num_args > 1 && arg_types[1] == TRACE_VALUE_TYPE_CONVERTABLE) {
-    arg_convertibles[1].reset(reinterpret_cast<v8::ConvertableToTraceFormat*>(
+    arg_convertables[1].reset(reinterpret_cast<v8::ConvertableToTraceFormat*>(
         static_cast<intptr_t>(arg_values[1])));
   }
   node::tracing::Agent* agent =
@@ -519,7 +519,7 @@ static V8_INLINE void AddMetadataEventImpl(
   if (agent == nullptr) return;
   return agent->GetTracingController()->AddMetadataEvent(
       category_group_enabled, name, num_args, arg_names, arg_types, arg_values,
-      arg_convertibles, flags);
+      arg_convertables, flags);
 }
 
 // Define SetTraceValue for each allowed type. It stores the type and


### PR DESCRIPTION
Most of the variables in the file were named `arg_convertables`, so I renamed `arg_convertibles` to be like them for consistency.