### PR TITLE
lib,repl: ignore `canBeRequiredByUsers` built-in

### DIFF
--- a/lib/internal/main/eval_string.js
+++ b/lib/internal/main/eval_string.js
@@ -16,7 +16,7 @@ const { addBuiltinLibsToObject } = require('internal/modules/cjs/helpers');
 const { getOptionValue } = require('internal/options');
 
 prepareMainThreadExecution();
-addBuiltinLibsToObject(globalThis);
+addBuiltinLibsToObject(globalThis, '<eval>');
 markBootstrapComplete();
 
 const source = getOptionValue('--eval');

--- a/lib/internal/modules/cjs/helpers.js
+++ b/lib/internal/modules/cjs/helpers.js
@@ -131,9 +131,16 @@ function stripBOM(content) {
   return content;
 }
 
-function addBuiltinLibsToObject(object) {
+function addBuiltinLibsToObject(object, dummyModuleName) {
   // Make built-in modules available directly (loaded lazily).
-  const { builtinModules } = require('internal/modules/cjs/loader').Module;
+  const Module = require('internal/modules/cjs/loader').Module;
+  const { builtinModules } = Module;
+
+  // To require built-in modules in user-land and ignore modules whose
+  // `canBeRequiredByUsers` is false. So we create a dummy module object and not
+  // use `require()` directly.
+  const dummyModule = new Module(dummyModuleName);
+
   ArrayPrototypeForEach(builtinModules, (name) => {
     // Neither add underscored modules, nor ones that contain slashes (e.g.,
     // 'fs/promises') or ones that are already defined.
@@ -157,7 +164,7 @@ function addBuiltinLibsToObject(object) {
 
     ObjectDefineProperty(object, name, {
       get: () => {
-        const lib = require(name);
+        const lib = dummyModule.require(name);
 
         // Disable the current getter/setter and set up a new
         // non-enumerable property.

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1098,7 +1098,7 @@ REPLServer.prototype.createContext = function() {
     value: makeRequireFunction(replModule)
   });
 
-  addBuiltinLibsToObject(context);
+  addBuiltinLibsToObject(context, '<REPL>');
 
   return context;
 };

--- a/test/parallel/test-repl-built-in-modules.js
+++ b/test/parallel/test-repl-built-in-modules.js
@@ -1,0 +1,32 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const cp = require('child_process');
+
+function runREPLWithAdditionalFlags(flags) {
+  // Use -i to force node into interactive mode, despite stdout not being a TTY
+  const args = ['-i'].concat(flags);
+  const ret = cp.execFileSync(process.execPath, args, {
+    input: 'require(\'events\');\nrequire(\'wasi\');',
+    encoding: 'utf8',
+  });
+  return ret;
+}
+
+// Run REPL in normal mode.
+let stdout = runREPLWithAdditionalFlags([]);
+assert.match(stdout, /\[Function: EventEmitter\] {/);
+assert.match(
+  stdout,
+  /Uncaught Error: Cannot find module 'wasi'[\w\W]+- <repl>\n/);
+
+// Run REPL with '--experimental-wasi-unstable-preview1'
+stdout = runREPLWithAdditionalFlags([
+  '--experimental-wasi-unstable-preview1',
+]);
+assert.match(stdout, /\[Function: EventEmitter\] {/);
+assert.doesNotMatch(
+  stdout,
+  /Uncaught Error: Cannot find module 'wasi'[\w\W]+- <repl>\n/);
+assert.match(stdout, /{ WASI: \[class WASI\] }/);


### PR DESCRIPTION
e.g. `wasi` under no `--experimental-wasi-unstable-preview1` flag
shouldn't be pre-required.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
