### PR TITLE
chore: added Apple M1 platform detection when compiling with Rosetta 2

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1022,6 +1022,34 @@ def cc_macros(cc=None):
       key = lst[1]
       val = lst[2]
       k[key] = val
+
+  try:
+    p = subprocess.Popen(shlex.split('uname') + ['-v'],
+                         stdin=subprocess.PIPE,
+                         stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE)
+  except OSError:
+    pass # ignore on systems not supporting uname
+
+  out = to_utf8(p.communicate()[0])
+
+  # edge-case check: trying to compile on Apple Silicon M1
+  # using a toolchain that is dual-arch (arm64e and x86_64)
+  # (transpiled by Rosetta 2) will set __x86_64__ = 1
+  # however the true host arch is indeed arm64 instead
+  # uname -v reveals the kernel version string
+  # which includes the version ARM64 tag which
+  # gives us certainty that this script is running
+  # on an ARM platform in reality.
+  # Handling this edge case is important because
+  # false-positive cross-compilation would lead v8
+  # to assume an x86_64 host which breaks the compilation
+  # as v8 will try to compile the wrong inline
+  # assembly code branch for the actual ARM based host CPU.
+  if 'Darwin' in out and 'ARM64' in out:
+    k['__x86_64__'] = '0'
+    k['__aarch64__'] = '1'
+
   return k
 
 


### PR DESCRIPTION
This PR handles the special case when a developer is trying to compile on an Apple Silicon M1 machine with a toolchain that is dual-arch (`arm64e` and `x86_64`) which is a valid case when the build toolchain is `x86_64` based and Rosetta 2 is active. In this case, the current `configure.py` is unable to figure out the correct host platform as the toolchain will just return `x86_64` even if the true host arch is `arm64`.

The impl. in the commit is trying to keep the current logic as untouched as possible to prevent any regressions.

Fixes: https://github.com/nodejs/node/issues/40302

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
