### PR TITLE
doc: simplify major release preparation

### DIFF
--- a/doc/guides/releases.md
+++ b/doc/guides/releases.md
@@ -782,18 +782,16 @@ announced immediately following the release of 12.0.0).
 
 ### Release branch
 
-Approximately three months before a major release, new `vN.x` and
+Approximately two months before a major release, new `vN.x` and
 `vN.x-staging` branches (where `N` indicates the major release) should be
-created as forks of the `master` branch. Up until one month before the release
-date, these must be kept in sync with `master` and must not be considered to
-be stable branches (e.g. they may be force pushed).
+created as forks of the `master` branch. Up until one week before the release
+date, these must be kept in sync with `master`.
 
 The `vN.x` and `vN.x-staging` branches must be kept in sync with one another
-up until the date of release.
+up until the date of the release.
 
-One month or less before the release date, commits must be cherry-picked into
-the two branches. To land `SEMVER-MAJOR` at this time requires no objections
-from the TSC.
+The TSC should be informed of any `SEMVER-MAJOR` commits that land within one
+month of the release.
 
 ### Create release labels
 
@@ -812,7 +810,7 @@ labels of previous releases.
 
 ### Release proposal
 
-A draft release proposal should be created two months before the release. A
+A draft release proposal should be created 6 weeks before the release. A
 separate `vN.x-proposal` branch should be created that tracks the `vN.x`
 branch. This branch will contain the draft release commit (with the draft
 changelog).


### PR DESCRIPTION
Proposed simplification of the major release process.

Changes/rational:
- Change the branch creation to two months prior from three months prior.
  - No builds are run until 6 weeks before so there's no significant impact of creating the branches any earlier.
- Do not cherry-pick commits within the last month. Mirror the `master` branch up until 1 week before the release. 
  - Mirroring the branches for as long as possible keeps the Git history in sync. 
-  Dropped 'semver major cut-off' and replace with 'Inform TSC of any majors which land within a month of the release'.
   - Majors are already gated with TSC approvals at land time.
   - We've had almost no objections for majors for the past few releases - and when there is an objection we have almost always reverted on master too.
   - Asking if there's any objections to the majors is a somewhat tiresome process, and in recent releases I've found there has been minimal engagement. (We're all busy people and it is easy to miss notifications.) 
  
cc: @nodejs/releasers @nodejs/tsc 
