### PR TITLE
test: avoid deep comparisons with literals

### DIFF
--- a/test/.eslintrc.yaml
+++ b/test/.eslintrc.yaml
@@ -13,6 +13,10 @@ rules:
   no-restricted-syntax:
     # Config copied from .eslintrc.js
     - error
+    - selector: "CallExpression:matches([callee.name='deepStrictEqual'], [callee.property.name='deepStrictEqual']):matches([arguments.1.type='Literal']:not([arguments.1.regex]), [arguments.1.type='Identifier'][arguments.1.name='undefined'])"
+      message: "Use strictEqual instead of deepStrictEqual for literals or undefined."
+    - selector: "CallExpression:matches([callee.name='notDeepStrictEqual'], [callee.property.name='notDeepStrictEqual']):matches([arguments.1.type='Literal']:not([arguments.1.regex]), [arguments.1.type='Identifier'][arguments.1.name='undefined'])"
+      message: "Use notStrictEqual instead of notDeepStrictEqual for literals or undefined."
     - selector: "CallExpression:matches([callee.name='deepStrictEqual'], [callee.property.name='deepStrictEqual'])[arguments.2.type='Literal']"
       message: "Do not use a literal for the third argument of assert.deepStrictEqual()"
     - selector: "CallExpression:matches([callee.name='doesNotThrow'], [callee.property.name='doesNotThrow'])"

