### PR TITLE
module: runtime deprecate trailing slash patterns

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2818,12 +2818,16 @@ and `'mgf1HashAlgorithm'`.
 <!-- YAML
 changes:
   - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/40017
+    description: Runtime deprecation.
+changes:
+  - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/40039
     description: Documentation-only deprecation
                  with `--pending-deprecation` support.
 -->
 
-Type: Documentation-only (supports [`--pending-deprecation`][])
+Type: Runtime
 
 The remapping of specifiers ending in `"/"` like `import 'pkg/x/'` is deprecated
 for package `"exports"` and `"imports"` pattern resolutions.

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2818,9 +2818,8 @@ and `'mgf1HashAlgorithm'`.
 <!-- YAML
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/40017
+    pr-url: https://github.com/nodejs/node/pull/40117
     description: Runtime deprecation.
-changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/40039
     description: Documentation-only deprecation

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -40,7 +40,6 @@ const { sep, relative, resolve } = require('path');
 const preserveSymlinks = getOptionValue('--preserve-symlinks');
 const preserveSymlinksMain = getOptionValue('--preserve-symlinks-main');
 const typeFlag = getOptionValue('--input-type');
-const pendingDeprecation = getOptionValue('--pending-deprecation');
 const { URL, pathToFileURL, fileURLToPath } = require('internal/url');
 const {
   ERR_INPUT_TYPE_NOT_ALLOWED,
@@ -108,7 +107,6 @@ function emitFolderMapDeprecation(match, pjsonUrl, isExports, base) {
 }
 
 function emitTrailingSlashPatternDeprecation(match, pjsonUrl, isExports, base) {
-  if (!pendingDeprecation) return;
   const pjsonPath = fileURLToPath(pjsonUrl);
   if (emittedPackageWarnings.has(pjsonPath + '|' + match))
     return;

--- a/test/es-module/test-esm-exports-deprecations.mjs
+++ b/test/es-module/test-esm-exports-deprecations.mjs
@@ -1,4 +1,3 @@
-// Flags: --pending-deprecation
 import { mustCall } from '../common/index.mjs';
 import assert from 'assert';
 

--- a/test/es-module/test-esm-local-deprecations.mjs
+++ b/test/es-module/test-esm-local-deprecations.mjs
@@ -1,5 +1,3 @@
-// Flags: --pending-deprecation
-
 import '../common/index.mjs';
 import assert from 'assert';
 import fixtures from '../common/fixtures.js';


### PR DESCRIPTION
This provides the runtime deprecation for the 17.x release to runtime deprecate trailing slash patterns per https://github.com/nodejs/node/pull/40039.