### PR TITLE
tools: remove Babel from license-builder.sh

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1360,32 +1360,6 @@ The externally maintained libraries used by Node.js are:
     THE SOFTWARE.
   """
 
-- Babel, located at tools/node_modules/@babel, is licensed as follows:
-  """
-    MIT License
-
-    Copyright (c) 2014-present Sebastian McKenzie and other contributors
-
-    Permission is hereby granted, free of charge, to any person obtaining
-    a copy of this software and associated documentation files (the
-    "Software"), to deal in the Software without restriction, including
-    without limitation the rights to use, copy, modify, merge, publish,
-    distribute, sublicense, and/or sell copies of the Software, and to
-    permit persons to whom the Software is furnished to do so, subject to
-    the following conditions:
-
-    The above copyright notice and this permission notice shall be
-    included in all copies or substantial portions of the Software.
-
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-    LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-    OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-    WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-  """
-
 - gtest, located at deps/googletest, is licensed as follows:
   """
     Copyright 2008, Google Inc.

--- a/tools/license-builder.sh
+++ b/tools/license-builder.sh
@@ -82,7 +82,6 @@ addlicense "markupsafe" "tools/inspector_protocol/markupsafe" "$(cat "${rootdir}
 addlicense "cpplint.py" "tools/cpplint.py" \
            "$(sed -e '/^$/,$d' -e 's/^#$//' -e 's/^# //' "${rootdir}"/tools/cpplint.py | tail -n +3)"
 addlicense "ESLint" "tools/node_modules/eslint" "$(cat "${rootdir}"/tools/node_modules/eslint/LICENSE)"
-addlicense "Babel" "tools/node_modules/@babel" "$(cat "${rootdir}"/tools/node_modules/@babel/core/LICENSE)"
 addlicense "gtest" "deps/googletest" "$(cat "${rootdir}"/deps/googletest/LICENSE)"
 
 # nghttp2


### PR DESCRIPTION
Babel is now installed as a dependency in our ESLint installation. The
current license-builder.sh will fail to find the license for Babel.

The license is sill present in the repository/code base/file system. So
as with all other dependencies that are installed in
tools/node_modules/eslint/node_modules and have an MIT license, we are
still complying with the license. The inclusion in our own LICENSE was
to clearly signal that things under tools/node_modules/@babel were not
covered by the Node.js license. Because it is now under
tools/node_modules/eslint, that "we aren't the license-holders of this
code" aspect of things is already covered by the inclusion of the ESLint
license.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
