### PR TITLE
bootstrap: split NodeMainInstance::Run() and move handle checking code to the snapshot builder

### DIFF
--- a/src/node_main_instance.cc
+++ b/src/node_main_instance.cc
@@ -224,8 +224,6 @@ NodeMainInstance::CreateMainEnvironment(int* exit_code,
     }
   }
 
-  CHECK(env->req_wrap_queue()->IsEmpty());
-  CHECK(env->handle_wrap_queue()->IsEmpty());
   return env;
 }
 

--- a/src/node_main_instance.h
+++ b/src/node_main_instance.h
@@ -59,6 +59,7 @@ class NodeMainInstance {
 
   // Start running the Node.js instances, return the exit code when finished.
   int Run(const EnvSerializeInfo* env_info);
+  void Run(int* exit_code, Environment* env);
 
   IsolateData* isolate_data() { return isolate_data_.get(); }
 

--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -165,7 +165,8 @@ void SnapshotBuilder::Generate(SnapshotData* out,
     // We cannot resurrect the handles from the snapshot, so make sure that
     // no handles are left open in the environment after the blob is created
     // (which should trigger a GC and close all handles that can be closed).
-    if (!env->req_wrap_queue()->IsEmpty() || !env->handle_wrap_queue()->IsEmpty()
+    if (!env->req_wrap_queue()->IsEmpty()
+        || !env->handle_wrap_queue()->IsEmpty()
         || per_process::enabled_debug_list.enabled(DebugCategory::MKSNAPSHOT)) {
       PrintLibuvHandleInformation(env->event_loop(), stderr);
     }

--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -157,7 +157,21 @@ void SnapshotBuilder::Generate(SnapshotData* out,
     // Must be out of HandleScope
     out->blob =
         creator.CreateBlob(SnapshotCreator::FunctionCodeHandling::kClear);
+
+    // We must be able to rehash the blob when we restore it or otherwise
+    // the hash seed would be fixed by V8, introducing a vulnerability.
     CHECK(out->blob.CanBeRehashed());
+
+    // We cannot resurrect the handles from the snapshot, so make sure that
+    // no handles are left open in the environment after the blob is created
+    // (which should trigger a GC and close all handles that can be closed).
+    if (!env->req_wrap_queue()->IsEmpty() || !env->handle_wrap_queue()->IsEmpty()
+        || per_process::enabled_debug_list.enabled(DebugCategory::MKSNAPSHOT)) {
+      PrintLibuvHandleInformation(env->event_loop(), stderr);
+    }
+    CHECK(env->req_wrap_queue()->IsEmpty());
+    CHECK(env->handle_wrap_queue()->IsEmpty());
+
     // Must be done while the snapshot creator isolate is entered i.e. the
     // creator is still alive.
     FreeEnvironment(env);


### PR DESCRIPTION
#### bootstrap: split NodeMainInstance::Run()

Split the running of the instance so that it can be reused
by the snapshot builder when we need to run the loop for
user code.

#### bootstrap: move event loop handle checking into snapshot builder

This is only necessary for the snapshot builder (because we
have no way to resurrect the handles at the moment). In addition,
print the handles if the debug flag is set or if the queues
are not empty after snapshot is created.

Refs: https://github.com/nodejs/node/issues/35711
Refs: https://github.com/nodejs/node/pull/38905