### PR TITLE
tools,meta: remove exclusions from AUTHORS

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -51,6 +51,7 @@ Ben Lugavere <b.lugavere@gmail.com>
 Ben Noordhuis <info@bnoordhuis.nl> <ben@strongloop.com>
 Ben Noordhuis <info@bnoordhuis.nl> <bnoordhuis@bender.(none)>
 Ben Taber <ben.taber@gmail.com>
+Benedikt Meurer <bmeurer@google.com> <bmeurer@chromium.org>
 Benjamin Coe <bencoe@gmail.com> <ben@npmjs.com>
 Benjamin Coe <bencoe@gmail.com> <bencoe@google.com>
 Benjamin Fleischer <github@benjaminfleischer.com> <benjamin.fleischer@swipesense.com>
@@ -93,6 +94,7 @@ Corey Martin <coreymartin496@gmail.com>
 Cyril Lakech <cyril.lakech@axa.fr> <1169286+clakech@users.noreply.github.com>
 Daiki Arai <darai0512@yahoo.co.jp> <darai@yahoo-corp.jp>
 Damien Simonin Feugas <damien.feugas@gmail.com>
+Dan Carney <dcarney@chromium.org>
 Dan Fabulich <dan@fabulich.com> <dan.fabulich@redfin.com>
 Dan Kaplun <dbkaplun@gmail.com> <dan@beardtree.com>
 Dan Williams <dan@igniter.com> <daniel@chat.za.net>
@@ -100,6 +102,7 @@ Daniel Abrão <danielpaladar@gmail.com>
 Daniel Berger <code+node@dpbis.net>
 Daniel Bevenius <daniel.bevenius@gmail.com>
 Daniel Chcouri <333222@gmail.com>
+Daniel Clifford <danno@chromium.org>
 Daniel Gröber <darklord@darkboxed.org>
 Daniel Gröber <darklord@darkboxed.org> <dxld@darkboxed.org>
 Daniel Paulino <d_paulino@outlook.com>
@@ -110,9 +113,9 @@ Danielle Adams <adamzdanielle@gmail.com> <danielle.adams@heroku.com>
 Danny Guo <danny@dannyguo.com> <dannyguo91@gmail.com>
 Danny Nemer <hi@dannynemer.com> <DannyNemer@users.noreply.github.com>
 Danny Nemer <hi@dannynemer.com> <hi@DannyNemer.com>
-Dave Olszewski <cxreg@pobox.com> <daveo@nodesource.com>
 Darshan Sen <raisinten@gmail.com>
 Darshan Sen <raisinten@gmail.com> <darshan.sen@postman.com>
+Dave Olszewski <cxreg@pobox.com> <daveo@nodesource.com>
 Dave Pacheco <dap@joyent.com> <dap@cs.brown.edu>
 David Cai <davidcai1993@yahoo.com>
 David Mark Clements <david.clements@nearform.com>
@@ -128,8 +131,10 @@ Eduard Burtescu <eddy_me08@yahoo.com>
 Einar Otto Stangvik <einaros@gmail.com>
 Elliott Cable <me@ell.io>
 Emanuel Buholzer <contact@emanuelbuholzer.com> <EmanuelBuholzer@outlook.com>
+Enrico Pertoso <epertoso@chromium.org>
 Eric Bickle <wolf.code@outlook.com> <ebickle@users.noreply.github.com>
 Eric Phetteplace <phette23@gmail.com>
+Erik Corry <erik.corry@gmail.com>
 Ernesto Salazar <ernestoalbertosalazar@gmail.com>
 Erwin W. Ramadhan <erwinwahyuramadhan@gmail.com>
 Ethan Arrowood <ethan@arrowood.dev> <ethan.arrowood@gmail.com>
@@ -155,6 +160,7 @@ Florian Margaine <florian@margaine.com>
 Forrest L Norvell <othiym23@gmail.com> <forrest@npmjs.com>
 Forrest L Norvell <othiym23@gmail.com> <ogd@aoaioxxysz.net>
 Franziska Hinkelmann <franziska.hinkelmann@gmail.com> <fhinkel@vt.edu>
