### PR TITLE
meta: remove duplicate AUTHORS entry for NigelKibodeaux

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -301,6 +301,7 @@ Nebu Pookins <nebu@nebupookins.net>
 Netto Farah <nettofarah@gmail.com>
 Nicholas Kinsey <pyrotechnick@feistystudios.com>
 Nick Soggin <nicksoggin@gmail.com> <iSkore@users.noreply.github.com>
+Nigel Kibodeaux <nigelmail@gmail.com> <nigel@team.about.me>
 Nikola Glavina <glavina.nikola5@gmail.com> <nikola.glavina@student.um.si>
 Nikolai Vavilov <vvnicholas@gmail.com>
 Nils Kuhnhenn <lain@volafile.io>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1242,7 +1242,7 @@ Dan Villa <danielavilla02@gmail.com>
 CodeTheInternet <edlerner+github@protonmail.com>
 Eric Gonzalez <ericxgonzalez@gmail.com>
 rgoodwin <rjngoodwin@gmial.com>
-Nigel Kibodeaux <nigel@team.about.me>
+Nigel Kibodeaux <nigelmail@gmail.com>
 fmizzell <fmizzell@1312210.no-reply.drupal.org>
 cdnadmin <cdnadmin@collaborare.net>
 Paul Lucas <pjl.paul@gmail.com>
@@ -1772,7 +1772,6 @@ Guilherme Akio Sakae <akio.xd@gmail.com>
 Martin Michaelis <code@mgjm.de>
 Christopher Sidebottom <chris@damouse.co.uk>
 Edward Andrew Robinson <earobinson@gmail.com>
-Nigel Kibodeaux <nigelmail@gmail.com>
 Shakeel Mohamed <contact@shakeel.xyz>
 Tobias Kieslich <tobias.kieslich@gmail.com>
 Ruy Adorno <ruyadorno@hotmail.com>


### PR DESCRIPTION
@NigelKibodeaux Can you confirm that keeping the gmail entry and treating the about.me entry as a duplicate is correct? If it should be the other way around, I'm happy to switch it.