### PR TITLE
fs: combine require() and destructure

### DIFF
--- a/lib/internal/fs/cp/cp-sync.js
+++ b/lib/internal/fs/cp/cp-sync.js
@@ -26,7 +26,6 @@ const {
   ERR_FS_EISDIR,
   ERR_INVALID_RETURN_VALUE,
 } = codes;
-const fs = require('fs');
 const {
   chmodSync,
   copyFileSync,
@@ -39,15 +38,14 @@ const {
   symlinkSync,
   unlinkSync,
   utimesSync,
-} = fs;
-const path = require('path');
+} = require('fs');
 const {
   dirname,
   isAbsolute,
   join,
   parse,
   resolve,
-} = path;
+} = require('path');
 const { isPromise } = require('util/types');
 
 function cpSyncFn(src, dest, opts) {


### PR DESCRIPTION
This commit combines two `require()` calls and subsequent destructuring operations.

Side note: it looks like the new `cp()` methods use the `readdir()` functions. I imagine that people will use `cp()` to copy large directory trees. We should probably look into incorporating the streaming read dir functions.
