### PR TITLE
benchmark: increase crypto DSA keygen params

### DIFF
--- a/benchmark/crypto/keygen.js
+++ b/benchmark/crypto/keygen.js
@@ -43,8 +43,8 @@ const methods = {
     bench.start();
     for (let i = 0; i < n; ++i) {
       generateKeyPairSync('dsa', {
-        modulusLength: 512,
-        divisorLength: 256,
+        modulusLength: 1024,
+        divisorLength: 160,
       });
     }
     bench.end(n);
@@ -60,8 +60,8 @@ const methods = {
     bench.start();
     for (let i = 0; i < n; ++i)
       generateKeyPair('dsa', {
-        modulusLength: 512,
-        divisorLength: 256,
+        modulusLength: 1024,
+        divisorLength: 160,
       }, done);
   },
 };


### PR DESCRIPTION
OpenSSL 3.0 increased the minimum values for these parameters.

Fixes: https://github.com/nodejs/node/issues/40410

