### PR TITLE
doc: use repository instead of repo

### DIFF
--- a/doc/guides/collaborator-guide.md
+++ b/doc/guides/collaborator-guide.md
@@ -95,7 +95,7 @@ issues. If a user opens a security issue in the public repository:
 
 * Ask the user to submit a report through HackerOne as outlined in
   [SECURITY.md][].
-* Move the issue to the private repo called
+* Move the issue to the private repository called
   [premature-disclosures](https://github.com/nodejs/premature-disclosures).
 * For any related pull requests, create an associated issue in the
   `premature-disclosures` repository.  Add a copy of the patch for the
@@ -552,7 +552,7 @@ Checkout proper target branch:
 $ git checkout master
 ```
 
-Update the tree (assumes your repo is set up as detailed in
+Update the tree (assumes your repository is set up as detailed in
 [CONTRIBUTING.md](./contributing/pull-requests.md#step-1-fork)):
 
 ```text


### PR DESCRIPTION
Stick with "repository" instead of using both "repository" and "repo".

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
