### PR TITLE
assert: allow arbitrary argument order in match() and doesNotMatch()

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -890,11 +890,16 @@ parameter is an instance of an [`Error`][] then it will be thrown instead of the
 
 ## `assert.doesNotMatch(string, regexp[, message])`
 
+## `assert.doesNotMatch(regexp, string[, message])`
+
 <!-- YAML
 added:
   - v13.6.0
   - v12.16.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/41007
+    description: The argument order may now be "regexp, string".
   - version: v16.0.0
     pr-url: https://github.com/nodejs/node/pull/38111
     description: This API is no longer experimental.
@@ -1415,11 +1420,16 @@ let err;
 
 ## `assert.match(string, regexp[, message])`
 
+## `assert.match(regexp, string[, message])`
+
 <!-- YAML
 added:
   - v13.6.0
   - v12.16.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/41007
+    description: The argument order may now be "regexp, string".
   - version: v16.0.0
     pr-url: https://github.com/nodejs/node/pull/38111
     description: This API is no longer experimental.

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -989,10 +989,17 @@ assert.ifError = function ifError(err) {
 
 function internalMatch(string, regexp, message, fn) {
   if (!isRegExp(regexp)) {
-    throw new ERR_INVALID_ARG_TYPE(
-      'regexp', 'RegExp', regexp
-    );
+    if (isRegExp(string)) {
+      const tmp = string;
+      string = regexp;
+      regexp = tmp;
+    } else {
+      throw new ERR_INVALID_ARG_TYPE(
+        'regexp', 'RegExp', regexp
+      );
+    }
   }
+
   const match = fn.name === 'match';
   if (typeof string !== 'string' ||
       RegExpPrototypeTest(regexp, string) !== match) {
@@ -1002,8 +1009,21 @@ function internalMatch(string, regexp, message, fn) {
 
     const generatedMessage = !message;
 
-    // 'The input was expected to not match the regular expression ' +
-    message = message || (typeof string !== 'string' ?
+    if (!message) {
+      if (typeof string !== 'string') {
+        message = 'The "string" argument must be of type string. ' +
+          `Received type ${typeof string} (${inspect(string)})`;
+      } else {
+        if (match) {
+          message = 'The input did not match the regular expression';
+        } else {
+          message = 'The input was expected to not match the regular ' +
+                    'expression';
+        }
+        message += ` ${inspect(regexp)}. Input:\n\n${inspect(string)}\n`;
+      }
+    }
+    message ||= (typeof string !== 'string' ?
       'The "string" argument must be of type string. Received type ' +
         `${typeof string} (${inspect(string)})` :
       (match ?

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -1372,11 +1372,34 @@ assert.throws(
 // Multiple assert.match() tests.
 {
   assert.throws(
-    () => assert.match(/abc/, 'string'),
+    () => assert.match(/abc/, 5),
     {
+      actual: 5,
+      expected: /abc/,
+      operator: 'match',
+      message: 'The "string" argument must be of type string. ' +
+               'Received type number (5)',
+      generatedMessage: true
+    }
+  );
+  assert.throws(
+    () => assert.match(5, 'string'),
+    {
+      name: 'TypeError',
       code: 'ERR_INVALID_ARG_TYPE',
       message: 'The "regexp" argument must be an instance of RegExp. ' +
-               "Received type string ('string')"
+               "Received type string ('string')",
+    }
+  );
+  assert.throws(
+    () => assert.match(/abc/, 'string'),
+    {
+      actual: 'string',
+      expected: /abc/,
+      operator: 'match',
+      message: 'The input did not match the regular expression /abc/. ' +
+               "Input:\n\n'string'\n",
+      generatedMessage: true
     }
   );
   assert.throws(
@@ -1422,8 +1445,31 @@ assert.throws(
 // Multiple assert.doesNotMatch() tests.
 {
   assert.throws(
-    () => assert.doesNotMatch(/abc/, 'string'),
+    () => assert.doesNotMatch(/string/, 5),
     {
+      actual: 5,
+      expected: /string/,
+      operator: 'doesNotMatch',
+      message: 'The "string" argument must be of type string. ' +
+               'Received type number (5)',
+      generatedMessage: true
+    }
+  );
+  assert.throws(
+    () => assert.doesNotMatch(/string/, 'string'),
+    {
+      actual: 'string',
+      expected: /string/,
+      operator: 'doesNotMatch',
+      message: 'The input was expected to not match the regular expression ' +
+               "/string/. Input:\n\n'string'\n",
+      generatedMessage: true
+    }
+  );
+  assert.throws(
+    () => assert.doesNotMatch(5, 'string'),
+    {
+      name: 'TypeError',
       code: 'ERR_INVALID_ARG_TYPE',
       message: 'The "regexp" argument must be an instance of RegExp. ' +
                "Received type string ('string')"


### PR DESCRIPTION
This allows assert.match() and assert.doesNotMatch() arguments to
be inserted in any order.

Signed-off-by: Ruben Bridgewater <ruben@bridgewater.de>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
