### PR TITLE
build: Pin actions to a full length commit SHA

### DIFF
--- a/.github/workflows/authors.yml
+++ b/.github/workflows/authors.yml
@@ -4,24 +4,33 @@ on:
     # Run once a week at 00:05 AM UTC on Sunday.
     - cron: '5 0 * * 0'
 
-  workflow_dispatch:
+  workflow_dispatch: null
 
 jobs:
   authors_update:
     if: github.repository == 'nodejs/node'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
         with:
-          fetch-depth: '0'  # This is required to actually get all the authors
-      - run: "tools/update-authors.js"  # Run the AUTHORS tool
-      - uses: gr2m/create-or-update-pull-request-action@v1  # Create a PR or update the Action's existing PR
+          fetch-depth: '0' # This is required to actually get all the authors
+      - run: "tools/update-authors.js" # Run the AUTHORS tool
+      - uses: gr2m/create-or-update-pull-request-action@8d7ac74bf44a6dafeb5a5d8deeadb771b707685b # pin v1.4.1
+        # Create a PR or update the Action's existing PR
         env:
           GITHUB_TOKEN: ${{ secrets.GH_USER_TOKEN }}
         with:
           author: Node.js GitHub Bot <github-bot@iojs.org>
-          body: "If this PR exists, there's presumably new additions to the AUTHORS file. This is an automatically generated PR by the `authors.yml` GitHub Action, which runs `tools/update-authors.js` and submits a new PR or updates an existing PR.\n\nPlease note that there might be duplicate entries. If there are, please remove them and add the duplicate emails to .mailmap directly to this PR."
-          branch: "actions/authors-update"  # Custom branch *just* for this Action.
+          body: "If this PR exists, there's presumably new additions to the AUTHORS file.
+            This is an automatically generated PR by the `authors.yml` GitHub
+            Action, which runs `tools/update-authors.js` and submits a new PR or
+            updates an existing PR.
+
+
+            Please note that there might be duplicate entries. If
+            there are, please remove them and add the duplicate emails to
+            .mailmap directly to this PR."
+          branch: "actions/authors-update" # Custom branch *just* for this Action.
           commit-message: "meta: update AUTHORS"
           labels: meta
           title: "meta: update AUTHORS"

--- a/.github/workflows/auto-start-ci.yml
+++ b/.github/workflows/auto-start-ci.yml
@@ -16,11 +16,11 @@ jobs:
     if: github.repository == 'nodejs/node'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
 
       # Install dependencies
       - name: Install Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@270253e841af726300e85d718a5f606959b2903c # pin@v2
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Install node-core-utils
@@ -33,7 +33,7 @@ jobs:
 
       # Get Pull Requests
       - name: Get Pull Requests
-        uses: octokit/graphql-action@v2.x
+        uses: octokit/graphql-action@7ffe46b60e9d2552d8f96c34d2de07588714a9fe # pin@v2.x
         id: get_prs_for_ci
         with:
           query: |
@@ -60,4 +60,6 @@ jobs:
           ncu-config set repo ${{ env.REPOSITORY }}
 
       - name: Start CI
-        run: ./tools/actions/start-ci.sh ${{ secrets.GITHUB_TOKEN }} ${{ env.OWNER }} ${{ env.REPOSITORY }} $(echo '${{ steps.get_prs_for_ci.outputs.data }}' | jq '.repository.pullRequests.nodes | map(.number) | .[]')
+        run: ./tools/actions/start-ci.sh ${{ secrets.GITHUB_TOKEN }} ${{ env.OWNER }}
+          ${{ env.REPOSITORY }} $(echo '${{ steps.get_prs_for_ci.outputs.data
+          }}' | jq '.repository.pullRequests.nodes | map(.number) | .[]')

--- a/.github/workflows/build-tarball.yml
+++ b/.github/workflows/build-tarball.yml
@@ -2,7 +2,7 @@ name: Build from tarball
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [ opened, synchronize, reopened, ready_for_review ]
     paths-ignore:
       - '.mailmap'
       - '**.md'
@@ -30,9 +30,9 @@ jobs:
       PYTHON_VERSION: 3.9
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6 # pin@v2
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Environment Information
@@ -46,7 +46,7 @@ jobs:
           mkdir tarballs
           mv *.tar.gz tarballs
       - name: Upload tarball artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@3446296876d12d4e3a0f3145a3c87e67bf0a16b5 # pin@v1
         with:
           name: tarballs
           path: tarballs
