### PR TITLE
test_crypto_engine: depends on non-shared openssl

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -1476,7 +1476,7 @@
     }], # end aix section
     # TODO(RaisinTen): Enable this to build on other platforms as well.
     ['(OS=="mac" or (OS=="linux" and target_arch=="x64")) and \
-      node_use_openssl=="true"', {
+      node_use_openssl=="true" and node_shared_openssl=="false"', {
       'targets': [
         {
           'target_name': 'test_crypto_engine',


### PR DESCRIPTION
test_crypto_engine is written such that it assumes node_shared_openssl is false (`deps/openssl/include` on linux, `deps/openssl/openssl.gyp:openssl` on mac), so update the condition to only when those are valid expectations. Without this, `deps/openssl` is built on mac even when building with  `--shared-openssl` (#40958).

closes #40958

It's possible the _right_ fix is to update the dependencies to point to shared openssl when true. I don't know how to do that, though, so feel free to close this and someone else can pursue that resolution.

This patch is confirmed to fix the spurious build part of the issue in https://github.com/conda-forge/nodejs-feedstock/pull/221
