### PR TITLE
Fixes hoisting of funcs with top level await in repl

### DIFF
--- a/lib/internal/repl/await.js
+++ b/lib/internal/repl/await.js
@@ -47,7 +47,7 @@ const visitorsWithoutAncestors = {
     walk.base.ForOfStatement(node, state, c);
   },
   FunctionDeclaration(node, state, c) {
-    state.prepend(node, `${node.id.name}=`);
+    state.prepend(node, `this.${node.id.name} = ${node.id.name}; `);
     ArrayPrototypePush(
       state.hoistedDeclarationStatements,
       `var ${node.id.name}; `

--- a/test/parallel/test-repl-preprocess-top-level-await.js
+++ b/test/parallel/test-repl-preprocess-top-level-await.js
@@ -54,11 +54,12 @@ const testCases = [
     '(async () => { return (console.log(`${(await { a: 1 }).a}`)) })()' ],
   /* eslint-enable no-template-curly-in-string */
   [ 'await 0; function foo() {}',
-    'var foo; (async () => { await 0; foo=function foo() {} })()' ],
+    'var foo; (async () => { await 0; this.foo = foo; function foo() {} })()' ],
   [ 'await 0; class Foo {}',
     'let Foo; (async () => { await 0; Foo=class Foo {} })()' ],
   [ 'if (await true) { function foo() {} }',
-    'var foo; (async () => { if (await true) { foo=function foo() {} } })()' ],
+    'var foo; (async () => { ' +
+      'if (await true) { this.foo = foo; function foo() {} } })()' ],
   [ 'if (await true) { class Foo{} }',
     '(async () => { if (await true) { class Foo{} } })()' ],
   [ 'if (await true) { var a = 1; }',
@@ -116,6 +117,9 @@ const testCases = [
     '(async () => { for (let i in {x:1}) { await 1 } })()'],
   [ 'for (const i in {x:1}) { await 1 }',
     '(async () => { for (const i in {x:1}) { await 1 } })()'],
+  [ 'var x = await foo(); async function foo() { return Promise.resolve(1);}',
+    'var x; var foo; (async () => { void (x = await foo()); this.foo = foo; ' +
+      'async function foo() { return Promise.resolve(1);} })()'],
 ];
 
 for (const [input, expected] of testCases) {


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/39744

The solution is fairly simple.
Problem, functions are not hoisted.
Today we seem to declare variables as `var foo = function foo(...`
But if the function is used earlier, its not hoisted.
Solution is to initialize a property `this.foo = foo` on the first line (we let node runtime to hoist the function and initialize the property).

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
