### PR TITLE
repl: add fallback error detection after processTopLevelAwait error

### DIFF
--- a/lib/internal/repl/await.js
+++ b/lib/internal/repl/await.js
@@ -120,7 +120,10 @@ function processTopLevelAwait(src) {
         '^\n\n' + RegExpPrototypeSymbolReplace(/ \([^)]+\)/, e.message, '');
     // V8 unexpected token errors include the token string.
     if (StringPrototypeEndsWith(message, 'Unexpected token'))
-      message += " '" + src[e.pos - wrapPrefix.length] + "'";
+      message += " '" +
+        // Wrapper end may cause acorn to report error position after the source
+        (src[e.pos - wrapPrefix.length] ?? src[src.length - 1]) +
+        "'";
     // eslint-disable-next-line no-restricted-syntax
     throw new SyntaxError(message);
   }

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -78,6 +78,7 @@ const {
   ReflectApply,
   RegExp,
   RegExpPrototypeExec,
+  RegExpPrototypeSymbolReplace,
   RegExpPrototypeTest,
   SafeSet,
   SafeWeakSet,
@@ -434,8 +435,39 @@ function REPLServer(prompt,
           awaitPromise = true;
         }
       } catch (e) {
-        decorateErrorStack(e);
-        err = e;
+        let recoverableError = false;
+        if (e.name === 'SyntaxError') {
+          let parentURL;
+          try {
+            const { pathToFileURL } = require('url');
+            // Adding `/repl` prevents dynamic imports from loading relative
+            // to the parent of `process.cwd()`.
+            parentURL = pathToFileURL(path.join(process.cwd(), 'repl')).href;
+          } catch {
+          }
+
+          // Remove all "await"s and attempt running the script
+          // in order to detect if error is truly non recoverable
+          const fallbackCode = RegExpPrototypeSymbolReplace(/\bawait\b/g, code, '');
+          try {
+            vm.createScript(fallbackCode, {
+              filename: file,
+              displayErrors: true,
+              importModuleDynamically: async (specifier) => {
+                return asyncESM.ESMLoader.import(specifier, parentURL);
+              }
+            });
+          } catch (fallbackError) {
+            if (isRecoverableError(fallbackError, fallbackCode)) {
+              recoverableError = true;
+              err = new Recoverable(e);
+            }
+          }
+        }
+        if (!recoverableError) {
+          decorateErrorStack(e);
+          err = e;
+        }
       }
     }
 

--- a/test/parallel/test-repl-top-level-await.js
+++ b/test/parallel/test-repl-top-level-await.js
@@ -152,6 +152,36 @@ async function ordinaryTests() {
        'Unexpected token \'.\'',
      ],
     ],
+    ['for (const x of [1,2,3]) {\nawait x\n}', [
+      'for (const x of [1,2,3]) {\r',
+      '... await x\r',
+      '... }\r',
+      'undefined',
+    ]],
+    ['for (const x of [1,2,3]) {\nawait x;\n}', [
+      'for (const x of [1,2,3]) {\r',
+      '... await x;\r',
+      '... }\r',
+      'undefined',
+    ]],
+    ['for await (const x of [1,2,3]) {\nconsole.log(x)\n}', [
+      'for await (const x of [1,2,3]) {\r',
+      '... console.log(x)\r',
+      '... }\r',
+      '1',
+      '2',
+      '3',
+      'undefined',
+    ]],
+    ['for await (const x of [1,2,3]) {\nconsole.log(x);\n}', [
+      'for await (const x of [1,2,3]) {\r',
+      '... console.log(x);\r',
+      '... }\r',
+      '1',
+      '2',
+      '3',
+      'undefined',
+    ]],
   ];
 
   for (const [input, expected = [`${input}\r`], options = {}] of testCases) {


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Fixes #32708

This PR adds a fallback error detection if `SyntaxError` was thrown, as it could be related to incomplete user input (due to splitting the code into multiple lines), that leads to premature evaluation and subsequently an error.