### PR TITLE
stream: add collect method

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -2045,6 +2045,15 @@ finished.
 
 An attempt was made to call [`stream.pipe()`][] on a [`Writable`][] stream.
 
+<a id="ERR_STREAM_COLLECT_LIMIT_EXCEEDED"></a>
+### `ERR_STREAM_COLLECT_LIMIT_EXCEEDED`
+<!-- YAML
+added: REPLACEME
+-->
+
+The stream on which [`readable.collect()`][] was called emitted more data than
+the given limit.
+
 <a id="ERR_STREAM_DESTROYED"></a>
 ### `ERR_STREAM_DESTROYED`
 
@@ -2813,6 +2822,7 @@ The native call from `process.cpuUsage` could not be processed.
 [`process.send()`]: process.md#process_process_send_message_sendhandle_options_callback
 [`process.setUncaughtExceptionCaptureCallback()`]: process.md#process_process_setuncaughtexceptioncapturecallback_fn
 [`readable._read()`]: stream.md#stream_readable_read_size_1
+[`readable.collect()`]: stream.md#stream_readable_collect_limit
 [`require('crypto').setEngine()`]: crypto.md#crypto_crypto_setengine_engine_flags
 [`require()`]: modules.md#modules_require_id
 [`server.close()`]: net.md#net_server_close_callback

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -987,6 +987,22 @@ added: v0.9.4
 The `'resume'` event is emitted when [`stream.resume()`][stream-resume] is
 called and `readableFlowing` is not `true`.
 
+#### `readable.collect([limit])`
+<!-- YAML
+added: REPLACEME
+-->
+
+* `limit` {Number} maximum number of bytes to collect. In object streams, this
+  is the maximum number of items to collect. **Default:** Infinity.
+* Returns: {Promise} Fulfills with all the data from the stream, in the form of:
+  * If `readable` is a `Buffer` stream with encoding set, then a string.
+  * If `readable` is a `Buffer` stream with encoding unset, then a `Buffer`.
+  * If `readable` is an object mode stream, then an `Array` of objects.
+
+Reads the stream to its `'end'`, collecting all the data in order.
+
+If the `limit` is reached, the promise is rejected with an error.
+
 ##### `readable.destroy([error])`
 <!-- YAML
 added: v8.0.0

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -992,7 +992,7 @@ called and `readableFlowing` is not `true`.
 added: REPLACEME
 -->
 
-* `limit` {Number} maximum number of bytes to collect. In object streams, this
+* `limit` {number} maximum number of bytes to collect. In object streams, this
   is the maximum number of items to collect. **Default:** Infinity.
 * Returns: {Promise} Fulfills with all the data from the stream, in the form of:
   * If `readable` is a `Buffer` stream with encoding set, then a string.

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -992,8 +992,11 @@ called and `readableFlowing` is not `true`.
 added: REPLACEME
 -->
 
-* `limit` {number} maximum number of bytes to collect. In object streams, this
-  is the maximum number of items to collect. **Default:** Infinity.
+* `options` {Object} Collect options
+  * `limit` {number} maximum number of bytes to collect. In object streams, this
+    is the maximum number of items to collect. **Default:** Infinity.
+  * `rejectAtLimit` {boolean} Whether to reject the promise if the limit is
+    reached.
 * Returns: {Promise} Fulfills with all the data from the stream, in the form of:
   * If `readable` is a `Buffer` stream with encoding set, then a string.
   * If `readable` is a `Buffer` stream with encoding unset, then a `Buffer`.
@@ -1001,7 +1004,16 @@ added: REPLACEME
 
 Reads the stream to its `'end'`, collecting all the data in order.
 
-If the `limit` is reached, the promise is rejected with an error.
+If `rejectAtLimit` is true and the limit is reached, then the promise is
+rejected and the stream is destroyed.
+
+If `rejectAtLimit` is true and the limit is reached, then the promise will
+resolve with all the data up to (but not including) the chunk that would put the
+result over the limit. In this case, stream will not be destroyed and the
+remaining data can still be read from it.
+
+The stream will always be destroyed if it emits an error, which will be
+propagated as a rejection.
 
 ##### `readable.destroy([error])`
 <!-- YAML

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1444,6 +1444,8 @@ E('ERR_STREAM_ALREADY_FINISHED',
   'Cannot call %s after a stream was finished',
   Error);
 E('ERR_STREAM_CANNOT_PIPE', 'Cannot pipe, not readable', Error);
