### PR TITLE
test: update OpenSSL3 error messages for 3.0.0+quic

### DIFF
--- a/test/parallel/test-crypto-key-objects.js
+++ b/test/parallel/test-crypto-key-objects.js
@@ -519,7 +519,8 @@ const privateDsa = fixtures.readKey('dsa_private_encrypted_1025.pem',
   // Reading an encrypted key without a passphrase should fail.
   assert.throws(() => createPrivateKey(privateDsa), common.hasOpenSSL3 ? {
     name: 'Error',
-    message: 'error:1E08010C:DECODER routines::unsupported',
+    message: 'error:07880109:common libcrypto routines::interrupted or ' +
+             'cancelled',
   } : {
     name: 'TypeError',
     code: 'ERR_MISSING_PASSPHRASE',
@@ -545,7 +546,7 @@ const privateDsa = fixtures.readKey('dsa_private_encrypted_1025.pem',
     passphrase: Buffer.alloc(1024, 'a')
   }), {
     message: common.hasOpenSSL3 ?
-      'error:1E08010C:DECODER routines::unsupported' :
+      'error:07880109:common libcrypto routines::interrupted or cancelled' :
       /bad decrypt/
   });
 

--- a/test/parallel/test-crypto-keygen.js
+++ b/test/parallel/test-crypto-keygen.js
@@ -578,7 +578,8 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     // Since the private key is encrypted, signing shouldn't work anymore.
     assert.throws(() => testSignVerify(publicKey, privateKey),
                   common.hasOpenSSL3 ? {
-                    message: 'error:1E08010C:DECODER routines::unsupported'
+                    message: 'error:07880109:common libcrypto ' +
+                             'routines::interrupted or cancelled'
                   } : {
                     name: 'TypeError',
                     code: 'ERR_MISSING_PASSPHRASE',
@@ -615,7 +616,8 @@ const sec1EncExp = (cipher) => getRegExpForPEM('EC PRIVATE KEY', cipher);
     // Since the private key is encrypted, signing shouldn't work anymore.
     assert.throws(() => testSignVerify(publicKey, privateKey),
                   common.hasOpenSSL3 ? {
-                    message: 'error:1E08010C:DECODER routines::unsupported'
+                    message: 'error:07880109:common libcrypto ' +
+                             'routines::interrupted or cancelled'
                   } : {
                     name: 'TypeError',
                     code: 'ERR_MISSING_PASSPHRASE',


### PR DESCRIPTION
This commit updates two OpenSSL 3.0.0 error messages required for
OpenSSL 3.0.0+quic.

Refs: https://github.com/nodejs/build/pull/2759