### PR TITLE
util: escape lone surrogate code points using .inspect()

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -176,10 +176,10 @@ const kArrayType = 1;
 const kArrayExtrasType = 2;
 
 /* eslint-disable no-control-regex */
-const strEscapeSequencesRegExp = /[\x00-\x1f\x27\x5c\x7f-\x9f]/;
-const strEscapeSequencesReplacer = /[\x00-\x1f\x27\x5c\x7f-\x9f]/g;
-const strEscapeSequencesRegExpSingle = /[\x00-\x1f\x5c\x7f-\x9f]/;
-const strEscapeSequencesReplacerSingle = /[\x00-\x1f\x5c\x7f-\x9f]/g;
+const strEscapeSequencesRegExp = /[\x00-\x1f\x27\x5c\x7f-\x9f]|[\ud800-\udbff](?![\udc00-\udfff])|(?<![\ud800-\udbff])[\udc00-\udfff]/;
+const strEscapeSequencesReplacer = /[\x00-\x1f\x27\x5c\x7f-\x9f]|[\ud800-\udbff](?![\udc00-\udfff])|(?<![\ud800-\udbff])[\udc00-\udfff]/g;
+const strEscapeSequencesRegExpSingle = /[\x00-\x1f\x5c\x7f-\x9f]|[\ud800-\udbff](?![\udc00-\udfff])|(?<![\ud800-\udbff])[\udc00-\udfff]/;
+const strEscapeSequencesReplacerSingle = /[\x00-\x1f\x5c\x7f-\x9f]|[\ud800-\udbff](?![\udc00-\udfff])|(?<![\ud800-\udbff])[\udc00-\udfff]/g;
 /* eslint-enable no-control-regex */
 
 const keyStrRegExp = /^[a-zA-Z_][a-zA-Z_0-9]*$/;
@@ -458,7 +458,10 @@ function addQuotes(str, quotes) {
   return `'${str}'`;
 }
 
-const escapeFn = (str) => meta[StringPrototypeCharCodeAt(str)];
+function escapeFn(str) {
+  const charCode = StringPrototypeCharCodeAt(str);
+  return meta.length > charCode ? meta[charCode] : `\\u${charCode.toString(16)}`;
+}
 
 // Escape control characters, single quotes and the backslash.
 // This is similar to JSON stringify escaping.
@@ -496,8 +499,7 @@ function strEscape(str) {
 
   let result = '';
   let last = 0;
-  const lastIndex = str.length;
-  for (let i = 0; i < lastIndex; i++) {
+  for (let i = 0; i < str.length; i++) {
     const point = StringPrototypeCharCodeAt(str, i);
     if (point === singleQuote ||
         point === 92 ||
@@ -509,10 +511,20 @@ function strEscape(str) {
         result += `${StringPrototypeSlice(str, last, i)}${meta[point]}`;
       }
       last = i + 1;
+    } else if (point >= 0xd800 && point <= 0xdfff) {
+      if (point <= 0xdbff && i + 1 < str.length) {
+        const point = StringPrototypeCharCodeAt(str, i + 1);
+        if (point >= 0xdc00 && point <= 0xdfff) {
+          i++;
+          continue;
+        }
+      }
+      result += `${StringPrototypeSlice(str, last, i)}${`\\u${point.toString(16)}`}`;
+      last = i + 1;
     }
   }
 
-  if (last !== lastIndex) {
+  if (last !== str.length) {
     result += StringPrototypeSlice(str, last);
   }
   return addQuotes(result, singleQuote);


### PR DESCRIPTION
Unpaired surrogate code points have no representation in UTF8.
Therefore, such code points are just "random" output that is
unreadable. Instead, escape the code points similar to C0 and C1
control characters.

Refs: https://unicodebook.readthedocs.io/unicode_encodings.html#utf-16-surrogate-pairs

Signed-off-by: Ruben Bridgewater <ruben@bridgewater.de>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
