### PR TITLE
meta: use .mailmap to consolidate AUTHORS entries for ide

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -187,6 +187,7 @@ Jake Verbaten <raynos2@gmail.com>
 Jamen Marzonie <jamenmarz@gmail.com> <jamenmarz+gh@gmail.com>
 James Beavers <jamesjbeavers@gmail.com>
 James Hartig <fastest963@gmail.com> <james.hartig@grooveshark.com>
+James Ide <ide@jameside.com> <ide@expo.io>
 James M Snell <jasnell@gmail.com>
 James Nimlos <james@nimlos.com>
 Jan Krems <jan.krems@gmail.com> <jan.krems@groupon.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -2266,7 +2266,6 @@ sagulati <sagulati@adobe.com>
 conectado <gabrielalejandro7@gmail.com>
 Vitor Bruno de Oliveira Barth <vbob@vbob.com.br>
 Christian Clauss <cclauss@me.com>
-James Ide <ide@expo.io>
 bhavayAnand9 <bhavayanandcse@gmail.com>
 Brandon Lee <40652534+brandonlwt@users.noreply.github.com>
 Oryan Moshe <iamoryanmoshe@gmail.com>


### PR DESCRIPTION
James Ide has two AUTHORS entries. Use .mailmap to consolidate them into
a single entry.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
