### PR TITLE
stream: expect _destroy to call the callback in thennables

### DIFF
--- a/lib/internal/streams/destroy.js
+++ b/lib/internal/streams/destroy.js
@@ -290,11 +290,7 @@ function constructNT(stream) {
       if (typeof then === 'function') {
         then.call(
           result,
-          function() {
-            if (!called) {
-              process.nextTick(onConstruct, null);
-            }
-          },
+          nop,
           function(err) {
             if (!called) {
               process.nextTick(onConstruct, err);

--- a/lib/internal/streams/destroy.js
+++ b/lib/internal/streams/destroy.js
@@ -19,6 +19,7 @@ const {
 
 const kDestroy = Symbol('kDestroy');
 const kConstruct = Symbol('kConstruct');
+function nop() {}
 
 function checkError(err, w, r) {
   if (err) {
@@ -112,9 +113,7 @@ function _destroy(self, err, cb) {
       if (typeof then === 'function') {
         then.call(
           result,
-          function() {
-            process.nextTick(onDestroy, null);
-          },
+          nop,
           function(err) {
             process.nextTick(onDestroy, err);
           });

--- a/lib/internal/streams/writable.js
+++ b/lib/internal/streams/writable.js
@@ -698,11 +698,7 @@ function callFinal(stream, state) {
       if (typeof then === 'function') {
         then.call(
           result,
-          function() {
-            if (!called) {
-              process.nextTick(onFinish, null);
-            }
-          },
+          nop,
           function(err) {
             if (!called) {
               process.nextTick(onFinish, err);

--- a/test/parallel/test-stream-construct-async-error.js
+++ b/test/parallel/test-stream-construct-async-error.js
@@ -33,6 +33,7 @@ const assert = require('assert');
     async _destroy(err, cb) {
       // eslint-disable-next-line no-restricted-syntax
       await setTimeout(common.platformTimeout(1));
+      cb(err);
     }
   }
 

--- a/test/parallel/test-stream-construct-async-error.js
+++ b/test/parallel/test-stream-construct-async-error.js
@@ -46,9 +46,10 @@ const assert = require('assert');
 
 {
   class Foo extends Duplex {
-    async _construct() {
+    async _construct(cb) {
       // eslint-disable-next-line no-restricted-syntax
       await setTimeout(common.platformTimeout(1));
+      cb();
     }
 
     _write = common.mustCall((chunk, encoding, cb) => {
@@ -88,9 +89,10 @@ const assert = require('assert');
       cb();
     });
 
-    async _final() {
+    async _final(cb) {
       // eslint-disable-next-line no-restricted-syntax
       await setTimeout(common.platformTimeout(1));
+      cb();
     }
   }
 


### PR DESCRIPTION
Update `_destroy` to only call `onDestroy` in case of errors, waiting for the user implementation to call `onDestroy` on the success path of async functions as well. This is already what happens with [`Readable._read`](https://github.com/nodejs/node/blob/85d4cd307957bd35e7c723d0f1d2b77175fd9b0f/lib/internal/streams/readable.js#L502).

Fixes: #40377

## Description of the problem

As @szmarczak pointed out, currenlty on master, if we have have some synchronous code like:

```js
const { Writable } = require('stream');

class SyncDestroy extends Writable {
    _destroy(error, callback) {
        console.log('Calling the callback soon...')
        setTimeout(() => callback(error), 0)
    }
}

const writer = new SyncDestroy()
writer.on('error', error => console.log(`${error}`))
writer.destroy(new Error('oh no!'))
```

Then we have the expected output of:

```raw
Calling the callback soon...
Error: oh no!
```

However, changing `_destroy` to async changes the behaviour unexpectedly.

```js
class AsyncDestroy extends Writable {
    async _destroy(error, callback) {
        console.log('Calling the callback soon...')
        setTimeout(() => callback(error), 0)
    }
}

const writer = new AsyncDestroy()
writer.on('error', error => console.log(`${error}`))
writer.destroy(new Error('oh no!'))
```

```raw
Calling the callback soon...
```