### PR TITLE
stream: alternative async generator transform

### DIFF
--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -6,6 +6,7 @@
 const {
   ArrayIsArray,
   Promise,
+  SymbolIterator,
   SymbolAsyncIterator,
 } = primordials;
 
@@ -22,6 +23,7 @@ const {
     ERR_STREAM_DESTROYED,
   },
 } = require('internal/errors');
+const { AbortController } = require('internal/abort_controller');
 
 const { validateCallback } = require('internal/validators');
 
@@ -101,6 +103,43 @@ async function* fromReadable(val) {
   }
 
   yield* Readable.prototype[SymbolAsyncIterator].call(val);
+}
+
+async function* pump2(src, gen) {
+  const ac = new AbortController();
+  let sent = null;
+  const context = {
+    get sent() {
+      return sent;
+    },
+    get signal() {
+      return ac.signal;
+    }
+  };
+  const dst = gen.call(context);
+
+  let iterator;
+  if (dst[SymbolIterator]) {
+    iterator = dst[SymbolIterator]();
+  } else {
+    iterator = dst[SymbolAsyncIterator]();
+  }
+
+  try {
+    for await (const chunk of src) {
+      sent = chunk;
+      const { done, value } = await iterator.next();
+      if (done) {
+        return;
+      }
+      yield value;
+    }
+    sent = null;
+    await iterator.next();
+  } finally {
+    iterator.return();
+    ac.abort();
+  }
 }
 
 async function pump(iterable, writable, finish) {
@@ -225,7 +264,12 @@ function pipeline(...streams) {
       }
     } else if (typeof stream === 'function') {
       ret = makeAsyncIterable(ret);
-      ret = stream(ret);
+
+      if (stream.length === 0) {
+        ret = pump2(ret, stream);
+      } else {
+        ret = stream(ret);
+      }
 
       if (reading) {
         if (!isIterable(ret, true)) {

--- a/tmp.mjs
+++ b/tmp.mjs
@@ -1,0 +1,32 @@
+async function* toUpper() {
+  while (true) {
+    yield this.sent.toUpperCase();
+  }
+}
+
+async function* src() {
+  yield 'hello'
+  yield 'world'
+}
+
+async function* pump(src, gen) {
+  const context = { sent: null }
+  const dst = gen.call(context)
+  const iterator = dst[Symbol.asyncIterator]()
+  try {
+    for await (const chunk of src) {
+      context.sent = chunk
+      const { done, value } = await iterator.next()
+      if (done) {
+        return
+      }
+      yield value
+    }
+  } finally {
+    iterator.return()
+  }
+}
+
+for await (const chunk of pump(src(), toUpper)) {
+  console.log(chunk)
+}


### PR DESCRIPTION
Adds an alternative and more unified async generator support to pipeline. The "old" `async function*(source)` syntax is still supported but should be considered legacy after this.

I believe this removes the need for #39067.

Refs: https://github.com/nodejs/node/issues/39279

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
