### PR TITLE
build: set persist-credentials: false on workflows

### DIFF
--- a/.github/workflows/authors.yml
+++ b/.github/workflows/authors.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: '0'  # This is required to actually get all the authors
+          persist-credentials: false
       - run: "tools/update-authors.js"  # Run the AUTHORS tool
       - uses: gr2m/create-or-update-pull-request-action@v1  # Create a PR or update the Action's existing PR
         env:

--- a/.github/workflows/auto-start-ci.yml
+++ b/.github/workflows/auto-start-ci.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       # Install dependencies
       - name: Install Node.js

--- a/.github/workflows/build-tarball.yml
+++ b/.github/workflows/build-tarball.yml
@@ -31,6 +31,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v2
         with:
@@ -57,6 +59,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -29,6 +29,8 @@ jobs:
     runs-on: ${{ matrix.windows }}
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: ${{ steps.nb-of-commits.outputs.plusOne }}
+          persist-credentials: false
       - run: git reset HEAD^2
       - name: Install Node.js
         uses: actions/setup-node@v2

--- a/.github/workflows/commit-queue.yml
+++ b/.github/workflows/commit-queue.yml
@@ -26,6 +26,7 @@ jobs:
           # Needs the whole git history for ncu to work
           # See https://github.com/nodejs/node-core-utils/pull/486
           fetch-depth: 0
+          persist-credentials: false
           # A personal token is required because pushing with GITHUB_TOKEN will
           # prevent commits from running CI after they land. It needs
           # to be set here because `checkout` configures GitHub authentication

--- a/.github/workflows/coverage-linux.yml
+++ b/.github/workflows/coverage-linux.yml
@@ -28,6 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/coverage-windows.yml
+++ b/.github/workflows/coverage-windows.yml
@@ -30,6 +30,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -15,6 +15,8 @@ jobs:
     container: gcc:11
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/find-inactive-collaborators.yml
+++ b/.github/workflows/find-inactive-collaborators.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: ${{ env.NUM_COMMITS }}
+          persist-credentials: false
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v2

--- a/.github/workflows/find-inactive-tsc.yml
+++ b/.github/workflows/find-inactive-tsc.yml
@@ -18,13 +18,16 @@ jobs:
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Clone nodejs/TSC repository
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          repository: nodejs/TSC
           path: .tmp
+          persist-credentials: false
+          repository: nodejs/TSC
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v2

--- a/.github/workflows/license-builder.yml
+++ b/.github/workflows/license-builder.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - run: "./tools/license-builder.sh"  # Run the license builder tool
       - uses: gr2m/create-or-update-pull-request-action@v1.x  # Create a PR or update the Action's existing PR
         env:

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v2
         with:
@@ -33,6 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v2
         with:
@@ -46,6 +50,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v2
         with:
@@ -68,6 +74,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v2
         with:
@@ -81,6 +89,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v2
         with:
@@ -96,6 +106,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: Use Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v2
         with:
@@ -112,6 +124,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - run: shellcheck -V
       - name: Lint Shell scripts
         run: tools/lint-sh.js .
@@ -120,6 +134,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - uses: mszostok/codeowners-validator@v0.6.0
         with:
           checks: "files,duppatterns"
@@ -130,5 +146,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 2
+          persist-credentials: false
       # GH Actions squashes all PR commits, HEAD^ refers to the base branch.
       - run: git diff HEAD^ HEAD -G"pr-url:" -- "*.md" | ./tools/lint-pr-url.mjs ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/misc.yml
+++ b/.github/workflows/misc.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/test-asan.yml
+++ b/.github/workflows/test-asan.yml
@@ -36,6 +36,8 @@ jobs:
       CONFIG_FLAGS: --enable-asan
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/test-internet.yml
+++ b/.github/workflows/test-internet.yml
@@ -28,6 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -25,6 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -31,6 +31,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -50,6 +50,8 @@ jobs:
               fi
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - run: ${{ matrix.run }}
       - uses: gr2m/create-or-update-pull-request-action@v1  # Create a PR or update the Action's existing PR
         env:


### PR DESCRIPTION
Out of extra caution, instruct `actions/checkout` to not save GitHub
authentication credentials in the git config for use by future steps.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
