### PR TITLE
lib,test,doc: add option to highlight outputs of `warn` and `error` methods

### DIFF
--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -127,6 +127,19 @@ changes:
     [`util.inspect()`][].
   * `groupIndentation` {number} Set group indentation.
     **Default:** `2`.
+  * `highlight` {Object} With this option you can highlight outputs of
+    [`console.warn()`][] and [`console.error()`][]. It's not enabled by default,
+    and only affects when coloring is enabled.
+    * `warn` {Object} Highlight options for [`console.warn()`][].
+      * `bgColor` {string} Background color used for highlighting, must be
+        one of the [`background colors`][] if not omitted.
+      * `indicator` {string} Optional leading string indicates if the output
+        is from [`console.warn()`][].
+    * `error` {Object} Highlight options for [`console.error()`][].
+      * `bgColor` {string} Background color used for highlighting, must be
+        one of the [`background colors`][] if not omitted.
+      * `indicator` {string} Optional leading string indicates if the output
+        is from [`console.error()`][].
 
 Creates a new `Console` with one or two writable stream instances. `stdout` is a
 writable stream to print log or info output. `stderr` is used for warning or
@@ -148,6 +161,25 @@ The global `console` is a special `Console` whose output is sent to
 
 ```js
 new Console({ stdout: process.stdout, stderr: process.stderr });
+```
+
+You can create your own `Console` with highlighting:
+
+```js
+const logger = new Console({
+  stdout: process.stdout,
+  stderr: process.stderr,
+  highlight: {
+    warn: { bgColor: 'bgYellowBright' },
+    error: { bgColor: 'bgRedBright', indicator: '\u274c' },
+  }
+});
+
+logger.warn('Warning!');
+// Will output message 'Warning!' along with bright yellow background.
+logger.error(new Error('Oops!'));
+// Will output message 'Oops!' along with bright red background,
+// and a unicode cross sign in front of the message indicating it is an error.
 ```
 
 ### `console.assert(value[, ...message])`
@@ -589,6 +621,7 @@ This method does not display anything unless used in the inspector. The
 `console.timeStamp()` method adds an event with the label `'label'` to the
 **Timeline** panel of the inspector.
 
+[`background colors`]: util.md#background-colors
 [`console.error()`]: #consoleerrordata-args
 [`console.group()`]: #consolegrouplabel
 [`console.log()`]: #consolelogdata-args
@@ -596,6 +629,7 @@ This method does not display anything unless used in the inspector. The
 [`console.profileEnd()`]: #consoleprofileendlabel
 [`console.time()`]: #consoletimelabel
 [`console.timeEnd()`]: #consoletimeendlabel
+[`console.warn()`]: #consolewarndata-args
 [`process.stderr`]: process.md#processstderr
 [`process.stdout`]: process.md#processstdout
 [`util.format()`]: util.md#utilformatformat-args

--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -51,6 +51,8 @@ const {
   validateArray,
   validateInteger,
   validateObject,
+  validateOneOf,
+  validateString,
 } = require('internal/validators');
 const { previewEntries } = internalBinding('util');
 const { Buffer: { isBuffer } } = require('buffer');
@@ -117,7 +119,8 @@ function Console(options /* or: stdout, stderr, ignoreErrors = true */) {
     stderr = stdout,
     ignoreErrors = true,
     colorMode = 'auto',
-    inspectOptions,
+    highlight,
+    inspectOptions = {},
     groupIndentation,
   } = options;
 
@@ -145,6 +148,33 @@ function Console(options /* or: stdout, stderr, ignoreErrors = true */) {
         'options.inspectOptions.color', 'colorMode');
     }
     optionsMap.set(this, inspectOptions);
