### PR TITLE
doc: make version picker usable on mobile

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -165,19 +165,6 @@ em code {
   line-height: 1.5rem;
 }
 
-#gtoc > ul > li {
-  display: inline;
-  border-right: 1px currentColor solid;
-  margin-right: .4rem;
-  padding-right: .4rem;
-}
-
-#gtoc > ul > li:last-child {
-  border-right: none;
-  margin-right: 0;
-  padding-right: 0;
-}
-
 li.version-picker {
   position: relative;
 }
@@ -739,6 +726,21 @@ kbd {
   border: none;
   background: transparent;
   outline: var(--brand3) dotted 2px;
+}
+
+@media only screen and (min-width: 577px) {
+  #gtoc > ul > li {
+    display: inline;
+    border-right: 1px currentColor solid;
+    margin-right: .4rem;
+    padding-right: .4rem;
+  }
+
+  #gtoc > ul > li:last-child {
+    border-right: none;
+    margin-right: 0;
+    padding-right: 0;
+  }
 }
 
 @media only screen and (max-width: 1024px) {


### PR DESCRIPTION
This makes the version picker usable on mobile devices.
Previously, the version picker was difficult to select from. This
change makes the #gtoc > ul > li elements have a display
of `block` instead of `inline`.

Before:

<span>
<img src="https://user-images.githubusercontent.com/677994/131533666-a7f10693-a24f-4254-a473-a16c4398fc29.PNG" width="40%">

<img src="https://user-images.githubusercontent.com/677994/131533679-9889f47c-5a20-4966-bc1b-1663d296d48b.PNG" width="40%">

</span>

After:

<span>

<img src="https://user-images.githubusercontent.com/677994/131533714-efa98edf-0d72-4deb-94ed-d077e70e2644.PNG" width="40%">

<img src="https://user-images.githubusercontent.com/677994/131533731-0019c26d-3fb6-480c-a621-629595d99265.PNG" width="40%">
</span>
