### PR TITLE
doc: remove obsolete cc recommendations

### DIFF
--- a/doc/guides/maintaining-V8.md
+++ b/doc/guides/maintaining-V8.md
@@ -179,7 +179,7 @@ fixed upstream first.
 ### Backporting to active branches
 
 If the bug exists in any of the active V8 branches, we may need to get the fix
-backported. At any given time there are [two active branches][V8ActiveBranches]
+backported. At any given time, there are [two active branches][V8ActiveBranches]
 (beta and stable) in addition to master. The following steps are needed to
 backport the fix:
 
@@ -191,9 +191,7 @@ backport the fix:
   * If a bug already exists
     * Add a reference to the GitHub issue.
     * Attach *merge-request-x.x* labels to the bug for any active branches
-      that still contain the bug. (e.g. merge-request-5.3,
-      merge-request-5.4)
-    * Add ofrobots-at-google.com to the cc list.
+      that still contain the bug.
 * Once the merge has been approved, it should be merged using the
   [merge script documented in the V8 wiki][V8MergingPatching]. Merging requires
   commit access to the V8 repository. If you don't have commit access you can
@@ -246,8 +244,7 @@ fix needed to be cherry-picked. To cherry-pick, here's an example workflow:
   not apply cleanly. It may help to try to cherry-pick the merge to the oldest
   branch that was done upstream in V8. In this example, this would be the patch
   from the merge to 5.2. The hope is that this would be closer to the V8 5.1,
-  and has a better chance of applying cleanly. If you're stuck, feel free to
-  ping @ofrobots for help.
+  and has a better chance of applying cleanly.
 * Modify the commit message to match the format we use for V8 backports and
   replace yourself as the author. `git commit --amend --reset-author`. You may
   want to add extra description if necessary to indicate the impact of the fix


### PR DESCRIPTION
In 2016, Ali added the instruction to cc him on particular V8 bugs and
the suggestion to contact him for certain problems. However, I'm pretty
sure Ali has not been working on V8 for 2+ years at this point. I'm
guessing those instructions are obsolete at this point. (I'll ping him
in the PR for this change to confirm, though.)

Also: Remove a parenthetical and add a comma, because I can't imagine
opening a separate pull request to add a comma. (OK, I'm lying, I
totally can and if anyone has done that in the past, it's probably me.)

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
