### PR TITLE
feat: add process.env.NODE_TLS_WARN_ON_UNAUTHORIZED to silence https warning

### DIFF
--- a/lib/internal/options.js
+++ b/lib/internal/options.js
@@ -5,7 +5,7 @@ const {
   getEmbedderOptions: getEmbedderOptionsFromBinding,
 } = internalBinding('options');
 
-let warnOnAllowUnauthorized = true;
+let warnOnAllowUnauthorized = process.env.NODE_TLS_WARN_ON_UNAUTHORIZED ?? true;
 
 let optionsMap;
 let aliasesMap;


### PR DESCRIPTION
I would like a way to silence that warning as I'm totally aware of all the security issues that this might bring but I'm doing it only to simplify the development.

I couldn't find where to add tests or add documentation so if anyone could tell me where it would be awesome.

I would appreciate any kind of feedback :D
