### PR TITLE
tools: fix installing headers on windows

### DIFF
--- a/tools/install.py
+++ b/tools/install.py
@@ -123,6 +123,7 @@ def corepack_files(action):
 def subdir_files(path, dest, action):
   ret = {}
   for dirpath, dirnames, filenames in os.walk(path):
+    if sys.platform == 'win32': dirpath = dirpath.replace('\\', '/')
     files_in_path = [dirpath + '/' + f for f in filenames if f.endswith('.h')]
     ret[dest + dirpath.replace(path, '')] = files_in_path
   for subdir, files_in_path in ret.items():

--- a/tools/install.py
+++ b/tools/install.py
@@ -123,7 +123,8 @@ def corepack_files(action):
 def subdir_files(path, dest, action):
   ret = {}
   for dirpath, dirnames, filenames in os.walk(path):
-    if sys.platform == 'win32': dirpath = dirpath.replace('\\', '/')
+    if sys.platform == 'win32':
+      dirpath = dirpath.replace('\\', '/')
     files_in_path = [dirpath + '/' + f for f in filenames if f.endswith('.h')]
     ret[dest + dirpath.replace(path, '')] = files_in_path
   for subdir, files_in_path in ret.items():


### PR DESCRIPTION
Installing headers on windows (`python3 .\tools\install.py install`) skips v8 headers in folders `cppgc` and `libplatform` caused by difference in directory separators returned by `os.walk` vs `v8_headers` whitelist. This change simply normalizes separators to match `v8_headers` whitelist.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
