### PR TITLE
lib: use helper for readability

### DIFF
--- a/lib/internal/js_stream_socket.js
+++ b/lib/internal/js_stream_socket.js
@@ -22,52 +22,41 @@ const kCurrentWriteRequest = Symbol('kCurrentWriteRequest');
 const kCurrentShutdownRequest = Symbol('kCurrentShutdownRequest');
 const kPendingShutdownRequest = Symbol('kPendingShutdownRequest');
 
-function isClosing() {
-  let socket = this[owner_symbol];
+function checkReusedHandle(self) {
+  let socket = self[owner_symbol];
 
-  if (socket.constructor.name === 'ReusedHandle') {
+  if (socket.constructor.name === 'ReusedHandle')
     socket = socket.handle;
-  }
+
+  return socket;
+}
+
+function isClosing() {
+  const socket = checkReusedHandle(this);
 
   return socket.isClosing();
 }
 
 function onreadstart() {
-  let socket = this[owner_symbol];
-
-  if (socket.constructor.name === 'ReusedHandle') {
-    socket = socket.handle;
-  }
+  const socket = checkReusedHandle(this);
 
   return socket.readStart();
 }
 
 function onreadstop() {
-  let socket = this[owner_symbol];
-
-  if (socket.constructor.name === 'ReusedHandle') {
-    socket = socket.handle;
-  }
+  const socket = checkReusedHandle(this);
 
   return socket.readStop();
 }
 
 function onshutdown(req) {
-  let socket = this[owner_symbol];
-
-  if (socket.constructor.name === 'ReusedHandle') {
-    socket = socket.handle;
-  }
+  const socket = checkReusedHandle(this);
 
   return socket.doShutdown(req);
 }
 
 function onwrite(req, bufs) {
-  let socket = this[owner_symbol];
-
-  if (socket.constructor.name === 'ReusedHandle') {
-    socket = socket.handle;
-  }
+  const socket = checkReusedHandle(this);
 
   return socket.doWrite(req, bufs);
 }


### PR DESCRIPTION
Used an extra `checkReusedHandle()` helper function to
increase readability.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
