### PR TITLE
doc: fix corepack grammar for `--force` flag

### DIFF
--- a/doc/api/corepack.md
+++ b/doc/api/corepack.md
@@ -101,7 +101,7 @@ install. To avoid this problem, consider one of the following options:
   binaries anyway and will ensure that the requested versions are always
   available, so installing the package managers explicitly isn't needed anymore.
 
-* Add the `--force` to `npm install`; this will tell npm that it's fine to
+* Add the `--force` flag to `npm install`; this will tell npm that it's fine to
   override binaries, but you'll erase the Corepack ones in the process (should
   that happen, run [`corepack enable`][] again to add them back).
 


### PR DESCRIPTION
This PR fixes the grammar in the corepack documentation.