### PR TITLE
http2: Do not call non-reentrant nghttp2 functions from nghttp2 callback

### DIFF
--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -921,6 +921,9 @@ class Http2Session : public AsyncWrap,
   // Also use the invalid frame count as a measure for rejecting input frames.
   uint32_t invalid_frame_count_ = 0;
 
+  // keep track of the depth of nghttp2 callbacks
+  uint32_t nghttp2_callback_scope_ = 0;
+
   void PushOutgoingBuffer(NgHttp2StreamWrite&& write);
 
   BaseObjectPtr<Http2State> http2_state_;
@@ -930,6 +933,7 @@ class Http2Session : public AsyncWrap,
 
   friend class Http2Scope;
   friend class Http2StreamListener;
+  friend class NgHttp2CallbackScope;
 };
 
 struct Http2SessionPerformanceEntryTraits {


### PR DESCRIPTION
The nghttp2 functions nghttp2_session_send, nghttp2_session_mem_send,
nghttp2_session_recv and nghttp2_session_mem_recv are documented as not
being able to be called from nghttp2 callback functions.

Add a tracker so we can tell when we are within the scope of an nghttp2
callback and early return from ConsumeHTTP2Data and SendPendingData
which are the only two methods that use the prohibited methods.

This prevents a use-after-free crash bug that can be triggered otherwise.

Fixes: https://github.com/nodejs/node/issues/38964
Refs: https://nghttp2.org/documentation/programmers-guide.html#remarks

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
