### PR TITLE
test: improve test coverage of dns/promises

### DIFF
--- a/test/parallel/test-dns-lookup-promises-options-deprecated.js
+++ b/test/parallel/test-dns-lookup-promises-options-deprecated.js
@@ -1,6 +1,7 @@
 // Flags: --expose-internals
 'use strict';
 const common = require('../common');
+const assert = require('assert');
 const { internalBinding } = require('internal/test/binding');
 const cares = internalBinding('cares_wrap');
 cares.getaddrinfo = () => internalBinding('uv').UV_ENOMEM;
@@ -8,8 +9,7 @@ cares.getaddrinfo = () => internalBinding('uv').UV_ENOMEM;
 // This test ensures that dns.lookup issue a DeprecationWarning
 // when invalid options type is given
 
-const dns = require('dns');
-const dnsPromises = dns.promises;
+const dnsPromises = require('dns/promises');
 
 common.expectWarning({
   'internal/test/binding': [
@@ -20,7 +20,12 @@ common.expectWarning({
   }
 });
 
-dnsPromises.lookup('127.0.0.1', { hints: '1024' });
+assert.throws(() => {
+  dnsPromises.lookup('127.0.0.1', { hints: '-1' });
+}, {
+  code: 'ERR_INVALID_ARG_VALUE',
+  name: 'TypeError'
+});
 dnsPromises.lookup('127.0.0.1', { family: '6' });
 dnsPromises.lookup('127.0.0.1', { all: 'true' });
 dnsPromises.lookup('127.0.0.1', { verbatim: 'true' });

--- a/test/parallel/test-dns-lookup-promises-options-deprecated.js
+++ b/test/parallel/test-dns-lookup-promises-options-deprecated.js
@@ -1,0 +1,27 @@
+// Flags: --expose-internals
+'use strict';
+const common = require('../common');
+const { internalBinding } = require('internal/test/binding');
+const cares = internalBinding('cares_wrap');
+cares.getaddrinfo = () => internalBinding('uv').UV_ENOMEM;
+
+// This test ensures that dns.lookup issue a DeprecationWarning
+// when invalid options type is given
+
+const dns = require('dns');
+const dnsPromises = dns.promises;
+
+common.expectWarning({
+  'internal/test/binding': [
+    'These APIs are for internal testing only. Do not use them.',
+  ],
+  'DeprecationWarning': {
+    DEP0153: 'Type coercion of dns.lookup options is deprecated'
+  }
+});
+
+dnsPromises.lookup('127.0.0.1', { hints: '1024' });
+dnsPromises.lookup('127.0.0.1', { family: '6' });
+dnsPromises.lookup('127.0.0.1', { all: 'true' });
+dnsPromises.lookup('127.0.0.1', { verbatim: 'true' });
+dnsPromises.lookup('127.0.0.1', '6');


### PR DESCRIPTION
This improves a test coverage in lib/internal/dns/promises.
It tests emitting warning when the options types of lookup method are invalid.

ref: https://coverage.nodejs.org/coverage-18ff5832501b66b4/lib/internal/dns/promises.js.html#L116