### PR TITLE
errors: remove eager stack generation for node errors

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -33,6 +33,7 @@ const {
   Number,
   NumberIsInteger,
   ObjectDefineProperty,
+  ObjectDefineProperties,
   ObjectIsExtensible,
   ObjectGetOwnPropertyDescriptor,
   ObjectKeys,
@@ -57,6 +58,8 @@ const {
   TypeError,
   URIError,
 } = primordials;
+
+const kIsNodeError = Symbol('kIsNodeError');
 
 const isWindows = process.platform === 'win32';
 
@@ -116,7 +119,12 @@ const prepareStackTrace = (globalThis, error, trace) => {
   // Error: Message
   //     at function (file)
   //     at file
-  const errorString = ErrorPrototypeToString(error);
+  let errorString;
+  if (kIsNodeError in error) {
+    errorString = `${error.name} [${error.code}]: ${error.message}`;
+  } else {
+    errorString = ErrorPrototypeToString(error);
+  }
   if (trace.length === 0) {
     return errorString;
   }
@@ -186,27 +194,6 @@ function lazyBuffer() {
   return buffer;
 }
 
-const addCodeToName = hideStackFrames(function addCodeToName(err, name, code) {
-  // Set the stack
-  err = captureLargerStackTrace(err);
-  // Add the error code to the name to include it in the stack trace.
-  err.name = `${name} [${code}]`;
-  // Access the stack to generate the error message including the error code
-  // from the name.
-  err.stack; // eslint-disable-line no-unused-expressions
-  // Reset the name to the actual name.
-  if (name === 'SystemError') {
-    ObjectDefineProperty(err, 'name', {
-      value: name,
-      enumerable: false,
-      writable: true,
-      configurable: true
-    });
-  } else {
-    delete err.name;
-  }
-});
-
 function isErrorStackTraceLimitWritable() {
   const desc = ObjectGetOwnPropertyDescriptor(Error, 'stackTraceLimit');
   if (desc === undefined) {
@@ -242,43 +229,55 @@ class SystemError extends Error {
     if (context.dest !== undefined)
       message += ` => ${context.dest}`;
 
-    ObjectDefineProperty(this, 'message', {
-      value: message,
-      enumerable: false,
-      writable: true,
-      configurable: true
-    });
-    addCodeToName(this, 'SystemError', key);
+    captureLargerStackTrace(this);
 
     this.code = key;
 
-    ObjectDefineProperty(this, 'info', {
-      value: context,
-      enumerable: true,
-      configurable: true,
-      writable: false
-    });
-
-    ObjectDefineProperty(this, 'errno', {
-      get() {
-        return context.errno;
+    ObjectDefineProperties(this, {
+      [kIsNodeError]: {
+        value: true,
+        enumerable: false,
+        writable: false,
+        configurable: true,
       },
-      set: (value) => {
-        context.errno = value;
+      name: {
+        value: 'SystemError',
+        enumerable: false,
+        writable: true,
+        configurable: true,
       },
-      enumerable: true,
-      configurable: true
-    });
-
-    ObjectDefineProperty(this, 'syscall', {
-      get() {
-        return context.syscall;
+      message: {
+        value: message,
+        enumerable: false,
+        writable: true,
+        configurable: true,
       },
-      set: (value) => {
-        context.syscall = value;
+      info: {
+        value: context,
+        enumerable: true,
+        configurable: true,
+        writable: false,
       },
-      enumerable: true,
-      configurable: true
+      errno: {
+        get() {
+          return context.errno;
+        },
+        set: (value) => {
+          context.errno = value;
+        },
+        enumerable: true,
+        configurable: true,
+      },
+      syscall: {
+        get() {
+          return context.syscall;
+        },
+        set: (value) => {
+          context.syscall = value;
+        },
+        enumerable: true,
+        configurable: true,
+      },
     });
 
     if (context.path !== undefined) {
@@ -346,21 +345,29 @@ function makeNodeErrorWithCode(Base, key) {
     // Reset the limit and setting the name property.
     if (isErrorStackTraceLimitWritable()) Error.stackTraceLimit = limit;
     const message = getMessage(key, args, error);
-    ObjectDefineProperty(error, 'message', {
-      value: message,
-      enumerable: false,
-      writable: true,
-      configurable: true,
-    });
-    ObjectDefineProperty(error, 'toString', {
-      value() {
-        return `${this.name} [${key}]: ${this.message}`;
+    ObjectDefineProperties(error, {
+      [kIsNodeError]: {
+        value: true,
+        enumerable: false,
+        writable: false,
+        configurable: true,
       },
-      enumerable: false,
-      writable: true,
-      configurable: true,
+      message: {
+        value: message,
+        enumerable: false,
+        writable: true,
+        configurable: true,
+      },
+      toString: {
+        value() {
+          return `${this.name} [${key}]: ${this.message}`;
+        },
+        enumerable: false,
+        writable: true,
+        configurable: true,
+      },
     });
-    addCodeToName(error, Base.name, key);
+    captureLargerStackTrace(error);
     error.code = key;
     return error;
   };
@@ -792,7 +799,6 @@ class AbortError extends Error {
   }
 }
 module.exports = {
-  addCodeToName, // Exported for NghttpError
   aggregateTwoErrors,
   codes,
   dnsException,
@@ -815,7 +821,9 @@ module.exports = {
   maybeOverridePrepareStackTrace,
   overrideStackTrace,
   kEnhanceStackBeforeInspector,
-  fatalExceptionStackEnhancers
+  fatalExceptionStackEnhancers,
+  kIsNodeError,
+  captureLargerStackTrace,
 };
 
 // To declare an error message, use the E(sym, val, def) function above. The sym

--- a/lib/internal/http2/util.js
+++ b/lib/internal/http2/util.js
@@ -9,6 +9,7 @@ const {
   MathMax,
   Number,
   ObjectCreate,
+  ObjectDefineProperty,
   ObjectKeys,
   SafeSet,
   String,
@@ -28,9 +29,10 @@ const {
     ERR_INVALID_ARG_TYPE,
     ERR_INVALID_HTTP_TOKEN
   },
-  addCodeToName,
+  captureLargerStackTrace,
   getMessage,
-  hideStackFrames
+  hideStackFrames,
+  kIsNodeError,
 } = require('internal/errors');
 
 const kSensitiveHeaders = Symbol('nodejs.http2.sensitiveHeaders');
@@ -550,7 +552,13 @@ class NghttpError extends Error {
       binding.nghttp2ErrorString(integerCode));
     this.code = customErrorCode || 'ERR_HTTP2_ERROR';
     this.errno = integerCode;
-    addCodeToName(this, super.name, this.code);
+    captureLargerStackTrace(this);
+    ObjectDefineProperty(this, kIsNodeError, {
+      value: true,
+      enumerable: false,
+      writable: false,
+      configurable: true,
+    });
   }
 
   toString() {

--- a/lib/internal/source_map/prepare_stack_trace.js
+++ b/lib/internal/source_map/prepare_stack_trace.js
@@ -21,7 +21,8 @@ const { findSourceMap } = require('internal/source_map/source_map_cache');
 const {
   kNoOverride,
   overrideStackTrace,
-  maybeOverridePrepareStackTrace
+  maybeOverridePrepareStackTrace,
+  kIsNodeError,
 } = require('internal/errors');
 const { fileURLToPath } = require('internal/url');
 
@@ -41,7 +42,12 @@ const prepareStackTrace = (globalThis, error, trace) => {
     maybeOverridePrepareStackTrace(globalThis, error, trace);
   if (globalOverride !== kNoOverride) return globalOverride;
 
-  const errorString = ErrorPrototypeToString(error);
+  let errorString;
+  if (kIsNodeError in error) {
+    errorString = `${error.name} [${error.code}]: ${error.message}`;
+  } else {
+    errorString = ErrorPrototypeToString(error);
+  }
 
   if (trace.length === 0) {
     return errorString;

--- a/test/message/esm_loader_not_found.out
+++ b/test/message/esm_loader_not_found.out
@@ -1,8 +1,8 @@
 (node:*) ExperimentalWarning: --experimental-loader is an experimental feature. This feature could change at any time
 (Use `* --trace-warnings ...` to show where the warning was created)
-node:internal/process/esm_loader:*
-    internalBinding('errors').triggerUncaughtException(
-                              ^
+node:internal/errors:*
+    ErrorCaptureStackTrace(err);
+    ^
 Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'i-dont-exist' imported from *
     at new NodeError (node:internal/errors:*:*)
     at packageResolve (node:internal/modules/esm/resolve:*:*)

--- a/test/parallel/test-repl-top-level-await.js
+++ b/test/parallel/test-repl-top-level-await.js
@@ -175,15 +175,17 @@ async function ordinaryTests() {
 
 async function ctrlCTest() {
   console.log('Testing Ctrl+C');
-  assert.deepStrictEqual(await runAndWait([
+  const output = await runAndWait([
     'await new Promise(() => {})',
     { ctrl: true, name: 'c' },
-  ]), [
+  ]);
+  assert.deepStrictEqual(output.slice(0, 3), [
     'await new Promise(() => {})\r',
     'Uncaught:',
-    '[Error [ERR_SCRIPT_EXECUTION_INTERRUPTED]: ' +
-      'Script execution was interrupted by `SIGINT`] {',
-    "  code: 'ERR_SCRIPT_EXECUTION_INTERRUPTED'",
+    'Error [ERR_SCRIPT_EXECUTION_INTERRUPTED]: ' +
+      'Script execution was interrupted by `SIGINT`',
+  ]);
+  assert.deepStrictEqual(output.slice(-2), [
     '}',
     PROMPT,
   ]);


### PR DESCRIPTION
Moves logic from `addCodeToName` to `prepareStackTrace`, which saves some upfront perf and also allows node errors to be overridden by `overrideStackTrace`.

cc @guybedford 

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
