### PR TITLE
worker: add `no-worker-extension-check` option

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -21,7 +21,6 @@ Execute without arguments to start the [REPL][].
 For more info about `node inspect`, see the [debugger][] documentation.
 
 ## Options
-
 <!-- YAML
 changes:
   - version: v10.12.0
@@ -40,7 +39,6 @@ command line take precedence over options passed through the [`NODE_OPTIONS`][]
 environment variable.
 
 ### `-`
-
 <!-- YAML
 added: v8.0.0
 -->
@@ -50,7 +48,6 @@ meaning that the script is read from stdin, and the rest of the options
 are passed to that script.
 
 ### `--`
-
 <!-- YAML
 added: v6.11.0
 -->
@@ -60,7 +57,6 @@ If no script filename or eval/print script is supplied prior to this, then
 the next argument is used as a script filename.
 
 ### `--abort-on-uncaught-exception`
-
 <!-- YAML
 added: v0.10.8
 -->
@@ -73,7 +69,6 @@ If this flag is passed, the behavior can still be set to not abort through
 `domain` module that uses it).
 
 ### `--completion-bash`
-
 <!-- YAML
 added: v10.12.0
 -->
@@ -81,12 +76,11 @@ added: v10.12.0
 Print source-able bash completion script for Node.js.
 
 ```console
-node --completion-bash > node_bash_completion
-source node_bash_completion
+$ node --completion-bash > node_bash_completion
+$ source node_bash_completion
 ```
 
 ### `-C=condition`, `--conditions=condition`
-
 <!-- YAML
 added:
   - v14.9.0
@@ -106,11 +100,10 @@ The default Node.js conditions of `"node"`, `"default"`, `"import"`, and
 For example, to run a module with "development" resolutions:
 
 ```console
-node -C=development app.js
+$ node -C=development app.js
 ```
 
 ### `--cpu-prof`
-
 <!-- YAML
 added: v12.0.0
 -->
@@ -133,7 +126,6 @@ CPU.20190409.202950.15293.0.0.cpuprofile
 ```
 
 ### `--cpu-prof-dir`
-
 <!-- YAML
 added: v12.0.0
 -->
@@ -147,7 +139,6 @@ The default value is controlled by the
 [--diagnostic-dir](#cli_diagnostic_dir_directory) command-line option.
 
 ### `--cpu-prof-interval`
-
 <!-- YAML
 added: v12.2.0
 -->
@@ -158,7 +149,6 @@ Specify the sampling interval in microseconds for the CPU profiles generated
 by `--cpu-prof`. The default is 1000 microseconds.
 
 ### `--cpu-prof-name`
-
 <!-- YAML
 added: v12.0.0
 -->
@@ -173,13 +163,11 @@ Set the directory to which all diagnostic output files are written.
 Defaults to current working directory.
 
 Affects the default output directory of:
-
 * [--cpu-prof-dir](#cli_cpu_prof_dir)
 * [--heap-prof-dir](#cli_heap_prof_dir)
 * [--redirect-warnings](#cli_redirect_warnings_file)
 
 ### `--disable-proto=mode`
-
 <!-- YAML
 added:
  - v13.12.0
@@ -191,7 +179,6 @@ property is removed entirely. If `mode` is `throw`, accesses to the
 property throw an exception with the code `ERR_PROTO_ACCESS`.
 
 ### `--disallow-code-generation-from-strings`
-
 <!-- YAML
 added: v9.8.0
 -->
@@ -201,14 +188,12 @@ code from strings throw an exception instead. This does not affect the Node.js
 `vm` module.
 
 ### `--dns-result-order=order`
-
 <!-- YAML
 added: v16.4.0
 -->
 
 Set the default value of `verbatim` in [`dns.lookup()`][] and
 [`dnsPromises.lookup()`][]. The value could be:
-
 * `ipv4first`: sets default `verbatim` `false`.
 * `verbatim`: sets default `verbatim` `true`.
 
@@ -216,7 +201,6 @@ The default is `ipv4first` and [`dns.setDefaultResultOrder()`][] have higher
 priority than `--dns-result-order`.
 
 ### `--enable-fips`
-
 <!-- YAML
 added: v6.0.0
 -->
@@ -225,7 +209,6 @@ Enable FIPS-compliant crypto at startup. (Requires Node.js to be built
 against FIPS-compatible OpenSSL.)
 
 ### `--enable-source-maps`
-
 <!-- YAML
 added: v12.12.0
 changes:
@@ -245,7 +228,6 @@ Overriding `Error.prepareStackTrace` prevents `--enable-source-maps` from
 modifying the stack trace.
 
 ### `--experimental-abortcontroller`
-
 <!-- YAML
 added:
   - v15.0.0
@@ -260,7 +242,6 @@ changes:
 Use of this command-line flag is no longer required.
 
 ### `--experimental-import-meta-resolve`
-
 <!-- YAML
 added:
   - v13.9.0
@@ -270,7 +251,6 @@ added:
 Enable experimental `import.meta.resolve()` support.
 
 ### `--experimental-json-modules`
-
 <!-- YAML
 added: v12.9.0
 -->
@@ -278,7 +258,6 @@ added: v12.9.0
 Enable experimental JSON support for the ES Module loader.
 
 ### `--experimental-loader=module`
-
 <!-- YAML
 added: v9.0.0
 -->
@@ -287,7 +266,6 @@ Specify the `module` of a custom experimental [ECMAScript Module loader][].
 `module` may be either a path to a file, or an ECMAScript Module name.
 
 ### `--experimental-modules`
-
 <!-- YAML
 added: v8.5.0
 -->
@@ -295,7 +273,6 @@ added: v8.5.0
 Enable latest experimental modules features (deprecated).
 
 ### `--experimental-policy`
-
 <!-- YAML
 added: v11.8.0
 -->
@@ -303,14 +280,12 @@ added: v11.8.0
 Use the specified file as a security policy.
 
 ### `--no-experimental-repl-await`
-
 <!-- YAML
 added: v16.6.0
  -->
  Use this flag to disable top-level await in REPL.
 
 ### `--experimental-specifier-resolution=mode`
-
 <!-- YAML
 added:
  - v13.4.0
@@ -327,7 +302,6 @@ the ability to import a directory that has an index file.
 See [customizing ESM specifier resolution][] for example usage.
 
 ### `--experimental-vm-modules`
-
 <!-- YAML
 added: v9.6.0
 -->
@@ -335,7 +309,6 @@ added: v9.6.0
 Enable experimental ES Module support in the `vm` module.
 
 ### `--experimental-wasi-unstable-preview1`
-
 <!-- YAML
 added:
   - v13.3.0
@@ -350,7 +323,6 @@ changes:
 Enable experimental WebAssembly System Interface (WASI) support.
 
 ### `--experimental-wasm-modules`
-
 <!-- YAML
 added: v12.3.0
 -->
@@ -358,7 +330,6 @@ added: v12.3.0
 Enable experimental WebAssembly module support.
 
 ### `--force-context-aware`
-
 <!-- YAML
 added: v12.12.0
 -->
@@ -366,7 +337,6 @@ added: v12.12.0
 Disable loading native addons that are not [context-aware][].
 
 ### `--force-fips`
-
 <!-- YAML
 added: v6.0.0
 -->
@@ -375,7 +345,6 @@ Force FIPS-compliant crypto on startup. (Cannot be disabled from script code.)
 (Same requirements as `--enable-fips`.)
 
 ### `--frozen-intrinsics`
-
 <!-- YAML
 added: v11.12.0
 -->
@@ -392,7 +361,6 @@ reference. Code may break under this flag.
 be added.
 
 ### `--heapsnapshot-near-heap-limit=max_count`
-
 <!-- YAML
 added: v15.1.0
 -->
@@ -439,7 +407,6 @@ FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaS
 ```
 
 ### `--heapsnapshot-signal=signal`
-
 <!-- YAML
 added: v12.0.0
 -->
