### PR TITLE
doc: replace outdated `util.promisify` timer examples with references to new awaitable timers

### DIFF
--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -170,25 +170,7 @@ next event loop iteration.
 If `callback` is not a function, a [`TypeError`][] will be thrown.
 
 This method has a custom variant for promises that is available using
-[`util.promisify()`][]:
-
-```js
-const util = require('util');
-const setImmediatePromise = util.promisify(setImmediate);
-
-setImmediatePromise('foobar').then((value) => {
-  // value === 'foobar' (passing values is optional)
-  // This is executed after all I/O callbacks.
-});
-
-// Or with async function
-async function timerExample() {
-  console.log('Before I/O callbacks');
-  await setImmediatePromise();
-  console.log('After I/O callbacks');
-}
-timerExample();
-```
+[`timersPromises.setImmediate()`][].
 
 ### `setInterval(callback[, delay[, ...args]])`
 <!-- YAML
@@ -207,6 +189,9 @@ When `delay` is larger than `2147483647` or less than `1`, the `delay` will be
 set to `1`. Non-integer delays are truncated to an integer.
 
 If `callback` is not a function, a [`TypeError`][] will be thrown.
+
+This method has an async iterator variant that is available using
+[`timersPromises.setInterval()`][].
 
 ### `setTimeout(callback[, delay[, ...args]])`
 <!-- YAML
@@ -232,17 +217,7 @@ will be set to `1`. Non-integer delays are truncated to an integer.
 If `callback` is not a function, a [`TypeError`][] will be thrown.
 
 This method has a custom variant for promises that is available using
-[`util.promisify()`][]:
-
-```js
-const util = require('util');
-const setTimeoutPromise = util.promisify(setTimeout);
-
-setTimeoutPromise(40, 'foobar').then((value) => {
-  // value === 'foobar' (passing values is optional)
-  // This is executed after about 40 milliseconds.
-});
-```
+[`timersPromises.setTimeout()`][].
 
 ## Cancelling timers
 
@@ -257,8 +232,7 @@ returned Promises will be rejected with an `'AbortError'`.
 For `setImmediate()`:
 
 ```js
-const util = require('util');
-const setImmediatePromise = util.promisify(setImmediate);
+const { setImmediate: setImmediatePromise } = require('timers/promises');
 
 const ac = new AbortController();
 const signal = ac.signal;
@@ -276,8 +250,7 @@ ac.abort();
 For `setTimeout()`:
 
 ```js
-const util = require('util');
-const setTimeoutPromise = util.promisify(setTimeout);
+const { setTimeout: setTimeoutPromise } = require('timers/promises');
 
 const ac = new AbortController();
 const signal = ac.signal;
@@ -478,6 +451,9 @@ const interval = 100;
 [`setImmediate()`]: #timers_setimmediate_callback_args
 [`setInterval()`]: #timers_setinterval_callback_delay_args
 [`setTimeout()`]: #timers_settimeout_callback_delay_args
+[`timersPromises.setImmediate()`]: timers.md#timerspromisessetimmediatevalue-options
+[`timersPromises.setInterval()`]: timers.md#timerspromisessetintervaldelay-value-options
+[`timersPromises.setTimeout()`]: timers.md#timerspromisessettimeoutdelay-value-options
 [`util.promisify()`]: util.md#util_util_promisify_original
 [`worker_threads`]: worker_threads.md
 [primitive]: #timers_timeout_symbol_toprimitive

--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -190,7 +190,7 @@ set to `1`. Non-integer delays are truncated to an integer.
 
 If `callback` is not a function, a [`TypeError`][] will be thrown.
 
-This method has an async iterator variant that is available using
+This method has a custom variant for promises that is available using
 [`timersPromises.setInterval()`][].
 
 ### `setTimeout(callback[, delay[, ...args]])`

--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -451,9 +451,8 @@ const interval = 100;
 [`setImmediate()`]: #timers_setimmediate_callback_args
 [`setInterval()`]: #timers_setinterval_callback_delay_args
 [`setTimeout()`]: #timers_settimeout_callback_delay_args
-[`timersPromises.setImmediate()`]: timers.md#timerspromisessetimmediatevalue-options
-[`timersPromises.setInterval()`]: timers.md#timerspromisessetintervaldelay-value-options
-[`timersPromises.setTimeout()`]: timers.md#timerspromisessettimeoutdelay-value-options
-[`util.promisify()`]: util.md#util_util_promisify_original
+[`timersPromises.setImmediate()`]: #timers_timerspromises_setimmediate_value_options
+[`timersPromises.setInterval()`]: #timers_timerspromises_setinterval_delay_value_options
+[`timersPromises.setTimeout()`]: #timers_timerspromises_settimeout_delay_value_options
 [`worker_threads`]: worker_threads.md
 [primitive]: #timers_timeout_symbol_toprimitive


### PR DESCRIPTION
Since the [new awaitable timers](https://nodejs.org/api/timers.html#timers_timers_promises_api) [graduated](https://github.com/nodejs/node/pull/38112) in [16.0.0](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V16.md#stable-timers-promises-api), the [references to using `util.promisify`](https://nodejs.org/api/timers.html#timers_setimmediate_callback_args) to promisify the callback versions of `setTimeout()`, `setImmediate()`, etc, are confusing and likely outdated.

This PR removes the `util.promisify` code samples and links to the `timers/promises` variants instead. 

Furthermore, it adds a link to the async iterator version of `setInterval()` in the respective docs for the callback-based version.