### PR TITLE
src: Reset error struct if error code is napi_ok

### DIFF
--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -761,12 +761,14 @@ napi_status napi_get_last_error_info(napi_env env,
       NAPI_ARRAYSIZE(error_messages) == last_status + 1,
       "Count of error messages must match count of error values");
   CHECK_LE(env->last_error.error_code, last_status);
-
   // Wait until someone requests the last error information to fetch the error
   // message string
   env->last_error.error_message =
       error_messages[env->last_error.error_code];
 
+  if (env->last_error.error_code == napi_ok) {
+     napi_clear_last_error(env);
+  }
   *result = &(env->last_error);
   return napi_ok;
 }

--- a/src/js_native_api_v8.h
+++ b/src/js_native_api_v8.h
@@ -159,6 +159,7 @@ static inline napi_status napi_clear_last_error(napi_env env) {
   // TODO(boingoing): Should this be a callback?
   env->last_error.engine_error_code = 0;
   env->last_error.engine_reserved = nullptr;
+  env->last_error.error_message = nullptr;
   return napi_ok;
 }
 

--- a/test/js-native-api/common.h
+++ b/test/js-native-api/common.h
@@ -8,12 +8,13 @@
     const napi_extended_error_info *error_info;                          \
     napi_get_last_error_info((env), &error_info);                        \
     bool is_pending;                                                     \
+    const char* err_message = error_info->error_message;                  \
     napi_is_exception_pending((env), &is_pending);                       \
     /* If an exception is already pending, don't rethrow it */           \
     if (!is_pending) {                                                   \
-      const char* error_message = error_info->error_message != NULL ?    \
-        error_info->error_message :                                      \
-        "empty error message";                                           \
+      const char* error_message = err_message != NULL ?                  \
+                       err_message :                                     \
+                      "empty error message";                             \
       napi_throw_error((env), NULL, error_message);                      \
     }                                                                    \
   } while (0)


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
Resetting `last_error` struct inside the env instance if the error code is `napi_ok` to make sure that the error code is consistent with any other meta data inside the struct. 
ref: https://github.com/nodejs/node-addon-api/issues/1089 