### PR TITLE
[v16.x] doc: remove {C,Dec}ompressionStream documentation

### DIFF
--- a/doc/api/webstreams.md
+++ b/doc/api/webstreams.md
@@ -1219,57 +1219,6 @@ added: v16.6.0
 
 * Type: {WritableStream}
 
-### Class: `CompressionStream`
-<!-- YAML
-added: v16.7.0
--->
-#### `new CompressionStream(format)`
-<!-- YAML
-added: v16.7.0
--->
-
-* `format` {string} One of either `'deflate'` or `'gzip'`.
-
-#### `compressionStream.readable`
-<!-- YAML
-added: v16.7.0
--->
-
-* Type: {ReadableStream}
-
-#### `compressionStream.writable`
-<!-- YAML
-added: v16.7.0
--->
-
-* Type: {WritableStream}
-
-### Class: `DecompressionStream`
-<!-- YAML
-added: v16.7.0
--->
-
-#### `new DecompressionStream(format)`
-<!-- YAML
-added: v16.7.0
--->
-
-* `format` {string} One of either `'deflate'` or `'gzip'`.
-
-#### `decompressionStream.readable`
-<!-- YAML
-added: v16.7.0
--->
-
-* Type: {ReadableStream}
-
-#### `deccompressionStream.writable`
-<!-- YAML
-added: v16.7.0
--->
-
-* Type: {WritableStream}
-
 ### Utility Consumers
 <!-- YAML
 added: v16.7.0


### PR DESCRIPTION
Documentation for `CompressionStream` and `DecompressionStream` was
erroneously added in https://github.com/nodejs/node/commit/f57a0e4d8b.

Fixes: https://github.com/nodejs/node/issues/39895

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
