### PR TITLE
build: add support for Visual Studio 2022

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -18,7 +18,11 @@ env:
 jobs:
   build-windows:
     if: github.event.pull_request.draft == false
-    runs-on: windows-latest
+    strategy:
+      matrix:
+        windows: [windows-2019, windows-2022]
+      fail-fast: false
+    runs-on: ${{ matrix.windows }}
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ env.PYTHON_VERSION }}

--- a/tools/gyp/.github/workflows/Python_tests.yml
+++ b/tools/gyp/.github/workflows/Python_tests.yml
@@ -23,7 +23,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements_dev.txt
       - name: Lint with flake8
-        run: flake8 . --count --show-source --statistics
+        run: flake8 . --ignore=E203,W503  --max-complexity=101 --max-line-length=88 --show-source --statistics
       - name: Test with pytest
         run: pytest
       # - name: Run doctests with pytest

--- a/tools/gyp/CHANGELOG.md
+++ b/tools/gyp/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.10.0](https://www.github.com/nodejs/gyp-next/compare/v0.9.6...v0.10.0) (2021-08-26)
+
+
+### Features
+
+* **msvs:** add support for Visual Studio 2022 ([#124](https://www.github.com/nodejs/gyp-next/issues/124)) ([4bd9215](https://www.github.com/nodejs/gyp-next/commit/4bd9215c44d300f06e916aec1d6327c22b78272d))
+
+### [0.9.6](https://www.github.com/nodejs/gyp-next/compare/v0.9.5...v0.9.6) (2021-08-23)
+
+
+### Bug Fixes
+
+* align flake8 test ([#122](https://www.github.com/nodejs/gyp-next/issues/122)) ([f1faa8d](https://www.github.com/nodejs/gyp-next/commit/f1faa8d3081e1a47e917ff910892f00dff16cf8a))
+* **msvs:** fix paths again in action command arguments ([#121](https://www.github.com/nodejs/gyp-next/issues/121)) ([7159dfb](https://www.github.com/nodejs/gyp-next/commit/7159dfbc5758c9ec717e215f2c36daf482c846a1))
+
 ### [0.9.5](https://www.github.com/nodejs/gyp-next/compare/v0.9.4...v0.9.5) (2021-08-18)
 
 

--- a/tools/gyp/pylib/gyp/MSVSVersion.py
+++ b/tools/gyp/pylib/gyp/MSVSVersion.py
@@ -269,6 +269,18 @@ def _CreateVersion(name, path, sdk_based=False):
     if path:
         path = os.path.normpath(path)
     versions = {
+        "2022": VisualStudioVersion(
+            "2022",
+            "Visual Studio 2022",
+            solution_version="12.00",
+            project_version="17.0",
+            flat_sln=False,
+            uses_vcxproj=True,
+            path=path,
+            sdk_based=sdk_based,
+            default_toolset="v143",
+            compatible_sdks=["v8.1", "v10.0"],
+        ),
         "2019": VisualStudioVersion(
             "2019",
             "Visual Studio 2019",
@@ -436,6 +448,7 @@ def _DetectVisualStudioVersions(versions_to_check, force_express):
       2015    - Visual Studio 2015 (14)
       2017    - Visual Studio 2017 (15)
       2019    - Visual Studio 2019 (16)
+      2022    - Visual Studio 2022 (17)
     Where (e) is e for express editions of MSVS and blank otherwise.
   """
     version_to_year = {
@@ -447,6 +460,7 @@ def _DetectVisualStudioVersions(versions_to_check, force_express):
         "14.0": "2015",
         "15.0": "2017",
         "16.0": "2019",
+        "17.0": "2022",
     }
     versions = []
     for version in versions_to_check:
@@ -522,7 +536,7 @@ def SelectVisualStudioVersion(version="auto", allow_fallback=True):
     if version == "auto":
         version = os.environ.get("GYP_MSVS_VERSION", "auto")
     version_map = {
-        "auto": ("16.0", "15.0", "14.0", "12.0", "10.0", "9.0", "8.0", "11.0"),
+        "auto": ("17.0", "16.0", "15.0", "14.0", "12.0", "10.0", "9.0", "8.0", "11.0"),
         "2005": ("8.0",),
         "2005e": ("8.0",),
         "2008": ("9.0",),
@@ -536,6 +550,7 @@ def SelectVisualStudioVersion(version="auto", allow_fallback=True):
         "2015": ("14.0",),
         "2017": ("15.0",),
         "2019": ("16.0",),
+        "2022": ("17.0",),
     }
     override_path = os.environ.get("GYP_MSVS_OVERRIDE_PATH")
     if override_path:

--- a/tools/gyp/pylib/gyp/msvs_emulation.py
+++ b/tools/gyp/pylib/gyp/msvs_emulation.py
@@ -74,8 +74,8 @@ def EncodeRspFileList(args, quote_cmd):
         program = call + " " + os.path.normpath(program)
     else:
         program = os.path.normpath(args[0])
-    return (program + " " +
-            " ".join(QuoteForRspFile(arg, quote_cmd) for arg in args[1:]))
+    return (program + " "
+            + " ".join(QuoteForRspFile(arg, quote_cmd) for arg in args[1:]))
 
 
 def _GenericRetrieve(root, default, path):

--- a/tools/gyp/setup.py
+++ b/tools/gyp/setup.py
@@ -15,7 +15,7 @@ with open(path.join(here, "README.md")) as in_file:
 
 setup(
     name="gyp-next",
-    version="0.9.5",
+    version="0.10.0",
     description="A fork of the GYP build system for use in the Node.js projects",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
- tools: add support for Visual Studio 2022 in GYP
- build: add support for Visual Studio 2022
- build: add windows-2022 to GitHub test matrix
- meta: temporarily run in draft

This is a blind try after seeing https://github.blog/changelog/2021-08-23-github-actions-windows-server-2022-with-visual-studio-2022-is-now-available-on-github-hosted-runners-public-beta/
I do not have VS2022 on my computer.