### PR TITLE
meta: remove unneeded .mailmap entry

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -63,7 +63,6 @@ Bidisha Pyne <pyne.bidisha2017@gmail.com> <bidipyne@in.ibm.com>
 bl-ue <bl-ue@users.noreply.github.com> bl-ue <54780737+bl-ue@users.noreply.github.com>
 Brad Decker <bhdecker84@gmail.com>
 Brad Larson <brad@waterfallmedia.net>
-Bradley Meck <bradley.meck@gmail.com>
 Brandon Benvie <brandon@bbenvie.com> <brandon@brandonbenvie.com>
 Brandon Kobel <kobelb@gmail.com> kobelb <brandon.kobel@elastic.co>
 Brendan Ashworth <brendan.ashworth@me.com> <squirrelslikeacorns@gmail.com>


### PR DESCRIPTION
The previous Perl script used to generate the AUTHORS file (probably)
needed more entries than the current JS script to avoid duplicate
entries in AUTHORS. The entry removed here is no longer needed for that
purpose, but it is creating a small issue around tooling for gathering
contributor metrics.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
