### PR TITLE
meta: move to emeritus automatically after 18 months

### DIFF
--- a/.github/workflows/find-inactive-collaborators.yml
+++ b/.github/workflows/find-inactive-collaborators.yml
@@ -9,7 +9,6 @@ on:
 
 env:
   NODE_VERSION: lts/*
-  NUM_COMMITS: 5000
 
 jobs:
   find:
@@ -19,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: ${{ env.NUM_COMMITS }}
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
@@ -28,7 +27,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Find inactive collaborators
-        run: tools/find-inactive-collaborators.mjs ${{ env.NUM_COMMITS }}
+        run: tools/find-inactive-collaborators.mjs
 
       - name: Open pull request
         uses: gr2m/create-or-update-pull-request-action@v1

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -67,6 +67,10 @@ See:
 The TSC can remove inactive collaborators or provide them with _emeritus_
 status. Emeriti may request that the TSC restore them to active status.
 
+A collaborator is automatically made emeritus (and removed from active
+collaborator status) if it has been more than 18 months since the collaborator
+has authored or approved a commit that has landed.
+
 ## Technical Steering Committee
 
 A subset of the collaborators forms the Technical Steering Committee (TSC).

--- a/tools/find-inactive-collaborators.mjs
+++ b/tools/find-inactive-collaborators.mjs
@@ -8,7 +8,7 @@ import cp from 'node:child_process';
 import fs from 'node:fs';
 import readline from 'node:readline';
 
-const SINCE = +process.argv[2] || 5000;
+const SINCE = +process.argv[2] || '18 months ago';
 
 async function runGitCommand(cmd, mapFn) {
   const childProcess = cp.spawn('/bin/sh', ['-c', cmd], {
@@ -42,19 +42,13 @@ async function runGitCommand(cmd, mapFn) {
 
 // Get all commit authors during the time period.
 const authors = await runGitCommand(
-  `git shortlog -n -s --email --max-count="${SINCE}" HEAD`,
-  (line) => line.trim().split('\t', 2)[1]
-);
-
-// Get all commit landers during the time period.
-const landers = await runGitCommand(
-  `git shortlog -n -s -c --email --max-count="${SINCE}" HEAD`,
+  `git shortlog -n -s --email --since="${SINCE}" HEAD`,
   (line) => line.trim().split('\t', 2)[1]
 );
 
 // Get all approving reviewers of landed commits during the time period.
 const approvingReviewers = await runGitCommand(
-  `git log --max-count="${SINCE}" | egrep "^    Reviewed-By: "`,
+  `git log --since="${SINCE}" | egrep "^    Reviewed-By: "`,
   (line) => /^    Reviewed-By: ([^<]+)/.exec(line)[1].trim()
 );
 
@@ -182,15 +176,13 @@ async function moveCollaboratorToEmeritus(peopleToMove) {
 // Get list of current collaborators from README.md.
 const collaborators = await getCollaboratorsFromReadme();
 
-console.log(`In the last ${SINCE} commits:\n`);
+console.log(`Since ${SINCE}:\n`);
 console.log(`* ${authors.size.toLocaleString()} authors have made commits.`);
-console.log(`* ${landers.size.toLocaleString()} landers have landed commits.`);
 console.log(`* ${approvingReviewers.size.toLocaleString()} reviewers have approved landed commits.`);
 console.log(`* ${collaborators.length.toLocaleString()} collaborators currently in the project.`);
 
 const inactive = collaborators.filter((collaborator) =>
   !authors.has(collaborator.mailmap) &&
-  !landers.has(collaborator.mailmap) &&
   !approvingReviewers.has(collaborator.name)
 );
 

--- a/tools/find-inactive-collaborators.mjs
+++ b/tools/find-inactive-collaborators.mjs
@@ -8,7 +8,7 @@ import cp from 'node:child_process';
 import fs from 'node:fs';
 import readline from 'node:readline';
 
-const SINCE = +process.argv[2] || '18 months ago';
+const SINCE = process.argv[2] || '18 months ago';
 
 async function runGitCommand(cmd, mapFn) {
   const childProcess = cp.spawn('/bin/sh', ['-c', cmd], {


### PR DESCRIPTION
Similar to the rules for automatic removal from active TSC membership,
provide criteria for automatic assignment to emeritus status for
inactive collaborators. Automate enforcement of these criteria.