### PR TITLE
[v14.x] build: pin build-docs workflow to Node.js 14

### DIFF
--- a/.github/workflows/misc.yml
+++ b/.github/workflows/misc.yml
@@ -11,7 +11,7 @@ on:
       - v[0-9]+.x
 
 env:
-  NODE_VERSION: lts/*
+  NODE_VERSION: 14
 
 jobs:
   build-docs:


### PR DESCRIPTION
The build-docs workflow runs tests which means it is sensitive to
globals and can fail if the `node` running the test has a different
set of globals to that expected by `test/common`.

e.g failure on current `v14.x-staging`
https://github.com/nodejs/node/runs/4301335343?check_suite_focus=true
```console
=== release test-apilinks ===
Path: doctool/test-apilinks
Error: --- stderr ---
node:assert:171
  throw err;
  ^

AssertionError [ERR_ASSERTION]: Unexpected global(s) found: performance
    at process.<anonymous> (/home/runner/work/node/node/test/common/index.js:302:14)
    at process.emit (node:events:402:35) {
  generatedMessage: false,
  code: 'ERR_ASSERTION',
  actual: undefined,
  expected: undefined,
  operator: 'fail'
}
Command: /opt/hostedtoolcache/node/16.13.0/x64/bin/node /home/runner/work/node/node/test/doctool/test-apilinks.mjs
```
compare to https://github.com/nodejs/node/blob/0682370d9c988f2ae2846eb4f12727e8450e202b/test/common/index.js#L253-L262

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