+Franziska Hinkelmann <franziska.hinkelmann@gmail.com> <franzih@chromium.org>
 Friedemann Altrock <frodenius@gmail.com>
 Fuji Goro <gfuji@cpan.org>
 Gabriel de Perthuis <g2p.code@gmail.com>
@@ -197,6 +203,7 @@ Isuru Siriwardana <isuruanatomy@gmail.com>
 Italo A. Casas <me@italoacasas.com> <italo@italoacasas.com>
 Jackson Tian <shyvo1987@gmail.com> <puling.tyq@alibaba-inc.com>
 Jake Verbaten <raynos2@gmail.com>
+Jakob Kummerow <jkummerow@chromium.org>
 Jamen Marzonie <jamenmarz@gmail.com> <jamenmarz+gh@gmail.com>
 James Beavers <jamesjbeavers@gmail.com>
 James Bromwell <james.bromwell@gdit.com> <943160+thw0rted@users.noreply.github.com>
@@ -212,12 +219,14 @@ Jennifer Bland <ratracegrad@gmail.com> <jennifer.bland@sbdinc.com>
 JeongHoon Byun <outsideris@gmail.com>
 Jered Schmidt <tr@nslator.jp>
 Jeremiah Senkpiel <fishrock123@rocketmail.com>
+Jeremy Apthorp <nornagon@nornagon.net> <jeremya@chromium.org>
 Jérémy Lal <kapouer@melix.org>
 Jérémy Lal <kapouer@melix.org> <holisme@gmail.com>
 Jerry Chin <qinjia@outlook.com>
 Jessica Quynh Tran <jessica.quynh.tran@gmail.com>
 Jesús Leganés-Combarro 'piranna <piranna@gmail.com>
 Jimb Esser <wasteland@gmail.com> <jimb@railgun3d.com>
+Jochen Eisinger <jochen@chromium.org> 
 Joe Shaw <joe@joeshaw.org> <joeshaw@litl.com>
 Johan Bergström <bugs@bergstroem.nu>
 Johan Dahlberg <jfd@distrop.com> <dahlberg.johan@gmail.com>
@@ -260,6 +269,7 @@ Kazuyuki Yamada <tasogare.pg@gmail.com>
 Ke Ding <dingkework@hotmail.com>
 Keith M Wesolowski <wesolows@joyent.com> <wesolows@foobazco.org>
 Kelsey Breseman <ifoundthemeaningoflife@gmail.com>
+Kevin Millikin <kmillikin@chromium.org>
 Khaidi Chu <i@2333.moe>
 Khaidi Chu <i@2333.moe> <admin@xcoder.in>
 Kimberly Wilber <gcr@sneakygcr.net>
@@ -273,6 +283,7 @@ Kyle Robinson Young <kyle@dontkry.com>
 Lakshmi Swetha Gopireddy <lakshmiswethagopireddy@gmail.com> <lakshmigopireddy@in.ibm.com>
 Lakshmi Swetha Gopireddy <lakshmiswethagopireddy@gmail.com> <lgopired@in.ibm.com>
 Lars-Magnus Skog <ralphtheninja@riseup.net> <lars.magnus.skog@gmail.com>
+Lasse R.H. Nielsen <lrn@chromium.org>
 Leeseean Chiu <leeseean@qq.com>
 Lucas Pardue <lucaspardue.24.7@gmail.com> <lucas.pardue@bbc.co.uk>
 Luke Bayes <lbayes@patternpark.com>
@@ -306,8 +317,10 @@ Matthew Lye <muddletoes@hotmail.com>
 Matthew Turner <matty_t47@hotmail.com> <ramesius@users.noreply.github.com>
 Matthias Bastian <dev@matthias-bastian.de> <piepmatz@users.noreply.github.com>
 Maurice Hayward <mauricehayward1@gmail.com>
+Maya Lekova <apokalyptra@gmail.com> <mslekova@chromium.org>
 Michael Bernstein <michaelrbernstein@gmail.com>
 Michael Dawson <michael_dawson@ca.ibm.com> <mdawson@devrus.com>
+Michael Starzinger <mstarzinger@chromium.org>
 Michaël Zasso <targos@protonmail.com> <mic.besace@gmail.com>
 Michael-Rainabba Richardson <rainabba@gmail.com>
 Michał Gołębiowski-Owczarek <m.goleb@gmail.com>
