### PR TITLE
streams: use finished for pump

### DIFF
--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -19,7 +19,7 @@ const {
     ERR_INVALID_ARG_TYPE,
     ERR_INVALID_RETURN_VALUE,
     ERR_MISSING_ARGS,
-    ERR_STREAM_DESTROYED
+    ERR_STREAM_DESTROYED,
   },
 } = require('internal/errors');
 

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -142,17 +142,9 @@ async function pump(iterable, writable, finish) {
     }
 
     for await (const chunk of iterable) {
-      if (error) {
-        throw error;
-      }
-
-      if (!writable.write(chunk)) {
+      if (writable.write(chunk) === false) {
         await wait();
       }
-    }
-
-    if (error) {
-      throw error;
     }
 
     writable.end();

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -134,7 +134,7 @@ async function pump(iterable, writable, finish) {
   });
 
   writable.on('drain', resume);
-  const cleanup = eos(writable, resume);
+  const cleanup = eos(writable, { readable: false }, resume);
 
   try {
     if (writable.writableNeedDrain) {
@@ -142,12 +142,14 @@ async function pump(iterable, writable, finish) {
     }
 
     for await (const chunk of iterable) {
-      if (writable.write(chunk) === false) {
+      if (!writable.write(chunk)) {
         await wait();
       }
     }
 
     writable.end();
+
+    await wait();
 
     finish();
   } catch (err) {

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -19,21 +19,17 @@ const {
     ERR_INVALID_ARG_TYPE,
     ERR_INVALID_RETURN_VALUE,
     ERR_MISSING_ARGS,
-    ERR_STREAM_DESTROYED,
-    ERR_STREAM_PREMATURE_CLOSE,
+    ERR_STREAM_DESTROYED
   },
 } = require('internal/errors');
 
 const { validateCallback } = require('internal/validators');
-
-function noop() {}
 
 const {
   isIterable,
   isReadable,
   isStream,
 } = require('internal/streams/utils');
-const assert = require('internal/assert');
 
 let PassThrough;
 let Readable;
@@ -109,62 +105,64 @@ async function* fromReadable(val) {
 
 async function pump(iterable, writable, finish) {
   let error;
-  let callback = noop;
+  let onresolve = null;
+
   const resume = (err) => {
-    error = aggregateTwoErrors(error, err);
-    const _callback = callback;
-    callback = noop;
-    _callback();
-  };
-  const onClose = () => {
-    resume(new ERR_STREAM_PREMATURE_CLOSE());
+    if (err) {
+      error = err;
+    }
+
+    if (onresolve) {
+      const callback = onresolve;
+      onresolve = null;
+      callback();
+    }
   };
 
-  const waitForDrain = () => new Promise((resolve) => {
-    assert(callback === noop);
-    if (error || writable.destroyed) {
-      resolve();
+  const wait = () => new Promise((resolve, reject) => {
+    if (error) {
+      reject(error);
     } else {
-      callback = resolve;
+      onresolve = () => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      };
     }
   });
 
-  writable
-    .on('drain', resume)
-    .on('error', resume)
-    .on('close', onClose);
+  writable.on('drain', resume);
+  const cleanup = eos(writable, resume);
 
   try {
     if (writable.writableNeedDrain) {
-      await waitForDrain();
-    }
-
-    if (error) {
-      return;
+      await wait();
     }
 
     for await (const chunk of iterable) {
-      if (!writable.write(chunk)) {
-        await waitForDrain();
-      }
       if (error) {
-        return;
+        throw error;
+      }
+
+      if (!writable.write(chunk)) {
+        await wait();
       }
     }
 
     if (error) {
-      return;
+      throw error;
     }
 
     writable.end();
+
+    finish();
   } catch (err) {
-    error = aggregateTwoErrors(error, err);
+    finish(error !== err ? aggregateTwoErrors(error, err) : err);
   } finally {
-    writable
-      .off('drain', resume)
-      .off('error', resume)
-      .off('close', onClose);
-    finish(error);
+    cleanup();
+    writable.off('drain', resume);
   }
 }
 

--- a/test/parallel/test-stream-pipeline.js
+++ b/test/parallel/test-stream-pipeline.js
@@ -1387,36 +1387,3 @@ const net = require('net');
     assert.strictEqual(res, content);
   }));
 }
-
-{
-  const writableLike = new Stream();
-  writableLike.writableNeedDrain = true;
-
-  pipeline(
-    async function *() {},
-    writableLike,
-    common.mustCall((err) => {
-      assert.strictEqual(err.code, 'ERR_STREAM_PREMATURE_CLOSE');
-    })
-  );
-
-  writableLike.emit('close');
-}
-
-{
-  const writableLike = new Stream();
-  writableLike.write = () => false;
-
-  pipeline(
-    async function *() {
-      yield null;
-      yield null;
-    },
-    writableLike,
-    common.mustCall((err) => {
-      assert.strictEqual(err.code, 'ERR_STREAM_PREMATURE_CLOSE');
-    })
-  );
-
-  writableLike.emit('close');
-}


### PR DESCRIPTION
Re-use existing compay logic for pump by using finished. Also cleans up logic a bit.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
