### PR TITLE
test: put common lint exceptions into config file

### DIFF
--- a/test/common/.eslintrc.yaml
+++ b/test/common/.eslintrc.yaml
@@ -1,0 +1,3 @@
+rules:
+  node-core/required-modules: off
+  node-core/require-common-first: off

--- a/test/common/arraystream.js
+++ b/test/common/arraystream.js
@@ -1,4 +1,3 @@
-/* eslint-disable node-core/require-common-first, node-core/required-modules */
 'use strict';
 
 const { Stream } = require('stream');

--- a/test/common/benchmark.js
+++ b/test/common/benchmark.js
@@ -1,5 +1,3 @@
-/* eslint-disable node-core/require-common-first, node-core/required-modules */
-
 'use strict';
 
 const assert = require('assert');

--- a/test/common/countdown.js
+++ b/test/common/countdown.js
@@ -1,5 +1,3 @@
-/* eslint-disable node-core/require-common-first, node-core/required-modules */
-
 'use strict';
 
 const assert = require('assert');

--- a/test/common/cpu-prof.js
+++ b/test/common/cpu-prof.js
@@ -1,5 +1,3 @@
-/* eslint-disable node-core/require-common-first, node-core/required-modules */
-
 'use strict';
 
 require('./');

--- a/test/common/dns.js
+++ b/test/common/dns.js
@@ -1,4 +1,3 @@
-/* eslint-disable node-core/require-common-first, node-core/required-modules */
 'use strict';
 
 const assert = require('assert');

--- a/test/common/duplexpair.js
+++ b/test/common/duplexpair.js
@@ -1,4 +1,3 @@
-/* eslint-disable node-core/require-common-first, node-core/required-modules */
 'use strict';
 const { Duplex } = require('stream');
 const assert = require('assert');

--- a/test/common/fixtures.js
+++ b/test/common/fixtures.js
@@ -1,4 +1,3 @@
-/* eslint-disable node-core/require-common-first, node-core/required-modules */
 'use strict';
 
 const path = require('path');

--- a/test/common/fixtures.mjs
+++ b/test/common/fixtures.mjs
@@ -1,4 +1,3 @@
-/* eslint-disable node-core/require-common-first, node-core/required-modules */
 import fixtures from './fixtures.js';
 
 const {

--- a/test/common/heap.js
+++ b/test/common/heap.js
@@ -1,4 +1,3 @@
-/* eslint-disable node-core/require-common-first, node-core/required-modules */
 'use strict';
 const assert = require('assert');
 const util = require('util');

--- a/test/common/hijackstdio.js
+++ b/test/common/hijackstdio.js
@@ -1,4 +1,3 @@
-/* eslint-disable node-core/require-common-first, node-core/required-modules */
 'use strict';
 
 // Hijack stdout and stderr

--- a/test/common/http2.js
+++ b/test/common/http2.js
@@ -1,4 +1,3 @@
-/* eslint-disable node-core/require-common-first, node-core/required-modules */
 'use strict';
 
 // An HTTP/2 testing tool used to create mock frames for direct testing

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -19,7 +19,6 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-/* eslint-disable node-core/require-common-first, node-core/required-modules */
 /* eslint-disable node-core/crypto-check */
 'use strict';
 const process = global.process;  // Some tests tamper with the process global.

--- a/test/common/index.mjs
+++ b/test/common/index.mjs
@@ -1,5 +1,3 @@
-/* eslint-disable node-core/require-common-first, node-core/required-modules */
-
 import { createRequire } from 'module';
 
 const require = createRequire(import.meta.url);

--- a/test/common/internet.js
+++ b/test/common/internet.js
@@ -1,4 +1,3 @@
-/* eslint-disable node-core/require-common-first, node-core/required-modules */
 'use strict';
 
 // Utilities for internet-related tests

--- a/test/common/measure-memory.js
+++ b/test/common/measure-memory.js
@@ -1,4 +1,3 @@
-/* eslint-disable node-core/require-common-first, node-core/required-modules */
 'use strict';
 
 const assert = require('assert');

--- a/test/common/report.js
+++ b/test/common/report.js
@@ -1,4 +1,3 @@
-/* eslint-disable node-core/require-common-first, node-core/required-modules */
 'use strict';
 const assert = require('assert');
 const fs = require('fs');

--- a/test/common/require-as.js
+++ b/test/common/require-as.js
@@ -1,4 +1,3 @@
-/* eslint-disable node-core/require-common-first, node-core/required-modules */
 'use strict';
 
 if (require.main !== module) {

--- a/test/common/tls.js
+++ b/test/common/tls.js
@@ -1,4 +1,3 @@
-/* eslint-disable node-core/require-common-first, node-core/required-modules */
 /* eslint-disable node-core/crypto-check */
 
 'use strict';

--- a/test/common/tmpdir.js
+++ b/test/common/tmpdir.js
@@ -1,4 +1,3 @@
-/* eslint-disable node-core/require-common-first, node-core/required-modules */
 'use strict';
 
 const fs = require('fs');

--- a/test/common/udppair.js
+++ b/test/common/udppair.js
@@ -1,4 +1,3 @@
-/* eslint-disable node-core/require-common-first, node-core/required-modules */
 'use strict';
 const { internalBinding } = require('internal/test/binding');
 const { JSUDPWrap } = internalBinding('js_udp_wrap');

--- a/test/common/wpt.js
+++ b/test/common/wpt.js
@@ -1,4 +1,3 @@
-/* eslint-disable node-core/require-common-first, node-core/required-modules */
 'use strict';
 
 const assert = require('assert');

--- a/test/common/wpt/worker.js
+++ b/test/common/wpt/worker.js
@@ -1,5 +1,3 @@
-/* eslint-disable node-core/required-modules,node-core/require-common-first */
-
 'use strict';
 
 const { runInThisContext } = require('vm');


### PR DESCRIPTION
For lint exceptions that are universal or near universal for
`test/common`, put the exceptions in a config file rather than disabling
the ESLint rules at the top of each file.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
