### PR TITLE
fs: use missing validator

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -802,6 +802,10 @@ rejection only when `recursive` is false.
 ### `fsPromises.mkdtemp(prefix[, options])`
 <!-- YAML
 added: v10.0.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/39028
+    description: The `prefix` parameter now accepts an empty string.
 -->
 
 * `prefix` {string}
@@ -2574,6 +2578,9 @@ See the POSIX mkdir(2) documentation for more details.
 <!-- YAML
 added: v5.10.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/39028
+    description: The `prefix` parameter now accepts an empty string.
   - version: v10.0.0
     pr-url: https://github.com/nodejs/node/pull/12562
     description: The `callback` parameter is no longer optional. Not passing
@@ -4509,6 +4516,10 @@ See the POSIX mkdir(2) documentation for more details.
 ### `fs.mkdtempSync(prefix[, options])`
 <!-- YAML
 added: v5.10.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/39028
+    description: The `prefix` parameter now accepts an empty string.
 -->
 
 * `prefix` {string}

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -74,7 +74,6 @@ const {
   codes: {
     ERR_FS_FILE_TOO_LARGE,
     ERR_INVALID_ARG_VALUE,
-    ERR_INVALID_ARG_TYPE,
     ERR_FEATURE_UNAVAILABLE_ON_PLATFORM,
   },
   AbortError,
@@ -136,6 +135,7 @@ const {
   validateEncoding,
   validateFunction,
   validateInteger,
+  validateString,
 } = require('internal/validators');
 
 const watchers = require('internal/fs/watchers');
@@ -2712,9 +2712,8 @@ realpath.native = (path, options, callback) => {
 function mkdtemp(prefix, options, callback) {
   callback = makeCallback(typeof options === 'function' ? options : callback);
   options = getOptions(options, {});
-  if (!prefix || typeof prefix !== 'string') {
-    throw new ERR_INVALID_ARG_TYPE('prefix', 'string', prefix);
-  }
+
+  validateString(prefix, 'prefix');
   nullCheck(prefix, 'prefix');
   warnOnNonPortableTemplate(prefix);
   const req = new FSReqCallback();
@@ -2730,9 +2729,8 @@ function mkdtemp(prefix, options, callback) {
  */
 function mkdtempSync(prefix, options) {
   options = getOptions(options, {});
-  if (!prefix || typeof prefix !== 'string') {
-    throw new ERR_INVALID_ARG_TYPE('prefix', 'string', prefix);
-  }
+
+  validateString(prefix, 'prefix');
   nullCheck(prefix, 'prefix');
   warnOnNonPortableTemplate(prefix);
   const path = `${prefix}XXXXXX`;

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -29,7 +29,6 @@ const { Buffer } = require('buffer');
 const {
   codes: {
     ERR_FS_FILE_TOO_LARGE,
-    ERR_INVALID_ARG_TYPE,
     ERR_INVALID_ARG_VALUE,
     ERR_METHOD_NOT_IMPLEMENTED,
   },
@@ -74,6 +73,7 @@ const {
   validateBuffer,
   validateEncoding,
   validateInteger,
+  validateString,
 } = require('internal/validators');
 const pathModule = require('path');
 const { promisify } = require('internal/util');
@@ -708,9 +708,8 @@ async function realpath(path, options) {
 
 async function mkdtemp(prefix, options) {
   options = getOptions(options, {});
-  if (!prefix || typeof prefix !== 'string') {
-    throw new ERR_INVALID_ARG_TYPE('prefix', 'string', prefix);
-  }
+
+  validateString(prefix, 'prefix');
   nullCheck(prefix);
   warnOnNonPortableTemplate(prefix);
   return binding.mkdtemp(`${prefix}XXXXXX`, options.encoding, kUsePromises);

--- a/test/parallel/test-fs-mkdtemp-prefix-check.js
+++ b/test/parallel/test-fs-mkdtemp-prefix-check.js
@@ -3,7 +3,7 @@ const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 
-const prefixValues = [undefined, null, 0, true, false, 1, ''];
+const prefixValues = [undefined, null, 0, true, false, 1];
 
 function fail(value) {
   assert.throws(


### PR DESCRIPTION
The `fs` lib module's `mkdtemp()` and `mkdtempSync()` methods are missing a validator.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