@@ -340,6 +353,7 @@ Nikolai Vavilov <vvnicholas@gmail.com>
 Nils Kuhnhenn <lain@volafile.io>
 Nitzan Uziely <linkgoron@gmail.com> <nitzan@testim.io>
 Noah Rose Ledesma <noahroseledesma@seattleacademy.org>
+Oliver Chang <ochang@chromium.org>
 Oluwaseun Omoyajowo <omoyajowo2015@gmail.com>
 Onne Gorter <onne@onnlucky.com>
 Oscar Martinez <oscar@mtnz-web.com> <oscar.martinez@hautelook.com>
@@ -348,6 +362,7 @@ Paul Querna <pquerna@apache.org> <paul@querna.org>
 Pedro Lima <pvsousalima@gmail.com>
 Peng Lyu <penn.lv@gmail.com>
 Peter Flannery <pflannery@users.noreply.github.com>
+Peter Marshall <p.s.marshall0@gmail.com> <petermarshall@chromium.org>
 Peter Marton <email@martonpeter.com> <peter@risingstack.com>
 Peter Paugh <ppaugh@chariotsolutions.com>
 Phillip Johnsen <johphi@gmail.com> <phillip.johnsen@finn.no>
@@ -392,9 +407,9 @@ Sam Roberts <vieuxtech@gmail.com> <sam@strongloop.com>
 Sam Shull <brickysam26@gmail.com> <brickysam26@samuel-shulls-computer.local>
 Sam Shull <brickysam26@gmail.com> <sam+github@samshull.com>
 Sam Shull <brickysam26@gmail.com> <sshull@squaremouth.com>
-Samuel Attard <samuel.r.attard@gmail.com> <sattard@slack-corp.com>
 Samantha Sample <ssample812@gmail.com> <=>
 Sambasiva Suda <sambasivarao@gmail.com>
+Samuel Attard <samuel.r.attard@gmail.com> <sattard@slack-corp.com>
 San-Tai Hsu <v@fatpipi.com>
 Santiago Gimeno <santiago.gimeno@gmail.com> <santiago.gimeno@ionide.es>
 Sarah Meyer <sarahsaltrick@gmail.com>
@@ -430,6 +445,7 @@ Stewart X Addison <sxa@redhat.com> <sxa@uk.ibm.com>
 Suraiya Hameed <hameedsuraiya@gmail.com>
 Suramya shah <shah.suramya@gmail.com> <ss22ever@users.noreply.github.com>
 Surya Panikkal <surya.com@gmail.com>
+Sven Panne <svenpanne@chromium.org>
 Szymon Marczak <sz.marczak@gmail.com> <36894700+szmarczak@users.noreply.github.com>
 Tadashi SAWADA <cesare@mayverse.jp>
 Tadhg Creedon <tadhgcreedon@gmail.com> <tadhg.creedon@rangle.io>
@@ -453,6 +469,7 @@ Tim Price <timprice@mangoraft.com>
 Tim Ruffles <timruffles@googlemail.com> <oi@truffles.me.uk>
 Tim Smart <timehandgod@gmail.com>
 Tim Smart <timehandgod@gmail.com> <tim@fostle.com>
+Timothy Gu <timothygu99@gmail.com> <timothygu@chromium.org>
 Timothy Leverett <zzzzBov@gmail.com>
 Timothy O. Peters <timotewpeters@gmail.com>
 Timur Shemsedinov <timur.shemsedinov@gmail.com>
@@ -470,20 +487,22 @@ Tom Hughes-Croucher <tom_croucher@yahoo.com>
 Tom Purcell <tpurcell@chariotsolutions.com>
 Tom White <tomtinkerer@gmail.com>
 Tomoki Okahana <umatomakun@gmail.com>
+Toon Verwaest <verwaest@chromium.org>
 Tracy Hinds <tracyhinds@gmail.com>
 Travis Meisenheimer <travis@indexoutofbounds.com> <tmeisenh@gmail.com>
 Trevor Burnham <trevor@databraid.com> <trevorburnham@gmail.com>
 Trivikram Kamat <trivikr.dev@gmail.com> <16024985+trivikr@users.noreply.github.com>
 ttzztztz <ttzztztz@outlook.com> <yangziyue80@outlook.com>
 Tyler Larson <talltyler@gmail.com>
