### PR TITLE
async_hooks: check for empty contexts before removing

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -257,7 +257,7 @@ inline void AsyncHooks::RemoveContext(v8::Local<v8::Context> ctx) {
   v8::HandleScope handle_scope(isolate);
   for (auto it = contexts_.begin(); it != contexts_.end(); it++) {
     if (it->IsEmpty()) {
-      contexts_.erase(it);
+      it = contexts_.erase(it);
       it--;
       continue;
     }

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -104,6 +104,11 @@ inline void AsyncHooks::SetJSPromiseHooks(v8::Local<v8::Function> init,
   js_promise_hooks_[2].Reset(env()->isolate(), after);
   js_promise_hooks_[3].Reset(env()->isolate(), resolve);
   for (auto it = contexts_.begin(); it != contexts_.end(); it++) {
+    if (it->IsEmpty()) {
+      it = contexts_.erase(it);
+      it--;
+      continue;
+    }
     PersistentToLocal::Weak(env()->isolate(), *it)
         ->SetPromiseHooks(init, before, after, resolve);
   }

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -256,8 +256,13 @@ inline void AsyncHooks::RemoveContext(v8::Local<v8::Context> ctx) {
   v8::Isolate* isolate = env()->isolate();
   v8::HandleScope handle_scope(isolate);
   for (auto it = contexts_.begin(); it != contexts_.end(); it++) {
+    if (it->IsEmpty()) {
+      contexts_.erase(it);
+      it--;
+      continue;
+    }
     v8::Local<v8::Context> saved_context =
-      PersistentToLocal::Weak(env()->isolate(), *it);
+      PersistentToLocal::Weak(isolate, *it);
     if (saved_context == ctx) {
       it->Reset();
       contexts_.erase(it);

--- a/test/parallel/test-async-hooks-vm-gc.js
+++ b/test/parallel/test-async-hooks-vm-gc.js
@@ -1,0 +1,15 @@
+// Flags: --expose-gc
+'use strict';
+
+require('../common');
+const asyncHooks = require('async_hooks');
+const vm = require('vm');
+
+// This is a regression test for https://github.com/nodejs/node/issues/39019
+//
+// It should not segfault.
+
+const hook = asyncHooks.createHook({ init() {} }).enable();
+vm.createContext();
+globalThis.gc();
+hook.disable();


### PR DESCRIPTION
This way we don't end up attempting to SetPromiseHooks on contexts that
have already been collected.

Fixes: https://github.com/nodejs/node/issues/39019

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
