### PR TITLE
module: resolver & spec hardening /w refactoring

### DIFF
--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -10,6 +10,7 @@ const {
   ObjectGetOwnPropertyNames,
   ObjectPrototypeHasOwnProperty,
   RegExp,
+  RegExpPrototypeExec,
   RegExpPrototypeSymbolReplace,
   RegExpPrototypeTest,
   SafeMap,
@@ -360,9 +361,10 @@ const encodedSepRegEx = /%2F|%5C/i;
 /**
  * @param {URL} resolved
  * @param {string | URL | undefined} base
+ * @param {boolean} preserveSymlinks
  * @returns {URL | undefined}
  */
-function finalizeResolution(resolved, base) {
+function finalizeResolution(resolved, base, preserveSymlinks) {
   if (RegExpPrototypeTest(encodedSepRegEx, resolved.pathname))
     throw new ERR_INVALID_MODULE_SPECIFIER(
       resolved.pathname, 'must not include encoded "/" or "\\" characters',
@@ -391,6 +393,17 @@ function finalizeResolution(resolved, base) {
   } else if (!stats.isFile()) {
     throw new ERR_MODULE_NOT_FOUND(
       path || resolved.pathname, base && fileURLToPath(base), 'module');
+  }
+
+  if (!preserveSymlinks) {
+    const real = realpathSync(path, {
+      [internalFS.realpathCacheKey]: realpathCache
+    });
+    const { search, hash } = resolved;
+    resolved =
+        pathToFileURL(real + (StringPrototypeEndsWith(path, sep) ? '/' : ''));
+    resolved.search = search;
+    resolved.hash = hash;
   }
 
   return resolved;
@@ -444,7 +457,8 @@ function throwInvalidPackageTarget(
     internal, base && fileURLToPath(base));
 }
 
-const invalidSegmentRegEx = /(^|\\|\/)(\.\.?|node_modules)(\\|\/|$)/;
+const invalidSegmentRegEx = /(^|\\|\/)((\.|%2e)(\.|%2e)?|(n|%6e|%4e)(o|%6f|%4f)(d|%64|%44)(e|%65|%45)(_|%5f)(m|%6d|%4d)(o|%6f|%4f)(d|%64|%44)(u|%75|%55)(l|%6c|%4c)(e|%65|%45)(s|%73|%53))(\\|\/|$)/i;
+const invalidPackageNameRegEx = /^\.|%|\\/;
 const patternRegEx = /\*/g;
 
 function resolvePackageTargetString(
@@ -777,13 +791,9 @@ function parsePackageName(specifier, base) {
     specifier : StringPrototypeSlice(specifier, 0, separatorIndex);
 
   // Package name cannot have leading . and cannot have percent-encoding or
-  // separators.
-  for (let i = 0; i < packageName.length; i++) {
-    if (packageName[i] === '%' || packageName[i] === '\\') {
-      validPackageName = false;
-      break;
-    }
-  }
+  // \\ separators.
+  if (RegExpPrototypeExec(invalidPackageNameRegEx, packageName) !== null)
+    validPackageName = false;
 
   if (!validPackageName) {
     throw new ERR_INVALID_MODULE_SPECIFIER(
@@ -803,6 +813,9 @@ function parsePackageName(specifier, base) {
  * @returns {URL}
  */
 function packageResolve(specifier, base, conditions) {
+  if (NativeModule.canBeRequiredByUsers(specifier))
+    return new URL('node:' + specifier);
+
   const { packageName, packageSubpath, isScoped } =
     parsePackageName(specifier, base);
 
@@ -879,9 +892,10 @@ function shouldBeTreatedAsRelativeOrAbsolutePath(specifier) {
  * @param {string} specifier
  * @param {string | URL | undefined} base
  * @param {Set<string>} conditions
+ * @param {boolean} preserveSymlinks
  * @returns {URL}
  */
-function moduleResolve(specifier, base, conditions) {
+function moduleResolve(specifier, base, conditions, preserveSymlinks) {
   // Order swapped from spec for minor perf gain.
   // Ok since relative URLs cannot parse as URLs.
   let resolved;
@@ -896,7 +910,9 @@ function moduleResolve(specifier, base, conditions) {
       resolved = packageResolve(specifier, base, conditions);
     }
   }
-  return finalizeResolution(resolved, base);
+  if (resolved.protocol !== 'file:')
+    return resolved;
+  return finalizeResolution(resolved, base, preserveSymlinks);
 }
 
 /**
@@ -968,28 +984,6 @@ function defaultResolve(specifier, context = {}, defaultResolveUnused) {
       }
     }
   }
-  let parsed;
-  try {
-    parsed = new URL(specifier);
-    if (parsed.protocol === 'data:') {
-      return {
-        url: specifier
-      };
-    }
-  } catch {}
-  if (parsed && parsed.protocol === 'node:')
-    return { url: specifier };
-  if (parsed && parsed.protocol !== 'file:' && parsed.protocol !== 'data:')
-    throw new ERR_UNSUPPORTED_ESM_URL_SCHEME(parsed);
-  if (NativeModule.canBeRequiredByUsers(specifier)) {
-    return {
-      url: 'node:' + specifier
-    };
-  }
-  if (parentURL && StringPrototypeStartsWith(parentURL, 'data:')) {
-    // This is gonna blow up, we want the error
-    new URL(specifier, parentURL);
-  }
 
   const isMain = parentURL === undefined;
   if (isMain) {
@@ -1008,7 +1002,8 @@ function defaultResolve(specifier, context = {}, defaultResolveUnused) {
   conditions = getConditionsSet(conditions);
   let url;
   try {
-    url = moduleResolve(specifier, parentURL, conditions);
+    url = moduleResolve(specifier, parentURL, conditions,
+                        isMain ? preserveSymlinksMain : preserveSymlinks);
   } catch (error) {
     // Try to give the user a hint of what would have been the
     // resolved CommonJS module
@@ -1032,17 +1027,9 @@ function defaultResolve(specifier, context = {}, defaultResolveUnused) {
     throw error;
   }
 
-  if (isMain ? !preserveSymlinksMain : !preserveSymlinks) {
-    const urlPath = fileURLToPath(url);
-    const real = realpathSync(urlPath, {
-      [internalFS.realpathCacheKey]: realpathCache
-    });
-    const old = url;
-    url = pathToFileURL(
-      real + (StringPrototypeEndsWith(urlPath, sep) ? '/' : ''));
-    url.search = old.search;
-    url.hash = old.hash;
-  }
+  if (url.protocol !== 'file:' && url.protocol !== 'data:' &&
+      url.protocol !== 'node:')
+    throw new ERR_UNSUPPORTED_ESM_URL_SCHEME(url);
 
   return { url: `${url}` };
 }

--- a/test/es-module/test-esm-exports.mjs
+++ b/test/es-module/test-esm-exports.mjs
@@ -104,6 +104,10 @@ import fromInside from '../fixtures/node_modules/pkgexports/lib/hole.js';
     // Even though 'pkgexports/sub/asdf.js' works, alternate "path-like"
     // variants do not to prevent confusion and accidental loopholes.
     ['pkgexports/sub/./../asdf.js', './sub/./../asdf.js'],
+    // Cannot reach into node_modules, even percent encoded
+    ['pkgexports/sub/no%64e_modules', './sub/no%64e_modules'],
+    // Cannot backtrack below exposed path, even with percent encoded "."
+    ['pkgexports/sub/%2e./asdf', './asdf'],
   ]);
 
   for (const [specifier, subpath] of undefinedExports) {


### PR DESCRIPTION
This PR includes the following hardening / refactorings to the ESM resolver & specification:

* In package subpath segment filtering, we throw for `.`, `..` and `node_modules` segments in package exports or package exports pattern replacements. This error checking is now extended to be case-insensitive and also check for percent encodings of these segments in the spec and resolver. Previously `import 'pkg/.%2e/.%2e/outside.js'` would be a way to bypass the restriction of only being able to resolve exports within the package (note this is not a security issue, because this is a usability / encapsulation feature and not a security feature).
* The invalid package name check in the resolver was not detecting package names starting with `.` as invalid per the spec, that has been corrected with a regex check instead of a for loop.
* The main resolver spec is now extended to support all URL schemes, special casing the `file:` scheme. We then indicate that for non `file:` schemes the associated content type can be used without explicitly specifying the source. This effectively generalizes the resolver to specify the `data:` behaviours already implemented today and also paves the way in the resolver for other URL schemes in future. We don't currently specify the MIME types directly, although that could be done here as well.
* A spec bug is fixed where `stream/web` would not have been detected as a valid builtin name since it would fail the valid package name test. Moving the builtin check higher up in the spec fixes this.
* The resolver implementation is further refactored to line up with the same execution flow as the specification, refactoring enabled by the unified JS resolver that wasn't previously possible with the C++ separation. This reduces unnecessary extra URL parsing steps by sharing more logic while retaining identical behaviours.
* The `ESM_FORMAT` spec function is extended to support the `".json"` file type per the JSON assertions implementation work.