### PR TITLE
typings: add a few JSDoc typings for child_process

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -92,6 +92,8 @@ const MAX_BUFFER = 1024 * 1024;
  * Spawns a new Node.js insatnce
  * using the execPath of the parent process
  * @param {string} modulePath
+ * @param {string[]} args
+ * @param {Object} options
  * @returns {ChildProcess}
  */
 
@@ -217,6 +219,9 @@ ObjectDefineProperty(exec, promisify.custom, {
  * Spawns the new specified excutable file
  * as a new process
  * @param {string} file
+ * @param {string[]} args
+ * @param {Object} options
+ * @param {Function} callback
  * @returns {ChildProcess}
  */
 

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -88,6 +88,13 @@ const {
 
 const MAX_BUFFER = 1024 * 1024;
 
+/**
+ * Spawns a new Node.js insatnce
+ * using the execPath of the parent process
+ * @param {string} modulePath
+ * @returns {ChildProcess}
+ */
+
 function fork(modulePath /* , args, options */) {
   validateString(modulePath, 'modulePath');
 
@@ -205,6 +212,13 @@ ObjectDefineProperty(exec, promisify.custom, {
   enumerable: false,
   value: customPromiseExecFunction(exec)
 });
+
+/**
+ * Spawns the new specified excutable file
+ * as a new process
+ * @param {string} file
+ * @returns {ChildProcess}
+ */
 
 function execFile(file /* , args, options, callback */) {
   let args = [];


### PR DESCRIPTION
Added a few JSDoc typings for the `child_process` lib module.