### PR TITLE
inspector: update inspector_protocol to 8ec18cf

### DIFF
--- a/tools/inspector_protocol/lib/Values_cpp.template
+++ b/tools/inspector_protocol/lib/Values_cpp.template
@@ -178,7 +178,12 @@ std::unique_ptr<DictionaryValue> parseMap(
       key = StringUtil::fromUTF8(key_span.data(), key_span.size());
       tokenizer->Next();
     } else if (tokenizer->TokenTag() == cbor::CBORTokenTag::STRING16) {
-      return nullptr;  // STRING16 not supported yet.
+      span<uint8_t> key_span = tokenizer->GetString16WireRep();
+      if (key_span.size() & 1) return nullptr;  // UTF16 is 2 byte multiple.
+      key = StringUtil::fromUTF16(
+          reinterpret_cast<const uint16_t*>(key_span.data()),
+          key_span.size() / 2);
+      tokenizer->Next();
     } else {
       // Error::CBOR_INVALID_MAP_KEY
       return nullptr;


### PR DESCRIPTION
Apply 8ec18cf: "Support STRING16 in the template when converting CBOR
map keys"

Refs: https://chromium.googlesource.com/deps/inspector_protocol/+/8ec18cf0885bef0b5c2a922c5dc3813cbf63e962

We're over 2 years out of date in the tools/inspector_protocol directory
and I have to imagine this will come back to bite us at some point. But
I also don't want to do a huge update all at once, so starting with a
single commit. I might bundle commits together a bit more if this goes
well.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
