### PR TITLE
doc: add styleguide

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -8,7 +8,7 @@ formatting. You do not need to learn the entire style guide before contributing
 to documentation. Someone can always edit your material later to conform with
 this guide.
 
-## Formatting and Structure
+## Formatting and structure
 
 ### Headings
 
@@ -19,7 +19,7 @@ this guide.
 * The page's title must follow [APA title case][title-case].
 * All chapters must follow [sentence case][sentence-style].
 
-### Markdown Rules
+### Markdown rules
 
 * Prefer affixing links (`[a link][]`) to inlining links
   (`[a link](http://example.com)`).
@@ -55,7 +55,7 @@ this guide.
   * No nesting lists more than 2 levels (due to the markdown renderer).
   * For unordered lists, use asterisks instead of dashes.
 
-### Document Rules
+### Document rules
 
 * Documentation is in markdown files with names formatted as
   `lowercase-with-dashes.md`.
@@ -66,7 +66,7 @@ this guide.
 
 ## Language
 
-### Spelling, Punctuation, Naming, and Referencing Rules
+### Spelling, punctuation, naming, and referencing rules
 
 * [Be direct][].
 * [Use US spelling][].
@@ -87,7 +87,7 @@ this guide.
   <!-- lint enable prohibited-strings remark-lint-->
   * When referring to the executable, _`node`_ is acceptable.
 
-## Additional Context and Rules
+## Additional context and rules
 
 * `.editorconfig` describes the preferred formatting.
   * A [plugin][] is available for some editors to apply these rules.
@@ -103,7 +103,7 @@ this guide.
 * When documenting APIs, every function should have a usage example or
   link to an example that uses the function.
 
-## API References
+## API references
 
 The following rules only apply to the documentation of APIs.
 
@@ -204,13 +204,13 @@ Using the `v8` classes as an example of some of the outlined structure:
 
 ## Class: Serializer
 
-### Instance Methods
+### Instance methods
 
 #### `serializer.writeHeader()`
 
 ## Class: Deserializer
 
-### Instance Methods
+### Instance methods
 
 #### `deserializer.readHeader()`
 
@@ -309,7 +309,7 @@ The properties chapter must be in following form:
 The heading can be `###` or `####`-levels depending on whether the property
 belongs to a module or a class.
 
-## See Also
+## See also
 
 * API documentation structure overview in [doctools README][].
 * [Microsoft Writing Style Guide][].

--- a/doc/README.md
+++ b/doc/README.md
@@ -12,12 +12,14 @@ this guide.
 
 ### Headings
 
-* Each page must have a single `#`-level title at the top.
-* Chapters in the same page must have `##`-level headings.
-* Sub-chapters need to increase the number of `#` in the heading according to
-  their nesting depth.
-* The page's title must follow [APA title case][title-case].
-* All chapters must follow [sentence case][sentence-style].
+* There must be exactly one `#` element at the start of each page containing
+  the title.
+* All headings that are not the title must be a level 2 heading (`##`) or below.
+* Nest headings semantically. For example, do not skip from level 2 (`##`) to
+  level 4 (`####`).
+* Follow Microsoft's conventions for [formatting titles][] and
+  [formatting headers][]. This usually means using sentence-style
+  capitalization.
 
 ### Markdown rules
 
@@ -319,8 +321,8 @@ belongs to a module or a class.
 [Use serial commas]: https://docs.microsoft.com/en-us/style-guide/punctuation/commas
 [`remark-preset-lint-node`]: https://github.com/nodejs/remark-preset-lint-node
 [doctools README]: ../tools/doc/README.md
+[formatting headers]: https://docs.microsoft.com/en-us/style-guide/scannable-content/headings#formatting-headings
+[formatting titles]: https://docs.microsoft.com/en-us/style-guide/text-formatting/formatting-titles
 [info string]: https://github.github.com/gfm/#info-string
 [language]: https://github.com/highlightjs/highlight.js/blob/HEAD/SUPPORTED_LANGUAGES.md
 [plugin]: https://editorconfig.org/#download
-[sentence-style]: https://docs.microsoft.com/en-us/style-guide/scannable-content/headings#formatting-headings
-[title-case]: https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case

--- a/doc/README.md
+++ b/doc/README.md
@@ -127,7 +127,7 @@ Using the `querystring` module as an example:
 ### Module methods and events
 
 For modules that are not classes, their methods and events must be listed under
