### PR TITLE
lib: use `validateObject`

### DIFF
--- a/lib/internal/encoding.js
+++ b/lib/internal/encoding.js
@@ -39,7 +39,10 @@ const {
   isUint8Array
 } = require('internal/util/types');
 
-const { validateString } = require('internal/validators');
+const {
+  validateString,
+  validateObject,
+} = require('internal/validators');
 
 const {
   encodeInto,
@@ -61,12 +64,6 @@ function validateEncoder(obj) {
 function validateDecoder(obj) {
   if (obj == null || obj[kDecoder] !== true)
     throw new ERR_INVALID_THIS('TextDecoder');
-}
-
-function validateArgument(prop, expected, propName, expectedName) {
-  // eslint-disable-next-line valid-typeof
-  if (typeof prop !== expected)
-    throw new ERR_INVALID_ARG_TYPE(propName, expectedName, prop);
 }
 
 const CONVERTER_FLAGS_FLUSH = 0x1;
@@ -381,7 +378,11 @@ function makeTextDecoderICU() {
   class TextDecoder {
     constructor(encoding = 'utf-8', options = {}) {
       encoding = `${encoding}`;
-      validateArgument(options, 'object', 'options', 'Object');
+      validateObject(options, 'options', {
+        nullable: true,
+        allowArray: true,
+        allowFunction: true,
+      });
 
       const enc = getEncodingFromLabel(encoding);
       if (enc === undefined)
@@ -413,7 +414,11 @@ function makeTextDecoderICU() {
                                        ['ArrayBuffer', 'ArrayBufferView'],
                                        input);
       }
-      validateArgument(options, 'object', 'options', 'Object');
+      validateObject(options, 'options', {
+        nullable: true,
+        allowArray: true,
+        allowFunction: true,
+      });
 
       let flags = 0;
       if (options !== null)
@@ -447,7 +452,11 @@ function makeTextDecoderJS() {
   class TextDecoder {
     constructor(encoding = 'utf-8', options = {}) {
       encoding = `${encoding}`;
-      validateArgument(options, 'object', 'options', 'Object');
+      validateObject(options, 'options', {
+        nullable: true,
+        allowArray: true,
+        allowFunction: true,
+      });
 
       const enc = getEncodingFromLabel(encoding);
       if (enc === undefined || !hasConverter(enc))
@@ -481,7 +490,11 @@ function makeTextDecoderJS() {
                                        ['ArrayBuffer', 'ArrayBufferView'],
                                        input);
       }
-      validateArgument(options, 'object', 'options', 'Object');
+      validateObject(options, 'options', {
+        nullable: true,
+        allowArray: true,
+        allowFunction: true,
+      });
 
       if (this[kFlags] & CONVERTER_FLAGS_FLUSH) {
         this[kBOMSeen] = false;


### PR DESCRIPTION
Used the `validateObject()` validator to keep consistency instead of a
custom validator which was only used to validate objects.
Refs: #39595

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
