### PR TITLE
url: detect hostname more reliably in url.parse()

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -187,6 +187,7 @@ Url.prototype.parse = function parse(url, parseQueryString, slashesDenoteHost) {
   // Back slashes before the query string get converted to forward slashes
   // See: https://code.google.com/p/chromium/issues/detail?id=25916
   let hasHash = false;
+  let hasAt = false;
   let start = -1;
   let end = -1;
   let rest = '';
@@ -219,6 +220,9 @@ Url.prototype.parse = function parse(url, parseQueryString, slashesDenoteHost) {
     // Only convert backslashes while we haven't seen a split character
     if (!split) {
       switch (code) {
+        case CHAR_AT:
+          hasAt = true;
+          break;
         case CHAR_HASH:
           hasHash = true;
         // Fall through
@@ -259,7 +263,7 @@ Url.prototype.parse = function parse(url, parseQueryString, slashesDenoteHost) {
     }
   }
 
-  if (!slashesDenoteHost && !hasHash) {
+  if (!slashesDenoteHost && !hasHash && !hasAt) {
     // Try fast path regexp
     const simplePath = simplePathPattern.exec(rest);
     if (simplePath) {

--- a/test/parallel/test-url-parse-format.js
+++ b/test/parallel/test-url-parse-format.js
@@ -946,7 +946,37 @@ const parseTests = {
     pathname: '/',
     path: '/',
     href: 'wss://www.example.com/'
-  }
+  },
+
+  '//fhqwhgads@example.com/everybody-to-the-limit': {
+    protocol: null,
+    slashes: true,
+    auth: 'fhqwhgads',
+    host: 'example.com',
+    port: null,
+    hostname: 'example.com',
+    hash: null,
+    search: null,
+    query: null,
+    pathname: '/everybody-to-the-limit',
+    path: '/everybody-to-the-limit',
+    href: '//fhqwhgads@example.com/everybody-to-the-limit'
+  },
+
+  '//fhqwhgads@example.com/everybody#to-the-limit': {
+    protocol: null,
+    slashes: true,
+    auth: 'fhqwhgads',
+    host: 'example.com',
+    port: null,
+    hostname: 'example.com',
+    hash: '#to-the-limit',
+    search: null,
+    query: null,
+    pathname: '/everybody',
+    path: '/everybody',
+    href: '//fhqwhgads@example.com/everybody#to-the-limit'
+  },
 };
 
 for (const u in parseTests) {


### PR DESCRIPTION
Based on existing tests and code comments, url.parse() is expected to
treat any URL containing user@host as having a hostname. However, it
turns out this behavior relies on the URL having a hash which is
surprising, to put it mildly. Detect the host even without the hash.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
