### PR TITLE
stream: return undefined writable/readable

### DIFF
--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -1166,8 +1166,8 @@ ObjectDefineProperties(Readable.prototype, {
       // where the readable side was disabled upon construction.
       // Compat. The user might manually disable readable side through
       // deprecated setter.
-      return !!r && r.readable !== false && !r.destroyed && !r.errorEmitted &&
-        !r.endEmitted;
+      if (!r || r.readable === false) return;
+      return !r.destroyed && !r.errorEmitted && !r.endEmitted;
     },
     set(val) {
       // Backwards compat.

--- a/lib/internal/streams/writable.js
+++ b/lib/internal/streams/writable.js
@@ -793,8 +793,8 @@ ObjectDefineProperties(Writable.prototype, {
       // where the writable side was disabled upon construction.
       // Compat. The user might manually disable writable side through
       // deprecated setter.
-      return !!w && w.writable !== false && !w.destroyed && !w.errored &&
-        !w.ending && !w.ended;
+      if (!w || w.writable === false) return;
+      return !w.destroyed && !w.errored && !w.ending && !w.ended;
     },
     set(val) {
       // Backwards compatible.

--- a/test/parallel/test-stream-compose.js
+++ b/test/parallel/test-stream-compose.js
@@ -274,8 +274,8 @@ const assert = require('assert');
     }
   });
 
-  assert.strictEqual(s1.writable, false);
-  assert.strictEqual(s1.readable, false);
+  assert.strictEqual(s1.writable, undefined);
+  assert.strictEqual(s1.readable, undefined);
 
   finished(s1.resume(), common.mustCall((err) => {
     assert(!err);

--- a/test/parallel/test-stream-duplex-from.js
+++ b/test/parallel/test-stream-duplex-from.js
@@ -14,7 +14,7 @@ const { Duplex, Readable, Writable, pipeline } = require('stream');
     })
   });
   assert.strictEqual(d.readable, true);
-  assert.strictEqual(d.writable, false);
+  assert.strictEqual(d.writable, undefined);
   d.once('readable', common.mustCall(function() {
     assert.strictEqual(d.read().toString(), 'asd');
   }));
@@ -31,7 +31,7 @@ const { Duplex, Readable, Writable, pipeline } = require('stream');
     }
   }));
   assert.strictEqual(d.readable, true);
-  assert.strictEqual(d.writable, false);
+  assert.strictEqual(d.writable, undefined);
   d.once('readable', common.mustCall(function() {
     assert.strictEqual(d.read().toString(), 'asd');
   }));
@@ -48,7 +48,7 @@ const { Duplex, Readable, Writable, pipeline } = require('stream');
       callback();
     }
   }));
-  assert.strictEqual(d.readable, false);
+  assert.strictEqual(d.readable, undefined);
   assert.strictEqual(d.writable, true);
   d.end('asd');
   d.on('finish', common.mustCall(function() {
@@ -67,7 +67,7 @@ const { Duplex, Readable, Writable, pipeline } = require('stream');
       }
     })
   });
-  assert.strictEqual(d.readable, false);
+  assert.strictEqual(d.readable, undefined);
   assert.strictEqual(d.writable, true);
   d.end('asd');
   d.on('finish', common.mustCall(function() {
@@ -110,7 +110,7 @@ const { Duplex, Readable, Writable, pipeline } = require('stream');
 {
   const d = Duplex.from(Promise.resolve('asd'));
   assert.strictEqual(d.readable, true);
-  assert.strictEqual(d.writable, false);
+  assert.strictEqual(d.writable, undefined);
   d.once('readable', common.mustCall(function() {
     assert.strictEqual(d.read().toString(), 'asd');
   }));

--- a/test/parallel/test-stream-duplex-readable-writable.js
+++ b/test/parallel/test-stream-duplex-readable-writable.js
@@ -8,7 +8,7 @@ const assert = require('assert');
   const duplex = new Duplex({
     readable: false
   });
-  assert.strictEqual(duplex.readable, false);
+  assert.strictEqual(duplex.readable, undefined);
   duplex.push('asd');
   duplex.on('error', common.mustCall((err) => {
     assert.strictEqual(err.code, 'ERR_STREAM_PUSH_AFTER_EOF');
@@ -22,7 +22,7 @@ const assert = require('assert');
     writable: false,
     write: common.mustNotCall()
   });
-  assert.strictEqual(duplex.writable, false);
+  assert.strictEqual(duplex.writable, undefined);
   duplex.write('asd');
   duplex.on('error', common.mustCall((err) => {
     assert.strictEqual(err.code, 'ERR_STREAM_WRITE_AFTER_END');
@@ -34,7 +34,7 @@ const assert = require('assert');
   const duplex = new Duplex({
     readable: false
   });
-  assert.strictEqual(duplex.readable, false);
+  assert.strictEqual(duplex.readable, undefined);
   duplex.on('data', common.mustNotCall());
   duplex.on('end', common.mustNotCall());
   async function run() {


### PR DESCRIPTION
Return undefined for writable/readable props if the stream
never was writable/readable. This way we can differentiate between
Duplex streams that never was writable/readable and Duplex streams
which has finished writing/reading.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
