### PR TITLE
dns: add "tries" option to Resolve options

### DIFF
--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -97,6 +97,9 @@ The following methods from the `dns` module are available:
 <!-- YAML
 added: v8.3.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/39610
+    description: The `options` object now accepts a `tries` option.
   - version: v12.18.3
     pr-url: https://github.com/nodejs/node/pull/33472
     description: The constructor now accepts an `options` object.
@@ -109,7 +112,7 @@ Create a new resolver.
   * `timeout` {integer} Query timeout in milliseconds, or `-1` to use the
     default timeout.
   * `tries` {integer} The number of tries the resolver will try contacting
-    each name server before giving up, `4` by default.
+    each name server before giving up. **Default:** `4`
 
 ### `resolver.cancel()`
 <!-- YAML

--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -108,6 +108,8 @@ Create a new resolver.
 * `options` {Object}
   * `timeout` {integer} Query timeout in milliseconds, or `-1` to use the
     default timeout.
+  * `tries` {integer} The number of tries the resolver will try contacting
+    each name server before giving up, `4` by default.
 
 ### `resolver.cancel()`
 <!-- YAML

--- a/lib/internal/dns/promises.js
+++ b/lib/internal/dns/promises.js
@@ -12,6 +12,7 @@ const {
   Resolver: CallbackResolver,
   validateHints,
   validateTimeout,
+  validateTries,
   emitInvalidHostnameWarning,
   getDefaultVerbatim,
 } = require('internal/dns/utils');
@@ -216,7 +217,8 @@ const resolveMap = ObjectCreate(null);
 class Resolver {
   constructor(options = undefined) {
     const timeout = validateTimeout(options);
-    this._handle = new ChannelWrap(timeout);
+    const tries = validateTries(options);
+    this._handle = new ChannelWrap(timeout, tries);
   }
 }
 

--- a/lib/internal/dns/utils.js
+++ b/lib/internal/dns/utils.js
@@ -43,11 +43,18 @@ function validateTimeout(options) {
   return timeout;
 }
 
+function validateTries(options) {
+  const { tries = 4 } = { ...options };
+  validateInt32(tries, 'options.tries', 1, 2 ** 31 - 1);
+  return tries;
+}
+
 // Resolver instances correspond 1:1 to c-ares channels.
 class Resolver {
   constructor(options = undefined) {
     const timeout = validateTimeout(options);
-    this._handle = new ChannelWrap(timeout);
+    const tries = validateTries(options);
+    this._handle = new ChannelWrap(timeout, tries);
   }
 
   cancel() {
@@ -209,6 +216,7 @@ module.exports = {
   setDefaultResolver,
   validateHints,
   validateTimeout,
+  validateTries,
   Resolver,
   emitInvalidHostnameWarning,
   getDefaultVerbatim,

--- a/src/cares_wrap.h
+++ b/src/cares_wrap.h
@@ -155,7 +155,11 @@ struct NodeAresTask final : public MemoryRetainer {
 
 class ChannelWrap final : public AsyncWrap {
  public:
-  ChannelWrap(Environment* env, v8::Local<v8::Object> object, int timeout);
+  ChannelWrap(
+    Environment* env,
+    v8::Local<v8::Object> object,
+    int timeout,
+    int tries);
   ~ChannelWrap() override;
 
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
@@ -189,6 +193,7 @@ class ChannelWrap final : public AsyncWrap {
   bool is_servers_default_ = true;
   bool library_inited_ = false;
   int timeout_;
+  int tries_;
   int active_query_count_ = 0;
   NodeAresTask::List task_list_;
 };

--- a/src/cares_wrap.h
+++ b/src/cares_wrap.h
@@ -156,10 +156,10 @@ struct NodeAresTask final : public MemoryRetainer {
 class ChannelWrap final : public AsyncWrap {
  public:
   ChannelWrap(
-    Environment* env,
-    v8::Local<v8::Object> object,
-    int timeout,
-    int tries);
+      Environment* env,
+      v8::Local<v8::Object> object,
+      int timeout,
+      int tries);
   ~ChannelWrap() override;
 
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

As stated in https://github.com/nodejs/node/issues/39562 the `timeout` currently won't exactly match the desired functionality, that's because the underneath lib, c-ares, has an internal option `tries` that defaults to 4, so actually what happens is it timeouts one time and then proceeds to timeout another three times.

From c-ares docs: `After the first try, the timeout algorithm becomes more complicated, but scales linearly with the value of timeout.` 

This pull request introduces the `tries` property to `Resolver` options so we can properly set how many tries we want, for example 1 so the timeout would match exactly.

This is my first pull request so a thing or two may be missing 😇