### PR TITLE
doc: improve async_context introduction

### DIFF
--- a/doc/api/async_context.md
+++ b/doc/api/async_context.md
@@ -1,4 +1,4 @@
-# Asynchronous Context Tracking
+# Asynchronous context tracking
 
 <!--introduced_in=v16.4.0-->
 
@@ -18,11 +18,11 @@ The `AsyncLocalStorage` and `AsyncResource` classes are part of the
 `async_hooks` module:
 
 ```mjs
-import async_hooks from 'async_hooks';
+import { AsyncLocalStorage, AsyncResource } from 'async_hooks';
 ```
 
 ```cjs
-const async_hooks = require('async_hooks');
+const { AsyncLocalStorage, AsyncResource } = require('async_hooks');
 ```
 
 ## Class: `AsyncLocalStorage`

--- a/doc/api/index.md
+++ b/doc/api/index.md
@@ -11,7 +11,7 @@
 <hr class="line"/>
 
 * [Assertion testing](assert.md)
-* [Async\_context](async\_context.md)
+* [Asynchronous context tracking](async\_context.md)
 * [Async hooks](async\_hooks.md)
 * [Buffer](buffer.md)
 * [C++ addons](addons.md)


### PR DESCRIPTION
- Rename "Async_context" to "Asynchronous context tracking" in toc.
- Use named imports to show how `AsyncLocalStorage` and `AsyncResource`
  can be imported.