### PR TITLE
src: remove extra semicolons outside fns

### DIFF
--- a/src/node_blob.cc
+++ b/src/node_blob.cc
@@ -497,5 +497,5 @@ void Blob::RegisterExternalReferences(ExternalReferenceRegistry* registry) {
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(blob, node::Blob::Initialize);
-NODE_MODULE_EXTERNAL_REFERENCE(blob, node::Blob::RegisterExternalReferences);
+NODE_MODULE_CONTEXT_AWARE_INTERNAL(blob, node::Blob::Initialize)
+NODE_MODULE_EXTERNAL_REFERENCE(blob, node::Blob::RegisterExternalReferences)


### PR DESCRIPTION
Fixes the following:

```
../../third_party/electron_node/src/node_blob.cc:500:65: error: extra ';' outside of a function is incompatible with C++98 [-Werror,-Wc++98-compat-extra-semi]
NODE_MODULE_CONTEXT_AWARE_INTERNAL(blob, node::Blob::Initialize);
                                                                ^
../../third_party/electron_node/src/node_blob.cc:501:77: error: extra ';' outside of a function is incompatible with C++98 [-Werror,-Wc++98-compat-extra-semi]
NODE_MODULE_EXTERNAL_REFERENCE(blob, node::Blob::RegisterExternalReferences);
                                                                            ^
2 errors generated.
```