### PR TITLE
tools: fix commit-lint workflow

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -22,4 +22,4 @@ jobs:
       - name: Validate commit messages
         run: |
           echo "::add-matcher::.github/workflows/commit-lint-problem-matcher.json"
-          git log --oneline ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} | grep -v -e fixup -e squash | awk '{ print $1 }' |  xargs npx -q core-validate-commit --no-validate-metadata --tap
+          git log --oneline -${{ github.event.pull_request.commits }} HEAD^ | awk '{ if ($2 != "fixup!" && $2 != "squash!") { print $1 } }' | xargs npx -q core-validate-commit --no-validate-metadata --tap


### PR DESCRIPTION
It seems that https://github.com/nodejs/node/pull/39128 broke something. If I understand correctly, depending on when the PR has diverged from the base branch, git may be incapable of computing the `${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}` commit range. Instead we can specify how many commits there are in the PR since it's an information we already have anyway.
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
