### PR TITLE
process: add `getActiveResourcesInfo()`

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1817,6 +1817,44 @@ a code.
 Specifying a code to [`process.exit(code)`][`process.exit()`] will override any
 previous setting of `process.exitCode`.
 
+## `process.getActiveResourcesInfo()`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+* Returns: {string\[]}
+
+The `process.getActiveResourcesInfo()` method returns an array of strings
+containing the types of the active resources that are currently keeping the
+event loop alive.
+
+```mjs
+import { getActiveResourcesInfo } from 'process';
+import { setTimeout } from 'timers';
+
+console.log('Before:', getActiveResourcesInfo());
+setTimeout(() => {}, 1000);
+console.log('After:', getActiveResourcesInfo());
+// Prints:
+//   Before: [ 'CloseReq', 'TTYWrap', 'TTYWrap', 'TTYWrap' ]
+//   After: [ 'CloseReq', 'TTYWrap', 'TTYWrap', 'TTYWrap', 'Timeout' ]
+```
+
+```cjs
+const { getActiveResourcesInfo } = require('process');
+const { setTimeout } = require('timers');
+
+console.log('Before:', getActiveResourcesInfo());
+setTimeout(() => {}, 1000);
+console.log('After:', getActiveResourcesInfo());
+// Prints:
+//   Before: [ 'TTYWrap', 'TTYWrap', 'TTYWrap' ]
+//   After: [ 'TTYWrap', 'TTYWrap', 'TTYWrap', 'Timeout' ]
+```
+
 ## `process.getegid()`
 
 <!-- YAML

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -39,6 +39,9 @@
 setupPrepareStackTrace();
 
 const {
+  ArrayPrototypeConcat,
+  ArrayPrototypeFilter,
+  ArrayPrototypeMap,
   FunctionPrototypeCall,
   JSONParse,
   ObjectDefineProperty,
@@ -46,12 +49,14 @@ const {
   ObjectGetPrototypeOf,
   ObjectPreventExtensions,
   ObjectSetPrototypeOf,
+  ObjectValues,
   ReflectGet,
   ReflectSet,
   SymbolToStringTag,
   globalThis,
 } = primordials;
 const config = internalBinding('config');
+const internalTimers = require('internal/timers');
 const { deprecate, lazyDOMExceptionClass } = require('internal/util');
 
 setupProcessObject();
@@ -149,6 +154,16 @@ const rawMethods = internalBinding('process_methods');
   // TODO(joyeecheung): either remove them or make them public
   process._getActiveRequests = rawMethods._getActiveRequests;
   process._getActiveHandles = rawMethods._getActiveHandles;
+
+  process.getActiveResourcesInfo = function() {
+    return ArrayPrototypeConcat(
+      rawMethods._getActiveRequestsInfo(),
+      rawMethods._getActiveHandlesInfo(),
+      ArrayPrototypeMap(
+        ArrayPrototypeFilter(ObjectValues(internalTimers.activeTimersMap),
+                             ({ resource }) => resource.hasRef()),
+        ({ type }) => type));
+  };
 
   // TODO(joyeecheung): remove these
   process.reallyExit = rawMethods.reallyExit;
@@ -360,9 +375,11 @@ process.emitWarning = emitWarning;
   // TODO(joyeecheung): either remove it or make it public
   process._tickCallback = runNextTicks;
 
-  const { getTimerCallbacks } = require('internal/timers');
   const { setupTimers } = internalBinding('timers');
-  const { processImmediate, processTimers } = getTimerCallbacks(runNextTicks);
+  const {
+    processImmediate,
+    processTimers,
+  } = internalTimers.getTimerCallbacks(runNextTicks);
   // Sets two per-Environment callbacks that will be run from libuv:
   // - processImmediate will be run in the callback of the per-Environment
   //   check handle.

--- a/lib/internal/timers.js
+++ b/lib/internal/timers.js
@@ -139,6 +139,12 @@ const kRefed = Symbol('refed');
 // Create a single linked list instance only once at startup
 const immediateQueue = new ImmediateList();
 
+// Object map containing timers
+//
+// - key = asyncId
+// - value = { type, resource }
+const activeTimersMap = ObjectCreate(null);
+
 let nextExpiry = Infinity;
 let refCount = 0;
 
@@ -160,6 +166,7 @@ function initAsyncResource(resource, type) {
     resource[trigger_async_id_symbol] = getDefaultTriggerAsyncId();
   if (initHooksExist())
     emitInit(asyncId, type, triggerAsyncId, resource);
+  activeTimersMap[asyncId] = { type, resource };
 }
 
 // Timer constructor function.
@@ -446,6 +453,8 @@ function getTimerCallbacks(runNextTicks) {
         continue;
       }
 
+      // TODO(RaisinTen): Destroy and unref the Immediate after _onImmediate()
+      // gets executed, just like how Timeouts work.
       immediate._destroyed = true;
 
       immediateInfo[kCount]--;
@@ -469,6 +478,7 @@ function getTimerCallbacks(runNextTicks) {
 
         if (destroyHooksExist())
           emitDestroy(asyncId);
+        delete activeTimersMap[asyncId];
 
         outstandingQueue.head = immediate = immediate._idleNext;
       }
@@ -541,6 +551,7 @@ function getTimerCallbacks(runNextTicks) {
 
           if (destroyHooksExist())
             emitDestroy(asyncId);
+          delete activeTimersMap[asyncId];
         }
         continue;
       }
