### PR TITLE
buffer: add Blob.prototype.stream method and other cleanups

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -4952,6 +4952,20 @@ added: v3.0.0
 
 An alias for [`buffer.constants.MAX_STRING_LENGTH`][].
 
+### `buffer.resolveObjectURL(id)`
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+* `id` {string} A `'blob:nodedata:...` URL string returned by a prior call to
+  `URL.createObjectURL()`.
+* Returns: {Blob}
+
+Resolves a `'blob:nodedata:...'` an associated {Blob} object registered using
+a prior call to `URL.createObjectURL()`.
+
 ### `buffer.transcode(source, fromEnc, toEnc)`
 <!-- YAML
 added: v7.1.0

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -507,6 +507,15 @@ added: v15.7.0
 Creates and returns a new `Blob` containing a subset of this `Blob` objects
 data. The original `Blob` is not altered.
 
+### `blob.stream()`
+<!-- YAML
+added: REPLACEME
+-->
+
+* Returns: {ReadableStream}
+
+Returns a new `ReadableStream` that allows the content of the `Blob` to be read.
+
 ### `blob.text()`
 <!-- YAML
 added: v15.7.0
@@ -514,8 +523,8 @@ added: v15.7.0
 
 * Returns: {Promise}
 
-Returns a promise that resolves the contents of the `Blob` decoded as a UTF-8
-string.
+Returns a promise that fulfills with the contents of the `Blob` decoded as a
+UTF-8 string.
 
 ### `blob.type`
 <!-- YAML

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -608,6 +608,53 @@ console.log(JSON.stringify(myURLs));
 // Prints ["https://www.example.com/","https://test.example.org/"]
 ```
 
+#### `URL.createObjectURL(blob)`
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+* `blob` {Blob}
+* Returns: {string}
+
+Creates a `'blob:nodedata:...'` URL string that represents the given {Blob}
+object and can be used to retrieve the `Blob` later.
+
+```js
+const {
+  Blob,
+  resolveObjectURL,
+} = require('buffer');
+
+const blob = new Blob(['hello']);
+const id = URL.createObjectURL(blob);
+
+// later...
+
+const otherBlob = resolveObjectURL(id);
+console.log(otherBlob.size);
+```
+
+The data stored by the registered {Blob} will be retained in memory until
+`URL.revokeObjectURL()` is called to remove it.
+
+`Blob` objects are registered within the current thread. If using Worker
+Threads, `Blob` objects registered within one Worker will not be available
+to other workers or the main thread.
+
+#### `URL.revokeObjectURL(id)`
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+* `id` {string} A `'blob:nodedata:...` URL string returned by a prior call to
+  `URL.createObjectURL()`.
+
+Removes the stored {Blob} identified by the given ID.
+
 ### Class: `URLSearchParams`
 <!-- YAML
 added:

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -120,6 +120,7 @@ const {
 
 const {
   Blob,
+  resolveObjectURL,
 } = require('internal/blob');
 
 FastBuffer.prototype.constructor = Buffer;
@@ -1239,6 +1240,7 @@ function atob(input) {
 
 module.exports = {
   Blob,
+  resolveObjectURL,
   Buffer,
   SlowBuffer,
   transcode,

--- a/lib/internal/blob.js
+++ b/lib/internal/blob.js
@@ -5,8 +5,10 @@ const {
   MathMax,
   MathMin,
   ObjectDefineProperty,
-  ObjectSetPrototypeOf,
   PromiseResolve,
+  PromiseReject,
+  PromisePrototypeFinally,
+  ReflectConstruct,
   RegExpPrototypeTest,
   StringPrototypeToLowerCase,
   Symbol,
@@ -16,14 +18,14 @@ const {
 } = primordials;
 
 const {
-  createBlob,
+  createBlob: _createBlob,
   FixedSizeBlobCopyJob,
 } = internalBinding('buffer');
 
 const { TextDecoder } = require('internal/encoding');
 
 const {
-  JSTransferable,
+  makeTransferable,
   kClone,
   kDeserialize,
 } = require('internal/worker/js_transferable');
@@ -44,6 +46,7 @@ const {
   AbortError,
   codes: {
     ERR_INVALID_ARG_TYPE,
+    ERR_INVALID_THIS,
     ERR_BUFFER_TOO_LARGE,
   }
 } = require('internal/errors');
@@ -56,15 +59,25 @@ const {
 const kHandle = Symbol('kHandle');
 const kType = Symbol('kType');
 const kLength = Symbol('kLength');
+const kArrayBufferPromise = Symbol('kArrayBufferPromise');
 
 const disallowedTypeCharacters = /[^\u{0020}-\u{007E}]/u;
 
 let Buffer;
+let ReadableStream;
 
 function lazyBuffer() {
   if (Buffer === undefined)
     Buffer = require('buffer').Buffer;
   return Buffer;
+}
+
+function lazyReadableStream(options) {
+  if (ReadableStream === undefined) {
+    ReadableStream =
+      require('internal/webstreams/readablestream').ReadableStream;
+  }
+  return new ReadableStream(options);
 }
 
 function isBlob(object) {
@@ -89,16 +102,7 @@ function getSource(source, encoding) {
   return [source.byteLength, source];
 }
 
-class InternalBlob extends JSTransferable {
-  constructor(handle, length, type = '') {
-    super();
-    this[kHandle] = handle;
-    this[kType] = type;
-    this[kLength] = length;
-  }
-}
-
-class Blob extends JSTransferable {
+class Blob {
   constructor(sources = [], options = {}) {
     emitExperimentalWarning('buffer.Blob');
     if (sources === null ||
@@ -120,13 +124,15 @@ class Blob extends JSTransferable {
     if (!isUint32(length))
       throw new ERR_BUFFER_TOO_LARGE(0xFFFFFFFF);
 
-    super();
-    this[kHandle] = createBlob(sources_, length);
+    this[kHandle] = _createBlob(sources_, length);
     this[kLength] = length;
 
     type = `${type}`;
     this[kType] = RegExpPrototypeTest(disallowedTypeCharacters, type) ?
       '' : StringPrototypeToLowerCase(type);
+
+    // eslint-disable-next-line no-constructor-return
+    return makeTransferable(this);
   }
 
   [kInspect](depth, options) {
@@ -150,7 +156,7 @@ class Blob extends JSTransferable {
     const length = this[kLength];
     return {
       data: { handle, type, length },
-      deserializeInfo: 'internal/blob:InternalBlob'
+      deserializeInfo: 'internal/blob:ClonedBlob'
     };
   }
 
@@ -160,11 +166,35 @@ class Blob extends JSTransferable {
     this[kLength] = length;
   }
 
-  get type() { return this[kType]; }
+  /**
+   * @readonly
+   * @type {string}
+   */
+  get type() {
+    if (!isBlob(this))
+      throw new ERR_INVALID_THIS('Blob');
+    return this[kType];
+  }
 
-  get size() { return this[kLength]; }
+  /**
+   * @readonly
+   * @type {number}
+   */
+  get size() {
+    if (!isBlob(this))
+      throw new ERR_INVALID_THIS('Blob');
+    return this[kLength];
+  }
 
+  /**
+   * @param {number} [start]
+   * @param {number} [end]
+   * @param {string} [contentType]
+   * @returns {Blob}
+   */
   slice(start = 0, end = this[kLength], contentType = '') {
+    if (!isBlob(this))
+      throw new ERR_INVALID_THIS('Blob');
     if (start < 0) {
       start = MathMax(this[kLength] + start, 0);
     } else {
@@ -188,35 +218,96 @@ class Blob extends JSTransferable {
 
     const span = MathMax(end - start, 0);
 
-    return new InternalBlob(
-      this[kHandle].slice(start, start + span), span, contentType);
+    return createBlob(
+      this[kHandle].slice(start, start + span),
+      span,
+      contentType);
   }
 
-  async arrayBuffer() {
+  /**
+   * @returns {Promise<ArrayBuffer>}
+   */
+  arrayBuffer() {
+    if (!isBlob(this))
+      return PromiseReject(new ERR_INVALID_THIS('Blob'));
+
+    // If there's already a promise in flight for the content,
+    // reuse it, but only once. After the cached promise resolves
+    // it will be cleared, allowing it to be garbage collected
+    // as soon as possible.
+    if (this[kArrayBufferPromise])
+      return this[kArrayBufferPromise];
+
     const job = new FixedSizeBlobCopyJob(this[kHandle]);
 
     const ret = job.run();
+
+    // If the job returns a value immediately, the ArrayBuffer
+    // was generated synchronously and should just be returned
+    // directly.
     if (ret !== undefined)
       return PromiseResolve(ret);
 
     const {
       promise,
       resolve,
-      reject
+      reject,
     } = createDeferredPromise();
+
     job.ondone = (err, ab) => {
       if (err !== undefined)
         return reject(new AbortError());
       resolve(ab);
     };
+    this[kArrayBufferPromise] =
+    PromisePrototypeFinally(
+      promise,
+      () => this[kArrayBufferPromise] = undefined);
 
-    return promise;
+    return this[kArrayBufferPromise];
   }
 
+  /**
+   *
+   * @returns {Promise<string>}
+   */
   async text() {
+    if (!isBlob(this))
+      throw new ERR_INVALID_THIS('Blob');
+
     const dec = new TextDecoder();
     return dec.decode(await this.arrayBuffer());
   }
+
+  /**
+   * @returns {ReadableStream}
+   */
+  stream() {
+    if (!isBlob(this))
+      throw new ERR_INVALID_THIS('Blob');
+
+    const self = this;
+    return new lazyReadableStream({
+      async start(controller) {
+        const ab = await self.arrayBuffer();
+        controller.enqueue(new Uint8Array(ab));
+        controller.close();
+      }
+    });
+  }
+}
+
+function ClonedBlob() {
+  return makeTransferable(ReflectConstruct(function() {}, [], Blob));
+}
+ClonedBlob.prototype[kDeserialize] = () => {};
+
+function createBlob(handle, length, type = '') {
+  return makeTransferable(ReflectConstruct(function() {
+    this[kHandle] = handle;
+    this[kType] = type;
+    this[kLength] = length;
+  }, [], Blob));
 }
 
 ObjectDefineProperty(Blob.prototype, SymbolToStringTag, {
@@ -224,13 +315,9 @@ ObjectDefineProperty(Blob.prototype, SymbolToStringTag, {
   value: 'Blob',
 });
 
-InternalBlob.prototype.constructor = Blob;
-ObjectSetPrototypeOf(
-  InternalBlob.prototype,
-  Blob.prototype);
-
 module.exports = {
   Blob,
-  InternalBlob,
+  ClonedBlob,
+  createBlob,
   isBlob,
 };

--- a/lib/internal/blob.js
+++ b/lib/internal/blob.js
@@ -7,10 +7,11 @@ const {
   ObjectDefineProperty,
   PromiseResolve,
   PromiseReject,
-  PromisePrototypeFinally,
+  SafePromisePrototypeFinally,
   ReflectConstruct,
   RegExpPrototypeTest,
   StringPrototypeToLowerCase,
+  StringPrototypeSplit,
   Symbol,
   SymbolIterator,
   SymbolToStringTag,
@@ -20,7 +21,8 @@ const {
 const {
   createBlob: _createBlob,
   FixedSizeBlobCopyJob,
-} = internalBinding('buffer');
+  getDataObject,
+} = internalBinding('blob');
 
 const { TextDecoder } = require('internal/encoding');
 
@@ -65,18 +67,26 @@ const disallowedTypeCharacters = /[^\u{0020}-\u{007E}]/u;
 
 let Buffer;
 let ReadableStream;
+let URL;
+
+
+// Yes, lazy loading is annoying but because of circular
+// references between the url, internal/blob, and buffer
+// modules, lazy loading here makes sure that things work.
+
+function lazyURL(id) {
+  URL ??= require('internal/url').URL;
+  return new URL(id);
+}
 
 function lazyBuffer() {
-  if (Buffer === undefined)
-    Buffer = require('buffer').Buffer;
+  Buffer ??= require('buffer').Buffer;
   return Buffer;
 }
 
 function lazyReadableStream(options) {
-  if (ReadableStream === undefined) {
-    ReadableStream =
-      require('internal/webstreams/readablestream').ReadableStream;
-  }
+  ReadableStream ??=
+    require('internal/webstreams/readablestream').ReadableStream;
   return new ReadableStream(options);
 }
 
@@ -232,9 +242,9 @@ class Blob {
       return PromiseReject(new ERR_INVALID_THIS('Blob'));
 
     // If there's already a promise in flight for the content,
-    // reuse it, but only once. After the cached promise resolves
-    // it will be cleared, allowing it to be garbage collected
-    // as soon as possible.
+    // reuse it, but only while it's in flight. After the cached
+    // promise resolves it will be cleared, allowing it to be
+    // garbage collected as soon as possible.
     if (this[kArrayBufferPromise])
       return this[kArrayBufferPromise];
 
@@ -260,7 +270,7 @@ class Blob {
       resolve(ab);
     };
     this[kArrayBufferPromise] =
-    PromisePrototypeFinally(
+    SafePromisePrototypeFinally(
       promise,
       () => this[kArrayBufferPromise] = undefined);
 
@@ -268,7 +278,6 @@ class Blob {
   }
 
   /**
-   *
    * @returns {Promise<string>}
    */
   async text() {
@@ -315,9 +324,47 @@ ObjectDefineProperty(Blob.prototype, SymbolToStringTag, {
   value: 'Blob',
 });
 
+function resolveObjectURL(url) {
+  url = `${url}`;
+  try {
+    const parsed = new lazyURL(url);
+
+    const split = StringPrototypeSplit(parsed.pathname, ':');
+
+    if (split.length !== 2)
+      return;
+
+    const {
+      0: base,
+      1: id,
+    } = split;
+
+    if (base !== 'nodedata')
+      return;
+
+    const ret = getDataObject(id);
+
+    if (ret === undefined)
+      return;
+
+    const {
+      0: handle,
+      1: length,
+      2: type,
+    } = ret;
+
+    if (handle !== undefined)
+      return createBlob(handle, length, type);
+  } catch {
+    // If there's an error, it's ignored and nothing is returned
+  }
+}
+
 module.exports = {
   Blob,
   ClonedBlob,
   createBlob,
   isBlob,
+  kHandle,
+  resolveObjectURL,
 };

--- a/lib/internal/blob.js
+++ b/lib/internal/blob.js
@@ -59,9 +59,12 @@ const {
 } = require('internal/validators');
 
 const kHandle = Symbol('kHandle');
+const kState = Symbol('kState');
 const kType = Symbol('kType');
 const kLength = Symbol('kLength');
 const kArrayBufferPromise = Symbol('kArrayBufferPromise');
+
+const kMaxChunkSize = 65536;
 
 const disallowedTypeCharacters = /[^\u{0020}-\u{007E}]/u;
 
@@ -297,10 +300,20 @@ class Blob {
 
     const self = this;
     return new lazyReadableStream({
-      async start(controller) {
-        const ab = await self.arrayBuffer();
-        controller.enqueue(new Uint8Array(ab));
-        controller.close();
+      async start() {
+        this[kState] = await self.arrayBuffer();
+      },
+
+      pull(controller) {
+        if (this[kState].byteLength <= kMaxChunkSize) {
+          controller.enqueue(new Uint8Array(this[kState]));
+          controller.close();
+          this[kState] = undefined;
+        } else {
+          const slice = this[kState].slice(0, kMaxChunkSize);
+          this[kState] = this[kState].slice(kMaxChunkSize);
+          controller.enqueue(new Uint8Array(slice));
+        }
       }
     });
   }

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -42,17 +42,20 @@ const {
 
 const { getConstructorOf, removeColors } = require('internal/util');
 const {
-  ERR_ARG_NOT_ITERABLE,
-  ERR_INVALID_ARG_TYPE,
-  ERR_INVALID_ARG_VALUE,
-  ERR_INVALID_FILE_URL_HOST,
-  ERR_INVALID_FILE_URL_PATH,
-  ERR_INVALID_THIS,
-  ERR_INVALID_TUPLE,
-  ERR_INVALID_URL,
-  ERR_INVALID_URL_SCHEME,
-  ERR_MISSING_ARGS
-} = require('internal/errors').codes;
+  codes: {
+    ERR_ARG_NOT_ITERABLE,
+    ERR_INVALID_ARG_TYPE,
+    ERR_INVALID_ARG_VALUE,
+    ERR_INVALID_FILE_URL_HOST,
+    ERR_INVALID_FILE_URL_PATH,
+    ERR_INVALID_THIS,
+    ERR_INVALID_TUPLE,
+    ERR_INVALID_URL,
+    ERR_INVALID_URL_SCHEME,
+    ERR_MISSING_ARGS,
+    ERR_NO_CRYPTO,
+  },
+} = require('internal/errors');
 const {
   CHAR_AMPERSAND,
   CHAR_BACKWARD_SLASH,
@@ -100,6 +103,11 @@ const {
   kSchemeStart
 } = internalBinding('url');
 
+const {
+  storeDataObject,
+  revokeDataObject,
+} = internalBinding('blob');
+
 const context = Symbol('context');
 const cannotBeBase = Symbol('cannot-be-base');
 const cannotHaveUsernamePasswordPort =
@@ -107,6 +115,24 @@ const cannotHaveUsernamePasswordPort =
 const special = Symbol('special');
 const searchParams = Symbol('query');
 const kFormat = Symbol('format');
+
+let blob;
+let cryptoRandom;
+
+function lazyBlob() {
+  blob ??= require('internal/blob');
+  return blob;
+}
+
+function lazyCryptoRandom() {
+  try {
+    cryptoRandom ??= require('internal/crypto/random');
+  } catch {
+    // If Node.js built without crypto support, we'll fall
+    // through here and handle it later.
+  }
+  return cryptoRandom;
+}
 
 // https://tc39.github.io/ecma262/#sec-%iteratorprototype%-object
 const IteratorPrototype = ObjectGetPrototypeOf(
@@ -929,6 +955,37 @@ class URL {
 
   toJSON() {
     return this[kFormat]({});
+  }
+
+  static createObjectURL(obj) {
+    const cryptoRandom = lazyCryptoRandom();
+    if (cryptoRandom === undefined)
+      throw new ERR_NO_CRYPTO();
+
+    // Yes, lazy loading is annoying but because of circular
+    // references between the url, internal/blob, and buffer
+    // modules, lazy loading here makes sure that things work.
+    const blob = lazyBlob();
+    if (!blob.isBlob(obj))
+      throw new ERR_INVALID_ARG_TYPE('obj', 'Blob', obj);
+
+    const id = cryptoRandom.randomUUID();
+
+    storeDataObject(id, obj[blob.kHandle], obj.size, obj.type);
+
+    return `blob:nodedata:${id}`;
+  }
+
+  static revokeObjectURL(url) {
+    url = `${url}`;
+    try {
+      const parsed = new URL(url);
+      const split = StringPrototypeSplit(parsed.pathname, ':');
+      if (split.length === 2)
+        revokeDataObject(split[1]);
+    } catch {
+      // If there's an error, it's ignored.
+    }
   }
 }
 

--- a/src/node_binding.cc
+++ b/src/node_binding.cc
@@ -40,6 +40,7 @@
 // __attribute__((constructor)) like mechanism in GCC.
 #define NODE_BUILTIN_STANDARD_MODULES(V)                                       \
   V(async_wrap)                                                                \
+  V(blob)                                                                      \
   V(block_list)                                                                \
   V(buffer)                                                                    \
   V(cares_wrap)                                                                \

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -1266,8 +1266,6 @@ void Initialize(Local<Object> target,
   env->SetMethod(target, "utf8Write", StringWrite<UTF8>);
 
   env->SetMethod(target, "getZeroFillToggle", GetZeroFillToggle);
-
-  Blob::Initialize(env, target);
 }
 
 }  // anonymous namespace
@@ -1311,9 +1309,6 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
 
   registry->Register(DetachArrayBuffer);
   registry->Register(CopyArrayBuffer);
-
-  Blob::RegisterExternalReferences(registry);
-  FixedSizeBlobCopyJob::RegisterExternalReferences(registry);
 }
 
 }  // namespace Buffer

--- a/src/node_external_reference.h
+++ b/src/node_external_reference.h
@@ -49,6 +49,7 @@ class ExternalReferenceRegistry {
 #define EXTERNAL_REFERENCE_BINDING_LIST_BASE(V)                                \
   V(async_wrap)                                                                \
   V(binding)                                                                   \
+  V(blob)                                                                      \
   V(buffer)                                                                    \
   V(contextify)                                                                \
   V(credentials)                                                               \

--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -5,6 +5,7 @@
 #include "base_object-inl.h"
 #include "debug_utils-inl.h"
 #include "env-inl.h"
+#include "node_blob.h"
 #include "node_errors.h"
 #include "node_external_reference.h"
 #include "node_file.h"

--- a/src/node_snapshotable.h
+++ b/src/node_snapshotable.h
@@ -15,7 +15,8 @@ struct SnapshotData;
 
 #define SERIALIZABLE_OBJECT_TYPES(V)                                           \
   V(fs_binding_data, fs::BindingData)                                          \
-  V(v8_binding_data, v8_utils::BindingData)
+  V(v8_binding_data, v8_utils::BindingData)                                    \
+  V(blob_binding_data, BlobBindingData)
 
 enum class EmbedderObjectType : uint8_t {
   k_default = 0,

--- a/test/parallel/test-blob-createobjecturl.js
+++ b/test/parallel/test-blob-createobjecturl.js
@@ -1,0 +1,48 @@
+// Flags: --no-warnings
+'use strict';
+
+const common = require('../common');
+
+// Because registering a Blob URL requires generating a random
+// UUID, it can only be done if crypto support is enabled.
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const {
+  URL,
+} = require('url');
+
+const {
+  Blob,
+  resolveObjectURL,
+} = require('buffer');
+
+const assert = require('assert');
+
+(async () => {
+  const blob = new Blob(['hello']);
+  const id = URL.createObjectURL(blob);
+  assert.strictEqual(typeof id, 'string');
+  const otherBlob = resolveObjectURL(id);
+  assert.strictEqual(otherBlob.size, 5);
+  assert.strictEqual(
+    Buffer.from(await otherBlob.arrayBuffer()).toString(),
+    'hello');
+  URL.revokeObjectURL(id);
+  assert.strictEqual(resolveObjectURL(id), undefined);
+
+  // Leaving a Blob registered should not cause an assert
+  // when Node.js exists
+  URL.createObjectURL(new Blob());
+
+})().then(common.mustCall());
+
+['not a url', undefined, 1, 'blob:nodedata:1:wrong', {}].forEach((i) => {
+  assert.strictEqual(resolveObjectURL(i), undefined);
+});
+
+[undefined, 1, '', false, {}].forEach((i) => {
+  assert.throws(() => URL.createObjectURL(i), {
+    code: 'ERR_INVALID_ARG_TYPE',
+  });
+});

--- a/test/parallel/test-blob.js
+++ b/test/parallel/test-blob.js
@@ -198,3 +198,21 @@ assert.throws(() => new Blob({}), {
                      'Blob { size: 0, type: \'\' }');
   assert.strictEqual(inspect(b, { depth: -1 }), '[Blob]');
 }
+
+{
+  // The Blob has to be over a specific size for the data to
+  // be copied asynchronously..
+  const b = new Blob(['hello', 'there'.repeat(820)]);
+  assert.strictEqual(b.arrayBuffer(), b.arrayBuffer());
+  b.arrayBuffer().then(common.mustCall());
+}
+
+(async () => {
+  const b = new Blob(['hello']);
+  const reader = b.stream().getReader();
+  let res = await reader.read();
+  assert.strictEqual(res.value.byteLength, 5);
+  assert(!res.done);
+  res = await reader.read();
+  assert(res.done);
+})().then(common.mustCall());

--- a/test/parallel/test-bootstrap-modules.js
+++ b/test/parallel/test-bootstrap-modules.js
@@ -130,6 +130,7 @@ const expectedModules = new Set([
   'NativeModule internal/vm/module',
   'NativeModule internal/worker/io',
   'NativeModule internal/worker/js_transferable',
+  'Internal Binding blob',
   'NativeModule internal/blob',
   'NativeModule async_hooks',
   'NativeModule path',

--- a/test/wpt/status/FileAPI/blob.json
+++ b/test/wpt/status/FileAPI/blob.json
@@ -8,9 +8,6 @@
   "Blob-slice.any.js": {
     "skip": "Depends on File API"
   },
-  "Blob-stream.any.js": {
-    "skip": "Depends on Web Streams API"
-  },
   "Blob-in-worker.worker.js": {
     "skip": "Depends on Web Workers API"
   }

--- a/test/wpt/test-blob.js
+++ b/test/wpt/test-blob.js
@@ -7,7 +7,9 @@ const runner = new WPTRunner('FileAPI/blob');
 
 runner.setInitScript(`
   const { Blob } = require('buffer');
+  const { ReadableStream } = require('stream/web');
   global.Blob = Blob;
+  global.ReadableStream = ReadableStream;
 `);
 
 runner.runJsTests();


### PR DESCRIPTION
There are a couple of changes here:

1. It cleans up the `Blob` implementation to better match the spec.
2. It adds the `Blob.prototype.stream()` method to get a `ReadableStream` from a `Blob`
3. It enables the relevant web platform tests for `stream()`
4. It adds an experimental implementation of `URL.createObjectURL()`, `URL.revokeObjectURL()`, and `buffer.resolveObjectURL()`. The `URL.createObjectURL()` and `URL.revokeObjectURL()` are standard Web Platform API.

/cc @bmeck 