### PR TITLE
repl: use ObjectDefineProperties

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -68,6 +68,7 @@ const {
   ObjectAssign,
   ObjectCreate,
   ObjectDefineProperty,
+  ObjectDefineProperties,
   ObjectGetOwnPropertyDescriptor,
   ObjectGetOwnPropertyNames,
   ObjectGetPrototypeOf,
@@ -279,37 +280,39 @@ function REPLServer(prompt,
   const preview = options.terminal &&
     (options.preview !== undefined ? !!options.preview : !eval_);
 
-  ObjectDefineProperty(this, 'inputStream', {
-    get: pendingDeprecation ?
-      deprecate(() => this.input,
-                'repl.inputStream and repl.outputStream are deprecated. ' +
+  ObjectDefineProperties(this, {
+    inputStream: {
+      get: pendingDeprecation ?
+        deprecate(() => this.input,
+                  'repl.inputStream and repl.outputStream are deprecated. ' +
                   'Use repl.input and repl.output instead',
-                'DEP0141') :
-      () => this.input,
-    set: pendingDeprecation ?
-      deprecate((val) => this.input = val,
-                'repl.inputStream and repl.outputStream are deprecated. ' +
+                  'DEP0141') :
+        () => this.input,
+      set: pendingDeprecation ?
+        deprecate((val) => this.input = val,
+                  'repl.inputStream and repl.outputStream are deprecated. ' +
                   'Use repl.input and repl.output instead',
-                'DEP0141') :
-      (val) => this.input = val,
-    enumerable: false,
-    configurable: true
-  });
-  ObjectDefineProperty(this, 'outputStream', {
-    get: pendingDeprecation ?
-      deprecate(() => this.output,
-                'repl.inputStream and repl.outputStream are deprecated. ' +
+                  'DEP0141') :
+        (val) => this.input = val,
+      enumerable: false,
+      configurable: true
+    },
+    outputStream: {
+      get: pendingDeprecation ?
+        deprecate(() => this.output,
+                  'repl.inputStream and repl.outputStream are deprecated. ' +
                   'Use repl.input and repl.output instead',
-                'DEP0141') :
-      () => this.output,
-    set: pendingDeprecation ?
-      deprecate((val) => this.output = val,
-                'repl.inputStream and repl.outputStream are deprecated. ' +
+                  'DEP0141') :
+        () => this.output,
+      set: pendingDeprecation ?
+        deprecate((val) => this.output = val,
+                  'repl.inputStream and repl.outputStream are deprecated. ' +
                   'Use repl.input and repl.output instead',
-                'DEP0141') :
-      (val) => this.output = val,
-    enumerable: false,
-    configurable: true
+                  'DEP0141') :
+        (val) => this.output = val,
+      enumerable: false,
+      configurable: true
+    }
   });
 
   this.allowBlockingCompletions = !!options.allowBlockingCompletions;


### PR DESCRIPTION
Usage of the `ObjectDefineProperties` (`Object.defineProperties()`) method is better here since multiple properties are defined than just one.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
