### PR TITLE
lib: use standard property names

### DIFF
--- a/lib/v8.js
+++ b/lib/v8.js
@@ -154,17 +154,17 @@ function getHeapStatistics() {
   updateHeapStatisticsBuffer();
 
   return {
-    'total_heap_size': buffer[kTotalHeapSizeIndex],
-    'total_heap_size_executable': buffer[kTotalHeapSizeExecutableIndex],
-    'total_physical_size': buffer[kTotalPhysicalSizeIndex],
-    'total_available_size': buffer[kTotalAvailableSize],
-    'used_heap_size': buffer[kUsedHeapSizeIndex],
-    'heap_size_limit': buffer[kHeapSizeLimitIndex],
-    'malloced_memory': buffer[kMallocedMemoryIndex],
-    'peak_malloced_memory': buffer[kPeakMallocedMemoryIndex],
-    'does_zap_garbage': buffer[kDoesZapGarbageIndex],
-    'number_of_native_contexts': buffer[kNumberOfNativeContextsIndex],
-    'number_of_detached_contexts': buffer[kNumberOfDetachedContextsIndex]
+    total_heap_size: buffer[kTotalHeapSizeIndex],
+    total_heap_size_executable: buffer[kTotalHeapSizeExecutableIndex],
+    total_physical_size: buffer[kTotalPhysicalSizeIndex],
+    total_available_size: buffer[kTotalAvailableSize],
+    used_heap_size: buffer[kUsedHeapSizeIndex],
+    heap_size_limit: buffer[kHeapSizeLimitIndex],
+    malloced_memory: buffer[kMallocedMemoryIndex],
+    peak_malloced_memory: buffer[kPeakMallocedMemoryIndex],
+    does_zap_garbage: buffer[kDoesZapGarbageIndex],
+    number_of_native_contexts: buffer[kNumberOfNativeContextsIndex],
+    number_of_detached_contexts: buffer[kNumberOfDetachedContextsIndex]
   };
 }
 
@@ -209,9 +209,9 @@ function getHeapCodeStatistics() {
 
   updateHeapCodeStatisticsBuffer();
   return {
-    'code_and_metadata_size': buffer[kCodeAndMetadataSizeIndex],
-    'bytecode_and_metadata_size': buffer[kBytecodeAndMetadataSizeIndex],
-    'external_script_source_size': buffer[kExternalScriptSourceSizeIndex]
+    code_and_metadata_size: buffer[kCodeAndMetadataSizeIndex],
+    bytecode_and_metadata_size: buffer[kBytecodeAndMetadataSizeIndex],
+    external_script_source_size: buffer[kExternalScriptSourceSizeIndex]
   };
 }
 


### PR DESCRIPTION
The standard property names that aren't strings can be used where appropriate, this is one of them.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
