### PR TITLE
doc: add point to ask H1 reporter about credit

### DIFF
--- a/doc/guides/security-release-process.md
+++ b/doc/guides/security-release-process.md
@@ -21,6 +21,11 @@ information described.
     the date in the slug so that it will move to the top of the blog list.)
   * [ ] pre-release: ***LINK TO PR***
   * [ ] post-release: ***LINK TO PR***
+    * Ask the HackerOne reporter if they would like to be credited on the
+      security release blog page:
+      ```text
+      Thank you to <name> for reporting this vulnerability.
+      ```
 
 * [ ] Get agreement on the planned date for the release: ***RELEASE DATE***
 


### PR DESCRIPTION
This commit updates the security release process document with a bullet
point to ask the HackerOne reporter if they would like to be credited
for reporting the vulnerability. We might also be able to add a question
like this to the HackerOne template when a report is created, but it
would still be good to have this bullet point to remember to include the
information in the security release blog post.

