### PR TITLE
benchmark: add benchmark groups

### DIFF
--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -24,15 +24,33 @@ class Benchmark {
 
     // Parse job-specific configuration from the command line arguments
     const argv = process.argv.slice(2);
-    const parsed_args = this._parseArgs(argv, configs, options);
-    this.options = parsed_args.cli;
-    this.extra_options = parsed_args.extra;
+
+    // The configuration list as a queue of jobs
+    this.queue = [];
+
+    if (options.byGroup) {
+      const groups = process.env.NODE_RUN_BENCHMARK_GROUPS ?
+        process.env.NODE_RUN_BENCHMARK_GROUPS.split(',') :
+        Object.keys(configs);
+
+      for (const key of groups) {
+        const config = configs[key];
+        config.group = key;
+        const parsed_args = this._parseArgs(argv, config, options);
+        this.options = parsed_args.cli;
+        this.extra_options = parsed_args.extra;
+        this.queue = this.queue.concat(this._queue(this.options));
+      }
+    } else {
+      const parsed_args = this._parseArgs(argv, configs, options);
+      this.options = parsed_args.cli;
+      this.extra_options = parsed_args.extra;
+      this.queue = this._queue(this.options);
+    }
+
     if (options.flags) {
       this.flags = this.flags.concat(options.flags);
     }
-
-    // The configuration list as a queue of jobs
-    this.queue = this._queue(this.options);
 
     // The configuration of the current job, head of the queue
     this.config = this.queue[0];

--- a/doc/guides/writing-and-running-benchmarks.md
+++ b/doc/guides/writing-and-running-benchmarks.md
@@ -444,8 +444,24 @@ The arguments of `createBenchmark` are:
   possible combinations of these parameters, unless specified otherwise.
   Each configuration is a property with an array of possible values.
   The configuration values can only be strings or numbers.
-* `options` {Object} The benchmark options. At the moment only the `flags`
-  option for specifying command line flags is supported.
+* `options` {Object} The benchmark options:
+  * `flags` option for specifying command line flags is supported
+  * `byGroup` option for processing `configs` by groups:
+
+```js
+const bench = common.createBenchmark(main, {
+  groupA: {
+    source: ['array'],
+    len: [10, 2048],
+    n: [50],
+  },
+  groupB: {
+    source: ['buffer', 'string'],
+    len: [2048],
+    n: [50, 2048],
+  }
+}, { byGroup: true });
+```
 
 `createBenchmark` returns a `bench` object, which is used for timing
 the runtime of the benchmark. Run `bench.start()` after the initialization


### PR DESCRIPTION
Add the `byGroup` option to have benchmark parameter grouping.
The environment variable `NODE_RUN_BENCHMARK_GROUPS` allows to benchmark
only certain groups: `NODE_RUN_BENCHMARK_GROUPS=groupA,groupB`.

Fixes: https://github.com/nodejs/node/issues/26425

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
