### PR TITLE
[v14.x backport] lint rules for globals

### DIFF
--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -29,6 +29,8 @@ rules:
     - error
     - name: globalThis
       message: "Use `const { globalThis } = primordials;` instead of the global."
+    - name: global
+      message: "Use `const { globalThis } = primordials;` instead of `global`."
   # Custom rules in tools/eslint-rules
   node-core/lowercase-name-for-primitive: error
   node-core/non-ascii-character: error

--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -25,6 +25,10 @@ rules:
       message: "Please use `require('internal/errors').hideStackFrames()` instead."
     - selector: "AssignmentExpression:matches([left.name='prepareStackTrace'], [left.property.name='prepareStackTrace'])"
       message: "Use 'overrideStackTrace' from 'lib/internal/errors.js' instead of 'Error.prepareStackTrace'."
+  no-restricted-globals:
+    - error
+    - name: globalThis
+      message: "Use `const { globalThis } = primordials;` instead of the global."
   # Custom rules in tools/eslint-rules
   node-core/lowercase-name-for-primitive: error
   node-core/non-ascii-character: error

--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -27,10 +27,58 @@ rules:
       message: "Use 'overrideStackTrace' from 'lib/internal/errors.js' instead of 'Error.prepareStackTrace'."
   no-restricted-globals:
     - error
-    - name: globalThis
-      message: "Use `const { globalThis } = primordials;` instead of the global."
+    - name: AbortController
+      message: "Use `const { AbortController } = require('internal/abort_controller');` instead of the global."
+    - name: AbortSignal
+      message: "Use `const { AbortSignal } = require('internal/abort_controller');` instead of the global."
+      # Atomics is not available in primordials because it can be
+      # disabled with --no-harmony-atomics CLI flag.
+    - name: Atomics
+      message: "Use `const { Atomics } = globalThis;` instead of the global."
+    - name: Buffer
+      message: "Use `const { Buffer } = require('buffer');` instead of the global."
+    - name: Event
+      message: "Use `const { Event } = require('internal/event_target');` instead of the global."
+    - name: EventTarget
+      message: "Use `const { EventTarget } = require('internal/event_target');` instead of the global."
+      # Intl is not available in primordials because it can be
+      # disabled with --without-intl build flag.
+    - name: Intl
+      message: "Use `const { Intl } = globalThis;` instead of the global."
+    - name: MessageChannel
+      message: "Use `const { MessageChannel } = require('internal/worker/io');` instead of the global."
+    - name: MessageEvent
+      message: "Use `const { MessageEvent } = require('internal/worker/io');` instead of the global."
+    - name: MessagePort
+      message: "Use `const { MessagePort } = require('internal/worker/io');` instead of the global."
+      # SharedArrayBuffer is not available in primordials because it can be
+      # disabled with --no-harmony-sharedarraybuffer CLI flag.
+    - name: SharedArrayBuffer
+      message: "Use `const { SharedArrayBuffer } = globalThis;` instead of the global."
+    - name: TextDecoder
+      message: "Use `const { TextDecoder } = require('internal/encoding');` instead of the global."
+    - name: TextEncoder
+      message: "Use `const { TextEncoder } = require('internal/encoding');` instead of the global."
+    - name: URL
+      message: "Use `const { URL } = require('internal/url');` instead of the global."
+    - name: URLSearchParams
+      message: "Use `const { URLSearchParams } = require('internal/url');` instead of the global."
+      # WebAssembly is not available in primordials because it can be
+      # disabled with --jitless CLI flag.
+    - name: WebAssembly
+      message: "Use `const { WebAssembly } = globalThis;` instead of the global."
+    - name: atob
+      message: "Use `const { atob } = require('buffer');` instead of the global."
+    - name: btoa
+      message: "Use `const { btoa } = require('buffer');` instead of the global."
     - name: global
       message: "Use `const { globalThis } = primordials;` instead of `global`."
+    - name: globalThis
+      message: "Use `const { globalThis } = primordials;` instead of the global."
+    - name: performance
+      message: "Use `const { performance } = require('perf_hooks');` instead of the global."
+    - name: queueMicrotask
+      message: "Use `const { queueMicrotask } = require('internal/process/task_queues');` instead of the global."
   # Custom rules in tools/eslint-rules
   node-core/lowercase-name-for-primitive: error
   node-core/non-ascii-character: error
