### PR TITLE
src: add option to disable loading native addons

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -598,6 +598,15 @@ added: v7.10.0
 
 This option is a no-op. It is kept for compatibility.
 
+### `--no-addons`
+<!-- YAML
+added: REPLACEME
+-->
+
+Enable a `no-addons` resolution condition as well as disable loading native
+addons. When `--no-addons` is specified, calling `process.dlopen` or requiring
+a native C++ addon will fail and throw an exception.
+
 ### `--no-deprecation`
 <!-- YAML
 added: v0.8.0
@@ -612,15 +621,6 @@ added: v9.0.0
 
 Disables runtime checks for `async_hooks`. These will still be enabled
 dynamically when `async_hooks` is enabled.
-
-### `--no-addons`
-<!-- YAML
-added: REPLACEME
--->
-
-Enable a `no-addons` resolution condition as well as disable loading native
-addons. When `--no-addons` is specified, calling `process.dlopen` or requiring
-a native C++ addon will fail and throw an exception.
 
 ### `--no-warnings`
 <!-- YAML
@@ -1430,10 +1430,10 @@ Node.js options that are allowed are:
 * `--inspect`
 * `--max-http-header-size`
 * `--napi-modules`
+* `--no-addons`
 * `--no-deprecation`
 * `--no-experimental-repl-await`
 * `--no-force-async-hooks-checks`
-* `--no-addons`
 * `--no-warnings`
 * `--node-memory-debug`
 * `--openssl-config`

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -618,8 +618,9 @@ dynamically when `async_hooks` is enabled.
 added: REPLACEME
 -->
 
-Enable a `no-addons` resolution condition as well as disable loading native addons. When `--no-addons` is specified,
-calling `process.dlopen` or requiring a native C++ addon will fail and throw an exception.
+Enable a `no-addons` resolution condition as well as disable loading native
+addons. When `--no-addons` is specified, calling `process.dlopen` or requiring
+a native C++ addon will fail and throw an exception.
 
 ### `--no-warnings`
 <!-- YAML

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1815,4 +1815,3 @@ $ node --max-old-space-size=1536 index.js
 [security warning]: #warning-binding-inspector-to-a-public-ipport-combination-is-insecure
 [timezone IDs]: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 [ways that `TZ` is handled in other environments]: https://www.gnu.org/software/libc/manual/html_node/TZ-Variable.html
-[`dlopen`]: https://nodejs.org/api/process.html#process_process_dlopen_module_filename_flags

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -603,9 +603,9 @@ This option is a no-op. It is kept for compatibility.
 added: REPLACEME
 -->
 
-Enable a `no-addons` resolution condition as well as disable loading native
-addons. When `--no-addons` is specified, calling `process.dlopen` or requiring
-a native C++ addon will fail and throw an exception.
+Disable the `node-addons` exports condition as well as disable loading
+native addons. When `--no-addons` is specified, calling `process.dlopen` or
+requiring a native C++ addon will fail and throw an exception.
 
 ### `--no-deprecation`
 <!-- YAML

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -613,6 +613,14 @@ added: v9.0.0
 Disables runtime checks for `async_hooks`. These will still be enabled
 dynamically when `async_hooks` is enabled.
 
+### `--no-addons`
+<!-- YAML
+added: REPLACEME
+-->
+
+Enable a `no-addons` resolution condition as well as disable loading native addons. When `--no-addons` is specified,
+calling `process.dlopen` or requiring a native C++ addon will fail and throw an exception.
+
 ### `--no-warnings`
 <!-- YAML
 added: v6.0.0
@@ -1424,6 +1432,7 @@ Node.js options that are allowed are:
 * `--no-deprecation`
 * `--no-experimental-repl-await`
 * `--no-force-async-hooks-checks`
+* `--no-addons`
 * `--no-warnings`
 * `--node-memory-debug`
 * `--openssl-config`
@@ -1805,3 +1814,4 @@ $ node --max-old-space-size=1536 index.js
 [security warning]: #warning-binding-inspector-to-a-public-ipport-combination-is-insecure
 [timezone IDs]: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 [ways that `TZ` is handled in other environments]: https://www.gnu.org/software/libc/manual/html_node/TZ-Variable.html
