### PR TITLE
doc: clarify behavior of napi_extended_error_info

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -980,7 +980,7 @@ about the last error that occurred.
 The content of the `napi_extended_error_info` returned is only valid up until
 a Node-API function is called on the same `env`. This includes a call to
 `napi_is_exception_pending` so it may often be necessary to make a copy
-of the information so that it can be used later. Note that the pointer returned
+of the information so that it can be used later. The pointer returned
 in error_message points to a statically defined string so it is safe to use
 that pointer if you have copied it out of the error_message field (which will
 be overwritten) before another Node-API function was called.


### PR DESCRIPTION
Fix up example and make it more explicit on how
you need to use napi_extended_error_info in order to
help people avoid what might be a common mistake that
we made in node-addon-api.

Refs: https://github.com/nodejs/node-addon-api/issues/1089

Signed-off-by: Michael Dawson <mdawson@devrus.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
