### PR TITLE
doc: add info on project's usage of coverity

### DIFF
--- a/doc/guides/offboarding.md
+++ b/doc/guides/offboarding.md
@@ -12,3 +12,6 @@ emeritus or leaves the project.
     a team listing. For example, if someone is removed from @nodejs/build,
     they should also be removed from the Build WG README.md file in the
     <https://github.com/nodejs/build> repository.
+* Open an issue in the [build](https://github.com/nodejs/build) repository
+  titled `Remove Collaborator from Coverity` asking that the collaborator
+  be removed from the Node.js coverity project if they had access.

--- a/doc/guides/static-analysis.md
+++ b/doc/guides/static-analysis.md
@@ -1,0 +1,16 @@
+# Static Analysis
+
+The project uses Coverity to scan Node.js source code and to report potential
+issues in the C/C++ code base.
+
+Those who have been added to the Node.js coverity project can receive emails
+when there are new issues reported as well as view all current issues
+through [https://scan9.coverity.com/reports.htm](https://scan9.coverity.com/reports.htm).
+
+Any collaborator can ask to be added to the Node.js coverity project
+by opening an issue in the [build](https://github.com/nodejs/build) repository
+titled `Please add me to coverity`. A member of the build WG with admin
+access will verify that the requestor is an existing collaborator as listed in
+the [colloborators section](https://github.com/nodejs/node#collaborators)
+on the nodejs/node project repo. Once validated the requestor will added
+to to the coverity project.

--- a/onboarding.md
+++ b/onboarding.md
@@ -249,6 +249,8 @@ needs to be pointed out separately during the onboarding.
   project. The Foundation has travel funds to cover participants' expenses
   including accommodations, transportation, visa fees, etc. if needed. Check out
   the [summit](https://github.com/nodejs/summit) repository for details.
+* If you are interested in helping to fix coverity reports consider requesting
+  access to the projects coverity project as outlined in [static-analysis][].
 
 [Code of Conduct]: https://github.com/nodejs/admin/blob/HEAD/CODE_OF_CONDUCT.md
 [Labels]: doc/guides/collaborator-guide.md#labels
@@ -259,6 +261,7 @@ needs to be pointed out separately during the onboarding.
 [`git-node`]: https://github.com/nodejs/node-core-utils/blob/HEAD/docs/git-node.md
 [`node-core-utils`]: https://github.com/nodejs/node-core-utils
 [set up the credentials]: https://github.com/nodejs/node-core-utils#setting-up-github-credentials
+[static-analysis]: doc/guides/static-analysis.md
 [two-factor authentication]: https://help.github.com/articles/securing-your-account-with-two-factor-authentication-2fa/
 [using a TOTP mobile app]: https://help.github.com/articles/configuring-two-factor-authentication-via-a-totp-mobile-app/
 [who-to-cc]: doc/guides/collaborator-guide.md#who-to-cc-in-the-issue-tracker


### PR DESCRIPTION
Document project's used of coverity and how
collaborators can get access.

Signed-off-by: Michael Dawson <mdawson@devrus.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
