### PR TITLE
tools: add find-inactive-collaborators.js

### DIFF
--- a/tools/find-inactive-collaborators.mjs
+++ b/tools/find-inactive-collaborators.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+
+// Identify inactive collaborators. "Inactive" is not quite right, as the things
+// this checks for are not the entirety of collaborator activities. Still, it is
+// a pretty good proxy. Feel free to suggest or implement further metrics.
+
+import cp from 'node:child_process';
+import fs from 'node:fs';
+import readline from 'node:readline';
+
+const SINCE = process.argv[2] || '6 months ago';
+
+async function runGitCommand(cmd, mapFn) {
+  const childProcess = cp.spawn('/bin/sh', ['-c', cmd], {
+    cwd: new URL('..', import.meta.url),
+    encoding: 'utf8',
+    stdio: ['inherit', 'pipe', 'inherit'],
+  });
+  const lines = readline.createInterface({
+    input: childProcess.stdout,
+  });
+  const errorHandler = new Promise(
+    (_, reject) => childProcess.on('error', reject)
+  );
+  const returnedSet = new Set();
+  await Promise.race([errorHandler, Promise.resolve()]);
+  for await (const line of lines) {
+    await Promise.race([errorHandler, Promise.resolve()]);
+    const val = mapFn(line);
+    if (val) {
+      returnedSet.add(val);
+    }
+  }
+  return Promise.race([errorHandler, Promise.resolve(returnedSet)]);
+}
+
+// Get all commit authors during the time period.
+const authors = await runGitCommand(
+  `git shortlog -n -s --since="${SINCE}"`,
+  (line) => line.trim().split('\t', 2)[1]
+);
+
+// Get all commit landers during the time period.
+const landers = await runGitCommand(
+  `git shortlog -n -s -c --since="${SINCE}"`,
+  (line) => line.trim().split('\t', 2)[1]
+);
+
+// Get all approving reviewers of landed commits during the time period.
+const approvingReviewers = await runGitCommand(
+  `git log --since="${SINCE}" | egrep "^    Reviewed-By: "`,
+  (line) => /^    Reviewed-By: ([^<]+)/.exec(line)[1].trim()
+);
+
+async function retrieveCollaboratorsFromReadme() {
+  const readmeText = readline.createInterface({
+    input: fs.createReadStream(new URL('../README.md', import.meta.url)),
+    crlfDelay: Infinity,
+  });
+  const returnedArray = [];
+  let processingCollaborators = false;
+  for await (const line of readmeText) {
+    const isCollaborator = processingCollaborators && line.length;
+    if (line === '### Collaborators') {
+      processingCollaborators = true;
+    }
+    if (line === '### Collaborator emeriti') {
+      processingCollaborators = false;
+      break;
+    }
+    if (line.startsWith('**') && isCollaborator) {
+      returnedArray.push(line.split('**', 2)[1].trim());
+    }
+  }
+  return returnedArray;
+}
+
+// Get list of current collaborators from README.md.
+const collaborators = await retrieveCollaboratorsFromReadme();
+
+console.log(`${authors.size.toLocaleString()} authors have made commits since ${SINCE}.`);
+console.log(`${landers.size.toLocaleString()} landers have landed commits since ${SINCE}.`);
+console.log(`${approvingReviewers.size.toLocaleString()} reviewers have approved landed commits since ${SINCE}.`);
+console.log(`${collaborators.length.toLocaleString()} collaborators currently in the project.`);
+
+const inactive = collaborators.filter((collaborator) =>
+  !authors.has(collaborator) &&
+  !landers.has(collaborator) &&
+  !approvingReviewers.has(collaborator)
+);
+
+if (inactive.length) {
+  console.log('\nInactive collaborators:');
+  console.log(inactive.join('\n'));
+}


### PR DESCRIPTION
The plan is to eventually call this script with a scheduled GitHub
Action that could automatically open pull requests to move collaborators
to emeritus status after (for example) a year of inactivity.

Sample run:

```console
$ node tools/find-inactive-collaborators.js '30 months ago'
864 authors have made commits since 30 months ago.
101 landers have landed commits since 30 months ago.
146 reviewers have approved landed commits since 30 months ago.
109 collaborators currently in the project.

Inactive collaborators:

Thomas Watson
$
```

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
