### PR TITLE
dns: default to verbatim=true in dns.lookup()

### DIFF
--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -170,6 +170,9 @@ section if a custom port is used.
 <!-- YAML
 added: v0.1.90
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/37681
+    description: The `verbatim` options defaults to `true` now.
   - version: v8.5.0
     pr-url: https://github.com/nodejs/node/pull/14731
     description: The `verbatim` option is supported now.
@@ -190,10 +193,9 @@ changes:
   * `verbatim` {boolean} When `true`, the callback receives IPv4 and IPv6
     addresses in the order the DNS resolver returned them. When `false`,
     IPv4 addresses are placed before IPv6 addresses.
-    **Default:** currently `false` (addresses are reordered) but this is
-    expected to change in the not too distant future. Default value is
+    **Default:** `true` (addresses are reordered). Default value is
     configurable using [`dns.setDefaultResultOrder()`][] or
-    [`--dns-result-order`][]. New code should use `{ verbatim: true }`.
+    [`--dns-result-order`][].
 * `callback` {Function}
   * `err` {Error}
   * `address` {string} A string representation of an IPv4 or IPv6 address.

--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -171,7 +171,7 @@ section if a custom port is used.
 added: v0.1.90
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/37681
+    pr-url: https://github.com/nodejs/node/pull/39987
     description: The `verbatim` options defaults to `true` now.
   - version: v8.5.0
     pr-url: https://github.com/nodejs/node/pull/14731

--- a/lib/internal/dns/utils.js
+++ b/lib/internal/dns/utils.js
@@ -193,15 +193,16 @@ function emitInvalidHostnameWarning(hostname) {
   );
 }
 
-let dnsOrder = getOptionValue('--dns-result-order') || 'ipv4first';
+let dnsOrder = getOptionValue('--dns-result-order') || 'verbatim';
 
 function getDefaultVerbatim() {
   switch (dnsOrder) {
     case 'verbatim':
       return true;
     case 'ipv4first':
-    default:
       return false;
+    default:
+      return true;
   }
 }
 

