### PR TITLE
src: move `ToUSVString()` to node_util.cc

### DIFF
--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -29,10 +29,6 @@ const {
 } = primordials;
 
 const {
-  toUSVString: _toUSVString,
-} = internalBinding('url');
-
-const {
   hideStackFrames,
   codes: {
     ERR_NO_CRYPTO,
@@ -47,7 +43,8 @@ const {
   setHiddenValue,
   arrow_message_private_symbol: kArrowMessagePrivateSymbolIndex,
   decorated_private_symbol: kDecoratedPrivateSymbolIndex,
-  sleep: _sleep
+  sleep: _sleep,
+  toUSVString: _toUSVString,
 } = internalBinding('util');
 const { isNativeError } = internalBinding('types');
 

--- a/src/util-inl.h
+++ b/src/util-inl.h
@@ -64,6 +64,14 @@
   (((x) & 0x00000000000000FFull) << 56)
 #endif
 
+#define CHAR_TEST(bits, name, expr)                                           \
+  template <typename T>                                                       \
+  bool name(const T ch) {                                                     \
+    static_assert(sizeof(ch) >= (bits) / 8,                                   \
+                  "Character must be wider than " #bits " bits");             \
+    return (expr);                                                            \
+  }
+
 namespace node {
 
 template <typename T>


### PR DESCRIPTION
Since `toUSVString()` was exposed in `util` as a public API, not only
for internal `url` any more.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
