### PR TITLE
stream: mark compose as experimental

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1861,6 +1861,8 @@ failure, this can cause event listener leaks and swallowed errors.
 added: REPLACEME
 -->
 
+> Stability: 1 - `stream.compose` is experimental.
+
 * `streams` {Stream[]|Iterable[]|AsyncIterable[]|Function[]}
 * Returns: {stream.Duplex}
 


### PR DESCRIPTION
Given https://github.com/nodejs/node/pull/39483 it seems prudent to mark `stream.compose` as experimental for now.