### PR TITLE
assert: prefer reference comparison over string comparison

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -832,7 +832,7 @@ function expectsError(stackStartFn, actual, error, message) {
       details += ` (${error.name})`;
     }
     details += message ? `: ${message}` : '.';
-    const fnType = stackStartFn.name === 'rejects' ? 'rejection' : 'exception';
+    const fnType = stackStartFn === assert.rejects ? 'rejection' : 'exception';
     innerFail({
       actual: undefined,
       expected: error,
@@ -879,7 +879,7 @@ function expectsNoError(stackStartFn, actual, error, message) {
 
   if (!error || hasMatchingError(actual, error)) {
     const details = message ? `: ${message}` : '.';
-    const fnType = stackStartFn.name === 'doesNotReject' ?
+    const fnType = stackStartFn === assert.doesNotReject ?
       'rejection' : 'exception';
     innerFail({
       actual,
@@ -993,7 +993,7 @@ function internalMatch(string, regexp, message, fn) {
       'regexp', 'RegExp', regexp
     );
   }
-  const match = fn.name === 'match';
+  const match = fn === assert.match;
   if (typeof string !== 'string' ||
       RegExpPrototypeTest(regexp, string) !== match) {
     if (message instanceof Error) {


### PR DESCRIPTION
Pointer comparison takes constant time and string comparison takes
linear time unless there is some string interning going on, so this
might be a little bit faster.

Signed-off-by: Darshan Sen <darshan.sen@postman.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
