### PR TITLE
build: use Clang 12 for test-asan workflow

### DIFF
--- a/.github/workflows/test-asan.yml
+++ b/.github/workflows/test-asan.yml
@@ -38,9 +38,9 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     env:
-      CC: clang
-      CXX: clang++
-      LINK: clang++
+      CC: clang-12
+      CXX: clang++-12
+      LINK: clang++-12
       CONFIG_FLAGS: --enable-asan
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
I have issues with the default (version 11) in the PR to update V8: https://github.com/nodejs/node/pull/39945
I hope it will fail here too and someone knows how to fix it :)