### PR TITLE
crypto: fix regression in RSA-PSS keygen

### DIFF
--- a/src/crypto/crypto_rsa.h
+++ b/src/crypto/crypto_rsa.h
@@ -25,10 +25,11 @@ struct RsaKeyPairParams final : public MemoryRetainer {
   unsigned int modulus_bits;
   unsigned int exponent;
 
-  // The following used for RSA-PSS
+  // The following options are used for RSA-PSS. If any of them are set, a
+  // RSASSA-PSS-params sequence will be added to the key.
   const EVP_MD* md = nullptr;
   const EVP_MD* mgf1_md = nullptr;
-  int saltlen = 0;
+  int saltlen = -1;
 
   SET_NO_MEMORY_INFO()
   SET_MEMORY_INFO_NAME(RsaKeyPairParams)

--- a/test/parallel/test-crypto-keygen.js
+++ b/test/parallel/test-crypto-keygen.js
@@ -347,6 +347,29 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
 }
 
 {
+  // 'rsa-pss' should not add a RSASSA-PSS-params sequence by default.
+  // Regression test for: https://github.com/nodejs/node/issues/39936
+
+  generateKeyPair('rsa-pss', {
+    modulusLength: 512
+  }, common.mustSucceed((publicKey, privateKey) => {
+    const expectedKeyDetails = {
+      modulusLength: 512,
+      publicExponent: 65537n
+    };
+    assert.deepStrictEqual(publicKey.asymmetricKeyDetails, expectedKeyDetails);
+    assert.deepStrictEqual(privateKey.asymmetricKeyDetails, expectedKeyDetails);
+
+    // To allow backporting the fix to versions that do not support
+    // asymmetricKeyDetails for RSA-PSS params, also verify that the exported
+    // AlgorithmIdentifier member of the SubjectPublicKeyInfo has the expected
+    // length of 11 bytes (as opposed to > 11 bytes if node added params).
+    const spki = publicKey.export({ format: 'der', type: 'spki' });
+    assert.strictEqual(spki[3], 11, spki.toString('hex'));
+  }));
+}
+
+{
   const privateKeyEncoding = {
     type: 'pkcs8',
     format: 'der'


### PR DESCRIPTION
This regression was introduced in https://github.com/nodejs/node/pull/35093. Node.js incorrectly adds `RSASSA-PSS-params` to RSA-PSS keys even when no parameters were specified by the user.

Fixes: https://github.com/nodejs/node/issues/39936
Refs: https://github.com/nodejs/node/pull/35093

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
