### PR TITLE
tools: add GitHub Action to run find-inactive-collaborators.mjs

### DIFF
--- a/.github/workflows/find-inactive-collaborators.yml
+++ b/.github/workflows/find-inactive-collaborators.yml
@@ -1,0 +1,17 @@
+name: Find inactive collaborators
+
+on:
+  schedule:
+    # Run on the 15th day of the month at 4:05 AM UTC.
+    - cron: '5 4 15 * *'
+
+  workflow_dispatch:
+
+jobs:
+  find:
+  
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - run: tools/find-inactive-collaborators.mjs '1 year ago'


### PR DESCRIPTION
Add a GitHub Action for find-inactive-collaborators.mjs that will run it
and list collaborators who have been inactive for more than a year. It
will run when manually triggered by a collaborator and on a schedule of
once a month.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
