### PR TITLE
src: fix multiple AddLinkedBinding() calls

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -659,10 +659,10 @@ void AddLinkedBinding(Environment* env, const node_module& mod) {
   CHECK_NOT_NULL(env);
   Mutex::ScopedLock lock(env->extra_linked_bindings_mutex());
 
-  node_module* prev_head = env->extra_linked_bindings_head();
+  node_module* prev_tail = env->extra_linked_bindings_tail();
   env->extra_linked_bindings()->push_back(mod);
-  if (prev_head != nullptr)
-    prev_head->nm_link = &env->extra_linked_bindings()->back();
+  if (prev_tail != nullptr)
+    prev_tail->nm_link = &env->extra_linked_bindings()->back();
 }
 
 void AddLinkedBinding(Environment* env, const napi_module& mod) {

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -930,6 +930,11 @@ inline node_module* Environment::extra_linked_bindings_head() {
       &extra_linked_bindings_.front() : nullptr;
 }
 
+inline node_module* Environment::extra_linked_bindings_tail() {
+  return extra_linked_bindings_.size() > 0 ?
+      &extra_linked_bindings_.back() : nullptr;
+}
+
 inline const Mutex& Environment::extra_linked_bindings_mutex() const {
   return extra_linked_bindings_mutex_;
 }

--- a/src/env.h
+++ b/src/env.h
@@ -1208,6 +1208,7 @@ class Environment : public MemoryRetainer {
   inline void set_stopping(bool value);
   inline std::list<node_module>* extra_linked_bindings();
   inline node_module* extra_linked_bindings_head();
+  inline node_module* extra_linked_bindings_tail();
   inline const Mutex& extra_linked_bindings_mutex() const;
 
   inline bool filehandle_close_warning() const;

--- a/test/cctest/test_linked_binding.cc
+++ b/test/cctest/test_linked_binding.cc
@@ -190,3 +190,35 @@ TEST_F(LinkedBindingTest, LocallyDefinedLinkedBindingNapiInstanceDataTest) {
   CHECK_EQ(*instance_data, 1);
   delete instance_data;
 }
+
+TEST_F(LinkedBindingTest, ManyBindingsTest) {
+  const v8::HandleScope handle_scope(isolate_);
+  const Argv argv;
+  Env test_env {handle_scope, argv};
+
+  int calls = 0;
+  AddLinkedBinding(*test_env, "local_linked1", InitializeLocalBinding, &calls);
+  AddLinkedBinding(*test_env, "local_linked2", InitializeLocalBinding, &calls);
+  AddLinkedBinding(*test_env, "local_linked3", InitializeLocalBinding, &calls);
+  AddLinkedBinding(*test_env, local_linked_napi); // Add a N-API addon as well
+  AddLinkedBinding(*test_env, "local_linked4", InitializeLocalBinding, &calls);
+  AddLinkedBinding(*test_env, "local_linked5", InitializeLocalBinding, &calls);
+
+  v8::Local<v8::Context> context = isolate_->GetCurrentContext();
+
+  const char* run_script =
+      "for (let i = 1; i <= 5; i++)process._linkedBinding(`local_linked${i}`);"
+      "process._linkedBinding('local_linked_napi').hello";
+  v8::Local<v8::Script> script = v8::Script::Compile(
+      context,
+      v8::String::NewFromOneByte(isolate_,
+                                 reinterpret_cast<const uint8_t*>(run_script))
+                                 .ToLocalChecked())
+      .ToLocalChecked();
+  v8::Local<v8::Value> completion_value = script->Run(context).ToLocalChecked();
+  v8::String::Utf8Value utf8val(isolate_, completion_value);
+  CHECK_NOT_NULL(*utf8val);
+  CHECK_EQ(strcmp(*utf8val, "world"), 0);
+  CHECK_EQ(calls, 5);
+}
+

--- a/test/cctest/test_linked_binding.cc
+++ b/test/cctest/test_linked_binding.cc
@@ -200,7 +200,7 @@ TEST_F(LinkedBindingTest, ManyBindingsTest) {
   AddLinkedBinding(*test_env, "local_linked1", InitializeLocalBinding, &calls);
   AddLinkedBinding(*test_env, "local_linked2", InitializeLocalBinding, &calls);
   AddLinkedBinding(*test_env, "local_linked3", InitializeLocalBinding, &calls);
-  AddLinkedBinding(*test_env, local_linked_napi); // Add a N-API addon as well
+  AddLinkedBinding(*test_env, local_linked_napi);  // Add a N-API addon as well.
   AddLinkedBinding(*test_env, "local_linked4", InitializeLocalBinding, &calls);
   AddLinkedBinding(*test_env, "local_linked5", InitializeLocalBinding, &calls);
 


### PR DESCRIPTION
Singly-linked lists are extended at their tail, not their head.
This fixes using more than 2 linked addons at a time.

---

I would appreciate early backports to v14.x and v12.x, since this is actually something I’m running into at work, and it’s a) a bugfix and b) only affects embedding scenarios, which makes it really low-risk for LTS imo.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
