### PR TITLE
build: work around bug in MSBuild v16.10.0

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -334,6 +334,8 @@ if "%target%"=="Build" (
   if defined cctest set target="Build"
 )
 if "%target%"=="node" if exist "%config%\cctest.exe" del "%config%\cctest.exe"
+@rem TODO(targos): Remove next line after MSBuild 16.10.1 is released.
+if "%target%"=="node" set target="Build"
 if defined msbuild_args set "extra_msbuild_args=%extra_msbuild_args% %msbuild_args%"
 @rem Setup env variables to use multiprocessor build
 set UseMultiToolTask=True


### PR DESCRIPTION
This allows to build Node.js at the (temporary) cost of longer build
times.

Refs: https://github.com/nodejs/node/issues/38872
Refs: https://github.com/dotnet/msbuild/releases/tag/v16.10.0
Refs: https://github.com/dotnet/msbuild/pull/6465
Refs: https://github.com/dotnet/msbuild/issues/6373
