### PR TITLE
test: add NumberFormat resolvedOptions test

### DIFF
--- a/test/parallel/test-intl.js
+++ b/test/parallel/test-intl.js
@@ -104,6 +104,13 @@ if (!common.hasIntl) {
     const numberFormat = new Intl.NumberFormat(['en']).format(12345.67890);
     assert.strictEqual(numberFormat, '12,345.679');
   }
+  // Number format resolved options
+  {
+    const numberFormat = new Intl.NumberFormat('en-US', { style: 'percent' });
+    const resolvedOptions = numberFormat.resolvedOptions();
+    assert.strictEqual(resolvedOptions.locale, 'en-US');
+    assert.strictEqual(resolvedOptions.style, 'percent');
+  }
   // Significant Digits
   {
     const loc = ['en-US'];


### PR DESCRIPTION
Add a regression test for NumberFormat resolvedOptions.

Refs: https://github.com/nodejs/node/issues/39050

---

I'd like to land this on v14.x-staging together with/as part of https://github.com/nodejs/node/pull/39051. We now have a CI job that builds Node.js dynamically linked against the minimum supported level of ICU but the job isn't failing on `v14.x-staging` for the problem reported in https://github.com/nodejs/node/issues/39050 as we don't have the coverage.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
