### PR TITLE
events: add stop propagation flag to Event.stopImmediatePropagation

### DIFF
--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -168,6 +168,10 @@ class Event {
   stopImmediatePropagation() {
     if (!isEvent(this))
       throw new ERR_INVALID_THIS('Event');
+    // Spec mention "stopImmediatePropagation should set both "stop propagation"
+    // and "stop immediate propagation" flags"
+    // cf: from https://dom.spec.whatwg.org/#dom-event-stopimmediatepropagation
+    this.stopPropagation();
     this[kStop] = true;
   }
 

--- a/test/parallel/test-eventtarget.js
+++ b/test/parallel/test-eventtarget.js
@@ -345,7 +345,9 @@ let asyncTest = Promise.resolve();
 {
   const target = new EventTarget();
   const event = new Event('foo');
+  strictEqual(event.cancelBubble, false);
   event.stopImmediatePropagation();
+  strictEqual(event.cancelBubble, true);
   target.addEventListener('foo', common.mustNotCall());
   target.dispatchEvent(event);
 }


### PR DESCRIPTION
Spec mention stopImmediatePropagation should set both flags:
"stop propagation" and "stop immediate propagation".

So the second is not supported by Node as there is no hierarchy and bubbling,
but the flags are both present as well as stopPropagation.

Would it make sense to follow specs on that?
Refs: https://dom.spec.whatwg.org/#dom-event-stopimmediatepropagation

