### PR TITLE
fs: add stream utilities to `FileHandle`

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -242,9 +242,9 @@ added: REPLACEME
   * `start` {integer}
   * `end` {integer} **Default:** `Infinity`
   * `highWaterMark` {integer} **Default:** `64 * 1024`
-* Returns: {fs.ReadStream} See [Readable Stream][].
+* Returns: {fs.ReadStream}
 
-Unlike the 16 kb default `highWaterMark` for a readable stream, the stream
+Unlike the 16 kb default `highWaterMark` for a {stream.Readable}, the stream
 returned by this method has a default `highWaterMark` of 64 kb.
 
 `options` can include `start` and `end` values to read a range of bytes from
@@ -261,8 +261,7 @@ is available. This can prevent the process from exiting and the stream from
 closing naturally.
 
 By default, the stream will emit a `'close'` event after it has been
-destroyed, like most `Readable` streams.  Set the `emitClose` option to
-`false` to change this behavior.
+destroyed.  Set the `emitClose` option to `false` to change this behavior.
 
 ```mjs
 import { open } from 'fs/promises';
@@ -307,7 +306,7 @@ added: REPLACEME
   * `autoClose` {boolean} **Default:** `true`
   * `emitClose` {boolean} **Default:** `true`
   * `start` {integer}
-* Returns: {fs.WriteStream} See [Writable Stream][].
+* Returns: {fs.WriteStream}
 
 `options` may also include a `start` option to allow writing data at some
 position past the beginning of the file, allowed values are in the
@@ -322,8 +321,7 @@ It is the application's responsibility to close it and make sure there's no
 file descriptor leak.
 
 By default, the stream will emit a `'close'` event after it has been
-destroyed, like most `Writable` streams.  Set the `emitClose` option to
-`false` to change this behavior.
+destroyed.  Set the `emitClose` option to `false` to change this behavior.
 
 #### `filehandle.datasync()`
 <!-- YAML
@@ -2072,9 +2070,9 @@ changes:
   * `end` {integer} **Default:** `Infinity`
   * `highWaterMark` {integer} **Default:** `64 * 1024`
   * `fs` {Object|null} **Default:** `null`
-* Returns: {fs.ReadStream} See [Readable Stream][].
+* Returns: {fs.ReadStream}
 
-Unlike the 16 kb default `highWaterMark` for a readable stream, the stream
+Unlike the 16 kb default `highWaterMark` for a {stream.Readable}, the stream
 returned by this method has a default `highWaterMark` of 64 kb.
 
 `options` can include `start` and `end` values to read a range of bytes from
@@ -2096,8 +2094,7 @@ available. This can prevent the process from exiting and the stream from
 closing naturally.
 
 By default, the stream will emit a `'close'` event after it has been
-destroyed, like most `Readable` streams.  Set the `emitClose` option to
-`false` to change this behavior.
+destroyed.  Set the `emitClose` option to `false` to change this behavior.
 
 By providing the `fs` option, it is possible to override the corresponding `fs`
 implementations for `open`, `read`, and `close`. When providing the `fs` option,
@@ -2185,7 +2182,7 @@ changes:
   * `emitClose` {boolean} **Default:** `true`
   * `start` {integer}
   * `fs` {Object|null} **Default:** `null`
-* Returns: {fs.WriteStream} See [Writable Stream][].
+* Returns: {fs.WriteStream}
 
 `options` may also include a `start` option to allow writing data at some
 position past the beginning of the file, allowed values are in the
@@ -2200,8 +2197,7 @@ It is the application's responsibility to close it and make sure there's no
 file descriptor leak.
 
 By default, the stream will emit a `'close'` event after it has been
-destroyed, like most `Writable` streams.  Set the `emitClose` option to
-`false` to change this behavior.
+destroyed.  Set the `emitClose` option to `false` to change this behavior.
 
 By providing the `fs` option it is possible to override the corresponding `fs`
 implementations for `open`, `write`, `writev` and `close`. Overriding `write()`
@@ -7011,8 +7007,6 @@ the file contents.
 [MSDN-Rel-Path]: https://docs.microsoft.com/en-us/windows/desktop/FileIO/naming-a-file#fully-qualified-vs-relative-paths
 [MSDN-Using-Streams]: https://docs.microsoft.com/en-us/windows/desktop/FileIO/using-streams
 [Naming Files, Paths, and Namespaces]: https://docs.microsoft.com/en-us/windows/desktop/FileIO/naming-a-file
-[Readable Stream]: stream.md#class-streamreadable
-[Writable Stream]: stream.md#class-streamwritable
 [`AHAFS`]: https://developer.ibm.com/articles/au-aix_event_infrastructure/
 [`Buffer.byteLength`]: buffer.md#static-method-bufferbytelengthstring-encoding
 [`FSEvents`]: https://developer.apple.com/documentation/coreservices/file_system_events

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -371,6 +371,80 @@ If one or more `filehandle.read()` calls are made on a file handle and then a
 position till the end of the file. It doesn't always read from the beginning
 of the file.
 
+#### `filehandle.readStream([options])`
+<!-- YAML
+added: REPLACEME
+-->
+
+* `options` {Object}
+  * `flags` {string} See [support of file system `flags`][]. **Default:**
+    `'r'`.
+  * `encoding` {string} **Default:** `null`
+  * `autoClose` {boolean} **Default:** `true`
+  * `emitClose` {boolean} **Default:** `true`
+  * `start` {integer}
+  * `end` {integer} **Default:** `Infinity`
+  * `highWaterMark` {integer} **Default:** `64 * 1024`
+  * `fs` {Object|null} **Default:** `null`
+* Returns: {fs.ReadStream} See [Readable Stream][].
+
+Unlike the 16 kb default `highWaterMark` for a readable stream, the stream
+returned by this method has a default `highWaterMark` of 64 kb.
+
+`options` can include `start` and `end` values to read a range of bytes from
+the file instead of the entire file. Both `start` and `end` are inclusive and
+start counting at 0, allowed values are in the
+[0, [`Number.MAX_SAFE_INTEGER`][]] range. If `start` is
+omitted or `undefined`, `filehandle.readStream()` reads sequentially from the
+current file position. The `encoding` can be any one of those accepted by
+{Buffer}.
+
+If the `FileHandle` points to a character device that only supports blocking
+reads (such as keyboard or sound card), read operations do not finish until data
+is available. This can prevent the process from exiting and the stream from
+closing naturally.
+
+By default, the stream will emit a `'close'` event after it has been
+destroyed, like most `Readable` streams.  Set the `emitClose` option to
+`false` to change this behavior.
+
+By providing the `fs` option, it is possible to override the corresponding `fs`
+implementations for `open`, `read`, and `close`. When providing the `fs` option,
+overrides for `open`, `read`, and `close` are required.
+
+```mjs
+import { open } from 'fs/promises';
+
+const fd = await open('/dev/input/event0');
+// Create a stream from some character device.
+const stream = fd.readStream();
+setTimeout(() => {
+  stream.close(); // This may not close the stream.
+  // Artificially marking end-of-stream, as if the underlying resource had
+  // indicated end-of-file by itself, allows the stream to close.
+  // This does not cancel pending read operations, and if there is such an
+  // operation, the process may still not be able to exit successfully
+  // until it finishes.
+  stream.push(null);
+  stream.read(0);
+}, 100);
+```
+
+If `autoClose` is false, then the file descriptor won't be closed, even if
+there's an error. It is the application's responsibility to close it and make
+sure there's no file descriptor leak. If `autoClose` is set to true (default
+behavior), on `'error'` or `'end'` the file descriptor will be closed
+automatically.
+
+An example to read the last 10 bytes of a file which is 100 bytes long:
+
+```mjs
+import { open } from 'fs/promises';
+
+const fd = await open('sample.txt');
+fd.readStream({ start: 90, end: 99 });
+```
+
 #### `filehandle.readv(buffers[, position])`
 <!-- YAML
 added:
@@ -581,6 +655,41 @@ If one or more `filehandle.write()` calls are made on a file handle and then a
 `filehandle.writeFile()` call is made, the data will be written from the
 current position till the end of the file. It doesn't always write from the
 beginning of the file.
+
+#### `filehandle.writeStream([options])`
+<!-- YAML
+added: REPLACEME
+-->
+
+* `options` {Object}
+  * `encoding` {string} **Default:** `'utf8'`
+  * `autoClose` {boolean} **Default:** `true`
+  * `emitClose` {boolean} **Default:** `true`
+  * `start` {integer}
+  * `fs` {Object|null} **Default:** `null`
+* Returns: {fs.WriteStream} See [Writable Stream][].
+
+`options` may also include a `start` option to allow writing data at some
+position past the beginning of the file, allowed values are in the
+[0, [`Number.MAX_SAFE_INTEGER`][]] range. Modifying a file rather than replacing
+it may require the `flags` `open` option to be set to `r+` rather than the
+default `r`. The `encoding` can be any one of those accepted by {Buffer}.
+
+If `autoClose` is set to true (default behavior) on `'error'` or `'finish'`
+the file descriptor will be closed automatically. If `autoClose` is false,
+then the file descriptor won't be closed, even if there's an error.
+It is the application's responsibility to close it and make sure there's no
+file descriptor leak.
+
+By default, the stream will emit a `'close'` event after it has been
+destroyed, like most `Writable` streams.  Set the `emitClose` option to
+`false` to change this behavior.
+
+By providing the `fs` option it is possible to override the corresponding `fs`
+implementations for `open`, `write`, `writev` and `close`. Overriding `write()`
+without `writev()` can reduce performance as some optimizations (`_writev()`)
+will be disabled. When providing the `fs` option,  overrides for `open`,
+`close`, and at least one of `write` and `writev` are required.
 
 #### `filehandle.writev(buffers[, position])`
 <!-- YAML

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -377,15 +377,12 @@ added: REPLACEME
 -->
 
 * `options` {Object}
-  * `flags` {string} See [support of file system `flags`][]. **Default:**
-    `'r'`.
   * `encoding` {string} **Default:** `null`
   * `autoClose` {boolean} **Default:** `true`
   * `emitClose` {boolean} **Default:** `true`
   * `start` {integer}
   * `end` {integer} **Default:** `Infinity`
   * `highWaterMark` {integer} **Default:** `64 * 1024`
-  * `fs` {Object|null} **Default:** `null`
 * Returns: {fs.ReadStream} See [Readable Stream][].
 
 Unlike the 16 kb default `highWaterMark` for a readable stream, the stream
@@ -407,10 +404,6 @@ closing naturally.
 By default, the stream will emit a `'close'` event after it has been
 destroyed, like most `Readable` streams.  Set the `emitClose` option to
 `false` to change this behavior.
-
-By providing the `fs` option, it is possible to override the corresponding `fs`
-implementations for `open`, `read`, and `close`. When providing the `fs` option,
-overrides for `open`, `read`, and `close` are required.
 
 ```mjs
 import { open } from 'fs/promises';
