### PR TITLE
build: check for duplicates in new AUTHORS entries

### DIFF
--- a/.github/workflows/authors.yml
+++ b/.github/workflows/authors.yml
@@ -15,12 +15,23 @@ jobs:
         with:
           fetch-depth: '0'  # This is required to actually get all the authors
       - run: "tools/update-authors.js"  # Run the AUTHORS tool
+      - name: "Check for duplicates"
+        run: |
+          PATTERN_FILE=`mktemp`;
+          git diff | egrep '^\+[^+]' | perl -pe 's/^\+(.+?) <.+\n/\1\n/g' > $PATTERN_FILE;
+          DUPLICATES=`grep -F -f $PATTERN_FILE AUTHORS | cut -d'<' -f1 | sort | uniq -c | sort -n | grep -v '^ *1 ' | perl -pe 's/^ *\d+ / /'`; # Last part here substitues a space at the start of each line
+          echo 'DUPLICATES<<EOF' >> $GITHUB_ENV
+          if [ ! -z "${DUPLICATES}" ]; then
+            echo "The following may be duplicates; consider adding a .mailmap entry for them:" >> $GITHUB_ENV;
+            echo "${DUPLICATES}" >> $GITHUB_ENV;
+          fi;
+          echo 'EOF' >> $GITHUB_ENV; # Each line of duplicates starts with a space, so it won't conflict with 'EOF'
       - uses: gr2m/create-or-update-pull-request-action@v1  # Create a PR or update the Action's existing PR
         env:
           GITHUB_TOKEN: ${{ secrets.GH_USER_TOKEN }}
         with:
           author: Node.js GitHub Bot <github-bot@iojs.org>
-          body: "If this PR exists, there's presumably new additions to the AUTHORS file. This is an automatically generated PR by the `authors.yml` GitHub Action, which runs `tools/update-authors.js` and submits a new PR or updates an existing PR.\n\nPlease note that there might be duplicate entries. If there are, please remove them and add the duplicate emails to .mailmap directly to this PR."
+          body: "Here are some new additions to the AUTHORS file. This is an automatically generated PR by the `authors.yml` GitHub Action, which runs `tools/update-authors.js`.\n\n{{ env.DUPLICATES}}"
           branch: "actions/authors-update"  # Custom branch *just* for this Action.
           commit-message: "meta: update AUTHORS"
           labels: meta

--- a/.github/workflows/authors.yml
+++ b/.github/workflows/authors.yml
@@ -31,7 +31,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_USER_TOKEN }}
         with:
           author: Node.js GitHub Bot <github-bot@iojs.org>
-          body: "Here are some new additions to the AUTHORS file. This is an automatically generated PR by the `authors.yml` GitHub Action, which runs `tools/update-authors.js`.\n\n{{ env.DUPLICATES}}"
+          body: "Here are some new additions to the AUTHORS file. This is an automatically generated PR by the `authors.yml` GitHub Action, which runs `tools/update-authors.js`.\n\n{{ env.DUPLICATES }}"
           branch: "actions/authors-update"  # Custom branch *just* for this Action.
           commit-message: "meta: update AUTHORS"
           labels: meta


### PR DESCRIPTION
When the GitHub Action adds new entries to the AUTHORS file, have it
also flag new entries that might be duplicates.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
