### PR TITLE
util: simplify strEscapeSequences* RegExps

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -174,12 +174,10 @@ const kObjectType = 0;
 const kArrayType = 1;
 const kArrayExtrasType = 2;
 
-/* eslint-disable no-control-regex */
-const strEscapeSequencesRegExp = /[\x00-\x1f\x27\x5c\x7f-\x9f]/;
-const strEscapeSequencesReplacer = /[\x00-\x1f\x27\x5c\x7f-\x9f]/g;
-const strEscapeSequencesRegExpSingle = /[\x00-\x1f\x5c\x7f-\x9f]/;
-const strEscapeSequencesReplacerSingle = /[\x00-\x1f\x5c\x7f-\x9f]/g;
-/* eslint-enable no-control-regex */
+const strEscapeSequencesRegExp = /[\p{Control}'\\]/u;
+const strEscapeSequencesReplacer = /[\p{Control}'\\]/gu;
+const strEscapeSequencesRegExpSingle = /[\p{Control}\\]/u;
+const strEscapeSequencesReplacerSingle = /[\p{Control}\\]/gu;
 
 const keyStrRegExp = /^[a-zA-Z_][a-zA-Z_0-9]*$/;
 const numberRegExp = /^(0|[1-9][0-9]*)$/;


### PR DESCRIPTION
The patterns can be simplified and made more readable by changing

    [\0-\x1f\x7f-\x9f]

…into the equivalent…

    \p{Control}