-Ujjwal Sharma <ryzokuken@disroot.org> <usharma1998@gmail.com>
 Ujjwal Sharma <ryzokuken@disroot.org> <ryzokuken@igalia.com>
+Ujjwal Sharma <ryzokuken@disroot.org> <usharma1998@gmail.com>
 Uttam Pawar <upawar@gmail.com> <uttam.c.pawar@intel.com>
 Viktor Karpov <viktor.s.karpov@gmail.com>
 Vincent Voyer <v@fasterize.com>
 Vladimir de Turckheim <vlad2t@hotmail.com>
 Voltrex <mohammadkeyvanzade94@gmail.com> <62040526+VoltrexMaster@users.noreply.github.com>
 vsemozhetbyt <vsemozhetbyt@gmail.com>
+Vyacheslav Egorov <vegorov@chromium.org>
 Wang Xinyong <wang.xy.chn@gmail.com> <wangxy.chn@gmail.com>
 Wei-Wei Wu <wuxx1045@umn.edu>
 Weijia Wang <starkwang@126.com>
@@ -497,6 +516,7 @@ Xavier J Ortiz <xavier.ortiz.ch@gmail.com>
 xiaoyu <306766053@qq.com>
 Xu Meng <dmabupt@gmail.com> <mengxumx@cn.ibm.com>
 Yael Hermon <yaelherm@gmail.com> <yaelhe@wix.com>
+Yang Guo <yangguo@chromium.org>
 ycjcl868 <45808948@qq.com> <chaolinjin@gmail.com>
 Yingchen Xue <yingchenxue@qq.com>
 Yongsheng Zhang <zyszys98@gmail.com>
@@ -514,15 +534,3 @@ Zachary Vacura <admin@hackzzila.com>
 Zoran Tomicic <ztomicic@gmail.com>
 Сковорода Никита Андреевич <chalkerx@gmail.com>
 隋鑫磊 <joshuasui@163.com>
-
-# These people didn't contribute patches to node directly,
-# but we've landed their v8 patches in the node repository:
-Daniel Clifford <danno@chromium.org>
-Erik Corry <erik.corry@gmail.com>
-Jakob Kummerow <jkummerow@chromium.org>
-Kevin Millikin <kmillikin@chromium.org>
-Lasse R.H. Nielsen <lrn@chromium.org>
-Michael Starzinger <mstarzinger@chromium.org>
-Toon Verwaest <verwaest@chromium.org>
-Vyacheslav Egorov <vegorov@chromium.org>
-Yang Guo <yangguo@chromium.org>

--- a/AUTHORS
+++ b/AUTHORS
@@ -149,6 +149,7 @@ Theo Schlossnagle <jesus@omniti.com>
 Kai Chen <kaichenxyz@gmail.com>
 Daniel Chcouri <333222@gmail.com>
 Mihai Călin Bazon <mihai@bazon.net>
+Kevin Millikin <kmillikin@chromium.org>
 Ali Farhadi <a.farhadi@gmail.com>
 Daniel Ennis <aikar@aikar.co>
 Carter Allen <CarterA@opt-6.com>
@@ -198,6 +199,7 @@ Kip Gebhardt <kip.gebhardt@voxer.com>
 Stefan Rusu <saltwaterc@gmail.com>
 Shigeki Ohtsu <ohtsu@ohtsu.org>
 Wojciech Wnętrzak <w.wnetrzak@gmail.com>
+Vyacheslav Egorov <vegorov@chromium.org>
 Devon Govett <devongovett@gmail.com>
 Steve Engledow <steve.engledow@proxama.com>
 Pierre-Alexandre St-Jean <pierrealexandre.stjean@gmail.com>
@@ -219,6 +221,7 @@ Antranig Basman <antranig.basman@colorado.edu>
 Maciej Małecki <maciej.malecki@notimplemented.org>
 Evan Martin <martine@danga.com>
 Peter Lyons <pete@peterlyons.com>
+Jakob Kummerow <jkummerow@chromium.org>
 Jann Horn <jannhorn@googlemail.com>
 Abimanyu Raja <abimanyuraja@gmail.com>
 Karl Skomski <karl@skomski.com>
