### PR TITLE
doc: remove outdated step in onboarding exercise

### DIFF
--- a/onboarding.md
+++ b/onboarding.md
@@ -204,12 +204,12 @@ needs to be pointed out separately during the onboarding.
   so that when the commit lands, the nomination issue url will be
   automatically closed.
 * Label your pull request with the `doc`, `notable-change`, and `fast-track`
-  labels.
+  labels. The `fast-track` label should cause the Node.js GitHub bot to post a
+  comment in the pull request asking collaborators to approve the pull request
+  by leaving a 👍 reaction on the comment.
 * Run CI on the pull request. Use the `node-test-pull-request` CI task.
 * After two Collaborator approvals for the change and two Collaborator approvals
-  for fast-tracking, land the pull request.
-* Leave a comment in the pull request:
-  `Please 👍 this comment to approve fast-tracking`.
+  for fast-tracking, land the PR.
 * If there are not enough approvals within a reasonable time, consider the
   single approval of the onboarding TSC member sufficient, and land the pull
   request.


### PR DESCRIPTION
The GitHub bot will leave a comment asking people to thumbs-up a fast
track request so there is no need to manually leave such a comment.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
