### PR TITLE
doc: add timeout.close

### DIFF
--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -72,6 +72,17 @@ timer is active. Each of the `Timeout` objects returned by these functions
 export both `timeout.ref()` and `timeout.unref()` functions that can be used to
 control this default behavior.
 
+### `timeout.close()`
+<!-- YAML
+added: v0.9.1
+-->
+
+> Stability: 3 - Legacy: Use [`clearTimeout()`][] instead.
+
+* Returns: {Timeout} a reference to `timeout`
+
+Cancels the timeout.
+
 ### `timeout.hasRef()`
 <!-- YAML
 added: v11.0.0


### PR DESCRIPTION
Hello,

I noticed that the `Timeout.close` is not documented. We have this method from v0.9.1:
https://github.com/nodejs/node/blob/985e3a25cb93f82dbef9b1b4279b8614f508898c/lib/timers.js#L274-L282

Current codebase wraps clearTimeout:
https://github.com/nodejs/node/blob/c4096a35d651399f79948395c233747dcacc83aa/lib/timers.js#L251-L254

This pull adds documentation for this method.