### PR TITLE
lib: use validators for consistency

### DIFF
--- a/lib/timers/promises.js
+++ b/lib/timers/promises.js
@@ -15,7 +15,6 @@ const {
 
 const {
   AbortError,
-  codes: { ERR_INVALID_ARG_TYPE }
 } = require('internal/errors');
 
 const {
@@ -33,12 +32,10 @@ function cancelListenerHandler(clear, reject) {
 
 function setTimeout(after, value, options = {}) {
   const args = value !== undefined ? [value] : value;
-  if (options == null || typeof options !== 'object') {
-    return PromiseReject(
-      new ERR_INVALID_ARG_TYPE(
-        'options',
-        'Object',
-        options));
+  try {
+    validateObject(options, 'options');
+  } catch (err) {
+    return PromiseReject(err);
   }
   const { signal, ref = true } = options;
   try {
@@ -46,12 +43,10 @@ function setTimeout(after, value, options = {}) {
   } catch (err) {
     return PromiseReject(err);
   }
-  if (typeof ref !== 'boolean') {
-    return PromiseReject(
-      new ERR_INVALID_ARG_TYPE(
-        'options.ref',
-        'boolean',
-        ref));
+  try {
+    validateBoolean(ref, 'options.ref');
+  } catch (err) {
+    return PromiseReject(err);
   }
   // TODO(@jasnell): If a decision is made that this cannot be backported
   // to 12.x, then this can be converted to use optional chaining to
@@ -77,12 +72,10 @@ function setTimeout(after, value, options = {}) {
 }
 
 function setImmediate(value, options = {}) {
-  if (options == null || typeof options !== 'object') {
-    return PromiseReject(
-      new ERR_INVALID_ARG_TYPE(
-        'options',
-        'Object',
-        options));
+  try {
+    validateObject(options, 'options');
+  } catch (err) {
+    return PromiseReject(err);
   }
   const { signal, ref = true } = options;
   try {
@@ -90,12 +83,10 @@ function setImmediate(value, options = {}) {
   } catch (err) {
     return PromiseReject(err);
   }
-  if (typeof ref !== 'boolean') {
-    return PromiseReject(
-      new ERR_INVALID_ARG_TYPE(
-        'options.ref',
-        'boolean',
-        ref));
+  try {
+    validateBoolean(ref, 'options.ref');
+  } catch (err) {
+    return PromiseReject(err);
   }
   // TODO(@jasnell): If a decision is made that this cannot be backported
   // to 12.x, then this can be converted to use optional chaining to


### PR DESCRIPTION
The validators should be used to keep consistency and clean up
validation.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