@@ -459,7 +426,6 @@ Heap.20190718.133405.15554.0.001.heapsnapshot
 ```
 
 ### `--heap-prof`
-
 <!-- YAML
 added: v12.4.0
 -->
@@ -482,7 +448,6 @@ Heap.20190409.202950.15293.0.001.heapprofile
 ```
 
 ### `--heap-prof-dir`
-
 <!-- YAML
 added: v12.4.0
 -->
@@ -496,7 +461,6 @@ The default value is controlled by the
 [--diagnostic-dir](#cli_diagnostic_dir_directory) command-line option.
 
 ### `--heap-prof-interval`
-
 <!-- YAML
 added: v12.4.0
 -->
@@ -507,7 +471,6 @@ Specify the average sampling interval in bytes for the heap profiles generated
 by `--heap-prof`. The default is 512 * 1024 bytes.
 
 ### `--heap-prof-name`
-
 <!-- YAML
 added: v12.4.0
 -->
@@ -517,7 +480,6 @@ added: v12.4.0
 Specify the file name of the heap profile generated by `--heap-prof`.
 
 ### `--icu-data-dir=file`
-
 <!-- YAML
 added: v0.11.15
 -->
@@ -525,7 +487,6 @@ added: v0.11.15
 Specify ICU data load path. (Overrides `NODE_ICU_DATA`.)
 
 ### `--input-type=type`
-
 <!-- YAML
 added: v12.0.0
 -->
@@ -536,7 +497,6 @@ module. String input is input via `--eval`, `--print`, or `STDIN`.
 Valid values are `"commonjs"` and `"module"`. The default is `"commonjs"`.
 
 ### `--inspect-brk[=[host:]port]`
-
 <!-- YAML
 added: v7.6.0
 -->
@@ -545,7 +505,6 @@ Activate inspector on `host:port` and break at start of user script.
 Default `host:port` is `127.0.0.1:9229`.
 
 ### `--inspect-port=[host:]port`
-
 <!-- YAML
 added: v7.6.0
 -->
@@ -559,7 +518,6 @@ See the [security warning](#inspector_security) below regarding the `host`
 parameter usage.
 
 ### `--inspect[=[host:]port]`
-
 <!-- YAML
 added: v6.3.0
 -->
@@ -571,7 +529,6 @@ and profile Node.js instances. The tools attach to Node.js instances via a
 tcp port and communicate using the [Chrome DevTools Protocol][].
 
 <a id="inspector_security"></a>
-
 #### Warning: binding inspector to a public IP:port combination is insecure
 
 Binding the inspector to a public IP (including `0.0.0.0`) with an open port is
@@ -596,7 +553,6 @@ By default inspector websocket url is available in stderr and under `/json/list`
 endpoint on `http://host:port/json/list`.
 
 ### `--insecure-http-parser`
-
 <!-- YAML
 added:
  - v13.4.0
@@ -610,7 +566,6 @@ request smuggling and other HTTP attacks that rely on invalid headers being
 accepted. Avoid using this option.
 
 ### `--jitless`
-
 <!-- YAML
 added: v12.0.0
 -->
@@ -623,7 +578,6 @@ This flag is inherited from V8 and is subject to change upstream. It may
 disappear in a non-semver-major release.
 
 ### `--max-http-header-size=size`
-
 <!-- YAML
 added:
  - v11.6.0
@@ -637,7 +591,6 @@ changes:
 Specify the maximum size, in bytes, of HTTP headers. Defaults to 16 KB.
 
 ### `--napi-modules`
-
 <!-- YAML
 added: v7.10.0
 -->
@@ -645,7 +598,6 @@ added: v7.10.0
 This option is a no-op. It is kept for compatibility.
 
 ### `--no-deprecation`
-
 <!-- YAML
 added: v0.8.0
 -->
@@ -653,7 +605,6 @@ added: v0.8.0
 Silence deprecation warnings.
 
 ### `--no-force-async-hooks-checks`
-
 <!-- YAML
 added: v9.0.0
 -->
@@ -662,7 +613,6 @@ Disables runtime checks for `async_hooks`. These will still be enabled
 dynamically when `async_hooks` is enabled.
 
 ### `--no-warnings`
-
 <!-- YAML
 added: v6.0.0
 -->
@@ -678,7 +628,6 @@ added: REPLACEME
 Disable runtime file extension check for worker.
 
 ### `--node-memory-debug`
-
 <!-- YAML
 added: v15.0.0
 -->
@@ -687,7 +636,6 @@ Enable extra debug checks for memory leaks in Node.js internals. This is
 usually only useful for developers debugging Node.js itself.
 
 ### `--openssl-config=file`
-
 <!-- YAML
 added: v6.9.0
 -->
@@ -697,7 +645,6 @@ used to enable FIPS-compliant crypto if Node.js is built
 against FIPS-enabled OpenSSL.
 
 ### `--pending-deprecation`
-
 <!-- YAML
 added: v8.0.0
 -->
@@ -712,7 +659,6 @@ are used to provide a kind of selective "early warning" mechanism that
 developers may leverage to detect deprecated API usage.
 
 ### `--policy-integrity=sri`
-
 <!-- YAML
 added: v12.7.0
 -->
@@ -724,7 +670,6 @@ the specified integrity. It expects a [Subresource Integrity][] string as a
 parameter.
 
 ### `--preserve-symlinks`
-
 <!-- YAML
 added: v6.3.0
 -->
@@ -769,7 +714,6 @@ The `--preserve-symlinks` flag does not apply to the main module, which allows
 behavior for the main module, also use `--preserve-symlinks-main`.
 
 ### `--preserve-symlinks-main`
-
 <!-- YAML
 added: v10.2.0
 -->
@@ -789,7 +733,6 @@ resolving relative paths.
 See `--preserve-symlinks` for more information.
 
 ### `--prof`
-
 <!-- YAML
 added: v2.0.0
 -->
@@ -797,7 +740,6 @@ added: v2.0.0
 Generate V8 profiler output.
 
 ### `--prof-process`
-
 <!-- YAML
 added: v5.2.0
 -->
@@ -805,7 +747,6 @@ added: v5.2.0
 Process V8 profiler output generated using the V8 option `--prof`.
 
 ### `--redirect-warnings=file`
-
 <!-- YAML
 added: v8.0.0
 -->
@@ -820,7 +761,6 @@ will be written to is controlled by the
 [--diagnostic-dir](#cli_diagnostic_dir_directory) command-line option.
 
 ### `--report-compact`
-
 <!-- YAML
 added:
  - v13.12.0
@@ -832,7 +772,6 @@ by log processing systems than the default multi-line format designed for
 human consumption.
 
 ### `--report-dir=directory`, `report-directory=directory`
-
 <!-- YAML
 added: v11.8.0
 changes:
@@ -850,7 +789,6 @@ changes:
 Location at which the report will be generated.
 
 ### `--report-filename=filename`
-
 <!-- YAML
 added: v11.8.0
 changes:
@@ -868,7 +806,6 @@ changes:
 Name of the file to which the report will be written.
 
 ### `--report-on-fatalerror`
-
 <!-- YAML
 added: v11.8.0
 changes:
@@ -891,7 +828,6 @@ stack, event loop state, resource consumption etc. to reason about the fatal
 error.
 
 ### `--report-on-signal`
-
 <!-- YAML
 added: v11.8.0
 changes:
@@ -911,7 +847,6 @@ signal to the running Node.js process. The signal to trigger the report is
 specified through `--report-signal`.
 
 ### `--report-signal=signal`
-
 <!-- YAML
 added: v11.8.0
 changes:
@@ -930,7 +865,6 @@ Sets or resets the signal for report generation (not supported on Windows).
 Default signal is `SIGUSR2`.
 
 ### `--report-uncaught-exception`
-
 <!-- YAML
 added: v11.8.0
 changes:
@@ -950,7 +884,6 @@ the JavaScript stack in conjunction with native stack and other runtime
 environment data.
 
 ### `--secure-heap=n`
-
 <!-- YAML
 added: v15.6.0
 -->
@@ -975,7 +908,6 @@ The secure heap is not available on Windows.
 See [`CRYPTO_secure_malloc_init`][] for more details.
 
 ### `--secure-heap-min=n`
-
 <!-- YAML
 added: v15.6.0
 -->
@@ -986,7 +918,6 @@ The maximum value is the lesser of `--secure-heap` or `2147483647`.
 The value given must be a power of two.
 
 ### `--throw-deprecation`
-
 <!-- YAML
 added: v0.11.14
 -->
@@ -994,7 +925,6 @@ added: v0.11.14
 Throw errors for deprecations.
 
 ### `--title=title`
-
 <!-- YAML
 added: v10.7.0
 -->
@@ -1002,7 +932,6 @@ added: v10.7.0
 Set `process.title` on startup.
 
 ### `--tls-cipher-list=list`
-
 <!-- YAML
 added: v4.0.0
 -->
@@ -1011,7 +940,6 @@ Specify an alternative default TLS cipher list. Requires Node.js to be built
 with crypto support (default).
 
 ### `--tls-keylog=file`
-
 <!-- YAML
 added:
  - v13.2.0
@@ -1023,7 +951,6 @@ format and can be used by software (such as Wireshark) to decrypt the TLS
 traffic.
 
 ### `--tls-max-v1.2`
-
 <!-- YAML
 added:
  - v12.0.0
@@ -1034,7 +961,6 @@ Set [`tls.DEFAULT_MAX_VERSION`][] to 'TLSv1.2'. Use to disable support for
 TLSv1.3.
 
 ### `--tls-max-v1.3`
-
 <!-- YAML
 added: v12.0.0
 -->
@@ -1043,7 +969,6 @@ Set default [`tls.DEFAULT_MAX_VERSION`][] to 'TLSv1.3'. Use to enable support
 for TLSv1.3.
 
 ### `--tls-min-v1.0`
-
 <!-- YAML
 added:
  - v12.0.0
@@ -1054,7 +979,6 @@ Set default [`tls.DEFAULT_MIN_VERSION`][] to 'TLSv1'. Use for compatibility with
 old TLS clients or servers.
 
 ### `--tls-min-v1.1`
-
 <!-- YAML
 added:
  - v12.0.0
@@ -1065,7 +989,6 @@ Set default [`tls.DEFAULT_MIN_VERSION`][] to 'TLSv1.1'. Use for compatibility
 with old TLS clients or servers.
 
 ### `--tls-min-v1.2`
-
 <!-- YAML
 added:
  - v12.2.0
@@ -1077,7 +1000,6 @@ Set default [`tls.DEFAULT_MIN_VERSION`][] to 'TLSv1.2'. This is the default for
 versions.
 
 ### `--tls-min-v1.3`
-
 <!-- YAML
 added: v12.0.0
 -->
@@ -1086,7 +1008,6 @@ Set default [`tls.DEFAULT_MIN_VERSION`][] to 'TLSv1.3'. Use to disable support
 for TLSv1.2, which is not as secure as TLSv1.3.
 
 ### `--trace-atomics-wait`
-
 <!-- YAML
 added: v14.3.0
 -->
@@ -1114,7 +1035,6 @@ The fields here correspond to:
 * The timeout passed to `Atomics.wait`
 
 ### `--trace-deprecation`
-
 <!-- YAML
 added: v0.8.0
 -->
@@ -1122,7 +1042,6 @@ added: v0.8.0
 Print stack traces for deprecations.
 
 ### `--trace-event-categories`
-
 <!-- YAML
 added: v7.7.0
 -->
@@ -1131,7 +1050,6 @@ A comma separated list of categories that should be traced when trace event
 tracing is enabled using `--trace-events-enabled`.
 
 ### `--trace-event-file-pattern`
-
 <!-- YAML
 added: v9.8.0
 -->
@@ -1140,7 +1058,6 @@ Template string specifying the filepath for the trace event data, it
 supports `${rotation}` and `${pid}`.
 
 ### `--trace-events-enabled`
-
 <!-- YAML
 added: v7.7.0
 -->
@@ -1148,7 +1065,6 @@ added: v7.7.0
 Enables the collection of trace event tracing information.
 
 ### `--trace-exit`
-
 <!-- YAML
 added:
  - v13.5.0
@@ -1159,7 +1075,6 @@ Prints a stack trace whenever an environment is exited proactively,
 i.e. invoking `process.exit()`.
 
 ### `--trace-sigint`
-
 <!-- YAML
 added:
  - v13.9.0
@@ -1169,7 +1084,6 @@ added:
 Prints a stack trace on SIGINT.
 
 ### `--trace-sync-io`
-
 <!-- YAML
 added: v2.1.0
 -->
@@ -1178,7 +1092,6 @@ Prints a stack trace whenever synchronous I/O is detected after the first turn
 of the event loop.
 
 ### `--trace-tls`
-
 <!-- YAML
 added: v12.2.0
 -->
@@ -1187,7 +1100,6 @@ Prints TLS packet trace information to `stderr`. This can be used to debug TLS
 connection problems.
 
 ### `--trace-uncaught`
-
 <!-- YAML
 added: v13.1.0
 -->
@@ -1200,7 +1112,6 @@ to be an `Error` instance).
 Enabling this option may affect garbage collection behavior negatively.
 
 ### `--trace-warnings`
-
 <!-- YAML
 added: v6.0.0
 -->
@@ -1208,7 +1119,6 @@ added: v6.0.0
 Print stack traces for process warnings (including deprecations).
 
 ### `--track-heap-objects`
-
 <!-- YAML
 added: v2.4.0
 -->
@@ -1216,7 +1126,6 @@ added: v2.4.0
 Track heap object allocations for heap snapshots.
 
 ### `--unhandled-rejections=mode`
-
 <!-- YAML
 added:
   - v12.0.0
@@ -1241,7 +1150,6 @@ occurs. One of the following modes can be chosen:
 * `none`: Silence all warnings.
 
 ### `--use-bundled-ca`, `--use-openssl-ca`
-
 <!-- YAML
 added: v6.11.0
 -->
@@ -1262,7 +1170,6 @@ environment variables.
 See `SSL_CERT_DIR` and `SSL_CERT_FILE`.
 
 ### `--use-largepages=mode`
-
 <!-- YAML
 added:
  - v13.6.0
@@ -1274,7 +1181,6 @@ the target system, this will cause the Node.js static code to be moved onto 2
 MiB pages instead of 4 KiB pages.
 
 The following values are valid for `mode`:
-
 * `off`: No mapping will be attempted. This is the default.
 * `on`: If supported by the OS, mapping will be attempted. Failure to map will
   be ignored and a message will be printed to standard error.
@@ -1282,7 +1188,6 @@ The following values are valid for `mode`:
   will be ignored and will not be reported.
 
 ### `--v8-options`
-
 <!-- YAML
 added: v0.1.3
 -->
@@ -1290,7 +1195,6 @@ added: v0.1.3
 Print V8 command-line options.
 
 ### `--v8-pool-size=num`
-
 <!-- YAML
 added: v5.10.0
 -->
@@ -1304,7 +1208,6 @@ If the value provided is larger than V8's maximum, then the largest value
 will be chosen.
 
 ### `--zero-fill-buffers`
-
 <!-- YAML
 added: v6.0.0
 -->
@@ -1313,7 +1216,6 @@ Automatically zero-fills all newly allocated [`Buffer`][] and [`SlowBuffer`][]
 instances.
 
 ### `-c`, `--check`
-
 <!-- YAML
 added:
   - v5.0.0
@@ -1327,7 +1229,6 @@ changes:
 Syntax check the script without executing.
 
 ### `-e`, `--eval "script"`
-
 <!-- YAML
 added: v0.5.2
 changes:
@@ -1344,7 +1245,6 @@ only recognizes double `"` for quoting. In Powershell or Git bash, both `'`
 and `"` are usable.
 
 ### `-h`, `--help`
-
 <!-- YAML
 added: v0.1.3
 -->
@@ -1353,7 +1253,6 @@ Print node command-line options.
 The output of this option is less detailed than this document.
 
 ### `-i`, `--interactive`
-
 <!-- YAML
 added: v0.7.7
 -->
@@ -1361,7 +1260,6 @@ added: v0.7.7
 Opens the REPL even if stdin does not appear to be a terminal.
 
 ### `-p`, `--print "script"`
-
 <!-- YAML
 added: v0.6.4
 changes:
@@ -1373,7 +1271,6 @@ changes:
 Identical to `-e` but prints the result.
 
 ### `-r`, `--require module`
-
 <!-- YAML
 added: v1.6.0
 -->
@@ -1387,7 +1284,6 @@ Only CommonJS modules are supported. Attempting to preload a
 ES6 Module using `--require` will fail with an error.
 
 ### `-v`, `--version`
-
 <!-- YAML
 added: v0.1.3
 -->
@@ -1409,9 +1305,7 @@ When `FORCE_COLOR` is used and set to a supported value, both the `NO_COLOR`,
 and `NODE_DISABLE_COLORS` environment variables are ignored.
 
 Any other value will result in colorized output being disabled.
-
 ### `NODE_DEBUG=module[,…]`
-
 <!-- YAML
 added: v0.1.32
 -->
@@ -1423,7 +1317,6 @@ added: v0.1.32
 `','`-separated list of core C++ modules that should print debug information.
 
 ### `NODE_DISABLE_COLORS=1`
-
 <!-- YAML
 added: v0.3.0
 -->
@@ -1431,7 +1324,6 @@ added: v0.3.0
 When set, colors will not be used in the REPL.
 
 ### `NODE_EXTRA_CA_CERTS=file`
-
 <!-- YAML
 added: v7.3.0
 -->
@@ -1453,7 +1345,6 @@ process is first launched. Changing the value at runtime using
 `process.env.NODE_EXTRA_CA_CERTS` has no effect on the current process.
 
 ### `NODE_ICU_DATA=file`
-
 <!-- YAML
 added: v0.11.15
 -->
@@ -1462,7 +1353,6 @@ Data path for ICU (`Intl` object) data. Will extend linked-in data when compiled
 with small-icu support.
 
 ### `NODE_NO_WARNINGS=1`
-
 <!-- YAML
 added: v6.11.0
 -->
@@ -1470,7 +1360,6 @@ added: v6.11.0
 When set to `1`, process warnings are silenced.
 
 ### `NODE_OPTIONS=options...`
-
 <!-- YAML
 added: v8.0.0
 -->
@@ -1543,7 +1432,6 @@ Node.js options that are allowed are:
 * `--no-experimental-repl-await`
 * `--no-force-async-hooks-checks`
 * `--no-warnings`
-* `--no-worker-extension-check`
 * `--node-memory-debug`
 * `--openssl-config`
 * `--pending-deprecation`
@@ -1611,7 +1499,6 @@ V8 options that are allowed are:
 `--perf-prof-unwinding-info`, and `--perf-prof` are only available on Linux.
 
 ### `NODE_PATH=path[:…]`
-
 <!-- YAML
 added: v0.1.32
 -->
@@ -1621,7 +1508,6 @@ added: v0.1.32
 On Windows, this is a `';'`-separated list instead.
 
 ### `NODE_PENDING_DEPRECATION=1`
-
 <!-- YAML
 added: v8.0.0
 -->
@@ -1641,7 +1527,6 @@ Set the number of pending pipe instance handles when the pipe server is waiting
 for connections. This setting applies to Windows only.
 
 ### `NODE_PRESERVE_SYMLINKS=1`
-
 <!-- YAML
 added: v7.1.0
 -->
@@ -1650,7 +1535,6 @@ When set to `1`, instructs the module loader to preserve symbolic links when
 resolving and caching modules.
 
 ### `NODE_REDIRECT_WARNINGS=file`
-
 <!-- YAML
 added: v8.0.0
 -->
@@ -1662,7 +1546,6 @@ warning to the file, the warning will be written to stderr instead. This is
 equivalent to using the `--redirect-warnings=file` command-line flag.
 
 ### `NODE_REPL_HISTORY=file`
-
 <!-- YAML
 added: v3.0.0
 -->
@@ -1672,7 +1555,6 @@ Path to the file used to store the persistent REPL history. The default path is
 to an empty string (`''` or `' '`) disables persistent REPL history.
 
 ### `NODE_REPL_EXTERNAL_MODULE=file`
-
 <!-- YAML
 added:
  - v13.0.0
@@ -1683,7 +1565,6 @@ Path to a Node.js module which will be loaded in place of the built-in REPL.
 Overriding this value to an empty string (`''`) will use the built-in REPL.
 
 ### `NODE_SKIP_PLATFORM_CHECK=value`
-
 <!-- YAML
 added: v14.5.0
 -->
@@ -1780,7 +1661,6 @@ and the line lengths of the source file (in the key `lineLengths`).
 environment variable is arbitrary.
 
 ### `OPENSSL_CONF=file`
-
 <!-- YAML
 added: v6.11.0
 -->
@@ -1793,7 +1673,6 @@ If the [`--openssl-config`][] command-line option is used, the environment
 variable is ignored.
 
 ### `SSL_CERT_DIR=dir`
-
 <!-- YAML
 added: v7.7.0
 -->
@@ -1806,7 +1685,6 @@ variable will be inherited by any child processes, and if they use OpenSSL, it
 may cause them to trust the same CAs as node.
 
 ### `SSL_CERT_FILE=file`
-
 <!-- YAML
 added: v7.7.0
 -->
@@ -1819,7 +1697,6 @@ variable will be inherited by any child processes, and if they use OpenSSL, it
 may cause them to trust the same CAs as node.
 
 ### `TZ`
-
 <!-- YAML
 added: v0.0.1
 changes:
@@ -1894,7 +1771,7 @@ On a machine with 2 GB of memory, consider setting this to
 1536 (1.5 GB) to leave some memory for other uses and avoid swapping.
 
 ```console
-node --max-old-space-size=1536 index.js
+$ node --max-old-space-size=1536 index.js
 ```
 
 [Chrome DevTools Protocol]: https://chromedevtools.github.io/devtools-protocol/

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -21,6 +21,7 @@ Execute without arguments to start the [REPL][].
 For more info about `node inspect`, see the [debugger][] documentation.
 
 ## Options
+
 <!-- YAML
 changes:
   - version: v10.12.0
@@ -39,6 +40,7 @@ command line take precedence over options passed through the [`NODE_OPTIONS`][]
 environment variable.
 
 ### `-`
+
 <!-- YAML
 added: v8.0.0
 -->
@@ -48,6 +50,7 @@ meaning that the script is read from stdin, and the rest of the options
 are passed to that script.
 
 ### `--`
+
 <!-- YAML
 added: v6.11.0
 -->
@@ -57,6 +60,7 @@ If no script filename or eval/print script is supplied prior to this, then
 the next argument is used as a script filename.
 
 ### `--abort-on-uncaught-exception`
+
 <!-- YAML
 added: v0.10.8
 -->
@@ -69,6 +73,7 @@ If this flag is passed, the behavior can still be set to not abort through
 `domain` module that uses it).
 
 ### `--completion-bash`
+
 <!-- YAML
 added: v10.12.0
 -->
@@ -76,11 +81,12 @@ added: v10.12.0
 Print source-able bash completion script for Node.js.
 
 ```console
-$ node --completion-bash > node_bash_completion
-$ source node_bash_completion
+node --completion-bash > node_bash_completion
+source node_bash_completion
 ```
 
 ### `-C=condition`, `--conditions=condition`
+
 <!-- YAML
 added:
   - v14.9.0
@@ -100,10 +106,11 @@ The default Node.js conditions of `"node"`, `"default"`, `"import"`, and
 For example, to run a module with "development" resolutions:
 
 ```console
-$ node -C=development app.js
+node -C=development app.js
 ```
 
 ### `--cpu-prof`
+
 <!-- YAML
 added: v12.0.0
 -->
@@ -126,6 +133,7 @@ CPU.20190409.202950.15293.0.0.cpuprofile
 ```
 
 ### `--cpu-prof-dir`
+
 <!-- YAML
 added: v12.0.0
 -->
@@ -139,6 +147,7 @@ The default value is controlled by the
 [--diagnostic-dir](#cli_diagnostic_dir_directory) command-line option.
 
 ### `--cpu-prof-interval`
+
 <!-- YAML
 added: v12.2.0
 -->
@@ -149,6 +158,7 @@ Specify the sampling interval in microseconds for the CPU profiles generated
 by `--cpu-prof`. The default is 1000 microseconds.
 
 ### `--cpu-prof-name`
+
 <!-- YAML
 added: v12.0.0
 -->
@@ -163,11 +173,13 @@ Set the directory to which all diagnostic output files are written.
 Defaults to current working directory.
 
 Affects the default output directory of:
+
 * [--cpu-prof-dir](#cli_cpu_prof_dir)
 * [--heap-prof-dir](#cli_heap_prof_dir)
 * [--redirect-warnings](#cli_redirect_warnings_file)
 
 ### `--disable-proto=mode`
+
 <!-- YAML
 added:
  - v13.12.0
@@ -179,6 +191,7 @@ property is removed entirely. If `mode` is `throw`, accesses to the
 property throw an exception with the code `ERR_PROTO_ACCESS`.
 
 ### `--disallow-code-generation-from-strings`
+
 <!-- YAML
 added: v9.8.0
 -->
@@ -188,12 +201,14 @@ code from strings throw an exception instead. This does not affect the Node.js
 `vm` module.
 
 ### `--dns-result-order=order`
+
 <!-- YAML
 added: v16.4.0
 -->
 
 Set the default value of `verbatim` in [`dns.lookup()`][] and
 [`dnsPromises.lookup()`][]. The value could be:
+
 * `ipv4first`: sets default `verbatim` `false`.
 * `verbatim`: sets default `verbatim` `true`.
 
@@ -201,6 +216,7 @@ The default is `ipv4first` and [`dns.setDefaultResultOrder()`][] have higher
 priority than `--dns-result-order`.
 
 ### `--enable-fips`
+
 <!-- YAML
 added: v6.0.0
 -->
@@ -209,6 +225,7 @@ Enable FIPS-compliant crypto at startup. (Requires Node.js to be built
 against FIPS-compatible OpenSSL.)
 
 ### `--enable-source-maps`
+
 <!-- YAML
 added: v12.12.0
 changes:
@@ -228,6 +245,7 @@ Overriding `Error.prepareStackTrace` prevents `--enable-source-maps` from
 modifying the stack trace.
 
 ### `--experimental-abortcontroller`
+
 <!-- YAML
 added:
   - v15.0.0
@@ -242,6 +260,7 @@ changes:
 Use of this command-line flag is no longer required.
 
 ### `--experimental-import-meta-resolve`
+
 <!-- YAML
 added:
   - v13.9.0
@@ -251,6 +270,7 @@ added:
 Enable experimental `import.meta.resolve()` support.
 
 ### `--experimental-json-modules`
+
 <!-- YAML
 added: v12.9.0
 -->
@@ -258,6 +278,7 @@ added: v12.9.0
 Enable experimental JSON support for the ES Module loader.
 
 ### `--experimental-loader=module`
+
 <!-- YAML
 added: v9.0.0
 -->
@@ -266,6 +287,7 @@ Specify the `module` of a custom experimental [ECMAScript Module loader][].
 `module` may be either a path to a file, or an ECMAScript Module name.
 
 ### `--experimental-modules`
+
 <!-- YAML
 added: v8.5.0
 -->
@@ -273,6 +295,7 @@ added: v8.5.0
 Enable latest experimental modules features (deprecated).
 
 ### `--experimental-policy`
+
 <!-- YAML
 added: v11.8.0
 -->
@@ -280,12 +303,14 @@ added: v11.8.0
 Use the specified file as a security policy.
 
 ### `--no-experimental-repl-await`
+
 <!-- YAML
 added: v16.6.0
  -->
  Use this flag to disable top-level await in REPL.
 
 ### `--experimental-specifier-resolution=mode`
+
 <!-- YAML
 added:
  - v13.4.0
@@ -302,6 +327,7 @@ the ability to import a directory that has an index file.
 See [customizing ESM specifier resolution][] for example usage.
 
 ### `--experimental-vm-modules`
+
 <!-- YAML
 added: v9.6.0
 -->
@@ -309,6 +335,7 @@ added: v9.6.0
 Enable experimental ES Module support in the `vm` module.
 
 ### `--experimental-wasi-unstable-preview1`
+
 <!-- YAML
 added:
   - v13.3.0
@@ -323,6 +350,7 @@ changes:
 Enable experimental WebAssembly System Interface (WASI) support.
 
 ### `--experimental-wasm-modules`
+
 <!-- YAML
 added: v12.3.0
 -->
@@ -330,6 +358,7 @@ added: v12.3.0
 Enable experimental WebAssembly module support.
 
 ### `--force-context-aware`
+
 <!-- YAML
 added: v12.12.0
 -->
@@ -337,6 +366,7 @@ added: v12.12.0
 Disable loading native addons that are not [context-aware][].
 
 ### `--force-fips`
+
 <!-- YAML
 added: v6.0.0
 -->
@@ -345,6 +375,7 @@ Force FIPS-compliant crypto on startup. (Cannot be disabled from script code.)
 (Same requirements as `--enable-fips`.)
 
 ### `--frozen-intrinsics`
+
 <!-- YAML
 added: v11.12.0
 -->
@@ -361,6 +392,7 @@ reference. Code may break under this flag.
 be added.
 
 ### `--heapsnapshot-near-heap-limit=max_count`
+
 <!-- YAML
 added: v15.1.0
 -->
@@ -407,6 +439,7 @@ FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaS
 ```
 
 ### `--heapsnapshot-signal=signal`
+
 <!-- YAML
 added: v12.0.0
 -->
@@ -426,6 +459,7 @@ Heap.20190718.133405.15554.0.001.heapsnapshot
 ```
 
 ### `--heap-prof`
+
 <!-- YAML
 added: v12.4.0
 -->
@@ -448,6 +482,7 @@ Heap.20190409.202950.15293.0.001.heapprofile
 ```
 
 ### `--heap-prof-dir`
+
 <!-- YAML
 added: v12.4.0
 -->
@@ -461,6 +496,7 @@ The default value is controlled by the
 [--diagnostic-dir](#cli_diagnostic_dir_directory) command-line option.
 
 ### `--heap-prof-interval`
+
 <!-- YAML
 added: v12.4.0
 -->
@@ -471,6 +507,7 @@ Specify the average sampling interval in bytes for the heap profiles generated
 by `--heap-prof`. The default is 512 * 1024 bytes.
 
 ### `--heap-prof-name`
+
 <!-- YAML
 added: v12.4.0
 -->
@@ -480,6 +517,7 @@ added: v12.4.0
 Specify the file name of the heap profile generated by `--heap-prof`.
 
 ### `--icu-data-dir=file`
+
 <!-- YAML
 added: v0.11.15
 -->
@@ -487,6 +525,7 @@ added: v0.11.15
 Specify ICU data load path. (Overrides `NODE_ICU_DATA`.)
 
 ### `--input-type=type`
+
 <!-- YAML
 added: v12.0.0
 -->
@@ -497,6 +536,7 @@ module. String input is input via `--eval`, `--print`, or `STDIN`.
 Valid values are `"commonjs"` and `"module"`. The default is `"commonjs"`.
 
 ### `--inspect-brk[=[host:]port]`
+
 <!-- YAML
 added: v7.6.0
 -->
@@ -505,6 +545,7 @@ Activate inspector on `host:port` and break at start of user script.
 Default `host:port` is `127.0.0.1:9229`.
 
 ### `--inspect-port=[host:]port`
+
 <!-- YAML
 added: v7.6.0
 -->
@@ -518,6 +559,7 @@ See the [security warning](#inspector_security) below regarding the `host`
 parameter usage.
 
 ### `--inspect[=[host:]port]`
+
 <!-- YAML
 added: v6.3.0
 -->
@@ -529,6 +571,7 @@ and profile Node.js instances. The tools attach to Node.js instances via a
 tcp port and communicate using the [Chrome DevTools Protocol][].
 
 <a id="inspector_security"></a>
+
 #### Warning: binding inspector to a public IP:port combination is insecure
 
 Binding the inspector to a public IP (including `0.0.0.0`) with an open port is
@@ -553,6 +596,7 @@ By default inspector websocket url is available in stderr and under `/json/list`
 endpoint on `http://host:port/json/list`.
 
 ### `--insecure-http-parser`
+
 <!-- YAML
 added:
  - v13.4.0
@@ -566,6 +610,7 @@ request smuggling and other HTTP attacks that rely on invalid headers being
 accepted. Avoid using this option.
 
 ### `--jitless`
+
 <!-- YAML
 added: v12.0.0
 -->
@@ -578,6 +623,7 @@ This flag is inherited from V8 and is subject to change upstream. It may
 disappear in a non-semver-major release.
 
 ### `--max-http-header-size=size`
+
 <!-- YAML
 added:
  - v11.6.0
@@ -591,6 +637,7 @@ changes:
 Specify the maximum size, in bytes, of HTTP headers. Defaults to 16 KB.
 
 ### `--napi-modules`
+
 <!-- YAML
 added: v7.10.0
 -->
@@ -598,6 +645,7 @@ added: v7.10.0
 This option is a no-op. It is kept for compatibility.
 
 ### `--no-deprecation`
+
 <!-- YAML
 added: v0.8.0
 -->
@@ -605,6 +653,7 @@ added: v0.8.0
 Silence deprecation warnings.
 
 ### `--no-force-async-hooks-checks`
+
 <!-- YAML
 added: v9.0.0
 -->
@@ -613,13 +662,23 @@ Disables runtime checks for `async_hooks`. These will still be enabled
 dynamically when `async_hooks` is enabled.
 
 ### `--no-warnings`
+
 <!-- YAML
 added: v6.0.0
 -->
 
 Silence all process warnings (including deprecations).
 
+### `--no-worker-extension-check`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+Disable runtime file extension check for worker.
+
 ### `--node-memory-debug`
+
 <!-- YAML
 added: v15.0.0
 -->
@@ -628,6 +687,7 @@ Enable extra debug checks for memory leaks in Node.js internals. This is
 usually only useful for developers debugging Node.js itself.
 
 ### `--openssl-config=file`
+
 <!-- YAML
 added: v6.9.0
 -->
@@ -637,6 +697,7 @@ used to enable FIPS-compliant crypto if Node.js is built
 against FIPS-enabled OpenSSL.
 
 ### `--pending-deprecation`
+
 <!-- YAML
 added: v8.0.0
 -->
@@ -651,6 +712,7 @@ are used to provide a kind of selective "early warning" mechanism that
 developers may leverage to detect deprecated API usage.
 
 ### `--policy-integrity=sri`
+
 <!-- YAML
 added: v12.7.0
 -->
@@ -662,6 +724,7 @@ the specified integrity. It expects a [Subresource Integrity][] string as a
 parameter.
 
 ### `--preserve-symlinks`
+
 <!-- YAML
 added: v6.3.0
 -->
@@ -706,6 +769,7 @@ The `--preserve-symlinks` flag does not apply to the main module, which allows
 behavior for the main module, also use `--preserve-symlinks-main`.
 
 ### `--preserve-symlinks-main`
+
 <!-- YAML
 added: v10.2.0
 -->
@@ -725,6 +789,7 @@ resolving relative paths.
 See `--preserve-symlinks` for more information.
 
 ### `--prof`
+
 <!-- YAML
 added: v2.0.0
 -->
@@ -732,6 +797,7 @@ added: v2.0.0
 Generate V8 profiler output.
 
 ### `--prof-process`
+
 <!-- YAML
 added: v5.2.0
 -->
@@ -739,6 +805,7 @@ added: v5.2.0
 Process V8 profiler output generated using the V8 option `--prof`.
 
 ### `--redirect-warnings=file`
+
 <!-- YAML
 added: v8.0.0
 -->
@@ -753,6 +820,7 @@ will be written to is controlled by the
 [--diagnostic-dir](#cli_diagnostic_dir_directory) command-line option.
 
 ### `--report-compact`
+
 <!-- YAML
 added:
  - v13.12.0
@@ -764,6 +832,7 @@ by log processing systems than the default multi-line format designed for
 human consumption.
 
 ### `--report-dir=directory`, `report-directory=directory`
+
 <!-- YAML
 added: v11.8.0
 changes:
@@ -781,6 +850,7 @@ changes:
 Location at which the report will be generated.
 
 ### `--report-filename=filename`
+
 <!-- YAML
 added: v11.8.0
 changes:
@@ -798,6 +868,7 @@ changes:
 Name of the file to which the report will be written.
 
 ### `--report-on-fatalerror`
+
 <!-- YAML
 added: v11.8.0
 changes:
@@ -820,6 +891,7 @@ stack, event loop state, resource consumption etc. to reason about the fatal
 error.
 
 ### `--report-on-signal`
+
 <!-- YAML
 added: v11.8.0
 changes:
@@ -839,6 +911,7 @@ signal to the running Node.js process. The signal to trigger the report is
 specified through `--report-signal`.
 
 ### `--report-signal=signal`
+
 <!-- YAML
 added: v11.8.0
 changes:
@@ -857,6 +930,7 @@ Sets or resets the signal for report generation (not supported on Windows).
 Default signal is `SIGUSR2`.
 
 ### `--report-uncaught-exception`
+
 <!-- YAML
 added: v11.8.0
 changes:
@@ -876,6 +950,7 @@ the JavaScript stack in conjunction with native stack and other runtime
 environment data.
 
 ### `--secure-heap=n`
+
 <!-- YAML
 added: v15.6.0
 -->
@@ -900,6 +975,7 @@ The secure heap is not available on Windows.
 See [`CRYPTO_secure_malloc_init`][] for more details.
 
 ### `--secure-heap-min=n`
+
 <!-- YAML
 added: v15.6.0
 -->
@@ -910,6 +986,7 @@ The maximum value is the lesser of `--secure-heap` or `2147483647`.
 The value given must be a power of two.
 
 ### `--throw-deprecation`
+
 <!-- YAML
 added: v0.11.14
 -->
@@ -917,6 +994,7 @@ added: v0.11.14
 Throw errors for deprecations.
 
 ### `--title=title`
+
 <!-- YAML
 added: v10.7.0
 -->
@@ -924,6 +1002,7 @@ added: v10.7.0
 Set `process.title` on startup.
 
 ### `--tls-cipher-list=list`
+
 <!-- YAML
 added: v4.0.0
 -->
@@ -932,6 +1011,7 @@ Specify an alternative default TLS cipher list. Requires Node.js to be built
 with crypto support (default).
 
 ### `--tls-keylog=file`
+
 <!-- YAML
 added:
  - v13.2.0
@@ -943,6 +1023,7 @@ format and can be used by software (such as Wireshark) to decrypt the TLS
 traffic.
 
 ### `--tls-max-v1.2`
+
 <!-- YAML
 added:
  - v12.0.0
@@ -953,6 +1034,7 @@ Set [`tls.DEFAULT_MAX_VERSION`][] to 'TLSv1.2'. Use to disable support for
 TLSv1.3.
 
 ### `--tls-max-v1.3`
+
 <!-- YAML
 added: v12.0.0
 -->
@@ -961,6 +1043,7 @@ Set default [`tls.DEFAULT_MAX_VERSION`][] to 'TLSv1.3'. Use to enable support
 for TLSv1.3.
 
 ### `--tls-min-v1.0`
+
 <!-- YAML
 added:
  - v12.0.0
@@ -971,6 +1054,7 @@ Set default [`tls.DEFAULT_MIN_VERSION`][] to 'TLSv1'. Use for compatibility with
 old TLS clients or servers.
 
 ### `--tls-min-v1.1`
+
 <!-- YAML
 added:
  - v12.0.0
@@ -981,6 +1065,7 @@ Set default [`tls.DEFAULT_MIN_VERSION`][] to 'TLSv1.1'. Use for compatibility
 with old TLS clients or servers.
 
 ### `--tls-min-v1.2`
+
 <!-- YAML
 added:
  - v12.2.0
@@ -992,6 +1077,7 @@ Set default [`tls.DEFAULT_MIN_VERSION`][] to 'TLSv1.2'. This is the default for
 versions.
 
 ### `--tls-min-v1.3`
+
 <!-- YAML
 added: v12.0.0
 -->
@@ -1000,6 +1086,7 @@ Set default [`tls.DEFAULT_MIN_VERSION`][] to 'TLSv1.3'. Use to disable support
 for TLSv1.2, which is not as secure as TLSv1.3.
 
 ### `--trace-atomics-wait`
+
 <!-- YAML
 added: v14.3.0
 -->
@@ -1027,6 +1114,7 @@ The fields here correspond to:
 * The timeout passed to `Atomics.wait`
 
 ### `--trace-deprecation`
+
 <!-- YAML
 added: v0.8.0
 -->
@@ -1034,6 +1122,7 @@ added: v0.8.0
 Print stack traces for deprecations.
 
 ### `--trace-event-categories`
+
 <!-- YAML
 added: v7.7.0
 -->
@@ -1042,6 +1131,7 @@ A comma separated list of categories that should be traced when trace event
 tracing is enabled using `--trace-events-enabled`.
 
 ### `--trace-event-file-pattern`
+
 <!-- YAML
 added: v9.8.0
 -->
@@ -1050,6 +1140,7 @@ Template string specifying the filepath for the trace event data, it
 supports `${rotation}` and `${pid}`.
 
 ### `--trace-events-enabled`
+
 <!-- YAML
 added: v7.7.0
 -->
@@ -1057,6 +1148,7 @@ added: v7.7.0
 Enables the collection of trace event tracing information.
 
 ### `--trace-exit`
+
 <!-- YAML
 added:
  - v13.5.0
@@ -1067,6 +1159,7 @@ Prints a stack trace whenever an environment is exited proactively,
 i.e. invoking `process.exit()`.
 
 ### `--trace-sigint`
+
 <!-- YAML
 added:
  - v13.9.0
@@ -1076,6 +1169,7 @@ added:
 Prints a stack trace on SIGINT.
 
 ### `--trace-sync-io`
+
 <!-- YAML
 added: v2.1.0
 -->
@@ -1084,6 +1178,7 @@ Prints a stack trace whenever synchronous I/O is detected after the first turn
 of the event loop.
 
 ### `--trace-tls`
+
 <!-- YAML
 added: v12.2.0
 -->
@@ -1092,6 +1187,7 @@ Prints TLS packet trace information to `stderr`. This can be used to debug TLS
 connection problems.
 
 ### `--trace-uncaught`
+
 <!-- YAML
 added: v13.1.0
 -->
@@ -1104,6 +1200,7 @@ to be an `Error` instance).
 Enabling this option may affect garbage collection behavior negatively.
 
 ### `--trace-warnings`
+
 <!-- YAML
 added: v6.0.0
 -->
@@ -1111,6 +1208,7 @@ added: v6.0.0
 Print stack traces for process warnings (including deprecations).
 
 ### `--track-heap-objects`
+
 <!-- YAML
 added: v2.4.0
 -->
@@ -1118,6 +1216,7 @@ added: v2.4.0
 Track heap object allocations for heap snapshots.
 
 ### `--unhandled-rejections=mode`
+
 <!-- YAML
 added:
   - v12.0.0
@@ -1142,6 +1241,7 @@ occurs. One of the following modes can be chosen:
 * `none`: Silence all warnings.
 
 ### `--use-bundled-ca`, `--use-openssl-ca`
+
 <!-- YAML
 added: v6.11.0
 -->
@@ -1162,6 +1262,7 @@ environment variables.
 See `SSL_CERT_DIR` and `SSL_CERT_FILE`.
 
 ### `--use-largepages=mode`
+
 <!-- YAML
 added:
  - v13.6.0
@@ -1173,6 +1274,7 @@ the target system, this will cause the Node.js static code to be moved onto 2
 MiB pages instead of 4 KiB pages.
 
 The following values are valid for `mode`:
+
 * `off`: No mapping will be attempted. This is the default.
 * `on`: If supported by the OS, mapping will be attempted. Failure to map will
   be ignored and a message will be printed to standard error.
@@ -1180,6 +1282,7 @@ The following values are valid for `mode`:
   will be ignored and will not be reported.
 
 ### `--v8-options`
+
 <!-- YAML
 added: v0.1.3
 -->
@@ -1187,6 +1290,7 @@ added: v0.1.3
 Print V8 command-line options.
 
 ### `--v8-pool-size=num`
+
 <!-- YAML
 added: v5.10.0
 -->
@@ -1200,6 +1304,7 @@ If the value provided is larger than V8's maximum, then the largest value
 will be chosen.
 
 ### `--zero-fill-buffers`
+
 <!-- YAML
 added: v6.0.0
 -->
@@ -1208,6 +1313,7 @@ Automatically zero-fills all newly allocated [`Buffer`][] and [`SlowBuffer`][]
 instances.
 
 ### `-c`, `--check`
+
 <!-- YAML
 added:
   - v5.0.0
@@ -1221,6 +1327,7 @@ changes:
 Syntax check the script without executing.
 
 ### `-e`, `--eval "script"`
+
 <!-- YAML
 added: v0.5.2
 changes:
@@ -1237,6 +1344,7 @@ only recognizes double `"` for quoting. In Powershell or Git bash, both `'`
 and `"` are usable.
 
 ### `-h`, `--help`
+
 <!-- YAML
 added: v0.1.3
 -->
@@ -1245,6 +1353,7 @@ Print node command-line options.
 The output of this option is less detailed than this document.
 
 ### `-i`, `--interactive`
+
 <!-- YAML
 added: v0.7.7
 -->
@@ -1252,6 +1361,7 @@ added: v0.7.7
 Opens the REPL even if stdin does not appear to be a terminal.
 
 ### `-p`, `--print "script"`
+
 <!-- YAML
 added: v0.6.4
 changes:
@@ -1263,6 +1373,7 @@ changes:
 Identical to `-e` but prints the result.
 
 ### `-r`, `--require module`
+
 <!-- YAML
 added: v1.6.0
 -->
@@ -1276,6 +1387,7 @@ Only CommonJS modules are supported. Attempting to preload a
 ES6 Module using `--require` will fail with an error.
 
 ### `-v`, `--version`
+
 <!-- YAML
 added: v0.1.3
 -->
@@ -1297,7 +1409,9 @@ When `FORCE_COLOR` is used and set to a supported value, both the `NO_COLOR`,
 and `NODE_DISABLE_COLORS` environment variables are ignored.
 
 Any other value will result in colorized output being disabled.
+
 ### `NODE_DEBUG=module[,…]`
+
 <!-- YAML
 added: v0.1.32
 -->
@@ -1309,6 +1423,7 @@ added: v0.1.32
 `','`-separated list of core C++ modules that should print debug information.
 
 ### `NODE_DISABLE_COLORS=1`
+
 <!-- YAML
 added: v0.3.0
 -->
@@ -1316,6 +1431,7 @@ added: v0.3.0
 When set, colors will not be used in the REPL.
 
 ### `NODE_EXTRA_CA_CERTS=file`
+
 <!-- YAML
 added: v7.3.0
 -->
@@ -1337,6 +1453,7 @@ process is first launched. Changing the value at runtime using
 `process.env.NODE_EXTRA_CA_CERTS` has no effect on the current process.
 
 ### `NODE_ICU_DATA=file`
+
 <!-- YAML
 added: v0.11.15
 -->
@@ -1345,6 +1462,7 @@ Data path for ICU (`Intl` object) data. Will extend linked-in data when compiled
 with small-icu support.
 
 ### `NODE_NO_WARNINGS=1`
+
 <!-- YAML
 added: v6.11.0
 -->
@@ -1352,6 +1470,7 @@ added: v6.11.0
 When set to `1`, process warnings are silenced.
 
 ### `NODE_OPTIONS=options...`
+
 <!-- YAML
 added: v8.0.0
 -->
@@ -1424,6 +1543,7 @@ Node.js options that are allowed are:
 * `--no-experimental-repl-await`
 * `--no-force-async-hooks-checks`
 * `--no-warnings`
+* `--no-worker-extension-check`
 * `--node-memory-debug`
 * `--openssl-config`
 * `--pending-deprecation`
@@ -1491,6 +1611,7 @@ V8 options that are allowed are:
 `--perf-prof-unwinding-info`, and `--perf-prof` are only available on Linux.
 
 ### `NODE_PATH=path[:…]`
+
 <!-- YAML
 added: v0.1.32
 -->
@@ -1500,6 +1621,7 @@ added: v0.1.32
 On Windows, this is a `';'`-separated list instead.
 
 ### `NODE_PENDING_DEPRECATION=1`
+
 <!-- YAML
 added: v8.0.0
 -->
@@ -1519,6 +1641,7 @@ Set the number of pending pipe instance handles when the pipe server is waiting
 for connections. This setting applies to Windows only.
 
 ### `NODE_PRESERVE_SYMLINKS=1`
+
 <!-- YAML
 added: v7.1.0
 -->
@@ -1527,6 +1650,7 @@ When set to `1`, instructs the module loader to preserve symbolic links when
 resolving and caching modules.
 
 ### `NODE_REDIRECT_WARNINGS=file`
+
 <!-- YAML
 added: v8.0.0
 -->
@@ -1538,6 +1662,7 @@ warning to the file, the warning will be written to stderr instead. This is
 equivalent to using the `--redirect-warnings=file` command-line flag.
 
 ### `NODE_REPL_HISTORY=file`
+
 <!-- YAML
 added: v3.0.0
 -->
@@ -1547,6 +1672,7 @@ Path to the file used to store the persistent REPL history. The default path is
 to an empty string (`''` or `' '`) disables persistent REPL history.
 
 ### `NODE_REPL_EXTERNAL_MODULE=file`
+
 <!-- YAML
 added:
  - v13.0.0
@@ -1557,6 +1683,7 @@ Path to a Node.js module which will be loaded in place of the built-in REPL.
 Overriding this value to an empty string (`''`) will use the built-in REPL.
 
 ### `NODE_SKIP_PLATFORM_CHECK=value`
+
 <!-- YAML
 added: v14.5.0
 -->
@@ -1653,6 +1780,7 @@ and the line lengths of the source file (in the key `lineLengths`).
 environment variable is arbitrary.
 
 ### `OPENSSL_CONF=file`
+
 <!-- YAML
 added: v6.11.0
 -->
@@ -1665,6 +1793,7 @@ If the [`--openssl-config`][] command-line option is used, the environment
 variable is ignored.
 
 ### `SSL_CERT_DIR=dir`
+
 <!-- YAML
 added: v7.7.0
 -->
@@ -1677,6 +1806,7 @@ variable will be inherited by any child processes, and if they use OpenSSL, it
 may cause them to trust the same CAs as node.
 
 ### `SSL_CERT_FILE=file`
+
 <!-- YAML
 added: v7.7.0
 -->
@@ -1689,6 +1819,7 @@ variable will be inherited by any child processes, and if they use OpenSSL, it
 may cause them to trust the same CAs as node.
 
 ### `TZ`
+
 <!-- YAML
 added: v0.0.1
 changes:
@@ -1763,7 +1894,7 @@ On a machine with 2 GB of memory, consider setting this to
 1536 (1.5 GB) to leave some memory for other uses and avoid swapping.
 
 ```console
-$ node --max-old-space-size=1536 index.js
+node --max-old-space-size=1536 index.js
 ```
 
 [Chrome DevTools Protocol]: https://chromedevtools.github.io/devtools-protocol/

--- a/doc/node.1
+++ b/doc/node.1
@@ -280,6 +280,9 @@ These will still be enabled dynamically when `async_hooks` is enabled.
 .It Fl -no-warnings
 Silence all process warnings (including deprecations).
 .
+It Fl -no-worker-extension-check
+Disable runtime file extension check for worker.
+.
 .It Fl -node-memory-debug
 Enable extra debug checks for memory leaks in Node.js internals. This is
 usually only useful for developers debugging Node.js itself.

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -169,7 +169,10 @@ class Worker extends EventEmitter {
       }
 
       const ext = path.extname(filename);
-      if (ext !== '.js' && ext !== '.mjs' && ext !== '.cjs') {
+      if (!getOptionValue('--no-worker-extension-check') &&
+        ext !== '.js' &&
+        ext !== '.mjs' &&
+        ext !== '.cjs') {
         throw new ERR_WORKER_UNSUPPORTED_EXTENSION(ext);
       }
     }

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -590,6 +590,13 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "set default TLS maximum to TLSv1.3 (default: TLSv1.3)",
             &EnvironmentOptions::tls_max_v1_3,
             kAllowedInEnvironment);
+  AddOption(
+    "--worker-extension-check",
+    "disable file extension check for worker thread",
+    &EnvironmentOptions::worker_extension_check,
+    kAllowedInEnvironment,
+    true
+  );
 }
 
 PerIsolateOptionsParser::PerIsolateOptionsParser(

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -590,13 +590,11 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "set default TLS maximum to TLSv1.3 (default: TLSv1.3)",
             &EnvironmentOptions::tls_max_v1_3,
             kAllowedInEnvironment);
-  AddOption(
-    "--worker-extension-check",
-    "disable file extension check for worker thread",
-    &EnvironmentOptions::worker_extension_check,
-    kAllowedInEnvironment,
-    true
-  );
+  AddOption("--worker-extension-check",
+            "disable file extension check for worker thread",
+            &EnvironmentOptions::worker_extension_check,
+            kAllowedInEnvironment,
+            true);
 }
 
 PerIsolateOptionsParser::PerIsolateOptionsParser(

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -127,6 +127,7 @@ class EnvironmentOptions : public Options {
   bool preserve_symlinks = false;
   bool preserve_symlinks_main = false;
   bool prof_process = false;
+  bool worker_extension_check = true;
 #if HAVE_INSPECTOR
   std::string cpu_prof_dir;
   static const uint64_t kDefaultCpuProfInterval = 1000;

--- a/test/parallel/test-worker-disable-extension-check.js
+++ b/test/parallel/test-worker-disable-extension-check.js
@@ -1,0 +1,9 @@
+// Flags: --no-worker-extension-check
+
+'use strict';
+const common = require('../common');
+const fixtures = require('../common/fixtures');
+
+const { Worker } = require('worker_threads');
+
+(common.mustCall(() => { new Worker(fixtures.path('foo')); }))();


### PR DESCRIPTION
Add `no-work-extension-check` CLI option to disable file extension check when starting a worker.

Fixes: https://github.com/nodejs/node/issues/39124

cc @addaleax 
