### PR TITLE
test: disable cctests that fail when built with `NODE_BUILTIN_MODULES_PATH`

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -1139,6 +1139,9 @@
              'HAVE_INSPECTOR=0',
            ]
         }],
+        [ 'node_builtin_modules_path!=""', {
+          'defines': [ 'NODE_BUILTIN_MODULES_PATH="<(node_builtin_modules_path)"' ]
+        }],
         ['OS=="solaris"', {
           'ldflags': [ '-I<(SHARED_INTERMEDIATE_DIR)' ]
         }],
@@ -1206,6 +1209,9 @@
           'xcode_settings': {
             'OTHER_LDFLAGS': [ '-Wl,-rpath,@loader_path', ],
           },
+        }],
+        [ 'node_builtin_modules_path!=""', {
+          'defines': [ 'NODE_BUILTIN_MODULES_PATH="<(node_builtin_modules_path)"' ]
         }],
         ['OS=="win"', {
           'libraries': [

--- a/node.gyp
+++ b/node.gyp
@@ -1139,9 +1139,6 @@
              'HAVE_INSPECTOR=0',
            ]
         }],
-        [ 'node_builtin_modules_path!=""', {
-          'defines': [ 'NODE_BUILTIN_MODULES_PATH="<(node_builtin_modules_path)"' ]
-        }],
         ['OS=="solaris"', {
           'ldflags': [ '-I<(SHARED_INTERMEDIATE_DIR)' ]
         }],
@@ -1209,9 +1206,6 @@
           'xcode_settings': {
             'OTHER_LDFLAGS': [ '-Wl,-rpath,@loader_path', ],
           },
