### PR TITLE
doc: stream.compose documentation improvement

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -2080,12 +2080,14 @@ added: v16.9.0
 * `streams` {Stream\[]|Iterable\[]|AsyncIterable\[]|Function\[]}
 * Returns: {stream.Duplex}
 
-Combines two or more `Duplex` streams (e.g. transforms) into a `Duplex` stream that writes to the
-first stream and reads from the last. Each provided stream is piped into
-the next, using `stream.pipeline`. If any of the streams error then all
-are destroyed, including the outer `Duplex` stream.
+Combines two or more `Duplex` streams (e.g. transforms) into a `Duplex` 
+stream that writes to the first stream and reads from the last. Each provided 
+stream is piped into the next, using `stream.pipeline`. If any of the streams 
+error then all are destroyed, including the outer `Duplex` stream.
 
-It should not be confused with `stream.Duplex.from({writable, readable})` which can combine a write-only stream with a read-only stream to create a `Duplex` (where the streams doesn't get piped).
+It should not be confused with `stream.Duplex.from({writable, readable})` 
+which can combine a write-only stream with a read-only stream to create a 
+`Duplex` (where the streams doesn't get piped).
 
 Because `stream.compose` returns a new stream that in turn can (and
 should) be piped into other streams, it enables composition. In contrast,

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -2080,10 +2080,12 @@ added: v16.9.0
 * `streams` {Stream\[]|Iterable\[]|AsyncIterable\[]|Function\[]}
 * Returns: {stream.Duplex}
 
-Combines two or more streams into a `Duplex` stream that writes to the
+Combines two or more `Duplex` streams (e.g. transforms) into a `Duplex` stream that writes to the
 first stream and reads from the last. Each provided stream is piped into
 the next, using `stream.pipeline`. If any of the streams error then all
 are destroyed, including the outer `Duplex` stream.
+
+It should not be confused with `stream.Duplex.from({writable, readable})` which can combine a write-only stream with a read-only stream to create a `Duplex` (where the streams doesn't get piped).
 
 Because `stream.compose` returns a new stream that in turn can (and
 should) be piped into other streams, it enables composition. In contrast,

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -2080,13 +2080,13 @@ added: v16.9.0
 * `streams` {Stream\[]|Iterable\[]|AsyncIterable\[]|Function\[]}
 * Returns: {stream.Duplex}
 
-Combines two or more `Duplex` streams (e.g. transforms) into a `Duplex` 
-stream that writes to the first stream and reads from the last. Each provided 
-stream is piped into the next, using `stream.pipeline`. If any of the streams 
+Combines two or more `Duplex` streams (e.g. transforms) into a `Duplex`
+stream that writes to the first stream and reads from the last. Each provided
+stream is piped into the next, using `stream.pipeline`. If any of the streams
 error then all are destroyed, including the outer `Duplex` stream.
 
-It should not be confused with `stream.Duplex.from({writable, readable})` 
-which can combine a write-only stream with a read-only stream to create a 
+It should not be confused with `stream.Duplex.from({writable, readable})`
+which can combine a write-only stream with a read-only stream to create a
 `Duplex` (where the streams doesn't get piped).
 
 Because `stream.compose` returns a new stream that in turn can (and


### PR DESCRIPTION
* made it more clear that it must be used with Duplex streams (e.g. transforms)
* and that its functionality should not be confused with `stream.Duplex.from({writable, readable})`

My first pull request ever, resolves #40812