### PR TITLE
stream: pipeline callback fix

### DIFF
--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -86,8 +86,9 @@ function eos(stream, options, callback) {
     if (stream.destroyed) willEmitClose = false;
 
     if (willEmitClose && (!stream.readable || readable)) {
+      // Otherwise s2 in pipeline(s1, s2, s1, cb) won't end
       if (!readableFinished && stream.readable)
-        stream.read(0);
+        stream.read(rState.length + 1);
 
       return;
     }

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -88,7 +88,7 @@ function eos(stream, options, callback) {
     if (willEmitClose && (!stream.readable || readable)) {
       // Otherwise s2 in pipeline(s1, s2, s1, cb) won't end
       if (!readableFinished && stream.readable)
-        stream.read(rState.length + 1);
+        stream.read(rState.length && rState.length + 1);
 
       return;
     }

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -85,7 +85,13 @@ function eos(stream, options, callback) {
     // we cannot trust willEmitClose.
     if (stream.destroyed) willEmitClose = false;
 
-    if (willEmitClose && (!stream.readable || readable)) return;
+    if (willEmitClose && (!stream.readable || readable)) {
+      if (!readableFinished && stream.readable)
+        stream.read(0);
+
+      return;
+    }
+
     if (!readable || readableFinished) callback.call(stream);
   };
 

--- a/test/parallel/test-stream-pipeline-callback.js
+++ b/test/parallel/test-stream-pipeline-callback.js
@@ -1,0 +1,52 @@
+'use strict';
+
+require('../common');
+const http = require('http');
+const net = require('net');
+const stream = require('stream');
+
+const main = async () => {
+  const server = http.createServer();
+
+  const promise = new Promise((resolve, reject) => {
+    server.once('upgrade', (req, socket) => {
+      setTimeout(() => socket.end(), 0);
+
+      stream.pipeline(
+        socket,
+        new stream.PassThrough(),
+        socket,
+        (err) => {
+          if (err) return reject(err);
+          resolve();
+        },
+      );
+    });
+
+    setTimeout(() => reject(new Error('Pipeline timed out')), 1e3);
+  });
+
+  server.listen(0, () => {
+    const conn = net
+      .createConnection(server.address().port)
+      .setEncoding('utf8');
+
+    conn.once('connect', () => {
+      conn.write([
+        'GET / HTTP/1.1',
+        'Upgrade: WebSocket',
+        'Connection: Upgrade',
+        '\r\n',
+      ].join('\r\n'));
+    });
+  });
+
+  await promise;
+
+  process.exit();
+};
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
Potential fix for #40279

I wrote a test similar to the code sample in the issue. With some debugging, I noticed that the [eos](https://github.com/zbo14/node/blob/6b67053e0f52ef557b696432af38af5eb8598453/lib/internal/streams/end-of-stream.js#L38) callback wasn't being called for the middle `PassThrough` stream. Neither [onend](https://github.com/zbo14/node/blob/6b67053e0f52ef557b696432af38af5eb8598453/lib/internal/streams/end-of-stream.js#L99) nor [onclose](https://github.com/zbo14/node/blob/6b67053e0f52ef557b696432af38af5eb8598453/lib/internal/streams/end-of-stream.js#L116) were called, but [onfinish](https://github.com/zbo14/node/blob/6b67053e0f52ef557b696432af38af5eb8598453/lib/internal/streams/end-of-stream.js#L81) was. I followed the code path and added a `read(0)` in hopes of triggering the end of the readable, which would call the callback. This worked for the test case I wrote (I haven't gotten it to work with a more generic test case though). If you comment out the if-clause I added, the pipeline should time out.