### PR TITLE
http: server check Host header in request, to meet RFC 7230 5.4 requirement

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -904,8 +904,20 @@ function parserOnIncoming(server, socket, state, req, keepAlive) {
          resOnFinish.bind(undefined,
                           req, res, socket, state, server));
 
-  if (req.headers.expect !== undefined &&
-      (req.httpVersionMajor === 1 && req.httpVersionMinor === 1)) {
+  const isHttp11 = (req.httpVersionMajor === 1 && req.httpVersionMinor === 1);
+
+  // From RFC 2730 5.4 https://datatracker.ietf.org/doc/html/rfc7230#section-5.4
+  // A server MUST respond with a 400 (Bad Request) status code to any
+  // HTTP/1.1 request message that lacks a Host header field and to any
+  // request message that contains more than one Host header field or a
+  // Host header field with an invalid field-value.
+  if (req.headers.host === undefined && isHttp11) {
+    res.writeHead(400);
+    res.end();
+    return 0;
+  }
+
+  if (req.headers.expect !== undefined && isHttp11) {
     if (RegExpPrototypeTest(continueExpression, req.headers.expect)) {
       res._expect_continue = true;
 

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -908,9 +908,7 @@ function parserOnIncoming(server, socket, state, req, keepAlive) {
 
   // From RFC 2730 5.4 https://datatracker.ietf.org/doc/html/rfc7230#section-5.4
   // A server MUST respond with a 400 (Bad Request) status code to any
-  // HTTP/1.1 request message that lacks a Host header field and to any
-  // request message that contains more than one Host header field or a
-  // Host header field with an invalid field-value.
+  // HTTP/1.1 request message that lacks a Host header field
   if (req.headers.host === undefined && isHttp11) {
     res.writeHead(400);
     res.end();

--- a/test/parallel/test-http-chunked-304.js
+++ b/test/parallel/test-http-chunked-304.js
@@ -47,7 +47,7 @@ function test(statusCode) {
     const conn = net.createConnection(
       server.address().port,
       common.mustCall(() => {
-        conn.write('GET / HTTP/1.1\r\n\r\n');
+        conn.write('GET / HTTP/1.1\r\nHost: example.com\r\n\r\n');
 
         let resp = '';
         conn.setEncoding('utf8');

--- a/test/parallel/test-http-client-headers-array.js
+++ b/test/parallel/test-http-client-headers-array.js
@@ -10,7 +10,8 @@ function execute(options) {
     const expectHeaders = {
       'x-foo': 'boom',
       'cookie': 'a=1; b=2; c=3',
-      'connection': 'close'
+      'connection': 'close',
+      'host': 'example.com',
     };
 
     // no Host header when you set headers an array
@@ -42,13 +43,20 @@ function execute(options) {
 // Should be the same except for implicit Host header on the first two
 execute({ headers: { 'x-foo': 'boom', 'cookie': 'a=1; b=2; c=3' } });
 execute({ headers: { 'x-foo': 'boom', 'cookie': [ 'a=1', 'b=2', 'c=3' ] } });
-execute({ headers: [[ 'x-foo', 'boom' ], [ 'cookie', 'a=1; b=2; c=3' ]] });
 execute({ headers: [
-  [ 'x-foo', 'boom' ], [ 'cookie', [ 'a=1', 'b=2', 'c=3' ]],
+  [ 'x-foo', 'boom' ],
+  [ 'cookie', 'a=1; b=2; c=3' ],
+  [ 'Host', 'example.com' ],
+] });
+execute({ headers: [
+  [ 'x-foo', 'boom' ],
+  [ 'cookie', [ 'a=1', 'b=2', 'c=3' ]],
+  [ 'Host', 'example.com' ],
 ] });
 execute({ headers: [
   [ 'x-foo', 'boom' ], [ 'cookie', 'a=1' ],
-  [ 'cookie', 'b=2' ], [ 'cookie', 'c=3'],
+  [ 'cookie', 'b=2' ], [ 'cookie', 'c=3' ],
+  [ 'Host', 'example.com'],
 ] });
 
 // Authorization and Host header both missing from the second
@@ -57,4 +65,5 @@ execute({ auth: 'foo:bar', headers:
 execute({ auth: 'foo:bar', headers: [
   [ 'x-foo', 'boom' ], [ 'cookie', 'a=1' ],
   [ 'cookie', 'b=2' ], [ 'cookie', 'c=3'],
+  [ 'Host', 'example.com'],
 ] });

--- a/test/parallel/test-http-content-length.js
+++ b/test/parallel/test-http-content-length.js
@@ -27,15 +27,18 @@ const server = http.createServer(function(req, res) {
 
   switch (req.url.substr(1)) {
     case 'multiple-writes':
+      delete req.headers.host;
       assert.deepStrictEqual(req.headers, expectedHeadersMultipleWrites);
       res.write('hello');
       res.end('world');
       break;
     case 'end-with-data':
+      delete req.headers.host;
       assert.deepStrictEqual(req.headers, expectedHeadersEndWithData);
       res.end('hello world');
       break;
     case 'empty':
+      delete req.headers.host;
       assert.deepStrictEqual(req.headers, expectedHeadersEndNoData);
       res.end();
       break;
@@ -55,7 +58,6 @@ server.listen(0, function() {
     path: '/multiple-writes'
   });
   req.removeHeader('Date');
-  req.removeHeader('Host');
   req.write('hello ');
   req.end('world');
   req.on('response', function(res) {
@@ -68,7 +70,6 @@ server.listen(0, function() {
     path: '/end-with-data'
   });
   req.removeHeader('Date');
-  req.removeHeader('Host');
   req.end('hello world');
   req.on('response', function(res) {
     assert.deepStrictEqual(res.headers, expectedHeadersEndWithData);
@@ -80,7 +81,6 @@ server.listen(0, function() {
     path: '/empty'
   });
   req.removeHeader('Date');
-  req.removeHeader('Host');
   req.end();
   req.on('response', function(res) {
     assert.deepStrictEqual(res.headers, expectedHeadersEndNoData);

--- a/test/parallel/test-http-header-badrequest.js
+++ b/test/parallel/test-http-header-badrequest.js
@@ -17,7 +17,7 @@ server.listen(0, mustCall(() => {
   let received = '';
 
   c.on('connect', mustCall(() => {
-    c.write('GET /blah HTTP/1.1\r\n\r\n');
+    c.write('GET /blah HTTP/1.1\r\nHost: example.com\r\n\r\n');
   }));
   c.on('data', mustCall((data) => {
     received += data.toString();

--- a/test/parallel/test-http-insecure-parser-per-stream.js
+++ b/test/parallel/test-http-insecure-parser-per-stream.js
@@ -22,6 +22,7 @@ const MakeDuplexPair = require('../common/duplexpair');
 
   serverSide.resume();  // Dump the request
   serverSide.end('HTTP/1.1 200 OK\r\n' +
+                 'Host: example.com\r\n' +
                  'Hello: foo\x08foo\r\n' +
                  'Content-Length: 0\r\n' +
                  '\r\n\r\n');
@@ -39,6 +40,7 @@ const MakeDuplexPair = require('../common/duplexpair');
 
   serverSide.resume();  // Dump the request
   serverSide.end('HTTP/1.1 200 OK\r\n' +
+                 'Host: example.com\r\n' +
                  'Hello: foo\x08foo\r\n' +
                  'Content-Length: 0\r\n' +
                  '\r\n\r\n');
@@ -62,6 +64,7 @@ const MakeDuplexPair = require('../common/duplexpair');
   server.emit('connection', serverSide);
 
   clientSide.write('GET / HTTP/1.1\r\n' +
+                   'Host: example.com\r\n' +
                    'Hello: foo\x08foo\r\n' +
                    '\r\n\r\n');
 }
@@ -77,6 +80,7 @@ const MakeDuplexPair = require('../common/duplexpair');
   server.emit('connection', serverSide);
 
   clientSide.write('GET / HTTP/1.1\r\n' +
+                   'Host: example.com\r\n' +
                    'Hello: foo\x08foo\r\n' +
                    '\r\n\r\n');
 }

--- a/test/parallel/test-http-insecure-parser.js
+++ b/test/parallel/test-http-insecure-parser.js
@@ -19,6 +19,7 @@ server.listen(0, common.mustCall(function() {
       client.write(
         'GET / HTTP/1.1\r\n' +
         'Content-Type: text/te\x08t\r\n' +
+        'Host: example.com' +
         'Connection: close\r\n\r\n');
     }
   );

--- a/test/parallel/test-http-malformed-request.js
+++ b/test/parallel/test-http-malformed-request.js
@@ -41,7 +41,7 @@ server.listen(0);
 server.on('listening', function() {
   const c = net.createConnection(this.address().port);
   c.on('connect', function() {
-    c.write('GET /hello?foo=%99bar HTTP/1.1\r\n\r\n');
+    c.write('GET /hello?foo=%99bar HTTP/1.1\r\nHost: example.com\r\n\r\n');
     c.end();
   });
 });

--- a/test/parallel/test-http-max-header-size-per-stream.js
+++ b/test/parallel/test-http-max-header-size-per-stream.js
@@ -62,6 +62,7 @@ const MakeDuplexPair = require('../common/duplexpair');
   server.emit('connection', serverSide);
 
   clientSide.write('GET / HTTP/1.1\r\n' +
+                   'Host: example.com\r\n' +
                    'Hello: ' + 'A'.repeat(http.maxHeaderSize * 3) + '\r\n' +
                    '\r\n\r\n');
 }

--- a/test/parallel/test-http-max-headers-count.js
+++ b/test/parallel/test-http-max-headers-count.js
@@ -27,7 +27,9 @@ const http = require('http');
 let requests = 0;
 let responses = 0;
 
-const headers = {};
+const headers = {
+  host: 'example.com'
+};
 const N = 100;
 for (let i = 0; i < N; ++i) {
   headers[`key${i}`] = i;
@@ -56,8 +58,8 @@ server.maxHeadersCount = max;
 server.listen(0, function() {
   const maxAndExpected = [ // for client
     [20, 20],
-    [1200, 103],
-    [0, N + 3], // Connection, Date and Transfer-Encoding
+    [1200, 104],
+    [0, N + 4], // Connection, Date and Transfer-Encoding
   ];
   doRequest();
 

--- a/test/parallel/test-http-pipeline-assertionerror-finish.js
+++ b/test/parallel/test-http-pipeline-assertionerror-finish.js
@@ -27,7 +27,7 @@ const server = http
   .listen(0, function() {
     const s = net.connect(this.address().port);
 
-    const big = 'GET / HTTP/1.1\r\n\r\n'.repeat(COUNT);
+    const big = 'GET / HTTP/1.1\r\nHost: example.com\r\n\r\n'.repeat(COUNT);
 
     s.write(big);
     s.resume();

--- a/test/parallel/test-http-pipeline-requests-connection-leak.js
+++ b/test/parallel/test-http-pipeline-requests-connection-leak.js
@@ -26,7 +26,7 @@ const server = http
     });
   })
   .listen(0, function() {
-    const req = 'GET / HTTP/1.1\r\n\r\n'.repeat(COUNT);
+    const req = 'GET / HTTP/1.1\r\nHost: example.com\r\n\r\n'.repeat(COUNT);
     client = net.connect(this.address().port, function() {
       client.write(req);
     });

--- a/test/parallel/test-http-pipeline-socket-parser-typeerror.js
+++ b/test/parallel/test-http-pipeline-socket-parser-typeerror.js
@@ -50,7 +50,7 @@ const server = http
   .listen(0, () => {
     const s = net.connect(server.address().port);
     more = () => {
-      s.write('GET / HTTP/1.1\r\n\r\n');
+      s.write('GET / HTTP/1.1\r\nHost: example.com\r\n\r\n');
     };
     done = () => {
       s.write(

--- a/test/parallel/test-http-req-close-robust-from-tampering.js
+++ b/test/parallel/test-http-req-close-robust-from-tampering.js
@@ -17,6 +17,7 @@ server.listen(0, common.mustCall(() => {
 
   const req = [
     'POST / HTTP/1.1',
+    'Host: example.com',
     'Content-Length: 11',
     '',
     'hello world',

--- a/test/parallel/test-http-response-splitting.js
+++ b/test/parallel/test-http-response-splitting.js
@@ -52,7 +52,7 @@ const server = http.createServer((req, res) => {
   res.end('ok');
 });
 server.listen(0, () => {
-  const end = 'HTTP/1.1\r\n\r\n';
+  const end = 'HTTP/1.1\r\nHost: example.com\r\n\r\n';
   const client = net.connect({ port: server.address().port }, () => {
     client.write(`GET ${str} ${end}`);
     client.write(`GET / ${end}`);

--- a/test/parallel/test-http-server-request-timeout-delayed-body.js
+++ b/test/parallel/test-http-server-request-timeout-delayed-body.js
@@ -44,6 +44,7 @@ server.listen(0, common.mustCall(() => {
 
   client.resume();
   client.write('POST / HTTP/1.1\r\n');
+  client.write('Host: example.com\r\n');
   client.write('Content-Length: 20\r\n');
   client.write('Connection: close\r\n');
   client.write('\r\n');

--- a/test/parallel/test-http-server-request-timeout-interrupted-body.js
+++ b/test/parallel/test-http-server-request-timeout-interrupted-body.js
@@ -55,6 +55,7 @@ server.listen(0, common.mustCall(() => {
 
   client.resume();
   client.write('POST / HTTP/1.1\r\n');
+  client.write('Host: example.com\r\n');
   client.write('Content-Length: 20\r\n');
   client.write('Connection: close\r\n');
   client.write('\r\n');

--- a/test/parallel/test-http-server-request-timeout-keepalive.js
+++ b/test/parallel/test-http-server-request-timeout-keepalive.js
@@ -12,7 +12,7 @@ const { connect } = require('net');
 
 function performRequestWithDelay(client, firstDelay, secondDelay) {
   client.resume();
-  client.write('GET / HTTP/1.1\r\n');
+  client.write('GET / HTTP/1.1\r\nHost: example.com\r\n');
 
   firstDelay = common.platformTimeout(firstDelay);
   secondDelay = common.platformTimeout(secondDelay);

--- a/test/parallel/test-http-server-unconsume.js
+++ b/test/parallel/test-http-server-unconsume.js
@@ -18,7 +18,7 @@ const net = require('net');
     server.close();
   }).listen(0, function() {
     const socket = net.connect(this.address().port, function() {
-      socket.write('PUT / HTTP/1.1\r\n\r\n');
+      socket.write('PUT / HTTP/1.1\r\nHost: example.com\r\n\r\n');
 
       socket.once('data', function() {
         socket.end('hello world');

--- a/test/parallel/test-http-server.js
+++ b/test/parallel/test-http-server.js
@@ -89,7 +89,9 @@ server.on('listening', function() {
   c.setEncoding('utf8');
 
   c.on('connect', function() {
-    c.write('GET /hello?hello=world&foo=b==ar HTTP/1.1\r\n\r\n');
+    c.write(
+      'GET /hello?hello=world&foo=b==ar HTTP/1.1\r\n' +
+      'Host: example.com\r\n\r\n');
     requests_sent += 1;
   });
 
@@ -97,13 +99,16 @@ server.on('listening', function() {
     server_response += chunk;
 
     if (requests_sent === 1) {
-      c.write('POST /quit HTTP/1.1\r\n\r\n');
+      c.write(
+        'POST /quit HTTP/1.1\r\n' +
+        'Host: example.com\r\n\r\n'
+      );
       requests_sent += 1;
     }
 
     if (requests_sent === 2) {
-      c.write('GET / HTTP/1.1\r\nX-X: foo\r\n\r\n' +
-              'GET / HTTP/1.1\r\nX-X: bar\r\n\r\n');
+      c.write('GET / HTTP/1.1\r\nX-X: foo\r\nHost: example.com\r\n\r\n' +
+              'GET / HTTP/1.1\r\nX-X: bar\r\nHost: example.com\r\n\r\n');
       // Note: we are making the connection half-closed here
       // before we've gotten the response from the server. This
       // is a pretty bad thing to do and not really supported

--- a/test/parallel/test-http-set-trailers.js
+++ b/test/parallel/test-http-set-trailers.js
@@ -59,7 +59,7 @@ function testHttp11(port, callback) {
 
   let tid;
   c.on('connect', function() {
-    c.write('GET / HTTP/1.1\r\n\r\n');
+    c.write('GET / HTTP/1.1\r\nHost: example.com\r\n\r\n');
     tid = setTimeout(common.mustNotCall(), 2000, 'Couldn\'t find last chunk.');
   });
 

--- a/test/parallel/test-http-status-message.js
+++ b/test/parallel/test-http-status-message.js
@@ -38,7 +38,10 @@ function test() {
   const client = net.connect(
     this.address().port,
     function() {
-      client.write('GET / HTTP/1.1\r\nConnection: close\r\n\r\n');
+      client.write(
+        'GET / HTTP/1.1\r\n' +
+        'Host: example.com\r\n' +
+        'Connection: close\r\n\r\n');
     }
   );
   client.on('data', function(chunk) {

--- a/test/parallel/test-http-upgrade-server.js
+++ b/test/parallel/test-http-upgrade-server.js
@@ -87,6 +87,7 @@ function test_upgrade_with_listener() {
   conn.on('connect', function() {
     writeReq(conn,
              'GET / HTTP/1.1\r\n' +
+             'Host: example.com\r\n' +
              'Upgrade: WebSocket\r\n' +
              'Connection: Upgrade\r\n' +
              '\r\n' +
@@ -124,6 +125,7 @@ function test_upgrade_no_listener() {
   conn.on('connect', function() {
     writeReq(conn,
              'GET / HTTP/1.1\r\n' +
+             'Host: example.com\r\n' +
              'Upgrade: WebSocket\r\n' +
              'Connection: Upgrade\r\n' +
              '\r\n');
@@ -146,7 +148,7 @@ function test_standard_http() {
   conn.setEncoding('utf8');
 
   conn.on('connect', function() {
-    writeReq(conn, 'GET / HTTP/1.1\r\n\r\n');
+    writeReq(conn, 'GET / HTTP/1.1\r\nHost: example.com\r\n\r\n');
   });
 
   conn.once('data', function(data) {

--- a/test/parallel/test-http.js
+++ b/test/parallel/test-http.js
@@ -113,7 +113,9 @@ server.on('listening', () => {
       path: '/world',
       headers: [ ['Cookie', 'abc=123'],
                  ['Cookie', 'def=456'],
-                 ['Cookie', 'ghi=789'] ],
+                 ['Cookie', 'ghi=789'],
+                 ['Host', 'example.com'],
+               ],
       agent: agent
     }, common.mustCall((res) => {
       const cookieHeaders = req._header.match(/^Cookie: .+$/img);

--- a/test/parallel/test-http.js
+++ b/test/parallel/test-http.js
@@ -115,7 +115,7 @@ server.on('listening', () => {
                  ['Cookie', 'def=456'],
                  ['Cookie', 'ghi=789'],
                  ['Host', 'example.com'],
-               ],
+      ],
       agent: agent
     }, common.mustCall((res) => {
       const cookieHeaders = req._header.match(/^Cookie: .+$/img);

--- a/test/parallel/test-https-agent-create-connection.js
+++ b/test/parallel/test-https-agent-create-connection.js
@@ -22,7 +22,7 @@ const expectCertError = /^Error: unable to verify the first certificate$/;
 const checkRequest = (socket, server) => {
   let result = '';
   socket.on('connect', common.mustCall((data) => {
-    socket.write('GET / HTTP/1.1\r\n\r\n');
+    socket.write('GET / HTTP/1.1\r\nHost: example.com\r\n\r\n');
     socket.end();
   }));
   socket.on('data', common.mustCall((chunk) => {

--- a/test/parallel/test-https-host-headers.js
+++ b/test/parallel/test-https-host-headers.js
@@ -25,7 +25,7 @@ const httpsServer = https.createServer({
   }
   res.writeHead(200, {});
   res.end('ok');
-}, 9)).listen(0, common.mustCall(function(err) {
+}, 6)).listen(0, common.mustCall(function(err) {
   debug(`test https server listening on port ${this.address().port}`);
   assert.ifError(err);
   https.get({

--- a/test/parallel/test-https-insecure-parse-per-stream.js
+++ b/test/parallel/test-https-insecure-parse-per-stream.js
@@ -37,6 +37,7 @@ const certFixture = {
 
   serverSide.resume();  // Dump the request
   serverSide.end('HTTP/1.1 200 OK\r\n' +
+                 'Host: example.com\r\n' +
                  'Hello: foo\x08foo\r\n' +
                  'Content-Length: 0\r\n' +
                  '\r\n\r\n');
@@ -55,6 +56,7 @@ const certFixture = {
 
   serverSide.resume();  // Dump the request
   serverSide.end('HTTP/1.1 200 OK\r\n' +
+                 'Host: example.com\r\n' + 
                  'Hello: foo\x08foo\r\n' +
                  'Content-Length: 0\r\n' +
                  '\r\n\r\n');
@@ -81,6 +83,7 @@ const certFixture = {
     });
     client.write(
       'GET / HTTP/1.1\r\n' +
+      'Host: example.com\r\n' +
       'Hello: foo\x08foo\r\n' +
       '\r\n\r\n');
     client.end();
@@ -107,6 +110,7 @@ const certFixture = {
     });
     client.write(
       'GET / HTTP/1.1\r\n' +
+      'Host: example.com\r\n' +
       'Hello: foo\x08foo\r\n' +
       '\r\n\r\n');
     client.end();

--- a/test/parallel/test-https-insecure-parse-per-stream.js
+++ b/test/parallel/test-https-insecure-parse-per-stream.js
@@ -56,7 +56,7 @@ const certFixture = {
 
   serverSide.resume();  // Dump the request
   serverSide.end('HTTP/1.1 200 OK\r\n' +
-                 'Host: example.com\r\n' + 
+                 'Host: example.com\r\n' +
                  'Hello: foo\x08foo\r\n' +
                  'Content-Length: 0\r\n' +
                  '\r\n\r\n');

--- a/test/parallel/test-https-max-header-size-per-stream.js
+++ b/test/parallel/test-https-max-header-size-per-stream.js
@@ -38,6 +38,7 @@ const certFixture = {
 
   serverSide.resume();  // Dump the request
   serverSide.end('HTTP/1.1 200 OK\r\n' +
+                 'Host: example.com\r\n' +
                  'Hello: ' + 'A'.repeat(http.maxHeaderSize * 3) + '\r\n' +
                  'Content-Length: 0\r\n' +
                  '\r\n\r\n');
@@ -55,6 +56,7 @@ const certFixture = {
 
   serverSide.resume();  // Dump the request
   serverSide.end('HTTP/1.1 200 OK\r\n' +
+                 'Host: example.com\r\n' +
                  'Hello: ' + 'A'.repeat(http.maxHeaderSize * 3) + '\r\n' +
                  'Content-Length: 0\r\n' +
                  '\r\n\r\n');
@@ -81,6 +83,7 @@ const certFixture = {
     });
     client.write(
       'GET / HTTP/1.1\r\n' +
+      'Host: example.com\r\n' +
       'Hello: ' + 'A'.repeat(http.maxHeaderSize * 3) + '\r\n' +
       '\r\n\r\n');
     client.end();
@@ -107,6 +110,7 @@ const certFixture = {
     });
     client.write(
       'GET / HTTP/1.1\r\n' +
+      'Host: example.com\r\n' +
       'Hello: ' + 'A'.repeat(http.maxHeaderSize * 3) + '\r\n' +
       '\r\n\r\n');
     client.end();

--- a/test/parallel/test-https-max-headers-count.js
+++ b/test/parallel/test-https-max-headers-count.js
@@ -16,7 +16,9 @@ const serverOptions = {
 let requests = 0;
 let responses = 0;
 
-const headers = {};
+const headers = {
+  host: 'example.com'
+};
 const N = 100;
 for (let i = 0; i < N; ++i) {
   headers[`key${i}`] = i;
@@ -45,8 +47,8 @@ server.maxHeadersCount = max;
 server.listen(0, common.mustCall(() => {
   const maxAndExpected = [ // for client
     [20, 20],
-    [1200, 103],
-    [0, N + 3], // Connection, Date and Transfer-Encoding
+    [1200, 104],
+    [0, N + 4], // Connection, Date and Transfer-Encoding
   ];
   const doRequest = common.mustCall(() => {
     const max = maxAndExpected[responses][0];


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Relate issues: #3094 #39033

According to RFC 2730 5.4 https://datatracker.ietf.org/doc/html/rfc7230#section-5.4:
A server MUST respond with a 400 (Bad Request) status code to any HTTP/1.1 request message that lacks a Host header field and to any request message that contains more than one Host header field or a Host header field with an invalid field-value.
