### PR TITLE
assert: use stricter stack frame detection in .ifError()

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -966,21 +966,27 @@ assert.ifError = function ifError(err) {
       // This will remove any duplicated frames from the error frames taken
       // from within `ifError` and add the original error frames to the newly
       // created ones.
-      const tmp2 = StringPrototypeSplit(origStack, '\n');
-      ArrayPrototypeShift(tmp2);
-      // Filter all frames existing in err.stack.
-      let tmp1 = StringPrototypeSplit(newErr.stack, '\n');
-      for (const errFrame of tmp2) {
-        // Find the first occurrence of the frame.
-        const pos = ArrayPrototypeIndexOf(tmp1, errFrame);
-        if (pos !== -1) {
-          // Only keep new frames.
-          tmp1 = ArrayPrototypeSlice(tmp1, 0, pos);
-          break;
+      const origStackStart = origStack.indexOf('\n    at');
+      if (origStackStart !== -1) {
+        const originalFrames = StringPrototypeSplit(
+          origStack.slice(origStackStart + 1),
+          '\n'
+        );
+        // Filter all frames existing in err.stack.
+        let newFrames = StringPrototypeSplit(newErr.stack, '\n');
+        for (const errFrame of originalFrames) {
+          // Find the first occurrence of the frame.
+          const pos = ArrayPrototypeIndexOf(newFrames, errFrame);
+          if (pos !== -1) {
+            // Only keep new frames.
+            newFrames = ArrayPrototypeSlice(newFrames, 0, pos);
+            break;
+          }
         }
+        const stackStart = ArrayPrototypeJoin(newFrames, '\n');
+        const stackEnd = ArrayPrototypeJoin(originalFrames, '\n');
+        newErr.stack = `${stackStart}\n${stackEnd}`;
       }
-      newErr.stack =
-        `${ArrayPrototypeJoin(tmp1, '\n')}\n${ArrayPrototypeJoin(tmp2, '\n')}`;
     }
 
     throw newErr;

--- a/test/parallel/test-assert-if-error.js
+++ b/test/parallel/test-assert-if-error.js
@@ -40,6 +40,18 @@ const stack = err.stack;
 })();
 
 assert.throws(
+  () => {
+    const error = new Error();
+    error.stack = 'Error: containing weird stack\nYes!\nI am part of a stack.';
+    assert.ifError(error);
+  },
+  (error) => {
+    assert(!error.stack.includes('Yes!'));
+    return true;
+  }
+);
+
+assert.throws(
   () => assert.ifError(new TypeError()),
   {
     message: 'ifError got unwanted exception: TypeError'


### PR DESCRIPTION
This makes sure arbitrary stack traces are not handled as stack
frames.

Signed-off-by: Ruben Bridgewater <ruben@bridgewater.de>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
