### PR TITLE
doc: add pref to using draft PR versus WIP label

### DIFF
--- a/doc/guides/contributing/pull-requests.md
+++ b/doc/guides/contributing/pull-requests.md
@@ -274,7 +274,7 @@ Once opened, pull requests are usually reviewed within a few days.
 To get feedback on your proposed change even though it is not ready
 to land, use the `Convert to draft` option in the GitHub UI.
 Do not use the `wip` label as it might not prevent the PR
-from being landed before you are ready.
+from landing before you are ready.
 
 ### Step 9: Discuss and update
 

--- a/doc/guides/contributing/pull-requests.md
+++ b/doc/guides/contributing/pull-requests.md
@@ -271,6 +271,11 @@ details, but feel free to skip parts if you're not sure what to put.
 
 Once opened, pull requests are usually reviewed within a few days.
 
+To get feedback on your proposed change even though it is not ready
+to land, use the `Convert to draft` option in the GitHub UI.
+This is preferred over the `WIP` label as it will prevent the PR
+from being landed before you are ready.
+
 ### Step 9: Discuss and update
 
 You will probably get feedback or requests for changes to your pull request.

--- a/doc/guides/contributing/pull-requests.md
+++ b/doc/guides/contributing/pull-requests.md
@@ -273,7 +273,7 @@ Once opened, pull requests are usually reviewed within a few days.
 
 To get feedback on your proposed change even though it is not ready
 to land, use the `Convert to draft` option in the GitHub UI.
-This is preferred over the `WIP` label as it will prevent the PR
+Do not use the `wip` label as it might not prevent the PR
 from being landed before you are ready.
 
 ### Step 9: Discuss and update


### PR DESCRIPTION
- add to the contribution guide that we prefer that
  people use draft PRs instead of the WIP label.

Signed-off-by: Michael Dawson <mdawson@devrus.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