@@ -569,6 +580,7 @@ function getTimerCallbacks(runNextTicks) {
 
           if (destroyHooksExist())
             emitDestroy(asyncId);
+          delete activeTimersMap[asyncId];
         }
       }
 
@@ -658,6 +670,7 @@ module.exports = {
   active,
   unrefActive,
   insert,
+  activeTimersMap,
   timerListMap,
   timerListQueue,
   decRefCount,

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -45,6 +45,7 @@ const {
   kRefed,
   kHasPrimitive,
   getTimerDuration,
+  activeTimersMap,
   timerListMap,
   timerListQueue,
   immediateQueue,
@@ -87,6 +88,7 @@ function unenroll(item) {
   // Fewer checks may be possible, but these cover everything.
   if (destroyHooksExist() && item[async_id_symbol] !== undefined)
     emitDestroy(item[async_id_symbol]);
+  delete activeTimersMap[item[async_id_symbol]];
 
   L.remove(item);
 
@@ -329,6 +331,7 @@ function clearImmediate(immediate) {
   if (destroyHooksExist() && immediate[async_id_symbol] !== undefined) {
     emitDestroy(immediate[async_id_symbol]);
   }
+  delete activeTimersMap[immediate[async_id_symbol]];
 
   immediate._onImmediate = null;
 

--- a/test/parallel/test-handle-wrap-isrefed.js
+++ b/test/parallel/test-handle-wrap-isrefed.js
@@ -106,5 +106,31 @@ const { kStateSymbol } = require('internal/dgram');
                 false, 'tcp_wrap: not unrefed on close')));
 }
 
+// timers
+{
+  strictEqual(process.getActiveResourcesInfo().filter(
+    (type) => type === 'Timeout').length, 0);
+  const timeout = setTimeout(() => {}, 500);
+  strictEqual(process.getActiveResourcesInfo().filter(
+    (type) => type === 'Timeout').length, 1);
+  timeout.unref();
+  strictEqual(process.getActiveResourcesInfo().filter(
+    (type) => type === 'Timeout').length, 0);
+  timeout.ref();
+  strictEqual(process.getActiveResourcesInfo().filter(
+    (type) => type === 'Timeout').length, 1);
+
+  strictEqual(process.getActiveResourcesInfo().filter(
+    (type) => type === 'Immediate').length, 0);
+  const immediate = setImmediate(() => {});
+  strictEqual(process.getActiveResourcesInfo().filter(
+    (type) => type === 'Immediate').length, 1);
+  immediate.unref();
+  strictEqual(process.getActiveResourcesInfo().filter(
+    (type) => type === 'Immediate').length, 0);
+  immediate.ref();
+  strictEqual(process.getActiveResourcesInfo().filter(
+    (type) => type === 'Immediate').length, 1);
+}
 
 // See also test/pseudo-tty/test-handle-wrap-isrefed-tty.js

--- a/test/parallel/test-process-getactiveresources-track-active-handles.js
+++ b/test/parallel/test-process-getactiveresources-track-active-handles.js
@@ -1,0 +1,44 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const net = require('net');
+const NUM = 8;
+const connections = [];
+const clients = [];
+let clients_counter = 0;
+
+const server = net.createServer(function listener(c) {
+  connections.push(c);
+}).listen(0, makeConnection);
+
+
+function makeConnection() {
+  if (clients_counter >= NUM) return;
+  net.connect(server.address().port, function connected() {
+    clientConnected(this);
+    makeConnection();
+  });
+}
+
+
+function clientConnected(client) {
+  clients.push(client);
+  if (++clients_counter >= NUM)
+    checkAll();
+}
+
+
+function checkAll() {
+  assert.strictEqual(process.getActiveResourcesInfo().filter(
+    (type) => type === 'TCPSocketWrap').length,
+                     clients.length + connections.length);
+
+  clients.forEach((item) => item.destroy());
+  connections.forEach((item) => item.end());
+
+  assert.strictEqual(process.getActiveResourcesInfo().filter(
+    (type) => type === 'TCPServerWrap').length, 1);
+
+  server.close();
+}

