### PR TITLE
fs: fix error codes for `fs.cp`

### DIFF
--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -25,8 +25,8 @@ rules:
       message: "Please use `require('internal/errors').hideStackFrames()` instead."
     - selector: "AssignmentExpression:matches([left.name='prepareStackTrace'], [left.property.name='prepareStackTrace'])"
       message: "Use 'overrideStackTrace' from 'lib/internal/errors.js' instead of 'Error.prepareStackTrace'."
-    - selector: "ThrowStatement > NewExpression:matches([callee.name=/^ERR_[A-Z_]+$/]) > ObjectExpression:first-child:not(:has([key.name='message']):has([key.name='code']):has([key.name='syscall']))"
-      message: "The context passed into this error must have .code, .syscall and .message."
+    - selector: "ThrowStatement > NewExpression[callee.name=/^ERR_[A-Z_]+$/] > ObjectExpression:first-child:not(:has([key.name='message']):has([key.name='code']):has([key.name='syscall']))"
+      message: "The context passed into SystemError constructor must have .code, .syscall and .message."
   no-restricted-globals:
     - error
     - name: AbortController

--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -25,6 +25,8 @@ rules:
       message: "Please use `require('internal/errors').hideStackFrames()` instead."
     - selector: "AssignmentExpression:matches([left.name='prepareStackTrace'], [left.property.name='prepareStackTrace'])"
       message: "Use 'overrideStackTrace' from 'lib/internal/errors.js' instead of 'Error.prepareStackTrace'."
+    - selector: "ThrowStatement > NewExpression:matches([callee.name=/^ERR_[A-Z_]+$/]) > ObjectExpression:first-child:not(:has([key.name='message']):has([key.name='code']):has([key.name='syscall']))"
+      message: "The context passed into this error must have .code, .syscall and .message."
   no-restricted-globals:
     - error
     - name: AbortController

--- a/lib/internal/fs/cp/cp-sync.js
+++ b/lib/internal/fs/cp/cp-sync.js
@@ -70,6 +70,7 @@ function checkPathsSync(src, dest, opts) {
         path: dest,
         syscall: 'cp',
         errno: EINVAL,
+        code: 'EINVAL',
       });
     }
     if (srcStat.isDirectory() && !destStat.isDirectory()) {
@@ -79,6 +80,7 @@ function checkPathsSync(src, dest, opts) {
         path: dest,
         syscall: 'cp',
         errno: EISDIR,
+        code: 'EISDIR',
       });
     }
     if (!srcStat.isDirectory() && destStat.isDirectory()) {
@@ -88,6 +90,7 @@ function checkPathsSync(src, dest, opts) {
         path: dest,
         syscall: 'cp',
         errno: ENOTDIR,
+        code: 'ENOTDIR',
       });
     }
   }
@@ -98,6 +101,7 @@ function checkPathsSync(src, dest, opts) {
       path: dest,
       syscall: 'cp',
       errno: EINVAL,
+      code: 'EINVAL',
     });
   }
   return { srcStat, destStat };
@@ -135,6 +139,7 @@ function checkParentPathsSync(src, srcStat, dest) {
       path: dest,
       syscall: 'cp',
       errno: EINVAL,
+      code: 'EINVAL',
     });
   }
   return checkParentPathsSync(src, srcStat, destParent);
@@ -170,6 +175,7 @@ function getStats(destStat, src, dest, opts) {
       path: src,
       syscall: 'cp',
       errno: EINVAL,
+      code: 'EISDIR',
     });
   } else if (srcStat.isFile() ||
            srcStat.isCharacterDevice() ||
@@ -183,6 +189,7 @@ function getStats(destStat, src, dest, opts) {
       path: dest,
       syscall: 'cp',
       errno: EINVAL,
+      code: 'EINVAL',
     });
   } else if (srcStat.isFIFO()) {
     throw new ERR_FS_CP_FIFO_PIPE({
@@ -190,6 +197,7 @@ function getStats(destStat, src, dest, opts) {
       path: dest,
       syscall: 'cp',
       errno: EINVAL,
+      code: 'EINVAL',
     });
   }
   throw new ERR_FS_CP_UNKNOWN({
@@ -197,6 +205,7 @@ function getStats(destStat, src, dest, opts) {
     path: dest,
     syscall: 'cp',
     errno: EINVAL,
+    code: 'EINVAL',
   });
 }
 
@@ -215,6 +224,7 @@ function mayCopyFile(srcStat, src, dest, opts) {
       path: dest,
       syscall: 'cp',
       errno: EEXIST,
+      code: 'EEXIST',
     });
   }
 }
