### PR TITLE
stream: make streams thenable

### DIFF
--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -40,6 +40,7 @@ Readable.ReadableState = ReadableState;
 
 const EE = require('events');
 const { Stream, prependListener } = require('internal/streams/legacy');
+const finished = require('internal/streams/end-of-stream');
 const { Buffer } = require('buffer');
 
 const {
@@ -1066,6 +1067,16 @@ Readable.prototype.iterator = function(options) {
     validateObject(options, 'options');
   }
   return streamToAsyncIterator(this, options);
+};
+
+Readable.prototype.then = function(onFulfill, onReject) {
+  finished(this, (err) => {
+    if (err) {
+      onReject(err);
+    } else {
+      onFulfill();
+    }
+  });
 };
 
 function streamToAsyncIterator(stream, options) {

--- a/lib/internal/streams/writable.js
+++ b/lib/internal/streams/writable.js
@@ -44,6 +44,7 @@ const EE = require('events');
 const Stream = require('internal/streams/legacy').Stream;
 const { Buffer } = require('buffer');
 const destroyImpl = require('internal/streams/destroy');
+const finished = require('internal/streams/end-of-stream');
 
 const {
   addAbortSignalNoValidate,
@@ -846,6 +847,16 @@ ObjectDefineProperties(Writable.prototype, {
     }
   }
 });
+
+Writable.prototype.then = function(onFulfill, onReject) {
+  finished(this, (err) => {
+    if (err) {
+      onReject(err);
+    } else {
+      onFulfill();
+    }
+  });
+};
 
 const destroy = destroyImpl.destroy;
 Writable.prototype.destroy = function(err, cb) {

--- a/test/parallel/test-stream-thenable.js
+++ b/test/parallel/test-stream-thenable.js
@@ -1,0 +1,96 @@
+'use strict';
+const common = require('../common');
+
+const { Writable, Duplex, Readable } = require('stream');
+
+{
+  const w = new Writable({
+    write(chunk, encoding, callback) {
+      callback();
+    }
+  });
+
+  (async function() {
+    await w;
+  }()).then(common.mustCall());
+
+  w.end();
+}
+
+
+{
+  const w = new Writable({
+    write(chunk, encoding, callback) {
+      callback();
+    }
+  });
+
+  (async function() {
+    await w;
+  }()).then(common.mustNotCall(), common.mustCall());
+
+  queueMicrotask(() => {
+    w.destroy(new Error('asd'));
+  });
+}
+
+{
+  const d = new Duplex({
+    write(chunk, encoding, callback) {
+      callback();
+    },
+    read() {}
+  });
+
+  (async function() {
+    await d;
+  }()).then(common.mustCall());
+
+  d.end('asd');
+  d.push(null);
+  d.resume();
+}
+
+{
+  const d = new Duplex({
+    write(chunk, encoding, callback) {
+      callback();
+    },
+    read() {}
+  });
+
+  (async function() {
+    await d;
+  }()).then(common.mustNotCall(), common.mustCall());
+
+  queueMicrotask(() => {
+    d.destroy(new Error('asd'));
+  });
+}
+
+{
+  const r = new Readable({
+    read() {}
+  });
+
+  (async function() {
+    await r;
+  }()).then(common.mustCall());
+
+  r.push(null);
+  r.resume();
+}
+
+{
+  const r = new Readable({
+    read() {}
+  });
+
+  (async function() {
+    await r;
+  }()).then(common.mustNotCall(), common.mustCall());
+
+  queueMicrotask(() => {
+    r.destroy(new Error('asd'));
+  });
+}


### PR DESCRIPTION
Make streams thenable as a shortcut to finished(stream).

Together with https://github.com/nodejs/node/pull/39029 this would provide a quite nice API without requiring importing helpers such as `finished` and `pipeline`.

e.g.

```js
await Duplex.from(
  fs.createReadStream('file. txt'),
  createGzip(),
  fs.createWriteStream('file. txt.gz')
)
```

instead of:

```js
for await (const dummy of Duplex.from(
  fs.createReadStream('file. txt'),
  createGzip(),
  fs.createWriteStream('file. txt.gz')
)) {
  // do nothing
}
```