### PR TITLE
esm: add option to interpret __esModule like Babel

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -73,6 +73,14 @@ If this flag is passed, the behavior can still be set to not abort through
 [`process.setUncaughtExceptionCaptureCallback()`][] (and through usage of the
 `domain` module that uses it).
 
+### `--cjs-import-interop`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+Enables the CommonJS default export recognition.
+
 ### `--completion-bash`
 
 <!-- YAML
@@ -1545,6 +1553,7 @@ Node.js options that are allowed are:
 
 <!-- node-options-node start -->
 
+* `--cjs-import-interop`
 * `--conditions`, `-C`
 * `--diagnostic-dir`
 * `--disable-proto`

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -364,6 +364,11 @@ When importing [CommonJS modules](#commonjs-namespaces), the
 available, provided by static analysis as a convenience for better ecosystem
 compatibility.
 
+If `--cjs-import-interop` is provided and the imported CommonJS module has
+`__esModule` exports as a truthy value, then the CommonJS module is treated as
+derived from an ES module. In this case, the `module.exports.default` value is
+used as the default export instead of `module.exports`.
+
 ### `require`
 
 The CommonJS module `require` always treats the files it references as CommonJS.

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -53,6 +53,8 @@ const { maybeCacheSourceMap } = require('internal/source_map/source_map_cache');
 const moduleWrap = internalBinding('module_wrap');
 const { ModuleWrap } = moduleWrap;
 const { getOptionValue } = require('internal/options');
+const cjsImportInterop =
+    getOptionValue('--cjs-import-interop');
 const experimentalImportMetaResolve =
     getOptionValue('--experimental-import-meta-resolve');
 const asyncESM = require('internal/process/esm_loader');
@@ -194,6 +196,14 @@ translators.set('commonjs', async function commonjsStrategy(url, source,
       }
     }
 
+    // We might trigger a getter -> dont fail.
+    let esModule = false;
+    if (cjsImportInterop) {
+      try {
+        esModule = !!exports.__esModule;
+      } catch {}
+    }
+
     for (const exportName of exportNames) {
       if (!ObjectPrototypeHasOwnProperty(exports, exportName) ||
           exportName === 'default')
@@ -205,7 +215,7 @@ translators.set('commonjs', async function commonjsStrategy(url, source,
       } catch {}
       this.setExport(exportName, value);
     }
-    this.setExport('default', exports);
+    this.setExport('default', esModule ? exports.default : exports);
   });
 });
 

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -292,6 +292,10 @@ DebugOptionsParser::DebugOptionsParser() {
 }
 
 EnvironmentOptionsParser::EnvironmentOptionsParser() {
+  AddOption("--cjs-import-interop",
+            "Supports interop with modules wiht __esModule",
+            &EnvironmentOptions::cjs_import_interop,
+            kAllowedInEnvironment);
   AddOption("--conditions",
             "additional user conditions for conditional exports and imports",
             &EnvironmentOptions::conditions,

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -293,7 +293,7 @@ DebugOptionsParser::DebugOptionsParser() {
 
 EnvironmentOptionsParser::EnvironmentOptionsParser() {
   AddOption("--cjs-import-interop",
-            "Supports interop with modules wiht __esModule",
+            "Supports interop for modules with __esModule",
             &EnvironmentOptions::cjs_import_interop,
             kAllowedInEnvironment);
   AddOption("--conditions",

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -107,6 +107,7 @@ class EnvironmentOptions : public Options {
   std::vector<std::string> conditions;
   std::string dns_result_order;
   bool enable_source_maps = false;
+  bool cjs_import_interop = false;
   bool experimental_json_modules = false;
   bool experimental_modules = false;
   std::string experimental_specifier_resolution;

--- a/test/es-module/test-esm-cjs-exports.js
+++ b/test/es-module/test-esm-cjs-exports.js
@@ -22,7 +22,7 @@ child.on('close', common.mustCall((code, signal) => {
 
 const entryInterop = fixtures.path('/es-modules/cjs-exports-interop.mjs');
 
-child = spawn(process.execPath, ["--cjs-import-interop", entryInterop]);
+child = spawn(process.execPath, ['--cjs-import-interop', entryInterop]);
 child.stderr.setEncoding('utf8');
 let stdout2 = '';
 child.stdout.setEncoding('utf8');

--- a/test/es-module/test-esm-cjs-exports.js
+++ b/test/es-module/test-esm-cjs-exports.js
@@ -20,6 +20,21 @@ child.on('close', common.mustCall((code, signal) => {
   assert.strictEqual(stdout, 'ok\n');
 }));
 
+const entryInterop = fixtures.path('/es-modules/cjs-exports-interop.mjs');
+
+child = spawn(process.execPath, ["--cjs-import-interop", entryInterop]);
+child.stderr.setEncoding('utf8');
+let stdout2 = '';
+child.stdout.setEncoding('utf8');
+child.stdout.on('data', (data) => {
+  stdout2 += data;
+});
+child.on('close', common.mustCall((code, signal) => {
+  assert.strictEqual(code, 0);
+  assert.strictEqual(signal, null);
+  assert.strictEqual(stdout2, 'ok\n');
+}));
+
 const entryInvalid = fixtures.path('/es-modules/cjs-exports-invalid.mjs');
 child = spawn(process.execPath, [entryInvalid]);
 let stderr = '';

--- a/test/fixtures/es-modules/cjs-exports-interop.mjs
+++ b/test/fixtures/es-modules/cjs-exports-interop.mjs
@@ -1,0 +1,37 @@
+import { strictEqual, deepEqual } from 'assert';
+
+import m, { π } from './exports-cases.js';
+import * as ns from './exports-cases.js';
+
+deepEqual(Object.keys(ns), ['?invalid', 'default', 'invalid identifier', 'isObject', 'package', 'z', 'π', '\u{d83c}\u{df10}']);
+strictEqual(π, 'yes');
+strictEqual(typeof m.isObject, 'undefined');
+strictEqual(m.π, 'yes');
+strictEqual(m.z, 'yes');
+strictEqual(m.package, 10);
+strictEqual(m['invalid identifier'], 'yes');
+strictEqual(m['?invalid'], 'yes');
+
+import m2, { __esModule as __esModule2, name as name2 } from './exports-cases2.js';
+import * as ns2 from './exports-cases2.js';
+
+strictEqual(__esModule2, true);
+strictEqual(name2, 'name');
+strictEqual(typeof ns2, 'object');
+strictEqual(m2, 'the default');
+strictEqual(ns2.__esModule, true);
+strictEqual(ns2.name, 'name');
+deepEqual(Object.keys(ns2), ['__esModule', 'case2', 'default', 'name', 'pi']);
+
+import m3, { __esModule as __esModule3, name as name3 } from './exports-cases3.js';
+import * as ns3 from './exports-cases3.js';
+
+strictEqual(__esModule3, true);
+strictEqual(name3, 'name');
+deepEqual(Object.keys(ns3), ['__esModule', 'case2', 'default', 'name', 'pi']);
+strictEqual(m3, 'the default');
+strictEqual(ns3.__esModule, true);
+strictEqual(ns3.name, 'name');
+strictEqual(ns3.case2, 'case2');
+
+console.log('ok');


### PR DESCRIPTION
This PR adds an option `--cjs-import-interop`. When enabled, a CJS module will be translated to ESM slightly differently with respect to default exports.

- When the module defines `module.exports.__esModule` as a truthy value, the value of `module.exports.default` is used as the default export.
- Otherwise, `module.exports` is used as the default export. (existing behavior)

It allows better interoperation between full ES modules and CJS modules transformed from ES modules by Babel or tsc. Consider the following example:

```javascript
// Transformed from:
// export default "Hello";
Object.defineProperty(module.exports, "__esModule", { value: true });
module.exports.default = "Hello";
```

When imported from the following module:

```javascript
import greeting from "./hello.cjs";
console.log(greeting);
```

With `--cjs-import-interop`, it will print "Hello".

Fixes: https://github.com/nodejs/node/issues/40891

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