@@ -308,10 +311,12 @@ Farid Neshat <FaridN_SOAD@yahoo.com>
 Johannes Wüller <johanneswueller@gmail.com>
 Erik Lundin <mjor.himself@gmail.com>
 Bryan Cantrill <bryan@joyent.com>
+Michael Starzinger <mstarzinger@chromium.org>
 Yosef Dinerstein <yosefd@microsoft.com>
 Nathan Friedly <nathan@nfriedly.com>
 Aaron Jacobs <jacobsa@google.com>
 Mustansir Golawala <mgolawala@gmail.com>
+Lasse R.H. Nielsen <lrn@chromium.org>
 Atsuo Fukaya <fukayatsu@gmail.com>
 Domenic Denicola <domenic@domenicdenicola.com>
 Joshua S. Weinstein <josher19@users.sf.net>
@@ -328,6 +333,7 @@ J. Lee Coltrane <lee@projectmastermind.com>
 Javier Hernández <jhernandez@emergya.com>
 James Koval <james.ross.koval@gmail.com>
 Kevin Gadd <kevin.gadd@gmail.com>
+Yang Guo <yangguo@chromium.org>
 Ray Solomon <raybsolomon@gmail.com>
 Kevin Bowman <github@magicmonkey.org>
 Erwin van der Koogh <github@koogh.com>
@@ -336,8 +342,11 @@ Simon Sturmer <sstur@me.com>
 Joel Brandt <joelrbrandt@gmail.com>
 Marc Harter <wavded@gmail.com>
 Nuno Job <nunojobpinto@gmail.com>
+Daniel Clifford <danno@chromium.org>
 Ben Kelly <ben@wanderview.com>
 Felix Böhm <felixboehm55@googlemail.com>
+Erik Corry <erik.corry@gmail.com>
+Toon Verwaest <verwaest@chromium.org>
 George Shank <shankga@gmail.com>
 Gabriel de Perthuis <g2p.code@gmail.com>
 Vladimir Beloborodov <redhead.ru@gmail.com>
@@ -522,6 +531,7 @@ Lorenz Leutgeb <lorenz.leutgeb@gmail.com>
 ayanamist <contact@ayanamist.com>
 gluxon <bcheng.gt@gmail.com>
 Tom Gallacher <tomgallacher23@gmail.com>
+Sven Panne <svenpanne@chromium.org>
 Jo Liss <joliss42@gmail.com>
 Jun Ma <roammm@gmail.com>
 Jacob Hoffman-Andrews <github@hoffman-andrews.com>
@@ -542,6 +552,7 @@ Saúl Ibarra Corretgé <s@saghul.net>
 Greg Brail <greg@apigee.com>
 Shuhei Kagawa <shuhei.kagawa@gmail.com>
 Josh Dague <jd@josh3736.net>
+Dan Carney <dcarney@chromium.org>
 Goh Yisheng (Andrew) <mail.yisheng@gmail.com>
 James Pickard <james.pickard@gmail.com>
 Andrew Low <Andrew_Low@ca.ibm.com>
@@ -564,6 +575,7 @@ Greg Sabia Tucker <greg@narrowlabs.com>
 Dan Kaplun <dbkaplun@gmail.com>
 Colin Ihrig <cjihrig@gmail.com>
 Mark Stosberg <mark@rideamigos.com>
+Jochen Eisinger <jochen@chromium.org>
 Calvin Metcalf <calvin.metcalf@gmail.com>
 Ryan Cole <ryan@rycole.com>
 Kevin Decker <kpdecker@gmail.com>
@@ -1001,6 +1013,7 @@ Ingvar Stepanyan <me@rreverser.com>
 Adrian Estrada <edsadr@gmail.com>
 Matt Lavin <matt.lavin@gmail.com>
 Joao Andrade <jjadonotenter@gmail.com>
+Pavel Feldman <pfeldman@chromium.org>
 Bartosz Sosnowski <bartosz@janeasystems.com>
 Nicolas Romer <nicolasromer@gmail.com>
 David A. Wheeler <dwheeler@dwheeler.com>
