### PR TITLE
http: remove 'data' and 'end' listener if client parser error

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -489,6 +489,8 @@ function socketOnData(d) {
     prepareError(ret, parser, d);
     debug('parse error', ret);
     freeParser(parser, req, socket);
+    socket.removeListener('data', socketOnData);
+    socket.removeListener('end', socketOnEnd);
     socket.destroy();
     req.socket._hadError = true;
     req.emit('error', ret);

--- a/test/parallel/test-http-client-parse-error.js
+++ b/test/parallel/test-http-client-parse-error.js
@@ -23,6 +23,7 @@
 const common = require('../common');
 const http = require('http');
 const net = require('net');
+const assert = require('assert');
 const Countdown = require('../common/countdown');
 
 const countdown = new Countdown(2, () => server.close());
@@ -38,10 +39,12 @@ const server =
 
 server.listen(0, common.mustCall(() => {
   for (let i = 0; i < 2; i++) {
-    http.get({
+    const req = http.get({
       port: server.address().port,
       path: '/'
     }).on('error', common.mustCall((e) => {
+      assert.strictEqual(req.socket.listenerCount('data'), 0);
+      assert.strictEqual(req.socket.listenerCount('end'), 1);
       common.expectsError({
         code: 'HPE_INVALID_CONSTANT',
         message: 'Parse Error: Expected HTTP/'


### PR DESCRIPTION
There might be the case of some more data coming through after
the parser has returned an error and we have destroyed the socket.
We should also be removing the 'data' event handler.

Fixes: https://github.com/nodejs/node/issues/40242

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
