### PR TITLE
doc: add blank line between comments

### DIFF
--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -1,6 +1,7 @@
 # C++ addons
 
 <!--introduced_in=v0.10.0-->
+
 <!-- type=misc -->
 
 _Addons_ are dynamically-linked shared objects written in C++. The

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1,6 +1,7 @@
 # Command-line options
 
 <!--introduced_in=v5.9.1-->
+
 <!--type=misc-->
 
 Node.js comes with a variety of CLI options. These options expose built-in

--- a/doc/api/corepack.md
+++ b/doc/api/corepack.md
@@ -1,6 +1,7 @@
 # Corepack
 
 <!-- introduced_in=v16.9.0 -->
+
 <!-- type=misc -->
 
 > Stability: 1 - Experimental

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -1,6 +1,7 @@
 # Deprecated APIs
 
 <!--introduced_in=v7.7.0-->
+
 <!-- type=misc -->
 
 Node.js APIs might be deprecated for any of the following reasons:

--- a/doc/api/documentation.md
+++ b/doc/api/documentation.md
@@ -1,6 +1,7 @@
 # About this documentation
 
 <!--introduced_in=v0.10.0-->
+
 <!-- type=misc -->
 
 Welcome to the official API reference documentation for Node.js!
@@ -51,6 +52,7 @@ a command-line flag. Experimental features may also emit a [warning][].
 
 ## Stability overview
 <!-- STABILITY_OVERVIEW_SLOT_BEGIN -->
+
 <!-- STABILITY_OVERVIEW_SLOT_END -->
 
 ## JSON output

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1,6 +1,7 @@
 # Errors
 
 <!--introduced_in=v4.0.0-->
+
 <!--type=misc-->
 
 Applications running in Node.js will generally experience four categories of

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -1,7 +1,9 @@
 # Modules: ECMAScript modules
 
 <!--introduced_in=v8.5.0-->
+
 <!-- type=misc -->
+
 <!-- YAML
 added: v8.5.0
 changes:

--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -1,6 +1,7 @@
 # Global objects
 
 <!--introduced_in=v0.10.0-->
+
 <!-- type=misc -->
 
 These objects are available in all modules. The following variables may appear

--- a/doc/api/intl.md
+++ b/doc/api/intl.md
@@ -1,6 +1,7 @@
 # Internationalization support
 
 <!--introduced_in=v8.2.0-->
+
 <!-- type=misc -->
 
 Node.js has many features that make it easier to write internationalized

--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -1,6 +1,7 @@
 # Modules: `module` API
 
 <!--introduced_in=v12.20.0-->
+
 <!-- YAML
 added: v0.3.7
 -->

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -280,6 +280,7 @@ irrespective of whether or not `./foo` and `./FOO` are the same file.
 ## Core modules
 
 <!--type=misc-->
+
 <!-- YAML
 changes:
   - version: v16.0.0
@@ -773,6 +774,7 @@ added: v0.1.16
 -->
 
 <!-- type=var -->
+
 <!-- name=module -->
 
 * {Object}

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -1,6 +1,7 @@
 # Node-API
 
 <!--introduced_in=v8.0.0-->
+
 <!-- type=misc -->
 
 > Stability: 2 - Stable

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -1,6 +1,7 @@
 # Net
 
 <!--introduced_in=v0.10.0-->
+
 <!--lint disable maximum-line-length-->
 
 > Stability: 2 - Stable

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -1,7 +1,9 @@
 # Modules: Packages
 
 <!--introduced_in=v12.20.0-->
+
 <!-- type=misc -->
+
 <!-- YAML
 changes:
   - version:

--- a/doc/api/policy.md
+++ b/doc/api/policy.md
@@ -1,6 +1,7 @@
 # Policies
 
 <!--introduced_in=v11.8.0-->
+
 <!-- type=misc -->
 
 > Stability: 1 - Experimental

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1,6 +1,7 @@
 # Process
 
 <!-- introduced_in=v0.10.0 -->
+
 <!-- type=global -->
 
 <!-- source_link=lib/process.js -->
@@ -665,6 +666,7 @@ A few of the warning types that are most common include:
 ### Signal events
 
 <!--type=event-->
+
 <!--name=SIGINT, SIGHUP, etc.-->
 
 Signal events will be emitted when the Node.js process receives a signal. Please

