### PR TITLE
src: ensure V8 initialized before marking milestone

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -458,8 +458,11 @@ void Environment::InitializeMainContext(Local<Context> context,
                            environment_start_time_);
   performance_state_->Mark(performance::NODE_PERFORMANCE_MILESTONE_NODE_START,
                            per_process::node_start_time);
-  performance_state_->Mark(performance::NODE_PERFORMANCE_MILESTONE_V8_START,
-                           performance::performance_v8_start);
+
+  if (per_process::v8_initialized) {
+    performance_state_->Mark(performance::NODE_PERFORMANCE_MILESTONE_V8_START,
+                            performance::performance_v8_start);
+  }
 }
 
 Environment::~Environment() {


### PR DESCRIPTION
Refs:
 * https://github.com/electron/electron/pull/31349
 * https://github.com/electron/electron/issues/31348

When Node.js is started within Electron's environment it doesn't initialize V8, so V8's start time is never set. As a result, Electron logs V8's start time as 0 and it breaks timestamps in the trace log.

This change fixes the issue by adding logic to log V8's start time only when V8 is initialized by Node.js.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
