### PR TITLE
net: activate setNoDelay by default

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -261,6 +261,9 @@ function initSocketHandle(self) {
     self._handle.onread = onStreamRead;
     self[async_id_symbol] = getNewAsyncId(self._handle);
 
+    if (self._handle.setNoDelay && self[kSetNoDelay] === true)
+      self._handle.setNoDelay(true);
+
     let userBuf = self[kBuffer];
     if (userBuf) {
       const bufGen = self[kBufferGen];
@@ -307,7 +310,7 @@ function Socket(options) {
   this[kHandle] = null;
   this._parent = null;
   this._host = null;
-  this[kSetNoDelay] = false;
+  this[kSetNoDelay] = true;
   this[kLastWriteQueueSize] = 0;
   this[kTimeout] = null;
   this[kBuffer] = null;

--- a/test/parallel/test-net-socket-setnodelay.js
+++ b/test/parallel/test-net-socket-setnodelay.js
@@ -29,14 +29,6 @@ truthyValues.forEach((testVal) => socket.setNoDelay(testVal));
 
 socket = new net.Socket({
   handle: {
-    setNoDelay: common.mustNotCall(),
-    readStart() {}
-  }
-});
-falseyValues.forEach((testVal) => socket.setNoDelay(testVal));
-
-socket = new net.Socket({
-  handle: {
     setNoDelay: common.mustCall(() => {}, 3),
     readStart() {}
   }

--- a/test/parallel/test-net-socket-setnodelay.js
+++ b/test/parallel/test-net-socket-setnodelay.js
@@ -13,7 +13,7 @@ const genSetNoDelay = (desiredArg) => (enable) => {
 // setNoDelay should default to true
 let socket = new net.Socket({
   handle: {
-    setNoDelay: common.mustCall(genSetNoDelay(true)),
+    setNoDelay: common.mustCall(genSetNoDelay(true), 1),
     readStart() {}
   }
 });
@@ -29,11 +29,19 @@ truthyValues.forEach((testVal) => socket.setNoDelay(testVal));
 
 socket = new net.Socket({
   handle: {
-    setNoDelay: common.mustCall(() => {}, 3),
+    setNoDelay: common.mustCall(() => {}, 2),
     readStart() {}
   }
 });
-truthyValues.concat(falseyValues).concat(truthyValues)
+falseyValues.forEach((testVal) => socket.setNoDelay(testVal));
+
+socket = new net.Socket({
+  handle: {
+    setNoDelay: common.mustCall(() => {}, 5),
+    readStart() {}
+  }
+});
+falseyValues.concat(truthyValues).concat(falseyValues).concat(truthyValues)
   .forEach((testVal) => socket.setNoDelay(testVal));
 
 // If a handler doesn't have a setNoDelay function it shouldn't be called.
@@ -44,5 +52,5 @@ socket = new net.Socket({
     readStart() {}
   }
 });
-const returned = socket.setNoDelay(true);
+const returned = socket.setNoDelay(false);
 assert.ok(returned instanceof net.Socket);


### PR DESCRIPTION
Fixes #34185

This is kind of a draft and is eg. lacking tests as I don't know how to test this (partly because it interacts deeply with the OS) and the fact that the current setup isn't tested either, so its an extra uphill in creating tests for this tiny change of default.

So, remaining:

- [x] Implement change
- [x] Test change
- [ ] Document change

I'm opening a PR anyway, so I don't block #34185 and maybe can get some help on how to proceed.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
