### PR TITLE
errors: remove source map rekey logic

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -76,7 +76,6 @@ const { NativeModule } = require('internal/bootstrap/loaders');
 const {
   getSourceMapsEnabled,
   maybeCacheSourceMap,
-  rekeySourceMap
 } = require('internal/source_map/source_map_cache');
 const { pathToFileURL, fileURLToPath, isURLInstance } = require('internal/url');
 const { deprecate } = require('internal/util');
@@ -822,7 +821,6 @@ Module._load = function(request, parent, isMain) {
       try {
         module.load(filename);
       } catch (err) {
-        rekeySourceMap(Module._cache[filename], err);
         throw err; /* node-do-not-add-exception-line */
       }
     } else {

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -74,7 +74,6 @@ module.exports = {
 
 const { NativeModule } = require('internal/bootstrap/loaders');
 const {
-  getSourceMapsEnabled,
   maybeCacheSourceMap,
 } = require('internal/source_map/source_map_cache');
 const { pathToFileURL, fileURLToPath, isURLInstance } = require('internal/url');
@@ -814,18 +813,7 @@ Module._load = function(request, parent, isMain) {
 
   let threw = true;
   try {
-    // Intercept exceptions that occur during the first tick and rekey them
-    // on error instance rather than module instance (which will immediately be
-    // garbage collected).
-    if (getSourceMapsEnabled()) {
-      try {
-        module.load(filename);
-      } catch (err) {
-        throw err; /* node-do-not-add-exception-line */
-      }
-    } else {
-      module.load(filename);
-    }
+    module.load(filename);
     threw = false;
   } finally {
     if (threw) {

--- a/lib/internal/source_map/source_map_cache.js
+++ b/lib/internal/source_map/source_map_cache.js
@@ -175,7 +175,11 @@ function sourcesToAbsolute(baseURL, data) {
 // Move source map from garbage collected module to alternate key.
 function rekeySourceMap(cjsModuleInstance, newInstance) {
   const sourceMap = cjsSourceMapCache.get(cjsModuleInstance);
-  if (sourceMap) {
+  // If an exception occurs before a module finishes loading it will removed
+  // from the module cache and our WeakMap. To allow a source map to still be
+  // applied to the stack trace when this happens, we rekey on the thrown error.
+  // This is only possible if the error is an object and not a primitive type.
+  if (sourceMap && typeof newInstance === 'object') {
     cjsSourceMapCache.set(newInstance, sourceMap);
   }
 }

--- a/lib/internal/source_map/source_map_cache.js
+++ b/lib/internal/source_map/source_map_cache.js
@@ -175,7 +175,7 @@ function sourcesToAbsolute(baseURL, data) {
 // Move source map from garbage collected module to alternate key.
 function rekeySourceMap(cjsModuleInstance, newInstance) {
   const sourceMap = cjsSourceMapCache.get(cjsModuleInstance);
-  // If an exception occurs before a module finishes loading it will removed
+  // If an exception occurs before a module finishes loading, it is removed
   // from the module cache and our WeakMap. To allow a source map to still be
   // applied to the stack trace when this happens, we rekey on the thrown error.
   // This is only possible if the error is an object and not a primitive type.

--- a/lib/internal/source_map/source_map_cache.js
+++ b/lib/internal/source_map/source_map_cache.js
@@ -172,18 +172,6 @@ function sourcesToAbsolute(baseURL, data) {
   return data;
 }
 
-// Move source map from garbage collected module to alternate key.
-function rekeySourceMap(cjsModuleInstance, newInstance) {
-  const sourceMap = cjsSourceMapCache.get(cjsModuleInstance);
-  // If an exception occurs before a module finishes loading, it is removed
-  // from the module cache and our WeakMap. To allow a source map to still be
-  // applied to the stack trace when this happens, we rekey on the thrown error.
-  // This is only possible if the error is an object and not a primitive type.
-  if (sourceMap && typeof newInstance === 'object') {
-    cjsSourceMapCache.set(newInstance, sourceMap);
-  }
-}
-
 // WARNING: The `sourceMapCacheToObject` and `appendCJSCache` run during
 // shutdown. In particular, they also run when Workers are terminated, making
 // it important that they do not call out to any user-provided code, including
@@ -244,6 +232,5 @@ module.exports = {
   findSourceMap,
   getSourceMapsEnabled,
   maybeCacheSourceMap,
-  rekeySourceMap,
   sourceMapCacheToObject,
 };

--- a/test/fixtures/source-map/throw-string-original.js
+++ b/test/fixtures/source-map/throw-string-original.js
@@ -1,0 +1,8 @@
+/*
+ * comments dropped by uglify.
+ */
+function Hello() {
+  throw 'goodbye';
+}
+
+Hello();

--- a/test/fixtures/source-map/throw-string.js
+++ b/test/fixtures/source-map/throw-string.js
@@ -1,0 +1,2 @@
+function Hello(){throw"goodbye"}Hello();
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInRocm93LXN0cmluZy1vcmlnaW5hbC5qcyJdLCJuYW1lcyI6WyJIZWxsbyJdLCJtYXBwaW5ncyI6IkFBR0EsU0FBU0EsUUFDUCxLQUFNLFVBR1JBIn0=

--- a/test/parallel/test-source-map-enable.js
+++ b/test/parallel/test-source-map-enable.js
@@ -307,6 +307,23 @@ function nextdir() {
   assert.ok(sourceMap);
 }
 
+// Does not attempt to rekey source map on primitive type.
+{
+  const coverageDirectory = nextdir();
+  const output = spawnSync(process.execPath, [
+    '--enable-source-maps',
+    require.resolve('../fixtures/source-map/throw-string.js'),
+  ], { env: { ...process.env, NODE_V8_COVERAGE: coverageDirectory } });
+  const sourceMap = getSourceMapFromCache(
+    'throw-string.js',
+    coverageDirectory
+  );
+  // Original stack trace.
+  assert.match(output.stderr.toString(), /goodbye/);
+  // Source map should have been serialized.
+  assert.ok(sourceMap);
+}
+
 function getSourceMapFromCache(fixtureFile, coverageDirectory) {
   const jsonFiles = fs.readdirSync(coverageDirectory);
   for (const jsonFile of jsonFiles) {

--- a/test/parallel/test-source-map-enable.js
+++ b/test/parallel/test-source-map-enable.js
@@ -307,7 +307,7 @@ function nextdir() {
   assert.ok(sourceMap);
 }
 
-// Does not attempt to rekey source map on primitive type.
+// Does not throw TypeError when primitive value is thrown.
 {
   const coverageDirectory = nextdir();
   const output = spawnSync(process.execPath, [


### PR DESCRIPTION
The rekeying logic no longer seems to be necessary to ensure that source maps
are written to disk before the application exits.

Fixes #38945

---

I believe improvements could be made to both this class of error and to the error described in #39017, such that we try to still annotate the stack trace with the original call site. But, in both cases, I think it's good to land the obvious fix initially.

What we ultimately lose with source-maps enabled is the syntactic sugar of:

```bash
/Users/bencoe/oss/node-1/test/fixtures/source-map/throw-string.js:1
function Hello(){throw"goodbye"}Hello();
                 ^
```

Which I don't think is standard stack trace output any ways.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
