### PR TITLE
src,doc: add SyntaxError napi support

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -1303,9 +1303,9 @@ added: REPLACEME
 
 ```c
 NAPI_EXTERN napi_status node_api_create_syntax_error(napi_env env,
-                                                napi_value code,
-                                                napi_value msg,
-                                                napi_value* result);
+                                                     napi_value code,
+                                                     napi_value msg,
+                                                     napi_value* result);
 ```
 
 * `[in] env`: The environment that the API is invoked under.

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -1189,7 +1189,8 @@ added: REPLACEME
 NAPI_EXTERN napi_status node_api_throw_syntax_error(napi_env env,
                                                const char* code,
                                                const char* msg);
-```
+                                                    const char* code,
+                                                    const char* msg);
 
 * `[in] env`: The environment that the API is invoked under.
 * `[in] code`: Optional error code to be set on the error.

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -1185,7 +1185,7 @@ This API throws a JavaScript `RangeError` with the text provided.
 added: REPLACEME
 -->
 
-```c
+````c
 NAPI_EXTERN napi_status node_api_throw_syntax_error(napi_env env,
                                                     const char* code,
                                                     const char* msg);
@@ -1209,7 +1209,7 @@ napiVersion: 1
 NAPI_EXTERN napi_status napi_is_error(napi_env env,
                                       napi_value value,
                                       bool* result);
-```
+````
 
 * `[in] env`: The environment that the API is invoked under.
 * `[in] value`: The `napi_value` to be checked.

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -1187,8 +1187,6 @@ added: REPLACEME
 
 ```c
 NAPI_EXTERN napi_status node_api_throw_syntax_error(napi_env env,
-                                               const char* code,
-                                               const char* msg);
                                                     const char* code,
                                                     const char* msg);
 

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -1065,12 +1065,11 @@ JavaScript value to be thrown.
 The following utility functions are also available in case native code
 needs to throw an exception or determine if a `napi_value` is an instance
 of a JavaScript `Error` object: [`napi_throw_error`][],
-[`napi_throw_type_error`][], [`napi_throw_range_error`][] and
-[`napi_is_error`][].
+[`napi_throw_type_error`][], [`napi_throw_range_error`][], [`napi_throw_syntax_error`][] and [`napi_is_error`][].
 
 The following utility functions are also available in case native
 code needs to create an `Error` object: [`napi_create_error`][],
-[`napi_create_type_error`][], and [`napi_create_range_error`][],
+[`napi_create_type_error`][], [`napi_create_range_error`][] and [`napi_create_syntax_error`][],
 where result is the `napi_value` that refers to the newly created
 JavaScript `Error` object.
 
@@ -1180,6 +1179,26 @@ Returns `napi_ok` if the API succeeded.
 
 This API throws a JavaScript `RangeError` with the text provided.
 
