### PR TITLE
lib: add reason to AbortSignal

### DIFF
--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -46,13 +46,20 @@ ac.abort();
 console.log(ac.signal.aborted);  // Prints True
 ```
 
-### `abortController.abort()`
+### `abortController.abort([reason])`
 
 <!-- YAML
 added:
   - v15.0.0
   - v14.17.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/40807
+    description: Added the new optional reason argument.
 -->
+
+* `reason` {any} An optional reason, retrievable on the `AbortSignal`s
+  `reason` property.
 
 Triggers the abort signal, causing the `abortController.signal` to emit
 the `'abort'` event.
@@ -80,14 +87,19 @@ added:
 The `AbortSignal` is used to notify observers when the
 `abortController.abort()` method is called.
 
-#### Static method: `AbortSignal.abort()`
+#### Static method: `AbortSignal.abort([reason])`
 
 <!-- YAML
 added:
   - v15.12.0
   - v14.17.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/40807
+    description: Added the new optional reason argument.
 -->
 
+* `reason`: {any}
 * Returns: {AbortSignal}
 
 Returns a new already aborted `AbortSignal`.
@@ -151,6 +163,22 @@ added:
 
 An optional callback function that may be set by user code to be notified
 when the `abortController.abort()` function has been called.
+
+#### `abortSignal.reason`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {any}
+
+An optional reason specified when the `AbortSignal` was triggered.
+
+```js
+const ac = new AbortController();
+ac.abort(new Error('boom!'));
+console.log(ac.signal.reason);  // Error('boom!');
+```
 
 ## Class: `Buffer`
 

--- a/lib/internal/abort_controller.js
+++ b/lib/internal/abort_controller.js
@@ -30,6 +30,7 @@ const {
 } = require('internal/errors');
 
 const kAborted = Symbol('kAborted');
+const kReason = Symbol('kReason');
 
 function customInspect(self, obj, depth, options) {
   if (depth < 0)
@@ -52,9 +53,20 @@ class AbortSignal extends EventTarget {
     throw new ERR_ILLEGAL_CONSTRUCTOR();
   }
 
+  /**
+   * @type {boolean}
+   */
   get aborted() {
     validateAbortSignal(this);
     return !!this[kAborted];
+  }
+
+  /**
+   * @type {any}
+   */
+  get reason() {
+    validateAbortSignal(this);
+    return this[kReason];
   }
 
   [customInspectSymbol](depth, options) {
@@ -63,8 +75,12 @@ class AbortSignal extends EventTarget {
     }, depth, options);
   }
 
-  static abort() {
-    return createAbortSignal(true);
+  /**
+   * @param {any} reason
+   * @returns {AbortSignal}
+   */
+  static abort(reason) {
+    return createAbortSignal(true, reason);
   }
 }
 
@@ -81,16 +97,18 @@ ObjectDefineProperty(AbortSignal.prototype, SymbolToStringTag, {
 
 defineEventHandler(AbortSignal.prototype, 'abort');
 
-function createAbortSignal(aborted = false) {
+function createAbortSignal(aborted = false, reason = undefined) {
   const signal = new EventTarget();
   ObjectSetPrototypeOf(signal, AbortSignal.prototype);
   signal[kAborted] = aborted;
+  signal[kReason] = reason;
   return signal;
 }
 
-function abortSignal(signal) {
+function abortSignal(signal, reason) {
   if (signal[kAborted]) return;
   signal[kAborted] = true;
+  signal[kReason] = reason;
   const event = new Event('abort', {
     [kTrustEvent]: true
   });
@@ -112,14 +130,20 @@ class AbortController {
     this[kSignal] = createAbortSignal();
   }
 
+  /**
+   * @type {AbortSignal}
+   */
   get signal() {
     validateAbortController(this);
     return this[kSignal];
   }
 
-  abort() {
+  /**
+   * @param {any} reason
+   */
+  abort(reason) {
     validateAbortController(this);
-    abortSignal(this[kSignal]);
+    abortSignal(this[kSignal], reason);
   }
 
   [customInspectSymbol](depth, options) {

--- a/test/parallel/test-abortcontroller.js
+++ b/test/parallel/test-abortcontroller.js
@@ -140,3 +140,16 @@ const { ok, strictEqual, throws } = require('assert');
   strictEqual(inspect(ac, { depth: null }),
               'AbortController { signal: AbortSignal { aborted: false } }');
 }
+
+{
+  // Test AbortSignal.reason
+  const ac = new AbortController();
+  ac.abort('reason');
+  strictEqual(ac.signal.reason, 'reason');
+}
+
+{
+  // Test AbortSignal.reason
+  const signal = AbortSignal.abort('reason');
+  strictEqual(signal.reason, 'reason');
+}


### PR DESCRIPTION
A new reason property was recently added to the AbortSignal spec.

```js
const ac = new AbortController();
ac.abort(new Error('boom!'));
console.loc(ac.signal.reason);  // Error('boom!');
```
