### PR TITLE
dns: cleanup validation

### DIFF
--- a/lib/internal/dns/utils.js
+++ b/lib/internal/dns/utils.js
@@ -32,7 +32,6 @@ const IPv6RE = /^\[([^[\]]*)\]/;
 const addrSplitRE = /(^.+?)(?::(\d+))?$/;
 const {
   ERR_DNS_SET_SERVERS_FAILED,
-  ERR_INVALID_ARG_TYPE,
   ERR_INVALID_ARG_VALUE,
   ERR_INVALID_IP_ADDRESS,
 } = errors.codes;
@@ -131,8 +130,8 @@ class Resolver {
   setLocalAddress(ipv4, ipv6) {
     validateString(ipv4, 'ipv4');
 
-    if (typeof ipv6 !== 'string' && ipv6 !== undefined) {
-      throw new ERR_INVALID_ARG_TYPE('ipv6', ['String', 'undefined'], ipv6);
+    if (ipv6 !== undefined) {
+      validateString(ipv6, 'ipv6');
     }
 
     this._handle.setLocalAddress(ipv4, ipv6);


### PR DESCRIPTION
The `validateString()` validator should cleanup the validation and keep consistency.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
