### PR TITLE
test,tools: remove armv6 from test tools and checks

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -252,9 +252,6 @@ function platformTimeout(ms) {
 
   const armv = process.config.variables.arm_version;
 
-  if (armv === '6')
-    return multipliers.seven * ms;  // ARMv6
-
   if (armv === '7')
     return multipliers.two * ms;  // ARMv7
 

--- a/test/pummel/test-crypto-dh-hash-modp18.js
+++ b/test/pummel/test-crypto-dh-hash-modp18.js
@@ -26,9 +26,8 @@ if (!common.hasCrypto) {
   common.skip('node compiled without OpenSSL.');
 }
 
-if ((process.config.variables.arm_version === '6') ||
-  (process.config.variables.arm_version === '7')) {
-  common.skip('Too slow for armv6 and armv7 bots');
+if (process.config.variables.arm_version === '7') {
+  common.skip('Too slow for armv7 bots');
 }
 
 const assert = require('assert');

--- a/test/pummel/test-crypto-dh-hash.js
+++ b/test/pummel/test-crypto-dh-hash.js
@@ -26,9 +26,8 @@ if (!common.hasCrypto) {
   common.skip('node compiled without OpenSSL.');
 }
 
-if ((process.config.variables.arm_version === '6') ||
-  (process.config.variables.arm_version === '7')) {
-  common.skip('Too slow for armv6 and armv7 bots');
+if (process.config.variables.arm_version === '7') {
+  common.skip('Too slow for armv7 bots');
 }
 
 const assert = require('assert');

--- a/test/pummel/test-crypto-dh-keys.js
+++ b/test/pummel/test-crypto-dh-keys.js
@@ -26,9 +26,8 @@ if (!common.hasCrypto) {
   common.skip('node compiled without OpenSSL.');
 }
 
-if ((process.config.variables.arm_version === '6') ||
-  (process.config.variables.arm_version === '7')) {
-  common.skip('Too slow for armv6 and armv7 bots');
+if (process.config.variables.arm_version === '7') {
+  common.skip('Too slow for armv7 bots');
 }
 
 const assert = require('assert');

--- a/test/pummel/test-dh-regr.js
+++ b/test/pummel/test-dh-regr.js
@@ -26,9 +26,8 @@ if (!common.hasCrypto) {
   common.skip('missing crypto');
 }
 
-if ((process.config.variables.arm_version === '6') ||
-  (process.config.variables.arm_version === '7')) {
-  common.skip('Too slow for armv6 and armv7 bots');
+if (process.config.variables.arm_version === '7') {
+  common.skip('Too slow for armv7 bots');
 }
 
 const assert = require('assert');

--- a/test/pummel/test-fs-watch-system-limit.js
+++ b/test/pummel/test-fs-watch-system-limit.js
@@ -9,9 +9,8 @@ if (!common.isLinux) {
   common.skip('The fs watch limit is OS-dependent');
 }
 
-if ((process.config.variables.arm_version === '6') ||
-  (process.config.variables.arm_version === '7')) {
-  common.skip('Too slow for armv6 and armv7 bots');
+if (process.config.variables.arm_version === '7') {
+  common.skip('Too slow for armv7 bots');
 }
 
 try {

--- a/test/pummel/test-hash-seed.js
+++ b/test/pummel/test-hash-seed.js
@@ -3,9 +3,9 @@
 // Check that spawn child doesn't create duplicated entries
 const common = require('../common');
 
-if ((process.config.variables.arm_version === '6') ||
-    (process.config.variables.arm_version === '7'))
-  common.skip('Too slow for armv6 and armv7 bots');
+if (process.config.variables.arm_version === '7') {
+  common.skip('Too slow for armv7 bots');
+}
 
 const kRepetitions = 2;
 const assert = require('assert');

--- a/test/pummel/test-heapsnapshot-near-heap-limit-bounded.js
+++ b/test/pummel/test-heapsnapshot-near-heap-limit-bounded.js
@@ -2,9 +2,8 @@
 
 const common = require('../common');
 
-if ((process.config.variables.arm_version === '6') ||
-  (process.config.variables.arm_version === '7')) {
-  common.skip('Too slow for armv6 and armv7 bots');
+if (process.config.variables.arm_version === '7') {
+  common.skip('Too slow for armv7 bots');
 }
 
 const tmpdir = require('../common/tmpdir');

--- a/test/pummel/test-heapsnapshot-near-heap-limit.js
+++ b/test/pummel/test-heapsnapshot-near-heap-limit.js
@@ -2,9 +2,8 @@
 
 const common = require('../common');
 
-if ((process.config.variables.arm_version === '6') ||
-  (process.config.variables.arm_version === '7')) {
-  common.skip('Too slow for armv6 and armv7 bots');
+if (process.config.variables.arm_version === '7') {
+  common.skip('Too slow for armv7 bots');
 }
 
 const tmpdir = require('../common/tmpdir');

--- a/test/pummel/test-net-bytes-per-incoming-chunk-overhead.js
+++ b/test/pummel/test-net-bytes-per-incoming-chunk-overhead.js
@@ -7,9 +7,8 @@ if (process.config.variables.asan) {
   common.skip('ASAN messes with memory measurements');
 }
 
-if ((process.config.variables.arm_version === '6') ||
-  (process.config.variables.arm_version === '7')) {
-  common.skip('Too slow for armv6 and armv7 bots');
+if (process.config.variables.arm_version === '7') {
+  common.skip('Too slow for armv7 bots');
 }
 
 const assert = require('assert');

--- a/test/pummel/test-next-tick-infinite-calls.js
+++ b/test/pummel/test-next-tick-infinite-calls.js
@@ -22,9 +22,8 @@
 'use strict';
 const common = require('../common');
 
-if ((process.config.variables.arm_version === '6') ||
-  (process.config.variables.arm_version === '7')) {
-  common.skip('Too slow for armv6 and armv7 bots');
+if (process.config.variables.arm_version === '7') {
+  common.skip('Too slow for armv7 bots');
 }
 
 let complete = 0;

--- a/test/pummel/test-policy-integrity.js
+++ b/test/pummel/test-policy-integrity.js
@@ -6,9 +6,8 @@ if (!common.hasCrypto) {
   common.skip('missing crypto');
 }
 
-if ((process.config.variables.arm_version === '6') ||
-  (process.config.variables.arm_version === '7')) {
-  common.skip('Too slow for armv6 and armv7 bots');
+if (process.config.variables.arm_version === '7') {
+  common.skip('Too slow for armv7 bots');
 }
 
 common.requireNoPackageJSONAbove();

--- a/test/pummel/test-webcrypto-derivebits-pbkdf2.js
+++ b/test/pummel/test-webcrypto-derivebits-pbkdf2.js
@@ -6,9 +6,8 @@ if (!common.hasCrypto) {
   common.skip('missing crypto');
 }
 
-if ((process.config.variables.arm_version === '6') ||
-  (process.config.variables.arm_version === '7')) {
-  common.skip('Too slow for armv6 and armv7 bots');
+if (process.config.variables.arm_version === '7') {
+  common.skip('Too slow for armv7 bots');
 }
 
 const assert = require('assert');

--- a/test/sequential/test-child-process-pass-fd.js
+++ b/test/sequential/test-child-process-pass-fd.js
@@ -9,9 +9,9 @@ const common = require('../common');
 // This test is basically `test-cluster-net-send` but creating lots of workers
 // so the issue reproduces on OS X consistently.
 
-if ((process.config.variables.arm_version === '6') ||
-    (process.config.variables.arm_version === '7'))
-  common.skip('Too slow for armv6 and armv7 bots');
+if (process.config.variables.arm_version === '7') {
+  common.skip('Too slow for armv7 bots');
+}
 
 const assert = require('assert');
 const { fork } = require('child_process');

--- a/tools/test.py
+++ b/tools/test.py
@@ -896,8 +896,7 @@ class LiteralTestSuite(TestSuite):
 
 
 TIMEOUT_SCALEFACTOR = {
-    'armv6' : { 'debug' : 12, 'release' : 3 },  # The ARM buildbots are slow.
-    'arm'   : { 'debug' :  8, 'release' : 2 },
+    'arm'   : { 'debug' :  8, 'release' : 2 }, # The ARM buildbots are slow.
     'ia32'  : { 'debug' :  4, 'release' : 1 },
     'ppc'   : { 'debug' :  4, 'release' : 1 },
     's390'  : { 'debug' :  4, 'release' : 1 } }

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -83,9 +83,7 @@ def GuessOS():
 def GuessArchitecture():
   id = platform.machine()
   id = id.lower()  # Windows 7 capitalizes 'AMD64'.
-  if id.startswith('armv6'): # Can return 'armv6l'.
-    return 'armv6'
-  elif id.startswith('arm') or id == 'aarch64':
+  if id.startswith('arm') or id == 'aarch64':
     return 'arm'
   elif (not id) or (not re.match('(x|i[3-6])86$', id) is None):
     return 'ia32'


### PR DESCRIPTION
We no longer have armv6 in our regular CI. Remove checks.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
