### PR TITLE
tools: abort CQ session when landing several commits

### DIFF
--- a/doc/guides/commit-queue.md
+++ b/doc/guides/commit-queue.md
@@ -37,8 +37,8 @@ From a high-level, the Commit Queue works as follow:
       3. Close the PR
       4. Go to next PR in the queue
 
-To make the Commit Queue squash all the commits on a pull request in the first
-one, add the `commit-queue-squash` label.
+To make the Commit Queue squash all the commits of a pull request into the
+first one, add the `commit-queue-squash` label.
 To make the Commit Queue land a pull request containing several commits, add the
 `commit-queue-rebase` label. When using this option, make sure
 that all commits are self-contained, meaning every commit should pass all tests.

--- a/doc/guides/commit-queue.md
+++ b/doc/guides/commit-queue.md
@@ -38,9 +38,9 @@ From a high-level, the Commit Queue works as follow:
       4. Go to next PR in the queue
 
 To make the Commit Queue squash all the commits on a pull request in the first
-one, add the `commit-queue-fixupAll` label.
+one, add the `commit-queue-squash` label.
 To make the Commit Queue land a pull request containing several commits, add the
-`commit-queue-land-multiple-commits` label. When using this option, make sure
+`commit-queue-rebase` label. When using this option, make sure
 that all commits are self-contained, meaning every commit should pass all tests.
 
 ## Current limitations

--- a/doc/guides/commit-queue.md
+++ b/doc/guides/commit-queue.md
@@ -25,7 +25,7 @@ From a high-level, the Commit Queue works as follow:
    2. Check if the last Jenkins CI is finished running (if it is not, skip this
       PR)
    3. Remove the `commit-queue` label
-   4. Run `git node land <pr>`
+   4. Run `git node land <pr> --oneCommitMax`
    5. If it fails:
       1. Abort `git node land` session
       2. Add `commit-queue-failed` label to the PR
@@ -36,6 +36,12 @@ From a high-level, the Commit Queue works as follow:
       2. Leave a comment on the PR with `Landed in ...`
       3. Close the PR
       4. Go to next PR in the queue
+
+To make the Commit Queue squash all the commits on a pull request in the first
+one, add the `commit-queue-fixupAll` label.
+To make the Commit Queue land a pull request containing several commits, add the
+`commit-queue-land-multiple-commits` label. When using this option, make sure
+that all commits are self-contained, meaning every commit should pass all tests.
 
 ## Current limitations
 

--- a/tools/actions/commit-queue.sh
+++ b/tools/actions/commit-queue.sh
@@ -70,7 +70,15 @@ for pr in "$@"; do
   # Delete the commit queue label
   gitHubCurl "$(labelsUrl "$pr")"/"$COMMIT_QUEUE_LABEL" DELETE
 
-  git node land --autorebase --yes "$pr" >output 2>&1 || echo "Failed to land #${pr}"
+  if gitHubCurl "$(labelsUrl "$pr")" GET | jq -e 'map(.name) | index("commit-queue-fixupAll")'; then
+    MULTIPLE_COMMIT_POLICY="--fixupAll"
+  elif gitHubCurl "$(labelsUrl "$pr")" GET | jq -e 'map(.name) | index("commit-queue-land-multiple-commits")'; then
+    MULTIPLE_COMMIT_POLICY=""
+  else
+    MULTIPLE_COMMIT_POLICY="--oneCommitMax"
+  fi
+
+  git node land --autorebase --yes $MULTIPLE_COMMIT_POLICY "$pr" >output 2>&1 || echo "Failed to land #${pr}"
   # cat here otherwise we'll be supressing the output of git node land
   cat output
 

--- a/tools/actions/commit-queue.sh
+++ b/tools/actions/commit-queue.sh
@@ -70,9 +70,9 @@ for pr in "$@"; do
   # Delete the commit queue label
   gitHubCurl "$(labelsUrl "$pr")"/"$COMMIT_QUEUE_LABEL" DELETE
 
-  if gitHubCurl "$(labelsUrl "$pr")" GET | jq -e 'map(.name) | index("commit-queue-fixupAll")'; then
+  if gitHubCurl "$(labelsUrl "$pr")" GET | jq -e 'map(.name) | index("commit-queue-squash")'; then
     MULTIPLE_COMMIT_POLICY="--fixupAll"
-  elif gitHubCurl "$(labelsUrl "$pr")" GET | jq -e 'map(.name) | index("commit-queue-land-multiple-commits")'; then
+  elif gitHubCurl "$(labelsUrl "$pr")" GET | jq -e 'map(.name) | index("commit-queue-rebase")'; then
     MULTIPLE_COMMIT_POLICY=""
   else
     MULTIPLE_COMMIT_POLICY="--oneCommitMax"


### PR DESCRIPTION
Most PRs are meant to be squashed in one commit when landing. If the
collaborator hasn't been using `fixup!` commits, the CQ will land the PR
as several commits. This change makes the CQ abort by default
when attempting to land several commits, unless there's another
label added to the PR to force squashing or landing as several commits.

Fixes: https://github.com/nodejs/node/issues/40436
~Blocked on https://github.com/nodejs/node-core-utils/pull/572~

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
