### PR TITLE
lib: cleanup instance validation

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -153,6 +153,10 @@ class URLContext {
   }
 }
 
+function isURLSearchParams(self) {
+  return self && self[searchParams] && !self[searchParams][searchParams];
+}
+
 class URLSearchParams {
   // URL Standard says the default value is '', but as undefined and '' have
   // the same result, undefined is used to prevent unnecessary parsing.
@@ -222,9 +226,8 @@ class URLSearchParams {
   }
 
   [inspect.custom](recurseTimes, ctx) {
-    if (!this || !this[searchParams] || this[searchParams][searchParams]) {
+    if (!isURLSearchParams(this))
       throw new ERR_INVALID_THIS('URLSearchParams');
-    }
 
     if (typeof recurseTimes === 'number' && recurseTimes < 0)
       return ctx.stylize('[Object]', 'special');
@@ -259,9 +262,9 @@ class URLSearchParams {
   }
 
   append(name, value) {
-    if (!this || !this[searchParams] || this[searchParams][searchParams]) {
+    if (!isURLSearchParams(this))
       throw new ERR_INVALID_THIS('URLSearchParams');
-    }
+
     if (arguments.length < 2) {
       throw new ERR_MISSING_ARGS('name', 'value');
     }
@@ -273,9 +276,9 @@ class URLSearchParams {
   }
 
   delete(name) {
-    if (!this || !this[searchParams] || this[searchParams][searchParams]) {
+    if (!isURLSearchParams(this))
       throw new ERR_INVALID_THIS('URLSearchParams');
-    }
+
     if (arguments.length < 1) {
       throw new ERR_MISSING_ARGS('name');
     }
@@ -294,9 +297,9 @@ class URLSearchParams {
   }
 
   get(name) {
-    if (!this || !this[searchParams] || this[searchParams][searchParams]) {
+    if (!isURLSearchParams(this))
       throw new ERR_INVALID_THIS('URLSearchParams');
-    }
+
     if (arguments.length < 1) {
       throw new ERR_MISSING_ARGS('name');
     }
@@ -312,9 +315,9 @@ class URLSearchParams {
   }
 
   getAll(name) {
-    if (!this || !this[searchParams] || this[searchParams][searchParams]) {
+    if (!isURLSearchParams(this))
       throw new ERR_INVALID_THIS('URLSearchParams');
-    }
+
     if (arguments.length < 1) {
       throw new ERR_MISSING_ARGS('name');
     }
@@ -331,9 +334,9 @@ class URLSearchParams {
   }
 
   has(name) {
-    if (!this || !this[searchParams] || this[searchParams][searchParams]) {
+    if (!isURLSearchParams(this))
       throw new ERR_INVALID_THIS('URLSearchParams');
-    }
+
     if (arguments.length < 1) {
       throw new ERR_MISSING_ARGS('name');
     }
@@ -349,9 +352,9 @@ class URLSearchParams {
   }
 
   set(name, value) {
-    if (!this || !this[searchParams] || this[searchParams][searchParams]) {
+    if (!isURLSearchParams(this))
       throw new ERR_INVALID_THIS('URLSearchParams');
-    }
+
     if (arguments.length < 2) {
       throw new ERR_MISSING_ARGS('name', 'value');
     }
@@ -436,17 +439,16 @@ class URLSearchParams {
   // Define entries here rather than [Symbol.iterator] as the function name
   // must be set to `entries`.
   entries() {
-    if (!this || !this[searchParams] || this[searchParams][searchParams]) {
+    if (!isURLSearchParams(this))
       throw new ERR_INVALID_THIS('URLSearchParams');
-    }
 
     return createSearchParamsIterator(this, 'key+value');
   }
 
   forEach(callback, thisArg = undefined) {
-    if (!this || !this[searchParams] || this[searchParams][searchParams]) {
+    if (!isURLSearchParams(this))
       throw new ERR_INVALID_THIS('URLSearchParams');
-    }
+
     validateCallback(callback);
 
     let list = this[searchParams];
@@ -464,17 +466,15 @@ class URLSearchParams {
 
   // https://heycam.github.io/webidl/#es-iterable
   keys() {
-    if (!this || !this[searchParams] || this[searchParams][searchParams]) {
+    if (!isURLSearchParams(this))
       throw new ERR_INVALID_THIS('URLSearchParams');
-    }
 
     return createSearchParamsIterator(this, 'key');
   }
 
   values() {
-    if (!this || !this[searchParams] || this[searchParams][searchParams]) {
+    if (!isURLSearchParams(this))
       throw new ERR_INVALID_THIS('URLSearchParams');
-    }
 
     return createSearchParamsIterator(this, 'value');
   }
@@ -482,9 +482,8 @@ class URLSearchParams {
   // https://heycam.github.io/webidl/#es-stringifier
   // https://url.spec.whatwg.org/#urlsearchparams-stringification-behavior
   toString() {
-    if (!this || !this[searchParams] || this[searchParams][searchParams]) {
+    if (!isURLSearchParams(this))
       throw new ERR_INVALID_THIS('URLSearchParams');
-    }
 
     return serializeParams(this[searchParams]);
   }


### PR DESCRIPTION
Cleaned up the `URLSearchParams`'s `this` validation to increase
readability by moving them to an extra helper function.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
