### PR TITLE
doc: update WASI example to use import.meta.url

### DIFF
--- a/doc/api/wasi.md
+++ b/doc/api/wasi.md
@@ -56,7 +56,7 @@ const importObject = { wasi_snapshot_preview1: wasi.wasiImport };
 
 (async () => {
   const wasm = await WebAssembly.compile(
-    await readFile(resolve(__dirname, './demo.wasm'))
+    await readFile(join(__dirname, 'demo.wasm'))
   );
   const instance = await WebAssembly.instantiate(wasm, importObject);
 

--- a/doc/api/wasi.md
+++ b/doc/api/wasi.md
@@ -24,7 +24,7 @@ const wasi = new WASI({
 });
 const importObject = { wasi_snapshot_preview1: wasi.wasiImport };
 
-const wasm = await WebAssembly.compile(fs.readFileSync('./demo.wasm'));
+const wasm = await WebAssembly.compile(fs.readFileSync(new URL('./demo.wasm', import.meta.url)));
 const instance = await WebAssembly.instantiate(wasm, importObject);
 
 wasi.start(instance);

--- a/doc/api/wasi.md
+++ b/doc/api/wasi.md
@@ -40,6 +40,7 @@ wasi.start(instance);
 const { readFile } = require('fs/promises');
 const { WASI } = require('wasi');
 const { argv, env } = require('process');
+const { resolve } = require('path');
 
 const wasi = new WASI({
   args: argv,
@@ -55,7 +56,7 @@ const importObject = { wasi_snapshot_preview1: wasi.wasiImport };
 
 (async () => {
   const wasm = await WebAssembly.compile(
-    await readFile(new URL('./demo.wasm', import.meta.url))
+    await readFile(resolve(__dirname, './demo.wasm'))
   );
   const instance = await WebAssembly.instantiate(wasm, importObject);
 

--- a/doc/api/wasi.md
+++ b/doc/api/wasi.md
@@ -11,7 +11,7 @@ specification. WASI gives sandboxed WebAssembly applications access to the
 underlying operating system via a collection of POSIX-like functions.
 
 ```mjs
-import fs from 'fs';
+import { readFile } from 'fs/promises';
 import { WASI } from 'wasi';
 import { argv, env } from 'process';
 
@@ -22,10 +22,13 @@ const wasi = new WASI({
     '/sandbox': '/some/real/path/that/wasm/can/access'
   }
 });
+
+// Some WASI binaries require:
+//   const importObject = { wasi_unstable: wasi.wasiImport };
 const importObject = { wasi_snapshot_preview1: wasi.wasiImport };
 
 const wasm = await WebAssembly.compile(
-  fs.readFileSync(new URL('./demo.wasm', import.meta.url))
+  await readFile(new URL('./demo.wasm', import.meta.url))
 );
 const instance = await WebAssembly.instantiate(wasm, importObject);
 
@@ -34,7 +37,7 @@ wasi.start(instance);
 
 ```cjs
 'use strict';
-const fs = require('fs');
+const { readFile } = require('fs/promises');
 const { WASI } = require('wasi');
 const { argv, env } = require('process');
 
@@ -45,10 +48,15 @@ const wasi = new WASI({
     '/sandbox': '/some/real/path/that/wasm/can/access'
   }
 });
+
+// Some WASI binaries require:
+//   const importObject = { wasi_unstable: wasi.wasiImport };
 const importObject = { wasi_snapshot_preview1: wasi.wasiImport };
 
 (async () => {
-  const wasm = await WebAssembly.compile(fs.readFileSync('./demo.wasm'));
+  const wasm = await WebAssembly.compile(
+    await readFile(new URL('./demo.wasm', import.meta.url))
+  );
   const instance = await WebAssembly.instantiate(wasm, importObject);
 
   wasi.start(instance);

--- a/doc/api/wasi.md
+++ b/doc/api/wasi.md
@@ -40,7 +40,7 @@ wasi.start(instance);
 const { readFile } = require('fs/promises');
 const { WASI } = require('wasi');
 const { argv, env } = require('process');
-const { resolve } = require('path');
+const { join } = require('path');
 
 const wasi = new WASI({
   args: argv,

--- a/doc/api/wasi.md
+++ b/doc/api/wasi.md
@@ -24,7 +24,9 @@ const wasi = new WASI({
 });
 const importObject = { wasi_snapshot_preview1: wasi.wasiImport };
 
-const wasm = await WebAssembly.compile(fs.readFileSync(new URL('./demo.wasm', import.meta.url)));
+const wasm = await WebAssembly.compile(
+  fs.readFileSync(new URL('./demo.wasm', import.meta.url))
+);
 const instance = await WebAssembly.instantiate(wasm, importObject);
 
 wasi.start(instance);


### PR DESCRIPTION
This updates the WASI documentation example to use `import.meta.url` to load the WASI file.

This ensures the example follows the more common pattern of a module-relative WASI import rather than a CWD relative one.

At the sime time I've also updated the example to use the FS promises readFile and also noted some WASI binaries need to use the `wasi_unstable` import name.