### PR TITLE
build: fix `host_arch_cc()` for AIX/IBM i

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1050,12 +1050,7 @@ def is_arm_hard_float_abi():
 def host_arch_cc():
   """Host architecture check using the CC command."""
 
-  if sys.platform.startswith('aix'):
-    # we only support gcc at this point and the default on AIX
-    # would be xlc so hard code gcc
-    k = cc_macros('gcc')
-  else:
-    k = cc_macros(os.environ.get('CC_host'))
+  k = cc_macros(os.environ.get('CC_host'))
 
   matchup = {
     '__aarch64__' : 'arm64',


### PR DESCRIPTION
The AIX/IBM i branch in `host_arch_cc()` that hardcodes the compiler
executable to `gcc` precludes picking up either `CC_host` or `CC`
environment variables (if set) as is done on other platforms. On an
AIX/IBM i platform where the compiler is, e.g. `gcc-10` instead of
just `gcc`, the current check will fail to detect the host architecture
and incorrectly default to `ia32`. Removing the AIX/IBM i specific
branch will follow the same logic as on the other platforms:
1. The value, if set, of the `CC_host` environment variable. https://github.com/nodejs/node/blob/d58f0e005efb9bcf9c308f0fde590c7e278f7ca6/configure.py#L1058
2. Otherwise, if set, the value of the `CC` environment variable. https://github.com/nodejs/node/blob/d58f0e005efb9bcf9c308f0fde590c7e278f7ca6/configure.py#L1000-L1004
3. `gcc` (`cc` if on macOS). https://github.com/nodejs/node/blob/d58f0e005efb9bcf9c308f0fde590c7e278f7ca6/configure.py#L32

cc @nodejs/platform-aix @nodejs/platform-ibmi @nodejs/build-files 

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