+#### `napi_throw_syntax_error`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+```c
+NAPI_EXTERN napi_status napi_throw_syntax_error(napi_env env,
+                                               const char* code,
+                                               const char* msg);
+```
+
+* `[in] env`: The environment that the API is invoked under.
+* `[in] code`: Optional error code to be set on the error.
+* `[in] msg`: C string representing the text to be associated with the error.
+
+Returns `napi_ok` if the API succeeded.
+
+This API throws a JavaScript `SyntaxError` with the text provided.
+
 #### `napi_is_error`
 
 <!-- YAML
@@ -1276,6 +1295,30 @@ NAPI_EXTERN napi_status napi_create_range_error(napi_env env,
 Returns `napi_ok` if the API succeeded.
 
 This API returns a JavaScript `RangeError` with the text provided.
+
+#### `napi_create_syntax_error`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+```c
+NAPI_EXTERN napi_status napi_create_syntax_error(napi_env env,
+                                                napi_value code,
+                                                napi_value msg,
+                                                napi_value* result);
+```
+
+* `[in] env`: The environment that the API is invoked under.
+* `[in] code`: Optional `napi_value` with the string for the error code to be
+  associated with the error.
+* `[in] msg`: `napi_value` that references a JavaScript `string` to be used as
+  the message for the `Error`.
+* `[out] result`: `napi_value` representing the error created.
+
+Returns `napi_ok` if the API succeeded.
+
+This API returns a JavaScript `SyntaxError` with the text provided.
 
 #### `napi_get_and_clear_last_exception`
 
@@ -6257,6 +6300,7 @@ the add-on's file name during loading.
 [`napi_create_external_arraybuffer`]: #napi_create_external_arraybuffer
 [`napi_create_range_error`]: #napi_create_range_error
 [`napi_create_reference`]: #napi_create_reference
+[`napi_create_syntax_error`]: #napi_create_syntax_error
 [`napi_create_type_error`]: #napi_create_type_error
 [`napi_define_class`]: #napi_define_class
 [`napi_delete_async_work`]: #napi_delete_async_work
@@ -6290,6 +6334,7 @@ the add-on's file name during loading.
 [`napi_threadsafe_function_call_js`]: #napi_threadsafe_function_call_js
 [`napi_throw_error`]: #napi_throw_error
 [`napi_throw_range_error`]: #napi_throw_range_error
+[`napi_throw_syntax_error`]: #napi_throw_syntax_error
 [`napi_throw_type_error`]: #napi_throw_type_error
 [`napi_throw`]: #napi_throw
 [`napi_unwrap`]: #napi_unwrap

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -6300,7 +6300,6 @@ the add-on's file name during loading.
 [`napi_create_external_arraybuffer`]: #napi_create_external_arraybuffer
 [`napi_create_range_error`]: #napi_create_range_error
 [`napi_create_reference`]: #napi_create_reference
-[`node_api_create_syntax_error`]: #node_api_create_syntax_error
 [`napi_create_type_error`]: #napi_create_type_error
 [`napi_define_class`]: #napi_define_class
 [`napi_delete_async_work`]: #napi_delete_async_work
@@ -6334,13 +6333,14 @@ the add-on's file name during loading.
 [`napi_threadsafe_function_call_js`]: #napi_threadsafe_function_call_js
 [`napi_throw_error`]: #napi_throw_error
 [`napi_throw_range_error`]: #napi_throw_range_error
-[`node_api_throw_syntax_error`]: #node_api_throw_syntax_error
 [`napi_throw_type_error`]: #napi_throw_type_error
 [`napi_throw`]: #napi_throw
 [`napi_unwrap`]: #napi_unwrap
 [`napi_wrap`]: #napi_wrap
 [`node-addon-api`]: https://github.com/nodejs/node-addon-api
 [`node_api.h`]: https://github.com/nodejs/node/blob/HEAD/src/node_api.h
+[`node_api_create_syntax_error`]: #node_api_create_syntax_error
+[`node_api_throw_syntax_error`]: #node_api_throw_syntax_error
 [`process.release`]: process.md#processrelease
 [`uv_ref`]: https://docs.libuv.org/en/v1.x/handle.html#c.uv_ref
 [`uv_unref`]: https://docs.libuv.org/en/v1.x/handle.html#c.uv_unref

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -1065,11 +1065,11 @@ JavaScript value to be thrown.
 The following utility functions are also available in case native code
 needs to throw an exception or determine if a `napi_value` is an instance
 of a JavaScript `Error` object: [`napi_throw_error`][],
-[`napi_throw_type_error`][], [`napi_throw_range_error`][], [`napi_throw_syntax_error`][] and [`napi_is_error`][].
+[`napi_throw_type_error`][], [`napi_throw_range_error`][], [`node_api_throw_syntax_error`][] and [`napi_is_error`][].
 
 The following utility functions are also available in case native
 code needs to create an `Error` object: [`napi_create_error`][],
-[`napi_create_type_error`][], [`napi_create_range_error`][] and [`napi_create_syntax_error`][],
+[`napi_create_type_error`][], [`napi_create_range_error`][] and [`node_api_create_syntax_error`][],
 where result is the `napi_value` that refers to the newly created
 JavaScript `Error` object.
 
@@ -1179,14 +1179,14 @@ Returns `napi_ok` if the API succeeded.
 
 This API throws a JavaScript `RangeError` with the text provided.
 
-#### `napi_throw_syntax_error`
+#### `node_api_throw_syntax_error`
 
 <!-- YAML
 added: REPLACEME
 -->
 
 ```c
