### PR TITLE
doc: add fspromises mkdir example

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1014,7 +1014,7 @@ try {
   const path = new URL('./test/project', import.meta.url);
   const createDir = await mkdir(path, { recursive: true });
 
-  console.log (`created ${createDir}`);
+  console.log(`created ${createDir}`);
 } catch (err) {
   console.error(err.message);
 }
@@ -1024,16 +1024,22 @@ try {
 const { mkdir } = require('fs/promises');
 const { resolve } = require('path');
 
-async function makeDirectory () {
-  const path = resolve('./test/project/lol/hi')
-  const dirCreation = await mkdir(path, { recursive: true });
-  
-  console.log(dirCreation)
-  return dirCreation;
+async function makeDirectory() {
+  try {
+    const path = resolve('./test/project/lol/hi');
+    const dirCreation = await mkdir(path, { recursive: true });
+
+    console.log(dirCreation);
+    return dirCreation;
+  } catch (err) {
+    console.error(err.message);
+  }
+
 }
 
 makeDirectory();
 ```
+
 ### `fsPromises.mkdtemp(prefix[, options])`
 
 <!-- YAML

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1007,6 +1007,33 @@ property indicating whether parent directories should be created. Calling
 `fsPromises.mkdir()` when `path` is a directory that exists results in a
 rejection only when `recursive` is false.
 
+```mjs
+import { mkdir } from 'fs/promises';
+
+try {
+  const path = new URL('./test/project', import.meta.url);
+  const createDir = await mkdir(path, { recursive: true });
+
+  console.log (`created ${createDir}`);
+} catch (err) {
+  console.error(err.message);
+}
+```
+
+```cjs
+const { mkdir } = require('fs/promises');
+const { resolve } = require('path');
+
+async function makeDirectory () {
+  const path = resolve('./test/project/lol/hi')
+  const dirCreation = await mkdir(path, { recursive: true });
+  
+  console.log(dirCreation)
+  return dirCreation;
+}
+
+makeDirectory();
+```
 ### `fsPromises.mkdtemp(prefix[, options])`
 
 <!-- YAML

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1008,7 +1008,7 @@ property indicating whether parent directories should be created. Calling
 rejection only when `recursive` is false.
 
 ```mjs
-import { mkdir } from 'fs/promises';
+import { mkdir } from 'node:fs/promises';
 
 try {
   const projectFolder = new URL('./test/project/', import.meta.url);

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1021,8 +1021,8 @@ try {
 ```
 
 ```cjs
-const { mkdir } = require('fs/promises');
-const { resolve } = require('path');
+const { mkdir } = require('node:fs/promises');
+const { resolve } = require('node:path');
 
 async function makeDirectory() {
   try {
@@ -1068,7 +1068,7 @@ The optional `options` argument can be a string specifying an encoding, or an
 object with an `encoding` property specifying the character encoding to use.
 
 ```mjs
-import { mkdtemp } from 'fs/promises';
+import { mkdtemp } from 'node:fs/promises';
 
 try {
   await mkdtemp(path.join(os.tmpdir(), 'foo-'));

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1022,12 +1022,12 @@ try {
 
 ```cjs
 const { mkdir } = require('node:fs/promises');
-const { resolve } = require('node:path');
+const { resolve, join } = require('node:path');
 
 async function makeDirectory() {
   try {
-    const projectFolder = resolve('./test/project/');
-    const dirCreation = await mkdir(path, { recursive: true });
+    const projectFolder = join(__dirname, 'test', 'project');
+    const dirCreation = await mkdir(projectFolder, { recursive: true });
 
     console.log(dirCreation);
     return dirCreation;

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1032,7 +1032,7 @@ async function makeDirectory() {
   return dirCreation;
 }
 
-makeDirectory().catch(console.error)
+makeDirectory().catch(console.error);
 ```
 
 ### `fsPromises.mkdtemp(prefix[, options])`

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1011,7 +1011,7 @@ rejection only when `recursive` is false.
 import { mkdir } from 'fs/promises';
 
 try {
-  const path = new URL('./test/project', import.meta.url);
+  const projectFolder = new URL('./test/project/', import.meta.url);
   const createDir = await mkdir(path, { recursive: true });
 
   console.log(`created ${createDir}`);
@@ -1026,7 +1026,7 @@ const { resolve } = require('path');
 
 async function makeDirectory() {
   try {
-    const path = resolve('./test/project/lol/hi');
+    const projectFolder = resolve('./test/project/');
     const dirCreation = await mkdir(path, { recursive: true });
 
     console.log(dirCreation);

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1025,19 +1025,14 @@ const { mkdir } = require('node:fs/promises');
 const { resolve, join } = require('node:path');
 
 async function makeDirectory() {
-  try {
-    const projectFolder = join(__dirname, 'test', 'project');
-    const dirCreation = await mkdir(projectFolder, { recursive: true });
+  const projectFolder = join(__dirname, 'test', 'project');
+  const dirCreation = await mkdir(projectFolder, { recursive: true });
 
-    console.log(dirCreation);
-    return dirCreation;
-  } catch (err) {
-    console.error(err.message);
-  }
-
+  console.log(dirCreation);
+  return dirCreation;
 }
 
-makeDirectory();
+makeDirectory().catch(console.error)
 ```
 
 ### `fsPromises.mkdtemp(prefix[, options])`


### PR DESCRIPTION
Adds an example to the fsPromises `mkdir` doc. Includes both cjs and mjs versions, because we should support both imo.