### PR TITLE
test: suppress warning in test_environment.cc

### DIFF
--- a/test/cctest/test_environment.cc
+++ b/test/cctest/test_environment.cc
@@ -331,8 +331,8 @@ static void at_exit_js(void* arg) {
   v8::Isolate* isolate = static_cast<v8::Isolate*>(arg);
   v8::HandleScope handle_scope(isolate);
   v8::Local<v8::Object> obj = v8::Object::New(isolate);
-  assert(!obj.IsEmpty());  // Assert VM is still alive.
-  assert(obj->IsObject());
+  EXPECT_FALSE(obj.IsEmpty());  // Assert VM is still alive.
+  EXPECT_TRUE(obj->IsObject());
   called_at_exit_js = true;
 }
 


### PR DESCRIPTION
Currently there is a compiler warning generated if a build defines
`NDEBUG`:
```console
$ env CXXFLAGS='-DNDEBUG' make -j8 cctest
../test/cctest/test_environment.cc:
In function ‘void at_exit_js(void*)’:
../test/cctest/test_environment.cc:333:25: warning:
variable ‘obj’ set but not used [-Wunused-but-set-variable]
  333 |   v8::Local<v8::Object> obj = v8::Object::New(isolate);
      |                         ^~~
```
`NDEBUG` is currently not defined using the main branch but this was discovered
when working on replacing OpenSSL 1.1.1 with OpenSSL 3.0.

This commit uses EXPECT statements instead of asserts to avoid the
warning.

