### PR TITLE
src: add a constructor overload for CallbackScope

### DIFF
--- a/src/api/async_resource.cc
+++ b/src/api/async_resource.cc
@@ -62,10 +62,8 @@ async_id AsyncResource::get_trigger_async_id() const {
   return async_context_.trigger_async_id;
 }
 
-// TODO(addaleax): We shouldn’t need to use env_->isolate() if we’re just going
-// to end up using the Isolate* to figure out the Environment* again.
 AsyncResource::CallbackScope::CallbackScope(AsyncResource* res)
-    : node::CallbackScope(res->env_->isolate(),
+    : node::CallbackScope(res->env_,
                           res->resource_.Get(res->env_->isolate()),
                           res->async_context_) {}
 

--- a/src/api/callback.cc
+++ b/src/api/callback.cc
@@ -18,13 +18,8 @@ using v8::Value;
 
 CallbackScope::CallbackScope(Isolate* isolate,
                              Local<Object> object,
-                             async_context asyncContext)
-  : private_(new InternalCallbackScope(Environment::GetCurrent(isolate),
-                                       object,
-                                       asyncContext)),
-    try_catch_(isolate) {
-  try_catch_.SetVerbose(true);
-}
+                             async_context async_context)
+  : CallbackScope(Environment::GetCurrent(isolate), object, async_context) {}
 
 CallbackScope::CallbackScope(Environment* env,
                              Local<Object> object,

--- a/src/api/callback.cc
+++ b/src/api/callback.cc
@@ -26,6 +26,16 @@ CallbackScope::CallbackScope(Isolate* isolate,
   try_catch_.SetVerbose(true);
 }
 
+CallbackScope::CallbackScope(Environment* env,
+                             Local<Object> object,
+                             async_context asyncContext)
+  : private_(new InternalCallbackScope(env,
+                                       object,
+                                       asyncContext)),
+    try_catch_(env->isolate()) {
+  try_catch_.SetVerbose(true);
+}
+
 CallbackScope::~CallbackScope() {
   if (try_catch_.HasCaught())
     private_->MarkAsFailed();

--- a/src/node.h
+++ b/src/node.h
@@ -1005,6 +1005,9 @@ class NODE_EXTERN CallbackScope {
   CallbackScope(v8::Isolate* isolate,
                 v8::Local<v8::Object> resource,
                 async_context asyncContext);
+  CallbackScope(Environment* env,
+                v8::Local<v8::Object> resource,
+                async_context asyncContext);
   ~CallbackScope();
 
   void operator=(const CallbackScope&) = delete;

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -539,7 +539,7 @@ class AsyncContext {
   class CallbackScope : public node::CallbackScope {
    public:
     explicit CallbackScope(AsyncContext* async_context)
-        : node::CallbackScope(async_context->node_env()->isolate(),
+        : node::CallbackScope(async_context->node_env(),
                               async_context->resource_.Get(
                                   async_context->node_env()->isolate()),
                               async_context->async_context()) {}


### PR DESCRIPTION
This overload accepts the current `Environment*` as an argument, unlike
the other constructor, which accepts an `Isolate*`. This is useful because
we can pass the current `Environment*` directly instead of recomputing it
from the `Isolate*` inside the constructor.

Signed-off-by: Darshan Sen <darshan.sen@postman.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
