### PR TITLE
test: add semicolon after chunk size

### DIFF
--- a/test/parallel/test-http-chunked-smuggling.js
+++ b/test/parallel/test-http-chunked-smuggling.js
@@ -23,7 +23,7 @@ function start() {
     'Host: localhost:8080\r\n' +
     'Transfer-Encoding: chunked\r\n' +
     '\r\n' +
-    '2 \n' +
+    '2;\n' +
     'xx\r\n' +
     '4c\r\n' +
     '0\r\n' +


### PR DESCRIPTION
The ABNF for chunk extensions as per RFC 7230 is

    chunk-ext      = *( ";" chunk-ext-name [ "=" chunk-ext-val ] )

    chunk-ext-name = token
    chunk-ext-val  = token / quoted-string

Add a semicolon after the chunk size for clarity.

This does not invalidate the test as it verifies that the HTTP parser
does not ignore chunk extensions.

Refs: https://grenfeldt.dev/2021/10/08/gunicorn-20.1.0-public-disclosure-of-request-smuggling

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
