### PR TITLE
doc: remove OpenJSF Slack nodejs from support doc

### DIFF
--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -15,7 +15,6 @@ If you didn't find an answer in the resources above, try these unofficial
 resources:
 
 * [Questions tagged 'node.js' on Stack Overflow](https://stackoverflow.com/questions/tagged/node.js)
-* [#nodejs](https://openjs-foundation.slack.com/archives/CK9Q4MB53) channel on the OpenJS Foundation Slack ([join here](https://slack-invite.openjsf.org/))
 * [#node.js channel on libera.chat](https://web.libera.chat?channels=node.js&uio=d4)
 * [Node.js Slack Community](https://node-js.slack.com/)
   * To register: [nodeslackers.com](https://www.nodeslackers.com/)


### PR DESCRIPTION
The OpenJSF Slack nodejs channel has a description that reads:

> 🚨 For Node.js application development questions, see:
> 
> - Node Slackers: https://www.nodeslackers.com/
> - Node.js help repo: https://github.com/nodejs/help

Let's not send people with support questions there just to get
ignored or redirected elsewhere.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
