### PR TITLE
crypto_scrypt.h: add missing semicolon

### DIFF
--- a/src/crypto/crypto_scrypt.h
+++ b/src/crypto/crypto_scrypt.h
@@ -77,7 +77,7 @@ struct ScryptJob {
   static void Initialize(
       Environment* env,
       v8::Local<v8::Object> target) {}
-}
+};
 #endif  // !OPENSSL_NO_SCRIPT
 
 }  // namespace crypto


### PR DESCRIPTION
This fixes:

| In file included from ../src/node_crypto.h:47,
|                  from ../src/node.cc:46:
| ../src/crypto/crypto_scrypt.h:80:2: error: expected ';' after struct definition
|    80 | }
|       |  ^
|       |  ;

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
