### PR TITLE
doc: fix transform stream example

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -3230,6 +3230,7 @@ pipeline(
         // Make sure is valid json.
         JSON.parse(this.data);
         this.push(this.data);
+        callback();
       } catch (err) {
         callback(err);
       }


### PR DESCRIPTION
There was a missing callback in the Transform#flush example
implementation.
