### PR TITLE
node-api: Loosen restriction on the type of value that we can create a ref on

### DIFF
--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -2460,9 +2460,9 @@ napi_status napi_create_reference(napi_env env,
   CHECK_ARG(env, result);
 
   v8::Local<v8::Value> v8_value = v8impl::V8LocalValueFromJsValue(value);
-
-  if (!(v8_value->IsObject() || v8_value->IsFunction())) {
-    return napi_set_last_error(env, napi_object_expected);
+  if (!(v8_value->IsObject() || v8_value->IsFunction() ||
+        v8_value->IsSymbol())) {
+    return napi_set_last_error(env, napi_invalid_arg);
   }
 
   v8impl::Reference* reference =

--- a/test/js-native-api/test_reference/test.js
+++ b/test/js-native-api/test_reference/test.js
@@ -15,6 +15,13 @@ assert.strictEqual(test_reference.finalizeCount, 0);
 // with an async delay and GC call between each.
 async function runTests() {
   (() => {
+    const symbol = test_reference.createSymbol('testSym');
+    test_reference.createReference(symbol, 0);
+    assert.strictEqual(test_reference.referenceValue, symbol);
+  })();
+  test_reference.deleteReference();
+
+  (() => {
     const value = test_reference.createExternal();
     assert.strictEqual(test_reference.finalizeCount, 0);
     assert.strictEqual(typeof value, 'object');

--- a/test/js-native-api/test_reference/test_reference.c
+++ b/test/js-native-api/test_reference/test_reference.c
@@ -35,6 +35,20 @@ static napi_value CreateExternal(napi_env env, napi_callback_info info) {
   return result;
 }
 
+static napi_value CreateSymbol(napi_env env, napi_callback_info info) {
+  
+    size_t argc = 1;
+    napi_value args[1];
+    
+    NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL,NULL));
+    NODE_API_ASSERT(env, argc == 1, "Expect one argument only(symbol description)");
+    
+    napi_value result_symbol;
+    
+    NODE_API_CALL(env, napi_create_symbol(env, args[0], &result_symbol));
+    return result_symbol;
+}
+
 static napi_value
 CreateExternalWithFinalize(napi_env env, napi_callback_info info) {
   napi_value result;
@@ -175,6 +189,7 @@ napi_value Init(napi_env env, napi_value exports) {
         CreateExternalWithFinalize),
     DECLARE_NODE_API_PROPERTY("checkExternal", CheckExternal),
     DECLARE_NODE_API_PROPERTY("createReference", CreateReference),
+    DECLARE_NODE_API_PROPERTY("createSymbol", CreateSymbol),
     DECLARE_NODE_API_PROPERTY("deleteReference", DeleteReference),
     DECLARE_NODE_API_PROPERTY("incrementRefcount", IncrementRefcount),
     DECLARE_NODE_API_PROPERTY("decrementRefcount", DecrementRefcount),

--- a/test/js-native-api/test_reference/test_reference.c
+++ b/test/js-native-api/test_reference/test_reference.c
@@ -41,7 +41,7 @@ static napi_value CreateSymbol(napi_env env, napi_callback_info info) {
     napi_value args[1];
     
     NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL,NULL));
-    NODE_API_ASSERT(env, argc == 1, "Expect one argument only(symbol description)");
+    NODE_API_ASSERT(env, argc == 1, "Expect one argument only (symbol description)");
     
     napi_value result_symbol;
     


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
In a recent discussion in NAPI regarding handling exceptions thrown by Javascript code that are not objects (https://github.com/nodejs/node-addon-api/issues/912) , we've discovered that unlike with other primitives (numbers, string, etc), symbol values cannot be retrieved. To deal with this issue we've decided to loosen the restriction on the type of values that ```napi_create_reference``` can receive. (At the moment only ```function``` and ```object``` types are allowed) 
