### PR TITLE
crypto: don't call callback twice in case crypto.randomBytes fails

### DIFF
--- a/lib/internal/crypto/random.js
+++ b/lib/internal/crypto/random.js
@@ -102,7 +102,7 @@ function randomBytes(size, callback) {
 
   // Keep the callback as a regular function so this is propagated.
   randomFill(buf.buffer, 0, size, function(error) {
-    if (error) FunctionPrototypeCall(callback, this, error);
+    if (error) return FunctionPrototypeCall(callback, this, error);
     FunctionPrototypeCall(callback, this, null, buf);
   });
 }


### PR DESCRIPTION
```
const crypto = require("crypto");

crypto.randomBytes(10, (err, buf) => {
  console.log(err, buf);
});
```

If `randomBytes` fails, this code will print to the console twice. First with the error message and then a second time without any error and a buffer full of zeros.

It was introduced by #35093 (see this diff: https://github.com/nodejs/node/commit/dae283d96fd31ad0f30840a7e55ac97294f505ac#diff-afe151ccd22dba4dff750df92b5c0062736027ed4d23ae2eade177b5f215b9efL59-R90). It was merged on v15 and exists on v16 and master. Thus this is a regression between v14 and v16.

I don't know how to write a test for this since I don't see a way to make `RandomBytesJob` fail consistently, but this commit is quite small. PS. I'm a first-time contributor.