### PR TITLE
repl,worker: fix crash when SharedArrayBuffer disabled

### DIFF
--- a/benchmark/worker/atomics-wait.js
+++ b/benchmark/worker/atomics-wait.js
@@ -7,6 +7,10 @@ const bench = common.createBenchmark(main, {
 });
 
 function main({ n }) {
+  if (typeof SharedArrayBuffer === 'undefined') {
+    throw new Error('SharedArrayBuffers must be enabled to run this benchmark');
+  }
+
   const i32arr = new Int32Array(new SharedArrayBuffer(4));
   bench.start();
   for (let i = 0; i < n; i++)

--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -9,7 +9,7 @@ const {
   ArrayPrototypeSplice,
   ObjectDefineProperty,
   PromisePrototypeCatch,
-  globalThis: { Atomics },
+  globalThis: { Atomics, SharedArrayBuffer },
 } = primordials;
 
 const {
@@ -142,6 +142,9 @@ port.on('message', (message) => {
     const originalCwd = process.cwd;
 
     process.cwd = function() {
+      // SharedArrayBuffers can be disabled with --no-harmony-sharedarraybuffer.
+      if (typeof SharedArrayBuffer === 'undefined') return originalCwd();
+
       const currentCounter = Atomics.load(cwdCounter, 0);
       if (currentCounter === lastCounter)
         return cachedCwd;

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -91,7 +91,8 @@ let cwdCounter;
 
 const environmentData = new SafeMap();
 
-if (isMainThread) {
+// SharedArrayBuffers can be disabled with --no-harmony-sharedarraybuffer.
+if (isMainThread && typeof SharedArrayBuffer !== 'undefined') {
   cwdCounter = new Uint32Array(new SharedArrayBuffer(4));
   const originalChdir = process.chdir;
   process.chdir = function(path) {

--- a/test/parallel/test-worker-no-sab.js
+++ b/test/parallel/test-worker-no-sab.js
@@ -1,0 +1,17 @@
+// Flags: --no-harmony-sharedarraybuffer
+
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { isMainThread, Worker } = require('worker_threads');
+
+// Regression test for https://github.com/nodejs/node/issues/39717.
+
+const w = new Worker(__filename);
+
+w.on('exit', common.mustCall((status) => {
+  assert.strictEqual(status, 2);
+}));
+
+if (!isMainThread) process.exit(2);


### PR DESCRIPTION
Closes https://github.com/nodejs/node/issues/39717.

It's possible for SharedArrayBuffers to be disabled with `--no-harmony-sharedarraybuffer` so we first need to check that this isn't the case before attempting to use them in the repl or the following crash occurs:

```
electron_node on git:a3d0cc7244 ❯ node --no-harmony-sharedarraybuffer       6:25PM
Welcome to Node.js v16.2.0.
Type ".help" for more information.
> snode:internal/readline/emitKeypressEvents:71
            throw err;
            ^

TypeError: SharedArrayBuffer is not a constructor
    at node:internal/worker:96:32
    at NativeModule.compileForInternalLoader (node:internal/bootstrap/loaders:312:7)
    at nativeModuleRequire (node:internal/bootstrap/loaders:341:14)
    at node:worker_threads:11:5
    at NativeModule.compileForInternalLoader (node:internal/bootstrap/loaders:312:7)
    at nativeModuleRequire (node:internal/bootstrap/loaders:341:14)
    at node:inspector:32:26
    at NativeModule.compileForInternalLoader (node:internal/bootstrap/loaders:312:7)
    at nativeModuleRequire (node:internal/bootstrap/loaders:341:14)
    at sendInspectorCommand (node:internal/util/inspector:14:21)
 ```

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
