### PR TITLE
dns: runtime deprecate type coercion of `dns.lookup` options

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2792,9 +2792,12 @@ changes:
   - version: v16.8.0
     pr-url: https://github.com/nodejs/node/pull/38906
     description: Documentation-only deprecation.
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/39793
+    description: Runtime deprecation.
 -->
 
-Type: Documentation-only
+Type: Runtime
 
 Using a non-nullish non-integer value for `family` option, a non-nullish
 non-number value for `hints` option, a non-nullish non-boolean value for `all`

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2789,12 +2789,12 @@ deprecated and should no longer be used.
 ### DEP0153: `dns.lookup` and `dnsPromises.lookup` options type coercion
 <!-- YAML
 changes:
-  - version: v16.8.0
-    pr-url: https://github.com/nodejs/node/pull/38906
-    description: Documentation-only deprecation.
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/39793
     description: Runtime deprecation.
+  - version: v16.8.0
+    pr-url: https://github.com/nodejs/node/pull/38906
+    description: Documentation-only deprecation.
 -->
 
 Type: Runtime

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -41,6 +41,7 @@ const {
   Resolver,
   validateHints,
   emitInvalidHostnameWarning,
+  emitTypeCoercionDeprecationWarning,
   getDefaultVerbatim,
   setDefaultResultOrder,
 } = require('internal/dns/utils');
@@ -112,15 +113,29 @@ function lookup(hostname, options, callback) {
     validateCallback(callback);
 
     if (options !== null && typeof options === 'object') {
+      if (options.hints != null && typeof options.hints !== 'number') {
+        emitTypeCoercionDeprecationWarning();
+      }
       hints = options.hints >>> 0;
+      if (options.family != null && typeof options.family !== 'number') {
+        emitTypeCoercionDeprecationWarning();
+      }
       family = options.family >>> 0;
+      if (options.all != null && typeof options.all !== 'boolean') {
+        emitTypeCoercionDeprecationWarning();
+      }
       all = options.all === true;
       if (typeof options.verbatim === 'boolean') {
         verbatim = options.verbatim === true;
+      } else if (options.verbatim != null) {
+        emitTypeCoercionDeprecationWarning();
       }
 
       validateHints(hints);
     } else {
+      if (options != null && typeof options !== 'number') {
+        emitTypeCoercionDeprecationWarning();
+      }
       family = options >>> 0;
     }
   }

--- a/lib/internal/dns/promises.js
+++ b/lib/internal/dns/promises.js
@@ -14,6 +14,7 @@ const {
   validateTimeout,
   validateTries,
   emitInvalidHostnameWarning,
+  emitTypeCoercionDeprecationWarning,
   getDefaultVerbatim,
 } = require('internal/dns/utils');
 const { codes, dnsException } = require('internal/errors');
@@ -110,15 +111,29 @@ function lookup(hostname, options) {
   if (hostname && typeof hostname !== 'string') {
     throw new ERR_INVALID_ARG_TYPE('hostname', 'string', hostname);
   } else if (options !== null && typeof options === 'object') {
+    if (options.hints != null && typeof options.hints !== 'number') {
+      emitTypeCoercionDeprecationWarning();
+    }
     hints = options.hints >>> 0;
+    if (options.family != null && typeof options.family !== 'number') {
+      emitTypeCoercionDeprecationWarning();
+    }
     family = options.family >>> 0;
+    if (options.all != null && typeof options.all !== 'boolean') {
+      emitTypeCoercionDeprecationWarning();
+    }
     all = options.all === true;
     if (typeof options.verbatim === 'boolean') {
       verbatim = options.verbatim === true;
+    } else if (options.verbatim != null) {
+      emitTypeCoercionDeprecationWarning();
     }
 
     validateHints(hints);
   } else {
+    if (options != null && typeof options !== 'number') {
+      emitTypeCoercionDeprecationWarning();
+    }
     family = options >>> 0;
   }
 

--- a/lib/internal/dns/utils.js
+++ b/lib/internal/dns/utils.js
@@ -193,6 +193,18 @@ function emitInvalidHostnameWarning(hostname) {
   );
 }
 
+let typeCoercionWarningEmitted = false;
+function emitTypeCoercionDeprecationWarning() {
+  if (!typeCoercionWarningEmitted) {
+    process.emitWarning(
+      'Type coercion of dns.lookup options is deprecated',
+      'DeprecationWarning',
+      'DEP0153'
+    );
+    typeCoercionWarningEmitted = true;
+  }
+}
+
 let dnsOrder = getOptionValue('--dns-result-order') || 'verbatim';
 
 function getDefaultVerbatim() {
@@ -213,6 +225,7 @@ module.exports = {
   validateTries,
   Resolver,
   emitInvalidHostnameWarning,
+  emitTypeCoercionDeprecationWarning,
   getDefaultVerbatim,
   setDefaultResultOrder,
 };

--- a/test/internet/test-dns-lookup.js
+++ b/test/internet/test-dns-lookup.js
@@ -44,3 +44,18 @@ dns.lookup(addresses.NOT_FOUND, {
   assert.strictEqual(error.syscall, 'getaddrinfo');
   assert.strictEqual(error.hostname, addresses.NOT_FOUND);
 }));
+
+common.expectWarning('DeprecationWarning',
+                     'Type coercion of dns.lookup options is deprecated',
+                     'DEP0153');
+
+assert.rejects(
+  dnsPromises.lookup(addresses.NOT_FOUND, {
+    family: 'IPv4',
+    all: 'all'
+  }),
+  {
+    code: 'ENOTFOUND',
+    message: `getaddrinfo ENOTFOUND ${addresses.NOT_FOUND}`
+  }
+);


### PR DESCRIPTION
Context: https://github.com/nodejs/node/pull/38906#issuecomment-859639715

> if https://github.com/nodejs/node/pull/37931 lands, the type coercion on the `verbatim` option could be a bit surprising as before any falsy value were interpreted as `false` – because that's still the default value. If the default changes, a falsy value that is not `false` will be interpreted as `true` – which could be a bit surprising.

> Other `dns.lookup` options have the behavior, which could be problematic as well. E.g., `dns.lookup('localhost', { family: 'ipv4' })`, the family value here is simply ignored and is silently converted to `0` – which again, should cause issues if/when `verbatim` default value changes, as `localhost` will point to `::1` instead of `127.0.0.1`.
My suggestion is to apply the same logic as we do in other part of the code base, which is to enforce types for `dns.lookup` options.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
