### PR TITLE
test: deflake fs-promises-watch

### DIFF
--- a/test/parallel/test-fs-promises-watch.js
+++ b/test/parallel/test-fs-promises-watch.js
@@ -47,9 +47,11 @@ for (const testCase of kCases) {
   const content1 = Date.now() + testCase.fileName.toLowerCase().repeat(1e4);
   fs.writeFileSync(testCase.filePath, content1);
 
+  let interval;
   async function test() {
     const watcher = watch(testCase[testCase.field]);
     for await (const { eventType, filename } of watcher) {
+      clearInterval(interval);
       assert.strictEqual(['rename', 'change'].includes(eventType), true);
       assert.strictEqual(filename, testCase.fileName);
       break;
@@ -64,10 +66,10 @@ for (const testCase of kCases) {
 
   // Long content so it's actually flushed. toUpperCase so there's real change.
   const content2 = Date.now() + testCase.fileName.toUpperCase().repeat(1e4);
-  setImmediate(() => {
+  interval = setInterval(() => {
     fs.writeFileSync(testCase.filePath, '');
     fs.writeFileSync(testCase.filePath, content2);
-  });
+  }, 100);
 
   test().then(common.mustCall());
 }


### PR DESCRIPTION
Change the contents of the file every 100 milliseconds until the watcher
notices the change. This is already done in the callback based version
of the test (`test-fs-watch.js`).

Fixes: https://github.com/nodejs/node/issues/37637

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
