### PR TITLE
url: fix performance regression

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -626,7 +626,7 @@ function onParseHashComplete(flags, protocol, username, password,
 }
 
 function isURLThis(self) {
-  return self?.[context] !== undefined;
+  return (self !== undefined && self !== null && self[context] !== undefined);
 }
 
 class URL {


### PR DESCRIPTION
This (mostly) fixes a performance regression introduced in e1e669b1095fdb9d89fbb58310c2500fb7a78dbc. While this PR does help, it doesn't completely restore performance levels pre- e1e669b1095fdb9d89fbb58310c2500fb7a78dbc but it's fairly close.

Example benchmark results:

```
                                                                       confidence improvement accuracy (*)   (**)  (***)
url/legacy-vs-whatwg-url-get-prop.js e=11 method='whatwg' type='auth'        ***     11.87 %       ±1.67% ±2.24% ±2.94%
```

/cc @jasnell 