### PR TITLE
test: fix "test/common/debugger" identify async function

### DIFF
--- a/test/common/debugger.js
+++ b/test/common/debugger.js
@@ -104,13 +104,12 @@ function startCLI(args, flags = [], spawnOpts = {}) {
     },
 
     async waitForInitialBreak() {
-      return this.waitFor(/break (?:on start )?in/i)
-        .then(async () => {
-          if (isPreBreak(this.output)) {
-            return this.command('next', false)
-              .then(() => this.waitFor(/break in/));
-          }
-        });
+      await this.waitFor(/break (?:on start )?in/i);
+
+      if (isPreBreak(this.output)) {
+        await this.command('next', false);
+        return this.waitFor(/break in/);
+      }
     },
 
     get breakInfo() {


### PR DESCRIPTION
test: use async to identify function

`waitForInitialBreak()` return a promise function, should use `async` to identify it