### PR TITLE
stream: fix performance regression

### DIFF
--- a/lib/internal/streams/duplex.js
+++ b/lib/internal/streams/duplex.js
@@ -56,19 +56,23 @@ function Duplex(options) {
   Readable.call(this, options);
   Writable.call(this, options);
 
-  this.allowHalfOpen = options?.allowHalfOpen !== false;
+  if (options) {
+    this.allowHalfOpen = options.allowHalfOpen !== false;
 
-  if (options?.readable === false) {
-    this._readableState.readable = false;
-    this._readableState.ended = true;
-    this._readableState.endEmitted = true;
-  }
+    if (options.readable === false) {
+      this._readableState.readable = false;
+      this._readableState.ended = true;
+      this._readableState.endEmitted = true;
+    }
 
-  if (options?.writable === false) {
-    this._writableState.writable = false;
-    this._writableState.ending = true;
-    this._writableState.ended = true;
-    this._writableState.finished = true;
+    if (options.writable === false) {
+      this._writableState.writable = false;
+      this._writableState.ending = true;
+      this._writableState.ended = true;
+      this._writableState.finished = true;
+    }
+  } else {
+    this.allowHalfOpen = true;
   }
 }
 


### PR DESCRIPTION
Benchmark result:

```
                                              confidence improvement accuracy (*)   (**)  (***)
streams/creation.js kind='duplex' n=50000000        ***     25.65 %       ±2.49% ±3.34% ±4.41%
```