### PR TITLE
assert,util: compare RegExp.lastIndex while using deep equal checks

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -465,6 +465,9 @@ An alias of [`assert.ok()`][].
 <!-- YAML
 added: v0.1.21
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/41020
+    description: Regular expressions lastIndex property is now compared as well.
   - version:
       - v16.0.0
       - v14.18.0
@@ -539,6 +542,8 @@ are also recursively evaluated by the following rules.
   objects.
 * [`Symbol`][] properties are not compared.
 * [`WeakMap`][] and [`WeakSet`][] comparison does not rely on their values.
+* [`RegExp`][] lastIndex, flags and source are always compared, even if these
+  are not enumerable properties.
 
 The following example does not throw an [`AssertionError`][] because the
 primitives are considered equal by the [Abstract Equality Comparison][]
@@ -642,6 +647,9 @@ parameter is an instance of an [`Error`][] then it will be thrown instead of the
 <!-- YAML
 added: v1.2.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/41020
+    description: Regular expressions lastIndex property is now compared as well.
   - version: v9.0.0
     pr-url: https://github.com/nodejs/node/pull/15169
     description: Enumerable symbol properties are now compared.
@@ -697,6 +705,8 @@ are recursively evaluated also by the following rules.
   reference.
 * [`WeakMap`][] and [`WeakSet`][] comparison does not rely on their values. See
   below for further details.
+* [`RegExp`][] lastIndex, flags and source are always compared, even if these
+  are not enumerable properties.
 
 ```mjs
 import assert from 'assert/strict';

--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -63,7 +63,9 @@ const kIsMap = 3;
 
 // Check if they have the same source and flags
 function areSimilarRegExps(a, b) {
-  return a.source === b.source && a.flags === b.flags;
+  return a.source === b.source &&
+         a.flags === b.flags &&
+         a.lastIndex === b.lastIndex;
 }
 
 function areSimilarFloatArrays(a, b) {

--- a/test/parallel/test-assert-deep.js
+++ b/test/parallel/test-assert-deep.js
@@ -712,7 +712,7 @@ assertNotDeepOrStrict(/a/igm, /a/im);
 {
   const re1 = /a/g;
   re1.lastIndex = 3;
-  assert.deepEqual(re1, /a/g);
+  assert.notDeepEqual(re1, /a/g);
 }
 
 assert.deepEqual(4, '4');
@@ -852,7 +852,7 @@ assert.throws(
 {
   const re1 = /a/;
   re1.lastIndex = 3;
-  assert.deepStrictEqual(re1, /a/);
+  assert.notDeepStrictEqual(re1, /a/);
 }
 
 assert.throws(


### PR DESCRIPTION
Compare the `lastIndex` property of regular expressions next to the
flags and source property.

Fixes: https://github.com/nodejs/node/issues/28766

Signed-off-by: Ruben Bridgewater <ruben@bridgewater.de>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
