### PR TITLE
test: improve test coverage of readline/promises

### DIFF
--- a/test/parallel/test-readline-promises-interface.js
+++ b/test/parallel/test-readline-promises-interface.js
@@ -919,9 +919,9 @@ for (let i = 0; i < 12; i++) {
     assert.rejects(
       rli.question('hello?', { signal }),
       {
-        code: 'ABORT_ERR'
+        name: 'AbortError'
       }
-    );
+    ).then(common.mustCall());
     rli.close();
   }
 

--- a/test/parallel/test-readline-promises-interface.js
+++ b/test/parallel/test-readline-promises-interface.js
@@ -910,6 +910,21 @@ for (let i = 0; i < 12; i++) {
     rli.close();
   }
 
+  // Throw an error when question is executed with an aborted signal
+  {
+    const ac = new AbortController();
+    const signal = ac.signal;
+    ac.abort();
+    const [rli] = getInterface({ terminal });
+    assert.rejects(
+      rli.question('hello?', { signal }),
+      {
+        code: 'ABORT_ERR'
+      }
+    );
+    rli.close();
+  }
+
   // Can create a new readline Interface with a null output argument
   {
     const [rli, fi] = getInterface({ output: null, terminal });


### PR DESCRIPTION
This improves a test coverage in `lib/readline/promises`.
It tests throwing `ABORT_ERROR` when the question method is executed with an aborted signal.

ref: https://coverage.nodejs.org/coverage-0c2011c6c5d311a9/lib/readline/promises.js.html#L33