@@ -305,6 +315,7 @@ function onLink(destStat, src, dest) {
       path: dest,
       syscall: 'cp',
       errno: EINVAL,
+      code: 'EINVAL',
     });
   }
   // Prevent copy if src is a subdir of dest since unlinking
@@ -316,6 +327,7 @@ function onLink(destStat, src, dest) {
       path: dest,
       syscall: 'cp',
       errno: EINVAL,
+      code: 'EINVAL',
     });
   }
   return copyLink(resolvedSrc, dest);

--- a/lib/internal/fs/cp/cp.js
+++ b/lib/internal/fs/cp/cp.js
@@ -82,6 +82,7 @@ async function checkPaths(src, dest, opts) {
         path: dest,
         syscall: 'cp',
         errno: EINVAL,
+        code: 'EINVAL',
       });
     }
     if (srcStat.isDirectory() && !destStat.isDirectory()) {
@@ -91,6 +92,7 @@ async function checkPaths(src, dest, opts) {
         path: dest,
         syscall: 'cp',
         errno: EISDIR,
+        code: 'EISDIR',
       });
     }
     if (!srcStat.isDirectory() && destStat.isDirectory()) {
@@ -100,6 +102,7 @@ async function checkPaths(src, dest, opts) {
         path: dest,
         syscall: 'cp',
         errno: ENOTDIR,
+        code: 'ENOTDIR',
       });
     }
   }
@@ -110,6 +113,7 @@ async function checkPaths(src, dest, opts) {
       path: dest,
       syscall: 'cp',
       errno: EINVAL,
+      code: 'EINVAL',
     });
   }
   return { srcStat, destStat };
@@ -171,6 +175,7 @@ async function checkParentPaths(src, srcStat, dest) {
       path: dest,
       syscall: 'cp',
       errno: EINVAL,
+      code: 'EINVAL',
     });
   }
   return checkParentPaths(src, srcStat, destParent);
@@ -209,7 +214,8 @@ async function getStatsForCopy(destStat, src, dest, opts) {
       message: `${src} is a directory (not copied)`,
       path: src,
       syscall: 'cp',
-      errno: EINVAL,
+      errno: EISDIR,
+      code: 'EISDIR',
     });
   } else if (srcStat.isFile() ||
             srcStat.isCharacterDevice() ||
@@ -223,6 +229,7 @@ async function getStatsForCopy(destStat, src, dest, opts) {
       path: dest,
       syscall: 'cp',
       errno: EINVAL,
+      code: 'EINVAL',
     });
   } else if (srcStat.isFIFO()) {
     throw new ERR_FS_CP_FIFO_PIPE({
@@ -230,6 +237,7 @@ async function getStatsForCopy(destStat, src, dest, opts) {
       path: dest,
       syscall: 'cp',
       errno: EINVAL,
+      code: 'EINVAL',
     });
   }
   throw new ERR_FS_CP_UNKNOWN({
@@ -237,6 +245,7 @@ async function getStatsForCopy(destStat, src, dest, opts) {
     path: dest,
     syscall: 'cp',
     errno: EINVAL,
+    code: 'EINVAL',
   });
 }
 
@@ -255,6 +264,7 @@ async function mayCopyFile(srcStat, src, dest, opts) {
       path: dest,
       syscall: 'cp',
       errno: EEXIST,
+      code: 'EEXIST',
     });
   }
 }
@@ -355,6 +365,7 @@ async function onLink(destStat, src, dest) {
       path: dest,
       syscall: 'cp',
       errno: EINVAL,
+      code: 'EINVAL',
     });
   }
   // Do not copy if src is a subdir of dest since unlinking
@@ -367,6 +378,7 @@ async function onLink(destStat, src, dest) {
       path: dest,
       syscall: 'cp',
       errno: EINVAL,
+      code: 'EINVAL',
     });
   }
   return copyLink(resolvedSrc, dest);


### PR DESCRIPTION
The context passed into this error must have `.code`, `.syscall` and
`.message`.
https://github.com/nodejs/node/blob/36c0ac05e6d82786c58bbbff46715bb24efe90b4/lib/internal/errors.js#L215-L216

Maybe it'd worth adding a ESLint rule to catch this kind of mistakes.

Fixes: https://github.com/nodejs/node/issues/41104

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
