### PR TITLE
doc: add undici notes

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -375,9 +375,9 @@ agent. Do not modify.
 added: v0.1.17
 -->
 
-* Extends: {Stream}
-
 XXX: UNDICI
+
+* Extends: {Stream}
 
 This object is created internally and returned from [`http.request()`][]. It
 represents an _in-progress_ request whose header has already been queued. The

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -54,6 +54,8 @@ list like the following:
 added: v0.3.4
 -->
 
+XXX: UNDICI
+
 An `Agent` is responsible for managing connection persistence
 and reuse for HTTP clients. It maintains a queue of pending requests
 for a given host and port, reusing a single socket connection for each
@@ -374,6 +376,8 @@ added: v0.1.17
 -->
 
 * Extends: {Stream}
+
+XXX: UNDICI
 
 This object is created internally and returned from [`http.request()`][]. It
 represents an _in-progress_ request whose header has already been queued. The
@@ -2705,6 +2709,8 @@ changes:
     description: The `options` parameter can be a WHATWG `URL` object.
 -->
 
+XXX: UNDICI
+
 * `url` {string | URL}
 * `options` {Object} Accepts the same `options` as
   [`http.request()`][], with the `method` always set to `GET`.
@@ -2823,6 +2829,8 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/10638
     description: The `options` parameter can be a WHATWG `URL` object.
 -->
+
+XXX: UNDICI
 
 * `url` {string | URL}
 * `options` {Object}

--- a/doc/api/https.md
+++ b/doc/api/https.md
@@ -22,6 +22,8 @@ changes:
                  sessions reuse.
 -->
 
+XXX: UNDICI
+
 An [`Agent`][] object for HTTPS similar to [`http.Agent`][]. See
 [`https.request()`][] for more information.
 
@@ -212,6 +214,8 @@ changes:
     description: The `options` parameter can be a WHATWG `URL` object.
 -->
 
+XXX: UNDICI
+
 * `url` {string | URL}
 * `options` {Object | string | URL} Accepts the same `options` as
   [`https.request()`][], with the `method` always set to `GET`.
@@ -267,6 +271,8 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/10638
     description: The `options` parameter can be a WHATWG `URL` object.
 -->
+
+XXX: UNDICI
 
 * `url` {string | URL}
 * `options` {Object | string | URL} Accepts all `options` from

--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -145,9 +145,7 @@ const undici = require('undici');
 const fs = require('fs');
 const { pipeline } = require('stream/promises');
 
-const { body, headers } = await undici.request({ host: 'example.com',
-                           path: '/',
-                           port: 80,
+const { body, headers } = await undici.request('http://example.com:80', {
                            headers: { 'Accept-Encoding': 'br,gzip,deflate' } });
 
 const output = fs.createWriteStream('example.com_index.html');

--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -140,10 +140,10 @@ tradeoffs involved in `zlib` usage.
 
 ```js
 // Client request example
-const zlib = require('zlib');
-const undici = require('undici');
-const fs = require('fs');
-const { pipeline } = require('stream/promises');
+import zlib from 'zlib';
+import undici from 'undici';
+import fs from 'fs';
+import { pipeline } from 'stream/promises';
 
 const { body, headers } = await undici.request('http://example.com:80', {
                            headers: { 'Accept-Encoding': 'br,gzip,deflate' } });

--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -146,7 +146,8 @@ import fs from 'fs';
 import { pipeline } from 'stream/promises';
 
 const { body, headers } = await undici.request('http://example.com:80', {
-                           headers: { 'Accept-Encoding': 'br,gzip,deflate' } });
+  headers: { 'Accept-Encoding': 'br,gzip,deflate' }
+});
 
 const output = fs.createWriteStream('example.com_index.html');
 


### PR DESCRIPTION
We discussed in  https://github.com/nodejs/node/issues/38533 that once [undici@4 is released]( https://nodejs.medium.com/introducing-undici-4-1e321243e007) we would in some fashion update the documentation to encourage users to use undici instead of the core http client.

I've tried to identify where in the documentation we might want to add a note and also updated the few examples I could find that use the core client to instead use undici.

I think I need a little help here in terms of what would be the best way to achieve this "encouragement", e.g. where in the documentation and what is an appropriate phrasing. I don't think we want to deprecate the core client just yet. We consider undici stable per se. However, due limited usage in the ecosystem I would still consider it experimental in the context of Node core.

Refs: https://github.com/nodejs/node/issues/38533

