### PR TITLE
Revert "test: skip different params test for OpenSSL 3.x"

### DIFF
--- a/test/parallel/test-crypto-dh-stateless.js
+++ b/test/parallel/test-crypto-dh-stateless.js
@@ -144,17 +144,13 @@ test(crypto.generateKeyPairSync('dh', { group: 'modp5' }),
 test(crypto.generateKeyPairSync('dh', { group: 'modp5' }),
      crypto.generateKeyPairSync('dh', { prime: group.getPrime() }));
 
-const list = [];
-// Same generator, but different primes.
-// TODO(danbev) only commenting out this so that we can get our CI build
-// to pass. I'll continue looking into the cause/change.
-// [{ group: 'modp5' }, { group: 'modp18' }]];
+const list = [
+  // Same generator, but different primes.
+  [{ group: 'modp5' }, { group: 'modp18' }]];
 
 // TODO(danbev): Take a closer look if there should be a check in OpenSSL3
 // when the dh parameters differ.
 if (!common.hasOpenSSL3) {
-  // Same generator, but different primes.
-  list.push([{ group: 'modp5' }, { group: 'modp18' }]);
   // Same primes, but different generator.
   list.push([{ group: 'modp5' }, { prime: group.getPrime(), generator: 5 }]);
   // Same generator, but different primes.
@@ -167,7 +163,7 @@ for (const [params1, params2] of list) {
          crypto.generateKeyPairSync('dh', params2));
   }, common.hasOpenSSL3 ? {
     name: 'Error',
-    code: 'ERR_OSSL_DH_INVALID_PUBLIC_KEY'
+    code: 'ERR_OSSL_MISMATCHING_DOMAIN_PARAMETERS'
   } : {
     name: 'Error',
     code: 'ERR_OSSL_EVP_DIFFERENT_PARAMETERS'


### PR DESCRIPTION
This reverts commit 269f5132cc5a4b47c9f7c211530cac03bd23f825.

Fixes: https://github.com/nodejs/node/issues/38216

