### PR TITLE
src: add kNoBrowserGlobals flag for Environment

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -703,7 +703,8 @@ parser.add_argument('--no-browser-globals',
     dest='no_browser_globals',
     default=None,
     help='do not export browser globals like setTimeout, console, etc. ' +
-         '(This mode is not officially supported for regular applications)')
+         '(This mode is deprecated and not officially supported for regular ' +
+         'applications)')
 
 parser.add_argument('--without-inspector',
     action='store_true',

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -52,7 +52,7 @@ const {
   globalThis,
 } = primordials;
 const config = internalBinding('config');
-const { deprecate, lazyDOMExceptionClass } = require('internal/util');
+const { deprecate } = require('internal/util');
 
 setupProcessObject();
 
@@ -184,82 +184,7 @@ if (credentials.implementsPosixCredentials) {
 const { nativeHooks } = require('internal/async_hooks');
 internalBinding('async_wrap').setupHooks(nativeHooks);
 
-const {
-  setupTaskQueue,
-  queueMicrotask
-} = require('internal/process/task_queues');
-
-if (!config.noBrowserGlobals) {
-  // Override global console from the one provided by the VM
-  // to the one implemented by Node.js
-  // https://console.spec.whatwg.org/#console-namespace
-  exposeNamespace(globalThis, 'console',
-                  createGlobalConsole(globalThis.console));
-
-  const { URL, URLSearchParams } = require('internal/url');
-  // https://url.spec.whatwg.org/#url
-  exposeInterface(globalThis, 'URL', URL);
-  // https://url.spec.whatwg.org/#urlsearchparams
-  exposeInterface(globalThis, 'URLSearchParams', URLSearchParams);
-  exposeGetterAndSetter(globalThis,
-                        'DOMException',
-                        lazyDOMExceptionClass,
-                        (value) => {
-                          exposeInterface(globalThis, 'DOMException', value);
-                        });
-
-  const {
-    TextEncoder, TextDecoder
-  } = require('internal/encoding');
-  // https://encoding.spec.whatwg.org/#textencoder
-  exposeInterface(globalThis, 'TextEncoder', TextEncoder);
-  // https://encoding.spec.whatwg.org/#textdecoder
-  exposeInterface(globalThis, 'TextDecoder', TextDecoder);
-
-  const {
-    AbortController,
-    AbortSignal,
-  } = require('internal/abort_controller');
-  exposeInterface(globalThis, 'AbortController', AbortController);
-  exposeInterface(globalThis, 'AbortSignal', AbortSignal);
-
-  const {
-    EventTarget,
-    Event,
-  } = require('internal/event_target');
-  exposeInterface(globalThis, 'EventTarget', EventTarget);
-  exposeInterface(globalThis, 'Event', Event);
-  const {
-    MessageChannel,
-    MessagePort,
-    MessageEvent,
-  } = require('internal/worker/io');
-  exposeInterface(globalThis, 'MessageChannel', MessageChannel);
-  exposeInterface(globalThis, 'MessagePort', MessagePort);
-  exposeInterface(globalThis, 'MessageEvent', MessageEvent);
-
-  // https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope
-  const timers = require('timers');
-  defineOperation(globalThis, 'clearInterval', timers.clearInterval);
-  defineOperation(globalThis, 'clearTimeout', timers.clearTimeout);
-  defineOperation(globalThis, 'setInterval', timers.setInterval);
-  defineOperation(globalThis, 'setTimeout', timers.setTimeout);
-
-  defineOperation(globalThis, 'queueMicrotask', queueMicrotask);
-
-  // https://www.w3.org/TR/hr-time-2/#the-performance-attribute
-  defineReplacableAttribute(globalThis, 'performance',
-                            require('perf_hooks').performance);
-
-  // Non-standard extensions:
-  defineOperation(globalThis, 'clearImmediate', timers.clearImmediate);
-  defineOperation(globalThis, 'setImmediate', timers.setImmediate);
-
-  const {
-    structuredClone,
-  } = require('internal/structured_clone');
-  defineOperation(globalThis, 'structuredClone', structuredClone);
-}
+const { setupTaskQueue } = require('internal/process/task_queues');
 
 // Set the per-Environment callback that will be called
 // when the TrackingTraceStateObserver updates trace state.
@@ -454,71 +379,5 @@ function setupBuffer() {
       writable: true,
       configurable: true,
     },
-  });
-}
-
-function createGlobalConsole(consoleFromVM) {
-  const consoleFromNode =
-    require('internal/console/global');
-  if (config.hasInspector) {
-    const inspector = require('internal/util/inspector');
-    // This will be exposed by `require('inspector').console` later.
-    inspector.consoleFromVM = consoleFromVM;
-    // TODO(joyeecheung): postpone this until the first time inspector
-    // is activated.
-    inspector.wrapConsole(consoleFromNode, consoleFromVM);
-    const { setConsoleExtensionInstaller } = internalBinding('inspector');
-    // Setup inspector command line API.
-    setConsoleExtensionInstaller(inspector.installConsoleExtensions);
-  }
-  return consoleFromNode;
-}
-
-// https://heycam.github.io/webidl/#es-namespaces
-function exposeNamespace(target, name, namespaceObject) {
-  ObjectDefineProperty(target, name, {
-    writable: true,
-    enumerable: false,
-    configurable: true,
-    value: namespaceObject
-  });
-}
-
-// https://heycam.github.io/webidl/#es-interfaces
-function exposeInterface(target, name, interfaceObject) {
-  ObjectDefineProperty(target, name, {
-    writable: true,
-    enumerable: false,
-    configurable: true,
-    value: interfaceObject
-  });
-}
-
-function exposeGetterAndSetter(target, name, getter, setter = undefined) {
-  ObjectDefineProperty(target, name, {
-    enumerable: false,
-    configurable: true,
-    get: getter,
-    set: setter,
-  });
-}
-
-// https://heycam.github.io/webidl/#define-the-operations
-function defineOperation(target, name, method) {
-  ObjectDefineProperty(target, name, {
-    writable: true,
-    enumerable: true,
-    configurable: true,
-    value: method
-  });
-}
-
-// https://heycam.github.io/webidl/#Replaceable
-function defineReplacableAttribute(target, name, value) {
-  ObjectDefineProperty(target, name, {
-    writable: true,
-    enumerable: true,
-    configurable: true,
-    value,
   });
 }

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -17,12 +17,17 @@ const { reconnectZeroFillToggle } = require('internal/buffer');
 
 const { Buffer } = require('buffer');
 const { ERR_MANIFEST_ASSERT_INTEGRITY } = require('internal/errors').codes;
