### PR TITLE
test: make tests pass on Windows with Unix EOL

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -885,8 +885,14 @@ const common = {
       throw new Error('common.PORT cannot be used in a parallelized test');
     }
     return +process.env.NODE_COMMON_PORT || 12346;
-  }
+  },
 
+  /**
+   * Returns the EOL character used by this Git checkout.
+   */
+  get checkoutEOL() {
+    return fs.readFileSync(__filename).includes('\r\n') ? '\r\n' : '\n';
+  },
 };
 
 const validProperties = new Set(Object.keys(common));

--- a/test/es-module/test-esm-invalid-pjson.js
+++ b/test/es-module/test-esm-invalid-pjson.js
@@ -21,7 +21,7 @@ child.on('close', mustCall((code, signal) => {
     stderr.includes(
       `[ERR_INVALID_PACKAGE_CONFIG]: Invalid package config ${invalidJson} ` +
       `while importing "invalid-pjson" from ${entry}. ` +
-      `Unexpected token } in JSON at position ${checkoutEOL === '\r\n' ? 16 : 14}`
+      `Unexpected token } in JSON at position ${12 + checkoutEOL.length * 2}`
     ),
     stderr);
 }));

--- a/test/es-module/test-esm-invalid-pjson.js
+++ b/test/es-module/test-esm-invalid-pjson.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { mustCall, isWindows } = require('../common');
+const { mustCall, checkoutEOL } = require('../common');
 const fixtures = require('../common/fixtures');
 const { spawn } = require('child_process');
 const { strictEqual, ok } = require('assert');
@@ -21,7 +21,7 @@ child.on('close', mustCall((code, signal) => {
     stderr.includes(
       `[ERR_INVALID_PACKAGE_CONFIG]: Invalid package config ${invalidJson} ` +
       `while importing "invalid-pjson" from ${entry}. ` +
-      `Unexpected token } in JSON at position ${isWindows ? 16 : 14}`
+      `Unexpected token } in JSON at position ${checkoutEOL === '\r\n' ? 16 : 14}`
     ),
     stderr);
 }));

--- a/test/parallel/test-source-map-enable.js
+++ b/test/parallel/test-source-map-enable.js
@@ -250,7 +250,7 @@ function nextdir() {
     'istanbul-throw.js',
     coverageDirectory
   );
-  if (common.isWindows) {
+  if (common.checkoutEOL === '\r\n') {
     assert.deepStrictEqual(sourceMap.lineLengths, [1086, 31, 185, 649, 0]);
   } else {
     assert.deepStrictEqual(sourceMap.lineLengths, [1085, 30, 184, 648, 0]);

--- a/test/wasi/test-wasi.js
+++ b/test/wasi/test-wasi.js
@@ -34,7 +34,7 @@ if (process.argv[2] === 'wasi-child') {
 } else {
   const assert = require('assert');
   const cp = require('child_process');
-  const { EOL } = require('os');
+  const { checkoutEOL } = common;
 
   function runWASI(options) {
     console.log('executing', options.test);
@@ -69,7 +69,7 @@ if (process.argv[2] === 'wasi-child') {
   }
   runWASI({ test: 'exitcode', exitCode: 120 });
   runWASI({ test: 'fd_prestat_get_refresh' });
-  runWASI({ test: 'freopen', stdout: `hello from input2.txt${EOL}` });
+  runWASI({ test: 'freopen', stdout: `hello from input2.txt${checkoutEOL}` });
   runWASI({ test: 'ftruncate' });
   runWASI({ test: 'getentropy' });
 
@@ -87,10 +87,10 @@ if (process.argv[2] === 'wasi-child') {
     runWASI({ test: 'readdir' });
   }
 
-  runWASI({ test: 'read_file', stdout: `hello from input.txt${EOL}` });
+  runWASI({ test: 'read_file', stdout: `hello from input.txt${checkoutEOL}` });
   runWASI({
     test: 'read_file_twice',
-    stdout: `hello from input.txt${EOL}hello from input.txt${EOL}`
+    stdout: `hello from input.txt${checkoutEOL}hello from input.txt${checkoutEOL}`
   });
   runWASI({ test: 'stat' });
   runWASI({ test: 'write_file' });


### PR DESCRIPTION
It is possible on Windows to configure Git to checkout line-endings
"as-is", which for Node.js means Unix-style.
This change makes the tests that rely on line endings pass in that case.
