### PR TITLE
src: add kNoBrowserGlobals flag for Environment

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -892,6 +892,15 @@ inline bool Environment::no_global_search_paths() const {
          !options_->global_search_paths;
 }
 
+inline bool Environment::no_browser_globals() const {
+  // configure --no-browser-globals
+#ifdef NODE_NO_BROWSER_GLOBALS
+  return true;
+#else
+  return flags_ & EnvironmentFlags::kNoBrowserGlobals;
+#endif
+}
+
 bool Environment::filehandle_close_warning() const {
   return emit_filehandle_warning_;
 }

--- a/src/env.h
+++ b/src/env.h
@@ -1204,6 +1204,7 @@ class Environment : public MemoryRetainer {
   inline bool tracks_unmanaged_fds() const;
   inline bool hide_console_windows() const;
   inline bool no_global_search_paths() const;
+  inline bool no_browser_globals() const;
   inline uint64_t thread_id() const;
   inline worker::Worker* worker_context() const;
   Environment* worker_parent_env() const;

--- a/src/node.h
+++ b/src/node.h
@@ -418,7 +418,9 @@ enum Flags : uint64_t {
   // $HOME/.node_modules and $NODE_PATH. This is used by standalone apps that
   // do not expect to have their behaviors changed because of globally
   // installed modules.
-  kNoGlobalSearchPaths = 1 << 7
+  kNoGlobalSearchPaths = 1 << 7,
+  // Do not export browser globals like setTimeout, console, etc.
+  kNoBrowserGlobals = 1 << 8,
 };
 }  // namespace EnvironmentFlags
 

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -68,12 +68,10 @@ static void Initialize(Local<Object> target,
   READONLY_FALSE_PROPERTY(target, "hasInspector");
 #endif
 
-// configure --no-browser-globals
-#ifdef NODE_NO_BROWSER_GLOBALS
-  READONLY_TRUE_PROPERTY(target, "noBrowserGlobals");
-#else
-  READONLY_FALSE_PROPERTY(target, "noBrowserGlobals");
-#endif  // NODE_NO_BROWSER_GLOBALS
+  if (env->no_browser_globals())
+    READONLY_TRUE_PROPERTY(target, "noBrowserGlobals");
+  else
+    READONLY_FALSE_PROPERTY(target, "noBrowserGlobals");
 
   READONLY_PROPERTY(target,
                     "bits",


### PR DESCRIPTION
This is the runtime equivalent of the `configure --no-browser-globals` build flag.

A runtime flag is needed because embedders may support multiple modes of Node.js that, Node.js may both run in a browser environment, and in an independent environment that has no browser globals. For example, Node.js script running in web page spawning a script with `child_process.fork`.

/cc @nodejs/embedders 