### PR TITLE
lib, doc: improve default read length

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -378,7 +378,7 @@ added:
   * `offset` {integer} The location in the buffer at which to start filling.
     **Default:** `0`
   * `length` {integer} The number of bytes to read. **Default:**
-    `buffer.byteLength`
+    `buffer.byteLength - offset`
   * `position` {integer} The location where to begin reading data from the
     file. If `null`, data will be read from the current file position, and
     the position will be updated. If `position` is an integer, the current
@@ -3022,7 +3022,7 @@ changes:
 * `options` {Object}
   * `buffer` {Buffer|TypedArray|DataView} **Default:** `Buffer.alloc(16384)`
   * `offset` {integer} **Default:** `0`
-  * `length` {integer} **Default:** `buffer.byteLength`
+  * `length` {integer} **Default:** `buffer.byteLength - offset`
   * `position` {integer|bigint} **Default:** `null`
 * `callback` {Function}
   * `err` {Error}

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -621,7 +621,7 @@ function read(fd, buffer, offset, length, position, callback) {
     ({
       buffer = Buffer.alloc(16384),
       offset = 0,
-      length = buffer.byteLength,
+      length = buffer.byteLength - offset,
       position
     } = options);
   }


### PR DESCRIPTION
This commit sets the default length of bytes to read to a value
that doesn't throw an error in the absence of another optional option.

I'm not 100% sure if there are additional places in the code or
documentation which should also be updated due to repetition.

Supersedes #40347 due to commit comment format requirements. 