### PR TITLE
doc: clean up weird notes about reentrancy

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -3303,7 +3303,6 @@ Returns `napi_ok` if the API succeeded.
 
 This API implements the abstract operation `ToBoolean()` as defined in
 [Section 7.1.2][] of the ECMAScript Language Specification.
-This API can be re-entrant if getters are defined on the passed-in `Object`.
 
 ### napi_coerce_to_number
 <!-- YAML
@@ -3325,7 +3324,8 @@ Returns `napi_ok` if the API succeeded.
 
 This API implements the abstract operation `ToNumber()` as defined in
 [Section 7.1.3][] of the ECMAScript Language Specification.
-This API can be re-entrant if getters are defined on the passed-in `Object`.
+This function potentially runs JS code if the passed-in value is an
+object.
 
 ### napi_coerce_to_object
 <!-- YAML
@@ -3347,7 +3347,6 @@ Returns `napi_ok` if the API succeeded.
 
 This API implements the abstract operation `ToObject()` as defined in
 [Section 7.1.13][] of the ECMAScript Language Specification.
-This API can be re-entrant if getters are defined on the passed-in `Object`.
 
 ### napi_coerce_to_string
 <!-- YAML
@@ -3369,7 +3368,8 @@ Returns `napi_ok` if the API succeeded.
 
 This API implements the abstract operation `ToString()` as defined in
 [Section 7.1.13][] of the ECMAScript Language Specification.
-This API can be re-entrant if getters are defined on the passed-in `Object`.
+This function potentially runs JS code if the passed-in value is an
+object.
 
 ### napi_typeof
 <!-- YAML


### PR DESCRIPTION
All N-API methods are reentrant, it does not make sense to talk
about specific ones here.

Some of these methods can run JS code, which of course can run
other N-API code. For those methods, let’s note that down explicitly.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
