### PR TITLE
tools,doc: fix email matching to be case-insensitive, simplify .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,50 +1,50 @@
 Aaron Bieber <aaron@bolddaemon.com> <deftly@gmail.com>
 Aaron Heckmann <aaron.heckmann@gmail.com> <aaron.heckmann+github@gmail.com>
-Aayush Ahuja <aayush.a@directi.com> aayush.a <aayush.a@directi.com>
+Aayush Ahuja <aayush.a@directi.com>
 Abe Fettig <abefettig@gmail.com> <abe@fettig.net>
 Abhimanyu Vashisht <abhimanyuvashisht.av@gmail.com>
 Akito Ito <akito0107@gmail.com> <akito_ito@r.recruit.co.jp>
 Alejandro Estrada <estrada9166@gmail.com>
 Alejandro Estrada <estrada9166@gmail.com> <estrada9166@hotmail.com>
-Alejandro Oviedo Garcia <alejandro.oviedo.g@gmail.com> Alejandro Oviedo <alejandro.oviedo.g@gmail.com>
-Alex Gilbert <alex@punkave.com> agilbert <alex@punkave.com>
+Alejandro Oviedo Garcia <alejandro.oviedo.g@gmail.com>
+Alex Gilbert <alex@punkave.com>
 Alex Hultman <alexhultman@gmail.com> <alexhultman@localhost.localdomain>
-Alex Jordan <alex@strugee.net> AJ Jordan <alex@strugee.net>
+Alex Jordan <alex@strugee.net>
 Alex Kocharin <rlidwka@kocharin.ru>
 Alex Kocharin <rlidwka@kocharin.ru> <alex@kocharin.ru>
-Alexander Marchenko <axvmindaweb@gmail.com> axvm <axvmindaweb@gmail.com>
+Alexander Marchenko <axvmindaweb@gmail.com>
 Alexey Kupershtokh <alexey.kupershtokh@gmail.com> <wicked@alawar.com>
 Alexis Campailla <alexis@janeasystems.com> <orangemocha@github.com>
 Alexis Sellier <self@cloudhead.net>
 Alexis Sellier <self@cloudhead.net> <alexis@cloudhead.io>
-Alfred Cepeda <AlfredJCepeda@gmail.com> ALJCepeda <AlfredJCepeda@gmail.com>
+Alfred Cepeda <AlfredJCepeda@gmail.com>
 Allen Yonghuang Wang <helloshuangzi@gmail.com>
-Amery <amery@xiangfa.org> 子丶言 <amery@xiangfa.org>
+Amery <amery@xiangfa.org>
 Amit Bendor <ajbendor@gmail.com>
 Anatoli Papirovski <apapirovski@mac.com> <anatoli.papirovski@postmates.com>
-Andreas Offenhaeuser <offenhaeuser@gmail.com> anoff <offenhaeuser@gmail.com>
+Andreas Offenhaeuser <offenhaeuser@gmail.com>
 Andrew Hughes <Andrew.Hughes1@ibm.com> <andrew.hughes.101@outlook.com>
 Andy Bettisworth <andy.bettisworth@accreu.com>
-Angel Stoyanov <atstojanov@gmail.com> atstojanov <atstojanov@gmail.com>
+Angel Stoyanov <atstojanov@gmail.com>
 Anna Henningsen <anna@addaleax.net> <sqrt@entless.org>
 Anna Henningsen <anna@addaleax.net> <github@addaleax.net>
 Anna Magdalena Kedzierska <anna.mag.kedzierska@gmail.com> AnnaMag <AnnaMag@users.noreply.github.com>
-Antoine Amara <amara.antoine@gmail.com> Antoine AMARA <amara.antoine@gmail.com>
+Antoine Amara <amara.antoine@gmail.com>
 Aria Stewart <aredridel@dinhe.net> <aredridel@nbtsc.org>
 Arlo Breault <arlolra@gmail.com>
-Arnaud Lefebvre <a.lefebvre@outlook.fr> BlackYoup <a.lefebvre@outlook.fr>
+Arnaud Lefebvre <a.lefebvre@outlook.fr>
 Artem Zaytsev <a.arepo@gmail.com>
-Artur G Vieira <vieira.artur.g@gmail.com> Artur Vieira <vieira.artur.g@gmail.com>
+Artur G Vieira <vieira.artur.g@gmail.com>
 Arnout Kazemier <info@3rd-Eden.com> <3rd-Eden@users.noreply.github.com>
-Asaf David <asafdav2@gmail.com> asafdav2 <asafdav2@gmail.com>
+Asaf David <asafdav2@gmail.com>
 Ash Cripps <acripps@redhat.com> <ashley.cripps@ibm.com>
 Ash Cripps <acripps@redhat.com> <email@ashleycripps.co.uk>
 Ash Cripps <acripps@redhat.com> <Ashley.Cripps@ibm.com>
-Ashley Maceli <ashley.maceli@gmail.com> ashleyraymaceli <ashley.maceli@gmail.com>
+Ashley Maceli <ashley.maceli@gmail.com>
 Ashok Suthar <coderatlabs@gmail.com>
 Ashutosh Kumar Singh <singhjug1994@gmail.com>
 Atsuo Fukaya <fukayatsu@gmail.com>
-Ben Lugavere <b.lugavere@gmail.com> blugavere <b.lugavere@gmail.com>
+Ben Lugavere <b.lugavere@gmail.com>
 Ben Noordhuis <info@bnoordhuis.nl> <bnoordhuis@bender.(none)>
 Ben Noordhuis <info@bnoordhuis.nl> <ben@strongloop.com>
 Ben Taber <ben.taber@gmail.com>
@@ -61,29 +61,29 @@ Bert Belder <bertbelder@gmail.com> <piscisaureus@Berts-MacBook-Pro.local>
 Beth Griggs <bgriggs@redhat.com> <Bethany.Griggs@uk.ibm.com>
 Bidisha Pyne <pyne.bidisha2017@gmail.com> <bidipyne@in.ibm.com>
 bl-ue <bl-ue@users.noreply.github.com> bl-ue <54780737+bl-ue@users.noreply.github.com>
