### PR TITLE
typings: add types for symbol and accessor properties on `primordials`

### DIFF
--- a/typings/primordials.d.ts
+++ b/typings/primordials.d.ts
@@ -1,11 +1,25 @@
-import { AsyncIterator } from "internal/webstreams/util";
-
 type UncurryThis<T extends (this: unknown, ...args: unknown[]) => unknown> =
   (self: ThisParameterType<T>, ...args: Parameters<T>) => ReturnType<T>;
 type UncurryThisStaticApply<T extends (this: unknown, ...args: unknown[]) => unknown> =
   (self: ThisParameterType<T>, args: Parameters<T>) => ReturnType<T>;
 type StaticApply<T extends (this: unknown, ...args: unknown[]) => unknown> =
   (args: Parameters<T>) => ReturnType<T>;
+
+type UncurryMethod<O, K extends keyof O, T = O> =
+  O[K] extends (this: infer U, ...args: infer A) => infer R
+    ? (self: unknown extends U ? T : U, ...args: A) => R
+    : never;
+type UncurryMethodApply<O, K extends keyof O, T = O> =
+  O[K] extends (this: infer U, ...args: infer A) => infer R
+    ? (self: unknown extends U ? T : U, args: A) => R
+    : never;
+
+type UncurryGetter<O, K extends keyof O, T = O> =
+  O[K] extends infer V ? (self: T) => V : never;
+type UncurrySetter<O, K extends keyof O, T = O> =
+  O[K] extends infer V ? (self: T, value: V) => void : never;
+
+type TypedArrayContentType<T extends TypedArray> = T extends { [k: number]: infer V } ? V : never;
 
 /**
  * Primordials are a way to safely use globals without fear of global mutation
@@ -24,17 +38,14 @@ type StaticApply<T extends (this: unknown, ...args: unknown[]) => unknown> =
  * primordials.StringPrototypeStartsWith('thing', 'hello')
  * ```
  */
