### PR TITLE
stream: add isDisturbed helper

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -2046,6 +2046,18 @@ added: REPLACEME
   * `signal` {AbortSignal}
 * Returns: {stream.Readable}
 
+### `stream.Readable.isDisturbed(stream)`
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+* `stream` {stream.Readable|ReadableStream}
+* Returns: `boolean`
+
+Returns whether the stream has been read from.
+
 ### `stream.Readable.toWeb(streamReadable)`
 <!-- YAML
 added: REPLACEME

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1261,16 +1261,27 @@ added: v11.4.0
 Is `true` if it is safe to call [`readable.read()`][stream-read], which means
 the stream has not been destroyed or emitted `'error'` or `'end'`.
 
+##### `readable.readableAborted`
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+* {boolean}
+
+Returns whether the stream was destroyed before `'end'` has been emitted.
+
 ##### `readable.readableDidRead`
 <!-- YAML
 added: REPLACEME
 -->
 
+> Stability: 1 - Experimental
+
 * {boolean}
 
-Allows determining if the stream has been or is about to be read.
-Returns true if `'data'`, `'end'`, `'error'` or `'close'` has been
-emitted.
+Returns whether `'data'` has been emitted.
 
 ##### `readable.readableEncoding`
 <!-- YAML

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -2056,7 +2056,7 @@ added: REPLACEME
 * `stream` {stream.Readable|ReadableStream}
 * Returns: `boolean`
 
-Returns whether the stream has been read from.
+Returns whether the stream has been read from or cancelled.
 
 ### `stream.Readable.toWeb(streamReadable)`
 <!-- YAML

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1270,7 +1270,7 @@ added: REPLACEME
 
 * {boolean}
 
-Returns whether the stream was destroyed before `'end'` has been emitted.
+Returns whether the stream was destroyed or errored before emitting `'end'`.
 
 ##### `readable.readableDidRead`
 <!-- YAML

--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -173,8 +173,6 @@ function ReadableState(options, stream, isDuplex) {
 
   this.dataEmitted = false;
 
-  this.aborted = false;
-
   this.decoder = null;
   this.encoding = null;
   if (options && options.encoding) {
@@ -217,12 +215,7 @@ function Readable(options) {
   });
 }
 
