### PR TITLE
tools: upgrade `highlight.js` to version 11.0.1

### DIFF
--- a/doc/api_assets/hljs.css
+++ b/doc/api_assets/hljs.css
@@ -8,7 +8,8 @@
 }
 
 .hljs-attribute,
-.hljs-keyword {
+.hljs-keyword,
+.hljs-type {
   color: #338;
 }
 
@@ -35,9 +36,10 @@
   color: var(--green4);
 }
 
-.dark-mode .hljs-keyword,
 .dark-mode .hljs-attribute,
-.dark-mode .hljs-doctag {
+.dark-mode .hljs-doctag,
+.dark-mode .hljs-keyword,
+.dark-mode .hljs-type {
   color: #66d9ef;
 }
 

--- a/tools/doc/package-lock.json
+++ b/tools/doc/package-lock.json
@@ -11,7 +11,7 @@
         "node-doc-generator": "generate.js"
       },
       "devDependencies": {
-        "highlight.js": "10.7.3",
+        "highlight.js": "11.0.1",
         "js-yaml": "4.1.0",
         "rehype-raw": "5.1.0",
         "rehype-stringify": "8.0.0",
@@ -25,7 +25,7 @@
         "unist-util-visit": "3.1.0"
       },
       "engines": {
-        "node": ">=12.10.0"
+        "node": ">=14.8.0"
       }
     },
     "node_modules/@types/hast": {
@@ -356,12 +356,12 @@
       }
     },
     "node_modules/highlight.js": {
-      "version": "10.7.3",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.0.1.tgz",
+      "integrity": "sha512-EqYpWyTF2s8nMfttfBA2yLKPNoZCO33pLS4MnbXQ4hECf1TKujCt1Kq7QAdrio7roL4+CqsfjqwYj4tYgq0pJQ==",
       "dev": true,
       "engines": {
-        "node": "*"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/html-void-elements": {
@@ -1513,9 +1513,9 @@
       }
     },
     "highlight.js": {
-      "version": "10.7.3",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.0.1.tgz",
+      "integrity": "sha512-EqYpWyTF2s8nMfttfBA2yLKPNoZCO33pLS4MnbXQ4hECf1TKujCt1Kq7QAdrio7roL4+CqsfjqwYj4tYgq0pJQ==",
       "dev": true
     },
     "html-void-elements": {

--- a/tools/doc/package.json
+++ b/tools/doc/package.json
@@ -7,7 +7,7 @@
     "node": ">=14.8.0"
   },
   "devDependencies": {
-    "highlight.js": "10.7.3",
+    "highlight.js": "11.0.1",
     "js-yaml": "4.1.0",
     "rehype-raw": "5.1.0",
     "rehype-stringify": "8.0.0",


### PR DESCRIPTION
It seems our tooling is not affected by any of the breaking changes `highlight.js` v11, I think there's no reason to keep using v10.x.

Refs: https://github.com/highlightjs/highlight.js/blob/main/VERSION_11_UPGRADE.md

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
