### PR TITLE
tools: fix typo in commit-queue.sh

### DIFF
--- a/tools/actions/commit-queue.sh
+++ b/tools/actions/commit-queue.sh
@@ -77,7 +77,7 @@ for pr in "$@"; do
     rm output output.json
     # If `git node land --abort` fails, we're in unknown state. Better to stop
     # the script here, current PR was removed from the queue so it shouldn't
-    # interfer again in the future
+    # interfere again in the future.
     git node land --abort --yes
   else
     rm output


### PR DESCRIPTION
Fix a typo in `tools/actions/commit-queue.sh` per https://github.com/nodejs/node/pull/36861#discussion_r649566393

/cc @aduh95 @mmarchini 