### PR TITLE
tools: avoid fetch extra commits when validating commit messages

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -9,10 +9,12 @@ jobs:
   lint-commit-message:
     runs-on: ubuntu-latest
     steps:
+      - name: Compute number of commits in the PR
+        id: nb-of-commits
+        run: echo "::set-output name=nb::$((${{ github.event.pull_request.commits }} + 1))"
       - uses: actions/checkout@v2
         with:
-          # Last 100 commits should be enough for a PR
-          fetch-depth: 100
+          fetch-depth: ${{ steps.nb-of-commits.outputs.nb }}
       - name: Install Node.js
         uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
We only need the number of commits in the PR, plus one for the merge commit.
I couldn't figure out a way to compute the `+ 1` operation without an extra step, if someone knows a cleaner way please chime in.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
