### PR TITLE
lib: make internal/options lazy

### DIFF
--- a/lib/internal/options.js
+++ b/lib/internal/options.js
@@ -1,12 +1,28 @@
 'use strict';
 
 const { getOptions, shouldNotRegisterESMLoader } = internalBinding('options');
-const { options, aliases } = getOptions();
 
 let warnOnAllowUnauthorized = true;
 
+let optionsMap;
+let aliasesMap;
+
+function getOptionsFromBinding() {
+  if (!optionsMap) {
+    ({ options: optionsMap } = getOptions());
+  }
+  return optionsMap;
+}
+
+function getAliasesFromBinding() {
+  if (!aliasesMap) {
+    ({ aliases: aliasesMap } = getOptions());
+  }
+  return aliasesMap;
+}
+
 function getOptionValue(option) {
-  return options.get(option)?.value;
+  return getOptionsFromBinding().get(option)?.value;
 }
 
 function getAllowUnauthorized() {
@@ -24,8 +40,12 @@ function getAllowUnauthorized() {
 }
 
 module.exports = {
-  options,
-  aliases,
+  get options() {
+    return getOptionsFromBinding();
+  },
+  get aliases() {
+    return getAliasesFromBinding();
+  },
   getOptionValue,
   getAllowUnauthorized,
   shouldNotRegisterESMLoader

--- a/lib/internal/options.js
+++ b/lib/internal/options.js
@@ -7,6 +7,10 @@ let warnOnAllowUnauthorized = true;
 let optionsMap;
 let aliasesMap;
 
+// getOptions() would serialize the option values from C++ land.
+// It would error if the values are queried before bootstrap is
+// complete so that we don't accidentally include runtime-dependent
+// states into a runtime-independent snapshot.
 function getOptionsFromBinding() {
   if (!optionsMap) {
     ({ options: optionsMap } = getOptions());


### PR DESCRIPTION
This way, internal modules can still require the module
and cache the function getOptionValue() early (therefore
these code can be included in the snapshots), but the
options map won't be serialized from C++ land until the
option values are actually queried.

Refs: https://github.com/nodejs/node/issues/35711
Refs: https://github.com/nodejs/node/pull/38905

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