-Brad Decker <bhdecker84@gmail.com> brad-decker <bhdecker84@gmail.com>
-Brad Larson <brad@waterfallmedia.net> BradLarson <brad@waterfallmedia.net>
-Bradley Meck <bradley.meck@gmail.com> Bradley Farias <bradley.meck@gmail.com>
+Brad Decker <bhdecker84@gmail.com>
+Brad Larson <brad@waterfallmedia.net>
+Bradley Meck <bradley.meck@gmail.com>
 Brandon Benvie <brandon@bbenvie.com> <brandon@brandonbenvie.com>
 Brandon Kobel <kobelb@gmail.com> kobelb <brandon.kobel@elastic.co>
 Brendan Ashworth <brendan.ashworth@me.com> <squirrelslikeacorns@gmail.com>
-Brent Pendergraft <bpent3l@gmail.com> penDerGraft <bpent3l@gmail.com>
+Brent Pendergraft <bpent3l@gmail.com>
 Brian White <mscdex@mscdex.net>
 Brian White <mscdex@mscdex.net> <mscdex@gmail.com>
 Caleb Boyd <caleb.boyd@gmail.com>
 Calvin Metcalf <calvin.metcalf@gmail.com> <calvin.metcalf@state.ma.us>
 Calvin Metcalf <calvin.metcalf@gmail.com> <cmetcalf@appgeo.com>
-Caralyn Reisle <caralynreisle@gmail.com> creisle <caralynreisle@gmail.com>
+Caralyn Reisle <caralynreisle@gmail.com>
 Charles <ineedpracticing@gmail.com> <cydjudge@users.noreply.github.com>
 Charles Rudolph <charles.rudolph@originate.com>
 Chen Gang <gangc.cxy@foxmail.com>
 Chew Choon Keat <choonkeat@gmail.com>
-Chris Andrews <cpandrews8@gmail.com> cpandrews8 <cpandrews8@gmail.com>
+Chris Andrews <cpandrews8@gmail.com>
 Chris Johnson <chris.s.johnson4@gmail.com>
 Chris Young <chris.young@tinder.com> <chris.young@gotinder.com>
 Christian Clauss <cclauss@me.com>
 Christian Clauss <cclauss@me.com> <cclauss@bluewin.ch>
-Christophe Naud-Dulude <christophe.naud.dulude@gmail.com> Chris911 <christophe.naud.dulude@gmail.com>
+Christophe Naud-Dulude <christophe.naud.dulude@gmail.com>
 Christopher Lenz <cmlenz@gmail.com> <chris@lamech.local>
 Claudio Rodriguez <cjrodr@yahoo.com> <cr@fansworld.tv>
 Colin Ihrig <cjihrig@gmail.com>
@@ -91,28 +91,28 @@ Corey Martin <coreymartin496@gmail.com>
 Damien Simonin Feugas <damien.feugas@gmail.com>
 Dan Kaplun <dbkaplun@gmail.com> <dan@beardtree.com>
 Dan Williams <dan@igniter.com> Dan.Williams <daniel@chat.za.net>
-Daniel Abrão <danielpaladar@gmail.com> Daniel Abrão <danielpaladar@gmail.com>
-Daniel Bevenius <daniel.bevenius@gmail.com> daniel.bevenius <daniel.bevenius@gmail.com>
+Daniel Abrão <danielpaladar@gmail.com>
+Daniel Bevenius <daniel.bevenius@gmail.com>
 Daniel Berger <code+node@dpbis.net>
 Daniel Chcouri <333222@gmail.com>
 Daniel Gröber <darklord@darkboxed.org>
 Daniel Gröber <darklord@darkboxed.org> <dxld@darkboxed.org>
-Daniel Paulino <d_paulino@outlook.com> dpaulino <d_paulino@outlook.com>
+Daniel Paulino <d_paulino@outlook.com>
 Daniel Pihlström <sciolist.se@gmail.com>
 Daniel Wang <wangyang0123@gmail.com> firedfox <wangyang02@baidu.com>
-Daniel Wang <wangyang0123@gmail.com> firedfox <wangyang0123@gmail.com>
+Daniel Wang <wangyang0123@gmail.com>
 Danielle Adams <adamzdanielle@gmail.com> Danielle Adams <danielle.adams@heroku.com>
 Danny Nemer <hi@dannynemer.com> <DannyNemer@users.noreply.github.com>
 Danny Nemer <hi@dannynemer.com> <hi@DannyNemer.com>
 Darshan Sen <raisinten@gmail.com>
 Darshan Sen <raisinten@gmail.com> <darshan.sen@postman.com>
 Dave Pacheco <dap@joyent.com> <dap@cs.brown.edu>
-David Cai <davidcai1993@yahoo.com> DavidCai <davidcai1993@yahoo.com>
+David Cai <davidcai1993@yahoo.com>
 David Mark Clements <david.clements@nearform.com>
 David Mark Clements <david.clements@nearform.com> <huperekchuno@googlemail.com>
 David Mark Clements <david.clements@nearform.com> <david.mark.clements@gmail.com>
 David Siegel <david@artcom.de> <david.siegel@artcom.de>
-DC <dcposch@dcpos.ch> dcposch@dcpos.ch <dcposch@dcpos.ch>
+DC <dcposch@dcpos.ch>
 Deepjyoti Mondal <djmdeveloper060796@gmail.com>
 Domenic Denicola <domenic@domenicdenicola.com>
 Domenic Denicola <domenic@domenicdenicola.com> <d@domenic.me>
@@ -122,22 +122,22 @@ Einar Otto Stangvik <einaros@gmail.com>
 Elliott Cable <me@ell.io>
 Eric Phetteplace <phette23@gmail.com>
 Ernesto Salazar <ernestoalbertosalazar@gmail.com>
