### PR TITLE
[v14.x] Backport Python 3.10 compatibility patches

### DIFF
--- a/.github/workflows/build-tarball.yml
+++ b/.github/workflows/build-tarball.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build-tarball:
     env:
-      PYTHON_VERSION: 3.9
+      PYTHON_VERSION: '3.10'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -41,7 +41,7 @@ jobs:
           path: tarballs
   test-tarball-linux:
     env:
-      PYTHON_VERSION: 3.9
+      PYTHON_VERSION: '3.10'
     needs: build-tarball
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -12,7 +12,7 @@ on:
       - v[0-9]+.x
 
 env:
-  PYTHON_VERSION: 3.9
+  PYTHON_VERSION: '3.10'
   FLAKY_TESTS: dontcare
 
 jobs:

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -11,7 +11,7 @@ on:
       - v[0-9]+.x
 
 env:
-  PYTHON_VERSION: 3.9
+  PYTHON_VERSION: '3.10'
   NODE_VERSION: lts/*
 
 jobs:

--- a/.github/workflows/test-asan.yml
+++ b/.github/workflows/test-asan.yml
@@ -18,7 +18,7 @@ on:
       - 'doc/**'
 
 env:
-  PYTHON_VERSION: 3.9
+  PYTHON_VERSION: '3.10'
   FLAKY_TESTS: dontcare
 
 jobs:

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -12,7 +12,7 @@ on:
       - v[0-9]+.x
 
 env:
-  PYTHON_VERSION: 3.9
+  PYTHON_VERSION: '3.10'
   FLAKY_TESTS: dontcare
 
 jobs:

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -18,7 +18,7 @@ on:
       - 'doc/**'
 
 env:
-  PYTHON_VERSION: 3.9
+  PYTHON_VERSION: '3.10'
   FLAKY_TESTS: dontcare
 
 jobs:

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -239,7 +239,7 @@ test with Python 3.
 * GNU Make 3.81 or newer
 * Python (see note above)
   * Python 2.7
-  * Python 3.5, 3.6, 3.7, or 3.8
+  * Python 3.5, 3.6, 3.7, 3.8, 3.9 or 3.10 (see note above)
 
 Installation via Linux package manager can be achieved with:
 
@@ -256,7 +256,7 @@ FreeBSD and OpenBSD users may also need to install `libexecinfo`.
 * Xcode Command Line Tools >= 10 for macOS
 * Python (see note above)
   * Python 2.7
-  * Python 3.5, 3.6, 3.7, or 3.8
+  * Python 3.6, 3.7, 3.8, 3.9, or 3.10 (see note above)
 
 macOS users can install the `Xcode Command Line Tools` by running
 `xcode-select --install`. Alternatively, if you already have the full Xcode

--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.84',
+    'v8_embedder_string': '-node.85',
 
     ##### V8 defaults for Node.js #####
 

--- a/configure
+++ b/configure
@@ -5,6 +5,7 @@
 # as is the fact that the ] goes on a new line.
 _=[ 'exec' '/bin/sh' '-c' '''
 test ${FORCE_PYTHON2} && exec python2 "$0" "$@"  # workaround for gclient
+command -v python3.10 >/dev/null && exec python3.10 "$0" "$@"
 command -v python3.9 >/dev/null && exec python3.9 "$0" "$@"
 command -v python3.8 >/dev/null && exec python3.8 "$0" "$@"
 command -v python3.7 >/dev/null && exec python3.7 "$0" "$@"
@@ -24,7 +25,7 @@ except ImportError:
   from distutils.spawn import find_executable as which
 
 print('Node.js configure: Found Python {0}.{1}.{2}...'.format(*sys.version_info))
-acceptable_pythons = ((3, 9), (3, 8), (3, 7), (3, 6), (3, 5), (2, 7))
+acceptable_pythons = ((3,10), (3, 9), (3, 8), (3, 7), (3, 6), (3, 5), (2, 7))
 if sys.version_info[:2] in acceptable_pythons:
   import configure
 else:

--- a/deps/v8/third_party/jinja2/tests.py
+++ b/deps/v8/third_party/jinja2/tests.py
@@ -10,7 +10,10 @@
 """
 import operator
 import re
-from collections import Mapping
+try:
+  from collections.abc import Mapping
+except ImportError:
+  from collections import Mapping
 from jinja2.runtime import Undefined
 from jinja2._compat import text_type, string_types, integer_types
 import decimal

--- a/tools/inspector_protocol/jinja2/tests.py
+++ b/tools/inspector_protocol/jinja2/tests.py
@@ -10,7 +10,10 @@
 """
 import operator
 import re
-from collections import Mapping
+try:
+  from collections.abc import Mapping
+except ImportError:
+  from collections import Mapping
 from jinja2.runtime import Undefined
 from jinja2._compat import text_type, string_types, integer_types
 import decimal


### PR DESCRIPTION
Backport of https://github.com/nodejs/node/pull/40296.

Required to fix the Windows CI with `v14.x-staging`. Conflicts were due to `v14.x` supporting fallback to Python 2 if Python 3 is not available.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
