### PR TITLE
build: preserves symbols during LTO with macOS linker

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -236,6 +236,19 @@
             'OTHER_LDFLAGS': [ '-Wl,-rpath,@loader_path', ],
           },
         }],
+        [ 'enable_lto=="true"', {
+          'xcode_settings': {
+            'OTHER_LDFLAGS': [
+              # man ld -export_dynamic:
+              # Preserves all global symbols in main executables during LTO.
+              # Without this option, Link Time Optimization is allowed to
+              # inline and remove global functions. This option is used when
+              # a main executable may load a plug-in which requires certain
+              # symbols from the main executable.
+              '-Wl,-export_dynamic',
+            ],
+          },
+        }],
         ['OS=="win"', {
           'libraries': [
             'Dbghelp.lib',


### PR DESCRIPTION
man ld -export_dynamic:

```
Preserves all global symbols in main executables during LTO.

Without this option, Link Time Optimization is allowed to inline
and remove global functions.

This option is used when a main executable may load a plug-in which
requires certain symbols from the main executable.
```

This fix should be backported to release lines that have ab71af34533a43e4d8d788e8ed678bf572672458.

Bug: vercel/pkg#1155
Signed-off-by: Jesse Chan <jc@linux.com>