### PR TITLE
stream: don't emit 'data' after 'error' or 'close'

### DIFF
--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -276,6 +276,8 @@ function readableAddChunk(stream, chunk, encoding, addToFront) {
     if (addToFront) {
       if (state.endEmitted)
         errorOrDestroy(stream, new ERR_STREAM_UNSHIFT_AFTER_END_EVENT());
+      else if (state.destroyed || state.errored)
+        return false;
       else
         addChunk(stream, state, chunk, true);
     } else if (state.ended) {
@@ -316,6 +318,7 @@ function addChunk(stream, state, chunk, addToFront) {
     } else {
       state.awaitDrainWriters = null;
     }
+
     state.dataEmitted = true;
     stream.emit('data', chunk);
   } else {
@@ -542,7 +545,7 @@ Readable.prototype.read = function(n) {
       endReadable(this);
   }
 
-  if (ret !== null) {
+  if (ret !== null && !state.errorEmitted && !state.closeEmitted) {
     state.dataEmitted = true;
     this.emit('data', ret);
   }

--- a/test/parallel/test-stream-readable-destroy.js
+++ b/test/parallel/test-stream-readable-destroy.js
@@ -319,3 +319,86 @@ const assert = require('assert');
   })(), /AbortError/);
   setTimeout(() => controller.abort(), 0);
 }
+
+{
+  const read = new Readable({
+    read() {
+    },
+  });
+  read.push('asd');
+
+  read.on('data', common.mustNotCall());
+  read.on('error', common.mustCall((e) => {
+    read.read();
+  }));
+  read.on('close', common.mustCall((e) => {
+    read.read();
+  }));
+  read.destroy(new Error('asd'));
+}
+
+{
+  const read = new Readable({
+    read() {
+    },
+  });
+  read.push('asd');
+
+  read.on('data', common.mustNotCall());
+  read.on('close', common.mustCall((e) => {
+    read.read();
+  }));
+  read.destroy();
+}
+
+{
+  const read = new Readable({
+    read() {
+    },
+  });
+  read.push('asd');
+
+  read.on('data', common.mustNotCall());
+  read.on('close', common.mustCall((e) => {
+    read.unshift('asd');
+  }));
+  read.destroy();
+}
+
+{
+  const read = new Readable({
+    read() {
+    },
+  });
+  read.push('asd');
+
+  read.on('data', common.mustNotCall());
+  read.destroy();
+  read.unshift('asd');
+}
+
+{
+  const read = new Readable({
+    read() {
+    },
+  });
+  read.push('asd');
+
+  read.on('data', common.mustNotCall());
+  read.on('close', common.mustCall((e) => {
+    read.push('asd');
+  }));
+  read.destroy();
+}
+
+{
+  const read = new Readable({
+    read() {
+    },
+  });
+  read.push('asd');
+
+  read.on('data', common.mustNotCall());
+  read.destroy();
+  read.push('asd');
+}

--- a/test/parallel/test-stream-readable-destroy.js
+++ b/test/parallel/test-stream-readable-destroy.js
@@ -325,13 +325,14 @@ const assert = require('assert');
     read() {
     },
   });
-  read.push('asd');
 
   read.on('data', common.mustNotCall());
   read.on('error', common.mustCall((e) => {
+    read.push('asd');
     read.read();
   }));
   read.on('close', common.mustCall((e) => {
+    read.push('asd');
     read.read();
   }));
   read.destroy(new Error('asd'));
@@ -342,10 +343,10 @@ const assert = require('assert');
     read() {
     },
   });
-  read.push('asd');
 
   read.on('data', common.mustNotCall());
   read.on('close', common.mustCall((e) => {
+    read.push('asd');
     read.read();
   }));
   read.destroy();
@@ -356,10 +357,10 @@ const assert = require('assert');
     read() {
     },
   });
-  read.push('asd');
 
   read.on('data', common.mustNotCall());
   read.on('close', common.mustCall((e) => {
+    read.push('asd');
     read.unshift('asd');
   }));
   read.destroy();
@@ -370,7 +371,6 @@ const assert = require('assert');
     read() {
     },
   });
-  read.push('asd');
 
   read.on('data', common.mustNotCall());
   read.destroy();
@@ -382,8 +382,8 @@ const assert = require('assert');
     read() {
     },
   });
-  read.push('asd');
 
+  read.resume();
   read.on('data', common.mustNotCall());
   read.on('close', common.mustCall((e) => {
     read.push('asd');
@@ -396,7 +396,6 @@ const assert = require('assert');
     read() {
     },
   });
-  read.push('asd');
 
   read.on('data', common.mustNotCall());
   read.destroy();


### PR DESCRIPTION
As per doc we should not emit further events after 'close' and only 'close' after 'error'.

Fixes: https://github.com/nodejs/node/issues/39630

Otherwise we can have unexpected bugs, a typical case that I've had in production was something like:

```js
fs.open(path, 'w', (err, fd) => {
  src.on('data', chunk => {
    fs.write(fd, chunk)
  })
  src.on('close', () => {
    fs.close(fd)
  })
})
```

Where we keep writing to fd after it's been closed which is undefined behavior.