--- a/test/parallel/test-process-getactiveresources-track-active-requests.js
+++ b/test/parallel/test-process-getactiveresources-track-active-requests.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const fs = require('fs');
+
+for (let i = 0; i < 12; i++) {
+  fs.open(__filename, 'r', common.mustCall());
+}
+
+assert.strictEqual(process.getActiveResourcesInfo().length, 12);

--- a/test/parallel/test-process-getactiveresources-track-interval-lifetime.js
+++ b/test/parallel/test-process-getactiveresources-track-interval-lifetime.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const common = require('../common');
+
+const assert = require('assert');
+
+assert.strictEqual(process.getActiveResourcesInfo().filter(
+  (type) => type === 'Timeout').length, 0);
+
+let count = 0;
+const interval = setInterval(common.mustCall(() => {
+  assert.strictEqual(process.getActiveResourcesInfo().filter(
+    (type) => type === 'Timeout').length, 1);
+  ++count;
+  if (count === 3) {
+    clearInterval(interval);
+  }
+}, 3), 0);
+
+assert.strictEqual(process.getActiveResourcesInfo().filter(
+  (type) => type === 'Timeout').length, 1);

--- a/test/parallel/test-process-getactiveresources-track-multiple-timers.js
+++ b/test/parallel/test-process-getactiveresources-track-multiple-timers.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+
+for (let i = 0; i < 10; ++i) {
+  for (let j = 0; j < 10; ++j) {
+    setTimeout(common.mustCall(), i);
+  }
+}
+
+assert.strictEqual(process.getActiveResourcesInfo().filter(
+  (type) => type === 'Timeout').length, 100);
+
+for (let i = 0; i < 10; ++i) {
+  setImmediate(common.mustCall());
+}
+
+assert.strictEqual(process.getActiveResourcesInfo().filter(
+  (type) => type === 'Immediate').length, 10);

--- a/test/parallel/test-process-getactiveresources-track-timer-lifetime.js
+++ b/test/parallel/test-process-getactiveresources-track-timer-lifetime.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const common = require('../common');
+
+const assert = require('assert');
+
+{
+  assert.strictEqual(process.getActiveResourcesInfo().filter(
+    (type) => type === 'Timeout').length, 0);
+
+  const timeout = setTimeout(common.mustCall(() => {
+    assert.strictEqual(process.getActiveResourcesInfo().filter(
+      (type) => type === 'Timeout').length, 1);
+    clearTimeout(timeout);
+    assert.strictEqual(process.getActiveResourcesInfo().filter(
+      (type) => type === 'Timeout').length, 0);
+  }), 0);
+
+  assert.strictEqual(process.getActiveResourcesInfo().filter(
+    (type) => type === 'Timeout').length, 1);
+}
+
+{
+  assert.strictEqual(process.getActiveResourcesInfo().filter(
+    (type) => type === 'Immediate').length, 0);
+
+  const immediate = setImmediate(common.mustCall(() => {
+    // TODO(RaisinTen): Change this test to the following when the Immediate is
+    // destroyed and unrefed after the callback gets executed.
+    // assert.strictEqual(process.getActiveResourcesInfo().filter(
+    //   (type) => type === 'Immediate').length, 1);
+    assert.strictEqual(process.getActiveResourcesInfo().filter(
+      (type) => type === 'Immediate').length, 0);
+    clearImmediate(immediate);
+    assert.strictEqual(process.getActiveResourcesInfo().filter(
+      (type) => type === 'Immediate').length, 0);
+  }));
+
+  assert.strictEqual(process.getActiveResourcesInfo().filter(
+    (type) => type === 'Immediate').length, 1);
+}

--- a/test/parallel/test-process-getactiveresources.js
+++ b/test/parallel/test-process-getactiveresources.js
@@ -1,0 +1,9 @@
+'use strict';
+
+require('../common');
+
+const assert = require('assert');
+
+setTimeout(() => {}, 0);
+
+assert.deepStrictEqual(process.getActiveResourcesInfo(), ['Timeout']);

--- a/test/sequential/test-net-connect-econnrefused.js
+++ b/test/sequential/test-net-connect-econnrefused.js
@@ -54,9 +54,8 @@ function pummel() {
 
 function check() {
   setTimeout(common.mustCall(function() {
-    assert.strictEqual(process._getActiveRequests().length, 0);
-    const activeHandles = process._getActiveHandles();
-    assert.ok(activeHandles.every((val) => val.constructor.name !== 'Socket'));
+    assert.strictEqual(process.getActiveResourcesInfo().filter(
+      (type) => type === 'TCPWRAP').length, 0);
   }), 0);
 }
 


### PR DESCRIPTION
This is supposed to be a public alternative of the private APIs,
`process._getActiveResources()` and `process._getActiveHandles()`. When
called, it returns an array of strings containing the types of the
active resources that are currently keeping the event loop alive.

Signed-off-by: Darshan Sen <darshan.sen@postman.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
