### PR TITLE
stream: finished should error on errored stream.

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -806,7 +806,7 @@ function onSocketNT(req, socket, err) {
         socket.emit('free');
       } else {
         finished(socket.destroy(err || req[kError]), (er) => {
-          if (er.code === 'ERR_STREAM_PREMATURE_CLOSE') {
+          if (er?.code === 'ERR_STREAM_PREMATURE_CLOSE') {
             er = null;
           }
           _destroy(req, er || err);

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -806,6 +806,9 @@ function onSocketNT(req, socket, err) {
         socket.emit('free');
       } else {
         finished(socket.destroy(err || req[kError]), (er) => {
+          if (er.code === 'ERR_STREAM_PREMATURE_CLOSE') {
+            er = null;
+          }
           _destroy(req, er || err);
         });
         return;

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -188,7 +188,7 @@ IncomingMessage.prototype._destroy = function _destroy(err, cb) {
   if (this.socket && !this.socket.destroyed && this.aborted) {
     this.socket.destroy(err);
     const cleanup = finished(this.socket, (e) => {
-      if (e.code === 'ERR_STREAM_PREMATURE_CLOSE') {
+      if (e?.code === 'ERR_STREAM_PREMATURE_CLOSE') {
         e = null;
       }
       cleanup();

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -188,6 +188,9 @@ IncomingMessage.prototype._destroy = function _destroy(err, cb) {
   if (this.socket && !this.socket.destroyed && this.aborted) {
     this.socket.destroy(err);
     const cleanup = finished(this.socket, (e) => {
+      if (e.code === 'ERR_STREAM_PREMATURE_CLOSE') {
+        e = null;
+      }
       cleanup();
       process.nextTick(onError, this, e || err, cb);
     });

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -98,8 +98,7 @@ function eos(stream, options, callback) {
     isWritable(stream) === writable
   );
 
-  let writableFinished = stream.writableFinished ||
-    (wState && wState.finished);
+  let writableFinished = stream.writableFinished || wState?.finished;
   const onfinish = () => {
     writableFinished = true;
     // Stream should not be destroyed here. If it is that
@@ -111,8 +110,7 @@ function eos(stream, options, callback) {
     if (!readable || readableEnded) callback.call(stream);
   };
 
-  let readableEnded = stream.readableEnded ||
-    (rState && rState.endEmitted);
+  let readableEnded = stream.readableEnded || rState?.endEmitted;
   const onend = () => {
     readableEnded = true;
     // Stream should not be destroyed here. If it is that

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -128,7 +128,17 @@ function eos(stream, options, callback) {
     callback.call(stream, err);
   };
 
+  let closed = false;
+
   const onclose = () => {
+    closed = true;
+
+    const errored = wState?.errored || rState?.errored;
+
+    if (errored && typeof errored !== 'boolean') {
+      return callback.call(stream, errored);
+    }
+
     if (readable && !readableEnded) {
       if (!isReadableEnded(stream))
         return callback.call(stream,
@@ -139,6 +149,7 @@ function eos(stream, options, callback) {
         return callback.call(stream,
                              new ERR_STREAM_PREMATURE_CLOSE());
     }
+
     callback.call(stream);
   };
 
@@ -168,29 +179,29 @@ function eos(stream, options, callback) {
   if (options.error !== false) stream.on('error', onerror);
   stream.on('close', onclose);
 
-  // _closed is for OutgoingMessage which is not a proper Writable.
-  const closed = (!wState && !rState && stream._closed === true) || (
-    (wState && wState.closed) ||
-    (rState && rState.closed) ||
-    (wState && wState.errorEmitted) ||
-    (rState && rState.errorEmitted) ||
-    (rState && stream.req && stream.aborted) ||
-    (
-      (!writable || (wState && wState.finished)) &&
-      (!readable || (rState && rState.endEmitted))
-    )
-  );
-
-  if (closed) {
-    // TODO(ronag): Re-throw error if errorEmitted?
-    // TODO(ronag): Throw premature close as if finished was called?
-    // before being closed? i.e. if closed but not errored, ended or finished.
-    // TODO(ronag): Throw some kind of error? Does it make sense
-    // to call finished() on a "finished" stream?
-    // TODO(ronag): willEmitClose?
-    process.nextTick(() => {
-      callback();
-    });
+  if (closed || wState?.closed || rState?.closed) {
+    process.nextTick(onclose);
+  } else if (wState?.errorEmitted || rState?.errorEmitted) {
+    if (!willEmitClose) {
+      process.nextTick(onclose);
+    }
+  } else if (
+    !readable &&
+    (!willEmitClose || stream.readable) &&
+    writableFinished
+  ) {
+    process.nextTick(onclose);
+  } else if (
+    !writable &&
+    (!willEmitClose || stream.writable) &&
+    readableEnded
+  ) {
+    process.nextTick(onclose);
+  } else if (!wState && !rState && stream._closed === true) {
+    // _closed is for OutgoingMessage which is not a proper Writable.
+    process.nextTick(onclose);
+  } else if ((rState && stream.req && stream.aborted)) {
+    process.nextTick(onclose);
   }
 
   const cleanup = () => {

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -128,7 +128,7 @@ function eos(stream, options, callback) {
     callback.call(stream, err);
   };
 
-  let closed = false;
+  let closed = wState?.closed || rState?.closed;
 
   const onclose = () => {
     closed = true;
@@ -179,7 +179,7 @@ function eos(stream, options, callback) {
   if (options.error !== false) stream.on('error', onerror);
   stream.on('close', onclose);
 
-  if (closed || wState?.closed || rState?.closed) {
+  if (closed) {
     process.nextTick(onclose);
   } else if (wState?.errorEmitted || rState?.errorEmitted) {
     if (!willEmitClose) {

--- a/test/parallel/test-stream-finished.js
+++ b/test/parallel/test-stream-finished.js
@@ -608,3 +608,26 @@ testClosed((opts) => new Writable({ write() {}, ...opts }));
     assert.strictEqual(closed, true);
   }));
 }
+
+{
+  const w = new Writable();
+  const _err = new Error();
+  w.destroy(_err);
+  finished(w, common.mustCall((err) => {
+    assert.strictEqual(_err, err);
+    finished(w, common.mustCall((err) => {
+      assert.strictEqual(_err, err);
+    }));
+  }));
+}
+
+{
+  const w = new Writable();
+  w.destroy();
+  finished(w, common.mustCall((err) => {
+    assert.strictEqual(err.code, 'ERR_STREAM_PREMATURE_CLOSE');
+    finished(w, common.mustCall((err) => {
+      assert.strictEqual(err.code, 'ERR_STREAM_PREMATURE_CLOSE');
+    }));
+  }));
+}


### PR DESCRIPTION
Calling finished before or after a stream has errored or closed
should end up with the same behavior.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