@@ -73,6 +121,7 @@ rules:
       into: Number
     - name: parseInt
       into: Number
+    - name: Proxy
     - name: Promise
     - name: RangeError
     - name: ReferenceError

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -43,6 +43,7 @@ let debug = require('internal/util/debuglog').debuglog(
     debug = fn;
   }
 );
+const { AbortController } = require('internal/abort_controller');
 const { Buffer } = require('buffer');
 const { Pipe, constants: PipeConstants } = internalBinding('pipe_wrap');
 

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -45,6 +45,7 @@ const {
   ObjectGetPrototypeOf,
   ObjectSetPrototypeOf,
   SymbolToStringTag,
+  globalThis,
 } = primordials;
 const config = internalBinding('config');
 const { deprecate } = require('internal/util');
@@ -119,34 +120,35 @@ if (!config.noBrowserGlobals) {
   // Override global console from the one provided by the VM
   // to the one implemented by Node.js
   // https://console.spec.whatwg.org/#console-namespace
-  exposeNamespace(global, 'console', createGlobalConsole(global.console));
+  exposeNamespace(globalThis, 'console',
+                  createGlobalConsole(globalThis.console));
 
   const { URL, URLSearchParams } = require('internal/url');
   // https://url.spec.whatwg.org/#url
-  exposeInterface(global, 'URL', URL);
+  exposeInterface(globalThis, 'URL', URL);
   // https://url.spec.whatwg.org/#urlsearchparams
-  exposeInterface(global, 'URLSearchParams', URLSearchParams);
+  exposeInterface(globalThis, 'URLSearchParams', URLSearchParams);
 
   const {
     TextEncoder, TextDecoder
   } = require('internal/encoding');
   // https://encoding.spec.whatwg.org/#textencoder
-  exposeInterface(global, 'TextEncoder', TextEncoder);
+  exposeInterface(globalThis, 'TextEncoder', TextEncoder);
   // https://encoding.spec.whatwg.org/#textdecoder
-  exposeInterface(global, 'TextDecoder', TextDecoder);
+  exposeInterface(globalThis, 'TextDecoder', TextDecoder);
 
   // https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope
   const timers = require('timers');
-  defineOperation(global, 'clearInterval', timers.clearInterval);
-  defineOperation(global, 'clearTimeout', timers.clearTimeout);
-  defineOperation(global, 'setInterval', timers.setInterval);
-  defineOperation(global, 'setTimeout', timers.setTimeout);
+  defineOperation(globalThis, 'clearInterval', timers.clearInterval);
+  defineOperation(globalThis, 'clearTimeout', timers.clearTimeout);
+  defineOperation(globalThis, 'setInterval', timers.setInterval);
+  defineOperation(globalThis, 'setTimeout', timers.setTimeout);
 
-  defineOperation(global, 'queueMicrotask', queueMicrotask);
+  defineOperation(globalThis, 'queueMicrotask', queueMicrotask);
 
   // Non-standard extensions:
-  defineOperation(global, 'clearImmediate', timers.clearImmediate);
-  defineOperation(global, 'setImmediate', timers.setImmediate);
+  defineOperation(globalThis, 'clearImmediate', timers.clearImmediate);
+  defineOperation(globalThis, 'setImmediate', timers.setImmediate);
 }
 
 // Set the per-Environment callback that will be called
@@ -280,7 +282,7 @@ function setupProcessObject() {
     value: 'process'
   });
   // Make process globally available to users by putting it on the global proxy
