### PR TITLE
Modify configure to explain how to bypass python version check if required.

### DIFF
--- a/configure
+++ b/configure
@@ -33,9 +33,10 @@ else:
       if python_cmd_path and 'pyenv/shims' not in python_cmd_path:
         sys.stderr.write('\t{} {}\n'.format(python_cmd_path, ' '.join(sys.argv[:1])))
   if sys.version_info > (3, 10):
-    sys.stderr.write('Running "configure" with newer versions of python has not been tested and may not work.\n')
-    sys.stderr.write('To bypass this check, run "python ./configure.py" and report whether it works via an issue at https://github.com/nodejs/node\n')
+    sys.stderr.write('Running "configure" with newer versions of Python has not been ' +
+          'tested and may not work.\n' +
+          'To bypass this check, run "python ./configure.py" and report whether it ' +
+          'works via an issue at https://github.com/nodejs/node\n')
   else:
-    sys.stderr.write('Running "configure" with a pre-3.6 version of python is not supported and will likely not work.\n')
-    sys.stderr.write('To bypass this check (not recommended) run "python ./configure.py\n"')
+    sys.stderr.write('"configure" will not work with a pre-3.6 version of Python.\n')
   sys.exit(1)

--- a/configure
+++ b/configure
@@ -32,4 +32,10 @@ else:
       python_cmd_path = which(python_cmd)
       if python_cmd_path and 'pyenv/shims' not in python_cmd_path:
         sys.stderr.write('\t{} {}\n'.format(python_cmd_path, ' '.join(sys.argv[:1])))
+  if sys.version_info > (3, 10):
+    sys.stderr.write('Running "configure" with newer versions of python has not been tested and may not work.\n')
+    sys.stderr.write('To bypass this check, run "python ./configure.py" and report whether it works via an issue at https://github.com/nodejs/node\n')
+  else:
+    sys.stderr.write('Running "configure" with a pre-3.6 version of python is not supported and will likely not work.\n')
+    sys.stderr.write('To bypass this check (not recommended) run "python ./configure.py\n"')
   sys.exit(1)


### PR DESCRIPTION
As new versions of python come out it's possible that a user will be using a later one than our supported list. This PR adds the message in that situation telling people how they can bypass the check and to encourage raising an issue/PR to support the new version if it works. It also adds information about the lowest supported version with an indication that earlier ones are unlikely to work (I could just remove this check, but it's good to be nice to users!)

I don't think this will be too controversial unless there is an objection to the new lines not being wrapped at <80 characters :-)

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
