### PR TITLE
build: add `--without-corepack`

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -641,6 +641,12 @@ parser.add_argument('--without-npm',
     default=None,
     help='do not install the bundled npm (package manager)')
 
+parser.add_argument('--without-corepack',
+    action='store_true',
+    dest='without_corepack',
+    default=None,
+    help='do not install the bundled Corepack')
+
 # Dummy option for backwards compatibility
 parser.add_argument('--without-report',
     action='store_true',
@@ -1154,6 +1160,7 @@ def configure_node(o):
     o['variables']['OS'] = 'android'
   o['variables']['node_prefix'] = options.prefix
   o['variables']['node_install_npm'] = b(not options.without_npm)
+  o['variables']['node_install_corepack'] = b(not options.without_corepack)
   o['variables']['debug_node'] = b(options.debug_node)
   o['default_configuration'] = 'Debug' if options.debug else 'Release'
   o['variables']['error_on_warn'] = b(options.error_on_warn)

--- a/tools/install.py
+++ b/tools/install.py
@@ -163,6 +163,8 @@ def files(action):
 
   if 'true' == variables.get('node_install_npm'):
     npm_files(action)
+
+  if 'true' == variables.get('node_install_corepack'):
     corepack_files(action)
 
   headers(action)


### PR DESCRIPTION
Adds a `--without-corepack` flag to `configure.py`.
This allows you to run `configure.py` to install Corepack but not npm.

Motivated by this issue on nodejs/corepack: https://github.com/nodejs/corepack/issues/74