### PR TITLE
fs: add `Blob` methods to `FileHandle`

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -426,6 +426,17 @@ Request that all data for the open file descriptor is flushed to the storage
 device. The specific implementation is operating system and device specific.
 Refer to the POSIX fsync(2) documentation for more detail.
 
+#### `filehandle.text()`
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+* Returns: {Promise} Fulfills with a {string} upon success.
+
+Reads the whole file as UTF-8 text.
+
 #### `filehandle.truncate(len)`
 <!-- YAML
 added: v10.0.0

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -188,6 +188,17 @@ When operating on file handles, the mode cannot be changed from what it was set
 to with [`fsPromises.open()`][]. Therefore, this is equivalent to
 [`filehandle.writeFile()`][].
 
+#### `filehandle.arrayBuffer()`
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+* Returns: {Promise} Fulfills with an {ArrayBuffer} upon success.
+
+Reads the whole file as binary data.
+
 #### `filehandle.chmod(mode)`
 <!-- YAML
 added: v10.0.0

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -257,6 +257,10 @@ class FileHandle extends EventEmitterMixin(JSTransferable) {
     return buffer.buffer;
   }
 
+  text() {
+    return this.readFile({ encoding: 'utf8' });
+  }
+
   [kTransfer]() {
     if (this[kClosePromise] || this[kRefs] > 1) {
       throw lazyDOMException('Cannot transfer FileHandle while in use',

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -252,6 +252,11 @@ class FileHandle extends EventEmitterMixin(JSTransferable) {
     return readable;
   }
 
+  async arrayBuffer() {
+    const buffer = await this.readFile();
+    return buffer.buffer;
+  }
+
   [kTransfer]() {
     if (this[kClosePromise] || this[kRefs] > 1) {
       throw lazyDOMException('Cannot transfer FileHandle while in use',

--- a/test/parallel/test-fs-promises-file-handle-arrayBuffer.js
+++ b/test/parallel/test-fs-promises-file-handle-arrayBuffer.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const common = require('../common');
+
+// The following tests validate FileHandle.prototype.arrayBuffer method.
+
+const fs = require('fs');
+const { open } = fs.promises;
+const path = require('path');
+const tmpdir = require('../common/tmpdir');
+const assert = require('assert');
+const tmpDir = tmpdir.path;
+
+tmpdir.refresh();
+
+(async () => {
+  const data = Buffer.allocUnsafe(100);
+  const filePath = path.resolve(tmpDir, 'arrayBuffer');
+  fs.writeFileSync(filePath, data);
+
+  let fileHandle;
+  try {
+    fileHandle = await open(filePath);
+
+    const fileContent = await fileHandle.arrayBuffer();
+    assert.deepStrictEqual(Buffer.from(fileContent), data);
+  } finally {
+    await fileHandle?.close();
+  }
+})().then(common.mustCall());

--- a/test/parallel/test-fs-promises-file-handle-text.js
+++ b/test/parallel/test-fs-promises-file-handle-text.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const common = require('../common');
+
+// The following tests validate FileHandle.prototype.text method.
+
+const fs = require('fs');
+const { open } = fs.promises;
+const path = require('path');
+const tmpdir = require('../common/tmpdir');
+const assert = require('assert');
+const tmpDir = tmpdir.path;
+
+tmpdir.refresh();
+
+(async () => {
+  const data = 'Hello World!';
+  const filePath = path.resolve(tmpDir, 'text');
+  fs.writeFileSync(filePath, data);
+
+  let fileHandle;
+  try {
+    fileHandle = await open(filePath);
+
+    const fileContent = await fileHandle.text();
+    assert.strictEqual(fileContent, data);
+  } finally {
+    await fileHandle?.close();
+  }
+})().then(common.mustCall());


### PR DESCRIPTION
Adding [`.text()`](https://w3c.github.io/FileAPI/#dom-blob-text) and [`.arrayBuffer()`](https://w3c.github.io/FileAPI/#dom-blob-arraybuffer) methods to `FileHandle` to make it closer to W3C [`File`](https://w3c.github.io/FileAPI/#dfn-file) interface.

I'm proposing to add [`.stream()`](https://w3c.github.io/FileAPI/#dom-blob-stream) in https://github.com/nodejs/node/pull/40016, and I don't think we want to have the [`.slice()`](https://w3c.github.io/FileAPI/#dfn-slice) as it would require a synchronous read of the file.
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
