### PR TITLE
tools: adjust script for use with 14.x

### DIFF
--- a/.github/workflows/find-inactive-collaborators.yml
+++ b/.github/workflows/find-inactive-collaborators.yml
@@ -7,6 +7,10 @@ on:
 
   workflow_dispatch:
 
+env:
+  NODE_VERSION: 16.x
+  NUM_COMMITS: 5000
+
 jobs:
   find:
   
@@ -14,11 +18,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-    
-      - name: Install Node.js
+        with:
+          fetch-depth: ${{ env.NUM_COMMITS }}
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v2
         with:
-          node-version: 16.x
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Find inactive collaborators
-        run: tools/find-inactive-collaborators.mjs '1 year ago'
+        run: tools/find-inactive-collaborators.mjs ${{ env.NUM_COMMITS }}

--- a/.github/workflows/find-inactive-collaborators.yml
+++ b/.github/workflows/find-inactive-collaborators.yml
@@ -13,5 +13,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - run: tools/find-inactive-collaborators.mjs '1 year ago'
+      - uses: actions/checkout@v2
+    
+      - name: Install Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16.x
+
+      - name: Find inactive collaborators
+        run: tools/find-inactive-collaborators.mjs '1 year ago'


### PR DESCRIPTION
find-inactive-collaborators.mjs works fine with Node.js 16.x, but GitHub
Actions currently use 14.x by default. This PR makes a small adjustment
so that it works with 14.x. (14.x does not accept URL objects as
paramemters for the `cwd` option in `spawn()`.)

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