--- a/doc/api/report.md
+++ b/doc/api/report.md
@@ -1,6 +1,7 @@
 # Diagnostic report
 
 <!--introduced_in=v11.8.0-->
+
 <!-- type=misc -->
 
 > Stability: 2 - Stable

--- a/doc/api/synopsis.md
+++ b/doc/api/synopsis.md
@@ -3,6 +3,7 @@
 ## Usage
 
 <!--introduced_in=v0.10.0-->
+
 <!--type=misc-->
 
 `node [options] [V8 options] [script.js | -e "script" | - ] [arguments]`

--- a/doc/changelogs/CHANGELOG_ARCHIVE.md
+++ b/doc/changelogs/CHANGELOG_ARCHIVE.md
@@ -1,8 +1,6 @@
 # Node.js ChangeLog Archive
 
-<!--lint disable prohibited-strings-->
-<!--lint disable maximum-line-length-->
-<!--lint disable no-literal-urls-->
+<!--lint disable maximum-line-length no-literal-urls prohibited-strings-->
 
 <table>
 <tr>

--- a/doc/changelogs/CHANGELOG_IOJS.md
+++ b/doc/changelogs/CHANGELOG_IOJS.md
@@ -1,8 +1,6 @@
 # io.js ChangeLog
 
-<!--lint disable prohibited-strings-->
-<!--lint disable maximum-line-length-->
-<!--lint disable no-literal-urls-->
+<!--lint disable maximum-line-length no-literal-urls prohibited-strings-->
 
 <table>
 <tr>

--- a/doc/changelogs/CHANGELOG_V010.md
+++ b/doc/changelogs/CHANGELOG_V010.md
@@ -1,8 +1,6 @@
 # Node.js 0.10 ChangeLog
 
-<!--lint disable prohibited-strings-->
-<!--lint disable maximum-line-length-->
-<!--lint disable no-literal-urls-->
+<!--lint disable maximum-line-length no-literal-urls prohibited-strings-->
 
 <table>
 <tr>

--- a/doc/changelogs/CHANGELOG_V012.md
+++ b/doc/changelogs/CHANGELOG_V012.md
@@ -1,8 +1,6 @@
 # Node.js 0.12 ChangeLog
 
-<!--lint disable prohibited-strings-->
-<!--lint disable maximum-line-length-->
-<!--lint disable no-literal-urls-->
+<!--lint disable maximum-line-length no-literal-urls prohibited-strings-->
 
 <table>
 <tr>

--- a/doc/changelogs/CHANGELOG_V10.md
+++ b/doc/changelogs/CHANGELOG_V10.md
@@ -1,8 +1,6 @@
 # Node.js 10 ChangeLog
 
-<!--lint disable prohibited-strings-->
-<!--lint disable maximum-line-length-->
-<!--lint disable no-literal-urls-->
+<!--lint disable maximum-line-length no-literal-urls prohibited-strings-->
 
 <table>
 <tr>

--- a/doc/changelogs/CHANGELOG_V11.md
+++ b/doc/changelogs/CHANGELOG_V11.md
@@ -1,8 +1,6 @@
 # Node.js 11 ChangeLog
 
-<!--lint disable prohibited-strings-->
-<!--lint disable maximum-line-length-->
-<!--lint disable no-literal-urls-->
+<!--lint disable maximum-line-length no-literal-urls prohibited-strings-->
 
 <table>
 <tr>

--- a/doc/changelogs/CHANGELOG_V12.md
+++ b/doc/changelogs/CHANGELOG_V12.md
@@ -1,8 +1,6 @@
 # Node.js 12 ChangeLog
 
-<!--lint disable prohibited-strings-->
-<!--lint disable maximum-line-length-->
-<!--lint disable no-literal-urls-->
+<!--lint disable maximum-line-length no-literal-urls prohibited-strings-->
 
 <table>
 <tr>

--- a/doc/changelogs/CHANGELOG_V13.md
+++ b/doc/changelogs/CHANGELOG_V13.md
@@ -1,8 +1,6 @@
 # Node.js 13 ChangeLog
 
-<!--lint disable prohibited-strings-->
-<!--lint disable maximum-line-length-->
-<!--lint disable no-literal-urls-->
+<!--lint disable maximum-line-length no-literal-urls prohibited-strings-->
 
 <table>
 <tr>

