### PR TITLE
stream: unify writableErrored and readableErrored

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -621,7 +621,7 @@ added:
 Number of times [`writable.uncork()`][stream-uncork] needs to be
 called in order to fully uncork the stream.
 
-##### `writable.writableErrored`
+##### `writable.errored`
 
 <!-- YAML
 added:
@@ -1377,7 +1377,7 @@ added: v12.9.0
 
 Becomes `true` when [`'end'`][] event is emitted.
 
-##### `readable.readableErrored`
+##### `readable.errored`
 
 <!-- YAML
 added:

--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -1239,7 +1239,7 @@ ObjectDefineProperties(Readable.prototype, {
     }
   },
 
-  readableErrored: {
+  errored: {
     enumerable: false,
     get() {
       return this._readableState ? this._readableState.errored : null;

--- a/lib/internal/streams/writable.js
+++ b/lib/internal/streams/writable.js
@@ -854,7 +854,7 @@ ObjectDefineProperties(Writable.prototype, {
     }
   },
 
-  writableErrored: {
+  errored: {
     enumerable: false,
     get() {
       return this._writableState ? this._writableState.errored : null;

--- a/test/parallel/test-stream-finished.js
+++ b/test/parallel/test-stream-finished.js
@@ -612,7 +612,7 @@ testClosed((opts) => new Writable({ write() {}, ...opts }));
   const w = new Writable();
   const _err = new Error();
   w.destroy(_err);
-  assert.strictEqual(w.writableErrored, _err);
+  assert.strictEqual(w.errored, _err);
   finished(w, common.mustCall((err) => {
     assert.strictEqual(_err, err);
     assert.strictEqual(w.closed, true);
@@ -625,7 +625,7 @@ testClosed((opts) => new Writable({ write() {}, ...opts }));
 {
   const w = new Writable();
   w.destroy();
-  assert.strictEqual(w.writableErrored, null);
+  assert.strictEqual(w.errored, null);
   finished(w, common.mustCall((err) => {
     assert.strictEqual(w.closed, true);
     assert.strictEqual(err.code, 'ERR_STREAM_PREMATURE_CLOSE');

--- a/test/parallel/test-stream-readable-destroy.js
+++ b/test/parallel/test-stream-readable-destroy.js
@@ -13,7 +13,7 @@ const assert = require('assert');
   read.on('close', common.mustCall());
 
   read.destroy();
-  assert.strictEqual(read.readableErrored, null);
+  assert.strictEqual(read.errored, null);
   assert.strictEqual(read.destroyed, true);
 }
 
@@ -32,7 +32,7 @@ const assert = require('assert');
   }));
 
   read.destroy(expected);
-  assert.strictEqual(read.readableErrored, expected);
+  assert.strictEqual(read.errored, expected);
   assert.strictEqual(read.destroyed, true);
 }
 


### PR DESCRIPTION
Both of these should always refer to the same error, hence there is no reason to separate them.

Refs: https://github.com/nodejs/node/pull/40696

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
