### PR TITLE
Clarify the documentation for TLS cipher configuration & defaults

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -361,14 +361,14 @@ The default can also be replaced on a per client or server basis using the
 in [`tls.createServer()`][], [`tls.connect()`][], and when creating new
 [`tls.TLSSocket`][]s.
 
-The ciphers list can contain a mixture of TLSv1.3 cipher suite names, the ones
-that start with `'TLS_'`, and specifications for TLSv1.2 and below cipher
-suites. The TLSv1.2 ciphers support a legacy specification format, consult
-the OpenSSL [cipher list format][] documentation for details, but those
-specifications do _not_ apply to TLSv1.3 ciphers. The TLSv1.3 suites can only
-be enabled by including their full name in the cipher list. They cannot, for
-example, be enabled or disabled by using the legacy TLSv1.2 `'EECDH'` or
-`'!EECDH'` specification.
+The ciphers list is colon-separated and can contain a mixture of TLSv1.3
+cipher suite names, the ones that start with `'TLS_'`, and specifications for
+TLSv1.2 and below cipher suites. The TLSv1.2 ciphers support a legacy
+specification format, consult the OpenSSL [cipher list format][] documentation
+for details, but those specifications do _not_ apply to TLSv1.3 ciphers. The
+TLSv1.3 suites can only be enabled by including their full name in the cipher
+list. They cannot, for example, be enabled or disabled by using the legacy
+TLSv1.2 `'EECDH'` or `'!EECDH'` specification.
 
 Despite the relative order of TLSv1.3 and TLSv1.2 cipher suites, the TLSv1.3
 protocol is significantly more secure than TLSv1.2, and will always be chosen
@@ -1844,10 +1844,11 @@ changes:
     'RSA+SHA384') or TLS v1.3 scheme names (e.g. `rsa_pss_pss_sha512`).
     See [OpenSSL man pages](https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set1_sigalgs_list.html)
     for more info.
-  * `ciphers` {string} Cipher suite specification, replacing the default. For
-    more information, see [Modifying the default TLS cipher suite][]. Permitted
-    ciphers can be obtained via [`tls.getCiphers()`][]. Cipher names must be
-    uppercased in order for OpenSSL to accept them.
+  * `ciphers` {string} Colon-separated cipher suite specification, replacing
+    the default. For more information, see
+    [modifying the default TLS cipher suite][]. Permitted ciphers can be
+    obtained via [`tls.getCiphers()`][]. Cipher names must be uppercased in
+    order for OpenSSL to accept them.
   * `clientCertEngine` {string} Name of an OpenSSL engine which can provide the
     client certificate.
   * `crl` {string|string\[]|Buffer|Buffer\[]} PEM formatted CRLs (Certificate

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -1849,6 +1849,7 @@ changes:
     [modifying the default TLS cipher suite][]. Permitted ciphers can be
     obtained via [`tls.getCiphers()`][]. Cipher names must be uppercased in
     order for OpenSSL to accept them.
+    **Default:** [`tls.DEFAULT_CIPHERS`][].
   * `clientCertEngine` {string} Name of an OpenSSL engine which can provide the
     client certificate.
   * `crl` {string|string\[]|Buffer|Buffer\[]} PEM formatted CRLs (Certificate
@@ -2177,6 +2178,21 @@ from the bundled Mozilla CA store as supplied by the current Node.js version.
 The bundled CA store, as supplied by Node.js, is a snapshot of Mozilla CA store
 that is fixed at release time. It is identical on all supported platforms.
 
+## `tls.DEFAULT_CIPHERS`
+
+<!-- YAML
+added: v0.11.3
+changes:
+  - version: v4.0.0
+    pr-url: https://github.com/nodejs/node/pull/2412
+    description: Made configurable using the --tls-cipher-list command line
+      switch.
+-->
+
+* {string} The default TLS cipher suites supported by this Node.js process,
+  as a colon-separated string. See [modifying the default TLS cipher suite][]
+  for further information.
+
 ## `tls.DEFAULT_ECDH_CURVE`
 
 <!-- YAML
@@ -2258,6 +2274,7 @@ added: v11.4.0
 [`server.listen()`]: net.md#serverlisten
 [`server.setTicketKeys()`]: #serversetticketkeyskeys
 [`socket.connect()`]: net.md#socketconnectoptions-connectlistener
+[`tls.DEFAULT_CIPHERS`]: #tlsdefault_ciphers
 [`tls.DEFAULT_ECDH_CURVE`]: #tlsdefault_ecdh_curve
 [`tls.DEFAULT_MAX_VERSION`]: #tlsdefault_max_version
 [`tls.DEFAULT_MIN_VERSION`]: #tlsdefault_min_version


### PR DESCRIPTION
I needed to set `ciphers` on a TLS socket today, and the format of the cipher list string doesn't appear to be documented anywhere.

To work out how it worked, I needed to check the default value, which unfortunately also isn't documented.

This PR fixes both: making it clear that ciphers is a colon-separated list, and documenting the `tls.DEFAULT_CIPHERS` property that is its default value.