### PR TITLE
modules: add import.meta.__dirname and import.meta.__filename

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -266,6 +266,44 @@ modules it can be used to load ES modules.
 The `import.meta` meta property is an `Object` that contains the following
 properties.
 
+### `import.meta.__dirname`
+
+> Stability: 3 - Legacy: Use `import.meta.url` instead.
+
+* {string} A convenience shortcut that provides the equivalent of the CommonJS
+  `__dirname` pseudo-global. Specifically, it returns the result of converting
+  the `import.meta.url` into a file path then returning the directory portion.
+
+The property is only available when `import.meta.url` specifies a `file://`
+URL.
+
+```mjs
+const { __dirname } = import.meta;
+```
+
+The `import.meta.__dirname` is provided as a convenience to help ease the
+transition from existing CommonJS code to ESM. New ESM code should use the
+`import.meta.url` property directly.
+
+### `import.meta.__filename`
+
+> Stability: 3 - Legacy: Use `import.meta.url` instead.
+
+* {string} A convenience shortcut that provides the equivalent of the CommonJS
+  `__filename` pseudo-global. Specifically, it returns the result of converting
+  the `import.meta.url` into a file path.
+
+The property is only available when `import.meta.url` specifies a `file://`
+URL.
+
+```mjs
+const { __filename } = import.meta;
+```
+
+The `import.meta.__filename` is provided as a convenience to help ease the
+transition from existing CommonJS code to ESM. New ESM code should use the
+`import.meta.url` property directly.
+
 ### `import.meta.url`
 
 * {string} The absolute `file:` URL of the module.

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -5,6 +5,7 @@ const {
   ArrayPrototypeMap,
   Boolean,
   JSONParse,
+  ObjectDefineProperties,
   ObjectGetPrototypeOf,
   ObjectPrototypeHasOwnProperty,
   ObjectKeys,
@@ -39,6 +40,7 @@ const {
   cjsParseCache
 } = require('internal/modules/cjs/loader');
 const internalURLModule = require('internal/url');
+const internalPathModule = require('path');
 const { defaultGetSource } = require(
   'internal/modules/esm/get_source');
 const { defaultTransformSource } = require(
@@ -129,6 +131,11 @@ function createImportMetaResolve(defaultParentUrl) {
 
 function initializeImportMeta(meta, { url }) {
   // Alphabetical
+  if (StringPrototypeStartsWith(url, 'file:')) {
+    meta.__filename = internalURLModule.fileURLToPath(new URL(url));
+    meta.__dirname = internalPathModule.dirname(meta.__filename);
+  }
+
   if (experimentalImportMetaResolve)
     meta.resolve = createImportMetaResolve(url);
   meta.url = url;

--- a/test/es-module/test-esm-import-meta.mjs
+++ b/test/es-module/test-esm-import-meta.mjs
@@ -3,7 +3,7 @@ import assert from 'assert';
 
 assert.strictEqual(Object.getPrototypeOf(import.meta), null);
 
-const keys = ['url'];
+const keys = ['__filename', '__dirname', 'url'];
 assert.deepStrictEqual(Reflect.ownKeys(import.meta), keys);
 
 const descriptors = Object.getOwnPropertyDescriptors(import.meta);
@@ -18,3 +18,9 @@ for (const descriptor of Object.values(descriptors)) {
 
 const urlReg = /^file:\/\/\/.*\/test\/es-module\/test-esm-import-meta\.mjs$/;
 assert(import.meta.url.match(urlReg));
+
+const filenameReg = /^\/.*\/test\/es-module\/test-esm-import-meta\.mjs$/;
+assert(import.meta.__filename.match(filenameReg));
+
+const dirnameReg = /^\/.*\/test\/es-module$/;
+assert(import.meta.__dirname.match(dirnameReg));


### PR DESCRIPTION
To help ease the transition from existing CommonJS code to
ESM, adds convenience properties to `import.meta` that are
explicitly marked "Legacy" in the documentation.

This may or may not be a good idea, but I've run into this
enough times that I figured I'd at least see. If folks don't
think this is a good idea, then I'm fine with it not landing.

```js
const {
  __filename,
  __dirname,
} = import.meta;
```

They are only available when `file://` modules are used.

