### PR TITLE
util: always visualize cause property in errors during inspection

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -1274,27 +1274,31 @@ function formatError(err, constructor, tag, ctx, keys) {
   const stackStart = stack.indexOf('\n    at', pos);
   if (stackStart === -1) {
     stack = `[${stack}]`;
-  } else if (ctx.colors) {
-    // Highlight userland code and node modules.
+  } else {
     let newStack = stack.slice(0, stackStart);
     const lines = getStackFrames(ctx, err, stack.slice(stackStart + 1));
-    for (const line of lines) {
-      const core = line.match(coreModuleRegExp);
-      if (core !== null && NativeModule.exists(core[1])) {
-        newStack += `\n${ctx.stylize(line, 'undefined')}`;
-      } else {
-        // This adds underscores to all node_modules to quickly identify them.
-        let nodeModule;
-        newStack += '\n';
-        let pos = 0;
-        while (nodeModule = nodeModulesRegExp.exec(line)) {
-          // '/node_modules/'.length === 14
-          newStack += line.slice(pos, nodeModule.index + 14);
-          newStack += ctx.stylize(nodeModule[1], 'module');
-          pos = nodeModule.index + nodeModule[0].length;
+    if (ctx.colors) {
+      // Highlight userland code and node modules.
+      for (const line of lines) {
+        const core = line.match(coreModuleRegExp);
+        if (core !== null && NativeModule.exists(core[1])) {
+          newStack += `\n${ctx.stylize(line, 'undefined')}`;
+        } else {
+          // This adds underscores to all node_modules to quickly identify them.
+          let nodeModule;
+          newStack += '\n';
+          let pos = 0;
+          while (nodeModule = nodeModulesRegExp.exec(line)) {
+            // '/node_modules/'.length === 14
+            newStack += line.slice(pos, nodeModule.index + 14);
+            newStack += ctx.stylize(nodeModule[1], 'module');
+            pos = nodeModule.index + nodeModule[0].length;
+          }
+          newStack += pos === 0 ? line : line.slice(pos);
         }
-        newStack += pos === 0 ? line : line.slice(pos);
       }
+    } else {
+      newStack += `\n${lines.join('\n')}`;
     }
     stack = newStack;
   }

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -1162,25 +1162,58 @@ function getFunctionBase(value, constructor, tag) {
   return base;
 }
 
-function formatError(err, constructor, tag, ctx, keys) {
-  const name = err.name != null ? String(err.name) : 'Error';
-  let len = name.length;
-  let stack = err.stack ? String(err.stack) : ErrorPrototypeToString(err);
-
-  // Do not "duplicate" error properties that are already included in the output
-  // otherwise.
-  if (!ctx.showHidden && keys.length !== 0) {
-    for (const name of ['name', 'message', 'stack']) {
-      const index = keys.indexOf(name);
-      // Only hide the property in case it's part of the original stack
-      if (index !== -1 && stack.includes(err[name])) {
-        keys.splice(index, 1);
+function identicalSequenceRange(a, b) {
+  for (let i = 0; i < a.length - 3; i++) {
+    // Find the first entry of b that matches the current entry of a.
+    const pos = b.indexOf(a[i]);
+    if (pos !== -1) {
+      const rest = b.length - pos;
+      if (rest > 3) {
+        let len = 1;
+        const maxLen = MathMin(a.length - i, rest);
+        // Count the number of consecutive entries.
+        while (maxLen > len && a[i + len] === b[pos + len]) {
+          len++;
+        }
+        if (len > 3) {
+          return { len, offset: i };
+        }
       }
     }
   }
 
+  return { len: 0, offset: 0 };
+}
+
+function getStackString(error) {
+  return error.stack ? String(error.stack) : ErrorPrototypeToString(error);
+}
+
+function getStackFrames(ctx, err, stack) {
+  const frames = stack.split('\n');
+
+  // Remove stack frames identical to frames in cause.
+  if (err.cause) {
+    const causeStack = getStackString(err.cause);
+    const causeStackStart = causeStack.indexOf('\n    at');
+    if (causeStackStart !== -1) {
+      const causeFrames = causeStack.slice(causeStackStart + 1).split('\n');
+      const { len, offset } = identicalSequenceRange(frames, causeFrames);
+      if (len > 0) {
+        const skipped = len - 2;
+        const msg = `    ... ${skipped} lines matching cause stack trace ...`;
+        frames.splice(offset + 1, skipped, ctx.stylize(msg, 'undefined'));
+      }
+    }
+  }
+  return frames;
+}
+
+function improveStack(stack, constructor, name, tag) {
   // A stack trace may contain arbitrary data. Only manipulate the output
   // for "regular errors" (errors that "look normal") for now.
+  let len = name.length;
+
   if (constructor === null ||
       (name.endsWith('Error') &&
       stack.startsWith(name) &&
@@ -1206,6 +1239,33 @@ function formatError(err, constructor, tag, ctx, keys) {
       }
     }
   }
+  return stack;
+}
+
+function removeDuplicateErrorKeys(ctx, keys, err, stack) {
+  if (!ctx.showHidden && keys.length !== 0) {
+    for (const name of ['name', 'message', 'stack']) {
+      const index = keys.indexOf(name);
+      // Only hide the property in case it's part of the original stack
+      if (index !== -1 && stack.includes(err[name])) {
+        keys.splice(index, 1);
+      }
+    }
+  }
+}
+
+function formatError(err, constructor, tag, ctx, keys) {
+  const name = err.name != null ? String(err.name) : 'Error';
+  let stack = getStackString(err);
+
+  removeDuplicateErrorKeys(ctx, keys, err, stack);
+
+  if (err.cause && (keys.length === 0 || !keys.includes('cause'))) {
+    keys.push('cause');
+  }
+
+  stack = improveStack(stack, constructor, name, tag);
+
   // Ignore the error message if it's contained in the stack.
   let pos = (err.message && stack.indexOf(err.message)) || -1;
   if (pos !== -1)
@@ -1217,7 +1277,7 @@ function formatError(err, constructor, tag, ctx, keys) {
   } else if (ctx.colors) {
     // Highlight userland code and node modules.
     let newStack = stack.slice(0, stackStart);
-    const lines = stack.slice(stackStart + 1).split('\n');
+    const lines = getStackFrames(ctx, err, stack.slice(stackStart + 1));
     for (const line of lines) {
       const core = line.match(coreModuleRegExp);
       if (core !== null && NativeModule.exists(core[1])) {

--- a/test/message/util-inspect-error-cause.js
+++ b/test/message/util-inspect-error-cause.js
@@ -1,0 +1,21 @@
+'use strict';
+
+require('../common');
+
+class FoobarError extends Error {
+  status = 'Feeling good';
+}
+
+const cause1 = new TypeError('Inner error');
+const cause2 = new FoobarError('Individual message', { cause: cause1 });
+cause2.extraProperties = 'Yes!';
+const cause3 = new Error('Stack causes', { cause: cause2 });
+
+process.nextTick(() => {
+  const error = new RangeError('New Stack Frames', { cause: cause2 });
+  const error2 = new RangeError('New Stack Frames', { cause: cause3 });
+
+  console.log(error);
+  console.log(cause3);
+  console.log(error2);
+});

--- a/test/message/util-inspect-error-cause.js
+++ b/test/message/util-inspect-error-cause.js
@@ -2,6 +2,8 @@
 
 require('../common');
 
+const { inspect } = require('util');
+
 class FoobarError extends Error {
   status = 'Feeling good';
 }
@@ -15,7 +17,15 @@ process.nextTick(() => {
   const error = new RangeError('New Stack Frames', { cause: cause2 });
   const error2 = new RangeError('New Stack Frames', { cause: cause3 });
 
-  console.log(error);
-  console.log(cause3);
-  console.log(error2);
+  inspect.defaultOptions.colors = true;
+
+  console.log(inspect(error));
+  console.log(inspect(cause3));
+  console.log(inspect(error2));
+
+  inspect.defaultOptions.colors = false;
+
+  console.log(inspect(error));
+  console.log(inspect(cause3));
+  console.log(inspect(error2));
 });

--- a/test/message/util-inspect-error-cause.out
+++ b/test/message/util-inspect-error-cause.out
@@ -1,5 +1,73 @@
 RangeError: New Stack Frames
     at *
+*[90m    at *[39m {
+  [cause]: FoobarError: Individual message
+      at *
+  *[90m    at *[39m
+  *[90m    ... 4 lines matching cause stack trace ...*[39m
+  *[90m    at *[39m {
+    status: *[32m'Feeling good'*[39m,
+    extraProperties: *[32m'Yes!'*[39m,
+    [cause]: TypeError: Inner error
+        at *
+    *[90m    at *[39m
+    *[90m    at *[39m
+    *[90m    at *[39m
+    *[90m    at *[39m
+    *[90m    at *[39m
+    *[90m    at *[39m
+  }
+}
+Error: Stack causes
+    at *
+*[90m    at *[39m
+*[90m    ... 4 lines matching cause stack trace ...*[39m
+*[90m    at *[39m {
+  [cause]: FoobarError: Individual message
+      at *
+  *[90m    at *[39m
+  *[90m    ... 4 lines matching cause stack trace ...*[39m
+  *[90m    at *[39m {
+    status: *[32m'Feeling good'*[39m,
+    extraProperties: *[32m'Yes!'*[39m,
+    [cause]: TypeError: Inner error
+        at *
+    *[90m    at *[39m
+    *[90m    at *[39m
+    *[90m    at *[39m
+    *[90m    at *[39m
+    *[90m    at *[39m
+    *[90m    at *[39m
+  }
+}
+RangeError: New Stack Frames
+    at *
+*[90m    at *[39m {
+  [cause]: Error: Stack causes
+      at *
+  *[90m    at *[39m
+  *[90m    ... 4 lines matching cause stack trace ...*[39m
+  *[90m    at *[39m {
+    [cause]: FoobarError: Individual message
+        at *
+    *[90m    at *[39m
+    *[90m    ... 4 lines matching cause stack trace ...*[39m
+    *[90m    at *[39m {
+      status: *[32m'Feeling good'*[39m,
+      extraProperties: *[32m'Yes!'*[39m,
+      [cause]: TypeError: Inner error
+          at *
+      *[90m    at *[39m
+      *[90m    at *[39m
+      *[90m    at *[39m
+      *[90m    at *[39m
+      *[90m    at *[39m
+      *[90m    at *[39m
+    }
+  }
+}
+RangeError: New Stack Frames
+    at *
     at * {
   [cause]: FoobarError: Individual message
       at *

--- a/test/message/util-inspect-error-cause.out
+++ b/test/message/util-inspect-error-cause.out
@@ -1,0 +1,68 @@
+RangeError: New Stack Frames
+    at *
+    at * {
+  [cause]: FoobarError: Individual message
+      at *
+      at *
+      ... 4 lines matching cause stack trace ...
+      at * {
+    status: 'Feeling good',
+    extraProperties: 'Yes!',
+    [cause]: TypeError: Inner error
+        at *
+        at *
+        at *
+        at *
+        at *
+        at *
+        at *
+  }
+}
+Error: Stack causes
+    at *
+    at *
+    ... 4 lines matching cause stack trace ...
+    at * {
+  [cause]: FoobarError: Individual message
+      at *
+      at *
+      ... 4 lines matching cause stack trace ...
+      at *
+    status: 'Feeling good',
+    extraProperties: 'Yes!',
+    [cause]: TypeError: Inner error
+        at *
+        at *
+        at *
+        at *
+        at *
+        at *
+        at *
+  }
+}
+RangeError: New Stack Frames
+    at *
+    at * {
+  [cause]: Error: Stack causes
+      at *
+      at *
+      ... 4 lines matching cause stack trace ...
+      at * {
+    [cause]: FoobarError: Individual message
+        at *
+        at *
+        ... 4 lines matching cause stack trace ...
+        at * {
+      status: 'Feeling good',
+      extraProperties: 'Yes!',
+      [cause]: TypeError: Inner error
+          at *
+          at *
+          at *
+          at *
+          at *
+          at *
+          at *
+    }
+  }
+}


### PR DESCRIPTION
While inspecting errors, always visualize the cause. That property
is non-enumerable by default while being useful in general for
debugging.

Duplicated stack frames are hidden.

Fixes: #40859
Fixes: #38725

Signed-off-by: Ruben Bridgewater <ruben@bridgewater.de>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