@@ -56,15 +56,15 @@ jobs:
     needs: build-tarball
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6 # pin@v2
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Environment Information
         run: npx envinfo
       - name: Download tarball
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@18f0f591fbc635562c815484d73b6e8e3980482e # pin@v1
         with:
           name: tarballs
       - name: Extract tarball

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -2,7 +2,7 @@ name: build-windows
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [ opened, synchronize, reopened, ready_for_review ]
   push:
     branches:
       - master
@@ -20,13 +20,13 @@ jobs:
     if: github.event.pull_request.draft == false
     strategy:
       matrix:
-        windows: [windows-2019, windows-2022]
+        windows: [ windows-2019, windows-2022 ]
       fail-fast: false
     runs-on: ${{ matrix.windows }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6 # pin@v2
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install deps

--- a/.github/workflows/close-stalled.yml
+++ b/.github/workflows/close-stalled.yml
@@ -8,14 +8,18 @@ jobs:
     if: github.repository == 'nodejs/node'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v3
+      - uses: actions/stale@98ed4cb500039dbcccf4bd9bedada4d0187f2757 # pin@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-close: 30
           stale-pr-label: stalled
           stale-issue-label: stalled
-          close-issue-message: Closing this because it has stalled. Feel free to reopen if this issue is still relevant, or to ping the collaborator who labelled it stalled if you have any questions.
-          close-pr-message: Closing this because it has stalled. Feel free to reopen if this PR is still relevant, or to ping the collaborator who labelled it stalled if you have any questions.
+          close-issue-message: Closing this because it has stalled. Feel free to reopen if
+            this issue is still relevant, or to ping the collaborator who
+            labelled it stalled if you have any questions.
+          close-pr-message: Closing this because it has stalled. Feel free to reopen if
+            this PR is still relevant, or to ping the collaborator who labelled
+            it stalled if you have any questions.
           # used to filter issues to check whether or not should be closed, avoids hitting maximum operations allowed if needing to paginate through all open issues
           only-labels: stalled
           # max requests it will send per run to the GitHub API before it deliberately exits to avoid hitting API rate limits

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,6 +1,6 @@
 name: "Commit messages adheres to guidelines at https://goo.gl/p2fr5Q"
 
-on: [pull_request]
+on: [ pull_request ]
 
 env:
   NODE_VERSION: lts/*
@@ -9,12 +9,12 @@ jobs:
   lint-commit-message:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
         with:
           # Last 100 commits should be enough for a PR
           fetch-depth: 100
       - name: Install Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@270253e841af726300e85d718a5f606959b2903c # pin@v2
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Validate commit messages

--- a/.github/workflows/coverage-linux.yml
+++ b/.github/workflows/coverage-linux.yml
@@ -2,7 +2,7 @@ name: coverage-linux
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [ opened, synchronize, reopened, ready_for_review ]
     paths-ignore:
       - '**.md'
       - 'benchmark/**'
@@ -27,9 +27,9 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6 # pin@v2
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Environment Information
@@ -41,17 +41,20 @@ jobs:
       # TODO(bcoe): fix the couple tests that fail with the inspector enabled.
       # The cause is most likely coverage's use of the inspector.
       - name: Test
-        run: NODE_V8_COVERAGE=coverage/tmp make test-cov -j2 V=1 TEST_CI_ARGS="-p dots" || exit 0
+        run: NODE_V8_COVERAGE=coverage/tmp make test-cov -j2 V=1 TEST_CI_ARGS="-p dots"
+          || exit 0
       - name: Report JS
         run: npx c8 report --check-coverage
         env:
           NODE_OPTIONS: --max-old-space-size=8192
       - name: Report C++
-        run: cd out && gcovr --gcov-exclude='.*\b(deps|usr|out|obj|cctest|embedding)\b' -v -r Release/obj.target --xml -o ../coverage/coverage-cxx.xml --root=$(cd ../ && pwd)
+        run: cd out && gcovr --gcov-exclude='.*\b(deps|usr|out|obj|cctest|embedding)\b'
+          -v -r Release/obj.target --xml -o ../coverage/coverage-cxx.xml
+          --root=$(cd ../ && pwd)
       # Clean temporary output from gcov and c8, so that it's not uploaded:
       - name: Clean tmp
         run: rm -rf coverage/tmp && rm -rf out
       - name: Upload
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@29386c70ef20e286228c72b668a06fd0e8399192 # pin@v1
         with:
           directory: ./coverage

--- a/.github/workflows/coverage-windows.yml
+++ b/.github/workflows/coverage-windows.yml
@@ -2,7 +2,7 @@ name: coverage-windows
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [ opened, synchronize, reopened, ready_for_review ]
     paths-ignore:
       - '**.md'
       - 'benchmark/**'
@@ -29,9 +29,9 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6 # pin@v2
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install deps
@@ -53,6 +53,6 @@ jobs:
       - name: Clean tmp
         run: npx rimraf ./coverage/tmp
       - name: Upload
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@29386c70ef20e286228c72b668a06fd0e8399192 # pin@v1
         with:
           directory: ./coverage

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,7 +1,7 @@
 name: Node.js daily job
 
 on:
-  workflow_dispatch:
+  workflow_dispatch: null
   schedule:
     - cron: "0 0 * * *"
 
@@ -14,9 +14,9 @@ jobs:
     # not working on gcc-8 and gcc-9 see https://github.com/nodejs/node/issues/38570
     container: gcc:11
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@270253e841af726300e85d718a5f606959b2903c # pin@v2
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Environment Information

--- a/.github/workflows/find-inactive-collaborators.yml
+++ b/.github/workflows/find-inactive-collaborators.yml
@@ -5,7 +5,7 @@ on:
     # Run on the 15th day of the month at 4:05 AM UTC.
     - cron: '5 4 15 * *'
 
-  workflow_dispatch:
+  workflow_dispatch: null
 
 env:
   NODE_VERSION: 16.x
@@ -17,12 +17,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
         with:
           fetch-depth: ${{ env.NUM_COMMITS }}
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@270253e841af726300e85d718a5f606959b2903c # pin@v2
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -30,7 +30,7 @@ jobs:
         run: tools/find-inactive-collaborators.mjs ${{ env.NUM_COMMITS }}
 
       - name: Open pull request
-        uses: gr2m/create-or-update-pull-request-action@v1
+        uses: gr2m/create-or-update-pull-request-action@d4c446af7f110d666d2a341a7fbb0a7f906a8dfc # pin@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GH_USER_TOKEN }}
         with:

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -2,14 +2,14 @@ name: Label PRs
 
 on:
   pull_request_target:
-    types: [opened]
+    types: [ opened ]
 
 jobs:
   label:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: nodejs/node-pr-labeler@v1
+      - uses: nodejs/node-pr-labeler@d4cf1b8b9f23189c37917000e5e17e796c770a6b # pin@v1
         with:
           repo-token: ${{ secrets.GH_USER_TOKEN }}
           configuration-path: .github/label-pr-config.yml

--- a/.github/workflows/license-builder.yml
+++ b/.github/workflows/license-builder.yml
@@ -4,20 +4,24 @@ on:
     # 00:00:00 every Monday
     # https://crontab.guru/#0_0_*_*_1
     - cron: "0 0 * * 1"
-  workflow_dispatch:
+  workflow_dispatch: null
 
 jobs:
   update_license:
     if: github.repository == 'nodejs/node'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - run: "./tools/license-builder.sh"  # Run the license builder tool
-      - uses: gr2m/create-or-update-pull-request-action@v1.x  # Create a PR or update the Action's existing PR
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
+      - run: "./tools/license-builder.sh" # Run the license builder tool
+      - uses: gr2m/create-or-update-pull-request-action@8d7ac74bf44a6dafeb5a5d8deeadb771b707685b # pin v1.4.1
+        # Create a PR or update the Action's existing PR
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           title: "doc: run license-builder"
-          body: "License is likely out of date. This is an automatically generated PR by the `license-builder.yml` GitHub Action, which runs `license-builder.sh` and submits a new PR or updates an existing PR."
+          body: "License is likely out of date. This is an automatically generated PR by
+            the `license-builder.yml` GitHub Action, which runs
+            `license-builder.sh` and submits a new PR or updates an existing
+            PR."
           commit-message: 'doc: run license-builder'
           labels: meta

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -2,7 +2,7 @@ name: linters
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [ opened, synchronize, reopened, ready_for_review ]
   push:
     branches:
       - master
@@ -19,9 +19,9 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@270253e841af726300e85d718a5f606959b2903c # pin@v2
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Environment Information
@@ -32,9 +32,9 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6 # pin@v2
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Environment Information
@@ -45,15 +45,16 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@270253e841af726300e85d718a5f606959b2903c # pin@v2
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Environment Information
         run: npx envinfo
       - name: Get release version numbers
-        if: ${{ github.event.pull_request && github.event.pull_request.base.ref == github.event.pull_request.base.repo.default_branch }}
+        if: ${{ github.event.pull_request && github.event.pull_request.base.ref ==
+          github.event.pull_request.base.repo.default_branch }}
         id: get-released-versions
         run: ./tools/lint-md/list-released-versions-from-changelogs.mjs
       - name: Lint docs
@@ -67,9 +68,9 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@270253e841af726300e85d718a5f606959b2903c # pin@v2
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Environment Information
@@ -80,9 +81,9 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6 # pin@v2
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Environment Information
@@ -95,9 +96,9 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
       - name: Use Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6 # pin@v2
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Environment Information
@@ -111,7 +112,7 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
       - run: shellcheck -V
       - name: Lint Shell scripts
         run: tools/lint-sh.js .
@@ -119,16 +120,17 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: mszostok/codeowners-validator@v0.4.0
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
+      - uses: mszostok/codeowners-validator@7a3a38f0758fa7020355e62b58e27b6ae5d8e790 # pin@v0.4.0
         with:
           checks: "files,duppatterns"
   lint-pr-url:
     if: ${{ github.event.pull_request }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
         with:
           fetch-depth: 2
       # GH Actions squashes all PR commits, HEAD^ refers to the base branch.
-      - run: git diff HEAD^ HEAD -G"pr-url:" -- "*.md" | ./tools/lint-pr-url.mjs ${{ github.event.pull_request.html_url }}
+      - run: git diff HEAD^ HEAD -G"pr-url:" -- "*.md" | ./tools/lint-pr-url.mjs ${{
+          github.event.pull_request.html_url }}

--- a/.github/workflows/misc.yml
+++ b/.github/workflows/misc.yml
@@ -2,7 +2,7 @@ name: misc
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [ opened, synchronize, reopened, ready_for_review ]
   push:
     branches:
       - master
@@ -18,16 +18,16 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@270253e841af726300e85d718a5f606959b2903c # pin@v2
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Environment Information
         run: npx envinfo
       - name: Build
         run: NODE=$(command -v node) make doc-only
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@3446296876d12d4e3a0f3145a3c87e67bf0a16b5 # pin@v1
         with:
           name: docs
           path: out/doc

--- a/.github/workflows/notify-force-push.yml
+++ b/.github/workflows/notify-force-push.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Slack Notification
-        uses: rtCamp/action-slack-notify@master
+        uses: rtCamp/action-slack-notify@28e8b353eabda5998a2e1203aed33c5999944779 # pin@master
         env:
           SLACK_COLOR: '#DE512A'
           SLACK_ICON: https://github.com/nodejs.png?size=48

--- a/.github/workflows/test-asan.yml
+++ b/.github/workflows/test-asan.yml
@@ -2,7 +2,7 @@ name: test-asan
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [ opened, synchronize, reopened, ready_for_review ]
     paths-ignore:
       - '.mailmap'
       - '**.md'
@@ -35,9 +35,9 @@ jobs:
       LINK: clang++
       CONFIG_FLAGS: --enable-asan
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6 # pin@v2
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Environment Information

--- a/.github/workflows/test-internet.yml
+++ b/.github/workflows/test-internet.yml
@@ -1,12 +1,12 @@
 name: test-internet
 
 on:
-  workflow_dispatch:
+  workflow_dispatch: null
   schedule:
     - cron: 5 0 * * *
 
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [ opened, synchronize, reopened, ready_for_review ]
     paths:
       - test/internet/**
   push:
@@ -27,9 +27,9 @@ jobs:
   test-internet:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6 # pin@v2
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Environment Information

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -2,7 +2,7 @@ name: test-linux
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [ opened, synchronize, reopened, ready_for_review ]
   push:
     branches:
       - master
@@ -20,9 +20,9 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6 # pin@v2
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Environment Information

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -2,7 +2,7 @@ name: test-macOS
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [ opened, synchronize, reopened, ready_for_review ]
     paths-ignore:
       - '.mailmap'
       - '**.md'
@@ -30,9 +30,9 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6 # pin@v2
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Environment Information


### PR DESCRIPTION
Pinning an action to a full length commit SHA is currently the only way to use an action as
an immutable release. Pinning to a particular SHA helps mitigate the risk of a bad actor adding a
backdoor to the action's repository, as they would need to generate a SHA-1 collision for
a valid Git object payload.

https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies

