### PR TITLE
net: fix IPv4 validation regex

### DIFF
--- a/lib/internal/net.js
+++ b/lib/internal/net.js
@@ -11,8 +11,8 @@ const { writeBuffer } = internalBinding('fs');
 const errors = require('internal/errors');
 
 // IPv4 Segment
-const v4Seg = '(?:[0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])';
-const v4Str = `(${v4Seg}[.]){3}${v4Seg}`;
+const v4Seg = '(?:[0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])';
+const v4Str = `(?:${v4Seg}\\.){3}${v4Seg}`;
 const IPv4Reg = new RegExp(`^${v4Str}$`);
 
 // IPv6 Segment


### PR DESCRIPTION
Fixed the IPv4's validation regex so it also matches IPv4 octets that are prefixed by a `0` as they're also considered valid octets.

Fixes: #40173

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
