### PR TITLE
lib: do not lazy load EOL in blob

### DIFF
--- a/lib/internal/blob.js
+++ b/lib/internal/blob.js
@@ -75,7 +75,6 @@ const disallowedTypeCharacters = /[^\u{0020}-\u{007E}]/u;
 
 let ReadableStream;
 let URL;
-let EOL;
 
 const enc = new TextEncoder();
 
@@ -94,13 +93,7 @@ function lazyReadableStream(options) {
   return new ReadableStream(options);
 }
 
-// TODO(@jasnell): This is annoying but this has to be lazy because
-// requiring the 'os' module too early causes building Node.js to
-// fail with an unknown reference failure.
-function lazyEOL() {
-  EOL ??= require('os').EOL;
-  return EOL;
-}
+const { EOL } = require('internal/constants');
 
 function isBlob(object) {
   return object?.[kHandle] !== undefined;
@@ -115,7 +108,7 @@ function getSource(source, endings) {
   } else if (!isArrayBufferView(source)) {
     source = `${source}`;
     if (endings === 'native')
-      source = RegExpPrototypeSymbolReplace(/\n|\r\n/g, source, lazyEOL());
+      source = RegExpPrototypeSymbolReplace(/\n|\r\n/g, source, EOL);
     source = enc.encode(source);
   }
 


### PR DESCRIPTION
This addresses a comment by loading the EOL from the constants file.

Signed-off-by: Ruben Bridgewater <ruben@bridgewater.de>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
