### PR TITLE
lib: remove default assignment

### DIFF
--- a/lib/internal/streams/from.js
+++ b/lib/internal/streams/from.js
@@ -25,7 +25,7 @@ function from(Readable, iterable, opts) {
     });
   }
 
-  let isAsync = false;
+  let isAsync;
   if (iterable && iterable[SymbolAsyncIterator]) {
     isAsync = true;
     iterator = iterable[SymbolAsyncIterator]();


### PR DESCRIPTION
There's no need to set to 'false', because we will set the value according to the actual condition.