### PR TITLE
doc: add missing parameter types

### DIFF
--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -307,7 +307,8 @@ Cancels an `Immediate` object created by [`setImmediate()`][].
 added: v0.0.1
 -->
 
-* `timeout` {Timeout} A `Timeout` object as returned by [`setInterval()`][].
+* `timeout` {Timeout|string|number} A `Timeout` object as returned by [`setInterval()`][]
+  or the ID of the `Timeout` object as a string or a number.
 
 Cancels a `Timeout` object created by [`setInterval()`][].
 
@@ -316,7 +317,8 @@ Cancels a `Timeout` object created by [`setInterval()`][].
 added: v0.0.1
 -->
 
-* `timeout` {Timeout} A `Timeout` object as returned by [`setTimeout()`][].
+* `timeout` {Timeout|string|number} A `Timeout` object as returned by [`setTimeout()`][]
+  or the ID of the `Timeout` object as a string or a number.
 
 Cancels a `Timeout` object created by [`setTimeout()`][].
 

--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -308,7 +308,7 @@ added: v0.0.1
 -->
 
 * `timeout` {Timeout|string|number} A `Timeout` object as returned by [`setInterval()`][]
-  or the ID of the `Timeout` object as a string or a number.
+  or the [primitive][] of the `Timeout` object as a string or a number.
 
 Cancels a `Timeout` object created by [`setInterval()`][].
 
@@ -318,7 +318,7 @@ added: v0.0.1
 -->
 
 * `timeout` {Timeout|string|number} A `Timeout` object as returned by [`setTimeout()`][]
-  or the ID of the `Timeout` object as a string or a number.
+  or the [primitive][] of the `Timeout` object as a string or a number.
 
 Cancels a `Timeout` object created by [`setTimeout()`][].
 
@@ -480,3 +480,4 @@ const interval = 100;
 [`setTimeout()`]: timers.md#timers_settimeout_callback_delay_args
 [`util.promisify()`]: util.md#util_util_promisify_original
 [`worker_threads`]: worker_threads.md
+[primitive]: timers.md#timers_timeout_symbol_toprimitive


### PR DESCRIPTION
Both of the `clearTimeout()` and `clearInterval()` functions in the `timers` lib accepts the primitive of the `Timeout` object returned by the functions in a number or string type, e.g.
```js
const t = setTimeout(console.log, 5000, 'test');

clearTimeout(t[Symbol.toPrimitive]());
```

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
