### PR TITLE
doc: remove GitHub mark

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -681,11 +681,6 @@ kbd {
   visibility: hidden;
 }
 
-.github_icon {
-  vertical-align: middle;
-  margin: -2px 3px 0 0;
-}
-
 /* API reference sidebar */
 @media only screen and (min-width: 1025px) {
   .apidoc #column2 > .line {

--- a/tools/doc/html.mjs
+++ b/tools/doc/html.mjs
@@ -489,8 +489,6 @@ function altDocs(filename, docCreated, versions) {
   ` : '';
 }
 
-// eslint-disable-next-line max-len
-const githubLogo = '<span class="github_icon"><svg height="16" width="16" viewBox="0 0 16.1 16.1" fill="currentColor"><path d="M8 0a8 8 0 0 0-2.5 15.6c.4 0 .5-.2.5-.4v-1.5c-2 .4-2.5-.5-2.7-1 0-.1-.5-.9-.8-1-.3-.2-.7-.6 0-.6.6 0 1 .6 1.2.8.7 1.2 1.9 1 2.4.7 0-.5.2-.9.5-1-1.8-.3-3.7-1-3.7-4 0-.9.3-1.6.8-2.2 0-.2-.3-1 .1-2 0 0 .7-.3 2.2.7a7.4 7.4 0 0 1 4 0c1.5-1 2.2-.8 2.2-.8.5 1.1.2 2 .1 2.1.5.6.8 1.3.8 2.2 0 3-1.9 3.7-3.6 4 .3.2.5.7.5 1.4v2.2c0 .2.1.5.5.4A8 8 0 0 0 16 8a8 8 0 0 0-8-8z"/></svg></span>';
 function editOnGitHub(filename) {
-  return `<li class="edit_on_github"><a href="https://github.com/nodejs/node/edit/master/doc/api/${filename}.md">${githubLogo}Edit on GitHub</a></li>`;
+  return `<li class="edit_on_github"><a href="https://github.com/nodejs/node/edit/master/doc/api/${filename}.md">Edit on GitHub</a></li>`;
 }


### PR DESCRIPTION
Judging from https://github.com/logos, we are misusing the GitHub mark.
That page indicates to not change the color (we change it from black to
green). Less clear, it says  "Use the Mark in social buttons to link to your GitHub profile or project" which isn't exactly what we're doing but also isn't
not what we're doing?

This might be an indication of my eyesight getting worse as I get older,
but I think the size that we display the mark at by default makes it not
entirely recognizable as the GitHub mark. Lastly, there's the
philosophical issue of whether we should display a commercial entity's
mark on our web pages in this particular instance. (For me, the answer
is "maybe".)

All told, I think we can remove it without damaging usability on the
website, so let's do it.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
