### PR TITLE
doc: add cc oss-security@lists.openwall.com

### DIFF
--- a/doc/guides/security-release-process.md
+++ b/doc/guides/security-release-process.md
@@ -38,9 +38,10 @@ information described.
   * Described in the pre/post announcements
 
 * [ ] Pre-release announcement [email][]: ***LINK TO EMAIL***
+   * CC: `oss-security@lists.openwall.com`
+   * Subject: `Security updates for all active release lines, Month Year`
+   * Body:
   ```text
-  Security updates for all active release lines, Month Year
-
   The Node.js project will release new versions of all supported release lines on or shortly after Day of week, Month Day of Month, Year
   For more information see: https://nodejs.org/en/blog/vulnerability/month-year-security-releases/
   ```
@@ -70,9 +71,10 @@ information described.
 * [ ] [Unlock CI](https://github.com/nodejs/build/blob/HEAD/doc/jenkins-guide.md#after-the-release)
 
 * [ ] Post-release announcement in reply [email][]: ***LINK TO EMAIL***
+   * CC: `oss-security@lists.openwall.com`
+   * Subject: `Security updates for all active release lines, Month Year`
+   * Body:
   ```text
-  Security updates for all active release lines, Month Year
-
   The Node.js project has now released new versions of all supported release lines.
   For more information see: https://nodejs.org/en/blog/vulnerability/month-year-security-releases/
   ```

--- a/doc/guides/security-release-process.md
+++ b/doc/guides/security-release-process.md
@@ -39,7 +39,7 @@ information described.
 
 * [ ] Pre-release announcement [email][]: ***LINK TO EMAIL***
    * CC: `oss-security@lists.openwall.com`
-   * Subject: `Security updates for all active release lines, Month Year`
+   * Subject: `Node.js security updates for all active release lines, Month Year`
    * Body:
   ```text
   The Node.js project will release new versions of all supported release lines on or shortly after Day of week, Month Day of Month, Year
@@ -72,7 +72,7 @@ information described.
 
 * [ ] Post-release announcement in reply [email][]: ***LINK TO EMAIL***
    * CC: `oss-security@lists.openwall.com`
-   * Subject: `Security updates for all active release lines, Month Year`
+   * Subject: `Node.js security updates for all active release lines, Month Year`
    * Body:
   ```text
   The Node.js project has now released new versions of all supported release lines.


### PR DESCRIPTION
This commit adds step to CC oss-security@lists.openwall.com as part of
the security release process.

Refs: https://github.com/nodejs/TSC/issues/1047