@@ -1040,12 +1053,14 @@ Joe Esposito <joe@joeyespo.com>
 Erin Spiceland <yes@erin.codes>
 Ravindra Barthwal <ravindrabarthwal@users.noreply.github.com>
 Joey Cozza <joeycozza@gmail.com>
+Franziska Hinkelmann <franziska.hinkelmann@gmail.com>
 Vladimir de Turckheim <vlad2t@hotmail.com>
 Taehee Kang <hugnosis@gmail.com>
 Igor Savin <iselwin@gmail.com>
 Pat Pannuto <pat.pannuto@gmail.com>
 Haojian Wu <hokein.wu@gmail.com>
 John Gardner <gardnerjohng@gmail.com>
+Enrico Pertoso <epertoso@chromium.org>
 Aleksei Koziatinskii <ak239spb@gmail.com>
 Adrian Nitu <adrian.nitu@intel.com>
 Ben Gourley <bn@grly.me>
@@ -1092,6 +1107,7 @@ Tarjei Husøy <git@thusoy.com>
 Wietse Venema <wvenema@xebia.com>
 Jonathan Prince <jonathan.prince@gmail.com>
 Fikret Burak Gazioglu <burakgazi@static.ip-217-149-135-181.signet.nl>
+Aleksey Kozyatinskiy <kozyatinskiy@chromium.org>
 delvedor <tommydelved@gmail.com>
 Jermaine Oppong <jeropp00@gmail.com>
 Richard Walker <digitalsadhu@gmail.com>
@@ -1540,6 +1556,7 @@ Ezequiel Garcia <ezequiel@vanguardiasur.com.ar>
 Kyle Farnung <kfarnung@microsoft.com>
 Weijia Wang <starkwang@126.com>
 Nataly Shrits <nataly@soluto.com>
+Oliver Chang <ochang@chromium.org>
 Jaime Bernardo <jaime@janeasystems.com>
 Natanael Log <natte.log@gmail.com>
 Chen Gang <gangc.cxy@foxmail.com>
@@ -1551,6 +1568,7 @@ Jimmy Thomson <jithomso@microsoft.com>
 David Drysdale <drysdale@google.com>
 Roman Shoryn <romanshoryn@gmail.com>
 Peter Czibik <p.czibik@gmail.com>
+Igor Sheludko <ishell@chromium.org>
 章礼平 <LipperZack@gmail.com>
 Fraser Xu <xvfeng123@gmail.com>
 Song, Bintao Garfield <songbintaochina@gmail.com>
@@ -1600,7 +1618,6 @@ Shivanth MP <fordearlinux@gmail.com>
 erdun <494251936@qq.com>
 Jiajie Hu <jiajie.hu@intel.com>
 Matt Woicik <mattwoicik@gmail.com>
-Franziska Hinkelmann <franziska.hinkelmann@gmail.com>
 alexbostock <alex@alexbostock.co.uk>
 Matthew Alsup <matt@thealsups.com>
 Greg Alexander <gregory.l.alexander@gmail.com>
@@ -1848,6 +1865,7 @@ Luke Childs <lukechilds123@gmail.com>
 Robert Nagy <ronagy@icloud.com>
 Nikki St Onge <nstonge@gasbuddy.com>
 zhangzifa <tonyzzf@163.com>
+Tobias Tebbi <tebbi@chromium.org>
 hwaisiu <hazels@telus.net>
 Thomas Karsten <thomas.karsten@fastretailing.com>
 Lance Barlaan <LPTBarlaan@gmail.com>
@@ -1869,6 +1887,7 @@ Tomoki Okahana <umatomakun@gmail.com>
 Aayush Ahuja <aayush.a@directi.com>
 Paul Marion Camantigue <Paul-Marion.F.Camantigue@kp.org>
 Jayson D. Henkel <jayson.henkel@split-horizon.net>
+Ben Smith <binji@chromium.org>
 Nicolas 'Pixel' Noble <pixel@nobis-crew.org>
 Ashish Kaila <ashishkaila@hotmail.com>
 c0b <14798161+c0b@users.noreply.github.com>
@@ -2013,6 +2032,7 @@ spring_raining <fdonthavei@gmail.com>
 Hiromu Yoshiwara <hiromoon0428@gmail.com>
 yuza yuko <blackcat.yuza@1pac.jp>
 smatsu-hl <sara-matsumoto@hands-lab.com>
