### PR TITLE
crypto: fix default MGF1 hash for OpenSSL 3

### DIFF
--- a/src/crypto/crypto_rsa.cc
+++ b/src/crypto/crypto_rsa.cc
@@ -63,10 +63,19 @@ EVPKeyCtxPointer RsaKeyGenTraits::Setup(RsaKeyPairGenConfig* params) {
       return EVPKeyCtxPointer();
     }
 
-    if (params->params.mgf1_md != nullptr &&
+    // TODO(tniessen): This appears to only be necessary in OpenSSL 3, while
+    // OpenSSL 1.1.1 behaves as recommended by RFC 8017 and defaults the MGF1
+    // hash algorithm to the RSA-PSS hashAlgorithm. Remove this code if the
+    // behavior of OpenSSL 3 changes.
+    const EVP_MD* mgf1_md = params->params.mgf1_md;
+    if (mgf1_md == nullptr && params->params.md != nullptr) {
+      mgf1_md = params->params.md;
+    }
+
+    if (mgf1_md != nullptr &&
         EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md(
             ctx.get(),
-            params->params.mgf1_md) <= 0) {
+            mgf1_md) <= 0) {
       return EVPKeyCtxPointer();
     }
 

--- a/test/parallel/test-crypto-keygen.js
+++ b/test/parallel/test-crypto-keygen.js
@@ -370,6 +370,28 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
 }
 
 {
+  // RFC 8017, 9.1.: "Assuming that the mask generation function is based on a
+  // hash function, it is RECOMMENDED that the hash function be the same as the
+  // one that is applied to the message."
+
+  generateKeyPair('rsa-pss', {
+    modulusLength: 512,
+    hashAlgorithm: 'sha256',
+    saltLength: 16
+  }, common.mustSucceed((publicKey, privateKey) => {
+    const expectedKeyDetails = {
+      modulusLength: 512,
+      publicExponent: 65537n,
+      hashAlgorithm: 'sha256',
+      mgf1HashAlgorithm: 'sha256',
+      saltLength: 16
+    };
+    assert.deepStrictEqual(publicKey.asymmetricKeyDetails, expectedKeyDetails);
+    assert.deepStrictEqual(privateKey.asymmetricKeyDetails, expectedKeyDetails);
+  }));
+}
+
+{
   const privateKeyEncoding = {
     type: 'pkcs8',
     format: 'der'


### PR DESCRIPTION
OpenSSL 3 does not seem to set the MGF1 hash algorithm to the RSA-PSS hash by default. In other words, calling `EVP_PKEY_CTX_set_rsa_pss_keygen_md` does not seem to update the MGF1 hash algorithm. Calling `EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md` after `EVP_PKEY_CTX_set_rsa_pss_keygen_md` seems to fix this difference in behavior between OpenSSL 1.1.1 and OpenSSL 3.

Refs: https://github.com/nodejs/node/pull/39999

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
