### PR TITLE
crypto: handle initEDRaw pkey failure

### DIFF
--- a/lib/internal/crypto/ec.js
+++ b/lib/internal/crypto/ec.js
@@ -127,7 +127,7 @@ function createECRawKey(namedCurve, keyData, isPublic) {
     throw lazyDOMException('Failure to generate key object');
   }
 
-  return isPublic ? new PublicKeyObject(handle) : PrivateKeyObject(handle);
+  return isPublic ? new PublicKeyObject(handle) : new PrivateKeyObject(handle);
 }
 
 async function ecGenerateKey(algorithm, extractable, keyUsages) {

--- a/lib/internal/crypto/ec.js
+++ b/lib/internal/crypto/ec.js
@@ -122,13 +122,12 @@ function createECRawKey(namedCurve, keyData, isPublic) {
       break;
   }
 
-  if (isPublic) {
-    handle.initEDRaw(namedCurve, keyData, kKeyTypePublic);
-    return new PublicKeyObject(handle);
+  const keyType = isPublic ? kKeyTypePublic : kKeyTypePrivate;
+  if (!handle.initEDRaw(namedCurve, keyData, keyType)) {
+    throw lazyDOMException('Failure to generate key object');
   }
 
-  handle.initEDRaw(namedCurve, keyData, kKeyTypePrivate);
-  return new PrivateKeyObject(handle);
+  return isPublic ? new PublicKeyObject(handle) : PrivateKeyObject(handle);
 }
 
 async function ecGenerateKey(algorithm, extractable, keyUsages) {

--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -435,16 +435,10 @@ function getKeyObjectHandleFromJwk(key, ctx) {
     }
 
     const handle = new KeyObjectHandle();
-    if (isPublic) {
-      handle.initEDRaw(
-        `NODE-${key.crv.toUpperCase()}`,
-        keyData,
-        kKeyTypePublic);
-    } else {
-      handle.initEDRaw(
-        `NODE-${key.crv.toUpperCase()}`,
-        keyData,
-        kKeyTypePrivate);
+
+    const keyType = isPublic ? kKeyTypePublic : kKeyTypePrivate;
+    if (!handle.initEDRaw(`NODE-${key.crv.toUpperCase()}`, keyData, keyType)) {
+      throw new ERR_CRYPTO_INVALID_JWK();
     }
 
     return handle;


### PR DESCRIPTION
Refs https://github.com/electron/electron/pull/31087.

It's possible that https://github.com/nodejs/node/blob/4441c3e3b5c3b0fdc97e5097db708421d90814a6/src/crypto/crypto_keys.cc#L1106 will fail, and `KeyObjectHandle::InitEDRaw` will set the return value to false. This means that the `data_` member will never be assigned. However, the return value of this function is never checked by any of its callsites, meaning that a keyObject is returned but that calling any functions on it, e.g. `export` or `asymmetricKeyType` will cause a nullptr crash when they try to access `key->Data()`. 

Fix this by checking the return value from `handle.initEdRaw()` and throwing an error on `false`.

I used the error from above the callsites but please let me know if there's another preferable one! 

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
