### PR TITLE
deps: V8: cherry-pick 00bb1a77c03e

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.19',
+    'v8_embedder_string': '-node.20',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/AUTHORS
+++ b/deps/v8/AUTHORS
@@ -86,6 +86,7 @@ Daniel Andersson <kodandersson@gmail.com>
 Daniel Bevenius <daniel.bevenius@gmail.com>
 Daniel Dromboski <dandromb@gmail.com>
 Daniel James <dnljms@gmail.com>
+Darshan Sen <raisinten@gmail.com>
 David Carlier <devnexen@gmail.com>
 David Manouchehri <david@davidmanouchehri.com>
 Deepak Mohan <hop2deep@gmail.com>

--- a/deps/v8/test/mjsunit/regress/regress-crbug-422858.js
+++ b/deps/v8/test/mjsunit/regress/regress-crbug-422858.js
@@ -3,21 +3,21 @@
 // found in the LICENSE file.
 
 var date = new Date("2016/01/02 10:00 GMT-8")
-assertEquals(0, date.getMinutes());
+assertEquals(0, date.getUTCMinutes());
 assertEquals(18, date.getUTCHours());
 
 date = new Date("2016/01/02 10:00 GMT-12")
-assertEquals(0, date.getMinutes());
+assertEquals(0, date.getUTCMinutes());
 assertEquals(22, date.getUTCHours());
 
 date = new Date("2016/01/02 10:00 GMT-123")
-assertEquals(23, date.getMinutes());
+assertEquals(23, date.getUTCMinutes());
 assertEquals(11, date.getUTCHours());
 
 date = new Date("2016/01/02 10:00 GMT-0856")
-assertEquals(56, date.getMinutes());
+assertEquals(56, date.getUTCMinutes());
 assertEquals(18, date.getUTCHours());
 
 date = new Date("2016/01/02 10:00 GMT-08000")
-assertEquals(NaN, date.getMinutes());
+assertEquals(NaN, date.getUTCMinutes());
 assertEquals(NaN, date.getUTCHours());


### PR DESCRIPTION
Original commit message:

    [date] Fix Date#getMinutes() test failures

    After building V8 using Clang (./out/x64.release/v8_build_config.json
    says that "is_clang" is true), I could reproduce the referenced bug
    report locally. Replacing the getMinutes() calls with getUTCMinutes()
    calls fixed the test failure.

    Signed-off-by: Darshan Sen <raisinten@gmail.com>
    Bug: v8:11200
    Change-Id: Ia36be481f2c8728380d550ead856ef8e51b1069c
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/3093362
    Reviewed-by: Toon Verwaest <verwaest@chromium.org>
    Commit-Queue: Toon Verwaest <verwaest@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#76367}

Refs: https://github.com/v8/v8/commit/00bb1a77c03ec951a5def21c64bee38cd855be7b
Signed-off-by: Darshan Sen <darshan.sen@postman.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
