### PR TITLE
events: allow dispatch many times without listener

### DIFF
--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -422,8 +422,11 @@ class EventTarget {
     }
 
     const root = this[kEvents].get(type);
-    if (root === undefined || root.next === undefined)
+    if (root === undefined || root.next === undefined) {
+      if (event !== undefined)
+        event[kIsBeingDispatched] = false;
       return true;
+    }
 
     let handler = root.next;
     let next;

--- a/test/parallel/test-eventtarget.js
+++ b/test/parallel/test-eventtarget.js
@@ -191,6 +191,22 @@ let asyncTest = Promise.resolve();
   strictEqual(event.target, eventTarget2);
   deepStrictEqual(event.composedPath(), []);
 }
+{
+  // Same event dispatched multiple times, without listeners added.
+  const event = new Event('foo');
+  const eventTarget1 = new EventTarget();
+  const eventTarget2 = new EventTarget();
+
+  eventTarget1.dispatchEvent(event);
+  strictEqual(event.eventPhase, Event.NONE);
+  strictEqual(event.target, eventTarget1);
+  deepStrictEqual(event.composedPath(), []);
+
+  eventTarget2.dispatchEvent(event);
+  strictEqual(event.eventPhase, Event.NONE);
+  strictEqual(event.target, eventTarget2);
+  deepStrictEqual(event.composedPath(), []);
+}
 
 {
   const eventTarget = new EventTarget();


### PR DESCRIPTION
This fixes an issue where the fast path of `EventTarget`'s hybrid dispatch (for when there aren't any listeners attached) didn't reset the `kIsBeingDispatchedFlag`, meaning an event couldn't be dispatched multiple times:

```js
const target = new EventTarget();
const event = new Event("test");
target.dispatchEvent(event);
target.dispatchEvent(event); // Uncaught Error [ERR_EVENT_RECURSION]: The event "test" is already being dispatched
```
