### PR TITLE
test: add test-debugger-breakpoint-exists

### DIFF
--- a/lib/internal/debugger/inspect_client.js
+++ b/lib/internal/debugger/inspect_client.js
@@ -40,8 +40,8 @@ const kMaskingKeyWidthInBytes = 4;
 // https://tools.ietf.org/html/rfc6455#section-1.3
 const WEBSOCKET_HANDSHAKE_GUID = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
 
-function unpackError({ code, message, data }) {
-  const err = new ERR_DEBUGGER_ERROR(`${message} - ${data}`);
+function unpackError({ code, message }) {
+  const err = new ERR_DEBUGGER_ERROR(`${message}`);
   err.code = code;
   ErrorCaptureStackTrace(err, unpackError);
   return err;

--- a/test/sequential/test-debugger-breakpoint-exists.js
+++ b/test/sequential/test-debugger-breakpoint-exists.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const common = require('../common');
+
+common.skipIfInspectorDisabled();
+
+const fixtures = require('../common/fixtures');
+const startCLI = require('../common/debugger');
+
+// Test for "Breakpoint at specified location already exists" error.
+{
+  const script = fixtures.path('debugger', 'three-lines.js');
+  const cli = startCLI([script]);
+
+  function onFatal(error) {
+    cli.quit();
+    throw error;
+  }
+
+  cli.waitForInitialBreak()
+    .then(() => cli.waitForPrompt())
+    .then(() => cli.command('setBreakpoint(1)'))
+    .then(() => cli.command('setBreakpoint(1)'))
+    .then(() => cli.waitFor(/Breakpoint at specified location already exists/))
+    .then(() => cli.quit())
+    .then(null, onFatal);
+}


### PR DESCRIPTION
* The data parameter of unpackError() is typically undefined. Remove it.
* ~In Node.js 15, calling `setBreakpoint(1)` and `restart` twice in a row
caused the debugger to exit. In Node.js 16, it no longer exits but
throws an error that is expected, or at least reasonable, or at least
better than exiting.~
* The error message previously had `undefined` appended to it. It no
longer does.
* This adds test coverage to `unpackError()` in
`lib/internal/debugger/inspect_client.js`. That function previously was
untested.

~Refs: https://github.com/nodejs/node-inspect/issues/101~