### PR TITLE
wasi: use missing validator

### DIFF
--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -229,6 +229,11 @@ const validateFunction = hideStackFrames((value, name) => {
     throw new ERR_INVALID_ARG_TYPE(name, 'Function', value);
 });
 
+const validateUndefined = hideStackFrames((value, name) => {
+  if (value !== undefined)
+    throw new ERR_INVALID_ARG_TYPE(name, 'undefined', value);
+});
+
 module.exports = {
   isInt32,
   isUint32,
@@ -247,6 +252,7 @@ module.exports = {
   validateSignalName,
   validateString,
   validateUint32,
+  validateUndefined,
   validateCallback,
   validateAbortSignal,
 };

--- a/lib/wasi.js
+++ b/lib/wasi.js
@@ -21,6 +21,7 @@ const {
   validateFunction,
   validateInt32,
   validateObject,
+  validateUndefined,
 } = require('internal/validators');
 const { WASI: _WASI } = internalBinding('wasi');
 const kExitCode = Symbol('kExitCode');
@@ -120,10 +121,7 @@ class WASI {
     const { _start, _initialize } = this[kInstance].exports;
 
     validateFunction(_start, 'instance.exports._start');
-    if (_initialize !== undefined) {
-      throw new ERR_INVALID_ARG_TYPE(
-        'instance.exports._initialize', 'undefined', _initialize);
-    }
+    validateUndefined(_initialize, 'instance.exports._initialize');
 
     try {
       _start();
@@ -147,16 +145,9 @@ class WASI {
 
     const { _start, _initialize } = this[kInstance].exports;
 
-    if (typeof _initialize !== 'function' && _initialize !== undefined) {
-      throw new ERR_INVALID_ARG_TYPE(
-        'instance.exports._initialize', 'function', _initialize);
-    }
-    if (_start !== undefined) {
-      throw new ERR_INVALID_ARG_TYPE(
-        'instance.exports._start', 'undefined', _initialize);
-    }
-
+    validateUndefined(_start, 'instance.exports._start');
     if (_initialize !== undefined) {
+      validateFunction(_initialize, 'instance.exports._initialize');
       _initialize();
     }
   }

--- a/test/wasi/test-wasi-initialize-validation.js
+++ b/test/wasi/test-wasi-initialize-validation.js
@@ -78,7 +78,8 @@ const bufferSource = fixtures.readSync('simple.wasm');
       () => { wasi.initialize(instance); },
       {
         code: 'ERR_INVALID_ARG_TYPE',
-        message: /"instance\.exports\._start" property must be undefined/
+        message: 'The "instance.exports._start" property must be' +
+          ' undefined. Received function _start',
       }
     );
   }

--- a/test/wasi/test-wasi-start-validation.js
+++ b/test/wasi/test-wasi-start-validation.js
@@ -78,7 +78,8 @@ const bufferSource = fixtures.readSync('simple.wasm');
       () => { wasi.start(instance); },
       {
         code: 'ERR_INVALID_ARG_TYPE',
-        message: /"instance\.exports\._initialize" property must be undefined/
+        message: 'The "instance.exports._initialize" property must be' +
+          ' undefined. Received function _initialize',
       }
     );
   }


### PR DESCRIPTION
The `wasi` lib module's `initialize()` and `start()` methods are missing validators.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
