### PR TITLE
lib: do not override browser globals for embedders

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -703,7 +703,8 @@ parser.add_argument('--no-browser-globals',
     dest='no_browser_globals',
     default=None,
     help='do not export browser globals like setTimeout, console, etc. ' +
-         '(This mode is not officially supported for regular applications)')
+         '(This mode is deprecated and not officially supported for regular ' +
+         'applications)')
 
 parser.add_argument('--without-inspector',
     action='store_true',

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -189,7 +189,10 @@ const {
   queueMicrotask
 } = require('internal/process/task_queues');
 
-if (!config.noBrowserGlobals) {
+// When bootstrapping Node.js in browser environments, the browser globals
+// should not be overridden by Node.js. It is assumed that this script is
+// running inside browser if `setTimeout` is defined before bootstrapping.
+if (globalThis.setTimeout === undefined && !config.noBrowserGlobals) {
   // Override global console from the one provided by the VM
   // to the one implemented by Node.js
   // https://console.spec.whatwg.org/#console-namespace


### PR DESCRIPTION
For embedders, Node.js may both run in a browser environment, and in an independent environment that has no browser globals. For example, Node.js script running in web page spawning a script with `child_process.fork`. So we need a runtime switch to control whether Node.js should insert browser globals like `setTimeout`.

This PR archives it by simply checking if `setTimeout` is defined during bootstrapping. This has not affect to official Node.js, because `setTimeout` can't be defined in the bootstrap stage. This will not break Electron and NW.js since this is exactly the behavior they want, and they will have one less patch on Node.js. 

Another option would be providing a runtime flag to manually control whether browser globals should be created, but that will hurt the bootstrap performance of official Node.js, check https://github.com/nodejs/node/pull/40496#discussion_r731571170.

/cc @nodejs/embedders @joyeecheung