### PR TITLE
module: use monkey-patchable `readFileSync`

### DIFF
--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -28,7 +28,7 @@ function lazyTypes() {
   return _TYPES = require('internal/util/types');
 }
 
-const { readFileSync } = require('fs');
+const fs = require('fs');
 const { extname, isAbsolute } = require('path');
 const {
   stripBOM,
@@ -237,7 +237,7 @@ function cjsPreparseModuleExports(filename) {
 
   let source;
   try {
-    source = readFileSync(filename, 'utf8');
+    source = fs.readFileSync(filename, 'utf8');
   } catch {}
 
   let exports, reexports;


### PR DESCRIPTION
Through monkey-patching `fs` and `module` it's possible to make Node
support files in zip archives for commonjs. Combined with the 
experimental loaders the same is possible for ESM. However [one line](https://github.com/nodejs/node/blob/5c4e673a9694ca62537834c0f67b5a37e4b3a140/lib/internal/modules/esm/translators.js#L240) 
prevents this from working when importing a commonjs file from an ESM 
file. To fix that this PR updates the commonjs translator to use the 
monkey-patchable `fs.readFileSync` instead of destructuring
`readFileSync` from `fs`.