### PR TITLE
stream: add map method to Readable:

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1744,6 +1744,7 @@ added: REPLACEME
 -->
 
 > Stability: 1 - Experimental
+
 * `fn` {Function|AsyncFunction} a function to map over every item in the stream.
   * `data` {any} a chunk of data from the stream.
   * `options` {Object}

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1777,7 +1777,7 @@ const dnsResults = await Readable.from([
   'www.linuxfoundation.org',
 ]).map((domain) => resolver.resolve4(domain), { concurrency: 2 });
 for await (const result of dnsResults) {
-  console.log(result); // Kogs the DNS result of resolver.resolve4.
+  console.log(result); // Logs the DNS result of resolver.resolve4.
 }
 ```
 

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1737,6 +1737,49 @@ async function showBoth() {
 showBoth();
 ```
 
+### `readable.map(fn[, options])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+* `fn` {Function|AsyncFunction} a function to map over every item in the stream.
+  * `data` {any} a chunk of data from the stream.
+  * `options` {Object}
+    * `signal` {AbortSignal} aborted if the stream is destroyed allowing to
+      abort the `fn` call early.
+* `options` {Object}
+  * `concurrency` {number} the maximal concurrent invocation of `fn` to call
+    on the stream at once. **Default:** `1`.
+  * `signal` {AbortSignal} allows destroying the stream if the signal is
+    aborted.
+* Returns: {Readable} a stream mapped with the function `fn`.
+
+This method allows mapping over the stream. The `fn` function will be called
+for every item in the stream. If the `fn` function returns a promise - that
+promise will be `await`ed before being passed to the result stream.
+
+```mjs
+import { Readable } from 'stream';
+import { Resolver } from 'dns/promises';
+
+// With a synchronous mapper.
+for await (const item of Readable.from([1, 2, 3, 4]).map((x) => x * 2)) {
+  console.log(item); // 2, 4, 6, 8
+}
+// With an asynchronous mapper, making at most 2 queries at a time.
+const resolver = new Resolver();
+const dnsResults = await Readable.from([
+  'nodejs.org',
+  'openjsf.org',
+  'www.linuxfoundation.org',
+]).map((domain) => resolver.resolve4(domain), { concurrency: 2 });
+for await (const result of dnsResults) {
+  console.log(result); // Kogs the DNS result of resolver.resolve4.
+}
+```
+
 ### Duplex and transform streams
 
 #### Class: `stream.Duplex`

--- a/lib/internal/streams/operators.js
+++ b/lib/internal/streams/operators.js
@@ -93,7 +93,7 @@ async function * map(fn, options) {
           next = null;
         }
 
