### PR TITLE
vm: use missing validator

### DIFF
--- a/lib/vm.js
+++ b/lib/vm.js
@@ -206,7 +206,7 @@ function getContextOptions(options) {
 }
 
 function isContext(object) {
-  validateObject(object, 'object');
+  validateObject(object, 'object', { allowArray: true });
 
   return _isContext(object);
 }

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -206,9 +206,8 @@ function getContextOptions(options) {
 }
 
 function isContext(object) {
-  if (typeof object !== 'object' || object === null) {
-    throw new ERR_INVALID_ARG_TYPE('object', 'Object', object);
-  }
+  validateObject(object, 'object');
+
   return _isContext(object);
 }
 


### PR DESCRIPTION
The `vm` lib module's `isContext()` function should use a validator.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
