### PR TITLE
Revert "build: add windows-2022 to GitHub test matrix"

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -18,11 +18,7 @@ env:
 jobs:
   build-windows:
     if: github.event.pull_request.draft == false
-    strategy:
-      matrix:
-        windows: [windows-2019, windows-2022]
-      fail-fast: false
-    runs-on: ${{ matrix.windows }}
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ env.PYTHON_VERSION }}


### PR DESCRIPTION
This reverts commit 13b569c679ca98fa2549ad5c801b3d52a4249d72.

V8 9.3 is not compatible.

Refs: https://github.com/nodejs/node/issues/39976
