### PR TITLE
scale the socket receive buffer on the fly #39092

### DIFF
--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -118,7 +118,7 @@ LibuvStreamWrap::LibuvStreamWrap(Environment* env,
                  provider),
       StreamBase(env),
       stream_(stream),
-      recvQSize(STREAM_WRAP_RECVQ_INITIAL) {
+      recvq_size(STREAM_WRAP_RECVQ_INITIAL) {
   StreamBase::AttachToObject(object);
 }
 
@@ -210,7 +210,7 @@ void LibuvStreamWrap::OnUvAlloc(size_t suggested_size, uv_buf_t* buf) {
   HandleScope scope(env()->isolate());
   Context::Scope context_scope(env()->context());
 
-  *buf = EmitAlloc(recvQSize);
+  *buf = EmitAlloc(recvq_size);
 }
 
 template <class WrapType>
@@ -254,10 +254,10 @@ void LibuvStreamWrap::OnUvRead(ssize_t nread, const uv_buf_t* buf) {
 
   if (nread > 0) {
     // Adjust the dynamic receive buffer
-    if (nread == recvQSize && recvQSize < STREAM_WRAP_RECVQ_MAX) {
-      recvQSize <<= 1;
-    } else if (nread < recvQSize / 4 && recvQSize > STREAM_WRAP_RECVQ_MIN) {
-      recvQSize >>= 1;
+    if (nread == recvq_size && recvq_size < STREAM_WRAP_RECVQ_MAX) {
+      recvq_size *= 2;
+    } else if (nread < recvq_size / 4 && recvq_size > STREAM_WRAP_RECVQ_MIN) {
+      recvq_size /= 2;
     }
 
     MaybeLocal<Object> pending_obj;

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -118,7 +118,7 @@ LibuvStreamWrap::LibuvStreamWrap(Environment* env,
                  provider),
       StreamBase(env),
       stream_(stream),
-      recvq_size(STREAM_WRAP_RECVQ_INITIAL) {
+      recvq_size_(STREAM_WRAP_RECVQ_INITIAL) {
   StreamBase::AttachToObject(object);
 }
 
@@ -210,7 +210,7 @@ void LibuvStreamWrap::OnUvAlloc(size_t suggested_size, uv_buf_t* buf) {
   HandleScope scope(env()->isolate());
   Context::Scope context_scope(env()->context());
 
-  *buf = EmitAlloc(recvq_size);
+  *buf = EmitAlloc(recvq_size_);
 }
 
 template <class WrapType>
@@ -254,10 +254,10 @@ void LibuvStreamWrap::OnUvRead(ssize_t nread, const uv_buf_t* buf) {
 
   if (nread > 0) {
     // Adjust the dynamic receive buffer
-    if (nread == recvq_size && recvq_size < STREAM_WRAP_RECVQ_MAX) {
-      recvq_size *= 2;
-    } else if (nread < recvq_size / 4 && recvq_size > STREAM_WRAP_RECVQ_MIN) {
-      recvq_size /= 2;
+    if (nread == recvq_size_ && recvq_size_ < STREAM_WRAP_RECVQ_MAX) {
+      recvq_size_ *= 2;
+    } else if (nread < recvq_size_ / 4 && recvq_size_ > STREAM_WRAP_RECVQ_MIN) {
+      recvq_size_ /= 2;
     }
 
     MaybeLocal<Object> pending_obj;

--- a/src/stream_wrap.h
+++ b/src/stream_wrap.h
@@ -28,6 +28,10 @@
 #include "handle_wrap.h"
 #include "v8.h"
 
+#define STREAM_WRAP_RECVQ_INITIAL   16*1024
+#define STREAM_WRAP_RECVQ_MIN       16*1024
+#define STREAM_WRAP_RECVQ_MAX       256*1024
+
 namespace node {
 
 class Environment;
@@ -111,6 +115,7 @@ class LibuvStreamWrap : public HandleWrap, public StreamBase {
   static void AfterUvShutdown(uv_shutdown_t* req, int status);
 
   uv_stream_t* const stream_;
+  ssize_t recvQSize;
 
 #ifdef _WIN32
   // We don't always have an FD that we could look up on the stream_

--- a/src/stream_wrap.h
+++ b/src/stream_wrap.h
@@ -28,9 +28,9 @@
 #include "handle_wrap.h"
 #include "v8.h"
 
-#define STREAM_WRAP_RECVQ_INITIAL   16*1024
-#define STREAM_WRAP_RECVQ_MIN       16*1024
-#define STREAM_WRAP_RECVQ_MAX       256*1024
+constexpr ssize_t STREAM_WRAP_RECVQ_INITIAL = 16 * 1024;
+constexpr ssize_t STREAM_WRAP_RECVQ_MIN = 16 * 1024;
+constexpr ssize_t STREAM_WRAP_RECVQ_MAX = 256 * 1024;
 
 namespace node {
 

--- a/src/stream_wrap.h
+++ b/src/stream_wrap.h
@@ -115,7 +115,7 @@ class LibuvStreamWrap : public HandleWrap, public StreamBase {
   static void AfterUvShutdown(uv_shutdown_t* req, int status);
 
   uv_stream_t* const stream_;
-  ssize_t recvq_size;
+  ssize_t recvq_size_;
 
 #ifdef _WIN32
   // We don't always have an FD that we could look up on the stream_

--- a/src/stream_wrap.h
+++ b/src/stream_wrap.h
@@ -115,7 +115,7 @@ class LibuvStreamWrap : public HandleWrap, public StreamBase {
   static void AfterUvShutdown(uv_shutdown_t* req, int status);
 
   uv_stream_t* const stream_;
-  ssize_t recvQSize;
+  ssize_t recvq_size;
 
 #ifdef _WIN32
   // We don't always have an FD that we could look up on the stream_


### PR DESCRIPTION
As an experiment, I tried scaling the receive buffer on the fly depending on how full it was on the last iteration
It has the advantage of using less memory for slow streams and being more efficient for faster streams

It does not allow for manual control (but this can probably be added) and it effectively short-circuits the back pressure mechanism - as the first read always gets through - which is not very well suited for stream originating from the network