### PR TITLE
esm: refine ERR_REQUIRE_ESM errors

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -14,7 +14,7 @@ const {
   AggregateError,
   ArrayFrom,
   ArrayIsArray,
-  ArrayPrototypeFilter,
+  ArrayPrototypeFindIndex,
   ArrayPrototypeIncludes,
   ArrayPrototypeIndexOf,
   ArrayPrototypeJoin,
@@ -117,6 +117,12 @@ const prepareStackTrace = (globalThis, error, trace) => {
 
   // try to avoid unnecessary getter calls
   const code = error.code;
+  if (code && overrideStackTraceByCode.has(code)) {
+    const f = overrideStackTraceByCode.get(code);
+    return f(error, trace);
+  }
+
+  const { code } = error;
   if (code && overrideStackTraceByCode.has(code)) {
     const f = overrideStackTraceByCode.get(code);
     return f(error, trace);
@@ -813,19 +819,13 @@ function setArrowMessage(err, arrowMessage) {
 function hideLeadingInternalFrames(error, stackFrames) {
   let frames = stackFrames;
   if (typeof stackFrames === 'object') {
-    let beforeUserCode = true;
-    frames = ArrayPrototypeFilter(
+    frames = ArrayPrototypeSlice(
       stackFrames,
-      (frm) => {
-        if (!beforeUserCode)
-          return true;
-        const isInternal = StringPrototypeStartsWith(frm.getFileName(),
-                                                     'node:internal');
-        if (!isInternal)
-          beforeUserCode = false;
-        return !isInternal;
-      },
-    );
+      ArrayPrototypeFindIndex(
+        stackFrames,
+        (frm) => !StringPrototypeStartsWith(frm.getFileName(),
+                                            'node:internal')
+    ));
   }
   ArrayPrototypeUnshift(frames, error);
   return ArrayPrototypeJoin(frames, '\n    at ');
@@ -1459,7 +1459,7 @@ E('ERR_REQUIRE_ESM',
     let msg = `require() of ES Module ${filename}${parentPath ? ` from ${
       parentPath}` : ''} not supported.`;
     if (!packageJsonPath) {
-      if (filename.endsWith('.mjs'))
+      if (StringPrototypeEndsWith(filename, '.mjs'))
         msg += `\nInstead change the require of ${filename} to a dynamic ` +
             'import() which is available in all CommonJS modules.';
       return msg;

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -825,7 +825,8 @@ function hideLeadingInternalFrames(error, stackFrames) {
         stackFrames,
         (frm) => !StringPrototypeStartsWith(frm.getFileName(),
                                             'node:internal')
-    ));
+      )
+    );
   }
   ArrayPrototypeUnshift(frames, error);
   return ArrayPrototypeJoin(frames, '\n    at ');

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1461,9 +1461,9 @@ E('ERR_REQUIRE_ESM',
       'which declares all .js files in that package scope as ES modules.' +
       `\nInstead rename ${basename} to end in .cjs, change the requiring ` +
       'code to use dynamic import() which is available in all CommonJS ' +
-      `modules, or remove "type": "module" from ${packageJsonPath} to ` +
-      'treat all .js files as CommonJS (using .mjs for all ES modules ' +
-      'instead).\n';
+      'modules, or change "type": "module" to "type": "commonjs" in ' +
+      `${packageJsonPath} to treat all .js files as CommonJS (using .mjs for ` +
+      'all ES modules instead).\n';
     return msg;
   }, Error);
 E('ERR_SCRIPT_EXECUTION_INTERRUPTED',

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -14,7 +14,7 @@ const {
   AggregateError,
   ArrayFrom,
   ArrayIsArray,
-  ArrayPrototypeFindIndex,
+  ArrayPrototypeFilter,
   ArrayPrototypeIncludes,
   ArrayPrototypeIndexOf,
   ArrayPrototypeJoin,
@@ -114,19 +114,6 @@ const prepareStackTrace = (globalThis, error, trace) => {
   const globalOverride =
     maybeOverridePrepareStackTrace(globalThis, error, trace);
   if (globalOverride !== kNoOverride) return globalOverride;
-
-  // try to avoid unnecessary getter calls
-  const code = error.code;
-  if (code && overrideStackTraceByCode.has(code)) {
-    const f = overrideStackTraceByCode.get(code);
-    return f(error, trace);
-  }
-
-  const { code } = error;
-  if (code && overrideStackTraceByCode.has(code)) {
-    const f = overrideStackTraceByCode.get(code);
-    return f(error, trace);
-  }
 
   // Normal error formatting:
   //
@@ -351,7 +338,7 @@ function makeSystemErrorWithCode(key) {
   };
 }
 
-function makeNodeErrorWithCode(Base, key, deferStack) {
+function makeNodeErrorWithCode(Base, key) {
   return function NodeError(...args) {
     const limit = Error.stackTraceLimit;
     if (isErrorStackTraceLimitWritable()) Error.stackTraceLimit = 0;
@@ -403,19 +390,18 @@ function hideStackFrames(fn) {
 // Utility function for registering the error codes. Only used here. Exported
 // *only* to allow for testing.
 function E(sym, val, def, ...otherClasses) {
-  const deferStack = overrideStackTraceByCode.has(sym);
   // Special case for SystemError that formats the error message differently
   // The SystemErrors only have SystemError as their base classes.
   messages.set(sym, val);
   if (def === SystemError) {
     def = makeSystemErrorWithCode(sym);
   } else {
-    def = makeNodeErrorWithCode(def, sym, deferStack);
+    def = makeNodeErrorWithCode(def, sym);
   }
 
   if (otherClasses.length !== 0) {
     otherClasses.forEach((clazz) => {
-      def[clazz.name] = makeNodeErrorWithCode(clazz, sym, deferStack);
+      def[clazz.name] = makeNodeErrorWithCode(clazz, sym);
     });
   }
   codes[sym] = def;
@@ -816,20 +802,19 @@ function setArrowMessage(err, arrowMessage) {
 }
 
 // Hide stack lines before the first user code line.
-function hideLeadingInternalFrames(error, stackFrames) {
-  let frames = stackFrames;
-  if (typeof stackFrames === 'object') {
-    frames = ArrayPrototypeSlice(
-      stackFrames,
-      ArrayPrototypeFindIndex(
+function hideInternalStackFrames(error) {
+  overrideStackTrace.set(error, (error, stackFrames) => {
+    let frames = stackFrames;
+    if (typeof stackFrames === 'object') {
+      frames = ArrayPrototypeFilter(
         stackFrames,
         (frm) => !StringPrototypeStartsWith(frm.getFileName(),
                                             'node:internal')
-      )
-    );
-  }
-  ArrayPrototypeUnshift(frames, error);
-  return ArrayPrototypeJoin(frames, '\n    at ');
+      );
+    }
+    ArrayPrototypeUnshift(frames, error);
+    return ArrayPrototypeJoin(frames, '\n    at ');
+  });
 }
 
 // Node uses an AbortError that isn't exactly the same as the DOMException
@@ -850,6 +835,7 @@ module.exports = {
   exceptionWithHostPort,
   getMessage,
   hideStackFrames,
+  hideInternalStackFrames,
   isErrorStackTraceLimitWritable,
   isStackOverflowError,
   setArrowMessage,
@@ -887,10 +873,6 @@ module.exports = {
 // Note: Please try to keep these in alphabetical order
 //
 // Note: Node.js specific errors must begin with the prefix ERR_
-
-// Custom error stack overrides.
-const overrideStackTraceByCode = new SafeMap()
-  .set('ERR_REQUIRE_ESM', hideLeadingInternalFrames);
 
 E('ERR_AMBIGUOUS_ARGUMENT', 'The "%s" argument is ambiguous. %s', TypeError);
 E('ERR_ARG_NOT_ITERABLE', '%s must be iterable', TypeError);
@@ -1456,7 +1438,8 @@ E('ERR_PERFORMANCE_INVALID_TIMESTAMP',
   '%d is not a valid timestamp', TypeError);
 E('ERR_PERFORMANCE_MEASURE_INVALID_OPTIONS', '%s', TypeError);
 E('ERR_REQUIRE_ESM',
-  (filename, hasEsmSyntax, parentPath = null, packageJsonPath = null) => {
+  function(filename, hasEsmSyntax, parentPath = null, packageJsonPath = null) {
+    hideInternalStackFrames(this);
     let msg = `require() of ES Module ${filename}${parentPath ? ` from ${
       parentPath}` : ''} not supported.`;
     if (!packageJsonPath) {

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -115,6 +115,13 @@ const prepareStackTrace = (globalThis, error, trace) => {
     maybeOverridePrepareStackTrace(globalThis, error, trace);
   if (globalOverride !== kNoOverride) return globalOverride;
 
+  // try to avoid unnecessary getter calls
+  const code = error.code;
+  if (code && overrideStackTraceByCode.has(code)) {
+    const f = overrideStackTraceByCode.get(code);
+    return f(error, trace);
+  }
+
   // Normal error formatting:
   //
   // Error: Message
@@ -881,9 +888,8 @@ module.exports = {
 // Note: Node.js specific errors must begin with the prefix ERR_
 
 // Custom error stack overrides.
-const overrideStackTraceByCode = new SafeMap([
-  ['ERR_REQUIRE_ESM', hideLeadingInternalFrames],
-]);
+const overrideStackTraceByCode = new SafeMap()
+  .set('ERR_REQUIRE_ESM', hideLeadingInternalFrames);
 
 E('ERR_AMBIGUOUS_ARGUMENT', 'The "%s" argument is ambiguous. %s', TypeError);
 E('ERR_ARG_NOT_ITERABLE', '%s must be iterable', TypeError);

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1470,7 +1470,7 @@ E('ERR_REQUIRE_ESM',
       'file whose nearest parent package.json contains "type": "module" ' +
       'which declares all .js files in that package scope as ES modules.' +
       `\nInstead rename ${basename} to end in .cjs, change the requiring ` +
-      'code to use dynamic import() which is available in all CommonJS' +
+      'code to use dynamic import() which is available in all CommonJS ' +
       `modules, or remove "type": "module" from ${packageJsonPath} to ` +
       'treat all .js files as CommonJS (using .mjs for all ES modules ' +
       'instead).\n';

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1449,7 +1449,7 @@ E('ERR_PERFORMANCE_INVALID_TIMESTAMP',
   '%d is not a valid timestamp', TypeError);
 E('ERR_PERFORMANCE_MEASURE_INVALID_OPTIONS', '%s', TypeError);
 E('ERR_REQUIRE_ESM',
-  function(filename, hasEsmSyntax, parentPath = null, packageJsonPath = null) {
+  (filename, hasEsmSyntax, parentPath = null, packageJsonPath = null) => {
     let msg = `require() of ES Module ${filename}${parentPath ? ` from ${
       parentPath}` : ''} not supported.`;
     if (!packageJsonPath) {

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -14,6 +14,7 @@ const {
   AggregateError,
   ArrayFrom,
   ArrayIsArray,
+  ArrayPrototypeFilter,
   ArrayPrototypeIncludes,
   ArrayPrototypeIndexOf,
   ArrayPrototypeJoin,
@@ -337,7 +338,7 @@ function makeSystemErrorWithCode(key) {
   };
 }
 
-function makeNodeErrorWithCode(Base, key) {
+function makeNodeErrorWithCode(Base, key, deferStack) {
   return function NodeError(...args) {
     const limit = Error.stackTraceLimit;
     if (isErrorStackTraceLimitWritable()) Error.stackTraceLimit = 0;
@@ -389,18 +390,19 @@ function hideStackFrames(fn) {
 // Utility function for registering the error codes. Only used here. Exported
 // *only* to allow for testing.
 function E(sym, val, def, ...otherClasses) {
+  const deferStack = overrideStackTraceByCode.has(sym);
   // Special case for SystemError that formats the error message differently
   // The SystemErrors only have SystemError as their base classes.
   messages.set(sym, val);
   if (def === SystemError) {
     def = makeSystemErrorWithCode(sym);
   } else {
-    def = makeNodeErrorWithCode(def, sym);
+    def = makeNodeErrorWithCode(def, sym, deferStack);
   }
 
   if (otherClasses.length !== 0) {
     otherClasses.forEach((clazz) => {
-      def[clazz.name] = makeNodeErrorWithCode(clazz, sym);
+      def[clazz.name] = makeNodeErrorWithCode(clazz, sym, deferStack);
     });
   }
   codes[sym] = def;
@@ -788,6 +790,40 @@ const fatalExceptionStackEnhancers = {
   }
 };
 
+// Ensures the printed error line is from user code.
+let _kArrowMessagePrivateSymbol, _setHiddenValue;
+function setArrowMessage(err, arrowMessage) {
+  if (!_kArrowMessagePrivateSymbol) {
+    ({
+      arrow_message_private_symbol: _kArrowMessagePrivateSymbol,
+      setHiddenValue: _setHiddenValue,
+    } = internalBinding('util'));
+  }
+  _setHiddenValue(err, _kArrowMessagePrivateSymbol, arrowMessage);
+}
+
+// Hide stack lines before the first user code line.
+function hideLeadingInternalFrames(error, stackFrames) {
+  let frames = stackFrames;
+  if (typeof stackFrames === 'object') {
+    let beforeUserCode = true;
+    frames = ArrayPrototypeFilter(
+      stackFrames,
+      (frm) => {
+        if (!beforeUserCode)
+          return true;
+        const isInternal = StringPrototypeStartsWith(frm.getFileName(),
+                                                     'node:internal');
+        if (!isInternal)
+          beforeUserCode = false;
+        return !isInternal;
+      },
+    );
+  }
+  ArrayPrototypeUnshift(frames, error);
+  return ArrayPrototypeJoin(frames, '\n    at ');
+}
+
 // Node uses an AbortError that isn't exactly the same as the DOMException
 // to make usage of the error in userland and readable-stream easier.
 // It is a regular error with `.code` and `.name`.
@@ -808,6 +844,7 @@ module.exports = {
   hideStackFrames,
   isErrorStackTraceLimitWritable,
   isStackOverflowError,
+  setArrowMessage,
   connResetException,
   uvErrmapGet,
   uvException,
@@ -842,6 +879,12 @@ module.exports = {
 // Note: Please try to keep these in alphabetical order
 //
 // Note: Node.js specific errors must begin with the prefix ERR_
+
+// Custom error stack overrides.
+const overrideStackTraceByCode = new SafeMap([
+  ['ERR_REQUIRE_ESM', hideLeadingInternalFrames],
+]);
+
 E('ERR_AMBIGUOUS_ARGUMENT', 'The "%s" argument is ambiguous. %s', TypeError);
 E('ERR_ARG_NOT_ITERABLE', '%s must be iterable', TypeError);
 E('ERR_ASSERTION', '%s', Error);
@@ -1406,23 +1449,31 @@ E('ERR_PERFORMANCE_INVALID_TIMESTAMP',
   '%d is not a valid timestamp', TypeError);
 E('ERR_PERFORMANCE_MEASURE_INVALID_OPTIONS', '%s', TypeError);
 E('ERR_REQUIRE_ESM',
-  (filename, parentPath = null, packageJsonPath = null) => {
-    let msg = `Must use import to load ES Module: ${filename}`;
-    if (parentPath && packageJsonPath) {
-      const path = require('path');
-      const basename = path.basename(filename) === path.basename(parentPath) ?
-        filename : path.basename(filename);
-      msg +=
-        '\nrequire() of ES modules is not supported.\nrequire() of ' +
-        `${filename} from ${parentPath} ` +
-        'is an ES module file as it is a .js file whose nearest parent ' +
-        'package.json contains "type": "module" which defines all .js ' +
-        'files in that package scope as ES modules.\nInstead rename ' +
-        `${basename} to end in .cjs, change the requiring code to use ` +
-        'import(), or remove "type": "module" from ' +
-        `${packageJsonPath}.\n`;
+  function(filename, hasEsmSyntax, parentPath = null, packageJsonPath = null) {
+    let msg = `require() of ES Module ${filename}${parentPath ? ` from ${
+      parentPath}` : ''} not supported.`;
+    if (!packageJsonPath) {
+      if (filename.endsWith('.mjs'))
+        msg += `\nInstead change the require of ${filename} to a dynamic ` +
+            'import() which is available in all CommonJS modules.';
       return msg;
     }
+    const path = require('path');
+    const basename = path.basename(filename) === path.basename(parentPath) ?
+      filename : path.basename(filename);
+    if (hasEsmSyntax) {
+      msg += `\nInstead change the require of ${basename} in ${parentPath} to` +
+        ' a dynamic import() which is available in all CommonJS modules.';
+      return msg;
+    }
+    msg += `\n${basename} is treated as an ES module file as it is a .js ` +
+      'file whose nearest parent package.json contains "type": "module" ' +
+      'which declares all .js files in that package scope as ES modules.' +
+      `\nInstead rename ${basename} to end in .cjs, change the requiring ` +
+      'code to use dynamic import() which is available in all CommonJS' +
+      `modules, or remove "type": "module" from ${packageJsonPath} to ` +
+      'treat all .js files as CommonJS (using .mjs for all ES modules ' +
+      'instead).\n';
     return msg;
   }, Error);
 E('ERR_SCRIPT_EXECUTION_INTERRUPTED',

--- a/lib/internal/modules/cjs/helpers.js
+++ b/lib/internal/modules/cjs/helpers.js
@@ -3,6 +3,7 @@
 const {
   ArrayPrototypeForEach,
   ArrayPrototypeJoin,
+  ArrayPrototypeSome,
   ObjectDefineProperty,
   ObjectPrototypeHasOwnProperty,
   SafeMap,
@@ -206,13 +207,10 @@ function hasEsmSyntax(code) {
     return false;
   }
 
-  for (const stmt of root.body) {
-    if (stmt.type === 'ExportNamedDeclaration' ||
-        stmt.type === 'ImportDeclaration' ||
-        stmt.type === 'ExportAllDeclaration')
-      return true;
-  }
-  return false;
+  return ArrayPrototypeSome(root.body, (stmt) =>
+    stmt.type === 'ExportNamedDeclaration' ||
+    stmt.type === 'ImportDeclaration' ||
+    stmt.type === 'ExportAllDeclaration');
 }
 
 module.exports = {

--- a/lib/internal/modules/cjs/helpers.js
+++ b/lib/internal/modules/cjs/helpers.js
@@ -30,13 +30,7 @@ let debug = require('internal/util/debuglog').debuglog('module', (fn) => {
   debug = fn;
 });
 
-const acorn = require('internal/deps/acorn/acorn/dist/acorn');
-const privateMethods =
-  require('internal/deps/acorn-plugins/acorn-private-methods/index');
-const classFields =
-  require('internal/deps/acorn-plugins/acorn-class-fields/index');
-const staticClassFeatures =
-  require('internal/deps/acorn-plugins/acorn-static-class-features/index');
+const parser = require('internal/deps/acorn/acorn/dist/acorn').Parser;
 
 // TODO: Use this set when resolving pkg#exports conditions in loader.js.
 const cjsConditions = new SafeSet(['require', 'node', ...userConditions]);
@@ -195,11 +189,6 @@ function normalizeReferrerURL(referrer) {
 
 // For error messages only - used to check if ESM syntax is in use.
 function hasEsmSyntax(code) {
-  const parser = acorn.Parser.extend(
-    privateMethods,
-    classFields,
-    staticClassFeatures
-  );
   let root;
   try {
     root = parser.parse(code, { sourceType: 'module', ecmaVersion: 'latest' });

--- a/lib/internal/modules/cjs/helpers.js
+++ b/lib/internal/modules/cjs/helpers.js
@@ -29,6 +29,14 @@ let debug = require('internal/util/debuglog').debuglog('module', (fn) => {
   debug = fn;
 });
 
+const acorn = require('internal/deps/acorn/acorn/dist/acorn');
+const privateMethods =
+  require('internal/deps/acorn-plugins/acorn-private-methods/index');
+const classFields =
+  require('internal/deps/acorn-plugins/acorn-class-fields/index');
+const staticClassFeatures =
+  require('internal/deps/acorn-plugins/acorn-static-class-features/index');
+
 // TODO: Use this set when resolving pkg#exports conditions in loader.js.
 const cjsConditions = new SafeSet(['require', 'node', ...userConditions]);
 
@@ -184,9 +192,33 @@ function normalizeReferrerURL(referrer) {
   return new URL(referrer).href;
 }
 
+// For error messages only - used to check if ESM syntax is in use.
+function hasEsmSyntax(code) {
+  const parser = acorn.Parser.extend(
+    privateMethods,
+    classFields,
+    staticClassFeatures
+  );
+  let root;
+  try {
+    root = parser.parse(code, { sourceType: 'module', ecmaVersion: 'latest' });
+  } catch {
+    return false;
+  }
+
+  for (const stmt of root.body) {
+    if (stmt.type === 'ExportNamedDeclaration' ||
+        stmt.type === 'ImportDeclaration' ||
+        stmt.type === 'ExportAllDeclaration')
+      return true;
+  }
+  return false;
+}
+
 module.exports = {
   addBuiltinLibsToObject,
   cjsConditions,
+  hasEsmSyntax,
   loadNativeModule,
   makeRequireFunction,
   normalizeReferrerURL,

--- a/lib/internal/modules/cjs/helpers.js
+++ b/lib/internal/modules/cjs/helpers.js
@@ -30,8 +30,6 @@ let debug = require('internal/util/debuglog').debuglog('module', (fn) => {
   debug = fn;
 });
 
-const parser = require('internal/deps/acorn/acorn/dist/acorn').Parser;
-
 // TODO: Use this set when resolving pkg#exports conditions in loader.js.
 const cjsConditions = new SafeSet(['require', 'node', ...userConditions]);
 
@@ -189,6 +187,7 @@ function normalizeReferrerURL(referrer) {
 
 // For error messages only - used to check if ESM syntax is in use.
 function hasEsmSyntax(code) {
+  const parser = require('internal/deps/acorn/acorn/dist/acorn').Parser;
   let root;
   try {
     root = parser.parse(code, { sourceType: 'module', ecmaVersion: 'latest' });

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -58,6 +58,7 @@ const {
   StringPrototypeLastIndexOf,
   StringPrototypeIndexOf,
   StringPrototypeMatch,
+  StringPrototypeRepeat,
   StringPrototypeSlice,
   StringPrototypeSplit,
   StringPrototypeStartsWith,
@@ -88,11 +89,12 @@ const { internalModuleStat } = internalBinding('fs');
 const packageJsonReader = require('internal/modules/package_json_reader');
 const { safeGetenv } = internalBinding('credentials');
 const {
+  cjsConditions,
+  hasEsmSyntax,
+  loadNativeModule,
   makeRequireFunction,
   normalizeReferrerURL,
   stripBOM,
-  cjsConditions,
-  loadNativeModule
 } = require('internal/modules/cjs/helpers');
 const { getOptionValue } = require('internal/options');
 const preserveSymlinks = getOptionValue('--preserve-symlinks');
@@ -107,11 +109,14 @@ const policy = getOptionValue('--experimental-policy') ?
 let hasLoadedAnyUserCJSModule = false;
 
 const {
-  ERR_INVALID_ARG_VALUE,
-  ERR_INVALID_MODULE_SPECIFIER,
-  ERR_REQUIRE_ESM,
-  ERR_UNKNOWN_BUILTIN_MODULE,
-} = require('internal/errors').codes;
+  codes: {
+    ERR_INVALID_ARG_VALUE,
+    ERR_INVALID_MODULE_SPECIFIER,
+    ERR_REQUIRE_ESM,
+    ERR_UNKNOWN_BUILTIN_MODULE,
+  },
+  setArrowMessage,
+} = require('internal/errors');
 const { validateString } = require('internal/validators');
 const pendingDeprecation = getOptionValue('--pending-deprecation');
 
@@ -970,7 +975,7 @@ Module.prototype.load = function(filename) {
   const extension = findLongestRegisteredExtension(filename);
   // allow .mjs to be overridden
   if (StringPrototypeEndsWith(filename, '.mjs') && !Module._extensions['.mjs'])
-    throw new ERR_REQUIRE_ESM(filename);
+    throw new ERR_REQUIRE_ESM(filename, true);
 
   Module._extensions[extension](this, filename);
   this.loaded = true;
@@ -1102,16 +1107,6 @@ Module.prototype._compile = function(content, filename) {
 
 // Native extension for .js
 Module._extensions['.js'] = function(module, filename) {
-  if (StringPrototypeEndsWith(filename, '.js')) {
-    const pkg = readPackageScope(filename);
-    // Function require shouldn't be used in ES modules.
-    if (pkg?.data?.type === 'module') {
-      const parent = moduleParentCache.get(module);
-      const parentPath = parent?.filename;
-      const packageJsonPath = path.resolve(pkg.path, 'package.json');
-      throw new ERR_REQUIRE_ESM(filename, parentPath, packageJsonPath);
-    }
-  }
   // If already analyzed the source, then it will be cached.
   const cached = cjsParseCache.get(module);
   let content;
@@ -1120,6 +1115,38 @@ Module._extensions['.js'] = function(module, filename) {
     cached.source = undefined;
   } else {
     content = fs.readFileSync(filename, 'utf8');
+  }
+  if (StringPrototypeEndsWith(filename, '.js')) {
+    const pkg = readPackageScope(filename);
+    // Function require shouldn't be used in ES modules.
+    if (pkg?.data?.type === 'module') {
+      const parent = moduleParentCache.get(module);
+      const parentPath = parent?.filename;
+      const packageJsonPath = path.resolve(pkg.path, 'package.json');
+      const usesEsm = hasEsmSyntax(content);
+      const err = new ERR_REQUIRE_ESM(filename, usesEsm, parentPath,
+                                      packageJsonPath);
+      // Attempt to reconstruct the parent require frame.
+      if (Module._cache[parentPath]) {
+        let parentSource;
+        try {
+          parentSource = fs.readFileSync(parentPath, 'utf8');
+        } catch {}
+        if (parentSource) {
+          const errLine = StringPrototypeSplit(StringPrototypeSlice(
+            err.stack, StringPrototypeIndexOf(err.stack, '    at ')), '\n')[0];
+          const { 1: line, 2: col } =
+              StringPrototypeMatch(errLine, /(\d+):(\d+)\)/) || [];
+          if (line && col) {
+            const srcLine = StringPrototypeSplit(parentSource, '\n')[line - 1];
+            const frame = `${parentPath}:${line}\n${srcLine}\n${
+              StringPrototypeRepeat(' ', col - 1)}^\n`;
+            setArrowMessage(err, frame);
+          }
+        }
+      }
+      throw err;
+    }
   }
   module._compile(content, filename);
 };

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -1134,9 +1134,9 @@ Module._extensions['.js'] = function(module, filename) {
         } catch {}
         if (parentSource) {
           const errLine = StringPrototypeSplit(StringPrototypeSlice(
-            err.stack, StringPrototypeIndexOf(err.stack, '    at ')), '\n')[0];
+            err.stack, StringPrototypeIndexOf(err.stack, '    at ')), '\n', 1)[0];
           const { 1: line, 2: col } =
-              StringPrototypeMatch(errLine, /(\d+):(\d+)\)/) || [];
+              RegExpPrototypeExec(/(\d+):(\d+)\)/, errLine) || [];
           if (line && col) {
             const srcLine = StringPrototypeSplit(parentSource, '\n')[line - 1];
             const frame = `${parentPath}:${line}\n${srcLine}\n${

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -1134,8 +1134,9 @@ Module._extensions['.js'] = function(module, filename) {
           parentSource = fs.readFileSync(parentPath, 'utf8');
         } catch {}
         if (parentSource) {
-          const errLine = StringPrototypeSplit(StringPrototypeSlice(
-            err.stack, StringPrototypeIndexOf(err.stack, '    at ')), '\n', 1)[0];
+          const errLine = StringPrototypeSplit(
+            StringPrototypeSlice(err.stack, StringPrototypeIndexOf(
+              err.stack, '    at ')), '\n', 1)[0];
           const { 1: line, 2: col } =
               RegExpPrototypeExec(/(\d+):(\d+)\)/, errLine) || [];
           if (line && col) {

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -48,6 +48,7 @@ const {
   Proxy,
   ReflectApply,
   ReflectSet,
+  RegExpPrototypeExec,
   RegExpPrototypeTest,
   SafeMap,
   SafeWeakMap,

--- a/src/node_errors.cc
+++ b/src/node_errors.cc
@@ -215,6 +215,12 @@ void AppendExceptionLine(Environment* env,
   Local<Object> err_obj;
   if (!er.IsEmpty() && er->IsObject()) {
     err_obj = er.As<Object>();
+    // If arrow_message is already set, skip.
+    auto maybe_value = err_obj->GetPrivate(env->context(),
+                                          env->arrow_message_private_symbol());
+    Local<Value> lvalue;
+    if (maybe_value.ToLocal(&lvalue) && lvalue->IsString())
+      return;
   }
 
   bool added_exception_line = false;

--- a/src/node_errors.cc
+++ b/src/node_errors.cc
@@ -219,7 +219,7 @@ void AppendExceptionLine(Environment* env,
     auto maybe_value = err_obj->GetPrivate(env->context(),
                                           env->arrow_message_private_symbol());
     Local<Value> lvalue;
-    if (maybe_value.ToLocal(&lvalue) && lvalue->IsString())
+    if (!maybe_value.ToLocal(&lvalue) || lvalue->IsString())
       return;
   }
 

--- a/test/es-module/test-cjs-esm-warn.js
+++ b/test/es-module/test-cjs-esm-warn.js
@@ -6,36 +6,59 @@ const { spawn } = require('child_process');
 const assert = require('assert');
 const path = require('path');
 
-const requiring = path.resolve(fixtures.path('/es-modules/cjs-esm.js'));
-const required = path.resolve(
-  fixtures.path('/es-modules/package-type-module/cjs.js')
-);
+const requiringCjsAsEsm = path.resolve(fixtures.path('/es-modules/cjs-esm.js'));
+const requiringEsm = path.resolve(fixtures.path('/es-modules/cjs-esm-esm.js'));
 const pjson = path.resolve(
   fixtures.path('/es-modules/package-type-module/package.json')
 );
 
-const basename = 'cjs.js';
+{
+  const required = path.resolve(
+    fixtures.path('/es-modules/package-type-module/cjs.js')
+  );
+  const basename = 'cjs.js';
+  const child = spawn(process.execPath, [requiringCjsAsEsm]);
+  let stderr = '';
+  child.stderr.setEncoding('utf8');
+  child.stderr.on('data', (data) => {
+    stderr += data;
+  });
+  child.on('close', common.mustCall((code, signal) => {
+    assert.strictEqual(code, 1);
+    assert.strictEqual(signal, null);
 
-const child = spawn(process.execPath, [requiring]);
-let stderr = '';
-child.stderr.setEncoding('utf8');
-child.stderr.on('data', (data) => {
-  stderr += data;
-});
-child.on('close', common.mustCall((code, signal) => {
-  assert.strictEqual(code, 1);
-  assert.strictEqual(signal, null);
+    assert.ok(stderr.replace(/\r/g, '').includes(
+      `Error [ERR_REQUIRE_ESM]: require() of ES Module ${required} from ${
+        requiringCjsAsEsm} not supported.\n`));
+    assert.ok(stderr.includes(
+      `Instead rename ${basename} to end in .cjs, change the requiring ` +
+      'code to use dynamic import() which is available in all CommonJS' +
+      `modules, or remove "type": "module" from ${pjson} to ` +
+      'treat all .js files as CommonJS (using .mjs for all ES modules ' +
+      'instead).\n'));
+  }));
+}
 
-  assert.ok(stderr.replace(/\r/g, '').includes(
-    `Error [ERR_REQUIRE_ESM]: Must use import to load ES Module: ${required}` +
-    '\nrequire() of ES modules is not supported.\nrequire() of ' +
-    `${required} from ${requiring} ` +
-    'is an ES module file as it is a .js file whose nearest parent ' +
-    'package.json contains "type": "module" which defines all .js ' +
-    'files in that package scope as ES modules.\nInstead rename ' +
-    `${basename} to end in .cjs, change the requiring code to use ` +
-    'import(), or remove "type": "module" from ' +
-    `${pjson}.\n`));
-  assert.ok(stderr.includes(
-    'Error [ERR_REQUIRE_ESM]: Must use import to load ES Module'));
-}));
+{
+  const required = path.resolve(
+    fixtures.path('/es-modules/package-type-module/esm.js')
+  );
+  const basename = 'esm.js';
+  const child = spawn(process.execPath, [requiringEsm]);
+  let stderr = '';
+  child.stderr.setEncoding('utf8');
+  child.stderr.on('data', (data) => {
+    stderr += data;
+  });
+  child.on('close', common.mustCall((code, signal) => {
+    assert.strictEqual(code, 1);
+    assert.strictEqual(signal, null);
+
+    assert.ok(stderr.replace(/\r/g, '').includes(
+      `Error [ERR_REQUIRE_ESM]: require() of ES Module ${required} from ${
+        requiringEsm} not supported.\n`));
+    assert.ok(stderr.includes(
+      `Instead change the require of ${basename} in ${requiringEsm} to` +
+      ' a dynamic import() which is available in all CommonJS modules.\n'));
+  }));
+}

--- a/test/es-module/test-cjs-esm-warn.js
+++ b/test/es-module/test-cjs-esm-warn.js
@@ -33,7 +33,7 @@ const pjson = path.resolve(
     assert.ok(stderr.includes(
       `Instead rename ${basename} to end in .cjs, change the requiring ` +
       'code to use dynamic import() which is available in all CommonJS ' +
-      `modules, or change "type": "module" to "type": "commonjs" from ${pjson} to ` +
+      `modules, or change "type": "module" to "type": "commonjs" in ${pjson} to ` +
       'treat all .js files as CommonJS (using .mjs for all ES modules ' +
       'instead).\n'));
   }));

--- a/test/es-module/test-cjs-esm-warn.js
+++ b/test/es-module/test-cjs-esm-warn.js
@@ -33,7 +33,7 @@ const pjson = path.resolve(
     assert.ok(stderr.includes(
       `Instead rename ${basename} to end in .cjs, change the requiring ` +
       'code to use dynamic import() which is available in all CommonJS ' +
-      `modules, or remove "type": "module" from ${pjson} to ` +
+      `modules, or change "type": "module" to "type": "commonjs" from ${pjson} to ` +
       'treat all .js files as CommonJS (using .mjs for all ES modules ' +
       'instead).\n'));
   }));

--- a/test/es-module/test-cjs-esm-warn.js
+++ b/test/es-module/test-cjs-esm-warn.js
@@ -35,7 +35,7 @@ const pjson = path.resolve(
       'code to use dynamic import() which is available in all CommonJS ' +
       `modules, or change "type": "module" to "type": "commonjs" in ${pjson} to ` +
       'treat all .js files as CommonJS (using .mjs for all ES modules ' +
-      'instead).\n'));
+      'instead).'));
   }));
 }
 

--- a/test/es-module/test-cjs-esm-warn.js
+++ b/test/es-module/test-cjs-esm-warn.js
@@ -32,7 +32,7 @@ const pjson = path.resolve(
         requiringCjsAsEsm} not supported.\n`));
     assert.ok(stderr.includes(
       `Instead rename ${basename} to end in .cjs, change the requiring ` +
-      'code to use dynamic import() which is available in all CommonJS' +
+      'code to use dynamic import() which is available in all CommonJS ' +
       `modules, or remove "type": "module" from ${pjson} to ` +
       'treat all .js files as CommonJS (using .mjs for all ES modules ' +
       'instead).\n'));

--- a/test/es-module/test-cjs-esm-warn.js
+++ b/test/es-module/test-cjs-esm-warn.js
@@ -27,7 +27,7 @@ const pjson = path.resolve(
     assert.strictEqual(code, 1);
     assert.strictEqual(signal, null);
 
-    assert.ok(stderr.replace(/\r/g, '').includes(
+    assert.ok(stderr.replaceAll('\r', '').includes(
       `Error [ERR_REQUIRE_ESM]: require() of ES Module ${required} from ${
         requiringCjsAsEsm} not supported.\n`));
     assert.ok(stderr.includes(

--- a/test/es-module/test-cjs-esm-warn.js
+++ b/test/es-module/test-cjs-esm-warn.js
@@ -30,12 +30,12 @@ const pjson = path.resolve(
     assert.ok(stderr.replaceAll('\r', '').includes(
       `Error [ERR_REQUIRE_ESM]: require() of ES Module ${required} from ${
         requiringCjsAsEsm} not supported.\n`));
-    assert.ok(stderr.includes(
+    assert.ok(stderr.replaceAll('\r', '').includes(
       `Instead rename ${basename} to end in .cjs, change the requiring ` +
       'code to use dynamic import() which is available in all CommonJS ' +
       `modules, or change "type": "module" to "type": "commonjs" in ${pjson} to ` +
       'treat all .js files as CommonJS (using .mjs for all ES modules ' +
-      'instead).'));
+      'instead).\n'));
   }));
 }
 
@@ -57,7 +57,7 @@ const pjson = path.resolve(
     assert.ok(stderr.replace(/\r/g, '').includes(
       `Error [ERR_REQUIRE_ESM]: require() of ES Module ${required} from ${
         requiringEsm} not supported.\n`));
-    assert.ok(stderr.includes(
+    assert.ok(stderr.replace(/\r/g, '').includes(
       `Instead change the require of ${basename} in ${requiringEsm} to` +
       ' a dynamic import() which is available in all CommonJS modules.\n'));
   }));

--- a/test/es-module/test-esm-type-flag-errors.js
+++ b/test/es-module/test-esm-type-flag-errors.js
@@ -29,8 +29,8 @@ try {
 } catch (e) {
   assert.strictEqual(e.name, 'Error');
   assert.strictEqual(e.code, 'ERR_REQUIRE_ESM');
-  assert(e.toString().match(/Must use import to load ES Module/g));
-  assert(e.message.match(/Must use import to load ES Module/g));
+  assert(e.toString().match(/require\(\) of ES Module/g));
+  assert(e.message.match(/require\(\) of ES Module/g));
 }
 
 function expect(opt = '', inputFile, want, wantsError = false) {

--- a/test/fixtures/es-modules/cjs-esm-esm.js
+++ b/test/fixtures/es-modules/cjs-esm-esm.js
@@ -1,0 +1,1 @@
+require('./package-type-module/esm.js');

--- a/test/fixtures/es-modules/package-type-module/esm.js
+++ b/test/fixtures/es-modules/package-type-module/esm.js
@@ -1,0 +1,1 @@
+export var p = 5;

--- a/test/parallel/test-bootstrap-modules.js
+++ b/test/parallel/test-bootstrap-modules.js
@@ -50,7 +50,6 @@ const expectedModules = new Set([
   'NativeModule internal/console/constructor',
   'NativeModule internal/console/global',
   'NativeModule internal/constants',
-  'NativeModule internal/deps/acorn/acorn/dist/acorn',
   'NativeModule internal/encoding',
   'NativeModule internal/errors',
   'NativeModule internal/event_target',

--- a/test/parallel/test-bootstrap-modules.js
+++ b/test/parallel/test-bootstrap-modules.js
@@ -50,6 +50,7 @@ const expectedModules = new Set([
   'NativeModule internal/console/constructor',
   'NativeModule internal/console/global',
   'NativeModule internal/constants',
+  'NativeModule internal/deps/acorn/acorn/dist/acorn',
   'NativeModule internal/encoding',
   'NativeModule internal/errors',
   'NativeModule internal/event_target',

--- a/test/parallel/test-require-mjs.js
+++ b/test/parallel/test-require-mjs.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 assert.throws(
   () => require('../fixtures/es-modules/test-esm-ok.mjs'),
   {
-    message: /Must use import to load ES Module/,
+    message: /dynamic import\(\) which is available in all CommonJS modules/,
     code: 'ERR_REQUIRE_ESM'
   }
 );


### PR DESCRIPTION
This PR attempts to improve the usability of the ERR_REQUIRE_ESM error messages with two major improvements:

1. When the module being required contains parseable ESM syntax, constrain the suggested fix to the message `"Instead change the require of X.js in Y.js to a dynamic import() which is available in all CommonJS modules."` which avoids confusion since we currently suggest all three of that plus changing the type and the extension to cjs, both of which are not appropriate in this case. This is implemented by using the acorn parser on the source at error time.
2. Ensure that the error mesage frame points to the exact location of the require. This was quite a bit of work to implement and involved a new primitive for exposing the `arrow_message_private_symbol` to JS so that JS code can inject this frame. The code to reconstruct the frame is more custom than it should be - ideally this could use the standard stack trace API with full source maps integration and be customizable in a way that fits with the stack trace overrides. I hope we can continue to improve this primitives over time to get better error messages more easily in Node.js.

In addition the internal frames are stripped from the error stack to remove the redundant internal stack lines to ensure that the output is as simple as possible for this error message.

I've provided two examples below. One for requiring CJS that Node.js thinks is ESM, and one requiring ESM that actually contains import / export syntax.

Requiring ESM with ESM syntax Before this PR:

```
internal/modules/cjs/loader.js:1080
      throw new ERR_REQUIRE_ESM(filename, parentPath, packageJsonPath);
      ^

Error [ERR_REQUIRE_ESM]: Must use import to load ES Module: /home/guybedford/Projects/node/test.js
require() of ES modules is not supported.
require() of /home/guybedford/Projects/node/test.js from /home/guybedford/Projects/node/test.cjs is an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which defines all .js files in that package scope as ES modules.
Instead rename test.js to end in .cjs, change the requiring code to use import(), or change "type": "module" to "type": "commonjs" in /home/guybedford/Projects/node/package.json to treat all .js files as CommonJS (using .mjs for all ES modules instead).

    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1080:13)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14)
    at Module.require (internal/modules/cjs/loader.js:952:19)
    at require (internal/modules/cjs/helpers.js:88:18)
    at Object.<anonymous> (/home/guybedford/Projects/node/test.cjs:1:1)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14) {
  code: 'ERR_REQUIRE_ESM'
}
```

Requiring ESM with ESM syntax after this PR:

```
/home/guybedford/Projects/node/test.cjs:1
require('./test.js');
^

Error [ERR_REQUIRE_ESM]: require() of ES Module /home/guybedford/Projects/node/test.js from /home/guybedford/Projects/node/test.cjs not supported.
Instead change the require of test.js in /home/guybedford/Projects/node/test.cjs to a dynamic import() which is available in all CommonJS modules.
    at Object.<anonymous> (/home/guybedford/Projects/node/test.cjs:1:1) {
  code: 'ERR_REQUIRE_ESM'
}
```

Requiring a .js file with no import or export syntax before this PR:

```
internal/modules/cjs/loader.js:1080
      throw new ERR_REQUIRE_ESM(filename, parentPath, packageJsonPath);
      ^

Error [ERR_REQUIRE_ESM]: Must use import to load ES Module: /home/guybedford/Projects/node/test.js
require() of ES modules is not supported.
require() of /home/guybedford/Projects/node/test.js from /home/guybedford/Projects/node/test.cjs is an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which defines all .js files in that package scope as ES modules.
Instead rename test.js to end in .cjs, change the requiring code to use import(), or change "type": "module" to "type": "commonjs" in /home/guybedford/Projects/node/package.json to treat all .js files as CommonJS (using .mjs for all ES modules instead).

    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1080:13)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14)
    at Module.require (internal/modules/cjs/loader.js:952:19)
    at require (internal/modules/cjs/helpers.js:88:18)
    at Object.<anonymous> (/home/guybedford/Projects/node/test.cjs:1:1)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14) {
  code: 'ERR_REQUIRE_ESM'
}
```

Requiring a .js file with no import or export syntax after this PR:

```
/home/guybedford/Projects/node/test.cjs:1
require('./test.js');
^

Error [ERR_REQUIRE_ESM]: require() of ES Module /home/guybedford/Projects/node/test.js from /home/guybedford/Projects/node/test.cjs not supported.
test.js is treated as an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which declares all .js files in that package scope as ES modules.
Instead rename test.js to end in .cjs, change the requiring code to use dynamic import() which is available in all CommonJS modules, or change "type": "module" to "type": "commonjs" in /home/guybedford/Projects/node/package.json to treat all .js files as CommonJS (using .mjs for all ES modules instead).

    at Object.<anonymous> (/home/guybedford/Projects/node/test.cjs:1:1) {
  code: 'ERR_REQUIRE_ESM'
}
```

Requiring a .mjs file before this PR:
```
internal/modules/cjs/loader.js:926
    throw new ERR_REQUIRE_ESM(filename);
    ^

Error [ERR_REQUIRE_ESM]: Must use import to load ES Module: /home/guybedford/Projects/node/test.mjs
    at Module.load (internal/modules/cjs/loader.js:926:11)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14)
    at Module.require (internal/modules/cjs/loader.js:952:19)
    at require (internal/modules/cjs/helpers.js:88:18)
    at Object.<anonymous> (/home/guybedford/Projects/node/test.cjs:1:1)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:72:12) {
  code: 'ERR_REQUIRE_ESM'
}
```

Requiring a .mjs file after this PR:
```
node:internal/modules/cjs/loader:978
    throw new ERR_REQUIRE_ESM(filename, true);
    ^

Error [ERR_REQUIRE_ESM]: require() of ES Module /home/guybedford/Projects/node/test.mjs not supported.
Instead change the require of /home/guybedford/Projects/node/test.mjs to a dynamic import() which is available in all CommonJS modules.
    at Object.<anonymous> (/home/guybedford/Projects/node/test.cjs:1:1) {
  code: 'ERR_REQUIRE_ESM'
}
```

@nodejs/modules