### PR TITLE
lib: do not crash using workers with disabled shared array buffers

### DIFF
--- a/benchmark/worker/atomics-wait.js
+++ b/benchmark/worker/atomics-wait.js
@@ -1,5 +1,12 @@
 'use strict';
-/* global SharedArrayBuffer */
+
+if (typeof SharedArrayBuffer === 'undefined') {
+  throw new Error('SharedArrayBuffers must be enabled to run this benchmark');
+}
+
+if (typeof Atomics === 'undefined') {
+  throw new Error('Atomics must be enabled to run this benchmark');
+}
 
 const common = require('../common.js');
 const bench = common.createBenchmark(main, {

--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -10,7 +10,10 @@ const {
   ObjectDefineProperty,
   PromisePrototypeThen,
   RegExpPrototypeExec,
-  globalThis: { Atomics },
+  globalThis: {
+    Atomics,
+    SharedArrayBuffer,
+  },
 } = primordials;
 
 const {
@@ -106,21 +109,23 @@ port.on('message', (message) => {
 
     require('internal/worker').assignEnvironmentData(environmentData);
 
-    // The counter is only passed to the workers created by the main thread, not
-    // to workers created by other workers.
-    let cachedCwd = '';
-    let lastCounter = -1;
-    const originalCwd = process.cwd;
+    if (SharedArrayBuffer !== undefined && Atomics !== undefined) {
+      // The counter is only passed to the workers created by the main thread,
+      // not to workers created by other workers.
+      let cachedCwd = '';
+      let lastCounter = -1;
+      const originalCwd = process.cwd;
 
-    process.cwd = function() {
-      const currentCounter = Atomics.load(cwdCounter, 0);
-      if (currentCounter === lastCounter)
+      process.cwd = function() {
+        const currentCounter = Atomics.load(cwdCounter, 0);
+        if (currentCounter === lastCounter)
+          return cachedCwd;
+        lastCounter = currentCounter;
+        cachedCwd = originalCwd();
         return cachedCwd;
-      lastCounter = currentCounter;
-      cachedCwd = originalCwd();
-      return cachedCwd;
-    };
-    workerIo.sharedCwdCounter = cwdCounter;
+      };
+      workerIo.sharedCwdCounter = cwdCounter;
+    }
 
     if (manifestSrc) {
       require('internal/process/policy').setup(manifestSrc, manifestURL);

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -95,7 +95,9 @@ let cwdCounter;
 
 const environmentData = new SafeMap();
 
-if (isMainThread) {
+// SharedArrayBuffers can be disabled with --no-harmony-sharedarraybuffer.
+// Atomics can be disabled with --no-harmony-atomics.
+if (isMainThread && SharedArrayBuffer !== undefined && Atomics !== undefined) {
   cwdCounter = new Uint32Array(new SharedArrayBuffer(4));
   const originalChdir = process.chdir;
   process.chdir = function(path) {

--- a/test/parallel/test-worker-no-atomics.js
+++ b/test/parallel/test-worker-no-atomics.js
@@ -1,0 +1,21 @@
+// Flags: --no-harmony-atomics
+
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { Worker } = require('worker_threads');
+
+// Regression test for https://github.com/nodejs/node/issues/39717.
+
+// Do not use isMainThread so that this test itself can be run inside a Worker.
+if (!process.env.HAS_STARTED_WORKER) {
+  process.env.HAS_STARTED_WORKER = 1;
+  const w = new Worker(__filename);
+
+  w.on('exit', common.mustCall((status) => {
+    assert.strictEqual(status, 2);
+  }));
+} else {
+  process.exit(2);
+}

--- a/test/parallel/test-worker-no-sab.js
+++ b/test/parallel/test-worker-no-sab.js
@@ -1,0 +1,21 @@
+// Flags: --no-harmony-sharedarraybuffer
+
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { Worker } = require('worker_threads');
+
+// Regression test for https://github.com/nodejs/node/issues/39717.
+
+// Do not use isMainThread so that this test itself can be run inside a Worker.
+if (!process.env.HAS_STARTED_WORKER) {
+  process.env.HAS_STARTED_WORKER = 1;
+  const w = new Worker(__filename);
+
+  w.on('exit', common.mustCall((status) => {
+    assert.strictEqual(status, 2);
+  }));
+} else {
+  process.exit(2);
+}


### PR DESCRIPTION
This allows the repl to function normally while using the
`--no-harmony-sharedarraybuffer` V8 flag.

Fixes: https://github.com/nodejs/node/issues/39717

Signed-off-by: Ruben Bridgewater <ruben@bridgewater.de>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
