### PR TITLE
node-api: avoid crashing on passed-in null string

### DIFF
--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -1483,7 +1483,8 @@ napi_status napi_create_string_latin1(napi_env env,
                                       size_t length,
                                       napi_value* result) {
   CHECK_ENV(env);
-  CHECK_ARG(env, str);
+  if (length > 0)
+      CHECK_ARG(env, str);
   CHECK_ARG(env, result);
   RETURN_STATUS_IF_FALSE(env,
       (length == NAPI_AUTO_LENGTH) || length <= INT_MAX,
@@ -1506,7 +1507,8 @@ napi_status napi_create_string_utf8(napi_env env,
                                     size_t length,
                                     napi_value* result) {
   CHECK_ENV(env);
-  CHECK_ARG(env, str);
+  if (length > 0)
+      CHECK_ARG(env, str);
   CHECK_ARG(env, result);
   RETURN_STATUS_IF_FALSE(env,
       (length == NAPI_AUTO_LENGTH) || length <= INT_MAX,
@@ -1528,7 +1530,8 @@ napi_status napi_create_string_utf16(napi_env env,
                                      size_t length,
                                      napi_value* result) {
   CHECK_ENV(env);
-  CHECK_ARG(env, str);
+  if (length > 0)
+      CHECK_ARG(env, str);
   CHECK_ARG(env, result);
   RETURN_STATUS_IF_FALSE(env,
       (length == NAPI_AUTO_LENGTH) || length <= INT_MAX,

--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -1483,6 +1483,7 @@ napi_status napi_create_string_latin1(napi_env env,
                                       size_t length,
                                       napi_value* result) {
   CHECK_ENV(env);
+  CHECK_ARG(env, str);
   CHECK_ARG(env, result);
   RETURN_STATUS_IF_FALSE(env,
       (length == NAPI_AUTO_LENGTH) || length <= INT_MAX,
@@ -1505,6 +1506,7 @@ napi_status napi_create_string_utf8(napi_env env,
                                     size_t length,
                                     napi_value* result) {
   CHECK_ENV(env);
+  CHECK_ARG(env, str);
   CHECK_ARG(env, result);
   RETURN_STATUS_IF_FALSE(env,
       (length == NAPI_AUTO_LENGTH) || length <= INT_MAX,
@@ -1526,6 +1528,7 @@ napi_status napi_create_string_utf16(napi_env env,
                                      size_t length,
                                      napi_value* result) {
   CHECK_ENV(env);
+  CHECK_ARG(env, str);
   CHECK_ARG(env, result);
   RETURN_STATUS_IF_FALSE(env,
       (length == NAPI_AUTO_LENGTH) || length <= INT_MAX,

--- a/test/js-native-api/test_string/binding.gyp
+++ b/test/js-native-api/test_string/binding.gyp
@@ -4,7 +4,9 @@
       "target_name": "test_string",
       "sources": [
         "../entry_point.c",
-        "test_string.c"
+        "test_string.c",
+        "test_null.c",
+        "../common.c",
       ]
     }
   ]

--- a/test/js-native-api/test_string/test_null.c
+++ b/test/js-native-api/test_string/test_null.c
@@ -20,7 +20,10 @@
                                                      &result));           \
                                                                           \
     napi_create_string_##charset(env, NULL, NAPI_AUTO_LENGTH, &result);   \
-    add_last_status(env, "stringIsNull", return_value);                   \
+    add_last_status(env, "stringIsNullNonZeroLength", return_value);      \
+                                                                          \
+    napi_create_string_##charset(env, NULL, 0, &result);                  \
+    add_last_status(env, "stringIsNullZeroLength", return_value);         \
                                                                           \
     napi_create_string_##charset(env, (str_arg), NAPI_AUTO_LENGTH, NULL); \
     add_last_status(env, "resultIsNull", return_value);                   \

--- a/test/js-native-api/test_string/test_null.c
+++ b/test/js-native-api/test_string/test_null.c
@@ -1,0 +1,68 @@
+#include <js_native_api.h>
+
+#include "../common.h"
+#include "test_null.h"
+
+#define DECLARE_TEST(charset, str_arg)                                    \
+  static napi_value                                                       \
+  test_create_##charset(napi_env env, napi_callback_info info) {          \
+    napi_value return_value, result;                                      \
+    NODE_API_CALL(env, napi_create_object(env, &return_value));           \
+                                                                          \
+    add_returned_status(env,                                              \
+                        "envIsNull",                                      \
+                        return_value,                                     \
+                        "Invalid argument",                               \
+                        napi_invalid_arg,                                 \
+                        napi_create_string_##charset(NULL,                \
+                                                     (str_arg),           \
+                                                     NAPI_AUTO_LENGTH,    \
+                                                     &result));           \
+                                                                          \
+    napi_create_string_##charset(env, NULL, NAPI_AUTO_LENGTH, &result);   \
+    add_last_status(env, "stringIsNull", return_value);                   \
+                                                                          \
+    napi_create_string_##charset(env, (str_arg), NAPI_AUTO_LENGTH, NULL); \
+    add_last_status(env, "resultIsNull", return_value);                   \
+                                                                          \
+    return return_value;                                                  \
+  }
+
+static const char16_t something[] = {
+  (char16_t)'s',
+  (char16_t)'o',
+  (char16_t)'m',
+  (char16_t)'e',
+  (char16_t)'t',
+  (char16_t)'h',
+  (char16_t)'i',
+  (char16_t)'n',
+  (char16_t)'g',
+  (char16_t)'\0'
+};
+
+DECLARE_TEST(utf8, "something")
+DECLARE_TEST(latin1, "something")
+DECLARE_TEST(utf16, something)
+
+void init_test_null(napi_env env, napi_value exports) {
+  napi_value test_null;
+
+  const napi_property_descriptor test_null_props[] = {
+    DECLARE_NODE_API_PROPERTY("test_create_utf8", test_create_utf8),
+    DECLARE_NODE_API_PROPERTY("test_create_latin1", test_create_latin1),
+    DECLARE_NODE_API_PROPERTY("test_create_utf16", test_create_utf16),
+  };
+
+  NODE_API_CALL_RETURN_VOID(env, napi_create_object(env, &test_null));
+  NODE_API_CALL_RETURN_VOID(env, napi_define_properties(
+      env, test_null, sizeof(test_null_props) / sizeof(*test_null_props),
+      test_null_props));
+
+  const napi_property_descriptor test_null_set = {
+    "testNull", NULL, NULL, NULL, NULL, test_null, napi_enumerable, NULL
+  };
+
+  NODE_API_CALL_RETURN_VOID(env,
+      napi_define_properties(env, exports, 1, &test_null_set));
+}

--- a/test/js-native-api/test_string/test_null.h
+++ b/test/js-native-api/test_string/test_null.h
@@ -1,0 +1,8 @@
+#ifndef TEST_JS_NATIVE_API_TEST_STRING_TEST_NULL_H_
+#define TEST_JS_NATIVE_API_TEST_STRING_TEST_NULL_H_
+
+#include <js_native_api.h>
+
+void init_test_null(napi_env env, napi_value exports);
+
+#endif  // TEST_JS_NATIVE_API_TEST_STRING_TEST_NULL_H_

--- a/test/js-native-api/test_string/test_null.js
+++ b/test/js-native-api/test_string/test_null.js
@@ -1,0 +1,16 @@
+'use strict';
+const common = require('../../common');
+const assert = require('assert');
+
+// Test passing NULL to object-related N-APIs.
+const { testNull } = require(`./build/${common.buildType}/test_string`);
+
+const expectedResult = {
+  envIsNull: 'Invalid argument',
+  stringIsNull: 'Invalid argument',
+  resultIsNull: 'Invalid argument',
+};
+
+assert.deepStrictEqual(expectedResult, testNull.test_create_latin1());
+assert.deepStrictEqual(expectedResult, testNull.test_create_utf8());
+assert.deepStrictEqual(expectedResult, testNull.test_create_utf16());

--- a/test/js-native-api/test_string/test_null.js
+++ b/test/js-native-api/test_string/test_null.js
@@ -7,7 +7,8 @@ const { testNull } = require(`./build/${common.buildType}/test_string`);
 
 const expectedResult = {
   envIsNull: 'Invalid argument',
-  stringIsNull: 'Invalid argument',
+  stringIsNullNonZeroLength: 'Invalid argument',
+  stringIsNullZeroLength: 'napi_ok',
   resultIsNull: 'Invalid argument',
 };
 

--- a/test/js-native-api/test_string/test_string.c
+++ b/test/js-native-api/test_string/test_string.c
@@ -2,6 +2,7 @@
 #include <string.h>
 #include <js_native_api.h>
 #include "../common.h"
+#include "test_null.h"
 
 static napi_value TestLatin1(napi_env env, napi_callback_info info) {
   size_t argc = 1;
@@ -282,6 +283,8 @@ napi_value Init(napi_env env, napi_value exports) {
     DECLARE_NODE_API_PROPERTY("TestLargeUtf16", TestLargeUtf16),
     DECLARE_NODE_API_PROPERTY("TestMemoryCorruption", TestMemoryCorruption),
   };
+
+  init_test_null(env, exports);
 
   NODE_API_CALL(env, napi_define_properties(
       env, exports, sizeof(properties) / sizeof(*properties), properties));


### PR DESCRIPTION
When `napi_create_string_*` receives a null pointer as its second
argument, it must null-check it before passing it into V8, otherwise a
crash will occur.

Signed-off-by: @gabrielschulhof

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