-Erwin W. Ramadhan <erwinwahyuramadhan@gmail.com> erwinwahyura <erwinwahyuramadhan@gmail.com>
-Eugene Obrezkov <ghaiklor@gmail.com> ghaiklor <ghaiklor@gmail.com>
+Erwin W. Ramadhan <erwinwahyuramadhan@gmail.com>
+Eugene Obrezkov <ghaiklor@gmail.com>
 EungJun Yi <semtlenori@gmail.com>
 Evan Larkin <evan.larkin.il.com> <evan.larkin.iit@gmail.com>
 Evan Lucas <evanlucas@me.com> <evan@btc.com>
 Evan Lucas <evanlucas@me.com> <evan.lucas@help.com>
-FangDun Cai <cfddream@gmail.com> Fangdun Cai (Fundon) <cfddream@gmail.com>
-Fangshi He <hefangshi@gmail.com> hefangshi <hefangshi@gmail.com>
+FangDun Cai <cfddream@gmail.com>
+Fangshi He <hefangshi@gmail.com>
 Farid Neshat <FaridN_SOAD@yahoo.com>
-Fatah N <nfatah41@gmail.com> fatahn <nfatah41@gmail.com>
+Fatah N <nfatah41@gmail.com>
 Fedor Indutny <fedor@indutny.com> <fedor.indutny@gmail.com>
 Felix Böhm <felixboehm55@googlemail.com> <me@feedic.com>
 Felix Geisendörfer <felix@debuggable.com>
 Felix Geisendörfer <felix@debuggable.com>
-Flandre Scarlet <panyilinlove@qq.com> Flandre <panyilinlove@qq.com>
-Florian Margaine <florian@margaine.com> Florian MARGAINE <florian@margaine.com>
+Flandre Scarlet <panyilinlove@qq.com>
+Florian Margaine <florian@margaine.com>
 Forrest L Norvell <forrest@npmjs.com> <ogd@aoaioxxysz.net>
 Franziska Hinkelmann <franziska.hinkelmann@gmail.com> F. Hinkelmann <fhinkel@vt.edu>
 Friedemann Altrock <frodenius@gmail.com>
@@ -145,25 +145,25 @@ Fuji Goro <gfuji@cpan.org>
 Gabriel de Perthuis <g2p.code@gmail.com>
 Gareth Ellis <gareth.ellis@uk.ibm.com> <gareth@gsellis.com>
 Garwah Lam <garwahlam@gmail.com>
-Geoffrey Bugaisky <gbugaisk@gmail.com> gbugaisky <gbugaisk@gmail.com>
+Geoffrey Bugaisky <gbugaisk@gmail.com>
 Gerhard Stoebich <deb2001-github@yahoo.de>
 Gibson Fahnestock <gibfahn@gmail.com> <gib@uk.ibm.com>
 Gil Pedersen <git@gpost.dk> <github@gpost.dk>
 Graham Fairweather <xotic750@gmail.com> Xotic750 <xotic750@gmail>
 Greg Sabia Tucker <greg@narrowlabs.com> <greg@tucke.rs>
-Gregor Martynus <gregor@martynus.net> Gregor <gregor@martynus.net>
-Guy Bedford <guybedford@gmail.com> guybedford <guybedford@gmail.com>
-Halil İbrahim Şener <hisener@yahoo.com> hisener <hisener@yahoo.com>
-Hannah Kim <h.heeeun.kim@gmail.com> heeeunkimmm <h.heeeun.kim@gmail.com>
+Gregor Martynus <gregor@martynus.net>
+Guy Bedford <guybedford@gmail.com>
+Halil İbrahim Şener <hisener@yahoo.com>
+Hannah Kim <h.heeeun.kim@gmail.com>
 Hannes Magnusson <hannes.magnusson@gmail.com> <hannes.magnusson@creditkarma.com>
-Hendrik Schwalm <mail@hendrikschwalm.de> hschwalm <mail@hendrikschwalm.de>
+Hendrik Schwalm <mail@hendrikschwalm.de>
 Hitesh Kanwathirtha <hiteshk@microsoft.com> <digitalinfinity@gmail.com>
 Henry Chin <hheennrryy@gmail.com>
 Herbert Vojčík <herby@mailbox.sk>
 himself65 <himself65@mask.io> <himself6565@gmail.com>
 himself65 <himself65@mask.io> <himself65@outlook.com>
 Icer Liang <liangshuangde@163.com> <wizicer@users.noreply.github.com>
-Igor Savin <iselwin@gmail.com> kibertoad <iselwin@gmail.com>
+Igor Savin <iselwin@gmail.com>
 Igor Soarez <igorsoarez@gmail.com>
 Igor Zinkovsky <igorzi@microsoft.com>
 Imran Iqbal <imran@imraniqbal.org> <imrani@ca.ibm.com>
@@ -171,52 +171,52 @@ Ionică Bizău <bizauionica@gmail.com> <bizauionica@yahoo.com>
 Isaac Z. Schlueter <i@izs.me>
 Isaac Z. Schlueter <i@izs.me> <i@foohack.com>
 Isaac Z. Schlueter <i@izs.me> isaacs <nope@not.real>
-Isuru Siriwardana <isuruanatomy@gmail.com> isurusiri <isuruanatomy@gmail.com>
+Isuru Siriwardana <isuruanatomy@gmail.com>
 Italo A. Casas <me@italoacasas.com> <italo@italoacasas.com>
 Jackson Tian <shyvo1987@gmail.com> <puling.tyq@alibaba-inc.com>
 Jake Verbaten <raynos2@gmail.com>
 Jamen Marzonie <jamenmarz@gmail.com> Jamen Marz <jamenmarz+gh@gmail.com>
-James Beavers <jamesjbeavers@gmail.com> Druotic <jamesjbeavers@gmail.com>
+James Beavers <jamesjbeavers@gmail.com>
 James Hartig <fastest963@gmail.com> <james.hartig@grooveshark.com>
 James M Snell <jasnell@gmail.com>
