### PR TITLE
policy: fix integrity when DEFAULT_ENCODING is set

### DIFF
--- a/lib/internal/policy/manifest.js
+++ b/lib/internal/policy/manifest.js
@@ -501,8 +501,10 @@ class Manifest {
             value: expected
           } = integrityEntries[i];
           const hash = createHash(algorithm);
-          HashUpdate(hash, content);
-          const digest = HashDigest(hash);
+          // TODO(tniessen): the content should not be passed as a string in the
+          // first place, see https://github.com/nodejs/node/issues/39707
+          HashUpdate(hash, content, 'utf8');
+          const digest = HashDigest(hash, 'buffer');
           if (digest.length === expected.length &&
             timingSafeEqual(digest, expected)) {
             return true;

--- a/test/fixtures/policy/crypto-default-encoding/.gitattributes
+++ b/test/fixtures/policy/crypto-default-encoding/.gitattributes
@@ -1,0 +1,1 @@
+*.js text eol=lf

--- a/test/fixtures/policy/crypto-default-encoding/dep.js
+++ b/test/fixtures/policy/crypto-default-encoding/dep.js
@@ -1,0 +1,3 @@
+'use strict';
+
+// No code.

--- a/test/fixtures/policy/crypto-default-encoding/parent.js
+++ b/test/fixtures/policy/crypto-default-encoding/parent.js
@@ -1,0 +1,4 @@
+'use strict';
+
+require('crypto').DEFAULT_ENCODING = process.env.DEFAULT_ENCODING;
+require('./dep.js');

--- a/test/fixtures/policy/crypto-default-encoding/policy.json
+++ b/test/fixtures/policy/crypto-default-encoding/policy.json
@@ -1,0 +1,14 @@
+{
+  "resources": {
+    "./parent.js": {
+      "integrity": "sha384-j4pMdq83q5Bq9+idcHuGKzi89FrYm1PhZYrEw3irbNob6g4i3vKBjfYiRNYwmoGr",
+      "dependencies": {
+        "crypto": true,
+        "./dep.js": true
+      }
+    },
+    "./dep.js": {
+      "integrity": "sha384-VU7GIrTix/HFLhUb4yqsV4n1xXqjPcWw6kLvjuKXtR1+9nmufJu5vZLajBs8brIW"
+    }
+  }
+}

--- a/test/parallel/test-policy-crypto-default-encoding.js
+++ b/test/parallel/test-policy-crypto-default-encoding.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+common.requireNoPackageJSONAbove();
+
+const fixtures = require('../common/fixtures');
+
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+
+const encodings = ['buffer', 'utf8', 'utf16le', 'latin1', 'base64', 'hex'];
+
+for (const encoding of encodings) {
+  const dep = fixtures.path('policy', 'crypto-default-encoding', 'parent.js');
+  const depPolicy = fixtures.path(
+    'policy',
+    'crypto-default-encoding',
+    'policy.json');
+  const { status } = spawnSync(
+    process.execPath,
+    [
+      '--experimental-policy', depPolicy, dep,
+    ],
+    {
+      env: {
+        ...process.env,
+        DEFAULT_ENCODING: encoding
+      }
+    }
+  );
+  assert.strictEqual(status, 0);
+}


### PR DESCRIPTION
The (deprecated) `crypto.DEFAULT_ENCODING` setting should not affect SRI checks.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