-the `## Methods` and `## Events` chapters.
+the `## Methods` and `## Events` headings.
 
 Using `fs` as an example:
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -8,38 +8,23 @@ formatting. You do not need to learn the entire style guide before contributing
 to documentation. Someone can always edit your material later to conform with
 this guide.
 
-* Documentation is in markdown files with names formatted as
-  `lowercase-with-dashes.md`.
-  * Use an underscore in the filename only if the underscore is part of the
-    topic name (e.g., `child_process`).
-  * Some files, such as top-level markdown files, are exceptions.
-* Documents should be word-wrapped at 80 characters.
-* `.editorconfig` describes the preferred formatting.
-  * A [plugin][] is available for some editors to apply these rules.
-* Check changes to documentation with `make test-doc -j` or `vcbuild test-doc`.
-* [Use US spelling][].
-* [Use serial commas][].
-* Avoid first-person pronouns (_I_, _we_).
-  * Exception: _we recommend foo_ is preferable to _foo is recommended_.
-* Use gender-neutral pronouns and gender-neutral plural nouns.
-  * OK: _they_, _their_, _them_, _folks_, _people_, _developers_
-  * NOT OK: _his_, _hers_, _him_, _her_, _guys_, _dudes_
-* When combining wrapping elements (parentheses and quotes), place terminal
-  punctuation:
-  * Inside the wrapping element if the wrapping element contains a complete
-    clause.
-  * Outside of the wrapping element if the wrapping element contains only a
-    fragment of a clause.
-* Documents must start with a level-one heading.
+## Formatting and Structure
+
+### Headings
+
+* Each page must have a single `#`-level title at the top.
+* Chapters in the same page must have `##`-level headings.
+* Sub-chapters need to increase the number of `#` in the heading according to
+  their nesting depth.
+* The page's title must follow [APA title case][title-case].
+* All chapters must follow [sentence case][sentence-style].
+
+### Markdown Rules
+
 * Prefer affixing links (`[a link][]`) to inlining links
   (`[a link](http://example.com)`).
