### PR TITLE
build: fix commit-queue default branch

### DIFF
--- a/.github/workflows/commit-queue.yml
+++ b/.github/workflows/commit-queue.yml
@@ -45,6 +45,7 @@ jobs:
         run: |
           echo "REPOSITORY=$(echo ${{ github.repository }} | cut -d/ -f2)" >> $GITHUB_ENV
           echo "OWNER=${{ github.repository_owner }}" >> $GITHUB_ENV
+          echo "DEFAULT_BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
 
       - name: Get Pull Requests
         uses: octokit/graphql-action@v2.x
@@ -63,19 +64,19 @@ jobs:
           owner: ${{ env.OWNER }}
           repo: ${{ env.REPOSITORY }}
           # Commit queue is only enabled for the default branch on the repository
-          base_ref: ${{ github.repository.default_branch }}
+          base_ref: ${{ env.DEFAULT_BRANCH }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure node-core-utils
         run: |
-          ncu-config set branch ${{ github.repository.default_branch }}
+          ncu-config set branch ${DEFAULT_BRANCH}
           ncu-config set upstream origin
           ncu-config set username "${{ secrets.GH_USER_NAME }}"
           ncu-config set token "${{ secrets.GH_USER_TOKEN }}"
           ncu-config set jenkins_token "${{ secrets.JENKINS_TOKEN }}"
-          ncu-config set repo "${{ env.REPOSITORY }}"
-          ncu-config set owner "${{ env.OWNER }}"
+          ncu-config set repo "${REPOSITORY}"
+          ncu-config set owner "${OWNER}"
 
       - name: Start the commit queue
-        run: ./tools/actions/commit-queue.sh ${{ env.OWNER }} ${{ env.REPOSITORY }} ${{ secrets.GITHUB_TOKEN }} $(echo '${{ steps.get_mergable_pull_requests.outputs.data }}' | jq '.repository.pullRequests.nodes | map(.number) | .[]')
+        run: ./tools/actions/commit-queue.sh ${OWNER} ${REPOSITORY} ${{ secrets.GITHUB_TOKEN }} $(echo '${{ steps.get_mergable_pull_requests.outputs.data }}' | jq '.repository.pullRequests.nodes | map(.number) | .[]')


### PR DESCRIPTION
`github.repository.default_branch` is not a valid context variable, and
GitHub doesn't have a context or environment variable containing the
default branch. It does have `github.ref` and `$GITHUB_REF`, which
contains the default branch _reference_ (as in `refs/heads/<branch>`),
so we can use that and remove the `refs/heads/` prefix.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
