### PR TITLE
[v14.x backport] fs: improve fsPromises readFile performance

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -24,10 +24,6 @@
 
 'use strict';
 
-// Most platforms don't allow reads or writes >= 2 GB.
-// See https://github.com/libuv/libuv/pull/1501.
-const kIoMaxLength = 2 ** 31 - 1;
-
 // When using FSReqCallback, make sure to create the object only *after* all
 // parameter validation has happened, so that the objects are not kept in memory
 // in case they are created but never used due to an exception.
@@ -79,6 +75,10 @@ const { FSReqCallback, statValues } = binding;
 const { toPathIfFileURL } = require('internal/url');
 const internalUtil = require('internal/util');
 const {
+  constants: {
+    kIoMaxLength,
+    kMaxUserId,
+  },
   copyObject,
   Dirent,
   getDirents,
@@ -121,8 +121,6 @@ const {
   validateInteger,
   validateInt32
 } = require('internal/validators');
-// 2 ** 32 - 1
-const kMaxUserId = 4294967295;
 
 let truncateWarn = true;
 let fs;

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -1,16 +1,6 @@
 'use strict';
 
-// Most platforms don't allow reads or writes >= 2 GB.
-// See https://github.com/libuv/libuv/pull/1501.
-const kIoMaxLength = 2 ** 31 - 1;
-
-// Note: This is different from kReadFileBufferLength used for non-promisified
-// fs.readFile.
-const kReadFileMaxChunkSize = 2 ** 14;
 const kWriteFileMaxChunkSize = 2 ** 14;
-
-// 2 ** 32 - 1
-const kMaxUserId = 4294967295;
 
 const {
   Error,
@@ -44,6 +34,12 @@ const {
 const { isArrayBufferView } = require('internal/util/types');
 const { rimrafPromises } = require('internal/fs/rimraf');
 const {
+  constants: {
+    kIoMaxLength,
+    kMaxUserId,
+    kReadFileBufferLength,
+    kReadFileUnknownBufferLength,
+  },
   copyObject,
   getDirents,
   getOptions,

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -3,6 +3,7 @@
 const kWriteFileMaxChunkSize = 2 ** 14;
 
 const {
+  ArrayPrototypePush,
   Error,
   MathMax,
   MathMin,
@@ -292,24 +293,46 @@ async function readFileHandle(filehandle, options) {
   if (size > kIoMaxLength)
     throw new ERR_FS_FILE_TOO_LARGE(size);
 
-  const chunks = [];
-  const chunkSize = size === 0 ?
-    kReadFileMaxChunkSize :
-    MathMin(size, kReadFileMaxChunkSize);
   let endOfFile = false;
+  let totalRead = 0;
+  const noSize = size === 0;
+  const buffers = [];
+  const fullBuffer = noSize ? undefined : Buffer.allocUnsafeSlow(size);
   do {
     if (signal && signal.aborted) {
       throw lazyDOMException('The operation was aborted', 'AbortError');
     }
-    const buf = Buffer.alloc(chunkSize);
-    const { bytesRead, buffer } =
-      await read(filehandle, buf, 0, chunkSize, -1);
-    endOfFile = bytesRead === 0;
-    if (bytesRead > 0)
-      chunks.push(buffer.slice(0, bytesRead));
+    let buffer;
+    let offset;
+    let length;
+    if (noSize) {
+      buffer = Buffer.allocUnsafeSlow(kReadFileUnknownBufferLength);
+      offset = 0;
+      length = kReadFileUnknownBufferLength;
+    } else {
+      buffer = fullBuffer;
+      offset = totalRead;
+      length = MathMin(size - totalRead, kReadFileBufferLength);
+    }
+
+    const bytesRead = (await binding.read(filehandle.fd, buffer, offset,
+                                          length, -1, kUsePromises)) || 0;
+    totalRead += bytesRead;
+    endOfFile = bytesRead === 0 || totalRead === size;
+    if (noSize && bytesRead > 0) {
+      const isBufferFull = bytesRead === kReadFileUnknownBufferLength;
+      const chunkBuffer = isBufferFull ? buffer : buffer.slice(0, bytesRead);
+      ArrayPrototypePush(buffers, chunkBuffer);
+    }
   } while (!endOfFile);
 
-  const result = chunks.length === 1 ? chunks[0] : Buffer.concat(chunks);
+  let result;
+  if (size > 0) {
+    result = totalRead === size ? fullBuffer : fullBuffer.slice(0, totalRead);
+  } else {
+    result = buffers.length === 1 ? buffers[0] : Buffer.concat(buffers,
+                                                               totalRead);
+  }
 
   return options.encoding ? result.toString(options.encoding) : result;
 }

--- a/lib/internal/fs/read_file_context.js
+++ b/lib/internal/fs/read_file_context.js
@@ -4,6 +4,13 @@ const {
   MathMin,
 } = primordials;
 
+const {
+  constants: {
+    kReadFileBufferLength,
+    kReadFileUnknownBufferLength,
+  }
+} = require('internal/fs/utils');
+
 const { Buffer } = require('buffer');
 
 const { FSReqCallback, close, read } = internalBinding('fs');
@@ -17,15 +24,6 @@ const lazyDOMException = hideStackFrames((message, name) => {
     DOMException = internalBinding('messaging').DOMException;
   return new DOMException(message, name);
 });
-
-// Use 64kb in case the file type is not a regular file and thus do not know the
-// actual file size. Increasing the value further results in more frequent over
-// allocation for small files and consumes CPU time and memory that should be
-// used else wise.
-// Use up to 512kb per read otherwise to partition reading big files to prevent
-// blocking other threads in case the available threads are all in use.
-const kReadFileUnknownBufferLength = 64 * 1024;
-const kReadFileBufferLength = 512 * 1024;
 
 function readFileAfterRead(err, bytesRead) {
   const context = this.context;

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -113,6 +113,21 @@ const kMaximumCopyMode = COPYFILE_EXCL |
                          COPYFILE_FICLONE |
                          COPYFILE_FICLONE_FORCE;
 
+// Most platforms don't allow reads or writes >= 2 GB.
+// See https://github.com/libuv/libuv/pull/1501.
+const kIoMaxLength = 2 ** 31 - 1;
+
+// Use 64kb in case the file type is not a regular file and thus do not know the
+// actual file size. Increasing the value further results in more frequent over
+// allocation for small files and consumes CPU time and memory that should be
+// used else wise.
+// Use up to 512kb per read otherwise to partition reading big files to prevent
+// blocking other threads in case the available threads are all in use.
+const kReadFileUnknownBufferLength = 64 * 1024;
+const kReadFileBufferLength = 512 * 1024;
+
+const kMaxUserId = 2 ** 32 - 1;
+
 const isWindows = process.platform === 'win32';
 
 let fs;
@@ -815,6 +830,12 @@ const validatePosition = hideStackFrames((position, name) => {
 });
 
 module.exports = {
+  constants: {
+    kIoMaxLength,
+    kMaxUserId,
+    kReadFileBufferLength,
+    kReadFileUnknownBufferLength,
+  },
   assertEncoding,
   BigIntStats,  // for testing
   copyObject,

--- a/test/parallel/test-fs-promises-file-handle-readFile.js
+++ b/test/parallel/test-fs-promises-file-handle-readFile.js
@@ -11,7 +11,7 @@ const {
   open,
   readFile,
   writeFile,
-  truncate
+  truncate,
 } = fs.promises;
 const path = require('path');
 const tmpdir = require('../common/tmpdir');
@@ -65,6 +65,7 @@ async function doReadAndCancel() {
     await assert.rejects(readFile(fileHandle, { signal }), {
       name: 'AbortError'
     });
+    await fileHandle.close();
   }
 
   // Signal aborted on first tick
@@ -75,10 +76,11 @@ async function doReadAndCancel() {
     fs.writeFileSync(filePathForHandle, buffer);
     const controller = new AbortController();
     const { signal } = controller;
-    tick(1, () => controller.abort());
+    process.nextTick(() => controller.abort());
     await assert.rejects(readFile(fileHandle, { signal }), {
       name: 'AbortError'
-    });
+    }, 'tick-0');
+    await fileHandle.close();
   }
 
   // Signal aborted right before buffer read
@@ -91,10 +93,12 @@ async function doReadAndCancel() {
 
     const controller = new AbortController();
     const { signal } = controller;
-    tick(2, () => controller.abort());
+    tick(1, () => controller.abort());
     await assert.rejects(fileHandle.readFile({ signal, encoding: 'utf8' }), {
       name: 'AbortError'
-    });
+    }, 'tick-1');
+
+    await fileHandle.close();
   }
 
   // Validate file size is within range for reading
@@ -112,6 +116,7 @@ async function doReadAndCancel() {
       name: 'RangeError',
       code: 'ERR_FS_FILE_TOO_LARGE'
     });
+    await fileHandle.close();
   }
 }
 


### PR DESCRIPTION
Improve the fsPromises readFile performance
by allocating only one buffer, when size is known,
increase the size of the readbuffer chunks,
and dont read more data if size bytes have been read.
Also moves constants to internal/fs/utils.

refs: #37583
(Old) Backport-PR-URL: #37703
PR-URL: #37608

This PR is backporting the fs readFile promise performance improvements to v14.x, essentially copying these two prs (i wasnt able to cherry-pick, not sure if its my git skills or something else):
https://github.com/nodejs/node/pull/38061 "fs: move constants to internal/fs/utils.js"
https://github.com/nodejs/node/pull/37703 "[v14.x backport] fs: improve fsPromises readFile performance"

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