-* When documenting APIs, update the YAML comment associated with the API as
-  appropriate. This is especially true when introducing or deprecating an API.
-* When documenting APIs, every function should have a usage example or
-  link to an example that uses the function.
 * For code blocks:
   * Use [language][]-aware fences. (<code>\`\`\`js</code>)
-
   * For the [info string][], use one of the following.
 
     | Meaning       | Info string  |
@@ -61,25 +46,39 @@ this guide.
     If one of your language-aware fences needs an info string that is not
     already on this list, you may use `text` until the grammar gets added to
     [`remark-preset-lint-node`][].
-
   * Code need not be complete. Treat code blocks as an illustration or aid to
     your point, not as complete running programs. If a complete running program
     is necessary, include it as an asset in `assets/code-examples` and link to
     it.
-* When using underscores, asterisks, and backticks, please use
-  backslash-escaping: `\_`, `\*`, and ``\` ``.
+  * When using underscores, asterisks, and backticks, please use
+    backslash-escaping: `\_`, `\*`, and ``\` ``.
+  * No nesting lists more than 2 levels (due to the markdown renderer).
+  * For unordered lists, use asterisks instead of dashes.
+
+### Document Rules
+
+* Documentation is in markdown files with names formatted as
+  `lowercase-with-dashes.md`.
+  * Use an underscore in the filename only if the underscore is part of the
+    topic name (e.g., `child_process`).
+  * Some files, such as top-level markdown files, are exceptions.
+* Documents should be word-wrapped at 80 characters.
+
+## Language
+
+### Spelling, Punctuation, Naming, and Referencing Rules
+
+* [Be direct][].
+* [Use US spelling][].
+* [Use serial commas][].
+* Avoid first-person pronouns (_I_, _we_).
+  * Exception: _we recommend foo_ is preferable to _foo is recommended_.
+* Use gender-neutral pronouns and gender-neutral plural nouns.
+  * OK: _they_, _their_, _them_, _folks_, _people_, _developers_
+  * NOT OK: _his_, _hers_, _him_, _her_, _guys_, _dudes_
 * Constructors should use PascalCase.
 * Instances should use camelCase.
 * Denote methods with parentheses: `socket.end()` instead of `socket.end`.
-* Function arguments or object properties should use the following format:
-  * ``* `name` {type|type2} Optional description. **Default:** `value`.``
-  <!--lint disable maximum-line-length remark-lint-->
-  * For example: <code>\* `byteOffset` {integer} Index of first byte to expose. **Default:** `0`.</code>
-  <!--lint enable maximum-line-length remark-lint-->
-  * The `type` should refer to a Node.js type or a [JavaScript type][].
-* Function returns should use the following format:
-  * <code>\* Returns: {type|type2} Optional description.</code>
-  * E.g. <code>\* Returns: {AsyncHook} A reference to `asyncHook`.</code>
 * Use official styling for capitalization in products and projects.
   * OK: JavaScript, Google's V8
   <!--lint disable prohibited-strings remark-lint-->
@@ -87,31 +86,242 @@ this guide.
 * Use _Node.js_ and not _Node_, _NodeJS_, or similar variants.
   <!-- lint enable prohibited-strings remark-lint-->
   * When referring to the executable, _`node`_ is acceptable.
-* [Be direct][].
 
-<!-- lint disable prohibited-strings remark-lint-->
+## Additional Context and Rules
 
-* When referring to a version of Node.js in prose, use _Node.js_ and the version
-  number. Do not prefix the version number with _v_ in prose. This is to avoid
-  confusion about whether _v8_ refers to Node.js 8.x or the V8 JavaScript
-  engine.
-  <!-- lint enable prohibited-strings remark-lint-->
-  * OK: _Node.js 14.x_, _Node.js 14.3.1_
-  * NOT OK: _Node.js v14_
-* [Use sentence-style capitalization for headings][].
+* `.editorconfig` describes the preferred formatting.
+  * A [plugin][] is available for some editors to apply these rules.
+* Check changes to documentation with `make test-doc -j` or `vcbuild test-doc`.
+* When combining wrapping elements (parentheses and quotes), place terminal
+  punctuation:
+  * Inside the wrapping element if the wrapping element contains a complete
+    clause.
+  * Outside of the wrapping element if the wrapping element contains only a
+    fragment of a clause.
+* When documenting APIs, update the YAML comment associated with the API as
+  appropriate. This is especially true when introducing or deprecating an API.
+* When documenting APIs, every function should have a usage example or
+  link to an example that uses the function.
 
-See also API documentation structure overview in [doctools README][].
+## API References
 
-For topics not covered here, refer to the [Microsoft Writing Style Guide][].
+The following rules only apply to the documentation of APIs.
+
+### Title and description
+
+Each module's API doc must use the actual object name returned by requiring it
+as its title (such as `path`, `fs`, and `querystring`).
+
+Directly under the page title, add a one-line description of the module
+as a markdown quote (beginning with `>`).
+
+Using the `querystring` module as an example:
+
+```markdown
+# querystring
+
+> Utilities for parsing and formatting URL query strings.
+```
+
+### Module methods and events
+
+For modules that are not classes, their methods and events must be listed under
+the `## Methods` and `## Events` chapters.
+
+Using `fs` as an example:
+
+```markdown
+# fs
+
+## Events
+
+### Event: 'close'
+
+## Methods
+
+### `fs.access(path[, mode], callback)`
+```
+
+### Methods and their arguments
+
+The methods chapter must be in the following form:
+
+```markdown
+### `objectName.methodName(required[, optional]))`
+
+* `required` string - A parameter description.
+* `optional` Integer (optional) - Another parameter description.
+
+...
+```
+
+#### Function signature
+
+For modules, the `objectName` is the module's name. For classes, it must be the
+name of the instance of the class, and must not be the same as the module's
+name.
+
+Optional arguments are notated by square brackets `[]` surrounding the optional
+argument as well as the comma required if this optional argument follows
+another argument:
+
+```markdown
+required[, optional]
+```
+
+#### Heading level
+
+The heading can be `###` or `####`-levels depending on whether the method
+belongs to a module or a class.
+
+### Classes
+
+* API classes or classes that are part of modules must be listed under a
+  `## Class: TheClassName` chapter.
+* One page can have multiple classes.
+* Constructors must be listed with `###`-level headings.
+* [Static Methods](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/static)
+  must be listed under a `### Static Methods` chapter.
+* [Instance Methods](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes#Prototype_methods)
+  must be listed under an `### Instance Methods` chapter.
+* All methods that have a return value must start their description with
+  ``Returns `[TYPE]` - (Return description)``
+  * If the method returns an `Object`, its structure can be specified
+    using a colon followed by a newline then an unordered list of properties in
+    the same style as function parameters.
+* Instance Events must be listed under an `### Instance Events` chapter.
+* Instance Properties must be listed under an `### Instance Properties` chapter.
+  * Instance Properties must start with `A [Property Type] ...`
+
+Using the `v8` classes as an example of some of the outlined structure:
+
+```markdown
+# `v8`
+
+## Methods
+
+### `v8.cachedDataVersionTag()`
+
+## Class: Serializer
+
+### Instance Methods
+
+#### `serializer.writeHeader()`
+
+## Class: Deserializer
+
+### Instance Methods
+
+#### `deserializer.readHeader()`
+
+...
+```
+
+### Methods and their arguments
+
+The methods chapter must be in the following form:
+
+```markdown
+### `objectName.methodName(required[, optional]))`
+
+* `required` string - A parameter description.
+* `optional` Integer (optional) - Another parameter description.
+
+...
+```
+
+#### Heading level
+
+The heading can be `###` or `####`-levels depending on whether the method
+belongs to a module or a class.
+
+#### Function signature
+
+For modules, the `objectName` is the module's name. For classes, it must be the
+name of the instance of the class, and must not be the same as the module's
+name.
+
+Optional arguments are notated by square brackets `[]` surrounding the optional
+argument as well as the comma required if this optional argument follows
+another argument:
+
+```markdown
+required[, optional]
+```
+
+#### Argument descriptions
+
+More detailed information on each of the arguments is noted in an unordered list
+below the method. The type of argument is notated by either JavaScript
+primitives (e.g. `string`, `Promise`, or `Object`), a custom API structure,
+or the wildcard `any`.
+
+If the argument is of type `Array`, use `[]` shorthand with the type of value
+inside the array (for example,`any[]` or `string[]`).
+
+If the argument is of type `Promise`, parametrize the type with what the promise
+resolves to (for example, `Promise<void>` or `Promise<string>`).
+
+If an argument can be of multiple types, separate the types with `|`.
+
+The description for `Function` type arguments should make it clear how it may be
+called and list the types of the parameters that will be passed to it.
+
+#### Platform-specific functionality
+
+If an argument or a method is unique to certain platforms, those platforms are
+denoted using a space-delimited italicized list following the datatype. Values
+can be `macOS`, `Windows` or `Linux`.
+
+```markdown
+* `path` boolean (optional) _macOS_ _Windows_ - the path to write a file to.
+```
+
+### Events
+
+The events chapter must be in following form:
+
+```markdown
+#### Event: 'message'
+
+Returns:
+
+* `value` any - The transmitted value.
+
+...
+```
+
+The heading can be `###` or `####`-levels depending on whether the event
+belongs to a module or a class.
+
+The arguments of an event follow the same rules as methods.
+
+### Properties
+
+The properties chapter must be in following form:
+
+```markdown
+#### `port.close()`
+
+...
+```
+
+The heading can be `###` or `####`-levels depending on whether the property
+belongs to a module or a class.
+
+## See Also
+
+* API documentation structure overview in [doctools README][].
+* [Microsoft Writing Style Guide][].
 
 [Be direct]: https://docs.microsoft.com/en-us/style-guide/word-choice/use-simple-words-concise-sentences
