### PR TITLE
src: use `As()` instead of `Cast()` for conversions

### DIFF
--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -1701,7 +1701,7 @@ void SetServers(const FunctionCallbackInfo<Value>& args) {
 
   CHECK(args[0]->IsArray());
 
-  Local<Array> arr = Local<Array>::Cast(args[0]);
+  Local<Array> arr = args[0].As<Array>();
 
   uint32_t len = arr->Length();
 
@@ -1718,8 +1718,7 @@ void SetServers(const FunctionCallbackInfo<Value>& args) {
   for (uint32_t i = 0; i < len; i++) {
     CHECK(arr->Get(env->context(), i).ToLocalChecked()->IsArray());
 
-    Local<Array> elm =
-        Local<Array>::Cast(arr->Get(env->context(), i).ToLocalChecked());
+    Local<Array> elm = arr->Get(env->context(), i).ToLocalChecked().As<Array>();
 
     CHECK(elm->Get(env->context(),
                    0).ToLocalChecked()->Int32Value(env->context()).FromJust());

--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -175,7 +175,7 @@ inline static napi_status ConcludeDeferred(napi_env env,
   v8::Local<v8::Value> v8_deferred =
       v8::Local<v8::Value>::New(env->isolate, *deferred_ref);
 
-  auto v8_resolver = v8::Local<v8::Promise::Resolver>::Cast(v8_deferred);
+  auto v8_resolver = v8_deferred.As<v8::Promise::Resolver>();
 
   v8::Maybe<bool> success = is_resolved ?
       v8_resolver->Resolve(context, v8impl::V8LocalValueFromJsValue(result)) :
@@ -293,7 +293,7 @@ class CallbackWrapperBase : public CallbackWrapper {
                         nullptr),
         _cbinfo(cbinfo) {
     _bundle = reinterpret_cast<CallbackBundle*>(
-        v8::Local<v8::External>::Cast(cbinfo.Data())->Value());
+        cbinfo.Data().As<v8::External>()->Value());
     _data = _bundle->cb_data;
   }
 
@@ -3131,8 +3131,7 @@ napi_status napi_run_script(napi_env env,
 
   v8::Local<v8::Context> context = env->context();
 
-  auto maybe_script = v8::Script::Compile(context,
-      v8::Local<v8::String>::Cast(v8_script));
+  auto maybe_script = v8::Script::Compile(context, v8_script.As<v8::String>());
   CHECK_MAYBE_EMPTY(env, maybe_script, napi_generic_failure);
 
   auto script_result =

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -292,8 +292,8 @@ void ModuleWrap::Link(const FunctionCallbackInfo<Value>& args) {
     for (int i = 0; i < raw_assertions->Length(); i += 3) {
       assertions
           ->Set(env->context(),
-                Local<String>::Cast(raw_assertions->Get(env->context(), i)),
-                Local<Value>::Cast(raw_assertions->Get(env->context(), i + 1)))
+                raw_assertions->Get(env->context(), i).As<String>(),
+                raw_assertions->Get(env->context(), i + 1).As<Value>())
           .ToChecked();
     }
 

--- a/src/node_contextify.h
+++ b/src/node_contextify.h
@@ -74,8 +74,8 @@ class ContextifyContext {
   }
 
   inline v8::Local<v8::Object> sandbox() const {
-    return v8::Local<v8::Object>::Cast(
-        context()->GetEmbedderData(ContextEmbedderIndex::kSandboxObject));
+    return context()->GetEmbedderData(ContextEmbedderIndex::kSandboxObject)
+        .As<v8::Object>();
   }
 
   inline std::shared_ptr<v8::MicrotaskQueue> microtask_queue() const {

--- a/src/node_dtrace.cc
+++ b/src/node_dtrace.cc
@@ -87,8 +87,8 @@ using v8::Value;
     return node::THROW_ERR_INVALID_ARG_TYPE(env,                           \
         "expected object for " #obj " to contain object member " #member); \
   }                                                                        \
-  *valp = Local<Object>::Cast(obj->Get(env->context(),                     \
-      OneByteString(env->isolate(), #member)).ToLocalChecked());
+  *valp = obj->Get(env->context(),                                         \
+      OneByteString(env->isolate(), #member)).ToLocalChecked().As<Object>();
 
 #define SLURP_CONNECTION(arg, conn)                                        \
   if (!(arg)->IsObject()) {                                                \
@@ -96,7 +96,7 @@ using v8::Value;
         "expected argument " #arg " to be a connection object");           \
   }                                                                        \
   node_dtrace_connection_t conn;                                           \
-  Local<Object> _##conn = Local<Object>::Cast(arg);                        \
+  Local<Object> _##conn = arg.As<Object>();                                \
   Local<Value> _handle =                                                   \
       (_##conn)->Get(env->context(),                                       \
                      FIXED_ONE_BYTE_STRING(env->isolate(), "_handle"))     \
@@ -116,7 +116,7 @@ using v8::Value;
         "expected argument " #arg " to be a connection object");           \
   }                                                                        \
   node_dtrace_connection_t conn;                                           \
-  Local<Object> _##conn = Local<Object>::Cast(arg);                        \
+  Local<Object> _##conn = arg.As<Object>();                                \
   SLURP_INT(_##conn, fd, &conn.fd);                                        \
   SLURP_STRING(_##conn, host, &conn.remote);                               \
   SLURP_INT(_##conn, port, &conn.port);                                    \
@@ -132,10 +132,10 @@ using v8::Value;
         "expected argument " #arg1 " to be a connection object");          \
   }                                                                        \
   node_dtrace_connection_t conn;                                           \
-  Local<Object> _##conn = Local<Object>::Cast(arg0);                       \
+  Local<Object> _##conn = arg0.As<Object>();                               \
   SLURP_INT(_##conn, fd, &conn.fd);                                        \
   SLURP_INT(_##conn, bufferSize, &conn.buffered);                          \
-  _##conn = Local<Object>::Cast(arg1);                                     \
+  _##conn = arg1.As<Object>();                                             \
   SLURP_STRING(_##conn, host, &conn.remote);                               \
   SLURP_INT(_##conn, port, &conn.port);
 
@@ -165,7 +165,7 @@ void DTRACE_HTTP_SERVER_REQUEST(const FunctionCallbackInfo<Value>& args) {
 
   Environment* env = Environment::GetCurrent(args);
   HandleScope scope(env->isolate());
-  Local<Object> arg0 = Local<Object>::Cast(args[0]);
+  Local<Object> arg0 = args[0].As<Object>();
   Local<Object> headers;
 
   memset(&req, 0, sizeof(req));
@@ -217,7 +217,7 @@ void DTRACE_HTTP_CLIENT_REQUEST(const FunctionCallbackInfo<Value>& args) {
    * caller here to retain their method and URL until the time at which
    * DTRACE_HTTP_CLIENT_REQUEST can be called.
    */
-  Local<Object> arg0 = Local<Object>::Cast(args[0]);
+  Local<Object> arg0 = args[0].As<Object>();
   SLURP_STRING(arg0, _header, &header);
 
   req.method = header;

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -186,7 +186,7 @@ class ProcessWrap : public HandleWrap {
     Local<Value> argv_v =
         js_options->Get(context, env->args_string()).ToLocalChecked();
     if (!argv_v.IsEmpty() && argv_v->IsArray()) {
-      Local<Array> js_argv = Local<Array>::Cast(argv_v);
+      Local<Array> js_argv = argv_v.As<Array>();
       int argc = js_argv->Length();
       CHECK_GT(argc + 1, 0);  // Check for overflow.
 
@@ -214,7 +214,7 @@ class ProcessWrap : public HandleWrap {
     Local<Value> env_v =
         js_options->Get(context, env->env_pairs_string()).ToLocalChecked();
     if (!env_v.IsEmpty() && env_v->IsArray()) {
-      Local<Array> env_opt = Local<Array>::Cast(env_v);
+      Local<Array> env_opt = env_v.As<Array>();
       int envc = env_opt->Length();
       CHECK_GT(envc + 1, 0);  // Check for overflow.
       options.env = new char*[envc + 1];  // Heap allocated to detect errors.


### PR DESCRIPTION
We mostly use `As()` instead of `Cast()` in our code, so this change
replaces the remaining calls to `Cast()` with calls to `As()` to maintain
the consistency.

Refs: https://github.com/nodejs/node/pull/39921/files#r702293529

Signed-off-by: Darshan Sen <darshan.sen@postman.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