-James Nimlos <james@nimlos.com> JamesNimlos <james@nimlos.com>
+James Nimlos <james@nimlos.com>
 Jan Krems <jan.krems@gmail.com> <jan.krems@groupon.com>
 Jenna Vuong <jennavuong@gmail.com> <hello@jennavuong.com>
-JeongHoon Byun <outsideris@gmail.com> Outsider <outsideris@gmail.com>
+JeongHoon Byun <outsideris@gmail.com>
 Jered Schmidt <tr@nslator.jp>
 Jeremiah Senkpiel <fishrock123@rocketmail.com>
 Jerry Chin <qinjia@outlook.com>
-Jessica Quynh Tran <jessica.quynh.tran@gmail.com> jessicaquynh <jessica.quynh.tran@gmail.com>
-Jesús Leganés-Combarro 'piranna <piranna@gmail.com> Jesús Leganés Combarro "piranna <piranna@gmail.com>
+Jessica Quynh Tran <jessica.quynh.tran@gmail.com>
+Jesús Leganés-Combarro 'piranna <piranna@gmail.com>
 Joe Shaw <joe@joeshaw.org> <joeshaw@litl.com>
 Johan Bergström <bugs@bergstroem.nu>
 Johan Dahlberg <jfd@distrop.com> <dahlberg.johan@gmail.com>
 Johann Hofmann <git@johann-hofmann.com>
 John Barboza <jbarboza@ca.ibm.com> jBarz <jBarz@users.noreply.github.com>
-John Barboza <jbarboza@ca.ibm.com> jBarz <jbarboza@ca.ibm.com>
-John Gardner <gardnerjohng@gmail.com> Alhadis <gardnerjohng@gmail.com>
-John McGuirk <johnmac81@gmail.com> jmcgui05 <johnmac81@gmail.com>
-John Musgrave <musgravejw@gmail.com> musgravejw <musgravejw@gmail.com>
+John Barboza <jbarboza@ca.ibm.com>
+John Gardner <gardnerjohng@gmail.com>
+John McGuirk <johnmac81@gmail.com>
+John Musgrave <musgravejw@gmail.com>
 Johnny Ray Austin <johnny@johnnyray.me> Johnny Ray <http://johnnyray.me>
-Jon Tippens <jwtippens@gmail.com> legalcodes <jwtippens@gmail.com>
+Jon Tippens <jwtippens@gmail.com>
 Jonas Pfenniger <jonas@pfenniger.name> <jonas@stvs.ch>
-Jonathan Gourlay <gourlayjd@linux.com> mrgorbo <gourlayjd@linux.com>
+Jonathan Gourlay <gourlayjd@linux.com>
 Jonathan Ong <jonathanrichardong@gmail.com> <jonathanong@users.noreply.github.com>
 Jonathan Persson <persson.jonathan@gmail.com> <jonathan.persson@creuna.se>
 Jonathan Rentzsch <jwr.git@redshed.net>
 Joseph Leon <joseph.leon.9@gmail.com>
-Jose Luis Vivero <josluivivgar@gmail.com> jlvivero <josluivivgar@gmail.com>
+Jose Luis Vivero <josluivivgar@gmail.com>
 Josh Erickson <josh@snoj.us>
-Josh Hunter <jopann@gmail.com> jopann <jopann@gmail.com>
+Josh Hunter <jopann@gmail.com>
 Joshua S. Weinstein <josher19@users.sf.net>
-Joyee Cheung <joyeec9h3@gmail.com> joyeecheung <joyeec9h3@gmail.com>
+Joyee Cheung <joyeec9h3@gmail.com>
 Joyee Cheung <joyeec9h3@gmail.com> Joyee Cheung <joyee@igalia.com>
 Juan Soto <juan@juansoto.me>
-Julien Klepatch <julien@julienklepatch.com> jklepatch <julien@julienklepatch.com>
-Julien Waechter <julien.waechter@gmail.com> julien.waechter <julien.waechter@gmail.com>
+Julien Klepatch <julien@julienklepatch.com>
+Julien Waechter <julien.waechter@gmail.com>
 Junliang Yan <john.yan1019@gmail.com>
 Junliang Yan <jyan@ca.ibm.com> <jyan@ca.ibm.ca>
-Junshu Okamoto <o_askgulf@icloud.com> jun-oka <o_askgulf@icloud.com>
+Junshu Okamoto <o_askgulf@icloud.com>
 Justin Beckwith <beckwith@google.com> <justin.beckwith@gmail.com>
 Justin Lee <justinlee0022@gmail.com> <justin.lee@ubc.ca>
 Jérémy Lal <kapouer@melix.org>
@@ -225,16 +225,16 @@ Juan Sebastian Velez Posada <sebasvelez@gmail.com>
 Kai Sasaki Lewuathe <sasaki_kai@lewuathe.sakura.ne.jp>
 Karl Skomski <karl@skomski.com> <mail@skomski.com>
 Kat Marchán <kzm@zkat.tech> <kzm@sykosomatic.org>
-Kathy Truong <kathy.yvy.truong@gmail.com> k3kathy <kathy.yvy.truong@gmail.com>
+Kathy Truong <kathy.yvy.truong@gmail.com>
 Kazuyuki Yamada <tasogare.pg@gmail.com>
 Keith M Wesolowski <wesolows@joyent.com> <wesolows@foobazco.org>
 Kelsey Breseman <ifoundthemeaningoflife@gmail.com>
 Ke Ding <dingkework@hotmail.com>
-Khaidi Chu <admin@xcoder.in> XadillaX <admin@xcoder.in>
+Khaidi Chu <admin@xcoder.in>
 Khaidi Chu <admin@xcoder.in> <i@2333.moe>
 Kimberly Wilber <gcr@sneakygcr.net>
 Kimberly Wilber <gcr@sneakygcr.net> <gcr@users.noreply.github.com>
