### PR TITLE
node: warn for Object.prototype.__* accessors common in security warnings

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2801,7 +2801,30 @@ non-number value for `hints` option, a non-nullish non-boolean value for `all`
 option, or a non-nullish non-boolean value for `verbatim` option in
 [`dns.lookup()`][] and [`dnsPromises.lookup()`][] is deprecated.
 
+### DEP0154: `Object.prototype` Legacy Accessors
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/38906
+    description: Documentation-only deprecation.
+-->
+
+Type: Runtime
+
+Accessors on `Object.prototype` are subject to object traversal attacks and
+cause concerns for security audits. A variety of these are considered deprecated
+by the [Legacy Object.prototype Accessor Methods][] by the JS standard. Modern
+replacements are `Object.defineProperty`, `Object.getPrototypeOf`, and
+`Object.setPrototypeOf` and not subject to path traversal. This affects:
+
+* `Object.prototype.__defineGetter__`
+* `Object.prototype.__defineSetter__`
+* `Object.prototype.__lookupGetter__`
+* `Object.prototype.__lookupSetter__`
+* `Object.prototype.__proto__`
+
 [Legacy URL API]: url.md#url_legacy_url_api
+[Legacy Object.prototype Accessor Methods]: https://tc39.es/ecma262/#sec-object.prototype-legacy-accessor-methods
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
 [RFC 6066]: https://tools.ietf.org/html/rfc6066#section-3
 [WHATWG URL API]: url.md#url_the_whatwg_url_api

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2801,7 +2801,7 @@ non-number value for `hints` option, a non-nullish non-boolean value for `all`
 option, or a non-nullish non-boolean value for `verbatim` option in
 [`dns.lookup()`][] and [`dnsPromises.lookup()`][] is deprecated.
 
-### DEP0154: `Object.prototype` Legacy Accessors
+### DEP0XXX: `Object.prototype` Legacy Accessors
 <!-- YAML
 changes:
   - version: REPLACEME

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2805,8 +2805,8 @@ option, or a non-nullish non-boolean value for `verbatim` option in
 <!-- YAML
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/38906
-    description: Documentation-only deprecation.
+    pr-url: https://github.com/nodejs/node/pull/39824
+    description: Runtime deprecation.
 -->
 
 Type: Runtime

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2812,7 +2812,7 @@ changes:
 Type: Runtime
 
 Accessors on `Object.prototype` are subject to object traversal attacks and
-cause concerns for security audits. A variety of these are considered deprecated
+cause concerns for security audits. A variety of these are deprecated
 by the [Legacy Object.prototype Accessor Methods][] by the JS standard. Modern
 replacements are `Object.defineProperty`, `Object.getPrototypeOf`, and
 `Object.setPrototypeOf` and not subject to path traversal. This affects:

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2813,7 +2813,7 @@ Type: Runtime
 
 Accessors on `Object.prototype` are subject to object traversal attacks and
 cause concerns for security audits. A variety of these are deprecated
-by the [Legacy Object.prototype Accessor Methods][] by the JS standard. Modern
+by [Legacy Object.prototype Accessor Methods][]. Modern
 replacements are `Object.defineProperty`, `Object.getPrototypeOf`, and
 `Object.setPrototypeOf` and not subject to path traversal. This affects:
 

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -336,53 +336,55 @@ function initializeDeprecations() {
     configurable: true
   });
 
