### PR TITLE
util: expose stripVTControlCharacters()

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1111,6 +1111,21 @@ doSomething[kCustomPromisifiedSymbol] = (foo) => {
 };
 ```
 
+## `util.stripVTControlCharacters(str)`
+<!-- YAML
+added: REPLACEME
+-->
+
+* `str` {string}
+* Returns: {string}
+
+Returns `str` with any ANSI escape codes removed.
+
+```js
+console.log(util.stripVTControlCharacters('\u001B[4mvalue\u001B[0m'));
+// Prints "value"
+```
+
 ## Class: `util.TextDecoder`
 <!-- YAML
 added: v8.3.0

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -140,6 +140,7 @@ const assert = require('internal/assert');
 const { NativeModule } = require('internal/bootstrap/loaders');
 const {
   validateObject,
+  validateString,
 } = require('internal/validators');
 
 let hexSlice;
@@ -2113,6 +2114,8 @@ if (internalBinding('config').hasIntl) {
  * Remove all VT control characters. Use to estimate displayed string width.
  */
 function stripVTControlCharacters(str) {
+  validateString(str, 'str');
+
   return str.replace(ansi, '');
 }
 

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -223,7 +223,8 @@ const meta = [
 // License: MIT, authors: @sindresorhus, Qix-, arjunmehta and LitoMore
 // Matches all ansi escape code sequences in a string
 const ansiPattern = '[\\u001B\\u009B][[\\]()#;?]*' +
-  '(?:(?:(?:[a-zA-Z\\d]*(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)' +
+  '(?:(?:(?:(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]+)*' +
+  '|[a-zA-Z\\d]+(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)' +
   '|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-ntqry=><~]))';
 const ansi = new RegExp(ansiPattern, 'g');
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -57,7 +57,8 @@ const {
 const {
   format,
   formatWithOptions,
-  inspect
+  inspect,
+  stripVTControlCharacters,
 } = require('internal/util/inspect');
 const { debuglog } = require('internal/util/debuglog');
 const {
@@ -369,6 +370,7 @@ module.exports = {
   isPrimitive,
   log,
   promisify,
+  stripVTControlCharacters,
   toUSVString,
   TextDecoder,
   TextEncoder,

--- a/test/parallel/test-util.js
+++ b/test/parallel/test-util.js
@@ -21,7 +21,7 @@
 
 'use strict';
 // Flags: --expose-internals
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const util = require('util');
 const errors = require('internal/errors');
@@ -178,3 +178,11 @@ assert.strictEqual(util.toUSVString('string\ud801'), 'string\ufffd');
     true
   );
 }
+
+assert.throws(() => {
+  util.stripVTControlCharacters({});
+}, {
+  code: 'ERR_INVALID_ARG_TYPE',
+  message: 'The "str" argument must be of type string.' +
+           common.invalidArgTypeHelper({})
+});


### PR DESCRIPTION
This PR exposes the existing `stripVTControlCharacters()` method with docs and some additional input validation. It also improves the regex used by the function.
