### PR TITLE
doc: update conditions, add "deno" and "types"

### DIFF
--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -619,7 +619,7 @@ used._
 * `"browser"` - any web browser environment.
 * `"development"` - can be used to define a development-only environment
   entry point, for example to provide additional debugging context such as
-  better error message when running in a development mode. _Must always be
+  better error messages when running in a development mode. _Must always be
   mutually exclusive with `"production"`._
 * `"production"` - can be used to define a production environment entry
   point. _Must always be mutually exclusive with `"development"`._
@@ -627,7 +627,7 @@ used._
 The above user conditions can be enabled in Node.js via the
 [`--conditions` flag][].
 
-Platform specific conditions such as `"electron"`, or `"react-native"` may
+Platform-specific conditions such as `"electron"`, or `"react-native"` may
 be used, but while there remain no implementation or integration intent
 from these platforms, we do not yet explicitly recommend them.
 

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -486,8 +486,17 @@ For example, a package that wants to provide different ES module exports for
 }
 ```
 
-Node.js implements the following conditions:
+Node.js implements the following conditions, listed in order from most
+specific to least specific as conditions should be defined:
 
+* `"node-addons"` - similar to `"node"` and matches for any Node.js environment.
+  This condition can be used to provide an entry point which uses native C++
+  addons as opposed to an entry point which is more universal and doesn't rely
+  on native addons. This condition can be disabled via the
+  [`--no-addons` flag][].
+* `"node"` - matches for any Node.js environment. Can be a CommonJS or ES
+  module file. _This condition should always come after `"import"` or
+  `"require"`._
 * `"import"` - matches when the package is loaded via `import` or
   `import()`, or via any top-level import or resolve operation by the
   ECMAScript module loader. Applies regardless of the module format of the
@@ -498,14 +507,6 @@ Node.js implements the following conditions:
   formats include CommonJS, JSON, and native addons but not ES modules as
   `require()` doesn't support them. _Always mutually exclusive with
   `"import"`._
-* `"node"` - matches for any Node.js environment. Can be a CommonJS or ES
-  module file. _This condition should always come after `"import"` or
-  `"require"`._
-* `"node-addons"` - similar to `"node"` and matches for any Node.js environment.
-  This condition can be used to provide an entry point which uses native C++
-  addons as opposed to an entry point which is more universal and doesn't rely
-  on native addons. This condition can be disabled via the
-  [`--no-addons` flag][].
 * `"default"` - the generic fallback that always matches. Can be a CommonJS
   or ES module file. _This condition should always come last._
 
@@ -607,21 +608,23 @@ Runtimes or tools other than Node.js can use them at their discretion.
 
 These user conditions can be enabled in Node.js via the [`--conditions` flag][].
 
-The following condition definitions are currently endorsed by Node.js:
+The following condition definitions are currently endorsed by Node.js, and
+are _listed in order from most to least specific, as conditions should be
+used._
 
+* `"types"` - can be used by typing systems to resolve the typing file for
+  the given export, possible since the interface should be the same for all
+  variations. _This condition should always be included first._
+* `"deno"` - indicates a variation for the Deno platform.
 * `"browser"` - any environment which implements a standard subset of global
   browser APIs available from JavaScript in web browsers, including the DOM
   APIs.
-* `"deno"` - indicates a variation for the Deno platform.
 * `"development"` - can be used to define a development-only environment
   entry point, for example to provide additional debugging context such as
   better error message when running in a development mode. _Must always be
   mutually exclusive with `"production"`._
 * `"production"` - can be used to define a production environment entry
   point. _Must always be mutually exclusive with `"development"`._
-* `"types"` - can be used by typing systems to resolve the typing file for
-  the given export, possible since the interface should be the same for all
-  variations. _This condition should always be included first._
 
 The above user conditions can be enabled in Node.js via the
 [`--conditions` flag][].

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -629,7 +629,7 @@ The above user conditions can be enabled in Node.js via the
 
 Platform-specific conditions such as `"electron"`, or `"react-native"` may
 be used, but while there remain no implementation or integration intent
-from these platforms, we do not yet explicitly recommend them.
+from these platforms, they are not currently explicitly recommended.
 
 New conditions definitions may be added to this list by creating a pull request
 to the [Node.js documentation for this section][]. The requirements for listing

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -611,8 +611,7 @@ usage, a list of common known package conditions and their strict definitions
 is provided below to assist with ecosystem coordination.
 
 * `"types"` - can be used by typing systems to resolve the typing file for
-  the given export, possible since the interface should be the same for all
-  variations. _This condition should always be included first._
+  the given export. _This condition should always be included first._
 * `"deno"` - indicates a variation for the Deno platform.
 * `"browser"` - any web browser environment.
 * `"development"` - can be used to define a development-only environment

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -518,6 +518,12 @@ least specific in object order_.
 Using the `"import"` and `"require"` conditions can lead to some hazards,
 which are further explained in [the dual CommonJS/ES module packages section][].
 
+The `"node-addons"` condition can be used to provide an entry point which
+uses native C++ addons. However, this condition can be disabled via the
+[`--no-addons` flag][]. When using `"node-addons"`, it's recommended to treat
+`"default"` as an enhancement that provides a more universal entry point, e.g.
+using WebAssembly instead of a native addon.
+
 Conditional exports can also be extended to exports subpaths, for example:
 
 ```json
