### PR TITLE
src: add get/set pair for unhandled rejections mode

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -560,6 +560,24 @@ inline bool Environment::abort_on_uncaught_exception() const {
   return options_->abort_on_uncaught_exception;
 }
 
+inline void Environment::set_unhandled_rejections_mode(
+  const std::string& mode) {
+  if (!mode.empty() &&
+      mode != "warn-with-error-code" &&
+      mode != "throw" &&
+      mode != "strict" &&
+      mode != "warn" &&
+      mode != "none") {
+    fprintf(stderr, "Invalid unhandled rejections mode: %s", mode.c_str());
+  } else {
+    options_->unhandled_rejections = mode;
+  }
+}
+
+inline std::string Environment::unhandled_rejections_mode() const {
+  return options_->unhandled_rejections;
+}
+
 inline void Environment::set_force_context_aware(bool value) {
   options_->force_context_aware = value;
 }

--- a/src/env.h
+++ b/src/env.h
@@ -1113,6 +1113,9 @@ class Environment : public MemoryRetainer {
   void PrintSyncTrace() const;
   inline void set_trace_sync_io(bool value);
 
+  inline void set_unhandled_rejections_mode(const std::string& mode);
+  inline std::string unhandled_rejections_mode() const;
+
   inline void set_force_context_aware(bool value);
   inline bool force_context_aware() const;
 


### PR DESCRIPTION
This PR adds a get/set pair for unhandled rejections modes. Electron wishes to be able to set this from C++ and not just a cli flag which is the only option right now.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
