### PR TITLE
tools: ensure the PR was not pushed before merging

### DIFF
--- a/tools/actions/commit-queue.sh
+++ b/tools/actions/commit-queue.sh
@@ -110,7 +110,8 @@ for pr in "$@"; do
     jq -n \
       --arg title "$(git log -1 --pretty='format:%s')" \
       --arg body "$(git log -1 --pretty='format:%b')" \
-      '{merge_method:"squash",commit_title:$title,commit_message:$body}' > output.json
+      --arg head "$(grep 'Fetched commits as' output | cut -d. -f3 | xargs git rev-parse)" \
+      '{merge_method:"squash",commit_title:$title,commit_message:$body,sha:$head}' > output.json
     cat output.json
     gitHubCurl "$(mergeUrl "$pr")" PUT --data @output.json > output
     cat output


### PR DESCRIPTION
When using Squash and Merge feature, it would allow to a malicious actor to push unreviewed code to their PR while the CQ is running and  bypass the usual checks.
This PR adds a check to refuse to land if the head of the PR branch is different from the one validated by ncu.
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