-  const legacy = [
-    ['__proto__', {
-      get: 'Object.getPrototypeOf',
-      set: 'Object.setPrototypeOf'
-    }],
-    ['__defineGetter__', 'Object.defineProperty'],
-    ['__defineSetter__', 'Object.defineProperty'],
-    ['__lookupGetter__', 'Object.getOwnPropertyDescriptor'],
-    ['__lookupSetter__', 'Object.getOwnPropertyDescriptor'],
-  ];
-  for (let i = 0; i < legacy.length; i++) {
-    const prop = legacy[i][0];
-    const replacement = legacy[i][1];
-    const getReplacement = typeof replacement === 'string' ?
-      replacement : replacement.get;
-    const setReplacement = typeof replacement === 'string' ?
-      replacement : replacement.set;
-    const protoDescriptor = ObjectGetOwnPropertyDescriptor(
-      ObjectPrototype,
-      prop);
-    if (protoDescriptor && 'value' in protoDescriptor) {
-      let value = protoDescriptor.value;
-      const writable = protoDescriptor.writable;
-      ObjectDefineProperty(ObjectPrototype, prop, {
-        get: deprecate(function() {
-          return value;
-        }, `${prop} is deprecated, use ${getReplacement} instead`, 'DEP0XXX'),
-        set: deprecate(function(v) {
-          if (!writable) return;
-          value = v;
-        }, `${prop} is deprecated, use ${setReplacement} instead`, 'DEP0XXX'),
-        enumerable: false,
-        configurable: true
-      });
-    } else {
-      const getter = uncurryThis(protoDescriptor.get);
-      const setter = uncurryThis(protoDescriptor.set);
-      ObjectDefineProperty(ObjectPrototype, prop, {
-        get: deprecate(function() {
-          return getter(this);
-        }, `${prop} is deprecated, use ${getReplacement} instead`, 'DEP0XXX'),
-        set: deprecate(function(value) {
-          setter(this, value);
-        }, `${prop} is deprecated, use ${setReplacement} instead`, 'DEP0XXX'),
-        enumerable: false,
-        configurable: true
-      });
+  if (pendingDeprecation) {
+    const legacy = [
+      ['__proto__', {
+        get: 'Object.getPrototypeOf',
+        set: 'Object.setPrototypeOf'
+      }],
+      ['__defineGetter__', 'Object.defineProperty'],
+      ['__defineSetter__', 'Object.defineProperty'],
+      ['__lookupGetter__', 'Object.getOwnPropertyDescriptor'],
+      ['__lookupSetter__', 'Object.getOwnPropertyDescriptor'],
+    ];
+    for (let i = 0; i < legacy.length; i++) {
+      const prop = legacy[i][0];
+      const replacement = legacy[i][1];
+      const getReplacement = typeof replacement === 'string' ?
+        replacement : replacement.get;
+      const setReplacement = typeof replacement === 'string' ?
+        replacement : replacement.set;
+      const protoDescriptor = ObjectGetOwnPropertyDescriptor(
+        ObjectPrototype,
+        prop);
+      if (protoDescriptor && 'value' in protoDescriptor) {
+        let value = protoDescriptor.value;
+        const writable = protoDescriptor.writable;
+        ObjectDefineProperty(ObjectPrototype, prop, {
+          get: deprecate(function() {
+            return value;
+          }, `${prop} is deprecated, use ${getReplacement} instead`, 'DEP0XXX'),
+          set: deprecate(function(v) {
+            if (!writable) return;
+            value = v;
+          }, `${prop} is deprecated, use ${setReplacement} instead`, 'DEP0XXX'),
+          enumerable: false,
+          configurable: true
+        });
+      } else {
+        const getter = uncurryThis(protoDescriptor.get);
+        const setter = uncurryThis(protoDescriptor.set);
+        ObjectDefineProperty(ObjectPrototype, prop, {
+          get: deprecate(function() {
+            return getter(this);
+          }, `${prop} is deprecated, use ${getReplacement} instead`, 'DEP0XXX'),
+          set: deprecate(function(value) {
+            setter(this, value);
+          }, `${prop} is deprecated, use ${setReplacement} instead`, 'DEP0XXX'),
+          enumerable: false,
+          configurable: true
+        });
+      }
     }
   }
 }

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -337,22 +337,30 @@ function initializeDeprecations() {
   });
 
   let warnedForProto = false;
