### PR TITLE
crypto: check webcrypto asymmetric key types during importKey

### DIFF
--- a/lib/internal/crypto/dsa.js
+++ b/lib/internal/crypto/dsa.js
@@ -230,6 +230,9 @@ async function dsaImportKey(
         'NotSupportedError');
   }
 
+  if (keyObject.asymmetricKeyType !== 'dsa')
+    throw lazyDOMException('Invalid key type', 'DataError');
+
   const {
     modulusLength,
     divisorLength,

--- a/lib/internal/crypto/ec.js
+++ b/lib/internal/crypto/ec.js
@@ -430,6 +430,39 @@ async function ecImportKey(
     }
   }
 
+  switch (algorithm.name) {
+    case 'ECDSA':
+      if (keyObject.asymmetricKeyType !== 'ec')
+        throw lazyDOMException('Invalid key type', 'DataError');
+      break;
+    case 'ECDH':
+      if (
+        algorithm.namedCurve === 'NODE-X25519' &&
+        keyObject.asymmetricKeyType !== 'x25519'
+      ) {
+        throw lazyDOMException('Invalid key type', 'DataError');
+      } else if (
+        algorithm.namedCurve === 'NODE-X448' &&
+        keyObject.asymmetricKeyType !== 'x448'
+      ) {
+        throw lazyDOMException('Invalid key type', 'DataError');
+      } else if (
+        algorithm.namedCurve.startsWith('P') &&
+        keyObject.asymmetricKeyType !== 'ec'
+      ) {
+        throw lazyDOMException('Invalid key type', 'DataError');
+      }
+      break;
+    case 'NODE-ED25519':
+      if (keyObject.asymmetricKeyType !== 'ed25519')
+        throw lazyDOMException('Invalid key type', 'DataError');
+      break;
+    case 'NODE-ED448':
+      if (keyObject.asymmetricKeyType !== 'ed448')
+        throw lazyDOMException('Invalid key type', 'DataError');
+      break;
+  }
+
   if (checkNamedCurve) {
     const {
       namedCurve: checkNamedCurve

--- a/lib/internal/crypto/rsa.js
+++ b/lib/internal/crypto/rsa.js
@@ -326,6 +326,17 @@ async function rsaImportKey(
         'NotSupportedError');
   }
 
+  if (algorithm.name === 'RSA-PSS') {
+    if (
+      keyObject.asymmetricKeyType !== 'rsa' &&
+      keyObject.asymmetricKeyType !== 'rsa-pss'
+    ) {
+      throw lazyDOMException('Invalid key type', 'DataError');
+    }
+  } else if (keyObject.asymmetricKeyType !== 'rsa') {
+    throw lazyDOMException('Invalid key type', 'DataError');
+  }
+
   const {
     modulusLength,
     publicExponent,

--- a/test/parallel/test-webcrypto-export-import-ec.js
+++ b/test/parallel/test-webcrypto-export-import-ec.js
@@ -1,12 +1,14 @@
 'use strict';
 
 const common = require('../common');
+const fixtures = require('../common/fixtures');
 
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
-const { subtle } = require('crypto').webcrypto;
+const crypto = require('crypto');
+const { subtle } = crypto.webcrypto;
 
 const curves = ['P-256', 'P-384', 'P-521'];
 
@@ -274,3 +276,36 @@ async function testImportJwk(
 
   await Promise.all(tests);
 })().then(common.mustCall());
+
+{
+  const rsaPublic = crypto.createPublicKey(
+    fixtures.readKey('rsa_public_2048.pem'));
+  const rsaPrivate = crypto.createPrivateKey(
+    fixtures.readKey('rsa_private_2048.pem'));
+
+  for (const [name, [publicUsage, privateUsage]] of Object.entries({
+    'ECDSA': ['verify', 'sign'],
+    'ECDH': ['deriveBits', 'deriveBits'],
+  })) {
+    assert.rejects(subtle.importKey(
+      'node.keyObject',
+      rsaPublic,
+      { name, hash: 'SHA-256', namedCurve: 'P-256' },
+      true, [publicUsage]), { message: /Invalid key type/ });
+    assert.rejects(subtle.importKey(
+      'node.keyObject',
+      rsaPrivate,
+      { name, hash: 'SHA-256', namedCurve: 'P-256' },
+      true, [privateUsage]), { message: /Invalid key type/ });
+    assert.rejects(subtle.importKey(
+      'spki',
+      rsaPublic.export({ format: 'der', type: 'spki' }),
+      { name, hash: 'SHA-256', namedCurve: 'P-256' },
+      true, [publicUsage]), { message: /Invalid key type/ });
+    assert.rejects(subtle.importKey(
+      'pkcs8',
+      rsaPrivate.export({ format: 'der', type: 'pkcs8' }),
+      { name, hash: 'SHA-256', namedCurve: 'P-256' },
+      true, [privateUsage]), { message: /Invalid key type/ });
+  }
+}


### PR DESCRIPTION
This PR fixes an issue where any `KeyObject.prototype.type` matching key would result in a `CryptoKey` despite it being the wrong `KeyObject.prototype.asymmetricKeyType`