### PR TITLE
process: deprecate `_getActive*` private APIs in favour of `async_hooks`

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3019,6 +3019,21 @@ should have the same effect. The receiving end should also check the
 [`readable.readableEnded`][] value on [`http.IncomingMessage`][] to get whether
 it was an aborted or graceful destroy.
 
+### DEP0157: `process._getActiveRequests()`, `process._getActiveHandles()` private APIs
+
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/40804
+    description: Runtime deprecation.
+-->
+
+Type: Runtime
+
+The `process._getActiveRequests()` and `process._getActiveHandles()` functions
+are not needed anymore because the `async_hooks` module already provides
+functionality that helps us to keep a track of the active resources.
+
 [Legacy URL API]: url.md#legacy-url-api
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
 [RFC 6066]: https://tools.ietf.org/html/rfc6066#section-3

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -146,9 +146,16 @@ const rawMethods = internalBinding('process_methods');
   process.dlopen = rawMethods.dlopen;
   process.uptime = rawMethods.uptime;
 
-  // TODO(joyeecheung): either remove them or make them public
-  process._getActiveRequests = rawMethods._getActiveRequests;
-  process._getActiveHandles = rawMethods._getActiveHandles;
+  process._getActiveRequests = deprecate(
+    rawMethods._getActiveRequests,
+    'process._getActiveRequests() is deprecated. Please use the `async_hooks`' +
+    ' module instead.',
+    'DEP0157');
+  process._getActiveHandles = deprecate(
+    rawMethods._getActiveHandles,
+    'process._getActiveHandles() is deprecated. Please use the `async_hooks`' +
+    ' module instead.',
+    'DEP0157');
 
   // TODO(joyeecheung): remove these
   process.reallyExit = rawMethods.reallyExit;

--- a/test/parallel/test-async-hooks-track-active-handles.js
+++ b/test/parallel/test-async-hooks-track-active-handles.js
@@ -1,0 +1,61 @@
+'use strict';
+
+require('../common');
+
+const assert = require('assert');
+const async_hooks = require('async_hooks');
+const net = require('net');
+
+const activeHandles = new Map();
+async_hooks.createHook({
+  init(asyncId, type, triggerAsyncId, resource) {
+    if (['TCPSERVERWRAP', 'TCPWRAP'].includes(type))
+      activeHandles.set(asyncId, resource);
+  },
+  destroy(asyncId) {
+    activeHandles.delete(asyncId);
+  }
+}).enable();
+
+const NUM = 8;
+const connections = [];
+const clients = [];
+let clients_counter = 0;
+
+const server = net.createServer(function listener(c) {
+  connections.push(c);
+}).listen(0, makeConnection);
+
+
+function makeConnection() {
+  if (clients_counter >= NUM) return;
+  net.connect(server.address().port, function connected() {
+    clientConnected(this);
+    makeConnection();
+  });
+}
+
+
+function clientConnected(client) {
+  clients.push(client);
+  if (++clients_counter >= NUM)
+    checkAll();
+}
+
+
+function checkAll() {
+  const handles = Array.from(activeHandles.values());
+
+  clients.forEach(function(item) {
+    assert.ok(handles.includes(item._handle));
+    item.destroy();
+  });
+
+  connections.forEach(function(item) {
+    assert.ok(handles.includes(item._handle));
+    item.end();
+  });
+
+  assert.ok(handles.includes(server._handle));
+  server.close();
+}

--- a/test/parallel/test-async-hooks-track-active-requests.js
+++ b/test/parallel/test-async-hooks-track-active-requests.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const common = require('../common');
+
+const assert = require('assert');
+const async_hooks = require('async_hooks');
+const fs = require('fs');
+
+let numFsReqCallbacks = 0;
+async_hooks.createHook({
+  init(asyncId, type, triggerAsyncId, resource) {
+    if (type === 'FSREQCALLBACK')
+      ++numFsReqCallbacks;
+  },
+  destroy(asyncId) {
+    --numFsReqCallbacks;
+  }
+}).enable();
+
+for (let i = 0; i < 12; i++)
+  fs.open(__filename, 'r', common.mustCall());
+
+assert.strictEqual(numFsReqCallbacks, 12);

--- a/test/parallel/test-process-getactivehandles.js
+++ b/test/parallel/test-process-getactivehandles.js
@@ -1,47 +1,11 @@
 'use strict';
 
-require('../common');
-const assert = require('assert');
-const net = require('net');
-const NUM = 8;
-const connections = [];
-const clients = [];
-let clients_counter = 0;
+const { expectWarning } = require('../common');
 
-const server = net.createServer(function listener(c) {
-  connections.push(c);
-}).listen(0, makeConnection);
+expectWarning(
+  'DeprecationWarning',
+  'process._getActiveHandles() is deprecated. Please use the `async_hooks` ' +
+  'module instead.',
+  'DEP0157');
 
-
-function makeConnection() {
-  if (clients_counter >= NUM) return;
-  net.connect(server.address().port, function connected() {
-    clientConnected(this);
-    makeConnection();
-  });
-}
-
-
-function clientConnected(client) {
-  clients.push(client);
-  if (++clients_counter >= NUM)
-    checkAll();
-}
-
-
-function checkAll() {
-  const handles = process._getActiveHandles();
-
-  clients.forEach(function(item) {
-    assert.ok(handles.includes(item));
-    item.destroy();
-  });
-
-  connections.forEach(function(item) {
-    assert.ok(handles.includes(item));
-    item.end();
-  });
-
-  assert.ok(handles.includes(server));
-  server.close();
-}
+process._getActiveHandles();

--- a/test/parallel/test-process-getactiverequests.js
+++ b/test/parallel/test-process-getactiverequests.js
@@ -1,10 +1,11 @@
 'use strict';
 
-const common = require('../common');
-const assert = require('assert');
-const fs = require('fs');
+const { expectWarning } = require('../common');
 
-for (let i = 0; i < 12; i++)
-  fs.open(__filename, 'r', common.mustCall());
+expectWarning(
+  'DeprecationWarning',
+  'process._getActiveRequests() is deprecated. Please use the `async_hooks` ' +
+  'module instead.',
+  'DEP0157');
 
-assert.strictEqual(process._getActiveRequests().length, 12);
+process._getActiveRequests();

--- a/test/pseudo-tty/ref_keeps_node_running.js
+++ b/test/pseudo-tty/ref_keeps_node_running.js
@@ -13,18 +13,14 @@ const handle = new TTY(0);
 handle.readStart();
 handle.onread = () => {};
 
-function isHandleActive(handle) {
-  return process._getActiveHandles().some((active) => active === handle);
-}
-
-strictEqual(isHandleActive(handle), true, 'TTY handle not initially active');
+strictEqual(handle.hasRef(), true, 'TTY handle not initially active');
 
 handle.unref();
 
-strictEqual(isHandleActive(handle), false, 'TTY handle active after unref()');
+strictEqual(handle.hasRef(), false, 'TTY handle active after unref()');
 
 handle.ref();
 
-strictEqual(isHandleActive(handle), true, 'TTY handle inactive after ref()');
+strictEqual(handle.hasRef(), true, 'TTY handle inactive after ref()');
 
 handle.unref();


### PR DESCRIPTION
The `process._getActiveRequests()` and `process._getActiveHandles()`
functions are not needed anymore because the `async_hooks` module
already provides functionality that helps us to keep a track of the
active resources.

Signed-off-by: Darshan Sen <darshan.sen@postman.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
