### PR TITLE
fix withoutintl builds

### DIFF
--- a/tools/doc/package-lock.json
+++ b/tools/doc/package-lock.json
@@ -11,7 +11,7 @@
         "node-doc-generator": "generate.js"
       },
       "devDependencies": {
-        "highlight.js": "^11.3.1",
+        "highlight.js": "^11.2.0",
         "js-yaml": "^4.1.0",
         "rehype-raw": "^6.1.0",
         "rehype-stringify": "^9.0.2",
@@ -413,9 +413,9 @@
       }
     },
     "node_modules/highlight.js": {
-      "version": "11.3.1",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.3.1.tgz",
-      "integrity": "sha512-PUhCRnPjLtiLHZAQ5A/Dt5F8cWZeMyj9KRsACsWT+OD6OP0x6dp5OmT5jdx0JgEyPxPZZIPQpRN2TciUT7occw==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.2.0.tgz",
+      "integrity": "sha512-JOySjtOEcyG8s4MLR2MNbLUyaXqUunmSnL2kdV/KuGJOmHZuAR5xC54Ko7goAXBWNhf09Vy3B+U7vR62UZ/0iw==",
       "dev": true,
       "engines": {
         "node": ">=12.0.0"
@@ -2124,9 +2124,9 @@
       }
     },
     "highlight.js": {
-      "version": "11.3.1",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.3.1.tgz",
-      "integrity": "sha512-PUhCRnPjLtiLHZAQ5A/Dt5F8cWZeMyj9KRsACsWT+OD6OP0x6dp5OmT5jdx0JgEyPxPZZIPQpRN2TciUT7occw==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.2.0.tgz",
+      "integrity": "sha512-JOySjtOEcyG8s4MLR2MNbLUyaXqUunmSnL2kdV/KuGJOmHZuAR5xC54Ko7goAXBWNhf09Vy3B+U7vR62UZ/0iw==",
       "dev": true
     },
     "html-void-elements": {

--- a/tools/doc/package.json
+++ b/tools/doc/package.json
@@ -7,7 +7,7 @@
     "node": ">=14.8.0"
   },
   "devDependencies": {
-    "highlight.js": "^11.3.1",
+    "highlight.js": "^11.2.0",
     "js-yaml": "^4.1.0",
     "rehype-raw": "^6.1.0",
     "rehype-stringify": "^9.0.2",


### PR DESCRIPTION
Recent upgrade of highlight.js has broken the docs build on the
withoutintl builds.

Refs: https://github.com/nodejs/node/issues/41077
Refs: https://github.com/nodejs/node/pull/41036

Consider this a quick fix to unblock the CI as the automated tooling will attempt to update again the next time it is run. It's getting late here on a Friday evening so maybe someone else can take a look and figure out if the break is due to highlight.js or something latent in Node.js/V8.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
