### PR TITLE
test: fix test-debugger-heap-profiler for workers

### DIFF
--- a/test/sequential/test-debugger-heap-profiler.js
+++ b/test/sequential/test-debugger-heap-profiler.js
@@ -3,24 +3,21 @@ const common = require('../common');
 
 common.skipIfInspectorDisabled();
 
-if (!common.isMainThread) {
-  common.skip('process.chdir() is not available in workers');
-}
-
 const fixtures = require('../common/fixtures');
 const startCLI = require('../common/debugger');
 const tmpdir = require('../common/tmpdir');
+const path = require('path');
 
 tmpdir.refresh();
-process.chdir(tmpdir.path);
 
 const { readFileSync } = require('fs');
 
-const filename = 'node.heapsnapshot';
+const filename = path.join(tmpdir.path, 'node.heapsnapshot');
 
 // Heap profiler take snapshot.
 {
-  const cli = startCLI([fixtures.path('debugger/empty.js')]);
+  const opts = { cwd: tmpdir.path };
+  const cli = startCLI([fixtures.path('debugger/empty.js')], [], opts);
 
   function onFatal(error) {
     cli.quit();


### PR DESCRIPTION
Fix `sequential/test-debugger-heap-profiler` so that it can be run
in a worker thread. `process.chdir()` is not allowed in worker threads
but passing a current working directory into a spawned child process
is allowed.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
