### PR TITLE
build: exclude markdown files from some GitHub Actions

### DIFF
--- a/.github/workflows/coverage-linux.yml
+++ b/.github/workflows/coverage-linux.yml
@@ -4,9 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
-      - 'doc/**'
-      - 'deps/**'
+      - '**.md'
       - 'benchmark/**'
+      - 'deps/**'
+      - 'doc/**'
       - 'tools/**'
   push:
     branches:

--- a/.github/workflows/coverage-linux.yml
+++ b/.github/workflows/coverage-linux.yml
@@ -13,9 +13,10 @@ on:
       - master
       - main
     paths-ignore:
-      - 'doc/**'
-      - 'deps/**'
+      - '**.md'
       - 'benchmark/**'
+      - 'deps/**'
+      - 'doc/**'
       - 'tools/**'
 
 env:

--- a/.github/workflows/coverage-windows.yml
+++ b/.github/workflows/coverage-windows.yml
@@ -4,9 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
-      - 'doc/**'
-      - 'deps/**'
+      - '**.md'
       - 'benchmark/**'
+      - 'deps/**'
+      - 'doc/**'
       - 'tools/**'
   push:
     branches:

--- a/.github/workflows/coverage-windows.yml
+++ b/.github/workflows/coverage-windows.yml
@@ -13,9 +13,10 @@ on:
       - master
       - main
     paths-ignore:
-      - 'doc/**'
-      - 'deps/**'
+      - '**.md'
       - 'benchmark/**'
+      - 'deps/**'
+      - 'doc/**'
       - 'tools/**'
 
 env:

--- a/.github/workflows/test-asan.yml
+++ b/.github/workflows/test-asan.yml
@@ -9,6 +9,7 @@ on:
       - v[0-9]+.x-staging
       - v[0-9]+.x
     paths-ignore:
+      - '**.md'
       - 'doc/**'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]

--- a/.github/workflows/test-asan.yml
+++ b/.github/workflows/test-asan.yml
@@ -13,6 +13,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
+      - '**.md'
       - 'doc/**'
 
 env:

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
+      - '**.md'
       - 'doc/**'
   push:
     branches:

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -13,6 +13,7 @@ on:
       - v[0-9]+.x-staging
       - v[0-9]+.x
     paths-ignore:
+      - '**.md'
       - 'doc/**'
 
 env:


### PR DESCRIPTION
Ignore all markdown files when determining if test-asan, coverage-*, and
test-macos need to run.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
