### PR TITLE
doc: fix color contrast for anchor marks in dark mode

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -32,6 +32,7 @@
   --color-fill-app: var(--white);
   --color-fill-side-nav: var(--gray6);
   --color-links: var(--green1);
+  --color-text-mark: var(--gray1);
   --color-text-nav: var(--gray3);
   --color-text-primary: var(--gray6);
   --color-text-secondary: var(--green2);
@@ -42,6 +43,7 @@
   --color-fill-app: var(--black1);
   --color-fill-side-nav: var(--black3);
   --color-links: var(--green5);
+  --color-text-mark: var(--gray5);
   --color-text-primary: var(--white);
 }
 
@@ -632,7 +634,7 @@ a code {
 
 span > .mark,
 span > .mark:visited {
-  color: #707070;
+  color: var(--color-text-mark);
   position: absolute;
   top: 0;
   right: 0;


### PR DESCRIPTION
Currently, in its dark mode, our website background color is #090C15 and
our anchor marks are #707070 for a contrast ratio of 3.94 to 1, falling
short of the WCAG AA 4.5 to 1. This changes the mark color in dark mode
only to #7A7A7A for a color contrast of 4.55 to 1.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
