### PR TITLE
crypto: add rsa-pss keygen parameters

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -3375,6 +3375,10 @@ generateKey('hmac', { length: 64 }, (err, key) => {
 <!-- YAML
 added: v10.12.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/39927
+    description: Add ability to define `RSASSA-PSS-params` sequence parameters
+                 for RSA-PSS keys pairs.
   - version:
      - v13.9.0
      - v12.17.0
@@ -3397,6 +3401,10 @@ changes:
 * `options`: {Object}
   * `modulusLength`: {number} Key size in bits (RSA, DSA).
   * `publicExponent`: {number} Public exponent (RSA). **Default:** `0x10001`.
+  * `hashAlgorithm`: {string} Name of the message digest (RSA-PSS).
+  * `mgf1HashAlgorithm`: {string} Name of the message digest used by
+    MGF1 (RSA-PSS).
+  * `saltLength`: {number} Minimal salt length in bytes (RSA-PSS).
   * `divisorLength`: {number} Size of `q` in bits (DSA).
   * `namedCurve`: {string} Name of the curve to use (EC).
   * `prime`: {Buffer} The prime parameter (DH).
@@ -3475,6 +3483,10 @@ a `Promise` for an `Object` with `publicKey` and `privateKey` properties.
 <!-- YAML
 added: v10.12.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/39927
+    description: Add ability to define `RSASSA-PSS-params` sequence parameters
+                 for RSA-PSS keys pairs.
   - version:
      - v13.9.0
      - v12.17.0
@@ -3494,6 +3506,10 @@ changes:
 * `options`: {Object}
   * `modulusLength`: {number} Key size in bits (RSA, DSA).
   * `publicExponent`: {number} Public exponent (RSA). **Default:** `0x10001`.
+  * `hashAlgorithm`: {string} Name of the message digest (RSA-PSS).
+  * `mgf1HashAlgorithm`: {string} Name of the message digest used by
+    MGF1 (RSA-PSS).
+  * `saltLength`: {number} Minimal salt length in bytes (RSA-PSS).
   * `divisorLength`: {number} Size of `q` in bits (DSA).
   * `namedCurve`: {string} Name of the curve to use (EC).
   * `prime`: {Buffer} The prime parameter (DH).

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2809,7 +2809,7 @@ changes:
     description: Documentation-only deprecation.
 -->
 
-Type: Runtime
+Type: Documentation-only
 
 The `'hash'` and `'mgf1Hash'` options are replaced with `'hashAlgorithm'`
 and `'mgf1HashAlgorithm'`.

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2809,7 +2809,7 @@ changes:
     description: Documentation-only deprecation.
 -->
 
-Type: Documentation-only
+Type: Documentation-only (supports [`--pending-deprecation`][])
 
 The `'hash'` and `'mgf1Hash'` options are replaced with `'hashAlgorithm'`
 and `'mgf1HashAlgorithm'`.

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2806,7 +2806,7 @@ option, or a non-nullish non-boolean value for `verbatim` option in
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/39927
-    description: Runtime deprecation.
+    description: Documentation-only deprecation.
 -->
 
 Type: Runtime

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2801,6 +2801,19 @@ non-number value for `hints` option, a non-nullish non-boolean value for `all`
 option, or a non-nullish non-boolean value for `verbatim` option in
 [`dns.lookup()`][] and [`dnsPromises.lookup()`][] is deprecated.
 
+### DEP0XXX: RSA-PSS generate key pair options
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/39927
+    description: Runtime deprecation.
+-->
+
+Type: Runtime
+
+The `'hash'` and `'mgf1Hash'` options are replaced with `'hashAlgorithm'`
+and `'mgf1HashAlgorithm'`.
+
 [Legacy URL API]: url.md#legacy-url-api
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
 [RFC 6066]: https://tools.ietf.org/html/rfc6066#section-3

--- a/lib/internal/crypto/keygen.js
+++ b/lib/internal/crypto/keygen.js
@@ -193,21 +193,47 @@ function createJob(mode, type, options) {
           ...encoding);
       }
 
-      const { hash, mgf1Hash, saltLength } = options;
-      if (hash !== undefined && typeof hash !== 'string')
-        throw new ERR_INVALID_ARG_VALUE('options.hash', hash);
-      if (mgf1Hash !== undefined && typeof mgf1Hash !== 'string')
-        throw new ERR_INVALID_ARG_VALUE('options.mgf1Hash', mgf1Hash);
+      const {
+        hash, mgf1Hash, hashAlgorithm, mgf1HashAlgorithm, saltLength
+      } = options;
       if (saltLength !== undefined && (!isInt32(saltLength) || saltLength < 0))
         throw new ERR_INVALID_ARG_VALUE('options.saltLength', saltLength);
+      if (hashAlgorithm !== undefined && typeof hashAlgorithm !== 'string')
+        throw new ERR_INVALID_ARG_VALUE('options.hashAlgorithm', hashAlgorithm);
+      if (mgf1HashAlgorithm !== undefined &&
+          typeof mgf1HashAlgorithm !== 'string')
+        throw new ERR_INVALID_ARG_VALUE('options.mgf1HashAlgorithm',
+                                        mgf1HashAlgorithm);
+      if (hash !== undefined) {
+        process.emitWarning(
+          '"options.hash" is deprecated, ' +
+          'use "options.hashAlgorithm" instead.',
+          'DeprecationWarning',
+          'DEP0XXX');
+        if (typeof hash !== 'string' ||
+          (hashAlgorithm && hash !== hashAlgorithm)) {
+          throw new ERR_INVALID_ARG_VALUE('options.hash', hash);
+        }
+      }
+      if (mgf1Hash !== undefined) {
+        process.emitWarning(
+          '"options.mgf1Hash" is deprecated, ' +
+          'use "options.mgf1HashAlgorithm" instead.',
+          'DeprecationWarning',
+          'DEP0XXX');
+        if (typeof mgf1Hash !== 'string' ||
+          (mgf1HashAlgorithm && mgf1Hash !== mgf1HashAlgorithm)) {
+          throw new ERR_INVALID_ARG_VALUE('options.mgf1Hash', mgf1Hash);
+        }
+      }
 
       return new RsaKeyPairGenJob(
         mode,
         kKeyVariantRSA_PSS,
         modulusLength,
         publicExponent,
-        hash,
-        mgf1Hash,
+        hashAlgorithm || hash,
+        mgf1HashAlgorithm || mgf1Hash,
         saltLength,
         ...encoding);
     }

