### PR TITLE
tools: pass bot token to node-pr-labeler

### DIFF
--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -11,4 +11,5 @@ jobs:
     steps:
       - uses: nodejs/node-pr-labeler@v1
         with:
+          repo-token: ${{ secrets.GH_USER_TOKEN }}
           configuration-path: .github/label-pr-config.yml


### PR DESCRIPTION
This should allow workflows that use the `labeled` event to be run.

Currently, fast-track requests for npm updates do not result in a comment: https://github.com/nodejs/node/pull/39225#event-4967351545