### PR TITLE
policy: fix message for invalid manifest specifier

### DIFF
--- a/lib/internal/policy/manifest.js
+++ b/lib/internal/policy/manifest.js
@@ -136,9 +136,8 @@ class DependencyMapperInstance {
           if (!target) {
             throw new ERR_MANIFEST_INVALID_SPECIFIER(
               this.href,
-              target +
-                ', pattern needs to have a single' +
-                'trailing "*" in target');
+              `${target}, pattern needs to have a single trailing "*" in target`
+            );
           }
           const prefix = target[1];
           const suffix = target[2];

--- a/test/fixtures/policy-manifest/invalid.json
+++ b/test/fixtures/policy-manifest/invalid.json
@@ -1,0 +1,9 @@
+{
+  "resources": {
+    "./fhqwhgads.js": {
+      "dependencies": {
+          "**": true
+      }
+    }
+  }
+}

--- a/test/parallel/test-policy-manifest.js
+++ b/test/parallel/test-policy-manifest.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const common = require('../common');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+common.requireNoPackageJSONAbove();
+
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+const fixtures = require('../common/fixtures.js');
+
+const policyFilepath = fixtures.path('policy-manifest', 'invalid.json');
+
+const result = spawnSync(process.execPath, [
+  '--experimental-policy',
+  policyFilepath,
+  './fhqwhgads.js',
+]);
+
+assert.notStrictEqual(result.status, 0);
+const stderr = result.stderr.toString();
+assert.match(stderr, /ERR_MANIFEST_INVALID_SPECIFIER/);
+assert.match(stderr, /pattern needs to have a single trailing "\*"/);


### PR DESCRIPTION
Add test for invalid manifest specifier and fix the error message
which is missing a space ("singletrailing" instead of
"single trailing").

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
