### PR TITLE
crypto: fix webcrypto Curve25519 and Curve448 spki/pkcs8 imports

### DIFF
--- a/lib/internal/crypto/ec.js
+++ b/lib/internal/crypto/ec.js
@@ -269,14 +269,12 @@ async function ecImportKey(
         case 'NODE-X25519':
           // Fall through
         case 'NODE-X448':
-          checkNamedCurve = false;
           if (algorithm.name !== 'ECDH')
             throw lazyDOMException('Invalid algorithm name.', 'DataError');
           break;
         case 'NODE-ED25519':
           // Fall through
         case 'NODE-ED448':
-          checkNamedCurve = false;
           if (algorithm.name !== namedCurve)
             throw lazyDOMException('Invalid algorithm name.', 'DataError');
           break;
@@ -310,7 +308,6 @@ async function ecImportKey(
         throw lazyDOMException('Invalid JWK keyData', 'DataError');
       switch (keyData.kty) {
         case 'OKP': {
-          checkNamedCurve = false;
           const isPublic = keyData.d === undefined;
 
           let type;
@@ -395,7 +392,6 @@ async function ecImportKey(
         case 'NODE-X25519':
           // Fall through
         case 'NODE-X448':
-          checkNamedCurve = false;
           if (algorithm.public !== undefined)
             validateBoolean(algorithm.public, 'algorithm.public');
           if (algorithm.name !== 'ECDH')
@@ -409,7 +405,6 @@ async function ecImportKey(
         case 'NODE-ED25519':
           // Fall through
         case 'NODE-ED448':
-          checkNamedCurve = false;
           if (algorithm.public !== undefined)
             validateBoolean(algorithm.public, 'algorithm.public');
           if (algorithm.name !== namedCurve)
@@ -436,30 +431,27 @@ async function ecImportKey(
         throw lazyDOMException('Invalid key type', 'DataError');
       break;
     case 'ECDH':
-      if (
-        algorithm.namedCurve === 'NODE-X25519' &&
-        keyObject.asymmetricKeyType !== 'x25519'
-      ) {
-        throw lazyDOMException('Invalid key type', 'DataError');
-      } else if (
-        algorithm.namedCurve === 'NODE-X448' &&
-        keyObject.asymmetricKeyType !== 'x448'
-      ) {
-        throw lazyDOMException('Invalid key type', 'DataError');
-      } else if (
-        algorithm.namedCurve.startsWith('P') &&
-        keyObject.asymmetricKeyType !== 'ec'
-      ) {
+      if (algorithm.namedCurve === 'NODE-X25519') {
+        if (keyObject.asymmetricKeyType !== 'x25519')
+          throw lazyDOMException('Invalid key type', 'DataError');
+        checkNamedCurve = false;
+      } else if (algorithm.namedCurve === 'NODE-X448') {
+        if (keyObject.asymmetricKeyType !== 'x448')
+          throw lazyDOMException('Invalid key type', 'DataError');
+        checkNamedCurve = false;
+      } else if (keyObject.asymmetricKeyType !== 'ec') {
         throw lazyDOMException('Invalid key type', 'DataError');
       }
       break;
     case 'NODE-ED25519':
       if (keyObject.asymmetricKeyType !== 'ed25519')
         throw lazyDOMException('Invalid key type', 'DataError');
+      checkNamedCurve = false;
       break;
     case 'NODE-ED448':
       if (keyObject.asymmetricKeyType !== 'ed448')
         throw lazyDOMException('Invalid key type', 'DataError');
+      checkNamedCurve = false;
       break;
   }
 

--- a/test/parallel/test-webcrypto-ed25519-ed448.js
+++ b/test/parallel/test-webcrypto-ed25519-ed448.js
@@ -382,6 +382,20 @@ assert.rejects(
         assert.strictEqual(cryptoKey.algorithm.name, namedCurve);
       }, common.mustNotCall());
 
+      subtle.importKey(
+        keyObject.type === 'private' ? 'pkcs8' : 'spki',
+        keyObject.export({
+          format: 'der',
+          type: keyObject.type === 'private' ? 'pkcs8' : 'spki',
+        }),
+        { name: namedCurve, namedCurve },
+        true,
+        keyObject.type === 'private' ? ['sign'] : ['verify'],
+      ).then((cryptoKey) => {
+        assert.strictEqual(cryptoKey.type, keyObject.type);
+        assert.strictEqual(cryptoKey.algorithm.name, namedCurve);
+      }, common.mustNotCall());
+
       assert.rejects(
         subtle.importKey(
           'node.keyObject',

--- a/test/parallel/test-webcrypto-ed25519-ed448.js
+++ b/test/parallel/test-webcrypto-ed25519-ed448.js
@@ -394,6 +394,7 @@ assert.rejects(
       ).then((cryptoKey) => {
         assert.strictEqual(cryptoKey.type, keyObject.type);
         assert.strictEqual(cryptoKey.algorithm.name, namedCurve);
+        assert.strictEqual(cryptoKey.algorithm.namedCurve, namedCurve);
       }, common.mustNotCall());
 
       assert.rejects(

--- a/test/parallel/test-webcrypto-x25519-x448.js
+++ b/test/parallel/test-webcrypto-x25519-x448.js
@@ -295,6 +295,21 @@ assert.rejects(
         assert.strictEqual(cryptoKey.type, keyObject.type);
         assert.strictEqual(cryptoKey.algorithm.name, 'ECDH');
       }, common.mustNotCall());
+
+      subtle.importKey(
+        keyObject.type === 'private' ? 'pkcs8' : 'spki',
+        keyObject.export({
+          format: 'der',
+          type: keyObject.type === 'private' ? 'pkcs8' : 'spki',
+        }),
+        { name: 'ECDH', namedCurve },
+        true,
+        keyObject.type === 'private' ? ['deriveBits'] : [],
+      ).then((cryptoKey) => {
+        assert.strictEqual(cryptoKey.type, keyObject.type);
+        assert.strictEqual(cryptoKey.algorithm.name, 'ECDH');
+        assert.strictEqual(cryptoKey.algorithm.namedCurve, namedCurve);
+      }, common.mustNotCall());
     }
   }
 }


### PR DESCRIPTION
Fixes the following webcrypto key algorithm' SPKI and PKCS8 imports

```
{ name: 'ECDH', namedCurve: 'NODE-X25519' }
{ name: 'ECDH', namedCurve: 'NODE-X448' }
{ name: 'NODE-ED25519', namedCurve: 'NODE-ED25519' }
{ name: 'NODE-ED448', namedCurve: 'NODE-ED448' }
```