### PR TITLE
http: don't write empty data on req/res end()

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -878,9 +878,10 @@ OutgoingMessage.prototype.end = function end(chunk, encoding, callback) {
 
   if (this._hasBody && this.chunkedEncoding) {
     this._send('0\r\n' + this._trailer + '\r\n', 'latin1', finish);
-  } else {
-    // Force a flush, HACK.
+  } else if (!this._headerSent || this.writableLength || chunk) {
     this._send('', 'latin1', finish);
+  } else {
+    process.nextTick(finish);
   }
 
   if (this.socket) {

--- a/test/parallel/test-http-sync-write-error-during-continue.js
+++ b/test/parallel/test-http-sync-write-error-during-continue.js
@@ -42,11 +42,11 @@ Connection: close
       // parser.finish() to be called while we are here in the 'continue'
       // callback, which is inside a parser.execute() call.
 
-      assert.strictEqual(chunk.length, 0);
+      assert.strictEqual(chunk.length, 4);
       clientSide.destroy(new Error('sometimes the code just doesn’t work'), cb);
     });
     req.on('error', common.mustCall());
-    req.end();
+    req.end('data');
 
     sync = false;
   }));


### PR DESCRIPTION
When calling OutgoingMessage.end() with empty data argument, avoid
writing to the socket unless there's still pending data to be sent.

Fixes: https://github.com/nodejs/node/issues/41062