### PR TITLE
dgram: skip dns lookup for IPs

### DIFF
--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -418,6 +418,8 @@ function _connect(port, address, callback) {
   }
 
   const afterDns = (ex, ip) => {
+    this.emit('lookup', ex, ip, addressType, address);
+
     defaultTriggerAsyncIdScope(
       this[async_id_symbol],
       doConnect,
@@ -670,7 +672,21 @@ Socket.prototype.send = function(buffer,
     return;
   }
 
+  if (connected) {
+    defaultTriggerAsyncIdScope(
+      this[async_id_symbol],
+      doSend,
+      null, this, null, list, address, port, callback
+    );
+
+    return;
+  }
+
+  const addressType = isIP(address);
+
   const afterDns = (ex, ip) => {
+    this.emit('lookup', ex, ip, addressType, address);
+
     defaultTriggerAsyncIdScope(
       this[async_id_symbol],
       doSend,
@@ -678,11 +694,18 @@ Socket.prototype.send = function(buffer,
     );
   };
 
-  if (!connected) {
-    state.handle.lookup(address, afterDns);
-  } else {
-    afterDns(null, null);
+  if (addressType) {
+    defaultTriggerAsyncIdScope(this[async_id_symbol], process.nextTick, () => {
+      defaultTriggerAsyncIdScope(
+        this[async_id_symbol],
+        doSend,
+        null, this, address, list, address, port, callback
+      );
+    });
+    return;
   }
+
+  state.handle.lookup(address, afterDns);
 };
 
 function doSend(ex, self, ip, list, address, port, callback) {

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -39,6 +39,7 @@ const {
   newHandle,
 } = require('internal/dgram');
 const { guessHandleType } = internalBinding('util');
+const { isIP } = require('internal/net');
 const {
   ERR_INVALID_ARG_TYPE,
   ERR_MISSING_ARGS,
@@ -402,6 +403,19 @@ function _connect(port, address, callback) {
   const state = this[kStateSymbol];
   if (callback)
     this.once('connect', callback);
+
+  // If host is an IP, skip performing a lookup.
+  const addressType = isIP(address);
+  if (addressType) {
+    defaultTriggerAsyncIdScope(this[async_id_symbol], process.nextTick, () => {
+      defaultTriggerAsyncIdScope(
+        this[async_id_symbol],
+        doConnect,
+        null, this, address, address, port, callback
+      );
+    });
+    return;
+  }
 
   const afterDns = (ex, ip) => {
     defaultTriggerAsyncIdScope(

--- a/test/parallel/test-dgram-dns-lookup.js
+++ b/test/parallel/test-dgram-dns-lookup.js
@@ -1,0 +1,41 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const dgram = require('dgram');
+
+const server = dgram.createSocket('udp4');
+const message_to_send = 'A message to send';
+
+server.on('message', common.mustCall((msg, rinfo) => {
+  assert.strictEqual(rinfo.address, common.localhostIPv4);
+  assert.strictEqual(msg.toString(), message_to_send.toString());
+  server.send(msg, 0, msg.length, rinfo.port, rinfo.address);
+}));
+
+server.bind(0, 'localhost', common.mustCall(function() {
+  const client = dgram.createSocket('udp4');
+  const port = server.address().port;
+  client.on('message', common.mustCall((msg, rinfo) => {
+    assert.strictEqual(rinfo.address, common.localhostIPv4);
+    assert.strictEqual(rinfo.port, port);
+    assert.strictEqual(msg.toString(), message_to_send.toString());
+    client.close();
+    server.close();
+  }));
+
+  client.on('lookup', common.mustCall(function(err, ip, type, host) {
+    assert.strictEqual(err, null);
+    assert.strictEqual(ip, '127.0.0.1');
+    assert.strictEqual(type, 4);
+    assert.strictEqual(host, 'localhost');
+  }));
+
+  server.on('lookup', common.mustNotCall());
+
+  client.send(message_to_send,
+              0,
+              message_to_send.length,
+              port,
+              'localhost');
+  client.on('close', common.mustCall());
+}));


### PR DESCRIPTION
Previously, we would call dns.lookup even for IP addresses
in Socket#connect. This now skips that to improve performance.

Fixes: https://github.com/nodejs/node/issues/39468

