### PR TITLE
doc: fix environment variable settings for ccache

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -521,22 +521,18 @@ installing `ccache` can help to greatly reduce build times. Set up with:
 
 On GNU/Linux:
 
-```console
-$ sudo apt install ccache   # for Debian/Ubuntu, included in most Linux distros
-$ ccache -o cache_dir=<tmp_dir>
-$ ccache -o max_size=5.0G
-$ export CC="ccache gcc"    # add to your .profile
-$ export CXX="ccache g++"   # add to your .profile
+```bash
+sudo apt install ccache   # for Debian/Ubuntu, included in most Linux distros
+export CC="ccache gcc"    # add to your .profile
+export CXX="ccache g++"   # add to your .profile
 ```
 
 On macOS:
 
-```console
-$ brew install ccache      # see https://brew.sh
-$ ccache -o cache_dir=<tmp_dir>
-$ ccache -o max_size=5.0G
-$ export CC="ccache cc"    # add to ~/.zshrc or other shell config file
-$ export CXX="ccache c++"  # add to ~/.zshrc or other shell config file
+```bash
+brew install ccache      # see https://brew.sh
+export CC="ccache cc"    # add to ~/.zshrc or other shell config file
+export CXX="ccache c++"  # add to ~/.zshrc or other shell config file
 ```
 
 This will allow for near-instantaneous rebuilds even when switching branches.


### PR DESCRIPTION
macOS requires `cc` and `c++` rather than `gcc` and `g++`.

Closes: https://github.com/nodejs/node/issues/40542

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
