### PR TITLE
lib: use validateArray over ArrayIsArray in trace_events

### DIFF
--- a/lib/trace_events.js
+++ b/lib/trace_events.js
@@ -5,7 +5,6 @@ const {
   SafeSet,
   Symbol,
 } = primordials;
-const { validateArray } = require('internal/validators');
 const { hasTracing } = internalBinding('config');
 const kHandle = Symbol('handle');
 const kEnabled = Symbol('enabled');
@@ -27,6 +26,7 @@ const { CategorySet, getEnabledCategories } = internalBinding('trace_events');
 const { customInspectSymbol } = require('internal/util');
 const { format } = require('internal/util/inspect');
 const {
+  validateArray,
   validateObject,
 } = require('internal/validators');
 

--- a/lib/trace_events.js
+++ b/lib/trace_events.js
@@ -1,12 +1,11 @@
 'use strict';
 
 const {
-  ArrayIsArray,
   ArrayPrototypeJoin,
   SafeSet,
   Symbol,
 } = primordials;
-
+const { validateArray } = require('internal/validators');
 const { hasTracing } = internalBinding('config');
 const kHandle = Symbol('handle');
 const kEnabled = Symbol('enabled');
@@ -85,7 +84,7 @@ class Tracing {
 function createTracing(options) {
   validateObject(options, 'options');
 
-  if (!ArrayIsArray(options.categories)) {
+  if (!validateArray(options.categories)) {
     throw new ERR_INVALID_ARG_TYPE('options.categories', 'string[]',
                                    options.categories);
   }

--- a/lib/trace_events.js
+++ b/lib/trace_events.js
@@ -84,7 +84,7 @@ class Tracing {
 function createTracing(options) {
   validateObject(options, 'options');
 
-  if (!validateArray(options.categories)) {
+  if (!validateArray(options.categories, 'options.categories')) {
     throw new ERR_INVALID_ARG_TYPE('options.categories', 'string[]',
                                    options.categories);
   }


### PR DESCRIPTION
Similar to `#39774`, this uses the internal `validateArray` for checking whether the passed input is an array data type. This is used in a [couple of internal and non-internal lib areas](https://github.com/nodejs/node/search?q=validateArray).

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
