### PR TITLE
lib: fix typos in lib code comments

### DIFF
--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -182,7 +182,7 @@ IncomingMessage.prototype._destroy = function _destroy(err, cb) {
   // If aborted and the underlying socket is not already destroyed,
   // destroy it.
   // We have to check if the socket is already destroyed because finished
-  // does not call the callback when this methdod is invoked from `_http_client`
+  // does not call the callback when this method is invoked from `_http_client`
   // in `test/parallel/test-http-client-spurious-aborted.js`
   if (this.socket && !this.socket.destroyed && this.aborted) {
     this.socket.destroy(err);

--- a/lib/events.js
+++ b/lib/events.js
@@ -242,7 +242,7 @@ function emitUnhandledRejectionOrErr(ee, err, type, args) {
     // we might end up in an infinite loop.
     const prev = ee[kCapture];
 
-    // If the error handler throws, it is not catcheable and it
+    // If the error handler throws, it is not catchable and it
     // will end up in 'uncaughtException'. We restore the previous
     // value of kCapture in case the uncaughtException is present
     // and the exception is handled.

--- a/lib/path.js
+++ b/lib/path.js
@@ -485,7 +485,7 @@ const win32 = {
   },
 
   /**
-   * It will solve the relative path from `from` to `to`, for instancee
+   * It will solve the relative path from `from` to `to`, for instance
    * from = 'C:\\orandea\\test\\aaa'
    * to = 'C:\\orandea\\impl\\bbb'
    * The output of the function should be: '..\\..\\impl\\bbb'


### PR DESCRIPTION
This fixes three typos in lib dir code comment.

- `methdod` → `method` in `lib/_http_incoming.js`
- `catcheable` → `catchable` in `lib/events.js`
- `instancee` → `instance` in `lib/path.js`

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
