### PR TITLE
doc: fix crypto.hkdf callback derivedKey type

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -3857,7 +3857,7 @@ added: v15.0.0
   the maximum HKDF output 16320 bytes).
 * `callback` {Function}
   * `err` {Error}
-  * `derivedKey` {Buffer}
+  * `derivedKey` {ArrayBuffer}
 
 HKDF is a simple key derivation function defined in RFC 5869. The given `key`,
 `salt` and `info` are used with the `digest` to derive a key of `keylen` bytes.


### PR DESCRIPTION
```js
crypto.hkdf('sha512', 'key', 'salt', 'info', 64, console.log)
// ArrayBuffer {
//  [Uint8Contents]: <24 15 6e 2c 35 52 5b aa f3 d0 fb b9 2b 73 4c 80 32 a1 10 a3 f1 2e 25 96 e4 41 e1 92 48 70 d8 4c 3a 50 06 52 a7 23 73 80 24 43 24 51 04 6f d2 37 ef ad 83 92 fb 68 6c 52 77 a5 9e 01 05 39 16 53>,
//  byteLength: 64
// }
```

The example snippet below this block as well as `hkdfSync` are correct in that ArrayBuffer is returned.