### PR TITLE
doc: fix property name 'detail' of performanceEntry

### DIFF
--- a/doc/api/perf_hooks.md
+++ b/doc/api/perf_hooks.md
@@ -274,7 +274,7 @@ is similar to [`window.performance.toJSON`][] in browsers.
 added: v8.5.0
 -->
 
-### `performanceEntry.details`
+### `performanceEntry.detail`
 <!-- YAML
 added: v16.0.0
 -->
@@ -382,7 +382,7 @@ Performance Entry.
 
 ### Garbage Collection ('gc') Details
 
-When `performanceEntry.type` is equal to `'gc'`, the `performanceEntry.details`
+When `performanceEntry.type` is equal to `'gc'`, the `performanceEntry.detail`
 property will be an {Object} with two properties:
 
 * `kind` {number} One of:
@@ -402,10 +402,10 @@ property will be an {Object} with two properties:
 ### HTTP/2 ('http2') Details
 
 When `performanceEntry.type` is equal to `'http2'`, the
-`performanceEntry.details` property will be an {Object} containing
+`performanceEntry.detail` property will be an {Object} containing
 additional performance information.
 
-If `performanceEntry.name` is equal to `Http2Stream`, the `details`
+If `performanceEntry.name` is equal to `Http2Stream`, the `detail`
 will contain the following properties:
 
 * `bytesRead` {number} The number of `DATA` frame bytes received for this
@@ -420,7 +420,7 @@ will contain the following properties:
 * `timeToFirstHeader` {number} The number of milliseconds elapsed between the
   `PerformanceEntry` `startTime` and the reception of the first header.
 
-If `performanceEntry.name` is equal to `Http2Session`, the `details` will
+If `performanceEntry.name` is equal to `Http2Session`, the `detail` will
 contain the following properties:
 
 * `bytesRead` {number} The number of bytes received for this `Http2Session`.
@@ -443,7 +443,7 @@ contain the following properties:
 ### Timerify ('function') Details
 
 When `performanceEntry.type` is equal to `'function'`, the
-`performanceEntry.details` property will be an {Array} listing
+`performanceEntry.detail` property will be an {Array} listing
 the input arguments to the timed function.
 
 ## Class: `PerformanceNodeTiming`


### PR DESCRIPTION
Hello,

I noticed that the `performanceEntry` that is passed to the callback of `PerformanceObserver` does not have a property `details` but it does have a property `detail` (without the "s"). This is also in line with [the deprecation warning](https://nodejs.org/docs/latest-v16.x/api/deprecations.html#deprecations_dep0152_extension_performanceentry_properties) and what I could find in the source code:

https://github.com/nodejs/node/blob/1c4df352b77514e93a46fb27e996755d45a0b530/lib/internal/perf/performance_entry.js#L44
https://github.com/nodejs/node/blob/1c4df352b77514e93a46fb27e996755d45a0b530/lib/internal/perf/performance_entry.js#L63
https://github.com/nodejs/node/blob/1c4df352b77514e93a46fb27e996755d45a0b530/lib/internal/perf/observe.js#L75

In case this is correct: I have changed the documentation accordingly. Please let me know if I can do anything else.

Thank you!