### PR TITLE
http2: fix double free due to handling of rst_stream with cancel code

### DIFF
--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -2196,14 +2196,23 @@ void Http2Stream::SubmitRstStream(const uint32_t code) {
   CHECK(!this->is_destroyed());
   code_ = code;
 
-  // If RST_STREAM is submitted with the cancel code, don't force purge the
-  // currently sending data. Instead add it to the pending stream list to
-  // avoid prioritizing over other operations.
+  // If RST_STREAM frame is received and stream is not writable
+  // because it is busy reading data, don't try force purging it.
+  // Instead add the stream to pending stream list and process
+  // the pending data when it is safe to do so. This is to avoid
+  // double free error due to unwanted behavior of nghttp2.
   // Ref:https://github.com/nodejs/node/issues/38964
-  if (code_ == NGHTTP2_CANCEL) {
+
+  // Add stream to the pending list if it is received with scope
+  // below in the stack. The pending list may not get processed
+  // if RST_STREAM received is not in scope and added to the list
+  // causing endpoint to hang.
+  if (session_->is_in_scope() &&
+      !is_writable() && is_reading()) {
     session_->AddPendingRstStream(id_);
     return;
   }
+
 
   // If possible, force a purge of any currently pending data here to make sure
   // it is sent before closing the stream. If it returns non-zero then we need


### PR DESCRIPTION
The PR changes add the stream to the pending list on receiving 
`RST_STREAM` frame with error code `nghttp2_cancel`. This is to
 avoid the force purging of data on receiving the rst_stream frame.

On force purging, the `nghttp2` raises close callback for already 
destroyed stream which is causing the double-free memory error.

Fixes: #38964  