### PR TITLE
node-api: avoid SecondPassCallback crash

### DIFF
--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -321,7 +321,8 @@ class Reference : public RefBase {
   Reference(napi_env env, v8::Local<v8::Value> value, Args&&... args)
       : RefBase(env, std::forward<Args>(args)...),
         _persistent(env->isolate, value),
-        _secondPassParameter(new SecondPassCallParameterRef(this)) {
+        _secondPassParameter(new SecondPassCallParameterRef(this)),
+        _secondPassScheduled(false) {
     if (RefCount() == 0) {
       SetWeak();
     }
@@ -348,7 +349,7 @@ class Reference : public RefBase {
     // If the second pass callback is scheduled, it will delete the
     // parameter passed to it, otherwise it will never be scheduled
     // and we need to delete it here.
-    if (_secondPassParameter != nullptr) {
+    if (!_secondPassScheduled) {
       delete _secondPassParameter;
     }
   }
@@ -445,8 +446,7 @@ class Reference : public RefBase {
     reference->_persistent.Reset();
     // Mark the parameter not delete-able until the second pass callback is
     // invoked.
-    reference->_secondPassParameter = nullptr;
-
+    reference->_secondPassScheduled = true;
     data.SetSecondPassCallback(SecondPassCallback);
   }
 
@@ -468,12 +468,14 @@ class Reference : public RefBase {
       // the reference itself has already been deleted so nothing to do
       return;
     }
+    reference->_secondPassParameter = nullptr;
     reference->Finalize();
   }
 
   bool env_teardown_finalize_started_ = false;
   v8impl::Persistent<v8::Value> _persistent;
   SecondPassCallParameterRef* _secondPassParameter;
+  bool _secondPassScheduled;
 };
 
 enum UnwrapAction {


### PR DESCRIPTION
PR https://github.com/nodejs/node/pull/38000 added
indirection so that we could stop finalization in
cases where it had been scheduled in a second
pass callback but we were doing it in advance in
environment teardown.

Unforunately we missed that the code which tries
to clear the second pass parameter checked if
the pointer to the parameter (_secondPassParameter)
was nullptr and that when the second pass callback
was scheduled we set _secondPassParameter to nullptr
in order to avoid it being deleted outside of the second
pass callback. The net result was that we
would not clear the _secondPassParameter contents
and failed to avoid the Finalization in the second pass
callback.

This PR adds an additional boolean for deciding if
the secondPassParameter should be deleted outside
of the second pass callback instead of setting
secondPassParameter to nullptr thus avoiding the
conflict between the 2 ways it was being used.

See the discussion starting at:
https://github.com/nodejs/node/pull/38273#issuecomment-852403751
for how this was discovered on OSX while trying to
upgrade to a new V8 version.

Signed-off-by: Michael Dawson <mdawson@devrus.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
