### PR TITLE
tty: expose `hasColor` and `getColorDepth` directly

### DIFF
--- a/lib/tty.js
+++ b/lib/tty.js
@@ -161,4 +161,4 @@ WriteStream.prototype.getWindowSize = function() {
   return [this.columns, this.rows];
 };
 
-module.exports = { isatty, ReadStream, WriteStream };
+module.exports = { isatty, getColorDepth, hasColors, ReadStream, WriteStream };


### PR DESCRIPTION
TODOs:-
- [x] Expose `hasColor`
- [x] Expose `getColorDepth`
- [ ] Document new methods
~~- [x] Deprecate `WriteStream.hasColor` and `WriteStream.getColorDepth`~~
~~- [x] Add tests for same~~
~~- [ ] Replace every instance of `WriteStream.hasColor` and `WriteStream.getColorPath` with new methods in `tty`~~
~~- [ ] Document new deprecated methods of `tty` and add documentation for new methods~~

About deprecating `tty.WriteStream.hasColor` and `tty.WriteStream.getColorDepth`, this requires a lot of changes to be done which is not so backward compactible.

`process.stdout` and `process.stderr` have `hasColor()` and `getColorDepth()` methods which are forwarded from `tty.WriteStream`, this means that deprecating `tty.WriteStream.hasColor()` will also mean deprecation of `process.stdout.hasColor`, similar for `process.stdout` and `getColorDepth)`

So I am dropping the idea of deprecating these two methods for now. I would really appreciate some feedback from the team regarding this.

Fixes #40236 