### PR TITLE
lib: refactor functions in internal/util/types.js to use arrow syntax

### DIFF
--- a/lib/internal/util/types.js
+++ b/lib/internal/util/types.js
@@ -6,53 +6,41 @@ const {
   TypedArrayPrototypeGetSymbolToStringTag,
 } = primordials;
 
-function isTypedArray(value) {
-  return TypedArrayPrototypeGetSymbolToStringTag(value) !== undefined;
-}
+const isTypedArray = (value) =>
+  TypedArrayPrototypeGetSymbolToStringTag(value) !== undefined;
 
-function isUint8Array(value) {
-  return TypedArrayPrototypeGetSymbolToStringTag(value) === 'Uint8Array';
-}
+const isUint8Array = (value) =>
+  TypedArrayPrototypeGetSymbolToStringTag(value) === 'Uint8Array';
 
-function isUint8ClampedArray(value) {
-  return TypedArrayPrototypeGetSymbolToStringTag(value) === 'Uint8ClampedArray';
-}
+const isUint8ClampedArray = (value) =>
+  TypedArrayPrototypeGetSymbolToStringTag(value) === 'Uint8ClampedArray';
 
-function isUint16Array(value) {
-  return TypedArrayPrototypeGetSymbolToStringTag(value) === 'Uint16Array';
-}
+const isUint16Array = (value) =>
+  TypedArrayPrototypeGetSymbolToStringTag(value) === 'Uint16Array';
 
-function isUint32Array(value) {
-  return TypedArrayPrototypeGetSymbolToStringTag(value) === 'Uint32Array';
-}
+const isUint32Array = (value) =>
+  TypedArrayPrototypeGetSymbolToStringTag(value) === 'Uint32Array';
 
-function isInt8Array(value) {
-  return TypedArrayPrototypeGetSymbolToStringTag(value) === 'Int8Array';
-}
+const isInt8Array = (value) =>
+  TypedArrayPrototypeGetSymbolToStringTag(value) === 'Int8Array';
 
-function isInt16Array(value) {
-  return TypedArrayPrototypeGetSymbolToStringTag(value) === 'Int16Array';
-}
+const isInt16Array = (value) =>
+  TypedArrayPrototypeGetSymbolToStringTag(value) === 'Int16Array';
 
-function isInt32Array(value) {
-  return TypedArrayPrototypeGetSymbolToStringTag(value) === 'Int32Array';
-}
+const isInt32Array = (value) =>
+  TypedArrayPrototypeGetSymbolToStringTag(value) === 'Int32Array';
 
-function isFloat32Array(value) {
-  return TypedArrayPrototypeGetSymbolToStringTag(value) === 'Float32Array';
-}
+const isFloat32Array = (value) =>
+  TypedArrayPrototypeGetSymbolToStringTag(value) === 'Float32Array';
 
-function isFloat64Array(value) {
-  return TypedArrayPrototypeGetSymbolToStringTag(value) === 'Float64Array';
-}
+const isFloat64Array = (value) =>
+  TypedArrayPrototypeGetSymbolToStringTag(value) === 'Float64Array';
 
-function isBigInt64Array(value) {
-  return TypedArrayPrototypeGetSymbolToStringTag(value) === 'BigInt64Array';
-}
+const isBigInt64Array = (value) =>
+  TypedArrayPrototypeGetSymbolToStringTag(value) === 'BigInt64Array';
 
-function isBigUint64Array(value) {
-  return TypedArrayPrototypeGetSymbolToStringTag(value) === 'BigUint64Array';
-}
+const isBigUint64Array = (value) =>
+  TypedArrayPrototypeGetSymbolToStringTag(value) === 'BigUint64Array';
 
 module.exports = {
   ...internalBinding('types'),


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
Refactored functions in lib/internal/util/types.js to use arrow functions syntax. This makes it easier to read.