### PR TITLE
stream: fix fromAsyncGen

### DIFF
--- a/lib/internal/streams/duplexify.js
+++ b/lib/internal/streams/duplexify.js
@@ -209,22 +209,28 @@ function fromAsyncGen(fn) {
   const signal = ac.signal;
   const value = fn(async function*() {
     while (true) {
-      const { chunk, done, cb } = await promise;
+      const _promise = promise;
+      promise = null;
+      const { chunk, done, cb } = await _promise;
       process.nextTick(cb);
       if (done) return;
       if (signal.aborted) throw new AbortError();
-      yield chunk;
       ({ promise, resolve } = createDeferredPromise());
+      yield chunk;
     }
   }(), { signal });
 
   return {
     value,
     write(chunk, encoding, cb) {
-      resolve({ chunk, done: false, cb });
+      const _resolve = resolve;
+      resolve = null;
+      _resolve({ chunk, done: false, cb });
     },
     final(cb) {
-      resolve({ done: true, cb });
+      const _resolve = resolve;
+      resolve = null;
+      _resolve({ done: true, cb });
     },
     destroy(err, cb) {
       ac.abort();


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/40497

The problem here is that the resolve does not get updated before yielding control back to the user, hence the user might call the wrong resolve and hang the pipeline.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
