### PR TITLE
module: deprecate trailing slash pattern mappings

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2815,6 +2815,12 @@ The `'hash'` and `'mgf1Hash'` options are replaced with `'hashAlgorithm'`
 and `'mgf1HashAlgorithm'`.
 
 ### DEP0155: Trailing slashes in pattern specifier resolutions
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/40039
+    description: Documentation-only.
+-->
 
 Type: Runtime
 

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2819,10 +2819,11 @@ and `'mgf1HashAlgorithm'`.
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/40039
-    description: Documentation-only.
+    description: Documentation-only deprecation
+                 with `--pending-deprecation` support.
 -->
 
-Type: Runtime
+Type: Documentation-only (supports [`--pending-deprecation`][])
 
 The remapping of specifiers ending in `"/"` like `import 'pkg/x/'` is deprecated
 for package `"exports"` and `"imports"` pattern resolutions.

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2814,6 +2814,13 @@ Type: Documentation-only (supports [`--pending-deprecation`][])
 The `'hash'` and `'mgf1Hash'` options are replaced with `'hashAlgorithm'`
 and `'mgf1HashAlgorithm'`.
 
+### DEP0155: Trailing slashes in pattern specifier resolutions
+
+Type: Runtime
+
+The remapping of specifiers ending in `"/"` like `import 'pkg/x/'` is deprecated
+for package `"exports"` and `"imports"` pattern resolutions.
+
 [Legacy URL API]: url.md#legacy-url-api
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
 [RFC 6066]: https://tools.ietf.org/html/rfc6066#section-3

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -1191,6 +1191,8 @@ _isImports_, _conditions_)
 >       _expansionKey_ up to but excluding the first _"*"_ character.
 >    1. If _patternBase_ is not **null** and _matchKey_ starts with but is not
 >       equal to _patternBase_, then
+>       1. If _matchKey_ ends with _"/"_, throw an _Invalid Module Specifier_
+>          error.
 >       1. Let _patternTrailer_ be the substring of _expansionKey_ from the
 >          index after the first _"*"_ character.
 >       1. If _patternTrailer_ has zero length, or if _matchKey_ ends with

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -97,6 +97,21 @@ function emitFolderMapDeprecation(match, pjsonUrl, isExports, base) {
   );
 }
 
