### PR TITLE
util: use missing validators

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -47,7 +47,6 @@ const {
 const {
   codes: {
     ERR_FALSY_VALUE_REJECTION,
-    ERR_INVALID_ARG_TYPE,
     ERR_OUT_OF_RANGE
   },
   errnoException,

--- a/lib/util.js
+++ b/lib/util.js
@@ -63,6 +63,7 @@ const { debuglog } = require('internal/util/debuglog');
 const {
   validateFunction,
   validateNumber,
+  validateObject,
 } = require('internal/validators');
 const { TextDecoder, TextEncoder } = require('internal/encoding');
 const { isBuffer } = require('buffer').Buffer;
@@ -229,17 +230,10 @@ function log(...args) {
  *     the super constructor lacks a prototype.
  */
 function inherits(ctor, superCtor) {
+  validateFunction(ctor, 'ctor');
+  validateFunction(superCtor, 'superCtor');
+  validateObject(superCtor.prototype, 'superCtor.prototype');
 
-  if (ctor === undefined || ctor === null)
-    throw new ERR_INVALID_ARG_TYPE('ctor', 'Function', ctor);
-
-  if (superCtor === undefined || superCtor === null)
-    throw new ERR_INVALID_ARG_TYPE('superCtor', 'Function', superCtor);
-
-  if (superCtor.prototype === undefined) {
-    throw new ERR_INVALID_ARG_TYPE('superCtor.prototype',
-                                   'Object', superCtor.prototype);
-  }
   ObjectDefineProperty(ctor, 'super_', {
     value: superCtor,
     writable: true,

--- a/test/parallel/test-util-inherits.js
+++ b/test/parallel/test-util-inherits.js
@@ -86,7 +86,7 @@ function F() {
   this.test = 'test';
 }
 
-F.prototype = null;
+F.prototype = undefined;
 
 // Should throw with invalid arguments
 assert.throws(() => {

--- a/test/parallel/test-util-inherits.js
+++ b/test/parallel/test-util-inherits.js
@@ -82,9 +82,15 @@ assert.strictEqual(e.d(), 'd');
 assert.strictEqual(e.e(), 'e');
 assert.strictEqual(e.constructor, E);
 
+function F() {
+  this.test = 'test';
+}
+
+F.prototype = null;
+
 // Should throw with invalid arguments
 assert.throws(() => {
-  inherits(A, {});
+  inherits(A, F);
 }, {
   code: 'ERR_INVALID_ARG_TYPE',
   name: 'TypeError',


### PR DESCRIPTION
The `inherits()` method in the `util` lib module is not using validators which others do use.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
