### PR TITLE
cluster: use linkedlist for round_robin_handle

### DIFF
--- a/lib/internal/cluster/round_robin_handle.js
+++ b/lib/internal/cluster/round_robin_handle.js
@@ -2,15 +2,15 @@
 
 const {
   ArrayIsArray,
-  ArrayPrototypePush,
-  ArrayPrototypeShift,
   Boolean,
+  ObjectCreate,
   SafeMap,
 } = primordials;
 
 const assert = require('internal/assert');
 const net = require('net');
 const { sendHelper } = require('internal/cluster/utils');
+const { append, init, isEmpty, peek, remove } = require('internal/linkedlist');
 const { constants } = internalBinding('tcp_wrap');
 
 module.exports = RoundRobinHandle;
@@ -19,7 +19,7 @@ function RoundRobinHandle(key, address, { port, fd, flags }) {
   this.key = key;
   this.all = new SafeMap();
   this.free = new SafeMap();
-  this.handles = [];
+  this.handles = init(ObjectCreate(null));
   this.handle = null;
   this.server = net.createServer(assert.fail);
 
@@ -81,10 +81,11 @@ RoundRobinHandle.prototype.remove = function(worker) {
   if (this.all.size !== 0)
     return false;
 
-  for (const handle of this.handles) {
+  while (!isEmpty(this.handles)) {
+    const handle = peek(this.handles);
     handle.close();
+    remove(handle);
   }
-  this.handles = [];
 
   this.handle.close();
   this.handle = null;
@@ -92,7 +93,7 @@ RoundRobinHandle.prototype.remove = function(worker) {
 };
 
 RoundRobinHandle.prototype.distribute = function(err, handle) {
-  ArrayPrototypePush(this.handles, handle);
+  append(this.handles, handle);
   // eslint-disable-next-line node-core/no-array-destructuring
   const [ workerEntry ] = this.free; // this.free is a SafeMap
 
@@ -108,12 +109,14 @@ RoundRobinHandle.prototype.handoff = function(worker) {
     return;  // Worker is closing (or has closed) the server.
   }
 
-  const handle = ArrayPrototypeShift(this.handles);
+  const handle = peek(this.handles);
 
-  if (handle === undefined) {
+  if (handle === null) {
     this.free.set(worker.id, worker);  // Add to ready queue again.
     return;
   }
+
+  remove(handle);
 
   const message = { act: 'newconn', key: this.key };
 

--- a/lib/internal/linkedlist.js
+++ b/lib/internal/linkedlist.js
@@ -3,6 +3,7 @@
 function init(list) {
   list._idleNext = list;
   list._idlePrev = list;
+  return list;
 }
 
 // Show the most idle item.


### PR DESCRIPTION
Currently, an array is used as a queue to manage handles, when there are many handles, the `ArrayPrototypeShift` may become a bottleneck, so using the builtin `linkedlist` to reduce the time complexity of `handoff` method to a constant level and may be helpful for #37343.