@@ -666,7 +659,6 @@ added: REPLACEME
   * `autoClose` {boolean} **Default:** `true`
   * `emitClose` {boolean} **Default:** `true`
   * `start` {integer}
-  * `fs` {Object|null} **Default:** `null`
 * Returns: {fs.WriteStream} See [Writable Stream][].
 
 `options` may also include a `start` option to allow writing data at some
@@ -684,12 +676,6 @@ file descriptor leak.
 By default, the stream will emit a `'close'` event after it has been
 destroyed, like most `Writable` streams.  Set the `emitClose` option to
 `false` to change this behavior.
-
-By providing the `fs` option it is possible to override the corresponding `fs`
-implementations for `open`, `write`, `writev` and `close`. Overriding `write()`
-without `writev()` can reduce performance as some optimizations (`_writev()`)
-will be disabled. When providing the `fs` option,  overrides for `open`,
-`close`, and at least one of `write` and `writev` are required.
 
 #### `filehandle.writev(buffers[, position])`
 <!-- YAML

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -271,7 +271,7 @@ class FileHandle extends EventEmitterMixin(JSTransferable) {
    *   }} [options]
    * @returns {NodeJSReadStream}
    */
-  readStream(options = undefined) {
+  createReadStream(options = undefined) {
     const { ReadStream } = lazyFsStreams();
     return new ReadStream(undefined, { ...options, fd: this });
   }
@@ -287,7 +287,7 @@ class FileHandle extends EventEmitterMixin(JSTransferable) {
    *   }} [options]
    * @returns {NodeJSWriteStream}
    */
