### PR TITLE
doc: remove `--experimental-abortcontroller` documentation

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1544,6 +1544,7 @@ Node.js options that are allowed are:
 * `--dns-result-order`
 * `--enable-fips`
 * `--enable-source-maps`
+* `--experimental-abortcontroller`
 * `--experimental-import-meta-resolve`
 * `--experimental-json-modules`
 * `--experimental-loader`

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -253,21 +253,6 @@ effort to report stack traces relative to the original source file.
 Overriding `Error.prepareStackTrace` prevents `--enable-source-maps` from
 modifying the stack trace.
 
-### `--experimental-abortcontroller`
-
-<!-- YAML
-added:
-  - v15.0.0
-  - v14.17.0
-changes:
-  - version: v15.0.0
-    pr-url: https://github.com/nodejs/node/pull/33527
-    description: --experimental-abortcontroller is no longer required.
--->
-
-`AbortController` and `AbortSignal` support is enabled by default.
-Use of this command-line flag is no longer required.
-
 ### `--experimental-import-meta-resolve`
 
 <!-- YAML
@@ -1559,7 +1544,6 @@ Node.js options that are allowed are:
 * `--dns-result-order`
 * `--enable-fips`
 * `--enable-source-maps`
-* `--experimental-abortcontroller`
 * `--experimental-import-meta-resolve`
 * `--experimental-json-modules`
 * `--experimental-loader`

--- a/test/parallel/test-process-env-allowed-flags-are-documented.js
+++ b/test/parallel/test-process-env-allowed-flags-are-documented.js
@@ -104,7 +104,6 @@ assert(undocumented.delete('--no-node-snapshot'));
 assert(undocumented.delete('--loader'));
 assert(undocumented.delete('--verify-base-objects'));
 assert(undocumented.delete('--no-verify-base-objects'));
-assert(undocumented.delete('--experimental-abortcontroller'));
 
 // Remove negated versions of the flags.
 for (const flag of undocumented) {

--- a/test/parallel/test-process-env-allowed-flags-are-documented.js
+++ b/test/parallel/test-process-env-allowed-flags-are-documented.js
@@ -104,6 +104,7 @@ assert(undocumented.delete('--no-node-snapshot'));
 assert(undocumented.delete('--loader'));
 assert(undocumented.delete('--verify-base-objects'));
 assert(undocumented.delete('--no-verify-base-objects'));
+assert(undocumented.delete('--experimental-abortcontroller'));
 
 // Remove negated versions of the flags.
 for (const flag of undocumented) {


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

According to the  [docs](https://nodejs.org/dist/latest-v16.x/docs/api/cli.html#cli_experimental_abortcontroller). 

AbortController and AbortSignal support is enabled by default. So I think we should delete this option.