### PR TITLE
doc: fix color contrast issue in light mode

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -11,7 +11,7 @@
   --red1: #d60027;
   --red2: #d50027;
   --red3: #ca5010;
-  --green1: #43853d;
+  --green1: #3e7a38;
   --green2: #5a8147;
   --green3: #64de64;
   --green4: #99cc7d;


### PR DESCRIPTION
There is a color contrast issue with links in light mode on the API
highlight background. This only appears in modules.md. This change fixes
it without introducing other contrast issues in either light or dark
mode. Previously, the color contrast for some text on modules.html was
failing WCAG AA in light mode.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
