### PR TITLE
stream: destroying stream without error is abort

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -421,6 +421,10 @@ This is a destructive and immediate way to destroy a stream. Previous calls to
 Use `end()` instead of destroy if data should flush before close, or wait for
 the `'drain'` event before destroying the stream.
 
+If `.destroy()` is called without an `error` and `autoDestroy` is
+enabled, then if the stream has not completed it will be
+automatically destroyed with an `AbortError`.
+
 ```cjs
 const { Writable } = require('stream');
 
@@ -1100,6 +1104,10 @@ further errors except from `_destroy()` may be emitted as `'error'`.
 
 Implementors should not override this method, but instead implement
 [`readable._destroy()`][readable-_destroy].
+
+If `.destroy()` is called without an `error` and `autoDestroy` is
+enabled, then if the stream has not completed it will be
+automatically destroyed with an `AbortError`.
 
 ##### `readable.closed`
 
@@ -1805,6 +1813,10 @@ unless `emitClose` is set in false.
 Once `destroy()` has been called, any further calls will be a no-op and no
 further errors except from `_destroy()` may be emitted as `'error'`.
 
+If `.destroy()` is called without an `error` and `autoDestroy` is
+enabled, then if the stream has not completed it will be
+automatically destroyed with an `AbortError`.
+
 ### `stream.finished(stream[, options], callback)`
 
 <!-- YAML
@@ -2508,6 +2520,8 @@ changes:
     [`stream._construct()`][writable-_construct] method.
   * `autoDestroy` {boolean} Whether this stream should automatically call
     `.destroy()` on itself after ending. **Default:** `true`.
+  * `autoAbort` {boolean} Whether this stream should automatically
+  error if `.destroy()` is called without an error before the stream has emitted `'finish'`.
   * `signal` {AbortSignal} A signal representing possible cancellation.
 
 <!-- eslint-disable no-useless-constructor -->
@@ -2865,6 +2879,8 @@ changes:
     [`stream._construct()`][readable-_construct] method.
   * `autoDestroy` {boolean} Whether this stream should automatically call
     `.destroy()` on itself after ending. **Default:** `true`.
+  * `autoAbort` {boolean} Whether this stream should automatically
+  error if `.destroy()` is called without an error before the stream has emitted `'end'`.
   * `signal` {AbortSignal} A signal representing possible cancellation.
 
 <!-- eslint-disable no-useless-constructor -->

--- a/lib/internal/streams/destroy.js
+++ b/lib/internal/streams/destroy.js
@@ -14,7 +14,9 @@ const {
   kDestroyed,
   isDestroyed,
   isFinished,
-  isServerRequest
+  isServerRequest,
+  isReadableFinished,
+  isWritableEnded
 } = require('internal/streams/utils');
 
 const kDestroy = Symbol('kDestroy');
@@ -85,6 +87,14 @@ function _destroy(self, err, cb) {
 
     const r = self._readableState;
     const w = self._writableState;
+
+    if (!err) {
+      if (r?.autoAbort && !isReadableFinished(self)) {
+        err = new AbortError();
+      } else if (w?.autoAbort && !isWritableEnded(self)) {
+        err = new AbortError();
+      }
+    }
 
     checkError(err, w, r);
 

--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -174,6 +174,8 @@ function ReadableState(options, stream, isDuplex) {
 
   this.dataEmitted = false;
 
+  this.autoAbort = options?.autoAbort ?? false;
+
   this.decoder = null;
   this.encoding = null;
   if (options && options.encoding) {

--- a/lib/internal/streams/writable.js
+++ b/lib/internal/streams/writable.js
@@ -196,6 +196,8 @@ function WritableState(options, stream, isDuplex) {
   // depending on emitClose.
   this.closeEmitted = false;
 
+  this.autoAbort = options?.autoAbort ?? false;
+
   this[kOnFinished] = [];
 }
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -324,6 +324,7 @@ function Socket(options) {
   // For backwards compat do not emit close on destroy.
   options.emitClose = false;
   options.autoDestroy = true;
+  options.autoAbort = false;
   // Handle strings directly.
   options.decodeStrings = false;
   stream.Duplex.call(this, options);

--- a/test/parallel/test-stream-auto-abort.js
+++ b/test/parallel/test-stream-auto-abort.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const common = require('../common');
+const { Readable, Writable } = require('stream');
+const assert = require('assert');
+
+{
+  const w = new Writable({
+    write() {
+
+    }
+  });
+  w.on('error', common.mustCall((err) => {
+    assert.strictEqual(err.name, 'AbortError');
+  }));
+  w.destroy();
+}
+
+{
+  const r = new Readable({
+    read() {
+
+    }
+  });
+  r.on('error', common.mustCall((err) => {
+    assert.strictEqual(err.name, 'AbortError');
+  }));
+  r.destroy();
+}


### PR DESCRIPTION
If an autoDestroy stream is destroyed by user without
an error we automatically convert it to an AbortError in
order to avoid a weird state.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
