### PR TITLE
intl: fix limit calculation

### DIFF
--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -447,8 +447,9 @@ void ConverterObject::Decode(const FunctionCallbackInfo<Value>& args) {
 
   // When flushing the final chunk, the limit is the maximum
   // of either the input buffer length or the number of pending
-  // characters times the min char size.
-  size_t limit = converter->min_char_size() *
+  // characters times the min char size, multiplied by 2 as unicode may
+  // take up to 2 UChars to encode a character
+  size_t limit = 2 * converter->min_char_size() *
       (!flush ?
           input.length() :
           std::max(
@@ -474,7 +475,7 @@ void ConverterObject::Decode(const FunctionCallbackInfo<Value>& args) {
   UChar* target = *result;
   ucnv_toUnicode(converter->conv(),
                  &target,
-                 target + (limit * sizeof(UChar)),
+                 target + limit,
                  &source,
                  source + source_length,
                  nullptr,


### PR DESCRIPTION
Coverity reported that the use of sizeof along with pointer
arithmetic was likely an error as the pointer arithmetic
would already be accounting for the size of what the
pointer points to.

Looking at the code that looked right but removing the
extra sizeOf caused tests to fail.

Looking more closely it seems like we were not allocating
a big enough buffer but the extra sizeof was allowing
us to convert even though it might have been corrupting
memory.

Signed-off-by: Michael Dawson <mdawson@devrus.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
