### PR TITLE
http2: update handling of streams on rst_stream frames

### DIFF
--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -2196,21 +2196,21 @@ void Http2Stream::SubmitRstStream(const uint32_t code) {
   CHECK(!this->is_destroyed());
   code_ = code;
 
-  // If RST_STREAM frame is received and stream is not writable
-  // because it is busy reading data, don't try force purging it.
-  // Instead add the stream to pending stream list and process
-  // the pending data when it is safe to do so. This is to avoid
-  // double free error due to unwanted behavior of nghttp2.
-  // Ref:https://github.com/nodejs/node/issues/38964
+  auto is_stream_cancel = [](const uint32_t code) {
+    return code == NGHTTP2_CANCEL;
+  };
 
-  // Add stream to the pending list if it is received with scope
+  // If RST_STREAM frame is received with error code NGHTTP2_CANCEL,
+  // add it to the pending list and don't force purge the data. It is
+  // to avoids the double free error due to unwanted behavior of nghttp2.
+
+  // Add stream to the pending list only if it is received with scope
   // below in the stack. The pending list may not get processed
   // if RST_STREAM received is not in scope and added to the list
   // causing endpoint to hang.
-  if (session_->is_in_scope() &&
-      !is_writable() && is_reading()) {
-    session_->AddPendingRstStream(id_);
-    return;
+  if (session_->is_in_scope() && is_stream_cancel(code)) {
+      session_->AddPendingRstStream(id_);
+      return;
   }
 
 

--- a/test/parallel/test-http2-cancel-while-client-reading.js
+++ b/test/parallel/test-http2-cancel-while-client-reading.js
@@ -1,0 +1,36 @@
+'use strict';
+const common = require('../common');
+const fixtures = require('../common/fixtures');
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+}
+
+const http2 = require('http2');
+const key = fixtures.readKey('agent1-key.pem', 'binary');
+const cert = fixtures.readKey('agent1-cert.pem', 'binary');
+
+const server = http2.createSecureServer({ key, cert });
+
+let client_stream;
+
+server.on('stream', common.mustCall(function(stream) {
+  stream.resume();
+  stream.on('data', function(chunk) {
+    stream.write(chunk);
+    client_stream.pause();
+    client_stream.close(http2.constants.NGHTTP2_CANCEL);
+  });
+}));
+
+server.listen(0, function() {
+  const client = http2.connect(`https://localhost:${server.address().port}`,
+                               { rejectUnauthorized: false }
+  );
+  client_stream = client.request({ ':method': 'POST' });
+  client_stream.on('close', common.mustCall(() => {
+    client.close();
+    server.close();
+  }));
+  client_stream.resume();
+  client_stream.write(Buffer.alloc(1024 * 1024));
+});


### PR DESCRIPTION
The PR updates the handling of rst_stream frames and add
all streams to the pending list on receiving rst frames with 
the error code `NGHTTP2_CANCEL`.
 
The changes will remove dependency on the stream state
that may allow bypassing the checks in certain cases. I think
a better solution is to delay streams in all cases if rst_stream
is received for the cancel events. 

The rst_stream frames can be received for protocol/connection
error as well it should be handled immediately. Adding
streams to the pending list in such cases may cause errors.

Previous PR ref: https://github.com/nodejs/node/pull/39423