-Kiyoshi Nomo <tokyoincidents.g@gmail.com> kysnm <tokyoincidents.g@gmail.com>
+Kiyoshi Nomo <tokyoincidents.g@gmail.com>
 Koichi Kobayashi <koichik@improvement.jp>
 Kostiantyn Wandalen <wandalen.me@gmail.com>
 Kris Kowal <kris.kowal@cixar.com>
@@ -242,46 +242,46 @@ Kyle Robinson Young <kyle@dontkry.com>
 Lakshmi Swetha Gopireddy <lakshmiswethagopireddy@gmail.com> LAKSHMI SWETHA GOPIREDDY <lgopired@in.ibm.com>
 Leeseean Chiu <leeseean@qq.com>
 Luke Bayes <lbayes@patternpark.com>
-Lydia Kats <llkats@gmail.com> Lydia Katsamberis <llkats@gmail.com>
+Lydia Kats <llkats@gmail.com>
 Maciej Małecki <maciej.malecki@notimplemented.org> <me@mmalecki.com>
 MaleDong <maledong_github@outlook.com> <maledong_private@qq.com>
 Malte-Thorben Bruns <skenqbx@gmail.com> <skenqbx@googlemail.com>
-Malte-Thorben Bruns <skenqbx@gmail.com> skenqbx <skenqbx@gmail.com>
+Malte-Thorben Bruns <skenqbx@gmail.com>
 Mandeep Singh <mandeep25894@gmail.com> <mandeep.singh@zomato.com>
-Manil Chowdhurian <manil.chowdhury@gmail.com> Chowdhurian <manil.chowdhury@gmail.com>
-Marcelo Gobelli <marcelo.gobelli@gmail.com> decareano <marcelo.gobelli@gmail.com>
+Manil Chowdhurian <manil.chowdhury@gmail.com>
+Marcelo Gobelli <marcelo.gobelli@gmail.com>
 Marcin Cieślak <saper@marcincieslak.com>
 Marcin Cieślak <saper@marcincieslak.com> <saper@saper.info>
-Marcin Zielinski <marzelin@gmail.com> marzelin <marzelin@gmail.com>
+Marcin Zielinski <marzelin@gmail.com>
 Marti Martz <thalamew@q.com>
 Martial James Jefferson <martial.jefferson@gmail.com>
-Martijn Schrage <martijn@oblomov.com> Oblosys <martijn@oblomov.com>
+Martijn Schrage <martijn@oblomov.com>
 Masato Ohba <over.rye@gmail.com>
 Mary Marchini <oss@mmarchini.me> <matheusdot@gmail.com>
 Mary Marchini <oss@mmarchini.me> <matheus@sthima.com.br>
 Mary Marchini <oss@mmarchini.me> <matheus@sthima.com>
 Mary Marchini <oss@mmarchini.me> <mmarchini@netflix.com>
 Mary Marchini <oss@mmarchini.me> <mat@mmarchini.me>
-Matt Lang <matt@mediasuite.co.nz> matt-in-a-hat <matt@mediasuite.co.nz>
-Matt Reed <matthewreed26@gmail.com> matthewreed26 <matthewreed26@gmail.com>
+Matt Lang <matt@mediasuite.co.nz>
+Matt Reed <matthewreed26@gmail.com>
 Matteo Collina <matteo.collina@gmail.com> <hello@matteocollina.com>
 Matthias Bastian <dev@matthias-bastian.de> piepmatz <piepmatz@users.noreply.github.com>
 Mathias Buus <mathiasbuus@gmail.com> <m@ge.tt>
 Mathias Pettersson <mape@mape.me>
 Matthew Lye <muddletoes@hotmail.com>
 Matthew Turner <matty_t47@hotmail.com> <ramesius@users.noreply.github.com>
-Maurice Hayward <mauricehayward1@gmail.com> maurice_hayward <mauricehayward1@gmail.com>
+Maurice Hayward <mauricehayward1@gmail.com>
 Michael Bernstein <michaelrbernstein@gmail.com>
 Michael Dawson <michael_dawson@ca.ibm.com> <mdawson@devrus.com>
 Michaël Zasso <targos@protonmail.com> <mic.besace@gmail.com>
-Michael-Rainabba Richardson <rainabba@gmail.com> rainabba <rainabba@gmail.com>
+Michael-Rainabba Richardson <rainabba@gmail.com>
 Michał Gołębiowski-Owczarek <m.goleb@gmail.com>
 Micheil Smith <micheil@brandedcode.com> <micheil@yettobebranded.net>
 Micleusanu Nicu <micnic90@gmail.com>
-Miguel Angel Asencio Hurtado <maasencioh@gmail.com> maasencioh <maasencioh@gmail.com>
+Miguel Angel Asencio Hurtado <maasencioh@gmail.com>
 Mikael Bourges-Sevenier <mikeseven@gmail.com> <msevenier@motorola.com>
 Mike Kaufman <mike.kaufman@microsoft.com> <mkaufman@microsoft.com>
-Minqi Pan <pmq2001@gmail.com> P.S.V.R <pmq2001@gmail.com>
+Minqi Pan <pmq2001@gmail.com>
 Minuk Park <parkm86@gmail.com>
 Minwoo Jung <nodecorelab@gmail.com> <jmwsoft@gmail.com>
 Minwoo Jung <nodecorelab@gmail.com> <minwoo@nodesource.com>
@@ -292,52 +292,50 @@ Myles Borins <mylesborins@github.com> <mylesborins@google.com>
 Myles Borins <mylesborins@github.com> <myles.borins@gmail.com>
 Nam Nguyen <nam.nguyen@de.ibm.com>
 Nebu Pookins <nebu@nebupookins.net>
