### PR TITLE
build: cache python exec path on configure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ out/Makefile: config.gypi common.gypi node.gyp \
 # and included in config.gypi
 config.gypi: configure configure.py src/node_version.h
 	@if [ -x config.status ]; then \
-		./config.status; \
+		export PATH="$(NO_BIN_OVERRIDE_PATH)" && ./config.status; \
 	else \
 		echo Missing or stale $@, please run ./$<; \
 		exit 1; \

--- a/configure.py
+++ b/configure.py
@@ -2010,6 +2010,10 @@ else:
 if options.compile_commands_json:
   gyp_args += ['-f', 'compile_commands_json']
 
+# override the variable `python` defined in common.gypi
+if bin_override is not None:
+  gyp_args += ['-Dpython=' + sys.executable]
+
 # pass the leftover positional arguments to GYP
 gyp_args += args
 

--- a/node.gyp
+++ b/node.gyp
@@ -790,7 +790,7 @@
               'outputs': ['<(SHARED_INTERMEDIATE_DIR)/openssl.def'],
               'process_outputs_as_sources': 1,
               'action': [
-                'python',
+                '<(python)',
                 'tools/mkssldef.py',
                 '<@(mkssldef_flags)',
                 '-o',
@@ -816,7 +816,7 @@
             '<(SHARED_INTERMEDIATE_DIR)/node_javascript.cc',
           ],
           'action': [
-            'python',
+            '<(python)',
             'tools/js2c.py',
             '--directory',
             'lib',


### PR DESCRIPTION
Prevent using different python interpreters on `configure` and on build scripts. Also fixed an issue on automatic re-configure with `make` that generates a `config.mk` without bin overrides.

Fix: https://github.com/nodejs/node/issues/39408
Fix: https://github.com/nodejs/node/issues/39456