### PR TITLE
tools: update gyp-next to v0.10.1

### DIFF
--- a/tools/gyp/.github/workflows/Python_tests.yml
+++ b/tools/gyp/.github/workflows/Python_tests.yml
@@ -11,7 +11,7 @@ jobs:
       max-parallel: 8
       matrix:
         os: [macos-latest, ubuntu-latest] # , windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/tools/gyp/.github/workflows/node-gyp.yml
+++ b/tools/gyp/.github/workflows/node-gyp.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python: [3.6, 3.9]
+        python: ["3.6", "3.10"]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/tools/gyp/CHANGELOG.md
+++ b/tools/gyp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### [0.10.1](https://www.github.com/nodejs/gyp-next/compare/v0.10.0...v0.10.1) (2021-11-24)
+
+
+### Bug Fixes
+
+* **make:** only generate makefile for multiple toolsets if requested ([#133](https://www.github.com/nodejs/gyp-next/issues/133)) ([f463a77](https://www.github.com/nodejs/gyp-next/commit/f463a77705973289ea38fec1b244c922ac438e26))
+
 ## [0.10.0](https://www.github.com/nodejs/gyp-next/compare/v0.9.6...v0.10.0) (2021-08-26)
 
 

--- a/tools/gyp/pylib/gyp/generator/make.py
+++ b/tools/gyp/pylib/gyp/generator/make.py
@@ -50,7 +50,7 @@ generator_default_variables = {
 }
 
 # Make supports multiple toolsets
-generator_supports_multiple_toolsets = True
+generator_supports_multiple_toolsets = gyp.common.CrossCompileRequested()
 
 # Request sorted dependencies in the order from dependents to dependencies.
 generator_wants_sorted_dependencies = False

--- a/tools/gyp/setup.py
+++ b/tools/gyp/setup.py
@@ -15,7 +15,7 @@ with open(path.join(here, "README.md")) as in_file:
 
 setup(
     name="gyp-next",
-    version="0.10.0",
+    version="0.10.1",
     description="A fork of the GYP build system for use in the Node.js projects",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This should fix the regression in compilation times after https://github.com/nodejs/node/pull/40488
I'll upstream to gyp-next if it works.