### PR TITLE
fs: rename `FileHandle#readableWebStream` to `stream`

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -302,52 +302,6 @@ Reads data from the file and stores that in the given buffer.
 If the file is not modified concurrently, the end-of-file is reached when the
 number of bytes read is zero.
 
-#### `filehandle.readableWebStream()`
-<!-- YAML
-added: REPLACEME
--->
-
-> Stability: 1 - Experimental
-
-* Returns: {ReadableStream}
-
-Returns a `ReadableStream` that may be used to read the files data.
-
-An error will be thrown if this method is called more than once or is called
-after the `FileHandle` is closed or closing.
-
-```mjs
-import {
-  open,
-} from 'node:fs/promises';
-
-const file = await open('./some/file/to/read');
-
-for await (const chunk of file.readableWebStream())
-  console.log(chunk);
-
-await file.close();
-```
-
-```cjs
-const {
-  open,
-} = require('fs/promises');
-
-(async () => {
-  const file = await open('./some/file/to/read');
-
-  for await (const chunk of file.readableWebStream())
-    console.log(chunk);
-
-  await file.close();
-})();
-```
-
-While the `ReadableStream` will read the file to completion, it will not
-close the `FileHandle` automatically. User code must still call the
-`fileHandle.close()` method.
-
 #### `filehandle.readFile(options)`
 <!-- YAML
 added: v10.0.0
@@ -403,6 +357,52 @@ changes:
   * `bigint` {boolean} Whether the numeric values in the returned
     {fs.Stats} object should be `bigint`. **Default:** `false`.
 * Returns: {Promise} Fulfills with an {fs.Stats} for the file.
+
+#### `filehandle.stream()`
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+* Returns: {ReadableStream}
+
+Returns a `ReadableStream` that may be used to read the files data.
+
+An error will be thrown if this method is called more than once or is called
+after the `FileHandle` is closed or closing.
+
+```mjs
+import {
+  open,
+} from 'node:fs/promises';
+
+const file = await open('./some/file/to/read');
+
+for await (const chunk of file.stream())
+  console.log(chunk);
+
+await file.close();
+```
+
+```cjs
+const {
+  open,
+} = require('fs/promises');
+
+(async () => {
+  const file = await open('./some/file/to/read');
+
+  for await (const chunk of file.stream())
+    console.log(chunk);
+
+  await file.close();
+})();
+```
+
+While the `ReadableStream` will read the file to completion, it will not
+close the `FileHandle` automatically. User code must still call the
+`fileHandle.close()` method.
 
 #### `filehandle.sync()`
 <!-- YAML

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -230,7 +230,7 @@ class FileHandle extends EventEmitterMixin(JSTransferable) {
    * } ReadableStream
    * @returns {ReadableStream}
    */
-  readableWebStream() {
+  stream() {
     if (this[kFd] === -1)
       throw new ERR_INVALID_STATE('The FileHandle is closed');
     if (this[kClosePromise])

--- a/test/parallel/test-filehandle-readablestream.js
+++ b/test/parallel/test-filehandle-readablestream.js
@@ -18,12 +18,12 @@ const check = readFileSync(__filename, { encoding: 'utf8' });
   const dec = new TextDecoder();
   const file = await open(__filename);
   let data = '';
-  for await (const chunk of file.readableWebStream())
+  for await (const chunk of file.stream())
     data += dec.decode(chunk);
 
   assert.strictEqual(check, data);
 
-  assert.throws(() => file.readableWebStream(), {
+  assert.throws(() => file.stream(), {
     code: 'ERR_INVALID_STATE',
   });
 
@@ -36,7 +36,7 @@ const check = readFileSync(__filename, { encoding: 'utf8' });
   const file = await open(__filename);
   await file.close();
 
-  assert.throws(() => file.readableWebStream(), {
+  assert.throws(() => file.stream(), {
     code: 'ERR_INVALID_STATE',
   });
 })().then(common.mustCall());
@@ -47,7 +47,7 @@ const check = readFileSync(__filename, { encoding: 'utf8' });
   const file = await open(__filename);
   file.close();
 
-  assert.throws(() => file.readableWebStream(), {
+  assert.throws(() => file.stream(), {
     code: 'ERR_INVALID_STATE',
   });
 })().then(common.mustCall());
@@ -56,7 +56,7 @@ const check = readFileSync(__filename, { encoding: 'utf8' });
 // FileHandle is closed.
 (async () => {
   const file = await open(__filename);
-  const readable = file.readableWebStream();
+  const readable = file.stream();
   const reader = readable.getReader();
   file.close();
   await reader.closed;
@@ -66,7 +66,7 @@ const check = readFileSync(__filename, { encoding: 'utf8' });
 // FileHandle is closed.
 (async () => {
   const file = await open(__filename);
-  const readable = file.readableWebStream();
+  const readable = file.stream();
   file.close();
   const reader = readable.getReader();
   await reader.closed;
@@ -76,7 +76,7 @@ const check = readFileSync(__filename, { encoding: 'utf8' });
 // when a ReadableStream has been acquired for it.
 (async () => {
   const file = await open(__filename);
-  file.readableWebStream();
+  file.stream();
   const mc = new MessageChannel();
   mc.port1.onmessage = common.mustNotCall();
   assert.throws(() => mc.port2.postMessage(file, [file]), {


### PR DESCRIPTION
It makes the method more aligned with the web standard
`Blob.prototype.stream`.

Now is a good time as ever to discuss renaming the method as it hasn't landed on any release line yet.

Refs: https://w3c.github.io/FileAPI/#dom-blob-stream

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