--- a/test/es-module/test-esm-data-urls.js
+++ b/test/es-module/test-esm-data-urls.js
@@ -15,7 +15,7 @@ function createBase64URL(mime, body) {
     const plainESMURL = createURL('text/javascript', body);
     const ns = await import(plainESMURL);
     assert.deepStrictEqual(Object.keys(ns), ['default']);
-    assert.deepStrictEqual(ns.default.a, 'aaa');
+    assert.strictEqual(ns.default.a, 'aaa');
     const importerOfURL = createURL(
       'text/javascript',
       `export {default as default} from ${JSON.stringify(plainESMURL)}`
@@ -35,40 +35,40 @@ function createBase64URL(mime, body) {
     const plainESMURL = createURL('text/javascript', body);
     const ns = await import(plainESMURL);
     assert.deepStrictEqual(Object.keys(ns), ['default']);
-    assert.deepStrictEqual(ns.default, plainESMURL);
+    assert.strictEqual(ns.default, plainESMURL);
   }
   {
     const body = 'export default import.meta.url;';
     const plainESMURL = createURL('text/javascript;charset=UTF-8', body);
     const ns = await import(plainESMURL);
     assert.deepStrictEqual(Object.keys(ns), ['default']);
-    assert.deepStrictEqual(ns.default, plainESMURL);
+    assert.strictEqual(ns.default, plainESMURL);
   }
   {
     const body = 'export default import.meta.url;';
     const plainESMURL = createURL('text/javascript;charset="UTF-8"', body);
     const ns = await import(plainESMURL);
     assert.deepStrictEqual(Object.keys(ns), ['default']);
-    assert.deepStrictEqual(ns.default, plainESMURL);
+    assert.strictEqual(ns.default, plainESMURL);
   }
   {
     const body = 'export default import.meta.url;';
     const plainESMURL = createURL('text/javascript;;a=a;b=b;;', body);
     const ns = await import(plainESMURL);
     assert.deepStrictEqual(Object.keys(ns), ['default']);
-    assert.deepStrictEqual(ns.default, plainESMURL);
+    assert.strictEqual(ns.default, plainESMURL);
   }
   {
     const ns = await import('data:application/json;foo="test,"this"');
     assert.deepStrictEqual(Object.keys(ns), ['default']);
-    assert.deepStrictEqual(ns.default, 'this');
+    assert.strictEqual(ns.default, 'this');
   }
   {
     const ns = await import(`data:application/json;foo=${
       encodeURIComponent('test,')
     },0`);
     assert.deepStrictEqual(Object.keys(ns), ['default']);
-    assert.deepStrictEqual(ns.default, 0);
+    assert.strictEqual(ns.default, 0);
   }
   {
     await assert.rejects(async () => {
@@ -83,14 +83,14 @@ function createBase64URL(mime, body) {
     const plainESMURL = createURL('application/json', body);
     const ns = await import(plainESMURL);
     assert.deepStrictEqual(Object.keys(ns), ['default']);
-    assert.deepStrictEqual(ns.default.x, 1);
+    assert.strictEqual(ns.default.x, 1);
   }
   {
     const body = '{"default": 2}';
     const plainESMURL = createURL('application/json', body);
     const ns = await import(plainESMURL);
     assert.deepStrictEqual(Object.keys(ns), ['default']);
-    assert.deepStrictEqual(ns.default.default, 2);
+    assert.strictEqual(ns.default.default, 2);
   }
   {
     const body = 'null';

--- a/test/js-native-api/test_conversions/test.js
+++ b/test/js-native-api/test_conversions/test.js
@@ -118,10 +118,10 @@ assert.deepStrictEqual(new String(''), test.toObject(''));
 assert.deepStrictEqual(new Number(0), test.toObject(0));
 assert.deepStrictEqual(new Number(Number.NaN), test.toObject(Number.NaN));
 assert.deepStrictEqual(new Object(testSym), test.toObject(testSym));
-assert.notDeepStrictEqual(test.toObject(false), false);
-assert.notDeepStrictEqual(test.toObject(true), true);
-assert.notDeepStrictEqual(test.toObject(''), '');
-assert.notDeepStrictEqual(test.toObject(0), 0);
+assert.notStrictEqual(test.toObject(false), false);
+assert.notStrictEqual(test.toObject(true), true);
+assert.notStrictEqual(test.toObject(''), '');
+assert.notStrictEqual(test.toObject(0), 0);
 assert.ok(!Number.isNaN(test.toObject(Number.NaN)));
 
 assert.strictEqual(test.toString(''), '');

--- a/test/parallel/test-assert-deep.js
+++ b/test/parallel/test-assert-deep.js
@@ -856,11 +856,13 @@ assert.throws(
 }
 
 assert.throws(
+  // eslint-disable-next-line no-restricted-syntax
   () => assert.deepStrictEqual(4, '4'),
   { message: `${defaultMsgStart}\n4 !== '4'\n` }
 );
 
 assert.throws(
+  // eslint-disable-next-line no-restricted-syntax
   () => assert.deepStrictEqual(true, 1),
   { message: `${defaultMsgStart}\ntrue !== 1\n` }
 );

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -1243,6 +1243,7 @@ assert.throws(
 {
   let threw = false;
   try {
+    // eslint-disable-next-line no-restricted-syntax
     assert.deepStrictEqual(Array(100).fill(1), 'foobar');
   } catch (err) {
     threw = true;

--- a/test/parallel/test-crypto-hmac.js
+++ b/test/parallel/test-crypto-hmac.js
@@ -422,8 +422,8 @@ assert.strictEqual(
   }
   {
     const h = crypto.createHmac('sha1', 'key').update('data');
-    assert.deepStrictEqual(h.digest('latin1'), expected);
-    assert.deepStrictEqual(h.digest('latin1'), '');
+    assert.strictEqual(h.digest('latin1'), expected);
+    assert.strictEqual(h.digest('latin1'), '');
   }
 }
 
@@ -440,8 +440,8 @@ assert.strictEqual(
   }
   {
     const h = crypto.createHmac('sha1', 'key');
-    assert.deepStrictEqual(h.digest('latin1'), expected);
-    assert.deepStrictEqual(h.digest('latin1'), '');
+    assert.strictEqual(h.digest('latin1'), expected);
+    assert.strictEqual(h.digest('latin1'), '');
   }
 }
 

--- a/test/parallel/test-dns-lookup.js
+++ b/test/parallel/test-dns-lookup.js
@@ -137,7 +137,7 @@ dns.lookup('127.0.0.1', {
   family: 4,
   all: false
 }, common.mustSucceed((result, addressType) => {
-  assert.deepStrictEqual(result, '127.0.0.1');
+  assert.strictEqual(result, '127.0.0.1');
   assert.strictEqual(addressType, 4);
 }));
 

--- a/test/parallel/test-dns.js
+++ b/test/parallel/test-dns.js
@@ -336,10 +336,10 @@ assert.throws(() => {
 
 {
   dns.resolveMx('foo.onion', function(err) {
-    assert.deepStrictEqual(err.code, 'ENOTFOUND');
-    assert.deepStrictEqual(err.syscall, 'queryMx');
-    assert.deepStrictEqual(err.hostname, 'foo.onion');
-    assert.deepStrictEqual(err.message, 'queryMx ENOTFOUND foo.onion');
+    assert.strictEqual(err.code, 'ENOTFOUND');
+    assert.strictEqual(err.syscall, 'queryMx');
+    assert.strictEqual(err.hostname, 'foo.onion');
+    assert.strictEqual(err.message, 'queryMx ENOTFOUND foo.onion');
   });
 }
 

--- a/test/parallel/test-error-serdes.js
+++ b/test/parallel/test-error-serdes.js
@@ -64,5 +64,5 @@ assert.strictEqual(cycle(Function), '[Function: Function]');
   }
 
   serializeError(new DynamicError());
-  assert.deepStrictEqual(called, true);
+  assert.strictEqual(called, true);
 }

--- a/test/parallel/test-fs-promises-file-handle-chmod.js
+++ b/test/parallel/test-fs-promises-file-handle-chmod.js
@@ -19,7 +19,7 @@ async function validateFilePermission() {
   const fileHandle = await open(filePath, 'w+', 0o444);
   // File created with r--r--r-- 444
   const statsBeforeMod = fs.statSync(filePath);
-  assert.deepStrictEqual(statsBeforeMod.mode & 0o444, 0o444);
+  assert.strictEqual(statsBeforeMod.mode & 0o444, 0o444);
 
   let expectedAccess;
   const newPermissions = 0o765;

--- a/test/parallel/test-fs-promises-file-handle-truncate.js
+++ b/test/parallel/test-fs-promises-file-handle-truncate.js
@@ -16,10 +16,10 @@ async function validateTruncate() {
   const buffer = Buffer.from(text, 'utf8');
   await fileHandle.write(buffer, 0, buffer.length);
 
-  assert.deepStrictEqual((await readFile(filename)).toString(), text);
+  assert.strictEqual((await readFile(filename)).toString(), text);
 
   await fileHandle.truncate(5);
-  assert.deepStrictEqual((await readFile(filename)).toString(), 'Hello');
+  assert.strictEqual((await readFile(filename)).toString(), 'Hello');
 
   await fileHandle.close();
 }

--- a/test/parallel/test-fs-promises-readfile-with-fd.js
+++ b/test/parallel/test-fs-promises-readfile-with-fd.js
@@ -22,10 +22,10 @@ async function readFileTest() {
   const buf = Buffer.alloc(5);
   const { bytesRead } = await handle.read(buf, 0, 5, null);
   assert.strictEqual(bytesRead, 5);
-  assert.deepStrictEqual(buf.toString(), 'Hello');
+  assert.strictEqual(buf.toString(), 'Hello');
 
   /* readFile() should read from position five, instead of zero. */
-  assert.deepStrictEqual((await handle.readFile()).toString(), ' World');
+  assert.strictEqual((await handle.readFile()).toString(), ' World');
 
   await handle.close();
 }

--- a/test/parallel/test-fs-promises-writefile-with-fd.js
+++ b/test/parallel/test-fs-promises-writefile-with-fd.js
@@ -26,7 +26,7 @@ async function writeFileTest() {
   await handle.writeFile('World');
 
   /* New content should be written at position five, instead of zero. */
-  assert.deepStrictEqual(readFileSync(fn).toString(), 'HelloWorld');
+  assert.strictEqual(readFileSync(fn).toString(), 'HelloWorld');
 
   await handle.close();
 }

--- a/test/parallel/test-fs-promises.js
+++ b/test/parallel/test-fs-promises.js
@@ -183,7 +183,7 @@ async function executeOnHandle(dest, func) {
         assert.strictEqual(ret.bytesRead, bufLen);
         assert.deepStrictEqual(ret.buffer, buf);
         await truncate(dest, 5);
-        assert.deepStrictEqual((await readFile(dest)).toString(), 'hello');
+        assert.strictEqual((await readFile(dest)).toString(), 'hello');
       });
     }
 

--- a/test/parallel/test-fs-readfile-fd.js
+++ b/test/parallel/test-fs-readfile-fd.js
@@ -64,11 +64,11 @@ function tempFdSync(callback) {
 
     // Read only five bytes, so that the position moves to five.
     const buf = Buffer.alloc(5);
-    assert.deepStrictEqual(fs.readSync(fd, buf, 0, 5), 5);
-    assert.deepStrictEqual(buf.toString(), 'Hello');
+    assert.strictEqual(fs.readSync(fd, buf, 0, 5), 5);
+    assert.strictEqual(buf.toString(), 'Hello');
 
     // readFileSync() should read from position five, instead of zero.
-    assert.deepStrictEqual(fs.readFileSync(fd).toString(), ' World');
+    assert.strictEqual(fs.readFileSync(fd).toString(), ' World');
 
     fs.closeSync(fd);
   }
@@ -81,11 +81,11 @@ function tempFdSync(callback) {
       // Read only five bytes, so that the position moves to five.
       fs.read(fd, buf, 0, 5, null, common.mustSucceed((bytes) => {
         assert.strictEqual(bytes, 5);
-        assert.deepStrictEqual(buf.toString(), 'Hello');
+        assert.strictEqual(buf.toString(), 'Hello');
 
         fs.readFile(fd, common.mustSucceed((data) => {
           // readFile() should read from position five, instead of zero.
-          assert.deepStrictEqual(data.toString(), ' World');
+          assert.strictEqual(data.toString(), ' World');
 
           fs.closeSync(fd);
         }));

--- a/test/parallel/test-fs-readv-promises.js
+++ b/test/parallel/test-fs-readv-promises.js
@@ -35,11 +35,11 @@ const allocateEmptyBuffers = (combinedLength) => {
 
     let { bytesRead, buffers } = await handle.readv([Buffer.from('')],
                                                     null);
-    assert.deepStrictEqual(bytesRead, 0);
+    assert.strictEqual(bytesRead, 0);
     assert.deepStrictEqual(buffers, [Buffer.from('')]);
 
     ({ bytesRead, buffers } = await handle.readv(bufferArr, null));
-    assert.deepStrictEqual(bytesRead, expectedLength);
+    assert.strictEqual(bytesRead, expectedLength);
     assert.deepStrictEqual(buffers, bufferArr);
     assert(Buffer.concat(bufferArr).equals(await fs.readFile(filename)));
     handle.close();
@@ -54,11 +54,11 @@ const allocateEmptyBuffers = (combinedLength) => {
     const expectedLength = exptectedBuff.length;
 
     let { bytesRead, buffers } = await handle.readv([Buffer.from('')]);
-    assert.deepStrictEqual(bytesRead, 0);
+    assert.strictEqual(bytesRead, 0);
     assert.deepStrictEqual(buffers, [Buffer.from('')]);
 
     ({ bytesRead, buffers } = await handle.readv(bufferArr));
-    assert.deepStrictEqual(bytesRead, expectedLength);
+    assert.strictEqual(bytesRead, expectedLength);
     assert.deepStrictEqual(buffers, bufferArr);
     assert(Buffer.concat(bufferArr).equals(await fs.readFile(filename)));
     handle.close();

--- a/test/parallel/test-fs-readv-sync.js
+++ b/test/parallel/test-fs-readv-sync.js
@@ -32,10 +32,10 @@ const allocateEmptyBuffers = (combinedLength) => {
   const bufferArr = allocateEmptyBuffers(exptectedBuff.length);
 
   let read = fs.readvSync(fd, [Buffer.from('')], 0);
-  assert.deepStrictEqual(read, 0);
+  assert.strictEqual(read, 0);
 
   read = fs.readvSync(fd, bufferArr, 0);
-  assert.deepStrictEqual(read, expectedLength);
+  assert.strictEqual(read, expectedLength);
 
   fs.closeSync(fd);
 
@@ -49,10 +49,10 @@ const allocateEmptyBuffers = (combinedLength) => {
   const bufferArr = allocateEmptyBuffers(exptectedBuff.length);
 
   let read = fs.readvSync(fd, [Buffer.from('')]);
-  assert.deepStrictEqual(read, 0);
+  assert.strictEqual(read, 0);
 
   read = fs.readvSync(fd, bufferArr);
-  assert.deepStrictEqual(read, expectedLength);
+  assert.strictEqual(read, expectedLength);
 
   fs.closeSync(fd);
 

--- a/test/parallel/test-fs-writefile-with-fd.js
+++ b/test/parallel/test-fs-writefile-with-fd.js
@@ -20,14 +20,14 @@ tmpdir.refresh();
   const fd = fs.openSync(filename, 'w');
   try {
     /* Write only five characters, so that the position moves to five. */
-    assert.deepStrictEqual(fs.writeSync(fd, 'Hello'), 5);
-    assert.deepStrictEqual(fs.readFileSync(filename).toString(), 'Hello');
+    assert.strictEqual(fs.writeSync(fd, 'Hello'), 5);
+    assert.strictEqual(fs.readFileSync(filename).toString(), 'Hello');
 
     /* Write some more with writeFileSync(). */
     fs.writeFileSync(fd, 'World');
 
     /* New content should be written at position five, instead of zero. */
-    assert.deepStrictEqual(fs.readFileSync(filename).toString(), 'HelloWorld');
+    assert.strictEqual(fs.readFileSync(filename).toString(), 'HelloWorld');
   } finally {
     fs.closeSync(fd);
   }
@@ -54,12 +54,12 @@ process.on('beforeExit', common.mustCall(() => {
     /* Write only five characters, so that the position moves to five. */
     fs.write(fd, 'Hello', common.mustSucceed((bytes) => {
       assert.strictEqual(bytes, 5);
-      assert.deepStrictEqual(fs.readFileSync(file).toString(), 'Hello');
+      assert.strictEqual(fs.readFileSync(file).toString(), 'Hello');
 
       /* Write some more with writeFile(). */
       fs.writeFile(fd, 'World', common.mustSucceed(() => {
         /* New content should be written at position five, instead of zero. */
-        assert.deepStrictEqual(fs.readFileSync(file).toString(), 'HelloWorld');
+        assert.strictEqual(fs.readFileSync(file).toString(), 'HelloWorld');
       }));
     }));
   }));

--- a/test/parallel/test-fs-writev-promises.js
+++ b/test/parallel/test-fs-writev-promises.js
@@ -22,7 +22,7 @@ tmpdir.refresh();
     const expectedLength = bufferArr.length * buffer.byteLength;
     let { bytesWritten, buffers } = await handle.writev([Buffer.from('')],
                                                         null);
-    assert.deepStrictEqual(bytesWritten, 0);
+    assert.strictEqual(bytesWritten, 0);
     assert.deepStrictEqual(buffers, [Buffer.from('')]);
     ({ bytesWritten, buffers } = await handle.writev(bufferArr, null));
     assert.deepStrictEqual(bytesWritten, expectedLength);
@@ -39,7 +39,7 @@ tmpdir.refresh();
     const bufferArr = [buffer, buffer, buffer];
     const expectedLength = bufferArr.length * buffer.byteLength;
     let { bytesWritten, buffers } = await handle.writev([Buffer.from('')]);
-    assert.deepStrictEqual(bytesWritten, 0);
+    assert.strictEqual(bytesWritten, 0);
     assert.deepStrictEqual(buffers, [Buffer.from('')]);
     ({ bytesWritten, buffers } = await handle.writev(bufferArr));
     assert.deepStrictEqual(bytesWritten, expectedLength);

--- a/test/parallel/test-fs-writev-sync.js
+++ b/test/parallel/test-fs-writev-sync.js
@@ -26,10 +26,10 @@ const getFileName = (i) => path.join(tmpdir.path, `writev_sync_${i}.txt`);
   const expectedLength = bufferArr.length * buffer.byteLength;
 
   let written = fs.writevSync(fd, [Buffer.from('')], null);
-  assert.deepStrictEqual(written, 0);
+  assert.strictEqual(written, 0);
 
   written = fs.writevSync(fd, bufferArr, null);
-  assert.deepStrictEqual(written, expectedLength);
+  assert.strictEqual(written, expectedLength);
 
   fs.closeSync(fd);
 
@@ -46,10 +46,10 @@ const getFileName = (i) => path.join(tmpdir.path, `writev_sync_${i}.txt`);
   const expectedLength = bufferArr.length * buffer.byteLength;
 
   let written = fs.writevSync(fd, [Buffer.from('')]);
-  assert.deepStrictEqual(written, 0);
+  assert.strictEqual(written, 0);
 
   written = fs.writevSync(fd, bufferArr);
-  assert.deepStrictEqual(written, expectedLength);
+  assert.strictEqual(written, expectedLength);
 
   fs.closeSync(fd);
 

--- a/test/parallel/test-http-agent-keepalive.js
+++ b/test/parallel/test-http-agent-keepalive.js
@@ -82,8 +82,8 @@ function second() {
 function remoteClose() {
   // Mock remote server close the socket
   const req = get('/remote_close', common.mustCall((res) => {
-    assert.deepStrictEqual(req.reusedSocket, true);
-    assert.deepStrictEqual(res.statusCode, 200);
+    assert.strictEqual(req.reusedSocket, true);
+    assert.strictEqual(res.statusCode, 200);
     res.on('data', checkDataAndSockets);
     res.on('end', common.mustCall(() => {
       assert.strictEqual(agent.sockets[name].length, 1);

--- a/test/parallel/test-http-mutable-headers.js
+++ b/test/parallel/test-http-mutable-headers.js
@@ -48,8 +48,8 @@ const s = http.createServer(common.mustCall((req, res) => {
       assert.deepStrictEqual(headers, exoticObj);
       assert.deepStrictEqual(res.getHeaderNames(), []);
       assert.deepStrictEqual(res.getRawHeaderNames(), []);
-      assert.deepStrictEqual(res.hasHeader('Connection'), false);
-      assert.deepStrictEqual(res.getHeader('Connection'), undefined);
+      assert.strictEqual(res.hasHeader('Connection'), false);
+      assert.strictEqual(res.getHeader('Connection'), undefined);
 
       assert.throws(
         () => res.setHeader(),

--- a/test/parallel/test-http.js
+++ b/test/parallel/test-http.js
@@ -43,7 +43,7 @@ const server = http.Server(common.mustCall((req, res) => {
       break;
     case '/world':
       assert.strictEqual(req.method, 'POST');
-      assert.deepStrictEqual(req.headers.cookie, 'abc=123; def=456; ghi=789');
+      assert.strictEqual(req.headers.cookie, 'abc=123; def=456; ghi=789');
       break;
     default:
       assert(false, `Unexpected request for ${req.url}`);

--- a/test/parallel/test-http2-goaway-opaquedata.js
+++ b/test/parallel/test-http2-goaway-opaquedata.js
@@ -22,8 +22,8 @@ server.on('close', common.mustCall());
 server.listen(0, () => {
   const client = http2.connect(`http://localhost:${server.address().port}`);
   client.once('goaway', common.mustCall((code, lastStreamID, buf) => {
-    assert.deepStrictEqual(code, 0);
-    assert.deepStrictEqual(lastStreamID, 1);
+    assert.strictEqual(code, 0);
+    assert.strictEqual(lastStreamID, 1);
     assert.deepStrictEqual(data, buf);
     session.close();
     server.close();

--- a/test/parallel/test-http2-multiheaders.js
+++ b/test/parallel/test-http2-multiheaders.js
@@ -29,16 +29,13 @@ src.__PROTO__ = 'bar';
 src.__Proto__ = 'baz';
 
 function checkHeaders(headers) {
-  assert.deepStrictEqual(headers.accept,
-                         'abc, def, ghijklmnop');
-  assert.deepStrictEqual(headers['www-authenticate'],
-                         'foo, bar, baz');
-  assert.deepStrictEqual(headers['proxy-authenticate'],
-                         'foo, bar, baz');
-  assert.deepStrictEqual(headers['x-foo'], 'foo, bar, baz');
-  assert.deepStrictEqual(headers.constructor, 'foo, bar, baz');
+  assert.strictEqual(headers.accept, 'abc, def, ghijklmnop');
+  assert.strictEqual(headers['www-authenticate'], 'foo, bar, baz');
+  assert.strictEqual(headers['proxy-authenticate'], 'foo, bar, baz');
+  assert.strictEqual(headers['x-foo'], 'foo, bar, baz');
+  assert.strictEqual(headers.constructor, 'foo, bar, baz');
   // eslint-disable-next-line no-proto
-  assert.deepStrictEqual(headers.__proto__, 'foo, bar, baz');
+  assert.strictEqual(headers.__proto__, 'foo, bar, baz');
 }
 
 server.on('stream', common.mustCall((stream, headers) => {

--- a/test/parallel/test-http2-removed-header-stays-removed.js
+++ b/test/parallel/test-http2-removed-header-stays-removed.js
@@ -13,7 +13,7 @@ server.listen(0, common.mustCall(() => {
   const session = http2.connect(`http://localhost:${server.address().port}`);
   const req = session.request();
   req.on('response', (headers, flags) => {
-    assert.deepStrictEqual(headers.date, 'snacks o clock');
+    assert.strictEqual(headers.date, 'snacks o clock');
   });
   req.on('end', () => {
     session.close();

--- a/test/parallel/test-inspector-bindings.js
+++ b/test/parallel/test-inspector-bindings.js
@@ -92,7 +92,7 @@ function testSampleDebugSession() {
   });
 
   debuggedFunction();
-  assert.deepStrictEqual(cbAsSecondArgCalled, true);
+  assert.strictEqual(cbAsSecondArgCalled, true);
   assert.deepStrictEqual(failures, []);
   assert.strictEqual(cur, 5);
   scopeCallback = null;

--- a/test/parallel/test-perf-hooks-usertiming.js
+++ b/test/parallel/test-perf-hooks-usertiming.js
@@ -42,7 +42,7 @@ assert.throws(() => mark(Symbol('a')), {
   const m = mark('a', { detail });
   assert.strictEqual(m.name, 'a');
   assert.strictEqual(m.entryType, 'mark');
-  assert.deepStrictEqual(m.detail, null);
+  assert.strictEqual(m.detail, null);
 });
 [1, 'any', {}, []].forEach((detail) => {
   const m = mark('a', { detail });

--- a/test/parallel/test-querystring-escape.js
+++ b/test/parallel/test-querystring-escape.js
@@ -4,14 +4,14 @@ const assert = require('assert');
 
 const qs = require('querystring');
 
-assert.deepStrictEqual(qs.escape(5), '5');
-assert.deepStrictEqual(qs.escape('test'), 'test');
-assert.deepStrictEqual(qs.escape({}), '%5Bobject%20Object%5D');
-assert.deepStrictEqual(qs.escape([5, 10]), '5%2C10');
-assert.deepStrictEqual(qs.escape('Ŋōđĕ'), '%C5%8A%C5%8D%C4%91%C4%95');
-assert.deepStrictEqual(qs.escape('testŊōđĕ'), 'test%C5%8A%C5%8D%C4%91%C4%95');
-assert.deepStrictEqual(qs.escape(`${String.fromCharCode(0xD800 + 1)}test`),
-                       '%F0%90%91%B4est');
+assert.strictEqual(qs.escape(5), '5');
+assert.strictEqual(qs.escape('test'), 'test');
+assert.strictEqual(qs.escape({}), '%5Bobject%20Object%5D');
+assert.strictEqual(qs.escape([5, 10]), '5%2C10');
+assert.strictEqual(qs.escape('Ŋōđĕ'), '%C5%8A%C5%8D%C4%91%C4%95');
+assert.strictEqual(qs.escape('testŊōđĕ'), 'test%C5%8A%C5%8D%C4%91%C4%95');
+assert.strictEqual(qs.escape(`${String.fromCharCode(0xD800 + 1)}test`),
+                   '%F0%90%91%B4est');
 
 assert.throws(
   () => qs.escape(String.fromCharCode(0xD800 + 1)),

--- a/test/parallel/test-readline-promises-csi.mjs
+++ b/test/parallel/test-readline-promises-csi.mjs
@@ -43,7 +43,7 @@ class TestWritable extends Writable {
 
   writable.data = '';
   await readline.clearScreenDown().rollback();
-  assert.deepStrictEqual(writable.data, '');
+  assert.strictEqual(writable.data, '');
 
   writable.data = '';
   await readline.clearLine(-1).commit();

--- a/test/parallel/test-stream-consumers.js
+++ b/test/parallel/test-stream-consumers.js
@@ -66,7 +66,7 @@ const kArrayBuffer =
 
   text(passthrough).then(common.mustCall(async (str) => {
     assert.strictEqual(str.length, 10);
-    assert.deepStrictEqual(str, 'hellothere');
+    assert.strictEqual(str, 'hellothere');
   }));
 
   passthrough.write('hello');
@@ -78,7 +78,7 @@ const kArrayBuffer =
 
   json(passthrough).then(common.mustCall(async (str) => {
     assert.strictEqual(str.length, 10);
-    assert.deepStrictEqual(str, 'hellothere');
+    assert.strictEqual(str, 'hellothere');
   }));
 
   passthrough.write('"hello');
@@ -126,7 +126,7 @@ const kArrayBuffer =
 
   text(readable).then(common.mustCall(async (str) => {
     assert.strictEqual(str.length, 10);
-    assert.deepStrictEqual(str, 'hellothere');
+    assert.strictEqual(str, 'hellothere');
   }));
 
   const writer = writable.getWriter();
@@ -144,7 +144,7 @@ const kArrayBuffer =
 
   json(readable).then(common.mustCall(async (str) => {
     assert.strictEqual(str.length, 10);
-    assert.deepStrictEqual(str, 'hellothere');
+    assert.strictEqual(str, 'hellothere');
   }));
 
   const writer = writable.getWriter();

--- a/test/parallel/test-stream-push-order.js
+++ b/test/parallel/test-stream-push-order.js
@@ -47,6 +47,6 @@ s.read(0);
 // ACTUALLY [1, 3, 5, 6, 4, 2]
 
 process.on('exit', function() {
-  assert.deepStrictEqual(s.readableBuffer.join(','), '1,2,3,4,5,6');
+  assert.strictEqual(s.readableBuffer.join(','), '1,2,3,4,5,6');
   console.log('ok');
 });

--- a/test/parallel/test-stream2-objects.js
+++ b/test/parallel/test-stream2-objects.js
@@ -60,7 +60,7 @@ function fromArray(list) {
 
   assert.deepStrictEqual(v1, { one: '1' });
   assert.deepStrictEqual(v2, { two: '2' });
-  assert.deepStrictEqual(v3, null);
+  assert.strictEqual(v3, null);
 }
 
 {

--- a/test/parallel/test-tls-peer-certificate.js
+++ b/test/parallel/test-tls-peer-certificate.js
@@ -128,7 +128,7 @@ connect({
   assert.strictEqual(peerCert.nistCurve, 'P-256');
   assert.strictEqual(peerCert.bits, 256);
 
-  assert.deepStrictEqual(peerCert.infoAccess, undefined);
+  assert.strictEqual(peerCert.infoAccess, undefined);
 
   const issuer = peerCert.issuerCertificate;
   assert.strictEqual(issuer.issuerCertificate, issuer);

--- a/test/parallel/test-util-promisify.js
+++ b/test/parallel/test-util-promisify.js
@@ -83,7 +83,7 @@ const stat = promisify(fs.stat);
     callback(null, 'foo', 'bar');
   }
   promisify(fn)().then(common.mustCall((value) => {
-    assert.deepStrictEqual(value, 'foo');
+    assert.strictEqual(value, 'foo');
   }));
 }
 

--- a/test/parallel/test-whatwg-webstreams-adapters-to-streamreadable.js
+++ b/test/parallel/test-whatwg-webstreams-adapters-to-streamreadable.js
@@ -143,7 +143,7 @@ class MySource {
   });
 
   readable.on('data', common.mustCall((chunk) => {
-    assert.deepStrictEqual(chunk, 'hello');
+    assert.strictEqual(chunk, 'hello');
   }));
   readable.on('end', common.mustCall());
   readable.on('close', common.mustCall());

--- a/test/parallel/test-whatwg-webstreams-adapters-to-streamwritable.js
+++ b/test/parallel/test-whatwg-webstreams-adapters-to-streamwritable.js
@@ -170,7 +170,7 @@ class TestSource {
   writable.on('finish', common.mustCall());
   writable.on('close', common.mustCall(() => {
     assert.strictEqual(source.chunks.length, 1);
-    assert.deepStrictEqual(source.chunks[0], 'hello');
+    assert.strictEqual(source.chunks[0], 'hello');
   }));
 
   writable.write('hello', common.mustCall());

--- a/test/parallel/test-worker-message-port-receive-message.js
+++ b/test/parallel/test-worker-message-port-receive-message.js
@@ -10,13 +10,13 @@ const message2 = { foo: 'bar' };
 
 // Make sure receiveMessageOnPort() works in a FIFO way, the same way it does
 // when we’re using events.
-assert.deepStrictEqual(receiveMessageOnPort(port2), undefined);
+assert.strictEqual(receiveMessageOnPort(port2), undefined);
 port1.postMessage(message1);
 port1.postMessage(message2);
 assert.deepStrictEqual(receiveMessageOnPort(port2), { message: message1 });
 assert.deepStrictEqual(receiveMessageOnPort(port2), { message: message2 });
-assert.deepStrictEqual(receiveMessageOnPort(port2), undefined);
-assert.deepStrictEqual(receiveMessageOnPort(port2), undefined);
+assert.strictEqual(receiveMessageOnPort(port2), undefined);
+assert.strictEqual(receiveMessageOnPort(port2), undefined);
 
 // Make sure message handlers aren’t called.
 port2.on('message', common.mustNotCall());

--- a/test/parallel/test-worker-workerdata-messageport.js
+++ b/test/parallel/test-worker-workerdata-messageport.js
@@ -28,7 +28,7 @@ const meowScript = () => 'meow';
 
 {
   const uint8Array = new Uint8Array([ 1, 2, 3, 4 ]);
-  assert.deepStrictEqual(uint8Array.length, 4);
+  assert.strictEqual(uint8Array.length, 4);
   new Worker(`
     const { parentPort, workerData } = require('worker_threads');
     parentPort.postMessage(workerData);
@@ -41,7 +41,7 @@ const meowScript = () => 'meow';
     (message) =>
       assert.deepStrictEqual(message, Uint8Array.of(1, 2, 3, 4))
   );
-  assert.deepStrictEqual(uint8Array.length, 0);
+  assert.strictEqual(uint8Array.length, 0);
 }
 
 {

--- a/test/parallel/test-zlib-reset-before-write.js
+++ b/test/parallel/test-zlib-reset-before-write.js
@@ -26,7 +26,7 @@ for (const fn of [
     })
     .on('data', (chunk) => output.push(chunk))
     .on('end', common.mustCall(
-      () => assert.deepStrictEqual(Buffer.concat(output).toString(), 'abc')));
+      () => assert.strictEqual(Buffer.concat(output).toString(), 'abc')));
 
   fn(deflate, () => {
     fn(inflate, () => {

--- a/test/parallel/test-zlib-unzip-one-byte-chunks.js
+++ b/test/parallel/test-zlib-unzip-one-byte-chunks.js
@@ -16,10 +16,10 @@ const unzip = zlib.createUnzip()
   })
   .on('data', (data) => resultBuffers.push(data))
   .on('finish', common.mustCall(() => {
-    assert.deepStrictEqual(Buffer.concat(resultBuffers).toString(), 'abcdef',
-                           `'${Buffer.concat(resultBuffers).toString()}' ` +
-                           'should match \'abcdef\' after ' +
-                           'zipping and unzipping');
+    const unzipped = Buffer.concat(resultBuffers).toString();
+    assert.strictEqual(unzipped, 'abcdef',
+                       `'${unzipped}' should match 'abcdef' after zipping ` +
+                       'and unzipping');
   }));
 
 for (let i = 0; i < data.length; i++) {

--- a/test/pseudo-tty/test-assert-position-indicator.js
+++ b/test/pseudo-tty/test-assert-position-indicator.js
@@ -7,12 +7,12 @@ process.stderr.columns = 20;
 
 // Confirm that there is no position indicator.
 assert.throws(
-  () => { assert.deepStrictEqual('a'.repeat(30), 'a'.repeat(31)); },
+  () => { assert.strictEqual('a'.repeat(30), 'a'.repeat(31)); },
   (err) => !err.message.includes('^')
 );
 
 // Confirm that there is a position indicator.
 assert.throws(
-  () => { assert.deepStrictEqual('aaaa', 'aaaaa'); },
+  () => { assert.strictEqual('aaaa', 'aaaaa'); },
   (err) => err.message.includes('^')
 );

--- a/test/report/test-report-uv-handles.js
+++ b/test/report/test-report-uv-handles.js
@@ -161,10 +161,10 @@ if (process.argv[2] === 'child') {
   child.stdout.on('data', (chunk) => { stdout += chunk; });
   child.on('exit', common.mustCall((code, signal) => {
     assert.strictEqual(stderr.trim(), '');
-    assert.deepStrictEqual(code, 0, 'Process exited unexpectedly with code: ' +
-                           `${code}`);
-    assert.deepStrictEqual(signal, null, 'Process should have exited cleanly,' +
-                            ` but did not: ${signal}`);
+    assert.strictEqual(code, 0, 'Process exited unexpectedly with code: ' +
+                       `${code}`);
+    assert.strictEqual(signal, null, 'Process should have exited cleanly,' +
+                       ` but did not: ${signal}`);
 
     const reports = helper.findReports(child.pid, tmpdir.path);
     assert.deepStrictEqual(reports, [], report_msg, reports);

--- a/test/sequential/test-diagnostic-dir-heap-prof.js
+++ b/test/sequential/test-diagnostic-dir-heap-prof.js
@@ -44,7 +44,7 @@ function verifyFrames(output, file, func) {
     console.log(output.stderr.toString());
     console.log(roots);
   }
-  assert.notDeepStrictEqual(frame, undefined);
+  assert.notStrictEqual(frame, undefined);
 }
 
 const kHeapProfInterval = 128;

--- a/test/sequential/test-heap-prof.js
+++ b/test/sequential/test-heap-prof.js
@@ -51,7 +51,7 @@ function verifyFrames(output, file, func) {
     console.log(output.stderr.toString());
     console.log(roots);
   }
-  assert.notDeepStrictEqual(frame, undefined);
+  assert.notStrictEqual(frame, undefined);
 }
 
 // We need to set --heap-prof-interval to a small enough value to make


### PR DESCRIPTION
As far as I know, comparing any value to any non-`RegExp` literal or `undefined` using `strictEqual` (or `notStrictEqual`) passes if and only if `deepStrictEqual` (or `notDeepStrictEqual`, respectively) passes.

Personally, I think that unnecessarily using deep comparisons adds confusion.

This patch adds an ESLint rule that forbids the use of `deepStrictEqual` and `notDeepStrictEqual` when the `expected` value (i.e., the second argument) is a non-`RegExp` literal or `undefined`.

For reference, an ESTree literal is defined as follows.

```js
extend interface Literal <: Expression {
    type: "Literal";
    value: string | boolean | null | number | RegExp | bigint;
}
```

The value `undefined` is an `Identifier` with `name: 'undefined'`.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
