### PR TITLE
stream: remove whatwg streams experimental warning

### DIFF
--- a/lib/stream/web.js
+++ b/lib/stream/web.js
@@ -1,12 +1,6 @@
 'use strict';
 
 const {
-  emitExperimentalWarning,
-} = require('internal/util');
-
-emitExperimentalWarning('stream/web');
-
-const {
   TransformStream,
   TransformStreamDefaultController,
 } = require('internal/webstreams/transformstream');


### PR DESCRIPTION
The API is still experimental, but the warning isn't necessary any longer

Refs: https://github.com/nodejs/node/issues/40950
