### PR TITLE
deps: add -fno-strict-aliasing flag to libuv

### DIFF
--- a/deps/uv/uv.gyp
+++ b/deps/uv/uv.gyp
@@ -221,6 +221,7 @@
             '-Wextra',
             '-Wno-unused-parameter',
             '-Wstrict-prototypes',
+            '-fno-strict-aliasing',
           ],
         }],
         [ 'OS in "mac ios"', {


### PR DESCRIPTION
This commit turns on `-fno-strict-aliasing` in libuv.

Fixes: https://github.com/nodejs/node/issues/40368
Refs: https://github.com/libuv/libuv/issues/1230
