### PR TITLE
Introduce a way to interrupt `diagnostics_channel` flow

### DIFF
--- a/doc/api/diagnostics_channel.md
+++ b/doc/api/diagnostics_channel.md
@@ -90,7 +90,7 @@ const channel = diagnostics_channel.channel('my-channel');
 ### Class: `Channel`
 
 The class `Channel` represents an individual named channel within the data
-pipeline. It is use to track subscribers and to publish messages when there
+pipeline. It is used to track subscribers and to publish messages when there
 are subscribers present. It exists as a separate object to avoid channel
 lookups at publish time, enabling very fast publish speeds and allowing
 for heavy use while incurring very minimal cost. Channels are created with

--- a/doc/api/diagnostics_channel.md
+++ b/doc/api/diagnostics_channel.md
@@ -142,7 +142,8 @@ channel.publish({
 
 Register a message handler to subscribe to this channel. This message handler
 will be run synchronously whenever a message is published to the channel. Any
-errors thrown in the message handler will trigger an [`'uncaughtException'`][].
+errors thrown in the message handler will trigger an [`'uncaughtException'`][]
+unless it is an instance of [`DCInterruptError`][].
 
 ```js
 const diagnostics_channel = require('diagnostics_channel');
@@ -175,6 +176,40 @@ channel.subscribe(onMessage);
 channel.unsubscribe(onMessage);
 ```
 
+### Class: `DCInterruptError`
+<!-- YAML
+added: REPLACEME
+-->
+
+* Extends: {errors.Error}
+
+Can be thrown inside a subscription to interrupt the code flow. (By default,
+throwing a different kind of error inside a subscription will redirect it.
+See: [`channel.subscribe(onMessage)`][].) Throwing an instance of
+`DCInterruptError` inside a subscriber will prevent subsequent subscriptions
+from running, and will forward the exception to the publisher instead of
+redirecting it to [`'uncaughtException'`][].
+
+```js
+const diagnostics_channel = require('diagnostics_channel');
+
+const channel = diagnostics_channel.channel('my-channel');
+
+channel.subscribe((message, name) => {
+  throw new diagnostics_channel.DCInterruptError('Subscriber Interruption');
+});
+
+channel.subscribe((message, name) => {
+  // This will not run
+});
+
+channel.publish({
+  some: 'message'
+});
+// Throws "DCInterruptError: Subscriber Interruption"
+```
+
 [`diagnostics_channel.channel(name)`]: #diagnostics_channel_diagnostics_channel_channel_name
 [`channel.subscribe(onMessage)`]: #diagnostics_channel_channel_subscribe_onmessage
 [`'uncaughtException'`]: process.md#process_event_uncaughtexception
+[`DCInterruptError`]: #diagnostics_channel_class_dcinterrupterror

--- a/lib/diagnostics_channel.js
+++ b/lib/diagnostics_channel.js
@@ -4,6 +4,7 @@ const {
   ArrayPrototypeIndexOf,
   ArrayPrototypePush,
   ArrayPrototypeSplice,
+  Error,
   ObjectCreate,
   ObjectGetPrototypeOf,
   ObjectSetPrototypeOf,
@@ -22,6 +23,13 @@ const {
 const { triggerUncaughtException } = internalBinding('errors');
 
 const { WeakReference } = internalBinding('util');
+
+class DCInterruptError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'DCInterruptError';
+  }
+}
 
 // TODO(qard): should there be a C++ channel interface?
 class ActiveChannel {
@@ -53,6 +61,8 @@ class ActiveChannel {
         const onMessage = this._subscribers[i];
         onMessage(data, this.name);
       } catch (err) {
+        if (err instanceof DCInterruptError) throw err;
+
         process.nextTick(() => {
           triggerUncaughtException(err, false);
         });
@@ -117,5 +127,6 @@ function hasSubscribers(name) {
 module.exports = {
   channel,
   hasSubscribers,
-  Channel
+  Channel,
+  DCInterruptError
 };

--- a/test/parallel/test-diagnostics-channel-interrupt-subscriber-error.js
+++ b/test/parallel/test-diagnostics-channel-interrupt-subscriber-error.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const common = require('../common');
+const dc = require('diagnostics_channel');
+const assert = require('assert');
+
+const input = {
+  foo: 'bar'
+};
+
+const channel = dc.channel('fail');
+
+const error = new dc.DCInterruptError('nope');
+
+// Should not redirect the exception to global handler
+process.on('uncaughtException', common.mustNotCall());
+
+channel.subscribe(common.mustCall((message, name) => {
+  throw error;
+}));
+
+// The interrupting subscriber *should* stop subsequent subscribers from running
+channel.subscribe(common.mustNotCall());
+
+// Publish should throw
+assert.throws(() => {
+  channel.publish(input);
+}, error);


### PR DESCRIPTION
This PR introduces a way to interrupt the flow of `diagnostics_channel`.

### Problem
Sometimes, a subscriber to a channel will want to stop further execution of the event. In a usual context this would be done by throwing an exception. However, `diagnostics_channel` has a mecanism to catch any exception coming from subscribers, and redirect it to the `process` event `uncaughtException`. This makes sense because we don't want a publisher to crash only because a subscriber is doing something wrong.
But a **way to circumvent this catch-all is necessary** for some use cases.

### Use cases
An example of a very real use case would be to have a monitoring subscriber that would collect metrics and monitor the health of the app, and could decide to interrupt an action if it exceeds certain limits, contains invalid or malicious data, etc...

Another possibility is that a user would want to not go forward with a certain action if it is not succesfully consummed by a subscriber.

The general idea is that we should let the user decide where an exception thrown inside a subscriber should go, by having a safe default (ie: `uncaughtException`) and an explicit bypass (ie: passed to the publisher).

### Solution
The proposed mecanism would rethrow a subscriber exception if it is an instance of `DCInterruptError` (taking suggestions for a better name), not call the `uncaughtException` event, and not execute the subsequent subscribers.

The public API is very simple (more details available in `doc/api/diagnostics_channel.md`
```js
const dc = require('diagnostics_channel');

const channel = dc.channel('test');

channel.subscribe((data) => {
  throw new dc.DCInterruptError('Subscriber Interruption');
});

try {
  channel.publish({ foo: 'bar' });
} catch (err) {
  // DCInterruptError: Subscriber Interruption
}
```

Here is an alternative approach to the public API addition (courtesy of @Qard), that I could implement instead, if requested:
```js
/////////////////////////////
// diagnostics_channel.js
// export an `interrupt` function that adds a symbol to a provided error object
const SymbolInterrupt = Symbol('DCInterrupt');

module.exports.interrupt = function interrupt (err) {
  err[SymbolInterrupt] = true;
  return err;
};

////////////////////////////
// app.js
channel.subscribe((data) => {
  throw dc.interrupt(new Error('Subscriber Interruption'));
});

////////////////////////////
// diagnostics_channel.js:ActiveChannel.publish()
// check if error contains the special symbol
try {
  onMessage(data);
} catch (err) {
  if (err[SymbolInterrupt]) throw err;
  // etc...
}
```

Since the `diagnostics_channel` module is still in experimental status, and early in its ecosystem adoption, I think it's a good idea to iterate on the idea now more than later.