### PR TITLE
src: use Isolate::TryGetCurrent where appropriate

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -147,7 +147,7 @@ unsigned int reverted_cve = 0;
 
 // util.h
 // Tells whether the per-process V8::Initialize() is called and
-// if it is safe to call v8::Isolate::GetCurrent().
+// if it is safe to call v8::Isolate::TryGetCurrent().
 bool v8_initialized = false;
 
 // node_internals.h

--- a/src/node_errors.cc
+++ b/src/node_errors.cc
@@ -430,7 +430,7 @@ void OnFatalError(const char* location, const char* message) {
     FPrintF(stderr, "FATAL ERROR: %s\n", message);
   }
 
-  Isolate* isolate = Isolate::GetCurrent();
+  Isolate* isolate = Isolate::TryGetCurrent();
   Environment* env = nullptr;
   if (isolate != nullptr) {
     env = Environment::GetCurrent(isolate);

--- a/src/util.cc
+++ b/src/util.cc
@@ -128,7 +128,7 @@ BufferValue::BufferValue(Isolate* isolate, Local<Value> value) {
 
 void LowMemoryNotification() {
   if (per_process::v8_initialized) {
-    auto isolate = Isolate::GetCurrent();
+    auto isolate = Isolate::TryGetCurrent();
     if (isolate != nullptr) {
       isolate->LowMemoryNotification();
     }

--- a/src/util.h
+++ b/src/util.h
@@ -91,7 +91,7 @@ inline T MultiplyWithOverflowCheck(T a, T b);
 
 namespace per_process {
 // Tells whether the per-process V8::Initialize() is called and
-// if it is safe to call v8::Isolate::GetCurrent().
+// if it is safe to call v8::Isolate::TryGetCurrent().
 extern bool v8_initialized;
 }  // namespace per_process
 

--- a/test/node-api/test_fatal/test_threads.js
+++ b/test/node-api/test_fatal/test_threads.js
@@ -4,10 +4,6 @@ const assert = require('assert');
 const child_process = require('child_process');
 const test_fatal = require(`./build/${common.buildType}/test_fatal`);
 
-if (common.buildType === 'Debug')
-  common.skip('as this will currently fail with a Debug check ' +
-              'in v8::Isolate::GetCurrent()');
-
 // Test in a child process because the test code will trigger a fatal error
 // that crashes the process.
 if (process.argv[2] === 'child') {


### PR DESCRIPTION
In two places, we call `Isolate::GetCurrent()` even though that is
technically invalid usage of the function.
Now that V8 exposes `Isolate::TryGetCurrent()`, we can do this
in a proper way.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