+[`dlopen`]: https://nodejs.org/api/process.html#process_process_dlopen_module_filename_flags

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1027,6 +1027,14 @@ added:
 
 The [debugger][] timed out waiting for the required host/port to be free.
 
+<a id="ERR_DLOPEN_DISABLED"></a>
+### `ERR_DLOPEN_DISABLED`
+<!-- YAML
+added: REPLACEME
+-->
+
+Loading native addons has been disabled using [`--no-addons`][].
+
 <a id="ERR_DLOPEN_FAILED"></a>
 ### `ERR_DLOPEN_FAILED`
 <!-- YAML
@@ -2879,6 +2887,7 @@ The native call from `process.cpuUsage` could not be processed.
 [`'uncaughtException'`]: process.md#event-uncaughtexception
 [`--disable-proto=throw`]: cli.md#--disable-protomode
 [`--force-fips`]: cli.md#--force-fips
+[`--no-addons`]: cli.md#--no-addons
 [`Class: assert.AssertionError`]: assert.md#class-assertassertionerror
 [`ERR_INVALID_ARG_TYPE`]: #err_invalid_arg_type
 [`ERR_MISSING_MESSAGE_PORT_IN_TRANSFER_LIST`]: #err_missing_message_port_in_transfer_list

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -537,6 +537,11 @@ Node.js implements the following conditions:
 * `"node"` - matches for any Node.js environment. Can be a CommonJS or ES
    module file. _This condition should always come after `"import"` or
    `"require"`._
+* `"node-addons"` - similar to `"node"` and matches for any Node.js environment.
+   This condition can be used to provide an entry point which uses native C++
+   addons as opposed to an entry point which is more universal and doesn't rely
+   on native addons. This condition can be disabled via the
+   [`--no-addons` flag][].
 * `"default"` - the generic fallback that always matches. Can be a CommonJS
    or ES module file. _This condition should always come last._
 