@@ -597,20 +603,14 @@ The `"import"`, `"require"`, `"node"`, `"node-addons"` and `"default"`
 conditions are defined and implemented in Node.js core,
 [as specified above](#conditional-exports).
 
-The `"node-addons"` condition can be used to provide an entry point which
-uses native C++ addons. However, this condition can be disabled via the
-[`--no-addons` flag][]. When using `"node-addons"`, it's recommended to treat
-`"default"` as an enhancement that provides a more universal entry point, e.g.
-using WebAssembly instead of a native addon.
-
 Other condition strings are unknown to Node.js and thus ignored by default.
 Runtimes or tools other than Node.js can use them at their discretion.
 
 These user conditions can be enabled in Node.js via the [`--conditions` flag][].
 
-The following condition definitions are currently endorsed by Node.js, and
-are _listed in order from most to least specific, as conditions should be
-used._
+Since user package conditions require clear definitions to ensure correct usage,
+a list of common known package conditions and their strict definitions is provided
+below to assist with ecosystem coordination.
 
 * `"types"` - can be used by typing systems to resolve the typing file for
   the given export, possible since the interface should be the same for all
@@ -626,10 +626,6 @@ used._
 
 The above user conditions can be enabled in Node.js via the
 [`--conditions` flag][].
-
-Platform-specific conditions such as `"electron"`, or `"react-native"` may
-be used, but while there remain no implementation or integration intent
-from these platforms, they are not currently explicitly recommended.
 
 New conditions definitions may be added to this list by creating a pull request
 to the [Node.js documentation for this section][]. The requirements for listing

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -495,8 +495,8 @@ specific to least specific as conditions should be defined:
   on native addons. This condition can be disabled via the
   [`--no-addons` flag][].
 * `"node"` - matches for any Node.js environment. Can be a CommonJS or ES
-  module file. _This condition should always come after `"import"` or
-  `"require"`._
+  module file. _In most cases explictily calling out the Node.js platform is
+  not necessary._
 * `"import"` - matches when the package is loaded via `import` or
   `import()`, or via any top-level import or resolve operation by the
   ECMAScript module loader. Applies regardless of the module format of the

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -619,6 +619,9 @@ The following condition definitions are currently endorsed by Node.js:
   point. _Must always be mutually exclusive with `"development"`._
 * `"source"` - indicates the original .js source file without minification
   or bundling optimizations, useful for development and debugging workflows.
+* `"types"` - can be used by typing systems to resolve the typing file for
+  the given export, possible since the interface should be the same for all
+  variations.
 
 The above user conditions can be enabled in Node.js via the
 [`--conditions` flag][].

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -495,7 +495,7 @@ specific to least specific as conditions should be defined:
   on native addons. This condition can be disabled via the
   [`--no-addons` flag][].
 * `"node"` - matches for any Node.js environment. Can be a CommonJS or ES
-  module file. _In most cases explictily calling out the Node.js platform is
+  module file. _In most cases explictly calling out the Node.js platform is
   not necessary._
 * `"import"` - matches when the package is loaded via `import` or
   `import()`, or via any top-level import or resolve operation by the

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -616,9 +616,7 @@ used._
   the given export, possible since the interface should be the same for all
   variations. _This condition should always be included first._
 * `"deno"` - indicates a variation for the Deno platform.
-* `"browser"` - any environment which implements a standard subset of global
-  browser APIs available from JavaScript in web browsers, including the DOM
-  APIs.
+* `"browser"` - any web browser environment.
 * `"development"` - can be used to define a development-only environment
   entry point, for example to provide additional debugging context such as
   better error message when running in a development mode. _Must always be

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -495,7 +495,7 @@ specific to least specific as conditions should be defined:
   on native addons. This condition can be disabled via the
   [`--no-addons` flag][].
 * `"node"` - matches for any Node.js environment. Can be a CommonJS or ES
-  module file. _In most cases explictly calling out the Node.js platform is
+  module file. _In most cases explicitly calling out the Node.js platform is
   not necessary._
 * `"import"` - matches when the package is loaded via `import` or
   `import()`, or via any top-level import or resolve operation by the

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -614,14 +614,14 @@ The following condition definitions are currently endorsed by Node.js:
   APIs.
 * `"deno"` - indicates a variation for the Deno platform.
 * `"development"` - can be used to define a development-only environment
-  entry point. _Must always be mutually exclusive with `"production"`._
+  entry point, for example to provide additional debugging context such as
+  better error message when running in a development mode. _Must always be
+  mutually exclusive with `"production"`._
 * `"production"` - can be used to define a production environment entry
   point. _Must always be mutually exclusive with `"development"`._
-* `"source"` - indicates the original .js source file without minification
-  or bundling optimizations, useful for development and debugging workflows.
 * `"types"` - can be used by typing systems to resolve the typing file for
   the given export, possible since the interface should be the same for all
-  variations.
+  variations. _This condition should always be included first._
 
 The above user conditions can be enabled in Node.js via the
 [`--conditions` flag][].

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -612,16 +612,19 @@ The following condition definitions are currently endorsed by Node.js:
 * `"browser"` - any environment which implements a standard subset of global
   browser APIs available from JavaScript in web browsers, including the DOM
   APIs.
+* `"deno"` - indicates a variation for the Deno platform.
 * `"development"` - can be used to define a development-only environment
   entry point. _Must always be mutually exclusive with `"production"`._
 * `"production"` - can be used to define a production environment entry
   point. _Must always be mutually exclusive with `"development"`._
+* `"source"` - indicates the original .js source file without minification
+  or bundling optimizations, useful for development and debugging workflows.
 
 The above user conditions can be enabled in Node.js via the
 [`--conditions` flag][].
 
-Platform specific conditions such as `"deno"`, `"electron"`, or `"react-native"`
-may be used, but while there remain no implementation or integration intent
+Platform specific conditions such as `"electron"`, or `"react-native"` may
+be used, but while there remain no implementation or integration intent
 from these platforms, the above are not explicitly endorsed by Node.js.
 
 New conditions definitions may be added to this list by creating a pull request

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -597,20 +597,18 @@ exports, while resolving the existing `"node"`, `"node-addons"`, `"default"`,
 
 Any number of custom conditions can be set with repeat flags.
 
-### Conditions Definitions
+### Community Conditions Definitions
 
-The `"import"`, `"require"`, `"node"`, `"node-addons"` and `"default"`
-conditions are defined and implemented in Node.js core,
-[as specified above](#conditional-exports).
+Conditions strings other than the `"import"`, `"require"`, `"node"`,
+`"node-addons"` and `"default"` conditions [implemented in Node.js core]
+(#conditional-exports) are ignored by default.
 
-Other condition strings are unknown to Node.js and thus ignored by default.
-Runtimes or tools other than Node.js can use them at their discretion.
+Other platforms may implement other conditions and user conditions can be enabled
+in Node.js via the [`--conditions` / `-C` flag][].
 
-These user conditions can be enabled in Node.js via the [`--conditions` flag][].
-
-Since user package conditions require clear definitions to ensure correct usage,
-a list of common known package conditions and their strict definitions is provided
-below to assist with ecosystem coordination.
+Since custom package conditions require clear definitions to ensure correct usage,
+a list of common known package conditions and their strict definitions is
+provided below to assist with ecosystem coordination.
 
 * `"types"` - can be used by typing systems to resolve the typing file for
   the given export, possible since the interface should be the same for all
@@ -623,9 +621,6 @@ below to assist with ecosystem coordination.
   mutually exclusive with `"production"`._
 * `"production"` - can be used to define a production environment entry
   point. _Must always be mutually exclusive with `"development"`._
-
-The above user conditions can be enabled in Node.js via the
-[`--conditions` flag][].
 
 New conditions definitions may be added to this list by creating a pull request
 to the [Node.js documentation for this section][]. The requirements for listing
@@ -1236,7 +1231,7 @@ This field defines [subpath imports][] for the current package.
 [`"name"`]: #name
 [`"packageManager"`]: #packagemanager
 [`"type"`]: #type
-[`--conditions` flag]: #resolving-user-conditions
+[`--conditions` / `-C` flag]: #resolving-user-conditions
 [`--no-addons` flag]: cli.md#--no-addons
 [`ERR_PACKAGE_PATH_NOT_EXPORTED`]: errors.md#err_package_path_not_exported
 [`esm`]: https://github.com/standard-things/esm#readme

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -628,7 +628,7 @@ The above user conditions can be enabled in Node.js via the
 
 Platform specific conditions such as `"electron"`, or `"react-native"` may
 be used, but while there remain no implementation or integration intent
-from these platforms, the above are not explicitly endorsed by Node.js.
+from these platforms, we do not yet explicitly recommend them.
 
 New conditions definitions may be added to this list by creating a pull request
 to the [Node.js documentation for this section][]. The requirements for listing

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -599,16 +599,16 @@ Any number of custom conditions can be set with repeat flags.
 
 ### Community Conditions Definitions
 
-Conditions strings other than the `"import"`, `"require"`, `"node"`,
-`"node-addons"` and `"default"` conditions [implemented in Node.js core]
-(#conditional-exports) are ignored by default.
+Condition strings other than the `"import"`, `"require"`, `"node"`,
+`"node-addons"` and `"default"` conditions
+[implemented in Node.js core](#conditional-exports) are ignored by default.
 
-Other platforms may implement other conditions and user conditions can be enabled
-in Node.js via the [`--conditions` / `-C` flag][].
+Other platforms may implement other conditions and user conditions can be
+enabled in Node.js via the [`--conditions` / `-C` flag][].
 
-Since custom package conditions require clear definitions to ensure correct usage,
-a list of common known package conditions and their strict definitions is
-provided below to assist with ecosystem coordination.
+Since custom package conditions require clear definitions to ensure correct
+usage, a list of common known package conditions and their strict definitions
+is provided below to assist with ecosystem coordination.
 
 * `"types"` - can be used by typing systems to resolve the typing file for
   the given export, possible since the interface should be the same for all


### PR DESCRIPTION
This adds two new conditions to the endorsed "exports" conditions list in the Node.js documentation.

1. "deno" - as of https://github.com/denoland/deno/pull/12424/files#diff-0523983fa24098bdaddcdb01d5f3771335b9e564df0c81d4b79101e75a108718R34, Deno now supports matching the `"deno"` condition when resolving using its Node.js compatibility resolver, allowing packages to define variants specifically for Deno. This makes the text in the Node.js documentation incorrect as since now the implementation exists we can correspondingly endorse its usage.
2. "types" - Angular have adopted this condition in the "exports" field as described in https://rc.angular.io/guide/angular-package-format#exports, explicitly calling out this pattern for typing can help move typing forward for the "exports" field.

It also reorders conditions by specificity and clarifies some of the definitions including:

* Browser is now defined strictly to be browser
* Development is strictly defined to imply debugging context

These could possibly be split out into separate PRs for further discussion if there are any objections to any of the specific conditions listed in this PR.

@nodejs/modules 