### PR TITLE
napi：napi_promise_then

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -5586,6 +5586,50 @@ napi_status napi_is_promise(napi_env env,
 * `[out] is_promise`: Flag indicating whether `promise` is a native promise
   object (that is, a promise object created by the underlying engine).
 
+### napi_promise_then_resolve
+<!-- YAML
+added: v17.0.0
+napiVersion: 8
+-->
+```c
+napi_status napi_promise_then_resolve(napi_env env,
+                                      napi_value promise,
+                                      napi_callback handler);
+```
+* `[in] env`: The environment that the API is invoked under.
+* `[in] promise`: The JavaScript Promise Object
+* `[in] handler`: when promise state is fulfilled will  callback.
+
+### napi_promise_then
+<!-- YAML
+added: v17.0.0
+napiVersion: 8
+-->
+```c
+napi_status napi_promise_then(napi_env env,
+                            napi_value promise,
+                            napi_callback on_resolve,
+                            napi_callback on_rejected)
+```
+* `[in] env`: The environment that the API is invoked under.
+* `[in] promise`: The JavaScript Promise Object
+* `[in] on_resolve`: when promise state is fulfilled will  callback.
+* `[in] on_rejected`: when promise state is rejected will  callback.
+
+### napi_promise_catch
+<!-- YAML
+added: v17.0.0
+napiVersion: 8
+-->
+```c
+napi_status napi_promise_catch(napi_env env,
+                              napi_value promise,
+                              napi_callback handler)
+```
+* `[in] env`: The environment that the API is invoked under.
+* `[in] promise`: The JavaScript Promise Object
+* `[in] handler`: when promise state  is rejected will  callback.
+
 ## Script execution
 
 Node-API provides an API for executing a string containing JavaScript using the

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -5602,33 +5602,19 @@ napi_status napi_promise_then_resolve(napi_env env,
 
 ### napi_promise_then
 <!-- YAML
-added: v17.0.0
+added: REPLACEME
 napiVersion: 8
 -->
 ```c
 napi_status napi_promise_then(napi_env env,
                             napi_value promise,
-                            napi_callback on_resolve,
-                            napi_callback on_rejected)
+                            napi_callback on_fulfilled,
+                            napi_callback on_rejected);
 ```
 * `[in] env`: The environment that the API is invoked under.
 * `[in] promise`: The JavaScript Promise Object
-* `[in] on_resolve`: when promise state is fulfilled will  callback.
+* `[in] on_fulfilled`: when promise state is fulfilled will  callback.
 * `[in] on_rejected`: when promise state is rejected will  callback.
-
-### napi_promise_catch
-<!-- YAML
-added: v17.0.0
-napiVersion: 8
--->
-```c
-napi_status napi_promise_catch(napi_env env,
-                              napi_value promise,
-                              napi_callback handler)
-```
-* `[in] env`: The environment that the API is invoked under.
-* `[in] promise`: The JavaScript Promise Object
-* `[in] handler`: when promise state  is rejected will  callback.
 
 ## Script execution
 

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -5586,20 +5586,6 @@ napi_status napi_is_promise(napi_env env,
 * `[out] is_promise`: Flag indicating whether `promise` is a native promise
   object (that is, a promise object created by the underlying engine).
 
-### napi_promise_then_resolve
-<!-- YAML
-added: v17.0.0
-napiVersion: 8
--->
-```c
-napi_status napi_promise_then_resolve(napi_env env,
-                                      napi_value promise,
-                                      napi_callback handler);
-```
-* `[in] env`: The environment that the API is invoked under.
-* `[in] promise`: The JavaScript Promise Object
-* `[in] handler`: when promise state is fulfilled will  callback.
-
 ### napi_promise_then
 <!-- YAML
 added: REPLACEME

--- a/src/js_native_api.h
+++ b/src/js_native_api.h
@@ -446,7 +446,18 @@ NAPI_EXTERN napi_status napi_reject_deferred(napi_env env,
 NAPI_EXTERN napi_status napi_is_promise(napi_env env,
                                         napi_value value,
                                         bool* is_promise);
-
+#if NAPI_VERSION >= 8
+NAPI_EXTERN napi_status napi_promise_then(napi_env env,
+                                          napi_value promise,
+                                          napi_callback on_resolve,
+                                          napi_callback on_rejected);
+NAPI_EXTERN napi_status napi_promise_then_resolve(napi_env env,
+                                        napi_value promise,
+                                        napi_callback handler);
+NAPI_EXTERN napi_status napi_promise_catch(napi_env env,
+                                          napi_value promise,
+                                          napi_callback handler);
+#endif
 // Running a script
 NAPI_EXTERN napi_status napi_run_script(napi_env env,
                                         napi_value script,

--- a/src/js_native_api.h
+++ b/src/js_native_api.h
@@ -2,8 +2,8 @@
 #define SRC_JS_NATIVE_API_H_
 
 // This file needs to be compatible with C compilers.
-#include <stddef.h>   // NOLINT(modernize-deprecated-headers)
 #include <stdbool.h>  // NOLINT(modernize-deprecated-headers)
+#include <stddef.h>   // NOLINT(modernize-deprecated-headers)
 
 // Use INT_MAX, this should only be consumed by the pre-processor anyway.
 #define NAPI_VERSION_EXPERIMENTAL 2147483647
@@ -26,14 +26,15 @@
 // If you need __declspec(dllimport), either include <node_api.h> instead, or
 // define NAPI_EXTERN as __declspec(dllimport) on the compiler's command line.
 #ifndef NAPI_EXTERN
-  #ifdef _WIN32
-    #define NAPI_EXTERN __declspec(dllexport)
-  #elif defined(__wasm32__)
-    #define NAPI_EXTERN __attribute__((visibility("default")))                \
-                        __attribute__((__import_module__("napi")))
-  #else
-    #define NAPI_EXTERN __attribute__((visibility("default")))
-  #endif
+#ifdef _WIN32
+#define NAPI_EXTERN __declspec(dllexport)
+#elif defined(__wasm32__)
+#define NAPI_EXTERN                                                            \
+  __attribute__((visibility("default")))                                       \
+      __attribute__((__import_module__("napi")))
+#else
+#define NAPI_EXTERN __attribute__((visibility("default")))
+#endif
 #endif
 
 #define NAPI_AUTO_LENGTH SIZE_MAX
@@ -49,8 +50,7 @@
 EXTERN_C_START
 
 NAPI_EXTERN napi_status
-napi_get_last_error_info(napi_env env,
-                         const napi_extended_error_info** result);
+napi_get_last_error_info(napi_env env, const napi_extended_error_info** result);
 
 // Getters for defined singletons
 NAPI_EXTERN napi_status napi_get_undefined(napi_env env, napi_value* result);
@@ -133,18 +133,12 @@ NAPI_EXTERN napi_status napi_get_value_bool(napi_env env,
                                             bool* result);
 
 // Copies LATIN-1 encoded bytes from a string into a buffer.
-NAPI_EXTERN napi_status napi_get_value_string_latin1(napi_env env,
-                                                     napi_value value,
-                                                     char* buf,
-                                                     size_t bufsize,
-                                                     size_t* result);
+NAPI_EXTERN napi_status napi_get_value_string_latin1(
+    napi_env env, napi_value value, char* buf, size_t bufsize, size_t* result);
 
 // Copies UTF-8 encoded bytes from a string into a buffer.
-NAPI_EXTERN napi_status napi_get_value_string_utf8(napi_env env,
-                                                   napi_value value,
-                                                   char* buf,
-                                                   size_t bufsize,
-                                                   size_t* result);
+NAPI_EXTERN napi_status napi_get_value_string_utf8(
+    napi_env env, napi_value value, char* buf, size_t bufsize, size_t* result);
 
 // Copies UTF-16 encoded bytes from a string into a buffer.
 NAPI_EXTERN napi_status napi_get_value_string_utf16(napi_env env,
@@ -196,17 +190,17 @@ NAPI_EXTERN napi_status napi_has_own_property(napi_env env,
                                               napi_value key,
                                               bool* result);
 NAPI_EXTERN napi_status napi_set_named_property(napi_env env,
-                                          napi_value object,
-                                          const char* utf8name,
-                                          napi_value value);
+                                                napi_value object,
+                                                const char* utf8name,
+                                                napi_value value);
 NAPI_EXTERN napi_status napi_has_named_property(napi_env env,
-                                          napi_value object,
-                                          const char* utf8name,
-                                          bool* result);
+                                                napi_value object,
+                                                const char* utf8name,
+                                                bool* result);
 NAPI_EXTERN napi_status napi_get_named_property(napi_env env,
-                                          napi_value object,
-                                          const char* utf8name,
-                                          napi_value* result);
+                                                napi_value object,
+                                                const char* utf8name,
+                                                napi_value* result);
 NAPI_EXTERN napi_status napi_set_element(napi_env env,
                                          napi_value object,
                                          uint32_t index,
@@ -347,12 +341,10 @@ NAPI_EXTERN napi_status napi_open_handle_scope(napi_env env,
                                                napi_handle_scope* result);
 NAPI_EXTERN napi_status napi_close_handle_scope(napi_env env,
                                                 napi_handle_scope scope);
-NAPI_EXTERN napi_status
-napi_open_escapable_handle_scope(napi_env env,
-                                 napi_escapable_handle_scope* result);
-NAPI_EXTERN napi_status
-napi_close_escapable_handle_scope(napi_env env,
-                                  napi_escapable_handle_scope scope);
+NAPI_EXTERN napi_status napi_open_escapable_handle_scope(
+    napi_env env, napi_escapable_handle_scope* result);
+NAPI_EXTERN napi_status napi_close_escapable_handle_scope(
+    napi_env env, napi_escapable_handle_scope scope);
 
 NAPI_EXTERN napi_status napi_escape_handle(napi_env env,
                                            napi_escapable_handle_scope scope,
@@ -365,11 +357,11 @@ NAPI_EXTERN napi_status napi_throw_error(napi_env env,
                                          const char* code,
                                          const char* msg);
 NAPI_EXTERN napi_status napi_throw_type_error(napi_env env,
-                                         const char* code,
-                                         const char* msg);
+                                              const char* code,
+                                              const char* msg);
 NAPI_EXTERN napi_status napi_throw_range_error(napi_env env,
-                                         const char* code,
-                                         const char* msg);
+                                               const char* code,
+                                               const char* msg);
 NAPI_EXTERN napi_status napi_is_error(napi_env env,
                                       napi_value value,
                                       bool* result);
@@ -446,18 +438,13 @@ NAPI_EXTERN napi_status napi_reject_deferred(napi_env env,
 NAPI_EXTERN napi_status napi_is_promise(napi_env env,
                                         napi_value value,
                                         bool* is_promise);
-#if NAPI_VERSION >= 8
+#ifdef NAPI_EXPERIMENTAL
 NAPI_EXTERN napi_status napi_promise_then(napi_env env,
-                                          napi_value promise,
-                                          napi_callback on_resolve,
+                                          napi_value* promise,
+                                          napi_callback on_fulfilled,
                                           napi_callback on_rejected);
-NAPI_EXTERN napi_status napi_promise_then_resolve(napi_env env,
-                                        napi_value promise,
-                                        napi_callback handler);
-NAPI_EXTERN napi_status napi_promise_catch(napi_env env,
-                                          napi_value promise,
-                                          napi_callback handler);
-#endif
+#endif  // #ifdef NAPI_EXPERIMENTAL
+
 // Running a script
 NAPI_EXTERN napi_status napi_run_script(napi_env env,
                                         napi_value script,
@@ -536,8 +523,7 @@ NAPI_EXTERN napi_status napi_set_instance_data(napi_env env,
                                                napi_finalize finalize_cb,
                                                void* finalize_hint);
 
-NAPI_EXTERN napi_status napi_get_instance_data(napi_env env,
-                                               void** data);
+NAPI_EXTERN napi_status napi_get_instance_data(napi_env env, void** data);
 #endif  // NAPI_VERSION >= 6
 
 #if NAPI_VERSION >= 7
@@ -561,10 +547,8 @@ napi_check_object_type_tag(napi_env env,
                            napi_value value,
                            const napi_type_tag* type_tag,
                            bool* result);
-NAPI_EXTERN napi_status napi_object_freeze(napi_env env,
-                                           napi_value object);
-NAPI_EXTERN napi_status napi_object_seal(napi_env env,
-                                         napi_value object);
+NAPI_EXTERN napi_status napi_object_freeze(napi_env env, napi_value object);
+NAPI_EXTERN napi_status napi_object_seal(napi_env env, napi_value object);
 #endif  // NAPI_VERSION >= 8
 
 EXTERN_C_END

--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -3070,6 +3070,72 @@ napi_status napi_is_promise(napi_env env,
   return napi_clear_last_error(env);
 }
 
+napi_status napi_promise_then(napi_env env,
+                            napi_value promise,
+                            napi_callback on_resolve,
+                            napi_callback on_rejected) {
+  NAPI_PREAMBLE(env);
+  CHECK_ENV(env);
+  CHECK_ARG(env, promise);
+  CHECK_ARG(env, on_resolve);
+  CHECK_ARG(env, on_rejected);
+  v8::Local<v8::Context> v8Context = env->context();
+  v8::Local<v8::Promise> v8Promise =
+      v8impl::V8LocalValueFromJsValue(promise).As<v8::Promise>();
+
+  v8::Local<v8::Function> v8ResolveFn;
+  STATUS_CALL(v8impl::FunctionCallbackWrapper::NewFunction(
+      env, on_resolve, nullptr, &v8ResolveFn));
+
+  v8::Local<v8::Function> v8RejectFn;
+  STATUS_CALL(v8impl::FunctionCallbackWrapper::NewFunction(
+      env, on_rejected, nullptr, &v8RejectFn));
+
+  v8Promise->Then(v8Context, v8ResolveFn, v8RejectFn);
+  return GET_RETURN_STATUS(env);
+}
+
+napi_status napi_promise_then_resolve(napi_env env,
+                                      napi_value promise,
+                                      napi_callback handler) {
+  NAPI_PREAMBLE(env);
+  CHECK_ENV(env);
+  CHECK_ARG(env, promise);
+  CHECK_ARG(env, handler);
+  v8::Local<v8::Context> v8Context = env->context();
+  v8::Local<v8::Promise> v8Promise =
+      v8impl::V8LocalValueFromJsValue(promise).As<v8::Promise>();
+
+  v8::Local<v8::Function> fn;
+  STATUS_CALL(v8impl::FunctionCallbackWrapper::NewFunction(
+        env, handler, nullptr, &fn));
+
+  v8Promise->Then(v8Context, fn).ToLocalChecked();
+
+  return GET_RETURN_STATUS(env);
+}
+
+napi_status napi_promise_catch(napi_env env,
+                              napi_value promise,
+                              napi_callback handler) {
+  NAPI_PREAMBLE(env);
+  CHECK_ENV(env);
+  CHECK_ARG(env, promise);
+  CHECK_ARG(env, handler);
+  v8::Local<v8::Context> v8Context = env->context();
+  v8::Local<v8::Promise> v8Promise =
+      v8impl::V8LocalValueFromJsValue(promise).As<v8::Promise>();
+
+  v8::Local<v8::Function> fn;
+  STATUS_CALL(
+      v8impl::FunctionCallbackWrapper::NewFunction(env, handler, nullptr, &fn));
+
+  v8Promise->Catch(v8Context, fn);
+
+  return GET_RETURN_STATUS(env);
+}
+
+
 napi_status napi_create_date(napi_env env,
                              double time,
                              napi_value* result) {

--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -1,43 +1,41 @@
+#include <algorithm>
 #include <climits>  // INT_MAX
 #include <cmath>
-#include <algorithm>
 #define NAPI_EXPERIMENTAL
 #include "env-inl.h"
-#include "js_native_api_v8.h"
 #include "js_native_api.h"
+#include "js_native_api_v8.h"
 #include "util-inl.h"
 
-#define CHECK_MAYBE_NOTHING(env, maybe, status) \
+#define CHECK_MAYBE_NOTHING(env, maybe, status)                                \
   RETURN_STATUS_IF_FALSE((env), !((maybe).IsNothing()), (status))
 
-#define CHECK_MAYBE_NOTHING_WITH_PREAMBLE(env, maybe, status) \
+#define CHECK_MAYBE_NOTHING_WITH_PREAMBLE(env, maybe, status)                  \
   RETURN_STATUS_IF_FALSE_WITH_PREAMBLE((env), !((maybe).IsNothing()), (status))
 
-#define CHECK_TO_NUMBER(env, context, result, src) \
+#define CHECK_TO_NUMBER(env, context, result, src)                             \
   CHECK_TO_TYPE((env), Number, (context), (result), (src), napi_number_expected)
 
 // n-api defines NAPI_AUTO_LENGHTH as the indicator that a string
 // is null terminated. For V8 the equivalent is -1. The assert
 // validates that our cast of NAPI_AUTO_LENGTH results in -1 as
 // needed by V8.
-#define CHECK_NEW_FROM_UTF8_LEN(env, result, str, len)                   \
-  do {                                                                   \
-    static_assert(static_cast<int>(NAPI_AUTO_LENGTH) == -1,              \
-                  "Casting NAPI_AUTO_LENGTH to int must result in -1");  \
-    RETURN_STATUS_IF_FALSE((env),                                        \
-        (len == NAPI_AUTO_LENGTH) || len <= INT_MAX,                     \
-        napi_invalid_arg);                                               \
-    RETURN_STATUS_IF_FALSE((env),                                        \
-        (str) != nullptr,                                                \
-        napi_invalid_arg);                                               \
-    auto str_maybe = v8::String::NewFromUtf8(                            \
-        (env)->isolate, (str), v8::NewStringType::kInternalized,         \
-        static_cast<int>(len));                                          \
-    CHECK_MAYBE_EMPTY((env), str_maybe, napi_generic_failure);           \
-    (result) = str_maybe.ToLocalChecked();                               \
+#define CHECK_NEW_FROM_UTF8_LEN(env, result, str, len)                         \
+  do {                                                                         \
+    static_assert(static_cast<int>(NAPI_AUTO_LENGTH) == -1,                    \
+                  "Casting NAPI_AUTO_LENGTH to int must result in -1");        \
+    RETURN_STATUS_IF_FALSE(                                                    \
+        (env), (len == NAPI_AUTO_LENGTH) || len <= INT_MAX, napi_invalid_arg); \
+    RETURN_STATUS_IF_FALSE((env), (str) != nullptr, napi_invalid_arg);         \
+    auto str_maybe = v8::String::NewFromUtf8((env)->isolate,                   \
+                                             (str),                            \
+                                             v8::NewStringType::kInternalized, \
+                                             static_cast<int>(len));           \
+    CHECK_MAYBE_EMPTY((env), str_maybe, napi_generic_failure);                 \
+    (result) = str_maybe.ToLocalChecked();                                     \
   } while (0)
 
-#define CHECK_NEW_FROM_UTF8(env, result, str) \
+#define CHECK_NEW_FROM_UTF8(env, result, str)                                  \
   CHECK_NEW_FROM_UTF8_LEN((env), (result), (str), NAPI_AUTO_LENGTH)
 
 #define CREATE_TYPED_ARRAY(                                                    \
@@ -45,12 +43,15 @@
   do {                                                                         \
     if ((size_of_element) > 1) {                                               \
       THROW_RANGE_ERROR_IF_FALSE(                                              \
-          (env), (byte_offset) % (size_of_element) == 0,                       \
+          (env),                                                               \
+          (byte_offset) % (size_of_element) == 0,                              \
           "ERR_NAPI_INVALID_TYPEDARRAY_ALIGNMENT",                             \
-          "start offset of "#type" should be a multiple of "#size_of_element); \
+          "start offset of " #type                                             \
+          " should be a multiple of " #size_of_element);                       \
     }                                                                          \
-    THROW_RANGE_ERROR_IF_FALSE((env), (length) * (size_of_element) +           \
-        (byte_offset) <= buffer->ByteLength(),                                 \
+    THROW_RANGE_ERROR_IF_FALSE(                                                \
+        (env),                                                                 \
+        (length) * (size_of_element) + (byte_offset) <= buffer->ByteLength(),  \
         "ERR_NAPI_INVALID_TYPEDARRAY_LENGTH",                                  \
         "Invalid typed array length");                                         \
     (out) = v8::type::New((buffer), (byte_offset), (length));                  \
@@ -60,15 +61,15 @@ namespace v8impl {
 
 namespace {
 
-inline static napi_status
-V8NameFromPropertyDescriptor(napi_env env,
-                             const napi_property_descriptor* p,
-                             v8::Local<v8::Name>* result) {
+inline static napi_status V8NameFromPropertyDescriptor(
+    napi_env env,
+    const napi_property_descriptor* p,
+    v8::Local<v8::Name>* result) {
   if (p->utf8name != nullptr) {
     CHECK_NEW_FROM_UTF8(env, *result, p->utf8name);
   } else {
     v8::Local<v8::Value> property_value =
-      v8impl::V8LocalValueFromJsValue(p->name);
+        v8impl::V8LocalValueFromJsValue(p->name);
 
     RETURN_STATUS_IF_FALSE(env, property_value->IsName(), napi_name_expected);
     *result = property_value.As<v8::Name>();
@@ -85,7 +86,7 @@ inline static v8::PropertyAttribute V8PropertyAttributesFromDescriptor(
   // The napi_writable attribute is ignored for accessor descriptors, but
   // V8 would throw `TypeError`s on assignment with nonexistence of a setter.
   if ((descriptor->getter == nullptr && descriptor->setter == nullptr) &&
-    (descriptor->attributes & napi_writable) == 0) {
+      (descriptor->attributes & napi_writable) == 0) {
     attribute_flags |= v8::PropertyAttribute::ReadOnly;
   }
 
@@ -99,13 +100,13 @@ inline static v8::PropertyAttribute V8PropertyAttributesFromDescriptor(
   return static_cast<v8::PropertyAttribute>(attribute_flags);
 }
 
-inline static napi_deferred
-JsDeferredFromNodePersistent(v8impl::Persistent<v8::Value>* local) {
+inline static napi_deferred JsDeferredFromNodePersistent(
+    v8impl::Persistent<v8::Value>* local) {
   return reinterpret_cast<napi_deferred>(local);
 }
 
-inline static v8impl::Persistent<v8::Value>*
-NodePersistentFromJsDeferred(napi_deferred local) {
+inline static v8impl::Persistent<v8::Value>* NodePersistentFromJsDeferred(
+    napi_deferred local) {
   return reinterpret_cast<v8impl::Persistent<v8::Value>*>(local);
 }
 
@@ -126,9 +127,7 @@ class EscapableHandleScopeWrapper {
  public:
   explicit EscapableHandleScopeWrapper(v8::Isolate* isolate)
       : scope(isolate), escape_called_(false) {}
-  bool escape_called() const {
-    return escape_called_;
-  }
+  bool escape_called() const { return escape_called_; }
   template <typename T>
   v8::Local<T> Escape(v8::Local<T> handle) {
     escape_called_ = true;
@@ -140,13 +139,13 @@ class EscapableHandleScopeWrapper {
   bool escape_called_;
 };
 
-inline static napi_handle_scope
-JsHandleScopeFromV8HandleScope(HandleScopeWrapper* s) {
+inline static napi_handle_scope JsHandleScopeFromV8HandleScope(
+    HandleScopeWrapper* s) {
   return reinterpret_cast<napi_handle_scope>(s);
 }
 
-inline static HandleScopeWrapper*
-V8HandleScopeFromJsHandleScope(napi_handle_scope s) {
+inline static HandleScopeWrapper* V8HandleScopeFromJsHandleScope(
+    napi_handle_scope s) {
   return reinterpret_cast<HandleScopeWrapper*>(s);
 }
 
@@ -177,9 +176,11 @@ inline static napi_status ConcludeDeferred(napi_env env,
 
   auto v8_resolver = v8::Local<v8::Promise::Resolver>::Cast(v8_deferred);
 
-  v8::Maybe<bool> success = is_resolved ?
-      v8_resolver->Resolve(context, v8impl::V8LocalValueFromJsValue(result)) :
-      v8_resolver->Reject(context, v8impl::V8LocalValueFromJsValue(result));
+  v8::Maybe<bool> success =
+      is_resolved ? v8_resolver->Resolve(
+                        context, v8impl::V8LocalValueFromJsValue(result))
+                  : v8_resolver->Reject(
+                        context, v8impl::V8LocalValueFromJsValue(result));
 
   delete deferred_ref;
 
@@ -188,10 +189,7 @@ inline static napi_status ConcludeDeferred(napi_env env,
   return GET_RETURN_STATUS(env);
 }
 
-enum UnwrapAction {
-  KeepWrap,
-  RemoveWrap
-};
+enum UnwrapAction { KeepWrap, RemoveWrap };
 
 inline static napi_status Unwrap(napi_env env,
                                  napi_value js_object,
@@ -210,7 +208,7 @@ inline static napi_status Unwrap(napi_env env,
   v8::Local<v8::Object> obj = value.As<v8::Object>();
 
   auto val = obj->GetPrivate(context, NAPI_PRIVATE_KEY(context, wrapper))
-      .ToLocalChecked();
+                 .ToLocalChecked();
   RETURN_STATUS_IF_FALSE(env, val->IsExternal(), napi_invalid_arg);
   Reference* reference =
       static_cast<v8impl::Reference*>(val.As<v8::External>()->Value());
@@ -221,7 +219,7 @@ inline static napi_status Unwrap(napi_env env,
 
   if (action == RemoveWrap) {
     CHECK(obj->DeletePrivate(context, NAPI_PRIVATE_KEY(context, wrapper))
-        .FromJust());
+              .FromJust());
     Reference::Delete(reference);
   }
 
@@ -240,8 +238,9 @@ class CallbackBundle {
  public:
   // Creates an object to be made available to the static function callback
   // wrapper, used to retrieve the native callback function and data pointer.
-  static inline v8::Local<v8::Value>
-  New(napi_env env, napi_callback cb, void* data) {
+  static inline v8::Local<v8::Value> New(napi_env env,
+                                         napi_callback cb,
+                                         void* data) {
     CallbackBundle* bundle = new CallbackBundle();
     bundle->cb = cb;
     bundle->cb_data = data;
@@ -251,9 +250,10 @@ class CallbackBundle {
     Reference::New(env, cbdata, 0, true, Delete, bundle, nullptr);
     return cbdata;
   }
-  napi_env       env;      // Necessary to invoke C++ NAPI callback
-  void*          cb_data;  // The user provided callback data
-  napi_callback  cb;
+  napi_env env;   // Necessary to invoke C++ NAPI callback
+  void* cb_data;  // The user provided callback data
+  napi_callback cb;
+
  private:
   static void Delete(napi_env env, void* data, void* hint) {
     CallbackBundle* bundle = static_cast<CallbackBundle*>(data);
@@ -288,9 +288,8 @@ class CallbackWrapperBase : public CallbackWrapper {
  public:
   inline CallbackWrapperBase(const v8::FunctionCallbackInfo<v8::Value>& cbinfo,
                              const size_t args_length)
-      : CallbackWrapper(JsValueFromV8LocalValue(cbinfo.This()),
-                        args_length,
-                        nullptr),
+      : CallbackWrapper(
+            JsValueFromV8LocalValue(cbinfo.This()), args_length, nullptr),
         _cbinfo(cbinfo) {
     _bundle = reinterpret_cast<CallbackBundle*>(
         v8::Local<v8::External>::Cast(cbinfo.Data())->Value());
@@ -307,9 +306,8 @@ class CallbackWrapperBase : public CallbackWrapper {
     napi_callback cb = _bundle->cb;
 
     napi_value result;
-    env->CallIntoModule([&](napi_env env) {
-      result = cb(env, cbinfo_wrapper);
-    });
+    env->CallIntoModule(
+        [&](napi_env env) { result = cb(env, cbinfo_wrapper); });
 
     if (result != nullptr) {
       this->SetReturnValue(result);
@@ -320,8 +318,7 @@ class CallbackWrapperBase : public CallbackWrapper {
   CallbackBundle* _bundle;
 };
 
-class FunctionCallbackWrapper
-    : public CallbackWrapperBase {
+class FunctionCallbackWrapper : public CallbackWrapperBase {
  public:
   static void Invoke(const v8::FunctionCallbackInfo<v8::Value>& info) {
     FunctionCallbackWrapper cbwrapper(info);
@@ -343,11 +340,12 @@ class FunctionCallbackWrapper
     return napi_clear_last_error(env);
   }
 
-  static inline napi_status NewTemplate(napi_env env,
-                    napi_callback cb,
-                    void* cb_data,
-                    v8::Local<v8::FunctionTemplate>* result,
-                    v8::Local<v8::Signature> sig = v8::Local<v8::Signature>()) {
+  static inline napi_status NewTemplate(
+      napi_env env,
+      napi_callback cb,
+      void* cb_data,
+      v8::Local<v8::FunctionTemplate>* result,
+      v8::Local<v8::Signature> sig = v8::Local<v8::Signature>()) {
     v8::Local<v8::Value> cbdata = v8impl::CallbackBundle::New(env, cb, cb_data);
     RETURN_STATUS_IF_FALSE(env, !cbdata.IsEmpty(), napi_generic_failure);
 
@@ -392,10 +390,7 @@ class FunctionCallbackWrapper
   }
 };
 
-enum WrapType {
-  retrievable,
-  anonymous
-};
+enum WrapType { retrievable, anonymous };
 
 template <WrapType wrap_type>
 inline napi_status Wrap(napi_env env,
@@ -415,9 +410,10 @@ inline napi_status Wrap(napi_env env,
 
   if (wrap_type == retrievable) {
     // If we've already wrapped this object, we error out.
-    RETURN_STATUS_IF_FALSE(env,
+    RETURN_STATUS_IF_FALSE(
+        env,
         !obj->HasPrivate(context, NAPI_PRIVATE_KEY(context, wrapper))
-            .FromJust(),
+             .FromJust(),
         napi_invalid_arg);
   } else if (wrap_type == anonymous) {
     // If no finalize callback is provided, we error out.
@@ -436,13 +432,21 @@ inline napi_status Wrap(napi_env env,
     *result = reinterpret_cast<napi_ref>(reference);
   } else {
     // Create a self-deleting reference.
-    reference = v8impl::Reference::New(env, obj, 0, true, finalize_cb,
-        native_object, finalize_cb == nullptr ? nullptr : finalize_hint);
+    reference = v8impl::Reference::New(
+        env,
+        obj,
+        0,
+        true,
+        finalize_cb,
+        native_object,
+        finalize_cb == nullptr ? nullptr : finalize_hint);
   }
 
   if (wrap_type == retrievable) {
-    CHECK(obj->SetPrivate(context, NAPI_PRIVATE_KEY(context, wrapper),
-          v8::External::New(env->isolate, reference)).FromJust());
+    CHECK(obj->SetPrivate(context,
+                          NAPI_PRIVATE_KEY(context, wrapper),
+                          v8::External::New(env->isolate, reference))
+              .FromJust());
   }
 
   return GET_RETURN_STATUS(env);
@@ -717,29 +721,29 @@ void Reference::SecondPassCallback(
 }  // end of namespace v8impl
 
 // Warning: Keep in-sync with napi_status enum
-static
-const char* error_messages[] = {nullptr,
-                                "Invalid argument",
-                                "An object was expected",
-                                "A string was expected",
-                                "A string or symbol was expected",
-                                "A function was expected",
-                                "A number was expected",
-                                "A boolean was expected",
-                                "An array was expected",
-                                "Unknown failure",
-                                "An exception is pending",
-                                "The async work item was cancelled",
-                                "napi_escape_handle already called on scope",
-                                "Invalid handle scope usage",
-                                "Invalid callback scope usage",
-                                "Thread-safe function queue is full",
-                                "Thread-safe function handle is closing",
-                                "A bigint was expected",
-                                "A date was expected",
-                                "An arraybuffer was expected",
-                                "A detachable arraybuffer was expected",
-                                "Main thread would deadlock",
+static const char* error_messages[] = {
+    nullptr,
+    "Invalid argument",
+    "An object was expected",
+    "A string was expected",
+    "A string or symbol was expected",
+    "A function was expected",
+    "A number was expected",
+    "A boolean was expected",
+    "An array was expected",
+    "Unknown failure",
+    "An exception is pending",
+    "The async work item was cancelled",
+    "napi_escape_handle already called on scope",
+    "Invalid handle scope usage",
+    "Invalid callback scope usage",
+    "Thread-safe function queue is full",
+    "Thread-safe function handle is closing",
+    "A bigint was expected",
+    "A date was expected",
+    "An arraybuffer was expected",
+    "A detachable arraybuffer was expected",
+    "Main thread would deadlock",
 };
 
 napi_status napi_get_last_error_info(napi_env env,
@@ -753,15 +757,13 @@ napi_status napi_get_last_error_info(napi_env env,
   // change each time a message was added.
   const int last_status = napi_would_deadlock;
 
-  static_assert(
-      NAPI_ARRAYSIZE(error_messages) == last_status + 1,
-      "Count of error messages must match count of error values");
+  static_assert(NAPI_ARRAYSIZE(error_messages) == last_status + 1,
+                "Count of error messages must match count of error values");
   CHECK_LE(env->last_error.error_code, last_status);
 
   // Wait until someone requests the last error information to fetch the error
   // message string
-  env->last_error.error_message =
-      error_messages[env->last_error.error_code];
+  env->last_error.error_message = error_messages[env->last_error.error_code];
 
   *result = &(env->last_error);
   return napi_ok;
@@ -854,12 +856,11 @@ napi_status napi_define_class(napi_env env,
             env, p->setter, p->data, &setter_tpl));
       }
 
-      tpl->PrototypeTemplate()->SetAccessorProperty(
-        property_name,
-        getter_tpl,
-        setter_tpl,
-        attributes,
-        v8::AccessControl::DEFAULT);
+      tpl->PrototypeTemplate()->SetAccessorProperty(property_name,
+                                                    getter_tpl,
+                                                    setter_tpl,
+                                                    attributes,
+                                                    v8::AccessControl::DEFAULT);
     } else if (p->method != nullptr) {
       v8::Local<v8::FunctionTemplate> t;
       STATUS_CALL(v8impl::FunctionCallbackWrapper::NewTemplate(
@@ -887,10 +888,8 @@ napi_status napi_define_class(napi_env env,
       }
     }
 
-    STATUS_CALL(napi_define_properties(env,
-                                       *result,
-                                       static_descriptors.size(),
-                                       static_descriptors.data()));
+    STATUS_CALL(napi_define_properties(
+        env, *result, static_descriptors.size(), static_descriptors.data()));
   }
 
   return GET_RETURN_STATUS(env);
@@ -903,8 +902,7 @@ napi_status napi_get_property_names(napi_env env,
       env,
       object,
       napi_key_include_prototypes,
-      static_cast<napi_key_filter>(napi_key_enumerable |
-                                   napi_key_skip_symbols),
+      static_cast<napi_key_filter>(napi_key_enumerable | napi_key_skip_symbols),
       napi_key_numbers_to_strings,
       result);
 }
@@ -924,29 +922,24 @@ napi_status napi_get_all_property_names(napi_env env,
 
   v8::PropertyFilter filter = v8::PropertyFilter::ALL_PROPERTIES;
   if (key_filter & napi_key_writable) {
-    filter =
-        static_cast<v8::PropertyFilter>(filter |
-                                        v8::PropertyFilter::ONLY_WRITABLE);
+    filter = static_cast<v8::PropertyFilter>(filter |
+                                             v8::PropertyFilter::ONLY_WRITABLE);
   }
   if (key_filter & napi_key_enumerable) {
-    filter =
-        static_cast<v8::PropertyFilter>(filter |
-                                        v8::PropertyFilter::ONLY_ENUMERABLE);
+    filter = static_cast<v8::PropertyFilter>(
+        filter | v8::PropertyFilter::ONLY_ENUMERABLE);
   }
   if (key_filter & napi_key_configurable) {
-    filter =
-        static_cast<v8::PropertyFilter>(filter |
-                                        v8::PropertyFilter::ONLY_WRITABLE);
+    filter = static_cast<v8::PropertyFilter>(filter |
+                                             v8::PropertyFilter::ONLY_WRITABLE);
   }
   if (key_filter & napi_key_skip_strings) {
-    filter =
-        static_cast<v8::PropertyFilter>(filter |
-                                        v8::PropertyFilter::SKIP_STRINGS);
+    filter = static_cast<v8::PropertyFilter>(filter |
+                                             v8::PropertyFilter::SKIP_STRINGS);
   }
   if (key_filter & napi_key_skip_symbols) {
-    filter =
-        static_cast<v8::PropertyFilter>(filter |
-                                        v8::PropertyFilter::SKIP_SYMBOLS);
+    filter = static_cast<v8::PropertyFilter>(filter |
+                                             v8::PropertyFilter::SKIP_SYMBOLS);
   }
   v8::KeyCollectionMode collection_mode;
   v8::KeyConversionMode conversion_mode;
@@ -1070,8 +1063,7 @@ napi_status napi_delete_property(napi_env env,
   v8::Maybe<bool> delete_maybe = obj->Delete(context, k);
   CHECK_MAYBE_NOTHING(env, delete_maybe, napi_generic_failure);
 
-  if (result != nullptr)
-    *result = delete_maybe.FromMaybe(false);
+  if (result != nullptr) *result = delete_maybe.FromMaybe(false);
 
   return GET_RETURN_STATUS(env);
 }
@@ -1241,8 +1233,7 @@ napi_status napi_delete_element(napi_env env,
   v8::Maybe<bool> delete_maybe = obj->Delete(context, index);
   CHECK_MAYBE_NOTHING(env, delete_maybe, napi_generic_failure);
 
-  if (result != nullptr)
-    *result = delete_maybe.FromMaybe(false);
+  if (result != nullptr) *result = delete_maybe.FromMaybe(false);
 
   return GET_RETURN_STATUS(env);
 }
@@ -1284,9 +1275,8 @@ napi_status napi_define_properties(napi_env env,
       descriptor.set_enumerable((p->attributes & napi_enumerable) != 0);
       descriptor.set_configurable((p->attributes & napi_configurable) != 0);
 
-      auto define_maybe = obj->DefineProperty(context,
-                                              property_name,
-                                              descriptor);
+      auto define_maybe =
+          obj->DefineProperty(context, property_name, descriptor);
 
       if (!define_maybe.FromMaybe(false)) {
         return napi_set_last_error(env, napi_invalid_arg);
@@ -1300,9 +1290,8 @@ napi_status napi_define_properties(napi_env env,
       descriptor.set_enumerable((p->attributes & napi_enumerable) != 0);
       descriptor.set_configurable((p->attributes & napi_configurable) != 0);
 
-      auto define_maybe = obj->DefineProperty(context,
-                                              property_name,
-                                              descriptor);
+      auto define_maybe =
+          obj->DefineProperty(context, property_name, descriptor);
 
       if (!define_maybe.FromMaybe(false)) {
         return napi_set_last_error(env, napi_generic_failure);
@@ -1327,8 +1316,7 @@ napi_status napi_define_properties(napi_env env,
   return GET_RETURN_STATUS(env);
 }
 
-napi_status napi_object_freeze(napi_env env,
-                               napi_value object) {
+napi_status napi_object_freeze(napi_env env, napi_value object) {
   NAPI_PREAMBLE(env);
 
   v8::Local<v8::Context> context = env->context();
@@ -1337,16 +1325,15 @@ napi_status napi_object_freeze(napi_env env,
   CHECK_TO_OBJECT(env, context, obj, object);
 
   v8::Maybe<bool> set_frozen =
-    obj->SetIntegrityLevel(context, v8::IntegrityLevel::kFrozen);
+      obj->SetIntegrityLevel(context, v8::IntegrityLevel::kFrozen);
 
-  RETURN_STATUS_IF_FALSE_WITH_PREAMBLE(env,
-    set_frozen.FromMaybe(false), napi_generic_failure);
+  RETURN_STATUS_IF_FALSE_WITH_PREAMBLE(
+      env, set_frozen.FromMaybe(false), napi_generic_failure);
 
   return GET_RETURN_STATUS(env);
 }
 
-napi_status napi_object_seal(napi_env env,
-                             napi_value object) {
+napi_status napi_object_seal(napi_env env, napi_value object) {
   NAPI_PREAMBLE(env);
 
   v8::Local<v8::Context> context = env->context();
@@ -1355,10 +1342,10 @@ napi_status napi_object_seal(napi_env env,
   CHECK_TO_OBJECT(env, context, obj, object);
 
   v8::Maybe<bool> set_sealed =
-    obj->SetIntegrityLevel(context, v8::IntegrityLevel::kSealed);
+      obj->SetIntegrityLevel(context, v8::IntegrityLevel::kSealed);
 
-  RETURN_STATUS_IF_FALSE_WITH_PREAMBLE(env,
-    set_sealed.FromMaybe(false), napi_generic_failure);
+  RETURN_STATUS_IF_FALSE_WITH_PREAMBLE(
+      env, set_sealed.FromMaybe(false), napi_generic_failure);
 
   return GET_RETURN_STATUS(env);
 }
@@ -1426,8 +1413,7 @@ napi_status napi_create_object(napi_env env, napi_value* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, result);
 
-  *result = v8impl::JsValueFromV8LocalValue(
-      v8::Object::New(env->isolate));
+  *result = v8impl::JsValueFromV8LocalValue(v8::Object::New(env->isolate));
 
   return napi_clear_last_error(env);
 }
@@ -1436,8 +1422,7 @@ napi_status napi_create_array(napi_env env, napi_value* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, result);
 
-  *result = v8impl::JsValueFromV8LocalValue(
-      v8::Array::New(env->isolate));
+  *result = v8impl::JsValueFromV8LocalValue(v8::Array::New(env->isolate));
 
   return napi_clear_last_error(env);
 }
@@ -1448,8 +1433,8 @@ napi_status napi_create_array_with_length(napi_env env,
   CHECK_ENV(env);
   CHECK_ARG(env, result);
 
-  *result = v8impl::JsValueFromV8LocalValue(
-      v8::Array::New(env->isolate, length));
+  *result =
+      v8impl::JsValueFromV8LocalValue(v8::Array::New(env->isolate, length));
 
   return napi_clear_last_error(env);
 }
@@ -1459,12 +1444,10 @@ napi_status napi_create_string_latin1(napi_env env,
                                       size_t length,
                                       napi_value* result) {
   CHECK_ENV(env);
-  if (length > 0)
-      CHECK_ARG(env, str);
+  if (length > 0) CHECK_ARG(env, str);
   CHECK_ARG(env, result);
-  RETURN_STATUS_IF_FALSE(env,
-      (length == NAPI_AUTO_LENGTH) || length <= INT_MAX,
-      napi_invalid_arg);
+  RETURN_STATUS_IF_FALSE(
+      env, (length == NAPI_AUTO_LENGTH) || length <= INT_MAX, napi_invalid_arg);
 
   auto isolate = env->isolate;
   auto str_maybe =
@@ -1483,19 +1466,14 @@ napi_status napi_create_string_utf8(napi_env env,
                                     size_t length,
                                     napi_value* result) {
   CHECK_ENV(env);
-  if (length > 0)
-      CHECK_ARG(env, str);
+  if (length > 0) CHECK_ARG(env, str);
   CHECK_ARG(env, result);
-  RETURN_STATUS_IF_FALSE(env,
-      (length == NAPI_AUTO_LENGTH) || length <= INT_MAX,
-      napi_invalid_arg);
+  RETURN_STATUS_IF_FALSE(
+      env, (length == NAPI_AUTO_LENGTH) || length <= INT_MAX, napi_invalid_arg);
 
   auto isolate = env->isolate;
-  auto str_maybe =
-      v8::String::NewFromUtf8(isolate,
-                              str,
-                              v8::NewStringType::kNormal,
-                              static_cast<int>(length));
+  auto str_maybe = v8::String::NewFromUtf8(
+      isolate, str, v8::NewStringType::kNormal, static_cast<int>(length));
   CHECK_MAYBE_EMPTY(env, str_maybe, napi_generic_failure);
   *result = v8impl::JsValueFromV8LocalValue(str_maybe.ToLocalChecked());
   return napi_clear_last_error(env);
@@ -1506,12 +1484,10 @@ napi_status napi_create_string_utf16(napi_env env,
                                      size_t length,
                                      napi_value* result) {
   CHECK_ENV(env);
-  if (length > 0)
-      CHECK_ARG(env, str);
+  if (length > 0) CHECK_ARG(env, str);
   CHECK_ARG(env, result);
-  RETURN_STATUS_IF_FALSE(env,
-      (length == NAPI_AUTO_LENGTH) || length <= INT_MAX,
-      napi_invalid_arg);
+  RETURN_STATUS_IF_FALSE(
+      env, (length == NAPI_AUTO_LENGTH) || length <= INT_MAX, napi_invalid_arg);
 
   auto isolate = env->isolate;
   auto str_maybe =
@@ -1525,26 +1501,22 @@ napi_status napi_create_string_utf16(napi_env env,
   return napi_clear_last_error(env);
 }
 
-napi_status napi_create_double(napi_env env,
-                               double value,
-                               napi_value* result) {
+napi_status napi_create_double(napi_env env, double value, napi_value* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, result);
 
-  *result = v8impl::JsValueFromV8LocalValue(
-      v8::Number::New(env->isolate, value));
+  *result =
+      v8impl::JsValueFromV8LocalValue(v8::Number::New(env->isolate, value));
 
   return napi_clear_last_error(env);
 }
 
-napi_status napi_create_int32(napi_env env,
-                              int32_t value,
-                              napi_value* result) {
+napi_status napi_create_int32(napi_env env, int32_t value, napi_value* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, result);
 
-  *result = v8impl::JsValueFromV8LocalValue(
-      v8::Integer::New(env->isolate, value));
+  *result =
+      v8impl::JsValueFromV8LocalValue(v8::Integer::New(env->isolate, value));
 
   return napi_clear_last_error(env);
 }
@@ -1561,9 +1533,7 @@ napi_status napi_create_uint32(napi_env env,
   return napi_clear_last_error(env);
 }
 
-napi_status napi_create_int64(napi_env env,
-                              int64_t value,
-                              napi_value* result) {
+napi_status napi_create_int64(napi_env env, int64_t value, napi_value* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, result);
 
@@ -1579,8 +1549,8 @@ napi_status napi_create_bigint_int64(napi_env env,
   CHECK_ENV(env);
   CHECK_ARG(env, result);
 
-  *result = v8impl::JsValueFromV8LocalValue(
-      v8::BigInt::New(env->isolate, value));
+  *result =
+      v8impl::JsValueFromV8LocalValue(v8::BigInt::New(env->isolate, value));
 
   return napi_clear_last_error(env);
 }
@@ -1608,11 +1578,10 @@ napi_status napi_create_bigint_words(napi_env env,
 
   v8::Local<v8::Context> context = env->context();
 
-  RETURN_STATUS_IF_FALSE(
-      env, word_count <= INT_MAX, napi_invalid_arg);
+  RETURN_STATUS_IF_FALSE(env, word_count <= INT_MAX, napi_invalid_arg);
 
-  v8::MaybeLocal<v8::BigInt> b = v8::BigInt::NewFromWords(
-      context, sign_bit, word_count, words);
+  v8::MaybeLocal<v8::BigInt> b =
+      v8::BigInt::NewFromWords(context, sign_bit, word_count, words);
 
   CHECK_MAYBE_EMPTY_WITH_PREAMBLE(env, b, napi_generic_failure);
 
@@ -1650,7 +1619,7 @@ napi_status napi_create_symbol(napi_env env,
     RETURN_STATUS_IF_FALSE(env, desc->IsString(), napi_string_expected);
 
     *result = v8impl::JsValueFromV8LocalValue(
-      v8::Symbol::New(isolate, desc.As<v8::String>()));
+        v8::Symbol::New(isolate, desc.As<v8::String>()));
   }
 
   return napi_clear_last_error(env);
@@ -1676,9 +1645,8 @@ static inline napi_status set_error_code(napi_env env,
     CHECK_NEW_FROM_UTF8(env, code_key, "code");
 
     v8::Maybe<bool> set_maybe = err_object->Set(context, code_key, code_value);
-    RETURN_STATUS_IF_FALSE(env,
-                           set_maybe.FromMaybe(false),
-                           napi_generic_failure);
+    RETURN_STATUS_IF_FALSE(
+        env, set_maybe.FromMaybe(false), napi_generic_failure);
   }
   return napi_ok;
 }
@@ -1790,8 +1758,7 @@ napi_status napi_get_undefined(napi_env env, napi_value* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, result);
 
-  *result = v8impl::JsValueFromV8LocalValue(
-      v8::Undefined(env->isolate));
+  *result = v8impl::JsValueFromV8LocalValue(v8::Undefined(env->isolate));
 
   return napi_clear_last_error(env);
 }
@@ -1800,8 +1767,7 @@ napi_status napi_get_null(napi_env env, napi_value* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, result);
 
-  *result = v8impl::JsValueFromV8LocalValue(
-        v8::Null(env->isolate));
+  *result = v8impl::JsValueFromV8LocalValue(v8::Null(env->isolate));
 
   return napi_clear_last_error(env);
 }
@@ -1871,8 +1837,11 @@ napi_status napi_call_function(napi_env env,
   v8::Local<v8::Function> v8func;
   CHECK_TO_FUNCTION(env, v8func, func);
 
-  auto maybe = v8func->Call(context, v8recv, argc,
-    reinterpret_cast<v8::Local<v8::Value>*>(const_cast<napi_value*>(argv)));
+  auto maybe = v8func->Call(
+      context,
+      v8recv,
+      argc,
+      reinterpret_cast<v8::Local<v8::Value>*>(const_cast<napi_value*>(argv)));
 
   if (try_catch.HasCaught()) {
     return napi_set_last_error(env, napi_pending_exception);
@@ -1906,9 +1875,7 @@ napi_status napi_throw(napi_env env, napi_value error) {
   return napi_clear_last_error(env);
 }
 
-napi_status napi_throw_error(napi_env env,
-                             const char* code,
-                             const char* msg) {
+napi_status napi_throw_error(napi_env env, const char* code, const char* msg) {
   NAPI_PREAMBLE(env);
 
   v8::Isolate* isolate = env->isolate;
@@ -2161,11 +2128,8 @@ napi_status napi_get_value_bool(napi_env env, napi_value value, bool* result) {
 // If buf is NULL, this method returns the length of the string (in bytes)
 // via the result parameter.
 // The result argument is optional unless buf is NULL.
-napi_status napi_get_value_string_latin1(napi_env env,
-                                         napi_value value,
-                                         char* buf,
-                                         size_t bufsize,
-                                         size_t* result) {
+napi_status napi_get_value_string_latin1(
+    napi_env env, napi_value value, char* buf, size_t bufsize, size_t* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, value);
 
@@ -2202,11 +2166,8 @@ napi_status napi_get_value_string_latin1(napi_env env,
 // If buf is NULL, this method returns the length of the string (in bytes)
 // via the result parameter.
 // The result argument is optional unless buf is NULL.
-napi_status napi_get_value_string_utf8(napi_env env,
-                                       napi_value value,
-                                       char* buf,
-                                       size_t bufsize,
-                                       size_t* result) {
+napi_status napi_get_value_string_utf8(
+    napi_env env, napi_value value, char* buf, size_t bufsize, size_t* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, value);
 
@@ -2285,26 +2246,25 @@ napi_status napi_coerce_to_bool(napi_env env,
 
   v8::Isolate* isolate = env->isolate;
   v8::Local<v8::Boolean> b =
-    v8impl::V8LocalValueFromJsValue(value)->ToBoolean(isolate);
+      v8impl::V8LocalValueFromJsValue(value)->ToBoolean(isolate);
   *result = v8impl::JsValueFromV8LocalValue(b);
   return GET_RETURN_STATUS(env);
 }
 
-#define GEN_COERCE_FUNCTION(UpperCaseName, MixedCaseName, LowerCaseName)      \
-  napi_status napi_coerce_to_##LowerCaseName(napi_env env,                    \
-                                             napi_value value,                \
-                                             napi_value* result) {            \
-    NAPI_PREAMBLE(env);                                                       \
-    CHECK_ARG(env, value);                                                    \
-    CHECK_ARG(env, result);                                                   \
-                                                                              \
-    v8::Local<v8::Context> context = env->context();                          \
-    v8::Local<v8::MixedCaseName> str;                                         \
-                                                                              \
-    CHECK_TO_##UpperCaseName(env, context, str, value);                       \
-                                                                              \
-    *result = v8impl::JsValueFromV8LocalValue(str);                           \
-    return GET_RETURN_STATUS(env);                                            \
+#define GEN_COERCE_FUNCTION(UpperCaseName, MixedCaseName, LowerCaseName)       \
+  napi_status napi_coerce_to_##LowerCaseName(                                  \
+      napi_env env, napi_value value, napi_value* result) {                    \
+    NAPI_PREAMBLE(env);                                                        \
+    CHECK_ARG(env, value);                                                     \
+    CHECK_ARG(env, result);                                                    \
+                                                                               \
+    v8::Local<v8::Context> context = env->context();                           \
+    v8::Local<v8::MixedCaseName> str;                                          \
+                                                                               \
+    CHECK_TO_##UpperCaseName(env, context, str, value);                        \
+                                                                               \
+    *result = v8impl::JsValueFromV8LocalValue(str);                            \
+    return GET_RETURN_STATUS(env);                                             \
   }
 
 GEN_COERCE_FUNCTION(NUMBER, Number, number)
@@ -2319,12 +2279,8 @@ napi_status napi_wrap(napi_env env,
                       napi_finalize finalize_cb,
                       void* finalize_hint,
                       napi_ref* result) {
-  return v8impl::Wrap<v8impl::retrievable>(env,
-                                           js_object,
-                                           native_object,
-                                           finalize_cb,
-                                           finalize_hint,
-                                           result);
+  return v8impl::Wrap<v8impl::retrievable>(
+      env, js_object, native_object, finalize_cb, finalize_hint, result);
 }
 
 napi_status napi_unwrap(napi_env env, napi_value obj, void** result) {
@@ -2349,13 +2305,8 @@ napi_status napi_create_external(napi_env env,
 
   // The Reference object will delete itself after invoking the finalizer
   // callback.
-  v8impl::Reference::New(env,
-      external_value,
-      0,
-      true,
-      finalize_cb,
-      data,
-      finalize_hint);
+  v8impl::Reference::New(
+      env, external_value, 0, true, finalize_cb, data, finalize_hint);
 
   *result = v8impl::JsValueFromV8LocalValue(external_value);
 
@@ -2374,21 +2325,17 @@ NAPI_EXTERN napi_status napi_type_tag_object(napi_env env,
   auto key = NAPI_PRIVATE_KEY(context, type_tag);
   auto maybe_has = obj->HasPrivate(context, key);
   CHECK_MAYBE_NOTHING_WITH_PREAMBLE(env, maybe_has, napi_generic_failure);
-  RETURN_STATUS_IF_FALSE_WITH_PREAMBLE(env,
-                                       !maybe_has.FromJust(),
-                                       napi_invalid_arg);
+  RETURN_STATUS_IF_FALSE_WITH_PREAMBLE(
+      env, !maybe_has.FromJust(), napi_invalid_arg);
 
-  auto tag = v8::BigInt::NewFromWords(context,
-                                   0,
-                                   2,
-                                   reinterpret_cast<const uint64_t*>(type_tag));
+  auto tag = v8::BigInt::NewFromWords(
+      context, 0, 2, reinterpret_cast<const uint64_t*>(type_tag));
   CHECK_MAYBE_EMPTY_WITH_PREAMBLE(env, tag, napi_generic_failure);
 
   auto maybe_set = obj->SetPrivate(context, key, tag.ToLocalChecked());
   CHECK_MAYBE_NOTHING_WITH_PREAMBLE(env, maybe_set, napi_generic_failure);
-  RETURN_STATUS_IF_FALSE_WITH_PREAMBLE(env,
-                                       maybe_set.FromJust(),
-                                       napi_generic_failure);
+  RETURN_STATUS_IF_FALSE_WITH_PREAMBLE(
+      env, maybe_set.FromJust(), napi_generic_failure);
 
   return GET_RETURN_STATUS(env);
 }
@@ -2405,8 +2352,8 @@ napi_check_object_type_tag(napi_env env,
   CHECK_ARG_WITH_PREAMBLE(env, type_tag);
   CHECK_ARG_WITH_PREAMBLE(env, result);
 
-  auto maybe_value = obj->GetPrivate(context,
-                                     NAPI_PRIVATE_KEY(context, type_tag));
+  auto maybe_value =
+      obj->GetPrivate(context, NAPI_PRIVATE_KEY(context, type_tag));
   CHECK_MAYBE_EMPTY_WITH_PREAMBLE(env, maybe_value, napi_generic_failure);
   v8::Local<v8::Value> val = maybe_value.ToLocalChecked();
 
@@ -2418,9 +2365,8 @@ napi_check_object_type_tag(napi_env env,
     int sign;
     int size = 2;
     napi_type_tag tag;
-    val.As<v8::BigInt>()->ToWordsArray(&sign,
-                                       &size,
-                                       reinterpret_cast<uint64_t*>(&tag));
+    val.As<v8::BigInt>()->ToWordsArray(
+        &sign, &size, reinterpret_cast<uint64_t*>(&tag));
     if (size == 2 && sign == 0)
       *result = (tag.lower == type_tag->lower && tag.upper == type_tag->upper);
   }
@@ -2572,8 +2518,7 @@ napi_status napi_close_handle_scope(napi_env env, napi_handle_scope scope) {
 }
 
 napi_status napi_open_escapable_handle_scope(
-    napi_env env,
-    napi_escapable_handle_scope* result) {
+    napi_env env, napi_escapable_handle_scope* result) {
   // Omit NAPI_PREAMBLE and GET_RETURN_STATUS because V8 calls here cannot throw
   // JS exceptions.
   CHECK_ENV(env);
@@ -2586,8 +2531,7 @@ napi_status napi_open_escapable_handle_scope(
 }
 
 napi_status napi_close_escapable_handle_scope(
-    napi_env env,
-    napi_escapable_handle_scope scope) {
+    napi_env env, napi_escapable_handle_scope scope) {
   // Omit NAPI_PREAMBLE and GET_RETURN_STATUS because V8 calls here cannot throw
   // JS exceptions.
   CHECK_ENV(env);
@@ -2639,8 +2583,10 @@ napi_status napi_new_instance(napi_env env,
   v8::Local<v8::Function> ctor;
   CHECK_TO_FUNCTION(env, ctor, constructor);
 
-  auto maybe = ctor->NewInstance(context, argc,
-    reinterpret_cast<v8::Local<v8::Value>*>(const_cast<napi_value*>(argv)));
+  auto maybe = ctor->NewInstance(
+      context,
+      argc,
+      reinterpret_cast<v8::Local<v8::Value>*>(const_cast<napi_value*>(argv)));
 
   CHECK_MAYBE_EMPTY(env, maybe, napi_pending_exception);
 
@@ -2664,9 +2610,8 @@ napi_status napi_instanceof(napi_env env,
   CHECK_TO_OBJECT(env, context, ctor, constructor);
 
   if (!ctor->IsFunction()) {
-    napi_throw_type_error(env,
-                          "ERR_NAPI_CONS_FUNCTION",
-                          "Constructor must be a function");
+    napi_throw_type_error(
+        env, "ERR_NAPI_CONS_FUNCTION", "Constructor must be a function");
 
     return napi_set_last_error(env, napi_function_expected);
   }
@@ -2702,7 +2647,7 @@ napi_status napi_get_and_clear_last_exception(napi_env env,
     return napi_get_undefined(env, result);
   } else {
     *result = v8impl::JsValueFromV8LocalValue(
-      v8::Local<v8::Value>::New(env->isolate, env->last_exception));
+        v8::Local<v8::Value>::New(env->isolate, env->last_exception));
     env->last_exception.Reset();
   }
 
@@ -2752,20 +2697,9 @@ napi_status napi_create_external_arraybuffer(napi_env env,
   // `Buffer` variant for easier implementation.
   napi_value buffer;
   STATUS_CALL(napi_create_external_buffer(
-      env,
-      byte_length,
-      external_data,
-      finalize_cb,
-      finalize_hint,
-      &buffer));
+      env, byte_length, external_data, finalize_cb, finalize_hint, &buffer));
   return napi_get_typedarray_info(
-      env,
-      buffer,
-      nullptr,
-      nullptr,
-      nullptr,
-      result,
-      nullptr);
+      env, buffer, nullptr, nullptr, nullptr, result, nullptr);
 }
 
 napi_status napi_get_arraybuffer_info(napi_env env,
@@ -2954,15 +2888,14 @@ napi_status napi_create_dataview(napi_env env,
 
   v8::Local<v8::ArrayBuffer> buffer = value.As<v8::ArrayBuffer>();
   if (byte_length + byte_offset > buffer->ByteLength()) {
-    napi_throw_range_error(
-        env,
-        "ERR_NAPI_INVALID_DATAVIEW_ARGS",
-        "byte_offset + byte_length should be less than or "
-        "equal to the size in bytes of the array passed in");
+    napi_throw_range_error(env,
+                           "ERR_NAPI_INVALID_DATAVIEW_ARGS",
+                           "byte_offset + byte_length should be less than or "
+                           "equal to the size in bytes of the array passed in");
     return napi_set_last_error(env, napi_pending_exception);
   }
-  v8::Local<v8::DataView> DataView = v8::DataView::New(buffer, byte_offset,
-                                                       byte_length);
+  v8::Local<v8::DataView> DataView =
+      v8::DataView::New(buffer, byte_offset, byte_length);
 
   *result = v8impl::JsValueFromV8LocalValue(DataView);
   return GET_RETURN_STATUS(env);
@@ -3058,9 +2991,7 @@ napi_status napi_reject_deferred(napi_env env,
   return v8impl::ConcludeDeferred(env, deferred, resolution, false);
 }
 
-napi_status napi_is_promise(napi_env env,
-                            napi_value value,
-                            bool* is_promise) {
+napi_status napi_is_promise(napi_env env, napi_value value, bool* is_promise) {
   CHECK_ENV(env);
   CHECK_ARG(env, value);
   CHECK_ARG(env, is_promise);
@@ -3070,75 +3001,47 @@ napi_status napi_is_promise(napi_env env,
   return napi_clear_last_error(env);
 }
 
+#ifdef NAPI_EXPERIMENTAL
 napi_status napi_promise_then(napi_env env,
-                            napi_value promise,
-                            napi_callback on_resolve,
-                            napi_callback on_rejected) {
+                              napi_value* promise,
+                              napi_callback on_fulfilled,
+                              napi_callback on_rejected) {
   NAPI_PREAMBLE(env);
   CHECK_ENV(env);
   CHECK_ARG(env, promise);
-  CHECK_ARG(env, on_resolve);
-  CHECK_ARG(env, on_rejected);
-  v8::Local<v8::Context> v8Context = env->context();
-  v8::Local<v8::Promise> v8Promise =
-      v8impl::V8LocalValueFromJsValue(promise).As<v8::Promise>();
 
   v8::Local<v8::Function> v8ResolveFn;
-  STATUS_CALL(v8impl::FunctionCallbackWrapper::NewFunction(
-      env, on_resolve, nullptr, &v8ResolveFn));
+  if (on_fulfilled) {
+    STATUS_CALL(v8impl::FunctionCallbackWrapper::NewFunction(
+        env, on_fulfilled, nullptr, &v8ResolveFn));
+  }
 
   v8::Local<v8::Function> v8RejectFn;
-  STATUS_CALL(v8impl::FunctionCallbackWrapper::NewFunction(
-      env, on_rejected, nullptr, &v8RejectFn));
+  if (on_rejected) {
+    STATUS_CALL(v8impl::FunctionCallbackWrapper::NewFunction(
+        env, on_rejected, nullptr, &v8RejectFn));
+  }
 
-  v8Promise->Then(v8Context, v8ResolveFn, v8RejectFn);
-  return GET_RETURN_STATUS(env);
-}
-
-napi_status napi_promise_then_resolve(napi_env env,
-                                      napi_value promise,
-                                      napi_callback handler) {
-  NAPI_PREAMBLE(env);
-  CHECK_ENV(env);
-  CHECK_ARG(env, promise);
-  CHECK_ARG(env, handler);
   v8::Local<v8::Context> v8Context = env->context();
   v8::Local<v8::Promise> v8Promise =
-      v8impl::V8LocalValueFromJsValue(promise).As<v8::Promise>();
+      v8impl::V8LocalValueFromJsValue(*promise).As<v8::Promise>();
+  v8::MaybeLocal<v8::Promise> maybePromise;
+  if (on_fulfilled && on_rejected) {
+    maybePromise = v8Promise->Then(v8Context, v8ResolveFn, v8RejectFn);
+  } else if (on_fulfilled) {
+    maybePromise = v8Promise->Then(v8Context, v8ResolveFn);
+  } else if (on_rejected) {
+    maybePromise = v8Promise->Catch(v8Context, v8RejectFn);
+  }
+  CHECK_MAYBE_EMPTY(env, maybePromise, napi_generic_failure);
 
-  v8::Local<v8::Function> fn;
-  STATUS_CALL(v8impl::FunctionCallbackWrapper::NewFunction(
-        env, handler, nullptr, &fn));
-
-  v8Promise->Then(v8Context, fn).ToLocalChecked();
-
-  return GET_RETURN_STATUS(env);
-}
-
-napi_status napi_promise_catch(napi_env env,
-                              napi_value promise,
-                              napi_callback handler) {
-  NAPI_PREAMBLE(env);
-  CHECK_ENV(env);
-  CHECK_ARG(env, promise);
-  CHECK_ARG(env, handler);
-  v8::Local<v8::Context> v8Context = env->context();
-  v8::Local<v8::Promise> v8Promise =
-      v8impl::V8LocalValueFromJsValue(promise).As<v8::Promise>();
-
-  v8::Local<v8::Function> fn;
-  STATUS_CALL(
-      v8impl::FunctionCallbackWrapper::NewFunction(env, handler, nullptr, &fn));
-
-  v8Promise->Catch(v8Context, fn);
+  *promise = v8impl::JsValueFromV8LocalValue(maybePromise.ToLocalChecked());
 
   return GET_RETURN_STATUS(env);
 }
+#endif  // NAPI_EXPERIMENTAL
 
-
-napi_status napi_create_date(napi_env env,
-                             double time,
-                             napi_value* result) {
+napi_status napi_create_date(napi_env env, double time, napi_value* result) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, result);
 
@@ -3150,9 +3053,7 @@ napi_status napi_create_date(napi_env env,
   return GET_RETURN_STATUS(env);
 }
 
-napi_status napi_is_date(napi_env env,
-                         napi_value value,
-                         bool* is_date) {
+napi_status napi_is_date(napi_env env, napi_value value, bool* is_date) {
   CHECK_ENV(env);
   CHECK_ARG(env, value);
   CHECK_ARG(env, is_date);
@@ -3193,12 +3094,11 @@ napi_status napi_run_script(napi_env env,
 
   v8::Local<v8::Context> context = env->context();
 
-  auto maybe_script = v8::Script::Compile(context,
-      v8::Local<v8::String>::Cast(v8_script));
+  auto maybe_script =
+      v8::Script::Compile(context, v8::Local<v8::String>::Cast(v8_script));
   CHECK_MAYBE_EMPTY(env, maybe_script, napi_generic_failure);
 
-  auto script_result =
-      maybe_script.ToLocalChecked()->Run(context);
+  auto script_result = maybe_script.ToLocalChecked()->Run(context);
   CHECK_MAYBE_EMPTY(env, script_result, napi_generic_failure);
 
   *result = v8impl::JsValueFromV8LocalValue(script_result.ToLocalChecked());
@@ -3211,12 +3111,8 @@ napi_status napi_add_finalizer(napi_env env,
                                napi_finalize finalize_cb,
                                void* finalize_hint,
                                napi_ref* result) {
-  return v8impl::Wrap<v8impl::anonymous>(env,
-                                         js_object,
-                                         native_object,
-                                         finalize_cb,
-                                         finalize_hint,
-                                         result);
+  return v8impl::Wrap<v8impl::anonymous>(
+      env, js_object, native_object, finalize_cb, finalize_hint, result);
 }
 
 napi_status napi_adjust_external_memory(napi_env env,
@@ -3225,8 +3121,8 @@ napi_status napi_adjust_external_memory(napi_env env,
   CHECK_ENV(env);
   CHECK_ARG(env, adjusted_value);
 
-  *adjusted_value = env->isolate->AdjustAmountOfExternalAllocatedMemory(
-      change_in_bytes);
+  *adjusted_value =
+      env->isolate->AdjustAmountOfExternalAllocatedMemory(change_in_bytes);
 
   return napi_clear_last_error(env);
 }
@@ -3244,18 +3140,13 @@ napi_status napi_set_instance_data(napi_env env,
     v8impl::RefBase::Delete(old_data);
   }
 
-  env->instance_data = v8impl::RefBase::New(env,
-                                            0,
-                                            true,
-                                            finalize_cb,
-                                            data,
-                                            finalize_hint);
+  env->instance_data =
+      v8impl::RefBase::New(env, 0, true, finalize_cb, data, finalize_hint);
 
   return napi_clear_last_error(env);
 }
 
-napi_status napi_get_instance_data(napi_env env,
-                                   void** data) {
+napi_status napi_get_instance_data(napi_env env, void** data) {
   CHECK_ENV(env);
   CHECK_ARG(env, data);
 

--- a/test/cctest/test_node_api.cc
+++ b/test/cctest/test_node_api.cc
@@ -7,35 +7,243 @@
 #include "node_binding.h"
 #include "node_test_fixture.h"
 
-using v8::Local;
-using v8::Object;
 
-static napi_env addon_env;
-
-class NodeApiTest : public EnvironmentTestFixture {
+class NodeApiTestEnv : public NodeTestFixture {
+ public:
+  napi_env env;
+  node::Environment* environment_;
+  v8::Global<v8::Context>* context_;
  private:
-  void SetUp() override { EnvironmentTestFixture::SetUp(); }
+  void SetUp() override {
+    NodeTestFixture::SetUp();
+    v8::HandleScope handle_scope(isolate_);
+    Argv argv;
+    v8::Local<v8::Context> context = node::NewContext(isolate_);
+    context_ = new v8::Global<v8::Context>(isolate_, context);
+    CHECK(!context.IsEmpty());
+    context->Enter();
 
-  void TearDown() override { NodeTestFixture::TearDown(); }
+    isolate_data_ = node::CreateIsolateData(
+        isolate_, &NodeTestFixture::current_loop, platform.get());
+    CHECK_NE(nullptr, isolate_data_);
+    std::vector<std::string> args(*argv, *argv + 1);
+    std::vector<std::string> exec_args(*argv, *argv + 1);
+    environment_ = node::CreateEnvironment(isolate_data_,
+                                context,
+                                args,
+                                exec_args,
+                                node::EnvironmentFlags::kDefaultFlags);
+    CHECK_NE(nullptr, environment_);
+
+    node::LoadEnvironment(environment_, "");
+
+    node_napi_env result;
+    result = new node_napi_env__(isolate_->GetCurrentContext(), "");
+    result->node_env()->AddCleanupHook(
+        [](void* arg) { static_cast<napi_env>(arg)->Unref(); },
+        static_cast<void*>(result));
+    this->env = reinterpret_cast<napi_env>(result);
+  }
+
+  void TearDown() override {
+    {
+      v8::HandleScope handleScope(isolate_);
+      context_->Get(isolate_)->Exit();
+      delete context_;
+    }
+    node::FreeEnvironment(environment_);
+    node::FreeIsolateData(isolate_data_);
+    NodeTestFixture::TearDown();
+  }
+
+  node::IsolateData* isolate_data_;
 };
 
-TEST_F(NodeApiTest, CreateNodeApiEnv) {
-  const v8::HandleScope handle_scope(isolate_);
-  Argv argv;
-
-  Env test_env{handle_scope, argv};
-
-  node::Environment* env = *test_env;
-  node::LoadEnvironment(env, "");
-
+static napi_env addon_env;
+TEST_F(NodeApiTestEnv, CreateNodeApiEnv) {
+  v8::HandleScope handleScope(isolate_);
   napi_addon_register_func init = [](napi_env env, napi_value exports) {
     addon_env = env;
     return exports;
   };
-  Local<Object> module_obj = Object::New(isolate_);
-  Local<Object> exports_obj = Object::New(isolate_);
-  napi_module_register_by_symbol(exports_obj, module_obj, env->context(), init);
+  v8::Local<v8::Object> module_obj = v8::Object::New(isolate_);
+  v8::Local<v8::Object> exports_obj = v8::Object::New(isolate_);
+  napi_module_register_by_symbol(exports_obj, module_obj,context_->Get(isolate_), init);
   ASSERT_NE(addon_env, nullptr);
   node_napi_env internal_env = reinterpret_cast<node_napi_env>(addon_env);
-  EXPECT_EQ(internal_env->node_env(), env);
+  EXPECT_EQ(internal_env->node_env(), environment_);
+}
+
+TEST_F(NodeApiTestEnv, number) {
+  v8::HandleScope handleScope(isolate_);
+
+  // uint32
+  napi_value node_uint32_result;
+  CHECK_EQ(napi_create_uint32(env, 1, &node_uint32_result) ,napi_ok);
+  uint32_t uint32_result;
+  CHECK_EQ(napi_get_value_uint32(env, node_uint32_result, &uint32_result),
+              napi_ok);
+  EXPECT_EQ(uint32_result, 1);
+
+  // int32
+  napi_value node_int32_result;
+  CHECK_EQ(napi_create_int32(env, -1, &node_int32_result) ,napi_ok);
+  int32_t int32_result;
+  CHECK_EQ(napi_get_value_int32(env, node_int32_result, &int32_result),
+              napi_ok);
+  EXPECT_EQ(int32_result, -1);
+
+  // int64
+  napi_value node_int64_result;
+  CHECK_EQ(napi_create_int64(env, -1, &node_int64_result), napi_ok);
+  int64_t int64_result;
+  CHECK_EQ(napi_get_value_int64(env, node_int64_result, &int64_result),
+              napi_ok);
+  EXPECT_EQ(int64_result, -1);
+
+  // double
+  napi_value node_double_result;
+  CHECK_EQ(napi_create_double(env, 0.1, &node_double_result), napi_ok);
+  double double_result;
+  CHECK_EQ(napi_get_value_double(env, node_double_result, &double_result),
+           napi_ok);
+  EXPECT_EQ(double_result, 0.1);
+}
+
+static int globalPromiseValue = 0;
+TEST_F(NodeApiTestEnv, promise) {
+  v8::HandleScope handleScope(isolate_);
+
+  ASSERT_TRUE(isolate_->GetMicrotasksPolicy() ==
+              v8::MicrotasksPolicy::kExplicit);
+
+  napi_value node_promise;
+  napi_deferred node_deferred;
+  CHECK_EQ(napi_create_promise(env, &node_deferred, &node_promise), napi_ok);
+
+  bool is_promise;
+  CHECK_EQ(napi_is_promise(env, node_promise, &is_promise), napi_ok);
+  EXPECT_TRUE(is_promise);
+
+  napi_value node_resolution;
+  CHECK_EQ(napi_create_int32(env, 1, &node_resolution) ,napi_ok);
+  CHECK_EQ(napi_resolve_deferred(env, node_deferred, node_resolution), napi_ok);
+
+  CHECK_EQ(napi_promise_then_resolve(env,
+                    node_promise,
+                    [](napi_env env, napi_callback_info info) -> napi_value {
+
+                    globalPromiseValue++;
+
+                    size_t argc = 1;
+                    napi_value argv[1];
+                    CHECK_EQ(napi_get_cb_info(
+                                 env, info, &argc, argv, nullptr, nullptr),
+                             napi_ok);
+
+                    int result;
+                    CHECK_EQ(napi_get_value_int32(env, argv[0], &result),
+                             napi_ok);
+                    EXPECT_TRUE(result == 1);
+                    return argv[0];
+                    }),napi_ok);
+
+  EXPECT_EQ(globalPromiseValue, 0);
+  // perform Microtask 
+  isolate_->PerformMicrotaskCheckpoint();
+  EXPECT_EQ(globalPromiseValue, 1);
+
+  CHECK_EQ(napi_promise_then(
+               env,
+               node_promise,
+               [](napi_env env, napi_callback_info info) -> napi_value {
+                 globalPromiseValue++;
+
+                 size_t argc = 1;
+                 napi_value argv[1];
+                 CHECK_EQ(
+                     napi_get_cb_info(env, info, &argc, argv, nullptr, nullptr),
+                     napi_ok);
+
+                 int result;
+                 CHECK_EQ(napi_get_value_int32(env, argv[0], &result), napi_ok);
+                 EXPECT_TRUE(result == 1);
+
+                 return nullptr;
+               },
+               [](napi_env env, napi_callback_info info) -> napi_value {
+                 globalPromiseValue += 2;
+                 return nullptr;
+               }),
+           napi_ok);
+
+  EXPECT_EQ(globalPromiseValue, 1);
+  // perform Microtask
+  isolate_->PerformMicrotaskCheckpoint();
+  EXPECT_EQ(globalPromiseValue, 2);
+
+  napi_value node_promise2;
+  napi_deferred node_deferred2;
+  CHECK_EQ(napi_create_promise(env, &node_deferred2, &node_promise2), napi_ok);
+
+  bool is_promise2;
+  CHECK_EQ(napi_is_promise(env, node_promise2, &is_promise2), napi_ok);
+  EXPECT_TRUE(is_promise2);
+
+  napi_value node_resolution2;
+  CHECK_EQ(napi_create_int32(env, -1, &node_resolution2), napi_ok);
+  CHECK_EQ(napi_reject_deferred(env, node_deferred2, node_resolution2), napi_ok);
+
+   
+  CHECK_EQ(napi_promise_then(
+               env,
+               node_promise2,
+               [](napi_env env, napi_callback_info info) -> napi_value {
+                 globalPromiseValue++;
+                 return nullptr;
+               },
+               [](napi_env env, napi_callback_info info) -> napi_value {
+                 globalPromiseValue += 2;
+                 size_t argc = 1;
+                 napi_value argv[1];
+                 CHECK_EQ(
+                     napi_get_cb_info(env, info, &argc, argv, nullptr, nullptr),
+                     napi_ok);
+
+                 int result;
+                 CHECK_EQ(napi_get_value_int32(env, argv[0], &result), napi_ok);
+                 EXPECT_TRUE(result == -1);
+                 return argv[0];
+               }),
+           napi_ok);
+
+  EXPECT_EQ(globalPromiseValue, 2);
+  // perform Microtask
+  isolate_->PerformMicrotaskCheckpoint();
+  EXPECT_EQ(globalPromiseValue, 4);
+
+  CHECK_EQ(napi_promise_catch(
+               env,
+               node_promise2,
+               [](napi_env env, napi_callback_info info) -> napi_value {
+                 globalPromiseValue += 2;
+
+                 size_t argc = 1;
+                 napi_value argv[1];
+                 CHECK_EQ(
+                     napi_get_cb_info(env, info, &argc, argv, nullptr, nullptr),
+                     napi_ok);
+
+                 int result;
+                 CHECK_EQ(napi_get_value_int32(env, argv[0], &result), napi_ok);
+                 EXPECT_TRUE(result == -1);
+
+                 return nullptr;
+               }),
+           napi_ok);
+
+  EXPECT_EQ(globalPromiseValue, 4);
+  // perform Microtask
+  isolate_->PerformMicrotaskCheckpoint();
+  EXPECT_EQ(globalPromiseValue, 6);
 }


### PR DESCRIPTION

Added the then callback processing of napi's promise. This way we can use promise callback processing in the native layer.

**I have a doubt. There is no connection between the place where I changed and the place where the test-linux error is reported.**