+Hannes Payer <hpayer@chromium.org>
 Bamieh <ahmadbamieh@gmail.com>
 WhoMeNope <toman.martin@live.com>
 Junichi Kajiwara <junichi.kajiwara@gmail.com>
@@ -2023,6 +2043,8 @@ Hannes Magnusson <hannes.magnusson@gmail.com>
 ChungNgoops <mr.mvagusta@gmail.com>
 Jose M. Palacios Diaz <jmpd1988@gmail.com>
 hmammedzadeh <hasan.mammed-zadeh@commercetools.de>
+Sergei Datsenko <dats@chromium.org>
+Marja Hölttä <marja@chromium.org>
 IHsuan <frostyjoan0829@livemail.tw>
 Francisco Gerardo Neri Andriano <on_neri@hotmail.com>
 Shilo Mangam <smangam@gmail.com>
@@ -2057,6 +2079,7 @@ Salame William <william.salame@student.uclouvain.be>
 Todd Wong <toddwong@leftart.com>
 Mykola Bilochub <nbelochub@gmail.com>
 Qingyan Li <qingyan.liqy@alibaba-inc.com>
+Jinho Bang <zino@chromium.org>
 Sho Miyamoto <shqld8@gmail.com>
 现充 <qixiang.cqx@alibaba-inc.com>
 furstenheim <furstenheim@gmail.com>
@@ -2106,6 +2129,7 @@ Eric Bickle <wolf.code@outlook.com>
 Ujjwal Sharma <ryzokuken@disroot.org>
 Wei-Wei Wu <wuxx1045@umn.edu>
 Prateek Singh <prateeksingh1@hotmail.com>
+Mythri Alle <mythria@chromium.org>
 Ken Lin <ken23421@gmail.com>
 Piotr Grzesik <pj.grzesik@gmail.com>
 Damien Simonin Feugas <damien.feugas@gmail.com>
@@ -2161,6 +2185,7 @@ John Musgrave <musgravejw@gmail.com>
 Dhansuhu Uzumaki <a.p.dhanushu@gmail.com>
 Beni von Cheni <benjaminlchen@gmail.com>
 Ilya Sotov <sotovilya@yandex.ru>
+Ulan Degenbaev <ulan@chromium.org>
 William Cohen <wcohen@redhat.com>
 Ajido <ajido@me.com>
 kailash k yogeshwar <kailashyogeshwar85@gmail.com>
@@ -2254,10 +2279,12 @@ Simionescu, Radu <radsimu@gmail.com>
 mariotsi <simone@mariotti.me>
 prayag21 <10997858+prayag21@users.noreply.github.com>
 Bruno Pinho <bpinhosilva@gmail.com>
+Michael Achenbach <machenbach@chromium.org>
 Anto Aravinth <anto.aravinth.cse@gmail.com>
 Helio Frota <00hf11@gmail.com>
 Jacob Page <jpage@godaddy.com>
 sagulati <sagulati@adobe.com>
+Gabriel Charette <gab@chromium.org>
 conectado <gabrielalejandro7@gmail.com>
 Vitor Bruno de Oliveira Barth <vbob@vbob.com.br>
 Christian Clauss <cclauss@me.com>
@@ -2272,6 +2299,7 @@ Ouyang Yadong <oyydoibh@gmail.com>
 yahavfuchs <yahavf6@gmail.com>
 Thomas Leah <thomas@leahfamily.plus.com>
 Musa Hamwala <musahamwala@icloud.com>
+Andrey Lushnikov <lushnikov@chromium.org>
 James Bromwell <james.bromwell@gdit.com>
 Jeremy Apthorp <nornagon@nornagon.net>
 Eugen Cazacu <32613393+oygen87@users.noreply.github.com>
@@ -2283,6 +2311,7 @@ Dzmitry_Prudnikau <dzmitriyprudnikov@gmail.com>
 Ian McKellar <ianloic@google.com>
 Jennifer Bland <ratracegrad@gmail.com>
 Kyle Fuller <kyle@fuller.li>
