### PR TITLE
build: v8 pointer compression is 64bit arch only

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -103,6 +103,11 @@
         'obj_dir%': '<(PRODUCT_DIR)/obj.target',
         'v8_base': '<(PRODUCT_DIR)/libv8_snapshot.a',
       }],
+      # V8 pointer compression only supports 64bit architectures.
+      ['target_arch in "arm ia32 mips mipsel ppc x32"', {
+        'v8_enable_pointer_compression': 0,
+        'v8_enable_31bit_smis_on_64bit_arch': 0,
+      }],
       ['target_arch in "ppc64 s390x"', {
         'v8_enable_backtrace': 1,
       }],


### PR DESCRIPTION
The V8 pointer compression only works for 64bit arches, and the `v8_enable_pointer_compression` should be forced off when not building for them.

#### Why this is needed

Node.js only provides one headers tarball, and the same `common.gypi` and `config.gypi` file are used for building all architectures.

So for Node.js distributions that have `v8_enable_pointer_compression=1`, their headers tarball will set `v8_enable_pointer_compression=1` in the `config.gypi` file, and building x86 native modules for those binaries will fail because `v8_enable_pointer_compression=1` can not work for 32bit architectures.

The official Node.js distribution will also have this problem if it turned on V8 pointer compression in future.

Force turning off `v8_enable_pointer_compression` for non-64bit targets can fix it.