### PR TITLE
crypto: use compatible ecdh function

### DIFF
--- a/src/crypto/crypto_ec.cc
+++ b/src/crypto/crypto_ec.cc
@@ -314,7 +314,7 @@ void ECDH::SetPrivateKey(const FunctionCallbackInfo<Value>& args) {
     return THROW_ERR_CRYPTO_OPERATION_FAILED(env,
         "Failed to set generated public key");
 
-  EC_KEY_copy(ecdh->key_.get(), new_key.get());
+  ecdh->key_ = std::move(new_key);
   ecdh->group_ = EC_KEY_get0_group(ecdh->key_.get());
 }
 

--- a/test/parallel/test-crypto-ecdh-convert-key.js
+++ b/test/parallel/test-crypto-ecdh-convert-key.js
@@ -117,7 +117,7 @@ if (getCurves().includes('secp256k1')) {
   // rather than Node's generic error message.
   const badKey = 'f'.repeat(128);
   assert.throws(
-    () => ECDH.convertKey(badKey, 'secp256k1', 'hex', 'hex', 'compressed'),
+    () => ECDH.convertKey(badKey, 'secp521r1', 'hex', 'hex', 'compressed'),
     /Failed to convert Buffer to EC_POINT/);
 
   // Next statement should not throw an exception.


### PR DESCRIPTION
Refs https://github.com/electron/electron/pull/27688.

This PR switches `ECDH::SetPrivateKey` to use a compatible ECDH function - the previously used one is a no-op in BoringSSL. Also change an algorithm in the associated test suite to one supported by BoringSSL so we can run more smoke tests.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
