### PR TITLE
crypto: add OPENSSL_IS_BORINGSSL guard

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -1030,7 +1030,7 @@ InitializationResult InitializeOncePerProcess(
   }
 
   if (init_flags & kInitOpenSSL) {
-#if HAVE_OPENSSL
+#if HAVE_OPENSSL && !defined(OPENSSL_IS_BORINGSSL)
     {
       std::string extra_ca_certs;
       if (credentials::SafeGetenv("NODE_EXTRA_CA_CERTS", &extra_ca_certs))
@@ -1091,7 +1091,7 @@ InitializationResult InitializeOncePerProcess(
   // V8 on Windows doesn't have a good source of entropy. Seed it from
   // OpenSSL's pool.
   V8::SetEntropySource(crypto::EntropySource);
-#endif  // HAVE_OPENSSL
+#endif  // HAVE_OPENSSL && !defined(OPENSSL_IS_BORINGSSL)
 }
   per_process::v8_platform.Initialize(
       static_cast<int>(per_process::cli_options->v8_thread_pool_size));


### PR DESCRIPTION
Follow-up to https://github.com/nodejs/node/pull/38888 - that PR addressed most of our needs but I neglected to include the guard for `OPENSSL_IS_BORINGSSL`.

This is necessary over and above the initialization flags conditional because several functions including `OPENSSL_init()` are not defined in BoringSSL, so while they might not be called for us anymore under the previous PR they still exist for the compiler and cause compiler errors. This fixes that.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
