### PR TITLE
lib: use validators

### DIFF
--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -30,7 +30,6 @@ const {
 const {
   hideStackFrames,
   codes: {
-    ERR_INVALID_ARG_TYPE,
     ERR_NO_CRYPTO,
     ERR_UNKNOWN_SIGNAL
   },
@@ -75,6 +74,8 @@ function isError(e) {
 // each one once.
 const codesWarned = new SafeSet();
 
+let validateString;
+
 // Mark that a method should not be used.
 // Returns a modified function which warns once by default.
 // If --no-deprecation is set, then it is a no-op.
@@ -83,8 +84,12 @@ function deprecate(fn, msg, code) {
     return fn;
   }
 
-  if (code !== undefined && typeof code !== 'string')
-    throw new ERR_INVALID_ARG_TYPE('code', 'string', code);
+  // Lazy-load to avoid a circular dependency.
+  if (validateString === undefined)
+    ({ validateString } = require('internal/validators'));
+
+  if (code !== undefined)
+    validateString(code, 'code');
 
   let warned = false;
   function deprecated(...args) {
@@ -300,15 +305,20 @@ function getSystemErrorMap() {
 const kCustomPromisifiedSymbol = SymbolFor('nodejs.util.promisify.custom');
 const kCustomPromisifyArgsSymbol = Symbol('customPromisifyArgs');
 
+let validateFunction;
+
 function promisify(original) {
-  if (typeof original !== 'function')
-    throw new ERR_INVALID_ARG_TYPE('original', 'Function', original);
+  // Lazy-load to avoid a circular dependency.
+  if (validateFunction === undefined)
+    ({ validateFunction } = require('internal/validators'));
+
+  validateFunction(original, 'original');
 
   if (original[kCustomPromisifiedSymbol]) {
     const fn = original[kCustomPromisifiedSymbol];
-    if (typeof fn !== 'function') {
-      throw new ERR_INVALID_ARG_TYPE('util.promisify.custom', 'Function', fn);
-    }
+
+    validateFunction(fn, 'util.promisify.custom');
+
     return ObjectDefineProperty(fn, kCustomPromisifiedSymbol, {
       value: fn, enumerable: false, writable: false, configurable: true
     });


### PR DESCRIPTION
Used more validators for the sake of consistency.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