-  writeStream(options = undefined) {
+  createWriteStream(options = undefined) {
     const { WriteStream } = lazyFsStreams();
     return new WriteStream(undefined, { ...options, fd: this });
   }

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -106,7 +106,6 @@ const {
 const {
   readableStreamCancel,
 } = require('internal/webstreams/readablestream');
-const { ReadStream, WriteStream } = require('internal/fs/streams');
 
 const getDirectoryEntriesPromise = promisify(getDirents);
 const validateRmOptionsPromise = promisify(validateRmOptions);
@@ -114,6 +113,12 @@ const validateRmOptionsPromise = promisify(validateRmOptions);
 let cpPromises;
 function lazyLoadCpPromises() {
   return cpPromises ??= require('internal/fs/cp/cp').cpFn;
+}
+
+// Lazy loaded to avoid circular dependency.
+let fsStreams;
+function lazyFsStreams() {
+  return fsStreams ??= require('internal/fs/streams');
 }
 
 class FileHandle extends EventEmitterMixin(JSTransferable) {
@@ -257,36 +262,34 @@ class FileHandle extends EventEmitterMixin(JSTransferable) {
    * @typedef {import('./streams').ReadStream
    * } NodeJSReadStream
    * @param {{
-   *   flags?: string;
    *   encoding?: string;
    *   autoClose?: boolean;
    *   emitClose?: boolean;
    *   start: number;
    *   end?: number;
    *   highWaterMark?: number;
-   *   fs?: Object | null;
    *   }} [options]
    * @returns {NodeJSReadStream}
    */
   readStream(options = undefined) {
-    return new ReadStream(undefined, { ...options, fd: this[kFd] });
+    const { ReadStream } = lazyFsStreams();
+    return new ReadStream(undefined, { ...options, fd: this });
   }
 
   /**
    * @typedef {import('./streams').WriteStream
    * } NodeJSWriteStream
    * @param {{
-   *   flags?: string;
    *   encoding?: string;
    *   autoClose?: boolean;
    *   emitClose?: boolean;
    *   start: number;
-   *   fs?: Object | null;
    *   }} [options]
    * @returns {NodeJSWriteStream}
    */
   writeStream(options = undefined) {
-    return new WriteStream(undefined, { ...options, fd: this[kFd] });
+    const { WriteStream } = lazyFsStreams();
+    return new WriteStream(undefined, { ...options, fd: this });
   }
 
   [kTransfer]() {

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -106,6 +106,7 @@ const {
 const {
   readableStreamCancel,
 } = require('internal/webstreams/readablestream');
+const { ReadStream, WriteStream } = require('internal/fs/streams');
 
 const getDirectoryEntriesPromise = promisify(getDirents);
 const validateRmOptionsPromise = promisify(validateRmOptions);
@@ -250,6 +251,42 @@ class FileHandle extends EventEmitterMixin(JSTransferable) {
     });
 
     return readable;
+  }
+
+  /**
+   * @typedef {import('./streams').ReadStream
+   * } NodeJSReadStream
+   * @param {{
+   *   flags?: string;
+   *   encoding?: string;
+   *   autoClose?: boolean;
+   *   emitClose?: boolean;
+   *   start: number;
+   *   end?: number;
+   *   highWaterMark?: number;
+   *   fs?: Object | null;
+   *   }} [options]
+   * @returns {NodeJSReadStream}
+   */
+  readStream(options = undefined) {
+    return new ReadStream(undefined, { ...options, fd: this[kFd] });
+  }
+
+  /**
+   * @typedef {import('./streams').WriteStream
+   * } NodeJSWriteStream
+   * @param {{
+   *   flags?: string;
+   *   encoding?: string;
+   *   autoClose?: boolean;
+   *   emitClose?: boolean;
+   *   start: number;
+   *   fs?: Object | null;
+   *   }} [options]
+   * @returns {NodeJSWriteStream}
+   */
+  writeStream(options = undefined) {
+    return new WriteStream(undefined, { ...options, fd: this[kFd] });
   }
 
   [kTransfer]() {

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -260,7 +260,7 @@ class FileHandle extends EventEmitterMixin(JSTransferable) {
 
   /**
    * @typedef {import('./streams').ReadStream
-   * } NodeJSReadStream
+   * } ReadStream
    * @param {{
    *   encoding?: string;
    *   autoClose?: boolean;
@@ -269,7 +269,7 @@ class FileHandle extends EventEmitterMixin(JSTransferable) {
    *   end?: number;
    *   highWaterMark?: number;
    *   }} [options]
-   * @returns {NodeJSReadStream}
+   * @returns {ReadStream}
    */
   createReadStream(options = undefined) {
     const { ReadStream } = lazyFsStreams();
@@ -278,14 +278,14 @@ class FileHandle extends EventEmitterMixin(JSTransferable) {
 
   /**
    * @typedef {import('./streams').WriteStream
-   * } NodeJSWriteStream
+   * } WriteStream
    * @param {{
    *   encoding?: string;
    *   autoClose?: boolean;
    *   emitClose?: boolean;
    *   start: number;
    *   }} [options]
-   * @returns {NodeJSWriteStream}
+   * @returns {WriteStream}
    */
   createWriteStream(options = undefined) {
     const { WriteStream } = lazyFsStreams();

--- a/test/parallel/test-fs-promises-file-handle-stream.js
+++ b/test/parallel/test-fs-promises-file-handle-stream.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const common = require('../common');
+
+// The following tests validate base functionality for the fs.promises
+// FileHandle.write method.
+
+const fs = require('fs');
+const { open } = fs.promises;
+const path = require('path');
+const tmpdir = require('../common/tmpdir');
+const assert = require('assert');
+const { finished } = require('stream/promises');
+const { Blob } = require('buffer');
+const tmpDir = tmpdir.path;
+
+tmpdir.refresh();
+
+async function validateWrite() {
+  const filePathForHandle = path.resolve(tmpDir, 'tmp-write.txt');
+  const fileHandle = await open(filePathForHandle, 'w');
+  const buffer = Buffer.from('Hello world'.repeat(100), 'utf8');
+
+  const stream = fileHandle.writeStream();
+  stream.end(buffer);
+  await finished(stream);
+
+  const readFileData = fs.readFileSync(filePathForHandle);
+  assert.deepStrictEqual(buffer, readFileData);
+}
+
+async function validateRead() {
+  const filePathForHandle = path.resolve(tmpDir, 'tmp-read.txt');
+  const buffer = Buffer.from('Hello world'.repeat(100), 'utf8');
+
+  fs.writeFileSync(filePathForHandle, buffer);
+
+  const fileHandle = await open(filePathForHandle);
+
+  const chunks = [];
+  for await (const chunk of fileHandle.readStream()) {
+    chunks.push(chunk);
+  }
+
+  const arrayBuffer = await new Blob(chunks).arrayBuffer();
+  assert.deepStrictEqual(Buffer.from(arrayBuffer), buffer);
+}
+
+Promise.all([
+  validateWrite(),
+  validateRead(),
+]).then(common.mustCall());

--- a/test/parallel/test-fs-promises-file-handle-stream.js
+++ b/test/parallel/test-fs-promises-file-handle-stream.js
@@ -11,7 +11,7 @@ const path = require('path');
 const tmpdir = require('../common/tmpdir');
 const assert = require('assert');
 const { finished } = require('stream/promises');
-const { Blob } = require('buffer');
+const { buffer } = require('stream/consumers');
 const tmpDir = tmpdir.path;
 
 tmpdir.refresh();
@@ -31,19 +31,15 @@ async function validateWrite() {
 
 async function validateRead() {
   const filePathForHandle = path.resolve(tmpDir, 'tmp-read.txt');
-  const buffer = Buffer.from('Hello world'.repeat(100), 'utf8');
+  const buf = Buffer.from('Hello world'.repeat(100), 'utf8');
 
-  fs.writeFileSync(filePathForHandle, buffer);
+  fs.writeFileSync(filePathForHandle, buf);
 
   const fileHandle = await open(filePathForHandle);
-
-  const chunks = [];
-  for await (const chunk of fileHandle.createReadStream()) {
-    chunks.push(chunk);
-  }
-
-  const arrayBuffer = await new Blob(chunks).arrayBuffer();
-  assert.deepStrictEqual(Buffer.from(arrayBuffer), buffer);
+  assert.deepStrictEqual(
+    await buffer(fileHandle.createReadStream()),
+    buf
+  );
 }
 
 Promise.all([

--- a/test/parallel/test-fs-promises-file-handle-stream.js
+++ b/test/parallel/test-fs-promises-file-handle-stream.js
@@ -21,7 +21,7 @@ async function validateWrite() {
   const fileHandle = await open(filePathForHandle, 'w');
   const buffer = Buffer.from('Hello world'.repeat(100), 'utf8');
 
-  const stream = fileHandle.writeStream();
+  const stream = fileHandle.createWriteStream();
   stream.end(buffer);
   await finished(stream);
 
@@ -38,7 +38,7 @@ async function validateRead() {
   const fileHandle = await open(filePathForHandle);
 
   const chunks = [];
-  for await (const chunk of fileHandle.readStream()) {
+  for await (const chunk of fileHandle.createReadStream()) {
     chunks.push(chunk);
   }
 


### PR DESCRIPTION
Adding `filehandle.createReadStream` and `filehandle.createWriteStream` methods to `FileHandle` class. This is useful to be able create `ReadStream` or `WriteStream` from `fs/promises`.

```js
import { open } from 'node:fs/promises';
import { stdout } from 'node:process';

try {
  const textFile = await open(new URL('./file.txt', import.meta.url));
  textFile.createReadStream().pipe(stdout);
} catch (err) {
  // error while opening the file
  // ...
}
```

It also accept the same functions as `fs.createReadStream` and `fs.createWriteStream` respectively:
```js
import { open } from 'node:fs/promises';
import { stdout } from 'node:process';
import { finished } from 'node:stream/promises';

let textFile;
try {
  textFile = await open(new URL('./file.txt', import.meta.url));
  await finished(textFile.createReadStream({ autoClose: false, encoding: 'utf8' }).pipe(stdout));
} catch (err) {
  // error while opening the file or while streaming the file
  // ...
} finally {
  await textFile?.close();
}
```
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
