### PR TITLE
child_process: add example for execFileSync method and ref to stdio

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -921,7 +921,8 @@ changes:
   * `input` {string|Buffer|TypedArray|DataView} The value which will be passed
     as stdin to the spawned process. If `stdio[0]` is set to `'pipe'`, Supplying
     this value will override `stdio[0]`.
-  * `stdio` {string|Array} Child's stdio configuration. `stderr` by default will
+  * `stdio` {string|Array} Child's stdio configuration.
+    See [`child_process.spawn()`][]'s [`stdio`][]. `stderr` by default will
     be output to the parent process' stderr unless `stdio` is specified.
     **Default:** `'pipe'`.
   * `env` {Object} Environment key-value pairs. **Default:** `process.env`.
@@ -962,6 +963,34 @@ If the process times out or has a non-zero exit code, this method will throw an
 function. Any input containing shell metacharacters may be used to trigger
 arbitrary command execution.**
 
+```js
+const { execFileSync } = require('node:child_process');
+
+try {
+  const stdout = execFileSync('my-script.sh', ['my-arg'], {
+    // Capture stdout and stderr from child process. Overrides the
+    // default behavior of streaming child stderr to the parent stderr
+    stdio: 'pipe',
+
+    // Use utf8 encoding for stdio pipes
+    encoding: 'utf8',
+  });
+
+  console.log(stdout);
+} catch (err) {
+  if (err.code) {
+    // Spawning child process failed
+    console.error(err.code);
+  } else {
+    // Child was spawned but exited with non-zero exit code
+    // Error contains any stdout and stderr from the child
+    const { stdout, stderr } = err;
+
+    console.error({ stdout, stderr });
+  }
+}
+```
+
 ### `child_process.execSync(command[, options])`
 
 <!-- YAML
@@ -991,7 +1020,8 @@ changes:
   * `input` {string|Buffer|TypedArray|DataView} The value which will be passed
     as stdin to the spawned process. If `stdio[0]` is set to `'pipe'`, Supplying
     this value will override `stdio[0]`.
-  * `stdio` {string|Array} Child's stdio configuration. `stderr` by default will
+  * `stdio` {string|Array} Child's stdio configuration.
+    See [`child_process.spawn()`][]'s [`stdio`][]. `stderr` by default will
     be output to the parent process' stderr unless `stdio` is specified.
     **Default:** `'pipe'`.
   * `env` {Object} Environment key-value pairs. **Default:** `process.env`.
@@ -1069,7 +1099,8 @@ changes:
     this value will override `stdio[0]`.
   * `argv0` {string} Explicitly set the value of `argv[0]` sent to the child
     process. This will be set to `command` if not specified.
-  * `stdio` {string|Array} Child's stdio configuration. **Default:** `'pipe'`.
+  * `stdio` {string|Array} Child's stdio configuration.
+    See [`child_process.spawn()`][]'s [`stdio`][]. **Default:** `'pipe'`.
   * `env` {Object} Environment key-value pairs. **Default:** `process.env`.
   * `uid` {number} Sets the user identity of the process (see setuid(2)).
   * `gid` {number} Sets the group identity of the process (see setgid(2)).


### PR DESCRIPTION
Added an example to the execFileSync method. This demonstrates how to
handle exceptions and access the stderr and stdio properties that are
attached to the Error object in a catch block.

Added a link to the detailed stdio section nested under
child_process.spawn() from each child_process sync method option
description.

Fixes: https://github.com/nodejs/node/issues/39306

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
