### PR TITLE
errors: don't throw TypeError on missing export

### DIFF
--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -24,6 +24,9 @@ const {
 const { ModuleWrap } = internalBinding('module_wrap');
 
 const { decorateErrorStack } = require('internal/util');
+const {
+  getSourceMapsEnabled,
+} = require('internal/source_map/source_map_cache');
 const assert = require('internal/assert');
 const resolvedPromise = PromiseResolve();
 
@@ -122,7 +125,12 @@ class ModuleJob {
       }
     } catch (e) {
       decorateErrorStack(e);
-      if (StringPrototypeIncludes(e.message,
+      // TODO(@bcoe): Add source map support to exception that occurs as result
+      // of missing named export. This is currently not possible because
+      // stack trace originates in module_job, not the file itself. A hidden
+      // symbol with filename could be set in node_errors.cc to facilitate this.
+      if (!getSourceMapsEnabled() &&
+          StringPrototypeIncludes(e.message,
                                   ' does not provide an export named')) {
         const splitStack = StringPrototypeSplit(e.stack, '\n');
         const parentFileUrl = StringPrototypeReplace(

--- a/test/fixtures/source-map/esm-export-missing-module.mjs.map
+++ b/test/fixtures/source-map/esm-export-missing-module.mjs.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"esm-export-missing-module.esm","sourceRoot":"","sources":["./exm-export-missing-module.ts"],"names":[],"mappings":"AAEA,MAAM,UAAU,SAAS;AAEzB,CAAC"}

--- a/test/fixtures/source-map/esm-export-missing.mjs
+++ b/test/fixtures/source-map/esm-export-missing.mjs
@@ -1,0 +1,2 @@
+import { Something } from './esm-export-missing-module.mjs';
+//# sourceMappingURL=esm-export-missing.mjs.map

--- a/test/fixtures/source-map/esm-export-missing.mjs.map
+++ b/test/fixtures/source-map/esm-export-missing.mjs.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"esm-export-missing.ts","sourceRoot":"","sources":["./esm-export-missing.ts"],"names":[],"mappings":"AACA,OAAO,EAAE,SAAS,EAAE,MAAM,gBAAgB,CAAC;AAC3C,OAAO,CAAC,IAAI,CAAC,SAAS,CAAC,CAAC"}

--- a/test/fixtures/source-map/esm-export-missing.ts
+++ b/test/fixtures/source-map/esm-export-missing.ts
@@ -1,0 +1,3 @@
+
+import { Something } from './exm-export-missing-module.mjs';
+console.info(Something);

--- a/test/parallel/test-source-map-enable.js
+++ b/test/parallel/test-source-map-enable.js
@@ -324,6 +324,25 @@ function nextdir() {
   assert.ok(sourceMap);
 }
 
+// Does not throw TypeError when exception occurs as result of missing named
+// export.
+{
+  const coverageDirectory = nextdir();
+  const output = spawnSync(process.execPath, [
+    '--enable-source-maps',
+    require.resolve('../fixtures/source-map/esm-export-missing.mjs'),
+  ], { env: { ...process.env, NODE_V8_COVERAGE: coverageDirectory } });
+  const sourceMap = getSourceMapFromCache(
+    'esm-export-missing.mjs',
+    coverageDirectory
+  );
+  // Module loader error displayed.
+  assert.match(output.stderr.toString(),
+               /does not provide an export named 'Something'/);
+  // Source map should have been serialized.
+  assert.ok(sourceMap);
+}
+
 function getSourceMapFromCache(fixtureFile, coverageDirectory) {
   const jsonFiles = fs.readdirSync(coverageDirectory);
   for (const jsonFile of jsonFiles) {


### PR DESCRIPTION
Logic in module_job.js assumes detailed stack trace from node_errors.cc
which is not populated when --enable-source-maps is set.

Fixes #38790

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
