### PR TITLE
tools: use GitHub Squash and Merge feature when using CQ

### DIFF
--- a/tools/actions/commit-queue.sh
+++ b/tools/actions/commit-queue.sh
@@ -18,6 +18,10 @@ issueUrl() {
   echo "$API_URL/repos/${OWNER}/${REPOSITORY}/issues/${1}"
 }
 
+mergeUrl() {
+  echo "$API_URL/repos/${OWNER}/${REPOSITORY}/pulls/${1}/merge"
+}
+
 labelsUrl() {
   echo "$(issueUrl "${1}")/labels"
 }
@@ -55,8 +59,9 @@ git config --local user.email "github-bot@iojs.org"
 git config --local user.name "Node.js GitHub Bot"
 
 for pr in "$@"; do
+  gitHubCurl "$(labelsUrl "$pr")" GET > labels.json
   # Skip PR if CI was requested
-  if gitHubCurl "$(labelsUrl "$pr")" GET | jq -e 'map(.name) | index("request-ci")'; then
+  if jq -e 'map(.name) | index("request-ci")' < labels.json; then
     echo "pr ${pr} skipped, waiting for CI to start"
     continue
   fi
@@ -70,9 +75,9 @@ for pr in "$@"; do
   # Delete the commit queue label
   gitHubCurl "$(labelsUrl "$pr")"/"$COMMIT_QUEUE_LABEL" DELETE
 
-  if gitHubCurl "$(labelsUrl "$pr")" GET | jq -e 'map(.name) | index("commit-queue-squash")'; then
+  if jq -e 'map(.name) | index("commit-queue-squash")' < labels.json; then
     MULTIPLE_COMMIT_POLICY="--fixupAll"
-  elif gitHubCurl "$(labelsUrl "$pr")" GET | jq -e 'map(.name) | index("commit-queue-rebase")'; then
+  elif jq -e 'map(.name) | index("commit-queue-rebase")' < labels.json; then
     MULTIPLE_COMMIT_POLICY=""
   else
     MULTIPLE_COMMIT_POLICY="--oneCommitMax"
@@ -92,17 +97,35 @@ for pr in "$@"; do
     git node land --abort --yes
     continue
   fi
-  
-  commits="$(git rev-parse $UPSTREAM/$DEFAULT_BRANCH)...$(git rev-parse HEAD)"
 
-  if ! git push $UPSTREAM $DEFAULT_BRANCH >> output 2>&1; then
-    commit_queue_failed "$pr"
-    continue
+  if [ -z "$MULTIPLE_COMMIT_POLICY" ]; then
+    commits="$(git rev-parse $UPSTREAM/$DEFAULT_BRANCH)...$(git rev-parse HEAD)"
+
+    if ! git push $UPSTREAM $DEFAULT_BRANCH >> output 2>&1; then
+      commit_queue_failed "$pr"
+      continue
+    fi
+  else
+    # If there's only one commit, we can use the Squash and Merge feature from GitHub
+    jq -n \
+      --arg title "$(git log -1 --pretty='format:%s')" \
+      --arg body "$(git log -1 HEAD^ --pretty='format:%b')" \
+      '{merge_method:"squash",commit_title:$title,commit_message:$body}' > output.json
+    cat output.json
+    gitHubCurl "$(mergeUrl "$pr")" PUT --data @output.json > output
+    cat output
+    if ! commits="$(jq 'if .merged then .sha else error("not merged") end' < output)"; then
+      commit_queue_failed "$pr"
+      continue
+    fi
+    rm output.json
   fi
 
   rm output
 
   gitHubCurl "$(commentsUrl "$pr")" POST --data '{"body": "Landed in '"$commits"'"}'
 
-  gitHubCurl "$(issueUrl "$pr")" PATCH --data '{"state": "closed"}'
+  [ -z "$MULTIPLE_COMMIT_POLICY" ] && gitHubCurl "$(issueUrl "$pr")" PATCH --data '{"state": "closed"}'
 done
+
+rm -f labels.json

--- a/tools/actions/commit-queue.sh
+++ b/tools/actions/commit-queue.sh
@@ -114,7 +114,7 @@ for pr in "$@"; do
     cat output.json
     gitHubCurl "$(mergeUrl "$pr")" PUT --data @output.json > output
     cat output
-    if ! commits="$(jq 'if .merged then .sha else error("not merged") end' < output)"; then
+    if ! commits="$(jq -r 'if .merged then .sha else error("not merged") end' < output)"; then
       commit_queue_failed "$pr"
       continue
     fi

--- a/tools/actions/commit-queue.sh
+++ b/tools/actions/commit-queue.sh
@@ -109,7 +109,7 @@ for pr in "$@"; do
     # If there's only one commit, we can use the Squash and Merge feature from GitHub
     jq -n \
       --arg title "$(git log -1 --pretty='format:%s')" \
-      --arg body "$(git log -1 HEAD^ --pretty='format:%b')" \
+      --arg body "$(git log -1 --pretty='format:%b')" \
       '{merge_method:"squash",commit_title:$title,commit_message:$body}' > output.json
     cat output.json
     gitHubCurl "$(mergeUrl "$pr")" PUT --data @output.json > output


### PR DESCRIPTION
GitHub REST API allows us to edit the commit message when using "Squash and Merge" feature, that would allow the CQ to "purple merge" PRs without needing to force-push to the user branch when the PR contains one commit max.

I've tested locally with https://github.com/nodejs/node-auto-test/pull/37, I also tried to test it using the CQ in https://github.com/nodejs/node-auto-test/pull/40 but the CQ is not working there. I think we should land this, and revert if it's broken.

Refs: https://docs.github.com/en/rest/reference/pulls#merge-a-pull-request
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