+const { lazyDOMExceptionClass } = require('internal/util');
 const assert = require('internal/assert');
+const config = internalBinding('config');
 
 function prepareMainThreadExecution(expandArgv1 = false) {
   // TODO(joyeecheung): this is also necessary for workers when they deserialize
   // this toggle from the snapshot.
   reconnectZeroFillToggle();
+
+  // Create globals exposing browser interfaces.
+  createBrowserGlobals();
 
   // Patch the process object with legacy properties and normalizations
   patchProcessObject(expandArgv1);
@@ -76,6 +81,148 @@ function prepareMainThreadExecution(expandArgv1 = false) {
   assert(!CJSLoader.hasLoadedAnyUserCJSModule);
   loadPreloadModules();
   initializeFrozenIntrinsics();
+}
+
+function createBrowserGlobals() {
+  if (getEmbedderOptions().noBrowserGlobals)
+    return;
+
+  // Override global console from the one provided by the VM
+  // to the one implemented by Node.js
+  // https://console.spec.whatwg.org/#console-namespace
+  exposeNamespace(globalThis, 'console',
+                  createGlobalConsole(globalThis.console));
+
+  const { URL, URLSearchParams } = require('internal/url');
+  // https://url.spec.whatwg.org/#url
+  exposeInterface(globalThis, 'URL', URL);
+  // https://url.spec.whatwg.org/#urlsearchparams
+  exposeInterface(globalThis, 'URLSearchParams', URLSearchParams);
+  exposeGetterAndSetter(globalThis,
+                        'DOMException',
+                        lazyDOMExceptionClass,
+                        (value) => {
+                          exposeInterface(globalThis, 'DOMException', value);
+                        });
+
+  const {
+    TextEncoder, TextDecoder
+  } = require('internal/encoding');
+  // https://encoding.spec.whatwg.org/#textencoder
+  exposeInterface(globalThis, 'TextEncoder', TextEncoder);
+  // https://encoding.spec.whatwg.org/#textdecoder
+  exposeInterface(globalThis, 'TextDecoder', TextDecoder);
+
+  const {
+    AbortController,
+    AbortSignal,
+  } = require('internal/abort_controller');
+  exposeInterface(globalThis, 'AbortController', AbortController);
+  exposeInterface(globalThis, 'AbortSignal', AbortSignal);
+
+  const {
+    EventTarget,
+    Event,
+  } = require('internal/event_target');
+  exposeInterface(globalThis, 'EventTarget', EventTarget);
+  exposeInterface(globalThis, 'Event', Event);
+  const {
+    MessageChannel,
+    MessagePort,
+    MessageEvent,
+  } = require('internal/worker/io');
+  exposeInterface(globalThis, 'MessageChannel', MessageChannel);
+  exposeInterface(globalThis, 'MessagePort', MessagePort);
+  exposeInterface(globalThis, 'MessageEvent', MessageEvent);
+
+  // https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope
+  const timers = require('timers');
+  defineOperation(globalThis, 'clearInterval', timers.clearInterval);
+  defineOperation(globalThis, 'clearTimeout', timers.clearTimeout);
+  defineOperation(globalThis, 'setInterval', timers.setInterval);
+  defineOperation(globalThis, 'setTimeout', timers.setTimeout);
+
+  const { queueMicrotask } = require('internal/process/task_queues');
+  defineOperation(globalThis, 'queueMicrotask', queueMicrotask);
+
+  // https://www.w3.org/TR/hr-time-2/#the-performance-attribute
+  defineReplacableAttribute(globalThis, 'performance',
+                            require('perf_hooks').performance);
+
+  // Non-standard extensions:
+  defineOperation(globalThis, 'clearImmediate', timers.clearImmediate);
+  defineOperation(globalThis, 'setImmediate', timers.setImmediate);
+
+  const {
+    structuredClone,
+  } = require('internal/structured_clone');
+  defineOperation(globalThis, 'structuredClone', structuredClone);
+}
+
+function createGlobalConsole(consoleFromVM) {
+  const consoleFromNode =
+    require('internal/console/global');
+  if (config.hasInspector) {
+    const inspector = require('internal/util/inspector');
+    // This will be exposed by `require('inspector').console` later.
+    inspector.consoleFromVM = consoleFromVM;
+    // TODO(joyeecheung): postpone this until the first time inspector
+    // is activated.
+    inspector.wrapConsole(consoleFromNode, consoleFromVM);
+    const { setConsoleExtensionInstaller } = internalBinding('inspector');
+    // Setup inspector command line API.
+    setConsoleExtensionInstaller(inspector.installConsoleExtensions);
+  }
+  return consoleFromNode;
+}
+
+// https://heycam.github.io/webidl/#es-namespaces
+function exposeNamespace(target, name, namespaceObject) {
+  ObjectDefineProperty(target, name, {
+    writable: true,
+    enumerable: false,
+    configurable: true,
+    value: namespaceObject
+  });
+}
+
+// https://heycam.github.io/webidl/#es-interfaces
+function exposeInterface(target, name, interfaceObject) {
+  ObjectDefineProperty(target, name, {
+    writable: true,
+    enumerable: false,
+    configurable: true,
+    value: interfaceObject
+  });
+}
+
+function exposeGetterAndSetter(target, name, getter, setter = undefined) {
+  ObjectDefineProperty(target, name, {
+    enumerable: false,
+    configurable: true,
+    get: getter,
+    set: setter,
+  });
+}
+
+// https://heycam.github.io/webidl/#define-the-operations
+function defineOperation(target, name, method) {
+  ObjectDefineProperty(target, name, {
+    writable: true,
+    enumerable: true,
+    configurable: true,
+    value: method
+  });
+}
+
+// https://heycam.github.io/webidl/#Replaceable
+function defineReplacableAttribute(target, name, value) {
+  ObjectDefineProperty(target, name, {
+    writable: true,
+    enumerable: true,
+    configurable: true,
+    value,
+  });
 }
 
 function patchProcessObject(expandArgv1) {
@@ -286,7 +433,7 @@ function initializeDeprecations() {
   // Now that we use the config binding to carry this information, remove
   // it from the process. We may consider exposing it properly in
   // process.features.
-  const { noBrowserGlobals } = internalBinding('config');
+  const { noBrowserGlobals } = getEmbedderOptions();
   if (noBrowserGlobals) {
     ObjectDefineProperty(process, '_noBrowserGlobals', {
       writable: false,
@@ -485,6 +632,7 @@ function loadPreloadModules() {
 }
 
 module.exports = {
+  createBrowserGlobals,
   patchProcessObject,
   setupCoverageHooks,
   setupWarningHandler,

--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -13,6 +13,7 @@ const {
 } = primordials;
 
 const {
+  createBrowserGlobals,
   patchProcessObject,
   setupCoverageHooks,
   setupInspectorHooks,
@@ -62,6 +63,7 @@ let debug = require('internal/util/debuglog').debuglog('worker', (fn) => {
 
 const assert = require('internal/assert');
 
+createBrowserGlobals();
 patchProcessObject();
 setupInspectorHooks();
 setupDebugEnv();

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -892,6 +892,15 @@ inline bool Environment::no_global_search_paths() const {
          !options_->global_search_paths;
 }
 
+inline bool Environment::no_browser_globals() const {
+  // configure --no-browser-globals
+#ifdef NODE_NO_BROWSER_GLOBALS
+  return true;
+#else
+  return flags_ & EnvironmentFlags::kNoBrowserGlobals;
+#endif
+}
+
 bool Environment::filehandle_close_warning() const {
   return emit_filehandle_warning_;
 }

--- a/src/env.h
+++ b/src/env.h
@@ -1204,6 +1204,7 @@ class Environment : public MemoryRetainer {
   inline bool tracks_unmanaged_fds() const;
   inline bool hide_console_windows() const;
   inline bool no_global_search_paths() const;
+  inline bool no_browser_globals() const;
   inline uint64_t thread_id() const;
   inline worker::Worker* worker_context() const;
   Environment* worker_parent_env() const;

--- a/src/node.h
+++ b/src/node.h
@@ -439,7 +439,9 @@ enum Flags : uint64_t {
   // $HOME/.node_modules and $NODE_PATH. This is used by standalone apps that
   // do not expect to have their behaviors changed because of globally
   // installed modules.
-  kNoGlobalSearchPaths = 1 << 7
+  kNoGlobalSearchPaths = 1 << 7,
+  // Do not export browser globals like setTimeout, console, etc.
+  kNoBrowserGlobals = 1 << 8,
 };
 }  // namespace EnvironmentFlags
 

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -1082,6 +1082,11 @@ void GetEmbedderOptions(const FunctionCallbackInfo<Value>& args) {
            Boolean::New(isolate, env->no_global_search_paths()))
       .IsNothing()) return;
 
+  if (ret->Set(context,
+           FIXED_ONE_BYTE_STRING(env->isolate(), "noBrowserGlobals"),
+           Boolean::New(isolate, env->no_browser_globals()))
+      .IsNothing()) return;
+
   args.GetReturnValue().Set(ret);
 }
 


### PR DESCRIPTION
This is the runtime equivalent of the `configure --no-browser-globals` build flag.

A runtime flag is needed because embedders can have multiple modes that, Node.js may both run in a browser environment, and in an independent environment that has no browser globals. For example, Node.js script running in web page spawning a script with `child_process.fork`.

And since the creation of browser globals is now controlled by a dynamic flag, I'm moving the code to `pre_execution.js`.

/cc @nodejs/embedders @joyeecheung