### PR TITLE
deps: V8: cherry-pick 9a607043cb31

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.10',
+    'v8_embedder_string': '-node.11',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/objects/lookup.cc
+++ b/deps/v8/src/objects/lookup.cc
@@ -1518,8 +1518,8 @@ base::Optional<PropertyCell> ConcurrentLookupIterator::TryGetPropertyCell(
   DisallowGarbageCollection no_gc;
 
   Map holder_map = holder->map();
-  CHECK(!holder_map.is_access_check_needed());
-  CHECK(!holder_map.has_named_interceptor());
+  if (holder_map.is_access_check_needed()) return {};
+  if (holder_map.has_named_interceptor()) return {};
 
   GlobalDictionary dict = holder->global_dictionary(kAcquireLoad);
   base::Optional<PropertyCell> cell =


### PR DESCRIPTION
Fix: https://github.com/nodejs/node/issues/40030


Original commit message:

    [compiler] Gracefully handle an unsupported situation

    ... by skipping the optimization instead of CHECK-failing.

    Bug: v8:12188
    Change-Id: I6709bf1c55506f3d12886efbfbb9934788cd02ce
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/3148132
    Auto-Submit: Georg Neis <neis@chromium.org>
    Commit-Queue: Jakob Gruber <jgruber@chromium.org>
    Reviewed-by: Jakob Gruber <jgruber@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#76741}

Refs: https://github.com/v8/v8/commit/9a607043cb3161f8ceae1583807bece595388108

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