-  ObjectDefineProperty(global, 'process', {
+  ObjectDefineProperty(globalThis, 'process', {
     value: process,
     enumerable: false,
     writable: true,
@@ -289,7 +291,7 @@ function setupProcessObject() {
 }
 
 function setupGlobalProxy() {
-  ObjectDefineProperty(global, SymbolToStringTag, {
+  ObjectDefineProperty(globalThis, SymbolToStringTag, {
     value: 'global',
     writable: false,
     enumerable: false,
@@ -306,7 +308,7 @@ function setupBuffer() {
   delete bufferBinding.setBufferPrototype;
   delete bufferBinding.zeroFill;
 
-  ObjectDefineProperty(global, 'Buffer', {
+  ObjectDefineProperty(globalThis, 'Buffer', {
     value: Buffer,
     enumerable: false,
     writable: true,

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -7,6 +7,7 @@ const {
   SafeMap,
   SafeWeakMap,
   StringPrototypeStartsWith,
+  globalThis,
 } = primordials;
 
 const {
@@ -290,7 +291,7 @@ function initializeDeprecations() {
   // deprecation path for these in ES Modules.
   // See https://github.com/nodejs/node/pull/26334.
   let _process = process;
-  ObjectDefineProperty(global, 'process', {
+  ObjectDefineProperty(globalThis, 'process', {
     get() {
       return _process;
     },
@@ -302,7 +303,7 @@ function initializeDeprecations() {
   });
 
   let _Buffer = Buffer;
-  ObjectDefineProperty(global, 'Buffer', {
+  ObjectDefineProperty(globalThis, 'Buffer', {
     get() {
       return _Buffer;
     },
@@ -321,7 +322,7 @@ function initializeAbortController() {
       AbortController,
       AbortSignal
     } = require('internal/abort_controller');
-    ObjectDefineProperties(global, {
+    ObjectDefineProperties(globalThis, {
       AbortController: {
         writable: true,
         enumerable: false,

--- a/lib/internal/freeze_intrinsics.js
+++ b/lib/internal/freeze_intrinsics.js
@@ -19,7 +19,7 @@
 // https://github.com/google/caja/blob/HEAD/src/com/google/caja/ses/repairES5.js
 // https://github.com/tc39/proposal-ses/blob/e5271cc42a257a05dcae2fd94713ed2f46c08620/shim/src/freeze.js
 
-/* global WebAssembly, SharedArrayBuffer, console */
+/* global console */
 'use strict';
 
 const {
@@ -73,6 +73,7 @@ const {
   ObjectPrototypeHasOwnProperty,
   Promise,
   PromisePrototype,
+  Proxy,
   RangeError,
   RangeErrorPrototype,
   ReferenceError,
@@ -111,7 +112,15 @@ const {
   decodeURIComponent,
   encodeURI,
   encodeURIComponent,
+  globalThis,
 } = primordials;
+
+const {
+  Atomics,
+  Intl,
+  SharedArrayBuffer,
+  WebAssembly
+} = globalThis;
 
 module.exports = function() {
   const {

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -7,6 +7,7 @@ const {
   ObjectCreate,
   ObjectKeys,
   ObjectPrototypeHasOwnProperty,
+  Proxy,
   ReflectGetPrototypeOf,
   Symbol,
 } = primordials;

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -12,6 +12,7 @@ const {
   ObjectDefineProperty,
   ObjectPrototypeHasOwnProperty,
   Promise,
+  Proxy,
   ReflectApply,
   ReflectGet,
   ReflectGetPrototypeOf,

--- a/lib/internal/main/eval_string.js
+++ b/lib/internal/main/eval_string.js
@@ -4,6 +4,10 @@
 // `--interactive`.
 
 const {
+  globalThis,
+} = primordials;
+
+const {
   prepareMainThreadExecution
 } = require('internal/bootstrap/pre_execution');
 const { evalModule, evalScript } = require('internal/process/execution');
@@ -12,7 +16,7 @@ const { addBuiltinLibsToObject } = require('internal/modules/cjs/helpers');
 const { getOptionValue } = require('internal/options');
 
 prepareMainThreadExecution();
-addBuiltinLibsToObject(global);
+addBuiltinLibsToObject(globalThis);
 markBootstrapComplete();
 
 const source = getOptionValue('--eval');

--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -9,6 +9,7 @@ const {
   ArrayPrototypeSplice,
   ObjectDefineProperty,
   PromisePrototypeCatch,
+  globalThis: { Atomics },
 } = primordials;
 
 const {

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -44,6 +44,7 @@ const {
   ObjectPrototype,
   ObjectPrototypeHasOwnProperty,
   ObjectSetPrototypeOf,
+  Proxy,
   ReflectApply,
   ReflectSet,
   RegExpPrototypeTest,

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -9,6 +9,7 @@ const {
   RegExpPrototypeExec,
   SafeWeakMap,
   StringPrototypeStartsWith,
+  globalThis,
 } = primordials;
 
 const {

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -1,7 +1,5 @@
 'use strict';
 
-/* global WebAssembly */
-
 const {
   ArrayPrototypeMap,
   Boolean,
@@ -19,6 +17,7 @@ const {
   StringPrototypeSplit,
   StringPrototypeStartsWith,
   SyntaxErrorPrototype,
+  globalThis: { WebAssembly },
 } = primordials;
 
 let _TYPES = null;
@@ -61,6 +60,7 @@ const experimentalImportMetaResolve =
     getOptionValue('--experimental-import-meta-resolve');
 const asyncESM = require('internal/process/esm_loader');
 const { emitWarningSync } = require('internal/process/warning');
+const { TextDecoder } = require('internal/encoding');
 
 let cjsParse;
 async function initCJSParse() {

--- a/lib/internal/per_context/primordials.js
+++ b/lib/internal/per_context/primordials.js
@@ -195,6 +195,7 @@ primordials.SafeWeakSet = makeSafe(
   'Math',
   'Reflect'
 ].forEach((name) => {
+  // eslint-disable-next-line no-restricted-globals
   copyPropsRenamed(global[name], primordials, name);
 });
 
@@ -235,6 +236,7 @@ primordials.SafeWeakSet = makeSafe(
   'WeakMap',
   'WeakSet',
 ].forEach((name) => {
+  // eslint-disable-next-line no-restricted-globals
   const original = global[name];
   primordials[name] = original;
   copyPropsRenamed(original, primordials, name);
@@ -247,6 +249,7 @@ primordials.SafeWeakSet = makeSafe(
 [
   'Promise',
 ].forEach((name) => {
+  // eslint-disable-next-line no-restricted-globals
   const original = global[name];
   primordials[name] = original;
   copyPropsRenamedBound(original, primordials, name);

--- a/lib/internal/per_context/primordials.js
+++ b/lib/internal/per_context/primordials.js
@@ -171,6 +171,14 @@ primordials.SafeWeakSet = makeSafe(
   }
 );
 
+// Create copies of configurable value properties of the global object
+[
+  'globalThis',
+].forEach((name) => {
+  // eslint-disable-next-line no-restricted-globals
+  primordials[name] = globalThis[name];
+});
+
 // Create copies of URI handling functions
 [
   decodeURI,

--- a/lib/internal/per_context/primordials.js
+++ b/lib/internal/per_context/primordials.js
@@ -173,6 +173,7 @@ primordials.SafeWeakSet = makeSafe(
 
 // Create copies of configurable value properties of the global object
 [
+  'Proxy',
   'globalThis',
 ].forEach((name) => {
   // eslint-disable-next-line no-restricted-globals
@@ -193,7 +194,8 @@ primordials.SafeWeakSet = makeSafe(
 [
   'JSON',
   'Math',
-  'Reflect'
+  'Proxy',
+  'Reflect',
 ].forEach((name) => {
   // eslint-disable-next-line no-restricted-globals
   copyPropsRenamed(global[name], primordials, name);

--- a/lib/internal/process/execution.js
+++ b/lib/internal/process/execution.js
@@ -1,5 +1,9 @@
 'use strict';
 
+const {
+  globalThis,
+} = primordials;
+
 const path = require('path');
 
 const {

--- a/lib/internal/test/binding.js
+++ b/lib/internal/test/binding.js
@@ -1,5 +1,9 @@
 'use strict';
 
+const {
+  globalThis,
+} = primordials;
+
 process.emitWarning(
   'These APIs are for internal testing only. Do not use them.',
   'internal/test/binding');

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -3,6 +3,7 @@
 const {
   Array,
   ArrayIsArray,
+  ArrayPrototypeFilter,
   BigIntPrototypeValueOf,
   BooleanPrototypeValueOf,
   DatePrototypeGetTime,
@@ -41,7 +42,9 @@ const {
   ObjectSetPrototypeOf,
   ReflectApply,
   RegExp,
+  RegExpPrototypeExec,
   RegExpPrototypeToString,
+  SafeSet,
   SafeStringIterator,
   Set,
   SetPrototypeGetSize,
@@ -55,6 +58,7 @@ const {
   TypedArrayPrototypeGetLength,
   TypedArrayPrototypeGetSymbolToStringTag,
   Uint8Array,
+  globalThis,
   uncurryThis,
 } = primordials;
 
@@ -120,8 +124,11 @@ const { NativeModule } = require('internal/bootstrap/loaders');
 
 let hexSlice;
 
-const builtInObjects = new Set(
-  ObjectGetOwnPropertyNames(global).filter((e) => /^[A-Z][a-zA-Z0-9]+$/.test(e))
+const builtInObjects = new SafeSet(
+  ArrayPrototypeFilter(
+    ObjectGetOwnPropertyNames(globalThis),
+    (e) => RegExpPrototypeExec(/^[A-Z][a-zA-Z0-9]+$/, e) !== null
+  )
 );
 
 // https://tc39.es/ecma262/#sec-IsHTMLDDA-internal-slot

--- a/lib/internal/util/iterable_weak_map.js
+++ b/lib/internal/util/iterable_weak_map.js
@@ -6,6 +6,7 @@ const {
   SafeSet,
   SafeWeakMap,
   SymbolIterator,
+  globalThis,
 } = primordials;
 
 // TODO(aduh95): Add FinalizationRegistry to primordials

--- a/lib/internal/v8_prof_polyfill.js
+++ b/lib/internal/v8_prof_polyfill.js
@@ -28,7 +28,7 @@
 'use strict';
 
 /* eslint-disable node-core/prefer-primordials */
-/* global Buffer, console */
+/* global console */
 
 module.exports = { versionCheck };
 
@@ -40,6 +40,7 @@ if (module.id === 'internal/v8_prof_polyfill') return;
 // Node polyfill
 const fs = require('fs');
 const cp = require('child_process');
+const { Buffer } = require('buffer');
 const os = { // eslint-disable-line no-unused-vars
   system: function(name, args) {
     if (process.platform === 'linux' && name === 'nm') {

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -1,7 +1,5 @@
 'use strict';
 
-/* global SharedArrayBuffer */
-
 const {
   ArrayIsArray,
   ArrayPrototypeMap,
@@ -20,6 +18,7 @@ const {
   SymbolFor,
   TypedArrayPrototypeFill,
   Uint32Array,
+  globalThis: { Atomics, SharedArrayBuffer },
 } = primordials;
 
 const EventEmitter = require('events');

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -43,6 +43,7 @@
 'use strict';
 
 const {
+  ArrayPrototypeForEach,
   Error,
   MathMax,
   NumberIsNaN,
@@ -67,6 +68,7 @@ const {
   SyntaxError,
   SyntaxErrorPrototype,
   WeakSet,
+  globalThis,
 } = primordials;
 
 const {
@@ -984,7 +986,7 @@ REPLServer.prototype.close = function close() {
 REPLServer.prototype.createContext = function() {
   let context;
   if (this.useGlobal) {
-    context = global;
+    context = globalThis;
   } else {
     sendInspectorCommand((session) => {
       session.post('Runtime.enable');
@@ -996,13 +998,13 @@ REPLServer.prototype.createContext = function() {
     }, () => {
       context = vm.createContext();
     });
-    for (const name of ObjectGetOwnPropertyNames(global)) {
+    ArrayPrototypeForEach(ObjectGetOwnPropertyNames(globalThis), (name) => {
       // Only set properties that do not already exist as a global builtin.
       if (!globalBuiltins.has(name)) {
         ObjectDefineProperty(context, name,
-                             ObjectGetOwnPropertyDescriptor(global, name));
+                             ObjectGetOwnPropertyDescriptor(globalThis, name));
       }
-    }
+    });
     context.global = context;
     const _console = new Console(this.output);
     ObjectDefineProperty(context, 'console', {


### PR DESCRIPTION
This should unblock https://github.com/nodejs/node/pull/39446, and should help notice uncompatible backports (`lib/child_process.js` was using `AbortController` as a global, but it's not available as a global on v14.x...).

Backports:
- https://github.com/nodejs/node/pull/38211
- https://github.com/nodejs/node/pull/38230
- https://github.com/nodejs/node/pull/38419

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
