### PR TITLE
streams: avoid loop when destroyed

### DIFF
--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -109,7 +109,6 @@ async function* fromReadable(val) {
 
 async function pump(iterable, writable, finish) {
   let error;
-  let ended = false;
   let callback = noop;
   const resume = (err) => {
     error = aggregateTwoErrors(error, err);
@@ -126,16 +125,19 @@ async function pump(iterable, writable, finish) {
       callback = resolve;
     }
   });
+  const onClose = () => {
+    resume(new ERR_STREAM_PREMATURE_CLOSE());
+  };
 
   writable
     .on('drain', resume)
     .on('error', resume)
-    .on('close', resume);
+    .on('close', onClose);
 
   try {
     if (writable.writableNeedDrain) {
       await waitForDrain();
-      if (destroyImpl.isDestroyed(writable)) {
+      if (error || destroyImpl.isDestroyed(writable)) {
         return;
       }
     }
@@ -143,24 +145,20 @@ async function pump(iterable, writable, finish) {
     for await (const chunk of iterable) {
       if (!writable.write(chunk)) {
         await waitForDrain();
-        if (destroyImpl.isDestroyed(writable)) {
+        if (error || destroyImpl.isDestroyed(writable)) {
           return;
         }
       }
     }
 
     writable.end();
-    ended = true;
   } catch (err) {
     error = aggregateTwoErrors(error, err);
   } finally {
-    if (!error && !ended) {
-      error = new ERR_STREAM_PREMATURE_CLOSE();
-    }
     writable
       .off('drain', resume)
       .off('error', resume)
-      .off('close', resume);
+      .off('close', onClose);
     finish(error);
   }
 }

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -12,7 +12,7 @@ const {
 const eos = require('internal/streams/end-of-stream');
 
 const { once } = require('internal/util');
-const { destroyer, isDestroyed } = require('internal/streams/destroy');
+const destroyImpl = require('internal/streams/destroy');
 const {
   aggregateTwoErrors,
   codes: {
@@ -75,7 +75,7 @@ function destroyer(stream, reading, writing, callback) {
   return (err) => {
     if (finished) return;
     finished = true;
-    destroyer(stream, err);
+    destroyImpl.destroyer(stream, err);
     callback(err || new ERR_STREAM_DESTROYED('pipe'));
   };
 }
@@ -122,7 +122,7 @@ async function pump(iterable, writable, finish) {
 
   const waitForDrain = () => new Promise((resolve) => {
     assert(callback === noop);
-    if (error || isDestroyed(writable)) {
+    if (error || destroyImpl.isDestroyed(writable)) {
       resolve();
     } else {
       callback = resolve;
@@ -137,7 +137,7 @@ async function pump(iterable, writable, finish) {
   try {
     if (writable.writableNeedDrain) {
       await waitForDrain();
-      if (isDestroyed(writable)) {
+      if (destroyImpl.isDestroyed(writable)) {
         return;
       }
     }
@@ -145,7 +145,7 @@ async function pump(iterable, writable, finish) {
     for await (const chunk of iterable) {
       if (!writable.write(chunk)) {
         await waitForDrain();
-        if (isDestroyed(writable)) {
+        if (destroyImpl.isDestroyed(writable)) {
           return;
         }
       }

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -109,15 +109,13 @@ async function* fromReadable(val) {
 
 async function pump(iterable, writable, finish) {
   let error;
+  let ended = false;
   let callback = noop;
   const resume = (err) => {
     error = aggregateTwoErrors(error, err);
     const _callback = callback;
     callback = noop;
     _callback();
-  };
-  const onClose = () => {
-    resume(new ERR_STREAM_PREMATURE_CLOSE());
   };
 
   const waitForDrain = () => new Promise((resolve) => {
@@ -132,7 +130,7 @@ async function pump(iterable, writable, finish) {
   writable
     .on('drain', resume)
     .on('error', resume)
-    .on('close', onClose);
+    .on('close', resume);
 
   try {
     if (writable.writableNeedDrain) {
@@ -152,13 +150,17 @@ async function pump(iterable, writable, finish) {
     }
 
     writable.end();
+    ended = true;
   } catch (err) {
     error = aggregateTwoErrors(error, err);
   } finally {
+    if (!error && !ended) {
+      error = new ERR_STREAM_PREMATURE_CLOSE();
+    }
     writable
       .off('drain', resume)
       .off('error', resume)
-      .off('close', onClose);
+      .off('close', resume);
     finish(error);
   }
 }

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -151,6 +151,10 @@ async function pump(iterable, writable, finish) {
       }
     }
 
+    if (error || destroyImpl.isDestroyed(writable)) {
+      return;
+    }
+
     writable.end();
   } catch (err) {
     error = aggregateTwoErrors(error, err);

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -116,6 +116,9 @@ async function pump(iterable, writable, finish) {
     callback = noop;
     _callback();
   };
+  const onClose = () => {
+    resume(new ERR_STREAM_PREMATURE_CLOSE());
+  };
 
   const waitForDrain = () => new Promise((resolve) => {
     assert(callback === noop);
@@ -125,9 +128,6 @@ async function pump(iterable, writable, finish) {
       callback = resolve;
     }
   });
-  const onClose = () => {
-    resume(new ERR_STREAM_PREMATURE_CLOSE());
-  };
 
   writable
     .on('drain', resume)

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -145,9 +145,9 @@ async function pump(iterable, writable, finish) {
     for await (const chunk of iterable) {
       if (!writable.write(chunk)) {
         await waitForDrain();
-        if (error || destroyImpl.isDestroyed(writable)) {
-          return;
-        }
+      }
+      if (error || destroyImpl.isDestroyed(writable)) {
+        return;
       }
     }
 

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -12,7 +12,7 @@ const {
 const eos = require('internal/streams/end-of-stream');
 
 const { once } = require('internal/util');
-const destroyImpl = require('internal/streams/destroy');
+const { destroyer, isDestroyed } = require('internal/streams/destroy');
 const {
   aggregateTwoErrors,
   codes: {
@@ -75,7 +75,7 @@ function destroyer(stream, reading, writing, callback) {
   return (err) => {
     if (finished) return;
     finished = true;
-    destroyImpl.destroyer(stream, err);
+    destroyer(stream, err);
     callback(err || new ERR_STREAM_DESTROYED('pipe'));
   };
 }
@@ -122,7 +122,7 @@ async function pump(iterable, writable, finish) {
 
   const waitForDrain = () => new Promise((resolve) => {
     assert(callback === noop);
-    if (error || writable.destroyed) {
+    if (error || isDestroyed(writable)) {
       resolve();
     } else {
       callback = resolve;
@@ -137,23 +137,18 @@ async function pump(iterable, writable, finish) {
   try {
     if (writable.writableNeedDrain) {
       await waitForDrain();
-    }
-
-    if (error) {
-      return;
+      if (isDestroyed(writable)) {
+        return;
+      }
     }
 
     for await (const chunk of iterable) {
       if (!writable.write(chunk)) {
         await waitForDrain();
+        if (isDestroyed(writable)) {
+          return;
+        }
       }
-      if (error) {
-        return;
-      }
-    }
-
-    if (error) {
-      return;
     }
 
     writable.end();


### PR DESCRIPTION
A little cleanup. Not sure if there is relevant tests to be made.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
