### PR TITLE
repl: do not include legacy getter/setter methods in completion

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1188,11 +1188,31 @@ function isIdentifier(str) {
   return true;
 }
 
+function isNotLegacyObjectPrototypeMethod(str) {
+  return isIdentifier(str) &&
+    str !== '__defineGetter__' &&
+    str !== '__defineSetter__' &&
+    str !== '__lookupGetter__' &&
+    str !== '__lookupSetter__';
+}
+
 function filteredOwnPropertyNames(obj) {
   if (!obj) return [];
+  // `Object.prototype` is the only non-contrived object that fulfills
+  // `Object.getPrototypeOf(X) === null &&
+  //  Object.getPrototypeOf(Object.getPrototypeOf(X.constructor)) === X`.
+  let isObjectPrototype = false;
+  if (ObjectGetPrototypeOf(obj) === null) {
+    const ctorDescriptor = ObjectGetOwnPropertyDescriptor(obj, 'constructor');
+    if (ctorDescriptor && ctorDescriptor.value) {
+      const ctorProto = ObjectGetPrototypeOf(ctorDescriptor.value);
+      isObjectPrototype = ctorProto && ObjectGetPrototypeOf(ctorProto) === obj;
+    }
+  }
   const filter = ALL_PROPERTIES | SKIP_SYMBOLS;
-  return ArrayPrototypeFilter(getOwnNonIndexProperties(obj, filter),
-                              isIdentifier);
+  return ArrayPrototypeFilter(
+      getOwnNonIndexProperties(obj, filter),
+      isObjectPrototype ? isNotLegacyObjectPrototypeMethod : isIdentifier);
 }
 
 function getGlobalLexicalScopeNames(contextId) {

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1211,8 +1211,8 @@ function filteredOwnPropertyNames(obj) {
   }
   const filter = ALL_PROPERTIES | SKIP_SYMBOLS;
   return ArrayPrototypeFilter(
-      getOwnNonIndexProperties(obj, filter),
-      isObjectPrototype ? isNotLegacyObjectPrototypeMethod : isIdentifier);
+    getOwnNonIndexProperties(obj, filter),
+    isObjectPrototype ? isNotLegacyObjectPrototypeMethod : isIdentifier);
 }
 
 function getGlobalLexicalScopeNames(contextId) {

--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -443,6 +443,18 @@ testMe.complete('obj.', common.mustCall((error, data) => {
   assert(data[0].includes('obj.key'));
 }));
 
+// Make sure tab completion does not include __defineSetter__ and friends.
+putIn.run(['.clear']);
+
+putIn.run(['var obj = {};']);
+testMe.complete('obj.', common.mustCall(function(error, data) {
+  assert.strictEqual(data[0].includes('obj.__defineGetter__'), false);
+  assert.strictEqual(data[0].includes('obj.__defineSetter__'), false);
+  assert.strictEqual(data[0].includes('obj.__lookupGetter__'), false);
+  assert.strictEqual(data[0].includes('obj.__lookupSetter__'), false);
+  assert.strictEqual(data[0].includes('obj.__proto__'), true);
+}));
+
 // Tab completion for files/directories
 {
   putIn.run(['.clear']);


### PR DESCRIPTION
For every object that inherits from `Object.prototype`, the REPL
includes the `Object.prototype` methods in its autocompletion.

This is already a little noisy, but in particular, this also
includes the legacy `__defineGetter__` family of methods;
since those are deprecated and not in practical use anymore,
it helps reduce noise a bit to remove them.

This commit does not remove `__proto__` as it is a little
more popular and, despite its downsides, a slightly more convenient
way to access the prototype of an object in the REPL than
`Object.getPrototypeOf(...)`.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
