### PR TITLE
meta: remove community-committee from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,21 +5,15 @@
 # 3. PRs touching any code with a codeowner must be signed off by at least one
 #    person on the code owner team.
 
-# tsc & commcomm
+# tsc
 
 /.github/CODEOWNERS @nodejs/tsc
 /GOVERNANCE.md @nodejs/tsc
 /onboarding.md @nodejs/tsc
-/CODE_OF_CONDUCT.md @nodejs/tsc @nodejs/community-committee
-/CONTRIBUTING.md @nodejs/tsc @nodejs/community-committee
-/LICENSE @nodejs/tsc @nodejs/community-committee
-/doc/guides/contributing/code-of-conduct.md @nodejs/tsc @nodejs/community-committee
-# TODO(mmarchini): the bot doens't have a notion of precedence, that might
-# change when move the codeowners code to an Action, at which point we can
-# uncomment the line below
-# /doc/guides/contributing/*.md @nodejs/tsc
-/doc/guides/contributing/issues.md @nodejs/tsc
-/doc/guides/contributing/pull-requests.md @nodejs/tsc
+/CODE_OF_CONDUCT.md @nodejs/tsc
+/CONTRIBUTING.md @nodejs/tsc
+/LICENSE @nodejs/tsc
+/doc/guides/contributing/*.md @nodejs/tsc
 /doc/guides/collaborator-guide.md @nodejs/tsc
 /doc/guides/offboarding.md @nodejs/tsc
 


### PR DESCRIPTION
Files previously managed by TSC + CommComm are now managed by TSC.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
