### PR TITLE
doc: deprecate type coercion for `dns.lookup` options

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2786,6 +2786,19 @@ These properties are now available within the standard `detail` property
 of the `PerformanceEntry` object. The existing accessors have been
 deprecated and should no longer be used.
 
+### DEP0153: Non boolean value for `verbatim` DNS lookup option
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: Documentation-only deprecation.
+-->
+
+Type: Documentation-only
+
+Using a non-boolean value for `verbatim` option in [`dns.lookup()`][] and
+[`dnsPromises.lookup()`][] is deprecated.
+
 [Legacy URL API]: url.md#url_legacy_url_api
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
 [RFC 6066]: https://tools.ietf.org/html/rfc6066#section-3
@@ -2825,6 +2838,8 @@ deprecated and should no longer be used.
 [`crypto.scrypt()`]: crypto.md#crypto_crypto_scrypt_password_salt_keylen_options_callback
 [`decipher.final()`]: crypto.md#crypto_decipher_final_outputencoding
 [`decipher.setAuthTag()`]: crypto.md#crypto_decipher_setauthtag_buffer_encoding
+[`dns.lookup()`]: domain.md#dns_dns_lookup_hostname_options_callback
+[`dnsPromises.lookup()`]: domain.md#dns_dnspromises_lookup_hostname_options
 [`domain`]: domain.md
 [`ecdh.setPublicKey()`]: crypto.md#crypto_ecdh_setpublickey_publickey_encoding
 [`emitter.listenerCount(eventName)`]: events.md#events_emitter_listenercount_eventname

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2786,7 +2786,7 @@ These properties are now available within the standard `detail` property
 of the `PerformanceEntry` object. The existing accessors have been
 deprecated and should no longer be used.
 
-### DEP0153: `dns.lookup` and `dnsPromises.lookup` options type coercion 
+### DEP0153: `dns.lookup` and `dnsPromises.lookup` options type coercion
 <!-- YAML
 changes:
   - version: REPLACEME
@@ -2796,10 +2796,10 @@ changes:
 
 Type: Documentation-only
 
-Using a non-integer value for `family` option, a non-number value for `hints`
-option, a non-boolean value for `all` option, or a non-boolean value for
-`verbatim` option in [`dns.lookup()`][] and [`dnsPromises.lookup()`][] is
-deprecated.
+Using a non-nullish non-integer value for `family` option, a non-nullish
+non-number value for `hints` option, a non-nullish non-boolean value for `all`
+option, or a non-nullish non-boolean value for `verbatim` option in
+[`dns.lookup()`][] and [`dnsPromises.lookup()`][] is deprecated.
 
 [Legacy URL API]: url.md#url_legacy_url_api
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2790,7 +2790,7 @@ deprecated and should no longer be used.
 <!-- YAML
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/00000
+    pr-url: https://github.com/nodejs/node/pull/38906
     description: Documentation-only deprecation.
 -->
 

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2786,7 +2786,7 @@ These properties are now available within the standard `detail` property
 of the `PerformanceEntry` object. The existing accessors have been
 deprecated and should no longer be used.
 
-### DEP0153: Non boolean value for `verbatim` DNS lookup option
+### DEP0153: `dns.lookup` and `dnsPromises.lookup` options type coercion 
 <!-- YAML
 changes:
   - version: REPLACEME
@@ -2796,8 +2796,10 @@ changes:
 
 Type: Documentation-only
 
-Using a non-boolean value for `verbatim` option in [`dns.lookup()`][] and
-[`dnsPromises.lookup()`][] is deprecated.
+Using a non-integer value for `family` option, a non-number value for `hints`
+option, a non-boolean value for `all` option, or a non-boolean value for
+`verbatim` option in [`dns.lookup()`][] and [`dnsPromises.lookup()`][] is
+deprecated.
 
 [Legacy URL API]: url.md#url_legacy_url_api
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf


### PR DESCRIPTION
The plan is to replace this check: https://github.com/nodejs/node/blob/d8797f5994d86c25b97f1c2b71e7f56eba302e65/lib/internal/dns/promises.js#L115-L117
with a more robust `validateBoolean` check – and similar for other `dns.lookup` options.
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
