### PR TITLE
Update Release guide

### DIFF
--- a/doc/guides/releases.md
+++ b/doc/guides/releases.md
@@ -345,10 +345,14 @@ accordingly by removing the bold styling from the previous release.
 If this release includes new APIs then it is necessary to document that they
 were first added in this version. The relevant commits should already include
 `REPLACEME` tags as per the example in the
-[docs README](../../tools/doc/README.md). Check for these tags with `grep
-REPLACEME doc/api/*.md`, and substitute this node version with `sed -i
-"s/REPLACEME/$VERSION/g" doc/api/*.md` or `perl -pi -e "s/REPLACEME/$VERSION/g"
-doc/api/*.md`.
+[docs README](../../tools/doc/README.md). Check for these tags with
+```console
+grep REPLACEME doc/api/*.md
+```
+and substitute this node version with
+```console
+sed -i "s/REPLACEME/$VERSION/g" doc/api/*.md` or `perl -pi -e "s/REPLACEME/$VERSION/g" doc/api/*.md
+```
 
 `$VERSION` should be prefixed with a `v`.
 

--- a/doc/guides/releases.md
+++ b/doc/guides/releases.md
@@ -243,34 +243,6 @@ be produced with a version string that does not have a trailing pre-release tag:
 #define NODE_VERSION_IS_RELEASE 1
 ```
 
-**Also consider whether to bump `NODE_MODULE_VERSION`**:
-
-This macro is used to signal an ABI version for native addons. It currently has
-two common uses in the community:
-
-* Determining what API to work against for compiling native addons, e.g.
-  [NAN](https://github.com/nodejs/nan) uses it to form a compatibility-layer for
-  much of what it wraps.
-* Determining the ABI for downloading pre-built binaries of native addons, e.g.
-  [node-pre-gyp](https://github.com/mapbox/node-pre-gyp) uses this value as
-  exposed via `process.versions.modules` to help determine the appropriate
-  binary to download at install-time.
-
-The general rule is to bump this version when there are _breaking ABI_ changes
-and also if there are non-trivial API changes. The rules are not yet strictly
-defined, so if in doubt, please confer with someone that will have a more
-informed perspective, such as a member of the NAN team.
-
-A registry of currently used `NODE_MODULE_VERSION` values is maintained at
-<https://github.com/nodejs/node/blob/HEAD/doc/abi_version_registry.json>.
-When bumping `NODE_MODULE_VERSION`, you should choose a new value not listed
-in the registry. Also include a change to the registry in your commit to
-reflect the newly used value.
-
-It is current TSC policy to bump major version when ABI changes. If you
-see a need to bump `NODE_MODULE_VERSION` then you should consult the TSC.
-Commits may need to be reverted or a major version bump may need to happen.
-
 ### 4. Update the changelog
 
 #### Step 1: Collect the formatted list of changes
@@ -837,6 +809,36 @@ changelog).
 Notify the `@nodejs/npm` team in the release proposal PR to inform them of the
 upcoming release. `npm` maintains a list of [supported versions](https://github.com/npm/cli/blob/latest/lib/utils/unsupported.js#L3)
 that will need updating to include the new major release.
+
+### Update `NODE_MODULE_VERSION`
+
+This macro in `src/node_version.h` is used to signal an ABI version for native
+addons. It currently has two common uses in the community:
+
+* Determining what API to work against for compiling native addons, e.g.
+  [NAN](https://github.com/nodejs/nan) uses it to form a compatibility-layer for
+  much of what it wraps.
+* Determining the ABI for downloading pre-built binaries of native addons, e.g.
+  [node-pre-gyp](https://github.com/mapbox/node-pre-gyp) uses this value as
+  exposed via `process.versions.modules` to help determine the appropriate
+  binary to download at install-time.
+
+The general rule is to bump this version when there are _breaking ABI_ changes
+and also if there are non-trivial API changes. The rules are not yet strictly
+defined, so if in doubt, please confer with someone that will have a more
+informed perspective, such as a member of the NAN team.
+
+A registry of currently used `NODE_MODULE_VERSION` values is maintained at
+<https://github.com/nodejs/node/blob/HEAD/doc/abi_version_registry.json>.
+When bumping `NODE_MODULE_VERSION`, you should choose a new value not listed
+in the registry. Also include a change to the registry in your commit to
+reflect the newly used value. Ensure that the release commit removes the
+`-pre` suffix for the major version being prepared.
+
+It is current TSC policy to bump major version when ABI changes. If you
+see a need to bump `NODE_MODULE_VERSION` outside of a majore release then
+you should consult the TSC. Commits may need to be reverted or a major
+version bump may need to happen.
 
 ### Test releases and release candidates
 

--- a/doc/guides/releases.md
+++ b/doc/guides/releases.md
@@ -175,7 +175,7 @@ duplicate or not.
 For a list of commits that could be landed in a patch release on v1.x:
 
 ```console
