### PR TITLE
console: _undestroy() the stream if it is stdio

### DIFF
--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -275,7 +275,20 @@ ObjectDefineProperties(Console.prototype, {
       }
       string += '\n';
 
-      if (ignoreErrors === false) return stream.write(string);
+      let destroyed = false
+
+      if (stream._isStdio && stream.destroyed) {
+        destroyed = true;
+        stream._undestroy();
+      }
+
+      if (ignoreErrors === false) {
+        stream.write(string);
+        if (destroyed) {
+          stream.destroy();
+        }
+        return
+      }
 
       // There may be an error occurring synchronously (e.g. for files or TTYs
       // on POSIX systems) or asynchronously (e.g. pipes on POSIX systems), so
@@ -294,6 +307,9 @@ ObjectDefineProperties(Console.prototype, {
           throw e;
         // Sorry, there's no proper way to pass along the error here.
       } finally {
+        if (destroyed) {
+          stream.destroy();
+        }
         stream.removeListener('error', noop);
       }
     }


### PR DESCRIPTION
This change matches our bootstrap code that never closes stdout or
stdeer. As the file descriptors are never closed, calling
`process.stdout.destroy()` should not prevent `console.log()` for
working.

Fixes: https://github.com/nodejs/node/issues/39447

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
