### PR TITLE
lib: allow mocking primordials with --expose-internals

### DIFF
--- a/lib/internal/per_context/primordials.js
+++ b/lib/internal/per_context/primordials.js
@@ -421,4 +421,3 @@ primordials.AsyncIteratorPrototype =
       async function* () {}).prototype);
 
 ObjectSetPrototypeOf(primordials, null);
-ObjectFreeze(primordials);


### PR DESCRIPTION
This pull request allows swapping primordials when `--expose-interals` is passed. This is required for libraries like SinonJS to mock `Date`.

I am not sure why primordials was frozen in the first place since the object is not user-accessible as far as I'm aware.

cc @aduh95 @fatso83

Refs: https://github.com/sinonjs/fake-timers/issues/344
Refs: https://github.com/nodejs/node/pull/36872