### PR TITLE
doc: adds note about weak reference

### DIFF
--- a/doc/api/diagnostics_channel.md
+++ b/doc/api/diagnostics_channel.md
@@ -77,6 +77,26 @@ if (channel.hasSubscribers) {
 }
 ```
 
+Note the channels are weakly held by the runtime. It is your responsibility to keep a reference to the channel to ensure your subscriber receives calls.
+
+For example, the channel may be deallocated, if the emitter does not publish any event before the next GC cycle.
+
+```cjs
+const diagnostics_channel = require('diagnostics_channel');
+
+function createSubscriber() {
+  // Get a reusable channel object
+  const channel = diagnostics_channel.channel('my-channel');
+
+  // Subscribe to the channel
+  channel.subscribe((message, name) => {
+    // Received data
+  });
+}
+
+createSubscriber();
+```
+
 #### `diagnostics_channel.hasSubscribers(name)`
 
 <!-- YAML


### PR DESCRIPTION
As the channels are weakly held, if the consumer does not keep a reference to the channel, it may be de-allocated before an emitter fires.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
