### PR TITLE
module: refine `enrichCJSError`

### DIFF
--- a/lib/internal/modules/cjs/helpers.js
+++ b/lib/internal/modules/cjs/helpers.js
@@ -187,6 +187,7 @@ function normalizeReferrerURL(referrer) {
 
 // For error messages only - used to check if ESM syntax is in use.
 function hasEsmSyntax(code) {
+  debug('Checking for ESM syntax');
   const parser = require('internal/deps/acorn/acorn/dist/acorn').Parser;
   let root;
   try {
@@ -196,6 +197,7 @@ function hasEsmSyntax(code) {
   }
 
   return ArrayPrototypeSome(root.body, (stmt) =>
+    stmt.type === 'ExportDefaultDeclaration' ||
     stmt.type === 'ExportNamedDeclaration' ||
     stmt.type === 'ImportDeclaration' ||
     stmt.type === 'ExportAllDeclaration');

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -1043,7 +1043,7 @@ function wrapSafe(filename, content, cjsModuleInstance) {
     });
   } catch (err) {
     if (process.mainModule === cjsModuleInstance)
-      enrichCJSError(err);
+      enrichCJSError(err, content);
     throw err;
   }
 }

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -10,13 +10,11 @@ const {
   ObjectKeys,
   PromisePrototypeCatch,
   PromiseReject,
-  RegExpPrototypeTest,
   SafeArrayIterator,
   SafeMap,
   SafeSet,
   StringPrototypeReplace,
   StringPrototypeSlice,
-  StringPrototypeSplit,
   StringPrototypeStartsWith,
   SyntaxErrorPrototype,
   globalThis: { WebAssembly },
@@ -31,8 +29,9 @@ function lazyTypes() {
 const { readFileSync } = require('fs');
 const { extname, isAbsolute } = require('path');
 const {
+  hasEsmSyntax,
+  loadNativeModule,
   stripBOM,
-  loadNativeModule
 } = require('internal/modules/cjs/helpers');
 const {
   Module: CJSModule,
@@ -152,18 +151,9 @@ translators.set('module', async function moduleStrategy(url) {
   return module;
 });
 
-function enrichCJSError(err) {
-  if (err == null || ObjectGetPrototypeOf(err) !== SyntaxErrorPrototype) {
-    return;
-  }
-  const stack = StringPrototypeSplit(err.stack, '\n');
-  /*
-  * The regular expression below targets the most common import statement
-  * usage. However, some cases are not matching, cases like import statement
-  * after a comment block and/or after a variable definition.
-  */
-  if (StringPrototypeStartsWith(err.message, 'Unexpected token \'export\'') ||
-    RegExpPrototypeTest(/^\s*import(?=[ {'"*])\s*(?![ (])/, stack[1])) {
+function enrichCJSError(err, content) {
+  if (err != null && ObjectGetPrototypeOf(err) === SyntaxErrorPrototype &&
+      hasEsmSyntax(content)) {
     // Emit the warning synchronously because we are in the middle of handling
     // a SyntaxError that will throw and likely terminate the process before an
     // asynchronous warning would be emitted.
@@ -200,7 +190,7 @@ translators.set('commonjs', async function commonjsStrategy(url, isMain) {
       try {
         exports = CJSModule._load(filename, undefined, isMain);
       } catch (err) {
-        enrichCJSError(err);
+        enrichCJSError(err, readFileSync(filename, 'utf-8'));
         throw err;
       }
     }

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -151,9 +151,14 @@ translators.set('module', async function moduleStrategy(url) {
   return module;
 });
 
-function enrichCJSError(err, content) {
+/**
+ * @param {Error | any} err 
+ * @param {string} [content] Content of the file, if known.
+ * @param {string} [filename] Useful only if `content` is unknown.
+ */
+function enrichCJSError(err, content, filename) {
   if (err != null && ObjectGetPrototypeOf(err) === SyntaxErrorPrototype &&
-      hasEsmSyntax(content)) {
+      hasEsmSyntax(content || readFileSync(filename, 'utf-8'))) {
     // Emit the warning synchronously because we are in the middle of handling
     // a SyntaxError that will throw and likely terminate the process before an
     // asynchronous warning would be emitted.
@@ -190,7 +195,7 @@ translators.set('commonjs', async function commonjsStrategy(url, isMain) {
       try {
         exports = CJSModule._load(filename, undefined, isMain);
       } catch (err) {
-        enrichCJSError(err, readFileSync(filename, 'utf-8'));
+        enrichCJSError(err, undefined, filename);
         throw err;
       }
     }

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -152,7 +152,7 @@ translators.set('module', async function moduleStrategy(url) {
 });
 
 /**
- * @param {Error | any} err 
+ * @param {Error | any} err
  * @param {string} [content] Content of the file, if known.
  * @param {string} [filename] Useful only if `content` is unknown.
  */


### PR DESCRIPTION
Using `hasESMSyntax` utility introduced in https://github.com/nodejs/node/pull/39175.

/cc @nodejs/modules 
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
