### PR TITLE
doc: add a note about `readStream.path` if `fd` is specified

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -5873,7 +5873,8 @@ added: v0.1.93
 The path to the file the stream is reading from as specified in the first
 argument to `fs.createReadStream()`. If `path` is passed as a string, then
 `readStream.path` will be a string. If `path` is passed as a {Buffer}, then
-`readStream.path` will be a {Buffer}.
+`readStream.path` will be a {Buffer}. If `fd` is specified, then
+`readStream.path` will be `undefined`.
 
 #### `readStream.pending`
 <!-- YAML


### PR DESCRIPTION
#40013 changed the behavior of `readStream.path`, it'll be `undefined` if `fd` is specified in `fs.createReadStream()`. This is not a breaking change as docs state:

> If `fd` is specified, `ReadStream` will ignore the `path` argument and will use the specified file descriptor.

However, this would be confusing for those who relied on `readStream.path` and this PR adds a note about it.