### PR TITLE
fs: fix `length` option being ignored during `read()`

### DIFF
--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -520,7 +520,7 @@ async function read(handle, bufferOrOptions, offset, length, position) {
       buffer = Buffer.alloc(16384);
     }
     offset = bufferOrOptions.offset || 0;
-    length = bufferOrOptions.length || buffer.byteLength;
+    length = bufferOrOptions.length ?? buffer.byteLength;
     position = bufferOrOptions.position ?? null;
   }
 

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -520,7 +520,7 @@ async function read(handle, bufferOrOptions, offset, length, position) {
       buffer = Buffer.alloc(16384);
     }
     offset = bufferOrOptions.offset || 0;
-    length = buffer.byteLength;
+    length = bufferOrOptions.length || buffer.byteLength;
     position = bufferOrOptions.position ?? null;
   }
 

--- a/test/parallel/test-fs-promises-file-handle-read.js
+++ b/test/parallel/test-fs-promises-file-handle-read.js
@@ -87,6 +87,16 @@ async function validateReadWithPositionZero() {
   }
 }
 
+async function validateReadLength() {
+  const len = 1;
+  const buf = Buffer.alloc(4);
+  const opts = { useConf: true };
+  const filePath = fixtures.path('x.txt');
+  const fileHandle = await open(filePath, 'r');
+  const { bytesRead } = await read(fileHandle, buf, 0, len, 0, opts);
+  assert.strictEqual(bytesRead, len);
+}
+
 
 (async function() {
   tmpdir.refresh();
@@ -98,4 +108,5 @@ async function validateReadWithPositionZero() {
   await validateLargeRead({ useConf: true });
   await validateReadNoParams();
   await validateReadWithPositionZero();
+  await validateReadLength();
 })().then(common.mustCall());

--- a/test/parallel/test-fs-promises-file-handle-read.js
+++ b/test/parallel/test-fs-promises-file-handle-read.js
@@ -87,8 +87,7 @@ async function validateReadWithPositionZero() {
   }
 }
 
-async function validateReadLength() {
-  const len = 1;
+async function validateReadLength(len) {
   const buf = Buffer.alloc(4);
   const opts = { useConf: true };
   const filePath = fixtures.path('x.txt');
@@ -108,5 +107,6 @@ async function validateReadLength() {
   await validateLargeRead({ useConf: true });
   await validateReadNoParams();
   await validateReadWithPositionZero();
-  await validateReadLength();
+  await validateReadLength(0);
+  await validateReadLength(1);
 })().then(common.mustCall());


### PR DESCRIPTION
Currently, calling read() with an options object always uses `buffer.byteLength`, ignoring `length` in the object.

First time opening a PR here, please let me know if anything doesn't conform to the guidelines.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
