### PR TITLE
child_process: refactor to use `validateBoolean`

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -75,6 +75,7 @@ const { getValidatedPath } = require('internal/fs/utils');
 const {
   isInt32,
   validateAbortSignal,
+  validateBoolean,
   validateObject,
   validateString,
 } = require('internal/validators');
@@ -459,10 +460,8 @@ function normalizeSpawnArguments(file, args, options) {
   }
 
   // Validate detached, if present.
-  if (options.detached != null &&
-      typeof options.detached !== 'boolean') {
-    throw new ERR_INVALID_ARG_TYPE('options.detached',
-                                   'boolean', options.detached);
+  if (options.detached != null) {
+    validateBoolean(options.detached, 'options.detached');
   }
 
   // Validate the uid, if present.
@@ -489,19 +488,15 @@ function normalizeSpawnArguments(file, args, options) {
   }
 
   // Validate windowsHide, if present.
-  if (options.windowsHide != null &&
-      typeof options.windowsHide !== 'boolean') {
-    throw new ERR_INVALID_ARG_TYPE('options.windowsHide',
-                                   'boolean', options.windowsHide);
+  if (options.windowsHide != null) {
+    validateBoolean(options.windowsHide, 'options.windowsHide');
   }
 
   // Validate windowsVerbatimArguments, if present.
   let { windowsVerbatimArguments } = options;
-  if (windowsVerbatimArguments != null &&
-      typeof windowsVerbatimArguments !== 'boolean') {
-    throw new ERR_INVALID_ARG_TYPE('options.windowsVerbatimArguments',
-                                   'boolean',
-                                   windowsVerbatimArguments);
+  if (windowsVerbatimArguments != null) {
+    validateBoolean(windowsVerbatimArguments,
+                    'options.windowsVerbatimArguments');
   }
 
   if (options.shell) {


### PR DESCRIPTION
Refactor to use `validateBoolean` in `internal/validators` to validate Boolean options