### PR TITLE
zlib: avoid converting `Uint8Array` instances to `Buffer`

### DIFF
--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -34,12 +34,14 @@ const {
   ObjectDefineProperties,
   ObjectDefineProperty,
   ObjectFreeze,
-  ObjectGetPrototypeOf,
   ObjectKeys,
   ObjectSetPrototypeOf,
   ReflectApply,
   StringPrototypeStartsWith,
   Symbol,
+  TypedArrayPrototypeGetBuffer,
+  TypedArrayPrototypeGetByteLength,
+  TypedArrayPrototypeGetByteOffset,
   TypedArrayPrototypeFill,
   Uint32Array,
 } = primordials;
@@ -60,7 +62,8 @@ const {
 } = require('internal/util');
 const {
   isArrayBufferView,
-  isAnyArrayBuffer
+  isAnyArrayBuffer,
+  isUint8Array,
 } = require('internal/util/types');
 const binding = internalBinding('zlib');
 const assert = require('internal/assert');
@@ -112,11 +115,14 @@ for (const ckey of ObjectKeys(codes)) {
 
 function zlibBuffer(engine, buffer, callback) {
   validateFunction(callback, 'callback');
-  // Streams do not support non-Buffer ArrayBufferViews yet. Convert it to a
+  // Streams do not support non-Uint8Array ArrayBufferViews yet. Convert it to a
   // Buffer without copying.
-  if (isArrayBufferView(buffer) &&
-      ObjectGetPrototypeOf(buffer) !== Buffer.prototype) {
-    buffer = Buffer.from(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+  if (isArrayBufferView(buffer) && !isUint8Array(buffer)) {
+    buffer = Buffer.from(
+      TypedArrayPrototypeGetBuffer(buffer),
+      TypedArrayPrototypeGetByteOffset(buffer),
+      TypedArrayPrototypeGetByteLength(buffer)
+    );
   } else if (isAnyArrayBuffer(buffer)) {
     buffer = Buffer.from(buffer);
   }

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -39,9 +39,6 @@ const {
   ReflectApply,
   StringPrototypeStartsWith,
   Symbol,
-  TypedArrayPrototypeGetBuffer,
-  TypedArrayPrototypeGetByteLength,
-  TypedArrayPrototypeGetByteOffset,
   TypedArrayPrototypeFill,
   Uint32Array,
 } = primordials;
@@ -118,11 +115,7 @@ function zlibBuffer(engine, buffer, callback) {
   // Streams do not support non-Uint8Array ArrayBufferViews yet. Convert it to a
   // Buffer without copying.
   if (isArrayBufferView(buffer) && !isUint8Array(buffer)) {
-    buffer = Buffer.from(
-      TypedArrayPrototypeGetBuffer(buffer),
-      TypedArrayPrototypeGetByteOffset(buffer),
-      TypedArrayPrototypeGetByteLength(buffer)
-    );
+    buffer = Buffer.from(buffer.buffer, buffer.byteOffset, buffer.byteLength);
   } else if (isAnyArrayBuffer(buffer)) {
     buffer = Buffer.from(buffer);
   }


### PR DESCRIPTION
Node.js Streams support `Uint8Array` since v8.0.0.
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
