### PR TITLE
build: use '<(python)' instead of 'python'

### DIFF
--- a/src/inspector/node_inspector.gypi
+++ b/src/inspector/node_inspector.gypi
@@ -84,7 +84,7 @@
         '<(SHARED_INTERMEDIATE_DIR)/src/node_protocol.json',
       ],
       'action': [
-        'python',
+        '<(python)',
         'tools/inspector_protocol/convert_protocol_to_json.py',
         '<@(_inputs)',
         '<@(_outputs)',
@@ -102,7 +102,7 @@
       ],
       'process_outputs_as_sources': 1,
       'action': [
-        'python',
+        '<(python)',
         'tools/inspector_protocol/code_generator.py',
         '--jinja_dir', '<@(protocol_tool_path)',
         '--output_base', '<(SHARED_INTERMEDIATE_DIR)/src/',
@@ -120,7 +120,7 @@
         '<(SHARED_INTERMEDIATE_DIR)/concatenated_protocol.json',
       ],
       'action': [
-        'python',
+        '<(python)',
         'tools/inspector_protocol/concatenate_protocols.py',
         '<@(_inputs)',
         '<@(_outputs)',
@@ -136,7 +136,7 @@
       ],
       'process_outputs_as_sources': 1,
       'action': [
-        'python',
+        '<(python)',
         'tools/compress_json.py',
         '<@(_inputs)',
         '<@(_outputs)',

--- a/tools/v8_gypfiles/inspector.gypi
+++ b/tools/v8_gypfiles/inspector.gypi
@@ -142,7 +142,7 @@
         '<@(inspector_generated_output_root)/src/js_protocol.stamp',
       ],
       'action': [
-        'python',
+        '<(python)',
         '<(inspector_protocol_path)/check_protocol_compatibility.py',
         '--stamp', '<@(_outputs)',
         '<@(_inputs)',
@@ -161,7 +161,7 @@
       ],
       'process_outputs_as_sources': 1,
       'action': [
-        'python',
+        '<(python)',
         '<(inspector_protocol_path)/code_generator.py',
         '--jinja_dir', '<(V8_ROOT)/third_party',
         '--output_base', '<(inspector_generated_output_root)/src/inspector',


### PR DESCRIPTION
Should use `<(python)` instead of `python` for scripts in gyp files, otherwise the scripts might be run with python2 on some environments.

Close https://github.com/nodejs/node/issues/40996.