### PR TITLE
meta: add mailmap entry for Ethan-Arrowood

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -123,6 +123,7 @@ Elliott Cable <me@ell.io>
 Eric Phetteplace <phette23@gmail.com>
 Ernesto Salazar <ernestoalbertosalazar@gmail.com>
 Erwin W. Ramadhan <erwinwahyuramadhan@gmail.com>
+Ethan Arrowood <ethan@arrowood.dev> <ethan.arrowood@gmail.com>
 Eugene Obrezkov <ghaiklor@gmail.com>
 Eugene Ostroukhov <eostroukhov@google.com> <eostroukhov@chromium.org>
 Eugene Ostroukhov <eostroukhov@google.com> <eostroukhov@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1237,7 +1237,7 @@ Josh Mays <josh.mays@creditcards.com>
 Matt Crummey <mcrummey@validusa.com>
 michael6 <michaelf614@gmail.com>
 Raja Panidepu <rpanidepu@lmdv-rpani.jomax.paholdings.com>
-Ethan Arrowood <ethan.arrowood@gmail.com>
+Ethan Arrowood <ethan@arrowood.dev>
 Dan Villa <danielavilla02@gmail.com>
 CodeTheInternet <edlerner+github@protonmail.com>
 Eric Gonzalez <ericxgonzalez@gmail.com>


### PR DESCRIPTION
The next update-authors.js run will add a second entry to AUTHORS for
Ethan-Arrowood because they use a new email address in a commit they
authored very recently. Add the new email address to mailmap and update
AUTHORS.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
