### PR TITLE
[v14.x backport] module: improve support of data: URLs

### DIFF
--- a/lib/internal/modules/esm/get_source.js
+++ b/lib/internal/modules/esm/get_source.js
@@ -2,6 +2,7 @@
 
 const {
   RegExpPrototypeExec,
+  decodeURIComponent,
 } = primordials;
 const { getOptionValue } = require('internal/options');
 // Do not eagerly grab .manifest, it may be in TDZ
@@ -31,8 +32,8 @@ async function defaultGetSource(url, { format } = {}, defaultGetSource) {
     if (!match) {
       throw new ERR_INVALID_URL(url);
     }
-    const [ , base64, body ] = match;
-    source = Buffer.from(body, base64 ? 'base64' : 'utf8');
+    const { 1: base64, 2: body } = match;
+    source = Buffer.from(decodeURIComponent(body), base64 ? 'base64' : 'utf8');
   } else {
     throw new ERR_INVALID_URL_SCHEME(['file', 'data']);
   }

--- a/test/es-module/test-esm-data-urls.js
+++ b/test/es-module/test-esm-data-urls.js
@@ -102,4 +102,9 @@ function createBase64URL(mime, body) {
       assert.strictEqual(e.code, 'ERR_INVALID_MODULE_SPECIFIER');
     }
   }
+  {
+    const plainESMURL = 'data:text/javascript,export%20default%202';
+    const module = await import(plainESMURL);
+    assert.strictEqual(module.default, 2);
+  }
 })().then(common.mustCall());


### PR DESCRIPTION
Add support for loading modules using percent-encoded URLs.

PR-URL: https://github.com/nodejs/node/pull/37392
Reviewed-By: Michaël Zasso <targos@protonmail.com>
Reviewed-By: Bradley Farias <bradley.meck@gmail.com>
Reviewed-By: Myles Borins <myles.borins@gmail.com>
Reviewed-By: Jan Krems <jan.krems@gmail.com>
Reviewed-By: Guy Bedford <guybedford@gmail.com>
Reviewed-By: Luigi Pinca <luigipinca@gmail.com>
Reviewed-By: Zijian Liu <lxxyxzj@gmail.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
