### PR TITLE
http: make .headers and .trailers to have no prototype

### DIFF
--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -107,7 +107,7 @@ ObjectDefineProperty(IncomingMessage.prototype, 'connection', {
 ObjectDefineProperty(IncomingMessage.prototype, 'headers', {
   get: function() {
     if (!this[kHeaders]) {
-      this[kHeaders] = {};
+      this[kHeaders] = Object.create(null);
 
       const src = this.rawHeaders;
       const dst = this[kHeaders];
@@ -126,7 +126,7 @@ ObjectDefineProperty(IncomingMessage.prototype, 'headers', {
 ObjectDefineProperty(IncomingMessage.prototype, 'trailers', {
   get: function() {
     if (!this[kTrailers]) {
-      this[kTrailers] = {};
+      this[kTrailers] = Object.create(null);
 
       const src = this.rawTrailers;
       const dst = this[kTrailers];

--- a/test/parallel/test-http-blank-header.js
+++ b/test/parallel/test-http-blank-header.js
@@ -28,11 +28,11 @@ const net = require('net');
 const server = http.createServer(common.mustCall((req, res) => {
   assert.strictEqual(req.method, 'GET');
   assert.strictEqual(req.url, '/blah');
-  assert.deepStrictEqual(req.headers, {
+  assert.deepStrictEqual(req.headers, Object.assign(Object.create(null), {
     host: 'example.org:443',
     origin: 'http://example.org',
     cookie: ''
-  });
+  }));
 }));
 
 

--- a/test/parallel/test-http-client-headers-array.js
+++ b/test/parallel/test-http-client-headers-array.js
@@ -7,11 +7,11 @@ const http = require('http');
 
 function execute(options) {
   http.createServer(function(req, res) {
-    const expectHeaders = {
+    const expectHeaders = Object.assign(Object.create(null), {
       'x-foo': 'boom',
       'cookie': 'a=1; b=2; c=3',
       'connection': 'close'
-    };
+    });
 
     // no Host header when you set headers an array
     if (!Array.isArray(options.headers)) {

--- a/test/parallel/test-http-content-length.js
+++ b/test/parallel/test-http-content-length.js
@@ -4,20 +4,20 @@ const assert = require('assert');
 const http = require('http');
 const Countdown = require('../common/countdown');
 
-const expectedHeadersMultipleWrites = {
+const expectedHeadersMultipleWrites = Object.assign(Object.create(null), {
   'connection': 'close',
   'transfer-encoding': 'chunked',
-};
+});
 
-const expectedHeadersEndWithData = {
+const expectedHeadersEndWithData = Object.assign(Object.create(null), {
   'connection': 'close',
   'content-length': String('hello world'.length)
-};
+});
 
-const expectedHeadersEndNoData = {
+const expectedHeadersEndNoData = Object.assign(Object.create(null), {
   'connection': 'close',
   'content-length': '0',
-};
+});
 
 
 const countdown = new Countdown(3, () => server.close());

--- a/test/parallel/test-http-raw-headers.js
+++ b/test/parallel/test-http-raw-headers.js
@@ -36,12 +36,12 @@ http.createServer(function(req, res) {
     'Connection',
     'close',
   ];
-  const expectHeaders = {
+  const expectHeaders = Object.assign(Object.create(null), {
     'host': `localhost:${this.address().port}`,
     'transfer-encoding': 'CHUNKED',
     'x-bar': 'yoyoyo',
     'connection': 'close'
-  };
+  });
   const expectRawTrailers = [
     'x-bAr',
     'yOyOyOy',
@@ -52,7 +52,9 @@ http.createServer(function(req, res) {
     'X-baR',
     'OyOyOyO',
   ];
-  const expectTrailers = { 'x-bar': 'yOyOyOy, OyOyOyO, yOyOyOy, OyOyOyO' };
+  const expectTrailers = Object.assign(Object.create(null), {
+    'x-bar': 'yOyOyOy, OyOyOyO, yOyOyOy, OyOyOyO'
+  });
 
   this.close();
 
@@ -95,12 +97,12 @@ http.createServer(function(req, res) {
       'Transfer-Encoding',
       'chunked',
     ];
-    const expectHeaders = {
+    const expectHeaders = Object.assign(Object.create(null), {
       'trailer': 'x-foo',
       'date': null,
       'connection': 'close',
       'transfer-encoding': 'chunked'
-    };
+    });
     res.rawHeaders[3] = null;
     res.headers.date = null;
     assert.deepStrictEqual(res.rawHeaders, expectRawHeaders);
@@ -116,7 +118,7 @@ http.createServer(function(req, res) {
         'X-foO',
         'OxOxOxO',
       ];
-      const expectTrailers = { 'x-foo': 'xOxOxOx, OxOxOxO, xOxOxOx, OxOxOxO' };
+      const expectTrailers = Object.assign(Object.create(null), { 'x-foo': 'xOxOxOx, OxOxOxO, xOxOxOx, OxOxOxO' });
 
       assert.deepStrictEqual(res.rawTrailers, expectRawTrailers);
       assert.deepStrictEqual(res.trailers, expectTrailers);

--- a/test/parallel/test-http-remove-header-stays-removed.js
+++ b/test/parallel/test-http-remove-header-stays-removed.js
@@ -51,7 +51,7 @@ process.on('exit', function() {
 server.listen(0, function() {
   http.get({ port: this.address().port }, function(res) {
     assert.strictEqual(res.statusCode, 200);
-    assert.deepStrictEqual(res.headers, { date: 'coffee o clock' });
+    assert.deepStrictEqual(res.headers, Object.assign(Object.create(null), { date: 'coffee o clock' }));
 
     res.setEncoding('ascii');
     res.on('data', function(chunk) {

--- a/test/parallel/test-http-server-capture-rejections.js
+++ b/test/parallel/test-http-server-capture-rejections.js
@@ -25,7 +25,7 @@ events.captureRejections = true;
 
     req.on('response', common.mustCall((res) => {
       assert.strictEqual(res.statusCode, 500);
-      assert.strictEqual(res.headers.hasOwnProperty('content-type'), false);
+      assert.strictEqual(Object.prototype.hasOwnProperty.call(res.headers, 'content-type'), false);
       let data = '';
       res.setEncoding('utf8');
       res.on('data', common.mustCall((chunk) => {

--- a/test/parallel/test-http-upgrade-agent.js
+++ b/test/parallel/test-http-upgrade-agent.js
@@ -71,10 +71,11 @@ server.listen(0, '127.0.0.1', common.mustCall(function() {
       assert.strictEqual(recvData.toString(), 'nurtzo');
     }));
 
-    console.log(res.headers);
-    const expectedHeaders = { 'hello': 'world',
-                              'connection': 'upgrade',
-                              'upgrade': 'websocket' };
+    const expectedHeaders = Object.assign(Object.create(null), {
+      'hello': 'world',
+      'connection': 'upgrade',
+      'upgrade': 'websocket'
+    });
     assert.deepStrictEqual(expectedHeaders, res.headers);
 
     // Make sure this request got removed from the pool.

--- a/test/parallel/test-http-upgrade-client.js
+++ b/test/parallel/test-http-upgrade-client.js
@@ -82,12 +82,11 @@ server.listen(0, common.mustCall(function() {
         assert.strictEqual(recvData.toString(), expectedRecvData);
       }));
 
-      console.log(res.headers);
-      const expectedHeaders = {
+      const expectedHeaders = Object.assign(Object.create(null), {
         hello: 'world',
         connection: 'upgrade',
         upgrade: 'websocket'
-      };
+      });
       assert.deepStrictEqual(res.headers, expectedHeaders);
       socket.end();
       countdown.dec();


### PR DESCRIPTION
Creating .headers and .trailers without a prototype by
using Object.create(null) improves the security of Node.js applications
making them less vulnerable to potential prototype pollution attacks.

This will improve the performance.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
