### PR TITLE
doc: markdown-syntax-and-html-tag-miss

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -861,7 +861,7 @@ warning will be written to stderr instead.
 
 The `file` name may be an absolute path. If it is not, the default directory it
 will be written to is controlled by the
-[`--diagnostic-dir`]() command-line option.
+[`--diagnostic-dir`][] command-line option.
 
 ### `--report-compact`
 

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -5639,6 +5639,7 @@ See the [list of SSL OP Flags][] for details.
     <td><code>SSL_OP_NO_TLSv1_3</code></td>
     <td>Instructs OpenSSL to turn off TLS v1.3</td>
   </tr>
+  <tr>
     <td><code>SSL_OP_PKCS1_CHECK_1</code></td>
     <td></td>
   </tr>
@@ -5664,6 +5665,7 @@ See the [list of SSL OP Flags][] for details.
     <td>Instructs OpenSSL to always create a new key when using
     temporary/ephemeral ECDH parameters.</td>
   </tr>
+  <tr>
     <td><code>SSL_OP_SSLEAY_080_CLIENT_DH_BUG</code></td>
     <td></td>
   </tr>

--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -344,7 +344,7 @@ records. The type and structure of individual results varies based on `rrtype`:
 | `'TXT'`   | text records                   | {string\[]} | [`dns.resolveTxt()`][]   |
 
 On error, `err` is an [`Error`][] object, where `err.code` is one of the
-[DNS error codes]().
+[DNS error codes][].
 
 ## `dns.resolve4(hostname[, options], callback)`
 
@@ -954,7 +954,7 @@ based on `rrtype`:
 | `'TXT'`   | text records                   | {string\[]} | [`dnsPromises.resolveTxt()`][]   |
 
 On error, the `Promise` is rejected with an [`Error`][] object, where `err.code`
-is one of the [DNS error codes]().
+is one of the [DNS error codes][].
 
 ### `dnsPromises.resolve4(hostname[, options])`
 
@@ -1224,7 +1224,7 @@ Performs a reverse DNS query that resolves an IPv4 or IPv6 address to an
 array of host names.
 
 On error, the `Promise` is rejected with an [`Error`][] object, where `err.code`
-is one of the [DNS error codes]().
+is one of the [DNS error codes][].
 
 ### `dnsPromises.setDefaultResultOrder(order)`
 

--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -954,7 +954,7 @@ The following error constants are exported by `os.constants.errno`.
   </tr>
   <tr>
     <td><code>EXDEV</code></td>
-    <td>Indicates an improper link.
+    <td>Indicates an improper link.</td>
   </tr>
 </table>
 

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -459,7 +459,7 @@ The `'secure'` event is emitted by the `SecurePair` object once a secure
 connection has been established.
 
 As with checking for the server
-[`'secureConnection'`]()
+[`'secureConnection'`][]
 event, `pair.cleartext.authorized` should be inspected to confirm whether the
 certificate used is properly authorized.
 


### PR DESCRIPTION
Try to build a custom doc app with Docusaurus. Found these non compatible syntax and some html tags missing.