### PR TITLE
meta: add mailmap entry for ratracegrad

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -190,6 +190,7 @@ James M Snell <jasnell@gmail.com>
 James Nimlos <james@nimlos.com>
 Jan Krems <jan.krems@gmail.com> <jan.krems@groupon.com>
 Jenna Vuong <jennavuong@gmail.com> <hello@jennavuong.com>
+Jennifer Bland <ratracegrad@gmail.com> <jennifer.bland@sbdinc.com>
 JeongHoon Byun <outsideris@gmail.com>
 Jered Schmidt <tr@nslator.jp>
 Jeremiah Senkpiel <fishrock123@rocketmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -2289,7 +2289,7 @@ Andreas Girgensohn <andreasg@fxpal.com>
 Caleb Sander <caleb.sander@gmail.com>
 Dzmitry_Prudnikau <dzmitriyprudnikov@gmail.com>
 Ian McKellar <ianloic@google.com>
-Jennifer Bland <jennifer.bland@sbdinc.com>
+Jennifer Bland <ratracegrad@gmail.com>
 Kyle Fuller <kyle@fuller.li>
 Yongsheng Zhang <zyszys98@gmail.com>
 Neeraj Laad <neeraj.laad@uk.ibm.com>
@@ -2320,7 +2320,6 @@ Alexander Mills <alex@oresoftware.com>
 Rodrigo Bruno <rfbpb@google.com>
 Lovingly <42682205+lovinglyy@users.noreply.github.com>
 Klaus Meinhardt <klaus.meinhardt1@gmail.com>
-Jennifer Bland <ratracegrad@gmail.com>
 Sintendo <bram.speeckaert@gmail.com>
 Nitish Sakhawalkar <nitsakh@icloud.com>
 André Cruz <andre@cabine.org>


### PR DESCRIPTION
There are two AUTHORS entries for ratracegrad. Use a mailmap entry to
consolidate them into a single entry.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
