### PR TITLE
deps: V8: cherry-pick 22bee2c92123

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.21',
+    'v8_embedder_string': '-node.22',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/snapshot/serializer.cc
+++ b/deps/v8/src/snapshot/serializer.cc
@@ -318,6 +318,23 @@ void Serializer::ResolvePendingForwardReference(int forward_reference_id) {
   }
 }
 
+ExternalReferenceEncoder::Value Serializer::EncodeExternalReference(
+    Address addr) {
+  Maybe<ExternalReferenceEncoder::Value> result =
+      external_reference_encoder_.TryEncode(addr);
+  if (result.IsNothing()) {
+#ifdef DEBUG
+    PrintStack(std::cerr);
+#endif
+    void* addr_ptr = reinterpret_cast<void*>(addr);
+    v8::base::OS::PrintError("Unknown external reference %p.\n", addr_ptr);
+    v8::base::OS::PrintError("%s\n",
+                             ExternalReferenceTable::ResolveSymbol(addr_ptr));
+    v8::base::OS::Abort();
+  }
+  return result.FromJust();
+}
+
 void Serializer::RegisterObjectIsPending(Handle<HeapObject> obj) {
   if (*obj == ReadOnlyRoots(isolate()).not_mapped_symbol()) return;
 

--- a/deps/v8/src/snapshot/serializer.h
+++ b/deps/v8/src/snapshot/serializer.h
@@ -244,9 +244,8 @@ class Serializer : public SerializerDeserializer {
   // Returns true if the given heap object is a bytecode handler code object.
   bool ObjectIsBytecodeHandler(Handle<HeapObject> obj) const;
 
-  ExternalReferenceEncoder::Value EncodeExternalReference(Address addr) {
-    return external_reference_encoder_.Encode(addr);
-  }
+  ExternalReferenceEncoder::Value EncodeExternalReference(Address addr);
+
   Maybe<ExternalReferenceEncoder::Value> TryEncodeExternalReference(
       Address addr) {
     return external_reference_encoder_.TryEncode(addr);


### PR DESCRIPTION
Original commit message:

    [serializer] print reference stack when external reference is unknown

    Print the reference stack when V8 is unable to encode an external
    reference in debug builds so that it's easier for the embedder
    to track the external reference down.

    Refs: https://github.com/nodejs/node/pull/38905
    Change-Id: Ia86eeb87833d7de0eccc7bc040301c78ddb3240c
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2988831
    Reviewed-by: Toon Verwaest <verwaest@chromium.org>
    Commit-Queue: Joyee Cheung <joyee@igalia.com>
    Cr-Commit-Position: refs/heads/master@{#75546}

Refs: https://github.com/v8/v8/commit/22bee2c92123db52426dc5a43194651d3cb77589

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
