### PR TITLE
doc: Remove ESLint disable comments which were breaking the CJS/ESM code block toggles

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -958,7 +958,6 @@ function. See [`assert.throws()`][] for more details.
 Besides the async nature to await the completion behaves identically to
 [`assert.doesNotThrow()`][].
 
-<!-- eslint-disable no-restricted-syntax -->
 ```mjs
 import assert from 'assert/strict';
 
@@ -983,7 +982,6 @@ const assert = require('assert/strict');
 })();
 ```
 
-<!-- eslint-disable no-restricted-syntax -->
 ```mjs
 import assert from 'assert/strict';
 
@@ -993,7 +991,6 @@ assert.doesNotReject(Promise.reject(new TypeError('Wrong value')))
   });
 ```
 
-<!-- eslint-disable no-restricted-syntax -->
 ```cjs
 const assert = require('assert/strict');
 
@@ -1042,7 +1039,6 @@ function. See [`assert.throws()`][] for more details.
 The following, for instance, will throw the [`TypeError`][] because there is no
 matching error type in the assertion:
 
-<!-- eslint-disable no-restricted-syntax -->
 ```mjs
 import assert from 'assert/strict';
 
@@ -1054,7 +1050,6 @@ assert.doesNotThrow(
 );
 ```
 
-<!-- eslint-disable no-restricted-syntax -->
 ```cjs
 const assert = require('assert/strict');
 
@@ -1069,7 +1064,6 @@ assert.doesNotThrow(
 However, the following will result in an [`AssertionError`][] with the message
 'Got unwanted exception...':
 
-<!-- eslint-disable no-restricted-syntax -->
 ```mjs
 import assert from 'assert/strict';
 
@@ -1081,7 +1075,6 @@ assert.doesNotThrow(
 );
 ```
 
-<!-- eslint-disable no-restricted-syntax -->
 ```cjs
 const assert = require('assert/strict');
 
@@ -1097,7 +1090,6 @@ If an [`AssertionError`][] is thrown and a value is provided for the `message`
 parameter, the value of `message` will be appended to the [`AssertionError`][]
 message:
 
-<!-- eslint-disable no-restricted-syntax -->
 ```mjs
 import assert from 'assert/strict';
 
@@ -1111,7 +1103,6 @@ assert.doesNotThrow(
 // Throws: AssertionError: Got unwanted exception: Whoops
 ```
 
-<!-- eslint-disable no-restricted-syntax -->
 ```cjs
 const assert = require('assert/strict');
 
@@ -2346,7 +2337,6 @@ message as the thrown error message is going to result in an
 `ERR_AMBIGUOUS_ARGUMENT` error. Please read the example below carefully if using
 a string as the second argument gets considered:
 
-<!-- eslint-disable no-restricted-syntax -->
 ```mjs
 import assert from 'assert/strict';
 
@@ -2383,7 +2373,6 @@ assert.throws(throwingFirst, /Second$/);
 // AssertionError [ERR_ASSERTION]
 ```
 
-<!-- eslint-disable no-restricted-syntax -->
 ```cjs
 const assert = require('assert/strict');
 


### PR DESCRIPTION
Some of the code blocks for the assert docs were not properly showing the CJS/ESM toggle which was due to some unnecessary ESLint disable comments.  Removing these comments fixed the issue so the code blocks once again work as expected.

See the current docs for an example of the currently broken behavior: https://nodejs.org/docs/latest-v16.x/api/assert.html#assert_assert_doesnotreject_asyncfn_error_message