### PR TITLE
tools: fix commit-lint GH Actions CI

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - run: git --no-pager log HEAD~${{ github.event.pull_request.commits }}
+      - run: git --no-pager log HEAD^
       - name: Validate commit message
         run: |
           echo "::add-matcher::.github/workflows/commit-lint-problem-matcher.json"

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -15,12 +15,12 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: ${{ steps.nb-of-commits.outputs.nb }}
-      - name: Install Node.js
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-      - run: git --no-pager log
-      - name: Validate commit message
-        run: |
-          echo "::add-matcher::.github/workflows/commit-lint-problem-matcher.json"
-          git rev-parse HEAD~${{ github.event.pull_request.commits }} | xargs npx -q core-validate-commit --no-validate-metadata --tap
+      - run: git --no-pager log HEAD^2~${{ github.event.pull_request.commits }}
+      # - name: Install Node.js
+      #   uses: actions/setup-node@v2
+      #   with:
+      #     node-version: ${{ env.NODE_VERSION }}
+      # - name: Validate commit message
+      #   run: |
+      #     echo "::add-matcher::.github/workflows/commit-lint-problem-matcher.json"
+      #     git rev-parse HEAD~${{ github.event.pull_request.commits }} | xargs npx -q core-validate-commit --no-validate-metadata --tap

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -19,8 +19,8 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - run: git --no-pager log HEAD~${{ steps.nb-of-commits.outputs.nb }}
+      - run: git --no-pager log HEAD~${{ github.event.pull_request.commits }}
       - name: Validate commit message
         run: |
           echo "::add-matcher::.github/workflows/commit-lint-problem-matcher.json"
-          git rev-parse HEAD~${{ steps.nb-of-commits.outputs.nb }} | xargs npx -q core-validate-commit --no-validate-metadata --tap
+          git rev-parse HEAD~${{ github.event.pull_request.commits }} | xargs npx -q core-validate-commit --no-validate-metadata --tap

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -15,7 +15,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: ${{ steps.nb-of-commits.outputs.nb }}
-      - run: git --no-pager log $(git rev-parse HEAD^2)~${{ github.event.pull_request.commits }}
+      - run: git reset HEAD^2
+      - run: git --no-pager log HEAD~${{ github.event.pull_request.commits }}
       # - name: Install Node.js
       #   uses: actions/setup-node@v2
       #   with:

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -11,12 +11,14 @@ jobs:
     steps:
       - name: Compute number of commits in the PR
         id: nb-of-commits
-        run: echo "::set-output name=nb::$((${{ github.event.pull_request.commits }} + 1))"
+        run: |
+          echo "::set-output name=plusOne::$((${{ github.event.pull_request.commits }} + 1))"
+          echo "::set-output name=minusOne::$((${{ github.event.pull_request.commits }} - 1))"
       - uses: actions/checkout@v2
         with:
-          fetch-depth: ${{ steps.nb-of-commits.outputs.nb }}
+          fetch-depth: ${{ steps.nb-of-commits.outputs.plusOne }}
       - run: git reset HEAD^2
-      - run: git --no-pager log HEAD~${{ github.event.pull_request.commits }}
+      - run: git --no-pager log HEAD~${{ steps.nb-of-commits.outputs.minusOne }}
       # - name: Install Node.js
       #   uses: actions/setup-node@v2
       #   with:

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - run: git --no-pager log HEAD^
+      - run: git --no-pager log
       - name: Validate commit message
         run: |
           echo "::add-matcher::.github/workflows/commit-lint-problem-matcher.json"

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: ${{ steps.nb-of-commits.outputs.nb }}
-      - run: git --no-pager log HEAD^2~${{ github.event.pull_request.commits }}
+      - run: git --no-pager log $(git rev-parse HEAD^2)~${{ github.event.pull_request.commits }}
       # - name: Install Node.js
       #   uses: actions/setup-node@v2
       #   with:

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -9,14 +9,18 @@ jobs:
   lint-commit-message:
     runs-on: ubuntu-latest
     steps:
+      - name: Compute number of commits in the PR
+        id: nb-of-commits
+        run: echo "::set-output name=nb::$((${{ github.event.pull_request.commits }} + 1))"
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 2
+          fetch-depth: ${{ steps.nb-of-commits.outputs.nb }}
       - name: Install Node.js
         uses: actions/setup-node@v2
         with:
           node-version: ${{ env.NODE_VERSION }}
+      - run: git --no-pager log HEAD~${{ steps.nb-of-commits.outputs.nb }}
       - name: Validate commit message
         run: |
           echo "::add-matcher::.github/workflows/commit-lint-problem-matcher.json"
-          git rev-parse HEAD^ | xargs npx -q core-validate-commit --no-validate-metadata --tap
+          git rev-parse HEAD~${{ steps.nb-of-commits.outputs.nb }} | xargs npx -q core-validate-commit --no-validate-metadata --tap

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -18,12 +18,11 @@ jobs:
         with:
           fetch-depth: ${{ steps.nb-of-commits.outputs.plusOne }}
       - run: git reset HEAD^2
-      - run: git --no-pager log HEAD~${{ steps.nb-of-commits.outputs.minusOne }}
-      # - name: Install Node.js
-      #   uses: actions/setup-node@v2
-      #   with:
-      #     node-version: ${{ env.NODE_VERSION }}
-      # - name: Validate commit message
-      #   run: |
-      #     echo "::add-matcher::.github/workflows/commit-lint-problem-matcher.json"
-      #     git rev-parse HEAD~${{ github.event.pull_request.commits }} | xargs npx -q core-validate-commit --no-validate-metadata --tap
+      - name: Install Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Validate commit message
+        run: |
+          echo "::add-matcher::.github/workflows/commit-lint-problem-matcher.json"
+          git rev-parse HEAD~${{ steps.nb-of-commits.outputs.minusOne }} | xargs npx -q core-validate-commit --no-validate-metadata --tap


### PR DESCRIPTION
In #40740, I tried to make a change to the `commit-lint` job for it to lint only one commit per PR. However, because I'm clearly lacking some git expertise, I did it completely wrong: instead of validating the first commit of the PR, it's now validating the.. last commit that landed on `master` before the CI starts. This PR aims to fix that.

I'm doing `git reset HEAD^2` to land to the last commit in the PR, there might be a more elegant way to target the commit we're after without doing a `git reset`, but also it's not a very expensive operation so it may be just fine.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
