### PR TITLE
readline: allow completer to rewrite existing input

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -705,10 +705,11 @@ Interface.prototype._tabComplete = function(lastKeypressWasTab) {
     // If there is a common prefix to all matches, then apply that portion.
     const prefix = commonPrefix(ArrayPrototypeFilter(completions,
                                                      (e) => e !== ''));
-    if (prefix.startsWith(completeOn) && prefix.length > completeOn.length) {
+    if (StringPrototypeStartsWith(prefix, completeOn) && 
+        prefix.length > completeOn.length) {
       this._insertString(StringPrototypeSlice(prefix, completeOn.length));
       return;
-    } else if (!completeOn.startsWith(prefix)) {
+    } else if (!StringPrototypeStartsWith(completeOn, prefix)) {
       this.line = StringPrototypeSlice(this.line,
                                        0,
                                        this.cursor - completeOn.length) +

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -705,8 +705,15 @@ Interface.prototype._tabComplete = function(lastKeypressWasTab) {
     // If there is a common prefix to all matches, then apply that portion.
     const prefix = commonPrefix(ArrayPrototypeFilter(completions,
                                                      (e) => e !== ''));
-    if (prefix.length > completeOn.length) {
+    if (prefix.startsWith(completeOn) && prefix.length > completeOn.length) {
       this._insertString(StringPrototypeSlice(prefix, completeOn.length));
+      return;
+    } else if (!completeOn.startsWith(prefix)) {
+      this.line = StringPrototypeSlice(this.line, 0, this.cursor - completeOn.length) +
+                  prefix +
+                  StringPrototypeSlice(this.line, this.cursor, this.line.length);
+      this.cursor = this.cursor - completeOn.length + prefix.length;
+      this._refreshLine();
       return;
     }
 

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -709,12 +709,12 @@ Interface.prototype._tabComplete = function(lastKeypressWasTab) {
       this._insertString(StringPrototypeSlice(prefix, completeOn.length));
       return;
     } else if (!completeOn.startsWith(prefix)) {
-      this.line = StringPrototypeSlice(this.line, 
-                                       0, 
+      this.line = StringPrototypeSlice(this.line,
+                                       0,
                                        this.cursor - completeOn.length) +
                   prefix +
-                  StringPrototypeSlice(this.line, 
-                                       this.cursor, 
+                  StringPrototypeSlice(this.line,
+                                       this.cursor,
                                        this.line.length);
       this.cursor = this.cursor - completeOn.length + prefix.length;
       this._refreshLine();

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -705,7 +705,7 @@ Interface.prototype._tabComplete = function(lastKeypressWasTab) {
     // If there is a common prefix to all matches, then apply that portion.
     const prefix = commonPrefix(ArrayPrototypeFilter(completions,
                                                      (e) => e !== ''));
-    if (StringPrototypeStartsWith(prefix, completeOn) && 
+    if (StringPrototypeStartsWith(prefix, completeOn) &&
         prefix.length > completeOn.length) {
       this._insertString(StringPrototypeSlice(prefix, completeOn.length));
       return;

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -709,9 +709,13 @@ Interface.prototype._tabComplete = function(lastKeypressWasTab) {
       this._insertString(StringPrototypeSlice(prefix, completeOn.length));
       return;
     } else if (!completeOn.startsWith(prefix)) {
-      this.line = StringPrototypeSlice(this.line, 0, this.cursor - completeOn.length) +
+      this.line = StringPrototypeSlice(this.line, 
+                                       0, 
+                                       this.cursor - completeOn.length) +
                   prefix +
-                  StringPrototypeSlice(this.line, this.cursor, this.line.length);
+                  StringPrototypeSlice(this.line, 
+                                       this.cursor, 
+                                       this.line.length);
       this.cursor = this.cursor - completeOn.length + prefix.length;
       this._refreshLine();
       return;


### PR DESCRIPTION
Sometimes, it makes sense for a completer to change the existing
input, e.g. by adjusting the casing (imagine a completer that
corrects `Number.isNan` to `Number.IsNaN`, for example).

This commit allows that in the readline implemention.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