-NAPI_EXTERN napi_status napi_throw_syntax_error(napi_env env,
+NAPI_EXTERN napi_status node_api_throw_syntax_error(napi_env env,
                                                const char* code,
                                                const char* msg);
 ```
@@ -1296,14 +1296,14 @@ Returns `napi_ok` if the API succeeded.
 
 This API returns a JavaScript `RangeError` with the text provided.
 
-#### `napi_create_syntax_error`
+#### `node_api_create_syntax_error`
 
 <!-- YAML
 added: REPLACEME
 -->
 
 ```c
-NAPI_EXTERN napi_status napi_create_syntax_error(napi_env env,
+NAPI_EXTERN napi_status node_api_create_syntax_error(napi_env env,
                                                 napi_value code,
                                                 napi_value msg,
                                                 napi_value* result);
@@ -6300,7 +6300,7 @@ the add-on's file name during loading.
 [`napi_create_external_arraybuffer`]: #napi_create_external_arraybuffer
 [`napi_create_range_error`]: #napi_create_range_error
 [`napi_create_reference`]: #napi_create_reference
-[`napi_create_syntax_error`]: #napi_create_syntax_error
+[`node_api_create_syntax_error`]: #node_api_create_syntax_error
 [`napi_create_type_error`]: #napi_create_type_error
 [`napi_define_class`]: #napi_define_class
 [`napi_delete_async_work`]: #napi_delete_async_work
@@ -6334,7 +6334,7 @@ the add-on's file name during loading.
 [`napi_threadsafe_function_call_js`]: #napi_threadsafe_function_call_js
 [`napi_throw_error`]: #napi_throw_error
 [`napi_throw_range_error`]: #napi_throw_range_error
-[`napi_throw_syntax_error`]: #napi_throw_syntax_error
+[`node_api_throw_syntax_error`]: #node_api_throw_syntax_error
 [`napi_throw_type_error`]: #napi_throw_type_error
 [`napi_throw`]: #napi_throw
 [`napi_unwrap`]: #napi_unwrap

--- a/src/js_native_api.h
+++ b/src/js_native_api.h
@@ -378,8 +378,8 @@ NAPI_EXTERN napi_status napi_throw_range_error(napi_env env,
                                          const char* msg);
 #ifdef NAPI_EXPERIMENTAL
 NAPI_EXTERN napi_status node_api_throw_syntax_error(napi_env env,
-                                              const char* code,
-                                              const char* msg);
+                                                   const char* code,
+                                                   const char* msg);
 #endif  // NAPI_EXPERIMENTAL
 NAPI_EXTERN napi_status napi_is_error(napi_env env,
                                       napi_value value,

--- a/src/js_native_api.h
+++ b/src/js_native_api.h
@@ -111,6 +111,10 @@ NAPI_EXTERN napi_status napi_create_range_error(napi_env env,
                                                 napi_value code,
                                                 napi_value msg,
                                                 napi_value* result);
+NAPI_EXTERN napi_status napi_create_syntax_error(napi_env env,
+                                                napi_value code,
+                                                napi_value msg,
+                                                napi_value* result);
 
 // Methods to get the native napi_value from Primitive type
 NAPI_EXTERN napi_status napi_typeof(napi_env env,
@@ -368,6 +372,9 @@ NAPI_EXTERN napi_status napi_throw_type_error(napi_env env,
                                          const char* code,
                                          const char* msg);
 NAPI_EXTERN napi_status napi_throw_range_error(napi_env env,
+                                         const char* code,
+                                         const char* msg);
+NAPI_EXTERN napi_status napi_throw_syntax_error(napi_env env,
                                          const char* code,
                                          const char* msg);
 NAPI_EXTERN napi_status napi_is_error(napi_env env,

--- a/src/js_native_api.h
+++ b/src/js_native_api.h
@@ -378,8 +378,8 @@ NAPI_EXTERN napi_status napi_throw_range_error(napi_env env,
                                          const char* msg);
 #ifdef NAPI_EXPERIMENTAL
 NAPI_EXTERN napi_status node_api_throw_syntax_error(napi_env env,
-                                         const char* code,
-                                         const char* msg);
+                                              const char* code,
+                                              const char* msg);
 #endif  // NAPI_EXPERIMENTAL
 NAPI_EXTERN napi_status napi_is_error(napi_env env,
                                       napi_value value,

--- a/src/js_native_api.h
+++ b/src/js_native_api.h
@@ -111,10 +111,12 @@ NAPI_EXTERN napi_status napi_create_range_error(napi_env env,
                                                 napi_value code,
                                                 napi_value msg,
                                                 napi_value* result);
+#ifdef NAPI_EXPERIMENTAL
 NAPI_EXTERN napi_status napi_create_syntax_error(napi_env env,
                                                 napi_value code,
                                                 napi_value msg,
                                                 napi_value* result);
+#endif  // NAPI_EXPERIMENTAL
 
 // Methods to get the native napi_value from Primitive type
 NAPI_EXTERN napi_status napi_typeof(napi_env env,
@@ -374,9 +376,11 @@ NAPI_EXTERN napi_status napi_throw_type_error(napi_env env,
 NAPI_EXTERN napi_status napi_throw_range_error(napi_env env,
                                          const char* code,
                                          const char* msg);
+#ifdef NAPI_EXPERIMENTAL
 NAPI_EXTERN napi_status napi_throw_syntax_error(napi_env env,
                                          const char* code,
                                          const char* msg);
+#endif  // NAPI_EXPERIMENTAL
 NAPI_EXTERN napi_status napi_is_error(napi_env env,
                                       napi_value value,
                                       bool* result);

--- a/src/js_native_api.h
+++ b/src/js_native_api.h
@@ -378,8 +378,8 @@ NAPI_EXTERN napi_status napi_throw_range_error(napi_env env,
                                          const char* msg);
 #ifdef NAPI_EXPERIMENTAL
 NAPI_EXTERN napi_status node_api_throw_syntax_error(napi_env env,
-                                                   const char* code,
-                                                   const char* msg);
+                                                    const char* code,
+                                                    const char* msg);
 #endif  // NAPI_EXPERIMENTAL
 NAPI_EXTERN napi_status napi_is_error(napi_env env,
                                       napi_value value,

--- a/src/js_native_api.h
+++ b/src/js_native_api.h
@@ -112,7 +112,7 @@ NAPI_EXTERN napi_status napi_create_range_error(napi_env env,
                                                 napi_value msg,
                                                 napi_value* result);
 #ifdef NAPI_EXPERIMENTAL
-NAPI_EXTERN napi_status napi_create_syntax_error(napi_env env,
+NAPI_EXTERN napi_status node_api_create_syntax_error(napi_env env,
                                                 napi_value code,
                                                 napi_value msg,
                                                 napi_value* result);
@@ -377,7 +377,7 @@ NAPI_EXTERN napi_status napi_throw_range_error(napi_env env,
                                          const char* code,
                                          const char* msg);
 #ifdef NAPI_EXPERIMENTAL
-NAPI_EXTERN napi_status napi_throw_syntax_error(napi_env env,
+NAPI_EXTERN napi_status node_api_throw_syntax_error(napi_env env,
                                          const char* code,
                                          const char* msg);
 #endif  // NAPI_EXPERIMENTAL

--- a/src/js_native_api.h
+++ b/src/js_native_api.h
@@ -113,9 +113,9 @@ NAPI_EXTERN napi_status napi_create_range_error(napi_env env,
                                                 napi_value* result);
 #ifdef NAPI_EXPERIMENTAL
 NAPI_EXTERN napi_status node_api_create_syntax_error(napi_env env,
-                                                napi_value code,
-                                                napi_value msg,
-                                                napi_value* result);
+                                                     napi_value code,
+                                                     napi_value msg,
+                                                     napi_value* result);
 #endif  // NAPI_EXPERIMENTAL
 
 // Methods to get the native napi_value from Primitive type

--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -1747,6 +1747,26 @@ napi_status napi_create_range_error(napi_env env,
   return napi_clear_last_error(env);
 }
 
+napi_status napi_create_syntax_error(napi_env env,
+                                    napi_value code,
+                                    napi_value msg,
+                                    napi_value* result) {
+  CHECK_ENV(env);
+  CHECK_ARG(env, msg);
+  CHECK_ARG(env, result);
+
+  v8::Local<v8::Value> message_value = v8impl::V8LocalValueFromJsValue(msg);
+  RETURN_STATUS_IF_FALSE(env, message_value->IsString(), napi_string_expected);
+
+  v8::Local<v8::Value> error_obj =
+      v8::Exception::SyntaxError(message_value.As<v8::String>());
+  STATUS_CALL(set_error_code(env, error_obj, code, nullptr));
+
+  *result = v8impl::JsValueFromV8LocalValue(error_obj);
+
+  return napi_clear_last_error(env);
+}
+
 napi_status napi_typeof(napi_env env,
                         napi_value value,
                         napi_valuetype* result) {
@@ -1956,6 +1976,24 @@ napi_status napi_throw_range_error(napi_env env,
   CHECK_NEW_FROM_UTF8(env, str, msg);
 
   v8::Local<v8::Value> error_obj = v8::Exception::RangeError(str);
+  STATUS_CALL(set_error_code(env, error_obj, nullptr, code));
+
+  isolate->ThrowException(error_obj);
+  // any VM calls after this point and before returning
+  // to the javascript invoker will fail
+  return napi_clear_last_error(env);
+}
+
+napi_status napi_throw_syntax_error(napi_env env,
+                                   const char* code,
+                                   const char* msg) {
+  NAPI_PREAMBLE(env);
+
+  v8::Isolate* isolate = env->isolate;
+  v8::Local<v8::String> str;
+  CHECK_NEW_FROM_UTF8(env, str, msg);
+
+  v8::Local<v8::Value> error_obj = v8::Exception::SyntaxError(str);
   STATUS_CALL(set_error_code(env, error_obj, nullptr, code));
 
   isolate->ThrowException(error_obj);

--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -1985,8 +1985,8 @@ napi_status napi_throw_range_error(napi_env env,
 }
 
 napi_status node_api_throw_syntax_error(napi_env env,
-                                   const char* code,
-                                   const char* msg) {
+                                        const char* code,
+                                        const char* msg) {
   NAPI_PREAMBLE(env);
 
   v8::Isolate* isolate = env->isolate;

--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -1748,9 +1748,9 @@ napi_status napi_create_range_error(napi_env env,
 }
 
 napi_status node_api_create_syntax_error(napi_env env,
-                                    napi_value code,
-                                    napi_value msg,
-                                    napi_value* result) {
+                                         napi_value code,
+                                         napi_value msg,
+                                         napi_value* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, msg);
   CHECK_ARG(env, result);

--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -1747,7 +1747,7 @@ napi_status napi_create_range_error(napi_env env,
   return napi_clear_last_error(env);
 }
 
-napi_status napi_create_syntax_error(napi_env env,
+napi_status node_api_create_syntax_error(napi_env env,
                                     napi_value code,
                                     napi_value msg,
                                     napi_value* result) {
@@ -1984,7 +1984,7 @@ napi_status napi_throw_range_error(napi_env env,
   return napi_clear_last_error(env);
 }
 
-napi_status napi_throw_syntax_error(napi_env env,
+napi_status node_api_throw_syntax_error(napi_env env,
                                    const char* code,
                                    const char* msg) {
   NAPI_PREAMBLE(env);

--- a/test/js-native-api/test_error/test.js
+++ b/test/js-native-api/test_error/test.js
@@ -60,6 +60,10 @@ assert.throws(() => {
   test_error.throwTypeError();
 }, /^TypeError: type error$/);
 
+assert.throws(() => {
+  test_error.throwSyntaxError();
+}, /^SyntaxError: syntax error$/);
+
 [42, {}, [], Symbol('xyzzy'), true, 'ball', undefined, null, NaN]
   .forEach((value) => assert.throws(
     () => test_error.throwArbitrary(value),
@@ -90,6 +94,13 @@ assert.throws(
     message: 'TypeError [type error]'
   });
 
+assert.throws(
+  () => test_error.throwSyntaxErrorCode(),
+  {
+    code: 'ERR_TEST_CODE',
+    message: 'SyntaxError [syntax error]'
+  });
+
 let error = test_error.createError();
 assert.ok(error instanceof Error, 'expected error to be an instance of Error');
 assert.strictEqual(error.message, 'error');
@@ -103,6 +114,11 @@ error = test_error.createTypeError();
 assert.ok(error instanceof TypeError,
           'expected error to be an instance of TypeError');
 assert.strictEqual(error.message, 'type error');
+
+error = test_error.createSyntaxError();
+assert.ok(error instanceof SyntaxError,
+          'expected error to be an instance of SyntaxError');
+assert.strictEqual(error.message, 'syntax error');
 
 error = test_error.createErrorCode();
 assert.ok(error instanceof Error, 'expected error to be an instance of Error');
@@ -123,3 +139,10 @@ assert.ok(error instanceof TypeError,
 assert.strictEqual(error.message, 'TypeError [type error]');
 assert.strictEqual(error.code, 'ERR_TEST_CODE');
 assert.strictEqual(error.name, 'TypeError');
+
+error = test_error.createSyntaxErrorCode();
+assert.ok(error instanceof SyntaxError,
+          'expected error to be an instance of SyntaxError');
+assert.strictEqual(error.message, 'SyntaxError [syntax error]');
+assert.strictEqual(error.code, 'ERR_TEST_CODE');
+assert.strictEqual(error.name, 'SyntaxError');

--- a/test/js-native-api/test_error/test_error.c
+++ b/test/js-native-api/test_error/test_error.c
@@ -40,6 +40,11 @@ static napi_value throwTypeError(napi_env env, napi_callback_info info) {
   return NULL;
 }
 
+static napi_value throwSyntaxError(napi_env env, napi_callback_info info) {
+  NODE_API_CALL(env, napi_throw_syntax_error(env, NULL, "syntax error"));
+  return NULL;
+}
+
 static napi_value throwErrorCode(napi_env env, napi_callback_info info) {
   NODE_API_CALL(env, napi_throw_error(env, "ERR_TEST_CODE", "Error [error]"));
   return NULL;
@@ -57,6 +62,11 @@ static napi_value throwTypeErrorCode(napi_env env, napi_callback_info info) {
   return NULL;
 }
 
+static napi_value throwSyntaxErrorCode(napi_env env, napi_callback_info info) {
+  NODE_API_CALL(env,
+      napi_throw_syntax_error(env, "ERR_TEST_CODE", "SyntaxError [syntax error]"));
+  return NULL;
+}
 
 static napi_value createError(napi_env env, napi_callback_info info) {
   napi_value result;
@@ -82,6 +92,15 @@ static napi_value createTypeError(napi_env env, napi_callback_info info) {
   NODE_API_CALL(env, napi_create_string_utf8(
       env, "type error", NAPI_AUTO_LENGTH, &message));
   NODE_API_CALL(env, napi_create_type_error(env, NULL, message, &result));
+  return result;
+}
+
+static napi_value createSyntaxError(napi_env env, napi_callback_info info) {
+  napi_value result;
+  napi_value message;
+  NODE_API_CALL(env, napi_create_string_utf8(
+      env, "syntax error", NAPI_AUTO_LENGTH, &message));
+  NODE_API_CALL(env, napi_create_syntax_error(env, NULL, message, &result));
   return result;
 }
 
@@ -120,6 +139,19 @@ static napi_value createTypeErrorCode(napi_env env, napi_callback_info info) {
   NODE_API_CALL(env, napi_create_string_utf8(
       env, "ERR_TEST_CODE", NAPI_AUTO_LENGTH, &code));
   NODE_API_CALL(env, napi_create_type_error(env, code, message, &result));
+  return result;
+}
+
+static napi_value createSyntaxErrorCode(napi_env env, napi_callback_info info) {
+  napi_value result;
+  napi_value message;
+  napi_value code;
+  NODE_API_CALL(env,
+      napi_create_string_utf8(
+          env, "SyntaxError [syntax error]", NAPI_AUTO_LENGTH, &message));
+  NODE_API_CALL(env, napi_create_string_utf8(
+      env, "ERR_TEST_CODE", NAPI_AUTO_LENGTH, &code));
+  NODE_API_CALL(env, napi_create_syntax_error(env, code, message, &result));
   return result;
 }
 

--- a/test/js-native-api/test_error/test_error.c
+++ b/test/js-native-api/test_error/test_error.c
@@ -171,16 +171,20 @@ napi_value Init(napi_env env, napi_value exports) {
     DECLARE_NODE_API_PROPERTY("throwError", throwError),
     DECLARE_NODE_API_PROPERTY("throwRangeError", throwRangeError),
     DECLARE_NODE_API_PROPERTY("throwTypeError", throwTypeError),
+    DECLARE_NODE_API_PROPERTY("throwSyntaxError", throwSyntaxError),
     DECLARE_NODE_API_PROPERTY("throwErrorCode", throwErrorCode),
     DECLARE_NODE_API_PROPERTY("throwRangeErrorCode", throwRangeErrorCode),
     DECLARE_NODE_API_PROPERTY("throwTypeErrorCode", throwTypeErrorCode),
+    DECLARE_NODE_API_PROPERTY("throwSyntaxErrorCode", throwSyntaxErrorCode),
     DECLARE_NODE_API_PROPERTY("throwArbitrary", throwArbitrary),
     DECLARE_NODE_API_PROPERTY("createError", createError),
     DECLARE_NODE_API_PROPERTY("createRangeError", createRangeError),
     DECLARE_NODE_API_PROPERTY("createTypeError", createTypeError),
+    DECLARE_NODE_API_PROPERTY("createSyntaxError", createSyntaxError),
     DECLARE_NODE_API_PROPERTY("createErrorCode", createErrorCode),
     DECLARE_NODE_API_PROPERTY("createRangeErrorCode", createRangeErrorCode),
     DECLARE_NODE_API_PROPERTY("createTypeErrorCode", createTypeErrorCode),
+    DECLARE_NODE_API_PROPERTY("createSyntaxErrorCode", createSyntaxErrorCode),
   };
 
   NODE_API_CALL(env, napi_define_properties(

--- a/test/js-native-api/test_error/test_error.c
+++ b/test/js-native-api/test_error/test_error.c
@@ -42,7 +42,7 @@ static napi_value throwTypeError(napi_env env, napi_callback_info info) {
 }
 
 static napi_value throwSyntaxError(napi_env env, napi_callback_info info) {
-  NODE_API_CALL(env, napi_throw_syntax_error(env, NULL, "syntax error"));
+  NODE_API_CALL(env, node_api_throw_syntax_error(env, NULL, "syntax error"));
   return NULL;
 }
 
@@ -65,7 +65,7 @@ static napi_value throwTypeErrorCode(napi_env env, napi_callback_info info) {
 
 static napi_value throwSyntaxErrorCode(napi_env env, napi_callback_info info) {
   NODE_API_CALL(env,
-      napi_throw_syntax_error(env, "ERR_TEST_CODE", "SyntaxError [syntax error]"));
+      node_api_throw_syntax_error(env, "ERR_TEST_CODE", "SyntaxError [syntax error]"));
   return NULL;
 }
 
@@ -101,7 +101,7 @@ static napi_value createSyntaxError(napi_env env, napi_callback_info info) {
   napi_value message;
   NODE_API_CALL(env, napi_create_string_utf8(
       env, "syntax error", NAPI_AUTO_LENGTH, &message));
-  NODE_API_CALL(env, napi_create_syntax_error(env, NULL, message, &result));
+  NODE_API_CALL(env, node_api_create_syntax_error(env, NULL, message, &result));
   return result;
 }
 
@@ -152,7 +152,7 @@ static napi_value createSyntaxErrorCode(napi_env env, napi_callback_info info) {
           env, "SyntaxError [syntax error]", NAPI_AUTO_LENGTH, &message));
   NODE_API_CALL(env, napi_create_string_utf8(
       env, "ERR_TEST_CODE", NAPI_AUTO_LENGTH, &code));
-  NODE_API_CALL(env, napi_create_syntax_error(env, code, message, &result));
+  NODE_API_CALL(env, node_api_create_syntax_error(env, code, message, &result));
   return result;
 }
 

--- a/test/js-native-api/test_error/test_error.c
+++ b/test/js-native-api/test_error/test_error.c
@@ -1,3 +1,4 @@
+#define NAPI_EXPERIMENTAL
 #include <js_native_api.h>
 #include "../common.h"
 


### PR DESCRIPTION
Add `napi_create_syntax_error` and `napi_throw_syntax_error`.

Fixes: https://github.com/nodejs/node-addon-api/issues/1099