-$ branch-diff v1.x-staging master --exclude-label=semver-major,semver-minor,dont-land-on-v1.x,backport-requested-v1.x,backport-blocked-v1.x --filter-release --format=simple
+$ branch-diff v1.x-staging master --exclude-label=semver-major,semver-minor,dont-land-on-v1.x,backport-requested-v1.x,backport-blocked-v1.x,backport-open-v1.x,backported-to-v1.x --filter-release --format=simple
 ```
 
 Previously released commits and version bumps do not need to be
@@ -195,7 +195,7 @@ command. (For semver-minor releases, make sure to remove the `semver-minor` tag
 from `exclude-label`.)
 
 ```console
-$ branch-diff v1.x-staging master --exclude-label=semver-major,semver-minor,dont-land-on-v1.x,backport-requested-v1.x,backport-blocked-v1.x --filter-release --format=sha --reverse | xargs git cherry-pick
+$ branch-diff v1.x-staging master --exclude-label=semver-major,semver-minor,dont-land-on-v1.x,backport-requested-v1.x,backport-blocked-v1.x,backport-open-v1.x,backported-to-v1.x --filter-release --format=sha --reverse | xargs git cherry-pick
 ```
 
 When cherry-picking commits, if there are simple conflicts you can resolve

--- a/doc/guides/releases.md
+++ b/doc/guides/releases.md
@@ -475,26 +475,6 @@ minutes which will prevent Jenkins from clearing the workspace to start a new
 one. This isn't a big deal, it's just a hassle because it'll result in another
 failed build if you start again!
 
-ARMv7 takes the longest to compile. Unfortunately ccache isn't as effective on
-release builds, I think it's because of the additional macro settings that go in
-to a release build that nullify previous builds. Also most of the release build
-machines are separate to the test build machines so they don't get any benefit
-from ongoing compiles between releases. You can expect 1.5 hours for the ARMv7
-builder to complete and you should normally wait for this to finish. It is
-possible to rush a release out if you want and add additional builds later but
-we normally provide ARMv7 from initial promotion.
-
-You do not have to wait for the ARMv6 / Raspberry PI builds if they take longer
-than the others. It is only necessary to have the main Linux (x64 and x86),
-macOS .pkg and .tar.gz, Windows (x64 and x86) .msi and .exe, source, headers,
-and docs (both produced currently by an macOS worker). **If you promote builds
-_before_ ARM builds have finished, you must repeat the promotion step for the
-ARM builds when they are ready**. If the ARMv6 build failed for some reason you
-can use the
-[`iojs-release-arm6-only`](https://ci-release.nodejs.org/job/iojs+release-arm6-only/)
-build in the release CI to re-run the build only for ARMv6. When launching the
-build make sure to use the same commit hash as for the original release.
-
 ### 10. Test the build
 
 Jenkins collects the artifacts from the builds, allowing you to download and
@@ -677,11 +657,6 @@ SHASUMS256.txt.sig.
 **g.** Upload the `SHASUMS256.txt` files back to the server into the release
 directory.
 </details>
-
-If you didn't wait for ARM builds in the previous step before promoting the
-release, you should re-run `tools/release.sh` after the ARM builds have
-finished. That will move the ARM artifacts into the correct location. You will
-be prompted to re-sign `SHASUMS256.txt`.
 
 **It is possible to only sign a release by running `./tools/release.sh -s
 vX.Y.Z`.**


### PR DESCRIPTION
cc @nodejs/releasers 

### doc: update backport labels in release guide

Add `backport-open-v1.x,backported-to-v1.x` labels to `branch-diff`
commands as these indicate pull requests that are being manually
backported and should not be cherry-picked.

### doc: fence command examples in release guide

Put the command examples for finding and replacing the `REPLACEME`
tags into code fences so that they are more easily copiable when
viewing the guide in the GitHub web UI.

### doc: remove outdated ARM information from release guide

We no longer produced ARMv6 builds, and the ARMv7 builds are now
cross compiled and are as quick as builds on the other platforms.

### doc: move NODE_MODULE_VERSION in release guide

Move the section on `NODE_MODULE_VERSION` into the section for
major releases as it should only be updated for a major release.
Add a note to remove the `-pre` suffix from the registry for the
release commit.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