-Netto Farah <nettofarah@gmail.com> nettofarah <nettofarah@gmail.com>
+Netto Farah <nettofarah@gmail.com>
 Nicholas Kinsey <pyrotechnick@feistystudios.com>
 Nick Soggin <nicksoggin@gmail.com> <iSkore@users.noreply.github.com>
 Nikolai Vavilov <vvnicholas@gmail.com>
 Nils Kuhnhenn <lain@volafile.io>
 Nitzan Uziely <linkgoron@gmail.com> Nitzan Uziely <nitzan@testim.io>
-Noah Rose Ledesma <noahroseledesma@seattleacademy.org> Noah Rose <noahroseledesma@seattleacademy.org>
-Noah Rose Ledesma <noahroseledesma@seattleacademy.org> <NoahRoseLedesma@seattleacademy.org>
+Noah Rose Ledesma <noahroseledesma@seattleacademy.org>
 Oluwaseun Omoyajowo <omoyajowo2015@gmail.com>
 Onne Gorter <onne@onnlucky.com>
 Paul Querna <pquerna@apache.org> <paul@querna.org>
 Pedro Lima <pvsousalima@gmail.com>
-Peng Lyu <penn.lv@gmail.com> rebornix <penn.lv@gmail.com>
+Peng Lyu <penn.lv@gmail.com>
 Peter Flannery <pflannery@users.noreply.github.com>
 Peter Marton <email@martonpeter.com> <peter@risingstack.com>
-Peter Paugh <ppaugh@chariotsolutions.com> Peter <ppaugh@chariotsolutions.com>
+Peter Paugh <ppaugh@chariotsolutions.com>
 Phillip Johnsen <johphi@gmail.com> <phillip.johnsen@finn.no>
 Prateek Singh <prateeksingh1@hotmail.com> <prateek1@ucla.edu>
-Rachel White <loveless@gmail.com> rachelnicole <loveless@gmail.com>
+Rachel White <loveless@gmail.com>
 Ratikesh Misra <ratikesh92@gmail.com>
-Ravindra Barthwal <ravindrabarthwal@users.noreply.github.com> Ravindra barthwal <ravindrabarthwal@users.noreply.github.com>
+Ravindra Barthwal <ravindrabarthwal@users.noreply.github.com>
 Ray Morgan <rmorgan@zappos.com>
 Ray Solomon <raybsolomon@gmail.com>
 Raymond Feng <enjoyjava@gmail.com> <raymond@strongloop.com>
 Rebecca Turner <me@re-becca.org> <rebecca@npmjs.com>
 Refael Ackermann <refack@gmail.com> <refael@empeeric.com>
-Reza Akhavan <reza@akhavan.me> jedireza <reza@akhavan.me>
-Ricardo Sánchez Gregorio <me@richnologies.io> richnologies <me@richnologies.io>
+Reza Akhavan <reza@akhavan.me>
+Ricardo Sánchez Gregorio <me@richnologies.io>
 Richard Lau <rlau@redhat.com> <riclau@uk.ibm.com>
 Rick Olson <technoweenie@gmail.com>
 Rob Adelmann <adelmann@adobe.com> <robadelmann@gmail.com>
-Rob Adelmann <adelmann@adobe.com> adelmann <adelmann@adobe.com>
+Rob Adelmann <adelmann@adobe.com>
 Robert Nagy <ronagy@icloud.com> Robert Nagy <robertnagy@Roberts-MacBook-Pro.local>
 Rod Machen <rod.machen@help.com> <mail@rodmachen.com>
 Roman Klauke <romaaan.git@gmail.com> <romankl@users.noreply.github.com>
 Roman Reiss <me@silverwind.io>
 Ron Korving <ron@ronkorving.nl> <rkorving@wizcorp.jp>
-Ron Korving <ron@ronkorving.nl> ronkorving <ron@ronkorving.nl>
+Ron Korving <ron@ronkorving.nl>
 Ruben Bridgewater <ruben@bridgewater.de> <ruben.bridgewater@fintura.de>
 Ruben Bridgewater <ruben@bridgewater.de> <ruben.bridgewater@maibornwolff.de>
 Russell Dempsey <sgtpooki@gmail.com> <SgtPooki@gmail.com>
 Ryan Dahl <ry@tinyclouds.org>
 Ryan Emery <seebees@gmail.com>
 Ryan Mahan <ryanmahan97@gmail.com>
-Ryan Scheel <ryan.havvy@gmail.com> Ryan Scheel <Ryan.havvy@gmail.com>
-Ryan Scheel <ryan.havvy@gmail.com> Ryan Scheel (Havvy) <ryan.havvy@gmail.com>
+Ryan Scheel <ryan.havvy@gmail.com>
 Saad Quadri <saad@saadq.com> saadq <saad@saadquadri.com>
 Sagir Khan <sagir.khan@gmail.com>
 Sakthipriyan Vairamani <thechargingvolcano@gmail.com>
@@ -350,27 +348,27 @@ Samantha Sample <ssample812@gmail.com> = <=>
 Sambasiva Suda <sambasivarao@gmail.com>
 San-Tai Hsu <v@fatpipi.com>
 Santiago Gimeno <santiago.gimeno@gmail.com> <santiago.gimeno@ionide.es>
-Sarah Meyer <sarahsaltrick@gmail.com> sarahmeyer <sarahsaltrick@gmail.com>
-Sartrey Lee <sartrey@163.com> sartrey <sartrey@163.com>
+Sarah Meyer <sarahsaltrick@gmail.com>
+Sartrey Lee <sartrey@163.com>
 Saúl Ibarra Corretgé <s@saghul.net> <saghul@gmail.com>
 Shobhit Chittora <chittorashobhit@gmail.com> <schittora@paypal.com>
 Scott Blomquist <github@scott.blomqui.st> <sblom@microsoft.com>
 Segu Riluvan <rilwan22@hotmail.com> <riluvan@gmail.com>
 Sergey Kryzhanovsky <skryzhanovsky@gmail.com> <another@dhcp199-223-red.yandex.net>
 Shannen Saez <shannenlaptop@gmail.com>
