### PR TITLE
dns: fix `uv_timer_start` usage

### DIFF
--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -748,19 +748,7 @@ void ChannelWrap::StartTimer() {
   }
   int timeout = timeout_;
   if (timeout == 0) timeout = 1;
-  /* -1 implies the default c-ares value, that is 5000, thus checking each
-   * second */
-  if (timeout <= -1) timeout = 1000;
-  if (timeout >= 1000) {
-    int thousands = (timeout / 1000) * 1000;
-    /* Pure seconds should be checked every second (for example 1000, 2000,
-     * 5000) */
-    if (timeout - thousands == 0) timeout = 1000;
-    /* If it's not just seconds (for example 1200, 1050, 2500) check for an
-     * entire 100ms */
-    else
-      timeout = 100;
-  }
+  if (timeout < 0 || timeout >= 500) timeout = 500;
   uv_timer_start(timer_handle_, AresTimeout, 0, timeout);
 }
 

--- a/test/parallel/test-dns-channel-tries.js
+++ b/test/parallel/test-dns-channel-tries.js
@@ -5,7 +5,7 @@ const dgram = require('dgram');
 const dns = require('dns');
 
 const TRIES = 1;
-const IMPRECISION_MS = 100;
+const IMPRECISION_MS = 500;
 
 // Tests for dns.Resolver option `tries`.
 // This will roughly test if a single try fails after the set `timeout`.
@@ -36,17 +36,16 @@ for (let timeout of [-1, 1000, 1500, 50]) {
 
     const timeStart = performance.now();
     resolver.resolve4('nodejs.org', common.mustCall((err) => {
-      const timeEnd = performance.now();
-
       assert.throws(() => { throw err; }, {
         code: 'ETIMEOUT',
         name: 'Error',
       });
+      const timeEnd = performance.now();
 
       // c-ares default (-1): 5000ms
       if (timeout === -1) timeout = 5000;
 
-      // Adding 100 due to imprecisions
+      // Adding 500ms due to imprecisions
       const elapsedMs = (timeEnd - timeStart);
       assert(elapsedMs <= timeout + IMPRECISION_MS, `The expected timeout did not occur. Expecting: ${timeout + IMPRECISION_MS} But got: ${elapsedMs}`);
 
@@ -71,7 +70,7 @@ for (let timeout of [-1, 1000, 1500, 50]) {
       // c-ares default (-1): 5000ms
       if (timeout === -1) timeout = 5000;
 
-      // Adding 100 due to imprecisions
+      // Adding 500ms due to imprecisions
       const elapsedMs = (timeEnd - timeStart);
       assert(elapsedMs <= timeout + IMPRECISION_MS, `The expected timeout did not occur. Expecting: ${timeout + IMPRECISION_MS} But got: ${elapsedMs}`);
 

--- a/test/parallel/test-dns-channel-tries.js
+++ b/test/parallel/test-dns-channel-tries.js
@@ -1,0 +1,78 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const dgram = require('dgram');
+const dns = require('dns');
+
+const TRIES = 1;
+const IMPRECISION_MS = 100;
+
+for (const ctor of [dns.Resolver, dns.promises.Resolver]) {
+  for (const tries of [null, true, false, '', '2']) {
+    assert.throws(() => new ctor({ tries }), {
+      code: 'ERR_INVALID_ARG_TYPE',
+      name: 'TypeError',
+    });
+  }
+
+  for (const tries of [-2, 0, 4.2, 2 ** 31]) {
+    assert.throws(() => new ctor({ tries }), {
+      code: 'ERR_OUT_OF_RANGE',
+      name: 'RangeError',
+    });
+  }
+
+  for (const tries of [2, 1, 5]) new ctor({ tries });
+}
+
+for (let timeout of [-1, 1000, 1500, 50]) {
+  const server = dgram.createSocket('udp4');
+  server.bind(0, '127.0.0.1', common.mustCall(() => {
+    const resolver = new dns.Resolver({ tries: TRIES, timeout });
+    resolver.setServers([`127.0.0.1:${server.address().port}`]);
+
+    const timeStart = performance.now();
+    resolver.resolve4('nodejs.org', common.mustCall((err) => {
+      const timeEnd = performance.now();
+
+      assert.throws(() => { throw err; }, {
+        code: 'ETIMEOUT',
+        name: 'Error',
+      });
+
+      // c-ares default (-1): 5000ms
+      if (timeout === -1) timeout = 5000;
+
+      // Adding 100 due to imprecisions
+      const elapsedMs = (timeEnd - timeStart);
+      assert(elapsedMs <= timeout + IMPRECISION_MS, `The expected timeout did not occur. Expecting: ${timeout + IMPRECISION_MS} But got: ${elapsedMs}`);
+
+      server.close();
+    }));
+  }));
+}
+
+for (let timeout of [-1, 1000, 1500, 50]) {
+  const server = dgram.createSocket('udp4');
+  server.bind(0, '127.0.0.1', common.mustCall(() => {
+    const resolver = new dns.promises.Resolver({ tries: TRIES, timeout });
+    resolver.setServers([`127.0.0.1:${server.address().port}`]);
+    const timeStart = performance.now();
+    resolver.resolve4('nodejs.org').catch(common.mustCall((err) => {
+      assert.throws(() => { throw err; }, {
+        code: 'ETIMEOUT',
+        name: 'Error',
+      });
+      const timeEnd = performance.now();
+
+      // c-ares default (-1): 5000ms
+      if (timeout === -1) timeout = 5000;
+
+      // Adding 100 due to imprecisions
+      const elapsedMs = (timeEnd - timeStart);
+      assert(elapsedMs <= timeout + IMPRECISION_MS, `The expected timeout did not occur. Expecting: ${timeout + IMPRECISION_MS} But got: ${elapsedMs}`);
+
+      server.close();
+    }));
+  }));
+}

--- a/test/parallel/test-dns-channel-tries.js
+++ b/test/parallel/test-dns-channel-tries.js
@@ -7,6 +7,9 @@ const dns = require('dns');
 const TRIES = 1;
 const IMPRECISION_MS = 100;
 
+// Tests for dns.Resolver option `tries`.
+// This will roughly test if a single try fails after the set `timeout`.
+
 for (const ctor of [dns.Resolver, dns.promises.Resolver]) {
   for (const tries of [null, true, false, '', '2']) {
     assert.throws(() => new ctor({ tries }), {


### PR DESCRIPTION
While implementing tests for new option `tries` on Resolver I noticed that it took at least 900ms more than it should when the timeout was > 1000.

So a 1000ms timeout would actually take ~1900ms to trigger.

The reason is that the wrapper would register a timer in which callback `interval` and `timeout` was 1000ms in this case,  which caused the callback to fire only after this `timeout`, leading to one more `interval` of waiting to be fired again.

In addition, this also adds missing tests for the option `tries`! 

Refs: https://github.com/nodejs/node/pull/39610 https://github.com/nodejs/node/issues/39562