### PR TITLE
stream: fix finished regression when working with legacy Stream

### DIFF
--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -165,13 +165,13 @@ function eos(stream, options, callback) {
   } else if (
     !readable &&
     (!willEmitClose || isReadable(stream)) &&
-    (writableFinished || !isWritable(stream))
+    (writableFinished || isWritable(stream) === false)
   ) {
     process.nextTick(onclose);
   } else if (
     !writable &&
     (!willEmitClose || isWritable(stream)) &&
-    (readableFinished || !isReadable(stream))
+    (readableFinished || isReadable(stream) === false)
   ) {
     process.nextTick(onclose);
   } else if ((rState && stream.req && stream.aborted)) {

--- a/test/parallel/test-stream-finished.js
+++ b/test/parallel/test-stream-finished.js
@@ -8,7 +8,7 @@ const {
   finished,
   Duplex,
   PassThrough,
-  Stream
+  Stream,
 } = require('stream');
 const assert = require('assert');
 const EE = require('events');

--- a/test/parallel/test-stream-finished.js
+++ b/test/parallel/test-stream-finished.js
@@ -7,7 +7,8 @@ const {
   Transform,
   finished,
   Duplex,
-  PassThrough
+  PassThrough,
+  Stream
 } = require('stream');
 const assert = require('assert');
 const EE = require('events');
@@ -629,4 +630,12 @@ testClosed((opts) => new Writable({ write() {}, ...opts }));
       assert.strictEqual(err.code, 'ERR_STREAM_PREMATURE_CLOSE');
     }));
   }));
+}
+
+{
+  // Legacy Streams do not inherit from Readable or Writable.
+  // We cannot really assume anything about them, so we cannot close them
+  // automatically.
+  const s = new Stream();
+  finished(s, common.mustNotCall());
 }


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Fixes a regression introduced in Node v17 that made Fastify test [fails](https://github.com/fastify/fastify/pull/3456).
The reason is that using `finished()` and `pipeline()` with the [`send`](http://npm.im/send) module started to error with "premature close" even if the stream did not close prematurely.