+Camillo Bruni <cbruni@chromium.org>
 Yongsheng Zhang <zyszys98@gmail.com>
 Neeraj Laad <neeraj.laad@uk.ibm.com>
 Scott Van Gilder <svangilder@gmail.com>
@@ -2297,6 +2326,7 @@ Szymon Marczak <sz.marczak@gmail.com>
 Tessei Kameyama <kamenoko315@ruri.waseda.jp>
 Chakravarthy S M <chakra.mithun@gmail.com>
 Andreas Haas <ahaas@google.com>
+Clemens Hammacher <clemensh@chromium.org>
 Saud Khanzada <muhammad.saud@tenpearls.com>
 Hariss096 <hariss096@gmail.com>
 William Skellenger <wskellenger@gmail.com>
@@ -2673,6 +2703,7 @@ toshi1127 <toshi.matsumoto.2n@stu.hosei.ac.jp>
 nd-02110114 <nd.12021218@gmail.com>
 dkundel <dominik.kundel@gmail.com>
 Evan Plaice <evanplaice@gmail.com>
+Simon Zünd <szuend@chromium.org>
 simon3000 <simon300000@users.noreply.github.com>
 Marcos Casagrande <marcoscvp90@gmail.com>
 Ruwan Geeganage <rpgeeg@gmail.com>
@@ -2845,6 +2876,7 @@ Patrick Housley <patrick.f.housley@gmail.com>
 Artem Maksimov <temamaksimov@gmail.com>
 Nolik <nolikfriendly@gmail.com>
 palmires <palmires@example.com>
+Clemens Backes <clemensb@chromium.org>
 Vadim Gorbachev <bmsdave@gmail.com>
 galina.prokofeva <g.k.prokofeva@gmail.com>
 Nadya <nadin.ts@gmail.com>
@@ -3033,6 +3065,7 @@ Karol Walasek <coreconviction@gmail.com>
 osher <osher.filter@gmail.com>
 szTheory <szTheory@users.noreply.github.com>
 Jonathan Buhacoff <jonathan@buhacoff.net>
+Shu-yu Guo <syg@chromium.org>
 Paolo Insogna <paolo@cowtech.it>
 Richard Townsend <Richard.Townsend@arm.com>
 Deep310 <55121371+Deep310@users.noreply.github.com>
@@ -3114,6 +3147,7 @@ Hussaina Begum Nandyala <hexxdump@gmail.com>
 Danny Sonnenschein <my.card.god@web.de>
 Sourav Shaw <shawsourav91@gmail.com>
 H Adinarayana <adharida@in.ibm.com>
+Kim-Anh Tran <kimanh@chromium.org>
 lucasg <lucas.georges@outlook.com>
 Brian 'bdougie' Douglas <ilikerobot@gmail.com>
 Lee, Bonggi <iyabong@gmail.com>
@@ -3321,6 +3355,7 @@ Ignacio Carbajo <icarbajop@gmail.com>
 Constantine Kim <elegantcoder@gmail.com>
 OliverOdo <rodomond.o@gmail.com>
 Mark Skelton <mskelton@widen.com>
+Ross McIlroy <rmcilroy@chromium.org>
 Isaac Brodsky <isaac@isaacbrodsky.com>
 simon-id <simon.id@protonmail.com>
 Francesco Trotta <github@fasttime.org>

--- a/tools/update-authors.js
+++ b/tools/update-authors.js
@@ -110,9 +110,7 @@ rl.on('line', (line) => {
     ({ author, email } = { author, email, ...replacement });
   }
 
-  if (seen.has(email) ||
-      /@chromium\.org/.test(email) ||
-      email === '<erik.corry@gmail.com>') {
+  if (seen.has(email)) {
     return;
   }
 


### PR DESCRIPTION
The update-authors tool omits Chromium team members. This was a decision
made years ago. The idea was that these folks contributed to V8 not to
Node.js, as they typically ended up in our code-base via cherry-picked
commits from V8.
Ref: https://github.com/nodejs/node/pull/232#discussion-diff-22412788

Now that there are over 3000 contributors identified in AUTHORS, some of
whom are bots that we run, I think it's time to undo this exception. If
we used someone else's code in a cherry-pick, congratulations to them,
they're authors. In particular, this will fix the omission of Yang
Guo who contributed extensively to Node.js outside of V8 contributions.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
