### PR TITLE
doc: mark Node.js v15.x as EOL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Select a Node.js version below to view the changelog history:
 
 * [Node.js 16](doc/changelogs/CHANGELOG_V16.md) **Current**
-* [Node.js 15](doc/changelogs/CHANGELOG_V15.md) **Current**
+* [Node.js 15](doc/changelogs/CHANGELOG_V15.md) End-of-Life
 * [Node.js 14](doc/changelogs/CHANGELOG_V14.md) **Long Term Support**
 * [Node.js 13](doc/changelogs/CHANGELOG_V13.md) End-of-Life
 * [Node.js 12](doc/changelogs/CHANGELOG_V12.md) Long Term Support
@@ -27,7 +27,6 @@ release.
 <table>
 <tr>
   <th title="Current"><a href="doc/changelogs/CHANGELOG_V16.md">16</a><sup>Current</sup></th>
-  <th title="Current"><a href="doc/changelogs/CHANGELOG_V15.md">15</a><sup>Current</sup></th>
   <th title="LTS Until 2023-04"><a href="doc/changelogs/CHANGELOG_V14.md">14</a><sup>LTS</sup></th>
   <th title="LTS Until 2022-04"><a href="doc/changelogs/CHANGELOG_V12.md">12</a><sup>LTS</sup></th>
 </tr>
@@ -36,26 +35,6 @@ release.
 <b><a href="doc/changelogs/CHANGELOG_V16.md#16.2.0">16.2.0</a></b><br/>
 <a href="doc/changelogs/CHANGELOG_V16.md#16.1.0">16.1.0</a><br/>
 <a href="doc/changelogs/CHANGELOG_V16.md#16.0.0">16.0.0</a><br/>
-    </td>
-    <td valign="top">
-<b><a href="doc/changelogs/CHANGELOG_V15.md#15.14.0">15.14.0</a></b><br/>
-<a href="doc/changelogs/CHANGELOG_V15.md#15.13.0">15.13.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V15.md#15.12.0">15.12.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V15.md#15.11.0">15.11.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V15.md#15.10.0">15.10.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V15.md#15.9.0">15.9.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V15.md#15.8.0">15.8.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V15.md#15.7.0">15.7.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V15.md#15.6.0">15.6.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V15.md#15.5.1">15.5.1</a><br/>
-<a href="doc/changelogs/CHANGELOG_V15.md#15.5.0">15.5.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V15.md#15.4.0">15.4.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V15.md#15.3.0">15.3.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V15.md#15.2.1">15.2.1</a><br/>
-<a href="doc/changelogs/CHANGELOG_V15.md#15.2.0">15.2.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V15.md#15.1.0">15.1.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V15.md#15.0.1">15.0.1</a><br/>
-<a href="doc/changelogs/CHANGELOG_V15.md#15.0.0">15.0.0</a><br/>
     </td>
     <td valign="top">
 <b><a href="doc/changelogs/CHANGELOG_V14.md#14.16.1">14.16.1</a></b><br/>


### PR DESCRIPTION
Today is 2021-06-01, which is the date v15.x release line is marked as
End-of-Life.

Refs: https://github.com/nodejs/Release/blob/main/schedule.json

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
