### PR TITLE
lib: use ERR_ILLEGAL_CONSTRUCTOR

### DIFF
--- a/lib/internal/abort_controller.js
+++ b/lib/internal/abort_controller.js
@@ -10,7 +10,6 @@ const {
   ObjectDefineProperty,
   Symbol,
   SymbolToStringTag,
-  TypeError,
 } = primordials;
 
 const {
@@ -25,6 +24,7 @@ const {
 const { inspect } = require('internal/util/inspect');
 const {
   codes: {
+    ERR_ILLEGAL_CONSTRUCTOR,
     ERR_INVALID_THIS,
   }
 } = require('internal/errors');
@@ -49,8 +49,7 @@ function validateAbortSignal(obj) {
 
 class AbortSignal extends EventTarget {
   constructor() {
-    // eslint-disable-next-line no-restricted-syntax
-    throw new TypeError('Illegal constructor');
+    throw new ERR_ILLEGAL_CONSTRUCTOR();
   }
 
   get aborted() {

--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -34,11 +34,11 @@ const {
   codes: {
     ERR_CRYPTO_INCOMPATIBLE_KEY_OPTIONS,
     ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE,
+    ERR_CRYPTO_INVALID_JWK,
+    ERR_ILLEGAL_CONSTRUCTOR,
     ERR_INVALID_ARG_TYPE,
     ERR_INVALID_ARG_VALUE,
     ERR_OUT_OF_RANGE,
-    ERR_OPERATION_FAILED,
-    ERR_CRYPTO_INVALID_JWK,
   }
 } = require('internal/errors');
 
@@ -631,7 +631,7 @@ function isKeyObject(obj) {
 // would be fantastic if we could find a way of making those interop.
 class CryptoKey extends JSTransferable {
   constructor() {
-    throw new ERR_OPERATION_FAILED('Illegal constructor');
+    throw new ERR_ILLEGAL_CONSTRUCTOR();
   }
 
   [kInspect](depth, options) {

--- a/lib/internal/histogram.js
+++ b/lib/internal/histogram.js
@@ -7,7 +7,6 @@ const {
   ObjectSetPrototypeOf,
   SafeMap,
   Symbol,
-  TypeError,
 } = primordials;
 
 const {
@@ -22,6 +21,7 @@ const { inspect } = require('util');
 
 const {
   codes: {
+    ERR_ILLEGAL_CONSTRUCTOR,
     ERR_INVALID_ARG_VALUE,
     ERR_INVALID_ARG_TYPE,
     ERR_OUT_OF_RANGE,
@@ -130,8 +130,7 @@ class Histogram extends JSTransferable {
 
 class RecordableHistogram extends Histogram {
   constructor() {
-    // eslint-disable-next-line no-restricted-syntax
-    throw new TypeError('illegal constructor');
+    throw new ERR_ILLEGAL_CONSTRUCTOR();
   }
 
   record(val) {

--- a/lib/internal/perf/event_loop_delay.js
+++ b/lib/internal/perf/event_loop_delay.js
@@ -1,8 +1,13 @@
 'use strict';
 const {
   Symbol,
-  TypeError,
 } = primordials;
+
+const {
+  codes: {
+    ERR_ILLEGAL_CONSTRUCTOR,
+  }
+} = require('internal/errors');
 
 const {
   ELDHistogram: _ELDHistogram,
@@ -23,8 +28,7 @@ const kEnabled = Symbol('kEnabled');
 class ELDHistogram extends Histogram {
   constructor(i) {
     if (!(i instanceof _ELDHistogram)) {
-      // eslint-disable-next-line no-restricted-syntax
-      throw new TypeError('illegal constructor');
+      throw new ERR_ILLEGAL_CONSTRUCTOR();
     }
     super(i);
     this[kEnabled] = false;

--- a/lib/internal/perf/performance.js
+++ b/lib/internal/perf/performance.js
@@ -4,8 +4,13 @@ const {
   ObjectDefineProperty,
   ObjectDefineProperties,
   ObjectSetPrototypeOf,
-  TypeError,
 } = primordials;
+
+const {
+  codes: {
+    ERR_ILLEGAL_CONSTRUCTOR,
+  }
+} = require('internal/errors');
 
 const {
   EventTarget,
@@ -35,8 +40,7 @@ const {
 
 class Performance extends EventTarget {
   constructor() {
-    // eslint-disable-next-line no-restricted-syntax
-    throw new TypeError('Illegal constructor');
+    throw new ERR_ILLEGAL_CONSTRUCTOR();
   }
 
   [kInspect](depth, options) {

--- a/lib/internal/perf/performance_entry.js
+++ b/lib/internal/perf/performance_entry.js
@@ -3,8 +3,13 @@
 const {
   ObjectSetPrototypeOf,
   Symbol,
-  TypeError,
 } = primordials;
+
+const {
+  codes: {
+    ERR_ILLEGAL_CONSTRUCTOR,
+  }
+} = require('internal/errors');
 
 const {
   customInspectSymbol: kInspect,
@@ -25,8 +30,7 @@ function isPerformanceEntry(obj) {
 
 class PerformanceEntry {
   constructor() {
-    // eslint-disable-next-line no-restricted-syntax
-    throw new TypeError('illegal constructor');
+    throw new ERR_ILLEGAL_CONSTRUCTOR();
   }
 
   get name() { return this[kName]; }

--- a/test/parallel/test-abortcontroller.js
+++ b/test/parallel/test-abortcontroller.js
@@ -56,10 +56,9 @@ const { ok, strictEqual, throws } = require('assert');
 {
   // Tests that AbortSignal is impossible to construct manually
   const ac = new AbortController();
-  throws(
-    () => new ac.signal.constructor(),
-    /^TypeError: Illegal constructor$/
-  );
+  throws(() => new ac.signal.constructor(), {
+    code: 'ERR_ILLEGAL_CONSTRUCTOR',
+  });
 }
 {
   // Symbol.toStringTag

--- a/test/parallel/test-perf-hooks-histogram.js
+++ b/test/parallel/test-perf-hooks-histogram.js
@@ -78,8 +78,5 @@ const { inspect } = require('util');
 {
   // Tests that RecordableHistogram is impossible to construct manually
   const h = createHistogram();
-  assert.throws(
-    () => new h.constructor(),
-    /^TypeError: illegal constructor$/
-  );
+  assert.throws(() => new h.constructor(), { code: 'ERR_ILLEGAL_CONSTRUCTOR' });
 }

--- a/test/parallel/test-webcrypto-keygen.js
+++ b/test/parallel/test-webcrypto-keygen.js
@@ -657,9 +657,7 @@ const vectors = {
 })().then(common.mustCall());
 
 // End user code cannot create CryptoKey directly
-assert.throws(() => new CryptoKey(), {
-  code: 'ERR_OPERATION_FAILED'
-});
+assert.throws(() => new CryptoKey(), { code: 'ERR_ILLEGAL_CONSTRUCTOR' });
 
 {
   const buffer = Buffer.from('Hello World');


### PR DESCRIPTION
Use ERR_ILLEGAL_CONSTRUCTOR error instead of `illegal constructor` or
`Illegal constructor` TypeError.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
