### PR TITLE
build: add devcontainer configuration

### DIFF
--- a/.devcontainer/.devcontainer.json
+++ b/.devcontainer/.devcontainer.json
@@ -10,11 +10,11 @@
   "dockerFile": "Dockerfile",
   "initializeCommand": "docker system prune -f -a",
   "settings": {
-        "terminal.integrated.profiles.linux": {
-          "zsh (login)": {
-            "path": "zsh",
-            "args": ["-l"]
-          }
+      "terminal.integrated.profiles.linux": {
+        "zsh (login)": {
+          "path": "zsh",
+          "args": ["-l"]
         }
       }
+    }
   }

--- a/.devcontainer/.devcontainer.json
+++ b/.devcontainer/.devcontainer.json
@@ -1,0 +1,20 @@
+{
+  "name": "Node.js Core Developer Environment",
+  "extensions": [
+      "eamodio.gitlens",
+      "github.vscode-pull-request-github",
+      "ms-vsliveshare.vsliveshare",
+      "vscode-icons-team.vscode-icons",
+      "visualstudioexptteam.vscodeintellicode"
+  ],
+  "dockerFile": "Dockerfile",
+  "initializeCommand": "docker system prune -f -a",
+  "settings": {
+        "terminal.integrated.profiles.linux": {
+          "zsh (login)": {
+            "path": "zsh",
+            "args": ["-l"]
+          }
+        }
+      }
+  }

--- a/.devcontainer/.devcontainer.json
+++ b/.devcontainer/.devcontainer.json
@@ -1,7 +1,6 @@
 {
   "name": "Node.js Core Developer Environment",
   "extensions": [
-      "eamodio.gitlens",
       "github.vscode-pull-request-github",
       "ms-vsliveshare.vsliveshare",
       "vscode-icons-team.vscode-icons",
@@ -10,11 +9,11 @@
   "dockerFile": "Dockerfile",
   "initializeCommand": "docker system prune -f -a",
   "settings": {
-      "terminal.integrated.profiles.linux": {
-        "zsh (login)": {
-          "path": "zsh",
-          "args": ["-l"]
-        }
+    "terminal.integrated.profiles.linux": {
+      "zsh (login)": {
+        "path": "zsh",
+        "args": ["-l"]
       }
     }
   }
+}

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,3 @@
+FROM nodejs/devcontainer:latest
+
+WORKDIR /home/developer/nodejs/node

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,1 @@
 FROM nodejs/devcontainer:latest
-
-WORKDIR /home/developer/nodejs/node

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,1 +1,1 @@
-FROM nodejs/devcontainer:latest
+FROM nodejs/devcontainer:nightly

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 .*
 # Exclude specific dotfiles that we want to track.
 !deps/**/.*
+!.devcontainer/
+!.devcontainer/.devcontainer.json
 !test/fixtures/**/.*
 !.clang-format
 !.cpplint


### PR DESCRIPTION
this PR adds two metadata files: 

1. `./.devcontainer/.devcontainer.json` provides metadata to GitHub Codespaces and other tools (like Docker Desktop's preview [Developer Environments](https://docs.docker.com/desktop/dev-environments/) feature) about how to build and configure a developer environment.
2. `./.devcontainer/Dockerfile` a very simple `Dockerfile` that the `.devcontainer.json` file uses to build from. This will consume the Docker image I've built out (pending https://github.com/nodejs/admin/issues/641 on moving it into nodejs/devcontainer) that will be built and published nightly.

These should add a relatively low maintenance burden - the `Dockerfile` is literally two LOC (most of the work for this is done in the nodejs/devcontainer repo!) and the `.devcontainer.json` is effectively a configuration file that represents some settings. It could be stripped down or more thoroughly built out if folks want, though I'd generally like to request that we err on configuring for a broader audience than just project members (think the audience at a Code and Learn event) while also serving ourselves.

This PR should not land until https://github.com/nodejs/admin/issues/641 lands.