### PR TITLE
stream: pipeline with end option

### DIFF
--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -233,7 +233,7 @@ function pipelineImpl(streams, callback, opts) {
 
     if (isNodeStream(stream)) {
       finishCount++;
-      destroys.push(destroyer(stream, reading, writing, (err) => {
+      destroys.push(destroyer(stream, reading, end && writing, (err) => {
         if (!err && !reading && isReadableFinished(stream, false)) {
           stream.read(0);
           destroyer(stream, true, writing, finish);

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -109,7 +109,7 @@ async function* fromReadable(val) {
   yield* Readable.prototype[SymbolAsyncIterator].call(val);
 }
 
-async function pump(iterable, writable, finish) {
+async function pump(iterable, writable, finish, opts) {
   let error;
   let onresolve = null;
 
@@ -153,7 +153,9 @@ async function pump(iterable, writable, finish) {
       }
     }
 
-    writable.end();
+    if (opts?.end !== false) {
+      writable.end();
+    }
 
     await wait();
 
@@ -227,6 +229,7 @@ function pipelineImpl(streams, callback, opts) {
     const stream = streams[i];
     const reading = i < streams.length - 1;
     const writing = i > 0;
+    const end = reading || opts?.end !== false;
 
     if (isNodeStream(stream)) {
       finishCount++;
@@ -282,14 +285,17 @@ function pipelineImpl(streams, callback, opts) {
           then.call(ret,
                     (val) => {
                       value = val;
-                      pt.end(val);
+                      pt.write(val);
+                      if (end) {
+                        pt.end();
+                      }
                     }, (err) => {
                       pt.destroy(err);
                     },
           );
         } else if (isIterable(ret, true)) {
           finishCount++;
-          pump(ret, pt, finish);
+          pump(ret, pt, finish, { end });
         } else {
           throw new ERR_INVALID_RETURN_VALUE(
             'AsyncIterable or Promise', 'destination', ret);
@@ -302,7 +308,7 @@ function pipelineImpl(streams, callback, opts) {
       }
     } else if (isNodeStream(stream)) {
       if (isReadableNodeStream(ret)) {
-        ret.pipe(stream);
+        ret.pipe(stream, { end });
 
         // Compat. Before node v10.12.0 stdio used to throw an error so
         // pipe() did/does not end() stdio destinations.
@@ -314,7 +320,7 @@ function pipelineImpl(streams, callback, opts) {
         ret = makeAsyncIterable(ret);
 
         finishCount++;
-        pump(ret, stream, finish);
+        pump(ret, stream, finish, { end });
       }
       ret = stream;
     } else {

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -232,15 +232,19 @@ function pipelineImpl(streams, callback, opts) {
     const end = reading || opts?.end !== false;
 
     if (isNodeStream(stream)) {
-      finishCount++;
-      destroys.push(destroyer(stream, reading, end && writing, (err) => {
-        if (!err && !reading && isReadableFinished(stream, false)) {
-          stream.read(0);
-          destroyer(stream, true, writing, finish);
-        } else {
-          finish(err);
-        }
-      }));
+      if (end) {
+        finishCount++;
+        destroys.push(destroyer(stream, reading, writing, (err) => {
+          if (!err && !reading && isReadableFinished(stream, false)) {
+            stream.read(0);
+            destroyer(stream, true, writing, finish);
+          } else {
+            finish(err);
+          }
+        }));
+      } else {
+        stream.on('error', finish);
+      }
     }
 
     if (i === 0) {

--- a/lib/stream/promises.js
+++ b/lib/stream/promises.js
@@ -16,11 +16,13 @@ const eos = require('internal/streams/end-of-stream');
 function pipeline(...streams) {
   return new Promise((resolve, reject) => {
     let signal;
+    let end;
     const lastArg = streams[streams.length - 1];
     if (lastArg && typeof lastArg === 'object' &&
         !isNodeStream(lastArg) && !isIterable(lastArg)) {
       const options = ArrayPrototypePop(streams);
       signal = options.signal;
+      end = options.end;
     }
 
     pl(streams, (err, value) => {
@@ -29,7 +31,7 @@ function pipeline(...streams) {
       } else {
         resolve(value);
       }
-    }, { signal });
+    }, { signal, end });
   });
 }
 

--- a/test/parallel/test-stream-pipeline.js
+++ b/test/parallel/test-stream-pipeline.js
@@ -1465,5 +1465,26 @@ const tsp = require('timers/promises');
     assert.strictEqual(duplex.destroyed, true);
   }
 
-  run();
+  run().then(common.mustCall());
+}
+
+{
+  const pipelinePromise = promisify(pipeline);
+
+  async function run() {
+    const read = new Readable({
+      read() {}
+    });
+
+    const duplex = new PassThrough();
+
+    read.push(null);
+
+    await pipelinePromise(read, duplex, { end: false });
+
+    assert.strictEqual(duplex.destroyed, false);
+    assert.strictEqual(duplex.writableEnded, false);
+  }
+
+  run().then(common.mustCall());
 }


### PR DESCRIPTION
Currently pipeline cannot fully replace pipe due
to the missing end option. This PR adds the end
option to the promisified pipeline method.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
