### PR TITLE
net: introduce removal methods for net.BlockList

### DIFF
--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -75,6 +75,16 @@ added: v15.0.0
 
 Adds a rule to block the given IP address.
 
+### `blockList.removeAddress(address[, type])`
+<!-- YAML
+added: v16.10.0
+-->
+
+* `address` {string|net.SocketAddress} An IPv4 or IPv6 address.
+* `type` {string} Either `'ipv4'` or `'ipv6'`. **Default:** `'ipv4'`.
+
+Removes a rule to block the given IP address.
+
 ### `blockList.addRange(start, end[, type])`
 <!-- YAML
 added: v15.0.0

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -77,7 +77,7 @@ Adds a rule to block the given IP address.
 
 ### `blockList.removeAddress(address[, type])`
 <!-- YAML
-added: v16.10.0
+added: v16.11.0
 -->
 
 * `address` {string|net.SocketAddress} An IPv4 or IPv6 address.
@@ -110,6 +110,19 @@ added: v15.0.0
 * `type` {string} Either `'ipv4'` or `'ipv6'`. **Default:** `'ipv4'`.
 
 Adds a rule to block a range of IP addresses specified as a subnet mask.
+
+### `blockList.removeSubnet(net, prefix[, type])`
+<!-- YAML
+added: v16.11.0
+-->
+
+* `net` {string|net.SocketAddress} The network IPv4 or IPv6 address.
+* `prefix` {number} The number of CIDR prefix bits. For IPv4, this
+  must be a value between `0` and `32`. For IPv6, this must be between
+  `0` and `128`.
+* `type` {string} Either `'ipv4'` or `'ipv6'`. **Default:** `'ipv4'`.
+
+Removes a rule to block a range of IP addresses specified as a subnet mask.
 
 ### `blockList.check(address[, type])`
 <!-- YAML

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -98,6 +98,19 @@ added: v15.0.0
 Adds a rule to block a range of IP addresses from `start` (inclusive) to
 `end` (inclusive).
 
+### `blockList.removeRange(start, end[, type])`
+<!-- YAML
+added: v16.11.0
+-->
+
+* `start` {string|net.SocketAddress} The starting IPv4 or IPv6 address in the
+  range.
+* `end` {string|net.SocketAddress} The ending IPv4 or IPv6 address in the range.
+* `type` {string} Either `'ipv4'` or `'ipv6'`. **Default:** `'ipv4'`.
+
+Removes a rule to block a range of IP addresses from `start` (inclusive) to
+`end` (inclusive).
+
 ### `blockList.addSubnet(net, prefix[, type])`
 <!-- YAML
 added: v15.0.0

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -77,7 +77,7 @@ Adds a rule to block the given IP address.
 
 ### `blockList.removeAddress(address[, type])`
 <!-- YAML
-added: v16.11.0
+added: REPLACEME
 -->
 
 * `address` {string|net.SocketAddress} An IPv4 or IPv6 address.
@@ -100,7 +100,7 @@ Adds a rule to block a range of IP addresses from `start` (inclusive) to
 
 ### `blockList.removeRange(start, end[, type])`
 <!-- YAML
-added: v16.11.0
+added: REPLACEME
 -->
 
 * `start` {string|net.SocketAddress} The starting IPv4 or IPv6 address in the
@@ -126,7 +126,7 @@ Adds a rule to block a range of IP addresses specified as a subnet mask.
 
 ### `blockList.removeSubnet(net, prefix[, type])`
 <!-- YAML
-added: v16.11.0
+added: REPLACEME
 -->
 
 * `net` {string|net.SocketAddress} The network IPv4 or IPv6 address.

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -82,8 +82,9 @@ added: REPLACEME
 
 * `address` {string|net.SocketAddress} An IPv4 or IPv6 address.
 * `type` {string} Either `'ipv4'` or `'ipv6'`. **Default:** `'ipv4'`.
+* Returns: {boolean}
 
-Removes a rule to block the given IP address.
+Returns `true` if a rule to block the given IP address was removed.
 
 ### `blockList.addRange(start, end[, type])`
 <!-- YAML
@@ -107,9 +108,10 @@ added: REPLACEME
   range.
 * `end` {string|net.SocketAddress} The ending IPv4 or IPv6 address in the range.
 * `type` {string} Either `'ipv4'` or `'ipv6'`. **Default:** `'ipv4'`.