-Shaopeng Zhang <szhang351@bloomberg.net> szhang351 <szhang351@bloomberg.net>
+Shaopeng Zhang <szhang351@bloomberg.net>
 Shelley Vohr <shelley.vohr@gmail.com> Shelley Vohr <codebytere@gmail.com>
 Shigeki Ohtsu <ohtsu@ohtsu.org> <ohtsu@iij.ad.jp>
 Shigeki Ohtsu <ohtsu@ohtsu.org> <ohtsu@d.jp>
 Shivang Saxena <shivangs44@gmail.com>
-Shiya Luo <luo.shiya@gmail.com> shiya <luo.shiya@gmail.com>
+Shiya Luo <luo.shiya@gmail.com>
 Siddharth Mahendraker <siddharth_mahen@hotmail.com> <siddharth_mahen@me.com>
 Simon Willison <simon@simonwillison.net>
-Siobhan O'Donovan <siobhan@justshiv.com> justshiv <siobhan@justshiv.com>
-Siyuan Gao <siyuangao@gmail.com> r1cebank <siyuangao@gmail.com>
+Siobhan O'Donovan <siobhan@justshiv.com>
+Siyuan Gao <siyuangao@gmail.com>
 solebox <solekiller@gmail.com> solebox <5013box@gmail.com>
 Sreepurna Jasti <sreepurna.jasti@gmail.com> <jsreepur@in.ibm.com>
-Sreepurna Jasti <sreepurna.jasti@gmail.com> <sreepurna.jasti@gmail.com>
+Sreepurna Jasti <sreepurna.jasti@gmail.com>
 Stanislav Opichal <opichals@gmail.com>
 Stefan Budeanu <stefan@budeanu.com> <stefanbu@ca.ibm.com>
 Stefan Bühler <stbuehler@web.de>
@@ -379,24 +377,24 @@ Stephen Belanger <admin@stephenbelanger.com> <stephen.belanger@elastic.co>
 Steve Mao <maochenyan@gmail.com> <maochenyan@msn.com>
 Steven R. Loomis <srloomis@us.ibm.com> <srl@icu-project.org>
 Stewart X Addison <sxa@redhat.com> <sxa@uk.ibm.com>
-Suraiya Hameed <hameedsuraiya@gmail.com> suraiyah <hameedsuraiya@gmail.com>
+Suraiya Hameed <hameedsuraiya@gmail.com>
 Suramya shah <shah.suramya@gmail.com> ss22ever <ss22ever@users.noreply.github.com>
 Surya Panikkal <surya.com@gmail.com>
-Taehee Kang <hugnosis@gmail.com> hugnosis <hugnosis@gmail.com>
+Taehee Kang <hugnosis@gmail.com>
 Tanuja-Sawant <f2013658@goa.bits-pilani.ac.in> <thinkbigtanu@gmail.com>
 Taylor Woll <taylor.woll@microsoft.com> taylor.woll <tawoll@ntdev.microsoft.com>
 Thomas Watson <w@tson.dk>
 Timothy O. Peters <timotewpeters@gmail.com>
-Timur Shemsedinov <timur.shemsedinov@gmail.com> tshemsedinov <timur.shemsedinov@gmail.com>
+Timur Shemsedinov <timur.shemsedinov@gmail.com>
 Ting Shao <ting.shao@intel.com>
-Toby Farley <tobyfarley@gmail.com> tobyfarley <tobyfarley@gmail.com>
+Toby Farley <tobyfarley@gmail.com>
 Toby Stableford <tobytronics@gmail.com> toboid <toboid@users.noreply.github.com>
 Todd Kennedy <todd@selfassembled.org> <toddself@users.noreply.github.com>
 TJ Holowaychuk <tj@vision-media.ca>
 TJ Holowaychuk <tj@vision-media.ca> <tjholowayhuk@gmail.com>
 Tadashi SAWADA <cesare@mayverse.jp>
 Takahiro ANDO <takahiro.ando@gmail.com>
-Tarun Batra <tarun.batra00@gmail.com> Tarun <tarun.batra00@gmail.com>
+Tarun Batra <tarun.batra00@gmail.com>
 Ted Young <ted@radicaldesigns.org>
 Teppei Sato <teppeis@gmail.com>
 Theotime Poisseau <theotime.poisseau@gmail.com>
@@ -404,31 +402,31 @@ Thomas Hunter II <me@thomashunter.name> <tom@intrinsic.com>
 Thomas Lee <thomas.lee@shinetech.com> <tom@tom-debian.sensis.com.au>
 Thomas Reggi <thomas@reggi.com>
 Tierney Cyren <hello@bnb.im> &! (bitandbang) <tieliaco@gmail.com>
-Tierney Cyren <hello@bnb.im> bitandbang <hello@bnb.im>
+Tierney Cyren <hello@bnb.im>
 Tim Caswell <tim@creationix.com> <tim@0-26-8-e9-4c-e1.dyn.utdallas.edu>
 Tim Price <timprice@mangoraft.com>
 Tim Smart <timehandgod@gmail.com> <tim@fostle.com>
-Tim Smart <timehandgod@gmail.com> <timehandgod@gmail.com>
-Timothy Leverett <zzzzBov@gmail.com> Timothy <zzzzBov@gmail.com>
+Tim Smart <timehandgod@gmail.com>
+Timothy Leverett <zzzzBov@gmail.com>
 Tobias Nießen <tniessen@tnie.de> <tniessen@users.noreply.github.com>
 Tom Atkinson <atkinson.tommy@nsoft.com> <atkinson.tommy@nhome.ba>
 Tom Atkinson <atkinson.tommy@nsoft.com> <atkinson.tommy@nsoft.ba>
 Tom Hughes <tom.hughes@palm.com> <tomtheengineer@gmail.com>
 Tom Hughes-Croucher <tom_croucher@yahoo.com>
-Tom Purcell <tpurcell@chariotsolutions.com> tpurcell <tpurcell@chariotsolutions.com>
+Tom Purcell <tpurcell@chariotsolutions.com>
 Tom White <tomtinkerer@gmail.com>
