### PR TITLE
url,lib: pass urlsearchparams-constructor.any.js

### DIFF
--- a/lib/internal/per_context/domexception.js
+++ b/lib/internal/per_context/domexception.js
@@ -10,12 +10,27 @@ const {
   TypeError,
 } = primordials;
 
-class ERR_INVALID_THIS extends TypeError {
-  constructor(type) {
-    super('Value of "this" must be of ' + type);
-  }
-
-  get code() { return 'ERR_INVALID_THIS'; }
+function throwInvalidThisError(Base, type) {
+  const err = new Base();
+  const key = 'ERR_INVALID_THIS';
+  ObjectDefineProperties(err, {
+    message: {
+      value: `Value of "this" must be of ${type}`,
+      enumerable: false,
+      writable: true,
+      configurable: true,
+    },
+    toString: {
+      value() {
+        return `${this.name} [${key}]: ${this.message}`;
+      },
+      enumerable: false,
+      writable: true,
+      configurable: true,
+    },
+  });
+  err.code = key;
+  throw err;
 }
 
 let internalsMap;
@@ -51,7 +66,7 @@ class DOMException extends Error {
     ensureInitialized();
     const internals = internalsMap.get(this);
     if (internals === undefined) {
-      throw new ERR_INVALID_THIS('DOMException');
+      throwInvalidThisError(TypeError, 'DOMException');
     }
     return internals.name;
   }
@@ -60,7 +75,7 @@ class DOMException extends Error {
     ensureInitialized();
     const internals = internalsMap.get(this);
     if (internals === undefined) {
-      throw new ERR_INVALID_THIS('DOMException');
+      throwInvalidThisError(TypeError, 'DOMException');
     }
     return internals.message;
   }
@@ -69,7 +84,7 @@ class DOMException extends Error {
     ensureInitialized();
     const internals = internalsMap.get(this);
     if (internals === undefined) {
-      throw new ERR_INVALID_THIS('DOMException');
+      throwInvalidThisError(TypeError, 'DOMException');
     }
     const code = nameToCodeMap.get(internals.name);
     return code === undefined ? 0 : code;

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -219,6 +219,7 @@ class URLSearchParams {
       } else {
         // Record<USVString, USVString>
         // Need to use reflection APIs for full spec compliance.
+        const visited = {};
         this[searchParams] = [];
         const keys = ReflectOwnKeys(init);
         for (let i = 0; i < keys.length; i++) {
@@ -227,7 +228,15 @@ class URLSearchParams {
           if (desc !== undefined && desc.enumerable) {
             const typedKey = toUSVString(key);
             const typedValue = toUSVString(init[key]);
-            this[searchParams].push(typedKey, typedValue);
+
+            // Two different key may result same after `toUSVString()`, we only
+            // leave the later one. Refers to WPT.
+            if (visited[typedKey] !== undefined) {
+              this[searchParams][visited[typedKey]] = typedValue;
+            } else {
+              this[searchParams].push(typedKey, typedValue);
+              visited[typedKey] = this[searchParams].length - 1;
+            }
           }
         }
       }

--- a/test/wpt/status/url.json
+++ b/test/wpt/status/url.json
@@ -12,9 +12,6 @@
   "urlencoded-parser.any.js": {
     "fail": "missing Request and Response"
   },
-  "urlsearchparams-constructor.any.js": {
-    "fail": "FormData is not defined"
-  },
   "url-constructor.any.js": {
     "requires": ["small-icu"]
   },

--- a/test/wpt/test-url.js
+++ b/test/wpt/test-url.js
@@ -11,6 +11,15 @@ runner.setScriptModifier((obj) => {
     // created via `document.createElement`. So we need to ignore them and just
     // test `URL`.
     obj.code = obj.code.replace(/\["url", "a", "area"\]/, '[ "url" ]');
+  } else if (typeof FormData === 'undefined' && // eslint-disable-line
+      obj.filename.includes('urlsearchparams-constructor.any.js')) {
+    // TODO(XadillaX): Remove this `else if` after `FormData` is supported.
+
+    // Ignore test named `URLSearchParams constructor, FormData.` because we do
+    // not have `FormData`.
+    obj.code = obj.code.replace(
+      /('URLSearchParams constructor, object\.'\);[\w\W]+)test\(function\(\) {[\w\W]*?}, 'URLSearchParams constructor, FormData\.'\);/,
+      '$1');
   }
 });
 runner.pretendGlobalThisAs('Window');


### PR DESCRIPTION
According to WPT:

1. `URLSearchParams` constructor should throw exactly `TypeError` if any
   Error occurrs.
2. When a record passed to `URLSearchParams` constructor, two different
   key may result same after `toUVString()`. We should leave only the
   later one.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
