### PR TITLE
    build: add daily/on-demand internet test workflow

### DIFF
--- a/.github/workflows/test-internet.yml
+++ b/.github/workflows/test-internet.yml
@@ -1,4 +1,4 @@
-name: test-linux
+name: test-internet
 
 on:
   workflow_dispatch:

--- a/.github/workflows/test-internet.yml
+++ b/.github/workflows/test-internet.yml
@@ -1,0 +1,26 @@
+name: test-linux
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "5 0 * * *"
+
+env:
+  PYTHON_VERSION: 3.9
+  FLAKY_TESTS: dontcare
+
+jobs:
+  test-internet:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Environment Information
+        run: npx envinfo
+      - name: Build
+        run: make build-ci -j2 V=1 CONFIG_FLAGS="--error-on-warn"
+      - name: Test Internet
+        run: make test-internet -j2 V=1;


### PR DESCRIPTION
Allows on-demand and nightly runs of the internet tests.