### PR TITLE
build: update coverage Makefile target comments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,11 +210,10 @@ coverage-clean:
 		-type f -exec $(RM) {} \;
 
 .PHONY: coverage
-# Build and test with code coverage reporting.  Leave the lib directory
-# instrumented for any additional runs the user may want to make.
-# For C++ coverage reporting, this needs to be run in conjunction with configure
-#  --coverage.  html coverage reports will be created under coverage/
-# Related CI job: node-test-commit-linux-coverage
+# Build and test with code coverage reporting. HTML coverage reports will be
+# created under coverage/. For C++ coverage reporting, this needs to be run
+# in conjunction with configure --coverage.
+# Related CI job: node-test-commit-linux-coverage-daily
 coverage: coverage-test ## Run the tests and generate a coverage report.
 
 .PHONY: coverage-build


### PR DESCRIPTION
Update the comments for the `coverage` Makefile target.
- Source files under `lib` are no longer instrumented since
https://github.com/nodejs/node/commit/d1dee495db1451e74f5364c8687148a53ff0b50d
- Fix the name of the related CI job.

Refs: https://github.com/nodejs/node/pull/25157
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
