### PR TITLE
fix typo ( compability → compatibility )

### DIFF
--- a/node.gypi
+++ b/node.gypi
@@ -362,7 +362,7 @@
             }],
           ]
         }, {
-          # Set 1.0.0 as the API compability level to avoid the
+          # Set 1.0.0 as the API compatibility level to avoid the
           # deprecation warnings when using OpenSSL 3.0.
           'defines': [ 'OPENSSL_API_COMPAT=0x10000000L', ]
         }],


### PR DESCRIPTION
Fixed typo

`compability → compatibility `