### PR TITLE
tools: fix inspector_protocol compiler warnings

### DIFF
--- a/.github/workflows/coverage-linux.yml
+++ b/.github/workflows/coverage-linux.yml
@@ -8,7 +8,6 @@ on:
       - 'benchmark/**'
       - 'deps/**'
       - 'doc/**'
-      - 'tools/**'
   push:
     branches:
       - master
@@ -18,7 +17,6 @@ on:
       - 'benchmark/**'
       - 'deps/**'
       - 'doc/**'
-      - 'tools/**'
 
 env:
   PYTHON_VERSION: 3.9

--- a/tools/inspector_protocol/encoding/encoding.cc
+++ b/tools/inspector_protocol/encoding/encoding.cc
@@ -831,8 +831,9 @@ void CBORTokenizer::ReadNextToken(bool enter_envelope) {
           // inspector_protocol, it's not a CBOR limitation), so we check
           // against the signed max, so that the allowable values are
           // 0, 1, 2, ... 2^31 - 1.
-          if (!bytes_read || std::numeric_limits<int32_t>::max() <
-                                 token_start_internal_value_) {
+          if (!bytes_read ||
+                static_cast<int64_t>(std::numeric_limits<int32_t>::max()) <
+                  static_cast<int64_t>(token_start_internal_value_)) {
             SetError(Error::CBOR_INVALID_INT32);
             return;
           }

--- a/tools/inspector_protocol/encoding/encoding.cc
+++ b/tools/inspector_protocol/encoding/encoding.cc
@@ -850,8 +850,9 @@ void CBORTokenizer::ReadNextToken(bool enter_envelope) {
           // We check the the payload in token_start_internal_value_ against
           // that range (2^31-1 is also known as
           // std::numeric_limits<int32_t>::max()).
-          if (!bytes_read || token_start_internal_value_ >
-                                 std::numeric_limits<int32_t>::max()) {
+          if (!bytes_read ||
+	      static_cast<int64_t>(token_start_internal_value_) >
+                static_cast<int64_t>(std::numeric_limits<int32_t>::max())) {
             SetError(Error::CBOR_INVALID_INT32);
             return;
           }

--- a/tools/inspector_protocol/lib/encoding_cpp.template
+++ b/tools/inspector_protocol/lib/encoding_cpp.template
@@ -858,8 +858,9 @@ void CBORTokenizer::ReadNextToken(bool enter_envelope) {
           // We check the the payload in token_start_internal_value_ against
           // that range (2^31-1 is also known as
           // std::numeric_limits<int32_t>::max()).
-          if (!bytes_read || token_start_internal_value_ >
-                                 std::numeric_limits<int32_t>::max()) {
+          if (!bytes_read ||
+	        static_cast<int64_t>(token_start_internal_value_) >
+                  static_cast<int64_t>(std::numeric_limits<int32_t>::max())) {
             SetError(Error::CBOR_INVALID_INT32);
             return;
           }

--- a/tools/inspector_protocol/lib/encoding_cpp.template
+++ b/tools/inspector_protocol/lib/encoding_cpp.template
@@ -839,8 +839,9 @@ void CBORTokenizer::ReadNextToken(bool enter_envelope) {
           // inspector_protocol, it's not a CBOR limitation), so we check
           // against the signed max, so that the allowable values are
           // 0, 1, 2, ... 2^31 - 1.
-          if (!bytes_read || std::numeric_limits<int32_t>::max() <
-                                 token_start_internal_value_) {
+          if (!bytes_read ||
+                static_cast<int64_t>(std::numeric_limits<int32_t>::max()) <
+                  static_cast<int64_t>(token_start_internal_value_)) {
             SetError(Error::CBOR_INVALID_INT32);
             return;
           }


### PR DESCRIPTION
This is an attempt to see if cherry-picking https://github.com/nodejs/node/commit/ffb34b6d5dbf002f182f08e45c32883d7174be8b (reverted by https://github.com/nodejs/node/pull/39694) fixes the currently broken coverage workflow.

https://github.com/nodejs/node/actions/workflows/coverage-linux.yml?query=
<details>

![image](https://user-images.githubusercontent.com/5445507/128900059-5234bbf9-8797-4ea6-bcbd-2f6ee9c97f77.png)
</details>

```
/home/runner/work/node/node/out/Release/obj/gen/src/node/inspector/protocol/Protocol.cpp: In member function ‘void node::inspector::protocol::cbor::CBORTokenizer::ReadNextToken(bool)’:
/home/runner/work/node/node/out/Release/obj/gen/src/node/inspector/protocol/Protocol.cpp:2567:66: error: comparison of integer expressions of different signedness: ‘int’ and ‘uint64_t’ {aka ‘long unsigned int’} [-Werror=sign-compare]
 2567 |           if (!bytes_read || std::numeric_limits<int32_t>::max() <
      |                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
 2568 |                                  token_start_internal_value_) {
      |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~      
/home/runner/work/node/node/out/Release/obj/gen/src/node/inspector/protocol/Protocol.cpp:2585:58: error: comparison of integer expressions of different signedness: ‘uint64_t’ {aka ‘long unsigned int’} and ‘int’ [-Werror=sign-compare]
 2585 |           if (!bytes_read || token_start_internal_value_ >
      |                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
 2586 |                                  std::numeric_limits<int32_t>::max()) {
      |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
make[2]: *** [libnode.target.mk:410: /home/runner/work/node/node/out/Release/obj.target/libnode/gen/src/node/inspector/protocol/Protocol.o] Error 1
```

The second commit reenables coverage (the workflow that appears to be broken) for `tools` as that's where the inspector protocol files are (I forget the reason but it was moved there a long time ago) and the workflow wasn't run on https://github.com/nodejs/node/pull/39694. 

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
