### PR TITLE
meta: move Fishrock123 to emeritus

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,8 +327,6 @@ For information about the governance of the Node.js project, see
   **Evan Lucas** \<evanlucas@me.com> (he/him)
 * [fhinkel](https://github.com/fhinkel) -
   **Franziska Hinkelmann** \<franziska.hinkelmann@gmail.com> (she/her)
-* [Fishrock123](https://github.com/Fishrock123) -
-  **Jeremiah Senkpiel** \<fishrock123@rocketmail.com>  (he/they)
 * [Flarna](https://github.com/Flarna) -
   **Gerhard Stöbich** \<deb2001-github@yahoo.de>  (he/they)
 * [gabrielschulhof](https://github.com/gabrielschulhof) -
@@ -501,6 +499,8 @@ For information about the governance of the Node.js project, see
   **Alexander Makarenko** \<estliberitas@gmail.com>
 * [firedfox](https://github.com/firedfox) -
   **Daniel Wang** \<wangyang0123@gmail.com>
+* [Fishrock123](https://github.com/Fishrock123) -
+  **Jeremiah Senkpiel** \<fishrock123@rocketmail.com> (he/they)
 * [gdams](https://github.com/gdams) -
   **George Adams** \<gadams@microsoft.com> (he/him)
 * [geek](https://github.com/geek) -


### PR DESCRIPTION
I've moved on. I do not wish to be responsible for anything here and have been inactive for more than a year.

I don't want to re-learn how to merge this. Someone should just do it instead of me. Thanks.

Edit: related, I also want to be removed from the collaborators team because I do not wish to be pinged.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
