### PR TITLE
stream: rename unknown primordial

### DIFF
--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -7,7 +7,7 @@ const {
   ArrayBufferPrototypeSlice,
   ArrayPrototypePush,
   ArrayPrototypeShift,
-  DataViewCtor,
+  DataView,
   FunctionPrototypeBind,
   FunctionPrototypeCall,
   MathMin,
@@ -2132,7 +2132,7 @@ function readableByteStreamControllerPullInto(
     pendingPullIntos,
   } = controller[kState];
   let elementSize = 1;
-  let ctor = DataViewCtor;
+  let ctor = DataView;
   if (isArrayBufferView(view) && !isDataView(view)) {
     elementSize = view.constructor.BYTES_PER_ELEMENT;
     ctor = view.constructor;

--- a/test/parallel/test-whatwg-readablestream.js
+++ b/test/parallel/test-whatwg-readablestream.js
@@ -1602,3 +1602,18 @@ class Source {
     isReadable(stream, false);
   })().then(common.mustCall());
 }
+
+{
+  const stream = new ReadableStream({
+    type: 'bytes',
+    start(controller) {
+      controller.close();
+    }
+  });
+
+  const buffer = new ArrayBuffer(1024);
+  const reader = stream.getReader({ mode: 'byob' });
+
+  reader.read(new DataView(buffer))
+    .then(common.mustCall());
+}


### PR DESCRIPTION
The primordials does not expose a primordial called `DataViewCtor`, leading up to a non-existent constructor.

Fixes: https://github.com/nodejs/node/issues/40612

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
