### PR TITLE
util: expose toUSVString

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -2492,6 +2492,18 @@ const util = require('util');
 util.log('Timestamped message.');
 ```
 
+
+### `util.toUSVString(string)`
+<!-- YAML
+added: REPLACEME
+-->
+
+* `string` {string}
+
+Returns the `string` after replacing any surrogate code points
+(or equivalently, any unpaired surrogate code units) with the
+Unicode "replacement character" U+FFFD.
+
 [Common System Errors]: errors.md#errors_common_system_errors
 [Custom inspection functions on objects]: #util_custom_inspection_functions_on_objects
 [Custom promisified functions]: #util_custom_promisified_functions

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -19,7 +19,6 @@ const {
   ReflectApply,
   ReflectGetOwnPropertyDescriptor,
   ReflectOwnKeys,
-  RegExpPrototypeExec,
   String,
   StringPrototypeCharCodeAt,
   StringPrototypeIncludes,
@@ -40,7 +39,12 @@ const {
   isHexTable
 } = require('internal/querystring');
 
-const { getConstructorOf, removeColors } = require('internal/util');
+const {
+  getConstructorOf,
+  removeColors,
+  toUSVString
+} = require('internal/util');
+
 const {
   ERR_ARG_NOT_ITERABLE,
   ERR_INVALID_ARG_TYPE,
@@ -79,7 +83,6 @@ const {
   domainToASCII: _domainToASCII,
   domainToUnicode: _domainToUnicode,
   encodeAuth,
-  toUSVString: _toUSVString,
   parse,
   setURLConstructor,
   URL_FLAGS_CANNOT_BE_BASE,
@@ -112,18 +115,6 @@ const kFormat = Symbol('format');
 const IteratorPrototype = ObjectGetPrototypeOf(
   ObjectGetPrototypeOf([][SymbolIterator]())
 );
-
-const unpairedSurrogateRe =
-    /(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])/;
-function toUSVString(val) {
-  const str = `${val}`;
-  // As of V8 5.5, `str.search()` (and `unpairedSurrogateRe[@@search]()`) are
-  // slower than `unpairedSurrogateRe.exec()`.
-  const match = RegExpPrototypeExec(unpairedSurrogateRe, str);
-  if (!match)
-    return str;
-  return _toUSVString(str, match.index);
-}
 
 // Refs: https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque
 const kOpaqueOrigin = 'null';

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -42,7 +42,7 @@ const {
 const {
   getConstructorOf,
   removeColors,
-  toUSVString
+  toUSVString,
 } = require('internal/util');
 
 const {

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -17,6 +17,7 @@ const {
   Promise,
   ReflectApply,
   ReflectConstruct,
+  RegExpPrototypeExec,
   RegExpPrototypeTest,
   SafeMap,
   SafeSet,
@@ -26,6 +27,10 @@ const {
   Symbol,
   SymbolFor,
 } = primordials;
+
+const {
+  toUSVString: _toUSVString,
+} = internalBinding('url');
 
 const {
   hideStackFrames,
@@ -52,6 +57,18 @@ const noCrypto = !process.versions.openssl;
 const experimentalWarnings = new SafeSet();
 
 const colorRegExp = /\u001b\[\d\d?m/g; // eslint-disable-line no-control-regex
+
+const unpairedSurrogateRe =
+  /(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])/;
+function toUSVString(val) {
+  const str = `${val}`;
+  // As of V8 5.5, `str.search()` (and `unpairedSurrogateRe[@@search]()`) are
+  // slower than `unpairedSurrogateRe.exec()`.
+  const match = RegExpPrototypeExec(unpairedSurrogateRe, str);
+  if (!match)
+    return str;
+  return _toUSVString(str, match.index);
+}
 
 let uvBinding;
 
@@ -487,6 +504,7 @@ module.exports = {
   sleep,
   spliceOne,
   structuredClone,
+  toUSVString,
   removeColors,
 
   // Symbol used to customize promisify conversion

--- a/lib/util.js
+++ b/lib/util.js
@@ -72,7 +72,8 @@ const {
   deprecate,
   getSystemErrorMap,
   getSystemErrorName: internalErrorName,
-  promisify
+  promisify,
+  toUSVString
 } = require('internal/util');
 
 let internalDeepEqual;
@@ -368,6 +369,7 @@ module.exports = {
   isPrimitive,
   log,
   promisify,
+  toUSVString,
   TextDecoder,
   TextEncoder,
   types

--- a/lib/util.js
+++ b/lib/util.js
@@ -73,7 +73,7 @@ const {
   getSystemErrorMap,
   getSystemErrorName: internalErrorName,
   promisify,
-  toUSVString
+  toUSVString,
 } = require('internal/util');
 
 let internalDeepEqual;

--- a/test/parallel/test-util.js
+++ b/test/parallel/test-util.js
@@ -148,6 +148,8 @@ assert.strictEqual(util.isFunction(function() {}), true);
 assert.strictEqual(util.isFunction(), false);
 assert.strictEqual(util.isFunction('string'), false);
 
+assert.strictEqual(util.toUSVString('string'), 'string');
+
 {
   assert.strictEqual(util.types.isNativeError(new Error()), true);
   assert.strictEqual(util.types.isNativeError(new TypeError()), true);

--- a/test/parallel/test-util.js
+++ b/test/parallel/test-util.js
@@ -148,7 +148,7 @@ assert.strictEqual(util.isFunction(function() {}), true);
 assert.strictEqual(util.isFunction(), false);
 assert.strictEqual(util.isFunction('string'), false);
 
-assert.strictEqual(util.toUSVString('string'), 'string');
+assert.strictEqual(util.toUSVString('string\ud801'), 'string\ufffd');
 
 {
   assert.strictEqual(util.types.isNativeError(new Error()), true);


### PR DESCRIPTION
Expose toUSVString to it can be used by user libraries.

Refs: https://github.com/nodejs/undici/pull/986

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
