### PR TITLE
debugger: validate sec-websocket-accept response header

### DIFF
--- a/lib/internal/debugger/inspect_client.js
+++ b/lib/internal/debugger/inspect_client.js
@@ -11,6 +11,7 @@ const {
 } = primordials;
 
 const Buffer = require('buffer').Buffer;
+const crypto = require('crypto');
 const { ERR_DEBUGGER_ERROR } = require('internal/errors').codes;
 const { EventEmitter } = require('events');
 const http = require('http');
@@ -35,11 +36,28 @@ const kTwoBytePayloadLengthField = 126;
 const kEightBytePayloadLengthField = 127;
 const kMaskingKeyWidthInBytes = 4;
 
+// This guid is defined in the Websocket Protocol RFC
+// https://tools.ietf.org/html/rfc6455#section-1.3
+const WEBSOCKET_HANDSHAKE_GUID = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
+
 function unpackError({ code, message, data }) {
   const err = new ERR_DEBUGGER_ERROR(`${message} - ${data}`);
   err.code = code;
   ErrorCaptureStackTrace(err, unpackError);
   return err;
+}
+
+function validateHandshake(requestKey, responseKey) {
+  const expectedResponseKeyBase = requestKey + WEBSOCKET_HANDSHAKE_GUID;
+  const shasum = crypto.createHash('sha1');
+  shasum.update(expectedResponseKeyBase);
+  const shabuf = shasum.digest();
+
+  if (shabuf.toString('base64') !== responseKey) {
+    throw new ERR_DEBUGGER_ERROR(
+      `WebSocket secret mismatch: ${requestKey} did not match ${responseKey}`
+    );
+  }
 }
 
 function encodeFrameHybi17(payload) {
@@ -287,8 +305,8 @@ class Client extends EventEmitter {
   _connectWebsocket(urlPath) {
     this.reset();
 
-    const key1 = require('crypto').randomBytes(16).toString('base64');
-    debuglog('request websocket', key1);
+    const requestKey = crypto.randomBytes(16).toString('base64');
+    debuglog('request WebSocket', requestKey);
 
     const httpReq = this._http = http.request({
       host: this._host,
@@ -297,7 +315,7 @@ class Client extends EventEmitter {
       headers: {
         'Connection': 'Upgrade',
         'Upgrade': 'websocket',
-        'Sec-WebSocket-Key': key1,
+        'Sec-WebSocket-Key': requestKey,
         'Sec-WebSocket-Version': '13',
       },
     });
@@ -314,7 +332,7 @@ class Client extends EventEmitter {
     });
 
     const handshakeListener = (res, socket) => {
-      // TODO: we *could* validate res.headers[sec-websocket-accept]
+      validateHandshake(requestKey, res.headers['sec-websocket-accept']);
       debuglog('websocket upgrade');
 
       this._socket = socket;

--- a/src/node_native_module.cc
+++ b/src/node_native_module.cc
@@ -70,6 +70,7 @@ void NativeModuleLoader::InitializeModuleCategories() {
   std::vector<std::string> prefixes = {
 #if !HAVE_OPENSSL
     "internal/crypto/",
+    "internal/debugger/",
 #endif  // !HAVE_OPENSSL
 
     "internal/bootstrap/",

--- a/test/parallel/test-debugger-websocket-secret-mismatch.js
+++ b/test/parallel/test-debugger-websocket-secret-mismatch.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const common = require('../common');
+common.skipIfInspectorDisabled();
+
+const assert = require('assert');
+const childProcess = require('child_process');
+const http = require('http');
+
+let port;
+
+const server = http.createServer(common.mustCall((req, res) => {
+  if (req.url.startsWith('/json')) {
+    res.writeHead(200);
+    res.end(`[ {
+      "description": "",
+      "devtoolsFrontendUrl": "/devtools/inspector.html?ws=localhost:${port}/devtools/page/DAB7FB6187B554E10B0BD18821265734",
+      "cid": "DAB7FB6187B554E10B0BD18821265734",
+      "title": "Fhqwhgads",
+      "type": "page",
+      "url": "https://www.example.com/",
+      "webSocketDebuggerUrl": "ws://localhost:${port}/devtools/page/DAB7FB6187B554E10B0BD18821265734"
+    } ]`);
+  } else {
+    res.setHeader('Upgrade', 'websocket');
+    res.setHeader('Connection', 'Upgrade');
+    res.setHeader('Sec-WebSocket-Accept', 'fhqwhgads');
+    res.setHeader('Sec-WebSocket-Protocol', 'chat');
+    res.writeHead(101);
+    res.end();
+  }
+}, 2)).listen(0, common.mustCall(() => {
+  port = server.address().port;
+  const proc =
+    childProcess.spawn(process.execPath, ['inspect', `localhost:${port}`]);
+
+  let stdout = '';
+  proc.stdout.on('data', (data) => {
+    stdout += data.toString();
+    assert.doesNotMatch(stdout, /\bok\b/);
+  });
+
+  let stderr = '';
+  proc.stderr.on('data', (data) => {
+    stderr += data.toString();
+  });
+
+  proc.on('exit', common.mustCall((code, signal) => {
+    assert.match(stderr, /\bWebSocket secret mismatch\b/);
+    assert.notStrictEqual(code, 0);
+    assert.strictEqual(signal, null);
+    server.close();
+  }));
+}));


### PR DESCRIPTION
First commit by @copperwall:

    debugger: validate sec-websocket-accept response header
    
    This addresses a TODO to validate that the sec-websocket-accept header
    in the websocket handshake response is valid. To do this we need to
    append the Websocket GUID to the original key sent in sec-websocket-key,
    sha1 hash it, and then compare the base64 encoding with the value sent
    in the sec-websocket-accept response header.
    
    If they don't match, an error is thrown.

Second commit:

    test: add test for websocket secret verification in debugger

Refs: https://github.com/nodejs/node-inspect/pull/93

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