--- a/lib/internal/dns/utils.js
+++ b/lib/internal/dns/utils.js
@@ -196,14 +196,7 @@ function emitInvalidHostnameWarning(hostname) {
 let dnsOrder = getOptionValue('--dns-result-order') || 'verbatim';
 
 function getDefaultVerbatim() {
-  switch (dnsOrder) {
-    case 'verbatim':
-      return true;
-    case 'ipv4first':
-      return false;
-    default:
-      return true;
-  }
+  return dnsOrder !== 'ipv4first';
 }
 
 function setDefaultResultOrder(value) {

--- a/test/common/inspector-helper.js
+++ b/test/common/inspector-helper.js
@@ -392,7 +392,7 @@ class NodeInstance extends EventEmitter {
     console.log('[test]', `Testing ${path}`);
     const headers = hostHeaderValue ? { 'Host': hostHeaderValue } : null;
     return this.portPromise.then((port) => new Promise((resolve, reject) => {
-      const req = http.get({ host, port, path, headers }, (res) => {
+      const req = http.get({ host, port, family: 4, path, headers }, (res) => {
         let response = '';
         res.setEncoding('utf8');
         res
@@ -418,6 +418,7 @@ class NodeInstance extends EventEmitter {
     const port = await this.portPromise;
     return http.get({
       port,
+      family: 4,
       path: parseURL(devtoolsUrl).path,
       headers: {
         'Connection': 'Upgrade',

--- a/test/parallel/test-cluster-message.js
+++ b/test/parallel/test-cluster-message.js
@@ -60,7 +60,7 @@ if (cluster.isWorker) {
     maybeReply();
   });
 
-  server.listen(0, '127.0.0.1');
+  server.listen(0);
 } else if (cluster.isPrimary) {
 
   const checks = {

--- a/test/parallel/test-http-localaddress.js
+++ b/test/parallel/test-http-localaddress.js
@@ -42,6 +42,7 @@ const server = http.createServer((req, res) => {
 server.listen(0, '127.0.0.1', () => {
   const options = { host: 'localhost',
                     port: server.address().port,
+                    family: 4,
                     path: '/',
                     method: 'GET',
                     localAddress: '127.0.0.2' };

--- a/test/parallel/test-http-upgrade-client.js
+++ b/test/parallel/test-http-upgrade-client.js
@@ -49,7 +49,7 @@ const server = net.createServer(function(c) {
   });
 });
 
-server.listen(0, '127.0.0.1', common.mustCall(function() {
+server.listen(0, common.mustCall(function() {
   const port = this.address().port;
   const headers = [
     {

--- a/test/parallel/test-http2-connect-options.js
+++ b/test/parallel/test-http2-connect-options.js
@@ -22,7 +22,7 @@ const server = http2.createServer((req, res) => {
 });
 
 server.listen(0, '127.0.0.1', common.mustCall(() => {
-  const options = { localAddress: '127.0.0.2' };
+  const options = { localAddress: '127.0.0.2', family: 4 };
 
   const client = http2.connect(
     'http://localhost:' + server.address().port,

--- a/test/parallel/test-https-localaddress.js
+++ b/test/parallel/test-https-localaddress.js
@@ -52,6 +52,7 @@ server.listen(0, '127.0.0.1', function() {
   const options = {
     host: 'localhost',
     port: this.address().port,
+    family: 4,
     path: '/',
     method: 'GET',
     localAddress: '127.0.0.2',

--- a/test/parallel/test-net-connect-options-port.js
+++ b/test/parallel/test-net-connect-options-port.js
@@ -83,7 +83,7 @@ const net = require('net');
     }
   }, expectedConnections));
 
-  server.listen(0, 'localhost', common.mustCall(() => {
+  server.listen(0, common.localhostIPv4, common.mustCall(() => {
     const port = server.address().port;
 
     // Total connections = 3 * 4(canConnect) * 6(doConnect) = 72
@@ -133,28 +133,35 @@ function doConnect(args, getCb) {
 }
 
 function syncFailToConnect(port, assertErr, optOnly) {
+  const family = 4;
   if (!optOnly) {
     // connect(port, cb) and connect(port)
-    const portArgFunctions = doConnect([port], () => common.mustNotCall());
+    const portArgFunctions = doConnect([{ port, family }],
+                                       () => common.mustNotCall());
     for (const fn of portArgFunctions) {
       assert.throws(fn, assertErr, `${fn.name}(${port})`);
     }
 
     // connect(port, host, cb) and connect(port, host)
-    const portHostArgFunctions = doConnect([port, 'localhost'],
+    const portHostArgFunctions = doConnect([{ port,
+                                              host: 'localhost',
+                                              family }],
                                            () => common.mustNotCall());
     for (const fn of portHostArgFunctions) {
       assert.throws(fn, assertErr, `${fn.name}(${port}, 'localhost')`);
     }
   }
   // connect({port}, cb) and connect({port})
-  const portOptFunctions = doConnect([{ port }], () => common.mustNotCall());
+  const portOptFunctions = doConnect([{ port, family }],
+                                     () => common.mustNotCall());
   for (const fn of portOptFunctions) {
     assert.throws(fn, assertErr, `${fn.name}({port: ${port}})`);
   }
 
   // connect({port, host}, cb) and connect({port, host})
-  const portHostOptFunctions = doConnect([{ port: port, host: 'localhost' }],
+  const portHostOptFunctions = doConnect([{ port: port,
+                                            host: 'localhost',
+                                            family: family }],
                                          () => common.mustNotCall());
   for (const fn of portHostOptFunctions) {
     assert.throws(fn,
@@ -165,27 +172,30 @@ function syncFailToConnect(port, assertErr, optOnly) {
 
 function canConnect(port) {
   const noop = () => common.mustCall();
+  const family = 4;
 
   // connect(port, cb) and connect(port)
-  const portArgFunctions = doConnect([port], noop);
+  const portArgFunctions = doConnect([{ port, family }], noop);
   for (const fn of portArgFunctions) {
     fn();
   }
 
   // connect(port, host, cb) and connect(port, host)
-  const portHostArgFunctions = doConnect([port, 'localhost'], noop);
+  const portHostArgFunctions = doConnect([{ port, host: 'localhost', family }],
+                                         noop);
   for (const fn of portHostArgFunctions) {
     fn();
   }
 
   // connect({port}, cb) and connect({port})
-  const portOptFunctions = doConnect([{ port }], noop);
+  const portOptFunctions = doConnect([{ port, family }], noop);
   for (const fn of portOptFunctions) {
     fn();
   }
 
   // connect({port, host}, cb) and connect({port, host})
-  const portHostOptFns = doConnect([{ port, host: 'localhost' }], noop);
+  const portHostOptFns = doConnect([{ port, host: 'localhost', family }],
+                                   noop);
   for (const fn of portHostOptFns) {
     fn();
   }
@@ -198,20 +208,22 @@ function asyncFailToConnect(port) {
   });
 
   const dont = () => common.mustNotCall();
+  const family = 4;
   // connect(port, cb) and connect(port)
-  const portArgFunctions = doConnect([port], dont);
+  const portArgFunctions = doConnect([{ port, family }], dont);
   for (const fn of portArgFunctions) {
     fn().on('error', onError());
   }
 
   // connect({port}, cb) and connect({port})
-  const portOptFunctions = doConnect([{ port }], dont);
+  const portOptFunctions = doConnect([{ port, family }], dont);
   for (const fn of portOptFunctions) {
     fn().on('error', onError());
   }
 
   // connect({port, host}, cb) and connect({port, host})
-  const portHostOptFns = doConnect([{ port, host: 'localhost' }], dont);
+  const portHostOptFns = doConnect([{ port, host: 'localhost', family }],
+                                   dont);
   for (const fn of portHostOptFns) {
     fn().on('error', onError());
   }

--- a/test/parallel/test-net-dns-lookup.js
+++ b/test/parallel/test-net-dns-lookup.js
@@ -33,7 +33,6 @@ server.listen(0, common.mustCall(function() {
   net.connect(this.address().port, 'localhost')
     .on('lookup', common.mustCall(function(err, ip, type, host) {
       assert.strictEqual(err, null);
-      assert.strictEqual(ip, '127.0.0.1');
       assert.match(ip, /^(127\.0\.0\.1|::1)$/);
       assert.match(type.toString, /^(4|6)$/);
       assert.strictEqual(host, 'localhost');

--- a/test/parallel/test-net-dns-lookup.js
+++ b/test/parallel/test-net-dns-lookup.js
@@ -34,7 +34,8 @@ server.listen(0, common.mustCall(function() {
     .on('lookup', common.mustCall(function(err, ip, type, host) {
       assert.strictEqual(err, null);
       assert.strictEqual(ip, '127.0.0.1');
-      assert.strictEqual(type, 4);
+      assert.match(ip,/^(127\.0\.0\.1|::1)$/);
+      assert.match(type.toString, /^(4|6)$/);
       assert.strictEqual(host, 'localhost');
     }));
 }));

--- a/test/parallel/test-net-dns-lookup.js
+++ b/test/parallel/test-net-dns-lookup.js
@@ -34,7 +34,7 @@ server.listen(0, common.mustCall(function() {
     .on('lookup', common.mustCall(function(err, ip, type, host) {
       assert.strictEqual(err, null);
       assert.match(ip, /^(127\.0\.0\.1|::1)$/);
-      assert.match(type.toString, /^(4|6)$/);
+      assert.match(type.toString(), /^(4|6)$/);
       assert.strictEqual(host, 'localhost');
     }));
 }));

--- a/test/parallel/test-net-dns-lookup.js
+++ b/test/parallel/test-net-dns-lookup.js
@@ -29,7 +29,7 @@ const server = net.createServer(function(client) {
   server.close();
 });
 
-server.listen(0, '127.0.0.1', common.mustCall(function() {
+server.listen(0, common.mustCall(function() {
   net.connect(this.address().port, 'localhost')
     .on('lookup', common.mustCall(function(err, ip, type, host) {
       assert.strictEqual(err, null);

--- a/test/parallel/test-net-dns-lookup.js
+++ b/test/parallel/test-net-dns-lookup.js
@@ -34,7 +34,7 @@ server.listen(0, common.mustCall(function() {
     .on('lookup', common.mustCall(function(err, ip, type, host) {
       assert.strictEqual(err, null);
       assert.strictEqual(ip, '127.0.0.1');
-      assert.match(ip,/^(127\.0\.0\.1|::1)$/);
+      assert.match(ip, /^(127\.0\.0\.1|::1)$/);
       assert.match(type.toString, /^(4|6)$/);
       assert.strictEqual(host, 'localhost');
     }));

--- a/test/parallel/test-net-pingpong.js
+++ b/test/parallel/test-net-pingpong.js
@@ -130,6 +130,4 @@ const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 pingPongTest(common.PIPE);
 pingPongTest(0);
-pingPongTest(0, 'localhost');
-if (common.hasIPv6)
-  pingPongTest(0, '::1');
+common.hasIPv6 ? pingPongTest(0, '::1') : pingPongTest(0, '127.0.0.1');

--- a/test/parallel/test-net-pingpong.js
+++ b/test/parallel/test-net-pingpong.js
@@ -130,4 +130,4 @@ const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 pingPongTest(common.PIPE);
 pingPongTest(0);
-common.hasIPv6 ? pingPongTest(0, '::1') : pingPongTest(0, '127.0.0.1');
+if (common.hasIPv6) pingPongTest(0, '::1'); else pingPongTest(0, '127.0.0.1');

--- a/test/parallel/test-net-remote-address-port.js
+++ b/test/parallel/test-net-remote-address-port.js
@@ -28,7 +28,7 @@ const net = require('net');
 let conns_closed = 0;
 
 const remoteAddrCandidates = [ common.localhostIPv4 ];
-if (common.hasIPv6) remoteAddrCandidates.push('::ffff:127.0.0.1');
+if (common.hasIPv6) remoteAddrCandidates.push('::1', '::ffff:127.0.0.1');
 
 const remoteFamilyCandidates = ['IPv4'];
 if (common.hasIPv6) remoteFamilyCandidates.push('IPv6');

--- a/test/parallel/test-net-remote-address-port.js
+++ b/test/parallel/test-net-remote-address-port.js
@@ -27,20 +27,17 @@ const net = require('net');
 
 let conns_closed = 0;
 
-const remoteAddrCandidates = [ common.localhostIPv4 ];
-if (common.hasIPv6) remoteAddrCandidates.push('::1', '::ffff:127.0.0.1');
+const remoteAddrCandidates = [ common.localhostIPv4,
+                               '::1',
+                               '::ffff:127.0.0.1' ];
 
-const remoteFamilyCandidates = ['IPv4'];
-if (common.hasIPv6) remoteFamilyCandidates.push('IPv6');
+const remoteFamilyCandidates = ['IPv4', 'IPv6'];
 
 const server = net.createServer(common.mustCall(function(socket) {
-  // REM: assert.match(socket.remoteAddress,
-  // REM:              /^127\.0\.0\.1$|^::1$|^::ffff:127\.0\.0\.1$/);
   assert.ok(remoteAddrCandidates.includes(socket.remoteAddress),
             `Illformed remoteAddress: ${socket.remoteAddress}`);
   assert.ok(remoteFamilyCandidates.includes(socket.remoteFamily),
             `Illformed remoteFamily: ${socket.remoteFamily}`);
-  // REM: assert.ok(remoteFamilyCandidates.includes(socket.remoteFamily));
   assert.ok(socket.remotePort);
   assert.notStrictEqual(socket.remotePort, this.address().port);
   socket.on('end', function() {

--- a/test/parallel/test-net-remote-address-port.js
+++ b/test/parallel/test-net-remote-address-port.js
@@ -35,9 +35,9 @@ const remoteFamilyCandidates = ['IPv4', 'IPv6'];
 
 const server = net.createServer(common.mustCall(function(socket) {
   assert.ok(remoteAddrCandidates.includes(socket.remoteAddress),
-            `Illformed remoteAddress: ${socket.remoteAddress}`);
+            `Invalid remoteAddress: ${socket.remoteAddress}`);
   assert.ok(remoteFamilyCandidates.includes(socket.remoteFamily),
-            `Illformed remoteFamily: ${socket.remoteFamily}`);
+            `Invalid remoteFamily: ${socket.remoteFamily}`);
   assert.ok(socket.remotePort);
   assert.notStrictEqual(socket.remotePort, this.address().port);
   socket.on('end', function() {

--- a/test/parallel/test-net-remote-address-port.js
+++ b/test/parallel/test-net-remote-address-port.js
@@ -34,11 +34,13 @@ const remoteFamilyCandidates = ['IPv4'];
 if (common.hasIPv6) remoteFamilyCandidates.push('IPv6');
 
 const server = net.createServer(common.mustCall(function(socket) {
-  // Test to see real value in CI log
-  assert.match(socket.remoteAddress,
-               /^127\.0\.0\.1$|^::1$|^::ffff:127\.0\.0\.1$/);
-  // REM: assert.ok(remoteAddrCandidates.includes(socket.remoteAddress));
-  assert.ok(remoteFamilyCandidates.includes(socket.remoteFamily));
+  // REM: assert.match(socket.remoteAddress,
+  // REM:              /^127\.0\.0\.1$|^::1$|^::ffff:127\.0\.0\.1$/);
+  assert.ok(remoteAddrCandidates.includes(socket.remoteAddress),
+            `Illformed remoteAddress: ${socket.remoteAddress}`);
+  assert.ok(remoteFamilyCandidates.includes(socket.remoteFamily),
+            `Illformed remoteFamily: ${socket.remoteFamily}`);
+  // REM: assert.ok(remoteFamilyCandidates.includes(socket.remoteFamily));
   assert.ok(socket.remotePort);
   assert.notStrictEqual(socket.remotePort, this.address().port);
   socket.on('end', function() {

--- a/test/parallel/test-net-remote-address-port.js
+++ b/test/parallel/test-net-remote-address-port.js
@@ -34,10 +34,10 @@ const remoteFamilyCandidates = ['IPv4'];
 if (common.hasIPv6) remoteFamilyCandidates.push('IPv6');
 
 const server = net.createServer(common.mustCall(function(socket) {
-  // test to see real value in CI log
+  // Test to see real value in CI log
   assert.match(socket.remoteAddress,
-               /^127\.0\.0\.1$|^::1$|^::ffff:127.0.0.1$/);
-  // assert.ok(remoteAddrCandidates.includes(socket.remoteAddress));
+               /^127\.0\.0\.1$|^::1$|^::ffff:127\.0\.0\.1$/);
+  // REM: assert.ok(remoteAddrCandidates.includes(socket.remoteAddress));
   assert.ok(remoteFamilyCandidates.includes(socket.remoteFamily));
   assert.ok(socket.remotePort);
   assert.notStrictEqual(socket.remotePort, this.address().port);

--- a/test/parallel/test-net-remote-address-port.js
+++ b/test/parallel/test-net-remote-address-port.js
@@ -34,7 +34,10 @@ const remoteFamilyCandidates = ['IPv4'];
 if (common.hasIPv6) remoteFamilyCandidates.push('IPv6');
 
 const server = net.createServer(common.mustCall(function(socket) {
-  assert.ok(remoteAddrCandidates.includes(socket.remoteAddress));
+  // test to see real value in CI log
+  assert.match(socket.remoteAddress,
+               /^127\.0\.0\.1$|^::1$|^::ffff:127.0.0.1$/);
+  // assert.ok(remoteAddrCandidates.includes(socket.remoteAddress));
   assert.ok(remoteFamilyCandidates.includes(socket.remoteFamily));
   assert.ok(socket.remotePort);
   assert.notStrictEqual(socket.remotePort, this.address().port);

--- a/test/parallel/test-net-remote-address-port.js
+++ b/test/parallel/test-net-remote-address-port.js
@@ -48,8 +48,8 @@ const server = net.createServer(common.mustCall(function(socket) {
   socket.resume();
 }, 2));
 
-server.listen(0, 'localhost', function() {
-  const client = net.createConnection(this.address().port, 'localhost');
+server.listen(0, function() {
+  const client = net.createConnection(this.address().port, '127.0.0.1');
   const client2 = net.createConnection(this.address().port);
   client.on('connect', function() {
     assert.ok(remoteAddrCandidates.includes(client.remoteAddress));

--- a/test/parallel/test-net-writable.js
+++ b/test/parallel/test-net-writable.js
@@ -6,10 +6,8 @@ const net = require('net');
 const server = net.createServer(common.mustCall(function(s) {
   server.close();
   s.end();
-})).listen(0, 'localhost', common.mustCall(function() {
-  const socket = net.connect(this.address().port, common.hasIPv6 ?
-    '::1' :
-    '127.0.0.1');
+})).listen(0, '127.0.0.1', common.mustCall(function() {
+  const socket = net.connect(this.address().port, '127.0.0.1');
   socket.on('end', common.mustCall(() => {
     assert.strictEqual(socket.writable, true);
     socket.write('hello world');

--- a/test/parallel/test-net-writable.js
+++ b/test/parallel/test-net-writable.js
@@ -7,7 +7,9 @@ const server = net.createServer(common.mustCall(function(s) {
   server.close();
   s.end();
 })).listen(0, 'localhost', common.mustCall(function() {
-  const socket = net.connect(this.address().port, 'localhost');
+  const socket = net.connect(this.address().port, common.hasIPv6 ?
+    '::1' :
+    '127.0.0.1');
   socket.on('end', common.mustCall(() => {
     assert.strictEqual(socket.writable, true);
     socket.write('hello world');

--- a/test/parallel/test-tcp-wrap-listen.js
+++ b/test/parallel/test-tcp-wrap-listen.js
@@ -14,7 +14,7 @@ const {
 
 const server = new TCP(TCPConstants.SOCKET);
 
-const r = server.bind('0.0.0.0', 0);
+const r = server.bind(0);
 assert.strictEqual(r, 0);
 let port = {};
 server.getsockname(port);

--- a/test/parallel/test-tcp-wrap-listen.js
+++ b/test/parallel/test-tcp-wrap-listen.js
@@ -14,7 +14,9 @@ const {
 
 const server = new TCP(TCPConstants.SOCKET);
 
-const r = server.bind(0);
+const r = (common.hasIPv6 ?
+  server.bind6('::', 0) :
+  server.bind('0.0.0.0', 0));
 assert.strictEqual(r, 0);
 let port = {};
 server.getsockname(port);

--- a/test/parallel/test-timers-socket-timeout-removes-other-socket-unref-timer.js
+++ b/test/parallel/test-timers-socket-timeout-removes-other-socket-unref-timer.js
@@ -28,7 +28,7 @@ const server = net.createServer(function onClient(client) {
   }
 });
 
-server.listen(0, common.localhostIPv4, common.mustCall(() => {
+server.listen(0, common.mustCall(() => {
   const countdown = new Countdown(2, () => server.close());
 
   {

--- a/test/parallel/test-tls-client-getephemeralkeyinfo.js
+++ b/test/parallel/test-tls-client-getephemeralkeyinfo.js
@@ -37,7 +37,7 @@ function test(size, type, name, cipher) {
 
   server.on('close', common.mustSucceed());
 
-  server.listen(0, '127.0.0.1', common.mustCall(() => {
+  server.listen(0, common.mustCall(() => {
     const client = tls.connect({
       port: server.address().port,
       rejectUnauthorized: false

--- a/test/parallel/test-tls-client-mindhsize.js
+++ b/test/parallel/test-tls-client-mindhsize.js
@@ -34,7 +34,7 @@ function test(size, err, next) {
     if (next) next();
   });
 
-  server.listen(0, '127.0.0.1', function() {
+  server.listen(0, function() {
     // Client set minimum DH parameter size to 2048 bits so that
     // it fails when it make a connection to the tls server where
     // dhparams is 1024 bits

--- a/test/parallel/test-tls-wrap-econnreset-localaddress.js
+++ b/test/parallel/test-tls-wrap-econnreset-localaddress.js
@@ -16,6 +16,7 @@ const server = net.createServer((c) => {
   let errored = false;
   tls.connect({
     port: port,
+    family: 4,
     localAddress: common.localhostIPv4
   }, common.localhostIPv4)
     .once('error', common.mustCall((e) => {

--- a/test/pummel/test-http-upload-timeout.js
+++ b/test/pummel/test-http-upload-timeout.js
@@ -44,7 +44,7 @@ server.on('request', function(req, res) {
   req.resume();
 });
 
-server.listen(0, '127.0.0.1', function() {
+server.listen(0, function() {
   for (let i = 0; i < 10; i++) {
     connections++;
 

--- a/test/pummel/test-net-pingpong.js
+++ b/test/pummel/test-net-pingpong.js
@@ -112,7 +112,7 @@ function pingPongTest(host, on_complete) {
 
 // All are run at once and will run on different ports.
 pingPongTest(null);
-common.hasIPv6 ? pingPongTest('::1') : pingPongTest('127.0.0.1');
+if (common.hasIPv6) pingPongTest('::1'); else pingPongTest('127.0.0.1');
 
 process.on('exit', function() {
   assert.strictEqual(tests_run, common.hasIPv6 ? 3 : 2);

--- a/test/pummel/test-net-pingpong.js
+++ b/test/pummel/test-net-pingpong.js
@@ -38,8 +38,8 @@ function pingPongTest(host, on_complete) {
     if (host === '127.0.0.1') {
       assert.strictEqual(address, '127.0.0.1');
     } else if (host == null || host === 'localhost') {
-      assert(address === '127.0.0.1' || address === '::ffff:127.0.0.1'
-        || address === '::1');
+      assert(address === '127.0.0.1' || address === '::ffff:127.0.0.1' ||
+        address === '::1');
     } else {
       console.log(`host = ${host}, remoteAddress = ${address}`);
       assert.strictEqual(address, '::1');

--- a/test/pummel/test-net-pingpong.js
+++ b/test/pummel/test-net-pingpong.js
@@ -111,10 +111,8 @@ function pingPongTest(host, on_complete) {
 }
 
 // All are run at once and will run on different ports.
-pingPongTest('localhost');
 pingPongTest(null);
-
-if (common.hasIPv6) pingPongTest('::1');
+common.hasIPv6 ? pingPongTest('::1') : pingPongTest('127.0.0.1');
 
 process.on('exit', function() {
   assert.strictEqual(tests_run, common.hasIPv6 ? 3 : 2);

--- a/test/pummel/test-net-pingpong.js
+++ b/test/pummel/test-net-pingpong.js
@@ -38,7 +38,8 @@ function pingPongTest(host, on_complete) {
     if (host === '127.0.0.1') {
       assert.strictEqual(address, '127.0.0.1');
     } else if (host == null || host === 'localhost') {
-      assert(address === '127.0.0.1' || address === '::ffff:127.0.0.1');
+      assert(address === '127.0.0.1' || address === '::ffff:127.0.0.1'
+        || address === '::1');
     } else {
       console.log(`host = ${host}, remoteAddress = ${address}`);
       assert.strictEqual(address, '::1');

--- a/test/pummel/test-net-pingpong.js
+++ b/test/pummel/test-net-pingpong.js
@@ -112,7 +112,8 @@ function pingPongTest(host, on_complete) {
 
 // All are run at once and will run on different ports.
 pingPongTest(null);
-if (common.hasIPv6) pingPongTest('::1'); else pingPongTest('127.0.0.1');
+pingPongTest('127.0.0.1');
+if (common.hasIPv6) pingPongTest('::1');
 
 process.on('exit', function() {
   assert.strictEqual(tests_run, common.hasIPv6 ? 3 : 2);

--- a/test/sequential/test-https-connect-localport.js
+++ b/test/sequential/test-https-connect-localport.js
@@ -23,7 +23,6 @@ const assert = require('assert');
       host: 'localhost',
       pathname: '/',
       port,
-      //family: 4,
       localPort: common.PORT,
       rejectUnauthorized: false,
     }, common.mustCall(() => {

--- a/test/sequential/test-https-connect-localport.js
+++ b/test/sequential/test-https-connect-localport.js
@@ -23,6 +23,7 @@ const assert = require('assert');
       host: 'localhost',
       pathname: '/',
       port,
+      family: common.hasIPv6 ? 6 : 4,
       localPort: common.PORT,
       rejectUnauthorized: false,
     }, common.mustCall(() => {

--- a/test/sequential/test-https-connect-localport.js
+++ b/test/sequential/test-https-connect-localport.js
@@ -17,13 +17,13 @@ const assert = require('assert');
     res.end();
   }));
 
-  server.listen(0, 'localhost', common.mustCall(() => {
+  server.listen(0, '127.0.0.1', common.mustCall(() => {
     const port = server.address().port;
     const req = https.get({
       host: 'localhost',
       pathname: '/',
       port,
-      family: common.hasIPv6 ? 6 : 4,
+      family: 4,
       localPort: common.PORT,
       rejectUnauthorized: false,
     }, common.mustCall(() => {

--- a/test/sequential/test-https-connect-localport.js
+++ b/test/sequential/test-https-connect-localport.js
@@ -23,7 +23,7 @@ const assert = require('assert');
       host: 'localhost',
       pathname: '/',
       port,
-      family: 4,
+      //family: 4,
       localPort: common.PORT,
       rejectUnauthorized: false,
     }, common.mustCall(() => {

--- a/test/sequential/test-inspector-open.js
+++ b/test/sequential/test-inspector-open.js
@@ -80,7 +80,7 @@ function reopenAfterClose(msg) {
 }
 
 function ping(port, callback) {
-  net.connect(port)
+  net.connect({ port, family: 4 })
     .on('connect', function() { close(this); })
     .on('error', function(err) { close(this, err); });
 

--- a/test/sequential/test-net-better-error-messages-port.js
+++ b/test/sequential/test-net-better-error-messages-port.js
@@ -10,5 +10,5 @@ c.on('connect', common.mustNotCall());
 c.on('error', common.mustCall(function(e) {
   assert.strictEqual(e.code, 'ECONNREFUSED');
   assert.strictEqual(e.port, common.PORT);
-  assert.strictEqual(e.address, '127.0.0.1');
+  assert.match(e.address, /^(127\.0\.0\.1|::1)$/);
 }));

--- a/test/sequential/test-net-connect-local-error.js
+++ b/test/sequential/test-net-connect-local-error.js
@@ -9,12 +9,14 @@ const expectedErrorCodes = ['ECONNREFUSED', 'EADDRINUSE'];
 
 const optionsIPv4 = {
   port: common.PORT,
+  family: 4,
   localPort: common.PORT + 1,
   localAddress: common.localhostIPv4
 };
 
 const optionsIPv6 = {
   host: '::1',
+  family: 6,
   port: common.PORT + 2,
   localPort: common.PORT + 3,
   localAddress: '::1',


### PR DESCRIPTION
Switch the default from false (reorder the result so that IPv4 addresses
come before IPv6 addresses) to true (return them exactly as the resolver
sent them to us.)

After having the option to manually override the default behavior, this is another attempt at changing the default behavior.

Fixes: nodejs#31566
Refs: nodejs#6307
Refs: nodejs#20710
Refs: nodejs#38099
Reissue of nodejs#31567
Reissue of nodejs#37681
Reissue of nodejs#37931

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
