### PR TITLE
src: add env and cli option to disable global search paths

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -629,6 +629,14 @@ added: v9.0.0
 Disables runtime checks for `async_hooks`. These will still be enabled
 dynamically when `async_hooks` is enabled.
 
+### `--no-global-search-paths`
+<!-- YAML
+added: REPLACEME
+-->
+
+Do not search modules from global paths like `$HOME/.node_modules` and
+`$NODE_PATH`.
+
 ### `--no-warnings`
 <!-- YAML
 added: v6.0.0
@@ -1442,6 +1450,7 @@ Node.js options that are allowed are:
 * `--no-experimental-repl-await`
 * `--no-extra-info-on-fatal-exception`
 * `--no-force-async-hooks-checks`
+* `--no-global-search-paths`
 * `--no-warnings`
 * `--node-memory-debug`
 * `--openssl-config`

--- a/doc/node.1
+++ b/doc/node.1
@@ -285,6 +285,9 @@ Disable the `node-addons` exports condition as well as disable loading native
 addons. When `--no-addons` is specified, calling `process.dlopen` or requiring
 a native C++ addon will fail and throw an exception.
 .
+.It Fl -no-global-search-paths
+Do not search modules from global paths.
+.
 .It Fl -no-warnings
 Silence all process warnings (including deprecations).
 .

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -11,7 +11,8 @@ const {
 
 const {
   getOptionValue,
-  shouldNotRegisterESMLoader
+  noGlobalSearchPaths,
+  shouldNotRegisterESMLoader,
 } = require('internal/options');
 const { reconnectZeroFillToggle } = require('internal/buffer');
 
@@ -420,7 +421,9 @@ function initializeWASI() {
 
 function initializeCJSLoader() {
   const CJSLoader = require('internal/modules/cjs/loader');
-  CJSLoader.Module._initPaths();
+  if (!noGlobalSearchPaths) {
+    CJSLoader.Module._initPaths();
+  }
   // TODO(joyeecheung): deprecate this in favor of a proper hook?
   CJSLoader.Module.runMain =
     require('internal/modules/run_main').executeUserEntryPoint;

--- a/lib/internal/options.js
+++ b/lib/internal/options.js
@@ -1,6 +1,10 @@
 'use strict';
 
-const { getOptions, shouldNotRegisterESMLoader } = internalBinding('options');
+const {
+  getOptions,
+  noGlobalSearchPaths,
+  shouldNotRegisterESMLoader,
+} = internalBinding('options');
 
 let warnOnAllowUnauthorized = true;
 
@@ -57,5 +61,6 @@ module.exports = {
   },
   getOptionValue,
   getAllowUnauthorized,
-  shouldNotRegisterESMLoader
+  noGlobalSearchPaths,
+  shouldNotRegisterESMLoader,
 };

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -886,6 +886,10 @@ inline bool Environment::hide_console_windows() const {
   return flags_ & EnvironmentFlags::kHideConsoleWindows;
 }
 
+inline bool Environment::no_global_search_paths() const {
+  return flags_ & EnvironmentFlags::kNoGlobalSearchPaths;
+}
+
 bool Environment::filehandle_close_warning() const {
   return emit_filehandle_warning_;
 }

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -887,7 +887,8 @@ inline bool Environment::hide_console_windows() const {
 }
 
 inline bool Environment::no_global_search_paths() const {
-  return flags_ & EnvironmentFlags::kNoGlobalSearchPaths;
+  return (flags_ & EnvironmentFlags::kNoGlobalSearchPaths) ||
+         !options_->global_search_paths;
 }
 
 bool Environment::filehandle_close_warning() const {

--- a/src/env.h
+++ b/src/env.h
@@ -1203,6 +1203,7 @@ class Environment : public MemoryRetainer {
   inline bool owns_inspector() const;
   inline bool tracks_unmanaged_fds() const;
   inline bool hide_console_windows() const;
+  inline bool no_global_search_paths() const;
   inline uint64_t thread_id() const;
   inline worker::Worker* worker_context() const;
   Environment* worker_parent_env() const;

--- a/src/node.h
+++ b/src/node.h
@@ -413,7 +413,12 @@ enum Flags : uint64_t {
   // so that a worker thread can't load a native addon even if `execArgv`
   // is overwritten and `--no-addons` is not specified but was specified
   // for this Environment instance.
-  kNoNativeAddons = 1 << 6
+  kNoNativeAddons = 1 << 6,
+  // Set this flag to disable searching modules from global paths like
+  // $HOME/.node_modules and $NODE_PATH. This is used by standalone apps that
+  // do not expect to have their behaviors changed because of globally
+  // installed modules.
+  kNoGlobalSearchPaths = 1 << 7
 };
 }  // namespace EnvironmentFlags
 

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -1078,6 +1078,12 @@ void Initialize(Local<Object> target,
             Boolean::New(isolate, env->should_not_register_esm_loader()))
       .Check();
 
+  target
+      ->Set(context,
+            FIXED_ONE_BYTE_STRING(env->isolate(), "noGlobalSearchPaths"),
+            Boolean::New(isolate, env->no_global_search_paths()))
+      .Check();
+
   Local<Object> types = Object::New(isolate);
   NODE_DEFINE_CONSTANT(types, kNoOp);
   NODE_DEFINE_CONSTANT(types, kV8Option);

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -407,6 +407,11 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             &EnvironmentOptions::allow_native_addons,
             kAllowedInEnvironment,
             true);
+  AddOption("--global-search-paths",
+            "disable global module search paths",
+            &EnvironmentOptions::global_search_paths,
+            kAllowedInEnvironment,
+            true);
   AddOption("--warnings",
             "silence all process warnings",
             &EnvironmentOptions::warnings,

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -122,6 +122,7 @@ class EnvironmentOptions : public Options {
   bool deprecation = true;
   bool force_async_hooks_checks = true;
   bool allow_native_addons = true;
+  bool global_search_paths = true;
   bool warnings = true;
   bool force_context_aware = false;
   bool pending_deprecation = false;

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -572,6 +572,8 @@ void Worker::New(const FunctionCallbackInfo<Value>& args) {
     worker->environment_flags_ |= EnvironmentFlags::kHideConsoleWindows;
   if (env->no_native_addons())
     worker->environment_flags_ |= EnvironmentFlags::kNoNativeAddons;
+  if (env->no_global_search_paths())
+    worker->environment_flags_ |= EnvironmentFlags::kNoGlobalSearchPaths;
 }
 
 void Worker::StartThread(const FunctionCallbackInfo<Value>& args) {


### PR DESCRIPTION
For embedders it is usually not allowed for Node.js to search modules from global paths like `$HOME/.node_modules`, otherwise the behavior of the app could be changed because of a global installed module. For example, a global installed `electron` module should not break all `require('electron')` calls.

This PR adds an option to disable searching modules from global paths.

Also note that this change will have a merge conflict with https://github.com/nodejs/node/pull/39712.