### PR TITLE
build: add --no-user for pip commands in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1392,8 +1392,8 @@ cpplint: lint-cpp
 # Try with '--system' if it fails without; the system may have set '--user'
 lint-py-build:
 	$(info Pip installing flake8 linter on $(shell $(PYTHON) --version)...)
-	$(PYTHON) -m pip install --upgrade -t tools/pip/site-packages flake8 || \
-		$(PYTHON) -m pip install --upgrade --system -t tools/pip/site-packages flake8
+	$(PYTHON) -m pip install --no-user --upgrade -t tools/pip/site-packages flake8 || \
+		$(PYTHON) -m pip install --no-user --upgrade --system -t tools/pip/site-packages flake8
 
 ifneq ("","$(wildcard tools/pip/site-packages/flake8)")
 .PHONY: lint-py
@@ -1412,8 +1412,8 @@ endif
 # Try with '--system' if it fails without; the system may have set '--user'
 lint-yaml-build:
 	$(info Pip installing yamllint on $(shell $(PYTHON) --version)...)
-	$(PYTHON) -m pip install --upgrade -t tools/pip/site-packages yamllint || \
-		$(PYTHON) -m pip install --upgrade --system -t tools/pip/site-packages yamllint
+	$(PYTHON) -m pip install --no-user --upgrade -t tools/pip/site-packages yamllint || \
+		$(PYTHON) -m pip install --no-user --upgrade --system -t tools/pip/site-packages yamllint
 
 .PHONY: lint-yaml
 # Lints the YAML files with yamllint.


### PR DESCRIPTION
I ran into "Cannot combine --user and --target" in an environment and
adding --no-user seemed to fix it.

Refs: https://stackoverflow.com/a/67259534/436641

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
