### PR TITLE
[v14.x backport] doc: fix CJS-ESM selector in Safari

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -780,6 +780,7 @@ kbd {
 }
 
 .js-flavor-selector {
+  -webkit-appearance: none;
   appearance: none;
   float: right;
   background-image: url(./js-flavor-cjs.svg);


### PR DESCRIPTION
Backport of https://github.com/nodejs/node/pull/40135:

> Safari needs a vendor prefix on the appearance of the checkbox
>
> <img width="241" alt="Screen Shot 2021-09-17 at 09 05 22" src="https://user-images.githubusercontent.com/234659/133796529-924579e8-ead1-4755-8313-0627db49207e.png">

The original commit lands cleanly, I'm opening this to make sure this is backported, feel free to close this PR if it's not actually necessary.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
