### PR TITLE
meta: consolidate duplicate AUTHORS entries for hassaanp

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -165,6 +165,7 @@ Guy Bedford <guybedford@gmail.com>
 Halil İbrahim Şener <hisener@yahoo.com>
 Hannah Kim <h.heeeun.kim@gmail.com>
 Hannes Magnusson <hannes.magnusson@gmail.com> <hannes.magnusson@creditkarma.com>
+Hassaan Pasha <pasha.hassaan@gmail.com> <hassaan.pasha@teamo.io>
 Hendrik Schwalm <mail@hendrikschwalm.de>
 Henry Chin <hheennrryy@gmail.com>
 Herbert Vojčík <herby@mailbox.sk>

--- a/AUTHORS
+++ b/AUTHORS
@@ -2995,7 +2995,7 @@ ExE Boss <3889017+ExE-Boss@users.noreply.github.com>
 Mateusz Krawczuk <krawczukmat@gmail.com>
 Jonathan MERCIER <jmercier@cng.fr>
 Jichan <development@jc-lab.net>
-Hassaan Pasha <hassaan.pasha@teamo.io>
+Hassaan Pasha <pasha.hassaan@gmail.com>
 Eric Dobbertin <eric@dairystatedesigns.com>
 Victor <doc999tor@gmail.com>
 Ling Samuel <lingsamuelgrace@gmail.com>
@@ -3224,7 +3224,6 @@ simov <simeonvelichkov@gmail.com>
 wwwzbwcom <zbwhome@outlook.com>
 David Glasser <glasser@davidglasser.net>
 pezhmanparsaee <p.parsaee@gmail.com>
-Hassaan Pasha <pasha.hassaan@gmail.com>
 Darkripper214 <phakorn214@gmail.com>
 Anu Pasumarthy <anupama.pasumarthy@gmail.com>
 HiroyukiYagihashi <hey@hiroy.uk>


### PR DESCRIPTION
Create a .mailmap entry to consolidate the two AUTHORS entries for
hassaanp into a single entry.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