--- a/lib/internal/crypto/keygen.js
+++ b/lib/internal/crypto/keygen.js
@@ -60,6 +60,9 @@ const {
 
 const { isArrayBufferView } = require('internal/util/types');
 
+const { getOptionValue } = require('internal/options');
+const pendingDeprecation = getOptionValue('--pending-deprecation');
+
 function wrapKey(key, ctor) {
   if (typeof key === 'string' ||
       isArrayBufferView(key) ||
@@ -205,7 +208,7 @@ function createJob(mode, type, options) {
         throw new ERR_INVALID_ARG_VALUE('options.mgf1HashAlgorithm',
                                         mgf1HashAlgorithm);
       if (hash !== undefined) {
-        process.emitWarning(
+        pendingDeprecation && process.emitWarning(
           '"options.hash" is deprecated, ' +
           'use "options.hashAlgorithm" instead.',
           'DeprecationWarning',
@@ -216,7 +219,7 @@ function createJob(mode, type, options) {
         }
       }
       if (mgf1Hash !== undefined) {
-        process.emitWarning(
+        pendingDeprecation && process.emitWarning(
           '"options.mgf1Hash" is deprecated, ' +
           'use "options.mgf1HashAlgorithm" instead.',
           'DeprecationWarning',

--- a/test/parallel/test-crypto-keygen-deprecation.js
+++ b/test/parallel/test-crypto-keygen-deprecation.js
@@ -1,0 +1,51 @@
+// Flags: --pending-deprecation
+
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const DeprecationWarning = [];
+DeprecationWarning.push([
+  '"options.hash" is deprecated, use "options.hashAlgorithm" instead.',
+  'DEP0XXX']);
+DeprecationWarning.push([
+  '"options.mgf1Hash" is deprecated, use "options.mgf1HashAlgorithm" instead.',
+  'DEP0XXX']);
+
+common.expectWarning({ DeprecationWarning });
+
+const assert = require('assert');
+const { generateKeyPair } = require('crypto');
+
+{
+  // This test makes sure deprecated options still work as intended
+
+  generateKeyPair('rsa-pss', {
+    modulusLength: 512,
+    saltLength: 16,
+    hash: 'sha256',
+    mgf1Hash: 'sha256'
+  }, common.mustSucceed((publicKey, privateKey) => {
+    assert.strictEqual(publicKey.type, 'public');
+    assert.strictEqual(publicKey.asymmetricKeyType, 'rsa-pss');
+    assert.deepStrictEqual(publicKey.asymmetricKeyDetails, {
+      modulusLength: 512,
+      publicExponent: 65537n,
+      hashAlgorithm: 'sha256',
+      mgf1HashAlgorithm: 'sha256',
+      saltLength: 16
+    });
+
+    assert.strictEqual(privateKey.type, 'private');
+    assert.strictEqual(privateKey.asymmetricKeyType, 'rsa-pss');
+    assert.deepStrictEqual(privateKey.asymmetricKeyDetails, {
+      modulusLength: 512,
+      publicExponent: 65537n,
+      hashAlgorithm: 'sha256',
+      mgf1HashAlgorithm: 'sha256',
+      saltLength: 16
+    });
+  }));
+}

--- a/test/parallel/test-crypto-keygen.js
+++ b/test/parallel/test-crypto-keygen.js
@@ -1548,7 +1548,7 @@ if (!common.hasOpenSSL3) {
 
 {
   // This test makes sure deprecated and new options may be used
-  // simultaneously so long as they're identical values
+  // simultaneously so long as they're identical values.
 
   generateKeyPair('rsa-pss', {
     modulusLength: 512,
@@ -1582,7 +1582,7 @@ if (!common.hasOpenSSL3) {
 
 {
   // This test makes sure deprecated and new options must
-  // be the same value
+  // be the same value.
 
   assert.throws(() => generateKeyPair('rsa-pss', {
     modulusLength: 512,

--- a/test/parallel/test-crypto-keygen.js
+++ b/test/parallel/test-crypto-keygen.js
@@ -302,8 +302,8 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
   generateKeyPair('rsa-pss', {
     modulusLength: 512,
     saltLength: 16,
-    hash: 'sha256',
-    mgf1Hash: 'sha256'
+    hashAlgorithm: 'sha256',
+    mgf1HashAlgorithm: 'sha256'
   }, common.mustSucceed((publicKey, privateKey) => {
     assert.strictEqual(publicKey.type, 'public');
     assert.strictEqual(publicKey.asymmetricKeyType, 'rsa-pss');
@@ -1301,12 +1301,12 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     assert.throws(() => {
       generateKeyPairSync('rsa-pss', {
         modulusLength: 4096,
-        hash: hashValue
+        hashAlgorithm: hashValue
       });
     }, {
       name: 'TypeError',
       code: 'ERR_INVALID_ARG_VALUE',
-      message: "The property 'options.hash' is invalid. " +
+      message: "The property 'options.hashAlgorithm' is invalid. " +
         `Received ${inspect(hashValue)}`
     });
   }
@@ -1316,8 +1316,8 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     generateKeyPair('rsa-pss', {
       modulusLength: 512,
       saltLength: 2147483648,
-      hash: 'sha256',
-      mgf1Hash: 'sha256'
+      hashAlgorithm: 'sha256',
+      mgf1HashAlgorithm: 'sha256'
     }, common.mustNotCall());
   }, {
     name: 'TypeError',
@@ -1330,8 +1330,8 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     generateKeyPair('rsa-pss', {
       modulusLength: 512,
       saltLength: -1,
-      hash: 'sha256',
-      mgf1Hash: 'sha256'
+      hashAlgorithm: 'sha256',
+      mgf1HashAlgorithm: 'sha256'
     }, common.mustNotCall());
   }, {
     name: 'TypeError',
@@ -1428,8 +1428,8 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
       generateKeyPair('rsa-pss', {
         modulusLength: 512,
         saltLength: 16,
-        hash: 'sha256',
-        mgf1Hash: undefined
+        hashAlgorithm: 'sha256',
+        mgf1HashAlgorithm: undefined
       });
     },
     {
@@ -1439,21 +1439,21 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     }
   );
 
-  for (const mgf1Hash of [null, 0, false, {}, []]) {
+  for (const mgf1HashAlgorithm of [null, 0, false, {}, []]) {
     assert.throws(
       () => {
         generateKeyPair('rsa-pss', {
           modulusLength: 512,
           saltLength: 16,
-          hash: 'sha256',
-          mgf1Hash
+          hashAlgorithm: 'sha256',
+          mgf1HashAlgorithm
         }, common.mustNotCall());
       },
       {
         name: 'TypeError',
         code: 'ERR_INVALID_ARG_VALUE',
-        message: "The property 'options.mgf1Hash' is invalid. " +
-          `Received ${inspect(mgf1Hash)}`
+        message: "The property 'options.mgf1HashAlgorithm' is invalid. " +
+          `Received ${inspect(mgf1HashAlgorithm)}`
 
       }
     );

--- a/test/parallel/test-crypto-keygen.js
+++ b/test/parallel/test-crypto-keygen.js
@@ -1545,3 +1545,56 @@ if (!common.hasOpenSSL3) {
     }
   }
 }
+
+{
+  // This test makes sure deprecated and new options may be used
+  // simultaneously so long as they're identical values
+
+  generateKeyPair('rsa-pss', {
+    modulusLength: 512,
+    saltLength: 16,
+    hash: 'sha256',
+    hashAlgorithm: 'sha256',
+    mgf1Hash: 'sha256',
+    mgf1HashAlgorithm: 'sha256'
+  }, common.mustSucceed((publicKey, privateKey) => {
+    assert.strictEqual(publicKey.type, 'public');
+    assert.strictEqual(publicKey.asymmetricKeyType, 'rsa-pss');
+    assert.deepStrictEqual(publicKey.asymmetricKeyDetails, {
+      modulusLength: 512,
+      publicExponent: 65537n,
+      hashAlgorithm: 'sha256',
+      mgf1HashAlgorithm: 'sha256',
+      saltLength: 16
+    });
+
+    assert.strictEqual(privateKey.type, 'private');
+    assert.strictEqual(privateKey.asymmetricKeyType, 'rsa-pss');
+    assert.deepStrictEqual(privateKey.asymmetricKeyDetails, {
+      modulusLength: 512,
+      publicExponent: 65537n,
+      hashAlgorithm: 'sha256',
+      mgf1HashAlgorithm: 'sha256',
+      saltLength: 16
+    });
+  }));
+}
+
+{
+  // This test makes sure deprecated and new options must
+  // be the same value
+
+  assert.throws(() => generateKeyPair('rsa-pss', {
+    modulusLength: 512,
+    saltLength: 16,
+    mgf1Hash: 'sha256',
+    mgf1HashAlgorithm: 'sha1'
+  }, common.mustNotCall()), { code: 'ERR_INVALID_ARG_VALUE' });
+
+  assert.throws(() => generateKeyPair('rsa-pss', {
+    modulusLength: 512,
+    saltLength: 16,
+    hash: 'sha256',
+    hashAlgorithm: 'sha1'
+  }, common.mustNotCall()), { code: 'ERR_INVALID_ARG_VALUE' });
+}


### PR DESCRIPTION
This PR deprecates (documentation-only deprecation with `--pending-deprecation`) undocumented API for RSA-PSS key generation parameters that specify the `RSASSA-PSS-params` sequence and replaces them with options aligned with `asymmetricKeyDetails` property names.

The update is so that the option names and their values match the ones exposed via `asymmetricKeyDetails` from #39851. See https://github.com/nodejs/node/pull/39851#issuecomment-903732658 and https://github.com/nodejs/node/pull/39851#issuecomment-907749171

~It is `semver-major` because despite it being undocumented before it might be in use in by users.~

Edit: We will runtime deprecate the undocumented ones via a followup PR, this is now a `semver-minor` as it is not breaking potential existing use of the undocumented API.