### PR TITLE
src: fix C4805 MSVC warning

### DIFF
--- a/src/crypto/crypto_util.cc
+++ b/src/crypto/crypto_util.cc
@@ -190,7 +190,7 @@ void SetFipsCrypto(const FunctionCallbackInfo<Value>& args) {
 #if OPENSSL_VERSION_MAJOR >= 3
   if (enable == EVP_default_properties_is_fips_enabled(nullptr))
 #else
-  if (enable == FIPS_mode())
+  if (static_cast<int>(enable) == FIPS_mode())
 #endif
     return;  // No action needed.
 


### PR DESCRIPTION
'==' : unsafe mix of type 'bool' and type 'int' in operation
