### PR TITLE
doc: add docs for duplex.allowHalfOpen property

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1593,6 +1593,21 @@ Examples of `Duplex` streams include:
 * [zlib streams][zlib]
 * [crypto streams][crypto]
 
+##### `duplex.allowHalfOpen`
+<!-- YAML
+added: v0.9.4
+-->
+
+* {boolean}
+
+If `false` then the stream will automatically end the writable side when the
+readable side ends. Set initially by the `allowHalfOpen` constructor option,
+which defaults to `false`.
+
+This can be changed manually to change the half-open behavior of an existing
+`Duplex` stream instance, but must be changed before the `'end'` event is
+emitted.
+
 #### Class: `stream.Transform`
 <!-- YAML
 added: v0.9.4


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Fixes #38989