+E('ERR_STREAM_COLLECT_LIMIT_EXCEEDED', 'Stream data length %s is beyond limit %s',
+  RangeError);
 E('ERR_STREAM_DESTROYED', 'Cannot call %s after a stream was destroyed', Error);
 E('ERR_STREAM_NULL_VALUES', 'May not write null values to stream', TypeError);
 E('ERR_STREAM_PREMATURE_CLOSE', 'Premature close', Error);

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1444,7 +1444,8 @@ E('ERR_STREAM_ALREADY_FINISHED',
   'Cannot call %s after a stream was finished',
   Error);
 E('ERR_STREAM_CANNOT_PIPE', 'Cannot pipe, not readable', Error);
-E('ERR_STREAM_COLLECT_LIMIT_EXCEEDED', 'Stream data length %s is beyond limit %s',
+E('ERR_STREAM_COLLECT_LIMIT_EXCEEDED',
+  'Stream data length %s is beyond limit %s',
   RangeError);
 E('ERR_STREAM_DESTROYED', 'Cannot call %s after a stream was destroyed', Error);
 E('ERR_STREAM_NULL_VALUES', 'May not write null values to stream', TypeError);

--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -1058,15 +1058,23 @@ Readable.prototype.wrap = function(stream) {
   return this;
 };
 
-Readable.prototype.collect = async function(limit = Infinity) {
+Readable.prototype.collect = async function({
+  limit = Infinity,
+  rejectAtLimit = true
+} = {}) {
   const bufs = [];
   let len = 0;
   const isObjectMode = this._readableState.objectMode;
   const encoding = isObjectMode ? false : this._readableState.encoding;
-  for await (const chunk of this) {
+  for await (const chunk of this.iterator({ destroyOnReturn: rejectAtLimit })) {
     const chunkLen = isObjectMode ? 1 : chunk.length;
     if (len + chunkLen > limit) {
-      throw new ERR_STREAM_COLLECT_LIMIT_EXCEEDED(len + chunk.length, limit);
+      if (rejectAtLimit) {
+        throw new ERR_STREAM_COLLECT_LIMIT_EXCEEDED(len + chunk.length, limit);
+      } else {
+        this.unshift(chunk);
+        break;
+      }
     }
     len += chunkLen;
     bufs.push(chunk);

--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -58,6 +58,7 @@ const {
 
 const {
   ERR_INVALID_ARG_TYPE,
+  ERR_STREAM_COLLECT_LIMIT_EXCEEDED,
   ERR_STREAM_PUSH_AFTER_EOF,
   ERR_METHOD_NOT_IMPLEMENTED,
   ERR_STREAM_UNSHIFT_AFTER_END_EVENT
@@ -1055,6 +1056,22 @@ Readable.prototype.wrap = function(stream) {
   }
 
   return this;
+};
+
+Readable.prototype.collect = async function(limit = Infinity) {
+  const bufs = [];
+  let len = 0;
+  const isObjectMode = this._readableState.objectMode;
+  const encoding = isObjectMode ? false : this._readableState.encoding;
+  for await (const chunk of this) {
+    const chunkLen = isObjectMode ? 1 : chunk.length;
+    if (len + chunkLen > limit) {
+      throw new ERR_STREAM_COLLECT_LIMIT_EXCEEDED(len + chunk.length, limit);
+    }
+    len += chunkLen;
+    bufs.push(chunk);
+  }
+  return isObjectMode ? bufs : encoding ? bufs.join('') : Buffer.concat(bufs);
 };
 
 Readable.prototype[SymbolAsyncIterator] = function() {

--- a/test/parallel/test-stream-readable-collect.js
+++ b/test/parallel/test-stream-readable-collect.js
@@ -9,7 +9,7 @@ const hello = Buffer.from('hello, ');
 const world = Buffer.from('world');
 
 async function tests() {
-  { // buffer, no limit
+  { // Buffer, no limit
     const r = new Readable();
 
     r.push(hello);
@@ -21,17 +21,18 @@ async function tests() {
     assert.strictEqual(result.compare(Buffer.from('hello, world')), 0);
   }
 
-  { // buffer, under limit
+  { // Buffer, under limit
     const r = new Readable();
 
     r.push(hello);
     r.push(world);
     r.push(null);
 
-    await assert.doesNotReject(r.collect(50));
+    // Does not reject
+    await r.collect(50);
   }
 
-  { // buffer, over limit
+  { // Buffer, over limit
     const r = new Readable();
     r.push(hello);
     r.push(world);
@@ -42,7 +43,7 @@ async function tests() {
     });
   }
 
-  { // buffer, setEncoding, no limit
+  { // Buffer, setEncoding, no limit
     const r = new Readable();
 
     r.setEncoding('utf8');
@@ -56,7 +57,7 @@ async function tests() {
     assert.strictEqual(result, 'hello, world');
   }
 
-  { // buffer, setEncoding, under limit
+  { // Buffer, setEncoding, under limit
     const r = new Readable();
 
     r.setEncoding('utf8');
@@ -65,10 +66,11 @@ async function tests() {
     r.push(world);
     r.push(null);
 
-    await assert.doesNotReject(r.collect(50));
+    // Does not reject
+    await r.collect(50);
   }
 
-  { // buffer, setEncoding, over limit
+  { // Buffer, setEncoding, over limit
     const r = new Readable();
 
     r.setEncoding('utf8');
@@ -82,7 +84,7 @@ async function tests() {
     });
   }
 
-  { // object, no limit
+  { // Object, no limit
     const r = new Readable({ objectMode: true });
 
     const objs = [{ n: 0 }, { n: 1 }];
@@ -96,7 +98,7 @@ async function tests() {
     assert.deepStrictEqual(result, objs);
   }
 
-  { // object, under limit
+  { // Object, under limit
     const r = new Readable({ objectMode: true });
 
     const objs = [{ n: 0 }, { n: 1 }];
@@ -105,10 +107,11 @@ async function tests() {
     r.push(objs[1]);
     r.push(null);
 
-    assert.doesNotReject(r.collect(5));
+    // Does not reject
+    await r.collect(5);
   }
 
-  { // object, over limit
+  { // Object, over limit
     const r = new Readable({ objectMode: true });
 
     const objs = [{ n: 0 }, { n: 1 }, { n: 2 }];

--- a/test/parallel/test-stream-readable-collect.js
+++ b/test/parallel/test-stream-readable-collect.js
@@ -38,9 +38,25 @@ async function tests() {
     r.push(world);
     r.push(null);
 
-    await assert.rejects(r.collect(6), {
+    await assert.rejects(r.collect({ limit: 10 }), {
       code: 'ERR_STREAM_COLLECT_LIMIT_EXCEEDED',
     });
+    assert.ok(r.destroyed);
+  }
+
+  { // Buffer, over limit, rejectAtLimit: false
+    const streamContents = [hello, world];
+    const r = new Readable({
+      read() {
+        this.push(streamContents.shift() || null);
+      }
+    });
+
+    assert.deepStrictEqual(
+      await r.collect({ limit: 10, rejectAtLimit: false }),
+      hello
+    );
+    assert.deepStrictEqual(await r.collect(), world);
   }
 
   { // Buffer, setEncoding, no limit
@@ -67,7 +83,7 @@ async function tests() {
     r.push(null);
 
     // Does not reject
-    await r.collect(50);
+    await r.collect({ limit: 50 });
   }
 
   { // Buffer, setEncoding, over limit
@@ -79,9 +95,26 @@ async function tests() {
     r.push(world);
     r.push(null);
 
-    await assert.rejects(r.collect(6), {
-      code: 'ERR_STREAM_COLLECT_LIMIT_EXCEEDED',
+    await assert.rejects(r.collect({ limit: 10 }), {
+      code: 'ERR_STREAM_COLLECT_LIMIT_EXCEEDED'
     });
+    assert.ok(r.destroyed);
+  }
+
+  { // Buffer, setEncoding, over limit, rejectAtLimit: false
+    const streamContents = [hello, world];
+    const r = new Readable({
+      read() {
+        this.push(streamContents.shift() || null);
+      }
+    });
+    r.setEncoding('utf8');
+
+    assert.deepStrictEqual(
+      await r.collect({ limit: 10, rejectAtLimit: false }),
+      'hello, '
+    );
+    assert.deepStrictEqual(await r.collect(), 'world');
   }
 
   { // Object, no limit
@@ -108,7 +141,7 @@ async function tests() {
     r.push(null);
 
     // Does not reject
-    await r.collect(5);
+    await r.collect({ limit: 5 });
   }
 
   { // Object, over limit
@@ -121,9 +154,43 @@ async function tests() {
     r.push(objs[2]);
     r.push(null);
 
-    await assert.rejects(r.collect(2), {
-      code: 'ERR_STREAM_COLLECT_LIMIT_EXCEEDED',
+    await assert.rejects(r.collect({ limit: 2 }), {
+      code: 'ERR_STREAM_COLLECT_LIMIT_EXCEEDED'
     });
+    assert.ok(r.destroyed);
+  }
+
+  { // Object, over limit, rejectAtLimit: false
+    const r = new Readable({ objectMode: true });
+
+    const objs = [{ n: 0 }, { n: 1 }, { n: 2 }];
+
+    r.push(objs[0]);
+    r.push(objs[1]);
+    r.push(objs[2]);
+    r.push(null);
+
+    assert.deepStrictEqual(
+      await r.collect({ limit: 2, rejectAtLimit: false }),
+      [{ n: 0 }, { n: 1 }]
+    );
+    assert.deepStrictEqual(await r.collect(), [{ n: 2 }]);
+  }
+
+  { // Stream emits an error
+    const error = new Error();
+    const r = new Readable({
+      read() {
+        this.emit('error', error);
+      }
+    });
+
+    const resultPromise = r.collect();
+
+    r.emit('error', error);
+
+    await assert.rejects(resultPromise, error);
+    assert.ok(r.destroyed);
   }
 }
 

--- a/test/parallel/test-stream-readable-collect.js
+++ b/test/parallel/test-stream-readable-collect.js
@@ -1,0 +1,127 @@
+'use strict';
+
+const common = require('../common');
+
+const { Readable } = require('stream');
+const assert = require('assert');
+
+const hello = Buffer.from('hello, ');
+const world = Buffer.from('world');
+
+async function tests() {
+  { // buffer, no limit
+    const r = new Readable();
+
+    r.push(hello);
+    r.push(world);
+    r.push(null);
+
+    const result = await r.collect();
+
+    assert.strictEqual(result.compare(Buffer.from('hello, world')), 0);
+  }
+
+  { // buffer, under limit
+    const r = new Readable();
+
+    r.push(hello);
+    r.push(world);
+    r.push(null);
+
+    await assert.doesNotReject(r.collect(50));
+  }
+
+  { // buffer, over limit
+    const r = new Readable();
+    r.push(hello);
+    r.push(world);
+    r.push(null);
+
+    await assert.rejects(r.collect(6), {
+      code: 'ERR_STREAM_COLLECT_LIMIT_EXCEEDED',
+    });
+  }
+
+  { // buffer, setEncoding, no limit
+    const r = new Readable();
+
+    r.setEncoding('utf8');
+
+    r.push(hello);
+    r.push(world);
+    r.push(null);
+
+    const result = await r.collect();
+
+    assert.strictEqual(result, 'hello, world');
+  }
+
+  { // buffer, setEncoding, under limit
+    const r = new Readable();
+
+    r.setEncoding('utf8');
+
+    r.push(hello);
+    r.push(world);
+    r.push(null);
+
+    await assert.doesNotReject(r.collect(50));
+  }
+
+  { // buffer, setEncoding, over limit
+    const r = new Readable();
+
+    r.setEncoding('utf8');
+
+    r.push(hello);
+    r.push(world);
+    r.push(null);
+
+    await assert.rejects(r.collect(6), {
+      code: 'ERR_STREAM_COLLECT_LIMIT_EXCEEDED',
+    });
+  }
+
+  { // object, no limit
+    const r = new Readable({ objectMode: true });
+
+    const objs = [{ n: 0 }, { n: 1 }];
+
+    r.push(objs[0]);
+    r.push(objs[1]);
+    r.push(null);
+
+    const result = await r.collect();
+
+    assert.deepStrictEqual(result, objs);
+  }
+
+  { // object, under limit
+    const r = new Readable({ objectMode: true });
+
+    const objs = [{ n: 0 }, { n: 1 }];
+
+    r.push(objs[0]);
+    r.push(objs[1]);
+    r.push(null);
+
+    assert.doesNotReject(r.collect(5));
+  }
+
+  { // object, over limit
+    const r = new Readable({ objectMode: true });
+
+    const objs = [{ n: 0 }, { n: 1 }, { n: 2 }];
+
+    r.push(objs[0]);
+    r.push(objs[1]);
+    r.push(objs[2]);
+    r.push(null);
+
+    await assert.rejects(r.collect(2), {
+      code: 'ERR_STREAM_COLLECT_LIMIT_EXCEEDED',
+    });
+  }
+}
+
+tests().then(common.mustCall());


### PR DESCRIPTION
Returns a promise fulfilling with a sensible representation of the entire stream's data, depending on the stream type.

Buffer streams collect to a single contiguous Buffer. Buffer streams with encoding set collect to a single contiguous string. Object-mode streams collect to an array of objects.

Limiting is allowed, enabling situations like capping request body sizes, or only consuming a limited amount of process.stdin.

Ref: https://github.com/nodejs/node/issues/35192
Ref: https://github.com/nodejs/tooling/issues/68

---

### Rationale

On the web, HTTP response objects have methods like [`arrayBuffer()`](https://developer.mozilla.org/en-US/docs/Web/API/Body/arrayBuffer) and [`text()`](https://developer.mozilla.org/en-US/docs/Web/API/Body/text) to get the full contents of the stream as a single item. In Node.js, tools like the [`body-parser`](https://developer.mozilla.org/en-US/docs/Web/API/Body/text) middleware are often used for server `IncomingMessage` streams, and tools like [`concat-stream`](https://www.npmjs.com/package/concat-stream) are used in other places. It would be remarkably handy for users if such a thing were built-in to the `Readable` prototype.

It's worth mentioning that the [stage 2 iterator helpers proposal](https://github.com/tc39/proposal-iterator-helpers) adds a `toArray()` method which reads an async iterator to completion in a similar way. That being said, in order to get, for example, a string from a readable stream of buffers, you'd still have to do something like

```js
console.log(Buffer.concat(await readable.toArray()).toString('utf8'));
```

wheras this PR enables something more like this

```js
readable.setEncoding('utf8');
console.log(await readable.collect());
```

or

```js
console.log((await readable.collect()).toString());
```

without waiting for that proposal to be implemented in V8.

This enables one-liners as well. Consider the following one-liner to uppercase stdin.

```bash
cat myfile.txt | node -e "(async()=>{const x=[];for await (const c of process.stdin)x.push(c);console.log((''+Buffer.concat(x)).toUpperCase())})()"
```

With this PR, we can shorten this to the following.

```bash
cat myfile.txt | node -e "(async()=>{console.log((''+await process.stdin.collect()).toUpperCase())})()"
```

Why the name? [Rust uses this name for similar functionality](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.collect) and it doesn't appear to clash with the iterator helpers proposal or other methods.

### Potential Alternative

It might make sense to add this as a static method on `Readable`, or a helper function on `util`, like `util.collect()` that behaves the way the stream method does in this PR, but also attempting to act appropriately on arbitrary (async) iterables. This would effectively be a slightly more stream-friendly version of the upcoming [`toArray()`](https://tc39.es/proposal-iterator-helpers/#sec-asynciteratorprototype.toarray).

### Help?

* Im not sure the documentation is the best way to describe what's going on, so I'm hoping reviewers can chime in a bit there.
* Are there edge-cases I'm missing in the test?
* Most of the work is deferred to the async iteration implementation. Maybe there's a more efficient and/or resilient way to do this? 