--- a/doc/changelogs/CHANGELOG_V14.md
+++ b/doc/changelogs/CHANGELOG_V14.md
@@ -1,8 +1,6 @@
 # Node.js 14 ChangeLog
 
-<!--lint disable prohibited-strings-->
-<!--lint disable maximum-line-length-->
-<!--lint disable no-literal-urls-->
+<!--lint disable maximum-line-length no-literal-urls prohibited-strings-->
 
 <table>
 <tr>

--- a/doc/changelogs/CHANGELOG_V15.md
+++ b/doc/changelogs/CHANGELOG_V15.md
@@ -1,8 +1,6 @@
 # Node.js 15 ChangeLog
 
-<!--lint disable prohibited-strings-->
-<!--lint disable maximum-line-length-->
-<!--lint disable no-literal-urls-->
+<!--lint disable maximum-line-length no-literal-urls prohibited-strings-->
 
 <table>
 <tr>

--- a/doc/changelogs/CHANGELOG_V16.md
+++ b/doc/changelogs/CHANGELOG_V16.md
@@ -1,8 +1,6 @@
 # Node.js 16 ChangeLog
 
-<!--lint disable prohibited-strings-->
-<!--lint disable maximum-line-length-->
-<!--lint disable no-literal-urls-->
+<!--lint disable maximum-line-length no-literal-urls prohibited-strings-->
 
 <table>
 <tr>

--- a/doc/changelogs/CHANGELOG_V4.md
+++ b/doc/changelogs/CHANGELOG_V4.md
@@ -1,8 +1,6 @@
 # Node.js 4 ChangeLog
 
-<!--lint disable prohibited-strings-->
-<!--lint disable maximum-line-length-->
-<!--lint disable no-literal-urls-->
+<!--lint disable maximum-line-length no-literal-urls prohibited-strings-->
 
 <table>
 <tr>

--- a/doc/changelogs/CHANGELOG_V5.md
+++ b/doc/changelogs/CHANGELOG_V5.md
@@ -1,8 +1,6 @@
 # Node.js 5 ChangeLog
 
-<!--lint disable prohibited-strings-->
-<!--lint disable maximum-line-length-->
-<!--lint disable no-literal-urls-->
+<!--lint disable maximum-line-length no-literal-urls prohibited-strings-->
 
 <table>
 <tr>

--- a/doc/changelogs/CHANGELOG_V6.md
+++ b/doc/changelogs/CHANGELOG_V6.md
@@ -1,8 +1,6 @@
 # Node.js 6 ChangeLog
 
-<!--lint disable prohibited-strings-->
-<!--lint disable maximum-line-length-->
-<!--lint disable no-literal-urls-->
+<!--lint disable maximum-line-length no-literal-urls prohibited-strings-->
 
 <table>
 <tr>

--- a/doc/changelogs/CHANGELOG_V7.md
+++ b/doc/changelogs/CHANGELOG_V7.md
@@ -1,8 +1,6 @@
 # Node.js 7 ChangeLog
 
-<!--lint disable prohibited-strings-->
-<!--lint disable maximum-line-length-->
-<!--lint disable no-literal-urls-->
+<!--lint disable maximum-line-length no-literal-urls prohibited-strings-->
 
 <table>
 <tr>

--- a/doc/changelogs/CHANGELOG_V8.md
+++ b/doc/changelogs/CHANGELOG_V8.md
@@ -1,8 +1,6 @@
 # Node.js 8 ChangeLog
 
-<!--lint disable prohibited-strings-->
-<!--lint disable maximum-line-length-->
-<!--lint disable no-literal-urls-->
+<!--lint disable maximum-line-length no-literal-urls prohibited-strings-->
 
 <table>
 <tr>

--- a/doc/changelogs/CHANGELOG_V9.md
+++ b/doc/changelogs/CHANGELOG_V9.md
@@ -1,8 +1,6 @@
 # Node.js 9 ChangeLog
 
-<!--lint disable prohibited-strings-->
-<!--lint disable maximum-line-length-->
-<!--lint disable no-literal-urls-->
+<!--lint disable maximum-line-length no-literal-urls prohibited-strings-->
 
 <table>
 <tr>


### PR DESCRIPTION
Upcoming remark-based formatting/linting will add a blank line between
comments in markdown. This is in preparation for that change.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
