### PR TITLE
test: deflake cluster-concurrent-disconnect

### DIFF
--- a/test/parallel/test-cluster-concurrent-disconnect.js
+++ b/test/parallel/test-cluster-concurrent-disconnect.js
@@ -26,7 +26,11 @@ if (cluster.isPrimary) {
     // to send messages when the worker is disconnecting.
     worker.on('error', (err) => {
       assert.strictEqual(err.syscall, 'write');
-      assert.strictEqual(err.code, 'EPIPE');
+      if (common.isOSX) {
+        assert(['EPIPE', 'ENOTCONN'].includes(err.code), err);
+      } else {
+        assert.strictEqual(err.code, 'EPIPE');
+      }
     });
 
     worker.once('disconnect', common.mustCall(() => {


### PR DESCRIPTION
Occasionally the error code is `'ENOTCONN'` on macOS. Add it as an
allowed/expected code.

Fixes: https://github.com/nodejs/node/issues/38405

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