-        }],
-        [ 'node_builtin_modules_path!=""', {
-          'defines': [ 'NODE_BUILTIN_MODULES_PATH="<(node_builtin_modules_path)"' ]
         }],
         ['OS=="win"', {
           'libraries': [

--- a/src/node_native_module.cc
+++ b/src/node_native_module.cc
@@ -209,11 +209,6 @@ MaybeLocal<String> NativeModuleLoader::LoadBuiltinModuleSource(Isolate* isolate,
   std::string contents;
   int r = ReadFileSync(&contents, filename.c_str());
   if (r != 0) {
-    const auto source_it = source_.find(id);
-    if (source_it != source_.end()) {
-      return source_it->second.ToStringChecked(isolate);
-    }
-
     const std::string buf = SPrintF("Cannot read local builtin. %s: %s \"%s\"",
                                     uv_err_name(r),
                                     uv_strerror(r),

--- a/src/node_native_module.cc
+++ b/src/node_native_module.cc
@@ -209,6 +209,11 @@ MaybeLocal<String> NativeModuleLoader::LoadBuiltinModuleSource(Isolate* isolate,
   std::string contents;
   int r = ReadFileSync(&contents, filename.c_str());
   if (r != 0) {
+    const auto source_it = source_.find(id);
+    if (source_it != source_.end()) {
+      return source_it->second.ToStringChecked(isolate);
+    }
+
     const std::string buf = SPrintF("Cannot read local builtin. %s: %s \"%s\"",
                                     uv_err_name(r),
                                     uv_strerror(r),

--- a/test/cctest/test_environment.cc
+++ b/test/cctest/test_environment.cc
@@ -181,7 +181,6 @@ TEST_F(EnvironmentTest, LoadEnvironmentWithCallback) {
   CHECK(called_cb);
 }
 
-#ifndef NODE_BUILTIN_MODULES_PATH
 TEST_F(EnvironmentTest, LoadEnvironmentWithSource) {
   const v8::HandleScope handle_scope(isolate_);
   const Argv argv;
@@ -208,7 +207,6 @@ TEST_F(EnvironmentTest, LoadEnvironmentWithSource) {
           .ToLocalChecked())
           .ToLocalChecked()->IsFunction());
 }
-#endif  // NODE_BUILTIN_MODULES_PATH
 
 TEST_F(EnvironmentTest, AtExitWithEnvironment) {
   const v8::HandleScope handle_scope(isolate_);
@@ -398,7 +396,6 @@ TEST_F(EnvironmentTest, BufferWithFreeCallbackIsDetached) {
   CHECK_EQ(ab->ByteLength(), 0);
 }
 
-#ifndef NODE_BUILTIN_MODULES_PATH
 #if HAVE_INSPECTOR
 TEST_F(EnvironmentTest, InspectorMultipleEmbeddedEnvironments) {
   // Tests that child Environments can be created through the public API
@@ -540,9 +537,7 @@ TEST_F(EnvironmentTest, InspectorMultipleEmbeddedEnvironments) {
   CHECK_EQ(from_inspector->IntegerValue(context).FromJust(), 42);
 }
 #endif  // HAVE_INSPECTOR
-#endif  // NODE_BUILTIN_MODULES_PATH
 
-#ifndef NODE_BUILTIN_MODULES_PATH
 TEST_F(EnvironmentTest, ExitHandlerTest) {
   const v8::HandleScope handle_scope(isolate_);
   const Argv argv;
@@ -559,7 +554,6 @@ TEST_F(EnvironmentTest, ExitHandlerTest) {
   node::LoadEnvironment(*env, "process.exit(42)").ToLocalChecked();
   EXPECT_EQ(callback_calls, 1);
 }
-#endif  // NODE_BUILTIN_MODULES_PATH
 
 TEST_F(EnvironmentTest, SetImmediateMicrotasks) {
   int called = 0;
@@ -587,7 +581,6 @@ TEST_F(EnvironmentTest, SetImmediateMicrotasks) {
   EXPECT_EQ(called, 1);
 }
 
-#ifndef NODE_BUILTIN_MODULES_PATH
 #ifndef _WIN32  // No SIGINT on Windows.
 TEST_F(NodeZeroIsolateTestFixture, CtrlCWithOnlySafeTerminationTest) {
   // We need to go through the whole setup dance here because we want to
@@ -649,9 +642,7 @@ TEST_F(NodeZeroIsolateTestFixture, CtrlCWithOnlySafeTerminationTest) {
   isolate->Dispose();
 }
 #endif  // _WIN32
-#endif  // NODE_BUILTIN_MODULES_PATH
 
-#ifndef NODE_BUILTIN_MODULES_PATH
 TEST_F(EnvironmentTest, NestedMicrotaskQueue) {
   const v8::HandleScope handle_scope(isolate_);
   const Argv argv;
@@ -724,4 +715,3 @@ TEST_F(EnvironmentTest, NestedMicrotaskQueue) {
   node::FreeEnvironment(env);
   node::FreeIsolateData(isolate_data);
 }
-#endif  // NODE_BUILTIN_MODULES_PATH

--- a/test/cctest/test_environment.cc
+++ b/test/cctest/test_environment.cc
@@ -181,6 +181,7 @@ TEST_F(EnvironmentTest, LoadEnvironmentWithCallback) {
   CHECK(called_cb);
 }
 
+#ifndef NODE_BUILTIN_MODULES_PATH
 TEST_F(EnvironmentTest, LoadEnvironmentWithSource) {
   const v8::HandleScope handle_scope(isolate_);
   const Argv argv;
@@ -207,6 +208,7 @@ TEST_F(EnvironmentTest, LoadEnvironmentWithSource) {
           .ToLocalChecked())
           .ToLocalChecked()->IsFunction());
 }
+#endif  // NODE_BUILTIN_MODULES_PATH
 
 TEST_F(EnvironmentTest, AtExitWithEnvironment) {
   const v8::HandleScope handle_scope(isolate_);
@@ -396,6 +398,7 @@ TEST_F(EnvironmentTest, BufferWithFreeCallbackIsDetached) {
   CHECK_EQ(ab->ByteLength(), 0);
 }
 
+#ifndef NODE_BUILTIN_MODULES_PATH
 #if HAVE_INSPECTOR
 TEST_F(EnvironmentTest, InspectorMultipleEmbeddedEnvironments) {
   // Tests that child Environments can be created through the public API
@@ -537,7 +540,9 @@ TEST_F(EnvironmentTest, InspectorMultipleEmbeddedEnvironments) {
   CHECK_EQ(from_inspector->IntegerValue(context).FromJust(), 42);
 }
 #endif  // HAVE_INSPECTOR
+#endif  // NODE_BUILTIN_MODULES_PATH
 
+#ifndef NODE_BUILTIN_MODULES_PATH
 TEST_F(EnvironmentTest, ExitHandlerTest) {
   const v8::HandleScope handle_scope(isolate_);
   const Argv argv;
@@ -554,6 +559,7 @@ TEST_F(EnvironmentTest, ExitHandlerTest) {
   node::LoadEnvironment(*env, "process.exit(42)").ToLocalChecked();
   EXPECT_EQ(callback_calls, 1);
 }
+#endif  // NODE_BUILTIN_MODULES_PATH
 
 TEST_F(EnvironmentTest, SetImmediateMicrotasks) {
   int called = 0;
@@ -581,6 +587,7 @@ TEST_F(EnvironmentTest, SetImmediateMicrotasks) {
   EXPECT_EQ(called, 1);
 }
 
+#ifndef NODE_BUILTIN_MODULES_PATH
 #ifndef _WIN32  // No SIGINT on Windows.
 TEST_F(NodeZeroIsolateTestFixture, CtrlCWithOnlySafeTerminationTest) {
   // We need to go through the whole setup dance here because we want to
@@ -642,7 +649,9 @@ TEST_F(NodeZeroIsolateTestFixture, CtrlCWithOnlySafeTerminationTest) {
   isolate->Dispose();
 }
 #endif  // _WIN32
+#endif  // NODE_BUILTIN_MODULES_PATH
 
+#ifndef NODE_BUILTIN_MODULES_PATH
 TEST_F(EnvironmentTest, NestedMicrotaskQueue) {
   const v8::HandleScope handle_scope(isolate_);
   const Argv argv;
@@ -715,3 +724,4 @@ TEST_F(EnvironmentTest, NestedMicrotaskQueue) {
   node::FreeEnvironment(env);
   node::FreeIsolateData(isolate_data);
 }
+#endif  // NODE_BUILTIN_MODULES_PATH

--- a/test/embedding/embedtest.cc
+++ b/test/embedding/embedtest.cc
@@ -21,10 +21,6 @@ static int RunNodeInstance(MultiIsolatePlatform* platform,
                            const std::vector<std::string>& exec_args);
 
 int main(int argc, char** argv) {
-#ifdef NODE_BUILTIN_MODULES_PATH
-  return 0;
-#endif
-
   argv = uv_setup_args(argc, argv);
   std::vector<std::string> args(argv, argv + argc);
   std::vector<std::string> exec_args;

--- a/test/embedding/embedtest.cc
+++ b/test/embedding/embedtest.cc
@@ -21,6 +21,10 @@ static int RunNodeInstance(MultiIsolatePlatform* platform,
                            const std::vector<std::string>& exec_args);
 
 int main(int argc, char** argv) {
+#ifdef NODE_BUILTIN_MODULES_PATH
+  return 0;
+#endif
+
   argv = uv_setup_args(argc, argv);
   std::vector<std::string> args(argv, argv + argc);
   std::vector<std::string> exec_args;


### PR DESCRIPTION
A number of tests that call `ToLocalChecked()` on the return value of
`LoadEnvironment()` in `test/cctest` and `test/embedding` fails with:
```sh
FATAL ERROR: v8::ToLocalChecked Empty MaybeLocal.
```
when run against a binary built with `NODE_BUILTIN_MODULES_PATH`.
This change disables those tests, so that `make cctest` passes.

Signed-off-by: Darshan Sen <darshan.sen@postman.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
