### PR TITLE
doc: fix typo in esm.md

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -1145,7 +1145,7 @@ The resolver can throw the following errors:
 >    1. Return **undefined**.
 > 1. If _pjson.name_ is equal to _packageName_, then
 >    1. Return the result of **PACKAGE_EXPORTS_RESOLVE**(_packageURL_,
->       _subpath_, _pjson.exports_, _defaultConditions_).
+>       _packageSubpath_, _pjson.exports_, _defaultConditions_).
 > 1. Otherwise, return **undefined**.
 
 **PACKAGE_EXPORTS_RESOLVE**(_packageURL_, _subpath_, _exports_, _conditions_)


### PR DESCRIPTION
_subpath_ is not defined in this context. This is pretty clearly meant to be _packageSubpath_, which is the second argument to `PACKAGE_SELF_RESOLVE`

