### PR TITLE
tools: only validate first commit message of a PR

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,4 +1,4 @@
-name: "Commit messages adheres to guidelines at https://goo.gl/p2fr5Q"
+name: "First commit messages adheres to guidelines at https://goo.gl/p2fr5Q"
 
 on: [pull_request]
 
@@ -9,17 +9,14 @@ jobs:
   lint-commit-message:
     runs-on: ubuntu-latest
     steps:
-      - name: Compute number of commits in the PR
-        id: nb-of-commits
-        run: echo "::set-output name=nb::$((${{ github.event.pull_request.commits }} + 1))"
       - uses: actions/checkout@v2
         with:
-          fetch-depth: ${{ steps.nb-of-commits.outputs.nb }}
+          fetch-depth: 2
       - name: Install Node.js
         uses: actions/setup-node@v2
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - name: Validate commit messages
+      - name: Validate commit message
         run: |
           echo "::add-matcher::.github/workflows/commit-lint-problem-matcher.json"
-          git log --oneline -${{ github.event.pull_request.commits }} HEAD^ | awk '{ if ($2 != "fixup!" && $2 != "squash!") { print $1 } }' | xargs npx -q core-validate-commit --no-validate-metadata --tap
+          git rev-parse HEAD^ | xargs npx -q core-validate-commit --no-validate-metadata --tap

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,4 +1,4 @@
-name: "First commit messages adheres to guidelines at https://goo.gl/p2fr5Q"
+name: "First commit message adheres to guidelines at https://goo.gl/p2fr5Q"
 
 on: [pull_request]
 


### PR DESCRIPTION
The `commit-lint` job was introduced to encourage contributors to generate PRs that would be landable using the CQ IIRC.
Now that https://github.com/nodejs/node/pull/40577 has introduced `commit-queue-squash` mechanism, having the `commint-lint` job lint all commit message defeats its purpose as it won't let the CQ land a PR if any of its commit do not conform to our guidelines – even though in the case of a squash, only the first commit message matters.

I'm suggesting validating only the first commit message, and discarding follow up commits in the validation.

_I have thought about making the job label-aware, and if the PR has a `commit-queue-rebase` label validate all the commits: that might be more effort than what's worth, the CQ will refuse to land a PR if the commit message do not pass the validation anyway._
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
