### PR TITLE
test: fix WASI link test

### DIFF
--- a/test/wasi/test-wasi-symlinks.js
+++ b/test/wasi/test-wasi-symlinks.js
@@ -14,7 +14,8 @@ if (process.argv[2] === 'wasi-child') {
     args: [],
     env: process.env,
     preopens: {
-      '/sandbox': process.argv[4]
+      '/sandbox': process.argv[4],
+      '/tmp': process.argv[5]
     }
   });
   const importObject = { wasi_snapshot_preview1: wasi.wasiImport };
@@ -45,9 +46,11 @@ if (process.argv[2] === 'wasi-child') {
   const escapingSymlink = path.join(sandboxedDir, 'outside.txt');
   const loopSymlink1 = path.join(sandboxedDir, 'loop1');
   const loopSymlink2 = path.join(sandboxedDir, 'loop2');
+  const sandboxedTmp = path.join(tmpdir.path, 'tmp');
 
   fs.mkdirSync(sandbox);
   fs.mkdirSync(sandboxedDir);
+  fs.mkdirSync(sandboxedTmp);
   fs.writeFileSync(sandboxedFile, 'hello from input.txt', 'utf8');
   fs.writeFileSync(externalFile, 'this should be inaccessible', 'utf8');
   fs.symlinkSync(path.join('.', 'input.txt'), sandboxedSymlink, 'file');
@@ -66,6 +69,7 @@ if (process.argv[2] === 'wasi-child') {
       'wasi-child',
       options.test,
       sandbox,
+      sandboxedTmp,
     ], opts);
     console.log(child.stderr.toString());
     assert.strictEqual(child.status, 0);
@@ -75,6 +79,7 @@ if (process.argv[2] === 'wasi-child') {
 
   runWASI({ test: 'create_symlink', stdout: 'hello from input.txt' });
   runWASI({ test: 'follow_symlink', stdout: 'hello from input.txt' });
+  runWASI({ test: 'link' });
   runWASI({ test: 'symlink_escape' });
   runWASI({ test: 'symlink_loop' });
 }

--- a/test/wasi/test-wasi.js
+++ b/test/wasi/test-wasi.js
@@ -78,7 +78,6 @@ if (process.argv[2] === 'wasi-child') {
     runWASI({ test: 'getrusage' });
   }
   runWASI({ test: 'gettimeofday' });
-  runWASI({ test: 'link' });
   runWASI({ test: 'main_args' });
   runWASI({ test: 'notdir' });
   runWASI({ test: 'poll' });


### PR DESCRIPTION
The WASI link test attempts to create a link in the temporary directory
to a file in the fixtures directory and can fail if those directories
are on different devices. Update the test so that both the source and
target of the link reside on the same device.

Fixes: https://github.com/nodejs/node/issues/39484
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
