### PR TITLE
doc: add strategic initiatives from TSC repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ For information on reporting security vulnerabilities in Node.js, see
 
 * [Contributing to the project][]
 * [Working Groups][]
-* [Strategic Initiatives][]
+* [Strategic initiatives][]
 * [Technical values and prioritization][]
 
 ## Current project team members
@@ -704,6 +704,6 @@ license text.
 [Contributing to the project]: CONTRIBUTING.md
 [Node.js Website]: https://nodejs.org/
 [OpenJS Foundation]: https://openjsf.org/
-[Strategic Initiatives]: https://github.com/nodejs/TSC/blob/HEAD/Strategic-Initiatives.md
+[Strategic initiatives]: doc/guides/strategic-initiatives.md
 [Technical values and prioritization]: doc/guides/technical-values.md
 [Working Groups]: https://github.com/nodejs/TSC/blob/HEAD/WORKING_GROUPS.md

--- a/doc/guides/strategic-initiatives.md
+++ b/doc/guides/strategic-initiatives.md
@@ -1,0 +1,40 @@
+# Strategic initiatives
+
+The Node.js project has several strategic initiatives underway.  The goal of the
+TSC is to have a champion for each of these initiatives and enable their
+success.
+
+A review of the initiatives is a standing item on the TSC agenda to ensure they
+are active and have the support needed.
+
+## Current initiatives
+
+| Initiative                | Champion                    | Links                                                                                    |
+|---------------------------|-----------------------------|------------------------------------------------------------------------------------------|
+| Core Promise APIs         | [Matteo Collina][mcollina]  |                                                                                          |
+| Future of Build Toolchain | [Mary Marchini][mmarchini]  | <https://github.com/nodejs/TSC/issues/901>, <https://github.com/nodejs/build-toolchain-next> |
+| QUIC / HTTP3              | [James M Snell][jasnell]    | <https://github.com/nodejs/quic>                                                           |
+| Startup performance       | [Joyee Cheung][joyeecheung] | <https://github.com/nodejs/node/issues/17058> <https://github.com/nodejs/node/issues/21563>  |
+| V8 Currency               | [Michaël Zasso][targos]     |                                                                                          |
+
+## Completed
+
+| Initiative         | Champion                   | Links                                           |
+|--------------------|----------------------------|--------------------------------------------------|
+| Build resources    | Michael Dawson             | <https://github.com/nodejs/build/issues/1154#issuecomment-448418977> |
+| CVE Management     | Michael Dawson             | <https://github.com/nodejs/security-wg/issues/33> |
+| Governance         | Myles Borins               |                                                 |
+| Moderation Team    | Rich Trott                 | <https://github.com/nodejs/TSC/issues/329>        |
+| Modules            | Myles Borins               | <https://github.com/nodejs/modules>               |
+| N-API              | Michael Dawson             | <https://github.com/nodejs/abi-stable-node>       |
+| npm Integration    | Myles Borins               | <https://github.com/nodejs/node/pull/21594>       |
+| OpenSSL Evolution  | Rod Vagg                   | <https://github.com/nodejs/TSC/issues/677>        |
+| Open Web Standards | Myles Borins, Joyee Cheung | <https://github.com/nodejs/open-standards>        |
+| VM module fix      | Franziska Hinkelmann       | <https://github.com/nodejs/node/issues/6283>      |
+| Workers            | Anna Henningsen            | <https://github.com/nodejs/worker>                |
+
+[jasnell]: https://github.com/jasnell
+[joyeecheung]: https://github.com/joyeecheung
+[mcollina]: https://github.com/mcollina
+[mmarchini]: https://github.com/mmarchini
+[targos]: https://github.com/targos


### PR DESCRIPTION
This (along with a corresponding PR for the TSC repo) moves the
strategic initiatives from the TSC repository to the main core repo.
This will increase visibility for strategic initiatives. It will also
facilitate the proposed reduced centrality of TSC champions to strategic
plans.

In the process, I made the text less wordy. I moved the Build Resources
initiatve out of the active list, as discussed at the most recent TSC
meeting. I alphabetized the table entries. (Chronological order isn't
obvious to a reader if no dates are provided.)

Refs: https://github.com/nodejs/TSC/issues/962#issuecomment-880233678

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
