### PR TITLE
benchmark: add `util.toUSVString()`'s benchmark

### DIFF
--- a/benchmark/util/to-usv-string.js
+++ b/benchmark/util/to-usv-string.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const common = require('../common');
+
+const BASE = 'string\ud801';
+
+const bench = common.createBenchmark(main, {
+  n: [1e5],
+  size: [10, 100, 500],
+});
+
+function main({ n, size }) {
+  const { toUSVString } = require('util');
+  const str = BASE.repeat(size);
+
+  bench.start();
+  for (let i = 0; i < n; i++) {
+    toUSVString(str);
+  }
+  bench.end(n);
+}


### PR DESCRIPTION
I've tried to replace `toUSVString()`'s code with:

```js
const surrogateRegexp = new RegExp('((?<![\ud800-\udbff])[\udc00-\udfff]|[\ud800-\udbff](?![\udc00-\udfff]))', 'g');
function toUSVString(val) {
  const str = `${val}`;
  if (!str) return str;
  return str ? str.replace(surrogateRegexp, '\ufffd') : str;
}
```

And run with the new benchmark:

```
# Pure JavaScript version
util/to-usv-string.js
util/to-usv-string.js size=10 n=100000: 1,289,465.0614219273
util/to-usv-string.js size=100 n=100000: 153,611.6972579318
util/to-usv-string.js size=500 n=100000: 31,669.01363984956

# Original version of Node.js
util/to-usv-string.js
util/to-usv-string.js size=10 n=100000: 3,030,237.0078664045
util/to-usv-string.js size=100 n=100000: 504,156.9606788727
util/to-usv-string.js size=500 n=100000: 108,351.93040720205
```

The original version is faster. So I decided to only add the benchmark and do not modify the implement.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
