### PR TITLE
repl: unflag --experimental-repl-await

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -279,13 +279,6 @@ added: v11.8.0
 
 Use the specified file as a security policy.
 
-### `--experimental-repl-await`
-<!-- YAML
-added: v10.0.0
--->
-
-Enable experimental top-level `await` keyword support in REPL.
-
 ### `--experimental-specifier-resolution=mode`
 <!-- YAML
 added:
@@ -1401,7 +1394,6 @@ Node.js options that are allowed are:
 * `--experimental-loader`
 * `--experimental-modules`
 * `--experimental-policy`
-* `--experimental-repl-await`
 * `--experimental-specifier-resolution`
 * `--experimental-top-level-await`
 * `--experimental-vm-modules`

--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -217,8 +217,7 @@ Error: foo
 
 #### `await` keyword
 
-With the [`--experimental-repl-await`][] command-line option specified,
-experimental support for the `await` keyword is enabled.
+Experimental support for the `await` keyword is supported.
 
 ```console
 > await Promise.resolve(123)
@@ -764,7 +763,6 @@ For an example of running a REPL instance over [`curl(1)`][], see:
 [TTY keybindings]: readline.md#readline_tty_keybindings
 [ZSH]: https://en.wikipedia.org/wiki/Z_shell
 [`'uncaughtException'`]: process.md#process_event_uncaughtexception
-[`--experimental-repl-await`]: cli.md#cli_experimental_repl_await
 [`ERR_DOMAIN_CANNOT_SET_UNCAUGHT_EXCEPTION_CAPTURE`]: errors.md#errors_err_domain_cannot_set_uncaught_exception_capture
 [`ERR_INVALID_REPL_INPUT`]: errors.md#errors_err_invalid_repl_input
 [`curl(1)`]: https://curl.haxx.se/docs/manpage.html

--- a/doc/node.1
+++ b/doc/node.1
@@ -153,11 +153,6 @@ to use as a custom module loader.
 .It Fl -experimental-policy
 Use the specified file as a security policy.
 .
-.It Fl -experimental-repl-await
-Enable experimental top-level
-.Sy await
-keyword support in REPL.
-.
 .It Fl -experimental-specifier-resolution
 Select extension resolution algorithm for ES Modules; either 'explicit' (default) or 'node'.
 .

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -149,9 +149,6 @@ const {
   validateObject,
 } = require('internal/validators');
 
-const experimentalREPLAwait = getOptionValue(
-  '--experimental-repl-await'
-);
 const pendingDeprecation = getOptionValue('--pending-deprecation');
 const {
   REPL_MODE_SLOPPY,
@@ -421,7 +418,7 @@ function REPLServer(prompt,
       wrappedCmd = true;
     }
 
-    if (experimentalREPLAwait && StringPrototypeIncludes(code, 'await')) {
+    if (StringPrototypeIncludes(code, 'await')) {
       if (processTopLevelAwait === undefined) {
         ({ processTopLevelAwait } = require('internal/repl/await'));
       }

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -346,10 +346,6 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             &EnvironmentOptions::experimental_policy_integrity,
             kAllowedInEnvironment);
   Implies("--policy-integrity", "[has_policy_integrity_string]");
-  AddOption("--experimental-repl-await",
-            "experimental await keyword support in REPL",
-            &EnvironmentOptions::experimental_repl_await,
-            kAllowedInEnvironment);
   AddOption("--experimental-vm-modules",
             "experimental ES Module support in vm module",
             &EnvironmentOptions::experimental_vm_modules,

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -112,7 +112,6 @@ class EnvironmentOptions : public Options {
   std::string experimental_policy;
   std::string experimental_policy_integrity;
   bool has_policy_integrity_string;
-  bool experimental_repl_await = false;
   bool experimental_vm_modules = false;
   bool expose_internals = false;
   bool frozen_intrinsics = false;

--- a/test/parallel/test-repl-import-referrer.js
+++ b/test/parallel/test-repl-import-referrer.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 const cp = require('child_process');
 const fixtures = require('../common/fixtures');
 
-const args = ['--interactive', '--experimental-repl-await'];
+const args = ['--interactive'];
 const opts = { cwd: fixtures.path('es-modules') };
 const child = cp.spawn(process.execPath, args, opts);
 

--- a/test/parallel/test-repl-top-level-await.js
+++ b/test/parallel/test-repl-top-level-await.js
@@ -8,7 +8,7 @@ const repl = require('repl');
 
 common.skipIfInspectorDisabled();
 
-// Flags: --expose-internals --experimental-repl-await
+// Flags: --expose-internals
 
 const PROMPT = 'await repl > ';
 


### PR DESCRIPTION
This enables the `--experimental-repl-await` flag automatically.

Personally I find the `await import('module')` pattern indispensible here and keep forgetting that the `--experimental-repl-await` flag exists. This really makes modules experimentation much much easier, amongst many other things.

I would propose we keep the feature itself classed as unstable, but the REPL should in theory be able to accommodate more churn than most outward Node.js APIs anyway.

//cc @nodejs/modules @nodejs/repl @devsnek