### PR TITLE
tools: update remark-html to v13.0.2

### DIFF
--- a/tools/doc/json.mjs
+++ b/tools/doc/json.mjs
@@ -187,7 +187,7 @@ export function jsonAPI({ filename }) {
               { type: 'root', children: nodes.concat(definitions) }
             );
           })
-          .use(html)
+          .use(html, { sanitize: false })
           .processSync('').toString().trim();
         if (!current.desc) delete current.desc;
       }

--- a/tools/doc/package-lock.json
+++ b/tools/doc/package-lock.json
@@ -17,7 +17,7 @@
         "rehype-stringify": "8.0.0",
         "remark-frontmatter": "^3.0.0",
         "remark-gfm": "^1.0.0",
-        "remark-html": "13.0.1",
+        "remark-html": "13.0.2",
         "remark-parse": "^9.0.0",
         "remark-rehype": "8.1.0",
         "to-vfile": "7.1.0",
@@ -951,9 +951,9 @@
       }
     },
     "node_modules/remark-html": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/remark-html/-/remark-html-13.0.1.tgz",
-      "integrity": "sha512-K5KQCXWVz+harnyC+UVM/J9eJWCgjYRqFeZoZf2NgP0iFbuuw/RgMZv3MA34b/OEpGnstl3oiOUtZzD3tJ+CBw==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/remark-html/-/remark-html-13.0.2.tgz",
+      "integrity": "sha512-LhSRQ+3RKdBqB/RGesFWkNNfkGqprDUCwjq54SylfFeNyZby5kqOG8Dn/vYsRoM8htab6EWxFXCY6XIZvMoRiQ==",
       "dev": true,
       "dependencies": {
         "hast-util-sanitize": "^3.0.0",
@@ -1992,9 +1992,9 @@
       }
     },
     "remark-html": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/remark-html/-/remark-html-13.0.1.tgz",
-      "integrity": "sha512-K5KQCXWVz+harnyC+UVM/J9eJWCgjYRqFeZoZf2NgP0iFbuuw/RgMZv3MA34b/OEpGnstl3oiOUtZzD3tJ+CBw==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/remark-html/-/remark-html-13.0.2.tgz",
+      "integrity": "sha512-LhSRQ+3RKdBqB/RGesFWkNNfkGqprDUCwjq54SylfFeNyZby5kqOG8Dn/vYsRoM8htab6EWxFXCY6XIZvMoRiQ==",
       "dev": true,
       "requires": {
         "hast-util-sanitize": "^3.0.0",

--- a/tools/doc/package.json
+++ b/tools/doc/package.json
@@ -13,7 +13,7 @@
     "rehype-stringify": "8.0.0",
     "remark-frontmatter": "^3.0.0",
     "remark-gfm": "^1.0.0",
-    "remark-html": "13.0.1",
+    "remark-html": "13.0.2",
     "remark-parse": "^9.0.0",
     "remark-rehype": "8.1.0",
     "to-vfile": "7.1.0",


### PR DESCRIPTION
No changes in the generated doc output.
