### PR TITLE
stream: manual destroy ServerResponse on pipeline

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -93,6 +93,11 @@ const kServerResponse = Symbol('ServerResponse');
 const kServerResponseStatistics = Symbol('ServerResponseStatistics');
 
 const {
+  kManualDestroy,
+  kPipelineStream
+} = require('internal/streams/utils');
+
+const {
   hasObserver,
 } = require('internal/perf/observe');
 
@@ -233,6 +238,10 @@ function onServerResponseClose() {
     emitCloseNT(this._httpMessage);
   }
 }
+
+ServerResponse.prototype[kPipelineStream] = function() {
+  this[kManualDestroy] = true;
+};
 
 ServerResponse.prototype.assignSocket = function assignSocket(socket) {
   assert(!socket._httpMessage);

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -33,6 +33,8 @@ const {
   isIterable,
   isReadableNodeStream,
   isNodeStream,
+  kManualDestroy,
+  kPipelineStream,
 } = require('internal/streams/utils');
 const { AbortController } = require('internal/abort_controller');
 
@@ -52,7 +54,9 @@ function destroyer(stream, reading, writing) {
   return (err) => {
     if (finished) return;
     finished = true;
-    destroyImpl.destroyer(stream, err || new ERR_STREAM_DESTROYED('pipe'));
+    if (stream[kManualDestroy] !== true) {
+      destroyImpl.destroyer(stream, err || new ERR_STREAM_DESTROYED('pipe'));
+    }
   };
 }
 
@@ -204,6 +208,10 @@ function pipelineImpl(streams, callback, opts) {
     const reading = i < streams.length - 1;
     const writing = i > 0;
     const end = reading || opts?.end !== false;
+
+    if (stream[kPipelineStream]) {
+      stream[kPipelineStream]();
+    }
 
     if (isNodeStream(stream)) {
       if (end) {

--- a/lib/internal/streams/utils.js
+++ b/lib/internal/streams/utils.js
@@ -8,6 +8,8 @@ const {
 
 const kDestroyed = Symbol('kDestroyed');
 const kIsDisturbed = Symbol('kIsDisturbed');
+const kManualDestroy = Symbol('kManualDestroy');
+const kPipelineStream = Symbol('kPipelineStream');
 
 function isReadableNodeStream(obj, strict = false) {
   return !!(
@@ -247,6 +249,8 @@ function isDisturbed(stream) {
 
 module.exports = {
   kDestroyed,
+  kManualDestroy,
+  kPipelineStream,
   isDisturbed,
   kIsDisturbed,
   isClosed,


### PR DESCRIPTION
Change the behavior to not destroy the ServerResponse stream on `stream.pipeline` when
an error happens.

Address: https://github.com/nodejs/node/issues/26311

---

I feel that https://github.com/nodejs/node/issues/38262 was a similar issue that was solved differently, however, I do not find a better way to solve it so far. I'm completely open to changing the current approach to a non-breaking one.