### PR TITLE
stream: readableDidRead if data has been read

### DIFF
--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -316,6 +316,7 @@ function addChunk(stream, state, chunk, addToFront) {
     } else {
       state.awaitDrainWriters = null;
     }
+    state.didRead = true;
     stream.emit('data', chunk);
   } else {
     // Update the buffer info.
@@ -541,10 +542,10 @@ Readable.prototype.read = function(n) {
       endReadable(this);
   }
 
-  if (ret !== null)
+  if (ret !== null) {
+    state.didRead = true;
     this.emit('data', ret);
-
-  state.didRead = true;
+  }
 
   return ret;
 };
@@ -851,7 +852,6 @@ function pipeOnDrain(src, dest) {
       EE.listenerCount(src, 'data')) {
       // TODO(ronag): Call resume() instead?
       state.flowing = true;
-      state.didRead = true;
       flow(src);
     }
   };
@@ -999,7 +999,6 @@ Readable.prototype.resume = function() {
 function resume(stream, state) {
   if (!state.resumeScheduled) {
     state.resumeScheduled = true;
-    state.didRead = true;
     process.nextTick(resume_, stream, state);
   }
 }

--- a/test/parallel/test-stream-readable-didRead.js
+++ b/test/parallel/test-stream-readable-didRead.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const Readable = require('stream').Readable;
 
@@ -10,7 +10,7 @@ const Readable = require('stream').Readable;
 
   assert.strictEqual(readable.readableDidRead, false);
   readable.read();
-  assert.strictEqual(readable.readableDidRead, true);
+  assert.strictEqual(readable.readableDidRead, false);
 }
 
 {
@@ -20,5 +20,30 @@ const Readable = require('stream').Readable;
 
   assert.strictEqual(readable.readableDidRead, false);
   readable.resume();
+  assert.strictEqual(readable.readableDidRead, false);
+}
+
+{
+  const readable = new Readable({
+    read: () => {}
+  });
+  readable.push('asd');
+
+  assert.strictEqual(readable.readableDidRead, false);
+  readable.read();
   assert.strictEqual(readable.readableDidRead, true);
+}
+
+{
+  const readable = new Readable({
+    read: () => {}
+  });
+  readable.push('asd');
+
+  assert.strictEqual(readable.readableDidRead, false);
+  readable.resume();
+  assert.strictEqual(readable.readableDidRead, false);
+  readable.on('data', common.mustCall(function() {
+    assert.strictEqual(readable.readableDidRead, true);
+  }));
 }


### PR DESCRIPTION
Only readableDidRead if there actually has been data read. 

We have a slight conflict of use case here:

1. If user has intention of reading, e.g. used by http to know if it's safe to dump. (https://github.com/nodejs/node/blob/master/lib/_http_server.js#L805-L806)
2. If user wants to know if data has been read and whether or not it is possible to get all data, for e.g. json parsing. (https://github.com/nodejs/node/pull/39520/files#diff-040c1f5a53844e600d40b33c4624f1fe39fcf2f8d62c76ca3fc5ea5442231469R1366-R1368)

1, If `resume()`, `read()`, `pipe()` has been called or `'data'` or `'readable'` listener exists.
2, If `read()` has returned data or `'end'` or `'data'` has been emitted.

Do we need two separate properties and if so what should they be called?

`readableDidRead`, `readableDisturbed`, `readableUsed` or `readableReading`?

If we only want/need one of them I would prefer 2. 

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
