### PR TITLE
build: apply workaround for msbuild 16.10.0 only

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -336,7 +336,7 @@ if "%target%"=="Build" (
 if "%target%"=="node" if exist "%config%\cctest.exe" del "%config%\cctest.exe"
 @rem Workaround bug in MSBuild 16.10.0. (https://github.com/dotnet/msbuild/pull/6465)
 for /F %%V in ('msbuild -version -nologo') do set msbuild_ver=%%V
-if "%msbuild_ver:~0,8%"=="16.10.0." (
+if "%msbuild_ver:~0,7%"=="16.10.0" (
   if "%target%"=="node" set target="Build"
 )
 if defined msbuild_args set "extra_msbuild_args=%extra_msbuild_args% %msbuild_args%"

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -334,8 +334,11 @@ if "%target%"=="Build" (
   if defined cctest set target="Build"
 )
 if "%target%"=="node" if exist "%config%\cctest.exe" del "%config%\cctest.exe"
-@rem TODO(targos): Remove next line after MSBuild 16.10.1 is released.
-if "%target%"=="node" set target="Build"
+@rem Workaround bug in MSBuild 16.10.0. (https://github.com/dotnet/msbuild/pull/6465)
+for /F %%V in ('msbuild -version -nologo') do set msbuild_ver=%%V
+if "%msbuild_ver:~0,8%"=="16.10.0." (
+  if "%target%"=="node" set target="Build"
+)
 if defined msbuild_args set "extra_msbuild_args=%extra_msbuild_args% %msbuild_args%"
 @rem Setup env variables to use multiprocessor build
 set UseMultiToolTask=True


### PR DESCRIPTION
Only apply the msbuild target workaround for msbuild 16.10.0 only as
that is the version containing the regression and the workaround will
still be needed if building with that version even when a newer version
of msbuild is available.

Refs: https://github.com/dotnet/msbuild/pull/6465
Refs: https://github.com/nodejs/node/issues/38872
Refs: https://github.com/nodejs/node/pull/38873

cc @targos @nodejs/platform-windows 
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
