### PR TITLE
perf_hooks: fix PerformanceObserver gc crash

### DIFF
--- a/lib/internal/perf/observe.js
+++ b/lib/internal/perf/observe.js
@@ -130,6 +130,7 @@ function maybeDecrementObserverCounts(entryTypes) {
       if (observerType === NODE_PERFORMANCE_ENTRY_TYPE_GC &&
           observerCounts[observerType] === 0) {
         removeGarbageCollectionTracking();
+        gcTrackingInstalled = false;
       }
     }
   }

--- a/test/parallel/test-perf-gc-crash.js
+++ b/test/parallel/test-perf-gc-crash.js
@@ -1,0 +1,25 @@
+'use strict';
+
+require('../common');
+
+// Refers to https://github.com/nodejs/node/issues/39548
+
+// The test fails if this crashes. If it closes normally,
+// then all is good.
+
+const {
+  PerformanceObserver,
+} = require('perf_hooks');
+
+// We don't actually care if the observer callback is called here.
+const gcObserver = new PerformanceObserver(() => {});
+
+gcObserver.observe({ entryTypes: ['gc'] });
+
+gcObserver.disconnect();
+
+const gcObserver2 = new PerformanceObserver(() => {});
+
+gcObserver2.observe({ entryTypes: ['gc'] });
+
+gcObserver2.disconnect();


### PR DESCRIPTION
Signed-off-by: James M Snell <jasnell@gmail.com>
Fixes: https://github.com/nodejs/node/issues/39548