+  }
+
+  // Now passing highlight object into console constructor,
+  // we can stylize 'warn' and 'error' output.
+  if (highlight !== undefined) {
+    validateObject(highlight, 'highlight');
+    const bgColors = ObjectKeys(inspect.colors)
+          .filter((k) => k.indexOf('bg') === 0);
+    if (highlight.warn !== undefined) {
+      validateObject(highlight.warn, 'highlight.warn');
+      if (highlight.warn.bgColor !== undefined) {
+        const bgColor = highlight.warn.bgColor;
+        validateOneOf(bgColor, 'highlight.warn.bgColor', bgColors);
+      }
+      if (highlight.warn.indicator !== undefined)
+        validateString(highlight.warn.indicator, 'highlight.warn.indicator');
+    }
+    if (highlight.error !== undefined) {
+      validateObject(highlight.error, 'highlight.error');
+      if (highlight.error.bgColor !== undefined) {
+        const bgColor = highlight.error.bgColor;
+        validateOneOf(bgColor, 'highlight.error.bgColor', bgColors);
+      }
+      if (highlight.error.indicator !== undefined)
+        validateString(highlight.error.indicator, 'highlight.error.indicator');
+    }
+    inspectOptions.highlight = highlight;
   }
 
   // Bind the prototype functions to this Console instance
