### PR TITLE
module: allow monkey-patching internal fs binding

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -86,7 +86,7 @@ const fs = require('fs');
 const internalFS = require('internal/fs/utils');
 const path = require('path');
 const { sep } = path;
-const { internalModuleStat } = internalBinding('fs');
+const internalFsBinding = internalBinding('fs');
 const packageJsonReader = require('internal/modules/package_json_reader');
 const { safeGetenv } = internalBinding('credentials');
 const {
@@ -154,7 +154,7 @@ function stat(filename) {
     const result = statCache.get(filename);
     if (result !== undefined) return result;
   }
-  const result = internalModuleStat(filename);
+  const result = internalFsBinding.internalModuleStat(filename);
   if (statCache !== null && result >= 0) {
     // Only set cache when `internalModuleStat(filename)` succeeds.
     statCache.set(filename, result);

--- a/lib/internal/modules/package_json_reader.js
+++ b/lib/internal/modules/package_json_reader.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { SafeMap } = primordials;
-const { internalModuleReadJSON } = internalBinding('fs');
+const internalFsBinding = internalBinding('fs');
 const { pathToFileURL } = require('url');
 const { toNamespacedPath } = require('path');
 
@@ -18,9 +18,8 @@ function read(jsonPath) {
     return cache.get(jsonPath);
   }
 
-  const { 0: string, 1: containsKeys } = internalModuleReadJSON(
-    toNamespacedPath(jsonPath)
-  );
+  const { 0: string, 1: containsKeys } =
+    internalFsBinding.internalModuleReadJSON(toNamespacedPath(jsonPath));
   const result = { string, containsKeys };
   const { getOptionValue } = require('internal/options');
   if (string !== undefined) {


### PR DESCRIPTION
For third party embedders that implement virtual filesystems, they must override methods of `internalBinding('fs')` to monkey-patch the module system, and to achieve so they must patch Node. Here are a few of them:

Pkg:
https://github.com/vercel/pkg-fetch/blob/main/patches/node.v16.4.1.cpp.patch#L214-L234
Electron:
https://github.com/electron/electron/blob/063ac1971244e9d0411a6046e4840c975e38f726/patches/node/refactor_allow_embedder_overriding_of_internal_fs_calls.patch
Yode:
https://github.com/yue/node/commit/72406854acf1ce69d841be31bff9ad4f1b6a000c

Since every embedder is doing this, I think it makes sense to have the change in Node.

/cc @nodejs/embedders 