### PR TITLE
stream: use pipe for async iterator

### DIFF
--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -1109,37 +1109,47 @@ function streamToAsyncIterator(stream, options) {
 }
 
 async function* createAsyncIterator(stream, options) {
-  let callback = nop;
-
-  function next(resolve) {
-    if (this === stream) {
-      callback();
-      callback = nop;
-    } else {
-      callback = resolve;
+  const controller = new class extends EE() {
+    constructor () {
+      this.callback = null
     }
-  }
-
-  stream.on('readable', next);
+    write (chunk) {
+      this.callback(null, chunk);
+      return false; // TODO (perf): This slows down things...
+    }
+    end () {
+      this.callback(null, null);
+    }
+  }()
 
   let error;
   eos(stream, { writable: false }, (err) => {
     error = err ? aggregateTwoErrors(error, err) : null;
-    callback();
-    callback = nop;
+    if (error) {
+      callback(null, null);
+    }
   });
+
+  stream.pipe(controller);
 
   try {
     while (true) {
-      const chunk = stream.destroyed ? null : stream.read();
+      const chunk = await new Promise((resolve, reject) => {
+        controller.callback = (err, val) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve(val);
+            controller.emit('drain');
+          }
+        };
+      });
       if (chunk !== null) {
         yield chunk;
       } else if (error) {
         throw error;
       } else if (error === null) {
         return;
-      } else {
-        await new Promise(next);
       }
     }
   } catch (err) {

--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -1108,57 +1108,72 @@ function streamToAsyncIterator(stream, options) {
   return iter;
 }
 
-async function* createAsyncIterator(stream, options) {
-  const controller = new class extends EE() {
-    constructor () {
-      this.callback = null
-    }
-    write (chunk) {
-      this.callback(null, chunk);
-      return false; // TODO (perf): This slows down things...
-    }
-    end () {
-      this.callback(null, null);
-    }
-  }()
+class AsyncIteratorController extends EE {
+  constructor () {
+    super();
+    this.errored = null;
+    this.resolve = null;
+    this.ended = false;
+    this.needDrain = false;
+    this.promise = null;
+  }
+  write (chunk) {
+    const { resolve } = this
+    this.resolve = null;
+    resolve(chunk);
 
-  let error;
-  eos(stream, { writable: false }, (err) => {
-    error = err ? aggregateTwoErrors(error, err) : null;
-    if (error) {
-      callback(null, null);
+    // TODO (perf): This slows down things...
+    this.needDrain = true;
+    return false;
+  }
+  end () {
+    const { resolve } = this
+    this.resolve = null;
+    this.ended = true;
+    resolve?.(null);
+  }
+  error (err) {
+    const { resolve } = this
+    this.resolve = null;
+    this.errored = aggregateTwoErrors(this.errored, err);
+    resolve?.(null);
+  }
+  read () {
+    return new Promise((resolve) => {
+      this.resolve = resolve;
+      if (this.needDrain) {
+        this.emit('drain');
+      }
+    })
+  }
+}
+
+async function* createAsyncIterator(stream, options) {
+  const controller = new AsyncIteratorController();
+  eos(stream.pipe(controller), { writable: false }, (err) => {
+    if (err) {
+      controller.error(err);
     }
   });
 
-  stream.pipe(controller);
-
   try {
     while (true) {
-      const chunk = await new Promise((resolve, reject) => {
-        controller.callback = (err, val) => {
-          if (err) {
-            reject(err);
-          } else {
-            resolve(val);
-            controller.emit('drain');
-          }
-        };
-      });
+      const chunk = stream.destroyed ? null : await controller.read();
       if (chunk !== null) {
         yield chunk;
-      } else if (error) {
-        throw error;
-      } else if (error === null) {
+      } else if (controller.errored) {
+        throw controller.errored;
+      } else if (controller.ended) {
         return;
       }
     }
   } catch (err) {
-    error = aggregateTwoErrors(error, err);
-    throw error;
+    controller.error(err);
+    throw controller.errored;
   } finally {
     if (
-      (error || options?.destroyOnReturn !== false) &&
-      (error === undefined || stream._readableState.autoDestroy)
+      (controller.errored || options?.destroyOnReturn !== false) &&
+      (controller.errored || stream._readableState.autoDestroy)
     ) {
       destroyImpl.destroyer(stream, null);
     }

--- a/test/parallel/test-stream-pipeline-async-iterator.js
+++ b/test/parallel/test-stream-pipeline-async-iterator.js
@@ -11,8 +11,7 @@ async function run() {
     read() {
     }
   });
-  source.push('hello');
-  source.push('world');
+  source.push('helloworld');
 
   setImmediate(() => { source.destroy(_err); });
 


### PR DESCRIPTION
This is just on a prototyping stage.

I'm current of the thought that we currently use 3 different stream apis to drive streams.

I would like to reduce and unify that to one, and the one that seems to have best "compatibility" is `.pipe`. I'm basically proposing removing all use of `.read()` and `'readable'` from inside core in favour of `.pipe`.

I believe this can be done from a behaviour perspective, however I'm very unsure it's possible with maintained performance.

I'm just opening this as a draft in case anyone have any comments or suggestions.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