@@ -255,7 +285,7 @@ ObjectDefineProperties(Console.prototype, {
   },
   [kWriteToConsole]: {
     ...consolePropAttributes,
-    value: function(streamSymbol, string) {
+    value: function(streamSymbol, string, opts = {}) {
       const ignoreErrors = this._ignoreErrors;
       const groupIndent = this[kGroupIndent];
 
@@ -270,6 +300,31 @@ ObjectDefineProperties(Console.prototype, {
         }
         string = groupIndent + string;
       }
+
+      // Highlight output with background color and indicator
+      const inspectOptions = this[kGetInspectOptions](stream);
+      if (typeof inspectOptions.highlight === 'object' &&
+          inspectOptions.highlight !== null &&
+          typeof opts === 'object' &&
+          opts !== null &&
+          typeof opts.style === 'string') {
+        const style = inspectOptions.highlight[opts.style];
+        if (style !== undefined) {
+          const indicator = style.indicator ? style.indicator + ' ' : '';
+          string = `${indicator}${string}`;
+          if (inspectOptions.colors && style.bgColor !== undefined) {
+            const colors = inspect.colors[style.bgColor];
+            if (colors !== undefined) {
+              string = StringPrototypeReplace(string, /\n/g, '\u001b[K\n');
+              if (string.slice(-1) !== '\n') {
+                string += '\u001b[K';
+              }
+              string = `\u001b[${colors[0]}m${string}\u001b[${colors[1]}m`;
+            }
+          }
+        }
+      }
+
       string += '\n';
 
       if (ignoreErrors === false) return stream.write(string);
@@ -362,9 +417,16 @@ const consoleMethods = {
 
 
   warn(...args) {
-    this[kWriteToConsole](kUseStderr, this[kFormatForStderr](args));
+    this[kWriteToConsole](kUseStderr,
+                          this[kFormatForStderr](args),
+                          { style: 'warn' });
   },
 
+  error(...args) {
+    this[kWriteToConsole](kUseStderr,
+                          this[kFormatForStderr](args),
+                          { style: 'error' });
+  },
 
   dir(object, options) {
     this[kWriteToConsole](kUseStdout, inspect(object, {
@@ -666,7 +728,6 @@ for (const method of ReflectOwnKeys(consoleMethods))
 Console.prototype.debug = Console.prototype.log;
 Console.prototype.info = Console.prototype.log;
 Console.prototype.dirxml = Console.prototype.log;
-Console.prototype.error = Console.prototype.warn;
 Console.prototype.groupCollapsed = Console.prototype.group;
 
 module.exports = {

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -764,6 +764,7 @@ const errorTests = [
       'Object [console] {',
       '  log: [Function: log],',
       '  warn: [Function: warn],',
+      '  error: [Function: error],',
       '  dir: [Function: dir],',
       '  time: [Function: time],',
       '  timeEnd: [Function: timeEnd],',
@@ -779,7 +780,6 @@ const errorTests = [
       / {2}debug: \[Function: (debug|log)],/,
       / {2}info: \[Function: (info|log)],/,
       / {2}dirxml: \[Function: (dirxml|log)],/,
-      / {2}error: \[Function: (error|warn)],/,
       / {2}groupCollapsed: \[Function: (groupCollapsed|group)],/,
       / {2}Console: \[Function: Console],?/,
       ...process.features.inspector ? [

--- a/test/pseudo-tty/test-console-highlighting-color.js
+++ b/test/pseudo-tty/test-console-highlighting-color.js
@@ -1,0 +1,53 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const { Console } = require('console');
+
+// Work with 16 colors
+process.env.FORCE_COLOR = 1;
+delete process.env.NODE_DISABLE_COLORS;
+delete process.env.NO_COLOR;
+
+// Arguments validations
+const invalidTypeError = {
+  code: 'ERR_INVALID_ARG_TYPE',
+  name: 'TypeError',
+  message: /must be of type/,
+};
+const mustBeOneOfError = {
+  code: 'ERR_INVALID_ARG_VALUE',
+  name: 'TypeError',
+  message: /must be one of/,
+};
+const options = {
+  stdout: process.stdout,
+  stderr: process.stderr,
+  ignoreErrors: true,
+};
+
+options.highlight = { warn: 'abc' };
+assert.throws(() => { new Console(options); }, invalidTypeError);
+
+options.highlight = { warn: { bgColor: 'abc' } };
+assert.throws(() => { new Console(options); }, mustBeOneOfError);
+
+options.highlight = { warn: { indicator: null } };
+assert.throws(() => { new Console(options); }, invalidTypeError);
+
+options.highlight = { error: 'abc' };
+assert.throws(() => { new Console(options); }, invalidTypeError);
+
+options.highlight = { error: { bgColor: 'abc' } };
+assert.throws(() => { new Console(options); }, mustBeOneOfError);
+
+options.highlight = { error: { indicator: null } };
+assert.throws(() => { new Console(options); }, invalidTypeError);
+
+options.highlight = {
+  warn: { bgColor: 'bgYellow', indicator: '[W]' },
+  error: { bgColor: 'bgRed', indicator: '[E]' },
+};
+
+const newInstance = new Console(options);
+newInstance.warn(new Error('test'));
+newInstance.error(new Error('test'));

--- a/test/pseudo-tty/test-console-highlighting-color.out
+++ b/test/pseudo-tty/test-console-highlighting-color.out
@@ -1,0 +1,17 @@
+*[43m[W] Error: test*[K
+    at * (*test-console-highlighting-color.js:*)*[K
+*    at *[K
+*    at *[K
+*    at *[K
+*    at *[K
+*    at *[K
+*    at *[K*[49m
+
+*[41m[E] Error: test*[K
+    at * (*test-console-highlighting-color.js:*)*[K
+*    at *[K
+*    at *[K
+*    at *[K
+*    at *[K
+*    at *[K
+*    at *[K*[49m

--- a/test/pseudo-tty/test-console-highlighting-no-color.js
+++ b/test/pseudo-tty/test-console-highlighting-no-color.js
@@ -1,0 +1,22 @@
+'use strict';
+require('../common');
+const { Console } = require('console');
+
+// Work with no color
+process.env.NODE_DISABLE_COLORS = true;
+process.env.FORCE_COLOR = 0;
+
+const options = {
+  stdout: process.stdout,
+  stderr: process.stderr,
+  ignoreErrors: true,
+  highlight: {
+    // Indicators should always work even if no coloring enabled
+    warn: { bgColor: 'bgYellow', indicator: '[W]' },
+    error: { bgColor: 'bgRed', indicator: '[E]' },
+  }
+};
+
+const newInstance = new Console(options);
+newInstance.warn(new Error('test'));
+newInstance.error(new Error('test'));

--- a/test/pseudo-tty/test-console-highlighting-no-color.out
+++ b/test/pseudo-tty/test-console-highlighting-no-color.out
@@ -1,0 +1,17 @@
+[W] Error: test
+    at * (*test-console-highlighting-no-color.js:*)
+*    at *
+*    at *
+*    at *
+*    at *
+*    at *
+*    at *
+
+[E] Error: test
+    at * (*test-console-highlighting-no-color.js:*)
+*    at *
+*    at *
+*    at *
+*    at *
+*    at *
+*    at *


### PR DESCRIPTION
### What changed

1. Add color style types for `console.error` and `console.warn`.
2. Colorize output from `console.error` and `console.warn`.
3. Update related tests.

Fix #40361 

Screenshot:
![image](https://user-images.githubusercontent.com/69779107/136910150-0389b66b-7e6d-4c5e-85a8-044df9b33330.png)
