### PR TITLE
src: throw error in LoadBuiltinModuleSource when reading fails

### DIFF
--- a/src/node_native_module.cc
+++ b/src/node_native_module.cc
@@ -205,33 +205,20 @@ MaybeLocal<String> NativeModuleLoader::LoadBuiltinModuleSource(Isolate* isolate,
 #ifdef NODE_BUILTIN_MODULES_PATH
   std::string filename = OnDiskFileName(id);
 
-  uv_fs_t req;
-  uv_file file =
-      uv_fs_open(nullptr, &req, filename.c_str(), O_RDONLY, 0, nullptr);
-  CHECK_GE(req.result, 0);
-  uv_fs_req_cleanup(&req);
-
-  auto defer_close = OnScopeLeave([file]() {
-    uv_fs_t close_req;
-    CHECK_EQ(0, uv_fs_close(nullptr, &close_req, file, nullptr));
-    uv_fs_req_cleanup(&close_req);
-  });
-
   std::string contents;
-  char buffer[4096];
-  uv_buf_t buf = uv_buf_init(buffer, sizeof(buffer));
-
-  while (true) {
-    const int r =
-        uv_fs_read(nullptr, &req, file, &buf, 1, contents.length(), nullptr);
-    CHECK_GE(req.result, 0);
-    uv_fs_req_cleanup(&req);
-    if (r <= 0) {
-      break;
-    }
-    contents.append(buf.base, r);
+  int r = ReadFileSync(&contents, filename.c_str());
+  if (r != 0) {
+    char buf[256];
+    snprintf(buf,
+             sizeof(buf),
+             "Cannot read local builtin. %s: %s \"%s\"",
+             uv_err_name(r),
+             uv_strerror(r),
+             filename.c_str());
+    Local<String> message = OneByteString(isolate, buf);
+    isolate->ThrowException(v8::Exception::Error(message));
+    return MaybeLocal<String>();
   }
-
   return String::NewFromUtf8(
       isolate, contents.c_str(), v8::NewStringType::kNormal, contents.length());
 #else

--- a/src/node_native_module.cc
+++ b/src/node_native_module.cc
@@ -208,14 +208,11 @@ MaybeLocal<String> NativeModuleLoader::LoadBuiltinModuleSource(Isolate* isolate,
   std::string contents;
   int r = ReadFileSync(&contents, filename.c_str());
   if (r != 0) {
-    char buf[256];
-    snprintf(buf,
-             sizeof(buf),
-             "Cannot read local builtin. %s: %s \"%s\"",
-             uv_err_name(r),
-             uv_strerror(r),
-             filename.c_str());
-    Local<String> message = OneByteString(isolate, buf);
+    const std::string buf = SPrintF("Cannot read local builtin. %s: %s \"%s\"",
+                                    uv_err_name(r),
+                                    uv_strerror(r),
+                                    filename);
+    Local<String> message = OneByteString(isolate, buf.c_str());
     isolate->ThrowException(v8::Exception::Error(message));
     return MaybeLocal<String>();
   }

--- a/src/util.cc
+++ b/src/util.cc
@@ -221,6 +221,39 @@ int WriteFileSync(v8::Isolate* isolate,
   return WriteFileSync(path, buf);
 }
 
+int ReadFileSync(std::string* result, const char* path) {
+  uv_fs_t req;
+  uv_file file = uv_fs_open(nullptr, &req, path, O_RDONLY, 0, nullptr);
+  if (req.result < 0) {
+    return req.result;
+  }
+  uv_fs_req_cleanup(&req);
+
+  auto defer_close = OnScopeLeave([file]() {
+    uv_fs_t close_req;
+    CHECK_EQ(0, uv_fs_close(nullptr, &close_req, file, nullptr));
+    uv_fs_req_cleanup(&close_req);
+  });
+
+  *result = std::string("");
+  char buffer[4096];
+  uv_buf_t buf = uv_buf_init(buffer, sizeof(buffer));
+
+  while (true) {
+    const int r =
+        uv_fs_read(nullptr, &req, file, &buf, 1, result->length(), nullptr);
+    if (req.result < 0) {
+      return req.result;
+    }
+    uv_fs_req_cleanup(&req);
+    if (r <= 0) {
+      break;
+    }
+    result->append(buf.base, r);
+  }
+  return 0;
+}
+
 void DiagnosticFilename::LocalTime(TIME_TYPE* tm_struct) {
 #ifdef _WIN32
   GetLocalTime(tm_struct);

--- a/src/util.cc
+++ b/src/util.cc
@@ -243,6 +243,7 @@ int ReadFileSync(std::string* result, const char* path) {
     const int r =
         uv_fs_read(nullptr, &req, file, &buf, 1, result->length(), nullptr);
     if (req.result < 0) {
+      uv_fs_req_cleanup(&req);
       return req.result;
     }
     uv_fs_req_cleanup(&req);

--- a/src/util.h
+++ b/src/util.h
@@ -813,8 +813,8 @@ std::unique_ptr<T> static_unique_pointer_cast(std::unique_ptr<U>&& ptr) {
 
 #define MAYBE_FIELD_PTR(ptr, field) ptr == nullptr ? nullptr : &(ptr->field)
 
-// Returns a non-zero code if it fail to open or read the file,
-// abort if it fails to close the file.
+// Returns a non-zero code if it fails to open or read the file,
+// aborts if it fails to close the file.
 int ReadFileSync(std::string* result, const char* path);
 }  // namespace node
 

--- a/src/util.h
+++ b/src/util.h
@@ -812,6 +812,10 @@ std::unique_ptr<T> static_unique_pointer_cast(std::unique_ptr<U>&& ptr) {
 }
 
 #define MAYBE_FIELD_PTR(ptr, field) ptr == nullptr ? nullptr : &(ptr->field)
+
+// Returns a non-zero code if it fail to open or read the file,
+// abort if it fails to close the file.
+int ReadFileSync(std::string* result, const char* path);
 }  // namespace node
 
 #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS


### PR DESCRIPTION
- Move the file reading code in LoadBuiltinModuleSource into
  util.h so that it can be reused by other C++ code, and
  return an error code from it when there is a failure for
  the caller to generate an error.
- Throw an error when reading local builtins fails in
  LoadBulitinModuleSource.

The error looks something like this

```
node:internal/bootstrap/loaders:311
      const fn = compileFunction(id);
                 ^

Error: Cannot read local builtin. ENOENT: no such file or directory "/Users/joyee/projects/node/lib/fs.js"
    at NativeModule.compileForInternalLoader (node:internal/bootstrap/loaders:311:18)
    at nativeModuleRequire (node:internal/bootstrap/loaders:341:14)
    at node:internal/bootstrap/node:362:1
```

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
