### PR TITLE
console: avoid unnecessary variables

### DIFF
--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -58,18 +58,14 @@ const {
   isTypedArray, isSet, isMap, isSetIterator, isMapIterator,
 } = require('internal/util/types');
 const {
-  CHAR_LOWERCASE_B,
-  CHAR_LOWERCASE_E,
-  CHAR_LOWERCASE_N,
-  CHAR_UPPERCASE_C,
+  CHAR_LOWERCASE_B: kTraceBegin,
+  CHAR_LOWERCASE_E: kTraceEnd,
+  CHAR_LOWERCASE_N: kTraceInstant,
+  CHAR_UPPERCASE_C: kTraceCount,
 } = require('internal/constants');
 const kCounts = Symbol('counts');
 
 const kTraceConsoleCategory = 'node,node.console';
-const kTraceCount = CHAR_UPPERCASE_C;
-const kTraceBegin = CHAR_LOWERCASE_B;
-const kTraceEnd = CHAR_LOWERCASE_E;
-const kTraceInstant = CHAR_LOWERCASE_N;
 
 const kSecond = 1000;
 const kMinute = 60 * kSecond;


### PR DESCRIPTION
By using destruction re-naming useless variables were eliminated.

