### PR TITLE
doc: add PerformanceObserver `buffered` document

### DIFF
--- a/doc/api/perf_hooks.md
+++ b/doc/api/perf_hooks.md
@@ -585,6 +585,10 @@ Disconnects the `PerformanceObserver` instance from all notifications.
 <!-- YAML
 added: v8.5.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/39297
+    description: Updated to conform to Performance Timeline Level 2. The
+                 buffered option has been added back.
   - version: v16.0.0
     pr-url: https://github.com/nodejs/node/pull/37136
     description: Updated to conform to User Timing Level 3. The
@@ -597,6 +601,10 @@ changes:
   * `entryTypes` {string[]} An array of strings identifying the types of
     {PerformanceEntry} instances the observer is interested in. If not
     provided an error will be thrown.
+  * `buffered` {boolean} If true, the observer callback is called with a
+    list global `PerformanceEntry` buffered entries. If false, only
+    `PerformanceEntry`s created after the time point are sent to the
+    observer callback. **Default:** `false`.
 
 Subscribes the {PerformanceObserver} instance to notifications of new
 {PerformanceEntry} instances identified either by `options.entryTypes`


### PR DESCRIPTION
The option `buffered` is not about queueing the `PerformanceEntry`s with
an event loop task or not. The option `buffered` in the spec is about filling 
the observer with the global `PerformanceEntry` buffer. The current 
(and the spec) behavior is different with Node.js version <= v16.0.0.

> Node.js v14.x: `buffered` <boolean> If true, the notification callback will be called using setImmediate() and multiple PerformanceEntry instance notifications will be buffered internally. If false, notifications will be immediate and synchronous. Default: false.

Refs: https://w3c.github.io/performance-timeline/#observe-method
Refs: https://nodejs.org/dist/latest-v14.x/docs/api/perf_hooks.html#perf_hooks_performanceobserver_observe_options
Refs: https://github.com/nodejs/node/pull/39297