### PR TITLE
fs: accept URL as argument for `fs.rm` and `fs.rmSync`

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -3580,6 +3580,11 @@ with options `{ recursive: true, force: true }`.
 
 <!-- YAML
 added: v14.14.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/41132
+    description: The `path` parameter can be a WHATWG `URL` object using `file:`
+                 protocol.
 -->
 
 * `path` {string|Buffer|URL}
@@ -5328,6 +5333,11 @@ with options `{ recursive: true, force: true }`.
 
 <!-- YAML
 added: v14.14.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/41132
+    description: The `path` parameter can be a WHATWG `URL` object using `file:`
+                 protocol.
 -->
 
 * `path` {string|Buffer|URL}

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1185,6 +1185,7 @@ function rm(path, options, callback) {
     callback = options;
     options = undefined;
   }
+  path = getValidatedPath(path);
 
   validateRmOptions(path, options, false, (err, options) => {
     if (err) {
@@ -1208,6 +1209,7 @@ function rm(path, options, callback) {
  * @returns {void}
  */
 function rmSync(path, options) {
+  path = getValidatedPath(path);
   options = validateRmOptionsSync(path, options, false);
 
   lazyLoadRimraf();

--- a/test/parallel/test-fs-rm.js
+++ b/test/parallel/test-fs-rm.js
@@ -5,7 +5,7 @@ const tmpdir = require('../common/tmpdir');
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
-const { pathToFileURL }=require('url');
+const { pathToFileURL } = require('url');
 const { execSync } = require('child_process');
 
 const { validateRmOptionsSync } = require('internal/fs/utils');

--- a/test/parallel/test-fs-rm.js
+++ b/test/parallel/test-fs-rm.js
@@ -5,6 +5,7 @@ const tmpdir = require('../common/tmpdir');
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
+const { pathToFileURL }=require('url');
 const { execSync } = require('child_process');
 
 const { validateRmOptionsSync } = require('internal/fs/utils');
@@ -97,6 +98,11 @@ function removeAsync(dir) {
   makeNonEmptyDirectory(2, 10, 2, dir, false);
   removeAsync(dir);
 
+  // Same test using URL instead of a path
+  dir = nextDirPath();
+  makeNonEmptyDirectory(2, 10, 2, dir, false);
+  removeAsync(pathToFileURL(dir));
+
   // Create a flat folder including symlinks
   dir = nextDirPath();
   makeNonEmptyDirectory(1, 10, 2, dir, true);
@@ -156,6 +162,16 @@ function removeAsync(dir) {
     fs.rmSync(filePath, { force: true });
   }
 
+  // Should accept URL
+  const fileURL = pathToFileURL(path.join(tmpdir.path, 'rm-file.txt'));
+  fs.writeFileSync(fileURL, '');
+
+  try {
+    fs.rmSync(fileURL, { recursive: true });
+  } finally {
+    fs.rmSync(fileURL, { force: true });
+  }
+
   // Recursive removal should succeed.
   fs.rmSync(dir, { recursive: true });
 
@@ -201,6 +217,16 @@ function removeAsync(dir) {
     await fs.promises.rm(filePath, { recursive: true });
   } finally {
     fs.rmSync(filePath, { force: true });
+  }
+
+  // Should accept URL
+  const fileURL = pathToFileURL(path.join(tmpdir.path, 'rm-promises-file.txt'));
+  fs.writeFileSync(fileURL, '');
+
+  try {
+    await fs.promises.rm(fileURL, { recursive: true });
+  } finally {
+    fs.rmSync(fileURL, { force: true });
   }
 })().then(common.mustCall());
 


### PR DESCRIPTION
if we pass the URL instead of string path we get: 
```js
Exception has occurred: TypeError [ERR_INVALID_ARG_TYPE]: The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object. Received an instance of URL
  at new NodeError (node:internal/errors:371:5)
    at Function.from (node:buffer:322:9)
    at _rmdirSync (node:internal/fs/rimraf:248:30)
    at rimrafSync (node:internal/fs/rimraf:193:7)
    at Module.rmSync (node:fs:1214:10)
```

_Originally posted by @dygabo in https://github.com/nodejs/node/pull/40980#discussion_r766395639_
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
