### PR TITLE
net: use missing validator

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -102,6 +102,7 @@ const {
 const { isUint8Array } = require('internal/util/types');
 const {
   validateAbortSignal,
+  validateFunction,
   validateInt32,
   validateNumber,
   validatePort,
@@ -1002,10 +1003,7 @@ function lookupAndConnect(self, options) {
     return;
   }
 
-  if (options.lookup && typeof options.lookup !== 'function')
-    throw new ERR_INVALID_ARG_TYPE('options.lookup',
-                                   'Function', options.lookup);
-
+  if (options.lookup) validateFunction(options.lookup, 'options.lookup');
 
   if (dns === undefined) dns = require('dns');
   const dnsopts = {

--- a/lib/net.js
+++ b/lib/net.js
@@ -1003,7 +1003,8 @@ function lookupAndConnect(self, options) {
     return;
   }
 
-  if (options.lookup) validateFunction(options.lookup, 'options.lookup');
+  if (options.lookup !== undefined)
+    validateFunction(options.lookup, 'options.lookup');
 
   if (dns === undefined) dns = require('dns');
   const dnsopts = {


### PR DESCRIPTION
The `net` lib module's `lookupAndConnect()` function is missing a validator.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
