### PR TITLE
crypto: fix label cast in EVP_PKEY_CTX_set0_rsa_oaep_label

### DIFF
--- a/src/crypto/crypto_cipher.cc
+++ b/src/crypto/crypto_cipher.cc
@@ -906,7 +906,7 @@ bool PublicKeyCipher::Cipher(
     void* label = OPENSSL_memdup(oaep_label.data(), oaep_label.size());
     CHECK_NOT_NULL(label);
     if (0 >= EVP_PKEY_CTX_set0_rsa_oaep_label(ctx.get(),
-                reinterpret_cast<unsigned char*>(label),
+                     static_cast<unsigned char*>(label),
                                       oaep_label.size())) {
       OPENSSL_free(label);
       return false;

--- a/src/crypto/crypto_rsa.cc
+++ b/src/crypto/crypto_rsa.cc
@@ -210,7 +210,10 @@ WebCryptoCipherStatus RSA_Cipher(
   if (label_len > 0) {
     void* label = OPENSSL_memdup(params.label.get(), label_len);
     CHECK_NOT_NULL(label);
-    if (EVP_PKEY_CTX_set0_rsa_oaep_label(ctx.get(), label, label_len) <= 0) {
+    if (EVP_PKEY_CTX_set0_rsa_oaep_label(
+      ctx.get(),
+      static_cast<unsigned char*>(label),
+      label_len) <= 0) {
       OPENSSL_free(label);
       return WebCryptoCipherStatus::FAILED;
     }


### PR DESCRIPTION
Corrects cast for `label` as passed to `EVP_PKEY_CTX_set0_rsa_oaep_label`

This has already been done [here](https://github.com/nodejs/node/blob/fa7cdd6fc9dffa8139f9350f54959b01bf7a1151/src/crypto/crypto_cipher.cc#L908-L913) and causes BoringSSL failures if not cast from `void*`.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
