### PR TITLE
build: set DESTCPU correctly for 'make binary' on Apple Silicon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -827,6 +827,9 @@ else
 ifeq ($(findstring s390,$(UNAME_M)),s390)
 DESTCPU ?= s390
 else
+ifeq ($(findstring arm64,$(UNAME_M)),arm64)
+DESTCPU ?= arm64
+else
 ifeq ($(findstring arm,$(UNAME_M)),arm)
 DESTCPU ?= arm
 else
@@ -840,6 +843,7 @@ ifeq ($(findstring riscv64,$(UNAME_M)),riscv64)
 DESTCPU ?= riscv64
 else
 DESTCPU ?= x86
+endif
 endif
 endif
 endif


### PR DESCRIPTION
When running `make binary -j8` on an Apple Silicon M1 it looks like the DESTCPU is not set correctly in the Makefile so you get the following error when building openssl

```
> make binary -j8
...
/opt/homebrew/opt/python@3.9/bin/python3.9 ./configure \
		--prefix=/ \
		--dest-cpu=arm \
		--tag= \
		--release-urlbase= \
		 --download=all --with-intl=full-icu

...

  cc -o /Users/cheister/Development/node/out/Release/obj.target/openssl/deps/openssl/openssl/crypto/bn/bn_add.o ../deps/openssl/openssl/crypto/bn/bn_add.c '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-DOPENSSL_NO_PINSHARED' '-DOPENSSL_THREADS' '-DOPENSSL_NO_HW' '-DNDEBUG' '-DOPENSSL_USE_NODELETE' '-DL_ENDIAN' '-DOPENSSL_PIC' '-DOPENSSL_CPUID_OBJ' '-DOPENSSL_IA32_SSE2' '-DOPENSSL_BN_ASM_MONT' '-DOPENSSL_BN_ASM_MONT5' '-DOPENSSL_BN_ASM_GF2m' '-DSHA1_ASM' '-DSHA256_ASM' '-DSHA512_ASM' '-DKECCAK1600_ASM' '-DRC4_ASM' '-DMD5_ASM' '-DAESNI_ASM' '-DVPAES_ASM' '-DGHASH_ASM' '-DECP_NISTZ256_ASM' '-DX25519_ASM' '-DPOLY1305_ASM' '-DOPENSSLDIR="/System/Library/OpenSSL/"' '-DENGINESDIR="/dev/null"' -I../deps/openssl/openssl -I../deps/openssl/openssl/include -I../deps/openssl/openssl/crypto -I../deps/openssl/openssl/crypto/include -I../deps/openssl/openssl/crypto/modes -I../deps/openssl/openssl/crypto/ec/curve448 -I../deps/openssl/openssl/crypto/ec/curve448/arch_32 -I../deps/openssl/config -I../deps/openssl/config/archs/linux-x86_64/asm_avx2 -I../deps/openssl/config/archs/linux-x86_64/asm_avx2/include -I../deps/openssl/config/archs/linux-x86_64/asm_avx2/crypto -I../deps/openssl/config/archs/linux-x86_64/asm_avx2/crypto/include/internal  -O3 -gdwarf-2 -mmacosx-version-min=10.13 -Wall -Wendif-labels -W -Wno-unused-parameter -Wno-missing-field-initializers -fno-strict-aliasing -MMD -MF /Users/cheister/Development/node/out/Release/.deps//Users/cheister/Development/node/out/Release/obj.target/openssl/deps/openssl/openssl/crypto/bn/bn_add.o.d.raw   -c
../deps/openssl/openssl/crypto/bn/asm/x86_64-gcc.c:120:9: error: invalid output constraint '=a' in asm
        mul_add(rp[0], ap[0], w, c1);
        ^
../deps/openssl/openssl/crypto/bn/asm/x86_64-gcc.c:78:19: note: expanded from macro 'mul_add'
                : "=a"(low),"=d"(high)  \
                  ^
../deps/openssl/openssl/crypto/bn/asm/x86_64-gcc.c:120:9: error: invalid output constraint '+d' in asm
../deps/openssl/openssl/crypto/bn/asm/x86_64-gcc.c:82:31: note: expanded from macro 'mul_add'
                : "+r"(carry),"+d"(high)\
                              ^
../deps/openssl/openssl/crypto/bn/asm/x86_64-gcc.c:120:9: error: invalid output constraint '+d' in asm
../deps/openssl/openssl/crypto/bn/asm/x86_64-gcc.c:86:27: note: expanded from macro 'mul_add'
                : "+m"(r),"+d"(high)    \
                          ^
../deps/openssl/openssl/crypto/bn/asm/x86_64-gcc.c:121:9: error: invalid output constraint '=a' in asm
        mul_add(rp[1], ap[1], w, c1);
```

On the M1 I get `arm64` for `uname -m` . This PR sets the DESTCPU to arm64 and everything builds fine after that.

