### PR TITLE
doc: remove emailing the TSC from offboarding doc

### DIFF
--- a/doc/guides/offboarding.md
+++ b/doc/guides/offboarding.md
@@ -6,8 +6,6 @@ Emeritus or leaves the project.
 * Remove the Collaborator from the @nodejs/collaborators team.
 * Open a fast-track pull request to move the Collaborator to Collaborator
   Emeriti in README.md.
-* Email the TSC mailing list to notify TSC members that the Collaborator is
-  moving to Collaborator Emeritus.
 * Determine what GitHub teams the Collaborator belongs to. In consultation with
   the Collaborator, determine which of those teams they should be removed from.
   * Some teams may also require a pull request to remove the Collaborator from


### PR DESCRIPTION
Emailing the TSC seems superfluous. Removing it.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
