### PR TITLE
build: add option to hide console window

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -877,6 +877,10 @@ inline bool Environment::tracks_unmanaged_fds() const {
   return flags_ & EnvironmentFlags::kTrackUnmanagedFds;
 }
 
+inline bool Environment::hide_console_windows() const {
+  return flags_ & EnvironmentFlags::kHideConsoleWindows;
+}
+
 bool Environment::filehandle_close_warning() const {
   return emit_filehandle_warning_;
 }

--- a/src/env.h
+++ b/src/env.h
@@ -1198,6 +1198,7 @@ class Environment : public MemoryRetainer {
   inline bool owns_process_state() const;
   inline bool owns_inspector() const;
   inline bool tracks_unmanaged_fds() const;
+  inline bool hide_console_windows() const;
   inline uint64_t thread_id() const;
   inline worker::Worker* worker_context() const;
   Environment* worker_parent_env() const;

--- a/src/node.h
+++ b/src/node.h
@@ -403,7 +403,11 @@ enum Flags : uint64_t {
   kNoRegisterESMLoader = 1 << 3,
   // Set this flag to make Node.js track "raw" file descriptors, i.e. managed
   // by fs.open() and fs.close(), and close them during FreeEnvironment().
-  kTrackUnmanagedFds = 1 << 4
+  kTrackUnmanagedFds = 1 << 4,
+  // Set this flag to force hiding console windows when spawning child
+  // processes. This is usually used when embedding Node.js in GUI programs on
+  // Windows.
+  kHideConsoleWindows = 1 << 5
 };
 }  // namespace EnvironmentFlags
 

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -558,6 +558,8 @@ void Worker::New(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[4]->IsBoolean());
   if (args[4]->IsTrue() || env->tracks_unmanaged_fds())
     worker->environment_flags_ |= EnvironmentFlags::kTrackUnmanagedFds;
+  if (env->hide_console_windows())
+    worker->environment_flags_ |= EnvironmentFlags::kHideConsoleWindows;
 }
 
 void Worker::StartThread(const FunctionCallbackInfo<Value>& args) {

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -238,6 +238,10 @@ class ProcessWrap : public HandleWrap {
       options.flags |= UV_PROCESS_WINDOWS_HIDE;
     }
 
+    if (env->hide_console_windows()) {
+      options.flags |= UV_PROCESS_WINDOWS_HIDE_CONSOLE;
+    }
+
     // options.windows_verbatim_arguments
     Local<Value> wva_v =
         js_options->Get(context, env->windows_verbatim_arguments_string())


### PR DESCRIPTION
For GUI apps on Windows, `CREATE_NO_WINDOW` property should be passed to `CreateProcessW` to avoid a flash of console window when creating child processes.

This PR adds a build option in Node to allow embedders to set `CREATE_NO_WINDOW` property when spawning processes.

This will remove the need of patches in Electron and NW.js:
https://github.com/electron/electron/blob/main/patches/node/fix_don_t_create_console_window_when_creating_process.patch
https://github.com/nwjs/node/blob/dbaa7a8dfcfcd25f6a81299eb4036aadc8057aef/deps/uv/src/win/process.c#L1101

/cc @nodejs/embedders 