### PR TITLE
debugger: reduce scope of eslint disable comment

### DIFF
--- a/lib/internal/inspector/_inspect.js
+++ b/lib/internal/inspector/_inspect.js
@@ -20,9 +20,6 @@
  * IN THE SOFTWARE.
  */
 
-// TODO(aduh95): remove restricted syntax errors
-/* eslint-disable no-restricted-syntax */
-
 'use strict';
 
 const {
@@ -53,8 +50,8 @@ const { EventEmitter } = require('events');
 const net = require('net');
 const util = require('util');
 const {
-  setInterval,
-  setTimeout,
+  setInterval: pSetInterval,
+  setTimeout: pSetTimeout,
 } = require('timers/promises');
 const {
   AbortController,
@@ -85,13 +82,13 @@ async function portIsFree(host, port, timeout = 9999) {
   const ac = new AbortController();
   const { signal } = ac;
 
-  setTimeout(timeout).then(() => ac.abort());
+  pSetTimeout(timeout).then(() => ac.abort());
 
-  const asyncIterator = setInterval(retryDelay);
+  const asyncIterator = pSetInterval(retryDelay);
   while (true) {
     await asyncIterator.next();
     if (signal.aborted) {
-      throw new StartupError(
+      throw new StartupError( // eslint-disable-line no-restricted-syntax
         `Timeout (${timeout}) waiting for ${host}:${port} to be free`);
     }
     const error = await new Promise((resolve) => {
@@ -251,7 +248,7 @@ class NodeInspector {
         return;
       } catch (error) {
         debuglog('connect failed', error);
-        await setTimeout(1000);
+        await pSetTimeout(1000);
       }
     }
     this.stdout.write(' failed to connect, please retry\n');


### PR DESCRIPTION
Current code masks setInterval and setTimeout with promisified versions.
This can be confusing to read and causes lint errors. Replace masking
with use of pSetInterval and pSetTimeout instead.

Move disabling of lint rule from entire file to the one remaining line
(after the above changes) that still needs it.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
