### PR TITLE
buffer: remove duplicate declaration

### DIFF
--- a/lib/internal/buffer.js
+++ b/lib/internal/buffer.js
@@ -981,7 +981,6 @@ function addBufferPrototypeMethods(proto) {
   proto.readUIntBE = readUIntBE;
   proto.readUInt32BE = readUInt32BE;
   proto.readUInt16BE = readUInt16BE;
-  proto.readUintLE = readUIntLE;
   proto.readUint32LE = readUInt32LE;
   proto.readUint16LE = readUInt16LE;
   proto.readUint8 = readUInt8;


### PR DESCRIPTION
`proto.readUintLE = readUIntLE;` is defined [here](https://github.com/nodejs/node/blob/97b8eb62fe7ad7722e7f27d658b3519c0e5f2110/lib/internal/buffer.js#L977) and [here](https://github.com/nodejs/node/blob/97b8eb62fe7ad7722e7f27d658b3519c0e5f2110/lib/internal/buffer.js#L984).