### PR TITLE
doc: fixed variable names in queueMicrotask example

### DIFF
--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -335,7 +335,7 @@ within each turn of the Node.js event loop.
 // before any other promise jobs.
 
 DataHandler.prototype.load = async function load(key) {
-  const hit = this._cache.get(url);
+  const hit = this._cache.get(key);
   if (hit !== undefined) {
     queueMicrotask(() => {
       this.emit('load', hit);
@@ -344,7 +344,7 @@ DataHandler.prototype.load = async function load(key) {
   }
 
   const data = await fetchData(key);
-  this._cache.set(url, data);
+  this._cache.set(key, data);
   this.emit('load', data);
 };
 ```


### PR DESCRIPTION
fixed variable name in queueMicrotask example where
`url` variable was used instead of `key` variable.