### PR TITLE
meta: consolidate AUTHORS entry for thw0rted

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -186,6 +186,7 @@ Jackson Tian <shyvo1987@gmail.com> <puling.tyq@alibaba-inc.com>
 Jake Verbaten <raynos2@gmail.com>
 Jamen Marzonie <jamenmarz@gmail.com> <jamenmarz+gh@gmail.com>
 James Beavers <jamesjbeavers@gmail.com>
+James Bromwell <james.bromwell@gdit.com> <943160+thw0rted@users.noreply.github.com>
 James Hartig <fastest963@gmail.com> <james.hartig@grooveshark.com>
 James Ide <ide@jameside.com> <ide@expo.io>
 James M Snell <jasnell@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -2280,7 +2280,6 @@ Musa Hamwala <musahamwala@icloud.com>
 James Bromwell <james.bromwell@gdit.com>
 Jeremy Apthorp <nornagon@nornagon.net>
 Eugen Cazacu <32613393+oygen87@users.noreply.github.com>
-James Bromwell <943160+thw0rted@users.noreply.github.com>
 Csaba Palfi <csaba@palfi.me>
 Ryan Petrich <rpetrich@gmail.com>
 Andreas Girgensohn <andreasg@fxpal.com>


### PR DESCRIPTION
Use a .mailmap entry to consolidate the two entries for thw0rted in
AUTHORS into one entry.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
