### PR TITLE
src: prevent extra copies of `TimerWrap::TimerCb`

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -642,6 +642,7 @@
         'src/tracing/trace_event_common.h',
         'src/tracing/traced_value.h',
         'src/timer_wrap.h',
+        'src/timer_wrap-inl.h',
         'src/tty_wrap.h',
         'src/udp_wrap.h',
         'src/util.h',

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -15,7 +15,7 @@
 #include "node_process-inl.h"
 #include "node_url.h"
 #include "util-inl.h"
-#include "timer_wrap.h"
+#include "timer_wrap-inl.h"
 #include "v8-inspector.h"
 #include "v8-platform.h"
 

--- a/src/timer_wrap-inl.h
+++ b/src/timer_wrap-inl.h
@@ -1,0 +1,32 @@
+#ifndef SRC_TIMER_WRAP_INL_H_
+#define SRC_TIMER_WRAP_INL_H_
+
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
+#include "timer_wrap.h"
+
+#include <utility>
+
+#include "env.h"
+#include "uv.h"
+
+namespace node {
+
+template <typename... Args>
+inline TimerWrap::TimerWrap(Environment* env, Args&&... args)
+    : env_(env), fn_(std::forward<Args>(args)...) {
+  uv_timer_init(env->event_loop(), &timer_);
+  timer_.data = this;
+}
+
+template <typename... Args>
+inline TimerWrapHandle::TimerWrapHandle(Environment* env, Args&&... args) {
+  timer_ = new TimerWrap(env, std::forward<Args>(args)...);
+  env->AddCleanupHook(CleanupHook, this);
+}
+
+}  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
+#endif  // SRC_TIMER_WRAP_INL_H_

--- a/src/timer_wrap.cc
+++ b/src/timer_wrap.cc
@@ -1,16 +1,11 @@
+#include "timer_wrap.h"  // NOLINT(build/include_inline)
+#include "timer_wrap-inl.h"
+
 #include "env-inl.h"
 #include "memory_tracker-inl.h"
-#include "timer_wrap.h"
 #include "uv.h"
 
 namespace node {
-
-TimerWrap::TimerWrap(Environment* env, const TimerCb& fn)
-    : env_(env),
-      fn_(fn) {
-  uv_timer_init(env->event_loop(), &timer_);
-  timer_.data = this;
-}
 
 void TimerWrap::Stop() {
   if (timer_.data == nullptr) return;
@@ -46,13 +41,6 @@ void TimerWrap::Unref() {
 void TimerWrap::OnTimeout(uv_timer_t* timer) {
   TimerWrap* t = ContainerOf(&TimerWrap::timer_, timer);
   t->fn_();
-}
-
-TimerWrapHandle::TimerWrapHandle(
-    Environment* env,
-    const TimerWrap::TimerCb& fn) {
-  timer_ = new TimerWrap(env, fn);
-  env->AddCleanupHook(CleanupHook, this);
 }
 
 void TimerWrapHandle::Stop() {

--- a/src/timer_wrap.h
+++ b/src/timer_wrap.h
@@ -16,7 +16,9 @@ class TimerWrap final : public MemoryRetainer {
  public:
   using TimerCb = std::function<void()>;
 
-  TimerWrap(Environment* env, const TimerCb& fn);
+  template <typename... Args>
+  explicit inline TimerWrap(Environment* env, Args&&... args);
+
   TimerWrap(const TimerWrap&) = delete;
 
   inline Environment* env() const { return env_; }
@@ -50,9 +52,8 @@ class TimerWrap final : public MemoryRetainer {
 
 class TimerWrapHandle : public MemoryRetainer  {
  public:
-  TimerWrapHandle(
-      Environment* env,
-      const TimerWrap::TimerCb& fn);
+  template <typename... Args>
+  explicit inline TimerWrapHandle(Environment* env, Args&&... args);
 
   TimerWrapHandle(const TimerWrapHandle&) = delete;
 


### PR DESCRIPTION
I noticed that we were taking `TimerCb` as a `const&` and then copying
that into the member. This is completely fine when the constructor is
called with an lvalue. However, when called with an rvalue, we can allow
the `std::function` to be moved into the member instead of falling back
to a copy, so I changed the constructors to take in universal
references. Also, `std::function` constructors can take in multiple
arguments, so I further modified the constructors to use variadic
templates.

Signed-off-by: Darshan Sen <darshan.sen@postman.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
