### PR TITLE
process: support hrtime in the snapshot

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -162,6 +162,9 @@ const rawMethods = internalBinding('process_methods');
   process.kill = wrapped.kill;
   process.exit = wrapped.exit;
 
+  process.hrtime = perThreadSetup.hrtime;
+  process.hrtime.bigint = perThreadSetup.hrtimeBigInt;
+
   process.openStdin = function() {
     process.stdin.resume();
     return process.stdin;

--- a/lib/internal/bootstrap/pre_execution.js
+++ b/lib/internal/bootstrap/pre_execution.js
@@ -82,16 +82,7 @@ function patchProcessObject(expandArgv1) {
   const binding = internalBinding('process_methods');
   binding.patchProcessObject(process);
 
-  // TODO(joyeecheung): snapshot fast APIs (which need to work with
-  // array buffers, whose connection with C++ needs to be rebuilt after
-  // deserialization).
-  const {
-    hrtime,
-    hrtimeBigInt
-  } = require('internal/process/per_thread').getFastAPIs(binding);
-
-  process.hrtime = hrtime;
-  process.hrtime.bigint = hrtimeBigInt;
+  require('internal/process/per_thread').refreshHrtimeBuffer();
 
   ObjectDefineProperty(process, 'argv0', {
     enumerable: true,

--- a/lib/internal/process/per_thread.js
+++ b/lib/internal/process/per_thread.js
@@ -54,49 +54,48 @@ function assert(x, msg) {
   if (!x) throw new ERR_ASSERTION(msg || 'assertion error');
 }
 
-function getFastAPIs(binding) {
-  const {
-    hrtime: _hrtime
-  } = binding.getFastAPIs();
+const binding = internalBinding('process_methods');
 
+let hrValues;
+let hrBigintValues;
+
+function refreshHrtimeBuffer() {
   // The 3 entries filled in by the original process.hrtime contains
   // the upper/lower 32 bits of the second part of the value,
   // and the remaining nanoseconds of the value.
-  const hrValues = new Uint32Array(_hrtime.buffer);
-
-  function hrtime(time) {
-    _hrtime.hrtime();
-
-    if (time !== undefined) {
-      validateArray(time, 'time');
-      if (time.length !== 2) {
-        throw new ERR_OUT_OF_RANGE('time', 2, time.length);
-      }
-
-      const sec = (hrValues[0] * 0x100000000 + hrValues[1]) - time[0];
-      const nsec = hrValues[2] - time[1];
-      const needsBorrow = nsec < 0;
-      return [needsBorrow ? sec - 1 : sec, needsBorrow ? nsec + 1e9 : nsec];
-    }
-
-    return [
-      hrValues[0] * 0x100000000 + hrValues[1],
-      hrValues[2],
-    ];
-  }
-
+  hrValues = new Uint32Array(binding.hrtimeBuffer);
   // Use a BigUint64Array in the closure because this is actually a bit
   // faster than simply returning a BigInt from C++ in V8 7.1.
-  const hrBigintValues = new BigUint64Array(_hrtime.buffer, 0, 1);
-  function hrtimeBigInt() {
-    _hrtime.hrtimeBigInt();
-    return hrBigintValues[0];
+  hrBigintValues = new BigUint64Array(binding.hrtimeBuffer, 0, 1);
+}
+
+// Create the buffers.
+refreshHrtimeBuffer();
+
+function hrtime(time) {
+  binding.hrtime();
+
+  if (time !== undefined) {
+    validateArray(time, 'time');
+    if (time.length !== 2) {
+      throw new ERR_OUT_OF_RANGE('time', 2, time.length);
+    }
+
+    const sec = (hrValues[0] * 0x100000000 + hrValues[1]) - time[0];
+    const nsec = hrValues[2] - time[1];
+    const needsBorrow = nsec < 0;
+    return [needsBorrow ? sec - 1 : sec, needsBorrow ? nsec + 1e9 : nsec];
   }
 
-  return {
-    hrtime,
-    hrtimeBigInt,
-  };
+  return [
+    hrValues[0] * 0x100000000 + hrValues[1],
+    hrValues[2],
+  ];
+}
+
+function hrtimeBigInt() {
+  binding.hrtimeBigInt();
+  return hrBigintValues[0];
 }
 
 // The execution of this function itself should not cause any side effects.
@@ -396,8 +395,10 @@ function toggleTraceCategoryState(asyncHooksEnabled) {
 
 module.exports = {
   toggleTraceCategoryState,
-  getFastAPIs,
   assert,
   buildAllowedFlags,
-  wrapProcessMethods
+  wrapProcessMethods,
+  hrtime,
+  hrtimeBigInt,
+  refreshHrtimeBuffer,
 };

--- a/src/env.h
+++ b/src/env.h
@@ -34,6 +34,7 @@
 #include "handle_wrap.h"
 #include "node.h"
 #include "node_binding.h"
+#include "node_external_reference.h"
 #include "node_main_instance.h"
 #include "node_options.h"
 #include "node_perf_common.h"
@@ -1238,19 +1239,22 @@ class Environment : public MemoryRetainer {
                                const char* path = nullptr,
                                const char* dest = nullptr);
 
-  inline v8::Local<v8::FunctionTemplate>
-      NewFunctionTemplate(v8::FunctionCallback callback,
-                          v8::Local<v8::Signature> signature =
-                              v8::Local<v8::Signature>(),
-                          v8::ConstructorBehavior behavior =
-                              v8::ConstructorBehavior::kAllow,
-                          v8::SideEffectType side_effect =
-                              v8::SideEffectType::kHasSideEffect);
+  inline v8::Local<v8::FunctionTemplate> NewFunctionTemplate(
+      v8::FunctionCallback callback,
+      v8::Local<v8::Signature> signature = v8::Local<v8::Signature>(),
+      v8::ConstructorBehavior behavior = v8::ConstructorBehavior::kAllow,
+      v8::SideEffectType side_effect = v8::SideEffectType::kHasSideEffect,
+      const v8::CFunction* c_function = nullptr);
 
   // Convenience methods for NewFunctionTemplate().
   inline void SetMethod(v8::Local<v8::Object> that,
                         const char* name,
                         v8::FunctionCallback callback);
+
+  inline void SetFastMethod(v8::Local<v8::Object> that,
+                            const char* name,
+                            v8::FunctionCallback slow_callback,
+                            const v8::CFunction* c_function);
 
   inline void SetProtoMethod(v8::Local<v8::FunctionTemplate> that,
                              const char* name,

--- a/src/node_external_reference.h
+++ b/src/node_external_reference.h
@@ -5,9 +5,12 @@
 
 #include <cinttypes>
 #include <vector>
+#include "v8-fast-api-calls.h"
 #include "v8.h"
 
 namespace node {
+
+using CFunctionCallback = void (*)(v8::Local<v8::Value> receiver);
 
 // This class manages the external references from the V8 heap
 // to the C++ addresses in Node.js.
@@ -16,6 +19,8 @@ class ExternalReferenceRegistry {
   ExternalReferenceRegistry();
 
 #define ALLOWED_EXTERNAL_REFERENCE_TYPES(V)                                    \
+  V(CFunctionCallback)                                                         \
+  V(const v8::CFunctionInfo*)                                                  \
   V(v8::FunctionCallback)                                                      \
   V(v8::AccessorGetterCallback)                                                \
   V(v8::AccessorSetterCallback)                                                \

--- a/src/node_process.h
+++ b/src/node_process.h
@@ -79,7 +79,7 @@ class BindingData : public SnapshotableObject {
   static void SlowBigInt(const v8::FunctionCallbackInfo<v8::Value>& args);
 
  private:
-  static const size_t kBufferSize =
+  static constexpr size_t kBufferSize =
       std::max(sizeof(uint64_t), sizeof(uint32_t) * 3);
   v8::Global<v8::ArrayBuffer> array_buffer_;
   std::shared_ptr<v8::BackingStore> backing_store_;

--- a/src/node_process.h
+++ b/src/node_process.h
@@ -3,9 +3,15 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
+#include "node_snapshotable.h"
+#include "v8-fast-api-calls.h"
 #include "v8.h"
 
 namespace node {
+
+class Environment;
+class MemoryTracker;
+class ExternalReferenceRegistry;
 
 v8::MaybeLocal<v8::Object> CreateEnvVarProxy(v8::Local<v8::Context> context,
                                              v8::Isolate* isolate);
@@ -38,6 +44,54 @@ v8::Maybe<bool> ProcessEmitDeprecationWarning(Environment* env,
 v8::MaybeLocal<v8::Object> CreateProcessObject(Environment* env);
 void PatchProcessObject(const v8::FunctionCallbackInfo<v8::Value>& args);
 
+namespace process {
+class BindingData : public SnapshotableObject {
+ public:
+  void AddMethods();
+  static void RegisterExternalReferences(ExternalReferenceRegistry* registry);
+
+  SERIALIZABLE_OBJECT_METHODS()
+  static constexpr FastStringKey type_name{"node::process::BindingData"};
+  static constexpr EmbedderObjectType type_int =
+      EmbedderObjectType::k_process_binding_data;
+
+  BindingData(Environment* env, v8::Local<v8::Object> object);
+
+  void MemoryInfo(MemoryTracker* tracker) const override;
+  SET_MEMORY_INFO_NAME(BindingData)
+  SET_SELF_SIZE(BindingData)
+
+  static BindingData* FromV8Value(v8::Local<v8::Value> receiver);
+  static void NumberImpl(BindingData* receiver);
+
+  static void FastNumber(v8::Local<v8::Value> receiver) {
+    NumberImpl(FromV8Value(receiver));
+  }
+
+  static void SlowNumber(const v8::FunctionCallbackInfo<v8::Value>& args);
+
+  static void BigIntImpl(BindingData* receiver);
+
+  static void FastBigInt(v8::Local<v8::Value> receiver) {
+    BigIntImpl(FromV8Value(receiver));
+  }
+
+  static void SlowBigInt(const v8::FunctionCallbackInfo<v8::Value>& args);
+
+ private:
+  static const size_t kBufferSize =
+      std::max(sizeof(uint64_t), sizeof(uint32_t) * 3);
+  v8::Global<v8::ArrayBuffer> array_buffer_;
+  std::shared_ptr<v8::BackingStore> backing_store_;
+
+  // These need to be static so that we have their addresses available to
+  // register as external references in the snapshot at environment creation
+  // time.
+  static v8::CFunction fast_number_;
+  static v8::CFunction fast_bigint_;
+};
+
+}  // namespace process
 }  // namespace node
 #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 #endif  // SRC_NODE_PROCESS_H_

--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -36,14 +36,10 @@ namespace node {
 
 using v8::Array;
 using v8::ArrayBuffer;
-using v8::BackingStore;
 using v8::CFunction;
-using v8::ConstructorBehavior;
 using v8::Context;
 using v8::Float64Array;
 using v8::FunctionCallbackInfo;
-using v8::FunctionTemplate;
-using v8::Global;
 using v8::HeapStatistics;
 using v8::Integer;
 using v8::Isolate;
@@ -51,9 +47,6 @@ using v8::Local;
 using v8::NewStringType;
 using v8::Number;
 using v8::Object;
-using v8::ObjectTemplate;
-using v8::SideEffectType;
-using v8::Signature;
 using v8::String;
 using v8::Uint32;
 using v8::Value;
@@ -423,124 +416,119 @@ static void ReallyExit(const FunctionCallbackInfo<Value>& args) {
   env->Exit(code);
 }
 
-class FastHrtime : public BaseObject {
- public:
-  static Local<Object> New(Environment* env) {
-    Local<FunctionTemplate> ctor = FunctionTemplate::New(env->isolate());
-    ctor->Inherit(BaseObject::GetConstructorTemplate(env));
-    Local<ObjectTemplate> otmpl = ctor->InstanceTemplate();
-    otmpl->SetInternalFieldCount(FastHrtime::kInternalFieldCount);
+namespace process {
 
-    auto create_func = [env](auto fast_func, auto slow_func) {
-      auto cfunc = CFunction::Make(fast_func);
-      return FunctionTemplate::New(env->isolate(),
-                                   slow_func,
-                                   Local<Value>(),
-                                   Local<Signature>(),
-                                   0,
-                                   ConstructorBehavior::kThrow,
-                                   SideEffectType::kHasNoSideEffect,
-                                   &cfunc);
-    };
+constexpr FastStringKey BindingData::type_name;
 
-    otmpl->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "hrtime"),
-               create_func(FastNumber, SlowNumber));
-    otmpl->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "hrtimeBigInt"),
-               create_func(FastBigInt, SlowBigInt));
-
-    Local<Object> obj = otmpl->NewInstance(env->context()).ToLocalChecked();
-
-    Local<ArrayBuffer> ab =
-        ArrayBuffer::New(env->isolate(),
-            std::max(sizeof(uint64_t), sizeof(uint32_t) * 3));
-    new FastHrtime(env, obj, ab);
-    obj->Set(
-           env->context(), FIXED_ONE_BYTE_STRING(env->isolate(), "buffer"), ab)
-        .ToChecked();
-
-    return obj;
-  }
-
- private:
-  FastHrtime(Environment* env,
-             Local<Object> object,
-             Local<ArrayBuffer> ab)
-      : BaseObject(env, object),
-        array_buffer_(env->isolate(), ab),
-        backing_store_(ab->GetBackingStore()) {
-    MakeWeak();
-  }
-
-  void MemoryInfo(MemoryTracker* tracker) const override {
-    tracker->TrackField("array_buffer", array_buffer_);
-  }
-  SET_MEMORY_INFO_NAME(FastHrtime)
-  SET_SELF_SIZE(FastHrtime)
-
-  static FastHrtime* FromV8Value(Local<Value> value) {
-    Local<Object> v8_object = value.As<Object>();
-    return static_cast<FastHrtime*>(
-        v8_object->GetAlignedPointerFromInternalField(BaseObject::kSlot));
-  }
-
-  // This is the legacy version of hrtime before BigInt was introduced in
-  // JavaScript.
-  // The value returned by uv_hrtime() is a 64-bit int representing nanoseconds,
-  // so this function instead fills in an Uint32Array with 3 entries,
-  // to avoid any integer overflow possibility.
-  // The first two entries contain the second part of the value
-  // broken into the upper/lower 32 bits to be converted back in JS,
-  // because there is no Uint64Array in JS.
-  // The third entry contains the remaining nanosecond part of the value.
-  static void NumberImpl(FastHrtime* receiver) {
-    uint64_t t = uv_hrtime();
-    uint32_t* fields = static_cast<uint32_t*>(receiver->backing_store_->Data());
-    fields[0] = (t / NANOS_PER_SEC) >> 32;
-    fields[1] = (t / NANOS_PER_SEC) & 0xffffffff;
-    fields[2] = t % NANOS_PER_SEC;
-  }
-
-  static void FastNumber(Local<Value> receiver) {
-    NumberImpl(FromV8Value(receiver));
-  }
-
-  static void SlowNumber(const FunctionCallbackInfo<Value>& args) {
-    NumberImpl(FromJSObject<FastHrtime>(args.Holder()));
-  }
-
-  static void BigIntImpl(FastHrtime* receiver) {
-    uint64_t t = uv_hrtime();
-    uint64_t* fields = static_cast<uint64_t*>(receiver->backing_store_->Data());
-    fields[0] = t;
-  }
-
-  static void FastBigInt(Local<Value> receiver) {
-    BigIntImpl(FromV8Value(receiver));
-  }
-
-  static void SlowBigInt(const FunctionCallbackInfo<Value>& args) {
-    BigIntImpl(FromJSObject<FastHrtime>(args.Holder()));
-  }
-
-  Global<ArrayBuffer> array_buffer_;
-  std::shared_ptr<BackingStore> backing_store_;
-};
-
-static void GetFastAPIs(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-  Local<Object> ret = Object::New(env->isolate());
-  ret->Set(env->context(),
-           FIXED_ONE_BYTE_STRING(env->isolate(), "hrtime"),
-           FastHrtime::New(env))
+BindingData::BindingData(Environment* env, v8::Local<v8::Object> object)
+    : SnapshotableObject(env, object, type_int) {
+  Local<ArrayBuffer> ab = ArrayBuffer::New(env->isolate(), kBufferSize);
+  array_buffer_.Reset(env->isolate(), ab);
+  object
+      ->Set(env->context(),
+            FIXED_ONE_BYTE_STRING(env->isolate(), "hrtimeBuffer"),
+            ab)
       .ToChecked();
-  args.GetReturnValue().Set(ret);
+  backing_store_ = ab->GetBackingStore();
 }
 
-static void InitializeProcessMethods(Local<Object> target,
-                                     Local<Value> unused,
-                                     Local<Context> context,
-                                     void* priv) {
+v8::CFunction BindingData::fast_number_(v8::CFunction::Make(FastNumber));
+v8::CFunction BindingData::fast_bigint_(v8::CFunction::Make(FastBigInt));
+
+void BindingData::AddMethods() {
+  env()->SetFastMethod(object(), "hrtime", SlowNumber, &fast_number_);
+  env()->SetFastMethod(object(), "hrtimeBigInt", SlowBigInt, &fast_bigint_);
+}
+
+void BindingData::RegisterExternalReferences(
+    ExternalReferenceRegistry* registry) {
+  registry->Register(SlowNumber);
+  registry->Register(SlowBigInt);
+  registry->Register(FastNumber);
+  registry->Register(FastBigInt);
+  registry->Register(fast_number_.GetTypeInfo());
+  registry->Register(fast_bigint_.GetTypeInfo());
+}
+
+BindingData* BindingData::FromV8Value(Local<Value> value) {
+  Local<Object> v8_object = value.As<Object>();
+  return static_cast<BindingData*>(
+      v8_object->GetAlignedPointerFromInternalField(BaseObject::kSlot));
+}
+
+void BindingData::MemoryInfo(MemoryTracker* tracker) const {
+  tracker->TrackField("array_buffer", array_buffer_);
+}
+
+// This is the legacy version of hrtime before BigInt was introduced in
+// JavaScript.
+// The value returned by uv_hrtime() is a 64-bit int representing nanoseconds,
+// so this function instead fills in an Uint32Array with 3 entries,
+// to avoid any integer overflow possibility.
+// The first two entries contain the second part of the value
+// broken into the upper/lower 32 bits to be converted back in JS,
+// because there is no Uint64Array in JS.
+// The third entry contains the remaining nanosecond part of the value.
+void BindingData::NumberImpl(BindingData* receiver) {
+  // Make sure we don't accidentally access buffers wiped for snapshot.
+  CHECK(!receiver->array_buffer_.IsEmpty());
+  uint64_t t = uv_hrtime();
+  uint32_t* fields = static_cast<uint32_t*>(receiver->backing_store_->Data());
+  fields[0] = (t / NANOS_PER_SEC) >> 32;
+  fields[1] = (t / NANOS_PER_SEC) & 0xffffffff;
+  fields[2] = t % NANOS_PER_SEC;
+}
+
+void BindingData::BigIntImpl(BindingData* receiver) {
+  // Make sure we don't accidentally access buffers wiped for snapshot.
+  CHECK(!receiver->array_buffer_.IsEmpty());
+  uint64_t t = uv_hrtime();
+  uint64_t* fields = static_cast<uint64_t*>(receiver->backing_store_->Data());
+  fields[0] = t;
+}
+
+void BindingData::SlowBigInt(const FunctionCallbackInfo<Value>& args) {
+  BigIntImpl(FromJSObject<BindingData>(args.Holder()));
+}
+
+void BindingData::SlowNumber(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  NumberImpl(FromJSObject<BindingData>(args.Holder()));
+}
+
+void BindingData::PrepareForSerialization(Local<Context> context,
+                                          v8::SnapshotCreator* creator) {
+  // It's not worth keeping.
+  // Release it, we will recreate it when the instance is dehydrated.
+  array_buffer_.Reset();
+}
+
+InternalFieldInfo* BindingData::Serialize(int index) {
+  DCHECK_EQ(index, BaseObject::kSlot);
+  InternalFieldInfo* info = InternalFieldInfo::New(type());
+  return info;
+}
+
+void BindingData::Deserialize(Local<Context> context,
+                              Local<Object> holder,
+                              int index,
+                              InternalFieldInfo* info) {
+  DCHECK_EQ(index, BaseObject::kSlot);
+  v8::HandleScope scope(context->GetIsolate());
   Environment* env = Environment::GetCurrent(context);
+  // Recreate the buffer in the constructor.
+  BindingData* binding = env->AddBindingData<BindingData>(context, holder);
+  CHECK_NOT_NULL(binding);
+}
+
+static void Initialize(Local<Object> target,
+                       Local<Value> unused,
+                       Local<Context> context,
+                       void* priv) {
+  Environment* env = Environment::GetCurrent(context);
+  BindingData* const binding_data =
+      env->AddBindingData<BindingData>(context, target);
+  if (binding_data == nullptr) return;
+  binding_data->AddMethods();
 
   // define various internal methods
   if (env->owns_process_state()) {
@@ -567,11 +555,11 @@ static void InitializeProcessMethods(Local<Object> target,
   env->SetMethod(target, "reallyExit", ReallyExit);
   env->SetMethodNoSideEffect(target, "uptime", Uptime);
   env->SetMethod(target, "patchProcessObject", PatchProcessObject);
-  env->SetMethod(target, "getFastAPIs", GetFastAPIs);
 }
 
-void RegisterProcessMethodsExternalReferences(
-    ExternalReferenceRegistry* registry) {
+void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
+  BindingData::RegisterExternalReferences(registry);
+
   registry->Register(DebugProcess);
   registry->Register(DebugEnd);
   registry->Register(Abort);
@@ -594,12 +582,11 @@ void RegisterProcessMethodsExternalReferences(
   registry->Register(ReallyExit);
   registry->Register(Uptime);
   registry->Register(PatchProcessObject);
-  registry->Register(GetFastAPIs);
 }
 
+}  // namespace process
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_INTERNAL(process_methods,
-                                   node::InitializeProcessMethods)
+NODE_MODULE_CONTEXT_AWARE_INTERNAL(process_methods, node::process::Initialize)
 NODE_MODULE_EXTERNAL_REFERENCE(process_methods,
-                               node::RegisterProcessMethodsExternalReferences)
+                               node::process::RegisterExternalReferences)

--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -11,6 +11,7 @@
 #include "node_file.h"
 #include "node_internals.h"
 #include "node_main_instance.h"
+#include "node_process.h"
 #include "node_v8.h"
 #include "node_v8_platform-inl.h"
 

--- a/src/node_snapshotable.h
+++ b/src/node_snapshotable.h
@@ -16,7 +16,8 @@ struct SnapshotData;
 #define SERIALIZABLE_OBJECT_TYPES(V)                                           \
   V(fs_binding_data, fs::BindingData)                                          \
   V(v8_binding_data, v8_utils::BindingData)                                    \
-  V(blob_binding_data, BlobBindingData)
+  V(blob_binding_data, BlobBindingData)                                        \
+  V(process_binding_data, process::BindingData)
 
 enum class EmbedderObjectType : uint8_t {
   k_default = 0,


### PR DESCRIPTION
Put the hrtime backing store in the process methods binding data
so that it can be integrated into the snapshot builder. For
now we simply discard the contents of the hrtime buffer during
serialization and create new buffers upon deserialization because
the contents are only useful in a synchronous call.

This also moves the helper function for creating V8 FastAPI methods
into `Environment::SetFastMethod()` for code reuse. The v8::CFunction
need to be created before the Environment is created so that we
have the CTypeInfo address available for external reference
registration.

This is split from https://github.com/nodejs/node/pull/38905

Refs: https://github.com/nodejs/node/issues/35711
Refs: https://github.com/nodejs/node/issues/37476

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
