### PR TITLE
[v12.x] build: pin macOS GitHub runner to macos-10.15

### DIFF
--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -8,11 +8,11 @@ env:
 
 jobs:
   test-macOS:
-    runs-on: macos-latest
+    runs-on: "macos-10.15"
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Environment Information


### PR DESCRIPTION
Node.js 12.x requires Python 2 to build. `macos-latest` GitHub
hosted runners are now macOS 11 and do not have Python 2 available.

Refs: https://github.com/actions/virtual-environments/issues/4060

---

Node.js 12 is in maintenance and goes End-of-Life next April (2022). This pull request is to attempt to fix the GitHub actions macOS workflow by pinning the runner to the macOS version we were previously testing on before GitHub updated what `macos-latest` points to, 

Example of failing run on https://github.com/nodejs/node/commit/b13340eff4a5eeae797fd8e083e3fd09955d7f09 (current `v12.x-staging`: https://github.com/nodejs/node/actions/runs/1559350131
![image](https://user-images.githubusercontent.com/5445507/145426903-9084e2cb-e7aa-42c2-9a99-f68590f25cd6.png)

If this doesn't work I'd propose dropping this workflow from `v12.x` -- I briefly looked at the Python 3 PRs that landed in the later release lines and I would not be comfortable attempting to backport those to `v12.x` this late in its lifecycle.
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
