### PR TITLE
streams: fixup property definition to avoid prototype polution

### DIFF
--- a/lib/internal/webstreams/queuingstrategies.js
+++ b/lib/internal/webstreams/queuingstrategies.js
@@ -21,6 +21,7 @@ const {
   isBrandCheck,
   kType,
   kState,
+  kEnumerableProperty,
 } = require('internal/webstreams/util');
 
 const {
@@ -102,8 +103,8 @@ class ByteLengthQueuingStrategy {
 }
 
 ObjectDefineProperties(ByteLengthQueuingStrategy.prototype, {
-  highWaterMark: { enumerable: true },
-  size: { enumerable: true },
+  highWaterMark: kEnumerableProperty,
+  size: kEnumerableProperty,
 });
 
 /**
@@ -158,8 +159,8 @@ class CountQueuingStrategy {
 }
 
 ObjectDefineProperties(CountQueuingStrategy.prototype, {
-  highWaterMark: { enumerable: true },
-  size: { enumerable: true },
+  highWaterMark: kEnumerableProperty,
+  size: kEnumerableProperty,
 });
 
 module.exports = {

--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -103,6 +103,7 @@ const {
   nonOpStart,
   kType,
   kState,
+  kEnumerableProperty,
 } = require('internal/webstreams/util');
 
 const {
@@ -553,12 +554,12 @@ ObjectDefineProperties(ReadableStream.prototype, {
     writable: true,
     value: ReadableStream.prototype.values,
   },
-  locked: { enumerable: true },
-  cancel: { enumerable: true },
-  getReader: { enumerable: true },
-  pipeThrough: { enumerable: true },
-  pipeTo: { enumerable: true },
-  tee: { enumerable: true },
+  locked: kEnumerableProperty,
+  cancel: kEnumerableProperty,
+  getReader: kEnumerableProperty,
+  pipeThrough: kEnumerableProperty,
+  pipeTo: kEnumerableProperty,
+  tee: kEnumerableProperty,
 });
 
 function TransferedReadableStream() {
@@ -654,9 +655,9 @@ class ReadableStreamBYOBRequest {
 }
 
 ObjectDefineProperties(ReadableStreamBYOBRequest.prototype, {
-  view: { enumerable: true },
-  respond: { enumerable: true },
-  respondWithNewView: { enumerable: true },
+  view: kEnumerableProperty,
+  respond: kEnumerableProperty,
+  respondWithNewView: kEnumerableProperty,
 });
 
 function createReadableStreamBYOBRequest(controller, view) {
@@ -801,10 +802,10 @@ class ReadableStreamDefaultReader {
 }
 
 ObjectDefineProperties(ReadableStreamDefaultReader.prototype, {
-  closed: { enumerable: true },
-  read: { enumerable: true },
-  releaseLock: { enumerable: true },
-  cancel: { enumerable: true },
+  closed: kEnumerableProperty,
+  read: kEnumerableProperty,
+  releaseLock: kEnumerableProperty,
+  cancel: kEnumerableProperty,
 });
 
 class ReadableStreamBYOBReader {
@@ -918,10 +919,10 @@ class ReadableStreamBYOBReader {
 }
 
 ObjectDefineProperties(ReadableStreamBYOBReader.prototype, {
-  closed: { enumerable: true },
-  read: { enumerable: true },
-  releaseLock: { enumerable: true },
-  cancel: { enumerable: true },
+  closed: kEnumerableProperty,
+  read: kEnumerableProperty,
+  releaseLock: kEnumerableProperty,
+  cancel: kEnumerableProperty,
 });
 
 class ReadableStreamDefaultController {
@@ -977,10 +978,10 @@ class ReadableStreamDefaultController {
 }
 
 ObjectDefineProperties(ReadableStreamDefaultController.prototype, {
-  desiredSize: { enumerable: true },
-  close: { enumerable: true },
-  enqueue: { enumerable: true },
-  error: { enumerable: true },
+  desiredSize: kEnumerableProperty,
+  close: kEnumerableProperty,
+  enqueue: kEnumerableProperty,
+  error: kEnumerableProperty,
 });
 
 function createReadableStreamDefaultController() {
@@ -1106,11 +1107,11 @@ class ReadableByteStreamController {
 }
 
 ObjectDefineProperties(ReadableByteStreamController.prototype, {
-  byobRequest: { enumerable: true },
-  desiredSize: { enumerable: true },
-  close: { enumerable: true },
-  enqueue: { enumerable: true },
-  error: { enumerable: true },
+  byobRequest: kEnumerableProperty,
+  desiredSize: kEnumerableProperty,
+  close: kEnumerableProperty,
+  enqueue: kEnumerableProperty,
+  error: kEnumerableProperty,
 });
 
 function createReadableByteStreamController() {

--- a/lib/internal/webstreams/transformstream.js
+++ b/lib/internal/webstreams/transformstream.js
@@ -45,6 +45,7 @@ const {
   nonOpFlush,
   kType,
   kState,
+  kEnumerableProperty,
 } = require('internal/webstreams/util');
 
 const {
@@ -226,8 +227,8 @@ class TransformStream {
 }
 
 ObjectDefineProperties(TransformStream.prototype, {
-  readable: { enumerable: true },
-  writable: { enumerable: true },
+  readable: kEnumerableProperty,
+  writable: kEnumerableProperty,
 });
 
 function TransferedTransformStream() {
@@ -310,10 +311,10 @@ class TransformStreamDefaultController {
 }
 
 ObjectDefineProperties(TransformStreamDefaultController.prototype, {
-  desiredSize: { enumerable: true },
-  enqueue: { enumerable: true },
-  error: { enumerable: true },
-  terminate: { enumerable: true },
+  desiredSize: kEnumerableProperty,
+  enqueue: kEnumerableProperty,
+  error: kEnumerableProperty,
+  terminate: kEnumerableProperty,
 });
 
 function createTransformStreamDefaultController() {

--- a/lib/internal/webstreams/util.js
+++ b/lib/internal/webstreams/util.js
@@ -207,6 +207,9 @@ function lazyTransfer() {
   return transfer;
 }
 
+const kEnumerableProperty = ObjectCreate(null);
+kEnumerableProperty.enumerable = true;
+
 module.exports = {
   ArrayBufferViewGetBuffer,
   ArrayBufferViewGetByteLength,
@@ -234,4 +237,5 @@ module.exports = {
   nonOpWrite,
   kType,
   kState,
+  kEnumerableProperty,
 };

--- a/lib/internal/webstreams/writablestream.js
+++ b/lib/internal/webstreams/writablestream.js
@@ -64,6 +64,7 @@ const {
   nonOpWrite,
   kType,
   kState,
+  kEnumerableProperty,
 } = require('internal/webstreams/util');
 
 const {
@@ -280,10 +281,10 @@ class WritableStream {
 }
 
 ObjectDefineProperties(WritableStream.prototype, {
-  locked: { enumerable: true },
-  abort: { enumerable: true },
-  close: { enumerable: true },
-  getWriter: { enumerable: true },
+  locked: kEnumerableProperty,
+  abort: kEnumerableProperty,
+  close: kEnumerableProperty,
+  getWriter: kEnumerableProperty,
 });
 
 function TransferedWritableStream() {
@@ -469,13 +470,13 @@ class WritableStreamDefaultWriter {
 }
 
 ObjectDefineProperties(WritableStreamDefaultWriter.prototype, {
-  closed: { enumerable: true },
-  ready: { enumerable: true },
-  desiredSize: { enumerable: true },
-  abort: { enumerable: true },
-  close: { enumerable: true },
-  releaseLock: { enumerable: true },
-  write: { enumerable: true },
+  closed: kEnumerableProperty,
+  ready: kEnumerableProperty,
+  desiredSize: kEnumerableProperty,
+  abort: kEnumerableProperty,
+  close: kEnumerableProperty,
+  releaseLock: kEnumerableProperty,
+  write: kEnumerableProperty,
 });
 
 class WritableStreamDefaultController {
@@ -534,9 +535,9 @@ class WritableStreamDefaultController {
 }
 
 ObjectDefineProperties(WritableStreamDefaultController.prototype, {
-  abortReason: { enumerable: true },
-  signal: { enumerable: true },
-  error: { enumerable: true },
+  abortReason: kEnumerableProperty,
+  signal: kEnumerableProperty,
+  error: kEnumerableProperty,
 });
 
 function createWritableStreamDefaultController() {


### PR DESCRIPTION
Fixup the definitions of the properties to avoid the possibility
of prototype polution on the object definitions.

Signed-off-by: James M Snell <jasnell@gmail.com>

/cc @aduh95 
