### PR TITLE
doc: fix typo in fs

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -6700,7 +6700,7 @@ a string, a {Buffer}, or a {URL} object using the `file:` protocol.
 
 #### String paths
 
-String from paths are interpreted as UTF-8 character sequences identifying
+String paths are interpreted as UTF-8 character sequences identifying
 the absolute or relative filename. Relative paths will be resolved relative
 to the current working directory as determined by calling `process.cwd()`.
 


### PR DESCRIPTION
The original text was "String form" meaning the string form of a path compared to other forms like a Buffer or URL object (as alluded to in the previous paragraph) was correct, however leaving "form" out entirely is slightly better and may confuse people less.