-  function warnOnProto() {
+  function warnOnProto(prop, replacement) {
     if (!warnedForProto) {
       warnedForProto = true;
-      process.emitWarning('usage of Object.prototype.__* properties are a' +
-        ' common security concern, use static methods on Object instead');
+      process.emitWarning(`usage of Object.prototype.${prop} is a common` +
+        `security concern due to object traversal, use ${replacement} instead`);
     }
   }
   const legacy = [
-    '__proto__',
-    '__defineGetter__',
-    '__defineSetter__',
-    '__lookupGetter__',
-    '__lookupSetter__',
+    ['__proto__', {
+      get: 'Object.getPrototypeOf',
+      set: 'Object.setPrototypeOf'
+    }],
+    ['__defineGetter__', 'Object.defineProperty'],
+    ['__defineSetter__', 'Object.defineProperty'],
+    ['__lookupGetter__', 'Object.getOwnPropertyDescriptor'],
+    ['__lookupSetter__', 'Object.getOwnPropertyDescriptor'],
   ];
   for (let i = 0; i < legacy.length; i++) {
-    const prop = legacy[i];
+    const prop = legacy[i][0];
+    const replacement = legacy[i][1];
+    const getReplacement = typeof replacement === 'string' ?
+      replacement : replacement.get;
+    const setReplacement = typeof replacement === 'string' ?
+      replacement : replacement.set;
     const protoDescriptor = ObjectGetOwnPropertyDescriptor(
       ObjectPrototype,
       prop);
@@ -360,15 +368,13 @@ function initializeDeprecations() {
       let value = protoDescriptor.value;
       const writable = protoDescriptor.writable;
       ObjectDefineProperty(ObjectPrototype, legacy[i], {
-        get() {
-          warnOnProto();
+        get: deprecate(function() {
           return value;
-        },
-        set(v) {
-          warnOnProto();
+        }, `${prop} is deprecated, use ${getReplacement} instead`, 'DEPXXXX'),
+        set: deprecate(function() {
           if (!writable) return;
           value = v;
-        },
+        }, `${prop} is deprecated, use ${setReplacement} instead`, 'DEPXXXX'),
         enumerable: false,
         configurable: true
       });
@@ -376,14 +382,12 @@ function initializeDeprecations() {
       const getter = uncurryThis(protoDescriptor.get);
       const setter = uncurryThis(protoDescriptor.set);
       ObjectDefineProperty(ObjectPrototype, legacy[i], {
-        get() {
-          warnOnProto();
-          return getter(this);
-        },
-        set(value) {
-          warnOnProto();
+        get: deprecate(function() {
+          getter(this, value);
+        }, `${prop} is deprecated, use ${getReplacement} instead`, 'DEPXXXX'),
+        set: deprecate(function() {
           setter(this, value);
-        },
+        }, `${prop} is deprecated, use ${setReplacement} instead`, 'DEPXXXX'),
         enumerable: false,
         configurable: true
       });

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -354,6 +354,7 @@ function initializeDeprecations() {
     ['__lookupGetter__', 'Object.getOwnPropertyDescriptor'],
     ['__lookupSetter__', 'Object.getOwnPropertyDescriptor'],
   ];
+  console.log('WTF');
   for (let i = 0; i < legacy.length; i++) {
     const prop = legacy[i][0];
     const replacement = legacy[i][1];
@@ -367,7 +368,7 @@ function initializeDeprecations() {
     if (protoDescriptor && 'value' in protoDescriptor) {
       let value = protoDescriptor.value;
       const writable = protoDescriptor.writable;
-      ObjectDefineProperty(ObjectPrototype, legacy[i], {
+      ObjectDefineProperty(ObjectPrototype, prop, {
         get: deprecate(function() {
           return value;
         }, `${prop} is deprecated, use ${getReplacement} instead`, 'DEPXXXX'),
@@ -381,7 +382,7 @@ function initializeDeprecations() {
     } else {
       const getter = uncurryThis(protoDescriptor.get);
       const setter = uncurryThis(protoDescriptor.set);
-      ObjectDefineProperty(ObjectPrototype, legacy[i], {
+      ObjectDefineProperty(ObjectPrototype, prop, {
         get: deprecate(function() {
           getter(this, value);
         }, `${prop} is deprecated, use ${getReplacement} instead`, 'DEPXXXX'),

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -336,14 +336,6 @@ function initializeDeprecations() {
     configurable: true
   });
 
-  let warnedForProto = false;
-  function warnOnProto(prop, replacement) {
-    if (!warnedForProto) {
-      warnedForProto = true;
-      process.emitWarning(`usage of Object.prototype.${prop} is a common` +
-        `security concern due to object traversal, use ${replacement} instead`);
-    }
-  }
   const legacy = [
     ['__proto__', {
       get: 'Object.getPrototypeOf',
@@ -354,7 +346,6 @@ function initializeDeprecations() {
     ['__lookupGetter__', 'Object.getOwnPropertyDescriptor'],
     ['__lookupSetter__', 'Object.getOwnPropertyDescriptor'],
   ];
-  console.log('WTF');
   for (let i = 0; i < legacy.length; i++) {
     const prop = legacy[i][0];
     const replacement = legacy[i][1];
@@ -371,11 +362,11 @@ function initializeDeprecations() {
       ObjectDefineProperty(ObjectPrototype, prop, {
         get: deprecate(function() {
           return value;
-        }, `${prop} is deprecated, use ${getReplacement} instead`, 'DEPXXXX'),
-        set: deprecate(function() {
+        }, `${prop} is deprecated, use ${getReplacement} instead`, 'DEP0XXX'),
+        set: deprecate(function(v) {
           if (!writable) return;
           value = v;
-        }, `${prop} is deprecated, use ${setReplacement} instead`, 'DEPXXXX'),
+        }, `${prop} is deprecated, use ${setReplacement} instead`, 'DEP0XXX'),
         enumerable: false,
         configurable: true
       });
@@ -384,11 +375,11 @@ function initializeDeprecations() {
       const setter = uncurryThis(protoDescriptor.set);
       ObjectDefineProperty(ObjectPrototype, prop, {
         get: deprecate(function() {
-          getter(this, value);
-        }, `${prop} is deprecated, use ${getReplacement} instead`, 'DEPXXXX'),
-        set: deprecate(function() {
+          getter(this);
+        }, `${prop} is deprecated, use ${getReplacement} instead`, 'DEP0XXX'),
+        set: deprecate(function(value) {
           setter(this, value);
-        }, `${prop} is deprecated, use ${setReplacement} instead`, 'DEPXXXX'),
+        }, `${prop} is deprecated, use ${setReplacement} instead`, 'DEP0XXX'),
         enumerable: false,
         configurable: true
       });

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -375,7 +375,7 @@ function initializeDeprecations() {
       const setter = uncurryThis(protoDescriptor.set);
       ObjectDefineProperty(ObjectPrototype, prop, {
         get: deprecate(function() {
-          getter(this);
+          return getter(this);
         }, `${prop} is deprecated, use ${getReplacement} instead`, 'DEP0XXX'),
         set: deprecate(function(value) {
           setter(this, value);

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -4,7 +4,7 @@ const {
   NumberParseInt,
   ObjectDefineProperty,
   ObjectGetOwnPropertyDescriptor,
-  ObjectGetPrototypeOf,
+  ObjectPrototype,
   SafeMap,
   SafeWeakMap,
   StringPrototypeStartsWith,
@@ -337,7 +337,6 @@ function initializeDeprecations() {
   });
 
   let warnedForProto = false;
-  const ObjectPrototype = ObjectGetPrototypeOf({});
   function warnOnProto() {
     if (!warnedForProto) {
       warnedForProto = true;

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -3,10 +3,13 @@
 const {
   NumberParseInt,
   ObjectDefineProperty,
+  ObjectGetOwnPropertyDescriptor,
+  ObjectGetPrototypeOf,
   SafeMap,
   SafeWeakMap,
   StringPrototypeStartsWith,
   globalThis,
+  uncurryThis,
 } = primordials;
 
 const {
@@ -332,6 +335,60 @@ function initializeDeprecations() {
     enumerable: false,
     configurable: true
   });
+
+  let warnedForProto = false;
+  const ObjectPrototype = ObjectGetPrototypeOf({});
+  function warnOnProto() {
+    if (!warnedForProto) {
+      warnedForProto = true;
+      process.emitWarning('usage of Object.prototype.__* properties are a common security concern, use static methods on Object instead');
+    }
+  }
+  let legacy = [
+    '__proto__',
+    '__defineGetter__',
+    '__defineSetter__',
+    '__lookupGetter__',
+    '__lookupSetter__'
+  ];
+  for (let i = 0; i < legacy.length; i++) {
+    let prop = legacy[i];
+    const protoDescriptor = ObjectGetOwnPropertyDescriptor(
+      ObjectPrototype,
+      prop);
+    if ('value' in protoDescriptor) {
+      let value = protoDescriptor.value;
+      const writable = protoDescriptor.writable;
+      ObjectDefineProperty(ObjectPrototype, legacy[i], {
+        get() {
+          warnOnProto();
+          return value;
+        },
+        set(v) {
+          warnOnProto();
+          if (!writable) return;
+          value = v;
+        },
+        enumerable: false,
+        configurable: true
+      });
+    } else {
+      const getter = uncurryThis(protoDescriptor.get);
+      const setter = uncurryThis(protoDescriptor.set);
+      ObjectDefineProperty(ObjectPrototype, legacy[i], {
+        get() {
+          warnOnProto();
+          return getter(this);
+        },
+        set(value) {
+          warnOnProto();
+          setter(this, value);
+        },
+        enumerable: false,
+        configurable: true
+      });
+    }
+  }
 }
 
 function setupChildProcessIpcChannel() {

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -357,7 +357,7 @@ function initializeDeprecations() {
     const protoDescriptor = ObjectGetOwnPropertyDescriptor(
       ObjectPrototype,
       prop);
-    if ('value' in protoDescriptor) {
+    if (protoDescriptor && 'value' in protoDescriptor) {
       let value = protoDescriptor.value;
       const writable = protoDescriptor.writable;
       ObjectDefineProperty(ObjectPrototype, legacy[i], {

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -341,18 +341,19 @@ function initializeDeprecations() {
   function warnOnProto() {
     if (!warnedForProto) {
       warnedForProto = true;
-      process.emitWarning('usage of Object.prototype.__* properties are a common security concern, use static methods on Object instead');
+      process.emitWarning('usage of Object.prototype.__* properties are a' +
+        ' common security concern, use static methods on Object instead');
     }
   }
-  let legacy = [
+  const legacy = [
     '__proto__',
     '__defineGetter__',
     '__defineSetter__',
     '__lookupGetter__',
-    '__lookupSetter__'
+    '__lookupSetter__',
   ];
   for (let i = 0; i < legacy.length; i++) {
-    let prop = legacy[i];
+    const prop = legacy[i];
     const protoDescriptor = ObjectGetOwnPropertyDescriptor(
       ObjectPrototype,
       prop);

--- a/test/parallel/test-object-proto-accessor-warning.js
+++ b/test/parallel/test-object-proto-accessor-warning.js
@@ -1,3 +1,4 @@
+// Flags: --pending-deprecation
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-object-proto-accessor-warning.js
+++ b/test/parallel/test-object-proto-accessor-warning.js
@@ -4,6 +4,8 @@ const common = require('../common');
 
 process.on('warning', common.mustCall());
 
-let obj = {};
-obj.__proto__;
+const obj = {};
+// eslint-disable-next-line
+const _ = obj.__proto__;
+// eslint-disable-next-line
 obj.__proto__ = null;

--- a/test/parallel/test-object-proto-accessor-warning.js
+++ b/test/parallel/test-object-proto-accessor-warning.js
@@ -2,9 +2,9 @@
 
 const common = require('../common');
 
-common.expectWarning('DeprecationWarning',
-  '__proto__ is deprecated, use Object.getPrototypeOf instead',
-  'DEP0XXX');
+common.expectWarning(
+  'DeprecationWarning',
+  '__proto__ is deprecated, use Object.getPrototypeOf instead', 'DEP0XXX');
 
 const obj = {};
 // eslint-disable-next-line

--- a/test/parallel/test-object-proto-accessor-warning.js
+++ b/test/parallel/test-object-proto-accessor-warning.js
@@ -2,7 +2,7 @@
 
 const common = require('../common');
 
-process.on('warning', common.mustCall());
+common.expectWarning('DeprecationWarning', '__proto__ is deprecated', 'DEP0XXX');
 
 const obj = {};
 // eslint-disable-next-line

--- a/test/parallel/test-object-proto-accessor-warning.js
+++ b/test/parallel/test-object-proto-accessor-warning.js
@@ -2,7 +2,7 @@
 
 const common = require('../common');
 
-common.expectWarning('DeprecationWarning', '__proto__ is deprecated', 'DEP0XXX');
+common.expectWarning('DeprecationWarning', '__proto__ is deprecated, use Object.getPrototypeOf instead', 'DEP0XXX');
 
 const obj = {};
 // eslint-disable-next-line

--- a/test/parallel/test-object-proto-accessor-warning.js
+++ b/test/parallel/test-object-proto-accessor-warning.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const common = require('../common');
+
+process.on('warning', common.mustCall());
+
+let obj = {};
+obj.__proto__;
+obj.__proto__ = null;

--- a/test/parallel/test-object-proto-accessor-warning.js
+++ b/test/parallel/test-object-proto-accessor-warning.js
@@ -2,7 +2,9 @@
 
 const common = require('../common');
 
-common.expectWarning('DeprecationWarning', '__proto__ is deprecated, use Object.getPrototypeOf instead', 'DEP0XXX');
+common.expectWarning('DeprecationWarning',
+  '__proto__ is deprecated, use Object.getPrototypeOf instead',
+  'DEP0XXX');
 
 const obj = {};
 // eslint-disable-next-line

--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -550,6 +550,7 @@ testMe.complete('obj.', common.mustCall(function(error, data) {
 
     data[0].forEach((key) => {
       if (!key || key === 'ele.biu') return;
+      console.error(key, ele[key.substr(4)]);
       assert.notStrictEqual(ele[key.substr(4)], undefined);
     });
   }));


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

These accessors cause too much noise in npm security audits for the ecosystem, we should start a path to removal. Figuring out/warning on usage seems a good first step prior to actual removal. This would also be a way to verify that a security audit warning actually is affecting something rather than being false positives. These are optional/legacy in the JS language specification https://tc39.es/ecma262/#sec-object.prototype-legacy-accessor-methods