### PR TITLE
src: use void* to clarify map key semantics

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -957,7 +957,7 @@ inline IsolateData* Environment::isolate_data() const {
   return isolate_data_;
 }
 
-std::unordered_map<char*, std::unique_ptr<v8::BackingStore>>*
+std::unordered_map<void*, std::unique_ptr<v8::BackingStore>>*
     Environment::released_allocated_buffers() {
   return &released_allocated_buffers_;
 }

--- a/src/env.h
+++ b/src/env.h
@@ -584,7 +584,7 @@ class IsolateData : public MemoryRetainer {
   inline v8::Local<v8::String> async_wrap_provider(int index) const;
 
   size_t max_young_gen_size = 1;
-  std::unordered_map<const char*, v8::Eternal<v8::String>> static_str_map;
+  std::unordered_map<const void*, v8::Eternal<v8::String>> static_str_map;
 
   inline v8::Isolate* isolate() const;
   IsolateData(const IsolateData&) = delete;
@@ -1431,7 +1431,7 @@ class Environment : public MemoryRetainer {
   void RunAndClearNativeImmediates(bool only_refed = false);
   void RunAndClearInterrupts();
 
-  inline std::unordered_map<char*, std::unique_ptr<v8::BackingStore>>*
+  inline std::unordered_map<void*, std::unique_ptr<v8::BackingStore>>*
       released_allocated_buffers();
 
   void AddUnmanagedFd(int fd);
@@ -1608,7 +1608,7 @@ class Environment : public MemoryRetainer {
 
   // Used by AllocatedBuffer::release() to keep track of the BackingStore for
   // a given pointer.
-  std::unordered_map<char*, std::unique_ptr<v8::BackingStore>>
+  std::unordered_map<void*, std::unique_ptr<v8::BackingStore>>
       released_allocated_buffers_;
 };
 


### PR DESCRIPTION
Using char* as a map key may suggest to readers of the code that
the map is using "string keys" when it's in fact using the pointer/
identity of the string. Switching to void* can help minimize the
potential for confusion.

This patch was originally submitted by @ElenaKwan.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
