### PR TITLE
esm: implement the getFileSystem hook

### DIFF
--- a/demo/foo/index.mjs
+++ b/demo/foo/index.mjs
@@ -1,0 +1,1 @@
+console.log(`foo`);

--- a/demo/index.mjs
+++ b/demo/index.mjs
@@ -1,0 +1,5 @@
+import './foo/index.mjs';
+import hash from './foo/index-sha512.mjs';
+
+console.log(`demo`);
+console.log(`demo hash:`, hash);

--- a/demo/loader-sha512.mjs
+++ b/demo/loader-sha512.mjs
@@ -1,0 +1,50 @@
+import crypto from 'crypto';
+import path from 'path';
+
+const shaRegExp = /-sha512(\.mjs)$/;
+
+function getSourcePath(p) {
+  if (p.protocol !== `file:`)
+    return p;
+
+  const pString = p.toString();
+  const pFixed = pString.replace(shaRegExp, `$1`);
+  if (pFixed === pString)
+    return p;
+
+  return new URL(pFixed);
+}
+
+export function getFileSystem(defaultGetFileSystem) {
+  const fileSystem = defaultGetFileSystem();
+
+  return {
+    readFileSync(p) {
+      const fixedP = getSourcePath(p);
+      if (fixedP === p)
+        return fileSystem.readFileSync(p);
+
+      const content = fileSystem.readFileSync(fixedP);
+      const hash = crypto.createHash(`sha512`).update(content).digest(`hex`);
+
+      return Buffer.from(`export default ${JSON.stringify(hash)};`);
+    },
+
+    statEntrySync(p) {
+      const fixedP = getSourcePath(p);
+      return fileSystem.statEntrySync(fixedP);
+    },
+
+    realpathSync(p) {
+      const fixedP = getSourcePath(p);
+      if (fixedP === p)
+        return fileSystem.realpathSync(p);
+
+      const realpath = fileSystem.realpathSync(fixedP);
+      if (path.extname(realpath) !== `.mjs`)
+        throw new Error(`Paths must be .mjs extension to go through the sha512 loader`);
+
+      return realpath.replace(/\.mjs$/, `-sha512.mjs`);
+    },
+  };
+}

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1342,6 +1342,7 @@ E('ERR_IPC_CHANNEL_CLOSED', 'Channel closed', Error);
 E('ERR_IPC_DISCONNECTED', 'IPC channel is already disconnected', Error);
 E('ERR_IPC_ONE_PIPE', 'Child process can have only one IPC pipe', Error);
 E('ERR_IPC_SYNC_FORK', 'IPC cannot be used with synchronous forks', Error);
