### PR TITLE
doc: update cjs-module-lexer repo link

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -1380,7 +1380,7 @@ success!
 [`process.dlopen`]: process.md#processdlopenmodule-filename-flags
 [`string`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String
 [`util.TextDecoder`]: util.md#class-utiltextdecoder
-[cjs-module-lexer]: https://github.com/guybedford/cjs-module-lexer/tree/1.2.2
+[cjs-module-lexer]: https://github.com/nodejs/cjs-module-lexer/tree/1.2.2
 [custom https loader]: #https-loader
 [load hook]: #loadurl-context-defaultload
 [resolve hook]: #resolvespecifier-context-defaultresolve


### PR DESCRIPTION
This updates the cjs-module-lexer docs link to point to the Node.js version now that this has been transferred to the Node.js organization.

@nodejs/modules 