### PR TITLE
tls: tweak clientCertEngine argument parsing

### DIFF
--- a/lib/internal/tls.js
+++ b/lib/internal/tls.js
@@ -305,15 +305,15 @@ function configSecureContext(context, options = {}, name = 'options') {
     }
   }
 
-  if (clientCertEngine !== undefined) {
+  if (typeof clientCertEngine === 'string') {
     if (typeof context.setClientCertEngine !== 'function')
       throw new ERR_CRYPTO_CUSTOM_ENGINE_NOT_SUPPORTED();
-    if (typeof clientCertEngine !== 'string') {
-      throw new ERR_INVALID_ARG_TYPE(`${name}.clientCertEngine`,
-                                     ['string', 'null', 'undefined'],
-                                     clientCertEngine);
-    }
-    context.setClientCertEngine(clientCertEngine);
+    else
+      context.setClientCertEngine(clientCertEngine);
+  } else if (clientCertEngine !== undefined) {
+    throw new ERR_INVALID_ARG_TYPE(`${name}.clientCertEngine`,
+                                   ['string', 'null', 'undefined'],
+                                   clientCertEngine);
   }
 
   if (ticketKeys !== undefined) {


### PR DESCRIPTION
This PR slightly tweaks the argument parsing within `configSecureContext`.

BoringSSL defines `OPENSSL_NO_ENGINE` and https://github.com/jasnell/node/commit/35274cbddf7206687b2e30d32e57d293750e19a0 changed behavior so that if a bad `clientCertEngine ` argument is passed, `ERR_CRYPTO_CUSTOM_ENGINE_NOT_SUPPORTED()` will be thrown _before_ `ERR_INVALID_ARG_TYPE`.

This made Electron's smoke test of `parallel/test-tls-clientcertengine-invalid-arg-type.js` fail - this PR makes that test pass once more for us.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
