### PR TITLE
module: fix $ pattern replacements

### DIFF
--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -461,7 +461,7 @@ function resolvePackageTargetString(
       } catch {}
       if (!isURL) {
         const exportTarget = pattern ?
-          StringPrototypeReplace(target, patternRegEx, subpath) :
+          StringPrototypeReplace(target, patternRegEx, () => subpath) :
           target + subpath;
         return packageResolve(exportTarget, packageJSONUrl, conditions);
       }
@@ -486,7 +486,7 @@ function resolvePackageTargetString(
 
   if (pattern)
     return new URL(StringPrototypeReplace(resolved.href, patternRegEx,
-                                          subpath));
+                                          () => subpath));
   return new URL(subpath, resolved);
 }
 

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -10,6 +10,7 @@ const {
   ObjectGetOwnPropertyNames,
   ObjectPrototypeHasOwnProperty,
   RegExp,
+  RegExpPrototypeSymbolReplace,
   RegExpPrototypeTest,
   SafeMap,
   SafeSet,
@@ -18,7 +19,6 @@ const {
   StringPrototypeIncludes,
   StringPrototypeIndexOf,
   StringPrototypeLastIndexOf,
-  StringPrototypeReplace,
   StringPrototypeSlice,
   StringPrototypeSplit,
   StringPrototypeStartsWith,
@@ -461,7 +461,7 @@ function resolvePackageTargetString(
       } catch {}
       if (!isURL) {
         const exportTarget = pattern ?
-          StringPrototypeReplace(target, patternRegEx, () => subpath) :
+          RegExpPrototypeSymbolReplace(target, patternRegEx, () => subpath) :
           target + subpath;
         return packageResolve(exportTarget, packageJSONUrl, conditions);
       }
@@ -485,8 +485,8 @@ function resolvePackageTargetString(
     throwInvalidSubpath(match + subpath, packageJSONUrl, internal, base);
 
   if (pattern)
-    return new URL(StringPrototypeReplace(resolved.href, patternRegEx,
-                                          () => subpath));
+    return new URL(RegExpPrototypeSymbolReplace(resolved.href, patternRegEx,
+                                                () => subpath));
   return new URL(subpath, resolved);
 }
 
@@ -930,7 +930,8 @@ function resolveAsCommonJS(specifier, parentURL) {
     // Normalize the path separator to give a valid suggestion
     // on Windows
     if (process.platform === 'win32') {
-      found = StringPrototypeReplace(found, new RegExp(`\\${sep}`, 'g'), '/');
+      found = RegExpPrototypeSymbolReplace(found,
+                                           new RegExp(`\\${sep}`, 'g'), '/');
     }
     return found;
   } catch {

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -461,7 +461,7 @@ function resolvePackageTargetString(
       } catch {}
       if (!isURL) {
         const exportTarget = pattern ?
-          RegExpPrototypeSymbolReplace(target, patternRegEx, () => subpath) :
+          RegExpPrototypeSymbolReplace(patternRegEx, target, () => subpath) :
           target + subpath;
         return packageResolve(exportTarget, packageJSONUrl, conditions);
       }
@@ -485,7 +485,7 @@ function resolvePackageTargetString(
     throwInvalidSubpath(match + subpath, packageJSONUrl, internal, base);
 
   if (pattern)
-    return new URL(RegExpPrototypeSymbolReplace(resolved.href, patternRegEx,
+    return new URL(RegExpPrototypeSymbolReplace(patternRegEx, resolved.href,
                                                 () => subpath));
   return new URL(subpath, resolved);
 }

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -930,8 +930,8 @@ function resolveAsCommonJS(specifier, parentURL) {
     // Normalize the path separator to give a valid suggestion
     // on Windows
     if (process.platform === 'win32') {
-      found = RegExpPrototypeSymbolReplace(found,
-                                           new RegExp(`\\${sep}`, 'g'), '/');
+      found = RegExpPrototypeSymbolReplace(new RegExp(`\\${sep}`, 'g'),
+                                           found,'/');
     }
     return found;
   } catch {

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -931,7 +931,7 @@ function resolveAsCommonJS(specifier, parentURL) {
     // on Windows
     if (process.platform === 'win32') {
       found = RegExpPrototypeSymbolReplace(new RegExp(`\\${sep}`, 'g'),
-                                           found,'/');
+                                           found, '/');
     }
     return found;
   } catch {

--- a/test/es-module/test-esm-exports.mjs
+++ b/test/es-module/test-esm-exports.mjs
@@ -156,6 +156,8 @@ import fromInside from '../fixtures/node_modules/pkgexports/lib/hole.js';
     ['pkgexports/no-ext', `pkgexports${sep}asdf`],
     // Pattern specificity
     ['pkgexports/dir2/trailer', `subpath${sep}dir2.js`],
+    // Pattern double $$ escaping!
+    ['pkgexports/a/$$', `subpath${sep}$$.js`],
   ]);
 
   if (!isRequire) {


### PR DESCRIPTION
This fixes the bug where `import 'pkg/$$.js'` will resolve to `pkg/$.js` when using the exports pattern `*.js -> *.js`, due to the JS String replace DSL footgun (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_a_parameter).

Thanks to @rich-harris for sharing this one on Twitter - https://twitter.com/Rich_Harris/status/1435703344354451458.

@nodejs/modules