### PR TITLE
module: fix ERR_REQUIRE_ESM for parentPath null

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1459,8 +1459,8 @@ E('ERR_REQUIRE_ESM',
       return msg;
     }
     const path = require('path');
-    const basename = path.basename(filename) === path.basename(parentPath) ?
-      filename : path.basename(filename);
+    const basename = parentPath && path.basename(filename) ===
+      path.basename(parentPath) ? filename : path.basename(filename);
     if (hasEsmSyntax) {
       msg += `\nInstead change the require of ${basename} in ${parentPath} to` +
         ' a dynamic import() which is available in all CommonJS modules.';


### PR DESCRIPTION
Just came across this one when running `require('./cjs.js')` in a REPL in a project with `"type": "module"` where the ERR_REQUIRE_ESM was getting masked by an `ERR_INVALID_ARG_TYPE` error error, followed by the terrible realization it was probably my own fault!