### PR TITLE
build: shorten path used in tarball build workflow

### DIFF
--- a/.github/workflows/build-tarball.yml
+++ b/.github/workflows/build-tarball.yml
@@ -58,8 +58,8 @@ jobs:
           name: tarballs
       - name: Extract tarball
         run: |
-          tar xzf tarballs/*.tar.gz
-          echo "TAR_DIR=`basename tarballs/*.tar.gz .tar.gz`" >> $GITHUB_ENV
+          tar xzf tarballs/*.tar.gz -C $RUNNER_TEMP
+          echo "TAR_DIR=$RUNNER_TEMP/`basename tarballs/*.tar.gz .tar.gz`" >> $GITHUB_ENV
       - name: Copy directories needed for testing
         run: |
           cp -r tools/node_modules $TAR_DIR/tools


### PR DESCRIPTION
Shorten the path to the workspace for the GitHub Actions `build-tarball`
workflow to avoid `execvp: printf: Argument list too long` errors from
`make`.

GitHub currently runs workflows in a `/home/runner/work/my-repo/my-repo`
directory where `my-repo` is the repository name and is repeated twice
(the second is from the git checkout). Some of the command lines in the
Node.js build, e.g. the `ar` command to create static libraries, pass
several fully qualified paths to filenames so the workflow directory is
repeat many times. The most recent V8 update added more files to the
command and has now tipped the command line length over the maximum
allowed when using forks of the `node` repository with a longer name
(e.g. `node-auto-test` and the private fork used to prepare security
releases).

Use GitHub's `RUNNER_TEMP` environment variable to extract the source
tarball into the temporary directory on the GitHub runner. This is
currently `/home/runner/work/_temp` and is not dependent on the name
of the repository.

---

This isn't happening in https://github.com/nodejs/node but we have hit this in the private forked repository used for preparing security releases. It does also occur on https://github.com/nodejs/node-auto-test which is at least publicly viewable.

Example failing action run: https://github.com/nodejs/node-auto-test/runs/2797591632?check_suite_focus=true
```
  g++ -o /home/runner/work/node-auto-test/node-auto-test/node-v17.0.0-nightly2021-06-1046d6b025d8/out/Release/obj.target/v8_base_without_compiler/deps/v8/src/api/api-arguments.o ../deps/v8/src/api/api-arguments.cc '-D_GLIBCXX_USE_CXX11_ABI=1' '-DV8_GYP_BUILD' '-DV8_TYPED_ARRAY_MAX_SIZE_IN_HEAP=64' '-D__STDC_FORMAT_MACROS' '-DOPENSSL_NO_PINSHARED' '-DOPENSSL_THREADS' '-DV8_TARGET_ARCH_X64' '-DV8_EMBEDDER_STRING="-node.13"' '-DENABLE_DISASSEMBLER' '-DV8_PROMISE_INTERNAL_FIELD_COUNT=1' '-DENABLE_MINOR_MC' '-DOBJECT_PRINT' '-DV8_INTL_SUPPORT' '-DV8_ENABLE_LAZY_SOURCE_POSITIONS' '-DV8_USE_SIPHASH' '-DDISABLE_UNTRUSTED_CODE_MITIGATIONS' '-DV8_WIN64_UNWINDING_INFO' '-DV8_ENABLE_REGEXP_INTERPRETER_THREADED_DISPATCH' '-DV8_SNAPSHOT_COMPRESSION' '-DV8_ENABLE_WEBASSEMBLY' '-DICU_UTIL_DATA_IMPL=ICU_UTIL_DATA_STATIC' '-DUCONFIG_NO_SERVICE=1' '-DU_ENABLE_DYLOAD=0' '-DU_STATIC_IMPLEMENTATION=1' '-DU_HAVE_STD_STRING=1' '-DUCONFIG_NO_BREAK_ITERATION=0' -I../deps/v8 -I../deps/v8/include -I/home/runner/work/node-auto-test/node-auto-test/node-v17.0.0-nightly2021-06-1046d6b025d8/out/Release/obj/gen/inspector-generated-output-root -I../deps/v8/third_party/inspector_protocol -I/home/runner/work/node-auto-test/node-auto-test/node-v17.0.0-nightly2021-06-1046d6b025d8/out/Release/obj/gen -I/home/runner/work/node-auto-test/node-auto-test/node-v17.0.0-nightly2021-06-1046d6b025d8/out/Release/obj/gen/generate-bytecode-output-root -I../deps/icu-small/source/i18n -I../deps/icu-small/source/common -I../deps/v8/third_party/zlib -I../deps/v8/third_party/zlib/google  -pthread -Wno-unused-parameter -m64 -Wno-return-type -fno-strict-aliasing -m64 -O3 -fno-omit-frame-pointer -fdata-sections -ffunction-sections -O3 -fno-rtti -fno-exceptions -std=gnu++14 -MMD -MF /home/runner/work/node-auto-test/node-auto-test/node-v17.0.0-nightly2021-06-1046d6b025d8/out/Release/.deps//home/runner/work/node-auto-test/node-auto-test/node-v17.0.0-nightly2021-06-1046d6b025d8/out/Release/obj.target/v8_base_without_compiler/deps/v8/src/api/api-arguments.o.d.raw   -c
  touch /home/runner/work/node-auto-test/node-auto-test/node-v17.0.0-nightly2021-06-1046d6b025d8/out/Release/obj.target/tools/v8_gypfiles/v8_compiler_for_mksnapshot.stamp
make[2]: execvp: printf: Argument list too long
make[2]: *** [tools/v8_gypfiles/v8_base_without_compiler.target.mk:1002: /home/runner/work/node-auto-test/node-auto-test/node-v17.0.0-nightly2021-06-1046d6b025d8/out/Release/obj.target/tools/v8_gypfiles/libv8_base_without_compiler.a] Error 127
```

(since the error is coming from `execvp: printf` I don't believe the actual failing command line is written to the log).
cc @nodejs/actions @BethGriggs 

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
