### PR TITLE
perf_hooks: use spec-compliant `structuredClone`

### DIFF
--- a/lib/internal/perf/usertiming.js
+++ b/lib/internal/perf/usertiming.js
@@ -26,7 +26,8 @@ const {
   },
 } = require('internal/errors');
 
-const { structuredClone, lazyDOMException } = require('internal/util');
+const { structuredClone } = require('internal/structured_clone');
+const { lazyDOMException } = require('internal/util');
 
 const markTimings = new SafeMap();
 

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -477,21 +477,6 @@ const lazyDOMException = hideStackFrames((message, name) => {
   return new _DOMException(message, name);
 });
 
-function structuredClone(value) {
-  const {
-    DefaultSerializer,
-    DefaultDeserializer,
-  } = require('v8');
-  const ser = new DefaultSerializer();
-  ser._getDataCloneError = hideStackFrames((message) =>
-    lazyDOMException(message, 'DataCloneError'));
-  ser.writeValue(value);
-  const serialized = ser.releaseBuffer();
-
-  const des = new DefaultDeserializer(serialized);
-  return des.readValue();
-}
-
 module.exports = {
   assertCrypto,
   cachedResult,
@@ -515,7 +500,6 @@ module.exports = {
   promisify,
   sleep,
   spliceOne,
-  structuredClone,
   toUSVString,
   removeColors,
 

--- a/test/parallel/test-perf-hooks-usertiming.js
+++ b/test/parallel/test-perf-hooks-usertiming.js
@@ -44,12 +44,15 @@ assert.throws(() => mark(Symbol('a')), {
   assert.strictEqual(m.entryType, 'mark');
   assert.strictEqual(m.detail, null);
 });
-[1, 'any', {}, []].forEach((detail) => {
+[1, 'any', {}, [], /a/].forEach((detail) => {
   const m = mark('a', { detail });
   assert.strictEqual(m.name, 'a');
   assert.strictEqual(m.entryType, 'mark');
   // Value of detail is structured cloned.
   assert.deepStrictEqual(m.detail, detail);
+  if (typeof detail === 'object') {
+    assert.notStrictEqual(m.detail, detail);
+  }
 });
 
 clearMarks();


### PR DESCRIPTION
Serialize PerformanceMark's `detail` correctly.

Fixes: https://github.com/nodejs/node/issues/40840
