### PR TITLE
doc: fix CCM cipher example in MJS

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -5260,7 +5260,7 @@ const receivedPlaintext = decipher.update(ciphertext, null, 'utf8');
 try {
   decipher.final();
 } catch (err) {
-  throw new Error('Authentication failed!');
+  throw new Error('Authentication failed!', { cause: err });
 }
 
 console.log(receivedPlaintext);

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -5304,7 +5304,7 @@ const receivedPlaintext = decipher.update(ciphertext, null, 'utf8');
 try {
   decipher.final();
 } catch (err) {
-  throw new Error('Authentication failed!');
+  throw new Error('Authentication failed!', { cause: err });
 }
 
 console.log(receivedPlaintext);

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -5260,8 +5260,7 @@ const receivedPlaintext = decipher.update(ciphertext, null, 'utf8');
 try {
   decipher.final();
 } catch (err) {
-  console.error('Authentication failed!');
-  return;
+  throw new Error('Authentication failed!');
 }
 
 console.log(receivedPlaintext);
@@ -5305,8 +5304,7 @@ const receivedPlaintext = decipher.update(ciphertext, null, 'utf8');
 try {
   decipher.final();
 } catch (err) {
-  console.error('Authentication failed!');
-  return;
+  throw new Error('Authentication failed!');
 }
 
 console.log(receivedPlaintext);


### PR DESCRIPTION
The original example used 'return' to terminate the current control
flow, which is valid in CommonJS. When the example was copied and
modified to use MJS syntax, the 'return' statement was left in but is
not allowed.

Refs: https://github.com/nodejs/node/pull/37594

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
