### PR TITLE
perf: remove duplicate codes

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -690,7 +690,6 @@ function onParserExecuteCommon(server, socket, parser, state, ret, d) {
 
   if (ret instanceof Error) {
     prepareError(ret, parser, d);
-    ret.rawPacket = d || parser.getCurrentBuffer();
     debug('parse error', ret);
     socketOnError.call(socket, ret);
   } else if (parser.incoming && parser.incoming.upgrade) {


### PR DESCRIPTION
This line of code has been implemented in the prepareError function

```
// lib/_http_common.js

function prepareError(err, parser, rawPacket) {
  err.rawPacket = rawPacket || parser.getCurrentBuffer();
  if (typeof err.reason === 'string')
    err.message = `Parse Error: ${err.reason}`;
}
```