### PR TITLE
build: restore libplatform headers in distribution

### DIFF
--- a/tools/install.py
+++ b/tools/install.py
@@ -160,6 +160,9 @@ def headers(action):
   def wanted_v8_headers(files_arg, dest):
     v8_headers = [
       'deps/v8/include/cppgc/common.h',
+      'deps/v8/include/libplatform/libplatform.h',
+      'deps/v8/include/libplatform/libplatform-export.h',
+      'deps/v8/include/libplatform/v8-tracing.h',
       'deps/v8/include/v8.h',
       'deps/v8/include/v8-internal.h',
       'deps/v8/include/v8-platform.h',


### PR DESCRIPTION
I maintain libnode/v8 bindings for the R programming language, which depend on libnode on most Linux distro's, e.g. [r-cran-v8](https://packages.debian.org/bullseye/r-cran-v8) in Debian/Ubuntu and [R-V8](https://src.fedoraproject.org/rpms/R-V8) in Fedora.

Headers considered non-essential were removed in #37570, however the libplatform API is actually needed by external software initiating the v8 engine. See for example the upstream v8 hello world example: https://chromium.googlesource.com/v8/v8/+/refs/heads/main/samples/hello-world.cc

I have also [asked upstream v8](https://groups.google.com/g/v8-users/c/GeIwDMWCq9I) if the API in question could maybe be moved to the top level `v8-*` headers,  but they have not responded.

I hope it can be reconsidered to ship these headers, otherwise it will no longer be possible for us to build bindings for libnode, which would be very unfortunate, because they are widely used.


<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