-Readable.prototype.destroy = function(err) {
-  if (!this._readableState.endEmitted) {
-    this._readableState.aborted = true;
-  }
-  destroyImpl.destroy.call(this, err);
-};
+Readable.prototype.destroy = destroyImpl.destroy;
 Readable.prototype._undestroy = destroyImpl.undestroy;
 Readable.prototype._destroy = function(err, cb) {
   cb(err);
@@ -1199,7 +1192,8 @@ ObjectDefineProperties(Readable.prototype, {
   readableAborted: {
     enumerable: false,
     get: function() {
-      return this._readableState.aborted;
+      return (this._readableState.destroyed || this._readableState.errored) &&
+        !this._readableState.endEmitted;
     }
   },
 

--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -1192,7 +1192,7 @@ ObjectDefineProperties(Readable.prototype, {
   readableAborted: {
     enumerable: false,
     get: function() {
-      return (this._readableState.destroyed || this._readableState.errored) &&
+      return !!(this._readableState.destroyed || this._readableState.errored) &&
         !this._readableState.endEmitted;
     }
   },

--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -173,6 +173,8 @@ function ReadableState(options, stream, isDuplex) {
 
   this.dataEmitted = false;
 
+  this.aborted = false;
+
   this.decoder = null;
   this.encoding = null;
   if (options && options.encoding) {
@@ -215,7 +217,12 @@ function Readable(options) {
   });
 }
 
-Readable.prototype.destroy = destroyImpl.destroy;
+Readable.prototype.destroy = function(err) {
+  if (!this._readableState.endEmitted) {
+    this._readableState.aborted = true;
+  }
+  destroyImpl.destroy.call(this, err);
+};
 Readable.prototype._undestroy = destroyImpl.undestroy;
 Readable.prototype._destroy = function(err, cb) {
   cb(err);
@@ -1185,12 +1192,14 @@ ObjectDefineProperties(Readable.prototype, {
   readableDidRead: {
     enumerable: false,
     get: function() {
-      return !!(
-        this._readableState.dataEmitted ||
-        this._readableState.endEmitted ||
-        this._readableState.errorEmitted ||
-        this._readableState.closeEmitted
-      );
+      return this._readableState.dataEmitted;
+    }
+  },
+
+  readableAborted: {
+    enumerable: false,
+    get: function() {
+      return this._readableState.aborted;
     }
   },
 

--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -1185,7 +1185,7 @@ ObjectDefineProperties(Readable.prototype, {
   readableDidRead: {
     enumerable: false,
     get: function() {
-      return (
+      return !!(
         this._readableState.dataEmitted ||
         this._readableState.endEmitted ||
         this._readableState.errorEmitted ||

--- a/lib/internal/streams/utils.js
+++ b/lib/internal/streams/utils.js
@@ -7,6 +7,7 @@ const {
 } = primordials;
 
 const kDestroyed = Symbol('kDestroyed');
+const kIsDisturbed = Symbol('kIsDisturbed');
 
 function isReadableNodeStream(obj) {
   return !!(
@@ -195,8 +196,20 @@ function willEmitClose(stream) {
   );
 }
 
+function isDisturbed(stream) {
+  const state = stream && stream._readableState;
+  return stream && (
+    stream.readableDidRead ||
+    isDestroyed(stream) ||
+    stream[kIsDisturbed] ||
+    (state && state.endEmitted)
+  );
+}
+
 module.exports = {
   kDestroyed,
+  isDisturbed,
+  kIsDisturbed,
   isClosed,
   isDestroyed,
   isFinished,

--- a/lib/internal/streams/utils.js
+++ b/lib/internal/streams/utils.js
@@ -197,12 +197,10 @@ function willEmitClose(stream) {
 }
 
 function isDisturbed(stream) {
-  const state = stream && stream._readableState;
   return !!(stream && (
     stream.readableDidRead ||
-    isDestroyed(stream) ||
-    stream[kIsDisturbed] ||
-    (state && state.endEmitted)
+    stream.readableAborted ||
+    stream[kIsDisturbed]
   ));
 }
 

--- a/lib/internal/streams/utils.js
+++ b/lib/internal/streams/utils.js
@@ -198,12 +198,12 @@ function willEmitClose(stream) {
 
 function isDisturbed(stream) {
   const state = stream && stream._readableState;
-  return stream && (
+  return !!(stream && (
     stream.readableDidRead ||
     isDestroyed(stream) ||
     stream[kIsDisturbed] ||
     (state && state.endEmitted)
-  );
+  ));
 }
 
 module.exports = {

--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -82,7 +82,7 @@ const {
 
 const {
   kIsDisturbed,
-} = require('internal/stream/utils');
+} = require('internal/streams/utils');
 
 const {
   ArrayBufferViewGetBuffer,

--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -81,6 +81,10 @@ const {
 } = require('internal/process/task_queues');
 
 const {
+  kIsDisturbed,
+} = require('internal/stream/utils');
+
+const {
   ArrayBufferViewGetBuffer,
   ArrayBufferViewGetByteLength,
   ArrayBufferViewGetByteOffset,
@@ -200,6 +204,7 @@ class ReadableStream {
         promise: undefined,
       }
     };
+
     // The spec requires handling of the strategy first
     // here. Specifically, if getting the size and
     // highWaterMark from the strategy fail, that has
@@ -230,6 +235,10 @@ class ReadableStream {
 
     // eslint-disable-next-line no-constructor-return
     return makeTransferable(this);
+  }
+
+  get [kIsDisturbed]() {
+    return this[kState].disturbed;
   }
 
   /**

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -38,6 +38,7 @@ const internalBuffer = require('internal/buffer');
 const promises = require('stream/promises');
 
 const Stream = module.exports = require('internal/streams/legacy').Stream;
+Stream.isDisturbed = require('internal/streams/utils').isDisturbed;
 Stream.Readable = require('internal/streams/readable');
 Stream.Writable = require('internal/streams/writable');
 Stream.Duplex = require('internal/streams/duplex');

--- a/test/parallel/test-stream-readable-aborted.js
+++ b/test/parallel/test-stream-readable-aborted.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { Readable } = require('stream');
+
+{
+  const readable = new Readable({
+    read() {
+    }
+  });
+  assert.strictEqual(readable.readableAborted, false);
+  readable.destroy();
+  assert.strictEqual(readable.readableAborted, true);
+}
+
+{
+  const readable = new Readable({
+    read() {
+    }
+  });
+  assert.strictEqual(readable.readableAborted, false);
+  readable.push(null);
+  readable.destroy();
+  assert.strictEqual(readable.readableAborted, true);
+}
+
+{
+  const readable = new Readable({
+    read() {
+    }
+  });
+  assert.strictEqual(readable.readableAborted, false);
+  readable.push('asd');
+  readable.destroy();
+  assert.strictEqual(readable.readableAborted, true);
+}
+
+{
+  const readable = new Readable({
+    read() {
+    }
+  });
+  assert.strictEqual(readable.readableAborted, false);
+  readable.push('asd');
+  readable.push(null);
+  readable.on('end', common.mustCall(() => {
+    assert.strictEqual(readable.readableAborted, false);
+    readable.destroy();
+    assert.strictEqual(readable.readableAborted, false);
+    queueMicrotask(() => {
+      assert.strictEqual(readable.readableAborted, false);
+    });
+  }));
+}

--- a/test/parallel/test-stream-readable-aborted.js
+++ b/test/parallel/test-stream-readable-aborted.js
@@ -44,6 +44,7 @@ const { Readable } = require('stream');
   assert.strictEqual(readable.readableAborted, false);
   readable.push('asd');
   readable.push(null);
+  assert.strictEqual(readable.readableAborted, false);
   readable.on('end', common.mustCall(() => {
     assert.strictEqual(readable.readableAborted, false);
     readable.destroy();
@@ -52,4 +53,5 @@ const { Readable } = require('stream');
       assert.strictEqual(readable.readableAborted, false);
     });
   }));
+  readable.resume();
 }

--- a/test/parallel/test-stream-readable-didRead.js
+++ b/test/parallel/test-stream-readable-didRead.js
@@ -1,12 +1,13 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const Readable = require('stream').Readable;
+const { isDisturbed, Readable } = require('stream');
 
 function noop() {}
 
 function check(readable, data, fn) {
   assert.strictEqual(readable.readableDidRead, false);
+  assert.strictEqual(isDisturbed(readable), false);
   if (data === -1) {
     readable.on('error', common.mustCall());
     readable.on('data', common.mustNotCall());
@@ -28,6 +29,7 @@ function check(readable, data, fn) {
   fn();
   setImmediate(() => {
     assert.strictEqual(readable.readableDidRead, true);
+    assert.strictEqual(isDisturbed(readable), true);
   });
 }
 

--- a/test/parallel/test-stream-readable-didRead.js
+++ b/test/parallel/test-stream-readable-didRead.js
@@ -28,8 +28,10 @@ function check(readable, data, fn) {
   readable.on('close', common.mustCall());
   fn();
   setImmediate(() => {
-    assert.strictEqual(readable.readableDidRead, true);
-    assert.strictEqual(isDisturbed(readable), true);
+    assert.strictEqual(readable.readableDidRead, data > 0);
+    if (data > 0) {
+      assert.strictEqual(isDisturbed(readable), true);
+    }
   });
 }
 


### PR DESCRIPTION
Adds a helper util used to determine whether a stream has been
disturbed (read or cancelled).

Refs: https://github.com/nodejs/node/issues/39627

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
