### PR TITLE
lib,test,tools: use consistent JSDoc types

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -784,7 +784,7 @@ function readvSync(fd, buffers, position) {
 /**
  * Writes `buffer` to the specified `fd` (file descriptor).
  * @param {number} fd
- * @param {Buffer | TypedArray | DataView | string | Object} buffer
+ * @param {Buffer | TypedArray | DataView | string | object} buffer
  * @param {number} [offset]
  * @param {number} [length]
  * @param {number} [position]
@@ -849,7 +849,7 @@ ObjectDefineProperty(write, internalUtil.customPromisifyArgs,
  * Synchronously writes `buffer` to the
  * specified `fd` (file descriptor).
  * @param {number} fd
- * @param {Buffer | TypedArray | DataView | string | Object} buffer
+ * @param {Buffer | TypedArray | DataView | string | object} buffer
  * @param {number} [offset]
  * @param {number} [length]
  * @param {number} [position]
@@ -2087,7 +2087,7 @@ function writeAll(fd, isUserFd, buffer, offset, length, signal, callback) {
 /**
  * Asynchronously writes data to the file.
  * @param {string | Buffer | URL | number} path
- * @param {string | Buffer | TypedArray | DataView | Object} data
+ * @param {string | Buffer | TypedArray | DataView | object} data
  * @param {{
  *   encoding?: string | null;
  *   mode?: number;
@@ -2131,7 +2131,7 @@ function writeFile(path, data, options, callback) {
 /**
  * Synchronously writes data to the file.
  * @param {string | Buffer | URL | number} path
- * @param {string | Buffer | TypedArray | DataView | Object} data
+ * @param {string | Buffer | TypedArray | DataView | object} data
  * @param {{
  *   encoding?: string | null;
  *   mode?: number;
@@ -2805,7 +2805,7 @@ function copyFileSync(src, dest, mode) {
  * symlink. The contents of directories will be copied recursively.
  * @param {string | URL} src
  * @param {string | URL} dest
- * @param {Object} [options]
+ * @param {object} [options]
  * @param {() => any} callback
  * @returns {void}
  */
@@ -2827,7 +2827,7 @@ function cp(src, dest, options, callback) {
  * symlink. The contents of directories will be copied recursively.
  * @param {string | URL} src
  * @param {string | URL} dest
- * @param {Object} [options]
+ * @param {object} [options]
  * @returns {void}
  */
 function cpSync(src, dest, options) {

--- a/lib/http.js
+++ b/lib/http.js
@@ -60,13 +60,13 @@ function createServer(opts, requestListener) {
 }
 
 /**
- * @typedef {Object} HTTPRequestOptions
+ * @typedef {object} HTTPRequestOptions
  * @property {httpAgent.Agent | boolean} [agent]
  * @property {string} [auth]
  * @property {Function} [createConnection]
  * @property {number} [defaultPort]
  * @property {number} [family]
- * @property {Object} [headers]
+ * @property {object} [headers]
  * @property {number} [hints]
  * @property {string} [host]
  * @property {string} [hostname]

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -474,7 +474,7 @@ const captureLargerStackTrace = hideStackFrames(
  * The goal is to migrate them to ERR_* errors later when compatibility is
  * not a concern.
  *
- * @param {Object} ctx
+ * @param {object} ctx
  * @returns {Error}
  */
 const uvException = hideStackFrames(function uvException(ctx) {

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -54,7 +54,7 @@ class ESMLoader {
   /**
    * Prior to ESM loading. These are called once before any modules are started.
    * @private
-   * @property {function[]} globalPreloaders First-in-first-out list of
+   * @property {Function[]} globalPreloaders First-in-first-out list of
    * preload hooks.
    */
   #globalPreloaders = [];
@@ -62,7 +62,7 @@ class ESMLoader {
   /**
    * Phase 2 of 2 in ESM loading.
    * @private
-   * @property {function[]} loaders First-in-first-out list of loader hooks.
+   * @property {Function[]} loaders First-in-first-out list of loader hooks.
    */
   #loaders = [
     defaultLoad,
@@ -71,7 +71,7 @@ class ESMLoader {
   /**
    * Phase 1 of 2 in ESM loading.
    * @private
-   * @property {function[]} resolvers First-in-first-out list of resolver hooks
+   * @property {Function[]} resolvers First-in-first-out list of resolver hooks
    */
   #resolvers = [
     defaultResolve,
@@ -341,8 +341,8 @@ class ESMLoader {
    * The internals of this WILL change when chaining is implemented,
    * depending on the resolution/consensus from #36954
    * @param {string} url The URL/path of the module to be loaded
-   * @param {Object} context Metadata about the module
-   * @returns {Object}
+   * @param {object} context Metadata about the module
+   * @returns {object}
    */
   async load(url, context = {}) {
     const defaultLoader = this.#loaders[0];

--- a/lib/internal/source_map/source_map.js
+++ b/lib/internal/source_map/source_map.js
@@ -148,7 +148,7 @@ class SourceMap {
   }
 
   /**
-   * @return {Object} raw source map v3 payload.
+   * @return {object} raw source map v3 payload.
    */
   get payload() {
     return cloneSourceMapV3(this.#payload);

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -280,7 +280,7 @@ function getUserOptions(ctx, isCrossContext) {
  * in the best way possible given the different types.
  *
  * @param {any} value The value to print out.
- * @param {Object} opts Optional options object that alters the output.
+ * @param {object} opts Optional options object that alters the output.
  */
 /* Legacy: value, showHidden, depth, colors */
 function inspect(value, opts) {

--- a/lib/v8.js
+++ b/lib/v8.js
@@ -269,7 +269,7 @@ class DefaultSerializer extends Serializer {
   /**
    * Used to write some kind of host object, i.e. an
    * object that is created by native C++ bindings.
-   * @param {Object} abView
+   * @param {object} abView
    * @returns {void}
    */
   _writeHostObject(abView) {

--- a/test/async-hooks/hook-checks.js
+++ b/test/async-hooks/hook-checks.js
@@ -8,12 +8,12 @@ const assert = require('assert');
  *
  * @name checkInvocations
  * @function
- * @param {Object} activity including timestamps for each life time event,
+ * @param {object} activity including timestamps for each life time event,
  *                 i.e. init, before ...
- * @param {Object} hooks the expected life time event invocations with a count
+ * @param {object} hooks the expected life time event invocations with a count
  *                       indicating how often they should have been invoked,
  *                       i.e. `{ init: 1, before: 2, after: 2 }`
- * @param {String} stage the name of the stage in the test at which we are
+ * @param {string} stage the name of the stage in the test at which we are
  *                       checking the invocations
  */
 exports.checkInvocations = function checkInvocations(activity, hooks, stage) {

--- a/tools/eslint-rules/require-common-first.js
+++ b/tools/eslint-rules/require-common-first.js
@@ -17,8 +17,8 @@ module.exports = function(context) {
 
   /**
    * Function to check if the path is a module and return its name.
-   * @param {String} str The path to check
-   * @returns {String} module name
+   * @param {string} str The path to check
+   * @returns {string} module name
    */
   function getModuleName(str) {
     if (str === '../common/index.mjs') {
@@ -32,7 +32,7 @@ module.exports = function(context) {
    * Function to check if a node has an argument that is a module and
    * return its name.
    * @param {ASTNode} node The node to check
-   * @returns {undefined|String} module name or undefined
+   * @returns {undefined | string} module name or undefined
    */
   function getModuleNameFromCall(node) {
     // Node has arguments and first argument is string

--- a/tools/eslint-rules/required-modules.js
+++ b/tools/eslint-rules/required-modules.js
@@ -27,8 +27,8 @@ module.exports = function(context) {
 
   /**
    * Function to check if the path is a required module and return its name.
-   * @param {String} str The path to check
-   * @returns {undefined|String} required module name or undefined
+   * @param {string} str The path to check
+   * @returns {undefined | string} required module name or undefined
    */
   function getRequiredModuleName(str) {
     const match = requiredModules.find(([, test]) => {
@@ -41,7 +41,7 @@ module.exports = function(context) {
    * Function to check if a node has an argument that is a required module and
    * return its name.
    * @param {ASTNode} node The node to check
-   * @returns {undefined|String} required module name or undefined
+   * @returns {undefined | string} required module name or undefined
    */
   function getRequiredModuleNameFromCall(node) {
     // Node has arguments and first argument is string


### PR DESCRIPTION
This could be in preparation of implementing the jsdoc/check-types
ESLint rule.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
