### PR TITLE
tools: implement markdown formatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1253,6 +1253,13 @@ tools/.mdlintstamp: $(LINT_MD_FILES)
 # Lints the markdown documents maintained by us in the codebase.
 lint-md: lint-js-doc | tools/.mdlintstamp
 
+run-format-md = tools/lint-md/lint-md.mjs --format $(LINT_MD_FILES)
+.PHONY: format-md
+# Formats the markdown documents maintained by us in the codebase.
+format-md:
+	@$(call available-node,$(run-format-md))
+
+
 
 LINT_JS_TARGETS = .eslintrc.js benchmark doc lib test tools
 

--- a/tools/lint-md/lint-md.mjs
+++ b/tools/lint-md/lint-md.mjs
@@ -27475,8 +27475,12 @@ function findUrl(_, protocol, domain, path, match) {
  * @param {RegExpMatchObject} match
  */
 function findEmail(_, atext, label, match) {
-  // Not an expected previous character.
-  if (!previous(match, true) || /[_-]$/.test(label)) {
+  if (
+    // Not an expected previous character.
+    !previous(match, true) ||
+    // Label ends in not allowed character.
+    /[_-\d]$/.test(label)
+  ) {
     return false
   }
 

--- a/tools/lint-md/lint-md.mjs
+++ b/tools/lint-md/lint-md.mjs
@@ -28936,7 +28936,7 @@ function reporter(files, options = {}) {
     files = [files];
   }
 
-  return format(transform(files, options), one, options)
+  return format$1(transform(files, options), one, options)
 }
 
 /**
@@ -29013,7 +29013,7 @@ function transform(files, options) {
  * @param {Options} options
  */
 // eslint-disable-next-line complexity
-function format(map, one, options) {
+function format$1(map, one, options) {
   /** @type {boolean} */
   const enabled =
     options.color === undefined || options.color === null
@@ -29155,6 +29155,18 @@ function size(value) {
 
 const paths = process.argv.slice(2);
 
+if (!paths.length) {
+  console.error('Usage: lint-md.mjs <path> [<path> ...]');
+  process.exit(1);
+}
+
+let format = false;
+
+if (paths[0] === '--format') {
+  paths.shift();
+  format = true;
+}
+
 const linter = unified()
   .use(remarkParse)
   .use(remarkGfm)
@@ -29164,9 +29176,10 @@ const linter = unified()
 paths.forEach(async (path) => {
   const file = await read(path);
   const result = await linter.process(file);
-  if (result.messages.length) {
+  if (format) {
+    fs.writeFileSync(path, result.toString());
+  } else if (result.messages.length) {
     process.exitCode = 1;
     console.error(reporter(result));
   }
-  // TODO: allow reformatting by writing `String(result)` to the input file
 });

--- a/tools/lint-md/package-lock.json
+++ b/tools/lint-md/package-lock.json
@@ -732,9 +732,9 @@
       }
     },
     "node_modules/mdast-util-gfm-autolink-literal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-1.0.1.tgz",
-      "integrity": "sha512-dCUDNYXCytIonTHIUOZXp5S3FWd1XAt6IVH1fBfH6BbUF9U+9m1T9XllfHPvKJCccKNI+0RlYmQJ0rfMTDxEtA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-1.0.2.tgz",
+      "integrity": "sha512-FzopkOd4xTTBeGXhXSBU0OCDDh5lUj2rd+HQqG92Ld+jL4lpUfgX2AT2OHAVP9aEeDKp7G92fuooSZcYJA3cRg==",
       "dependencies": {
         "@types/mdast": "^3.0.0",
         "ccount": "^2.0.0",
@@ -3243,9 +3243,9 @@
       }
     },
     "mdast-util-gfm-autolink-literal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-1.0.1.tgz",
-      "integrity": "sha512-dCUDNYXCytIonTHIUOZXp5S3FWd1XAt6IVH1fBfH6BbUF9U+9m1T9XllfHPvKJCccKNI+0RlYmQJ0rfMTDxEtA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-1.0.2.tgz",
+      "integrity": "sha512-FzopkOd4xTTBeGXhXSBU0OCDDh5lUj2rd+HQqG92Ld+jL4lpUfgX2AT2OHAVP9aEeDKp7G92fuooSZcYJA3cRg==",
       "requires": {
         "@types/mdast": "^3.0.0",
         "ccount": "^2.0.0",

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -726,6 +726,20 @@ for /D %%D IN (doc\*) do (
 ENDLOCAL
 goto exit
 
+:format-md
+if not defined lint_md goto exit
+echo Running Markdown formatter on docs...
+SETLOCAL ENABLEDELAYEDEXPANSION
+set lint_md_files=
+for /D %%D IN (doc\*) do (
+  for %%F IN (%%D\*.md) do (
+    set "lint_md_files="%%F" !lint_md_files!"
+  )
+)
+%node_exe% tools\lint-md\lint-md.mjs --format %lint_md_files%
+ENDLOCAL
+goto exit
+
 :create-msvs-files-failed
 echo Failed to create vc project files.
 del .used_configure_flags


### PR DESCRIPTION
Markdown formatter is now available via `mark format-md` (or`vcbuild format-md` on Windows).

~This PR depends on https://github.com/nodejs/node/pull/40180 which is the first (large) commit in this PR. To see the relevant part, view the diff for the remaining commits only. The first commit will go away when 40180 lands.~ (40180 has landed so the paragraph crossed out here is no longer relevant.)

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
