### PR TITLE
doc: clarify that ObjectWrap requires manual cleanup on shutdown

### DIFF
--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -966,7 +966,7 @@ or removal at any time. They are not documented by Node.js or V8, and they
 should never be used outside of testing.
 
 During shutdown of the process or worker threads destructors are not called
-by the JS engine. Therefore it's in the responsibility of the user to track
+by the JS engine. Therefore it's the responsibility of the user to track
 these objects and ensure proper destruction to avoid resource leaks.
 
 ### Factory of wrapped objects

--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -965,6 +965,10 @@ provided by the underlying V8 JavaScript engine. They are subject to change
 or removal at any time. They are not documented by Node.js or V8, and they
 should never be used outside of testing.
 
+During shutdown of the process or worker threads destructors are not called
+by the JS engine. Therefore it's in the responsibility of the user to track
+these objects and ensure proper destruction to avoid resource leaks.
+
 ### Factory of wrapped objects
 
 Alternatively, it is possible to use a factory pattern to avoid explicitly


### PR DESCRIPTION
Clarify that ObjectWrap instances are not destroyed on process or worker shutdown and require manual destruction to avoid resource leaks.

fixes: #38816

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
