### PR TITLE
webstream: convert premature close to AbortError

### DIFF
--- a/lib/internal/webstreams/adapters.js
+++ b/lib/internal/webstreams/adapters.js
@@ -50,6 +50,7 @@ const {
     ERR_INVALID_STATE,
     ERR_STREAM_PREMATURE_CLOSE,
   },
+  AbortError,
 } = require('internal/errors');
 
 const {
@@ -120,6 +121,10 @@ function newWritableStreamFromStreamWritable(streamWritable) {
   }
 
   const cleanup = finished(streamWritable, (error) => {
+    if (error?.code === 'ERR_STREAM_PREMATURE_CLOSE') {
+      error = new AbortError();
+    }
+
     cleanup();
     // This is a protection against non-standard, legacy streams
     // that happen to emit an error event again after finished is called.

--- a/lib/internal/webstreams/adapters.js
+++ b/lib/internal/webstreams/adapters.js
@@ -151,7 +151,7 @@ function newWritableStreamFromStreamWritable(streamWritable) {
       closed = undefined;
       return;
     }
-    controller.error(new ERR_STREAM_PREMATURE_CLOSE());
+    controller.error(new AbortError());
     controller = undefined;
   });
 
@@ -402,6 +402,12 @@ function newReadableStreamFromStreamReadable(streamReadable) {
   streamReadable.pause();
 
   const cleanup = finished(streamReadable, (error) => {
+    if (error?.code === 'ERR_STREAM_PREMATURE_CLOSE') {
+      const err = new AbortError();
+      err.cause = error;
+      error = err;
+    }
+
     cleanup();
     // This is a protection against non-standard, legacy streams
     // that happen to emit an error event again after finished is called.

--- a/lib/internal/webstreams/adapters.js
+++ b/lib/internal/webstreams/adapters.js
@@ -122,7 +122,9 @@ function newWritableStreamFromStreamWritable(streamWritable) {
 
   const cleanup = finished(streamWritable, (error) => {
     if (error?.code === 'ERR_STREAM_PREMATURE_CLOSE') {
-      error = new AbortError();
+      const err = new AbortError();
+      err.cause = error;
+      error = err;
     }
 
     cleanup();

--- a/test/parallel/test-whatwg-webstreams-adapters-to-readablestream.js
+++ b/test/parallel/test-whatwg-webstreams-adapters-to-readablestream.js
@@ -59,7 +59,7 @@ const {
   const reader = readableStream.getReader();
 
   assert.rejects(reader.closed, {
-    code: 'ERR_STREAM_PREMATURE_CLOSE',
+    code: 'ABORT_ERR',
   });
 
   readable.on('end', common.mustNotCall());

--- a/test/parallel/test-whatwg-webstreams-adapters-to-readablewritablepair.js
+++ b/test/parallel/test-whatwg-webstreams-adapters-to-readablewritablepair.js
@@ -27,11 +27,11 @@ const {
   const writer = writable.getWriter();
 
   assert.rejects(reader.closed, {
-    code: 'ERR_STREAM_PREMATURE_CLOSE',
+    code: 'ABORT_ERR',
   });
 
   assert.rejects(writer.closed, {
-    code: 'ERR_STREAM_PREMATURE_CLOSE',
+    code: 'ABORT_ERR',
   });
 
   duplex.destroy();
@@ -165,7 +165,7 @@ const {
 
   reader.closed.then(common.mustCall());
   assert.rejects(writer.closed, {
-    code: 'ERR_STREAM_PREMATURE_CLOSE',
+    code: 'ABORT_ERR',
   });
 
   duplex.end();

--- a/test/parallel/test-whatwg-webstreams-adapters-to-writablestream.js
+++ b/test/parallel/test-whatwg-webstreams-adapters-to-writablestream.js
@@ -92,7 +92,7 @@ class TestWritable extends Writable {
   const writableStream = newWritableStreamFromStreamWritable(writable);
 
   assert.rejects(writableStream.close(), {
-    code: 'ERR_STREAM_PREMATURE_CLOSE'
+    code: 'ABORT_ERR'
   });
 
   writable.end();


### PR DESCRIPTION
AbortError is a more "web" align alternative to
ERR_STREAM_PREMATURE_CLOSE.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