-[Javascript type]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Grammar_and_types#Data_structures_and_types
 [Microsoft Writing Style Guide]: https://docs.microsoft.com/en-us/style-guide/welcome/
 [Use US spelling]: https://docs.microsoft.com/en-us/style-guide/word-choice/use-us-spelling-avoid-non-english-words
-[Use sentence-style capitalization for headings]: https://docs.microsoft.com/en-us/style-guide/scannable-content/headings#formatting-headings
 [Use serial commas]: https://docs.microsoft.com/en-us/style-guide/punctuation/commas
 [`remark-preset-lint-node`]: https://github.com/nodejs/remark-preset-lint-node
 [doctools README]: ../tools/doc/README.md
 [info string]: https://github.github.com/gfm/#info-string
 [language]: https://github.com/highlightjs/highlight.js/blob/HEAD/SUPPORTED_LANGUAGES.md
 [plugin]: https://editorconfig.org/#download
+[sentence-style]: https://docs.microsoft.com/en-us/style-guide/scannable-content/headings#formatting-headings
+[title-case]: https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case

--- a/doc/README.md
+++ b/doc/README.md
@@ -52,7 +52,6 @@ this guide.
     it.
   * When using underscores, asterisks, and backticks, please use
     backslash-escaping: `\_`, `\*`, and ``\` ``.
-  * No nesting lists more than 2 levels (due to the markdown renderer).
   * For unordered lists, use asterisks instead of dashes.
 
 ### Document rules


### PR DESCRIPTION
This PR adds a documentation style guide. This comes as a result of https://github.com/nodejs/node/discussions/40953 and the various next-10 discussions that led to it. It is _largely_ a copy/paste from electron/electron's [styleguide.md](https://github.com/electron/electron/blob/main/docs/styleguide.md), with some changes.

The goal of this is not to have it as an immediately enforceable, but rather to have it be planted as the guide that we'll eventually fully enforce on all documentation that it can be enforced on (some documentation, like native APIs, it can only be partially enforced on).

Landing this and, eventually, having all of our documentation written in this style should allows us the ability to use [docs-parser](https://github.com/electron/docs-parser) which produces a high-quality JSON output of markdown documentation written as the style guide defines. This would allow the DefinitelyTyped people to produce higher quality type definitions, potentially even just using Electron's [typescript-definitions](https://github.com/electron/typescript-definitions) tooling that parses docs-parser output into `.d.ts` files.

There are other, less objective benefits:
- highly consistent authoring experience that provides a consistent framework for writing and reviewing documentation
- more digestible documentation for end-users, structuring all documentation in a hierarchy that's consistent across pages while still being specific enough to provide meaningful context regardless of content

Worth noting, I also created https://github.com/nodejs/node/issues/32206 some time ago, and this is one step towards that as a reality. In doing so, I also created [bnb/node-docs-parser](https://github.com/bnb/node-docs-parser) which snapshotted a few examples from the Node.js documentation at the time I created it and provided an example of what those documents would look like if they were migrated. While it's been a pandemic worth of time since I last worked on that repo and some of the docs have been updated (querystring in particular is much more consistent!), the documents in `/docs/api` are still pretty close to what the "translated" versions would look like if you want a reference.

changes to the styleguide.md from the e/e version include:

- updating the name (`Electron` > `Node.js`)
- removing references to `markdownlint`
  - given that Electron and docs-parser use markdownlint, it might make sense to migrate to it.
- removed a TODO above the linter rules, noting that they should be checked against what the electron/electron markdown parser checks for.
  - potentially worth investigating finding a middle ground and both using one set of tooling.
- tweaked examples to fit Node.js. As we build out the documentation to fit this style guide, we should update these examples to me more thorough.
- removed one example under the "function signature" heading on line 169, as I'm not immediately familiar of a class that has the same name as its module and can be used as an example. Happy to re-add this when I find a good example.
  - here's the original text, for reference: 
    - > For example, the methods of the `Session` class under the `session` module must use `ses` as the `objectName`.
- removed a reference on line 181 to Electron's cookie API custom sturcutre. Happy to re-add this back in once we've got our own custom structures added.
- added backticks to line 228 where they weren't in the Electron documentation. I believe the backticks are allowed/required, but should double check just to make sure that's a correct assertion before merging.

a few things to discuss:
- js code linting
  - Electron's standardized on StandardJS and has proper tooling for it, including [standard-markdown](https://www.npmjs.com/package/standard-markdown). While I'm personally fine with this, I assume the Node.js project would want a different linter solution documented.
  - happy to change the text on lines 55-56 referencing this if we don't want to keep this.
- I'm not sure if we have platform-specific functionality. If we don't and never plan on doing so, happy to remove line 194-203.
- how we want to approach inline YAML changelogs. Particularly, it was raised that it would be nice to have in Markdown but it may also become burdensome for those who backport, which is definitely not something I'd want to see.
  - potential solution here is to document an additional markdown structure for changelogs and then have a small tool convert YAML into that Markdown structure as a build step.
  - I'm unopinionated on what a solution is here, but ideally, we will *eventually* not have any YAML frontmatter.

and just for context, the ideal next steps _after_ this PR lands would be to begin incrementally migrating documentation to fit the style guide.