### PR TITLE
http: fix keepAliveTimeout for HTTP server after answering a POST request synchronously

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -930,7 +930,7 @@ function parserOnIncoming(server, socket, state, req, keepAlive) {
 }
 
 function resetSocketTimeout(server, socket, state) {
-  if (!state.keepAliveTimeoutSet)
+  if (!state.keepAliveTimeoutSet || state.outgoing.length === 0)
     return;
 
   socket.setTimeout(server.timeout || 0);

--- a/test/parallel/test-http-keep-alive-timeout-close.js
+++ b/test/parallel/test-http-keep-alive-timeout-close.js
@@ -1,0 +1,82 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { createServer } = require('http');
+const { createConnection } = require('net');
+
+const server = createServer();
+server.keepAliveTimeout = 1;
+
+server.on('request', (req, res) => {
+  if (req.url === '/async') {
+    req.on('data', () => {});
+    req.on('end', () => {
+      res.end('test-body');
+      console.log('Server: Sent response asynchronously');
+    });
+  } else {
+    res.end('test-body');
+    console.log('Server: Sent response synchronously');
+  }
+});
+
+server.listen(0, async () => {
+  await sendRequests('async', 'get');
+  await sendRequests('async', 'post');
+  await sendRequests('sync', 'get');
+  await sendRequests('sync', 'post'); // keepAliveTimeout does not work here!!
+
+  server.close();
+});
+
+async function sendRequests(type, method) {
+  console.log(`=== Testing ${type} response for method "${method}" and wait for keep-alive-close`);
+
+  return new Promise((resolve) => {
+    const client = createConnection(server.address().port);
+    let closeTimeout = null;
+
+    client.on('connect', () => {
+      console.log('Client: Connected to server');
+
+      httpRequest();
+
+      closeTimeout = setTimeout(() => {
+        console.log('Client: ERROR: HTTP-Connection is still open - closing from client side now');
+        closeTimeout = null;
+        client.end();
+
+        assert.fail('keepAliveTimeout did not work');
+      }, 1000);
+    });
+
+    client.on('data', (data) => {
+      console.log('Client: Got response data');
+    });
+
+    client.on('close', () => {
+      if (closeTimeout) {
+        console.log('Client: Server closed connection as expected');
+        clearTimeout(closeTimeout);
+      }
+      resolve();
+    });
+
+    function httpRequest() {
+      const rawRequests = {
+        'post': 'POST /' + type + ' HTTP/1.1\r\n' +
+          'Connection: keep-alive\r\n' +
+          'Content-Type: application/x-www-form-urlencoded\r\n' +
+          'Content-Length: 10\r\n' +
+          '\r\n' +
+          'Test=67890',
+        'get': 'GET /' + type + ' HTTP/1.1\r\n' +
+          'Connection: keep-alive\r\n' +
+          '\r\n'
+      };
+
+      console.log('Client: Sending request');
+      client.write(rawRequests[method]);
+    }
+  });
+}


### PR DESCRIPTION
This is a draft PR for fixing #39137 ... primarily for the test-case for now.

My changes to `lib/_http_server.js` are just an experiment as a base for discussion - it fixes this issue, but I don't want to fix it that way (and it currently breaks other tests):

- I don't want a new `responseSent` flag - I'm sure we can use an existing flag, but I didn't find a suitable one
- Maybe the `resetSocketTimeout()` in `onParserExecuteCommon()` can be even moved to somewhere else? Not when data (body?) arrives, but when the request (header?) arrives
- It seems `resetSocketTimeout()` only resets the timeout if `keepAliveTimeoutSet`, which is set only in `resOnFinish` ... so maybe the experimental `responseSent` flag makes `keepAliveTimeoutSet` useless
- Resetting `responseSent` in `onParserExecuteCommon()` is probably the wrong place anyway ... currently theese two tests are broken:
  - sequential/test-http-server-keep-alive-timeout-slow-client-headers.js
  - sequential/test-http-server-keep-alive-timeout-slow-server.js
