### PR TITLE
doc: update maintaining openssl guide

### DIFF
--- a/doc/guides/maintaining-openssl.md
+++ b/doc/guides/maintaining-openssl.md
@@ -7,14 +7,13 @@ currently need to generate three PRs as follows:
 
 * a PR for master which is generated following the instructions
   below.
-* a PR for 14.x following the instruction below based on the
-  14,x branch. This PR should cherry pick back to the active release
-  lines except for the 10.x line.
+* a PR for 14.x following the instructions in the v14.x-staging version
+  of this guide.
 * a PR which uses the same commit from the second PR to apply the
   updates to the openssl source code, with a new commit generated
-  by following steps 2 onwards on the 10.x line. This is
-  necessary because differences in 10.x requires that the
-  configuration files be regenerated specifically for 10.x.
+  by following steps 2 onwards on the 12.x line. This is
+  necessary because the configuration files have embedded timestamps
+  which lead to merge conflicts if cherry-picked from the second PR.
 
 ## Use of the quictls/openssl fork
 


### PR DESCRIPTION
Update the maintaining openssl guide to mention following the
instructions in the v14.x-staging version of the guide for the
v14.x-staging branch as the instructions for the quic fork use
a git clone/checkout of the forked repository while the previous
instructions for the non-forked openssl use the release tarball.

Remove references to End-of-Life Node.js 10 and update for Node.js
12 as it is necessary to regenerate the configution files.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