-declare namespace Primordials {
-  export function uncurryThis<
-      T extends (...args: unknown[]) => unknown
-    > (fn: T):
-      (self: ThisType<T>, ...args: Parameters<T>) => ReturnType<T>;
+declare namespace primordials {
+  export function uncurryThis<T extends (...args: unknown[]) => unknown>(fn: T): UncurryThis<T>;
   export function makeSafe<T extends NewableFunction>(unsafe: NewableFunction, safe: T): T;
 
-  export const decodeURI: typeof globalThis.decodeURI;
-  export const decodeURIComponent: typeof globalThis.decodeURIComponent;
-  export const encodeURI: typeof globalThis.encodeURI;
-  export const encodeURIComponent: typeof globalThis.encodeURIComponent;
+  export import decodeURI = globalThis.decodeURI;
+  export import decodeURIComponent = globalThis.decodeURIComponent;
+  export import encodeURI = globalThis.encodeURI;
+  export import encodeURIComponent = globalThis.encodeURIComponent;
   export const JSONParse: typeof JSON.parse
   export const JSONStringify: typeof JSON.stringify
   export const MathAbs: typeof Math.abs
@@ -94,11 +105,11 @@ declare namespace Primordials {
   export const ReflectPreventExtensions: typeof Reflect.preventExtensions
   export const ReflectSet: typeof Reflect.set
   export const ReflectSetPrototypeOf: typeof Reflect.setPrototypeOf
-  export const AggregateError: typeof globalThis.AggregateError;
+  export import AggregateError = globalThis.AggregateError;
   export const AggregateErrorLength: typeof AggregateError.length
   export const AggregateErrorName: typeof AggregateError.name
   export const AggregateErrorPrototype: typeof AggregateError.prototype
-  export const Array: typeof globalThis.Array;
+  export import Array = globalThis.Array;
   export const ArrayLength: typeof Array.length
   export const ArrayName: typeof Array.name
   export const ArrayPrototype: typeof Array.prototype
@@ -138,14 +149,15 @@ declare namespace Primordials {
   export const ArrayPrototypeReduceRight: UncurryThis<typeof Array.prototype.reduceRight>
   export const ArrayPrototypeToLocaleString: UncurryThis<typeof Array.prototype.toLocaleString>
   export const ArrayPrototypeToString: UncurryThis<typeof Array.prototype.toString>
-  export const ArrayBuffer: typeof globalThis.ArrayBuffer;
+  export const ArrayPrototypeSymbolIterator: UncurryMethod<typeof Array.prototype, typeof Symbol.iterator>;
+  export import ArrayBuffer = globalThis.ArrayBuffer;
   export const ArrayBufferLength: typeof ArrayBuffer.length
   export const ArrayBufferName: typeof ArrayBuffer.name
   export const ArrayBufferPrototype: typeof ArrayBuffer.prototype
   export const ArrayBufferIsView: typeof ArrayBuffer.isView
   export const ArrayBufferPrototypeSlice: UncurryThis<typeof ArrayBuffer.prototype.slice>
-  export const AsyncIteratorPrototype: UncurryThis<typeof AsyncIterator>
-  export const BigInt: typeof globalThis.BigInt;
+  export const AsyncIteratorPrototype: AsyncIterable<any>;
+  export import BigInt = globalThis.BigInt;
   export const BigIntLength: typeof BigInt.length
   export const BigIntName: typeof BigInt.name
   export const BigIntPrototype: typeof BigInt.prototype
@@ -154,23 +166,23 @@ declare namespace Primordials {
   export const BigIntPrototypeToLocaleString: UncurryThis<typeof BigInt.prototype.toLocaleString>
   export const BigIntPrototypeToString: UncurryThis<typeof BigInt.prototype.toString>
   export const BigIntPrototypeValueOf: UncurryThis<typeof BigInt.prototype.valueOf>
-  export const BigInt64Array: typeof globalThis.BigInt64Array;
+  export import BigInt64Array = globalThis.BigInt64Array;
   export const BigInt64ArrayLength: typeof BigInt64Array.length
   export const BigInt64ArrayName: typeof BigInt64Array.name
   export const BigInt64ArrayPrototype: typeof BigInt64Array.prototype
   export const BigInt64ArrayBYTES_PER_ELEMENT: typeof BigInt64Array.BYTES_PER_ELEMENT
-  export const BigUint64Array: typeof globalThis.BigUint64Array;
+  export import BigUint64Array = globalThis.BigUint64Array;
   export const BigUint64ArrayLength: typeof BigUint64Array.length
   export const BigUint64ArrayName: typeof BigUint64Array.name
   export const BigUint64ArrayPrototype: typeof BigUint64Array.prototype
   export const BigUint64ArrayBYTES_PER_ELEMENT: typeof BigUint64Array.BYTES_PER_ELEMENT
-  export const Boolean: typeof globalThis.Boolean;
+  export import Boolean = globalThis.Boolean;
   export const BooleanLength: typeof Boolean.length
   export const BooleanName: typeof Boolean.name
   export const BooleanPrototype: typeof Boolean.prototype
   export const BooleanPrototypeToString: UncurryThis<typeof Boolean.prototype.toString>
   export const BooleanPrototypeValueOf: UncurryThis<typeof Boolean.prototype.valueOf>
-  export const DataView: typeof globalThis.DataView;
+  export import DataView = globalThis.DataView;
   export const DataViewLength: typeof DataView.length
   export const DataViewName: typeof DataView.name
   export const DataViewPrototype: typeof DataView.prototype
@@ -194,7 +206,10 @@ declare namespace Primordials {
   export const DataViewPrototypeSetBigInt64: UncurryThis<typeof DataView.prototype.setBigInt64>
   export const DataViewPrototypeGetBigUint64: UncurryThis<typeof DataView.prototype.getBigUint64>
   export const DataViewPrototypeSetBigUint64: UncurryThis<typeof DataView.prototype.setBigUint64>
-  export const Date: typeof globalThis.Date;
+  export const DataViewPrototypeGetBuffer: UncurryGetter<typeof DataView.prototype, "buffer">;
+  export const DataViewPrototypeGetByteLength: UncurryGetter<typeof DataView.prototype, "byteLength">;
+  export const DataViewPrototypeGetByteOffset: UncurryGetter<typeof DataView.prototype, "byteOffset">;
+  export import Date = globalThis.Date;
   export const DateLength: typeof Date.length
   export const DateName: typeof Date.name
   export const DatePrototype: typeof Date.prototype
@@ -247,28 +262,29 @@ declare namespace Primordials {
   export const DatePrototypeToLocaleString: UncurryThis<typeof Date.prototype.toLocaleString>
   export const DatePrototypeToLocaleDateString: UncurryThis<typeof Date.prototype.toLocaleDateString>
   export const DatePrototypeToLocaleTimeString: UncurryThis<typeof Date.prototype.toLocaleTimeString>
-  export const Error: typeof globalThis.Error;
+  export const DatePrototypeSymbolToPrimitive: UncurryMethod<typeof Date.prototype, typeof Symbol.toPrimitive>;
+  export import Error = globalThis.Error;
   export const ErrorLength: typeof Error.length
   export const ErrorName: typeof Error.name
   export const ErrorPrototype: typeof Error.prototype
   export const ErrorCaptureStackTrace: typeof Error.captureStackTrace
   export const ErrorStackTraceLimit: typeof Error.stackTraceLimit
   export const ErrorPrototypeToString: UncurryThis<typeof Error.prototype.toString>
-  export const EvalError: typeof globalThis.EvalError;
+  export import EvalError = globalThis.EvalError;
   export const EvalErrorLength: typeof EvalError.length
   export const EvalErrorName: typeof EvalError.name
   export const EvalErrorPrototype: typeof EvalError.prototype
-  export const Float32Array: typeof globalThis.Float32Array;
+  export import Float32Array = globalThis.Float32Array;
   export const Float32ArrayLength: typeof Float32Array.length
   export const Float32ArrayName: typeof Float32Array.name
   export const Float32ArrayPrototype: typeof Float32Array.prototype
   export const Float32ArrayBYTES_PER_ELEMENT: typeof Float32Array.BYTES_PER_ELEMENT
-  export const Float64Array: typeof globalThis.Float64Array;
+  export import Float64Array = globalThis.Float64Array;
   export const Float64ArrayLength: typeof Float64Array.length
   export const Float64ArrayName: typeof Float64Array.name
   export const Float64ArrayPrototype: typeof Float64Array.prototype
   export const Float64ArrayBYTES_PER_ELEMENT: typeof Float64Array.BYTES_PER_ELEMENT
-  export const Function: typeof globalThis.Function;
+  export import Function = globalThis.Function;
   export const FunctionLength: typeof Function.length
   export const FunctionName: typeof Function.name
   export const FunctionPrototype: typeof Function.prototype
@@ -276,22 +292,22 @@ declare namespace Primordials {
   export const FunctionPrototypeBind: UncurryThis<typeof Function.prototype.bind>
   export const FunctionPrototypeCall: UncurryThis<typeof Function.prototype.call>
   export const FunctionPrototypeToString: UncurryThis<typeof Function.prototype.toString>
-  export const Int16Array: typeof globalThis.Int16Array;
+  export import Int16Array = globalThis.Int16Array;
   export const Int16ArrayLength: typeof Int16Array.length
   export const Int16ArrayName: typeof Int16Array.name
   export const Int16ArrayPrototype: typeof Int16Array.prototype
   export const Int16ArrayBYTES_PER_ELEMENT: typeof Int16Array.BYTES_PER_ELEMENT
-  export const Int32Array: typeof globalThis.Int32Array;
+  export import Int32Array = globalThis.Int32Array;
   export const Int32ArrayLength: typeof Int32Array.length
   export const Int32ArrayName: typeof Int32Array.name
   export const Int32ArrayPrototype: typeof Int32Array.prototype
   export const Int32ArrayBYTES_PER_ELEMENT: typeof Int32Array.BYTES_PER_ELEMENT
-  export const Int8Array: typeof globalThis.Int8Array;
+  export import Int8Array = globalThis.Int8Array;
   export const Int8ArrayLength: typeof Int8Array.length
   export const Int8ArrayName: typeof Int8Array.name
   export const Int8ArrayPrototype: typeof Int8Array.prototype
   export const Int8ArrayBYTES_PER_ELEMENT: typeof Int8Array.BYTES_PER_ELEMENT
-  export const Map: typeof globalThis.Map;
+  export import Map = globalThis.Map;
   export const MapLength: typeof Map.length
   export const MapName: typeof Map.name
   export const MapPrototype: typeof Map.prototype
@@ -304,7 +320,8 @@ declare namespace Primordials {
   export const MapPrototypeForEach: UncurryThis<typeof Map.prototype.forEach>
   export const MapPrototypeKeys: UncurryThis<typeof Map.prototype.keys>
   export const MapPrototypeValues: UncurryThis<typeof Map.prototype.values>
-  export const Number: typeof globalThis.Number;
+  export const MapPrototypeGetSize: UncurryGetter<typeof Map.prototype, "size">;
+  export import Number = globalThis.Number;
   export const NumberLength: typeof Number.length
   export const NumberName: typeof Number.name
   export const NumberPrototype: typeof Number.prototype
@@ -328,7 +345,7 @@ declare namespace Primordials {
   export const NumberPrototypeToString: UncurryThis<typeof Number.prototype.toString>
   export const NumberPrototypeValueOf: UncurryThis<typeof Number.prototype.valueOf>
   export const NumberPrototypeToLocaleString: UncurryThis<typeof Number.prototype.toLocaleString>
-  export const Object: typeof globalThis.Object;
+  export import Object = globalThis.Object;
   export const ObjectLength: typeof Object.length
   export const ObjectName: typeof Object.name
   export const ObjectPrototype: typeof Object.prototype
@@ -363,15 +380,15 @@ declare namespace Primordials {
   export const ObjectPrototypeToString: UncurryThis<typeof Object.prototype.toString>
   export const ObjectPrototypeValueOf: UncurryThis<typeof Object.prototype.valueOf>
   export const ObjectPrototypeToLocaleString: UncurryThis<typeof Object.prototype.toLocaleString>
-  export const RangeError: typeof globalThis.RangeError;
+  export import RangeError = globalThis.RangeError;
   export const RangeErrorLength: typeof RangeError.length
   export const RangeErrorName: typeof RangeError.name
   export const RangeErrorPrototype: typeof RangeError.prototype
-  export const ReferenceError: typeof globalThis.ReferenceError;
+  export import ReferenceError = globalThis.ReferenceError;
   export const ReferenceErrorLength: typeof ReferenceError.length
   export const ReferenceErrorName: typeof ReferenceError.name
   export const ReferenceErrorPrototype: typeof ReferenceError.prototype
-  export const RegExp: typeof globalThis.RegExp;
+  export import RegExp = globalThis.RegExp;
   export const RegExpLength: typeof RegExp.length
   export const RegExpName: typeof RegExp.name
   export const RegExpPrototype: typeof RegExp.prototype
@@ -379,7 +396,15 @@ declare namespace Primordials {
   export const RegExpPrototypeCompile: UncurryThis<typeof RegExp.prototype.compile>
   export const RegExpPrototypeToString: UncurryThis<typeof RegExp.prototype.toString>
   export const RegExpPrototypeTest: UncurryThis<typeof RegExp.prototype.test>
-  export const Set: typeof globalThis.Set;
+  export const RegExpPrototypeGetDotAll: UncurryGetter<typeof RegExp.prototype, "dotAll">;
+  export const RegExpPrototypeGetFlags: UncurryGetter<typeof RegExp.prototype, "flags">;
+  export const RegExpPrototypeGetGlobal: UncurryGetter<typeof RegExp.prototype, "global">;
+  export const RegExpPrototypeGetIgnoreCase: UncurryGetter<typeof RegExp.prototype, "ignoreCase">;
+  export const RegExpPrototypeGetMultiline: UncurryGetter<typeof RegExp.prototype, "multiline">;
+  export const RegExpPrototypeGetSource: UncurryGetter<typeof RegExp.prototype, "source">;
+  export const RegExpPrototypeGetSticky: UncurryGetter<typeof RegExp.prototype, "sticky">;
+  export const RegExpPrototypeGetUnicode: UncurryGetter<typeof RegExp.prototype, "unicode">;
+  export import Set = globalThis.Set;
   export const SetLength: typeof Set.length
   export const SetName: typeof Set.name
   export const SetPrototype: typeof Set.prototype
@@ -391,7 +416,8 @@ declare namespace Primordials {
   export const SetPrototypeForEach: UncurryThis<typeof Set.prototype.forEach>
   export const SetPrototypeValues: UncurryThis<typeof Set.prototype.values>
   export const SetPrototypeKeys: UncurryThis<typeof Set.prototype.keys>
-  export const String: typeof globalThis.String;
+  export const SetPrototypeGetSize: UncurryGetter<typeof Set.prototype, "size">;
+  export import String = globalThis.String;
   export const StringLength: typeof String.length
   export const StringName: typeof String.name
   export const StringPrototype: typeof String.prototype
@@ -445,7 +471,7 @@ declare namespace Primordials {
   export const StringPrototypeToUpperCase: UncurryThis<typeof String.prototype.toUpperCase>
   export const StringPrototypeValueOf: UncurryThis<typeof String.prototype.valueOf>
   export const StringPrototypeReplaceAll: UncurryThis<typeof String.prototype.replaceAll>
-  export const Symbol: typeof globalThis.Symbol;
+  export import Symbol = globalThis.Symbol;
   export const SymbolLength: typeof Symbol.length
   export const SymbolName: typeof Symbol.name
   export const SymbolPrototype: typeof Symbol.prototype
@@ -466,39 +492,82 @@ declare namespace Primordials {
   export const SymbolUnscopables: typeof Symbol.unscopables
   export const SymbolPrototypeToString: UncurryThis<typeof Symbol.prototype.toString>
   export const SymbolPrototypeValueOf: UncurryThis<typeof Symbol.prototype.valueOf>
-  export const SyntaxError: typeof globalThis.SyntaxError;
+  export const SymbolPrototypeSymbolToPrimitive: UncurryMethod<typeof Symbol.prototype, typeof Symbol.toPrimitive, symbol | Symbol>;
+  export const SymbolPrototypeGetDescription: UncurryGetter<typeof Symbol.prototype, "description", symbol | Symbol>;
+  export import SyntaxError = globalThis.SyntaxError;
   export const SyntaxErrorLength: typeof SyntaxError.length
   export const SyntaxErrorName: typeof SyntaxError.name
   export const SyntaxErrorPrototype: typeof SyntaxError.prototype
-  export const TypeError: typeof globalThis.TypeError;
+  export import TypeError = globalThis.TypeError;
   export const TypeErrorLength: typeof TypeError.length
   export const TypeErrorName: typeof TypeError.name
   export const TypeErrorPrototype: typeof TypeError.prototype
-  export const URIError: typeof globalThis.URIError;
+  export function TypedArrayFrom<T extends TypedArray>(
+    constructor: new (length: number) => T,
+    source:
+      | Iterable<TypedArrayContentType<T>>
+      | ArrayLike<TypedArrayContentType<T>>,
+  ): T;
+  export function TypedArrayFrom<T extends TypedArray, U, THIS_ARG = undefined>(
+    constructor: new (length: number) => T,
+    source: Iterable<U> | ArrayLike<U>,
+    mapfn: (
+      this: THIS_ARG,
+      value: U,
+      index: number,
+    ) => TypedArrayContentType<T>,
+    thisArg?: THIS_ARG,
+  ): T;
+  export function TypedArrayOf<T extends TypedArray>(
+    constructor: new (length: number) => T,
+    ...items: readonly TypedArrayContentType<T>[]
+  ): T;
+  export function TypedArrayOfApply<T extends TypedArray>(
+    constructor: new (length: number) => T,
+    items: readonly TypedArrayContentType<T>[],
+  ): T;
+  export const TypedArrayPrototypeGetBuffer: UncurryGetter<TypedArray, "buffer">;
+  export const TypedArrayPrototypeGetByteLength: UncurryGetter<TypedArray, "byteLength">;
+  export const TypedArrayPrototypeGetByteOffset: UncurryGetter<TypedArray, "byteOffset">;
+  export const TypedArrayPrototypeGetLength: UncurryGetter<TypedArray, "length">;
+  export function TypedArrayPrototypeGetSymbolToStringTag(self: unknown):
+    | 'Int8Array'
+    | 'Int16Array'
+    | 'Int32Array'
+    | 'Uint8Array'
+    | 'Uint16Array'
+    | 'Uint32Array'
+    | 'Uint8ClampedArray'
+    | 'BigInt64Array'
+    | 'BigUint64Array'
+    | 'Float32Array'
+    | 'Float64Array'
+    | undefined;
+  export import URIError = globalThis.URIError;
   export const URIErrorLength: typeof URIError.length
   export const URIErrorName: typeof URIError.name
   export const URIErrorPrototype: typeof URIError.prototype
-  export const Uint16Array: typeof globalThis.Uint16Array;
+  export import Uint16Array = globalThis.Uint16Array;
   export const Uint16ArrayLength: typeof Uint16Array.length
   export const Uint16ArrayName: typeof Uint16Array.name
   export const Uint16ArrayPrototype: typeof Uint16Array.prototype
   export const Uint16ArrayBYTES_PER_ELEMENT: typeof Uint16Array.BYTES_PER_ELEMENT
-  export const Uint32Array: typeof globalThis.Uint32Array;
+  export import Uint32Array = globalThis.Uint32Array;
   export const Uint32ArrayLength: typeof Uint32Array.length
   export const Uint32ArrayName: typeof Uint32Array.name
   export const Uint32ArrayPrototype: typeof Uint32Array.prototype
   export const Uint32ArrayBYTES_PER_ELEMENT: typeof Uint32Array.BYTES_PER_ELEMENT
-  export const Uint8Array: typeof globalThis.Uint8Array;
+  export import Uint8Array = globalThis.Uint8Array;
   export const Uint8ArrayLength: typeof Uint8Array.length
   export const Uint8ArrayName: typeof Uint8Array.name
   export const Uint8ArrayPrototype: typeof Uint8Array.prototype
   export const Uint8ArrayBYTES_PER_ELEMENT: typeof Uint8Array.BYTES_PER_ELEMENT
-  export const Uint8ClampedArray: typeof globalThis.Uint8ClampedArray;
+  export import Uint8ClampedArray = globalThis.Uint8ClampedArray;
   export const Uint8ClampedArrayLength: typeof Uint8ClampedArray.length
   export const Uint8ClampedArrayName: typeof Uint8ClampedArray.name
   export const Uint8ClampedArrayPrototype: typeof Uint8ClampedArray.prototype
   export const Uint8ClampedArrayBYTES_PER_ELEMENT: typeof Uint8ClampedArray.BYTES_PER_ELEMENT
-  export const WeakMap: typeof globalThis.WeakMap;
+  export import WeakMap = globalThis.WeakMap;
   export const WeakMapLength: typeof WeakMap.length
   export const WeakMapName: typeof WeakMap.name
   export const WeakMapPrototype: typeof WeakMap.prototype
@@ -506,14 +575,14 @@ declare namespace Primordials {
   export const WeakMapPrototypeGet: UncurryThis<typeof WeakMap.prototype.get>
   export const WeakMapPrototypeSet: UncurryThis<typeof WeakMap.prototype.set>
   export const WeakMapPrototypeHas: UncurryThis<typeof WeakMap.prototype.has>
-  export const WeakSet: typeof globalThis.WeakSet;
+  export import WeakSet = globalThis.WeakSet;
   export const WeakSetLength: typeof WeakSet.length
   export const WeakSetName: typeof WeakSet.name
   export const WeakSetPrototype: typeof WeakSet.prototype
   export const WeakSetPrototypeDelete: UncurryThis<typeof WeakSet.prototype.delete>
   export const WeakSetPrototypeHas: UncurryThis<typeof WeakSet.prototype.has>
   export const WeakSetPrototypeAdd: UncurryThis<typeof WeakSet.prototype.add>
-  export const Promise: typeof globalThis.Promise;
+  export import Promise = globalThis.Promise;
   export const PromiseLength: typeof Promise.length
   export const PromiseName: typeof Promise.name
   export const PromisePrototype: typeof Promise.prototype
@@ -526,8 +595,4 @@ declare namespace Primordials {
   export const PromisePrototypeThen: UncurryThis<typeof Promise.prototype.then>
   export const PromisePrototypeCatch: UncurryThis<typeof Promise.prototype.catch>
   export const PromisePrototypeFinally: UncurryThis<typeof Promise.prototype.finally>
-}
-
-declare global {
-  const primordials: typeof Primordials;
 }


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

I also fixed the types of `primordials.uncurryThis` and `primordials.AsyncIteratorPrototype`, added <code>[%TypedArray%]</code> statics, and made global properties use:
```ts
export import NAME = globalThis.NAME;
```
In order to re‑export types as well as values.

[%TypedArray%]: https://tc39.es/ecma262/#sec-%typedarray%-intrinsic-object