### PR TITLE
node-api: handle pending exception in callback wrapper

### DIFF
--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -306,12 +306,16 @@ class CallbackWrapperBase : public CallbackWrapper {
     napi_env env = _bundle->env;
     napi_callback cb = _bundle->cb;
 
-    napi_value result;
+    napi_value result = nullptr;
+    bool exceptionOccurred = false;
     env->CallIntoModule([&](napi_env env) {
       result = cb(env, cbinfo_wrapper);
+    }, [&](napi_env env, v8::Local<v8::Value> value) {
+      exceptionOccurred = true;
+      env->isolate->ThrowException(value);
     });
 
-    if (result != nullptr) {
+    if (!exceptionOccurred && (result != nullptr)) {
       this->SetReturnValue(result);
     }
   }

--- a/test/js-native-api/test_function/test.js
+++ b/test/js-native-api/test_function/test.js
@@ -42,3 +42,11 @@ assert.deepStrictEqual(test_function.TestCreateFunctionParameters(), {
   cbIsNull: 'Invalid argument',
   resultIsNull: 'Invalid argument'
 });
+
+assert.throws(
+  () => test_function.TestBadReturnExceptionPending(),
+  {
+    code: 'throwing exception',
+    name: 'Error'
+  }
+);


### PR DESCRIPTION
fixes: https://github.com/nodejs/node-addon-api/issues/1025

The functionreference test from the node-api tests
was reporting a failed v8 check when Node.js was compiled
as debug. The failure was because an exception was
pending but the C++ wrappers were returning
a return value that was invalid.

Signed-off-by: Michael Dawson <mdawson@devrus.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
