### PR TITLE
doc: add descriptions about when `options.mode` is ignored

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -659,6 +659,9 @@ exist. `data` can be a string or a {Buffer}.
 
 If `options` is a string, then it specifies the `encoding`.
 
+The `mode` option only affects the newly created file. See [`fs.open()`][]
+for more details.
+
 The `path` may be specified as a {FileHandle} that has been opened
 for appending (using `fsPromises.open()`).
 
@@ -1374,6 +1377,9 @@ The `encoding` option is ignored if `data` is a buffer.
 
 If `options` is a string, then it specifies the encoding.
 
+The `mode` option only affects the newly created file. See [`fs.open()`][]
+for more details.
+
 Any specified {FileHandle} has to support writing.
 
 It is unsafe to use `fsPromises.writeFile()` multiple times on the same file
@@ -1639,6 +1645,9 @@ changes:
 
 Asynchronously append data to a file, creating the file if it does not yet
 exist. `data` can be a string or a {Buffer}.
+
+The `mode` option only affects the newly created file. See [`fs.open()`][]
+for more details.
 
 ```mjs
 import { appendFile } from 'fs';
@@ -4081,6 +4090,9 @@ a file descriptor.
 
 The `encoding` option is ignored if `data` is a buffer.
 
+The `mode` option only affects the newly created file. See [`fs.open()`][]
+for more details.
+
 If `data` is a plain object, it must have an own (not inherited) `toString`
 function property.
 
@@ -4254,6 +4266,9 @@ changes:
 
 Synchronously append data to a file, creating the file if it does not yet
 exist. `data` can be a string or a {Buffer}.
+
+The `mode` option only affects the newly created file. See [`fs.open()`][]
+for more details.
 
 ```mjs
 import { appendFileSync } from 'fs';
@@ -5210,6 +5225,9 @@ Returns `undefined`.
 
 If `data` is a plain object, it must have an own (not inherited) `toString`
 function property.
+
+The `mode` option only affects the newly created file. See [`fs.open()`][]
+for more details.
 
 For detailed information, see the documentation of the asynchronous version of
 this API: [`fs.writeFile()`][].


### PR DESCRIPTION
Fix: #39859

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
