### PR TITLE
build: use Node.js 14 in commit-lint.yml

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -2,6 +2,9 @@ name: "Commit messages adheres to guidelines at https://goo.gl/p2fr5Q"
 
 on: [pull_request]
 
+env:
+  NODE_VERSION: 14.x
+
 jobs:
   lint-commit-message:
     runs-on: ubuntu-latest
@@ -10,10 +13,10 @@ jobs:
         with:
           # Last 100 commits should be enough for a PR
           fetch-depth: 100
-      - name: Use Node.js 12
+      - name: Install Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: ${{ env.NODE_VERSION }}
       - name: Validate commit messages
         run: |
           echo "::add-matcher::.github/workflows/commit-lint-problem-matcher.json"


### PR DESCRIPTION
All of our workflows use Node.js 14.x or 16.x except for commit-lint.yml
which has 12.x hard-coded. Update it to 14.x and change it to using an
environment variable so it is consistent with our other workflows.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
