### PR TITLE
doc: add duplicate CVE check in sec. release doc

### DIFF
--- a/doc/guides/security-release-process.md
+++ b/doc/guides/security-release-process.md
@@ -40,6 +40,9 @@ information described.
   * Approved
   * Pass `make test`
   * Have CVEs
+     * Make sure that dependent libraries have CVEs for their issues. We should
+       only create CVEs for vulnerabilities in Node.js itself. This is to avoid
+       having duplicate CVEs for the same vulnerability.
   * Described in the pre/post announcements
 
 * [ ] Pre-release announcement [email][]: ***LINK TO EMAIL***


### PR DESCRIPTION
This commit adds a note about only creating a CVE for Node.js
vulnerabilities.

The motivation for this is a recent HackerOne report where I created a
CVE for a c-ares issue. This CVE should have been created by the c-ares
project, and it was later, but we never updated our HackerOne report to
use their CVE number. Hopefully this extra note in the release doc will
help us check for this situaion and avoid this in the future.

Refs: https://hackerone.com/reports/1178337

