### PR TITLE
deps: suppress zlib compiler warnings

### DIFF
--- a/deps/zlib/zlib.gyp
+++ b/deps/zlib/zlib.gyp
@@ -51,10 +51,10 @@
               '.',
             ],
           },
-          'cflags': [ '-Wno-implicit-fallthrough' ],
           'conditions': [
             ['OS!="win"', {
               'cflags!': [ '-ansi' ],
+              'cflags': [ '-Wno-implicit-fallthrough' ],
               'defines': [ 'HAVE_HIDDEN' ],
             }],
             ['OS=="mac" or OS=="ios" or OS=="freebsd" or OS=="android"', {


### PR DESCRIPTION
Currently, there are a number of compilation warnings from zlib like the
following one:
```console
../deps/zlib/infback.c: In function ‘inflateBack’:
../deps/zlib/infback.c:479:25: warning:
this statement may fall through [-Wimplicit-fallthrough=]
  479 |             state->mode = LEN;
      |             ~~~~~~~~~~~~^~~~~
../deps/zlib/infback.c:481:9: note: here
  481 |         case LEN:
      |         ^~~~
```
In this case there is no break statement and the intention is to fall
through:
```c
           Tracev((stderr, "inflate:       codes ok\n"));
           state->mode = LEN;

        case LEN:
```
This commit adds `-Wno-implicit-fallthrough` to zlib.gyp to suppress
these warnings.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
