### PR TITLE
doc: add fsPromises.readFile() example

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1147,6 +1147,32 @@ platform-specific. On macOS, Linux, and Windows, the promise will be rejected
 with an error. On FreeBSD, a representation of the directory's contents will be
 returned.
 
+An example of reading a `package.json` file located in the same directory of the running code:
+```mjs
+import { readFile } from 'fs/promises';
+try {
+  const contents = await readFile(new URL('./package.json', import.meta.url), { encoding: 'utf8' });
+  
+  console.log(contents);
+} catch (err) {
+  console.error(err.message);
+}
+```
+
+```cjs
+const { readFile } = require('fs/promises');
+const { resolve } = require('path');
+async function logFile() {
+  try {
+    const contents = await readFile(resolve('./package.json'), { encoding: 'utf8' });
+    console.log(contents);
+  } catch (err) {
+    console.error(err.message);
+  }
+}
+logFile();
+```
+
 It is possible to abort an ongoing `readFile` using an {AbortSignal}. If a
 request is aborted the promise returned is rejected with an `AbortError`:
 

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1162,8 +1162,8 @@ try {
 ```
 
 ```cjs
-const { readFile } = require('fs/promises');
-const { resolve } = require('path');
+const { readFile } = require('node:fs/promises');
+const { resolve } = require('node:path');
 async function logFile() {
   try {
     const filePath = resolve('./package.json');

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1151,7 +1151,8 @@ An example of reading a `package.json` file located in the same directory of the
 ```mjs
 import { readFile } from 'fs/promises';
 try {
-  const contents = await readFile(new URL('./package.json', import.meta.url), { encoding: 'utf8' });
+  const filePath = new URL('./package.json', import.meta.url);
+  const contents = await readFile(filePath, { encoding: 'utf8' });
   
   console.log(contents);
 } catch (err) {

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1151,7 +1151,7 @@ An example of reading a `package.json` file located in the same directory of the
 running code:
 
 ```mjs
-import { readFile } from 'fs/promises';
+import { readFile } from 'node:fs/promises';
 try {
   const filePath = new URL('./package.json', import.meta.url);
   const contents = await readFile(filePath, { encoding: 'utf8' });

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1165,7 +1165,8 @@ const { readFile } = require('fs/promises');
 const { resolve } = require('path');
 async function logFile() {
   try {
-    const contents = await readFile(resolve('./package.json'), { encoding: 'utf8' });
+    const filePath = resolve('./package.json');
+    const contents = await readFile(filePath, { encoding: 'utf8' });
     console.log(contents);
   } catch (err) {
     console.error(err.message);

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1147,7 +1147,9 @@ platform-specific. On macOS, Linux, and Windows, the promise will be rejected
 with an error. On FreeBSD, a representation of the directory's contents will be
 returned.
 
-An example of reading a `package.json` file located in the same directory of the running code:
+An example of reading a `package.json` file located in the same directory of the
+running code:
+
 ```mjs
 import { readFile } from 'fs/promises';
 try {

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1153,7 +1153,6 @@ import { readFile } from 'fs/promises';
 try {
   const filePath = new URL('./package.json', import.meta.url);
   const contents = await readFile(filePath, { encoding: 'utf8' });
-  
   console.log(contents);
 } catch (err) {
   console.error(err.message);


### PR DESCRIPTION
Adds a CJS and MJS example to the `readFile` method on fsPromises. There is an example with AbortController but it's slightly misleading if you're just looking at the examples, since you don't actually need to do that.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
