### PR TITLE
worker_threads: add brand checks for detached properties/methods

### DIFF
--- a/lib/internal/worker/io.js
+++ b/lib/internal/worker/io.js
@@ -53,6 +53,7 @@ const { inspect } = require('internal/util/inspect');
 const {
   codes: {
     ERR_INVALID_ARG_TYPE,
+    ERR_INVALID_THIS,
     ERR_MISSING_ARGS,
   }
 } = require('internal/errors');
@@ -74,6 +75,7 @@ const kStartedReading = Symbol('kStartedReading');
 const kStdioWantsMoreDataCallback = Symbol('kStdioWantsMoreDataCallback');
 const kCurrentlyReceivingPorts =
   SymbolFor('nodejs.internal.kCurrentlyReceivingPorts');
+const kType = Symbol('kType');
 
 const messageTypes = {
   UP_AND_RUNNING: 'upAndRunning',
@@ -349,11 +351,16 @@ function onMessageEvent(type, data) {
   this.dispatchEvent(new MessageEvent(type, { data }));
 }
 
+function isBroadcastChannel(value) {
+  return value?.[kType] === 'BroadcastChannel';
+}
+
 class BroadcastChannel extends EventTarget {
   constructor(name) {
     if (arguments.length === 0)
       throw new ERR_MISSING_ARGS('name');
     super();
+    this[kType] = 'BroadcastChannel';
     this[kName] = `${name}`;
     this[kHandle] = broadcastChannel(this[kName]);
     this[kOnMessage] = FunctionPrototypeBind(onMessageEvent, this, 'message');
@@ -364,6 +371,8 @@ class BroadcastChannel extends EventTarget {
   }
 
   [inspect.custom](depth, options) {
+    if (!isBroadcastChannel(this))
+      throw new ERR_INVALID_THIS('BroadcastChannel');
     if (depth < 0)
       return 'BroadcastChannel';
 
@@ -378,9 +387,15 @@ class BroadcastChannel extends EventTarget {
     }, opts)}`;
   }
 
-  get name() { return this[kName]; }
+  get name() {
+    if (!isBroadcastChannel(this))
+      throw new ERR_INVALID_THIS('BroadcastChannel');
+    return this[kName];
+  }
 
   close() {
+    if (!isBroadcastChannel(this))
+      throw new ERR_INVALID_THIS('BroadcastChannel');
     if (this[kHandle] === undefined)
       return;
     this[kHandle].off('message', this[kOnMessage]);
@@ -392,6 +407,8 @@ class BroadcastChannel extends EventTarget {
   }
 
   postMessage(message) {
+    if (!isBroadcastChannel(this))
+      throw new ERR_INVALID_THIS('BroadcastChannel');
     if (arguments.length === 0)
       throw new ERR_MISSING_ARGS('message');
     if (this[kHandle] === undefined)
@@ -400,18 +417,39 @@ class BroadcastChannel extends EventTarget {
       throw new DOMException('Message could not be posted.');
   }
 
+  // TODO(@jasnell): The ref() method is Node.js specific and not part
+  // of the standard BroadcastChannel API definition. Typically we shouldn't
+  // extend Web Platform APIs with Node.js specific methods but ref and unref
+  // are a bit special. We may want to revisit this, however.
   ref() {
+    if (!isBroadcastChannel(this))
+      throw new ERR_INVALID_THIS('BroadcastChannel');
     if (this[kHandle])
       this[kHandle].ref();
     return this;
   }
 
+  // TODO(@jasnell): The unref() method is Node.js specific and not part
+  // of the standard BroadcastChannel API definition. Typically we shouldn't
+  // extend Web Platform APIs with Node.js specific methods but ref and unref
+  // are a bit special. We may want to revisit this, however.
   unref() {
+    if (!isBroadcastChannel(this))
+      throw new ERR_INVALID_THIS('BroadcastChannel');
     if (this[kHandle])
       this[kHandle].unref();
     return this;
   }
 }
+
+const kEnumerableProperty = ObjectCreate(null);
+kEnumerableProperty.enumerable = true;
+
+ObjectDefineProperties(BroadcastChannel.prototype, {
+  name: kEnumerableProperty,
+  close: kEnumerableProperty,
+  postMessage: kEnumerableProperty,
+});
 
 defineEventHandler(BroadcastChannel.prototype, 'message');
 defineEventHandler(BroadcastChannel.prototype, 'messageerror');

--- a/lib/internal/worker/io.js
+++ b/lib/internal/worker/io.js
@@ -417,10 +417,10 @@ class BroadcastChannel extends EventTarget {
       throw new DOMException('Message could not be posted.');
   }
 
-  // TODO(@jasnell): The ref() method is Node.js specific and not part
-  // of the standard BroadcastChannel API definition. Typically we shouldn't
-  // extend Web Platform APIs with Node.js specific methods but ref and unref
-  // are a bit special. We may want to revisit this, however.
+  // The ref() method is Node.js specific and not part of the standard
+  // BroadcastChannel API definition. Typically we shouldn't extend Web
+  // Platform APIs with Node.js specific methods but ref and unref
+  // are a bit special.
   ref() {
     if (!isBroadcastChannel(this))
       throw new ERR_INVALID_THIS('BroadcastChannel');
@@ -429,10 +429,10 @@ class BroadcastChannel extends EventTarget {
     return this;
   }
 
-  // TODO(@jasnell): The unref() method is Node.js specific and not part
-  // of the standard BroadcastChannel API definition. Typically we shouldn't
-  // extend Web Platform APIs with Node.js specific methods but ref and unref
-  // are a bit special. We may want to revisit this, however.
+  // The unref() method is Node.js specific and not part of the standard
+  // BroadcastChannel API definition. Typically we shouldn't extend Web
+  // Platform APIs with Node.js specific methods but ref and unref
+  // are a bit special.
   unref() {
     if (!isBroadcastChannel(this))
       throw new ERR_INVALID_THIS('BroadcastChannel');

--- a/test/parallel/test-worker-broadcastchannel.js
+++ b/test/parallel/test-worker-broadcastchannel.js
@@ -151,3 +151,20 @@ assert.throws(() => new BroadcastChannel(), {
   bc1.close();
   bc2.close();
 }
+
+{
+  assert.throws(() => Reflect.get(BroadcastChannel.prototype, 'name', {}), {
+    code: 'ERR_INVALID_THIS',
+  });
+
+  [
+    'close',
+    'postMessage',
+    'ref',
+    'unref',
+  ].forEach((i) => {
+    assert.throws(() => Reflect.apply(BroadcastChannel.prototype[i], [], {}), {
+      code: 'ERR_INVALID_THIS',
+    });
+  });
+}


### PR DESCRIPTION
Add proper brand-checking for detached property and method
accesses. Also adds a note about non-standard APIs and
makes the standard accessors enumerable.

Signed-off-by: James M Snell <jasnell@gmail.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