+* Returns: {boolean}
 
-Removes a rule to block a range of IP addresses from `start` (inclusive) to
-`end` (inclusive).
+Returns `true` if a rule to block the given range of IP addresses
+was removed.
 
 ### `blockList.addSubnet(net, prefix[, type])`
 <!-- YAML
@@ -134,8 +136,9 @@ added: REPLACEME
   must be a value between `0` and `32`. For IPv6, this must be between
   `0` and `128`.
 * `type` {string} Either `'ipv4'` or `'ipv6'`. **Default:** `'ipv4'`.
+* Returns: {boolean}
 
-Removes a rule to block a range of IP addresses specified as a subnet mask.
+Returns `true` if a rule to block the given IP subnet was removed.
 
 ### `blockList.check(address[, type])`
 <!-- YAML

--- a/lib/internal/blocklist.js
+++ b/lib/internal/blocklist.js
@@ -36,6 +36,30 @@ const {
 
 const { validateInt32, validateString } = require('internal/validators');
 
+const validateAddress = (address, family, name = 'address') => {
+  if (!SocketAddress.isSocketAddress(address)) {
+    validateString(address, name);
+    validateString(family, 'family');
+    address = new SocketAddress({
+      address,
+      family,
+    });
+  }
+
+  return address;
+};
+
+const validateSubnet = (network, prefix) => {
+  switch (network.family) {
+    case 'ipv4':
+      validateInt32(prefix, 'prefix', 0, 32);
+      break;
+    case 'ipv6':
+      validateInt32(prefix, 'prefix', 0, 128);
+      break;
+  }
+};
+
 class BlockList extends JSTransferable {
   constructor() {
     super();
@@ -58,46 +82,18 @@ class BlockList extends JSTransferable {
   }
 
   addAddress(address, family = 'ipv4') {
-    if (!SocketAddress.isSocketAddress(address)) {
-      validateString(address, 'address');
-      validateString(family, 'family');
-      address = new SocketAddress({
-        address,
-        family,
-      });
-    }
+    address = validateAddress(address, family);
     this[kHandle].addAddress(address[kSocketAddressHandle]);
   }
 
   removeAddress(address, family = 'ipv4') {
-    if (!SocketAddress.isSocketAddress(address)) {
-      validateString(address, 'address');
-      validateString(family, 'family');
-      address = new SocketAddress({
-        address,
-        family,
-      });
-    }
+    address = validateAddress(address, family);
     this[kHandle].removeAddress(address[kSocketAddressHandle]);
   }
 
   addRange(start, end, family = 'ipv4') {
-    if (!SocketAddress.isSocketAddress(start)) {
-      validateString(start, 'start');
-      validateString(family, 'family');
-      start = new SocketAddress({
-        address: start,
-        family,
-      });
-    }
-    if (!SocketAddress.isSocketAddress(end)) {
-      validateString(end, 'end');
-      validateString(family, 'family');
-      end = new SocketAddress({
-        address: end,
-        family,
-      });
-    }
+    start = validateAddress(start, family, 'start');
+    end = validateAddress(end, family, 'end');
     const ret = this[kHandle].addRange(
       start[kSocketAddressHandle],
       end[kSocketAddressHandle]);
@@ -105,43 +101,25 @@ class BlockList extends JSTransferable {
       throw new ERR_INVALID_ARG_VALUE('start', start, 'must come before end');
   }
 
+  removeRange(start, end, family = 'ipv4') {
+    start = validateAddress(start, family, 'start');
+    end = validateAddress(end, family, 'end');
+    const ret = this[kHandle].removeRange(
+      start[kSocketAddressHandle],
+      end[kSocketAddressHandle]);
+    if (ret === false)
+      throw new ERR_INVALID_ARG_VALUE('start', start, 'must come before end');
+  }
+
   addSubnet(network, prefix, family = 'ipv4') {
-    if (!SocketAddress.isSocketAddress(network)) {
-      validateString(network, 'network');
-      validateString(family, 'family');
-      network = new SocketAddress({
-        address: network,
-        family,
-      });
-    }
-    switch (network.family) {
-      case 'ipv4':
-        validateInt32(prefix, 'prefix', 0, 32);
-        break;
-      case 'ipv6':
-        validateInt32(prefix, 'prefix', 0, 128);
-        break;
-    }
+    network = validateAddress(network, family);
+    validateSubnet(network, prefix);
     this[kHandle].addSubnet(network[kSocketAddressHandle], prefix);
   }
 
   removeSubnet(network, prefix, family = 'ipv4') {
-    if (!SocketAddress.isSocketAddress(network)) {
-      validateString(network, 'network');
-      validateString(family, 'family');
-      network = new SocketAddress({
-        address: network,
-        family,
-      });
-    }
-    switch (network.family) {
-      case 'ipv4':
-        validateInt32(prefix, 'prefix', 0, 32);
-        break;
-      case 'ipv6':
-        validateInt32(prefix, 'prefix', 0, 128);
-        break;
-    }
+    network = validateAddress(network, family);
+    validateSubnet(network, prefix);
     this[kHandle].removeSubnet(network[kSocketAddressHandle], prefix);
   }
 

--- a/lib/internal/blocklist.js
+++ b/lib/internal/blocklist.js
@@ -125,6 +125,26 @@ class BlockList extends JSTransferable {
     this[kHandle].addSubnet(network[kSocketAddressHandle], prefix);
   }
 
+  removeSubnet(network, prefix, family = 'ipv4') {
+    if (!SocketAddress.isSocketAddress(network)) {
+      validateString(network, 'network');
+      validateString(family, 'family');
+      network = new SocketAddress({
+        address: network,
+        family,
+      });
+    }
+    switch (network.family) {
+      case 'ipv4':
+        validateInt32(prefix, 'prefix', 0, 32);
+        break;
+      case 'ipv6':
+        validateInt32(prefix, 'prefix', 0, 128);
+        break;
+    }
+    this[kHandle].removeSubnet(network[kSocketAddressHandle], prefix);
+  }
+
   check(address, family = 'ipv4') {
     if (!SocketAddress.isSocketAddress(address)) {
       validateString(address, 'address');

--- a/lib/internal/blocklist.js
+++ b/lib/internal/blocklist.js
@@ -69,6 +69,18 @@ class BlockList extends JSTransferable {
     this[kHandle].addAddress(address[kSocketAddressHandle]);
   }
 
+  removeAddress(address, family = 'ipv4') {
+    if (!SocketAddress.isSocketAddress(address)) {
+      validateString(address, 'address');
+      validateString(family, 'family');
+      address = new SocketAddress({
+        address,
+        family,
+      });
+    }
+    this[kHandle].removeAddress(address[kSocketAddressHandle]);
+  }
+
   addRange(start, end, family = 'ipv4') {
     if (!SocketAddress.isSocketAddress(start)) {
       validateString(start, 'start');

--- a/lib/internal/blocklist.js
+++ b/lib/internal/blocklist.js
@@ -88,7 +88,10 @@ class BlockList extends JSTransferable {
 
   removeAddress(address, family = 'ipv4') {
     address = validateAddress(address, family);
+    const nrules = this.rules.length;
     this[kHandle].removeAddress(address[kSocketAddressHandle]);
+
+    return nrules - 1 === this.rules.length;
   }
 
   addRange(start, end, family = 'ipv4') {
@@ -104,11 +107,14 @@ class BlockList extends JSTransferable {
   removeRange(start, end, family = 'ipv4') {
     start = validateAddress(start, family, 'start');
     end = validateAddress(end, family, 'end');
+    const nrules = this.rules.length;
     const ret = this[kHandle].removeRange(
       start[kSocketAddressHandle],
       end[kSocketAddressHandle]);
     if (ret === false)
       throw new ERR_INVALID_ARG_VALUE('start', start, 'must come before end');
+
+    return nrules - 1 === this.rules.length;
   }
 
   addSubnet(network, prefix, family = 'ipv4') {
@@ -120,7 +126,10 @@ class BlockList extends JSTransferable {
   removeSubnet(network, prefix, family = 'ipv4') {
     network = validateAddress(network, family);
     validateSubnet(network, prefix);
+    const nrules = this.rules.length;
     this[kHandle].removeSubnet(network[kSocketAddressHandle], prefix);
+
+    return nrules - 1 === this.rules.length;
   }
 
   check(address, family = 'ipv4') {

--- a/src/node_sockaddr-inl.h
+++ b/src/node_sockaddr-inl.h
@@ -199,7 +199,7 @@ const SocketAddressMask* SocketAddressMask::operator->() const {
 }
 
 bool SocketAddressMask::operator==(const SocketAddressMask& other) const {
-  return (this->address_ == other->address_ &&
+  return (this->network_ == other->network_ &&
           this->prefix_ == other->prefix_);
 }
 
@@ -208,19 +208,44 @@ bool SocketAddressMask::operator!=(const SocketAddressMask& other) const {
 }
 
 int SocketAddressMask::family() const {
-  return address_.family();
+  return network_.family();
 }
 
 std::string SocketAddressMask::address() const {
-  return address_.address();
+  return network_.address();
 }
 
-const SocketAddress* SocketAddressMask::socketAddress() const {
-  return &address_;
+const SocketAddress* SocketAddressMask::network() const {
+  return &network_;
 }
 
 int SocketAddressMask::prefix() const {
   return prefix_;
+}
+
+const SocketAddressRange& SocketAddressRange::operator*() const {
+  return *this;
+}
+
+const SocketAddressRange* SocketAddressRange::operator->() const {
+  return this;
+}
+
+bool SocketAddressRange::operator==(const SocketAddressRange& other) const {
+  return (this->start_ == other->start_ &&
+          this->end_ == other->end_);
+}
+
+bool SocketAddressRange::operator!=(const SocketAddressRange& other) const {
+  return !(*this == other);
+}
+
+const SocketAddress* SocketAddressRange::start() const {
+  return &start_;
+}
+
+const SocketAddress* SocketAddressRange::end() const {
+  return &end_;
 }
 
 template <typename T>

--- a/src/node_sockaddr-inl.h
+++ b/src/node_sockaddr-inl.h
@@ -190,6 +190,23 @@ bool SocketAddress::operator>=(const SocketAddress& other) const {
   return compare(other) >= CompareResult::SAME;
 }
 
+const SocketAddressMask& SocketAddressMask::operator*() const {
+  return *this;
+}
+
+const SocketAddressMask* SocketAddressMask::operator->() const {
+  return this;
+}
+
+bool SocketAddressMask::operator==(const SocketAddressMask& other) const {
+  return (this->address_ == other->address_ &&
+          this->prefix_ == other->prefix_);
+}
+
+bool SocketAddressMask::operator!=(const SocketAddressMask& other) const {
+  return !(*this == other);
+}
+
 template <typename T>
 SocketAddressLRU<T>::SocketAddressLRU(
     size_t max_size)

--- a/src/node_sockaddr-inl.h
+++ b/src/node_sockaddr-inl.h
@@ -207,6 +207,22 @@ bool SocketAddressMask::operator!=(const SocketAddressMask& other) const {
   return !(*this == other);
 }
 
+int SocketAddressMask::family() const {
+  return address_.family();
+}
+
+std::string SocketAddressMask::address() const {
+  return address_.address();
+}
+
+const SocketAddress* SocketAddressMask::socketAddress() const {
+  return &address_;
+}
+
+int SocketAddressMask::prefix() const {
+  return prefix_;
+}
+
 template <typename T>
 SocketAddressLRU<T>::SocketAddressLRU(
     size_t max_size)

--- a/src/node_sockaddr.cc
+++ b/src/node_sockaddr.cc
@@ -604,6 +604,21 @@ void SocketAddressBlockListWrap::AddAddress(
   args.GetReturnValue().Set(true);
 }
 
+void SocketAddressBlockListWrap::RemoveAddress(
+    const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  SocketAddressBlockListWrap* wrap;
+  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
+
+  CHECK(SocketAddressBase::HasInstance(env, args[0]));
+  SocketAddressBase* addr;
+  ASSIGN_OR_RETURN_UNWRAP(&addr, args[0]);
+
+  wrap->blocklist_->RemoveSocketAddress(addr->address());
+
+  args.GetReturnValue().Set(true);
+}
+
 void SocketAddressBlockListWrap::AddRange(
     const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
@@ -702,6 +717,7 @@ Local<FunctionTemplate> SocketAddressBlockListWrap::GetConstructorTemplate(
     tmpl->Inherit(BaseObject::GetConstructorTemplate(env));
     tmpl->InstanceTemplate()->SetInternalFieldCount(kInternalFieldCount);
     env->SetProtoMethod(tmpl, "addAddress", AddAddress);
+    env->SetProtoMethod(tmpl, "removeAddress", RemoveAddress);
     env->SetProtoMethod(tmpl, "addRange", AddRange);
     env->SetProtoMethod(tmpl, "addSubnet", AddSubnet);
     env->SetProtoMethod(tmpl, "check", Check);

--- a/src/node_sockaddr.h
+++ b/src/node_sockaddr.h
@@ -168,6 +168,15 @@ class SocketAddressMask : public MemoryRetainer {
   inline const SocketAddressMask& operator*() const;
   inline const SocketAddressMask* operator->() const;
 
+  inline int family() const;
+  inline std::string address() const;
+  inline const SocketAddress* socketAddress() const;
+  inline int prefix() const;
+
+  // Returns true if the subnet specified by this SocketAddressMask
+  // contains the given SocketAddress
+  bool contains_address(const SocketAddress& address) const;
+
   inline v8::Local<v8::Object> ToJS(
       Environment* env,
       v8::Local<v8::Object> obj = v8::Local<v8::Object>()) const;
@@ -346,12 +355,10 @@ class SocketAddressBlockList : public MemoryRetainer {
   };
 
   struct SocketAddressMaskRule final : Rule {
-    std::shared_ptr<SocketAddress> network;
-    int prefix;
+    std::shared_ptr<SocketAddressMask> mask;
 
     SocketAddressMaskRule(
-        const std::shared_ptr<SocketAddress>& address,
-        int prefix);
+        const std::shared_ptr<SocketAddressMask>& mask);
 
     bool Apply(const std::shared_ptr<SocketAddress>& address) override;
     std::string ToString() override;

--- a/src/node_sockaddr.h
+++ b/src/node_sockaddr.h
@@ -262,6 +262,10 @@ class SocketAddressBlockList : public MemoryRetainer {
       const std::shared_ptr<SocketAddress>& address,
       int prefix);
 
+  void RemoveSocketAddressMask(
+      const std::shared_ptr<SocketAddress>& address,
+      int prefix);
+
   bool Apply(const std::shared_ptr<SocketAddress>& address);
 
   size_t size() const { return rules_.size(); }
@@ -330,7 +334,12 @@ class SocketAddressBlockList : public MemoryRetainer {
 
   std::shared_ptr<SocketAddressBlockList> parent_;
   std::list<std::unique_ptr<Rule>> rules_;
+  std::list<std::unique_ptr<int>> prefixes_;
   SocketAddress::Map<std::list<std::unique_ptr<Rule>>::iterator> address_rules_;
+  SocketAddress::Map<
+    std::list<std::unique_ptr<int>>::iterator
+  > subnet_prefixes_;
+  SocketAddress::Map<std::list<std::unique_ptr<Rule>>::iterator> subnet_rules_;
 
   Mutex mutex_;
 };
@@ -355,6 +364,7 @@ class SocketAddressBlockListWrap : public BaseObject {
   static void RemoveAddress(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void AddRange(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void AddSubnet(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void RemoveSubnet(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Check(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void GetRules(const v8::FunctionCallbackInfo<v8::Value>& args);
 

--- a/src/node_sockaddr.h
+++ b/src/node_sockaddr.h
@@ -352,6 +352,7 @@ class SocketAddressBlockListWrap : public BaseObject {
 
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void AddAddress(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void RemoveAddress(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void AddRange(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void AddSubnet(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Check(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/src/node_sockaddr.h
+++ b/src/node_sockaddr.h
@@ -218,7 +218,7 @@ class SocketAddressRange : public MemoryRetainer {
   inline const SocketAddress* start() const;
   inline const SocketAddress* end() const;
 
-  // Returns true if the  given SocketAddress falls within
+  // Returns true if the given SocketAddress falls within
   // this SocketAddressRange
   bool contains_address(const SocketAddress& address) const;
 

--- a/test/parallel/test-blocklist.js
+++ b/test/parallel/test-blocklist.js
@@ -70,6 +70,23 @@ const util = require('util');
 
 {
   const blockList = new BlockList();
+  const sa = new SocketAddress({
+    address: '8592:757c:efae:4e45:fb5d:d62a:0d00:8e17',
+    family: 'ipv6'
+  });
+
+  blockList.addAddress('1.1.1.1');
+  blockList.addAddress(sa);
+
+  blockList.removeAddress('1.1.1.1');
+  blockList.removeAddress(sa);
+
+  assert(!blockList.check('1.1.1.1'));
+  assert(!blockList.check('8592:757c:efae:4e45:fb5d:d62a:0d00:8e17', 'ipv6'));
+}
+
+{
+  const blockList = new BlockList();
   const sa1 = new SocketAddress({ address: '1.1.1.1' });
   const sa2 = new SocketAddress({
     address: '8592:757c:efae:4e45:fb5d:d62a:0d00:8e17',

--- a/test/parallel/test-blocklist.js
+++ b/test/parallel/test-blocklist.js
@@ -91,9 +91,13 @@ const util = require('util');
   blockList.addAddress('1.1.1.1');
   blockList.addAddress('1.1.1.1');
 
+  assert.deepStrictEqual(blockList.rules, [
+    'Address: IPv4 1.1.1.1',
+  ]);
+
   blockList.removeAddress('1.1.1.1');
 
-  assert(blockList.check('1.1.1.1'));
+  assert(!blockList.check('1.1.1.1'));
 }
 
 {
@@ -207,22 +211,13 @@ const util = require('util');
 
 {
   const blockList = new BlockList();
-  blockList.addSubnet('1.1.1.0', 16);
   blockList.addSubnet('8592:757c:efae:4e45::', 64, 'ipv6');
   blockList.addSubnet('8592:757c:efae:4e45::', 64, 'ipv6');
-
-  blockList.removeSubnet('1.1.1.0', 16);
-  blockList.removeSubnet('8592:757c:efae:4e45::', 64, 'ipv6');
 
   const rulesCheck = [
     'Subnet: IPv6 8592:757c:efae:4e45::/64',
   ];
   assert.deepStrictEqual(blockList.rules, rulesCheck);
-
-  assert(!blockList.check('1.1.0.1'));
-  assert(!blockList.check('1.1.1.1'));
-  assert(!blockList.check('1.2.0.1'));
-  assert(!blockList.check('::ffff:1.1.0.1', 'ipv6'));
 
   assert(blockList.check('8592:757c:efae:4e45:f::', 'ipv6'));
   assert(blockList.check('8592:757c:efae:4e45::f', 'ipv6'));

--- a/test/parallel/test-blocklist.js
+++ b/test/parallel/test-blocklist.js
@@ -150,6 +150,62 @@ const util = require('util');
 
 {
   const blockList = new BlockList();
+  blockList.addRange('1.1.1.1', '1.1.1.10');
+  blockList.addRange('::1', '::f', 'ipv6');
+
+  {
+    const rulesCheck = [
+      'Range: IPv6 ::1-::f',
+      'Range: IPv4 1.1.1.1-1.1.1.10',
+    ];
+    assert.deepStrictEqual(blockList.rules, rulesCheck);
+  }
+
+  blockList.removeRange('1.1.1.1', '1.1.1.11');
+  blockList.removeRange('::1', '::f', 'ipv6');
+
+  {
+    const rulesCheck = [
+      'Range: IPv4 1.1.1.1-1.1.1.10',
+    ];
+    assert.deepStrictEqual(blockList.rules, rulesCheck);
+  }
+
+  assert(!blockList.check('1.1.1.0'));
+  for (let n = 1; n <= 10; n++)
+    assert(blockList.check(`1.1.1.${n}`));
+  assert(!blockList.check('1.1.1.11'));
+
+  for (let n = 0x1; n <= 0xf; n++) {
+    assert(!blockList.check(`::${n.toString(16)}`, 'ipv6'),
+           `::${n.toString(16)} check failed`);
+  }
+}
+
+{
+  const blockList = new BlockList();
+  const sa = new SocketAddress({ address: '1.1.1.10' });
+  blockList.addRange('1.1.1.1', '1.1.1.10');
+  blockList.addRange('1.1.1.1', sa);
+
+  const rulesCheck = [
+    'Range: IPv4 1.1.1.1-1.1.1.10',
+  ];
+  assert.deepStrictEqual(blockList.rules, rulesCheck);
+}
+
+{
+  const blockList = new BlockList();
+  const sa = new SocketAddress({ address: '1.1.1.10' });
+  blockList.addRange('1.1.1.1', '1.1.1.10');
+  blockList.addRange('1.1.1.1', sa);
+  blockList.removeRange('1.1.1.1', sa);
+
+  assert.deepStrictEqual(blockList.rules, []);
+}
+
+{
+  const blockList = new BlockList();
   const sa1 = new SocketAddress({ address: '1.1.1.1' });
   const sa2 = new SocketAddress({ address: '1.1.1.10' });
   const sa3 = new SocketAddress({ address: '::1', family: 'ipv6' });

--- a/test/parallel/test-blocklist.js
+++ b/test/parallel/test-blocklist.js
@@ -87,6 +87,17 @@ const util = require('util');
 
 {
   const blockList = new BlockList();
+
+  blockList.addAddress('1.1.1.1');
+  blockList.addAddress('1.1.1.1');
+
+  blockList.removeAddress('1.1.1.1');
+
+  assert(blockList.check('1.1.1.1'));
+}
+
+{
+  const blockList = new BlockList();
   const sa1 = new SocketAddress({ address: '1.1.1.1' });
   const sa2 = new SocketAddress({
     address: '8592:757c:efae:4e45:fb5d:d62a:0d00:8e17',
@@ -165,6 +176,53 @@ const util = require('util');
   assert(blockList.check('1.1.1.1'));
   assert(!blockList.check('1.2.0.1'));
   assert(blockList.check('::ffff:1.1.0.1', 'ipv6'));
+
+  assert(blockList.check('8592:757c:efae:4e45:f::', 'ipv6'));
+  assert(blockList.check('8592:757c:efae:4e45::f', 'ipv6'));
+  assert(!blockList.check('8592:757c:efae:4f45::f', 'ipv6'));
+}
+
+{
+  const blockList = new BlockList();
+  blockList.addSubnet('1.1.1.0', 16);
+  blockList.addSubnet('8592:757c:efae:4e45::', 64, 'ipv6');
+
+  blockList.removeSubnet('1.1.1.0', 16);
+  blockList.removeSubnet('8592:757c:efae:4e45::', 32, 'ipv6');
+
+  const rulesCheck = [
+    'Subnet: IPv6 8592:757c:efae:4e45::/64',
+  ];
+  assert.deepStrictEqual(blockList.rules, rulesCheck);
+
+  assert(!blockList.check('1.1.0.1'));
+  assert(!blockList.check('1.1.1.1'));
+  assert(!blockList.check('1.2.0.1'));
+  assert(!blockList.check('::ffff:1.1.0.1', 'ipv6'));
+
+  assert(blockList.check('8592:757c:efae:4e45:f::', 'ipv6'));
+  assert(blockList.check('8592:757c:efae:4e45::f', 'ipv6'));
+  assert(!blockList.check('8592:757c:efae:4f45::f', 'ipv6'));
+}
+
+{
+  const blockList = new BlockList();
+  blockList.addSubnet('1.1.1.0', 16);
+  blockList.addSubnet('8592:757c:efae:4e45::', 64, 'ipv6');
+  blockList.addSubnet('8592:757c:efae:4e45::', 64, 'ipv6');
+
+  blockList.removeSubnet('1.1.1.0', 16);
+  blockList.removeSubnet('8592:757c:efae:4e45::', 64, 'ipv6');
+
+  const rulesCheck = [
+    'Subnet: IPv6 8592:757c:efae:4e45::/64',
+  ];
+  assert.deepStrictEqual(blockList.rules, rulesCheck);
+
+  assert(!blockList.check('1.1.0.1'));
+  assert(!blockList.check('1.1.1.1'));
+  assert(!blockList.check('1.2.0.1'));
+  assert(!blockList.check('::ffff:1.1.0.1', 'ipv6'));
 
   assert(blockList.check('8592:757c:efae:4e45:f::', 'ipv6'));
   assert(blockList.check('8592:757c:efae:4e45::f', 'ipv6'));

--- a/test/parallel/test-blocklist.js
+++ b/test/parallel/test-blocklist.js
@@ -78,8 +78,8 @@ const util = require('util');
   blockList.addAddress('1.1.1.1');
   blockList.addAddress(sa);
 
-  blockList.removeAddress('1.1.1.1');
-  blockList.removeAddress(sa);
+  assert(blockList.removeAddress('1.1.1.1'));
+  assert(blockList.removeAddress(sa));
 
   assert(!blockList.check('1.1.1.1'));
   assert(!blockList.check('8592:757c:efae:4e45:fb5d:d62a:0d00:8e17', 'ipv6'));
@@ -95,8 +95,7 @@ const util = require('util');
     'Address: IPv4 1.1.1.1',
   ]);
 
-  blockList.removeAddress('1.1.1.1');
-
+  assert(blockList.removeAddress('1.1.1.1'));
   assert(!blockList.check('1.1.1.1'));
 }
 
@@ -161,8 +160,8 @@ const util = require('util');
     assert.deepStrictEqual(blockList.rules, rulesCheck);
   }
 
-  blockList.removeRange('1.1.1.1', '1.1.1.11');
-  blockList.removeRange('::1', '::f', 'ipv6');
+  assert(!blockList.removeRange('1.1.1.1', '1.1.1.11'));
+  assert(blockList.removeRange('::1', '::f', 'ipv6'));
 
   {
     const rulesCheck = [
@@ -199,8 +198,8 @@ const util = require('util');
   const sa = new SocketAddress({ address: '1.1.1.10' });
   blockList.addRange('1.1.1.1', '1.1.1.10');
   blockList.addRange('1.1.1.1', sa);
-  blockList.removeRange('1.1.1.1', sa);
 
+  assert(blockList.removeRange('1.1.1.1', sa));
   assert.deepStrictEqual(blockList.rules, []);
 }
 
@@ -247,8 +246,8 @@ const util = require('util');
   blockList.addSubnet('1.1.1.0', 16);
   blockList.addSubnet('8592:757c:efae:4e45::', 64, 'ipv6');
 
-  blockList.removeSubnet('1.1.1.0', 16);
-  blockList.removeSubnet('8592:757c:efae:4e45::', 32, 'ipv6');
+  assert(blockList.removeSubnet('1.1.1.0', 16));
+  assert(!blockList.removeSubnet('8592:757c:efae:4e45::', 32, 'ipv6'));
 
   const rulesCheck = [
     'Subnet: IPv6 8592:757c:efae:4e45::/64',


### PR DESCRIPTION
Hello! This is my 1st PR and I'm not a C++ developer so bear with me :)

### High level changes
Currently, to "remove" a rule from `net.BlockList`, one must create a new `BlockList` and add every other existing rule to it. This PR introduces `removeAddress()`, `removeRange()`, and `removeSubnet()` methods to `lib/internal/blocklist.js` so users can easily modify rule sets. 

Adding redundant addresses, ranges, or subnets no longer creates multiple rules in the `BlockList`. However, this behavior doesn't apply to a subnet that overlaps another subnet or a subnet that's equivalent to a range. The modification to rule-adding behavior eases rule removal discussed in the next section.

### Low level changes
To achieve the functionality mentioned, this PR adds `SocketAddressRange` and `SocketAddressMask` classes to `src/node_sockaddr*`. These classes have their own hashing implementations so their instances can be uniquely mapped to rules. `SocketAddressRangeRule` and `SocketAddressMaskRule` now utilize these classes, respectively.

`SocketAddressBlocklist` now has separate mappings for address, range, and subnet rules. This way, `SocketAddressBlocklist` can uniquely identify an address, range, or subnet and its corresponding rule. This makes rule removal easier but also compels a change to rule-adding behavior where redundant addresses, ranges, or subnets do not create additional rules *when compared to rules in the same category*.

I updated the documentation and added test cases for rule removal and checking redundant addition of rules.

### Some open questions
1. Is the general approach here ok?
2. Any missing test/edge cases?
3. Could/should `SocketAddressRange` and `SocketAddressMask` be exposed in the `net` API? If so, would it make sense to do this in a separate PR?
4. Any idioms or best practices I'm missing?