### PR TITLE
doc: move util.toUSVString() outside of deprecated group

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1306,6 +1306,17 @@ const { read, written } = encoder.encodeInto(src, dest);
 
 The encoding supported by the `TextEncoder` instance. Always set to `'utf-8'`.
 
+## `util.toUSVString(string)`
+<!-- YAML
+added: REPLACEME
+-->
+
+* `string` {string}
+
+Returns the `string` after replacing any surrogate code points
+(or equivalently, any unpaired surrogate code units) with the
+Unicode "replacement character" U+FFFD.
+
 ## `util.types`
 <!-- YAML
 added: v10.0.0
@@ -2491,18 +2502,6 @@ const util = require('util');
 
 util.log('Timestamped message.');
 ```
-
-
-### `util.toUSVString(string)`
-<!-- YAML
-added: REPLACEME
--->
-
-* `string` {string}
-
-Returns the `string` after replacing any surrogate code points
-(or equivalently, any unpaired surrogate code units) with the
-Unicode "replacement character" U+FFFD.
 
 [Common System Errors]: errors.md#errors_common_system_errors
 [Custom inspection functions on objects]: #util_custom_inspection_functions_on_objects


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/39814/files#r693445849

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
