### PR TITLE
doc: fix typos in n-api docs

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -1574,7 +1574,7 @@ NAPI_EXTERN napi_status napi_create_reference(napi_env env,
 
 Returns `napi_ok` if the API succeeded.
 
-This API create a new reference with the specified reference count
+This API creates a new reference with the specified reference count
 to the `Object` passed in.
 
 #### napi_delete_reference
@@ -4132,7 +4132,7 @@ napi_status napi_set_element(napi_env env,
 
 Returns `napi_ok` if the API succeeded.
 
-This API sets and element on the `Object` passed in.
+This API sets an element on the `Object` passed in.
 
 #### napi_get_element
 <!-- YAML


### PR DESCRIPTION
A couple of typos fixed in the `n-api` docs.
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
