### PR TITLE
 lib: avoid creating a throw away object in `validateObject`

### DIFF
--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -140,12 +140,21 @@ function validateBoolean(value, name) {
     throw new ERR_INVALID_ARG_TYPE(name, 'boolean', value);
 }
 
+/**
+ * @param {unknown} value
+ * @param {string} name
+ * @param {{
+ *   allowArray?: boolean,
+ *   allowFunction?: boolean,
+ *   nullable?: boolean
+ * }} [options]
+ */
 const validateObject = hideStackFrames(
-  (value, name, {
-    nullable = false,
-    allowArray = false,
-    allowFunction = false,
-  } = {}) => {
+  (value, name, options) => {
+    const useDefaultOptions = options == null;
+    const allowArray = useDefaultOptions ? false : options.allowArray;
+    const allowFunction = useDefaultOptions ? false : options.allowFunction;
+    const nullable = useDefaultOptions ? false : options.nullable;
     if ((!nullable && value === null) ||
         (!allowArray && ArrayIsArray(value)) ||
         (typeof value !== 'object' && (


### PR DESCRIPTION
This also avoids unexpected behavior if `Object.prototype.allowArray` et al. is not `undefined`.
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
