### PR TITLE
doc: remove instructions for unsupported Node.js versions

### DIFF
--- a/doc/guides/maintaining-V8.md
+++ b/doc/guides/maintaining-V8.md
@@ -213,17 +213,12 @@ to be cherry-picked in the Node.js repository and V8-CI must test the change.
   * Checkout a branch off the appropriate *vY.x-staging* branch (e.g.
     *v6.x-staging* to fix an issue in V8 5.1).
   * Cherry-pick the commit(s) from the V8 repository.
-  * On Node.js < 9.0.0: Increase the patch level version in `v8-version.h`.
-    This will not cause any problems with versioning because V8 will not
-    publish other patches for this branch, so Node.js can effectively bump the
-    patch version.
-  * On Node.js >= 9.0.0: Increase the `v8_embedder_string` number in
-    `common.gypi`.
+  * Increase the `v8_embedder_string` number in `common.gypi`.
   * In some cases the patch may require extra effort to merge in case V8 has
-    changed substantially. For important issues we may be able to lean on the
+    changed substantially. For important issues, we may be able to lean on the
     V8 team to get help with reimplementing the patch.
-  * Open a cherry-pick PR on `nodejs/node` targeting the *vY.x-staging* branch
-    and notify the `@nodejs/v8` team.
+  * Open a cherry-pick pull request on `nodejs/node` targeting the
+    *vY.x-staging* branch and notify the `@nodejs/v8` team.
   * Run the Node.js [V8 CI][] in addition to the [Node.js CI][].
     The CI uses the `test-v8` target in the `Makefile`, which uses
     `tools/make-v8.sh` to reconstruct a git tree in the `deps/v8` directory to


### PR DESCRIPTION
Remove special V8 maintenance instructions for versions of Node.js prior
to 9.0.0. Perform other minor edits in nearby text.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
