### PR TITLE
crypto: fix JWK RSA-PSS SubtleCrypto.exportKey

### DIFF
--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -141,7 +141,7 @@ const {
         validateOneOf(
           options.format, 'options.format', [undefined, 'buffer', 'jwk']);
         if (options.format === 'jwk') {
-          return this[kHandle].exportJwk({});
+          return this[kHandle].exportJwk({}, false);
         }
       }
       return this[kHandle].export();
@@ -196,7 +196,7 @@ const {
 
     export(options) {
       if (options && options.format === 'jwk') {
-        return this[kHandle].exportJwk({});
+        return this[kHandle].exportJwk({}, false);
       }
       const {
         format,
@@ -217,7 +217,7 @@ const {
           throw new ERR_CRYPTO_INCOMPATIBLE_KEY_OPTIONS(
             'jwk', 'does not support encryption');
         }
-        return this[kHandle].exportJwk({});
+        return this[kHandle].exportJwk({}, false);
       }
       const {
         format,

--- a/lib/internal/crypto/webcrypto.js
+++ b/lib/internal/crypto/webcrypto.js
@@ -328,7 +328,7 @@ async function exportKeyJWK(key) {
   const jwk = key[kKeyObject][kHandle].exportJwk({
     key_ops: key.usages,
     ext: key.extractable,
-  });
+  }, true);
   switch (key.algorithm.name) {
     case 'RSASSA-PKCS1-v1_5':
       jwk.alg = normalizeHashName(

--- a/test/parallel/test-webcrypto-export-import-rsa.js
+++ b/test/parallel/test-webcrypto-export-import-rsa.js
@@ -506,7 +506,8 @@ const testVectors = [
       { name: 'RSA-PSS', hash: 'SHA-256' },
       true,
       ['verify']);
-    await subtle.exportKey('jwk', key);
+    const jwk = await subtle.exportKey('jwk', key);
+    assert.equal(jwk.alg, 'PS256');
   })().then(common.mustCall());
 
   (async () => {
@@ -516,6 +517,7 @@ const testVectors = [
       { name: 'RSA-PSS', hash: 'SHA-256' },
       true,
       ['sign']);
-    await subtle.exportKey('jwk', key);
+    const jwk = await subtle.exportKey('jwk', key);
+    assert.equal(jwk.alg, 'PS256');
   })().then(common.mustCall());
 }

--- a/test/parallel/test-webcrypto-export-import-rsa.js
+++ b/test/parallel/test-webcrypto-export-import-rsa.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const common = require('../common');
+const fixtures = require('../common/fixtures');
 
 if (!common.hasCrypto)
   common.skip('missing crypto');
@@ -478,3 +479,43 @@ const testVectors = [
   });
   await Promise.all(variations);
 })().then(common.mustCall());
+
+{
+  const publicPem = fixtures.readKey('rsa_pss_public_2048.pem', 'ascii');
+  const privatePem = fixtures.readKey('rsa_pss_private_2048.pem', 'ascii');
+
+  const publicDer = Buffer.from(
+    publicPem.replace(
+      /(?:-----(?:BEGIN|END) PUBLIC KEY-----|\s)/g,
+      ''
+    ),
+    'base64'
+  );
+  const privateDer = Buffer.from(
+    privatePem.replace(
+      /(?:-----(?:BEGIN|END) PRIVATE KEY-----|\s)/g,
+      ''
+    ),
+    'base64'
+  );
+
+  (async () => {
+    const key = await subtle.importKey(
+      'spki',
+      publicDer,
+      { name: 'RSA-PSS', hash: 'SHA-256' },
+      true,
+      ['verify']);
+    await subtle.exportKey('jwk', key);
+  })().then(common.mustCall());
+
+  (async () => {
+    const key = await subtle.importKey(
+      'pkcs8',
+      privateDer,
+      { name: 'RSA-PSS', hash: 'SHA-256' },
+      true,
+      ['sign']);
+    await subtle.exportKey('jwk', key);
+  })().then(common.mustCall());
+}

--- a/test/parallel/test-webcrypto-export-import-rsa.js
+++ b/test/parallel/test-webcrypto-export-import-rsa.js
@@ -507,7 +507,7 @@ const testVectors = [
       true,
       ['verify']);
     const jwk = await subtle.exportKey('jwk', key);
-    assert.equal(jwk.alg, 'PS256');
+    assert.strictEqual(jwk.alg, 'PS256');
   })().then(common.mustCall());
 
   (async () => {
@@ -518,6 +518,6 @@ const testVectors = [
       true,
       ['sign']);
     const jwk = await subtle.exportKey('jwk', key);
-    assert.equal(jwk.alg, 'PS256');
+    assert.strictEqual(jwk.alg, 'PS256');
   })().then(common.mustCall());
 }


### PR DESCRIPTION
Allows JWK export from WebCryptoAPI whilst keeping the restriction on `KeyObject.prototype.export()`

Refs #39805