+function emitTrailingSlashPatternDeprecation(match, pjsonUrl, isExports, base) {
+  const pjsonPath = fileURLToPath(pjsonUrl);
+  if (emittedPackageWarnings.has(pjsonPath + '|' + match))
+    return;
+  emittedPackageWarnings.add(pjsonPath + '|' + match);
+  process.emitWarning(
+    `Use of deprecated trailing slash pattern mapping "${match}" in the ${
+      isExports ? '"exports"' : '"imports"'} field module resolution of the ` +
+      `package at ${pjsonPath}${base ? ` imported from ${fileURLToPath(base)}` :
+        ''}. Mapping specifiers ending in "/" is no longer supported.`,
+    'DeprecationWarning',
+    'DEP0155'
+  );
+}
+
 /**
  * @param {URL} url
  * @param {URL} packageJSONUrl
@@ -630,6 +645,9 @@ function packageExportsResolve(
     if (patternIndex !== -1 &&
         StringPrototypeStartsWith(packageSubpath,
                                   StringPrototypeSlice(key, 0, patternIndex))) {
+      if (StringPrototypeEndsWith(packageSubpath, '/'))
+        emitTrailingSlashPatternDeprecation(packageSubpath, packageJSONUrl,
+                                            true, base);
       const patternTrailer = StringPrototypeSlice(key, patternIndex + 1);
       if (packageSubpath.length >= key.length &&
           StringPrototypeEndsWith(packageSubpath, patternTrailer) &&

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -40,6 +40,7 @@ const { sep, relative, resolve } = require('path');
 const preserveSymlinks = getOptionValue('--preserve-symlinks');
 const preserveSymlinksMain = getOptionValue('--preserve-symlinks-main');
 const typeFlag = getOptionValue('--input-type');
+const pendingDeprecation = getOptionValue('--pending-deprecation');
 const { URL, pathToFileURL, fileURLToPath } = require('internal/url');
 const {
   ERR_INPUT_TYPE_NOT_ALLOWED,
@@ -98,6 +99,7 @@ function emitFolderMapDeprecation(match, pjsonUrl, isExports, base) {
 }
 
 function emitTrailingSlashPatternDeprecation(match, pjsonUrl, isExports, base) {
+  if (!pendingDeprecation) return;
   const pjsonPath = fileURLToPath(pjsonUrl);
   if (emittedPackageWarnings.has(pjsonPath + '|' + match))
     return;

--- a/test/es-module/test-esm-exports-deprecations.mjs
+++ b/test/es-module/test-esm-exports-deprecations.mjs
@@ -5,13 +5,17 @@ let curWarning = 0;
 const expectedWarnings = [
   '"./sub/"',
   '"./fallbackdir/"',
+  '"./trailing-pattern-slash/"',
   '"./subpath/"',
+  '"./subpath/dir1/"',
+  '"./subpath/dir2/"',
   'no_exports',
   'default_index',
 ];
 
 process.addListener('warning', mustCall((warning) => {
   assert(warning.stack.includes(expectedWarnings[curWarning++]), warning.stack);
+  console.log(expectedWarnings[curWarning - 1] + ' passed');
 }, expectedWarnings.length));
 
 await import('./test-esm-exports.mjs');

--- a/test/es-module/test-esm-exports-deprecations.mjs
+++ b/test/es-module/test-esm-exports-deprecations.mjs
@@ -1,3 +1,4 @@
+// Flags: --pending-deprecation
 import { mustCall } from '../common/index.mjs';
 import assert from 'assert';
 

--- a/test/es-module/test-esm-exports-deprecations.mjs
+++ b/test/es-module/test-esm-exports-deprecations.mjs
@@ -16,7 +16,6 @@ const expectedWarnings = [
 
 process.addListener('warning', mustCall((warning) => {
   assert(warning.stack.includes(expectedWarnings[curWarning++]), warning.stack);
-  console.log(expectedWarnings[curWarning - 1] + ' passed');
 }, expectedWarnings.length));
 
 await import('./test-esm-exports.mjs');

--- a/test/es-module/test-esm-exports.mjs
+++ b/test/es-module/test-esm-exports.mjs
@@ -41,13 +41,19 @@ import fromInside from '../fixtures/node_modules/pkgexports/lib/hole.js';
     ['pkgexports/dir2/dir2/trailer', { default: 'index' }],
     ['pkgexports/a/dir1/dir1', { default: 'main' }],
     ['pkgexports/a/b/dir1/dir1', { default: 'main' }],
+
+    // Deprecated:
+    ['pkgexports/trailing-pattern-slash/',
+     { default: 'trailing-pattern-slash' }],
   ]);
 
   if (isRequire) {
     validSpecifiers.set('pkgexports/subpath/file', { default: 'file' });
     validSpecifiers.set('pkgexports/subpath/dir1', { default: 'main' });
+    // Deprecated:
     validSpecifiers.set('pkgexports/subpath/dir1/', { default: 'main' });
     validSpecifiers.set('pkgexports/subpath/dir2', { default: 'index' });
+    // Deprecated:
     validSpecifiers.set('pkgexports/subpath/dir2/', { default: 'index' });
   } else {
     // No exports or main field

--- a/test/es-module/test-esm-local-deprecations.mjs
+++ b/test/es-module/test-esm-local-deprecations.mjs
@@ -9,10 +9,14 @@ const selfDeprecatedFolders =
 const deprecatedFoldersIgnore =
     fixtures.path('/es-modules/deprecated-folders-ignore/main.js');
 
+const deprecatedTrailingSlashPattern =
+    fixtures.path('/es-modules/pattern-trailing-slash.mjs');
+
 const expectedWarnings = [
   '"./" in the "exports" field',
   '"#self/" in the "imports" field',
   '"./folder/" in the "exports" field',
+  '"./trailing-pattern-slash/" in the "exports" field',
 ];
 
 process.addListener('warning', (warning) => {
@@ -28,5 +32,6 @@ process.on('exit', () => {
 (async () => {
   await import(pathToFileURL(selfDeprecatedFolders));
   await import(pathToFileURL(deprecatedFoldersIgnore));
+  await import(pathToFileURL(deprecatedTrailingSlashPattern));
 })()
 .catch((err) => console.error(err));

--- a/test/es-module/test-esm-local-deprecations.mjs
+++ b/test/es-module/test-esm-local-deprecations.mjs
@@ -1,3 +1,5 @@
+// Flags: --pending-deprecation
+
 import '../common/index.mjs';
 import assert from 'assert';
 import fixtures from '../common/fixtures.js';

--- a/test/fixtures/es-modules/pattern-trailing-slash.mjs
+++ b/test/fixtures/es-modules/pattern-trailing-slash.mjs
@@ -1,0 +1,1 @@
+import 'pkgexports/trailing-pattern-slash/';

--- a/test/fixtures/node_modules/pkgexports/package.json
+++ b/test/fixtures/node_modules/pkgexports/package.json
@@ -57,6 +57,7 @@
     "./subpath/": "./subpath/",
     "./subpath/sub-*": "./subpath/dir1/*.js",
     "./subpath/sub-*.js": "./subpath/dir1/*.js",
-    "./features/*": "./subpath/*/*.js"
+    "./features/*": "./subpath/*/*.js",
+    "./trailing-pattern-slash*": "./trailing-pattern-slash*index.js"
   }
 }

--- a/test/fixtures/node_modules/pkgexports/trailing-pattern-slash/index.js
+++ b/test/fixtures/node_modules/pkgexports/trailing-pattern-slash/index.js
@@ -1,0 +1,1 @@
+module.exports = 'trailing-pattern-slash';


### PR DESCRIPTION
This PR deprecates the ability for pattern mappings to be able to resolve import specifiers ending in `/` like `import('pkg/subpath/')`, with a new deprecation warning and message.

The primary motivation here is that the import maps specification does not support trailing `/` mappings resolving.

For example:

```html
<!doctype html>
<script type="importmap">
{
  "imports": {
    "pkg/subpath/": "/pkg/index.js"
  }
}
</script>
<script type="module">
import 'pkg/subpath/';
</script>
```

will give the browser console error:

```
Ignored an import map value of "pkg/subpath/": Since specifierKey ended in a slash, so must the address: /pkg/index.js
```

See https://github.com/WICG/import-maps/issues/244 for more background here.

Since we deprecated folder subpaths, there are no common patterns of trailing `/` usage yet. It is only with the introduction of pattern trailers in https://github.com/nodejs/node/pull/39635 that it is now easy to define maps like:

```js
{
  "exports": {
    "./*/": "./*/index.js"
  }
}
```

to support `import('pkg/asdf/')` resolving to `pkg/asdf/index.js` for any name.

The risk is that users start defining packages like this and then these packages will never be supportable in import maps environments. By deprecating this now we can avoid this outcome.