@@ -615,16 +620,22 @@ node --conditions=development main.js
 ```
 
 which would then resolve the `"development"` condition in package imports and
-exports, while resolving the existing `"node"`, `"default"`, `"import"`, and
-`"require"` conditions as appropriate.
+exports, while resolving the existing `"node"`, `"node-addons"`, `"default"`,
+`"import"`, and `"require"` conditions as appropriate.
 
 Any number of custom conditions can be set with repeat flags.
 
 ### Conditions Definitions
 
-The `"import"`, `"require"`, `"node"` and `"default"` conditions are defined
-and implemented in Node.js core,
+The `"import"`, `"require"`, `"node"`, `"node-addons"` and `"default"`
+conditions are defined and implemented in Node.js core,
 [as specified above](#conditional-exports).
+
+The `"node-addons"` condition can be used to provide an entry point which
+uses native C++ addons. However, this condition can be disabled via the
+[`--no-addons` flag][]. When using `"node-addons"`, it's recommended to treat
+`"default"` as an enhancement that provides a more universal entry point, e.g.
+using WebAssembly instead of a native addon.
 
 Other condition strings are unknown to Node.js and thus ignored by default.
 Runtimes or tools other than Node.js can use them at their discretion.
@@ -1249,6 +1260,7 @@ This field defines [subpath imports][] for the current package.
 [`"packageManager"`]: #packagemanager
 [`"type"`]: #type
 [`--conditions` flag]: #resolving-user-conditions
+[`--no-addons` flag]: cli.md#--no-addons
 [`ERR_PACKAGE_PATH_NOT_EXPORTED`]: errors.md#err_package_path_not_exported
 [`esm`]: https://github.com/standard-things/esm#readme
 [`package.json`]: #nodejs-packagejson-field-definitions

--- a/doc/node.1
+++ b/doc/node.1
@@ -277,6 +277,10 @@ Silence deprecation warnings.
 Disable runtime checks for `async_hooks`.
 These will still be enabled dynamically when `async_hooks` is enabled.
 .
+.It Fl -no-addons
+Enable a `no-addons` resolution condition as well as disable loading native addons. When `--no-addons` is specified,
+calling `process.dlopen` or requiring a native C++ addon will fail and throw an exception.
+.
 .It Fl -no-warnings
 Silence all process warnings (including deprecations).
 .

--- a/doc/node.1
+++ b/doc/node.1
@@ -278,8 +278,9 @@ Disable runtime checks for `async_hooks`.
 These will still be enabled dynamically when `async_hooks` is enabled.
 .
 .It Fl -no-addons
-Enable a `no-addons` resolution condition as well as disable loading native addons. When `--no-addons` is specified,
-calling `process.dlopen` or requiring a native C++ addon will fail and throw an exception.
+Disable the `node-addons` exports condition as well as disable loading native
+addons. When `--no-addons` is specified, calling `process.dlopen` or requiring
+a native C++ addon will fail and throw an exception.
 .
 .It Fl -no-warnings
 Silence all process warnings (including deprecations).

--- a/lib/internal/modules/cjs/helpers.js
+++ b/lib/internal/modules/cjs/helpers.js
@@ -33,6 +33,10 @@ let debug = require('internal/util/debuglog').debuglog('module', (fn) => {
 // TODO: Use this set when resolving pkg#exports conditions in loader.js.
 const cjsConditions = new SafeSet(['require', 'node', ...userConditions]);
 
+if (getOptionValue('--no-addons')) {
+  cjsConditions.add('no-addons');
+}
+
 function loadNativeModule(filename, request) {
   const mod = NativeModule.map.get(filename);
   if (mod?.canBeRequiredByUsers) {

--- a/lib/internal/modules/cjs/helpers.js
+++ b/lib/internal/modules/cjs/helpers.js
@@ -30,12 +30,16 @@ let debug = require('internal/util/debuglog').debuglog('module', (fn) => {
   debug = fn;
 });
 
-// TODO: Use this set when resolving pkg#exports conditions in loader.js.
-const cjsConditions = new SafeSet(['require', 'node', ...userConditions]);
+const noAddons = getOptionValue('--no-addons');
+const addonConditions = noAddons ? [] : ['node-addons'];
 
-if (getOptionValue('--no-addons')) {
-  cjsConditions.add('no-addons');
-}
+// TODO: Use this set when resolving pkg#exports conditions in loader.js.
+const cjsConditions = new SafeSet([
+  'require',
+  'node',
+  ...addonConditions,
+  ...userConditions
+]);
 
 function loadNativeModule(filename, request) {
   const mod = NativeModule.map.get(filename);

--- a/lib/internal/modules/cjs/helpers.js
+++ b/lib/internal/modules/cjs/helpers.js
@@ -38,7 +38,7 @@ const cjsConditions = new SafeSet([
   'require',
   'node',
   ...addonConditions,
-  ...userConditions
+  ...userConditions,
 ]);
 
 function loadNativeModule(filename, request) {

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -58,7 +58,8 @@ const { Module: CJSModule } = require('internal/modules/cjs/loader');
 
 const packageJsonReader = require('internal/modules/package_json_reader');
 const userConditions = getOptionValue('--conditions');
-const DEFAULT_CONDITIONS = ObjectFreeze(['node', 'import', ...userConditions]);
+const noAddons = getOptionValue('--no-addons');
+const DEFAULT_CONDITIONS = ObjectFreeze(['node', 'import', ...(noAddons ? ['no-addons'] : []), ...userConditions]);
 const DEFAULT_CONDITIONS_SET = new SafeSet(DEFAULT_CONDITIONS);
 
 /**

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -59,11 +59,12 @@ const { Module: CJSModule } = require('internal/modules/cjs/loader');
 const packageJsonReader = require('internal/modules/package_json_reader');
 const userConditions = getOptionValue('--conditions');
 const noAddons = getOptionValue('--no-addons');
+const addonConditions = noAddons ? [] : ['node-addons'];
 
 const DEFAULT_CONDITIONS = ObjectFreeze([
   'node',
   'import',
-  ...(noAddons ? ['no-addons'] : []),
+  ...addonConditions,
   ...userConditions,
 ]);
 

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -59,7 +59,14 @@ const { Module: CJSModule } = require('internal/modules/cjs/loader');
 const packageJsonReader = require('internal/modules/package_json_reader');
 const userConditions = getOptionValue('--conditions');
 const noAddons = getOptionValue('--no-addons');
-const DEFAULT_CONDITIONS = ObjectFreeze(['node', 'import', ...(noAddons ? ['no-addons'] : []), ...userConditions]);
+
+const DEFAULT_CONDITIONS = ObjectFreeze([
+  'node',
+  'import',
+  ...(noAddons ? ['no-addons'] : []),
+  ...userConditions,
+]);
+
 const DEFAULT_CONDITIONS_SET = new SafeSet(DEFAULT_CONDITIONS);
 
 /**

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -861,6 +861,11 @@ inline bool Environment::is_main_thread() const {
   return worker_context() == nullptr;
 }
 
+inline bool Environment::no_native_addons() const {
+  return (flags_ & EnvironmentFlags::kNoNativeAddons) ||
+          !options_->allow_native_addons;
+}
+
 inline bool Environment::should_not_register_esm_loader() const {
   return flags_ & EnvironmentFlags::kNoRegisterESMLoader;
 }

--- a/src/env.h
+++ b/src/env.h
@@ -1197,6 +1197,7 @@ class Environment : public MemoryRetainer {
   inline void set_has_serialized_options(bool has_serialized_options);
 
   inline bool is_main_thread() const;
+  inline bool no_native_addons() const;
   inline bool should_not_register_esm_loader() const;
   inline bool owns_process_state() const;
   inline bool owns_inspector() const;

--- a/src/node.h
+++ b/src/node.h
@@ -407,7 +407,13 @@ enum Flags : uint64_t {
   // Set this flag to force hiding console windows when spawning child
   // processes. This is usually used when embedding Node.js in GUI programs on
   // Windows.
-  kHideConsoleWindows = 1 << 5
+  kHideConsoleWindows = 1 << 5,
+  // Set this flag to disable loading native addons via `process.dlopen`.
+  // This environment flag is especially important for worker threads
+  // so that a worker thread can't load a native addon even if `execArgv`
+  // is overwritten and `--no-addons` is not specified but was specified
+  // for this Environment instance.
+  kNoNativeAddons = 1 << 6
 };
 }  // namespace EnvironmentFlags
 

--- a/src/node_binding.cc
+++ b/src/node_binding.cc
@@ -415,6 +415,11 @@ inline napi_addon_register_func GetNapiInitializerCallback(DLib* dlib) {
 // cache that's a plain C list or hash table that's shared across contexts?
 void DLOpen(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+
+  if (!env->options()->allow_native_addons) {
+    return THROW_ERR_DLOPEN_FAILED(env, "Cannot load native addon because loading addons is disabled.");
+  }
+
   auto context = env->context();
 
   CHECK_NULL(thread_local_modpending);

--- a/src/node_binding.cc
+++ b/src/node_binding.cc
@@ -416,8 +416,8 @@ inline napi_addon_register_func GetNapiInitializerCallback(DLib* dlib) {
 void DLOpen(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
-  if (UNLIKELY(!env->options()->allow_native_addons)) {
-    return THROW_ERR_DLOPEN_FAILED(
+  if (env->no_native_addons()) {
+    return THROW_ERR_DLOPEN_DISABLED(
       env, "Cannot load native addon because loading addons is disabled.");
   }
 

--- a/src/node_binding.cc
+++ b/src/node_binding.cc
@@ -416,8 +416,9 @@ inline napi_addon_register_func GetNapiInitializerCallback(DLib* dlib) {
 void DLOpen(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
-  if (!env->options()->allow_native_addons) {
-    return THROW_ERR_DLOPEN_FAILED(env, "Cannot load native addon because loading addons is disabled.");
+  if (UNLIKELY(!env->options()->allow_native_addons)) {
+    return THROW_ERR_DLOPEN_FAILED(
+      env, "Cannot load native addon because loading addons is disabled.");
   }
 
   auto context = env->context();

--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -57,6 +57,7 @@ void OnFatalError(const char* location, const char* message);
   V(ERR_CRYPTO_UNKNOWN_DH_GROUP, Error)                                        \
   V(ERR_CRYPTO_UNSUPPORTED_OPERATION, Error)                                   \
   V(ERR_CRYPTO_JOB_INIT_FAILED, Error)                                         \
+  V(ERR_DLOPEN_DISABLED, Error)                                                \
   V(ERR_DLOPEN_FAILED, Error)                                                  \
   V(ERR_EXECUTION_ENVIRONMENT_NOT_AVAILABLE, Error)                            \
   V(ERR_INVALID_ADDRESS, Error)                                                \

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -402,6 +402,11 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             &EnvironmentOptions::force_async_hooks_checks,
             kAllowedInEnvironment,
             true);
+  AddOption("--addons",
+            "disable loading native addons",
+            &EnvironmentOptions::allow_native_addons,
+            kAllowedInEnvironment,
+            true);
   AddOption("--warnings",
             "silence all process warnings",
             &EnvironmentOptions::warnings,

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -121,6 +121,7 @@ class EnvironmentOptions : public Options {
   uint64_t max_http_header_size = 16 * 1024;
   bool deprecation = true;
   bool force_async_hooks_checks = true;
+  bool allow_native_addons = true;
   bool warnings = true;
   bool force_context_aware = false;
   bool pending_deprecation = false;

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -560,6 +560,8 @@ void Worker::New(const FunctionCallbackInfo<Value>& args) {
     worker->environment_flags_ |= EnvironmentFlags::kTrackUnmanagedFds;
   if (env->hide_console_windows())
     worker->environment_flags_ |= EnvironmentFlags::kHideConsoleWindows;
+  if (env->no_native_addons())
+    worker->environment_flags_ |= EnvironmentFlags::kNoNativeAddons;
 }
 
 void Worker::StartThread(const FunctionCallbackInfo<Value>& args) {

--- a/test/addons/no-addons/binding.gyp
+++ b/test/addons/no-addons/binding.gyp
@@ -1,0 +1,9 @@
+{
+  'targets': [
+    {
+      'target_name': 'binding',
+      'sources': [ '../hello-world/binding.cc' ],
+      'includes': ['../common.gypi'],
+    }
+  ]
+}

--- a/test/addons/no-addons/test-worker.js
+++ b/test/addons/no-addons/test-worker.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const common = require('../../common');
+const assert = require('assert');
+const path = require('path');
+const { Worker } = require('worker_threads');
+
+const binding = path.resolve(__dirname, `./build/${common.buildType}/binding`);
+
+const worker = new Worker(`require(${JSON.stringify(binding)})`, { eval: true });
+
+worker.on('error', common.mustCall((error) => {
+  assert.strictEqual(error.code, 'ERR_DLOPEN_FAILED');
+  assert.strictEqual(error.message, 'Cannot load native addon because loading addons is disabled.');
+}));

--- a/test/addons/no-addons/test-worker.js
+++ b/test/addons/no-addons/test-worker.js
@@ -1,3 +1,5 @@
+// Flags: --no-addons
+
 'use strict';
 
 const common = require('../../common');
@@ -7,17 +9,39 @@ const { Worker } = require('worker_threads');
 
 const binding = path.resolve(__dirname, `./build/${common.buildType}/binding`);
 
-const worker = new Worker(`require(${JSON.stringify(binding)})`, {
-  eval: true,
-});
+const expectError = (error) => {
+  assert.strictEqual(error.code, 'ERR_DLOPEN_DISABLED');
+  assert.strictEqual(
+    error.message,
+    'Cannot load native addon because loading addons is disabled.'
+  );
+};
 
-worker.on(
-  'error',
-  common.mustCall((error) => {
-    assert.strictEqual(error.code, 'ERR_DLOPEN_FAILED');
-    assert.strictEqual(
-      error.message,
-      'Cannot load native addon because loading addons is disabled.'
-    );
-  })
-);
+{
+  // flags should be inherited
+  const worker = new Worker(`require(${JSON.stringify(binding)})`, {
+    eval: true,
+  });
+
+  worker.on('error', common.mustCall(expectError));
+}
+
+{
+  // explicitly pass `--no-addons`
+  const worker = new Worker(`require(${JSON.stringify(binding)})`, {
+    eval: true,
+    execArgv: ['--no-addons'],
+  });
+
+  worker.on('error', common.mustCall(expectError));
+}
+
+{
+  // if `execArgv` is overwritten it should still fail to load addons
+  const worker = new Worker(`require(${JSON.stringify(binding)})`, {
+    eval: true,
+    execArgv: [],
+  });
+
+  worker.on('error', common.mustCall(expectError));
+}

--- a/test/addons/no-addons/test-worker.js
+++ b/test/addons/no-addons/test-worker.js
@@ -7,9 +7,17 @@ const { Worker } = require('worker_threads');
 
 const binding = path.resolve(__dirname, `./build/${common.buildType}/binding`);
 
-const worker = new Worker(`require(${JSON.stringify(binding)})`, { eval: true });
+const worker = new Worker(`require(${JSON.stringify(binding)})`, {
+  eval: true,
+});
 
-worker.on('error', common.mustCall((error) => {
-  assert.strictEqual(error.code, 'ERR_DLOPEN_FAILED');
-  assert.strictEqual(error.message, 'Cannot load native addon because loading addons is disabled.');
-}));
+worker.on(
+  'error',
+  common.mustCall((error) => {
+    assert.strictEqual(error.code, 'ERR_DLOPEN_FAILED');
+    assert.strictEqual(
+      error.message,
+      'Cannot load native addon because loading addons is disabled.'
+    );
+  })
+);

--- a/test/addons/no-addons/test-worker.js
+++ b/test/addons/no-addons/test-worker.js
@@ -18,7 +18,7 @@ const expectError = (error) => {
 };
 
 {
-  // flags should be inherited
+  // Flags should be inherited
   const worker = new Worker(`require(${JSON.stringify(binding)})`, {
     eval: true,
   });
@@ -27,7 +27,7 @@ const expectError = (error) => {
 }
 
 {
-  // explicitly pass `--no-addons`
+  // Explicitly pass `--no-addons`
   const worker = new Worker(`require(${JSON.stringify(binding)})`, {
     eval: true,
     execArgv: ['--no-addons'],
@@ -37,7 +37,7 @@ const expectError = (error) => {
 }
 
 {
-  // if `execArgv` is overwritten it should still fail to load addons
+  // If `execArgv` is overwritten it should still fail to load addons
   const worker = new Worker(`require(${JSON.stringify(binding)})`, {
     eval: true,
     execArgv: [],

--- a/test/addons/no-addons/test-worker.js
+++ b/test/addons/no-addons/test-worker.js
@@ -9,7 +9,7 @@ const { Worker } = require('worker_threads');
 
 const binding = path.resolve(__dirname, `./build/${common.buildType}/binding`);
 
-const expectError = (error) => {
+const assertError = (error) => {
   assert.strictEqual(error.code, 'ERR_DLOPEN_DISABLED');
   assert.strictEqual(
     error.message,
@@ -23,7 +23,19 @@ const expectError = (error) => {
     eval: true,
   });
 
-  worker.on('error', common.mustCall(expectError));
+  worker.on('error', common.mustCall(assertError));
+}
+
+{
+  // Should throw when using `process.dlopen` directly
+  const worker = new Worker(
+    `process.dlopen({ exports: {} }, ${JSON.stringify(binding)});`,
+    {
+      eval: true,
+    }
+  );
+
+  worker.on('error', common.mustCall(assertError));
 }
 
 {
@@ -33,7 +45,7 @@ const expectError = (error) => {
     execArgv: ['--no-addons'],
   });
 
-  worker.on('error', common.mustCall(expectError));
+  worker.on('error', common.mustCall(assertError));
 }
 
 {
@@ -43,5 +55,5 @@ const expectError = (error) => {
     execArgv: [],
   });
 
-  worker.on('error', common.mustCall(expectError));
+  worker.on('error', common.mustCall(assertError));
 }

--- a/test/addons/no-addons/test.js
+++ b/test/addons/no-addons/test.js
@@ -13,7 +13,10 @@ try {
   threw = true;
   assert(error instanceof Error);
   assert.strictEqual(error.code, 'ERR_DLOPEN_FAILED');
-  assert.strictEqual(error.message, 'Cannot load native addon because loading addons is disabled.');
+  assert.strictEqual(
+    error.message,
+    'Cannot load native addon because loading addons is disabled.'
+  );
 }
 
 assert(threw);

--- a/test/addons/no-addons/test.js
+++ b/test/addons/no-addons/test.js
@@ -7,18 +7,37 @@ const assert = require('assert');
 
 const bindingPath = require.resolve(`./build/${common.buildType}/binding`);
 
-let threw = false;
-
-try {
-  require(bindingPath);
-} catch (error) {
-  threw = true;
+const assertError = (error) => {
   assert(error instanceof Error);
   assert.strictEqual(error.code, 'ERR_DLOPEN_DISABLED');
   assert.strictEqual(
     error.message,
     'Cannot load native addon because loading addons is disabled.'
   );
+};
+
+{
+  let threw = false;
+
+  try {
+    require(bindingPath);
+  } catch (error) {
+    assertError(error);
+    threw = true;
+  }
+
+  assert(threw);
 }
 
-assert(threw);
+{
+  let threw = false;
+
+  try {
+    process.dlopen({ exports: {} }, bindingPath);
+  } catch (error) {
+    assertError(error);
+    threw = true;
+  }
+
+  assert(threw);
+}

--- a/test/addons/no-addons/test.js
+++ b/test/addons/no-addons/test.js
@@ -1,3 +1,5 @@
+// Flags: --no-addons
+
 'use strict';
 
 const common = require('../../common');
@@ -12,7 +14,7 @@ try {
 } catch (error) {
   threw = true;
   assert(error instanceof Error);
-  assert.strictEqual(error.code, 'ERR_DLOPEN_FAILED');
+  assert.strictEqual(error.code, 'ERR_DLOPEN_DISABLED');
   assert.strictEqual(
     error.message,
     'Cannot load native addon because loading addons is disabled.'

--- a/test/addons/no-addons/test.js
+++ b/test/addons/no-addons/test.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const common = require('../../common');
+const assert = require('assert');
+
+const bindingPath = require.resolve(`./build/${common.buildType}/binding`);
+
+let threw = false;
+
+try {
+  require(bindingPath);
+} catch (error) {
+  threw = true;
+  assert(error instanceof Error);
+  assert.strictEqual(error.code, 'ERR_DLOPEN_FAILED');
+  assert.strictEqual(error.message, 'Cannot load native addon because loading addons is disabled.');
+}
+
+assert(threw);

--- a/test/es-module/test-esm-no-addons.mjs
+++ b/test/es-module/test-esm-no-addons.mjs
@@ -1,0 +1,27 @@
+import { mustCall } from '../common/index.mjs';
+import { Worker, isMainThread } from 'worker_threads';
+import assert from 'assert';
+import { fileURLToPath } from 'url';
+import { requireFixture, importFixture } from '../fixtures/pkgexports.mjs';
+
+if (isMainThread) {
+  const tests = [[], ['--no-addons']];
+
+  for (const execArgv of tests) {
+    new Worker(fileURLToPath(import.meta.url), { execArgv });
+  }
+} else {
+  [requireFixture, importFixture].forEach((loadFixture) => {
+    loadFixture('pkgexports/no-addons').then(
+      mustCall((module) => {
+        const message = module.default;
+
+        if (process.execArgv.length === 0) {
+          assert.strictEqual(message, 'using native addons');
+        } else {
+          assert.strictEqual(message, 'not using native addons');
+        }
+      })
+    );
+  });
+}

--- a/test/fixtures/es-module-loaders/loader-with-custom-condition.mjs
+++ b/test/fixtures/es-module-loaders/loader-with-custom-condition.mjs
@@ -1,8 +1,14 @@
-import {ok, deepStrictEqual} from 'assert';
+import { ok, deepStrictEqual } from 'assert';
 
 export async function resolve(specifier, context, defaultResolve) {
   ok(Array.isArray(context.conditions), 'loader receives conditions array');
-  deepStrictEqual([...context.conditions].sort(), ['import', 'node']);
+
+  deepStrictEqual([...context.conditions].sort(), [
+    'import',
+    'node',
+    'node-addons',
+  ]);
+
   return defaultResolve(specifier, {
     ...context,
     conditions: ['custom-condition', ...context.conditions],

--- a/test/fixtures/node_modules/pkgexports/addons-entry.js
+++ b/test/fixtures/node_modules/pkgexports/addons-entry.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = 'using native addons';

--- a/test/fixtures/node_modules/pkgexports/no-addons-entry.js
+++ b/test/fixtures/node_modules/pkgexports/no-addons-entry.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = 'not using native addons';

--- a/test/fixtures/node_modules/pkgexports/package.json
+++ b/test/fixtures/node_modules/pkgexports/package.json
@@ -20,6 +20,10 @@
     "./nofallback1": [],
     "./nofallback2": [null, {}, "builtin:x"],
     "./nodemodules": "./node_modules/internalpkg/x.js",
+    "./no-addons": {
+      "no-addons": "./no-addons-entry.js",
+      "default": "./addons-entry.js"
+    },
     "./condition": [{
       "custom-condition": {
         "import": "./custom-condition.mjs",

--- a/test/fixtures/node_modules/pkgexports/package.json
+++ b/test/fixtures/node_modules/pkgexports/package.json
@@ -21,8 +21,8 @@
     "./nofallback2": [null, {}, "builtin:x"],
     "./nodemodules": "./node_modules/internalpkg/x.js",
     "./no-addons": {
-      "no-addons": "./no-addons-entry.js",
-      "default": "./addons-entry.js"
+      "node-addons": "./addons-entry.js",
+      "default": "./no-addons-entry.js"
     },
     "./condition": [{
       "custom-condition": {

--- a/test/parallel/test-no-addons-resolution-condition.js
+++ b/test/parallel/test-no-addons-resolution-condition.js
@@ -1,15 +1,17 @@
 'use strict';
 
-const { Worker, isMainThread, parentPort } = require('worker_threads');
 const common = require('../common');
-const assert = require('assert');
 const fixtures = require('../common/fixtures');
+const { Worker, isMainThread, parentPort } = require('worker_threads');
+const assert = require('assert');
 const { createRequire } = require('module');
 
 const loadFixture = createRequire(fixtures.path('node_modules'));
 
 if (isMainThread) {
-  [[], ['--no-addons']].map((execArgv) => {
+  const tests = [[], ['--no-addons']];
+
+  for (const execArgv of tests) {
     const worker = new Worker(__filename, { execArgv });
 
     worker.on('message', common.mustCall((message) => {
@@ -19,7 +21,8 @@ if (isMainThread) {
         assert.strictEqual(message, 'not using native addons');
       }
     }));
-  });
+  }
+
 } else {
   const message = loadFixture('pkgexports/no-addons');
   parentPort.postMessage(message);

--- a/test/parallel/test-no-addons-resolution-condition.js
+++ b/test/parallel/test-no-addons-resolution-condition.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const { Worker, isMainThread, parentPort } = require('worker_threads');
+const common = require('../common');
+const assert = require('assert');
+const fixtures = require('../common/fixtures');
+const { createRequire } = require('module');
+
+const loadFixture = createRequire(fixtures.path('node_modules'));
+
+if (isMainThread) {
+  [[], ['--no-addons']].map((execArgv) => {
+    const worker = new Worker(__filename, { execArgv });
+
+    worker.on('message', common.mustCall((message) => {
+      if (execArgv.length === 0) {
+        assert.strictEqual(message, 'using native addons');
+      } else {
+        assert.strictEqual(message, 'not using native addons');
+      }
+    }));
+  });
+} else {
+  const message = loadFixture('pkgexports/no-addons');
+  parentPort.postMessage(message);
+}


### PR DESCRIPTION
This PR adds a new CLI option `--no-addons` which disables loading native addons. When this option is specified, loading a native addon will throw from the internal side (`node_binding.cc#DLOpen`). In addition, using this option will enable a new resolution condition `no-addons`. The motivation behind this PR originates from [this proposal](https://github.com/stackblitz/webcontainer-core/issues/286). The TLDR is that we wanted to propose a way to disable native addons and allow open source maintainers to conditionally export different entry points, e.g. an entry point that uses native addons vs. an entry point that for instance uses WebAssembly to enable it to run in environments that don't allow running native code such as browsers.

For the initial PR I have decided to go with `--no-addons` for the CLI option, but if anyone has suggestions I am happy to change it.

- [x] Tests added
- [x] `make -j4 test` passes
