### PR TITLE
crypto: fix build without scrypt

### DIFF
--- a/src/crypto/crypto_scrypt.h
+++ b/src/crypto/crypto_scrypt.h
@@ -77,8 +77,8 @@ struct ScryptJob {
   static void Initialize(
       Environment* env,
       v8::Local<v8::Object> target) {}
-}
-#endif  // !OPENSSL_NO_SCRIPT
+};
+#endif  // !OPENSSL_NO_SCRYPT
 
 }  // namespace crypto
 }  // namespace node


### PR DESCRIPTION
* add missing semicolon to fix:
```
In file included from ../src/node_crypto.h:47,
                 from ../src/node.cc:46:
../src/crypto/crypto_scrypt.h:80:2: error: expected ';' after struct definition
   80 | }
      |  ^
      |  ;
```
  and fix typo in the comment

Signed-off-by: Martin Jansa <martin.jansa@lge.com>