### PR TITLE
console: use validators for consistency

### DIFF
--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -42,12 +42,15 @@ const {
   isStackOverflowError,
   codes: {
     ERR_CONSOLE_WRITABLE_STREAM,
-    ERR_INVALID_ARG_TYPE,
     ERR_INVALID_ARG_VALUE,
     ERR_INCOMPATIBLE_OPTION_PAIR,
   },
 } = require('internal/errors');
-const { validateInteger } = require('internal/validators');
+const {
+  validateArray,
+  validateInteger,
+  validateObject,
+} = require('internal/validators');
 const { previewEntries } = internalBinding('util');
 const { Buffer: { isBuffer } } = require('buffer');
 const {
@@ -136,18 +139,15 @@ function Console(options /* or: stdout, stderr, ignoreErrors = true */) {
                     0, kMaxGroupIndentation);
   }
 
-  if (typeof inspectOptions === 'object' && inspectOptions !== null) {
+  if (inspectOptions !== undefined) {
+    validateObject(inspectOptions, 'options.inspectOptions');
+
     if (inspectOptions.colors !== undefined &&
         options.colorMode !== undefined) {
       throw new ERR_INCOMPATIBLE_OPTION_PAIR(
         'options.inspectOptions.color', 'colorMode');
     }
     optionsMap.set(this, inspectOptions);
-  } else if (inspectOptions !== undefined) {
-    throw new ERR_INVALID_ARG_TYPE(
-      'options.inspectOptions',
-      'object',
-      inspectOptions);
   }
 
   // Bind the prototype functions to this Console instance
@@ -483,8 +483,8 @@ const consoleMethods = {
 
   // https://console.spec.whatwg.org/#table
   table(tabularData, properties) {
-    if (properties !== undefined && !ArrayIsArray(properties))
-      throw new ERR_INVALID_ARG_TYPE('properties', 'Array', properties);
+    if (properties !== undefined)
+      validateArray(properties, 'properties');
 
     if (tabularData === null || typeof tabularData !== 'object')
       return this.log(tabularData);


### PR DESCRIPTION
The usage of more validators could clean up validation and keep
consistency.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
