### PR TITLE
test: use template to concatenate string

### DIFF
--- a/test/parallel/test-trace-events-fs-sync.js
+++ b/test/parallel/test-trace-events-fs-sync.js
@@ -23,7 +23,7 @@ tests['fs.sync.chmod'] = 'fs.writeFileSync("fs.txt", "123", "utf8");' +
                          'fs.chmodSync("fs.txt",100);' +
                          'fs.unlinkSync("fs.txt")';
 tests['fs.sync.chown'] = 'fs.writeFileSync("fs.txt", "123", "utf8");' +
-                         'fs.chownSync("fs.txt",' + uid + ',' + gid + ');' +
+                         `fs.chownSync("fs.txt", ${uid}, ${gid});` +
                          'fs.unlinkSync("fs.txt")';
 tests['fs.sync.close'] = 'fs.writeFileSync("fs.txt", "123", "utf8");' +
                          'fs.unlinkSync("fs.txt")';
@@ -36,7 +36,7 @@ tests['fs.sync.fchmod'] = 'fs.writeFileSync("fs.txt", "123", "utf8");' +
                           'fs.unlinkSync("fs.txt")';
 tests['fs.sync.fchown'] = 'fs.writeFileSync("fs.txt", "123", "utf8");' +
                           'const fd = fs.openSync("fs.txt", "r+");' +
-                          'fs.fchownSync(fd,' + uid + ',' + gid + ');' +
+                          `fs.fchownSync(fd, ${uid}, ${gid});` +
                           'fs.unlinkSync("fs.txt")';
 tests['fs.sync.fdatasync'] = 'fs.writeFileSync("fs.txt", "123", "utf8");' +
                              'const fd = fs.openSync("fs.txt", "r+");' +
@@ -58,7 +58,7 @@ tests['fs.sync.futimes'] = 'fs.writeFileSync("fs.txt", "123", "utf8");' +
                            'fs.futimesSync(fd,1,1);' +
                            'fs.unlinkSync("fs.txt")';
 tests['fs.sync.lchown'] = 'fs.writeFileSync("fs.txt", "123", "utf8");' +
-                          'fs.lchownSync("fs.txt",' + uid + ',' + gid + ');' +
+                          `fs.lchownSync("fs.txt", ${uid}, ${gid});` +
                           'fs.unlinkSync("fs.txt")';
 tests['fs.sync.link'] = 'fs.writeFileSync("fs.txt", "123", "utf8");' +
                         'fs.linkSync("fs.txt", "linkx");' +


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
This commit converts the variable to be embedded within string literals using template string in the file **test/parallel/test-trace-events-fs-sync.js**.

### Checklist
- [X] make -j4 test (UNIX) or vcbuild test (Windows) passes
- [X] commit message follow  [commit guidelines](https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

I used **./node test/parallel/test-trace-events-fs-sync.js** as well, and it run without errors.