### PR TITLE
module: fix ERR_REQUIRE_ESM error for null frames

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -808,7 +808,7 @@ function hideInternalStackFrames(error) {
     if (typeof stackFrames === 'object') {
       frames = ArrayPrototypeFilter(
         stackFrames,
-        (frm) => !StringPrototypeStartsWith(frm.getFileName(),
+        (frm) => !StringPrototypeStartsWith(frm.getFileName() || '',
                                             'node:internal')
       );
     }

--- a/test/fixtures/es-modules/cjs-esm.js
+++ b/test/fixtures/es-modules/cjs-esm.js
@@ -1,1 +1,1 @@
-require('./package-type-module/cjs.js');
+eval("require('./package-type-module/cjs.js')");


### PR DESCRIPTION
Fixes a bug where ERR_REQUIRE_ESM would throw a `endsWith` error for string when checking null error frames as reported in https://github.com/nodejs/node/commit/e2a6399be742f53103474d9fc1e56fadf7f90ccc#commitcomment-54198959.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
