### PR TITLE
doc: add updating expected assets to release guide

### DIFF
--- a/doc/guides/releases.md
+++ b/doc/guides/releases.md
@@ -905,7 +905,7 @@ judgment there.
 The promotion script does a basic check that the expected files are present.
 Open a pull request in the Build repository to add the list of expected files
 for the new release line as a new file, `v{N}.x` (where `{N}` is the major
-version of the release), in the [expected assets][] folder. The change will 
+version of the release), in the [expected assets][] folder. The change will
 need to be deployed onto the web server by a member of the [build-infra team][]
 before the release is promoted.
 


### PR DESCRIPTION
Add a section to the Major Releases section of the release guide
to cover updating the list of expected files for the promotion tool.

cc @nodejs/releasers 

FWIW I've opened the corresponding PR for Node.js 17: https://github.com/nodejs/build/pull/2793

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
