### PR TITLE
lib: make validateAbortSignal stricter

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -690,7 +690,9 @@ function abortChildProcess(child, killSignal) {
 function spawn(file, args, options) {
   options = normalizeSpawnArguments(file, args, options);
   validateTimeout(options.timeout);
-  validateAbortSignal(options.signal, 'options.signal');
+  if (options.signal !== undefined)
+    validateAbortSignal(options.signal, 'options.signal');
+
   const killSignal = sanitizeKillSignal(options.killSignal);
   const child = new ChildProcess();
 

--- a/lib/events.js
+++ b/lib/events.js
@@ -808,7 +808,8 @@ function getEventListeners(emitterOrTarget, type) {
  */
 async function once(emitter, name, options = {}) {
   const signal = options?.signal;
-  validateAbortSignal(signal, 'options.signal');
+  if (signal !== undefined)
+    validateAbortSignal(signal, 'options.signal');
   if (signal?.aborted)
     throw new AbortError();
   return new Promise((resolve, reject) => {
@@ -886,7 +887,8 @@ function eventTargetAgnosticAddListener(emitter, name, listener, flags) {
  */
 function on(emitter, event, options) {
   const signal = options?.signal;
-  validateAbortSignal(signal, 'options.signal');
+  if (signal !== undefined)
+    validateAbortSignal(signal, 'options.signal');
   if (signal?.aborted)
     throw new AbortError();
 

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -813,7 +813,8 @@ async function writeFile(path, data, options) {
     data = Buffer.from(data, options.encoding || 'utf8');
   }
 
-  validateAbortSignal(options.signal);
+  if (options.signal !== undefined)
+    validateAbortSignal(options.signal);
   if (path instanceof FileHandle)
     return writeFileHandle(path, data, options.signal, options.encoding);
 

--- a/lib/internal/fs/watchers.js
+++ b/lib/internal/fs/watchers.js
@@ -308,7 +308,8 @@ async function* watch(filename, options = {}) {
 
   validateBoolean(persistent, 'options.persistent');
   validateBoolean(recursive, 'options.recursive');
-  validateAbortSignal(signal, 'options.signal');
+  if (signal !== undefined)
+    validateAbortSignal(signal, 'options.signal');
 
   if (encoding && !isEncoding(encoding)) {
     const reason = 'is invalid encoding';

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -45,7 +45,8 @@ function eos(stream, options, callback) {
     validateObject(options, 'options');
   }
   validateFunction(callback, 'callback');
-  validateAbortSignal(options.signal, 'options.signal');
+  if (options.signal !== undefined)
+    validateAbortSignal(options.signal, 'options.signal');
 
   callback = once(callback);
 

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -182,7 +182,8 @@ function pipelineImpl(streams, callback, opts) {
   const signal = ac.signal;
   const outerSignal = opts?.signal;
 
-  validateAbortSignal(outerSignal, 'options.signal');
+  if (outerSignal !== undefined)
+    validateAbortSignal(outerSignal, 'options.signal');
 
   function abort() {
     finishImpl(new AbortError());

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -224,10 +224,8 @@ const validateCallback = hideStackFrames((callback) => {
 });
 
 const validateAbortSignal = hideStackFrames((signal, name) => {
-  if (signal !== undefined &&
-      (signal === null ||
-       typeof signal !== 'object' ||
-       !('aborted' in signal))) {
+  if (signal === null || typeof signal !== 'object' ||
+      !('aborted' in signal)) {
     throw new ERR_INVALID_ARG_TYPE(name, 'AbortSignal', signal);
   }
 });

--- a/lib/timers/promises.js
+++ b/lib/timers/promises.js
@@ -41,10 +41,12 @@ function setTimeout(after, value, options = {}) {
         options));
   }
   const { signal, ref = true } = options;
-  try {
-    validateAbortSignal(signal, 'options.signal');
-  } catch (err) {
-    return PromiseReject(err);
+  if (signal !== undefined) {
+    try {
+      validateAbortSignal(signal, 'options.signal');
+    } catch (err) {
+      return PromiseReject(err);
+    }
   }
   if (typeof ref !== 'boolean') {
     return PromiseReject(
@@ -85,10 +87,12 @@ function setImmediate(value, options = {}) {
         options));
   }
   const { signal, ref = true } = options;
-  try {
-    validateAbortSignal(signal, 'options.signal');
-  } catch (err) {
-    return PromiseReject(err);
+  if (signal !== undefined) {
+    try {
+      validateAbortSignal(signal, 'options.signal');
+    } catch (err) {
+      return PromiseReject(err);
+    }
   }
   if (typeof ref !== 'boolean') {
     return PromiseReject(
@@ -123,7 +127,8 @@ function setImmediate(value, options = {}) {
 async function* setInterval(after, value, options = {}) {
   validateObject(options, 'options');
   const { signal, ref = true } = options;
-  validateAbortSignal(signal, 'options.signal');
+  if (signal !== undefined)
+    validateAbortSignal(signal, 'options.signal');
   validateBoolean(ref, 'options.ref');
 
   if (signal?.aborted)


### PR DESCRIPTION
We should not force-check if the passed signal is **NOT** undefined and then proceed to check whether the value is an abort signal or not as the validator won't throw an error if the value is undefined as we straight up validate the values instead of checking if they're not undefined first. This unnecessary check can be done explicitly outside of the validator to only pass the value to the validator if its not undefined.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
