### PR TITLE
lib: implement various stream utils for webstreams

### DIFF
--- a/doc/api/webstreams.md
+++ b/doc/api/webstreams.md
@@ -33,6 +33,9 @@ There are three primary types of objects
 * `WritableStream` - Represents a destination for streaming data.
 * `TransformStream` - Represents an algorithm for transforming streaming data.
 
+Additionally, this module includes the utility functions
+[`pipeline()`](#pipeline), [`finished()`](#finished), and [`addAbortSignal()`](#addabortsignal).
+
 ### Example `ReadableStream`
 
 This example creates a simple `ReadableStream` that pushes the current

--- a/lib/internal/webstreams/add-abort-signal.js
+++ b/lib/internal/webstreams/add-abort-signal.js
@@ -1,55 +1,55 @@
 'use strict';
 
-const { validateAbortSignal } = require("internal/validators");
+const { validateAbortSignal } = require('internal/validators');
 const { isWebstream } = require('internal/webstreams/util');
 const { finished } = require('internal/webstreams/finished');
-const { AbortError, codes } = require("internal/errors");
+const { AbortError, codes } = require('internal/errors');
 const { ERR_INVALID_ARG_TYPE } = codes;
 
 function addAbortSignal(signal, stream) {
-    validateInputs(signal, stream);
+  validateInputs(signal, stream);
 
-    const onAbort = () => {
-        stream.abort(new AbortError());
-    }
+  const onAbort = () => {
+    stream.abort(new AbortError());
+  };
 
-    if (signalIsAborted(signal)){
-        onAbort();
-    } else {
-        addAbortCallbackToSignal(signal, stream, onAbort);
-    }
+  if (signalIsAborted(signal)) {
+    onAbort();
+  } else {
+    addAbortCallbackToSignal(signal, stream, onAbort);
+  }
 
-    return stream;
+  return stream;
 }
 
 function validateInputs(signal, stream) {
-    validateAbortSignal(signal, 'signal');
-    throwErrorIfNotWebstream(stream);
+  validateAbortSignal(signal, 'signal');
+  throwErrorIfNotWebstream(stream);
 }
 
 function throwErrorIfNotWebstream(stream) {
-    if (isWebstream(stream)) {
-      return;
-    }
-  
-    throw new ERR_INVALID_ARG_TYPE(
-      'stream',
-      'ReadableStream|WritableStream|TransformStream',
-      stream,
-    );
+  if (isWebstream(stream)) {
+    return;
+  }
+
+  throw new ERR_INVALID_ARG_TYPE(
+    'stream',
+    'ReadableStream|WritableStream|TransformStream',
+    stream,
+  );
 }
 
 function signalIsAborted(signal) {
-    return signal.aborted;
+  return signal.aborted;
 }
 
 function addAbortCallbackToSignal(signal, stream, callback) {
-    signal.addEventListener('abort', callback);
-    finished(stream, () => {
-        signal.removeEventListener('abort', callback); 
-    });
+  signal.addEventListener('abort', callback);
+  finished(stream, () => {
+    signal.removeEventListener('abort', callback);
+  });
 }
 
 module.exports = {
-    addAbortSignal
-}
+  addAbortSignal
+};

--- a/lib/internal/webstreams/add-abort-signal.js
+++ b/lib/internal/webstreams/add-abort-signal.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const { validateAbortSignal } = require("internal/validators");
+const { isWebstream } = require('internal/webstreams/util');
+const { finished } = require('internal/webstreams/finished');
+const { AbortError, codes } = require("internal/errors");
+const { ERR_INVALID_ARG_TYPE } = codes;
+
+function addAbortSignal(signal, stream) {
+    validateInputs(signal, stream);
+
+    const onAbort = () => {
+        stream.abort(new AbortError());
+    }
+
+    if (signalIsAborted(signal)){
+        onAbort();
+    } else {
+        addAbortCallbackToSignal(signal, stream, onAbort);
+    }
+
+    return stream;
+}
+
+function validateInputs(signal, stream) {
+    validateAbortSignal(signal, 'signal');
+    throwErrorIfNotWebstream(stream);
+}
+
+function throwErrorIfNotWebstream(stream) {
+    if (isWebstream(stream)) {
+      return;
+    }
+  
+    throw new ERR_INVALID_ARG_TYPE(
+      'stream',
+      'ReadableStream|WritableStream|TransformStream',
+      stream,
+    );
+}
+
+function signalIsAborted(signal) {
+    return signal.aborted;
+}
+
+function addAbortCallbackToSignal(signal, stream, callback) {
+    signal.addEventListener('abort', callback);
+    finished(stream, () => {
+        signal.removeEventListener('abort', callback); 
+    });
+}
+
+module.exports = {
+    addAbortSignal
+}

--- a/lib/internal/webstreams/finished.js
+++ b/lib/internal/webstreams/finished.js
@@ -1,0 +1,118 @@
+'use strict';
+
+const { validateFunction } = require('internal/validators');
+const { isWebstream } = require('internal/webstreams/util');
+const { isTransformStream } = require('internal/webstreams/transformstream');
+const {
+  isWritableStreamClosed,
+  isWritableStreamErrored,
+  writableStreamAddFinishedCallback,
+  writableStreamRemoveAllFinishedCallbacks,
+} = require('internal/webstreams/writablestream');
+const {
+  isReadableStream,
+  isReadableStreamClosed,
+  isReadableStreamErrored,
+  readableStreamAddFinishedCallback,
+  readableStreamRemoveAllFinishedCallbacks,
+} = require('internal/webstreams/readablestream');
+const { once } = require('internal/util');
+const { codes } = require('internal/errors');
+const { ERR_INVALID_ARG_TYPE, ERR_MISSING_ARGS } = codes;
+
+function finished(stream, callback) {
+  validateAndFixInputs(stream, callback);
+
+  if (isTransformStream(stream)) {
+    return finishedForTransformStream(stream, callback);
+  }
+
+  addCallbackToStream(stream, callback);
+  callCallbackIfStreamIsFinished(stream, callback);
+
+  return getCleanupFuncForStream(stream);
+}
+
+function validateAndFixInputs(stream, callback) {
+  throwErrorIfNullStream(stream);
+  callback = replaceWithNoOpIfNull(callback);
+  validateInputs(stream, callback);
+  return stream, once(callback);
+}
+
+function throwErrorIfNullStream(stream) {
+  if (!stream) {
+    throw new ERR_MISSING_ARGS('stream');
+  }
+}
+
+function replaceWithNoOpIfNull(callback) {
+  if (!callback) {
+    callback = () => {};
+  }
+  return callback;
+}
+
+function validateInputs(stream, callback) {
+  validateFunction(callback, 'callback');
+  throwErrorIfNotWebstream(stream);
+}
+
+function throwErrorIfNotWebstream(stream) {
+  if (isWebstream(stream)) {
+    return;
+  }
+
+  throw new ERR_INVALID_ARG_TYPE(
+    'stream',
+    'ReadableStream|WritableStream|TransformStream',
+    stream
+  );
+}
+
+function finishedForTransformStream(transformStream, callback) {
+  return finished(transformStream.readable, callback);
+}
+
+function addCallbackToStream(stream, callback) {
+  if (isReadableStream(stream)) {
+    readableStreamAddFinishedCallback(stream, callback);
+    return;
+  }
+  writableStreamAddFinishedCallback(stream, callback);
+}
+
+function callCallbackIfStreamIsFinished(stream, callback) {
+  if (isWebstreamFinished(stream)) {
+    callback();
+  }
+}
+
+function isWebstreamFinished(stream) {
+  if (isReadableStream(stream)) {
+    return isReadableStreamFinished(stream);
+  }
+  return isWritableStreamFinished(stream);
+}
+
+function isReadableStreamFinished(rs) {
+  return isReadableStreamClosed(rs) || isReadableStreamErrored(rs);
+}
+
+function isWritableStreamFinished(ws) {
+  return isWritableStreamClosed(ws) || isWritableStreamErrored(ws);
+}
+
+function getCleanupFuncForStream(stream) {
+  if (isReadableStream(stream)) {
+    return () => {
+      readableStreamRemoveAllFinishedCallbacks(stream);
+    };
+  }
+
+  return () => {
+    writableStreamRemoveAllFinishedCallbacks(stream);
+  };
+}
+
+module.exports = { finished };

--- a/lib/internal/webstreams/pipeline.js
+++ b/lib/internal/webstreams/pipeline.js
@@ -11,13 +11,13 @@ const { codes } = require('internal/errors');
 const { ERR_INVALID_ARG_TYPE, ERR_MISSING_ARGS } = codes;
 
 function pipeline(...input) {
-  const [streams, callback] = parseAndValidateInput(input);
+  const { 0: streams, 1: callback } = parseAndValidateInput(input);
   pipeStreams(streams).then(callback);
 }
 
 function parseAndValidateInput(input) {
   validateInput(input);
-  const [streams, callback] = parseInput(input);
+  const { 0: streams, 1: callback } = parseInput(input);
 
   validateStreams(streams);
   validateCallback(callback);

--- a/lib/internal/webstreams/pipeline.js
+++ b/lib/internal/webstreams/pipeline.js
@@ -1,0 +1,132 @@
+'use strict';
+
+const { ArrayIsArray } = primordials;
+
+const { validateCallback } = require('internal/validators');
+const { isTransformStream } = require('internal/webstreams/transformstream');
+const { isReadableStream } = require('internal/webstreams/readablestream');
+const { isWritableStream } = require('internal/webstreams/writablestream');
+const { once } = require('internal/util');
+const { codes } = require('internal/errors');
+const { ERR_INVALID_ARG_TYPE, ERR_MISSING_ARGS } = codes;
+
+function pipeline(...input) {
+  const [streams, callback] = parseAndValidateInput(input);
+  pipeStreams(streams).then(callback);
+}
+
+function parseAndValidateInput(input) {
+  validateInput(input);
+  const [streams, callback] = parseInput(input);
+
+  validateStreams(streams);
+  validateCallback(callback);
+  return [streams, once(callback)];
+}
+
+function validateInput(input) {
+  if (!input || input.length < 2) {
+    throw new ERR_MISSING_ARGS('input');
+  }
+}
+
+function parseInput(input) {
+  const callback = popCallbackFromInput(input);
+  const streams = unnestArrayIfIsArray(input);
+  return [streams, callback];
+}
+
+function popCallbackFromInput(input) {
+  return input.pop();
+}
+
+function unnestArrayIfIsArray(array) {
+  if (ArrayIsArray(array[0]) && array.length === 1) {
+    return array[0];
+  }
+  return array;
+}
+
+function validateStreams(streams) {
+  throwErrorIfInsufficientStreams(streams);
+
+  const allButFirstStream = streams.slice(1);
+  throwErrorIfStreamsNotWritable(allButFirstStream);
+
+  const allButLastStream = streams.slice(0, -1);
+  throwErrorIfStreamsNotReadable(allButLastStream);
+}
+
+function throwErrorIfInsufficientStreams(streams) {
+  if (streams.length < 2) {
+    throw new ERR_MISSING_ARGS('streams');
+  }
+}
+
+function throwErrorIfStreamsNotWritable(streams) {
+  if (streams.some(cannotWriteToStream)) {
+    throw new ERR_INVALID_ARG_TYPE(
+      'streams',
+      'WritableStream|TransformStream',
+      streams
+    );
+  }
+}
+
+function cannotWriteToStream(stream) {
+  return !(isWritableStream(stream) || isTransformStream(stream));
+}
+
+function throwErrorIfStreamsNotReadable(streams) {
+  if (streams.some(cannotReadFromStream)) {
+    throw new ERR_INVALID_ARG_TYPE(
+      'streams',
+      'ReadableStream|TransformStream',
+      streams
+    );
+  }
+}
+
+function cannotReadFromStream(stream) {
+  return !(isReadableStream(stream) || isTransformStream(stream));
+}
+
+async function pipeStreams(streams) {
+  for (let i = 0; i < streams.length - 1; i++) {
+    const source = streams[i];
+    const dest = streams[i + 1];
+    await pipeStreamPair(source, dest);
+  }
+}
+
+async function pipeStreamPair(source, dest) {
+  if (isTransformStream(source)) {
+    return pipeStreamPairWithTransformSource(source, dest);
+  }
+
+  if (isTransformStream(dest)) {
+    return source.pipeThrough(dest);
+  }
+
+  return source.pipeTo(dest);
+}
+
+async function pipeStreamPairWithTransformSource(source, dest) {
+  throwErrorIfTransformStreamHasNoReadable(source);
+  return pipeStreamPair(source.readable, dest);
+}
+
+function throwErrorIfTransformStreamHasNoReadable(transform) {
+  const readable = transform?.readable;
+  if (!isReadableStream(readable)) {
+    throw new ERR_INVALID_ARG_TYPE(
+      'transform.readable',
+      'ReadableStream',
+      readable
+    );
+  }
+}
+
+module.exports = {
+  pipeline,
+};

--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -38,9 +38,7 @@ const {
   },
 } = require('internal/errors');
 
-const {
-  DOMException,
-} = internalBinding('messaging');
+const { DOMException } = internalBinding('messaging');
 
 const {
   isArrayBufferView,
@@ -52,22 +50,13 @@ const {
   customInspectSymbol: kInspect,
 } = require('internal/util');
 
-const {
-  serialize,
-  deserialize,
-} = require('v8');
+const { serialize, deserialize } = require('v8');
 
-const {
-  validateObject,
-} = require('internal/validators');
+const { validateObject } = require('internal/validators');
 
-const {
-  kAborted,
-} = require('internal/abort_controller');
+const { kAborted } = require('internal/abort_controller');
 
-const {
-  MessageChannel,
-} = require('internal/worker/io');
+const { MessageChannel } = require('internal/worker/io');
 
 const {
   kDeserialize,
@@ -76,9 +65,7 @@ const {
   makeTransferable,
 } = require('internal/worker/js_transferable');
 
-const {
-  queueMicrotask,
-} = require('internal/process/task_queues');
+const { queueMicrotask } = require('internal/process/task_queues');
 
 const {
   ArrayBufferViewGetBuffer,
@@ -179,7 +166,9 @@ const kPull = Symbol('kPull');
 class ReadableStream {
   [kType] = 'ReadableStream';
 
-  get [SymbolToStringTag]() { return this[kType]; }
+  get [SymbolToStringTag]() {
+    return this[kType];
+  }
 
   /**
    * @param {UnderlyingSource} [source]
@@ -198,8 +187,11 @@ class ReadableStream {
         port1: undefined,
         port2: undefined,
         promise: undefined,
-      }
+      },
     };
+
+    this.finishedCallbacks = [];
+
     // The spec requires handling of the strategy first
     // here. Specifically, if getting the size and
     // highWaterMark from the strategy fail, that has
@@ -216,7 +208,8 @@ class ReadableStream {
       setupReadableByteStreamControllerFromSource(
         this,
         source,
-        extractHighWaterMark(highWaterMark, 0));
+        extractHighWaterMark(highWaterMark, 0)
+      );
       return;
     }
 
@@ -226,7 +219,8 @@ class ReadableStream {
       this,
       source,
       extractHighWaterMark(highWaterMark, 1),
-      extractSizeAlgorithm(size));
+      extractSizeAlgorithm(size)
+    );
 
     // eslint-disable-next-line no-constructor-return
     return makeTransferable(this);
@@ -237,8 +231,7 @@ class ReadableStream {
    * @type {boolean}
    */
   get locked() {
-    if (!isReadableStream(this))
-      throw new ERR_INVALID_THIS('ReadableStream');
+    if (!isReadableStream(this)) throw new ERR_INVALID_THIS('ReadableStream');
     return isReadableStreamLocked(this);
   }
 
@@ -251,9 +244,17 @@ class ReadableStream {
       return PromiseReject(new ERR_INVALID_THIS('ReadableStream'));
     if (isReadableStreamLocked(this)) {
       return PromiseReject(
-        new ERR_INVALID_STATE.TypeError('ReadableStream is locked'));
+        new ERR_INVALID_STATE.TypeError('ReadableStream is locked')
+      );
     }
     return readableStreamCancel(this, reason);
+  }
+
+  /**
+   * @param {any} reason
+   */
+  abort(reason = undefined) {
+    this.cancel(reason);
   }
 
   /**
@@ -263,13 +264,11 @@ class ReadableStream {
    * @returns {ReadableStreamReader}
    */
   getReader(options = {}) {
-    if (!isReadableStream(this))
-      throw new ERR_INVALID_THIS('ReadableStream');
+    if (!isReadableStream(this)) throw new ERR_INVALID_THIS('ReadableStream');
     validateObject(options, 'options', { nullable: true, allowFunction: true });
     const mode = options?.mode;
 
-    if (mode === undefined)
-      return new ReadableStreamDefaultReader(this);
+    if (mode === undefined) return new ReadableStreamDefaultReader(this);
 
     if (`${mode}` !== 'byob')
       throw new ERR_INVALID_ARG_VALUE('options.mode', mode);
@@ -282,21 +281,22 @@ class ReadableStream {
    * @returns {ReadableStream}
    */
   pipeThrough(transform, options = {}) {
-    if (!isReadableStream(this))
-      throw new ERR_INVALID_THIS('ReadableStream');
+    if (!isReadableStream(this)) throw new ERR_INVALID_THIS('ReadableStream');
     const readable = transform?.readable;
     if (!isReadableStream(readable)) {
       throw new ERR_INVALID_ARG_TYPE(
         'transform.readable',
         'ReadableStream',
-        readable);
+        readable
+      );
     }
     const writable = transform?.writable;
     if (!isWritableStream(writable)) {
       throw new ERR_INVALID_ARG_TYPE(
         'transform.writable',
         'WritableStream',
-        writable);
+        writable
+      );
     }
 
     // The web platform tests require that these be handled one at a
@@ -320,7 +320,8 @@ class ReadableStream {
       !!preventClose,
       !!preventAbort,
       !!preventCancel,
-      signal);
+      signal
+    );
     setPromiseHandled(promise);
 
     return readable;
@@ -333,13 +334,13 @@ class ReadableStream {
    */
   pipeTo(destination, options = {}) {
     try {
-      if (!isReadableStream(this))
-        throw new ERR_INVALID_THIS('ReadableStream');
+      if (!isReadableStream(this)) throw new ERR_INVALID_THIS('ReadableStream');
       if (!isWritableStream(destination)) {
         throw new ERR_INVALID_ARG_TYPE(
           'transform.writable',
           'WritableStream',
-          destination);
+          destination
+        );
       }
 
       const preventAbort = options?.preventAbort;
@@ -361,7 +362,8 @@ class ReadableStream {
         !!preventClose,
         !!preventAbort,
         !!preventCancel,
-        signal);
+        signal
+      );
     } catch (error) {
       return PromiseReject(error);
     }
@@ -371,8 +373,7 @@ class ReadableStream {
    * @returns {ReadableStream[]}
    */
   tee() {
-    if (!isReadableStream(this))
-      throw new ERR_INVALID_THIS('ReadableStream');
+    if (!isReadableStream(this)) throw new ERR_INVALID_THIS('ReadableStream');
     return readableStreamTee(this, false);
   }
 
@@ -383,12 +384,9 @@ class ReadableStream {
    * @returns {AsyncIterable}
    */
   values(options = {}) {
-    if (!isReadableStream(this))
-      throw new ERR_INVALID_THIS('ReadableStream');
+    if (!isReadableStream(this)) throw new ERR_INVALID_THIS('ReadableStream');
     validateObject(options, 'options');
-    const {
-      preventCancel = false,
-    } = options;
+    const { preventCancel = false } = options;
 
     const reader = new ReadableStreamDefaultReader(this);
     let done = false;
@@ -402,13 +400,14 @@ class ReadableStream {
     // unnecessary Promise allocations to occur, which just add
     // cost.
     function nextSteps() {
-      if (done)
-        return PromiseResolve({ done: true, value: undefined });
+      if (done) return PromiseResolve({ done: true, value: undefined });
 
       if (reader[kState].stream === undefined) {
         return PromiseReject(
           new ERR_INVALID_STATE.TypeError(
-            'The reader is not bound to a ReadableStream'));
+            'The reader is not bound to a ReadableStream'
+          )
+        );
       }
       const promise = createDeferredPromise();
 
@@ -428,19 +427,19 @@ class ReadableStream {
           done = true;
           readableStreamReaderGenericRelease(reader);
           promise.reject(error);
-        }
+        },
       });
       return promise.promise;
     }
 
     async function returnSteps(value) {
-      if (done)
-        return { done: true, value };
+      if (done) return { done: true, value };
       done = true;
 
       if (reader[kState].stream === undefined) {
         throw new ERR_INVALID_STATE.TypeError(
-          'The reader is not bound to a ReadableStream');
+          'The reader is not bound to a ReadableStream'
+        );
       }
       assert(!reader[kState].readRequests.length);
       if (!preventCancel) {
@@ -487,12 +486,17 @@ class ReadableStream {
           PromisePrototypeThen(
             current,
             () => returnSteps(error),
-            () => returnSteps(error)) :
+            () => returnSteps(error)
+          ) :
           returnSteps(error);
       },
 
-      [SymbolAsyncIterator]() { return this; }
-    }, AsyncIterator);
+      [SymbolAsyncIterator]() {
+        return this;
+      },
+    },
+                                AsyncIterator
+    );
   }
 
   [kInspect](depth, options) {
@@ -503,23 +507,21 @@ class ReadableStream {
   }
 
   [kTransfer]() {
-    if (!isReadableStream(this))
-      throw new ERR_INVALID_THIS('ReadableStream');
+    if (!isReadableStream(this)) throw new ERR_INVALID_THIS('ReadableStream');
     if (this.locked) {
       this[kState].transfer.port1?.close();
       this[kState].transfer.port1 = undefined;
       this[kState].transfer.port2 = undefined;
       throw new DOMException(
         'Cannot transfer a locked ReadableStream',
-        'DataCloneError');
+        'DataCloneError'
+      );
     }
 
-    const {
-      writable,
-      promise,
-    } = lazyTransfer().newCrossRealmWritableSink(
+    const { writable, promise } = lazyTransfer().newCrossRealmWritableSink(
       this,
-      this[kState].transfer.port1);
+      this[kState].transfer.port1
+    );
 
     this[kState].transfer.writable = writable;
     this[kState].transfer.promise = promise;
@@ -535,7 +537,7 @@ class ReadableStream {
     const { port1, port2 } = new MessageChannel();
     this[kState].transfer.port1 = port1;
     this[kState].transfer.port2 = port2;
-    return [ port2 ];
+    return [port2];
   }
 
   [kDeserialize]({ port }) {
@@ -543,7 +545,9 @@ class ReadableStream {
     setupReadableStreamDefaultControllerFromSource(
       this,
       new transfer.CrossRealmTransformReadableSource(port),
-      0, () => 1);
+      0,
+      () => 1
+    );
   }
 }
 
