### PR TITLE
build: re-enable V8 concurrent marking

### DIFF
--- a/tools/v8_gypfiles/features.gypi
+++ b/tools/v8_gypfiles/features.gypi
@@ -147,6 +147,16 @@
     # Sets -dV8_TRACE_FEEDBACK_UPDATES.
     'v8_enable_trace_feedback_updates%': 0,
 
+    # Sets -dV8_ATOMIC_OBJECT_FIELD_WRITES and turns all field write operations
+    # into relaxed atomic operations.
+    'v8_enable_atomic_object_field_writes%': 1,
+
+    # Sets -dV8_ATOMIC_MARKING_STATE
+    'v8_enable_atomic_marking_state%': 1,
+
+    # Has no effect in Node.js. Here for completeness with V8's config.
+    'v8_enable_concurrent_marking%': 1,
+
     # Enables various testing features.
     'v8_enable_test_features%': 0,
 
@@ -342,6 +352,12 @@
       }],
       ['v8_enable_third_party_heap==1', {
         'defines': ['V8_ENABLE_THIRD_PARTY_HEAP',],
+      }],
+      ['v8_enable_atomic_object_field_writes==1', {
+        'defines': ['V8_ATOMIC_OBJECT_FIELD_WRITES',],
+      }],
+      ['v8_enable_atomic_marking_state==1', {
+        'defines': ['V8_ATOMIC_MARKING_STATE',],
       }],
       ['v8_enable_lazy_source_positions==1', {
         'defines': ['V8_ENABLE_LAZY_SOURCE_POSITIONS',],

--- a/tools/v8_gypfiles/v8.gyp
+++ b/tools/v8_gypfiles/v8.gyp
@@ -1713,12 +1713,9 @@
               'is_ubsan_vptr=0',
               'target_cpu=<(target_arch)',
               'v8_current_cpu=<(v8_current_cpu)',
-              # Not available in gyp.
-              'v8_enable_atomic_marking_state=0',
-              # Not available in gyp.
-              'v8_enable_atomic_object_field_writes=0',
-              # Not available in gyp.
-              'v8_enable_concurrent_marking=0',
+              'v8_enable_atomic_marking_state=<(v8_enable_atomic_marking_state)',
+              'v8_enable_atomic_object_field_writes=<(v8_enable_atomic_object_field_writes)',
+              'v8_enable_concurrent_marking=<(v8_enable_concurrent_marking)',
               'v8_enable_i18n_support=<(v8_enable_i18n_support)',
               'v8_enable_verify_predictable=<(v8_enable_verify_predictable)',
               'v8_enable_verify_csa=<(v8_enable_verify_csa)',


### PR DESCRIPTION
It was unintentionally disabled during a V8 update.

Fixes: https://github.com/nodejs/node/issues/41012
