### PR TITLE
repl: skip `EmptyStatement`s and return result with TLA

### DIFF
--- a/lib/internal/repl/await.js
+++ b/lib/internal/repl/await.js
@@ -221,22 +221,26 @@ function processTopLevelAwait(src) {
     return null;
   }
 
-  const last = body.body[body.body.length - 1];
-  if (last.type === 'ExpressionStatement') {
-    // For an expression statement of the form
-    // ( expr ) ;
-    // ^^^^^^^^^^   // last
-    //   ^^^^       // last.expression
-    //
-    // We do not want the left parenthesis before the `return` keyword;
-    // therefore we prepend the `return (` to `last`.
-    //
-    // On the other hand, we do not want the right parenthesis after the
-    // semicolon. Since there can only be more right parentheses between
-    // last.expression.end and the semicolon, appending one more to
-    // last.expression should be fine.
-    state.prepend(last, 'return (');
-    state.append(last.expression, ')');
+  for (let i = body.body.length - 1; i > 0; i--) {
+    const node = body.body[i];
+    if (node.type === 'EmptyStatement') continue;
+    if (node.type === 'ExpressionStatement') {
+      // For an expression statement of the form
+      // ( expr ) ;
+      // ^^^^^^^^^^   // node
+      //   ^^^^       // node.expression
+      //
+      // We do not want the left parenthesis before the `return` keyword;
+      // therefore we prepend the `return (` to `node`.
+      //
+      // On the other hand, we do not want the right parenthesis after the
+      // semicolon. Since there can only be more right parentheses between
+      // node.expression.end and the semicolon, appending one more to
+      // node.expression should be fine.
+      state.prepend(node, 'return (');
+      state.append(node.expression, ')');
+    }
+    break;
   }
 
   return (

--- a/lib/internal/repl/await.js
+++ b/lib/internal/repl/await.js
@@ -221,7 +221,7 @@ function processTopLevelAwait(src) {
     return null;
   }
 
-  for (let i = body.body.length - 1; i > 0; i--) {
+  for (let i = body.body.length - 1; i >= 0; i--) {
     const node = body.body[i];
     if (node.type === 'EmptyStatement') continue;
     if (node.type === 'ExpressionStatement') {

--- a/test/parallel/test-repl-preprocess-top-level-await.js
+++ b/test/parallel/test-repl-preprocess-top-level-await.js
@@ -22,6 +22,8 @@ const testCases = [
     `(async () => { return (await ${surrogate}) })()` ],
   [ 'await 0;',
     '(async () => { return (await 0); })()' ],
+  [ 'await 0;;;',
+    '(async () => { return (await 0); })()' ],
   [ `await ${surrogate};`,
     `(async () => { return (await ${surrogate}); })()` ],
   [ `await ${surrogate};`,

--- a/test/parallel/test-repl-preprocess-top-level-await.js
+++ b/test/parallel/test-repl-preprocess-top-level-await.js
@@ -23,7 +23,7 @@ const testCases = [
   [ 'await 0;',
     '(async () => { return (await 0); })()' ],
   [ 'await 0;;;',
-    '(async () => { return (await 0); })()' ],
+    '(async () => { return (await 0);;; })()' ],
   [ `await ${surrogate};`,
     `(async () => { return (await ${surrogate}); })()` ],
   [ `await ${surrogate};`,


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/39932

Finally, since I didn't get any comments under the issue, I think it's better to return anyway, it would be more consistent with `something;;` which return something.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
