### PR TITLE
tools: make internal link checker more robust

### DIFF
--- a/tools/doc/allhtml.mjs
+++ b/tools/doc/allhtml.mjs
@@ -76,13 +76,13 @@ fs.writeFileSync(new URL('./all.html', source), all, 'utf8');
 
 // Validate all hrefs have a target.
 const ids = new Set();
-const idRe = / id="(\w+)"/g;
+const idRe = / id="([^"]+)"/g;
 let match;
 while (match = idRe.exec(all)) {
   ids.add(match[1]);
 }
 
-const hrefRe = / href="#(\w+)"/g;
+const hrefRe = / href="#([^"]+)"/g;
 while (match = hrefRe.exec(all)) {
   if (!ids.has(match[1])) throw new Error(`link not found: ${match[1]}`);
 }


### PR DESCRIPTION
The internal link checker was missing some broken links because it was
being too restrictive about the characters it accepted as part of a link
hash. Accept anything that isn't a terminating quotation mark.

Refs: https://github.com/nodejs/node/pull/39426
Refs: https://github.com/nodejs/node/pull/39425

This is blocked on the above two PRs as they fix broken links this improved check will find.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