-        if (!done && queue.length >= concurrency) {
+        if (!done && queue.length && queue.length >= concurrency) {
           await new Promise((resolve) => {
             resume = resolve;
           });

--- a/lib/internal/streams/operators.js
+++ b/lib/internal/streams/operators.js
@@ -119,13 +119,11 @@ async function * map(fn, options) {
   try {
     while (true) {
       while (queue.length > 0) {
-        let val = queue[0];
+        const val = await queue[0];
 
         if (val === kEof) {
           return;
         }
-
-        val = await val;
 
         if (signal.aborted) {
           throw new AbortError();

--- a/lib/internal/streams/operators.js
+++ b/lib/internal/streams/operators.js
@@ -1,0 +1,161 @@
+'use strict';
+
+const { AbortController } = require('internal/abort_controller');
+const { kWeakHandler } = require('internal/event_target');
+const {
+  codes: {
+    ERR_INVALID_ARG_TYPE,
+    ERR_INVALID_ARG_VALUE,
+  }, AbortError,
+} = require('internal/errors');
+
+const {
+  MathFloor,
+  NumberIsInteger,
+  Promise,
+  PromiseReject,
+  Symbol,
+} = primordials;
+
+const kEmpty = Symbol('kEmpty');
+const kEof = Symbol('kEof');
+
+async function * map(fn, options) {
+  if (typeof fn !== 'function') {
+    throw new ERR_INVALID_ARG_TYPE(
+      'fn', ['Function', 'AsyncFunction'], this);
+  }
+
+  if (options != null && typeof options !== 'object') {
+    throw new ERR_INVALID_ARG_TYPE('options', ['Object']);
+  }
+
+  let concurrency = 1;
+  if (options?.concurrency != null) {
+    concurrency = MathFloor(options.concurrency);
+  }
+
+  if (!NumberIsInteger(concurrency)) {
+    throw new ERR_INVALID_ARG_TYPE(
+      'concurrency', ['Integer'], concurrency);
+  }
+
+  if (concurrency < 1) {
+    throw new ERR_INVALID_ARG_VALUE('concurrency', concurrency);
+  }
+
+  const ac = new AbortController();
+  const stream = this;
+  const queue = [];
+  const signal = ac.signal;
+  const signalOpt = { signal };
+
+  options?.signal?.addEventListener('abort', () => ac.abort(), {
+    [kWeakHandler]: signalOpt
+  });
+
+  let next;
+  let resume;
+  let done = false;
+
+  function onDone() {
+    done = true;
+  }
+
+  async function pump() {
+    try {
+      for await (let val of stream) {
+        if (done) {
+          return;
+        }
+
+        if (signal.aborted) {
+          throw new AbortError();
+        }
+
+        try {
+          val = fn(val, signalOpt);
+        } catch (err) {
+          val = PromiseReject(err);
+        }
+
+        if (val === kEmpty) {
+          continue;
+        }
+
+        if (typeof val?.catch === 'function') {
+          val.catch(onDone);
+        }
+
+        queue.push(val);
+        if (next) {
+          next();
+          next = null;
+        }
+
+        if (!done && queue.length >= concurrency) {
+          await new Promise((resolve) => {
+            resume = resolve;
+          });
+        }
+      }
+      queue.push(kEof);
+    } catch (err) {
+      const val = PromiseReject(err);
+      val.catch(onDone);
+      queue.push(val);
+    } finally {
+      done = true;
+      if (next) {
+        next();
+        next = null;
+      }
+    }
+  }
+
+  pump();
+
+  try {
+    while (true) {
+      while (queue.length > 0) {
+        let val = queue[0];
+
+        if (val === kEof) {
+          return;
+        }
+
+        val = await val;
+
+        if (signal.aborted) {
+          throw new AbortError();
+        }
+
+        if (val !== kEmpty) {
+          yield val;
+        }
+
+        queue.shift();
+        if (resume) {
+          resume();
+          resume = null;
+        }
+      }
+
+      await new Promise((resolve) => {
+        next = resolve;
+      });
+    }
+  } finally {
+    ac.abort();
+
+    done = true;
+    if (resume) {
+      resume();
+      resume = null;
+    }
+  }
+}
+
+module.exports = {
+  map
+};

--- a/lib/internal/streams/operators.js
+++ b/lib/internal/streams/operators.js
@@ -5,7 +5,8 @@ const {
   codes: {
     ERR_INVALID_ARG_TYPE,
     ERR_INVALID_ARG_VALUE,
-  }, AbortError,
+  },
+  AbortError,
 } = require('internal/errors');
 
 const {
@@ -34,13 +35,7 @@ async function * map(fn, options) {
     concurrency = MathFloor(options.concurrency);
   }
 
-  if (!NumberIsInteger(concurrency)) {
-    throw new ERR_INVALID_ARG_TYPE('concurrency', ['Integer']);
-  }
-
-  if (concurrency < 1) {
-    throw new ERR_INVALID_ARG_VALUE('concurrency', concurrency);
-  }
+  validateInteger(concurrency, 'concurrency', 1);
 
   const ac = new AbortController();
   const stream = this;
@@ -99,7 +94,7 @@ async function * map(fn, options) {
       queue.push(kEof);
     } catch (err) {
       const val = PromiseReject(err);
-      val.catch(onDone);
+      PromisePrototypeCatch(val, onDone);
       queue.push(val);
     } finally {
       done = true;
@@ -153,5 +148,5 @@ async function * map(fn, options) {
 }
 
 module.exports = {
-  map
+  map,
 };

--- a/lib/internal/streams/operators.js
+++ b/lib/internal/streams/operators.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { AbortController } = require('internal/abort_controller');
-const { kWeakHandler } = require('internal/event_target');
 const {
   codes: {
     ERR_INVALID_ARG_TYPE,
@@ -52,9 +51,8 @@ async function * map(fn, options) {
   const signal = ac.signal;
   const signalOpt = { signal };
 
-  options?.signal?.addEventListener('abort', () => ac.abort(), {
-    [kWeakHandler]: signalOpt
-  });
+  const abort = () => ac.abort()
+  options?.signal?.addEventListener('abort', abort);
 
   let next;
   let resume;
@@ -112,6 +110,7 @@ async function * map(fn, options) {
         next();
         next = null;
       }
+      options?.signal?.removeEventListener('abort', abort);
     }
   }
 

--- a/lib/internal/streams/operators.js
+++ b/lib/internal/streams/operators.js
@@ -8,10 +8,13 @@ const {
     ERR_INVALID_ARG_VALUE,
   }, AbortError,
 } = require('internal/errors');
+const {
+  validateInteger,
+  validateObject,
+} = require('internal/validators');
 
 const {
   MathFloor,
-  NumberIsInteger,
   Promise,
   PromiseReject,
   Symbol,
@@ -30,15 +33,14 @@ async function * map(fn, options) {
     throw new ERR_INVALID_ARG_TYPE('options', ['Object']);
   }
 
+  validateObject(options, 'options', { nullable: true });
+
   let concurrency = 1;
   if (options?.concurrency != null) {
     concurrency = MathFloor(options.concurrency);
   }
 
-  if (!NumberIsInteger(concurrency)) {
-    throw new ERR_INVALID_ARG_TYPE(
-      'concurrency', ['Integer'], concurrency);
-  }
+  validateInteger(concurrency, 'concurrency', 1);
 
   if (concurrency < 1) {
     throw new ERR_INVALID_ARG_VALUE('concurrency', concurrency);

--- a/lib/internal/streams/operators.js
+++ b/lib/internal/streams/operators.js
@@ -4,16 +4,16 @@ const { AbortController } = require('internal/abort_controller');
 const {
   codes: {
     ERR_INVALID_ARG_TYPE,
-    ERR_INVALID_ARG_VALUE,
   },
   AbortError,
 } = require('internal/errors');
+const { validateInteger } = require('internal/validators');
 
 const {
   MathFloor,
-  NumberIsInteger,
   Promise,
   PromiseReject,
+  PromisePrototypeCatch,
   Symbol,
 } = primordials;
 

--- a/lib/internal/streams/operators.js
+++ b/lib/internal/streams/operators.js
@@ -32,8 +32,6 @@ async function * map(fn, options) {
     throw new ERR_INVALID_ARG_TYPE('options', ['Object']);
   }
 
-  validateObject(options, 'options', { nullable: true });
-
   let concurrency = 1;
   if (options?.concurrency != null) {
     concurrency = MathFloor(options.concurrency);

--- a/lib/internal/streams/operators.js
+++ b/lib/internal/streams/operators.js
@@ -7,12 +7,10 @@ const {
     ERR_INVALID_ARG_VALUE,
   }, AbortError,
 } = require('internal/errors');
-const {
-  validateInteger,
-} = require('internal/validators');
 
 const {
   MathFloor,
+  NumberIsInteger,
   Promise,
   PromiseReject,
   Symbol,
@@ -36,7 +34,9 @@ async function * map(fn, options) {
     concurrency = MathFloor(options.concurrency);
   }
 
-  validateInteger(concurrency, 'concurrency', 1);
+  if (!NumberIsInteger(concurrency)) {
+    throw new ERR_INVALID_ARG_TYPE('concurrency', ['Integer']);
+  }
 
   if (concurrency < 1) {
     throw new ERR_INVALID_ARG_VALUE('concurrency', concurrency);

--- a/lib/internal/streams/operators.js
+++ b/lib/internal/streams/operators.js
@@ -51,7 +51,7 @@ async function * map(fn, options) {
   const signal = ac.signal;
   const signalOpt = { signal };
 
-  const abort = () => ac.abort()
+  const abort = () => ac.abort();
   options?.signal?.addEventListener('abort', abort);
 
   let next;

--- a/lib/internal/streams/operators.js
+++ b/lib/internal/streams/operators.js
@@ -9,7 +9,6 @@ const {
 } = require('internal/errors');
 const {
   validateInteger,
-  validateObject,
 } = require('internal/validators');
 
 const {

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -47,7 +47,7 @@ Stream.Readable = require('internal/streams/readable');
 for (const key of ObjectKeys(operators)) {
   const op = operators[key];
   Stream.Readable.prototype[key] = function(...args) {
-    return Stream.Readable.from(op.apply(this, args));
+    return Stream.Readable.from(ReflectApply(op, this, arguments));
   };
 }
 Stream.Writable = require('internal/streams/writable');

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -24,6 +24,7 @@
 const {
   ObjectDefineProperty,
   ObjectKeys,
+  ReflectApply,
 } = primordials;
 
 const {

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -23,12 +23,14 @@
 
 const {
   ObjectDefineProperty,
+  ObjectKeys,
 } = primordials;
 
 const {
   promisify: { custom: customPromisify },
 } = require('internal/util');
 
+const operators = require('internal/streams/operators');
 const compose = require('internal/streams/compose');
 const { pipeline } = require('internal/streams/pipeline');
 const { destroyer } = require('internal/streams/destroy');
@@ -42,6 +44,12 @@ const Stream = module.exports = require('internal/streams/legacy').Stream;
 Stream.isDisturbed = utils.isDisturbed;
 Stream.isErrored = utils.isErrored;
 Stream.Readable = require('internal/streams/readable');
+for (const key of ObjectKeys(operators)) {
+  const op = operators[key];
+  Stream.Readable.prototype[key] = function(...args) {
+    return Stream.Readable.from(op.apply(this, args));
+  };
+}
 Stream.Writable = require('internal/streams/writable');
 Stream.Duplex = require('internal/streams/duplex');
 Stream.Transform = require('internal/streams/transform');

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -47,7 +47,7 @@ Stream.Readable = require('internal/streams/readable');
 for (const key of ObjectKeys(operators)) {
   const op = operators[key];
   Stream.Readable.prototype[key] = function(...args) {
-    return Stream.Readable.from(ReflectApply(op, this, arguments));
+    return Stream.Readable.from(ReflectApply(op, this, args));
   };
 }
 Stream.Writable = require('internal/streams/writable');

--- a/test/parallel/test-bootstrap-modules.js
+++ b/test/parallel/test-bootstrap-modules.js
@@ -110,6 +110,7 @@ const expectedModules = new Set([
   'NativeModule internal/streams/end-of-stream',
   'NativeModule internal/streams/from',
   'NativeModule internal/streams/legacy',
+  'NativeModule internal/streams/operators',
   'NativeModule internal/streams/passthrough',
   'NativeModule internal/streams/pipeline',
   'NativeModule internal/streams/readable',

--- a/test/parallel/test-stream-map.js
+++ b/test/parallel/test-stream-map.js
@@ -95,7 +95,7 @@ const { setTimeout } = require('timers/promises');
     for await (const _ of Readable.from([1]).map((x) => x, {
       concurrency: 'Foo'
     }));
-  }, /ERR_INVALID_ARG_TYPE/).then(common.mustCall());
+  }, /ERR_OUT_OF_RANGE/).then(common.mustCall());
   assert.rejects(async () => {
     // eslint-disable-next-line no-unused-vars
     for await (const _ of Readable.from([1]).map((x) => x, 1));

--- a/test/parallel/test-stream-map.js
+++ b/test/parallel/test-stream-map.js
@@ -89,17 +89,17 @@ const { setTimeout } = require('timers/promises');
   assert.rejects(async () => {
     // eslint-disable-next-line no-unused-vars
     for await (const unused of Readable.from([1]).map(1));
-  }, /ERR_INVALID_ARG_TYPE/);
+  }, /ERR_INVALID_ARG_TYPE/).then(common.mustCall());
   assert.rejects(async () => {
     // eslint-disable-next-line no-unused-vars
     for await (const _ of Readable.from([1]).map((x) => x, {
       concurrency: 'Foo'
     }));
-  }, /ERR_INVALID_ARG_TYPE/);
+  }, /ERR_INVALID_ARG_TYPE/).then(common.mustCall());
   assert.rejects(async () => {
     // eslint-disable-next-line no-unused-vars
     for await (const _ of Readable.from([1]).map((x) => x, 1));
-  }, /ERR_INVALID_ARG_TYPE/);
+  }, /ERR_INVALID_ARG_TYPE/).then(common.mustCall());
 }
 {
   // Test result is a Readable

--- a/test/parallel/test-stream-map.js
+++ b/test/parallel/test-stream-map.js
@@ -1,0 +1,108 @@
+'use strict';
+
+const common = require('../common');
+const {
+  Readable,
+} = require('stream');
+const assert = require('assert');
+const { setTimeout } = require('timers/promises');
+
+{
+  // Map works on synchronous streams with a synchronous mapper
+  const stream = Readable.from([1, 2, 3, 4, 5]).map((x) => x + x);
+  const result = [2, 4, 6, 8, 10];
+  (async () => {
+    for await (const item of stream) {
+      assert.strictEqual(item, result.shift());
+    }
+  })().then(common.mustCall());
+}
+
+{
+  // Map works on synchronous streams with an asynchronous mapper
+  const stream = Readable.from([1, 2, 3, 4, 5]).map(async (x) => {
+    await Promise.resolve();
+    return x + x;
+  });
+  const result = [2, 4, 6, 8, 10];
+  (async () => {
+    for await (const item of stream) {
+      assert.strictEqual(item, result.shift());
+    }
+  })().then(common.mustCall());
+}
+
+{
+  // Map works on asynchronous streams with a asynchronous mapper
+  const stream = Readable.from([1, 2, 3, 4, 5]).map(async (x) => {
+    return x + x;
+  }).map((x) => x + x);
+  const result = [4, 8, 12, 16, 20];
+  (async () => {
+    for await (const item of stream) {
+      assert.strictEqual(item, result.shift());
+    }
+  })().then(common.mustCall());
+}
+
+{
+  // Concurrency + AbortSignal
+  const ac = new AbortController();
+  let calls = 0;
+  const stream = Readable.from([1, 2, 3, 4, 5]).map(async (_, { signal }) => {
+    calls++;
+    await setTimeout(100, { signal });
+  }, { signal: ac.signal, concurrency: 2 });
+  // pump
+  (async () => {
+    for await (const item of stream) {
+      // nope
+      console.log(item);
+    }
+  })().catch(common.mustCall((e) => {
+    assert.strictEqual(e.name, 'AbortError');
+  }));
+
+  setImmediate(() => {
+    ac.abort();
+    assert.strictEqual(calls, 2);
+  });
+}
+
+{
+  // Concurrency result order
+  const stream = Readable.from([1, 2]).map(async (item, { signal }) => {
+    await setTimeout(10 - item, { signal });
+    return item;
+  }, { concurrency: 2 });
+
+  (async () => {
+    const expected = [1, 2];
+    for await (const item of stream) {
+      assert.strictEqual(item, expected.shift());
+    }
+  })().then(common.mustCall());
+}
+
+{
+  // Error cases
+  assert.rejects(async () => {
+    // eslint-disable-next-line no-unused-vars
+    for await (const unused of Readable.from([1]).map(1));
+  }, /ERR_INVALID_ARG_TYPE/);
+  assert.rejects(async () => {
+    // eslint-disable-next-line no-unused-vars
+    for await (const _ of Readable.from([1]).map((x) => x, {
+      concurrency: 'Foo'
+    }));
+  }, /ERR_INVALID_ARG_TYPE/);
+  assert.rejects(async () => {
+    // eslint-disable-next-line no-unused-vars
+    for await (const _ of Readable.from([1]).map((x) => x, 1));
+  }, /ERR_INVALID_ARG_TYPE/);
+}
+{
+  // Test result is a Readable
+  const stream = Readable.from([1, 2, 3, 4, 5]).map((x) => x);
+  assert.strictEqual(stream.readable, true);
+}

--- a/test/parallel/test-stream-map.js
+++ b/test/parallel/test-stream-map.js
@@ -54,14 +54,14 @@ const { setTimeout } = require('timers/promises');
     await setTimeout(100, { signal });
   }, { signal: ac.signal, concurrency: 2 });
   // pump
-  (async () => {
+  assert.rejects(async () => {
     for await (const item of stream) {
       // nope
       console.log(item);
     }
-  })().catch(common.mustCall((e) => {
-    assert.strictEqual(e.name, 'AbortError');
-  }));
+  }, {
+    name: 'AbortError',
+  }).then(common.mustCall());
 
   setImmediate(() => {
     ac.abort();

--- a/tools/doc/type-parser.mjs
+++ b/tools/doc/type-parser.mjs
@@ -208,12 +208,12 @@ const customTypesMap = {
 
   'Stream': 'stream.html#stream',
   'stream.Duplex': 'stream.html#class-streamduplex',
-  'stream.Readable': 'stream.html#class-streamreadable',
-  'stream.Transform': 'stream.html#class-streamtransform',
-  'stream.Writable': 'stream.html#class-streamwritable',
   'Duplex': 'stream.html#class-streamduplex',
+  'stream.Readable': 'stream.html#class-streamreadable',
   'Readable': 'stream.html#class-streamreadable',
+  'stream.Transform': 'stream.html#class-streamtransform',
   'Transform': 'stream.html#class-streamtransform',
+  'stream.Writable': 'stream.html#class-streamwritable',,
   'Writable': 'stream.html#class-streamwritable',
 
   'Immediate': 'timers.html#class-immediate',

--- a/tools/doc/type-parser.mjs
+++ b/tools/doc/type-parser.mjs
@@ -213,7 +213,7 @@ const customTypesMap = {
   'Readable': 'stream.html#class-streamreadable',
   'stream.Transform': 'stream.html#class-streamtransform',
   'Transform': 'stream.html#class-streamtransform',
-  'stream.Writable': 'stream.html#class-streamwritable',,
+  'stream.Writable': 'stream.html#class-streamwritable',
   'Writable': 'stream.html#class-streamwritable',
 
   'Immediate': 'timers.html#class-immediate',


### PR DESCRIPTION
This is very much work in progress when meeting @ronag at NodeTLV.

This is based on the ongoing standards work in https://github.com/tc39/proposal-iterator-helpers in order to make Node.js more compatible with the language in the future.

In addition, people often really just want to map a stream and this provides a simpler API than `compose` or `pipeline` for simple cases.

This is still missing docs, I want to bikeshed the API and see we have consensus first.