### PR TITLE
test: add test for debugger restart message issue

### DIFF
--- a/test/known_issues/test-debugger-restart-message.js
+++ b/test/known_issues/test-debugger-restart-message.js
@@ -1,0 +1,57 @@
+'use strict';
+
+// Refs: https://github.com/nodejs/node/issues/39272
+
+const common = require('../common');
+
+const assert = require('assert');
+
+// When this is moved out of known_issues, this skip can be removed.
+if (common.isOSX) {
+  assert.fail('does not fail reliably on macOS in CI');
+}
+
+// When this is moved out of known_issues, this can be removed and replaced with
+// the commented-out use of common.skipIfInspectorDisabled() below.
+if (!process.features.inspector) {
+  assert.fail('Known issues test should fail, so if the inspector is disabled');
+}
+
+// Will need to uncomment this when moved out of known_issues.
+// common.skipIfInspectorDisabled();
+
+// This can be reduced to 2 or even 1 (and the loop removed) once the debugger
+// is fixed. It's set higher to make sure that the error is tripped reliably
+// in CI. On most systems, the error will be tripped on the first test, but
+// on a few platforms in CI, it needs to be many times.
+const RESTARTS = 16;
+
+const fixtures = require('../common/fixtures');
+const startCLI = require('../common/debugger');
+
+// Using `restart` should result in only one "Connect/For help" message.
+{
+  const script = fixtures.path('debugger', 'three-lines.js');
+  const cli = startCLI([script]);
+
+  function onFatal(error) {
+    cli.quit();
+    throw error;
+  }
+
+  const listeningRegExp = /Debugger listening on/g;
+
+  cli.waitForInitialBreak()
+    .then(() => cli.waitForPrompt())
+    .then(() => {
+      assert.strictEqual(cli.output.match(listeningRegExp).length, 1);
+    })
+    .then(async () => {
+      for (let i = 0; i < RESTARTS; i++) {
+        await cli.stepCommand('restart');
+        assert.strictEqual(cli.output.match(listeningRegExp).length, 1);
+      }
+    })
+    .then(() => cli.quit())
+    .then(null, onFatal);
+}


### PR DESCRIPTION
Running "restart" in the debugger confusingly prints an out-of-date
"Debugger listening on..." message before printing a second updated one.

Refs: https://github.com/nodejs/node/issues/39272

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
