### PR TITLE
util: do not reduce to a single line if not appropriate using inspect

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -1913,8 +1913,11 @@ function reduceToSingleString(
         const start = output.length + ctx.indentationLvl +
                       braces[0].length + base.length + 10;
         if (isBelowBreakLength(ctx, output, start, base)) {
-          return `${base ? `${base} ` : ''}${braces[0]} ${join(output, ', ')}` +
-            ` ${braces[1]}`;
+          const joinedOutput = join(output, ', ');
+          if (!joinedOutput.includes('\n')) {
+            return `${base ? `${base} ` : ''}${braces[0]} ${joinedOutput}` +
+              ` ${braces[1]}`;
+          }
         }
       }
     }

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -2572,6 +2572,24 @@ assert.strictEqual(
 
   assert.strictEqual(out, expected);
 
+  // Array grouping should prevent lining up outer elements on a single line.
+  obj = [[[1, 2, 3, 4, 5, 6, 7, 8, 9]]];
+
+  out = util.inspect(obj, { compact: 3 });
+
+  expected = [
+    '[',
+    '  [',
+    '    [',
+    '      1, 2, 3, 4, 5,',
+    '      6, 7, 8, 9',
+    '    ]',
+    '  ]',
+    ']',
+  ].join('\n');
+
+  assert.strictEqual(out, expected);
+
   // Verify that array grouping and line consolidation does not happen together.
   obj = {
     a: {


### PR DESCRIPTION
This makes sure entries are not lined up on a single line if the
content contains any new line. That would otherwise cause confusing
output.

Before:
![image](https://user-images.githubusercontent.com/8822573/144698018-2234f9e4-5441-4a4a-ad48-991f9cecbb0d.png)

Now:
![image](https://user-images.githubusercontent.com/8822573/144698033-13744bc4-cf72-4b46-9088-2e26aea0667a.png)

Signed-off-by: Ruben Bridgewater <ruben@bridgewater.de>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