@@ -585,7 +589,9 @@ TransferredReadableStream.prototype[kDeserialize] = () => {};
 class ReadableStreamBYOBRequest {
   [kType] = 'ReadableStreamBYOBRequest';
 
-  get [SymbolToStringTag]() { return this[kType]; }
+  get [SymbolToStringTag]() {
+    return this[kType];
+  }
 
   constructor() {
     throw new ERR_ILLEGAL_CONSTRUCTOR();
@@ -607,13 +613,11 @@ class ReadableStreamBYOBRequest {
   respond(bytesWritten) {
     if (!isReadableStreamBYOBRequest(this))
       throw new ERR_INVALID_THIS('ReadableStreamBYOBRequest');
-    const {
-      view,
-      controller,
-    } = this[kState];
+    const { view, controller } = this[kState];
     if (controller === undefined) {
       throw new ERR_INVALID_STATE.TypeError(
-        'This BYOB request has been invalidated');
+        'This BYOB request has been invalidated'
+      );
     }
 
     const viewByteLength = ArrayBufferViewGetByteLength(view);
@@ -622,7 +626,8 @@ class ReadableStreamBYOBRequest {
 
     if (viewByteLength === 0 || viewBufferByteLength === 0) {
       throw new ERR_INVALID_STATE.TypeError(
-        'View ArrayBuffer is zero-length or detached');
+        'View ArrayBuffer is zero-length or detached'
+      );
     }
 
     readableByteStreamControllerRespond(controller, bytesWritten);
@@ -634,13 +639,12 @@ class ReadableStreamBYOBRequest {
   respondWithNewView(view) {
     if (!isReadableStreamBYOBRequest(this))
       throw new ERR_INVALID_THIS('ReadableStreamBYOBRequest');
-    const {
-      controller,
-    } = this[kState];
+    const { controller } = this[kState];
 
     if (controller === undefined) {
       throw new ERR_INVALID_STATE.TypeError(
-        'This BYOB request has been invalidated');
+        'This BYOB request has been invalidated'
+      );
     }
 
     readableByteStreamControllerRespondWithNewView(controller, view);
@@ -691,7 +695,9 @@ class DefaultReadRequest {
     this[kState].reject?.(error);
   }
 
-  get promise() { return this[kState].promise; }
+  get promise() {
+    return this[kState].promise;
+  }
 }
 
 class ReadIntoRequest {
@@ -711,13 +717,17 @@ class ReadIntoRequest {
     this[kState].reject?.(error);
   }
 
-  get promise() { return this[kState].promise; }
+  get promise() {
+    return this[kState].promise;
+  }
 }
 
 class ReadableStreamDefaultReader {
   [kType] = 'ReadableStreamDefaultReader';
 
-  get [SymbolToStringTag]() { return this[kType]; }
+  get [SymbolToStringTag]() {
+    return this[kType];
+  }
 
   /**
    * @param {ReadableStream} stream
@@ -749,7 +759,9 @@ class ReadableStreamDefaultReader {
     if (this[kState].stream === undefined) {
       return PromiseReject(
         new ERR_INVALID_STATE.TypeError(
-          'The reader is not attached to a stream'));
+          'The reader is not attached to a stream'
+        )
+      );
     }
     const readRequest = new DefaultReadRequest();
     readableStreamDefaultReaderRead(this, readRequest);
@@ -759,11 +771,11 @@ class ReadableStreamDefaultReader {
   releaseLock() {
     if (!isReadableStreamDefaultReader(this))
       throw new ERR_INVALID_THIS('ReadableStreamDefaultReader');
-    if (this[kState].stream === undefined)
-      return;
+    if (this[kState].stream === undefined) return;
     if (this[kState].readRequests.length) {
       throw new ERR_INVALID_STATE.TypeError(
-        'Cannot release with pending read requests');
+        'Cannot release with pending read requests'
+      );
     }
     readableStreamReaderGenericRelease(this);
   }
@@ -786,8 +798,11 @@ class ReadableStreamDefaultReader {
     if (!isReadableStreamDefaultReader(this))
       return PromiseReject(new ERR_INVALID_THIS('ReadableStreamDefaultReader'));
     if (this[kState].stream === undefined) {
-      return PromiseReject(new ERR_INVALID_STATE.TypeError(
-        'The reader is not attached to a stream'));
+      return PromiseReject(
+        new ERR_INVALID_STATE.TypeError(
+          'The reader is not attached to a stream'
+        )
+      );
     }
     return readableStreamReaderGenericCancel(this, reason);
   }
@@ -811,7 +826,9 @@ ObjectDefineProperties(ReadableStreamDefaultReader.prototype, {
 class ReadableStreamBYOBReader {
   [kType] = 'ReadableStreamBYOBReader';
 
-  get [SymbolToStringTag]() { return this[kType]; }
+  get [SymbolToStringTag]() {
+    return this[kType];
+  }
 
   /**
    * @param {ReadableStream} stream
@@ -845,12 +862,10 @@ class ReadableStreamBYOBReader {
       return PromiseReject(
         new ERR_INVALID_ARG_TYPE(
           'view',
-          [
-            'Buffer',
-            'TypedArray',
-            'DataView',
-          ],
-          view));
+          ['Buffer', 'TypedArray', 'DataView'],
+          view
+        )
+      );
     }
     const viewByteLength = ArrayBufferViewGetByteLength(view);
     const viewBuffer = ArrayBufferViewGetBuffer(view);
@@ -859,14 +874,18 @@ class ReadableStreamBYOBReader {
     if (viewByteLength === 0 || viewBufferByteLength === 0) {
       return PromiseReject(
         new ERR_INVALID_STATE.TypeError(
-          'View ArrayBuffer is zero-length or detached'));
+          'View ArrayBuffer is zero-length or detached'
+        )
+      );
     }
     // Supposed to assert here that the view's buffer is not
     // detached, but there's no API available to use to check that.
     if (this[kState].stream === undefined) {
       return PromiseReject(
         new ERR_INVALID_STATE.TypeError(
-          'The reader is not attached to a stream'));
+          'The reader is not attached to a stream'
+        )
+      );
     }
     const readIntoRequest = new ReadIntoRequest();
     readableStreamBYOBReaderRead(this, view, readIntoRequest);
@@ -876,11 +895,11 @@ class ReadableStreamBYOBReader {
   releaseLock() {
     if (!isReadableStreamBYOBReader(this))
       throw new ERR_INVALID_THIS('ReadableStreamBYOBReader');
-    if (this[kState].stream === undefined)
-      return;
+    if (this[kState].stream === undefined) return;
     if (this[kState].readIntoRequests.length) {
       throw new ERR_INVALID_STATE.TypeError(
-        'Cannot release with pending read requests');
+        'Cannot release with pending read requests'
+      );
     }
     readableStreamReaderGenericRelease(this);
   }
@@ -903,8 +922,11 @@ class ReadableStreamBYOBReader {
     if (!isReadableStreamBYOBReader(this))
       return PromiseReject(new ERR_INVALID_THIS('ReadableStreamBYOBReader'));
     if (this[kState].stream === undefined) {
-      return PromiseReject(new ERR_INVALID_STATE.TypeError(
-        'The reader is not attached to a stream'));
+      return PromiseReject(
+        new ERR_INVALID_STATE.TypeError(
+          'The reader is not attached to a stream'
+        )
+      );
     }
     return readableStreamReaderGenericCancel(this, reason);
   }
@@ -928,7 +950,9 @@ ObjectDefineProperties(ReadableStreamBYOBReader.prototype, {
 class ReadableStreamDefaultController {
   [kType] = 'ReadableStreamDefaultController';
 
-  get [SymbolToStringTag]() { return this[kType]; }
+  get [SymbolToStringTag]() {
+    return this[kType];
+  }
 
   constructor() {
     throw new ERR_ILLEGAL_CONSTRUCTOR();
@@ -973,7 +997,7 @@ class ReadableStreamDefaultController {
   }
 
   [kInspect](depth, options) {
-    return customInspect(depth, options, this[kType], { });
+    return customInspect(depth, options, this[kType], {});
   }
 }
 
@@ -991,14 +1015,16 @@ function createReadableStreamDefaultController() {
       this[kState] = {};
     },
     [],
-    ReadableStreamDefaultController,
+    ReadableStreamDefaultController
   );
 }
 
 class ReadableByteStreamController {
   [kType] = 'ReadableByteStreamController';
 
-  get [SymbolToStringTag]() { return this[kType]; }
+  get [SymbolToStringTag]() {
+    return this[kType];
+  }
 
   constructor() {
     throw new ERR_ILLEGAL_CONSTRUCTOR();
@@ -1011,19 +1037,17 @@ class ReadableByteStreamController {
   get byobRequest() {
     if (!isReadableByteStreamController(this))
       throw new ERR_INVALID_THIS('ReadableByteStreamController');
-    if (this[kState].byobRequest === null &&
-        this[kState].pendingPullIntos.length) {
-      const {
+    if (
+      this[kState].byobRequest === null &&
+      this[kState].pendingPullIntos.length
+    ) {
+      const { buffer, byteOffset, bytesFilled, byteLength } =
+        this[kState].pendingPullIntos[0];
+      const view = new Uint8Array(
         buffer,
-        byteOffset,
-        bytesFilled,
-        byteLength,
-      } = this[kState].pendingPullIntos[0];
-      const view =
-        new Uint8Array(
-          buffer,
-          byteOffset + bytesFilled,
-          byteLength - bytesFilled);
+        byteOffset + bytesFilled,
+        byteLength - bytesFilled
+      );
       this[kState].byobRequest = createReadableStreamBYOBRequest(this, view);
     }
     return this[kState].byobRequest;
@@ -1058,12 +1082,9 @@ class ReadableByteStreamController {
     if (!isArrayBufferView(chunk)) {
       throw new ERR_INVALID_ARG_TYPE(
         'chunk',
-        [
-          'Buffer',
-          'TypedArray',
-          'DataView',
-        ],
-        chunk);
+        ['Buffer', 'TypedArray', 'DataView'],
+        chunk
+      );
     }
     const chunkByteLength = ArrayBufferViewGetByteLength(chunk);
     const chunkByteOffset = ArrayBufferViewGetByteOffset(chunk);
@@ -1071,7 +1092,8 @@ class ReadableByteStreamController {
     const chunkBufferByteLength = ArrayBufferGetByteLength(chunkBuffer);
     if (chunkByteLength === 0 || chunkBufferByteLength === 0) {
       throw new ERR_INVALID_STATE.TypeError(
-        'chunk ArrayBuffer is zero-length or detached');
+        'chunk ArrayBuffer is zero-length or detached'
+      );
     }
     if (this[kState].closeRequested)
       throw new ERR_INVALID_STATE.TypeError('Controller is already closed');
@@ -1081,7 +1103,8 @@ class ReadableByteStreamController {
       this,
       chunkBuffer,
       chunkByteLength,
-      chunkByteOffset);
+      chunkByteOffset
+    );
   }
 
   /**
@@ -1102,7 +1125,7 @@ class ReadableByteStreamController {
   }
 
   [kInspect](depth, options) {
-    return customInspect(depth, options, this[kType], { });
+    return customInspect(depth, options, this[kType], {});
   }
 }
 
@@ -1121,7 +1144,7 @@ function createReadableByteStreamController() {
       this[kState] = {};
     },
     [],
-    ReadableByteStreamController,
+    ReadableByteStreamController
   );
 }
 
@@ -1138,32 +1161,34 @@ function createTeeReadableStream(start, pull, cancel) {
           writable: undefined,
           port: undefined,
           promise: undefined,
-        }
+        },
       };
       setupReadableStreamDefaultControllerFromSource(
         this,
         ObjectCreate(null, {
           start: { value: start },
           pull: { value: pull },
-          cancel: { value: cancel }
+          cancel: { value: cancel },
         }),
         1,
-        () => 1);
+        () => 1
+      );
       return makeTransferable(this);
-    }, [], ReadableStream,
+    },
+    [],
+    ReadableStream
   );
 }
 
-const isReadableStream =
-  isBrandCheck('ReadableStream');
-const isReadableByteStreamController =
-  isBrandCheck('ReadableByteStreamController');
-const isReadableStreamBYOBRequest =
-  isBrandCheck('ReadableStreamBYOBRequest');
-const isReadableStreamDefaultReader =
-  isBrandCheck('ReadableStreamDefaultReader');
-const isReadableStreamBYOBReader =
-  isBrandCheck('ReadableStreamBYOBReader');
+const isReadableStream = isBrandCheck('ReadableStream');
+const isReadableByteStreamController = isBrandCheck(
+  'ReadableByteStreamController'
+);
+const isReadableStreamBYOBRequest = isBrandCheck('ReadableStreamBYOBRequest');
+const isReadableStreamDefaultReader = isBrandCheck(
+  'ReadableStreamDefaultReader'
+);
+const isReadableStreamBYOBReader = isBrandCheck('ReadableStreamBYOBReader');
 
 // ---- ReadableStream Implementation
 
@@ -1173,8 +1198,8 @@ function readableStreamPipeTo(
   preventClose,
   preventAbort,
   preventCancel,
-  signal) {
-
+  signal
+) {
   let reader;
   let writer;
   // Both of these can throw synchronously. We want to capture
@@ -1192,10 +1217,8 @@ function readableStreamPipeTo(
 
   if (signal !== undefined && signal?.[kAborted] === undefined) {
     return PromiseReject(
-      new ERR_INVALID_ARG_TYPE(
-        'options.signal',
-        'AbortSignal',
-        signal));
+      new ERR_INVALID_ARG_TYPE('options.signal', 'AbortSignal', signal)
+    );
   }
 
   const promise = createDeferredPromise();
@@ -1210,28 +1233,26 @@ function readableStreamPipeTo(
     readableStreamReaderGenericRelease(reader);
     if (signal !== undefined)
       signal.removeEventListener('abort', abortAlgorithm);
-    if (rejected)
-      promise.reject(error);
-    else
-      promise.resolve();
+    if (rejected) promise.reject(error);
+    else promise.resolve();
   }
 
   async function waitForCurrentWrite() {
     const write = currentWrite;
     await write;
-    if (write !== currentWrite)
-      await waitForCurrentWrite();
+    if (write !== currentWrite) await waitForCurrentWrite();
   }
 
   function shutdownWithAnAction(action, rejected, originalError) {
     if (shuttingDown) return;
     shuttingDown = true;
-    if (dest[kState].state === 'writable' &&
-        !writableStreamCloseQueuedOrInFlight(dest)) {
-      PromisePrototypeThen(
-        waitForCurrentWrite(),
-        complete,
-        (error) => finalize(true, error));
+    if (
+      dest[kState].state === 'writable' &&
+      !writableStreamCloseQueuedOrInFlight(dest)
+    ) {
+      PromisePrototypeThen(waitForCurrentWrite(), complete, (error) =>
+        finalize(true, error)
+      );
       return;
     }
     complete();
@@ -1240,19 +1261,23 @@ function readableStreamPipeTo(
       PromisePrototypeThen(
         action(),
         () => finalize(rejected, originalError),
-        (error) => finalize(true, error));
+        (error) => finalize(true, error)
+      );
     }
   }
 
   function shutdown(rejected, error) {
     if (shuttingDown) return;
     shuttingDown = true;
-    if (dest[kState].state === 'writable' &&
-        !writableStreamCloseQueuedOrInFlight(dest)) {
+    if (
+      dest[kState].state === 'writable' &&
+      !writableStreamCloseQueuedOrInFlight(dest)
+    ) {
       PromisePrototypeThen(
         waitForCurrentWrite(),
         () => finalize(rejected, error),
-        (error) => finalize(true, error));
+        (error) => finalize(true, error)
+      );
       return;
     }
     finalize(rejected, error);
@@ -1263,66 +1288,56 @@ function readableStreamPipeTo(
     const error = new DOMException('The operation was aborted', 'AbortError');
     const actions = [];
     if (!preventAbort) {
-      ArrayPrototypePush(
-        actions,
-        () => {
-          if (dest[kState].state === 'writable')
-            return writableStreamAbort(dest, error);
-          return PromiseResolve();
-        });
+      ArrayPrototypePush(actions, () => {
+        if (dest[kState].state === 'writable')
+          return writableStreamAbort(dest, error);
+        return PromiseResolve();
+      });
     }
     if (!preventCancel) {
-      ArrayPrototypePush(
-        actions,
-        () => {
-          if (source[kState].state === 'readable')
-            return readableStreamCancel(source, error);
-          return PromiseResolve();
-        });
+      ArrayPrototypePush(actions, () => {
+        if (source[kState].state === 'readable')
+          return readableStreamCancel(source, error);
+        return PromiseResolve();
+      });
     }
 
     shutdownWithAnAction(
       async () => PromiseAll(actions.map((action) => action())),
       true,
-      error);
+      error
+    );
   }
 
   function watchErrored(stream, promise, action) {
-    if (stream[kState].state === 'errored')
-      action(stream[kState].storedError);
-    else
-      PromisePrototypeCatch(promise, action);
+    if (stream[kState].state === 'errored') action(stream[kState].storedError);
+    else PromisePrototypeCatch(promise, action);
   }
 
   function watchClosed(stream, promise, action) {
-    if (stream[kState].state === 'closed')
-      action(stream[kState].storedError);
-    else
-      PromisePrototypeThen(promise, action, () => {});
+    if (stream[kState].state === 'closed') action(stream[kState].storedError);
+    else PromisePrototypeThen(promise, action, () => {});
   }
 
   async function step() {
-    if (shuttingDown)
-      return true;
+    if (shuttingDown) return true;
     await writer[kState].ready.promise;
     return new Promise((resolve, reject) => {
-      readableStreamDefaultReaderRead(
-        reader,
-        {
-          [kChunk](chunk) {
-            currentWrite = writableStreamDefaultWriterWrite(writer, chunk);
-            setPromiseHandled(currentWrite);
-            resolve(false);
-          },
-          [kClose]: () => resolve(true),
-          [kError]: reject,
-        });
+      readableStreamDefaultReaderRead(reader, {
+        [kChunk](chunk) {
+          currentWrite = writableStreamDefaultWriterWrite(writer, chunk);
+          setPromiseHandled(currentWrite);
+          resolve(false);
+        },
+        [kClose]: () => resolve(true),
+        [kError]: reject,
+      });
     });
   }
 
   async function run() {
     // Run until step resolves as true
-    while (!await step()) {}
+    while (!(await step())) {}
   }
 
   if (signal !== undefined) {
@@ -1340,7 +1355,8 @@ function readableStreamPipeTo(
       return shutdownWithAnAction(
         () => writableStreamAbort(dest, error),
         true,
-        error);
+        error
+      );
     }
     shutdown(true, error);
   });
@@ -1350,26 +1366,34 @@ function readableStreamPipeTo(
       return shutdownWithAnAction(
         () => readableStreamCancel(source, error),
         true,
-        error);
+        error
+      );
     }
     shutdown(true, error);
   });
 
   watchClosed(source, reader[kState].close.promise, () => {
     if (!preventClose) {
-      return shutdownWithAnAction(
-        () => writableStreamDefaultWriterCloseWithErrorPropagation(writer));
+      return shutdownWithAnAction(() =>
+        writableStreamDefaultWriterCloseWithErrorPropagation(writer)
+      );
     }
     shutdown();
   });
 
-  if (writableStreamCloseQueuedOrInFlight(dest) ||
-      dest[kState].state === 'closed') {
+  if (
+    writableStreamCloseQueuedOrInFlight(dest) ||
+    dest[kState].state === 'closed'
+  ) {
     const error = new ERR_INVALID_STATE.TypeError(
-      'Destination WritableStream is closed');
+      'Destination WritableStream is closed'
+    );
     if (!preventCancel) {
       shutdownWithAnAction(
-        () => readableStreamCancel(source, error), true, error);
+        () => readableStreamCancel(source, error),
+        true,
+        error
+      );
     } else {
       shutdown(true, error);
     }
@@ -1405,12 +1429,14 @@ function readableStreamTee(stream, cloneForBranch2) {
           if (!canceled1) {
             readableStreamDefaultControllerEnqueue(
               branch1[kState].controller,
-              value1);
+              value1
+            );
           }
           if (!canceled2) {
             readableStreamDefaultControllerEnqueue(
               branch2[kState].controller,
-              value2);
+              value2
+            );
           }
         });
       },
@@ -1420,8 +1446,7 @@ function readableStreamTee(stream, cloneForBranch2) {
           readableStreamDefaultControllerClose(branch1[kState].controller);
         if (!canceled2)
           readableStreamDefaultControllerClose(branch2[kState].controller);
-        if (!canceled1 || !canceled2)
-          cancelPromise.resolve();
+        if (!canceled1 || !canceled2) cancelPromise.resolve();
       },
       [kError]() {
         reading = false;
@@ -1450,32 +1475,29 @@ function readableStreamTee(stream, cloneForBranch2) {
     return cancelPromise.promise;
   }
 
-  branch1 =
-    createTeeReadableStream(nonOpStart, pullAlgorithm, cancel1Algorithm);
-  branch2 =
-    createTeeReadableStream(nonOpStart, pullAlgorithm, cancel2Algorithm);
+  branch1 = createTeeReadableStream(
+    nonOpStart,
+    pullAlgorithm,
+    cancel1Algorithm
+  );
+  branch2 = createTeeReadableStream(
+    nonOpStart,
+    pullAlgorithm,
+    cancel2Algorithm
+  );
 
-  PromisePrototypeCatch(
-    reader[kState].close.promise,
-    (error) => {
-      readableStreamDefaultControllerError(branch1[kState].controller, error);
-      readableStreamDefaultControllerError(branch2[kState].controller, error);
-      if (!canceled1 || !canceled2)
-        cancelPromise.resolve();
-    });
+  PromisePrototypeCatch(reader[kState].close.promise, (error) => {
+    readableStreamDefaultControllerError(branch1[kState].controller, error);
+    readableStreamDefaultControllerError(branch2[kState].controller, error);
+    if (!canceled1 || !canceled2) cancelPromise.resolve();
+  });
 
   return [branch1, branch2];
 }
 
 function readableByteStreamControllerConvertPullIntoDescriptor(desc) {
-  const {
-    buffer,
-    bytesFilled,
-    byteLength,
-    byteOffset,
-    ctor,
-    elementSize,
-  } = desc;
+  const { buffer, bytesFilled, byteLength, byteOffset, ctor, elementSize } =
+    desc;
   if (bytesFilled > byteLength)
     throw new ERR_INVALID_STATE.RangeError('The buffer size is invalid');
   assert(!(bytesFilled % elementSize));
@@ -1488,6 +1510,7 @@ function isReadableStreamLocked(stream) {
 }
 
 function readableStreamCancel(stream, reason) {
+  // XXX
   stream[kState].disturbed = true;
   switch (stream[kState].state) {
     case 'closed':
@@ -1496,9 +1519,7 @@ function readableStreamCancel(stream, reason) {
       return PromiseReject(stream[kState].storedError);
   }
   readableStreamClose(stream);
-  const {
-    reader,
-  } = stream[kState];
+  const { reader } = stream[kState];
   if (reader !== undefined && readableStreamHasBYOBReader(stream)) {
     for (let n = 0; n < reader[kState].readIntoRequests.length; n++)
       reader[kState].readIntoRequests[n][kClose]();
@@ -1509,20 +1530,21 @@ function readableStreamCancel(stream, reason) {
     ensureIsPromise(
       stream[kState].controller[kCancel],
       stream[kState].controller,
-      reason),
-    () => {});
+      reason
+    ),
+    () => {}
+  );
 }
 
 function readableStreamClose(stream) {
   assert(stream[kState].state === 'readable');
   stream[kState].state = 'closed';
 
-  const {
-    reader,
-  } = stream[kState];
+  readableStreamCallAllFinishedCallbacks(stream);
 
-  if (reader === undefined)
-    return;
+  const { reader } = stream[kState];
+
+  if (reader === undefined) return;
 
   reader[kState].close.resolve();
 
@@ -1538,12 +1560,11 @@ function readableStreamError(stream, error) {
   stream[kState].state = 'errored';
   stream[kState].storedError = error;
 
-  const {
-    reader
-  } = stream[kState];
+  readableStreamCallAllFinishedCallbacks(stream);
 
-  if (reader === undefined)
-    return;
+  const { reader } = stream[kState];
+
+  if (reader === undefined) return;
 
   reader[kState].close.reject(error);
   setPromiseHandled(reader[kState].close.promise);
@@ -1560,16 +1581,23 @@ function readableStreamError(stream, error) {
   }
 }
 
+function isReadableStreamClosed(stream) {
+  return stream[kState].state === 'closed';
+}
+
+function isReadableStreamErrored(stream) {
+  return stream[kState].state === 'errored';
+}
+
 function readableStreamHasDefaultReader(stream) {
-  const {
-    reader,
-  } = stream[kState];
+  const { reader } = stream[kState];
 
-  if (reader === undefined)
-    return false;
+  if (reader === undefined) return false;
 
-  return reader[kState] !== undefined &&
-         reader[kType] === 'ReadableStreamDefaultReader';
+  return (
+    reader[kState] !== undefined &&
+    reader[kType] === 'ReadableStreamDefaultReader'
+  );
 }
 
 function readableStreamGetNumReadRequests(stream) {
@@ -1578,15 +1606,13 @@ function readableStreamGetNumReadRequests(stream) {
 }
 
 function readableStreamHasBYOBReader(stream) {
-  const {
-    reader,
-  } = stream[kState];
+  const { reader } = stream[kState];
 
-  if (reader === undefined)
-    return false;
+  if (reader === undefined) return false;
 
-  return reader[kState] !== undefined &&
-         reader[kType] === 'ReadableStreamBYOBReader';
+  return (
+    reader[kState] !== undefined && reader[kType] === 'ReadableStreamBYOBReader'
+  );
 }
 
 function readableStreamGetNumReadIntoRequests(stream) {
@@ -1596,9 +1622,7 @@ function readableStreamGetNumReadIntoRequests(stream) {
 
 function readableStreamFulfillReadRequest(stream, chunk, done) {
   assert(readableStreamHasDefaultReader(stream));
-  const {
-    reader,
-  } = stream[kState];
+  const { reader } = stream[kState];
   assert(reader[kState].readRequests.length);
   const readRequest = ArrayPrototypeShift(reader[kState].readRequests);
 
@@ -1606,23 +1630,17 @@ function readableStreamFulfillReadRequest(stream, chunk, done) {
   // will be true here. The spec requires this check but none of the
   // WPT's or other tests trigger it. Will need to investigate how to
   // get coverage for this.
-  if (done)
-    readRequest[kClose]();
-  else
-    readRequest[kChunk](chunk);
+  if (done) readRequest[kClose]();
+  else readRequest[kChunk](chunk);
 }
 
 function readableStreamFulfillReadIntoRequest(stream, chunk, done) {
   assert(readableStreamHasBYOBReader(stream));
-  const {
-    reader,
-  } = stream[kState];
+  const { reader } = stream[kState];
   assert(reader[kState].readIntoRequests.length);
   const readIntoRequest = ArrayPrototypeShift(reader[kState].readIntoRequests);
-  if (done)
-    readIntoRequest[kClose](chunk);
-  else
-    readIntoRequest[kChunk](chunk);
+  if (done) readIntoRequest[kClose](chunk);
+  else readIntoRequest[kChunk](chunk);
 }
 
 function readableStreamAddReadRequest(stream, readRequest) {
@@ -1636,13 +1654,12 @@ function readableStreamAddReadIntoRequest(stream, readIntoRequest) {
   assert(stream[kState].state !== 'errored');
   ArrayPrototypePush(
     stream[kState].reader[kState].readIntoRequests,
-    readIntoRequest);
+    readIntoRequest
+  );
 }
 
 function readableStreamReaderGenericCancel(reader, reason) {
-  const {
-    stream,
-  } = reader[kState];
+  const { stream } = reader[kState];
   assert(stream !== undefined);
   return readableStreamCancel(stream, reason);
 }
@@ -1673,19 +1690,19 @@ function readableStreamReaderGenericInitialize(reader, stream) {
 }
 
 function readableStreamReaderGenericRelease(reader) {
-  const {
-    stream,
-  } = reader[kState];
+  const { stream } = reader[kState];
   assert(stream !== undefined);
   assert(stream[kState].reader === reader);
 
   if (stream[kState].state === 'readable') {
     reader[kState].close.reject?.(
-      new ERR_INVALID_STATE.TypeError('Reader released'));
+      new ERR_INVALID_STATE.TypeError('Reader released')
+    );
   } else {
     reader[kState].close = {
       promise: PromiseReject(
-        new ERR_INVALID_STATE.TypeError('Reader released')),
+        new ERR_INVALID_STATE.TypeError('Reader released')
+      ),
       resolve: undefined,
       reject: undefined,
     };
@@ -1696,9 +1713,7 @@ function readableStreamReaderGenericRelease(reader) {
 }
 
 function readableStreamBYOBReaderRead(reader, view, readIntoRequest) {
-  const {
-    stream,
-  } = reader[kState];
+  const { stream } = reader[kState];
   assert(stream !== undefined);
   stream[kState].disturbed = true;
   if (stream[kState].state === 'errored') {
@@ -1708,13 +1723,12 @@ function readableStreamBYOBReaderRead(reader, view, readIntoRequest) {
   readableByteStreamControllerPullInto(
     stream[kState].controller,
     view,
-    readIntoRequest);
+    readIntoRequest
+  );
 }
 
 function readableStreamDefaultReaderRead(reader, readRequest) {
-  const {
-    stream,
-  } = reader[kState];
+  const { stream } = reader[kState];
   assert(stream !== undefined);
   stream[kState].disturbed = true;
   switch (stream[kState].state) {
@@ -1732,9 +1746,7 @@ function readableStreamDefaultReaderRead(reader, readRequest) {
 function setupReadableStreamBYOBReader(reader, stream) {
   if (isReadableStreamLocked(stream))
     throw new ERR_INVALID_STATE.TypeError('ReadableStream is locked');
-  const {
-    controller,
-  } = stream[kState];
+  const { controller } = stream[kState];
   if (!isReadableByteStreamController(controller))
     throw new ERR_INVALID_ARG_VALUE('reader', reader, 'must be a byte stream');
   readableStreamReaderGenericInitialize(reader, stream);
@@ -1749,8 +1761,7 @@ function setupReadableStreamDefaultReader(reader, stream) {
 }
 
 function readableStreamDefaultControllerClose(controller) {
-  if (!readableStreamDefaultControllerCanCloseOrEnqueue(controller))
-    return;
+  if (!readableStreamDefaultControllerCanCloseOrEnqueue(controller)) return;
   controller[kState].closeRequested = true;
   if (!controller[kState].queue.length) {
     readableStreamDefaultControllerClearAlgorithms(controller);
@@ -1759,23 +1770,22 @@ function readableStreamDefaultControllerClose(controller) {
 }
 
 function readableStreamDefaultControllerEnqueue(controller, chunk) {
-  if (!readableStreamDefaultControllerCanCloseOrEnqueue(controller))
-    return;
+  if (!readableStreamDefaultControllerCanCloseOrEnqueue(controller)) return;
 
-  const {
-    stream,
-  } = controller[kState];
+  const { stream } = controller[kState];
 
-  if (isReadableStreamLocked(stream) &&
-      readableStreamGetNumReadRequests(stream)) {
+  if (
+    isReadableStreamLocked(stream) &&
+    readableStreamGetNumReadRequests(stream)
+  ) {
     readableStreamFulfillReadRequest(stream, chunk, false);
   } else {
     try {
-      const chunkSize =
-        FunctionPrototypeCall(
-          controller[kState].sizeAlgorithm,
-          undefined,
-          chunk);
+      const chunkSize = FunctionPrototypeCall(
+        controller[kState].sizeAlgorithm,
+        undefined,
+        chunk
+      );
       enqueueValueWithSize(controller, chunk, chunkSize);
     } catch (error) {
       readableStreamDefaultControllerError(controller, error);
@@ -1790,37 +1800,36 @@ function readableStreamDefaultControllerHasBackpressure(controller) {
 }
 
 function readableStreamDefaultControllerCanCloseOrEnqueue(controller) {
-  const {
-    stream,
-  } = controller[kState];
-  return !controller[kState].closeRequested &&
-         stream[kState].state === 'readable';
+  const { stream } = controller[kState];
+  return (
+    !controller[kState].closeRequested && stream[kState].state === 'readable'
+  );
 }
 
 function readableStreamDefaultControllerGetDesiredSize(controller) {
-  const {
-    stream,
-    highWaterMark,
-    queueTotalSize,
-  } = controller[kState];
+  const { stream, highWaterMark, queueTotalSize } = controller[kState];
   switch (stream[kState].state) {
-    case 'errored': return null;
-    case 'closed': return 0;
+    case 'errored':
+      return null;
+    case 'closed':
+      return 0;
     default:
       return highWaterMark - queueTotalSize;
   }
 }
 
 function readableStreamDefaultControllerShouldCallPull(controller) {
-  const {
-    stream,
-  } = controller[kState];
-  if (!readableStreamDefaultControllerCanCloseOrEnqueue(controller) ||
-      !controller[kState].started)
+  const { stream } = controller[kState];
+  if (
+    !readableStreamDefaultControllerCanCloseOrEnqueue(controller) ||
+    !controller[kState].started
+  )
     return false;
 
-  if (isReadableStreamLocked(stream) &&
-      readableStreamGetNumReadRequests(stream)) {
+  if (
+    isReadableStreamLocked(stream) &&
+    readableStreamGetNumReadRequests(stream)
+  ) {
     return true;
   }
 
@@ -1831,8 +1840,7 @@ function readableStreamDefaultControllerShouldCallPull(controller) {
 }
 
 function readableStreamDefaultControllerCallPullIfNeeded(controller) {
-  if (!readableStreamDefaultControllerShouldCallPull(controller))
-    return;
+  if (!readableStreamDefaultControllerShouldCallPull(controller)) return;
   if (controller[kState].pulling) {
     controller[kState].pullAgain = true;
     return;
@@ -1848,7 +1856,8 @@ function readableStreamDefaultControllerCallPullIfNeeded(controller) {
         readableStreamDefaultControllerCallPullIfNeeded(controller);
       }
     },
-    (error) => readableStreamDefaultControllerError(controller, error));
+    (error) => readableStreamDefaultControllerError(controller, error)
+  );
 }
 
 function readableStreamDefaultControllerClearAlgorithms(controller) {
@@ -1858,9 +1867,7 @@ function readableStreamDefaultControllerClearAlgorithms(controller) {
 }
 
 function readableStreamDefaultControllerError(controller, error) {
-  const {
-    stream,
-  } = controller[kState];
+  const { stream } = controller[kState];
   if (stream[kState].state === 'readable') {
     resetQueue(controller);
     readableStreamDefaultControllerClearAlgorithms(controller);
@@ -1876,10 +1883,7 @@ function readableStreamDefaultControllerCancelSteps(controller, reason) {
 }
 
 function readableStreamDefaultControllerPullSteps(controller, readRequest) {
-  const {
-    stream,
-    queue,
-  } = controller[kState];
+  const { stream, queue } = controller[kState];
   if (queue.length) {
     const chunk = dequeueValue(controller);
     if (controller[kState].closeRequested && !queue.length) {
@@ -1902,7 +1906,8 @@ function setupReadableStreamDefaultController(
   pullAlgorithm,
   cancelAlgorithm,
   highWaterMark,
-  sizeAlgorithm) {
+  sizeAlgorithm
+) {
   assert(stream[kState].controller === undefined);
   controller[kState] = {
     cancelAlgorithm,
@@ -1929,14 +1934,16 @@ function setupReadableStreamDefaultController(
       assert(!controller[kState].pullAgain);
       readableStreamDefaultControllerCallPullIfNeeded(controller);
     },
-    (error) => readableStreamDefaultControllerError(controller, error));
+    (error) => readableStreamDefaultControllerError(controller, error)
+  );
 }
 
 function setupReadableStreamDefaultControllerFromSource(
   stream,
   source,
   highWaterMark,
-  sizeAlgorithm) {
+  sizeAlgorithm
+) {
   const controller = createReadableStreamDefaultController();
   const start = source?.start;
   const pull = source?.pull;
@@ -1959,19 +1966,15 @@ function setupReadableStreamDefaultControllerFromSource(
     pullAlgorithm,
     cancelAlgorithm,
     highWaterMark,
-    sizeAlgorithm);
+    sizeAlgorithm
+  );
 }
 
 function readableByteStreamControllerClose(controller) {
-  const {
-    closeRequested,
-    pendingPullIntos,
-    queueTotalSize,
-    stream,
-  } = controller[kState];
+  const { closeRequested, pendingPullIntos, queueTotalSize, stream } =
+    controller[kState];
 
-  if (closeRequested || stream[kState].state !== 'readable')
-    return;
+  if (closeRequested || stream[kState].state !== 'readable') return;
 
   if (queueTotalSize) {
     controller[kState].closeRequested = true;
@@ -2011,8 +2014,7 @@ function readableByteStreamControllerCommitPullIntoDescriptor(stream, desc) {
 }
 
 function readableByteStreamControllerInvalidateBYOBRequest(controller) {
-  if (controller[kState].byobRequest === null)
-    return;
+  if (controller[kState].byobRequest === null) return;
   controller[kState].byobRequest[kState].controller = undefined;
   controller[kState].byobRequest[kState].view = null;
   controller[kState].byobRequest = null;
@@ -2029,34 +2031,37 @@ function readableByteStreamControllerClearPendingPullIntos(controller) {
 }
 
 function readableByteStreamControllerGetDesiredSize(controller) {
-  const {
-    stream,
-    highWaterMark,
-    queueTotalSize,
-  } = controller[kState];
+  const { stream, highWaterMark, queueTotalSize } = controller[kState];
   switch (stream[kState].state) {
-    case 'errored': return null;
-    case 'closed': return 0;
-    default: return highWaterMark - queueTotalSize;
+    case 'errored':
+      return null;
+    case 'closed':
+      return 0;
+    default:
+      return highWaterMark - queueTotalSize;
   }
 }
 
 function readableByteStreamControllerShouldCallPull(controller) {
-  const {
-    stream,
-  } = controller[kState];
-  if (stream[kState].state !== 'readable' ||
-      controller[kState].closeRequested ||
-      !controller[kState].started) {
+  const { stream } = controller[kState];
+  if (
+    stream[kState].state !== 'readable' ||
+    controller[kState].closeRequested ||
+    !controller[kState].started
+  ) {
     return false;
   }
-  if (readableStreamHasDefaultReader(stream) &&
-      readableStreamGetNumReadRequests(stream) > 0) {
+  if (
+    readableStreamHasDefaultReader(stream) &&
+    readableStreamGetNumReadRequests(stream) > 0
+  ) {
     return true;
   }
 
-  if (readableStreamHasBYOBReader(stream) &&
-      readableStreamGetNumReadIntoRequests(stream) > 0) {
+  if (
+    readableStreamHasBYOBReader(stream) &&
+    readableStreamGetNumReadIntoRequests(stream) > 0
+  ) {
     return true;
   }
 
@@ -2067,11 +2072,7 @@ function readableByteStreamControllerShouldCallPull(controller) {
 }
 
 function readableByteStreamControllerHandleQueueDrain(controller) {
-  const {
-    closeRequested,
-    queueTotalSize,
-    stream,
-  } = controller[kState];
+  const { closeRequested, queueTotalSize, stream } = controller[kState];
   assert(stream[kState].state === 'readable');
   if (!queueTotalSize && closeRequested) {
     readableByteStreamControllerClearAlgorithms(controller);
@@ -2084,12 +2085,9 @@ function readableByteStreamControllerHandleQueueDrain(controller) {
 function readableByteStreamControllerPullInto(
   controller,
   view,
-  readIntoRequest) {
-  const {
-    closeRequested,
-    stream,
-    pendingPullIntos,
-  } = controller[kState];
+  readIntoRequest
+) {
+  const { closeRequested, stream, pendingPullIntos } = controller[kState];
   let elementSize = 1;
   let ctor = DataViewCtor;
   if (isArrayBufferView(view) && !isDataView(view)) {
@@ -2129,9 +2127,12 @@ function readableByteStreamControllerPullInto(
     return;
   }
   if (controller[kState].queueTotalSize) {
-    if (readableByteStreamControllerFillPullIntoDescriptorFromQueue(
-      controller,
-      desc)) {
+    if (
+      readableByteStreamControllerFillPullIntoDescriptorFromQueue(
+        controller,
+        desc
+      )
+    ) {
       const filledView =
         readableByteStreamControllerConvertPullIntoDescriptor(desc);
       readableByteStreamControllerHandleQueueDrain(controller);
@@ -2151,16 +2152,14 @@ function readableByteStreamControllerPullInto(
 }
 
 function readableByteStreamControllerRespondInternal(controller, bytesWritten) {
-  const {
-    stream,
-    pendingPullIntos,
-  } = controller[kState];
+  const { stream, pendingPullIntos } = controller[kState];
   const desc = pendingPullIntos[0];
   readableByteStreamControllerInvalidateBYOBRequest(controller);
   if (stream[kState].state === 'closed') {
     if (bytesWritten)
       throw new ERR_INVALID_STATE.TypeError(
-        'Controller is closed but view is not zero-length');
+        'Controller is closed but view is not zero-length'
+      );
     readableByteStreamControllerRespondInClosedState(controller, desc);
   } else {
     assert(stream[kState].state === 'readable');
@@ -2169,16 +2168,14 @@ function readableByteStreamControllerRespondInternal(controller, bytesWritten) {
     readableByteStreamControllerRespondInReadableState(
       controller,
       bytesWritten,
-      desc);
+      desc
+    );
   }
   readableByteStreamControllerCallPullIfNeeded(controller);
 }
 
 function readableByteStreamControllerRespond(controller, bytesWritten) {
-  const {
-    pendingPullIntos,
-    stream,
-  } = controller[kState];
+  const { pendingPullIntos, stream } = controller[kState];
   assert(pendingPullIntos.length);
   const desc = pendingPullIntos[0];
 
@@ -2191,7 +2188,7 @@ function readableByteStreamControllerRespond(controller, bytesWritten) {
     if (!bytesWritten)
       throw new ERR_INVALID_ARG_VALUE('bytesWritten', bytesWritten);
 
-    if ((desc.bytesFilled + bytesWritten) > desc.byteLength)
+    if (desc.bytesFilled + bytesWritten > desc.byteLength)
       throw new ERR_INVALID_ARG_VALUE.RangeError('bytesWritten', bytesWritten);
   }
 
@@ -2202,14 +2199,13 @@ function readableByteStreamControllerRespond(controller, bytesWritten) {
 
 function readableByteStreamControllerRespondInClosedState(controller, desc) {
   assert(!desc.bytesFilled);
-  const {
-    stream,
-  } = controller[kState];
+  const { stream } = controller[kState];
   if (readableStreamHasBYOBReader(stream)) {
     while (readableStreamGetNumReadIntoRequests(stream) > 0) {
       readableByteStreamControllerCommitPullIntoDescriptor(
         stream,
-        readableByteStreamControllerShiftPendingPullInto(controller));
+        readableByteStreamControllerShiftPendingPullInto(controller)
+      );
     }
   }
 }
@@ -2217,11 +2213,9 @@ function readableByteStreamControllerRespondInClosedState(controller, desc) {
 function readableByteStreamControllerFillHeadPullIntoDescriptor(
   controller,
   size,
-  desc) {
-  const {
-    pendingPullIntos,
-    byobRequest,
-  } = controller[kState];
+  desc
+) {
+  const { pendingPullIntos, byobRequest } = controller[kState];
   assert(!pendingPullIntos.length || pendingPullIntos[0] === desc);
   assert(byobRequest === null);
   desc.bytesFilled += size;
@@ -2231,31 +2225,30 @@ function readableByteStreamControllerEnqueue(
   controller,
   buffer,
   byteLength,
-  byteOffset) {
-  const {
-    closeRequested,
-    pendingPullIntos,
-    queue,
-    stream,
-  } = controller[kState];
+  byteOffset
+) {
+  const { closeRequested, pendingPullIntos, queue, stream } =
+    controller[kState];
 
-  if (closeRequested || stream[kState].state !== 'readable')
-    return;
+  if (closeRequested || stream[kState].state !== 'readable') return;
 
   const transferredBuffer = transferArrayBuffer(buffer);
 
   if (pendingPullIntos.length) {
     const firstPendingPullInto = pendingPullIntos[0];
 
-    const pendingBufferByteLength =
-      ArrayBufferGetByteLength(firstPendingPullInto.buffer);
+    const pendingBufferByteLength = ArrayBufferGetByteLength(
+      firstPendingPullInto.buffer
+    );
     if (pendingBufferByteLength === 0) {
       throw new ERR_INVALID_STATE.TypeError(
-        'Destination ArrayBuffer is zero-length or detached');
+        'Destination ArrayBuffer is zero-length or detached'
+      );
     }
 
-    firstPendingPullInto.buffer =
-      transferArrayBuffer(firstPendingPullInto.buffer);
+    firstPendingPullInto.buffer = transferArrayBuffer(
+      firstPendingPullInto.buffer
+    );
   }
 
   readableByteStreamControllerInvalidateBYOBRequest(controller);
@@ -2266,7 +2259,8 @@ function readableByteStreamControllerEnqueue(
         controller,
         transferredBuffer,
         byteOffset,
-        byteLength);
+        byteLength
+      );
     } else {
       assert(!queue.length);
       const transferredView =
@@ -2278,16 +2272,19 @@ function readableByteStreamControllerEnqueue(
       controller,
       transferredBuffer,
       byteOffset,
-      byteLength);
+      byteLength
+    );
     readableByteStreamControllerProcessPullIntoDescriptorsUsingQueue(
-      controller);
+      controller
+    );
   } else {
     assert(!isReadableStreamLocked(stream));
     readableByteStreamControllerEnqueueChunkToQueue(
       controller,
       transferredBuffer,
       byteOffset,
-      byteLength);
+      byteLength
+    );
   }
   readableByteStreamControllerCallPullIfNeeded(controller);
 }
@@ -2296,31 +2293,26 @@ function readableByteStreamControllerEnqueueChunkToQueue(
   controller,
   buffer,
   byteOffset,
-  byteLength) {
-  ArrayPrototypePush(
-    controller[kState].queue,
-    {
-      buffer,
-      byteOffset,
-      byteLength,
-    });
+  byteLength
+) {
+  ArrayPrototypePush(controller[kState].queue, {
+    buffer,
+    byteOffset,
+    byteLength,
+  });
   controller[kState].queueTotalSize += byteLength;
 }
 
 function readableByteStreamControllerFillPullIntoDescriptorFromQueue(
   controller,
-  desc) {
-  const {
-    buffer,
-    byteLength,
-    byteOffset,
-    bytesFilled,
-    elementSize,
-  } = desc;
+  desc
+) {
+  const { buffer, byteLength, byteOffset, bytesFilled, elementSize } = desc;
   const currentAlignedBytes = bytesFilled - (bytesFilled % elementSize);
   const maxBytesToCopy = MathMin(
     controller[kState].queueTotalSize,
-    byteLength - bytesFilled);
+    byteLength - bytesFilled
+  );
   const maxBytesFilled = bytesFilled + maxBytesToCopy;
   const maxAlignedBytes = maxBytesFilled - (maxBytesFilled % elementSize);
   let totalBytesToCopyRemaining = maxBytesToCopy;
@@ -2329,20 +2321,20 @@ function readableByteStreamControllerFillPullIntoDescriptorFromQueue(
     totalBytesToCopyRemaining = maxAlignedBytes - bytesFilled;
     ready = true;
   }
-  const {
-    queue,
-  } = controller[kState];
+  const { queue } = controller[kState];
 
   while (totalBytesToCopyRemaining) {
     const headOfQueue = queue[0];
     const bytesToCopy = MathMin(
       totalBytesToCopyRemaining,
-      headOfQueue.byteLength);
+      headOfQueue.byteLength
+    );
     const destStart = byteOffset + desc.bytesFilled;
     const arrayBufferByteLength = ArrayBufferGetByteLength(buffer);
     if (arrayBufferByteLength - destStart < bytesToCopy) {
       throw new ERR_INVALID_STATE.RangeError(
-        'view ArrayBuffer size is invalid');
+        'view ArrayBuffer size is invalid'
+      );
     }
     assert(arrayBufferByteLength - destStart >= bytesToCopy);
     copyArrayBuffer(
@@ -2350,7 +2342,8 @@ function readableByteStreamControllerFillPullIntoDescriptorFromQueue(
       destStart,
       headOfQueue.buffer,
       headOfQueue.byteOffset,
-      bytesToCopy);
+      bytesToCopy
+    );
     if (headOfQueue.byteLength === bytesToCopy) {
       ArrayPrototypeShift(queue);
     } else {
@@ -2361,7 +2354,8 @@ function readableByteStreamControllerFillPullIntoDescriptorFromQueue(
     readableByteStreamControllerFillHeadPullIntoDescriptor(
       controller,
       bytesToCopy,
-      desc);
+      desc
+    );
     totalBytesToCopyRemaining -= bytesToCopy;
   }
 
@@ -2374,20 +2368,19 @@ function readableByteStreamControllerFillPullIntoDescriptorFromQueue(
 }
 
 function readableByteStreamControllerProcessPullIntoDescriptorsUsingQueue(
-  controller) {
-  const {
-    closeRequested,
-    pendingPullIntos,
-    stream,
-  } = controller[kState];
+  controller
+) {
+  const { closeRequested, pendingPullIntos, stream } = controller[kState];
   assert(!closeRequested);
   while (pendingPullIntos.length) {
-    if (!controller[kState].queueTotalSize)
-      return;
+    if (!controller[kState].queueTotalSize) return;
     const desc = pendingPullIntos[0];
-    if (readableByteStreamControllerFillPullIntoDescriptorFromQueue(
-      controller,
-      desc)) {
+    if (
+      readableByteStreamControllerFillPullIntoDescriptorFromQueue(
+        controller,
+        desc
+      )
+    ) {
       readableByteStreamControllerShiftPendingPullInto(controller);
       readableByteStreamControllerCommitPullIntoDescriptor(stream, desc);
     }
@@ -2397,12 +2390,9 @@ function readableByteStreamControllerProcessPullIntoDescriptorsUsingQueue(
 function readableByteStreamControllerRespondInReadableState(
   controller,
   bytesWritten,
-  desc) {
-  const {
-    buffer,
-    bytesFilled,
-    byteLength,
-  } = desc;
+  desc
+) {
+  const { buffer, bytesFilled, byteLength } = desc;
 
   if (bytesFilled + bytesWritten > byteLength)
     throw new ERR_INVALID_STATE.RangeError('The buffer size is invalid');
@@ -2410,10 +2400,10 @@ function readableByteStreamControllerRespondInReadableState(
   readableByteStreamControllerFillHeadPullIntoDescriptor(
     controller,
     bytesWritten,
-    desc);
+    desc
+  );
 
-  if (desc.bytesFilled < desc.elementSize)
-    return;
+  if (desc.bytesFilled < desc.elementSize) return;
 
   readableByteStreamControllerShiftPendingPullInto(controller);
 
@@ -2422,29 +2412,24 @@ function readableByteStreamControllerRespondInReadableState(
   if (remainderSize) {
     const end = desc.byteOffset + desc.bytesFilled;
     const start = end - remainderSize;
-    const remainder =
-      ArrayBufferPrototypeSlice(
-        buffer,
-        start,
-        end);
+    const remainder = ArrayBufferPrototypeSlice(buffer, start, end);
     readableByteStreamControllerEnqueueChunkToQueue(
       controller,
       remainder,
       0,
-      ArrayBufferGetByteLength(remainder));
+      ArrayBufferGetByteLength(remainder)
+    );
   }
   desc.bytesFilled -= remainderSize;
   readableByteStreamControllerCommitPullIntoDescriptor(
     controller[kState].stream,
-    desc);
+    desc
+  );
   readableByteStreamControllerProcessPullIntoDescriptorsUsingQueue(controller);
 }
 
 function readableByteStreamControllerRespondWithNewView(controller, view) {
-  const {
-    stream,
-    pendingPullIntos,
-  } = controller[kState];
+  const { stream, pendingPullIntos } = controller[kState];
   assert(pendingPullIntos.length);
 
   const desc = pendingPullIntos[0];
@@ -2453,24 +2438,16 @@ function readableByteStreamControllerRespondWithNewView(controller, view) {
   if (!isArrayBufferView(view)) {
     throw new ERR_INVALID_ARG_TYPE(
       'view',
-      [
-        'Buffer',
-        'TypedArray',
-        'DataView',
-      ],
-      view);
+      ['Buffer', 'TypedArray', 'DataView'],
+      view
+    );
   }
   const viewByteLength = ArrayBufferViewGetByteLength(view);
   const viewByteOffset = ArrayBufferViewGetByteOffset(view);
   const viewBuffer = ArrayBufferViewGetBuffer(view);
   const viewBufferByteLength = ArrayBufferGetByteLength(viewBuffer);
 
-  const {
-    byteOffset,
-    byteLength,
-    bytesFilled,
-    bufferByteLength,
-  } = desc;
+  const { byteOffset, byteLength, bytesFilled, bufferByteLength } = desc;
 
   if (byteOffset + bytesFilled !== viewByteOffset)
     throw new ERR_INVALID_ARG_VALUE.RangeError('view', view);
@@ -2492,8 +2469,7 @@ function readableByteStreamControllerShiftPendingPullInto(controller) {
 }
 
 function readableByteStreamControllerCallPullIfNeeded(controller) {
-  if (!readableByteStreamControllerShouldCallPull(controller))
-    return;
+  if (!readableByteStreamControllerShouldCallPull(controller)) return;
   if (controller[kState].pulling) {
     controller[kState].pullAgain = true;
     return;
@@ -2509,15 +2485,13 @@ function readableByteStreamControllerCallPullIfNeeded(controller) {
         readableByteStreamControllerCallPullIfNeeded(controller);
       }
     },
-    (error) => readableByteStreamControllerError(controller, error));
+    (error) => readableByteStreamControllerError(controller, error)
+  );
 }
 
 function readableByteStreamControllerError(controller, error) {
-  const {
-    stream,
-  } = controller[kState];
-  if (stream[kState].state !== 'readable')
-    return;
+  const { stream } = controller[kState];
+  if (stream[kState].state !== 'readable') return;
   readableByteStreamControllerClearPendingPullIntos(controller);
   resetQueue(controller);
   readableByteStreamControllerClearAlgorithms(controller);
@@ -2533,43 +2507,31 @@ function readableByteStreamControllerCancelSteps(controller, reason) {
 }
 
 function readableByteStreamControllerPullSteps(controller, readRequest) {
-  const {
-    pendingPullIntos,
-    queue,
-    queueTotalSize,
-    stream,
-  } = controller[kState];
+  const { pendingPullIntos, queue, queueTotalSize, stream } =
+    controller[kState];
   assert(readableStreamHasDefaultReader(stream));
   if (queueTotalSize) {
     assert(!readableStreamGetNumReadRequests(stream));
-    const {
-      buffer,
-      byteOffset,
-      byteLength,
-    } = ArrayPrototypeShift(queue);
+    const { buffer, byteOffset, byteLength } = ArrayPrototypeShift(queue);
     controller[kState].queueTotalSize -= byteLength;
     readableByteStreamControllerHandleQueueDrain(controller);
     const view = new Uint8Array(buffer, byteOffset, byteLength);
     readRequest[kChunk](view);
     return;
   }
-  const {
-    autoAllocateChunkSize,
-  } = controller[kState];
+  const { autoAllocateChunkSize } = controller[kState];
   if (autoAllocateChunkSize !== undefined) {
     try {
       const buffer = new ArrayBuffer(autoAllocateChunkSize);
-      ArrayPrototypePush(
-        pendingPullIntos,
-        {
-          buffer,
-          byteOffset: 0,
-          byteLength: autoAllocateChunkSize,
-          bytesFilled: 0,
-          elementSize: 1,
-          ctor: Uint8Array,
-          type: 'default',
-        });
+      ArrayPrototypePush(pendingPullIntos, {
+        buffer,
+        byteOffset: 0,
+        byteLength: autoAllocateChunkSize,
+        bytesFilled: 0,
+        elementSize: 1,
+        ctor: Uint8Array,
+        type: 'default',
+      });
     } catch (error) {
       readRequest[kError](error);
       return;
@@ -2587,7 +2549,8 @@ function setupReadableByteStreamController(
   pullAlgorithm,
   cancelAlgorithm,
   highWaterMark,
-  autoAllocateChunkSize) {
+  autoAllocateChunkSize
+) {
   assert(stream[kState].controller === undefined);
   if (autoAllocateChunkSize !== undefined) {
     assert(NumberIsInteger(autoAllocateChunkSize));
@@ -2620,13 +2583,15 @@ function setupReadableByteStreamController(
       assert(!controller[kState].pullAgain);
       readableByteStreamControllerCallPullIfNeeded(controller);
     },
-    (error) => readableByteStreamControllerError(controller, error));
+    (error) => readableByteStreamControllerError(controller, error)
+  );
 }
 
 function setupReadableByteStreamControllerFromSource(
   stream,
   source,
-  highWaterMark) {
+  highWaterMark
+) {
   const controller = createReadableByteStreamController();
   const start = source?.start;
   const pull = source?.pull;
@@ -2645,7 +2610,8 @@ function setupReadableByteStreamControllerFromSource(
   if (autoAllocateChunkSize === 0) {
     throw new ERR_INVALID_ARG_VALUE(
       'source.autoAllocateChunkSize',
-      autoAllocateChunkSize);
+      autoAllocateChunkSize
+    );
   }
   setupReadableByteStreamController(
     stream,
@@ -2654,7 +2620,25 @@ function setupReadableByteStreamControllerFromSource(
     pullAlgorithm,
     cancelAlgorithm,
     highWaterMark,
-    autoAllocateChunkSize);
+    autoAllocateChunkSize
+  );
+}
+
+function readableStreamAddFinishedCallback(stream, callback) {
+  assert(isReadableStream(stream));
+  stream.finishedCallbacks.push(callback);
+}
+
+function readableStreamRemoveAllFinishedCallbacks(stream) {
+  assert(isReadableStream(stream));
+  stream.finishedCallbacks = [];
+}
+
+function readableStreamCallAllFinishedCallbacks(stream) {
+  assert(isReadableStream(stream));
+  stream.finishedCallbacks.forEach((cb) => {
+    cb();
+  });
 }
 
 module.exports = {
@@ -2675,10 +2659,13 @@ module.exports = {
   isWritableStreamDefaultWriter,
   isWritableStreamDefaultController,
 
+  isReadableStreamClosed,
+  isReadableStreamErrored,
+  isReadableStreamLocked,
+
   readableStreamPipeTo,
   readableStreamTee,
   readableByteStreamControllerConvertPullIntoDescriptor,
-  isReadableStreamLocked,
   readableStreamCancel,
   readableStreamClose,
   readableStreamError,
@@ -2690,6 +2677,9 @@ module.exports = {
   readableStreamFulfillReadIntoRequest,
   readableStreamAddReadRequest,
   readableStreamAddReadIntoRequest,
+  readableStreamAddFinishedCallback,
+  readableStreamRemoveAllFinishedCallbacks,
+  readableStreamCallAllFinishedCallbacks,
   readableStreamReaderGenericCancel,
   readableStreamReaderGenericInitialize,
   readableStreamReaderGenericRelease,

--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -188,9 +188,8 @@ class ReadableStream {
         port2: undefined,
         promise: undefined,
       },
+      finishedCallbacks: [],
     };
-
-    this.finishedCallbacks = [];
 
     // The spec requires handling of the strategy first
     // here. Specifically, if getting the size and
@@ -1510,7 +1509,6 @@ function isReadableStreamLocked(stream) {
 }
 
 function readableStreamCancel(stream, reason) {
-  // XXX
   stream[kState].disturbed = true;
   switch (stream[kState].state) {
     case 'closed':
@@ -2626,18 +2624,18 @@ function setupReadableByteStreamControllerFromSource(
 
 function readableStreamAddFinishedCallback(stream, callback) {
   assert(isReadableStream(stream));
-  stream.finishedCallbacks.push(callback);
+  stream[kState].finishedCallbacks.push(callback);
 }
 
 function readableStreamRemoveAllFinishedCallbacks(stream) {
   assert(isReadableStream(stream));
-  stream.finishedCallbacks = [];
+  stream[kState].finishedCallbacks = [];
 }
 
 function readableStreamCallAllFinishedCallbacks(stream) {
   assert(isReadableStream(stream));
-  stream.finishedCallbacks.forEach((cb) => {
-    cb();
+  stream[kState].finishedCallbacks?.forEach((cb) => {
+    cb(stream[kState].storedError);
   });
 }
 

--- a/lib/internal/webstreams/transformstream.js
+++ b/lib/internal/webstreams/transformstream.js
@@ -181,6 +181,13 @@ class TransformStream {
     return this[kState].writable;
   }
 
+  /**
+  * @param {any} reason
+  */
+  abort(reason = undefined) {
+    this?.readable?.abort?.(reason);
+  }
+
   [kInspect](depth, options) {
     return customInspect(depth, options, this[kType], {
       readable: this.readable,
@@ -308,6 +315,7 @@ class TransformStreamDefaultController {
       stream: this[kState].stream,
     });
   }
+
 }
 
 ObjectDefineProperties(TransformStreamDefaultController.prototype, {

--- a/lib/internal/webstreams/util.js
+++ b/lib/internal/webstreams/util.js
@@ -117,6 +117,16 @@ function isBrandCheck(brand) {
   };
 }
 
+function isWebstream(stream) {
+  const isReadableStream = isBrandCheck('ReadableStream');
+  const isWritableStream = isBrandCheck('WritableStream');
+  const isTransformStream = isBrandCheck('TransformStream');
+
+  return isReadableStream(stream) 
+      || isWritableStream(stream) 
+      || isTransformStream(stream);
+} 
+
 function transferArrayBuffer(buffer) {
   const res = detachArrayBuffer(buffer);
   if (res === undefined) {
@@ -225,6 +235,7 @@ module.exports = {
   extractSizeAlgorithm,
   lazyTransfer,
   isBrandCheck,
+  isWebstream,
   isPromisePending,
   peekQueueValue,
   resetQueue,

--- a/lib/internal/webstreams/util.js
+++ b/lib/internal/webstreams/util.js
@@ -122,10 +122,10 @@ function isWebstream(stream) {
   const isWritableStream = isBrandCheck('WritableStream');
   const isTransformStream = isBrandCheck('TransformStream');
 
-  return isReadableStream(stream) 
-      || isWritableStream(stream) 
-      || isTransformStream(stream);
-} 
+  return isReadableStream(stream) ||
+      isWritableStream(stream) ||
+      isTransformStream(stream);
+}
 
 function transferArrayBuffer(buffer) {
   const res = detachArrayBuffer(buffer);

--- a/lib/internal/webstreams/writablestream.js
+++ b/lib/internal/webstreams/writablestream.js
@@ -159,7 +159,8 @@ class WritableStream {
         port1: undefined,
         port2: undefined,
         promise: undefined,
-      }
+      },
+      finishedCallbacks: [],
     };
 
     const size = extractSizeAlgorithm(strategy?.size);
@@ -170,8 +171,6 @@ class WritableStream {
       sink,
       highWaterMark,
       size);
-
-    this.finishedCallbacks = [];
 
     // eslint-disable-next-line no-constructor-return
     return makeTransferable(this);
@@ -674,11 +673,6 @@ function writableStreamClose(stream) {
   stream[kState].closeRequest = createDeferredPromise();
   const { promise } = stream[kState].closeRequest;
 
-  (async () => {
-    await promise;
-    writableStreamCallAllFinishedCallbacks(stream);
-  })();
-
   if (writer !== undefined && backpressure && state === 'writable')
     writer[kState].ready.resolve?.();
   writableStreamDefaultControllerClose(controller);
@@ -851,6 +845,7 @@ function writableStreamFinishInFlightClose(stream) {
     }
   }
   stream[kState].state = 'closed';
+  writableStreamCallAllFinishedCallbacks(stream);
   if (stream[kState].writer !== undefined)
     stream[kState].writer[kState].close.resolve?.();
   assert(stream[kState].pendingAbortRequest.abort.promise === undefined);
@@ -1297,18 +1292,18 @@ function setupWritableStreamDefaultController(
 
 function writableStreamAddFinishedCallback(stream, callback) {
   assert(isWritableStream(stream));
-  stream.finishedCallbacks.push(callback);
+  stream[kState].finishedCallbacks.push(callback);
 }
 
 function writableStreamRemoveAllFinishedCallbacks(stream) {
   assert(isWritableStream(stream));
-  stream.finishedCallbacks = [];
+  stream[kState].finishedCallbacks = [];
 }
 
 function writableStreamCallAllFinishedCallbacks(stream) {
   assert(isWritableStream(stream));
-  stream.finishedCallbacks.forEach((cb) => {
-    cb();
+  stream[kState].finishedCallbacks?.forEach((cb) => {
+    cb(stream[kState].storedError);
   });
 }
 

--- a/lib/internal/webstreams/writablestream.js
+++ b/lib/internal/webstreams/writablestream.js
@@ -171,6 +171,8 @@ class WritableStream {
       highWaterMark,
       size);
 
+    this.finishedCallbacks = [];
+
     // eslint-disable-next-line no-constructor-return
     return makeTransferable(this);
   }
@@ -267,7 +269,7 @@ class WritableStream {
     const { port1, port2 } = new MessageChannel();
     this[kState].transfer.port1 = port1;
     this[kState].transfer.port2 = port2;
-    return [ port2 ];
+    return [port2];
   }
 
   [kDeserialize]({ port }) {
@@ -567,7 +569,7 @@ function setupWritableStreamDefaultWriter(writer, stream) {
   switch (stream[kState].state) {
     case 'writable':
       if (!writableStreamCloseQueuedOrInFlight(stream) &&
-          stream[kState].backpressure) {
+        stream[kState].backpressure) {
         writer[kState].ready = createDeferredPromise();
       } else {
         writer[kState].ready = {
@@ -668,13 +670,29 @@ function writableStreamClose(stream) {
   }
   assert(state === 'writable' || state === 'erroring');
   assert(!writableStreamCloseQueuedOrInFlight(stream));
+
   stream[kState].closeRequest = createDeferredPromise();
   const { promise } = stream[kState].closeRequest;
+
+  (async () => {
+    await promise;
+    writableStreamCallAllFinishedCallbacks(stream);
+  })();
+
   if (writer !== undefined && backpressure && state === 'writable')
     writer[kState].ready.resolve?.();
   writableStreamDefaultControllerClose(controller);
   return promise;
 }
+
+function isWritableStreamClosed(stream) {
+  return stream[kState].state === 'closed';
+}
+
+function isWritableStreamErrored(stream) {
+  return stream[kState].state === 'errored';
+}
+
 
 function writableStreamUpdateBackpressure(stream, backpressure) {
   assert(stream[kState].state === 'writable');
@@ -706,7 +724,7 @@ function writableStreamStartErroring(stream, reason) {
     writableStreamDefaultWriterEnsureReadyPromiseRejected(writer, reason);
   }
   if (!writableStreamHasOperationMarkedInFlight(stream) &&
-      controller[kState].started) {
+    controller[kState].started) {
     writableStreamFinishErroring(stream);
   }
 }
@@ -755,7 +773,7 @@ function writableStreamHasOperationMarkedInFlight(stream) {
     inFlightCloseRequest,
   } = stream[kState];
   if (inFlightWriteRequest.promise === undefined &&
-      inFlightCloseRequest.promise === undefined) {
+    inFlightCloseRequest.promise === undefined) {
     return false;
   }
   return true;
@@ -770,7 +788,7 @@ function writableStreamFinishInFlightWriteWithError(stream, error) {
     reject: undefined,
   };
   assert(stream[kState].state === 'writable' ||
-         stream[kState].state === 'erroring');
+    stream[kState].state === 'erroring');
   writableStreamDealWithRejection(stream, error);
 }
 
@@ -793,7 +811,7 @@ function writableStreamFinishInFlightCloseWithError(stream, error) {
     reject: undefined,
   };
   assert(stream[kState].state === 'writable' ||
-         stream[kState].state === 'erroring');
+    stream[kState].state === 'erroring');
   if (stream[kState].pendingAbortRequest.abort.promise !== undefined) {
     stream[kState].pendingAbortRequest.abort.reject?.(error);
     stream[kState].pendingAbortRequest = {
@@ -849,6 +867,8 @@ function writableStreamFinishErroring(stream) {
     stream[kState].writeRequests[n].reject?.(storedError);
   stream[kState].writeRequests = [];
 
+  writableStreamCallAllFinishedCallbacks(stream);
+
   if (stream[kState].pendingAbortRequest.abort.promise === undefined) {
     writableStreamRejectCloseAndClosedPromiseIfNeeded(stream);
     return;
@@ -899,7 +919,7 @@ function writableStreamDealWithRejection(stream, error) {
 
 function writableStreamCloseQueuedOrInFlight(stream) {
   if (stream[kState].closeRequest.promise === undefined &&
-      stream[kState].inFlightCloseRequest.promise === undefined) {
+    stream[kState].inFlightCloseRequest.promise === undefined) {
     return false;
   }
   return true;
@@ -980,7 +1000,7 @@ function writableStreamDefaultWriterGetDesiredSize(writer) {
   } = writer[kState];
   switch (stream[kState].state) {
     case 'errored':
-      // Fall through
+    // Fall through
     case 'erroring':
       return null;
     case 'closed':
@@ -1062,7 +1082,7 @@ function writableStreamDefaultControllerWrite(controller, chunk, chunkSize) {
     stream,
   } = controller[kState];
   if (!writableStreamCloseQueuedOrInFlight(stream) &&
-      stream[kState].state === 'writable') {
+    stream[kState].state === 'writable') {
     writableStreamUpdateBackpressure(
       stream,
       writableStreamDefaultControllerGetBackpressure(controller));
@@ -1087,7 +1107,7 @@ function writableStreamDefaultControllerProcessWrite(controller, chunk) {
       assert(state === 'writable' || state === 'erroring');
       dequeueValue(controller);
       if (!writableStreamCloseQueuedOrInFlight(stream) &&
-          state === 'writable') {
+        state === 'writable') {
         writableStreamUpdateBackpressure(
           stream,
           writableStreamDefaultControllerGetBackpressure(controller));
@@ -1263,16 +1283,33 @@ function setupWritableStreamDefaultController(
     PromiseResolve(startResult),
     () => {
       assert(stream[kState].state === 'writable' ||
-             stream[kState].state === 'erroring');
+        stream[kState].state === 'erroring');
       controller[kState].started = true;
       writableStreamDefaultControllerAdvanceQueueIfNeeded(controller);
     },
     (error) => {
       assert(stream[kState].state === 'writable' ||
-             stream[kState].state === 'erroring');
+        stream[kState].state === 'erroring');
       controller[kState].started = true;
       writableStreamDealWithRejection(stream, error);
     });
+}
+
+function writableStreamAddFinishedCallback(stream, callback) {
+  assert(isWritableStream(stream));
+  stream.finishedCallbacks.push(callback);
+}
+
+function writableStreamRemoveAllFinishedCallbacks(stream) {
+  assert(isWritableStream(stream));
+  stream.finishedCallbacks = [];
+}
+
+function writableStreamCallAllFinishedCallbacks(stream) {
+  assert(isWritableStream(stream));
+  stream.finishedCallbacks.forEach((cb) => {
+    cb();
+  });
 }
 
 module.exports = {
@@ -1286,7 +1323,10 @@ module.exports = {
   isWritableStreamDefaultController,
   isWritableStreamDefaultWriter,
 
+  isWritableStreamClosed,
+  isWritableStreamErrored,
   isWritableStreamLocked,
+
   setupWritableStreamDefaultWriter,
   writableStreamAbort,
   writableStreamClose,
@@ -1304,6 +1344,9 @@ module.exports = {
   writableStreamDealWithRejection,
   writableStreamCloseQueuedOrInFlight,
   writableStreamAddWriteRequest,
+  writableStreamAddFinishedCallback,
+  writableStreamRemoveAllFinishedCallbacks,
+  writableStreamCallAllFinishedCallbacks,
   writableStreamDefaultWriterWrite,
   writableStreamDefaultWriterRelease,
   writableStreamDefaultWriterGetDesiredSize,

--- a/lib/stream/web.js
+++ b/lib/stream/web.js
@@ -1,8 +1,6 @@
 'use strict';
 
-const {
-  emitExperimentalWarning,
-} = require('internal/util');
+const { emitExperimentalWarning } = require('internal/util');
 
 emitExperimentalWarning('stream/web');
 
@@ -40,6 +38,9 @@ const {
   CompressionStream,
   DecompressionStream,
 } = require('internal/webstreams/compression');
+const { finished } = require('internal/webstreams/finished');
+const { addAbortSignal } = require('internal/webstreams/add-abort-signal');
+const { pipeline } = require('internal/webstreams/pipeline');
 
 module.exports = {
   ReadableStream,
@@ -59,4 +60,7 @@ module.exports = {
   TextDecoderStream,
   CompressionStream,
   DecompressionStream,
+  addAbortSignal,
+  finished,
+  pipeline,
 };

--- a/lib/stream/web/promises.js
+++ b/lib/stream/web/promises.js
@@ -1,6 +1,9 @@
 'use strict';
 
 const {
+  Promise
+} = primordials;
+const {
   finished: noPromiseFinished,
 } = require('internal/webstreams/finished');
 const {

--- a/lib/stream/web/promises.js
+++ b/lib/stream/web/promises.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const {
+  finished: noPromiseFinished,
+} = require('internal/webstreams/finished');
+const {
+  pipeline: noPromisePipeline,
+} = require('internal/webstreams/pipeline');
+
+
+function finished(stream) {
+  return new Promise((resolve, reject) => {
+    noPromiseFinished(stream, (err) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+function pipeline(...streams) {
+  return new Promise((resolve, reject) => {
+    noPromisePipeline(streams, (err, value) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(value);
+      }
+    });
+  });
+}
+
+module.exports = {
+  finished,
+  pipeline,
+};

--- a/test/parallel/test-whatwg-readablestream.js
+++ b/test/parallel/test-whatwg-readablestream.js
@@ -3,12 +3,8 @@
 
 const common = require('../common');
 const assert = require('assert');
-const {
-  isPromise,
-} = require('util/types');
-const {
-  setImmediate: delay
-} = require('timers/promises');
+const { isPromise } = require('util/types');
+const { setImmediate: delay } = require('timers/promises');
 
 const {
   ByteLengthQueuingStrategy,
@@ -33,25 +29,14 @@ const {
   readableByteStreamControllerRespond,
 } = require('internal/webstreams/readablestream');
 
-const {
-  kState
-} = require('internal/webstreams/util');
+const { kState } = require('internal/webstreams/util');
 
-const {
-  createReadStream,
-  readFileSync,
-} = require('fs');
-const {
-  Buffer,
-} = require('buffer');
+const { createReadStream, readFileSync } = require('fs');
+const { Buffer } = require('buffer');
 
-const {
-  kTransfer,
-} = require('internal/worker/js_transferable');
+const { kTransfer } = require('internal/worker/js_transferable');
 
-const {
-  inspect,
-} = require('util');
+const { inspect } = require('util');
 
 {
   const r = new ReadableStream();
@@ -161,39 +146,54 @@ const {
 }
 
 ['a', {}, false].forEach((size) => {
-  assert.throws(() => {
-    new ReadableStream({}, { size });
-  }, {
-    code: 'ERR_INVALID_ARG_TYPE',
-  });
+  assert.throws(
+    () => {
+      new ReadableStream({}, { size });
+    },
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+    }
+  );
 });
 
 ['a', {}].forEach((highWaterMark) => {
-  assert.throws(() => {
-    new ReadableStream({}, { highWaterMark });
-  }, {
-    code: 'ERR_INVALID_ARG_VALUE',
-  });
+  assert.throws(
+    () => {
+      new ReadableStream({}, { highWaterMark });
+    },
+    {
+      code: 'ERR_INVALID_ARG_VALUE',
+    }
+  );
 
-  assert.throws(() => {
-    new ReadableStream({ type: 'bytes' }, { highWaterMark });
-  }, {
-    code: 'ERR_INVALID_ARG_VALUE',
-  });
+  assert.throws(
+    () => {
+      new ReadableStream({ type: 'bytes' }, { highWaterMark });
+    },
+    {
+      code: 'ERR_INVALID_ARG_VALUE',
+    }
+  );
 });
 
 [-1, NaN].forEach((highWaterMark) => {
-  assert.throws(() => {
-    new ReadableStream({}, { highWaterMark });
-  }, {
-    code: 'ERR_INVALID_ARG_VALUE',
-  });
+  assert.throws(
+    () => {
+      new ReadableStream({}, { highWaterMark });
+    },
+    {
+      code: 'ERR_INVALID_ARG_VALUE',
+    }
+  );
 
-  assert.throws(() => {
-    new ReadableStream({ type: 'bytes' }, { highWaterMark });
-  }, {
-    code: 'ERR_INVALID_ARG_VALUE',
-  });
+  assert.throws(
+    () => {
+      new ReadableStream({ type: 'bytes' }, { highWaterMark });
+    },
+    {
+      code: 'ERR_INVALID_ARG_VALUE',
+    }
+  );
 });
 
 {
@@ -223,7 +223,7 @@ const {
   const r = new ReadableStream({
     async start() {
       throw new Error('boom');
-    }
+    },
   });
 
   setImmediate(() => {
@@ -267,11 +267,18 @@ const {
 }
 
 assert.throws(() => {
-  new ReadableStream({
-    get start() { throw new Error('boom1'); }
-  }, {
-    get size() { throw new Error('boom2'); }
-  });
+  new ReadableStream(
+    {
+      get start() {
+        throw new Error('boom1');
+      },
+    },
+    {
+      get size() {
+        throw new Error('boom2');
+      },
+    }
+  );
 }, /boom2/);
 
 {
@@ -297,16 +304,10 @@ assert.throws(() => {
   const read2 = reader.read();
 
   // The stream is empty so the read will never settle.
-  read1.then(
-    common.mustNotCall(),
-    common.mustNotCall()
-  );
+  read1.then(common.mustNotCall(), common.mustNotCall());
 
   // The stream is empty so the read will never settle.
-  read2.then(
-    common.mustNotCall(),
-    common.mustNotCall()
-  );
+  read2.then(common.mustNotCall(), common.mustNotCall());
 
   assert.notStrictEqual(read1, read2);
 
@@ -344,7 +345,7 @@ assert.throws(() => {
   const stream = new ReadableStream({
     start(controller) {
       controller.enqueue(Buffer.from('hello'));
-    }
+    },
   });
 
   const reader = stream.getReader();
@@ -355,17 +356,19 @@ assert.throws(() => {
 
   reader.cancel();
 
-  reader.read().then(common.mustCall(({ value, done }) => {
-    assert.strictEqual(value, undefined);
-    assert(done);
-  }));
+  reader.read().then(
+    common.mustCall(({ value, done }) => {
+      assert.strictEqual(value, undefined);
+      assert(done);
+    })
+  );
 }
 
 {
   const stream = new ReadableStream({
     start(controller) {
       controller.close();
-    }
+    },
   });
   assert(!stream.locked);
 
@@ -374,16 +377,18 @@ assert.throws(() => {
 
   assert.notStrictEqual(cancel1, cancel2);
 
-  Promise.all([cancel1, cancel2]).then(common.mustCall((res) => {
-    assert.deepStrictEqual(res, [undefined, undefined]);
-  }));
+  Promise.all([cancel1, cancel2]).then(
+    common.mustCall((res) => {
+      assert.deepStrictEqual(res, [undefined, undefined]);
+    })
+  );
 }
 
 {
   const stream = new ReadableStream({
     start(controller) {
       controller.close();
-    }
+    },
   });
 
   stream.getReader().releaseLock();
@@ -395,7 +400,7 @@ assert.throws(() => {
   const stream = new ReadableStream({
     start(controller) {
       controller.close();
-    }
+    },
   });
 
   stream.getReader();
@@ -416,14 +421,18 @@ assert.throws(() => {
 
   reader.closed.then(common.mustCall());
 
-  reader.read().then(common.mustCall(({ value, done }) => {
-    assert.strictEqual(value, undefined);
-    assert(done);
-    reader.read().then(common.mustCall(({ value, done }) => {
+  reader.read().then(
+    common.mustCall(({ value, done }) => {
       assert.strictEqual(value, undefined);
       assert(done);
-    }));
-  }));
+      reader.read().then(
+        common.mustCall(({ value, done }) => {
+          assert.strictEqual(value, undefined);
+          assert(done);
+        })
+      );
+    })
+  );
 }
 
 {
@@ -485,9 +494,11 @@ assert.throws(() => {
   assert.notStrictEqual(cancel1, closed);
   assert.notStrictEqual(cancel2, closed);
 
-  Promise.all([cancel1, cancel2]).then(common.mustCall((res) => {
-    assert.deepStrictEqual(res, [undefined, undefined]);
-  }));
+  Promise.all([cancel1, cancel2]).then(
+    common.mustCall((res) => {
+      assert.deepStrictEqual(res, [undefined, undefined]);
+    })
+  );
 }
 
 {
@@ -509,9 +520,11 @@ assert.throws(() => {
   assert.notStrictEqual(cancel1, closed);
   assert.notStrictEqual(cancel2, closed);
 
-  Promise.all([cancel1, cancel2]).then(common.mustCall((res) => {
-    assert.deepStrictEqual(res, [undefined, undefined]);
-  }));
+  Promise.all([cancel1, cancel2]).then(
+    common.mustCall((res) => {
+      assert.deepStrictEqual(res, [undefined, undefined]);
+    })
+  );
 }
 
 {
@@ -520,14 +533,21 @@ assert.throws(() => {
   const cancel2 = stream.cancel();
   assert.notStrictEqual(cancel1, cancel2);
 
-  Promise.all([cancel1, cancel2]).then(common.mustCall((res) => {
-    assert.deepStrictEqual(res, [undefined, undefined]);
-  }));
+  Promise.all([cancel1, cancel2]).then(
+    common.mustCall((res) => {
+      assert.deepStrictEqual(res, [undefined, undefined]);
+    })
+  );
 
-  stream.getReader().read().then(common.mustCall(({ value, done }) => {
-    assert.strictEqual(value, undefined);
-    assert(done);
-  }));
+  stream
+    .getReader()
+    .read()
+    .then(
+      common.mustCall(({ value, done }) => {
+        assert.strictEqual(value, undefined);
+        assert(done);
+      })
+    );
 }
 
 {
@@ -535,7 +555,7 @@ assert.throws(() => {
   const stream = new ReadableStream({
     start(controller) {
       controller.error(error);
-    }
+    },
   });
   stream.getReader().releaseLock();
   const reader = stream.getReader();
@@ -549,7 +569,7 @@ assert.throws(() => {
   const stream = new ReadableStream({
     start(controller) {
       controller.error(error);
-    }
+    },
   });
   const reader = stream.getReader();
   const cancel1 = reader.cancel();
@@ -564,7 +584,7 @@ assert.throws(() => {
   const stream = new ReadableStream({
     async start(controller) {
       throw error;
-    }
+    },
   });
   stream.getReader().releaseLock();
   const reader = stream.getReader();
@@ -582,22 +602,28 @@ assert.throws(() => {
       controller.enqueue(buf1);
       controller.enqueue(buf2);
       doClose = controller.close.bind(controller);
-    }
+    },
   });
   const reader = stream.getReader();
   doClose();
-  reader.read().then(common.mustCall(({ value, done }) => {
-    assert.deepStrictEqual(value, buf1);
-    assert(!done);
-    reader.read().then(common.mustCall(({ value, done }) => {
-      assert.deepStrictEqual(value, buf2);
+  reader.read().then(
+    common.mustCall(({ value, done }) => {
+      assert.deepStrictEqual(value, buf1);
       assert(!done);
-      reader.read().then(common.mustCall(({ value, done }) => {
-        assert.strictEqual(value, undefined);
-        assert(done);
-      }));
-    }));
-  }));
+      reader.read().then(
+        common.mustCall(({ value, done }) => {
+          assert.deepStrictEqual(value, buf2);
+          assert(!done);
+          reader.read().then(
+            common.mustCall(({ value, done }) => {
+              assert.strictEqual(value, undefined);
+              assert(done);
+            })
+          );
+        })
+      );
+    })
+  );
 }
 
 {
@@ -607,19 +633,23 @@ assert.throws(() => {
     start(controller) {
       controller.enqueue(buf1);
       controller.enqueue(buf2);
-    }
+    },
   });
   const reader = stream.getReader();
-  reader.read().then(common.mustCall(({ value, done }) => {
-    assert.deepStrictEqual(value, buf1);
-    assert(!done);
-    reader.read().then(common.mustCall(({ value, done }) => {
-      assert.deepStrictEqual(value, buf2);
+  reader.read().then(
+    common.mustCall(({ value, done }) => {
+      assert.deepStrictEqual(value, buf1);
       assert(!done);
-      reader.read().then(common.mustNotCall());
-      delay().then(common.mustCall());
-    }));
-  }));
+      reader.read().then(
+        common.mustCall(({ value, done }) => {
+          assert.deepStrictEqual(value, buf2);
+          assert(!done);
+          reader.read().then(common.mustNotCall());
+          delay().then(common.mustCall());
+        })
+      );
+    })
+  );
 }
 
 {
@@ -628,7 +658,7 @@ assert.throws(() => {
       controller.enqueue('a');
       controller.enqueue('b');
       controller.close();
-    }
+    },
   });
 
   const { 0: s1, 1: s2 } = stream.tee();
@@ -638,18 +668,15 @@ assert.throws(() => {
 
   async function read(stream) {
     const reader = stream.getReader();
-    assert.deepStrictEqual(
-      await reader.read(), { value: 'a', done: false });
-    assert.deepStrictEqual(
-      await reader.read(), { value: 'b', done: false });
-    assert.deepStrictEqual(
-      await reader.read(), { value: undefined, done: true });
+    assert.deepStrictEqual(await reader.read(), { value: 'a', done: false });
+    assert.deepStrictEqual(await reader.read(), { value: 'b', done: false });
+    assert.deepStrictEqual(await reader.read(), {
+      value: undefined,
+      done: true,
+    });
   }
 
-  Promise.all([
-    read(s1),
-    read(s2),
-  ]).then(common.mustCall());
+  Promise.all([read(s1), read(s2)]).then(common.mustCall());
 }
 
 {
@@ -659,7 +686,9 @@ assert.throws(() => {
       controller.enqueue('a');
       controller.enqueue('b');
     },
-    pull() { throw error; }
+    pull() {
+      throw error;
+    },
   });
 
   const { 0: s1, 1: s2 } = stream.tee();
@@ -687,7 +716,7 @@ assert.throws(() => {
       controller.enqueue('a');
       controller.enqueue('b');
       controller.close();
-    }
+    },
   });
 
   const { 0: s1, 1: s2 } = stream.tee();
@@ -700,19 +729,16 @@ assert.throws(() => {
   async function read(stream, canceled = false) {
     const reader = stream.getReader();
     if (!canceled) {
-      assert.deepStrictEqual(
-        await reader.read(), { value: 'a', done: false });
-      assert.deepStrictEqual(
-        await reader.read(), { value: 'b', done: false });
+      assert.deepStrictEqual(await reader.read(), { value: 'a', done: false });
+      assert.deepStrictEqual(await reader.read(), { value: 'b', done: false });
     }
-    assert.deepStrictEqual(
-      await reader.read(), { value: undefined, done: true });
+    assert.deepStrictEqual(await reader.read(), {
+      value: undefined,
+      done: true,
+    });
   }
 
-  Promise.all([
-    read(s1),
-    read(s2, true),
-  ]).then(common.mustCall());
+  Promise.all([read(s1), read(s2, true)]).then(common.mustCall());
 }
 
 {
@@ -722,7 +748,7 @@ assert.throws(() => {
   const stream = new ReadableStream({
     cancel(reason) {
       assert.deepStrictEqual(reason, [error1, error2]);
-    }
+    },
   });
 
   const { 0: s1, 1: s2 } = stream.tee();
@@ -737,7 +763,7 @@ assert.throws(() => {
   const stream = new ReadableStream({
     cancel(reason) {
       assert.deepStrictEqual(reason, [error1, error2]);
-    }
+    },
   });
 
   const { 0: s1, 1: s2 } = stream.tee();
@@ -751,7 +777,7 @@ assert.throws(() => {
   const stream = new ReadableStream({
     cancel() {
       throw error;
-    }
+    },
   });
 
   const { 0: s1, 1: s2 } = stream.tee();
@@ -766,7 +792,7 @@ assert.throws(() => {
   const stream = new ReadableStream({
     start(controller) {
       c = controller;
-    }
+    },
   });
 
   const { 0: s1, 1: s2 } = stream.tee();
@@ -782,7 +808,7 @@ assert.throws(() => {
   const stream = new ReadableStream({
     start(controller) {
       c = controller;
-    }
+    },
   });
 
   const { 0: s1, 1: s2 } = stream.tee();
@@ -803,27 +829,31 @@ assert.throws(() => {
   let pullCount = 0;
   const stream = new ReadableStream({
     pull(controller) {
-      if (pullCount)
-        controller.enqueue(pullCount);
+      if (pullCount) controller.enqueue(pullCount);
       pullCount++;
     },
   });
 
   const reader = stream.getReader();
 
-  queueMicrotask(common.mustCall(() => {
-    assert.strictEqual(pullCount, 1);
-    reader.read().then(common.mustCall(({ value, done }) => {
-      assert.strictEqual(value, 1);
-      assert(!done);
+  queueMicrotask(
+    common.mustCall(() => {
+      assert.strictEqual(pullCount, 1);
+      reader.read().then(
+        common.mustCall(({ value, done }) => {
+          assert.strictEqual(value, 1);
+          assert(!done);
 
-      reader.read().then(common.mustCall(({ value, done }) => {
-        assert.strictEqual(value, 2);
-        assert(!done);
-      }));
-
-    }));
-  }));
+          reader.read().then(
+            common.mustCall(({ value, done }) => {
+              assert.strictEqual(value, 2);
+              assert(!done);
+            })
+          );
+        })
+      );
+    })
+  );
 }
 
 {
@@ -834,10 +864,15 @@ assert.throws(() => {
     pull: common.mustCall(),
   });
 
-  stream.getReader().read().then(common.mustCall(({ value, done }) => {
-    assert.strictEqual(value, 'a');
-    assert(!done);
-  }));
+  stream
+    .getReader()
+    .read()
+    .then(
+      common.mustCall(({ value, done }) => {
+        assert.strictEqual(value, 'a');
+        assert(!done);
+      })
+    );
 }
 
 {
@@ -850,15 +885,19 @@ assert.throws(() => {
   });
 
   const reader = stream.getReader();
-  reader.read().then(common.mustCall(({ value, done }) => {
-    assert.strictEqual(value, 'a');
-    assert(!done);
-
-    reader.read().then(common.mustCall(({ value, done }) => {
-      assert.strictEqual(value, 'b');
+  reader.read().then(
+    common.mustCall(({ value, done }) => {
+      assert.strictEqual(value, 'a');
       assert(!done);
-    }));
-  }));
+
+      reader.read().then(
+        common.mustCall(({ value, done }) => {
+          assert.strictEqual(value, 'b');
+          assert(!done);
+        })
+      );
+    })
+  );
 }
 
 {
@@ -872,21 +911,26 @@ assert.throws(() => {
   });
 
   const reader = stream.getReader();
-  reader.read().then(common.mustCall(({ value, done }) => {
-    assert.strictEqual(value, 'a');
-    assert(!done);
-
-    reader.read().then(common.mustCall(({ value, done }) => {
-      assert.strictEqual(value, 'b');
+  reader.read().then(
+    common.mustCall(({ value, done }) => {
+      assert.strictEqual(value, 'a');
       assert(!done);
 
-      reader.read().then(common.mustCall(({ value, done }) => {
-        assert.strictEqual(value, undefined);
-        assert(done);
-      }));
+      reader.read().then(
+        common.mustCall(({ value, done }) => {
+          assert.strictEqual(value, 'b');
+          assert(!done);
 
-    }));
-  }));
+          reader.read().then(
+            common.mustCall(({ value, done }) => {
+              assert.strictEqual(value, undefined);
+              assert(done);
+            })
+          );
+        })
+      );
+    })
+  );
 }
 
 {
@@ -896,9 +940,9 @@ assert.throws(() => {
   const stream = new ReadableStream({
     pull(controller) {
       controller.enqueue(++calls);
-      promise = new Promise((resolve) => res = resolve);
+      promise = new Promise((resolve) => (res = resolve));
       return promise;
-    }
+    },
   });
 
   const reader = stream.getReader();
@@ -915,17 +959,22 @@ assert.throws(() => {
 }
 
 {
-  const stream = new ReadableStream({
-    start(controller) {
-      controller.enqueue('a');
-      controller.enqueue('b');
-      controller.enqueue('c');
+  const stream = new ReadableStream(
+    {
+      start(controller) {
+        controller.enqueue('a');
+        controller.enqueue('b');
+        controller.enqueue('c');
+      },
+      pull: common.mustCall(4),
     },
-    pull: common.mustCall(4),
-  }, {
-    highWaterMark: Infinity,
-    size() { return 1; }
-  });
+    {
+      highWaterMark: Infinity,
+      size() {
+        return 1;
+      },
+    }
+  );
 
   const reader = stream.getReader();
   (async () => {
@@ -937,18 +986,23 @@ assert.throws(() => {
 }
 
 {
-  const stream = new ReadableStream({
-    start(controller) {
-      controller.enqueue('a');
-      controller.enqueue('b');
-      controller.enqueue('c');
-      controller.close();
+  const stream = new ReadableStream(
+    {
+      start(controller) {
+        controller.enqueue('a');
+        controller.enqueue('b');
+        controller.enqueue('c');
+        controller.close();
+      },
+      pull: common.mustNotCall(),
     },
-    pull: common.mustNotCall(),
-  }, {
-    highWaterMark: Infinity,
-    size() { return 1; }
-  });
+    {
+      highWaterMark: Infinity,
+      size() {
+        return 1;
+      },
+    }
+  );
 
   const reader = stream.getReader();
   (async () => {
@@ -962,27 +1016,33 @@ assert.throws(() => {
 {
   let calls = 0;
   let res;
-  const ready = new Promise((resolve) => res = resolve);
+  const ready = new Promise((resolve) => (res = resolve));
 
-  new ReadableStream({
-    pull(controller) {
-      controller.enqueue(++calls);
-      if (calls === 4)
-        res();
+  new ReadableStream(
+    {
+      pull(controller) {
+        controller.enqueue(++calls);
+        if (calls === 4) res();
+      },
+    },
+    {
+      size() {
+        return 1;
+      },
+      highWaterMark: 4,
     }
-  }, {
-    size() { return 1; },
-    highWaterMark: 4
-  });
+  );
 
-  ready.then(common.mustCall(() => {
-    assert.strictEqual(calls, 4);
-  }));
+  ready.then(
+    common.mustCall(() => {
+      assert.strictEqual(calls, 4);
+    })
+  );
 }
 
 {
   const stream = new ReadableStream({
-    pull: common.mustCall((controller) => controller.close())
+    pull: common.mustCall((controller) => controller.close()),
   });
 
   const reader = stream.getReader();
@@ -993,7 +1053,7 @@ assert.throws(() => {
 {
   const error = new Error('boom');
   const stream = new ReadableStream({
-    pull: common.mustCall((controller) => controller.error(error))
+    pull: common.mustCall((controller) => controller.error(error)),
   });
 
   const reader = stream.getReader();
@@ -1008,7 +1068,7 @@ assert.throws(() => {
     pull: common.mustCall((controller) => {
       controller.error(error);
       throw error2;
-    })
+    }),
   });
 
   const reader = stream.getReader();
@@ -1023,10 +1083,10 @@ assert.throws(() => {
       controller.enqueue('a');
       controller.close();
       assert.throws(() => controller.enqueue('b'), {
-        code: 'ERR_INVALID_STATE'
+        code: 'ERR_INVALID_STATE',
       });
       startCalled = true;
-    })
+    }),
   });
   assert(startCalled);
 }
@@ -1037,10 +1097,10 @@ assert.throws(() => {
     start: common.mustCall((controller) => {
       controller.close();
       assert.throws(() => controller.enqueue('b'), {
-        code: 'ERR_INVALID_STATE'
+        code: 'ERR_INVALID_STATE',
       });
       startCalled = true;
-    })
+    }),
   });
   assert(startCalled);
 }
@@ -1085,31 +1145,37 @@ assert.throws(() => {
 
 {
   let startCalled = false;
-  new ReadableStream({
-    start(controller) {
-      assert.strictEqual(controller.desiredSize, 10);
-      controller.close();
-      assert.strictEqual(controller.desiredSize, 0);
-      startCalled = true;
+  new ReadableStream(
+    {
+      start(controller) {
+        assert.strictEqual(controller.desiredSize, 10);
+        controller.close();
+        assert.strictEqual(controller.desiredSize, 0);
+        startCalled = true;
+      },
+    },
+    {
+      highWaterMark: 10,
     }
-  }, {
-    highWaterMark: 10
-  });
+  );
   assert(startCalled);
 }
 
 {
   let startCalled = false;
-  new ReadableStream({
-    start(controller) {
-      assert.strictEqual(controller.desiredSize, 10);
-      controller.error();
-      assert.strictEqual(controller.desiredSize, null);
-      startCalled = true;
+  new ReadableStream(
+    {
+      start(controller) {
+        assert.strictEqual(controller.desiredSize, 10);
+        controller.error();
+        assert.strictEqual(controller.desiredSize, null);
+        startCalled = true;
+      },
+    },
+    {
+      highWaterMark: 10,
     }
-  }, {
-    highWaterMark: 10
-  });
+  );
   assert(startCalled);
 }
 
@@ -1133,7 +1199,7 @@ assert.throws(() => {
       controller.enqueue('a');
       assert.strictEqual(controller.desiredSize, -3);
       startCalled = true;
-    }
+    },
   });
   assert(startCalled);
 }
@@ -1143,7 +1209,7 @@ assert.throws(() => {
   const stream = new ReadableStream({
     start(controller) {
       c = controller;
-    }
+    },
   });
 
   const reader = stream.getReader();
@@ -1169,7 +1235,7 @@ assert.throws(() => {
   new ReadableStream({
     start(controller) {
       c = controller;
-    }
+    },
   });
   assert(c instanceof ReadableStreamDefaultController);
   assert.strictEqual(typeof c.desiredSize, 'number');
@@ -1189,8 +1255,7 @@ class Source {
       controller.enqueue(chunk);
     });
     this.stream.once('end', () => {
-      if (!this.cancelCalled)
-        controller.close();
+      if (!this.cancelCalled) controller.close();
     });
     this.stream.once('error', (error) => {
       controller.error(error);
@@ -1217,10 +1282,12 @@ class Source {
     return Buffer.concat(chunks);
   }
 
-  read(stream).then(common.mustCall((data) => {
-    const check = readFileSync(__filename);
-    assert.deepStrictEqual(data, check);
-  }));
+  read(stream).then(
+    common.mustCall((data) => {
+      const check = readFileSync(__filename);
+      assert.deepStrictEqual(data, check);
+    })
+  );
 }
 
 {
@@ -1229,18 +1296,19 @@ class Source {
 
   async function read(stream) {
     const chunks = [];
-    for await (const chunk of stream)
-      chunks.push(chunk);
+    for await (const chunk of stream) chunks.push(chunk);
     return Buffer.concat(chunks);
   }
 
-  read(stream).then(common.mustCall((data) => {
-    const check = readFileSync(__filename);
-    assert.deepStrictEqual(data, check);
+  read(stream).then(
+    common.mustCall((data) => {
+      const check = readFileSync(__filename);
+      assert.deepStrictEqual(data, check);
 
-    assert.strictEqual(stream[kState].state, 'closed');
-    assert(!stream.locked);
-  }));
+      assert.strictEqual(stream[kState].state, 'closed');
+      assert(!stream.locked);
+    })
+  );
 }
 
 {
@@ -1255,13 +1323,14 @@ class Source {
 
   async function read(stream) {
     // eslint-disable-next-line no-unused-vars
-    for await (const _ of stream.values({ preventCancel: true }))
-      return;
+    for await (const _ of stream.values({ preventCancel: true })) return;
   }
 
-  read(stream).then(common.mustCall((data) => {
-    assert.strictEqual(stream[kState].state, 'readable');
-  }));
+  read(stream).then(
+    common.mustCall((data) => {
+      assert.strictEqual(stream[kState].state, 'readable');
+    })
+  );
 }
 
 {
@@ -1270,30 +1339,14 @@ class Source {
 
   async function read(stream) {
     // eslint-disable-next-line no-unused-vars
-    for await (const _ of stream.values({ preventCancel: false }))
-      return;
+    for await (const _ of stream.values({ preventCancel: false })) return;
   }
 
-  read(stream).then(common.mustCall((data) => {
-    assert.strictEqual(stream[kState].state, 'closed');
-  }));
-}
-
-{
-  const source = new Source();
-  const stream = new ReadableStream(source);
-
-  const error = new Error('boom');
-
-  async function read(stream) {
-    // eslint-disable-next-line no-unused-vars
-    for await (const _ of stream.values({ preventCancel: true }))
-      throw error;
-  }
-
-  assert.rejects(read(stream), error).then(common.mustCall(() => {
-    assert.strictEqual(stream[kState].state, 'readable');
-  }));
+  read(stream).then(
+    common.mustCall((data) => {
+      assert.strictEqual(stream[kState].state, 'closed');
+    })
+  );
 }
 
 {
@@ -1304,13 +1357,32 @@ class Source {
 
   async function read(stream) {
     // eslint-disable-next-line no-unused-vars
-    for await (const _ of stream.values({ preventCancel: false }))
-      throw error;
+    for await (const _ of stream.values({ preventCancel: true })) throw error;
   }
 
-  assert.rejects(read(stream), error).then(common.mustCall(() => {
-    assert.strictEqual(stream[kState].state, 'closed');
-  }));
+  assert.rejects(read(stream), error).then(
+    common.mustCall(() => {
+      assert.strictEqual(stream[kState].state, 'readable');
+    })
+  );
+}
+
+{
+  const source = new Source();
+  const stream = new ReadableStream(source);
+
+  const error = new Error('boom');
+
+  async function read(stream) {
+    // eslint-disable-next-line no-unused-vars
+    for await (const _ of stream.values({ preventCancel: false })) throw error;
+  }
+
+  assert.rejects(read(stream), error).then(
+    common.mustCall(() => {
+      assert.strictEqual(stream[kState].state, 'closed');
+    })
+  );
 }
 
 {
@@ -1335,58 +1407,85 @@ class Source {
   assert.rejects(() => ReadableStreamDefaultReader.prototype.cancel.call({}), {
     code: 'ERR_INVALID_THIS',
   });
-  assert.rejects(() => {
-    return Reflect.get(ReadableStreamDefaultReader.prototype, 'closed');
-  }, {
-    code: 'ERR_INVALID_THIS',
-  });
-  assert.throws(() => {
-    ReadableStreamDefaultReader.prototype.releaseLock.call({});
-  }, {
-    code: 'ERR_INVALID_THIS',
-  });
+  assert.rejects(
+    () => {
+      return Reflect.get(ReadableStreamDefaultReader.prototype, 'closed');
+    },
+    {
+      code: 'ERR_INVALID_THIS',
+    }
+  );
+  assert.throws(
+    () => {
+      ReadableStreamDefaultReader.prototype.releaseLock.call({});
+    },
+    {
+      code: 'ERR_INVALID_THIS',
+    }
+  );
   assert.rejects(() => ReadableStreamBYOBReader.prototype.read.call({}), {
     code: 'ERR_INVALID_THIS',
   });
-  assert.throws(() => {
-    ReadableStreamBYOBReader.prototype.releaseLock.call({});
-  }, {
-    code: 'ERR_INVALID_THIS',
-  });
-  assert.rejects(() => {
-    return Reflect.get(ReadableStreamBYOBReader.prototype, 'closed');
-  }, {
-    code: 'ERR_INVALID_THIS',
-  });
+  assert.throws(
+    () => {
+      ReadableStreamBYOBReader.prototype.releaseLock.call({});
+    },
+    {
+      code: 'ERR_INVALID_THIS',
+    }
+  );
+  assert.rejects(
+    () => {
+      return Reflect.get(ReadableStreamBYOBReader.prototype, 'closed');
+    },
+    {
+      code: 'ERR_INVALID_THIS',
+    }
+  );
   assert.rejects(() => ReadableStreamBYOBReader.prototype.cancel.call({}), {
     code: 'ERR_INVALID_THIS',
   });
 
-  assert.throws(() => {
-    Reflect.get(ReadableByteStreamController.prototype, 'byobRequest', {});
-  }, {
-    code: 'ERR_INVALID_THIS',
-  });
-  assert.throws(() => {
-    Reflect.get(ReadableByteStreamController.prototype, 'desiredSize', {});
-  }, {
-    code: 'ERR_INVALID_THIS',
-  });
-  assert.throws(() => {
-    ReadableByteStreamController.prototype.close.call({});
-  }, {
-    code: 'ERR_INVALID_THIS',
-  });
-  assert.throws(() => {
-    ReadableByteStreamController.prototype.enqueue.call({});
-  }, {
-    code: 'ERR_INVALID_THIS',
-  });
-  assert.throws(() => {
-    ReadableByteStreamController.prototype.error.call({});
-  }, {
-    code: 'ERR_INVALID_THIS',
-  });
+  assert.throws(
+    () => {
+      Reflect.get(ReadableByteStreamController.prototype, 'byobRequest', {});
+    },
+    {
+      code: 'ERR_INVALID_THIS',
+    }
+  );
+  assert.throws(
+    () => {
+      Reflect.get(ReadableByteStreamController.prototype, 'desiredSize', {});
+    },
+    {
+      code: 'ERR_INVALID_THIS',
+    }
+  );
+  assert.throws(
+    () => {
+      ReadableByteStreamController.prototype.close.call({});
+    },
+    {
+      code: 'ERR_INVALID_THIS',
+    }
+  );
+  assert.throws(
+    () => {
+      ReadableByteStreamController.prototype.enqueue.call({});
+    },
+    {
+      code: 'ERR_INVALID_THIS',
+    }
+  );
+  assert.throws(
+    () => {
+      ReadableByteStreamController.prototype.error.call({});
+    },
+    {
+      code: 'ERR_INVALID_THIS',
+    }
+  );
 
   assert.throws(() => new ReadableStreamBYOBRequest(), {
     code: 'ERR_ILLEGAL_CONSTRUCTOR',
@@ -1404,40 +1503,39 @@ class Source {
 {
   let controller;
   const readable = new ReadableStream({
-    start(c) { controller = c; }
+    start(c) {
+      controller = c;
+    },
   });
 
   assert.strictEqual(
     inspect(readable),
-    'ReadableStream { locked: false, state: \'readable\' }');
+    "ReadableStream { locked: false, state: 'readable' }"
+  );
   assert.strictEqual(
     inspect(readable, { depth: null }),
-    'ReadableStream { locked: false, state: \'readable\' }');
+    "ReadableStream { locked: false, state: 'readable' }"
+  );
   assert.strictEqual(
     inspect(readable, { depth: 0 }),
-    'ReadableStream [Object]');
+    'ReadableStream [Object]'
+  );
 
-  assert.strictEqual(
-    inspect(controller),
-    'ReadableStreamDefaultController {}');
+  assert.strictEqual(inspect(controller), 'ReadableStreamDefaultController {}');
   assert.strictEqual(
     inspect(controller, { depth: null }),
-    'ReadableStreamDefaultController {}');
+    'ReadableStreamDefaultController {}'
+  );
   assert.strictEqual(
     inspect(controller, { depth: 0 }),
-    'ReadableStreamDefaultController {}');
+    'ReadableStreamDefaultController {}'
+  );
 
   const reader = readable.getReader();
 
-  assert.match(
-    inspect(reader),
-    /ReadableStreamDefaultReader/);
-  assert.match(
-    inspect(reader, { depth: null }),
-    /ReadableStreamDefaultReader/);
-  assert.match(
-    inspect(reader, { depth: 0 }),
-    /ReadableStreamDefaultReader/);
+  assert.match(inspect(reader), /ReadableStreamDefaultReader/);
+  assert.match(inspect(reader, { depth: null }), /ReadableStreamDefaultReader/);
+  assert.match(inspect(reader, { depth: 0 }), /ReadableStreamDefaultReader/);
 
   assert.rejects(readableStreamPipeTo(1), {
     code: 'ERR_INVALID_ARG_TYPE',
@@ -1454,10 +1552,12 @@ class Source {
       false,
       false,
       false,
-      {}),
+      {}
+    ),
     {
       code: 'ERR_INVALID_ARG_TYPE',
-    });
+    }
+  );
 }
 
 {
@@ -1478,30 +1578,37 @@ class Source {
   const readable = new ReadableStream({
     start(controller) {
       controller.enqueue('hello');
-    }
+    },
   });
   const [r1, r2] = readableStreamTee(readable, true);
-  r1.getReader().read().then(
-    common.mustCall(({ value }) => assert.strictEqual(value, 'hello')));
-  r2.getReader().read().then(
-    common.mustCall(({ value }) => assert.strictEqual(value, 'hello')));
+  r1.getReader()
+    .read()
+    .then(common.mustCall(({ value }) => assert.strictEqual(value, 'hello')));
+  r2.getReader()
+    .read()
+    .then(common.mustCall(({ value }) => assert.strictEqual(value, 'hello')));
 }
 
 {
-  assert.throws(() => {
-    readableByteStreamControllerConvertPullIntoDescriptor({
-      bytesFilled: 10,
-      byteLength: 5
-    });
-  }, {
-    code: 'ERR_INVALID_STATE',
-  });
+  assert.throws(
+    () => {
+      readableByteStreamControllerConvertPullIntoDescriptor({
+        bytesFilled: 10,
+        byteLength: 5,
+      });
+    },
+    {
+      code: 'ERR_INVALID_STATE',
+    }
+  );
 }
 
 {
   let controller;
   const readable = new ReadableStream({
-    start(c) { controller = c; }
+    start(c) {
+      controller = c;
+    },
   });
 
   controller[kState].pendingPullIntos = [{}];

--- a/test/parallel/test-whatwg-stream-add-abort-signal.js
+++ b/test/parallel/test-whatwg-stream-add-abort-signal.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { 
+  addAbortSignal, 
+  ReadableStream, 
+  WritableStream, 
+  TransformStream, 
+  finished,
+} = require("stream/web");
+
+{
+  assert.throws(() => {
+    addAbortSignal('INVALID_SIGNAL');
+  }, /ERR_INVALID_ARG_TYPE/);
+
+  const ac = new AbortController();
+  assert.throws(() => {
+    addAbortSignal(ac.signal, 'INVALID_STREAM');
+  }, /ERR_INVALID_ARG_TYPE/);
+}
+
+{
+  const rs = new ReadableStream();
+  const ac = new AbortController()
+  assert.deepStrictEqual(rs, addAbortSignal(ac.signal, rs));
+}
+
+{
+  const rs = new ReadableStream();
+  finished(rs, common.mustSucceed())
+
+  const ac = new AbortController();
+  addAbortSignal(ac.signal, rs);
+
+  ac.abort();
+}
+
+{
+  const ws = new WritableStream();
+  finished(ws, common.mustSucceed())
+
+  const ac = new AbortController();
+  addAbortSignal(ac.signal, ws);
+
+  ac.abort();
+}
+  
+{
+  const ts = new TransformStream();
+  finished(ts, common.mustSucceed())
+
+  const ac = new AbortController();
+  addAbortSignal(ac.signal, ts);
+
+  ac.abort();
+}
+  

--- a/test/parallel/test-whatwg-stream-add-abort-signal.js
+++ b/test/parallel/test-whatwg-stream-add-abort-signal.js
@@ -2,13 +2,13 @@
 
 const common = require('../common');
 const assert = require('assert');
-const { 
-  addAbortSignal, 
-  ReadableStream, 
-  WritableStream, 
-  TransformStream, 
+const {
+  addAbortSignal,
+  ReadableStream,
+  WritableStream,
+  TransformStream,
   finished,
-} = require("stream/web");
+} = require('stream/web');
 
 {
   assert.throws(() => {
@@ -23,13 +23,13 @@ const {
 
 {
   const rs = new ReadableStream();
-  const ac = new AbortController()
+  const ac = new AbortController();
   assert.deepStrictEqual(rs, addAbortSignal(ac.signal, rs));
 }
 
 {
   const rs = new ReadableStream();
-  finished(rs, common.mustSucceed())
+  finished(rs, (err) => { common.mustSucceed()(); });
 
   const ac = new AbortController();
   addAbortSignal(ac.signal, rs);
@@ -39,21 +39,20 @@ const {
 
 {
   const ws = new WritableStream();
-  finished(ws, common.mustSucceed())
+  finished(ws, (err) => { common.mustSucceed()(); });
 
   const ac = new AbortController();
   addAbortSignal(ac.signal, ws);
 
   ac.abort();
 }
-  
+
 {
   const ts = new TransformStream();
-  finished(ts, common.mustSucceed())
+  finished(ts, (err) => { common.mustSucceed()(); });
 
   const ac = new AbortController();
   addAbortSignal(ac.signal, ts);
 
   ac.abort();
 }
-  

--- a/test/parallel/test-whatwg-stream-finished.js
+++ b/test/parallel/test-whatwg-stream-finished.js
@@ -1,0 +1,173 @@
+'use strict';
+
+const common = require('../common');
+const {
+  ReadableStream,
+  WritableStream,
+  TransformStream,
+  finished,
+  CountQueuingStrategy,
+} = require('stream/web');
+const { Readable } = require('stream');
+const assert = require('assert');
+
+/* Errors */
+
+{
+  assert.throws(() => {
+    finished();
+  }, /ERR_MISSING_ARGS/);
+}
+
+{
+  assert.throws(() => {
+    finished('NOT_A_STREAM', common.mustNotCall());
+  }, /ERR_INVALID_ARG_TYPE/);
+}
+
+{
+  const stream = new ReadableStream();
+  assert.throws(() => {
+    finished(stream, 'NOT_A_FUNC');
+  }, /ERR_INVALID_ARG_TYPE/);
+}
+
+{
+  const nonWebStream = new Readable();
+  assert.throws(() => {
+    finished(nonWebStream, common.mustNotCall());
+  }, /ERR_INVALID_ARG_TYPE/);
+}
+
+{
+  const rs = new ReadableStream();
+  const ws = new WritableStream();
+  const ts = new TransformStream();
+  assert.doesNotThrow(() => {
+    finished(rs);
+    finished(ws);
+    finished(ts);
+  });
+}
+
+/* ReadableStreams */
+
+{
+  const rs = new ReadableStream();
+
+  finished(rs, common.mustSucceed());
+
+  rs.cancel();
+}
+
+{
+  const rs = new ReadableStream();
+
+  const removeCallbacks = finished(rs, common.mustNotCall());
+  removeCallbacks();
+
+  rs.cancel();
+}
+
+{
+  const rs = new ReadableStream();
+
+  finished(rs, common.mustNotCall());
+  const removeCallbacks = finished(rs, common.mustNotCall());
+  removeCallbacks();
+
+  rs.cancel();
+}
+
+{
+  const rs = new ReadableStream({
+    start(controller) {
+      controller.close();
+    },
+  });
+
+  finished(rs, common.mustCall());
+
+  async function readEntireStream(s) {
+    const r = s.getReader();
+    let result;
+    do {
+      result = await r.read();
+    } while (!result.done);
+  }
+
+  readEntireStream(rs).then(common.mustCall());
+}
+
+/* WritableStreams */
+
+{
+  const ws = new WritableStream();
+
+  finished(ws, common.mustSucceed());
+
+  ws.close();
+}
+
+{
+  const ws = new WritableStream();
+
+  finished(ws, common.mustSucceed());
+
+  ws.abort();
+}
+
+{
+  const ws = new WritableStream();
+  const removeCallbacks = finished(ws, common.mustNotCall());
+  removeCallbacks();
+
+  ws.close();
+}
+
+{
+  const ws = new WritableStream();
+
+  finished(ws, common.mustNotCall());
+  const removeCallbacks = finished(ws, common.mustNotCall());
+  removeCallbacks();
+
+  ws.close();
+}
+
+/* TransformStreams */
+
+{
+  const ts = new TransformStream();
+
+  finished(ts, common.mustSucceed());
+
+  ts.readable.cancel();
+}
+
+{
+  const ts = new TransformStream();
+
+  finished(ts, common.mustSucceed());
+
+  ts.readable.abort();
+}
+
+{
+  const ts = new TransformStream();
+
+  const removeCallbacks = finished(ts, common.mustNotCall());
+  removeCallbacks();
+
+  ts.readable.cancel();
+}
+
+{
+  const ts = new TransformStream();
+
+  finished(ts, common.mustNotCall());
+  const removeCallbacks = finished(ts, common.mustNotCall());
+  removeCallbacks();
+
+  ts.readable.cancel();
+}

--- a/test/parallel/test-whatwg-stream-pipeline.js
+++ b/test/parallel/test-whatwg-stream-pipeline.js
@@ -1,13 +1,12 @@
-'use strict'
+'use strict';
 
-const { 
-  ReadableStream, 
-  WritableStream, 
-  TransformStream, 
-  pipeline,
-  finished,
-} = require("stream/web");
 const common = require('../common');
+const {
+  ReadableStream,
+  WritableStream,
+  TransformStream,
+  pipeline,
+} = require('stream/web');
 const assert = require('assert');
 
 class Sink {
@@ -56,7 +55,7 @@ class Sink {
     pipeline(ws, rs, () => {});
   }, /ERR_INVALID_ARG_TYPE/);
 }
-  
+
 {
   const rs = new ReadableStream();
   const ws1 = new WritableStream();
@@ -82,7 +81,7 @@ class Sink {
       controller.close();
     },
   });
-  
+
   pipeline(rs, ws, common.mustCall());
 }
 
@@ -127,7 +126,7 @@ class Sink {
 
   pipeline(rs, ws, common.mustCall(() => {
     assert.strictEqual(
-      sink.chunks.toString(), 
+      sink.chunks.toString(),
       'hello'
     );
   }));
@@ -151,7 +150,7 @@ class Sink {
 
   pipeline(rs, ts, ws, common.mustCall(() => {
     assert.strictEqual(
-      sink.chunks.toString(), 
+      sink.chunks.toString(),
       'hello'
     );
   }));

--- a/test/parallel/test-whatwg-stream-pipeline.js
+++ b/test/parallel/test-whatwg-stream-pipeline.js
@@ -1,0 +1,158 @@
+'use strict'
+
+const { 
+  ReadableStream, 
+  WritableStream, 
+  TransformStream, 
+  pipeline,
+  finished,
+} = require("stream/web");
+const common = require('../common');
+const assert = require('assert');
+
+class Sink {
+  constructor() {
+    this.chunks = [];
+  }
+  start() {
+    this.started = true;
+  }
+  write(chunk) {
+    this.chunks.push(chunk);
+  }
+  close() {
+    this.closed = true;
+  }
+  abort() {
+    this.aborted = true;
+  }
+}
+
+{
+  const rs = new ReadableStream();
+
+  assert.throws(() => {
+    pipeline(rs, () => {});
+  }, /ERR_MISSING_ARGS/);
+
+  assert.throws(() => {
+    pipeline(() => {});
+  }, /ERR_MISSING_ARGS/);
+}
+
+{
+  const rs = new ReadableStream();
+  const ws = new WritableStream();
+
+  assert.throws(() => {
+    pipeline(rs, ws, null);
+  }, /ERR_INVALID_CALLBACK/);
+}
+
+{
+  const rs = new ReadableStream();
+  const ws = new WritableStream();
+  assert.throws(() => {
+    pipeline(ws, rs, () => {});
+  }, /ERR_INVALID_ARG_TYPE/);
+}
+  
+{
+  const rs = new ReadableStream();
+  const ws1 = new WritableStream();
+  const ws2 = new WritableStream();
+  assert.throws(() => {
+    pipeline(rs, ws1, ws2, () => {});
+  }, /ERR_INVALID_ARG_TYPE/);
+}
+
+{
+  const rs1 = new ReadableStream();
+  const rs2 = new ReadableStream();
+  const ws = new WritableStream();
+  assert.throws(() => {
+    pipeline(rs1, rs2, ws, () => {});
+  }, /ERR_INVALID_ARG_TYPE/);
+}
+
+{
+  const ws = new WritableStream();
+  const rs = new ReadableStream({
+    start(controller) {
+      controller.close();
+    },
+  });
+  
+  pipeline(rs, ws, common.mustCall());
+}
+
+{
+  const ws = new WritableStream();
+  const ts = new TransformStream();
+  const rs = new ReadableStream({
+    start(controller) {
+      controller.close();
+    },
+  });
+
+  pipeline(rs, ts, ws, common.mustCall());
+}
+
+{
+  const ws = new WritableStream();
+  const ts1 = new TransformStream();
+  const ts2 = new TransformStream();
+  const rs = new ReadableStream({
+    start(controller) {
+      controller.close();
+    },
+  });
+
+  pipeline(rs, ts1, ts2, ws, common.mustCall());
+}
+
+{
+  const sink = new Sink();
+  const ws = new WritableStream(
+    sink, { highWaterMark: 1 }
+  );
+
+  const data = Buffer.from('hello');
+  const rs = new ReadableStream({
+    start(controller) {
+      controller.enqueue(data);
+      controller.close();
+    },
+  });
+
+  pipeline(rs, ws, common.mustCall(() => {
+    assert.strictEqual(
+      sink.chunks.toString(), 
+      'hello'
+    );
+  }));
+}
+
+{
+  const sink = new Sink();
+  const ws = new WritableStream(
+    sink, { highWaterMark: 1 }
+  );
+
+  const data = Buffer.from('hello');
+  const rs = new ReadableStream({
+    start(controller) {
+      controller.enqueue(data);
+      controller.close();
+    },
+  });
+
+  const ts = new TransformStream();
+
+  pipeline(rs, ts, ws, common.mustCall(() => {
+    assert.strictEqual(
+      sink.chunks.toString(), 
+      'hello'
+    );
+  }));
+}

--- a/test/parallel/test-whatwg-stream-promises.js
+++ b/test/parallel/test-whatwg-stream-promises.js
@@ -1,0 +1,80 @@
+'use strict'
+
+const { 
+  ReadableStream, 
+  WritableStream, 
+  TransformStream, 
+  finished: noPromiseFinished,
+} = require("stream/web");
+const { pipeline } = require('stream/web/promises');
+const { finished } = require('stream/web/promises');
+const common = require('../common');
+const assert = require('assert');
+
+class Sink {
+  constructor() {
+    this.chunks = [];
+  }
+  start() {
+    this.started = true;
+  }
+  write(chunk) {
+    this.chunks.push(chunk);
+  }
+  close() {
+    this.closed = true;
+  }
+  abort() {
+    this.aborted = true;
+  }
+}
+
+
+{
+  const stream = new ReadableStream();
+
+  async function runInner(stream) {
+    let ended = false;
+    noPromiseFinished(stream, () => {
+      ended = true;
+    });
+    await finished(stream);
+    assert(ended);
+  }
+
+  async function run(stream) {
+    runInner(stream).then(common.mustCall());
+  }
+
+  run(stream);
+  stream.cancel();
+}
+
+{
+  const sink = new Sink();
+  const ws = new WritableStream(
+    sink, { highWaterMark: 1 }
+  );
+
+  const data = Buffer.from('hello');
+  const rs = new ReadableStream({
+    start(controller) {
+      controller.enqueue(data);
+      controller.close();
+    },
+  });
+
+  const ts = new TransformStream();
+
+  let finished = false;
+  noPromiseFinished(ws, () => {
+    finished = true;
+  })
+
+  pipeline(rs, ts, ws).then(common.mustCall(() => {
+    assert.ok(finished);
+    assert.strictEqual(sink.chunks.toString(), 'hello');
+  }));
+  
+
+}

--- a/test/parallel/test-whatwg-stream-promises.js
+++ b/test/parallel/test-whatwg-stream-promises.js
@@ -1,14 +1,13 @@
-'use strict'
+'use strict';
 
-const { 
-  ReadableStream, 
-  WritableStream, 
-  TransformStream, 
-  finished: noPromiseFinished,
-} = require("stream/web");
-const { pipeline } = require('stream/web/promises');
-const { finished } = require('stream/web/promises');
 const common = require('../common');
+const {
+  ReadableStream,
+  WritableStream,
+  TransformStream,
+  finished: noPromiseFinished,
+} = require('stream/web');
+const { pipeline, finished } = require('stream/web/promises');
 const assert = require('assert');
 
 class Sink {
@@ -69,12 +68,12 @@ class Sink {
   let finished = false;
   noPromiseFinished(ws, () => {
     finished = true;
-  })
+  });
 
   pipeline(rs, ts, ws).then(common.mustCall(() => {
     assert.ok(finished);
     assert.strictEqual(sink.chunks.toString(), 'hello');
   }));
-  
+
 
 }


### PR DESCRIPTION
Implements the finished, addAbortSignal, and pipeline functions for webstreams, and adds the documentation and tests for each function. The promisified versions of finished and pipeline are also added.

Refs: https://github.com/nodejs/node/issues/39316
