### PR TITLE
meta: consolidate AUTHORS entries for evantorrie

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -132,6 +132,7 @@ EungJun Yi <semtlenori@gmail.com>
 Evan Larkin <evan.larkin.il.com> <evan.larkin.iit@gmail.com>
 Evan Lucas <evanlucas@me.com> <evan.lucas@help.com>
 Evan Lucas <evanlucas@me.com> <evan@btc.com>
+Evan Torrie <evan.torrie@yahoo.com> <evant@yahoo-inc.com>
 FangDun Cai <cfddream@gmail.com>
 Fangshi He <hefangshi@gmail.com>
 Farid Neshat <FaridN_SOAD@yahoo.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1332,7 +1332,6 @@ Benedikt Meurer <bmeurer@google.com>
 Kai Cataldo <kaicataldo@gmail.com>
 Victor Felder <victor@draft.li>
 Yann Pringault <yann@cinq-s.com>
-Evan Torrie <evant@yahoo-inc.com>
 Michael Lefkowitz <lefkowitz.michael@gmail.com>
 Viktor Karpov <viktor.s.karpov@gmail.com>
 Lukasz Gasior <lukasz@gasior.net.pl>


### PR DESCRIPTION
Add a .mailmap entry for evantorrie to consolidate their two AUTHORS
entries into one.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