-Tomoki Okahana <umatomakun@gmail.com> umatoma <umatomakun@gmail.com>
-Tracy Hinds <tracyhinds@gmail.com> Tracy <tracyhinds@gmail.com>
+Tomoki Okahana <umatomakun@gmail.com>
+Tracy Hinds <tracyhinds@gmail.com>
 Travis Meisenheimer <travis@indexoutofbounds.com> <tmeisenh@gmail.com>
 Trevor Burnham <trevor@databraid.com> <trevorburnham@gmail.com>
 Trivikram Kamat <trivikr.dev@gmail.com> <16024985+trivikr@users.noreply.github.com>
 Tyler Larson <talltyler@gmail.com>
 Ujjwal Sharma <usharma1998@gmail.com> <ryzokuken@disroot.org>
-Viktor Karpov <viktor.s.karpov@gmail.com> vitkarpov <viktor.s.karpov@gmail.com>
+Viktor Karpov <viktor.s.karpov@gmail.com>
 Vincent Voyer <v@fasterize.com>
 Vladimir de Turckheim <vlad2t@hotmail.com>
 Voltrex <mohammadkeyvanzade94@gmail.com> Voltrex <62040526+VoltrexMaster@users.noreply.github.com>
-vsemozhetbyt <vsemozhetbyt@gmail.com> Vse Mozhet Byt <vsemozhetbyt@gmail.com>
+vsemozhetbyt <vsemozhetbyt@gmail.com>
 Wang Xinyong <wang.xy.chn@gmail.com> <wangxy.chn@gmail.com>
 Weijia Wang <381152119@qq.com>
 Weijia Wang <381152119@qq.com> <starkwang@126.com>
@@ -437,9 +435,9 @@ Wei-Wei Wu <wuxx1045@umn.edu>
 Willi Eggeling <email@wje-online.de>
 Will Hayslett <william.hayslettjr@gmail.com>
 Wilson Lin <wla80@sfu.ca>
-Wyatt Preul <wpreul@gmail.com> geek <wpreul@gmail.com>
+Wyatt Preul <wpreul@gmail.com>
 Xavier J Ortiz <xavier.ortiz.ch@gmail.com>
-xiaoyu <306766053@qq.com> Poker <306766053@qq.com>
+xiaoyu <306766053@qq.com>
 Yael Hermon <yaelherm@gmail.com> <yaelhe@wix.com>
 Yazhong Liu <yorkiefixer@gmail.com> <l900422@vip.qq.com>
 Yazhong Liu <yorkiefixer@gmail.com>
@@ -450,12 +448,12 @@ Yongsheng Zhang <zyszys98@gmail.com> <zhangyongsheng@youzan.com>
 Yoshihiro KIKUCHI <yknetg@gmail.com>
 Yosuke Furukawa <yosuke.furukawa@gmail.com> <furukawa.yosuke@dena.jp>
 Yuichiro MASUI <masui@masuidrive.jp>
-Yuta Hiroto <git@about-hiroppy.com> abouthiroppy <git@about-hiroppy.com>
+Yuta Hiroto <git@about-hiroppy.com>
 Zach Bjornson <bjornson@stanford.edu> <zbbjornson@gmail.com>
 Zachary Scott <zachary@zacharyscott.net> <zachary.s.scott@gmail.com>
 Zachary Vacura <admin@hackzzila.com>
 Zoran Tomicic <ztomicic@gmail.com>
-Сковорода Никита Андреевич <chalkerx@gmail.com> ChALkeR <chalkerx@gmail.com>
+Сковорода Никита Андреевич <chalkerx@gmail.com>
 隋鑫磊 <joshuasui@163.com>
 
 # These people didn't contribute patches to node directly,

--- a/tools/update-authors.js
+++ b/tools/update-authors.js
@@ -41,19 +41,21 @@ const mailmap = new CaseIndifferentMap();
     let match;
     // Replaced Name <original@example.com>
     if (match = line.match(/^([^<]+)\s+(<[^>]+>)$/)) {
-      mailmap.set(match[2], { author: match[1] });
+      mailmap.set(match[2].toLowerCase(), {
+        author: match[1], email: match[2]
+      });
     // <replaced@example.com> <original@example.com>
     } else if (match = line.match(/^<([^>]+)>\s+(<[^>]+>)$/)) {
-      mailmap.set(match[2], { email: match[1] });
+      mailmap.set(match[2].toLowerCase(), { email: match[1] });
     // Replaced Name <replaced@example.com> <original@example.com>
     } else if (match = line.match(/^([^<]+)\s+(<[^>]+>)\s+(<[^>]+>)$/)) {
-      mailmap.set(match[3], {
+      mailmap.set(match[3].toLowerCase(), {
         author: match[1], email: match[2]
       });
     // Replaced Name <replaced@example.com> Original Name <original@example.com>
     } else if (match =
         line.match(/^([^<]+)\s+(<[^>]+>)\s+([^<]+)\s+(<[^>]+>)$/)) {
-      mailmap.set(match[3] + '\0' + match[4], {
+      mailmap.set(match[3] + '\0' + match[4].toLowerCase(), {
         author: match[1], email: match[2]
       });
     } else {
@@ -75,8 +77,10 @@ rl.on('line', (line) => {
   if (!match) return;
 
   let { author, email } = match.groups;
+  const emailLower = email.toLowerCase();
 
-  const replacement = mailmap.get(author + '\0' + email) || mailmap.get(email);
+  const replacement =
+    mailmap.get(author + '\0' + emailLower) || mailmap.get(emailLower);
   if (replacement) {
     ({ author, email } = { author, email, ...replacement });
   }


### PR DESCRIPTION
`git` uses case-insensitive matching for email addresses in `.mailmap` but our `update-authors.js`  has been matching case-sensitive, requiring some needlessly specific entries in `.mailmap`. Change matching in the script to be case insensitive, and simplify entries in `.mailmap`.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
