### PR TITLE
build: use lts shorthand in GitHub Actions

### DIFF
--- a/.github/workflows/auto-start-ci.yml
+++ b/.github/workflows/auto-start-ci.yml
@@ -10,7 +10,7 @@ on:
     - cron: "*/5 * * * *"
 
 env:
-  NODE_VERSION: 14.x
+  NODE_VERSION: lts/*
 
 jobs:
   startCI:

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -3,7 +3,7 @@ name: "Commit messages adheres to guidelines at https://goo.gl/p2fr5Q"
 on: [pull_request]
 
 env:
-  NODE_VERSION: 14.x
+  NODE_VERSION: lts/*
 
 jobs:
   lint-commit-message:

--- a/.github/workflows/commit-queue.yml
+++ b/.github/workflows/commit-queue.yml
@@ -15,7 +15,7 @@ on:
     - cron: "*/5 * * * *"
 
 env:
-  NODE_VERSION: 14.x
+  NODE_VERSION: lts/*
 
 jobs:
   commitQueue:

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -6,7 +6,7 @@ on:
     - cron: "0 0 * * *"
 
 env:
-  NODE_VERSION: 14.x
+  NODE_VERSION: lts/*
 
 jobs:
   build-lto:

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   PYTHON_VERSION: 3.9
-  NODE_VERSION: 14.x
+  NODE_VERSION: lts/*
 
 jobs:
   lint-addon-docs:

--- a/.github/workflows/misc.yml
+++ b/.github/workflows/misc.yml
@@ -11,7 +11,7 @@ on:
       - v[0-9]+.x
 
 env:
-  NODE_VERSION: 14.x
+  NODE_VERSION: lts/*
 
 jobs:
   build-docs:


### PR DESCRIPTION
Rather than hard-coding GitHub Actions to use Node.js 14.x, use the
`lts/*` shorthand for "most recent LTS version".

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
