### PR TITLE
async_hooks: eliminate require side effects

### DIFF
--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -137,8 +137,6 @@ function callbackTrampoline(asyncId, resource, cb, ...args) {
   return result;
 }
 
-setCallbackTrampoline(callbackTrampoline);
-
 const topLevelResource = {};
 
 function executionAsyncResource() {
@@ -372,6 +370,8 @@ function promiseResolveHook(promise) {
 let wantPromiseHook = false;
 function enableHooks() {
   async_hook_fields[kCheck] += 1;
+
+  setCallbackTrampoline(callbackTrampoline);
 }
 
 let stopPromiseHook;
@@ -397,6 +397,8 @@ function disableHooks() {
   async_hook_fields[kCheck] -= 1;
 
   wantPromiseHook = false;
+
+  setCallbackTrampoline();
 
   // Delay the call to `disablePromiseHook()` because we might currently be
   // between the `before` and `after` calls of a Promise.

--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -327,9 +327,11 @@ void AsyncWrap::QueueDestroyAsyncId(const FunctionCallbackInfo<Value>& args) {
 void AsyncWrap::SetCallbackTrampoline(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
-  CHECK(args[0]->IsFunction());
-
-  env->set_async_hooks_callback_trampoline(args[0].As<Function>());
+  if (args[0]->IsFunction()) {
+    env->set_async_hooks_callback_trampoline(args[0].As<Function>());
+  } else {
+    env->set_async_hooks_callback_trampoline(Local<Function>());
+  }
 }
 
 Local<FunctionTemplate> AsyncWrap::GetConstructorTemplate(Environment* env) {
@@ -439,6 +441,7 @@ void AsyncWrap::Initialize(Local<Object> target,
   env->set_async_hooks_after_function(Local<Function>());
   env->set_async_hooks_destroy_function(Local<Function>());
   env->set_async_hooks_promise_resolve_function(Local<Function>());
+  env->set_async_hooks_callback_trampoline(Local<Function>());
   env->set_async_hooks_binding(target);
 }
 


### PR DESCRIPTION
Just a minor improvement to avoid any unintended side effects to requiring async_hooks.

cc @nodejs/async_hooks 