+E('ERR_LOADER_MISSING_SYNC_FS', 'Missing synchronous filesystem implementation of a loader', Error);
 E('ERR_MANIFEST_ASSERT_INTEGRITY',
   (moduleURL, realIntegrities) => {
     let msg = `The content of "${

--- a/lib/internal/modules/esm/get_file_system.js
+++ b/lib/internal/modules/esm/get_file_system.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const {
+  FunctionPrototypeBind,
+  ObjectCreate,
+  ObjectKeys,
+  SafeMap,
+} = primordials;
+
+const realpathCache = new SafeMap();
+
+const internalFS = require('internal/fs/utils');
+const fs = require('fs');
+const fsPromises = require('internal/fs/promises').exports;
+const packageJsonReader = require('internal/modules/package_json_reader');
+const { fileURLToPath } = require('url');
+const { internalModuleStat } = internalBinding('fs');
+
+const implementation = {
+  async readFile(p) {
+    return fsPromises.readFile(p);
+  },
+
+  async statEntry(p) {
+    return internalModuleStat(fileURLToPath(p));
+  },
+
+  async readJson(p) {
+    return packageJsonReader.read(fileURLToPath(p));
+  },
+
+  async realpath(p) {
+    return fsPromises.realpath(p, {
+      [internalFS.realpathCacheKey]: realpathCache
+    });
+  },
+
+  readFileSync(p) {
+    return fs.readFileSync(p);
+  },
+
+  statEntrySync(p) {
+    return internalModuleStat(fileURLToPath(p));
+  },
+
+  readJsonSync(p) {
+    return packageJsonReader.read(fileURLToPath(p));
+  },
+
+  realpathSync(p) {
+    return fs.realpathSync(p, {
+      [internalFS.realpathCacheKey]: realpathCache
+    });
+  },
+};
+
+function defaultGetFileSystem(defaultGetFileSystem) {
+  const copy = ObjectCreate(null);
+
+  const keys = ObjectKeys(implementation);
+  for (let t = 0; t < keys.length; ++t)
+    copy[keys[t]] = FunctionPrototypeBind(implementation[keys[t]], null);
+
+  return copy;
+}
+
+module.exports = {
+  defaultGetFileSystem,
+};

--- a/lib/internal/modules/esm/get_file_system.js
+++ b/lib/internal/modules/esm/get_file_system.js
@@ -1,9 +1,8 @@
 'use strict';
 
 const {
-  FunctionPrototypeBind,
+  ObjectAssign,
   ObjectCreate,
-  ObjectKeys,
   SafeMap,
 } = primordials;
 
@@ -16,7 +15,7 @@ const packageJsonReader = require('internal/modules/package_json_reader');
 const { fileURLToPath } = require('url');
 const { internalModuleStat } = internalBinding('fs');
 
-const implementation = {
+const defaultFileSystem = {
   async readFile(p) {
     return fsPromises.readFile(p);
   },
@@ -55,13 +54,7 @@ const implementation = {
 };
 
 function defaultGetFileSystem(defaultGetFileSystem) {
-  const copy = ObjectCreate(null);
-
-  const keys = ObjectKeys(implementation);
-  for (let t = 0; t < keys.length; ++t)
-    copy[keys[t]] = FunctionPrototypeBind(implementation[keys[t]], null);
-
-  return copy;
+  return ObjectAssign(ObjectCreate(null), defaultFileSystem);
 }
 
 module.exports = {

--- a/lib/internal/modules/esm/get_source.js
+++ b/lib/internal/modules/esm/get_source.js
@@ -5,6 +5,8 @@ const {
   decodeURIComponent,
 } = primordials;
 const { getOptionValue } = require('internal/options');
+const esmLoader = require('internal/process/esm_loader');
+
 // Do not eagerly grab .manifest, it may be in TDZ
 const policy = getOptionValue('--experimental-policy') ?
   require('internal/process/policy') :
@@ -12,13 +14,11 @@ const policy = getOptionValue('--experimental-policy') ?
 
 const { Buffer } = require('buffer');
 
-const fs = require('internal/fs/promises').exports;
 const { URL } = require('internal/url');
 const {
   ERR_INVALID_URL,
   ERR_INVALID_URL_SCHEME,
 } = require('internal/errors').codes;
-const readFileAsync = fs.readFile;
 
 const DATA_URL_PATTERN = /^[^/]+\/[^,;]+(?:[^,]*?)(;base64)?,([\s\S]*)$/;
 
@@ -26,7 +26,7 @@ async function defaultGetSource(url, { format } = {}, defaultGetSource) {
   const parsed = new URL(url);
   let source;
   if (parsed.protocol === 'file:') {
-    source = await readFileAsync(parsed);
+    source = await esmLoader.getFileSystem().readFile(parsed);
   } else if (parsed.protocol === 'data:') {
     const match = RegExpPrototypeExec(DATA_URL_PATTERN, parsed.pathname);
     if (!match) {

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -9,6 +9,7 @@ const {
   ArrayPrototypeFilter,
   ArrayPrototypeJoin,
   ArrayPrototypePush,
+  ArrayPrototypeSlice,
   FunctionPrototypeBind,
   FunctionPrototypeCall,
   ObjectAssign,
@@ -31,7 +32,8 @@ const {
   ERR_INVALID_MODULE_SPECIFIER,
   ERR_INVALID_RETURN_PROPERTY_VALUE,
   ERR_INVALID_RETURN_VALUE,
-  ERR_UNKNOWN_MODULE_FORMAT
+  ERR_UNKNOWN_MODULE_FORMAT,
+  ERR_LOADER_MISSING_SYNC_FS
 } = require('internal/errors').codes;
 const { pathToFileURL, isURLInstance } = require('internal/url');
 const {
@@ -90,7 +92,7 @@ class ESMLoader {
 
   /**
    * @private
-   * @property {Function[]} resolvers First-in-first-out list of resolver hooks
+   * @property {Function[]} fileSystemBuilders First-in-first-out list of file system utilities compositors
    */
   #fileSystemBuilders = [
     defaultGetFileSystem,
@@ -119,10 +121,10 @@ class ESMLoader {
   translators = translators;
 
   static pluckHooks({
+    getFileSystem,
     globalPreload,
     resolve,
     load,
-    getFileSystem,
     // obsolete hooks:
     dynamicInstantiate,
     getFormat,
@@ -233,7 +235,7 @@ class ESMLoader {
   buildFileSystem() {
     // Note: makes assumptions as to how chaining will work to demonstrate
     // the capability; subject to change once chaining's API is finalized.
-    const fileSystemFactories = [...this.#fileSystemBuilders];
+    const fileSystemFactories = ArrayPrototypeSlice(this.#fileSystemBuilders);
 
     const defaultFileSystemFactory = fileSystemFactories[0];
     let finalFileSystem =
@@ -255,13 +257,18 @@ class ESMLoader {
         const asyncKey = asyncKeys[j];
         const syncKey = `${asyncKey}Sync`;
 
+        const hasAsync = ObjectPrototypeHasOwnProperty(fileSystem, asyncKey);
+        const hasSync = ObjectPrototypeHasOwnProperty(fileSystem, syncKey);
+
         if (
-          !ObjectPrototypeHasOwnProperty(fileSystem, asyncKey) &&
-          ObjectPrototypeHasOwnProperty(fileSystem, syncKey)
+          !hasAsync &&
+          hasSync
         ) {
           fileSystem[asyncKey] = async (...args) => {
             return fileSystem[syncKey](...args);
           };
+        } else if (!hasSync && hasAsync) {
+          throw new ERR_LOADER_MISSING_SYNC_FS();
         }
       }
 

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -6,17 +6,21 @@ require('internal/modules/cjs/loader');
 const {
   Array,
   ArrayIsArray,
+  ArrayPrototypeFilter,
   ArrayPrototypeJoin,
   ArrayPrototypePush,
   FunctionPrototypeBind,
   FunctionPrototypeCall,
   ObjectAssign,
   ObjectCreate,
+  ObjectKeys,
+  ObjectPrototypeHasOwnProperty,
   ObjectSetPrototypeOf,
   PromiseAll,
   RegExpPrototypeExec,
   SafeArrayIterator,
   SafeWeakMap,
+  StringPrototypeEndsWith,
   globalThis,
 } = primordials;
 const { MessageChannel } = require('internal/worker/io');
@@ -45,6 +49,9 @@ const {
   initializeImportMeta
 } = require('internal/modules/esm/initialize_import_meta');
 const { defaultLoad } = require('internal/modules/esm/load');
+const {
+  defaultGetFileSystem
+} = require('internal/modules/esm/get_file_system');
 const { translators } = require(
   'internal/modules/esm/translators');
 const { getOptionValue } = require('internal/options');
@@ -81,6 +88,14 @@ class ESMLoader {
     defaultResolve,
   ];
 
+  /**
+   * @private
+   * @property {Function[]} resolvers First-in-first-out list of resolver hooks
+   */
+  #fileSystemBuilders = [
+    defaultGetFileSystem,
+  ];
+
   #importMetaInitializer = initializeImportMeta;
 
   /**
@@ -107,6 +122,7 @@ class ESMLoader {
     globalPreload,
     resolve,
     load,
+    getFileSystem,
     // obsolete hooks:
     dynamicInstantiate,
     getFormat,
@@ -159,8 +175,15 @@ class ESMLoader {
     if (load) {
       acceptedHooks.loader = FunctionPrototypeBind(load, null);
     }
+    if (getFileSystem) {
+      acceptedHooks.getFileSystem = FunctionPrototypeBind(getFileSystem, null);
+    }
 
     return acceptedHooks;
+  }
+
+  constructor() {
+    this.buildFileSystem();
   }
 
   /**
@@ -180,6 +203,7 @@ class ESMLoader {
         globalPreloader,
         resolver,
         loader,
+        getFileSystem,
       } = ESMLoader.pluckHooks(exports);
 
       if (globalPreloader) ArrayPrototypePush(
@@ -194,11 +218,61 @@ class ESMLoader {
         this.#loaders,
         FunctionPrototypeBind(loader, null), // [1]
       );
+      if (getFileSystem) ArrayPrototypePush(
+        this.#fileSystemBuilders,
+        FunctionPrototypeBind(getFileSystem, null), // [1]
+      );
     }
 
     // [1] ensure hook function is not bound to ESMLoader instance
 
+    this.buildFileSystem();
     this.preload();
+  }
+
+  buildFileSystem() {
+    // Note: makes assumptions as to how chaining will work to demonstrate
+    // the capability; subject to change once chaining's API is finalized.
+    const fileSystemFactories = [...this.#fileSystemBuilders];
+
+    const defaultFileSystemFactory = fileSystemFactories[0];
+    let finalFileSystem =
+      defaultFileSystemFactory();
+
+    const asyncKeys = ArrayPrototypeFilter(
+      ObjectKeys(finalFileSystem),
+      (name) => !StringPrototypeEndsWith(name, 'Sync'),
+    );
+
+    for (let i = 1; i < fileSystemFactories.length; ++i) {
+      const currentFileSystem = finalFileSystem;
+      const fileSystem = fileSystemFactories[i](() => currentFileSystem);
+
+      // If the loader specifies a sync hook but omits the async one we
+      // leverage the sync version by default, so that most hook authors
+      // don't have to write their implementations twice.
+      for (let j = 0; j < asyncKeys.length; ++j) {
+        const asyncKey = asyncKeys[j];
+        const syncKey = `${asyncKey}Sync`;
+
+        if (
+          !ObjectPrototypeHasOwnProperty(fileSystem, asyncKey) &&
+          ObjectPrototypeHasOwnProperty(fileSystem, syncKey)
+        ) {
+          fileSystem[asyncKey] = async (...args) => {
+            return fileSystem[syncKey](...args);
+          };
+        }
+      }
+
+      finalFileSystem = ObjectAssign(
+        ObjectCreate(null),
+        currentFileSystem,
+        fileSystem,
+      );
+    }
+
+    this.fileSystem = finalFileSystem;
   }
 
   async eval(

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -158,7 +158,7 @@ function getPackageConfig(path, specifier, base) {
   }
 
   const source = esmLoader.getFileSystem()
-    .readJsonSync(pathToFileURL(path)).string;
+    .readPackageJsonSync(pathToFileURL(path)).string;
   if (source === undefined) {
     const packageConfig = {
       pjsonPath: path,
@@ -338,7 +338,7 @@ function resolveDirectoryEntry(search) {
   const pkgJsonPath = resolve(dirPath, 'package.json');
   if (fileExists(pkgJsonPath)) {
     const pkgJson = esmLoader.getFileSystem()
-      .readJsonSync(pathToFileURL(pkgJsonPath));
+      .readPackageJsonSync(pathToFileURL(pkgJsonPath));
     if (pkgJson.containsKeys) {
       const { main } = JSONParse(pkgJson.string);
       if (main != null) {

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -25,13 +25,7 @@ const {
   StringPrototypeSplit,
   StringPrototypeStartsWith,
 } = primordials;
-const internalFS = require('internal/fs/utils');
 const { NativeModule } = require('internal/bootstrap/loaders');
-const {
-  realpathSync,
-  statSync,
-  Stats,
-} = require('fs');
 const { getOptionValue } = require('internal/options');
 // Do not eagerly grab .manifest, it may be in TDZ
 const policy = getOptionValue('--experimental-policy') ?
@@ -42,6 +36,7 @@ const preserveSymlinks = getOptionValue('--preserve-symlinks');
 const preserveSymlinksMain = getOptionValue('--preserve-symlinks-main');
 const typeFlag = getOptionValue('--input-type');
 const { URL, pathToFileURL, fileURLToPath } = require('internal/url');
+const esmLoader = require('internal/process/esm_loader');
 const {
   ERR_INPUT_TYPE_NOT_ALLOWED,
   ERR_INVALID_ARG_VALUE,
@@ -57,7 +52,6 @@ const {
 } = require('internal/errors').codes;
 const { Module: CJSModule } = require('internal/modules/cjs/loader');
 
-const packageJsonReader = require('internal/modules/package_json_reader');
 const userConditions = getOptionValue('--conditions');
 const noAddons = getOptionValue('--no-addons');
 const addonConditions = noAddons ? [] : ['node-addons'];
@@ -149,15 +143,7 @@ function getConditionsSet(conditions) {
   return DEFAULT_CONDITIONS_SET;
 }
 
-const realpathCache = new SafeMap();
 const packageJSONCache = new SafeMap();  /* string -> PackageConfig */
-
-/**
- * @param {string | URL} path
- * @returns {import('fs').Stats}
- */
-const tryStatSync =
-  (path) => statSync(path, { throwIfNoEntry: false }) ?? new Stats();
 
 /**
  * @param {string} path
@@ -170,7 +156,9 @@ function getPackageConfig(path, specifier, base) {
   if (existing !== undefined) {
     return existing;
   }
-  const source = packageJsonReader.read(path).string;
+
+  const source = esmLoader.getFileSystem()
+    .readJsonSync(pathToFileURL(path)).string;
   if (source === undefined) {
     const packageConfig = {
       pjsonPath: path,
@@ -257,7 +245,11 @@ function getPackageScopeConfig(resolved) {
  * @returns {boolean}
  */
 function fileExists(url) {
-  return statSync(url, { throwIfNoEntry: false })?.isFile() ?? false;
+  return esmLoader.getFileSystem().statEntrySync(
+    typeof url === 'string' ?
+      pathToFileURL(url) :
+      url
+  ) === 0;
 }
 
 /**
@@ -345,7 +337,8 @@ function resolveDirectoryEntry(search) {
   const dirPath = fileURLToPath(search);
   const pkgJsonPath = resolve(dirPath, 'package.json');
   if (fileExists(pkgJsonPath)) {
-    const pkgJson = packageJsonReader.read(pkgJsonPath);
+    const pkgJson = esmLoader.getFileSystem()
+      .readJsonSync(pathToFileURL(pkgJsonPath));
     if (pkgJson.containsKeys) {
       const { main } = JSONParse(pkgJson.string);
       if (main != null) {
@@ -384,21 +377,23 @@ function finalizeResolution(resolved, base, preserveSymlinks) {
       resolved.pathname, fileURLToPath(base), 'module');
   }
 
-  const stats = tryStatSync(StringPrototypeEndsWith(path, '/') ?
-    StringPrototypeSlice(path, -1) : path);
-  if (stats.isDirectory()) {
+  const stats = esmLoader.getFileSystem().statEntrySync(
+    StringPrototypeEndsWith(path, '/') ?
+      pathToFileURL(StringPrototypeSlice(path, -1)) :
+      resolved
+  );
+
+  if (stats === 1) {
     const err = new ERR_UNSUPPORTED_DIR_IMPORT(path, fileURLToPath(base));
     err.url = String(resolved);
     throw err;
-  } else if (!stats.isFile()) {
+  } else if (stats < 0) {
     throw new ERR_MODULE_NOT_FOUND(
       path || resolved.pathname, base && fileURLToPath(base), 'module');
   }
 
   if (!preserveSymlinks) {
-    const real = realpathSync(path, {
-      [internalFS.realpathCacheKey]: realpathCache
-    });
+    const real = esmLoader.getFileSystem().realpathSync(resolved);
     const { search, hash } = resolved;
     resolved =
         pathToFileURL(real + (StringPrototypeEndsWith(path, sep) ? '/' : ''));
@@ -836,9 +831,12 @@ function packageResolve(specifier, base, conditions) {
   let packageJSONPath = fileURLToPath(packageJSONUrl);
   let lastPath;
   do {
-    const stat = tryStatSync(StringPrototypeSlice(packageJSONPath, 0,
-                                                  packageJSONPath.length - 13));
-    if (!stat.isDirectory()) {
+    const stat = esmLoader.fileSystem.statEntrySync(
+      pathToFileURL(
+        StringPrototypeSlice(packageJSONPath, 0, packageJSONPath.length - 13)
+      )
+    );
+    if (stat !== 1) {
       lastPath = packageJSONPath;
       packageJSONUrl = new URL((isScoped ?
         '../../../../node_modules/' : '../../../node_modules/') +

--- a/lib/internal/process/esm_loader.js
+++ b/lib/internal/process/esm_loader.js
@@ -43,6 +43,9 @@ const esmLoader = new ESMLoader();
 
 exports.esmLoader = esmLoader;
 
+exports.getFileSystem = () =>
+  esmLoader.fileSystem;
+
 /**
  * Causes side-effects: user-defined loader hooks are added to esmLoader.
  * @returns {void}


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This is the implementation of https://github.com/nodejs/loaders/pull/44, as discussed at the last Loaders meeting (cc @nodejs/loaders). I leave it as draft because I expect to get feedback that could change the design, but it's already in a working state and I'd appreciate reviews. This PR includes:

- A new `getFileSystem` hook lets user interact with the Node resolution by letting them override the code I/O dependencies of the resolution algorithms. Four functions have been ported, in both async and sync versions (look below for a more detailed sync/async discussion).

    - Unlike [my initial plans for a `readFile` hook](https://github.com/nodejs/loaders/pull/44), which would have implied to eventually create other hooks for `statFile` etc, this implementation takes a different approach by defining a single hook which must return an interface of utilities. This approach works better in my opinion:
    
      - It's more scalable; more filesystem utilities can be added without having to make them full-blown hooks, which would imo needlessly complexify the design (if only in terms of documentation; with `getFileSystem`, the filesystem utilities can be documented in a different place than the proper hooks).
      
      - Filesystem utilities are very connected to each other. As a result, it stands to reason some hook author would want to return one set of utilities or another based on various conditions (for example we could imagine a loader that would allow disabling its features by returning the default filesystem utilities if a certain environment variable is set). If each utility was its own hook, this would be convoluted to achieve.
  
      - It also addresses the concerns @GeoffreyBooth had by avoiding to entangle the hook calls: the `getFileSystem` hook is only called when Node boots, not from within other hooks (the filesystem utilities themselves will be called during the hooks execution, of course, but it seems to be this shouldn't be a problem as those functions should be assumed to have no visible side effect).
      
    - The hook already implements the four utilities currently required for the Node resolution. I remember we discussed doing only `readFile` as a demo before adding the other ones, but I realized when implementing it that some things would appear over-engineered if I didn't show an example that used multiple utilities (for example, having `getFileSystem` that returns an object would make no sense if we only needed `readFile` - but we don't, which makes a design like `getFileSystem` more valuable).

    - I made the utilities have the exact same return values as the Node core functions they replaced (in particular for `internalModuleStat` and `InternalModuleReadJSON`, which have unusual return types). I'm open to ideas as to how the utility signatures should be for the final version.
 
    - I however normalised all utilities' inputs so that they all take a `URL` instance as parameter. In many case it just meant reusing url instances, and only in a few places I needed to instantiate new ones.

- The `demo/` folder is of course temporary and just meant to discuss how the hook looks like in practice. For this example, I implemented a loader that, given a file `foo.mjs` (or any other name), simulates the existence of a `foo-sha512.mjs` file that exports the hash of the original file). I picked this example because it's easy to conceptualise, and cannot be achieved by the other hooks.

    - I considered writing a "load modules from http" loader, but it's a little more difficult due to the Node algorithms currently relying a lot on synchronous operations, even in the esm pipeline. It would still have been possible with workers and atomics, but I felt like this would be better avoided for a simple demo use case.

  - I didn't write tests or documentation yet; those will be written once I un-draft the PR. For now, the `demo/` folder can be seen as the reference on how to use and experiment with the PR.

## Async vs sync

I initially implemented all the filesystem utilities as async functions, but quickly noticed that the Node resolution (even in the esm pipeline) was relying on them being sync. After some thoughts, I decided to implement both versions, even if some of them aren't in use right now. There are a few reasons for that:

- I didn't want to rework the entirety of the Node resolution pipeline. Changing sync functions to become async was a no-goal for me, especially considering the other points that follow.

- The loader implementation cost of having to write two different versions of a same hook can be offset by Node automatically reusing the sync version of an utility if the same loader declares it (check my demo loader for an example).

- There's a decent case that the cjs resolution pipeline could benefit from the `getFileSystem` hooks as well, which would allow us to close https://github.com/nodejs/node/issues/33423. This is something I'd like to tackle once the current task is done, so I don't think it'd hurt to document both sync and async utilities and suggest implementers implement both.
