### PR TITLE
doc,lib,test: rename HKDF 'key' argument

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -3839,14 +3839,14 @@ const {
 console.log(getHashes()); // ['DSA', 'DSA-SHA', 'DSA-SHA1', ...]
 ```
 
-### `crypto.hkdf(digest, key, salt, info, keylen, callback)`
+### `crypto.hkdf(digest, ikm, salt, info, keylen, callback)`
 <!-- YAML
 added: v15.0.0
 -->
 
 * `digest` {string} The digest algorithm to use.
-* `key` {string|ArrayBuffer|Buffer|TypedArray|DataView|KeyObject} The secret
-  key. It must be at least one byte in length.
+* `ikm` {string|ArrayBuffer|Buffer|TypedArray|DataView|KeyObject} The input
+  keying material. It must be at least one byte in length.
 * `salt` {string|ArrayBuffer|Buffer|TypedArray|DataView} The salt value. Must
   be provided but can be zero-length.
 * `info` {string|ArrayBuffer|Buffer|TypedArray|DataView} Additional info value.
@@ -3859,7 +3859,7 @@ added: v15.0.0
   * `err` {Error}
   * `derivedKey` {Buffer}
 
-HKDF is a simple key derivation function defined in RFC 5869. The given `key`,
+HKDF is a simple key derivation function defined in RFC 5869. The given `ikm`,
 `salt` and `info` are used with the `digest` to derive a key of `keylen` bytes.
 
 The supplied `callback` function is called with two arguments: `err` and
@@ -3892,14 +3892,14 @@ hkdf('sha512', 'key', 'salt', 'info', 64, (err, derivedKey) => {
 });
 ```
 
-### `crypto.hkdfSync(digest, key, salt, info, keylen)`
+### `crypto.hkdfSync(digest, ikm, salt, info, keylen)`
 <!-- YAML
 added: v15.0.0
 -->
 
 * `digest` {string} The digest algorithm to use.
-* `key` {string|ArrayBuffer|Buffer|TypedArray|DataView|KeyObject} The secret
-  key. It must be at least one byte in length.
+* `ikm` {string|ArrayBuffer|Buffer|TypedArray|DataView|KeyObject} The input
+  keying material. It must be at least one byte in length.
 * `salt` {string|ArrayBuffer|Buffer|TypedArray|DataView} The salt value. Must
   be provided but can be zero-length.
 * `info` {string|ArrayBuffer|Buffer|TypedArray|DataView} Additional info value.
@@ -3911,7 +3911,7 @@ added: v15.0.0
 * Returns: {ArrayBuffer}
 
 Provides a synchronous HKDF key derivation function as defined in RFC 5869. The
-given `key`, `salt` and `info` are used with the `digest` to derive a key of
+given `ikm`, `salt` and `info` are used with the `digest` to derive a key of
 `keylen` bytes.
 
 The successfully generated `derivedKey` will be returned as an {ArrayBuffer}.

--- a/lib/internal/crypto/hkdf.js
+++ b/lib/internal/crypto/hkdf.js
@@ -91,7 +91,7 @@ function prepareKey(key) {
 
   if (!isArrayBufferView(key)) {
     throw new ERR_INVALID_ARG_TYPE(
-      'key',
+      'ikm',
       [
         'string',
         'SecretKeyObject',

--- a/test/parallel/test-crypto-hkdf.js
+++ b/test/parallel/test-crypto-hkdf.js
@@ -29,11 +29,11 @@ const {
   [1, {}, [], false, Infinity].forEach((i) => {
     assert.throws(() => hkdf('sha256', i), {
       code: 'ERR_INVALID_ARG_TYPE',
-      message: /^The "key" argument must be /
+      message: /^The "ikm" argument must be /
     });
     assert.throws(() => hkdfSync('sha256', i), {
       code: 'ERR_INVALID_ARG_TYPE',
-      message: /^The "key" argument must be /
+      message: /^The "ikm" argument must be /
     });
   });
 


### PR DESCRIPTION
HKDF is a key derivation function, which, as the name implies, can be used to _produce_ a key. However, the input is usually not a cryptographic key. (Internally, HKDF passes the "key" to HMAC, but **not** as a key, but as data to be hashed. The `salt` argument is actually used as the key internally.)

To avoid confusion and the ambiguity of having two (or three) "keys" (input keying material and output keying material, and internally the pseudorandom key), this renames the argument in documentation and error messages.

I'd be happy about alternatives to the name `ikm`, which is not exactly self-explanatory. Is `inputKeyingMaterial` (or `inputKeyMaterial`)  too verbose?

Refs: #39471

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
