### PR TITLE
http2: handle existing socket data when creating HTTP/2 server sessions

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1262,6 +1262,21 @@ class Http2Session extends EventEmitter {
     this.on('newListener', sessionListenerAdded);
     this.on('removeListener', sessionListenerRemoved);
 
+    // Process data on the next tick - a remoteSettings handler may be attached.
+    // https://github.com/nodejs/node/issues/35981
+    process.nextTick(() => {
+      // Socket already has some buffered data - emulate receiving it
+      // https://github.com/nodejs/node/issues/35475
+      // https://github.com/nodejs/node/issues/34532
+      if (socket.readableLength) {
+        let buf;
+        while ((buf = socket.read()) !== null) {
+          debugSession(type, `${buf.length} bytes already in buffer`);
+          this[kHandle].receive(buf);
+        }
+      }
+    });
+
     debugSession(type, 'created');
   }
 
@@ -3275,21 +3290,6 @@ function connect(authority, options, listener) {
 
   if (typeof listener === 'function')
     session.once('connect', listener);
-
-  // Process data on the next tick - a remoteSettings handler may be attached.
-  // https://github.com/nodejs/node/issues/35981
-  process.nextTick(() => {
-    debug('Http2Session connect', options.createConnection);
-    // Socket already has some buffered data - emulate receiving it
-    // https://github.com/nodejs/node/issues/35475
-    if (socket && socket.readableLength) {
-      let buf;
-      while ((buf = socket.read()) !== null) {
-        debug(`Http2Session connect: ${buf.length} bytes already in buffer`);
-        session[kHandle].receive(buf);
-      }
-    }
-  });
 
   return session;
 }

--- a/test/parallel/test-http2-autoselect-protocol.js
+++ b/test/parallel/test-http2-autoselect-protocol.js
@@ -1,0 +1,72 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const net = require('net');
+const http = require('http');
+const http2 = require('http2');
+
+// Example test for HTTP/1 vs HTTP/2 protocol autoselection.
+// Refs: https://github.com/nodejs/node/issues/34532
+
+const h1Server = http.createServer(common.mustCall((req, res) => {
+  res.end('HTTP/1 Response');
+}));
+
+const h2Server = http2.createServer(common.mustCall((req, res) => {
+  res.end('HTTP/2 Response');
+}));
+
+const rawServer = net.createServer(common.mustCall(function listener(socket) {
+  const data = socket.read(3);
+
+  if (!data) { // Repeat until data is available
+    socket.once('readable', () => listener(socket));
+    return;
+  }
+
+  // Put the data back, so the real server can handle it:
+  socket.unshift(data);
+
+  if (data.toString('ascii') === 'PRI') { // Very dumb preface check
+    h2Server.emit('connection', socket);
+  } else {
+    h1Server.emit('connection', socket);
+  }
+}, 2));
+
+rawServer.listen(common.mustCall(() => {
+  const { port } = rawServer.address();
+
+  let done = 0;
+  {
+    // HTTP/2 Request
+    const client = http2.connect(`http://localhost:${port}`);
+    const req = client.request({ ':path': '/' });
+    req.end();
+
+    let content = '';
+    req.setEncoding('utf8');
+    req.on('data', (chunk) => content += chunk);
+    req.on('end', common.mustCall(() => {
+      assert.strictEqual(content, 'HTTP/2 Response');
+      if (++done === 2) rawServer.close();
+      client.close();
+    }));
+  }
+
+  {
+    // HTTP/1 Request
+    http.get(`http://localhost:${port}`, common.mustCall((res) => {
+      let content = '';
+      res.setEncoding('utf8');
+      res.on('data', (chunk) => content += chunk);
+      res.on('end', common.mustCall(() => {
+        assert.strictEqual(content, 'HTTP/1 Response');
+        if (++done === 2) rawServer.close();
+      }));
+    }));
+  }
+}));


### PR DESCRIPTION
Fixes #34532 (maybe #29902 too, TBC)

When emitting a 'connection' event to manually inject connections into a server, it's common for the provided stream to already contain readable data, e.g. after sniffing a connection to detect HTTP/2 from the initial bytes.

Previously this was supported only for outgoing HTTP/2 sessions created with `http2.connect()`. This change ensures that HTTP/2 over existing streams is supported on both outgoing and incoming sessions.

There was an attempt to fix this previously in https://github.com/nodejs/node/pull/34958, which works! Unfortunately that was closed and replaced by https://github.com/nodejs/node/pull/35678, which fixes the same issue but only for outgoing connections (by fixing `http2.connect` directly), not all HTTP/2 sessions.

This PR takes the HTTP/2 test from #34958 (which covers the server case) and moves the fix from #35678 into the session so it applies to _all_ HTTP/2 sessions.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
